### PR TITLE
fix: use original directory name for temp URI lookup in TreeBuilder

### DIFF
--- a/openviking/parse/tree_builder.py
+++ b/openviking/parse/tree_builder.py
@@ -127,8 +127,11 @@ class TreeBuilder:
                 f"[TreeBuilder] Expected 1 document directory in {temp_uri}, found {len(doc_dirs)}"
             )
 
-        doc_name = VikingURI.sanitize_segment(doc_dirs[0]["name"])
-        temp_doc_uri = f"{temp_uri}/{doc_name}"
+        original_name = doc_dirs[0]["name"]
+        doc_name = VikingURI.sanitize_segment(original_name)
+        temp_doc_uri = f"{temp_uri}/{original_name}"  # use original name to find temp dir
+        if original_name != doc_name:
+            logger.debug(f"[TreeBuilder] Sanitized doc name: {original_name!r} -> {doc_name!r}")
 
         # 2. Determine base_uri and final document name with org/repo for GitHub/GitLab
         if base_uri is None:


### PR DESCRIPTION
## Problem

`TreeBuilder._finalize_from_temp()` applies `VikingURI.sanitize_segment()` to
the temp document directory name (e.g. `__test__` → `_test_`), then uses the
sanitized name to construct `temp_doc_uri`. However, the actual temp directory
on disk retains its original (unsanitized) name, causing `FileNotFoundError`
during `_move_temp_to_dest()` when the name contains consecutive underscores
or other characters that `sanitize_segment()` modifies.

## Fix

Use the original directory name for `temp_doc_uri` (locating the temp
directory), while continuing to use the sanitized name for `candidate_uri`
(the final destination URI). Added debug log when sanitization changes the name.

## Changes (1 file, +5 −2)

- `openviking/parse/tree_builder.py`: Split `doc_dirs[0]["name"]` into
  `original_name` (for temp lookup) and `doc_name` (sanitized, for final URI).

## Test plan

- [ ] `add_resource` with filenames containing `__`, leading/trailing underscores
- [ ] `add_resource` with normal filenames (no sanitization change) still works
- [ ] Verify final URI uses sanitized name, temp lookup uses original name
- [ ] Sanitized name conflicts with existing URI: verify `_resolve_unique_uri()` still handles renaming correctly