### PR TITLE
chore: bump CLI version to 0.2.1

### DIFF
--- a/crates/ov_cli/Cargo.toml
+++ b/crates/ov_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ov_cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["OpenViking Contributors"]
 description = "Rust CLI client for OpenViking"


### PR DESCRIPTION
prepare for cli@0.2.1 release