### PR TITLE
feat: support GitHub tree/<ref> URL for code repository import

### DIFF
--- a/openviking/parse/parsers/code/code.py
+++ b/openviking/parse/parsers/code/code.py
@@ -121,13 +121,13 @@ class CodeRepositoryParser(BaseParser):
                 )
             elif source_str.startswith(("http://", "https://", "git://", "ssh://")):
                 repo_url, branch, commit = self._parse_repo_source(source_str, **kwargs)
-                if self._is_github_url(repo_url) and not commit:
-                    # Use GitHub ZIP API: single HTTPS download, no git history, much faster
+                if self._is_github_url(repo_url):
+                    # Use GitHub ZIP API: supports branch names, tags, and commit SHAs
                     local_dir, repo_name = await self._github_zip_download(
-                        repo_url, branch, temp_local_dir
+                        repo_url, branch or commit, temp_local_dir
                     )
                 else:
-                    # Non-GitHub URL or specific commit: fall back to git clone
+                    # Non-GitHub URL: use git clone
                     repo_name = await self._git_clone(
                         repo_url,
                         temp_local_dir,
@@ -243,8 +243,17 @@ class CodeRepositoryParser(BaseParser):
         if "tree" in parts:
             idx = parts.index("tree")
             if idx + 1 < len(parts):
-                branch = unquote(parts[idx + 1])
+                ref = unquote(parts[idx + 1])
+                if self._looks_like_sha(ref):
+                    commit = ref
+                else:
+                    branch = ref
         return branch, commit
+
+    @staticmethod
+    def _looks_like_sha(ref: str) -> bool:
+        """Return True if ref looks like a git commit SHA (7-40 hex chars)."""
+        return 7 <= len(ref) <= 40 and all(c in "0123456789abcdefABCDEF" for c in ref)
 
     def _normalize_repo_url(self, url: str) -> str:
         if url.startswith(("http://", "https://", "git://", "ssh://")):
@@ -346,7 +355,7 @@ class CodeRepositoryParser(BaseParser):
         repo_slug = repo_raw[:-4] if repo_raw.endswith(".git") else repo_raw
 
         if branch:
-            zip_url = f"https://github.com/{owner}/{repo_slug}/archive/refs/heads/{branch}.zip"
+            zip_url = f"https://github.com/{owner}/{repo_slug}/archive/{branch}.zip"
         else:
             zip_url = f"https://github.com/{owner}/{repo_slug}/archive/HEAD.zip"
 

--- a/openviking/utils/code_hosting_utils.py
+++ b/openviking/utils/code_hosting_utils.py
@@ -179,6 +179,12 @@ def is_git_repo_url(url: str) -> bool:
         # Strip .git suffix from last part for counting
         if path_parts and path_parts[-1].endswith(".git"):
             path_parts[-1] = path_parts[-1][:-4]
-        return len(path_parts) == 2
+        # owner/repo
+        if len(path_parts) == 2:
+            return True
+        # owner/repo/tree/<ref> (branch name or commit SHA)
+        if len(path_parts) == 4 and path_parts[2] == "tree":
+            return True
+        return False
 
     return False


### PR DESCRIPTION
Background

  Previously, only plain repository URLs (https://github.com/user/repo) were recognized as code repositories. URLs containing a specific branch or commit ref (e.g.,
  https://github.com/user/repo/tree/main) were routed to HTMLParser and treated as regular web pages, making it impossible to import a specific version of a repository.

  Changes

  openviking/utils/code_hosting_utils.py

  Extended is_git_repo_url to recognize owner/repo/tree/<ref> URLs in addition to plain owner/repo URLs. Only exactly 4-segment paths with tree at position 2 are matched,
  avoiding false positives like /blob/, /issues/, or deeper sub-paths.

  openviking/parse/parsers/code/code.py

  - _parse_ref_from_path: When a tree/<ref> URL is parsed, the ref is now checked against a hex heuristic (_looks_like_sha). If it looks like a commit SHA (7–40 hex
  characters), it is placed in the commit field; otherwise it goes to branch. This ensures non-GitHub hosts use the correct git operation (--branch for branches, fetch +
  checkout for SHAs).
  - _github_zip_download: Fixed ZIP URL construction — removed the refs/heads/ prefix so the URL works for branch names, tags, and commit SHAs alike (archive/{ref}.zip).
  - parse(): GitHub now always uses the ZIP API regardless of whether a branch or commit is specified, passing branch or commit as the ref.

  Usage

  # branch
  client.add_resource("https://github.com/user/repo/tree/main")

  # commit SHA (short or full)
  client.add_resource("https://github.com/user/repo/tree/ab849f44f252e65b2ea3106322c235d8c2f349ad")
  client.add_resource("https://github.com/user/repo/tree/ab849f4")