### PR TITLE
fix: replace bare except with Exception in llm utils

### DIFF
--- a/openviking_cli/utils/llm.py
+++ b/openviking_cli/utils/llm.py
@@ -104,7 +104,7 @@ def _fix_json_quotes(json_str: str) -> str:
     try:
         fixed = re.sub(pattern, fix_quotes_in_match, json_str)
         return fixed
-    except:
+    except Exception:
         return json_str
 
 


### PR DESCRIPTION
This PR fixes a bare `except:` clause in `openviking_cli/utils/llm.py` that was catching ALL exceptions including KeyboardInterrupt, SystemExit, and GeneratorExit. 

According to PEP 8, bare except clauses should be avoided as they can hide unexpected errors and make debugging difficult. This change replaces the bare `except:` with `except Exception:` to only catch standard exceptions while allowing system-level exceptions to propagate properly.

PEP 8 reference: https://peps.python.org/pep-0008/#programming-recommendations