### PR TITLE
fix: Session.add_message() support parts parameter

### DIFF
--- a/examples/claude-memory-plugin/scripts/ov_memory.py
+++ b/examples/claude-memory-plugin/scripts/ov_memory.py
@@ -15,7 +15,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -63,11 +62,7 @@ def _health_check(url: str, timeout: float = 1.2) -> bool:
 
 
 def _resolve_local_data_path(project_dir: Path, ov_conf: Dict[str, Any]) -> str:
-    raw = (
-        ov_conf.get("storage", {})
-        .get("vectordb", {})
-        .get("path", "./data")
-    )
+    raw = ov_conf.get("storage", {}).get("vectordb", {}).get("path", "./data")
     if not raw:
         raw = "./data"
     p = Path(str(raw)).expanduser()
@@ -134,8 +129,14 @@ class OVClient:
     def create_session(self) -> Dict[str, Any]:
         return self.client.create_session()
 
-    def add_message(self, session_id: str, role: str, content: str) -> Dict[str, Any]:
-        return self.client.add_message(session_id, role, content)
+    def add_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str | None = None,
+        parts: list[dict] | None = None,
+    ) -> Dict[str, Any]:
+        return self.client.add_message(session_id, role, content, parts)
 
     def commit_session(self, session_id: str) -> Dict[str, Any]:
         return self.client.commit_session(session_id)
@@ -623,7 +624,9 @@ def cmd_recall(args: argparse.Namespace) -> int:
             uri = item.get("uri", "")
             if not uri:
                 continue
-            if uri not in dedup or float(item.get("score", 0.0)) > float(dedup[uri].get("score", 0.0)):
+            if uri not in dedup or float(item.get("score", 0.0)) > float(
+                dedup[uri].get("score", 0.0)
+            ):
                 dedup[uri] = item
 
         ranked = sorted(

--- a/openviking/client/session.py
+++ b/openviking/client/session.py
@@ -5,8 +5,10 @@
 Session delegates all operations to the underlying Client (LocalClient or AsyncHTTPClient).
 """
 
-from typing import TYPE_CHECKING, Any, Dict
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from openviking.message.part import Part
 from openviking_cli.session.user_id import UserIdentifier
 
 if TYPE_CHECKING:
@@ -32,17 +34,28 @@ class Session:
         self.session_id = session_id
         self.user = user
 
-    async def add_message(self, role: str, content: str) -> Dict[str, Any]:
+    async def add_message(
+        self,
+        role: str,
+        content: Optional[str] = None,
+        parts: Optional[List[Part]] = None,
+    ) -> Dict[str, Any]:
         """Add a message to the session.
 
         Args:
             role: Message role (e.g., "user", "assistant")
-            content: Message content
+            content: Text content (simple mode)
+            parts: Parts list (TextPart, ContextPart, ToolPart)
+
+        If both content and parts are provided, parts takes precedence.
 
         Returns:
             Result dict with session_id and message_count
         """
-        return await self._client.add_message(self.session_id, role, content)
+        if parts is not None:
+            parts_dicts = [asdict(p) for p in parts]
+            return await self._client.add_message(self.session_id, role, parts=parts_dicts)
+        return await self._client.add_message(self.session_id, role, content=content)
 
     async def commit(self) -> Dict[str, Any]:
         """Commit the session (archive messages and extract memories).


### PR DESCRIPTION
## Description

Fix Session.add_message() and OVClient.add_message() to support the parts parameter (TextPart, ContextPart, ToolPart), aligning the wrapper API with the underlying BaseClient and documentation.

## Related Issue

Fixes #397

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **openviking/client/session.py**: Updated Session.add_message() signature to accept optional parts: List[Part] in addition to content: str. When parts is provided, converts Part dataclass objects to dicts via dataclasses.asdict() before passing to the underlying client.
- **examples/claude-memory-plugin/scripts/ov_memory.py**: Updated OVClient.add_message() to expose the parts parameter, passing it through to the underlying sync client.

## Testing

- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The underlying infrastructure (BaseClient, AsyncHTTPClient, LocalClient, server-side Session) all already support parts. Only the user-facing Session wrapper class and the OVClient example were missing this parameter.