### PR TITLE
fix(storage): 修复快速重启时向量存储锁竞争问题

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -292,6 +292,9 @@ class OpenVikingService:
             self._transaction_manager.stop()
             self._transaction_manager = None
 
+        if self._vikingdb_manager:
+            self._vikingdb_manager.mark_closing()
+
         if self._queue_manager:
             self._queue_manager.stop()
             self._queue_manager = None

--- a/openviking/storage/vikingdb_manager.py
+++ b/openviking/storage/vikingdb_manager.py
@@ -51,9 +51,18 @@ class VikingDBManager(VikingVectorIndexBackend):
         self._queue_manager = queue_manager
         self._closing = False
 
+    def mark_closing(self) -> None:
+        """Mark the manager as entering shutdown flow.
+
+        Queue workers may still be draining messages before the backend is
+        finally closed. Handlers should check ``is_closing`` and stop writing
+        into vector storage to avoid lock contention during rapid restart.
+        """
+        self._closing = True
+
     async def close(self) -> None:
         """Close storage connection and release resources."""
-        self._closing = True
+        self.mark_closing()
         try:
             # We do NOT stop the queue manager here as it is an injected dependency
             # and should be managed by the creator (OpenVikingService).

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.models.embedder.base import EmbedResult
+from openviking.storage.collection_schemas import TextEmbeddingHandler
+from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
+
+
+class _DummyEmbedder:
+    def __init__(self):
+        self.calls = 0
+
+    def embed(self, text: str) -> EmbedResult:
+        self.calls += 1
+        return EmbedResult(dense_vector=[0.1, 0.2])
+
+
+class _DummyConfig:
+    def __init__(self, embedder: _DummyEmbedder):
+        self.storage = SimpleNamespace(vectordb=SimpleNamespace(name="context"))
+        self.embedding = SimpleNamespace(
+            dimension=2,
+            get_embedder=lambda: embedder,
+        )
+
+
+def _build_queue_payload() -> dict:
+    msg = EmbeddingMsg(
+        message="hello",
+        context_data={
+            "id": "id-1",
+            "uri": "viking://resources/sample",
+            "account_id": "default",
+            "abstract": "sample",
+        },
+    )
+    return {"data": json.dumps(msg.to_dict())}
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_skip_all_work_when_manager_is_closing(monkeypatch):
+    class _ClosingVikingDB:
+        is_closing = True
+
+        async def upsert(self, _data):  # pragma: no cover - should never run
+            raise AssertionError("upsert should not be called during shutdown")
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+
+    handler = TextEmbeddingHandler(_ClosingVikingDB())
+    status = {"success": 0, "error": 0}
+    handler.set_callbacks(
+        on_success=lambda: status.__setitem__("success", status["success"] + 1),
+        on_error=lambda *_: status.__setitem__("error", status["error"] + 1),
+    )
+
+    result = await handler.on_dequeue(_build_queue_payload())
+
+    assert result is None
+    assert embedder.calls == 0
+    assert status["success"] == 1
+    assert status["error"] == 0
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_treats_shutdown_write_lock_as_success(monkeypatch):
+    class _ClosingDuringUpsertVikingDB:
+        def __init__(self):
+            self.is_closing = False
+            self.calls = 0
+
+        async def upsert(self, _data):
+            self.calls += 1
+            self.is_closing = True
+            raise RuntimeError("IO error: lock /tmp/LOCK: already held by process")
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+
+    vikingdb = _ClosingDuringUpsertVikingDB()
+    handler = TextEmbeddingHandler(vikingdb)
+    status = {"success": 0, "error": 0}
+    handler.set_callbacks(
+        on_success=lambda: status.__setitem__("success", status["success"] + 1),
+        on_error=lambda *_: status.__setitem__("error", status["error"] + 1),
+    )
+
+    result = await handler.on_dequeue(_build_queue_payload())
+
+    assert result is None
+    assert vikingdb.calls == 1
+    assert embedder.calls == 1
+    assert status["success"] == 1
+    assert status["error"] == 0


### PR DESCRIPTION
## Description

修复快速重启场景下，队列 worker 仍在 drain 消息并尝试写入向量存储时，与正在关闭的后端产生 LOCK 文件竞争的问题。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- VikingDBManager 提取 mark_closing() 方法，支持在 close() 之前提前标记关闭状态
- OpenVikingService.shutdown() 在停止队列之前先调用 mark_closing()，避免队列 worker 写入已关闭的向量存储
- TextEmbeddingHandler 在 dequeue 入口和 upsert 异常捕获处检查 is_closing 标志，shutdown 期间跳过写入并标记为成功
- 新增 tests/storage/test_collection_schemas.py，覆盖 shutdown 期间跳过 embedding 和 upsert 锁冲突两种场景

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

在 shutdown 流程中，mark_closing() 被提前调用（在停止队列之前），这样队列 worker 在 drain 剩余消息时能感知到关闭状态，主动跳过向量写入操作，避免与 VikingDBManager.close() 产生锁竞争。