### PR TITLE
fix(fs): ls --simple skips abstract fetching and returns only URIs

### DIFF
--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -54,6 +54,21 @@ class FSService:
         """
         viking_fs = self._ensure_initialized()
 
+        if simple:
+            # Only return URIs — skip expensive abstract fetching to save tokens
+            if recursive:
+                entries = await viking_fs.tree(
+                    uri,
+                    output="original",
+                    show_all_hidden=show_all_hidden,
+                    node_limit=node_limit,
+                )
+            else:
+                entries = await viking_fs.ls(
+                    uri, output="original", show_all_hidden=show_all_hidden
+                )
+            return [e.get("uri", "") for e in entries]
+
         if recursive:
             entries = await viking_fs.tree(
                 uri,
@@ -66,9 +81,6 @@ class FSService:
             entries = await viking_fs.ls(
                 uri, output=output, abs_limit=abs_limit, show_all_hidden=show_all_hidden
             )
-
-        if simple:
-            return [e.get("rel_path", e.get("name", e.get("uri", ""))) for e in entries]
         return entries
 
     async def mkdir(self, uri: str) -> None:

--- a/tests/client/test_filesystem.py
+++ b/tests/client/test_filesystem.py
@@ -23,7 +23,7 @@ class TestLs:
         assert len(entries) > 0
 
     async def test_ls_simple_mode(self, client_with_resource):
-        """Test simple mode listing"""
+        """Test simple mode listing returns non-empty URI strings (fixes #218)"""
         client, uri = client_with_resource
         parent_uri = "/".join(uri.split("/")[:-1]) + "/"
 
@@ -31,6 +31,7 @@ class TestLs:
 
         assert isinstance(entries, list)
         assert all(isinstance(e, str) for e in entries)
+        assert all(e.startswith("viking://") for e in entries)
 
     async def test_ls_recursive(self, client_with_resource):
         """Test recursive listing"""

--- a/tests/server/test_api_filesystem.py
+++ b/tests/server/test_api_filesystem.py
@@ -25,6 +25,25 @@ async def test_ls_simple(client: httpx.AsyncClient):
     body = resp.json()
     assert body["status"] == "ok"
     assert isinstance(body["result"], list)
+    # Each item must be a non-empty URI string (fixes #218)
+    for item in body["result"]:
+        assert isinstance(item, str)
+        assert item.startswith("viking://")
+
+
+async def test_ls_simple_agent_output(client: httpx.AsyncClient):
+    """Ensure --simple with output=agent returns URI strings, not empty."""
+    resp = await client.get(
+        "/api/v1/fs/ls",
+        params={"uri": "viking://", "simple": True, "output": "agent"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert isinstance(body["result"], list)
+    for item in body["result"]:
+        assert isinstance(item, str)
+        assert item.startswith("viking://")
 
 
 async def test_mkdir_and_ls(client: httpx.AsyncClient):


### PR DESCRIPTION
## Summary

Fix `ls --simple` returning empty output when `output=agent` (the default). The agent format omits `name`/`rel_path` fields, causing the old fallback chain to fail silently.

Now `simple=True` short-circuits early: uses `output="original"` to skip expensive abstract fetching (`_batch_fetch_abstracts`), then extracts only the `uri` field. This follows the author's guidance ("只保留 uri 列") to save tokens.

## Type of Change

- [x] Bug fix (fix)

## Testing

- [x] Unit tests pass (`tests/client/test_filesystem.py::TestLs::test_ls_simple_mode`)
- [x] Added assertion that simple output items are valid `viking://` URIs
- [x] Added `test_ls_simple_agent_output` for the specific `output=agent` + `simple=True` scenario
- [x] Ruff lint passes

## Related Issues

- Fixes #218