### PR TITLE
fix: invalid Go version format in agfs-server go.mod

### DIFF
--- a/third_party/agfs/agfs-server/go.mod
+++ b/third_party/agfs/agfs-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/c4pt0r/agfs/agfs-server
 
-go 1.25.1
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.2


### PR DESCRIPTION
go.mod specifies 'go 1.25.1' but Go only supports two-component version directives (MAJOR.MINOR). The three-component format causes 'go mod tidy' and builds to fail with:

  go: invalid go version '1.25.1': must match format 1.N

This blocks pip install of OpenViking on any system that needs to compile the AGFS server component.

Fix: Change 'go 1.25.1' to 'go 1.25' to match Go's version spec.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
