### PR TITLE
fix: skill search ranking - use overview for embedding and fix visited set filtering

### DIFF
--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -74,9 +74,11 @@ class SkillProcessor:
                 "source_path": skill_dict.get("source_path", ""),
             },
         )
-        context.set_vectorize(Vectorize(text=context.abstract))
-
         overview = await self._generate_overview(skill_dict, config)
+
+        # Use overview for vectorization (richer semantic content than abstract alone)
+        vectorize_text = overview if overview else context.abstract
+        context.set_vectorize(Vectorize(text=vectorize_text))
 
         skill_dir_uri = f"viking://agent/skills/{context.meta['name']}"
 


### PR DESCRIPTION
## Problem

After `add-skill`, `ov search` returned incorrect/incomplete skill rankings:
- Some skills were completely missing from results
- Rankings were swapped (e.g. searching "adding memory" returned "searching-context" as #216)
- The more relevant a result was, the more likely it got dropped

## Root Causes

### 1. Poor embedding text for skills (`skill_processor.py`)

**What:** The vectorization text for skills was set to just the short `description` field from SKILL.md frontmatter — typically one sentence. The LLM-generated overview (a rich multi-paragraph summary) was generated *after* the vectorize text was set and never used for embedding.

**Compare with resources:** `semantic_processor.py` correctly uses `overview` text for directory vectorization and full `content`/`summary` for files. Skills were the only context type embedding with just the short abstract.

**Fix:** Generate overview first, then use it as the vectorization text — aligning skills with how resources handle directory vectorization.

### 2. Visited set drops the most relevant results (`hierarchical_retriever.py`)

**What:** The `_recursive_search` method conflated two concepts: "visited for directory traversal" and "collected as a search result." This caused the highest-scoring results to be systematically dropped.

**Detailed flow (before fix):**

The retriever works in stages:
1. **Global vector search** finds top-3 non-leaf entries across the entire collection. For a query like "adding memory" against skills, this returns e.g. `adding-memory` (0.5), `searching-context` (0.3), `openviking` (0.2).

2. **Merge starting points** combines these with root URIs. Priority queue becomes: `[(adding-memory, 0.5), (searching-context, 0.3), (openviking, 0.2), (viking://agent/skills, 0.0)]`

3. **Recursive search** pops highest-score first:
   - Pops `adding-memory` (0.5) → adds to `visited` set → searches for children with `parent_uri=adding-memory` → **0 results** (skills have no children)
   - Pops `searching-context` (0.3) → adds to `visited` → 0 children
   - Pops `openviking` (0.2) → adds to `visited` → 0 children
   - Pops `viking://agent/skills` (0.0) → searches children → **finds all 4 skills**
   - Old code: `if passes_threshold(score) and uri not in visited` — three skills are in `visited`, so they are **silently skipped**
   - Only `adding-resource` (not in global top-3) gets collected

**When it happens:** Any time global search returns URIs that are also children of a root/parent directory. This affects **all context types** (skills, resources, memories) since they share `HierarchicalRetriever`. Ironically, the most relevant results (highest global scores → processed earliest → visited first) are the ones most likely to be dropped.

**Fix:** Separate "visited for traversal" from "collected as result." The `visited` set now only prevents re-entering directories for child search. Results that pass the score threshold are always collected, regardless of visited status.

## Testing

Before fix:
```
ov search "adding memory" -u viking://agent/skills  →  searching-context (wrong, only 1 result)
ov search "search context" -u viking://agent/skills  →  adding-memory (wrong, only 1 result)
ov search "RAG semantic search" -u viking://agent/skills  →  adding-memory (wrong, only 1 result)
```

After fix:
```
ov search "adding memory" -u viking://agent/skills
  → adding-memory #1 (0.508) ✓
  → adding-resource #2 (0.241)
  → openviking #3 (0.222)
  → searching-context #4 (0.185)

ov search "search context" -u viking://agent/skills
  → searching-context #1 (0.500) ✓
  → openviking #2 (0.323)
  → adding-resource #3 (0.190)
  → adding-memory #4 (0.163)

ov search "RAG semantic search" -u viking://agent/skills
  → openviking #1 (0.372) ✓
  → searching-context #2 (0.343)
  → adding-resource #3 (0.259)
  → adding-memory #4 (0.141)
```

All 4 skills appear with correct ranking order.