### PR TITLE
suggestion: align grep and glob options

### DIFF
--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -262,6 +262,7 @@ enum Commands {
     /// Run content pattern search
     Grep {
         /// Target URI
+        #[arg(short, long, default_value = "viking://")]
         uri: String,
         /// Search pattern
         pattern: String,

--- a/openviking_cli/cli/commands/search.py
+++ b/openviking_cli/cli/commands/search.py
@@ -69,7 +69,7 @@ def register(app: typer.Typer) -> None:
     @app.command("grep")
     def grep_command(
         ctx: typer.Context,
-        uri: str = typer.Argument(..., help="Target URI"),
+        uri: str = typer.Option("viking://", "--uri", "-u", help="Target URI"),
         pattern: str = typer.Argument(..., help="Search pattern"),
         ignore_case: bool = typer.Option(False, "--ignore-case", "-i", help="Case insensitive"),
     ) -> None:


### PR DESCRIPTION
align grep and glob options. tested

current behavior
<img width="1014" height="976" alt="image" src="https://github.com/user-attachments/assets/375ed5b5-3048-4d4c-8e20-e228f3c1cd70" />


expect:
grep also have --uri option with default value viking://