### PR TITLE
fix: 为 openviking-server 添加 --version 并修复 AGFS 模式判断

### DIFF
--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -12,11 +12,25 @@ from openviking.server.config import load_server_config
 from openviking_cli.utils.logger import configure_uvicorn_logging
 
 
+def _get_version() -> str:
+    try:
+        from openviking import __version__
+
+        return __version__
+    except ImportError:
+        return "unknown"
+
+
 def main():
     """Main entry point for openviking-server command."""
     parser = argparse.ArgumentParser(
         description="OpenViking HTTP Server",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"openviking-server {_get_version()}",
     )
     parser.add_argument(
         "--host",

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -112,7 +112,7 @@ class OpenVikingService:
         from openviking.utils.agfs_utils import create_agfs_client
 
         mode = getattr(config.agfs, "mode", "http-client")
-        if mode == "http-client" and config.agfs.backend == "local":
+        if mode == "http-client":
             self._agfs_manager = AGFSManager(config=config.agfs)
             self._agfs_manager.start()
             self._agfs_url = self._agfs_manager.url


### PR DESCRIPTION
## Description

为 `openviking-server` 命令添加 `--version` 参数支持，并修复 AGFS 初始化时多余的条件判断。

## Related Issue

close #354

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `openviking/server/bootstrap.py`：添加 `--version` 参数，通过 argparse 的 `action="version"` 实现，版本号从 `openviking.__version__` 读取
- `openviking/service/core.py`：移除 AGFS 初始化中 `config.agfs.backend == "local"` 的多余条件，使 http-client 模式下始终启动 AGFSManager

## Testing

- [x] `openviking-server --version` 正常输出版本号（`openviking-server 0.2.1.dev23`）
- [x] `openviking-server --help` 正常显示 `--version` 选项
- [x] `ov --version`（Rust CLI）确认已支持（`openviking 0.2.0`）
- [x] pre-commit hooks（ruff check + ruff format）通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

`openviking-server` 之前缺少 `--version` 参数，agent 误调用 `openviking-server --version` 时会报 option not found 导致安装流程中断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
