### PR TITLE
feat:常规环境下，增加python3.13适配

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61.0",
-    "pybind11>=2.10.0",
+    "pybind11>=2.13.0",
     "cmake>=3.15",
     "wheel",
 ]
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Description

常规环境下，增加 Python 3.13 适配。

**根因分析**：
- OpenViking 使用 pybind11 绑定 C++ 代码（`src/pybind11_interface.cpp`）
- 原配置要求 `pybind11>=2.10.0`，但 **pybind11 v2.13.0 (2024-06-25) 才正式支持 Python 3.13**
- pybind11 2.13.0 包含 Python 3.13 C API 变更适配（如 `PyEval_AcquireLock()` 移除等）及 refcount bug 修复

**注意**：Anaconda Python 环境存在一个独立的段错误问题（发生在 `take_gil` 函数中），这是 Anaconda 编译配置的问题，与 pybind11 版本和 Python 版本无关，不在本次 PR 范围内。

## Related Issue

https://github.com/volcengine/OpenViking/issues/42

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 将 `pybind11` 最低版本从 `>=2.10.0` 提升至 `>=2.13.0`
- 添加 Python 3.13 classifier 声明支持

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS (Homebrew Python 3.10/3.13)
  - [ ] Windows

**测试结果**：

| 环境 | Python 3.10 | Python 3.13 |
|------|-------------|-------------|
| Homebrew Python | 正常 | 正常 |

```
Python version: 3.13.3 (main, Apr  8 2025, 13:54:08) [Clang 16.0.0]

Testing import openviking.storage.vectordb.engine...
  [OK] engine module imported successfully

=== All tests passed on Python 3.13! ===
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

**兼容性验证**：
- pybind11 2.13.0 仍支持 Python 3.7+，对 Python 3.9-3.12 用户无影响
- pybind11 2.10→2.13 之间无破坏性 API 变更

**已知限制**：
- Anaconda Python 环境可能存在独立的 GIL 相关段错误问题，建议使用 Homebrew/pyenv 等其他 Python 发行版