### PR TITLE
feat(client): ovcli.conf 支持 timeout 配置 + 修复 Rust CLI agent_id

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -16,13 +16,19 @@ pub struct HttpClient {
     http: ReqwestClient,
     base_url: String,
     api_key: Option<String>,
+    agent_id: Option<String>,
 }
 
 impl HttpClient {
     /// Create a new HTTP client
-    pub fn new(base_url: impl Into<String>, api_key: Option<String>) -> Self {
+    pub fn new(
+        base_url: impl Into<String>,
+        api_key: Option<String>,
+        agent_id: Option<String>,
+        timeout_secs: f64,
+    ) -> Self {
         let http = ReqwestClient::builder()
-            .timeout(std::time::Duration::from_secs(60))
+            .timeout(std::time::Duration::from_secs_f64(timeout_secs))
             .build()
             .expect("Failed to build HTTP client");
 
@@ -30,6 +36,7 @@ impl HttpClient {
             http,
             base_url: base_url.into().trim_end_matches('/').to_string(),
             api_key,
+            agent_id,
         }
     }
 
@@ -118,6 +125,11 @@ impl HttpClient {
         if let Some(api_key) = &self.api_key {
             if let Ok(value) = reqwest::header::HeaderValue::from_str(api_key) {
                 headers.insert("X-API-Key", value);
+            }
+        }
+        if let Some(agent_id) = &self.agent_id {
+            if let Ok(value) = reqwest::header::HeaderValue::from_str(agent_id) {
+                headers.insert("X-OpenViking-Agent", value);
             }
         }
         headers

--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -8,13 +8,19 @@ pub struct Config {
     #[serde(default = "default_url")]
     pub url: String,
     pub api_key: Option<String>,
-    pub user: Option<String>,
+    pub agent_id: Option<String>,
+    #[serde(default = "default_timeout")]
+    pub timeout: f64,
     #[serde(default = "default_output_format")]
     pub output: String,
 }
 
 fn default_url() -> String {
     "http://localhost:1933".to_string()
+}
+
+fn default_timeout() -> f64 {
+    60.0
 }
 
 fn default_output_format() -> String {
@@ -26,7 +32,8 @@ impl Default for Config {
         Self {
             url: "http://localhost:1933".to_string(),
             api_key: None,
-            user: None,
+            agent_id: None,
+            timeout: 60.0,
             output: "table".to_string(),
         }
     }

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -29,7 +29,12 @@ impl CliContext {
     }
 
     pub fn get_client(&self) -> client::HttpClient {
-        client::HttpClient::new(&self.config.url, self.config.api_key.clone())
+        client::HttpClient::new(
+            &self.config.url,
+            self.config.api_key.clone(),
+            self.config.agent_id.clone(),
+            self.config.timeout,
+        )
     }
 }
 

--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -58,6 +58,7 @@ client = ov.SyncHTTPClient(
     url="http://localhost:1933",
     api_key="your-key",
     agent_id="my-agent",
+    timeout=120.0,
 )
 client.initialize()
 ```
@@ -80,6 +81,7 @@ export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf
 |-------|-------------|---------|
 | `url` | Server address | (required) |
 | `api_key` | API key | `null` (no auth) |
+| `timeout` | HTTP request timeout in seconds | `60.0` |
 | `output` | Default output format: `"table"` or `"json"` | `"table"` |
 
 See the [Configuration Guide](../guides/01-configuration.md#ovcliconf) for details.

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -58,6 +58,7 @@ client = ov.SyncHTTPClient(
     url="http://localhost:1933",
     api_key="your-key",
     agent_id="my-agent",
+    timeout=120.0,
 )
 client.initialize()
 ```
@@ -81,6 +82,7 @@ export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf
 | `url` | 服务端地址 | （必填） |
 | `api_key` | API Key | `null`（无认证） |
 | `agent_id` | Agent 标识符 | `null` |
+| `timeout` | HTTP 请求超时时间（秒） | `60.0` |
 | `output` | 默认输出格式：`"table"` 或 `"json"` | `"table"` |
 
 详见 [配置指南](../guides/01-configuration.md#ovcliconf)。

--- a/examples/cloud/GUIDE.md
+++ b/examples/cloud/GUIDE.md
@@ -317,7 +317,8 @@ import openviking as ov
 client = ov.SyncHTTPClient(
     url="http://localhost:1933",
     api_key="USER_API_KEY",
-    agent_id="my-agent"
+    agent_id="my-agent",
+    timeout=120.0,  # HTTP request timeout in seconds (default: 60.0)
 )
 client.initialize()
 

--- a/examples/ovcli.conf.example
+++ b/examples/ovcli.conf.example
@@ -2,5 +2,6 @@
   "url": "http://localhost:1933",
   "api_key": null,
   "agent_id": null,
+  "timeout": 60.0,
   "output": "table"
 }

--- a/examples/server_client/README.md
+++ b/examples/server_client/README.md
@@ -114,7 +114,7 @@ main()
 ```python
 import openviking as ov
 
-client = ov.SyncHTTPClient(url="http://localhost:1933", api_key="your-key")
+client = ov.SyncHTTPClient(url="http://localhost:1933", api_key="your-key", timeout=120.0)
 client.initialize()
 
 client.add_resource(path="./document.md")
@@ -129,7 +129,7 @@ client.close()
 ```python
 import openviking as ov
 
-client = ov.AsyncHTTPClient(url="http://localhost:1933", api_key="your-key")
+client = ov.AsyncHTTPClient(url="http://localhost:1933", api_key="your-key", timeout=120.0)
 await client.initialize()
 
 await client.add_resource(path="./document.md")

--- a/examples/server_client/client_async.py
+++ b/examples/server_client/client_async.py
@@ -38,9 +38,12 @@ async def main():
     parser.add_argument("--url", default="http://localhost:1933", help="Server URL")
     parser.add_argument("--api-key", default=None, help="API key")
     parser.add_argument("--agent-id", default=None, help="Agent ID")
+    parser.add_argument("--timeout", type=float, default=60.0, help="HTTP timeout in seconds")
     args = parser.parse_args()
 
-    client = ov.AsyncHTTPClient(url=args.url, api_key=args.api_key, agent_id=args.agent_id)
+    client = ov.AsyncHTTPClient(
+        url=args.url, api_key=args.api_key, agent_id=args.agent_id, timeout=args.timeout
+    )
 
     try:
         # ── Connect ──

--- a/examples/server_client/client_sync.py
+++ b/examples/server_client/client_sync.py
@@ -64,9 +64,12 @@ def main():
     parser.add_argument("--url", default="http://localhost:1933", help="Server URL")
     parser.add_argument("--api-key", default=None, help="API key")
     parser.add_argument("--agent-id", default=None, help="Agent ID")
+    parser.add_argument("--timeout", type=float, default=60.0, help="HTTP timeout in seconds")
     args = parser.parse_args()
 
-    client = ov.SyncHTTPClient(url=args.url, api_key=args.api_key, agent_id=args.agent_id)
+    client = ov.SyncHTTPClient(
+        url=args.url, api_key=args.api_key, agent_id=args.agent_id, timeout=args.timeout
+    )
 
     try:
         # ── Connect ──

--- a/openviking_cli/client/sync_http.py
+++ b/openviking_cli/client/sync_http.py
@@ -32,8 +32,11 @@ class SyncHTTPClient:
         url: Optional[str] = None,
         api_key: Optional[str] = None,
         agent_id: Optional[str] = None,
+        timeout: float = 60.0,
     ):
-        self._async_client = AsyncHTTPClient(url=url, api_key=api_key, agent_id=agent_id)
+        self._async_client = AsyncHTTPClient(
+            url=url, api_key=api_key, agent_id=agent_id, timeout=timeout
+        )
         self._initialized = False
 
     # ============= Lifecycle =============


### PR DESCRIPTION
## Description

为 Python 和 Rust CLI 客户端添加通过 `ovcli.conf` 配置 HTTP 超时的支持，同时修复 Rust CLI 未正确读取 `agent_id` 的问题。

## Related Issue

Closes #306

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Changes Made

- **Python HTTP 客户端** (`openviking_cli/client/http.py`): 从 `ovcli.conf` 读取 `timeout`, 优先级: SDK 显式传参 > ovcli.conf > 默认值 60.0
- **Python 同步客户端** (`openviking_cli/client/sync_http.py`): 透传 `timeout` 参数到 `AsyncHTTPClient`
- **Rust CLI 配置** (`crates/ov_cli/src/config.rs`): 将未使用的 `user` 字段替换为 `agent_id`, 新增 `timeout` 字段 (serde 默认 60.0)
- **Rust CLI 客户端** (`crates/ov_cli/src/client.rs`): 接收 `agent_id` 和 `timeout_secs` 参数, 发送 `X-OpenViking-Agent` 请求头, 与 Python 客户端对齐
- **Rust CLI 入口** (`crates/ov_cli/src/main.rs`): 将配置中的 `agent_id` 和 `timeout` 传递给 `HttpClient`
- **文档**: 将 timeout 文档从 configuration guide 移至 API overview (中英文)
- **示例**: `ovcli.conf.example` 加入 `timeout` 字段, 更新代码示例

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Rust CLI 此前有一个从未使用的 `user` 字段, 且不支持 `agent_id` 和可配置超时。本 PR 将 Rust CLI 与 Python 客户端对齐:
1. 从 `ovcli.conf` 读取 `agent_id` 并作为 `X-OpenViking-Agent` 请求头发送
2. 从 `ovcli.conf` 读取 `timeout` 并应用到 reqwest HTTP 客户端
