### PR TITLE
feat: add Jina AI embedding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Create a configuration file `~/.openviking/ov.conf`:
 }
 ```
 
-> **Note**: For embedding models, currently only `volcengine` (Doubao) and `openai` providers are supported. For VLM models, we support multiple providers including volcengine, openai, deepseek, anthropic, gemini, moonshot, zhipu, dashscope, minimax, and more.
+> **Note**: For embedding models, currently `volcengine` (Doubao), `openai`, and `jina` providers are supported. For VLM models, we support multiple providers including volcengine, openai, deepseek, anthropic, gemini, moonshot, zhipu, dashscope, minimax, and more.
 
 #### Configuration Examples
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -91,7 +91,7 @@ OpenViking 支持多种模型服务：
     "dense": {
       "api_base" : "<api-endpoint>",   // API 服务端点地址
       "api_key"  : "<your-api-key>",   // 模型服务的 API 密钥
-      "provider" : "<provider-type>",  // 提供商类型（volcengine 或 openai）
+      "provider" : "<provider-type>",  // 提供商类型（volcengine、openai 或 jina）
       "dimension": 1024,               // 向量维度
       "model"    : "<model-name>"      // Embedding 模型名称（如 doubao-embedding-vision-250615 或 text-embedding-3-large）
     }
@@ -99,7 +99,7 @@ OpenViking 支持多种模型服务：
   "vlm": {
     "api_base" : "<api-endpoint>",     // API 服务端点地址
     "api_key"  : "<your-api-key>",     // 模型服务的 API 密钥
-    "provider" : "<provider-type>",    // 提供商类型（volcengine 或 openai）
+    "provider" : "<provider-type>",    // 提供商类型（volcengine、openai 或 jina）
     "model"    : "<model-name>"        // VLM 模型名称（如 doubao-seed-1-8-251228 或 gpt-4-vision-preview）
   }
 }

--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -35,7 +35,7 @@ Minimal configuration example:
     "dense": {
       "api_base": "<api-endpoint>",
       "api_key": "<your-api-key>",
-      "provider": "<volcengine|openai>",
+      "provider": "<volcengine|openai|jina>",
       "dimension": 1024,
       "model": "<model-name>"
     }
@@ -43,7 +43,7 @@ Minimal configuration example:
   "vlm": {
     "api_base": "<api-endpoint>",
     "api_key": "<your-api-key>",
-    "provider": "<volcengine|openai>",
+    "provider": "<volcengine|openai|jina>",
     "model": "<model-name>"
   }
 }

--- a/docs/en/faq/faq.md
+++ b/docs/en/faq/faq.md
@@ -109,6 +109,7 @@ Config files at the default path `~/.openviking/ov.conf` are loaded automaticall
 | `volcengine` | Volcengine Embedding API (Recommended) |
 | `openai` | OpenAI Embedding API |
 | `vikingdb` | VikingDB Embedding API |
+| `jina` | Jina AI Embedding API |
 
 Supports Dense, Sparse, and Hybrid embedding modes.
 

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -118,7 +118,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `provider` | str | `"volcengine"`, `"openai"`, or `"vikingdb"` |
+| `provider` | str | `"volcengine"`, `"openai"`, `"vikingdb"`, or `"jina"` |
 | `api_key` | str | API key |
 | `model` | str | Model name |
 | `dimension` | int | Vector dimension |
@@ -138,6 +138,7 @@ With `input: "multimodal"`, OpenViking can embed text, images (PNG, JPG, etc.), 
 - `openai`: OpenAI Embedding API
 - `volcengine`: Volcengine Embedding API
 - `vikingdb`: VikingDB Embedding API
+- `jina`: Jina AI Embedding API
 
 **vikingdb provider example:**
 
@@ -151,6 +152,43 @@ With `input: "multimodal"`, OpenViking can embed text, images (PNG, JPG, etc.), 
       "sk": "your-secret-key",
       "region": "cn-beijing",
       "dimension": 1024
+    }
+  }
+}
+```
+
+**jina provider example:**
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "provider": "jina",
+      "api_key": "jina_xxx",
+      "model": "jina-embeddings-v5-text-small",
+      "dimension": 1024
+    }
+  }
+}
+```
+
+Available Jina models:
+- `jina-embeddings-v5-text-small`: 677M params, 1024 dim, max seq 32768 (default)
+- `jina-embeddings-v5-text-nano`: 239M params, 768 dim, max seq 8192
+
+Get your API key at https://jina.ai
+
+**Local deployment (GGUF/MLX):** Jina embedding models are open-weight and available in GGUF and MLX formats on [Hugging Face](https://huggingface.co/jinaai). You can run them locally with any OpenAI-compatible server (e.g. llama.cpp, MLX, vLLM) and point the `api_base` to your local endpoint:
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "provider": "jina",
+      "api_key": "local",
+      "api_base": "http://localhost:8080/v1",
+      "model": "jina-embeddings-v5-text-nano",
+      "dimension": 768
     }
   }
 }

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -35,7 +35,7 @@ export OPENVIKING_CONFIG_FILE=/path/to/ov.conf
     "dense": {
       "api_base": "<api-endpoint>",
       "api_key": "<your-api-key>",
-      "provider": "<volcengine|openai>",
+      "provider": "<volcengine|openai|jina>",
       "dimension": 1024,
       "model": "<model-name>"
     }
@@ -43,7 +43,7 @@ export OPENVIKING_CONFIG_FILE=/path/to/ov.conf
   "vlm": {
     "api_base": "<api-endpoint>",
     "api_key": "<your-api-key>",
-    "provider": "<volcengine|openai>",
+    "provider": "<volcengine|openai|jina>",
     "model": "<model-name>"
   }
 }

--- a/docs/zh/faq/faq.md
+++ b/docs/zh/faq/faq.md
@@ -109,6 +109,7 @@ pip install openviking
 | `volcengine` | 火山引擎 Embedding API（推荐） |
 | `openai` | OpenAI Embedding API |
 | `vikingdb` | VikingDB Embedding API |
+| `jina` | Jina AI Embedding API |
 
 支持 Dense、Sparse 和 Hybrid 三种 Embedding 模式。
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -120,7 +120,7 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
-| `provider` | str | `"volcengine"`、`"openai"` 或 `"vikingdb"` |
+| `provider` | str | `"volcengine"`、`"openai"`、`"vikingdb"` 或 `"jina"` |
 | `api_key` | str | API Key |
 | `model` | str | 模型名称 |
 | `dimension` | int | 向量维度 |
@@ -140,6 +140,7 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 - `openai`: OpenAI Embedding API
 - `volcengine`: 火山引擎 Embedding API
 - `vikingdb`: VikingDB Embedding API
+- `jina`: Jina AI Embedding API
 
 **vikingdb provider 配置示例:**
 
@@ -157,6 +158,43 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
   }
 }
 ```
+
+**jina provider 配置示例:**
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "provider": "jina",
+      "api_key": "jina_xxx",
+      "model": "jina-embeddings-v5-text-small",
+      "dimension": 1024
+    }
+  }
+}
+```
+
+可用 Jina 模型:
+- `jina-embeddings-v5-text-small`: 677M 参数, 1024 维, 最大序列长度 32768 (默认)
+- `jina-embeddings-v5-text-nano`: 239M 参数, 768 维, 最大序列长度 8192
+
+**本地部署 (GGUF/MLX):** Jina 嵌入模型是开源的, 在 [Hugging Face](https://huggingface.co/jinaai) 上提供 GGUF 和 MLX 格式。可以使用任何 OpenAI 兼容的推理服务器 (如 llama.cpp、MLX、vLLM) 本地运行, 并将 `api_base` 指向本地端点:
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "provider": "jina",
+      "api_key": "local",
+      "api_base": "http://localhost:8080/v1",
+      "model": "jina-embeddings-v5-text-nano",
+      "dimension": 768
+    }
+  }
+}
+```
+
+获取 API Key: https://jina.ai
 
 #### Sparse Embedding
 

--- a/openviking/models/embedder/__init__.py
+++ b/openviking/models/embedder/__init__.py
@@ -11,6 +11,7 @@ Provides three embedder abstractions:
 Supported providers:
 - OpenAI: Dense only
 - Volcengine: Dense, Sparse, Hybrid
+- Jina AI: Dense only
 """
 
 from openviking.models.embedder.base import (
@@ -21,6 +22,7 @@ from openviking.models.embedder.base import (
     HybridEmbedderBase,
     SparseEmbedderBase,
 )
+from openviking.models.embedder.jina_embedders import JinaDenseEmbedder
 from openviking.models.embedder.openai_embedders import OpenAIDenseEmbedder
 from openviking.models.embedder.vikingdb_embedders import (
     VikingDBDenseEmbedder,
@@ -41,6 +43,8 @@ __all__ = [
     "SparseEmbedderBase",
     "HybridEmbedderBase",
     "CompositeHybridEmbedder",
+    # Jina AI implementations
+    "JinaDenseEmbedder",
     # OpenAI implementations
     "OpenAIDenseEmbedder",
     # Volcengine implementations

--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Jina AI Embedder Implementation"""
+
+from typing import Any, Dict, List, Optional
+
+import openai
+
+from openviking.models.embedder.base import (
+    DenseEmbedderBase,
+    EmbedResult,
+)
+
+# Default dimensions for Jina embedding models
+JINA_MODEL_DIMENSIONS = {
+    "jina-embeddings-v5-text-small": 1024,  # 677M params, max seq 32768
+    "jina-embeddings-v5-text-nano": 768,  # 239M params, max seq 8192
+}
+
+
+class JinaDenseEmbedder(DenseEmbedderBase):
+    """Jina AI Dense Embedder Implementation
+
+    Uses Jina AI embedding API via OpenAI-compatible client.
+    Supports task-specific embeddings and Matryoshka dimension reduction.
+
+    Example:
+        >>> embedder = JinaDenseEmbedder(
+        ...     model_name="jina-embeddings-v5-text-small",
+        ...     api_key="jina_xxx",
+        ...     dimension=512,
+        ...     task="retrieval.query"
+        ... )
+        >>> result = embedder.embed("Hello world")
+        >>> print(len(result.dense_vector))
+        512
+    """
+
+    def __init__(
+        self,
+        model_name: str = "jina-embeddings-v5-text-small",
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        dimension: Optional[int] = None,
+        task: Optional[str] = None,
+        late_chunking: Optional[bool] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ):
+        """Initialize Jina AI Dense Embedder
+
+        Args:
+            model_name: Jina model name, defaults to jina-embeddings-v5-text-small
+            api_key: API key, required
+            api_base: API base URL, defaults to https://api.jina.ai/v1
+            dimension: Dimension for Matryoshka reduction, optional
+            task: Task type for task-specific embeddings, optional.
+                  Valid values: retrieval.query, retrieval.passage,
+                  text-matching, classification, separation
+            late_chunking: Enable late chunking via extra_body, optional
+            config: Additional configuration dict
+
+        Raises:
+            ValueError: If api_key is not provided
+        """
+        super().__init__(model_name, config)
+
+        self.api_key = api_key
+        self.api_base = api_base or "https://api.jina.ai/v1"
+        self.dimension = dimension
+        self.task = task
+        self.late_chunking = late_chunking
+
+        if not self.api_key:
+            raise ValueError("api_key is required")
+
+        # Initialize OpenAI-compatible client with Jina base URL
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url=self.api_base,
+        )
+
+        # Determine dimension
+        max_dim = JINA_MODEL_DIMENSIONS.get(model_name, 1024)
+        if dimension is not None and dimension > max_dim:
+            raise ValueError(
+                f"Requested dimension {dimension} exceeds maximum {max_dim} for model '{model_name}'. "
+                f"Jina models support Matryoshka dimension reduction up to {max_dim}."
+            )
+        self._dimension = dimension if dimension is not None else max_dim
+
+    def _build_extra_body(self) -> Optional[Dict[str, Any]]:
+        """Build extra_body dict for Jina-specific parameters"""
+        extra_body = {}
+        if self.task is not None:
+            extra_body["task"] = self.task
+        if self.late_chunking is not None:
+            extra_body["late_chunking"] = self.late_chunking
+        return extra_body if extra_body else None
+
+    def embed(self, text: str) -> EmbedResult:
+        """Perform dense embedding on text
+
+        Args:
+            text: Input text
+
+        Returns:
+            EmbedResult: Result containing only dense_vector
+
+        Raises:
+            RuntimeError: When API call fails
+        """
+        try:
+            kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
+            if self.dimension:
+                kwargs["dimensions"] = self.dimension
+
+            extra_body = self._build_extra_body()
+            if extra_body:
+                kwargs["extra_body"] = extra_body
+
+            response = self.client.embeddings.create(**kwargs)
+            vector = response.data[0].embedding
+
+            return EmbedResult(dense_vector=vector)
+        except openai.APIError as e:
+            raise RuntimeError(f"Jina API error: {e.message}") from e
+        except Exception as e:
+            raise RuntimeError(f"Embedding failed: {str(e)}") from e
+
+    def embed_batch(self, texts: List[str]) -> List[EmbedResult]:
+        """Batch embedding (Jina native support)
+
+        Args:
+            texts: List of texts
+
+        Returns:
+            List[EmbedResult]: List of embedding results
+
+        Raises:
+            RuntimeError: When API call fails
+        """
+        if not texts:
+            return []
+
+        try:
+            kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
+            if self.dimension:
+                kwargs["dimensions"] = self.dimension
+
+            extra_body = self._build_extra_body()
+            if extra_body:
+                kwargs["extra_body"] = extra_body
+
+            response = self.client.embeddings.create(**kwargs)
+
+            return [EmbedResult(dense_vector=item.embedding) for item in response.data]
+        except openai.APIError as e:
+            raise RuntimeError(f"Jina API error: {e.message}") from e
+        except Exception as e:
+            raise RuntimeError(f"Batch embedding failed: {str(e)}") from e
+
+    def get_dimension(self) -> int:
+        """Get embedding dimension
+
+        Returns:
+            int: Vector dimension
+        """
+        return self._dimension
+

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Add Jina AI as a supported embedding provider for dense embeddings.

<img src="https://jina-ai-gmbh.ghost.io/content/images/2026/02/IMG_1153.JPG" width="800" alt="MMTEB Multilingual Benchmark">

*MMTEB scores vs model size. jina-v5-text models (red) outperform models 2-16x their size.*

<img src="https://jina-ai-gmbh.ghost.io/content/images/2026/02/IMG_1154.JPG" width="800" alt="MTEB English Benchmark">

*MTEB English v2 scores. v5-text-nano (239M) achieves 71.0, matching models with 2x+ parameters.*

Both models are open-weight (Apache 2.0) and support Matryoshka dimension reduction, task-specific embeddings, and local deployment via GGUF/MLX.

Paper: [arXiv:2602.15547](https://arxiv.org/abs/2602.15547) | [Blog](https://jina.ai/news/jina-embeddings-v5-text-distilling-4b-quality-into-sub-1b-multilingual-embeddings) | [HuggingFace](https://huggingface.co/jinaai)

## Features

- **API mode**: Jina AI hosted API at `https://api.jina.ai/v1` (OpenAI-compatible)
- **Local mode**: Open-weight models available in GGUF and MLX formats on HuggingFace. Run locally with llama.cpp, MLX, or vLLM and point `api_base` to your local server.
- Task-specific embeddings via `task` parameter
- Late chunking support via `late_chunking` parameter
- Matryoshka dimension reduction via `dimensions` parameter

## Changes

- New `jina_embedders.py` with `JinaDenseEmbedder`
- Register `jina` provider in `embedding_config.py`
- Update docs (EN/ZH), README, FAQ with Jina provider info
- Add unit tests with mocked API calls