### PR TITLE
feat: support cloud vikingDB

### DIFF
--- a/openviking/storage/vectordb/collection/volcengine_collection.py
+++ b/openviking/storage/vectordb/collection/volcengine_collection.py
@@ -123,8 +123,8 @@ class VolcengineCollection(ICollection):
             return v
         s = v.strip()
         if s.startswith("viking://"):
-            s = s[len("viking://"):]
-        s = s.strip('/')
+            s = s[len("viking://") :]
+        s = s.strip("/")
         if not s:
             return None
         return f"/{s}/"
@@ -146,7 +146,11 @@ class VolcengineCollection(ICollection):
         """Sanitize dictionary-type payload"""
         # Handle filter DSL: must condition's conds list (for uri/parent_uri fields)
         field_name = obj.get("field")
-        if field_name in ("uri", "parent_uri") and "conds" in obj and isinstance(obj["conds"], list):
+        if (
+            field_name in ("uri", "parent_uri")
+            and "conds" in obj
+            and isinstance(obj["conds"], list)
+        ):
             new_conds = cls._sanitize_filter_conds(obj["conds"])
             if not new_conds:
                 return None


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

resolves #278 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

集中处理：在 VolcengineCollection 类中修改 _data_post 方法，使其在发送 POST 请求前，统一调用新增的 _sanitize_payload 方法对 data 参数进行深度净化。这确保了所有通过此路径的数据操作（如 upsert_data, search_* 等）都能覆盖到。

递归净化：_sanitize_payload 方法能够递归地遍历整个 payload 结构（包括字典和列表），查找并处理所有需要净化的字段。

URI 格式标准化：

新增核心工具方法 _sanitize_uri_value，专门负责将 uri 和 parent_uri 的值标准化。
移除 viking:// 前缀。
将路径统一为以 / 开头和结尾的格式，例如 my/path 会被转换为 /my/path/。
对于无效或空字符串值，会返回 None，并在上层调用中被有效过滤，避免将空路径传入后端。
Filter DSL 适配：净化逻辑特别适配了 VikingDB 的过滤查询语言（Filter DSL）。它能正确处理 conds 列表中的 uri 值，以及 prefix 操作符中的路径前缀。

强制补充 parent_uri：为了保证数据模型的完整性，新增了 _ensure_parent_uri 逻辑。当一个数据记录（判断标准是其包含 uri 字段）中缺少 parent_uri 字段或该字段值为空时，系统会自动为其补充一个默认值 /。

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

此变更将透明地影响所有与 VikingDB 进行数据交互的场景，特别是：

collection.upsert_data(data_list=...)
collection.search_by_vector(filters=...)
collection.search_by_id(filters=...)
collection.aggregate_data(filters=...)
当上述方法的 data_list 或 filters 参数中包含 uri 或 parent_uri 字段时，该净化逻辑会被自动触发。

示例：
一个用户调用 upsert_data，传入的数据为：


```json
[
  {"id": "1", "uri": "viking://my_doc.txt", "text": "content1"},
  {"id": "2", "uri": "folder/subfolder/", "parent_uri": "", "text": "content2"}
]
```

经过净化后，实际发送到后端的 payload 会变为：



``` json
[
  {"id": "1", "uri": "/my_doc.txt/", "text": "content1", "parent_uri": "/"},
  {"id": "2", "uri": "/folder/subfolder/", "parent_uri": "/", "text": "content2"}
]
```
