### PR TITLE
docs: 修复 openviking serve 命令引用并更新贡献文档

### DIFF
--- a/examples/k8s-helm/templates/deployment.yaml
+++ b/examples/k8s-helm/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              exec uv run --with openviking openviking serve \
+              exec uv run --with openviking openviking-server \
                 --host {{ .Values.server.host }} \
                 --port {{ .Values.server.port }} \
                 --config /etc/openviking/ov.conf

--- a/examples/multi_tenant/admin_workflow.sh
+++ b/examples/multi_tenant/admin_workflow.sh
@@ -10,7 +10,7 @@
 #   1. Configure & start the server with root_api_key:
 #      Copy ov.conf.example to ov.conf, fill in your model API keys, then:
 #
-#      openviking serve --config ./ov.conf
+#      openviking-server --config ./ov.conf
 #
 #      The key config for multi-tenant auth:
 #        {

--- a/examples/server_client/README.md
+++ b/examples/server_client/README.md
@@ -23,9 +23,9 @@ uv sync
 #    参见 ov.conf.example 了解完整配置项
 
 # 2. 启动 Server（另开终端）
-openviking serve                            # 从默认路径读取 ov.conf
-openviking serve --config ./ov.conf         # 指定配置文件
-openviking serve --host 0.0.0.0 --port 1933 # 覆盖 host/port
+openviking-server                            # 从默认路径读取 ov.conf
+openviking-server --config ./ov.conf         # 指定配置文件
+openviking-server --host 0.0.0.0 --port 1933 # 覆盖 host/port
 
 # 3. 配置 CLI 连接（ovcli.conf）
 #    CLI 读取配置的优先级：
@@ -89,16 +89,16 @@ pyproject.toml      # 项目依赖
 
 ```bash
 # 基本启动（从 ~/.openviking/ov.conf 或 $OPENVIKING_CONFIG_FILE 读取配置）
-openviking serve
+openviking-server
 
 # 指定配置文件
-openviking serve --config ./ov.conf
+openviking-server --config ./ov.conf
 
 # 覆盖 host/port
-openviking serve --host 0.0.0.0 --port 1933
+openviking-server --host 0.0.0.0 --port 1933
 ```
 
-`serve` 命令支持 `--config`、`--host`、`--port` 三个选项。认证密钥等其他配置通过 ov.conf 的 `server` 段设置。
+`openviking-server` 命令支持 `--config`、`--host`、`--port` 三个选项。认证密钥等其他配置通过 ov.conf 的 `server` 段设置。
 
 ### Python 脚本
 

--- a/examples/server_client/client_async.py
+++ b/examples/server_client/client_async.py
@@ -5,7 +5,7 @@ OpenViking 异步客户端示例 (HTTP mode)
 使用 AsyncHTTPClient 通过 HTTP 连接远程 Server，演示完整 API。
 
 前置条件:
-    先启动 Server: openviking serve
+    先启动 Server: openviking-server
 
 运行:
     uv run client_async.py

--- a/examples/server_client/client_cli.sh
+++ b/examples/server_client/client_cli.sh
@@ -13,9 +13,9 @@
 #        b) ~/.openviking/ov.conf                  # default path
 #      See ov.conf.example for template.
 #
-#      openviking serve                            # default: localhost:1933
-#      openviking serve --port 8080                # custom port
-#      openviking serve --config /path/to/ov.conf  # explicit config path
+#      openviking-server                            # default: localhost:1933
+#      openviking-server --port 8080                # custom port
+#      openviking-server --config /path/to/ov.conf  # explicit config path
 #
 #   2. Configure CLI connection (ovcli.conf):
 #      CLI reads ovcli.conf from (priority high → low):

--- a/examples/server_client/client_sync.py
+++ b/examples/server_client/client_sync.py
@@ -5,7 +5,7 @@ OpenViking 同步客户端示例 (HTTP mode)
 使用 SyncHTTPClient 通过 HTTP 连接远程 Server，演示完整 API。
 
 前置条件:
-    先启动 Server: openviking serve
+    先启动 Server: openviking-server
 
 运行:
     uv run client_sync.py


### PR DESCRIPTION
## Summary

- 将示例和脚本中失效的裸命令 `openviking serve` 统一替换为 `openviking-server`（`openviking` 入口已改为 Rust CLI 包装器）
- CONTRIBUTING 文档新增 Rust CLI 编译安装说明（`cargo install --path crates/ov_cli`）
- 修正 CONTRIBUTING 中测试示例：移除多余的 `@pytest.mark.asyncio` 装饰器（项目使用 `asyncio_mode = "auto"`）、更正测试文件路径和 fixture 用法
- 更新 CONTRIBUTING 项目结构，补充 `server/`、`crates/ov_cli/`、`src/`、测试子目录等缺失条目

## Type of Change

- [x] Documentation (docs)

## Testing

- [ ] 文档变更，无需运行测试
- [ ] 手动确认所有 `openviking serve` 裸命令引用已替换
- [ ] `python -m openviking serve` 引用保持不变（仍可用）

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] 中英文 CONTRIBUTING 同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)