### PR TITLE
feat(config): expose embedding.max_concurrent and vlm.max_concurrent …

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,15 @@ Create a configuration file `~/.openviking/ov.conf`, remove the comments before 
       "provider" : "<provider-type>",  // Provider type: "volcengine" or "openai" (currently supported)
       "dimension": 1024,               // Vector dimension
       "model"    : "<model-name>"      // Embedding model name (e.g., doubao-embedding-vision-250615 or text-embedding-3-large)
-    }
+    },
+    "max_concurrent": 10               // Max concurrent embedding requests (default: 10)
   },
   "vlm": {
     "api_base" : "<api-endpoint>",     // API endpoint address
     "api_key"  : "<your-api-key>",     // Model service API Key
     "provider" : "<provider-type>",    // Provider type (volcengine, openai, deepseek, anthropic, etc.)
-    "model"    : "<model-name>"        // VLM model name (e.g., doubao-seed-1-8-251228 or gpt-4-vision-preview)
+    "model"    : "<model-name>",       // VLM model name (e.g., doubao-seed-1-8-251228 or gpt-4-vision-preview)
+    "max_concurrent": 100              // Max concurrent LLM calls for semantic processing (default: 100)
   }
 }
 ```
@@ -259,13 +261,15 @@ Create a configuration file `~/.openviking/ov.conf`, remove the comments before 
       "provider" : "volcengine",
       "dimension": 1024,
       "model"    : "doubao-embedding-vision-250615"
-    }
+    },
+    "max_concurrent": 10
   },
   "vlm": {
     "api_base" : "https://ark.cn-beijing.volces.com/api/v3",
     "api_key"  : "your-volcengine-api-key",
     "provider" : "volcengine",
-    "model"    : "doubao-seed-1-8-251228"
+    "model"    : "doubao-seed-1-8-251228",
+    "max_concurrent": 100
   }
 }
 ```
@@ -291,13 +295,15 @@ Create a configuration file `~/.openviking/ov.conf`, remove the comments before 
       "provider" : "openai",
       "dimension": 3072,
       "model"    : "text-embedding-3-large"
-    }
+    },
+    "max_concurrent": 10
   },
   "vlm": {
     "api_base" : "https://api.openai.com/v1",
     "api_key"  : "your-openai-api-key",
     "provider" : "openai",
-    "model"    : "gpt-4-vision-preview"
+    "model"    : "gpt-4-vision-preview",
+    "max_concurrent": 100
   }
 }
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -101,13 +101,15 @@ OpenViking 支持多种模型服务：
       "provider" : "<provider-type>",  // 提供商类型（volcengine、openai 或 jina）
       "dimension": 1024,               // 向量维度
       "model"    : "<model-name>"      // Embedding 模型名称（如 doubao-embedding-vision-250615 或 text-embedding-3-large）
-    }
+    },
+    "max_concurrent": 10               // Embedding 最大并发请求数（默认：10）
   },
   "vlm": {
     "api_base" : "<api-endpoint>",     // API 服务端点地址
     "api_key"  : "<your-api-key>",     // 模型服务的 API 密钥
     "provider" : "<provider-type>",    // 提供商类型（volcengine、openai 或 jina）
-    "model"    : "<model-name>"        // VLM 模型名称（如 doubao-seed-1-8-251228 或 gpt-4-vision-preview）
+    "model"    : "<model-name>",       // VLM 模型名称（如 doubao-seed-1-8-251228 或 gpt-4-vision-preview）
+    "max_concurrent": 100              // 语义处理最大并发 LLM 调用数（默认：100）
   }
 }
 ```
@@ -135,13 +137,15 @@ OpenViking 支持多种模型服务：
       "provider" : "volcengine",
       "dimension": 1024,
       "model"    : "doubao-embedding-vision-250615"
-    }
+    },
+    "max_concurrent": 10
   },
   "vlm": {
     "api_base" : "https://ark.cn-beijing.volces.com/api/v3",
     "api_key"  : "your-volcengine-api-key",
     "provider" : "volcengine",
-    "model"    : "doubao-seed-1-8-251228"
+    "model"    : "doubao-seed-1-8-251228",
+    "max_concurrent": 100
   }
 }
 ```
@@ -167,13 +171,15 @@ OpenViking 支持多种模型服务：
       "provider" : "openai",
       "dimension": 3072,
       "model"    : "text-embedding-3-large"
-    }
+    },
+    "max_concurrent": 10
   },
   "vlm": {
     "api_base" : "https://api.openai.com/v1",
     "api_key"  : "your-openai-api-key",
     "provider" : "openai",
-    "model"    : "gpt-4-vision-preview"
+    "model"    : "gpt-4-vision-preview",
+    "max_concurrent": 100
   }
 }
 ```

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -30,7 +30,8 @@ def init_queue_manager(
     agfs_url: str = "http://localhost:8080",
     timeout: int = 10,
     mount_point: str = "/queue",
-    max_concurrent_embedding: int = 1,
+    max_concurrent_embedding: int = 10,
+    max_concurrent_semantic: int = 100,
 ) -> "QueueManager":
     """Initialize QueueManager singleton."""
     global _instance
@@ -39,6 +40,7 @@ def init_queue_manager(
         timeout=timeout,
         mount_point=mount_point,
         max_concurrent_embedding=max_concurrent_embedding,
+        max_concurrent_semantic=max_concurrent_semantic,
     )
     return _instance
 
@@ -66,13 +68,15 @@ class QueueManager:
         agfs_url: str = "http://localhost:8080",
         timeout: int = 10,
         mount_point: str = "/queue",
-        max_concurrent_embedding: int = 1,
+        max_concurrent_embedding: int = 10,
+        max_concurrent_semantic: int = 100,
     ):
         """Initialize QueueManager."""
         self._agfs_url = agfs_url
         self.timeout = timeout
         self.mount_point = mount_point
         self._max_concurrent_embedding = max_concurrent_embedding
+        self._max_concurrent_semantic = max_concurrent_semantic
         self._agfs: Optional[Any] = None
         self._queues: Dict[str, NamedQueue] = {}
         self._started = False
@@ -124,7 +128,7 @@ class QueueManager:
         logger.info("Embedding queue initialized with TextEmbeddingHandler")
 
         # Semantic Queue
-        semantic_processor = SemanticProcessor()
+        semantic_processor = SemanticProcessor(max_concurrent_llm=self._max_concurrent_semantic)
         self.get_queue(
             self.SEMANTIC,
             dequeue_handler=semantic_processor,

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -105,7 +105,7 @@ class EmbeddingConfig(BaseModel):
     hybrid: Optional[EmbeddingModelConfig] = Field(default=None)
 
     max_concurrent: int = Field(
-        default=1, description="Maximum number of concurrent embedding requests"
+        default=10, description="Maximum number of concurrent embedding requests"
     )
 
     model_config = {"extra": "forbid"}

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -28,6 +28,10 @@ class VLMConfig(BaseModel):
 
     thinking: bool = Field(default=False, description="Enable thinking mode for VolcEngine models")
 
+    max_concurrent: int = Field(
+        default=100, description="Maximum number of concurrent LLM calls for semantic processing"
+    )
+
     _vlm_instance: Optional[Any] = None
 
     model_config = {"arbitrary_types_allowed": True, "extra": "forbid"}


### PR DESCRIPTION
 - Add `max_concurrent` field to VLMConfig (default: 100) to control
    concurrent LLM calls inside SemanticProcessor
  - Change EmbeddingConfig.max_concurrent default from 1 to 10
  - Thread both values through core._init_storage → init_queue_manager
    → QueueManager (_max_concurrent_embedding / _max_concurrent_semantic)
    → SemanticProcessor(max_concurrent_llm)
  - Update README and README_CN with the new config fields and defaults