### PR TITLE
feat: expose session(must_exist) and session_exists() on public API

### DIFF
--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -94,14 +94,29 @@ class AsyncOpenViking:
 
     # ============= Session methods =============
 
-    def session(self, session_id: Optional[str] = None) -> Session:
+    def session(self, session_id: Optional[str] = None, must_exist: bool = False) -> Session:
         """
         Create a new session or load an existing one.
 
         Args:
             session_id: Session ID, creates a new session (auto-generated ID) if None
+            must_exist: If True and session_id is provided, raises NotFoundError
+                        when the session does not exist.
+                        If session_id is None, must_exist is ignored.
         """
-        return self._client.session(session_id)
+        return self._client.session(session_id, must_exist=must_exist)
+
+    async def session_exists(self, session_id: str) -> bool:
+        """Check whether a session exists in storage.
+
+        Args:
+            session_id: Session ID to check
+
+        Returns:
+            True if the session exists, False otherwise
+        """
+        await self._ensure_initialized()
+        return await self._client.session_exists(session_id)
 
     async def create_session(self) -> Dict[str, Any]:
         """Create a new session."""

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -28,9 +28,13 @@ class SyncOpenViking:
         run_async(self._async_client.initialize())
         self._initialized = True
 
-    def session(self, session_id: Optional[str] = None) -> "Session":
+    def session(self, session_id: Optional[str] = None, must_exist: bool = False) -> "Session":
         """Create new session or load existing session."""
-        return self._async_client.session(session_id)
+        return self._async_client.session(session_id, must_exist=must_exist)
+
+    def session_exists(self, session_id: str) -> bool:
+        """Check whether a session exists in storage."""
+        return run_async(self._async_client.session_exists(session_id))
 
     def create_session(self) -> Dict[str, Any]:
         """Create a new session."""

--- a/openviking_cli/client/base.py
+++ b/openviking_cli/client/base.py
@@ -251,14 +251,33 @@ class BaseClient(ABC):
         ...
 
     @abstractmethod
-    def session(self, session_id: Optional[str] = None) -> Any:
+    def session(self, session_id: Optional[str] = None, must_exist: bool = False) -> Any:
         """Create a new session or load an existing one.
 
         Args:
             session_id: Session ID, creates a new session if None
+            must_exist: If True and session_id is provided, raises NotFoundError
+                        when the session does not exist instead of silently
+                        returning a fresh empty session.
+                        If session_id is None, must_exist is ignored.
 
         Returns:
             Session object
+
+        Raises:
+            NotFoundError: If must_exist=True and the session does not exist.
+        """
+        ...
+
+    @abstractmethod
+    async def session_exists(self, session_id: str) -> bool:
+        """Check whether a session exists in storage.
+
+        Args:
+            session_id: Session ID to check
+
+        Returns:
+            True if the session exists, False otherwise
         """
         ...
 

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -773,21 +773,45 @@ class AsyncHTTPClient(BaseClient):
 
     # ============= New methods for BaseClient interface =============
 
-    def session(self, session_id: Optional[str] = None) -> Any:
+    def session(self, session_id: Optional[str] = None, must_exist: bool = False) -> Any:
         """Create a new session or load an existing one.
 
         Args:
             session_id: Session ID, creates a new session if None
+            must_exist: If True and session_id is provided, raises NotFoundError
+                        when the session does not exist.
+                        If session_id is None, must_exist is ignored.
 
         Returns:
             Session object
+
+        Raises:
+            NotFoundError: If must_exist=True and the session does not exist.
         """
         from openviking.client.session import Session
 
         if not session_id:
             result = run_async(self.create_session())
             session_id = result.get("session_id", "")
+        elif must_exist:
+            # get_session() raises NotFoundError (via _handle_response) for 404.
+            run_async(self.get_session(session_id))
         return Session(self, session_id, self._user)
+
+    async def session_exists(self, session_id: str) -> bool:
+        """Check whether a session exists in storage.
+
+        Args:
+            session_id: Session ID to check
+
+        Returns:
+            True if the session exists, False otherwise
+        """
+        try:
+            await self.get_session(session_id)
+            return True
+        except NotFoundError:
+            return False
 
     def get_status(self) -> Dict[str, Any]:
         """Get system status.

--- a/openviking_cli/client/sync_http.py
+++ b/openviking_cli/client/sync_http.py
@@ -53,9 +53,22 @@ class SyncHTTPClient:
 
     # ============= session =============
 
-    def session(self, session_id: Optional[str] = None) -> Any:
-        """Create new session or load existing session."""
-        return self._async_client.session(session_id)
+    def session(self, session_id: Optional[str] = None, must_exist: bool = False) -> Any:
+        """Create a new session or load an existing one.
+
+        Args:
+            session_id: Session ID, creates a new session if None
+            must_exist: If True and session_id is provided, raises NotFoundError
+                        when the session does not exist.
+
+        Returns:
+            Session object
+        """
+        return self._async_client.session(session_id, must_exist=must_exist)
+
+    def session_exists(self, session_id: str) -> bool:
+        """Check whether a session exists in storage."""
+        return run_async(self._async_client.session_exists(session_id))
 
     def create_session(self) -> Dict[str, Any]:
         """Create a new session."""


### PR DESCRIPTION
## Summary

`Session.exists()` (added in #235) provides session existence checks at the internal service layer, but this capability is **not exposed through the public client API**:

- `AsyncOpenViking` / `SyncOpenViking` have no way to check if a session exists
- `BaseClient` and its implementations (`LocalClient`, `AsyncHTTPClient`, `SyncHTTPClient`) lack existence checks
- The HTTP-mode `Session` class (`openviking.client.session.Session`) does not have an `exists()` method — only the embedded-mode `Session` does

This PR surfaces existence checks at the public API level with two opt-in mechanisms (default behavior unchanged, fully backward compatible):

1. **`session(must_exist=True)`** — raises `NotFoundError` if the session does not exist.
2. **`session_exists(session_id)`** — async convenience method returning `True`/`False` without loading the full session.

Both work uniformly across embedded and HTTP modes. No changes to `session.py` or `session_service.py`.

## Type of Change

- [x] New feature (feat)
- [ ] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Testing

6 new tests in `tests/session/test_session_lifecycle.py`:

- `test_must_exist_raises_for_nonexistent` — NotFoundError raised for unknown ID
- `test_must_exist_succeeds_after_create` — works after `create_session()`
- `test_must_exist_false_default_accepts_unknown_id` — backward compatibility
- `test_session_exists_true_after_create` — True after creation
- `test_session_exists_false_for_unknown` — False for unknown ID
- `test_session_exists_true_after_add_message` — True for session with messages

- [x] Unit tests pass
- [x] Manual testing completed

## Related Issues

N/A (feature request from downstream plugin development)

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (if needed)
- [x] All tests pass

---

<details>
<summary>Files changed (7)</summary>

| File | What changed |
|------|-------------|
| openviking_cli/client/base.py | Updated abstract interface with must_exist param and session_exists() |
| openviking/client/local.py | must_exist via Session.exists(); session_exists() delegate |
| openviking_cli/client/http.py | must_exist via get_session() HTTP call; session_exists() |
| openviking_cli/client/sync_http.py | Pass-through for both methods |
| openviking/async_client.py | session(must_exist) + session_exists() on AsyncOpenViking |
| openviking/sync_client.py | Pass-through on SyncOpenViking |
| tests/session/test_session_lifecycle.py | 6 new tests (3 must_exist + 3 session_exists) |

</details>