### PR TITLE
fix: include name and rel_path in agent-format ls/tree output

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -323,6 +323,8 @@ class VikingFS:
                     continue
                 rel_path = f"{current_rel}/{name}" if current_rel else name
                 new_entry = {
+                    "name": name,
+                    "rel_path": rel_path,
                     "uri": str(VikingURI(uri).join(rel_path)),
                     "size": entry.get("size", 0),
                     "isDir": entry.get("isDir", False),
@@ -1005,6 +1007,7 @@ class VikingFS:
         for entry in entries:
             name = entry.get("name", "")
             new_entry = {
+                "name": name,
                 "uri": str(VikingURI(uri).join(name)),
                 "size": entry.get("size", 0),
                 "isDir": entry.get("isDir", False),


### PR DESCRIPTION
Closes #218

The agent-format output from `ls` and `tree` omits the `name` and `rel_path` fields, which causes `--simple` mode to return empty strings (falls through to empty `uri` fallback in some cases).

This fix adds `name` to the `_ls_agent` output and both `name` and `rel_path` to the `_tree_agent` output, making `--simple` mode work correctly with agent-format output.