### PR TITLE
fix(parse): prevent Zip Slip path traversal in _extract_zip (CWE-22)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -153,6 +153,10 @@ Miscellaneous tests.
 | File | Description | Key Test Cases |
 |------|-------------|----------------|
 | `test_vikingdb_observer.py` | Database observer | State change notifications, observer registration/unregistration, event filtering |
+| `test_code_parser.py` | Code repository parser | `ignore_dirs` compliance, `ignore_extensions` compliance, file type detection, symbolic link handling |
+| `test_config_validation.py` | Configuration validation | Config schema validation, required fields, type checking |
+| `test_debug_service.py` | Debug service | Debug endpoint tests, service diagnostics |
+| `test_extract_zip.py` | Zip extraction security (Zip Slip) | Path traversal prevention (`../`), absolute path rejection, symlink entry filtering, backslash traversal, UNC path rejection, directory entry skipping, normal extraction |
 
 ### engine/
 

--- a/tests/misc/test_extract_zip.py
+++ b/tests/misc/test_extract_zip.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for CodeRepositoryParser._extract_zip Zip Slip protection."""
+
+import io
+import os
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from openviking.parse.parsers.code.code import CodeRepositoryParser
+
+
+def _make_zip(entries: dict[str, str], target_path: str) -> None:
+    """Create a zip file with the given filename->content mapping."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+    Path(target_path).write_bytes(buf.getvalue())
+
+
+def _make_zip_with_symlink(target_path: str) -> None:
+    """Create a zip containing a symlink entry via raw external_attr."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        info = zipfile.ZipInfo("evil_link")
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        zf.writestr(info, "/etc/passwd")
+    Path(target_path).write_bytes(buf.getvalue())
+
+
+def _assert_no_escape(tmp_path: Path, target_dir: str) -> None:
+    """Assert no files were written outside target_dir within tmp_path."""
+    target = Path(target_dir).resolve()
+    for f in tmp_path.rglob("*"):
+        resolved = f.resolve()
+        if resolved == target or resolved.is_relative_to(target):
+            continue
+        if f.suffix == ".zip":
+            continue
+        raise AssertionError(f"File escaped target_dir: {resolved}")
+
+
+@pytest.fixture
+def parser():
+    return CodeRepositoryParser()
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Provide a temp workspace with zip_path, target_dir, and tmp_path."""
+    zip_path = str(tmp_path / "test.zip")
+    target_dir = str(tmp_path / "extracted")
+    os.makedirs(target_dir)
+    return tmp_path, zip_path, target_dir
+
+
+class TestExtractZipNormal:
+    """Verify normal zip extraction still works."""
+
+    async def test_extracts_files_correctly(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip(
+            {"src/main.py": "print('hello')", "README.md": "# Test"},
+            zip_path,
+        )
+        name = await parser._extract_zip(zip_path, target_dir)
+        assert name == "test"
+        assert (Path(target_dir) / "src" / "main.py").read_text() == "print('hello')"
+        assert (Path(target_dir) / "README.md").read_text() == "# Test"
+
+    async def test_returns_stem_as_name(self, parser, tmp_path):
+        zip_path = str(tmp_path / "my-repo.zip")
+        target_dir = str(tmp_path / "out")
+        os.makedirs(target_dir)
+        _make_zip({"a.txt": "content"}, zip_path)
+        name = await parser._extract_zip(zip_path, target_dir)
+        assert name == "my-repo"
+
+
+class TestExtractZipPathTraversal:
+    """Verify Zip Slip path traversal raises ValueError."""
+
+    async def test_rejects_dot_dot_traversal(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip({"../../evil.txt": "pwned"}, zip_path)
+        with pytest.raises(ValueError, match="Zip Slip detected"):
+            await parser._extract_zip(zip_path, target_dir)
+        _assert_no_escape(tmp_path, target_dir)
+
+    async def test_rejects_absolute_path(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip({"/etc/passwd": "root:x:0:0"}, zip_path)
+        with pytest.raises(ValueError, match="Zip Slip detected"):
+            await parser._extract_zip(zip_path, target_dir)
+        _assert_no_escape(tmp_path, target_dir)
+
+    async def test_rejects_nested_traversal(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip({"foo/../../evil.txt": "pwned"}, zip_path)
+        with pytest.raises(ValueError, match="Zip Slip detected"):
+            await parser._extract_zip(zip_path, target_dir)
+        _assert_no_escape(tmp_path, target_dir)
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-specific test")
+    async def test_rejects_windows_drive_path(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip({"C:\\evil.txt": "pwned"}, zip_path)
+        with pytest.raises(ValueError, match="Zip Slip detected"):
+            await parser._extract_zip(zip_path, target_dir)
+        _assert_no_escape(tmp_path, target_dir)
+
+    async def test_rejects_backslash_traversal(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip({"..\\..\\evil.txt": "pwned"}, zip_path)
+        with pytest.raises(ValueError, match="Zip Slip detected"):
+            await parser._extract_zip(zip_path, target_dir)
+        _assert_no_escape(tmp_path, target_dir)
+
+    async def test_rejects_unc_path(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip({"\\\\server\\share\\evil.txt": "pwned"}, zip_path)
+        with pytest.raises(ValueError, match="Zip Slip detected"):
+            await parser._extract_zip(zip_path, target_dir)
+        _assert_no_escape(tmp_path, target_dir)
+
+
+class TestExtractZipSymlink:
+    """Verify symlink entries are skipped."""
+
+    async def test_skips_symlink_entry(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        _make_zip_with_symlink(zip_path)
+        await parser._extract_zip(zip_path, target_dir)
+        extracted_files = list(Path(target_dir).rglob("*"))
+        assert len(extracted_files) == 0
+
+
+class TestExtractZipEmptyNormalization:
+    """Verify entries containing '..' are rejected even if they normalize safely."""
+
+    async def test_rejects_dot_dot_entry(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            # "./.." contains ".." and must be rejected
+            info = zipfile.ZipInfo("./..")
+            info.external_attr = 0
+            zf.writestr(info, "should be rejected")
+            zf.writestr("src/main.py", "print('ok')")
+        Path(zip_path).write_bytes(buf.getvalue())
+        with pytest.raises(ValueError, match="Zip Slip detected"):
+            await parser._extract_zip(zip_path, target_dir)
+
+
+class TestExtractZipDirectoryEntry:
+    """Verify explicit directory entries are skipped without error."""
+
+    async def test_skips_directory_entries(self, parser, workspace):
+        tmp_path, zip_path, target_dir = workspace
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("mydir/", "")
+            zf.writestr("mydir/file.txt", "content")
+        Path(zip_path).write_bytes(buf.getvalue())
+        await parser._extract_zip(zip_path, target_dir)
+        assert (Path(target_dir) / "mydir" / "file.txt").read_text() == "content"


### PR DESCRIPTION
## Description

`CodeRepositoryParser._extract_zip()` calls `zipfile.extractall()` without validating member paths. An attacker can craft a malicious zip containing entries like `../../evil.txt`, `/etc/passwd`, `C:\evil.txt`, `..\..\evil.txt`, `\server\share\evil.txt`, or symlink entries to write files outside the target directory during extraction (Zip Slip, CWE-22).

This PR replaces `extractall()` with per-member extraction and implements 5-layer defense-in-depth:

1. **Skip directory entries** (`info.is_dir()` + `stat.S_ISDIR`) — directories are created implicitly when extracting their children
2. **Skip symlink entries** (`stat.S_ISLNK`) — prevents symlink-based escapes to external paths
3. **Pre-extraction rejection of raw filename** — raise `ValueError` if raw path contains `..` components, is absolute, or has a drive letter
4. **Post-normalization verification** — normalize path using the same algorithm as `zipfile._extract_member`, then verify with `Path.is_relative_to()`
5. **Post-extraction verification** — verify the actual path written to disk, clean up and raise `ValueError` if it escapes

## Related Issue

No existing issue. Vulnerability discovered via code audit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Replace `zip_ref.extractall(target_dir)` with per-member safe extraction and 5-layer path validation (`code.py` +50/-2)
- Add `import stat` and `from pathlib import PurePosixPath`
- Add `tests/misc/test_extract_zip.py` (11 regression tests)
- Update `tests/README.md` with missing entries for the misc/ test directory

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

11 test cases covering the following scenarios:

| Category | Test Case | Expected Behavior |
|----------|-----------|-------------------|
| Normal extraction | Multi-file zip, stem name return | No regression, files extracted correctly |
| `../` traversal | `../../evil.txt` | raise ValueError, no file escape |
| Absolute path | `/etc/passwd` | raise ValueError, no file escape |
| Nested traversal | `foo/../../evil.txt` | raise ValueError, no file escape |
| Windows drive path | `C:\evil.txt` | raise ValueError, no file escape |
| Backslash traversal | `..\..\evil.txt` | raise ValueError, no file escape |
| UNC path | `\server\share\evil.txt` | raise ValueError, no file escape |
| Symlink entry | `external_attr` set to `S_IFLNK` | Silently skipped, not extracted |
| `..` normalization | `./..` (contains `..`, normalizes to empty) | raise ValueError (fail-fast, `..` rejected before normalization) |
| Directory entry | `mydir/` | Silently skipped, child files extracted normally |

All attack vectors verified as successfully blocked on Windows + Python 3.13.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

**Behavioral impact**: No change for legitimate zip files. `extractall()` is replaced with equivalent per-member `extract()` calls (internally, `extractall` is just a loop over `extract`). The only new behavior is raising `ValueError` on malicious entries.

**Performance impact**: Negligible. All added checks are in-memory string operations (`split`, `replace`, `is_relative_to`) with no additional I/O.

**Fail-fast design decision**: The implementation raises `ValueError` immediately upon detecting a malicious entry, rather than skipping it and continuing. A zip containing malicious entries is considered untrustworthy as a whole — continuing to extract remaining members carries risk. Fail-fast ensures the caller is notified and can handle the exception.

**Python compatibility**: The project requires Python 3.9+, and `zipfile`'s built-in `../` sanitization was only added in Python 3.12+. On Python 3.9–3.11, `extractall()` performs no path traversal protection at all, making this fix necessary. Even on Python 3.12+, this fix provides independent defense covering attack vectors that `zipfile` does not handle (symlink entries, absolute paths, drive letter paths).