### PR TITLE
proposal: resolve relative CLI paths to absolute before sending to server

### DIFF
--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -470,6 +470,18 @@ async fn main() {
     }
 }
 
+/// Resolve a relative local path to absolute. Pass through URLs and raw content unchanged.
+fn resolve_path(s: String) -> String {
+    let p = std::path::Path::new(&s);
+    if p.exists() {
+        std::fs::canonicalize(p)
+            .map(|abs| abs.to_string_lossy().into_owned())
+            .unwrap_or(s)
+    } else {
+        s
+    }
+}
+
 async fn handle_add_resource(
     mut path: String,
     to: Option<String>,
@@ -509,7 +521,7 @@ async fn handle_add_resource(
     
     let client = ctx.get_client();
     commands::resources::add_resource(
-        &client, &path, to, reason, instruction, wait, timeout, ctx.output_format, ctx.compact
+        &client, &resolve_path(path), to, reason, instruction, wait, timeout, ctx.output_format, ctx.compact
     ).await
 }
 
@@ -521,7 +533,7 @@ async fn handle_add_skill(
 ) -> Result<()> {
     let client = ctx.get_client();
     commands::resources::add_skill(
-        &client, &data, wait, timeout, ctx.output_format, ctx.compact
+        &client, &resolve_path(data), wait, timeout, ctx.output_format, ctx.compact
     ).await
 }
 
@@ -556,7 +568,7 @@ async fn handle_unlink(
 
 async fn handle_export(uri: String, to: String, ctx: CliContext) -> Result<()> {
     let client = ctx.get_client();
-    commands::pack::export(&client, &uri, &to, ctx.output_format, ctx.compact
+    commands::pack::export(&client, &uri, &resolve_path(to), ctx.output_format, ctx.compact
     ).await
 }
 
@@ -569,7 +581,7 @@ async fn handle_import(
 ) -> Result<()> {
     let client = ctx.get_client();
     commands::pack::import(
-        &client, &file_path, &target_uri, force, no_vectorize, ctx.output_format, ctx.compact
+        &client, &resolve_path(file_path), &target_uri, force, no_vectorize, ctx.output_format, ctx.compact
     ).await
 }
 

--- a/openviking_cli/cli/commands/pack.py
+++ b/openviking_cli/cli/commands/pack.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Import/export pack commands."""
 
+from pathlib import Path
+
 import typer
 
 from openviking_cli.cli.errors import run
@@ -17,7 +19,8 @@ def register(app: typer.Typer) -> None:
         to: str = typer.Argument(..., help="Output .ovpack file path"),
     ) -> None:
         """Export context as .ovpack."""
-        run(ctx, lambda client: {"file": client.export_ovpack(uri, to)})
+        abs_to = str(Path(to).resolve())
+        run(ctx, lambda client: {"file": client.export_ovpack(uri, abs_to)})
 
     @app.command("import")
     def import_command(
@@ -32,11 +35,12 @@ def register(app: typer.Typer) -> None:
         ),
     ) -> None:
         """Import .ovpack into target URI."""
+        abs_file_path = str(Path(file_path).resolve())
         run(
             ctx,
             lambda client: {
                 "uri": client.import_ovpack(
-                    file_path=file_path,
+                    file_path=abs_file_path,
                     target=target_uri,
                     force=force,
                     vectorize=not no_vectorize,

--- a/openviking_cli/cli/commands/resources.py
+++ b/openviking_cli/cli/commands/resources.py
@@ -10,6 +10,14 @@ import typer
 from openviking_cli.cli.errors import run
 
 
+def _resolve_path(value: str) -> str:
+    """Resolve a relative local path to absolute. Pass through URLs and raw content."""
+    p = Path(value)
+    if p.exists():
+        return str(p.resolve())
+    return value
+
+
 def register(app: typer.Typer) -> None:
     """Register resource commands."""
 
@@ -79,7 +87,7 @@ def register(app: typer.Typer) -> None:
         run(
             ctx,
             lambda client: client.add_resource(
-                path=final_path,
+                path=_resolve_path(final_path),
                 target=to,
                 reason=reason,
                 instruction=instruction,
@@ -99,7 +107,7 @@ def register(app: typer.Typer) -> None:
         run(
             ctx,
             lambda client: client.add_skill(
-                data=data,
+                data=_resolve_path(data),
                 wait=wait,
                 timeout=timeout,
             ),


### PR DESCRIPTION
## Problem

When running `ov add-skill ./my-skill` or `ov add-resource ./my-file` from any directory other than the server's working directory, the command fails because relative paths are sent as-is to the server, which resolves them relative to its own CWD.

**`add-skill` error:**
```
Error: API error: SKILL.md must have YAML frontmatter
```
(Server can't find the path, falls through to treating the string as raw content)

**`add-resource` error:**
```
FileNotFoundError: Path ./my-file does not exist
```

## Root Cause

Both the Python CLI (`openviking_cli`) and Rust CLI (`ov`) send the raw path string directly to the server via HTTP. The server resolves it using Python's `pathlib.Path()` relative to its own working directory, not the caller's CWD.

## Fix

Resolve any path that exists on the local filesystem to its absolute path **before** sending to the server. URLs and raw content strings are passed through unchanged.

### Files changed

| File | Commands fixed |
|------|---------------|
| `openviking_cli/cli/commands/resources.py` | `add-resource`, `add-skill` |
| `openviking_cli/cli/commands/pack.py` | `export`, `import` |
| `crates/ov_cli/src/main.rs` | `add-resource`, `add-skill`, `export`, `import` |

## Test

```bash
# Previously failed from any dir other than server root
cd /some/other/directory
ov add-skill ./path/to/my-skill      # now works
ov add-resource ./path/to/my-file    # now works
ov import ./my-export.ovpack viking://resources/target  # now works
```

- [x] tested
- [x] macos