### PR TITLE
fix: use reason as instruction fallback in resource processing

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from pyagfs import AGFSClient
 
 from openviking.storage.vikingdb_interface import VikingDBInterface
-from openviking.utils.time_utils import format_simplified, get_current_timestamp
+from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
 from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
 
@@ -327,7 +327,7 @@ class VikingFS:
                     "size": entry.get("size", 0),
                     "isDir": entry.get("isDir", False),
                     "modTime": format_simplified(
-                        datetime.fromisoformat(entry.get("modTime", "")), now
+                        parse_iso_datetime(entry.get("modTime", "")), now
                     ),
                 }
                 if entry.get("isDir"):
@@ -1016,7 +1016,7 @@ class VikingFS:
                 "uri": str(VikingURI(uri).join(name)),
                 "size": entry.get("size", 0),
                 "isDir": entry.get("isDir", False),
-                "modTime": format_simplified(datetime.fromisoformat(raw_time), now),
+                "modTime": format_simplified(parse_iso_datetime(raw_time), now),
             }
             if entry.get("isDir"):
                 all_entries.append(new_entry)

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -95,9 +95,12 @@ class ResourceProcessor:
         # ============ Phase 1: Parse source (Parser generates L0/L1 and writes to temp) ============
         try:
             media_processor = self._get_media_processor()
+            # Use reason as instruction fallback so it influences L0/L1
+            # generation and improves search relevance as documented.
+            effective_instruction = instruction or reason
             parse_result = await media_processor.process(
                 source=path,
-                instruction=instruction,
+                instruction=effective_instruction,
                 **kwargs,
             )
             result["source_path"] = parse_result.source_path or path

--- a/openviking/utils/time_utils.py
+++ b/openviking/utils/time_utils.py
@@ -1,4 +1,18 @@
+import re
 from datetime import datetime, timezone
+
+# Matches fractional seconds with more than 6 digits (e.g. .1470042)
+_EXCESS_FRAC_RE = re.compile(r"(\.\d{6})\d+")
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO 8601 datetime string, tolerating >6-digit fractional seconds.
+
+    Windows may produce timestamps like ``2026-02-21T13:20:23.1470042+08:00``
+    where the fractional seconds exceed Python's 6-digit microsecond limit.
+    This helper truncates the excess digits before parsing.
+    """
+    return datetime.fromisoformat(_EXCESS_FRAC_RE.sub(r"\1", value))
 
 
 def format_iso8601(dt: datetime) -> str:


### PR DESCRIPTION
## Problem

The `reason` parameter in `process_resource()` is [documented](https://github.com/volcengine/OpenViking/blob/main/docs/zh/api/02-resources.md#L44) as improving search relevance, but it is never actually used — the variable is accepted and silently discarded.

## Fix

Use `reason` as a fallback for `instruction` when `instruction` is empty. This way, `reason` influences L0/L1 generation via the media processor, fulfilling its documented purpose.

```python
effective_instruction = instruction or reason
```

When both are provided, `instruction` takes precedence (more specific). When only `reason` is provided, it serves as the processing context.

Fixes #243