### PR TITLE
fix: auto-rename on duplicate filename conflict

### DIFF
--- a/tests/misc/test_tree_builder_dedup.py
+++ b/tests/misc/test_tree_builder_dedup.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for TreeBuilder._resolve_unique_uri — duplicate filename auto-rename."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+
+def _make_viking_fs_mock(existing_uris: set[str]):
+    """Create a mock VikingFS whose stat() raises for non-existing URIs."""
+    fs = MagicMock()
+
+    async def _stat(uri):
+        if uri in existing_uris:
+            return {"name": uri.split("/")[-1], "isDir": True}
+        raise FileNotFoundError(f"Not found: {uri}")
+
+    fs.stat = AsyncMock(side_effect=_stat)
+    return fs
+
+
+class TestResolveUniqueUri:
+
+    @pytest.mark.asyncio
+    async def test_no_conflict(self):
+        """When the URI is free, return it unchanged."""
+        from openviking.parse.tree_builder import TreeBuilder
+
+        fs = _make_viking_fs_mock(set())
+        builder = TreeBuilder()
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            result = await builder._resolve_unique_uri("viking://resources/report")
+
+        assert result == "viking://resources/report"
+
+    @pytest.mark.asyncio
+    async def test_single_conflict(self):
+        """When base name exists, should return name_1."""
+        from openviking.parse.tree_builder import TreeBuilder
+
+        existing = {"viking://resources/report"}
+        fs = _make_viking_fs_mock(existing)
+        builder = TreeBuilder()
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            result = await builder._resolve_unique_uri("viking://resources/report")
+
+        assert result == "viking://resources/report_1"
+
+    @pytest.mark.asyncio
+    async def test_multiple_conflicts(self):
+        """When _1 and _2 also exist, should return _3."""
+        from openviking.parse.tree_builder import TreeBuilder
+
+        existing = {
+            "viking://resources/report",
+            "viking://resources/report_1",
+            "viking://resources/report_2",
+        }
+        fs = _make_viking_fs_mock(existing)
+        builder = TreeBuilder()
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            result = await builder._resolve_unique_uri("viking://resources/report")
+
+        assert result == "viking://resources/report_3"
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_exceeded(self):
+        """When all candidate names are taken, raise FileExistsError."""
+        from openviking.parse.tree_builder import TreeBuilder
+
+        existing = {"viking://resources/report"} | {
+            f"viking://resources/report_{i}" for i in range(1, 6)
+        }
+        fs = _make_viking_fs_mock(existing)
+        builder = TreeBuilder()
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            with pytest.raises(FileExistsError, match="Cannot resolve unique name"):
+                await builder._resolve_unique_uri(
+                    "viking://resources/report", max_attempts=5
+                )
+
+    @pytest.mark.asyncio
+    async def test_gap_in_sequence(self):
+        """If _1 exists but _2 does not, should return _2 (not skip to _3)."""
+        from openviking.parse.tree_builder import TreeBuilder
+
+        existing = {
+            "viking://resources/report",
+            "viking://resources/report_1",
+        }
+        fs = _make_viking_fs_mock(existing)
+        builder = TreeBuilder()
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            result = await builder._resolve_unique_uri("viking://resources/report")
+
+        assert result == "viking://resources/report_2"


### PR DESCRIPTION
## Problem

Closes #178

Uploading a file with the same name as an existing resource (e.g. uploading `report.pdf` twice) causes a **409 Conflict** error from AGFS `mkdir`. This is especially problematic in multi-user (account) scenarios.

**Root cause:** `TreeBuilder.finalize_from_temp()` builds the final URI directly from the source filename without checking whether a resource at that URI already exists. The subsequent `mkdir()` call (without `exist_ok=True`) fails when the directory is already present.

## Solution

Added `_resolve_unique_uri()` to `TreeBuilder` that:
1. Checks if the target URI already exists via `stat()`
2. If it does, appends `_1`, `_2`, … until a free name is found
3. Behavior mirrors macOS Finder / Windows Explorer auto-rename

Example: uploading `report.pdf` three times produces:
- `viking://resources/report`
- `viking://resources/report_1`
- `viking://resources/report_2`

## Changes

- **`openviking/parse/tree_builder.py`**: Added `_resolve_unique_uri()` method; updated `finalize_from_temp()` to use it
- **`tests/misc/test_tree_builder_dedup.py`**: 5 new unit tests covering no-conflict, single conflict, multiple conflicts, max-attempts exceeded, and gap-in-sequence scenarios

## Testing

```
pytest tests/misc/test_tree_builder_dedup.py -v
# 5 passed
```