### PR TITLE
refactor: extract ObserverService from DebugService for cleaner status access API

### DIFF
--- a/docs/design/server_client/prompt.md
+++ b/docs/design/server_client/prompt.md
@@ -35,7 +35,7 @@ openviking/service/
 - `SearchService`: find, search
 - `SessionService`: session, sessions, add_message, compress, extract
 - `RelationService`: link, unlink, relations
-- `DebugService`: get_queue_status, get_vikingdb_status, get_vlm_status, get_system_status, is_healthy
+- `DebugService`: observer (ObserverService)
 - `PackService`: export_ovpack, import_ovpack
 
 3. **创建 OpenVikingService 主类**：

--- a/docs/en/api/01-client.md
+++ b/docs/en/api/01-client.md
@@ -252,78 +252,21 @@ ov.OpenViking.reset()
 
 ---
 
-### get_status()
+## Debug Methods
 
-Get system status including health status of all components.
+For system health monitoring and component status, see [Debug API](./07-debug.md).
 
-**Signature**
-
-```python
-def get_status(self) -> SystemStatus
-```
-
-**Parameters**
-
-None.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| SystemStatus | System status object |
-
-**Return Structure**
+**Quick Reference**
 
 ```python
-SystemStatus(
-    is_healthy=True,                    # Overall system health
-    components={                        # Component statuses
-        "queue": ComponentStatus(...),
-        "vikingdb": ComponentStatus(...),
-        "vlm": ComponentStatus(...)
-    },
-    errors=[]                           # Error list
-)
-```
-
-**Example**
-
-```python
-status = client.get_status()
-print(f"System healthy: {status.is_healthy}")
-print(f"Queue status: {status.components['queue'].is_healthy}")
-```
-
----
-
-### is_healthy()
-
-Quick health check.
-
-**Signature**
-
-```python
-def is_healthy(self) -> bool
-```
-
-**Parameters**
-
-None.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| bool | True if all components are healthy, False otherwise |
-
-**Example**
-
-```python
+# Quick health check
 if client.is_healthy():
     print("System OK")
-else:
-    status = client.get_status()
-    print(f"Errors: {status.errors}")
+
+# Access component status via observer
+print(client.observer.vikingdb)
+print(client.observer.queue)
+print(client.observer.system)
 ```
 
 ---

--- a/docs/en/api/07-debug.md
+++ b/docs/en/api/07-debug.md
@@ -1,0 +1,254 @@
+# Debug
+
+OpenViking provides debug and observability APIs for monitoring system health and component status.
+
+## API Reference
+
+### observer
+
+Property that provides convenient access to component status through `ObserverService`.
+
+**Signature**
+
+```python
+@property
+def observer(self) -> ObserverService
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| ObserverService | Service for accessing component status |
+
+**Example**
+
+```python
+import openviking as ov
+
+client = ov.OpenViking(path="./data")
+client.initialize()
+
+# Print component status directly
+print(client.observer.vikingdb)
+# Output:
+# [vikingdb] (healthy)
+# Collection  Index Count  Vector Count  Status
+# context     1            55            OK
+# TOTAL       1            55
+
+client.close()
+```
+
+---
+
+## ObserverService
+
+`ObserverService` provides properties for accessing individual component status.
+
+### queue
+
+Get queue system status.
+
+**Signature**
+
+```python
+@property
+def queue(self) -> ComponentStatus
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| ComponentStatus | Queue system status |
+
+**Example**
+
+```python
+print(client.observer.queue)
+# Output:
+# [queue] (healthy)
+# Queue                 Pending  In Progress  Processed  Errors  Total
+# Embedding             0        0            10         0       10
+# Semantic              0        0            10         0       10
+# TOTAL                 0        0            20         0       20
+```
+
+---
+
+### vikingdb
+
+Get VikingDB status.
+
+**Signature**
+
+```python
+@property
+def vikingdb(self) -> ComponentStatus
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| ComponentStatus | VikingDB status |
+
+**Example**
+
+```python
+print(client.observer.vikingdb)
+# Output:
+# [vikingdb] (healthy)
+# Collection  Index Count  Vector Count  Status
+# context     1            55            OK
+# TOTAL       1            55
+
+# Access specific properties
+print(client.observer.vikingdb.is_healthy)  # True
+print(client.observer.vikingdb.status)      # Status table string
+```
+
+---
+
+### vlm
+
+Get VLM (Vision Language Model) token usage status.
+
+**Signature**
+
+```python
+@property
+def vlm(self) -> ComponentStatus
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| ComponentStatus | VLM token usage status |
+
+**Example**
+
+```python
+print(client.observer.vlm)
+# Output:
+# [vlm] (healthy)
+# Model                          Provider      Prompt  Completion  Total  Last Updated
+# doubao-1-5-vision-pro-32k      volcengine    1000    500         1500   2024-01-01 12:00:00
+# TOTAL                                        1000    500         1500
+```
+
+---
+
+### system
+
+Get overall system status including all components.
+
+**Signature**
+
+```python
+@property
+def system(self) -> SystemStatus
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| SystemStatus | Overall system status |
+
+**Example**
+
+```python
+print(client.observer.system)
+# Output:
+# [queue] (healthy)
+# ...
+#
+# [vikingdb] (healthy)
+# ...
+#
+# [vlm] (healthy)
+# ...
+#
+# [system] (healthy)
+```
+
+---
+
+### is_healthy()
+
+Quick health check for the entire system.
+
+**Signature**
+
+```python
+def is_healthy(self) -> bool
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| bool | True if all components are healthy |
+
+**Example**
+
+```python
+if client.observer.is_healthy():
+    print("System OK")
+else:
+    print(client.observer.system)
+```
+
+---
+
+## Data Structures
+
+### ComponentStatus
+
+Status information for a single component.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | str | Component name |
+| is_healthy | bool | Whether the component is healthy |
+| has_errors | bool | Whether the component has errors |
+| status | str | Status table string |
+
+**String Representation**
+
+```python
+print(component_status)
+# Output:
+# [component_name] (healthy)
+# Status table content...
+```
+
+---
+
+### SystemStatus
+
+Overall system status including all components.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| is_healthy | bool | Whether the entire system is healthy |
+| components | Dict[str, ComponentStatus] | Status of each component |
+| errors | List[str] | List of error messages |
+
+**String Representation**
+
+```python
+print(system_status)
+# Output:
+# [queue] (healthy)
+# ...
+#
+# [vikingdb] (healthy)
+# ...
+#
+# [system] (healthy)
+# Errors: error1, error2  (if any)
+```

--- a/docs/en/concepts/01-architecture.md
+++ b/docs/en/concepts/01-architecture.md
@@ -73,7 +73,7 @@ The Service layer decouples business logic from the transport layer, enabling re
 | **ResourceService** | Resource import | add_resource, add_skill, wait_processed |
 | **RelationService** | Relation management | relations, link, unlink |
 | **PackService** | Import/export | export_ovpack, import_ovpack |
-| **DebugService** | Debug service | get_system_status, get_queue_status, get_vikingdb_status, get_vlm_status, is_healthy |
+| **DebugService** | Debug service | observer (ObserverService) |
 
 ## Dual-Layer Storage
 

--- a/docs/zh/api/01-client.md
+++ b/docs/zh/api/01-client.md
@@ -252,78 +252,21 @@ ov.OpenViking.reset()
 
 ---
 
-### get_status()
+## 调试方法
 
-获取系统状态，包含所有组件的健康状态。
+系统健康监控和组件状态相关内容，请参阅 [调试 API](./07-debug.md)。
 
-**签名**
-
-```python
-def get_status(self) -> SystemStatus
-```
-
-**参数**
-
-无。
-
-**返回值**
-
-| 类型 | 说明 |
-|------|------|
-| SystemStatus | 系统状态对象 |
-
-**返回结构**
+**快速参考**
 
 ```python
-SystemStatus(
-    is_healthy=True,                    # 系统整体是否健康
-    components={                        # 各组件状态
-        "queue": ComponentStatus(...),
-        "vikingdb": ComponentStatus(...),
-        "vlm": ComponentStatus(...)
-    },
-    errors=[]                           # 错误列表
-)
-```
-
-**示例**
-
-```python
-status = client.get_status()
-print(f"系统健康: {status.is_healthy}")
-print(f"队列状态: {status.components['queue'].is_healthy}")
-```
-
----
-
-### is_healthy()
-
-快速健康检查。
-
-**签名**
-
-```python
-def is_healthy(self) -> bool
-```
-
-**参数**
-
-无。
-
-**返回值**
-
-| 类型 | 说明 |
-|------|------|
-| bool | 所有组件健康返回 True，否则返回 False |
-
-**示例**
-
-```python
+# 快速健康检查
 if client.is_healthy():
     print("系统正常")
-else:
-    status = client.get_status()
-    print(f"错误: {status.errors}")
+
+# 通过 observer 访问组件状态
+print(client.observer.vikingdb)
+print(client.observer.queue)
+print(client.observer.system)
 ```
 
 ---

--- a/docs/zh/api/07-debug.md
+++ b/docs/zh/api/07-debug.md
@@ -1,0 +1,254 @@
+# 调试
+
+OpenViking 提供调试和可观测性 API，用于监控系统健康状态和组件状态。
+
+## API 参考
+
+### observer
+
+提供便捷访问组件状态的属性，返回 `ObserverService`。
+
+**签名**
+
+```python
+@property
+def observer(self) -> ObserverService
+```
+
+**返回值**
+
+| 类型 | 说明 |
+|------|------|
+| ObserverService | 用于访问组件状态的服务 |
+
+**示例**
+
+```python
+import openviking as ov
+
+client = ov.OpenViking(path="./data")
+client.initialize()
+
+# 直接打印组件状态
+print(client.observer.vikingdb)
+# 输出:
+# [vikingdb] (healthy)
+# Collection  Index Count  Vector Count  Status
+# context     1            55            OK
+# TOTAL       1            55
+
+client.close()
+```
+
+---
+
+## ObserverService
+
+`ObserverService` 提供访问各个组件状态的属性。
+
+### queue
+
+获取队列系统状态。
+
+**签名**
+
+```python
+@property
+def queue(self) -> ComponentStatus
+```
+
+**返回值**
+
+| 类型 | 说明 |
+|------|------|
+| ComponentStatus | 队列系统状态 |
+
+**示例**
+
+```python
+print(client.observer.queue)
+# 输出:
+# [queue] (healthy)
+# Queue                 Pending  In Progress  Processed  Errors  Total
+# Embedding             0        0            10         0       10
+# Semantic              0        0            10         0       10
+# TOTAL                 0        0            20         0       20
+```
+
+---
+
+### vikingdb
+
+获取 VikingDB 状态。
+
+**签名**
+
+```python
+@property
+def vikingdb(self) -> ComponentStatus
+```
+
+**返回值**
+
+| 类型 | 说明 |
+|------|------|
+| ComponentStatus | VikingDB 状态 |
+
+**示例**
+
+```python
+print(client.observer.vikingdb)
+# 输出:
+# [vikingdb] (healthy)
+# Collection  Index Count  Vector Count  Status
+# context     1            55            OK
+# TOTAL       1            55
+
+# 访问具体属性
+print(client.observer.vikingdb.is_healthy)  # True
+print(client.observer.vikingdb.status)      # 状态表格字符串
+```
+
+---
+
+### vlm
+
+获取 VLM（视觉语言模型）token 使用状态。
+
+**签名**
+
+```python
+@property
+def vlm(self) -> ComponentStatus
+```
+
+**返回值**
+
+| 类型 | 说明 |
+|------|------|
+| ComponentStatus | VLM token 使用状态 |
+
+**示例**
+
+```python
+print(client.observer.vlm)
+# 输出:
+# [vlm] (healthy)
+# Model                          Provider      Prompt  Completion  Total  Last Updated
+# doubao-1-5-vision-pro-32k      volcengine    1000    500         1500   2024-01-01 12:00:00
+# TOTAL                                        1000    500         1500
+```
+
+---
+
+### system
+
+获取系统整体状态，包含所有组件。
+
+**签名**
+
+```python
+@property
+def system(self) -> SystemStatus
+```
+
+**返回值**
+
+| 类型 | 说明 |
+|------|------|
+| SystemStatus | 系统整体状态 |
+
+**示例**
+
+```python
+print(client.observer.system)
+# 输出:
+# [queue] (healthy)
+# ...
+#
+# [vikingdb] (healthy)
+# ...
+#
+# [vlm] (healthy)
+# ...
+#
+# [system] (healthy)
+```
+
+---
+
+### is_healthy()
+
+快速健康检查。
+
+**签名**
+
+```python
+def is_healthy(self) -> bool
+```
+
+**返回值**
+
+| 类型 | 说明 |
+|------|------|
+| bool | 所有组件健康返回 True |
+
+**示例**
+
+```python
+if client.observer.is_healthy():
+    print("系统正常")
+else:
+    print(client.observer.system)
+```
+
+---
+
+## 数据结构
+
+### ComponentStatus
+
+单个组件的状态信息。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| name | str | 组件名称 |
+| is_healthy | bool | 组件是否健康 |
+| has_errors | bool | 组件是否有错误 |
+| status | str | 状态表格字符串 |
+
+**字符串表示**
+
+```python
+print(component_status)
+# 输出:
+# [component_name] (healthy)
+# 状态表格内容...
+```
+
+---
+
+### SystemStatus
+
+系统整体状态，包含所有组件。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| is_healthy | bool | 整个系统是否健康 |
+| components | Dict[str, ComponentStatus] | 各组件状态 |
+| errors | List[str] | 错误信息列表 |
+
+**字符串表示**
+
+```python
+print(system_status)
+# 输出:
+# [queue] (healthy)
+# ...
+#
+# [vikingdb] (healthy)
+# ...
+#
+# [system] (healthy)
+# Errors: error1, error2  (如果有)
+```

--- a/docs/zh/concepts/01-architecture.md
+++ b/docs/zh/concepts/01-architecture.md
@@ -72,7 +72,7 @@ Service 层将业务逻辑与传输层解耦，便于 HTTP Server 和 CLI 复用
 | **ResourceService** | 资源导入 | add_resource, add_skill, wait_processed |
 | **RelationService** | 关联管理 | relations, link, unlink |
 | **PackService** | 导入导出 | export_ovpack, import_ovpack |
-| **DebugService** | 调试服务 | get_system_status, get_queue_status, get_vikingdb_status, get_vlm_status, is_healthy |
+| **DebugService** | 调试服务 | observer (ObserverService) |
 
 ## 双层存储
 

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -433,7 +433,7 @@ class AsyncOpenViking:
         Returns:
             SystemStatus containing health status of all components.
         """
-        return self._service.debug.get_system_status()
+        return self._service.debug.observer.system
 
     def is_healthy(self) -> bool:
         """Quick health check.
@@ -441,4 +441,9 @@ class AsyncOpenViking:
         Returns:
             True if all components are healthy, False otherwise.
         """
-        return self._service.debug.is_healthy()
+        return self._service.debug.observer.is_healthy()
+
+    @property
+    def observer(self):
+        """Get observer service for component status."""
+        return self._service.debug.observer

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -177,6 +177,11 @@ class SyncOpenViking:
         return self._async_client.is_healthy()
 
     @property
+    def observer(self):
+        """Get observer service for component status."""
+        return self._async_client.observer
+
+    @property
     def viking_fs(self):
         return self._async_client.viking_fs
 


### PR DESCRIPTION

## Description

- Create ObserverService class with queue/vikingdb/vlm/system properties
- DebugService holds ObserverService as a member
- Add client.observer property, enabling print(client.observer.vikingdb) syntax
- Add __str__ method to ComponentStatus and SystemStatus for direct printing
- Create dedicated debug API documentation (07-debug.md)
- Update architecture docs with new DebugService description
- Update unit tests

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
