### PR TITLE
fix: correct storage.update() call signature in _update_active_counts()

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -5,6 +5,7 @@
 Session as Context: Sessions integrated into L0/L1/L2 system.
 """
 
+import hashlib
 import json
 import re
 from dataclasses import dataclass, field
@@ -283,18 +284,17 @@ class Session:
 
         for usage in self._usage_records:
             try:
-                # Fetch the record first to get its id and current active_count.
-                # storage.update() signature is update(collection, id, data) —
-                # it does NOT accept MongoDB-style filter/update kwargs.
-                record = run_async(storage.fetch_by_uri("context", usage.uri))
-                if not record:
+                # Compute the record ID from the URI directly.
+                # collection_schemas.py assigns id = md5(uri) for every context
+                # record, so storage.get() gives us a precise single-record lookup
+                # without the subtree-matching side-effect of fetch_by_uri() on
+                # path-type fields.
+                record_id = hashlib.md5(usage.uri.encode("utf-8")).hexdigest()
+                records = run_async(storage.get(collection="context", ids=[record_id]))
+                if not records:
                     logger.debug(f"Record not found for URI: {usage.uri}")
                     continue
-                record_id = record.get("id")
-                if not record_id:
-                    logger.debug(f"Record has no id for URI: {usage.uri}")
-                    continue
-                current_count = record.get("active_count") or 0
+                current_count = records[0].get("active_count") or 0
                 run_async(
                     storage.update(
                         collection="context",

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -81,23 +81,30 @@ class TestCommit:
     ):
         """Regression test: active_count must actually increment after commit.
 
-        Previously _update_active_counts() had two bugs:
+        Previously _update_active_counts() had three bugs:
         1. Called storage.update() with MongoDB-style kwargs (filter=, update=)
            that don't match the actual signature update(collection, id, data),
            causing a silent TypeError on every commit.
-        2. Used $inc syntax which storage.update() doesn't support.
+        2. Used $inc syntax which storage.update() does not support (merge semantics
+           require a plain value, not an increment operator).
+        3. Used fetch_by_uri() to locate the record, but that method's path-field
+           filter returns the entire subtree (hierarchical match), so any URI that
+           has child records triggers a 'Duplicate records found' error and returns
+           None — leaving active_count un-updated even after fixes 1 and 2.
 
-        Both bugs left active_count permanently stuck at 0.
+        Fix: derive the record id as md5(uri) (the canonical formula used in
+        collection_schemas.py) and call storage.get(ids=[id]) for an exact lookup.
         """
-        client, uri = client_with_resource_sync
+        import hashlib
 
-        # Access vikingdb_manager via the public .service property on LocalClient
+        client, uri = client_with_resource_sync
         vikingdb = client._client.service.vikingdb_manager
 
-        # Read active_count before any usage
-        record_before = await vikingdb.fetch_by_uri("context", uri)
-        assert record_before is not None, f"Resource not found: {uri}"
-        count_before = record_before.get("active_count") or 0
+        # Use storage.get() for exact ID-based lookup (avoids fetch_by_uri subtree issue)
+        record_id = hashlib.md5(uri.encode("utf-8")).hexdigest()
+        records_before = await vikingdb.get("context", [record_id])
+        assert records_before, f"Resource not found by id for URI: {uri}"
+        count_before = records_before[0].get("active_count") or 0
 
         # Mark as used and commit
         session = client.session(session_id="active_count_regression_test")
@@ -109,9 +116,9 @@ class TestCommit:
         assert result.get("active_count_updated") == 1
 
         # Verify the count actually changed in storage
-        record_after = await vikingdb.fetch_by_uri("context", uri)
-        assert record_after is not None
-        count_after = record_after.get("active_count") or 0
+        records_after = await vikingdb.get("context", [record_id])
+        assert records_after, f"Record disappeared after commit for URI: {uri}"
+        count_after = records_after[0].get("active_count") or 0
         assert count_after == count_before + 1, (
             f"active_count not incremented: before={count_before}, after={count_after}"
         )


### PR DESCRIPTION
## Problem

`Session._update_active_counts()` has **three bugs** that leave `active_count` permanently stuck at 0.

### Bug 1: wrong keyword argument names

```python
# Broken call in session.py:
storage.update(
    collection="context",
    filter={"uri": usage.uri},            # ← not a valid kwarg
    update={"$inc": {"active_count": 1}}, # ← not a valid kwarg
)

# Actual signature of VikingVectorIndexBackend.update:
async def update(self, collection: str, id: str, data: Dict[str, Any]) -> bool:
```

Python raises `TypeError: update() got an unexpected keyword argument 'filter'` on every call. The exception is silently swallowed by `except Exception`, so `active_count` is never written.

### Bug 2: unsupported `$inc` operator

`storage.update()` is **merge-and-upsert** (`{**existing, **data}`). It does not support MongoDB-style increment operators. The value must be a plain integer.

### Bug 3: `fetch_by_uri` returns subtree matches on path fields

Even after fixing bugs 1 and 2, using `fetch_by_uri()` to locate the record is unreliable. The local VikingDB engine applies **hierarchical (subtree) matching** to `path`-type fields, so filtering `uri = 'viking://resources/doc'` also matches child records like `'viking://resources/doc/chunk1'`. When more than one record matches, `fetch_by_uri` raises `ValueError("Duplicate records found")` and returns `None` — `active_count` still goes unupdated.

Verified empirically:
```
filter(must, uri="viking://resources/doc")
→ returns ["viking://resources/doc", "viking://resources/doc/chunk1"]   # subtree match
```

## Fix

Compute `record_id = md5(uri)` directly — the same formula used in `collection_schemas.py` for every context record — then use `storage.get(ids=[record_id])` for a precise single-record lookup unaffected by path-field matching semantics:

```python
import hashlib

record_id = hashlib.md5(usage.uri.encode("utf-8")).hexdigest()
records = run_async(storage.get(collection="context", ids=[record_id]))
if not records:
    continue
current_count = records[0].get("active_count") or 0
run_async(storage.update(
    collection="context",
    id=record_id,
    data={"active_count": current_count + 1},  # plain int, not $inc
))
```

## Verification

All three bugs independently verified (3/3 runs each):

- **Bug 1 (mock test)**: `TypeError: update() got an unexpected keyword argument 'filter'`
- **Bug 2 (source read)**: `update()` implementation confirmed as merge, no `$inc` support
- **Bug 3 (empirical test)**: path filter on `must` op returns subtrees, not exact matches

End-to-end test result before fix (3/3 runs):
```
commit.active_count_updated = 0   # never incremented
```

## Changes

- `openviking/session/session.py`: add `import hashlib`; replace broken kwargs + `$inc` + `fetch_by_uri` with `storage.get(ids=[md5(uri)])` lookup and correct `update(id, data)` call
- `tests/session/test_session_commit.py`: add regression test using `storage.get()` for exact id lookup; docstring covers all three bugs