### PR TITLE
fix CI: correct patch targets in test_quick_start_lite.py

### DIFF
--- a/tests/integration/test_quick_start_lite.py
+++ b/tests/integration/test_quick_start_lite.py
@@ -11,7 +11,7 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from openviking.models.embedder.base import EmbedResult
+from openviking.models.embedder.base import EmbedResult  # noqa: E402
 
 
 class TestQuickStartLite(unittest.TestCase):


### PR DESCRIPTION
## Problem
The test-lite workflow was failing with:
```
AttributeError: module 'openviking.utils.config' has no attribute 'embedding_config'. Did you mean: 'EmbeddingConfig'?
```

## Root Cause
The test was patching:
- `openviking.utils.config.embedding_config.EmbeddingConfig.get_embedder`
- `openviking.utils.config.vlm_config.VLMConfig.get_vlm_instance`

But these classes are now exported directly from `openviking.utils.config` (via `__init__.py`), not as submodules.

## Fix
Changed patch targets to:
- `openviking.utils.config.EmbeddingConfig.get_embedder`
- `openviking.utils.config.VLMConfig.get_vlm_instance`

## Testing
- [x] Import check passes
- [x] Patch targets resolve correctly