### PR TITLE
fix(tui): correct root scopes in filesystem tree

### DIFF
--- a/crates/ov_cli/src/tui/tree.rs
+++ b/crates/ov_cli/src/tui/tree.rs
@@ -59,8 +59,7 @@ impl TreeState {
     }
 
     /// Known root-level scopes in OpenViking
-    const ROOT_SCOPES: &'static [&'static str] =
-        &["resources", "memories", "skills", "temp", "agent", "queue", "user", "session"];
+    const ROOT_SCOPES: &'static [&'static str] = &["agent", "resources", "session", "user"];
 
     pub async fn load_root(&mut self, client: &HttpClient, uri: &str) {
         let is_root = uri == "viking://" || uri == "viking:///";


### PR DESCRIPTION
## Summary

Fixes incorrect root-level scopes displayed in the TUI filesystem tree view.

## Problem

The TUI was showing invalid root scopes that are not actual `viking://` URI roots:
- `memories` - subdirectory under `user/` and `agent/`
- `skills` - subdirectory under `agent/`  
- `temp` - transient processing directories, not browsable
- `queue` - internal AGFS plugin path (`/queue`), not a user-facing scope

## Solution

Updated `ROOT_SCOPES` in `crates/ov_cli/src/tui/tree.rs` to only include valid root scopes:
- `agent`
- `resources`
- `session`
- `user`

These align with `PRESET_DIRECTORIES` in `openviking/core/directories.py` and actual `viking://` URI usage throughout the codebase.

## Changes

```diff
- const ROOT_SCOPES: &'static [&'static str] =
-     &["resources", "memories", "skills", "temp", "agent", "queue", "user", "session"];
+ const ROOT_SCOPES: &'static [&'static str] = &["agent", "resources", "session", "user"];
```