### PR TITLE
fix: expand tilde in storage config paths

### DIFF
--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -335,7 +335,7 @@ def initialize_openviking_config(
         config.storage.vectordb.backend = config.storage.vectordb.backend or "local"
         # Resolve and update workspace + dependent paths (model_validator won't
         # re-run on attribute assignment, so sync agfs.path / vectordb.path here).
-        workspace_path = Path(path).resolve()
+        workspace_path = Path(path).expanduser().resolve()
         workspace_path.mkdir(parents=True, exist_ok=True)
         resolved = str(workspace_path)
         config.storage.workspace = resolved

--- a/openviking_cli/utils/config/storage_config.py
+++ b/openviking_cli/utils/config/storage_config.py
@@ -51,7 +51,7 @@ class StorageConfig(BaseModel):
             )
 
         # Update paths to use workspace
-        workspace_path = Path(self.workspace).resolve()
+        workspace_path = Path(self.workspace).expanduser().resolve()
         workspace_path.mkdir(parents=True, exist_ok=True)
         self.workspace = str(workspace_path)
         self.agfs.path = self.workspace
@@ -65,7 +65,7 @@ class StorageConfig(BaseModel):
         Returns:
             Path to {workspace}/temp/upload directory
         """
-        workspace_path = Path(self.workspace).resolve()
+        workspace_path = Path(self.workspace).expanduser().resolve()
         upload_temp_dir = workspace_path / "temp" / "upload"
         upload_temp_dir.mkdir(parents=True, exist_ok=True)
         return upload_temp_dir


### PR DESCRIPTION
## Summary
- Fix `~` (tilde) not being expanded in storage config paths
- `Path.resolve()` does not expand `~` to home directory; added `expanduser()` before `resolve()` so users can use paths like `~/.openviking/data` in config

## Test plan
- [x] Verify `storage.workspace: "~/data"` expands correctly to `/home/user/data`
- [x] Verify absolute paths still work unchanged
- [ ] Verify relative paths still resolve correctly