### PR TITLE
fix: handle is_healthy() AttributeError when not initialized (closes #298)

### DIFF
--- a/openviking/service/debug_service.py
+++ b/openviking/service/debug_service.py
@@ -74,6 +74,11 @@ class ObserverService:
         self._config = config
 
     @property
+    def _dependencies_ready(self) -> bool:
+        """Check if both vikingdb and config dependencies are set."""
+        return self._vikingdb is not None and self._config is not None
+
+    @property
     def queue(self) -> ComponentStatus:
         """Get queue status."""
         observer = QueueObserver(get_queue_manager())
@@ -87,6 +92,13 @@ class ObserverService:
     @property
     def vikingdb(self) -> ComponentStatus:
         """Get VikingDB status."""
+        if self._vikingdb is None:
+            return ComponentStatus(
+                name="vikingdb",
+                is_healthy=False,
+                has_errors=True,
+                status="Not initialized",
+            )
         observer = VikingDBObserver(self._vikingdb)
         return ComponentStatus(
             name="vikingdb",
@@ -98,6 +110,13 @@ class ObserverService:
     @property
     def vlm(self) -> ComponentStatus:
         """Get VLM status."""
+        if self._config is None:
+            return ComponentStatus(
+                name="vlm",
+                is_healthy=False,
+                has_errors=True,
+                status="Not initialized",
+            )
         observer = VLMObserver(self._config.vlm.get_vlm_instance())
         return ComponentStatus(
             name="vlm",
@@ -143,6 +162,8 @@ class ObserverService:
 
     def is_healthy(self) -> bool:
         """Quick health check."""
+        if not self._dependencies_ready:
+            return False
         return self.system.is_healthy
 
 

--- a/tests/misc/test_debug_service.py
+++ b/tests/misc/test_debug_service.py
@@ -284,6 +284,38 @@ class TestObserverService:
         status = service.system
         assert all(c.is_healthy for name, c in status.components.items() if name != "transaction")
 
+    def test_is_healthy_without_dependencies(self):
+        """Test is_healthy returns False (not raises) when dependencies not set."""
+        service = ObserverService()
+        assert service.is_healthy() is False
+
+    def test_vikingdb_property_without_dependency(self):
+        """Test vikingdb property returns unhealthy ComponentStatus when vikingdb is None."""
+        service = ObserverService()
+        status = service.vikingdb
+        assert isinstance(status, ComponentStatus)
+        assert status.name == "vikingdb"
+        assert status.is_healthy is False
+        assert status.has_errors is True
+        assert status.status == "Not initialized"
+
+    def test_vlm_property_without_dependency(self):
+        """Test vlm property returns unhealthy ComponentStatus when config is None."""
+        service = ObserverService()
+        status = service.vlm
+        assert isinstance(status, ComponentStatus)
+        assert status.name == "vlm"
+        assert status.is_healthy is False
+        assert status.has_errors is True
+        assert status.status == "Not initialized"
+
+    def test_system_property_without_dependencies(self):
+        """Test system property returns unhealthy SystemStatus when dependencies not set."""
+        service = ObserverService()
+        status = service.system
+        assert isinstance(status, SystemStatus)
+        assert status.is_healthy is False
+
     @patch("openviking.service.debug_service.get_queue_manager")
     @patch("openviking.service.debug_service.QueueObserver")
     @patch("openviking.service.debug_service.VikingDBObserver")


### PR DESCRIPTION
## Problem

`is_healthy()` throws `AttributeError` when called before `initialize()`:

```
AttributeError: 'NoneType' object has no attribute 'vlm'
```

**Root cause:** `ObserverService.vlm` property accesses `self._config.vlm.get_vlm_instance()`, but `self._config` is `None` before `set_dependencies()` is called during `initialize()`. Similarly, `self._vikingdb` is `None`.

## Fix

- Add `None` guards to `ObserverService.vikingdb` and `vlm` properties — return unhealthy `ComponentStatus` instead of crashing
- Add early `return False` in `is_healthy()` when dependencies aren't ready
- Add 4 tests covering the uninitialized state

## Changes

- `openviking/service/debug_service.py` — defensive None checks in ObserverService
- `tests/misc/test_debug_service.py` — 4 new tests (25 total, all passing)

Closes #298