### PR TITLE
fix: convert Session.load() and get_context_for_search() to async to prevent deadlock

### DIFF
--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -188,7 +188,7 @@ class LocalClient(BaseClient):
         session = None
         if session_id:
             session = self._service.sessions.session(session_id)
-            session.load()
+            await session.load()
         return await self._service.search.search(
             query=query,
             target_uri=target_uri,
@@ -237,7 +237,7 @@ class LocalClient(BaseClient):
     async def get_session(self, session_id: str) -> Dict[str, Any]:
         """Get session details."""
         session = self._service.sessions.session(session_id)
-        session.load()
+        await session.load()
         return {
             "session_id": session.session_id,
             "user": session.user.to_dict(),
@@ -255,7 +255,7 @@ class LocalClient(BaseClient):
     async def add_message(self, session_id: str, role: str, content: str) -> Dict[str, Any]:
         """Add a message to a session."""
         session = self._service.sessions.session(session_id)
-        session.load()
+        await session.load()
         session.add_message(role, content)
         return {
             "session_id": session_id,

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -82,7 +82,7 @@ async def search(
     session = None
     if request.session_id:
         session = service.sessions.session(request.session_id)
-        session.load()
+        await session.load()
 
     result = await service.search.search(
         query=request.query,

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -67,7 +67,7 @@ async def get_session(
     """Get session details."""
     service = get_service()
     session = service.sessions.session(session_id)
-    session.load()
+    await session.load()
     return Response(
         status="ok",
         result={
@@ -120,7 +120,7 @@ async def add_message(
     """Add a message to a session."""
     service = get_service()
     session = service.sessions.session(session_id)
-    session.load()
+    await session.load()
     session.add_message(request.role, [TextPart(text=request.content)])
     return Response(
         status="ok",

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -60,7 +60,7 @@ class SearchService:
 
         session_info = None
         if session:
-            session_info = session.get_context_for_search(query)
+            session_info = await session.get_context_for_search(query)
 
         return await viking_fs.search(
             query=query,

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -128,7 +128,7 @@ class SessionService:
         """
         self._ensure_initialized()
         session = self.session(session_id)
-        session.load()
+        await session.load()
         return session.commit()
 
     async def extract(self, session_id: str) -> List[Any]:
@@ -145,7 +145,7 @@ class SessionService:
             raise NotInitializedError("SessionCompressor")
 
         session = self.session(session_id)
-        session.load()
+        await session.load()
 
         return await self._session_compressor.extract_long_term_memories(
             messages=session.messages,

--- a/tests/integration/test_full_workflow.py
+++ b/tests/integration/test_full_workflow.py
@@ -128,7 +128,7 @@ class TestSessionWorkflow:
 
         # 2. Reload session
         session2 = client.session(session_id=session_id)
-        session2.load()
+        await session2.load()
 
         # 3. Continue conversation
         session2.add_message("user", [TextPart("Second message")])

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -115,7 +115,7 @@ async def test_add_message_persistence_regression(
 
     # Verify stored message content survives load/decode.
     session = service.sessions.session(session_id)
-    session.load()
+    await session.load()
     assert len(session.messages) == 2
     assert session.messages[0].content == "Message A"
     assert session.messages[1].content == "Message B"

--- a/tests/session/test_session_context.py
+++ b/tests/session/test_session_context.py
@@ -13,14 +13,14 @@ class TestGetContextForSearch:
 
     async def test_get_context_basic(self, session_with_messages: Session):
         """Test basic context retrieval"""
-        context = session_with_messages.get_context_for_search(query="testing help")
+        context = await session_with_messages.get_context_for_search(query="testing help")
 
         assert isinstance(context, dict)
         assert "summaries" in context or "recent_messages" in context
 
     async def test_get_context_with_max_messages(self, session_with_messages: Session):
         """Test limiting max messages"""
-        context = session_with_messages.get_context_for_search(query="test", max_messages=2)
+        context = await session_with_messages.get_context_for_search(query="test", max_messages=2)
 
         assert isinstance(context, dict)
         if "recent_messages" in context:
@@ -38,13 +38,13 @@ class TestGetContextForSearch:
         # Add more messages
         session.add_message("user", [TextPart("Second message")])
 
-        context = session.get_context_for_search(query="test", max_archives=1)
+        context = await session.get_context_for_search(query="test", max_archives=1)
 
         assert isinstance(context, dict)
 
     async def test_get_context_empty_session(self, session: Session):
         """Test getting context from empty session"""
-        context = session.get_context_for_search(query="test")
+        context = await session.get_context_for_search(query="test")
 
         assert isinstance(context, dict)
 
@@ -63,6 +63,6 @@ class TestGetContextForSearch:
         session.add_message("user", [TextPart("New message after commit")])
 
         # Getting context should include archive summary
-        context = session.get_context_for_search(query="test")
+        context = await session.get_context_for_search(query="test")
 
         assert isinstance(context, dict)

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -52,7 +52,7 @@ class TestSessionLoad:
 
         # Create new session instance and load
         new_session = client.session(session_id=session_id)
-        new_session.load()
+        await new_await session.load()
 
         # Verify messages loaded
         assert len(new_session.messages) > 0
@@ -60,7 +60,7 @@ class TestSessionLoad:
     async def test_load_nonexistent_session(self, client: AsyncOpenViking):
         """Test loading nonexistent session"""
         session = client.session(session_id="nonexistent_session_xyz")
-        session.load()
+        await session.load()
 
         # Nonexistent session should be empty after loading
         assert len(session.messages) == 0


### PR DESCRIPTION
## Problem

`SyncOpenViking.search(session=sess)` deadlocks (hangs indefinitely) as reported in #226.

### Root Cause

`run_async()` submits coroutines to a shared background event loop thread. When `SyncOpenViking.search()` calls `run_async(async_client.search(...))`, the entire coroutine chain runs on that background loop. Inside, `Session.load()` and `Session.get_context_for_search()` call `run_async()` again, which submits new futures to the **same** loop and blocks waiting for them — but the loop is already occupied running the outer coroutine. This creates a deadlock.

### Fix

Convert `Session.load()` and `Session.get_context_for_search()` from sync methods (using `run_async()`) to native `async` methods (using `await`). This allows them to participate in the existing coroutine chain without nesting `run_async()` calls.

All callers are already in async contexts (FastAPI routes, async client methods, service layer), so adding `await` is safe and requires no architectural changes.

### Changes

- `openviking/session/session.py`: `load()` and `get_context_for_search()` → `async`
- `openviking/client/local.py`: `await session.load()`
- `openviking/server/routers/sessions.py`: `await session.load()`
- `openviking/server/routers/search.py`: `await session.load()`
- `openviking/service/search_service.py`: `await session.get_context_for_search()`
- `openviking/service/session_service.py`: `await session.load()`
- Updated all related tests

Fixes #226