### PR TITLE
fix: VikingDB volcengine URI prefix loss and stale is_leaf filter

### DIFF
--- a/openviking/session/memory_deduplicator.py
+++ b/openviking/session/memory_deduplicator.py
@@ -135,7 +135,7 @@ class MemoryDeduplicator:
         # Build filter by memory scope + uri prefix (schema does not have category field yet).
         filter_conds = [
             {"field": "context_type", "op": "must", "conds": ["memory"]},
-            {"field": "is_leaf", "op": "must", "conds": [True]},
+            {"field": "level", "op": "must", "conds": [2]},
         ]
         owner = candidate.user
         if hasattr(owner, "account_id"):


### PR DESCRIPTION
## Description

修复 VikingDB volcengine 后端的两个 bug 以及 S3 后端的一个 bug：
1. 读取记录时 URI `viking://` 前缀丢失，导致 Access Denied
2. `memory_deduplicator.py` 中残留已废弃的 `is_leaf` 字段过滤（PR #271 遗漏）
3. S3 目录 rename 只移动单个文件，未处理整个子目录树

## Related Issue

Fixes #288

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 在 `VikingVectorIndexBackend` 中添加 `_restore_uri_fields()` 静态方法，在读取记录时还原 `uri`/`parent_uri` 字段的 `viking://` 前缀。在 `get()`、`fetch_by_uri()`、`search()`、`filter()` 四个出口处调用，`scroll()` 和 `_remove_descendants()` 经由 `filter()` 间接覆盖。幂等操作，对 local/http 后端无副作用。
- 将 `memory_deduplicator.py` 中 `{"field": "is_leaf", "op": "must", "conds": [True]}` 替换为 `{"field": "level", "op": "must", "conds": [2]}`，与 PR #271 的 schema 变更对齐。
- S3 client 新增 `CopyObject()` 和 `ListAllObjects()` 方法；重构 `s3fs.Rename()` 支持目录级别的移动，通过服务端 copy + delete 递归处理整个子目录树。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- `_restore_uri_fields()` 是 `volcengine_collection._sanitize_uri_value()` 的逆操作：去除首尾 `/` 后加上 `viking://` 前缀。通过 `not val.startswith("viking://")` 保证对 local/http 后端幂等安全。
