### PR TITLE
fix: resolve -o option conflict between global output and filesystem output-format

### DIFF
--- a/openviking_cli/cli/commands/filesystem.py
+++ b/openviking_cli/cli/commands/filesystem.py
@@ -22,7 +22,7 @@ def register(app: typer.Typer) -> None:
             help="List all subdirectories recursively",
         ),
         output_format: str = typer.Option(
-            "agent", "--output-format", "-o", help="Output format: agent or original"
+            "agent", "--output-format", "-f", help="Output format: agent or original"
         ),
         abs_limit: int = typer.Option(256, "--abs-limit", "-l", help="Abstract content limit"),
         show_all_hidden: bool = typer.Option(False, "--all", "-a", help="Show all hidden files"),
@@ -49,7 +49,7 @@ def register(app: typer.Typer) -> None:
         ctx: typer.Context,
         uri: str = typer.Argument(..., help="Viking URI"),
         output_format: str = typer.Option(
-            "agent", "--output-format", "-o", help="Output format: agent or original"
+            "agent", "--output-format", "-f", help="Output format: agent or original"
         ),
         abs_limit: int = typer.Option(128, "--abs-limit", "-l", help="Abstract content limit"),
         show_all_hidden: bool = typer.Option(False, "--all", "-a", help="Show all hidden files"),


### PR DESCRIPTION
Closes #219

The `-o` short flag is used for both the global `--output` option (json/table) and the filesystem `--output-format` option (agent/original), causing conflicts when used together (e.g. `ov ls -o original`).

This fix changes the filesystem `--output-format` short flag from `-o` to `-f`, resolving the ambiguity. Users can now use:
- `-o json` / `-o table` for global output format
- `-f agent` / `-f original` for filesystem content format