### PR TITLE
fix: build target name

### DIFF
--- a/.github/workflows/rust-cli.yml
+++ b/.github/workflows/rust-cli.yml
@@ -86,7 +86,7 @@ jobs:
           ${{ runner.os }}-target-${{ matrix.target }}-
 
     - name: Build CLI
-      run: cargo build --release --target ${{ matrix.target }} -p openviking-cli
+      run: cargo build --release --target ${{ matrix.target }} -p ov_cli
         
     - name: Create compressed artifacts
       shell: bash


### PR DESCRIPTION
previous build failed, because target name is changed to ov_cli.

quick fix.