### PR TITLE
fix(server): 未配置 root_api_key 时仅允许 localhost 绑定

### DIFF
--- a/docs/en/guides/04-authentication.md
+++ b/docs/en/guides/04-authentication.md
@@ -101,16 +101,18 @@ client = ov.SyncHTTPClient(
 
 ## Development Mode
 
-When no `root_api_key` is configured, authentication is disabled. All requests are accepted as ROOT with the default account.
+When no `root_api_key` is configured, authentication is disabled. All requests are accepted as ROOT with the default account. **This is only allowed when the server binds to localhost** (`127.0.0.1`, `localhost`, or `::1`). If `host` is set to a non-loopback address (e.g. `0.0.0.0`) without a `root_api_key`, the server will refuse to start.
 
 ```json
 {
   "server": {
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 1933
   }
 }
 ```
+
+> **Security note:** The default `host` is `127.0.0.1`. If you need to expose the server on the network, you **must** configure `root_api_key`.
 
 ## Unauthenticated Endpoints
 

--- a/docs/zh/guides/04-authentication.md
+++ b/docs/zh/guides/04-authentication.md
@@ -101,16 +101,18 @@ client = ov.SyncHTTPClient(
 
 ## 开发模式
 
-不配置 `root_api_key` 时，认证禁用。所有请求以 ROOT 身份访问 default account。
+不配置 `root_api_key` 时，认证禁用，所有请求以 ROOT 身份访问 default account。**此模式仅允许在服务器绑定 localhost 时使用**（`127.0.0.1`、`localhost` 或 `::1`）。如果 `host` 设置为非回环地址（如 `0.0.0.0`）且未配置 `root_api_key`，服务器将拒绝启动。
 
 ```json
 {
   "server": {
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 1933
   }
 }
 ```
+
+> **安全提示：** 默认 `host` 为 `127.0.0.1`。如需将服务暴露到网络，**必须**配置 `root_api_key`。
 
 ## 无需认证的端点
 

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Server configuration for OpenViking HTTP Server."""
 
+import sys
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from openviking_cli.utils import get_logger
 from openviking_cli.utils.config.config_loader import (
     DEFAULT_OV_CONF,
     OPENVIKING_CONFIG_ENV,
@@ -12,12 +14,14 @@ from openviking_cli.utils.config.config_loader import (
     resolve_config_path,
 )
 
+logger = get_logger(__name__)
+
 
 @dataclass
 class ServerConfig:
     """Server configuration (from the ``server`` section of ov.conf)."""
 
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 1933
     root_api_key: Optional[str] = None
     cors_origins: List[str] = field(default_factory=lambda: ["*"])
@@ -59,10 +63,47 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
     server_data = data.get("server", {})
 
     config = ServerConfig(
-        host=server_data.get("host", "0.0.0.0"),
+        host=server_data.get("host", "127.0.0.1"),
         port=server_data.get("port", 1933),
         root_api_key=server_data.get("root_api_key"),
         cors_origins=server_data.get("cors_origins", ["*"]),
     )
 
     return config
+
+
+_LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def _is_localhost(host: str) -> bool:
+    """Return True if *host* resolves to a loopback address."""
+    return host in _LOCALHOST_HOSTS
+
+
+def validate_server_config(config: ServerConfig) -> None:
+    """Validate server config for safe startup.
+
+    When ``root_api_key`` is not set, authentication is disabled (dev mode).
+    This is only acceptable when the server binds to localhost.  Binding to a
+    non-loopback address without authentication exposes an unauthenticated ROOT
+    endpoint to the network.
+
+    Raises:
+        SystemExit: If the configuration is unsafe.
+    """
+    if config.root_api_key:
+        return
+
+    if not _is_localhost(config.host):
+        logger.error(
+            "SECURITY: server.root_api_key is not configured and server.host "
+            "is '%s' (non-localhost). This would expose an unauthenticated "
+            "ROOT endpoint to the network.",
+            config.host,
+        )
+        logger.error(
+            "To fix, either:\n"
+            "  1. Set server.root_api_key in ov.conf, or\n"
+            '  2. Bind to localhost (server.host = "127.0.0.1")'
+        )
+        sys.exit(1)


### PR DESCRIPTION
## Description

修复安全漏洞：当 `server.root_api_key` 未配置时，`resolve_identity()` 将所有请求解析为 `Role.ROOT`，结合默认绑定 `0.0.0.0`（所有网络接口），导致任何网络请求均可执行管理员操作。

本 PR 将默认绑定地址改为 `127.0.0.1`，并在启动阶段校验配置安全性：无认证 + 非 localhost 绑定时拒绝启动。

## Related Issue

Fixes #302

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- **`openviking/server/config.py`**：默认 `host` 从 `0.0.0.0` 改为 `127.0.0.1`（`ServerConfig` 和 `load_server_config` 两处）；新增 `_is_localhost()` 辅助函数和 `validate_server_config()` 启动校验函数，无 key + 非 localhost 时调用 `sys.exit(1)` 并输出错误日志和修复建议
- **`openviking/server/app.py`**：`create_app()` 中加载 config 后调用 `validate_server_config()`；dev mode 日志从 `logger.info` 升级为 `logger.warning`，明确提示认证已禁用
- **`tests/server/test_auth.py`**：新增 6 个测试用例（含参数化共 10 个 case），覆盖 `_is_localhost` 和 `validate_server_config` 的各种场景
- **`docs/{en,zh}/guides/04-authentication.md`**：更新开发模式段落，示例 host 改为 `127.0.0.1`，添加安全说明

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证场景：
1. `pytest tests/server/test_auth.py` — 全部 22 个测试通过
2. `host: "0.0.0.0"` + 无 `root_api_key` → 服务器拒绝启动（`SystemExit`）
3. `host: "127.0.0.1"` + 无 `root_api_key` → 正常启动，输出 WARNING 日志
4. `host: "0.0.0.0"` + 有 `root_api_key` → 正常启动

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- 现有测试 fixture 中 `ServerConfig()` 默认值改为 `127.0.0.1` 后，因属于 localhost 范围，校验自动通过，无需修改 conftest
- `auth.py` 中 `resolve_identity()` 逻辑保持不变，安全保护在启动阶段完成
