### PR TITLE
fix: handle >6-digit fractional seconds in ISO timestamps on Windows

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from pyagfs import AGFSClient
 
 from openviking.storage.vikingdb_interface import VikingDBInterface
-from openviking.utils.time_utils import format_simplified, get_current_timestamp
+from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
 from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
 
@@ -327,7 +327,7 @@ class VikingFS:
                     "size": entry.get("size", 0),
                     "isDir": entry.get("isDir", False),
                     "modTime": format_simplified(
-                        datetime.fromisoformat(entry.get("modTime", "")), now
+                        parse_iso_datetime(entry.get("modTime", "")), now
                     ),
                 }
                 if entry.get("isDir"):
@@ -1016,7 +1016,7 @@ class VikingFS:
                 "uri": str(VikingURI(uri).join(name)),
                 "size": entry.get("size", 0),
                 "isDir": entry.get("isDir", False),
-                "modTime": format_simplified(datetime.fromisoformat(raw_time), now),
+                "modTime": format_simplified(parse_iso_datetime(raw_time), now),
             }
             if entry.get("isDir"):
                 all_entries.append(new_entry)

--- a/openviking/utils/time_utils.py
+++ b/openviking/utils/time_utils.py
@@ -1,4 +1,18 @@
+import re
 from datetime import datetime, timezone
+
+# Matches fractional seconds with more than 6 digits (e.g. .1470042)
+_EXCESS_FRAC_RE = re.compile(r"(\.\d{6})\d+")
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO 8601 datetime string, tolerating >6-digit fractional seconds.
+
+    Windows may produce timestamps like ``2026-02-21T13:20:23.1470042+08:00``
+    where the fractional seconds exceed Python's 6-digit microsecond limit.
+    This helper truncates the excess digits before parsing.
+    """
+    return datetime.fromisoformat(_EXCESS_FRAC_RE.sub(r"\1", value))
 
 
 def format_iso8601(dt: datetime) -> str:


### PR DESCRIPTION
## Problem

On Windows, `ls` fails with:
```
ValueError: Invalid isoformat string: '2026-02-21T13:20:23.1470042+08:00'
```

Windows generates ISO timestamps with 7-digit fractional seconds, but Python's `datetime.fromisoformat()` only supports up to 6 digits.

## Fix

Add a `parse_iso_datetime()` helper in `time_utils.py` that truncates excess fractional digits before parsing. Replace the two `datetime.fromisoformat()` calls in `viking_fs.py` with this helper.

Fixes #242