### PR TITLE
fix: improve ISO datetime parsing

### DIFF
--- a/openviking/core/context.py
+++ b/openviking/core/context.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
-from openviking.utils.time_utils import format_iso8601
+from openviking.utils.time_utils import format_iso8601, parse_iso_datetime
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -199,12 +199,12 @@ class Context:
             context_type=data.get("context_type"),
             category=data.get("category"),
             created_at=(
-                datetime.fromisoformat(data["created_at"])
+                parse_iso_datetime(data["created_at"])
                 if isinstance(data.get("created_at"), str)
                 else data.get("created_at")
             ),
             updated_at=(
-                datetime.fromisoformat(data["updated_at"])
+                parse_iso_datetime(data["updated_at"])
                 if isinstance(data.get("updated_at"), str)
                 else data.get("updated_at")
             ),

--- a/openviking/message/message.py
+++ b/openviking/message/message.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
 from openviking.message.part import ContextPart, Part, TextPart, ToolPart
-from openviking.utils.time_utils import format_iso8601
+from openviking.utils.time_utils import format_iso8601, parse_iso_datetime
 
 
 @dataclass
@@ -108,7 +108,7 @@ class Message:
             id=data["id"],
             role=data["role"],
             parts=parts,
-            created_at=datetime.fromisoformat(data["created_at"]),
+            created_at=parse_iso_datetime(data["created_at"]),
         )
 
     @classmethod

--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -16,6 +16,7 @@ from openviking.retrieve.memory_lifecycle import hotness_score
 from openviking.server.identity import RequestContext, Role
 from openviking.storage import VikingVectorIndexBackend
 from openviking.storage.viking_fs import get_viking_fs
+from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.retrieve.types import (
     ContextType,
     MatchedContext,
@@ -398,7 +399,7 @@ class HierarchicalRetriever:
             updated_at_raw = c.get("updated_at")
             if isinstance(updated_at_raw, str):
                 try:
-                    updated_at_val = datetime.fromisoformat(updated_at_raw)
+                    updated_at_val = parse_iso_datetime(updated_at_raw)
                 except (ValueError, TypeError):
                     updated_at_val = None
             elif isinstance(updated_at_raw, datetime):

--- a/openviking/utils/time_utils.py
+++ b/openviking/utils/time_utils.py
@@ -12,7 +12,10 @@ def parse_iso_datetime(value: str) -> datetime:
     where the fractional seconds exceed Python's 6-digit microsecond limit.
     This helper truncates the excess digits before parsing.
     """
-    return datetime.fromisoformat(_EXCESS_FRAC_RE.sub(r"\1", value))
+    normalized = _EXCESS_FRAC_RE.sub(r"\1", value)
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    return datetime.fromisoformat(normalized)
 
 
 def format_iso8601(dt: datetime) -> str:

--- a/tests/unit/test_time_utils.py
+++ b/tests/unit/test_time_utils.py
@@ -1,0 +1,24 @@
+from datetime import timezone
+
+from openviking.core.context import Context
+from openviking.utils.time_utils import parse_iso_datetime
+
+
+def test_parse_iso_datetime_accepts_z_suffix():
+    dt = parse_iso_datetime("2026-03-03T01:26:14.481Z")
+    assert dt.tzinfo is not None
+    assert dt.utcoffset() == timezone.utc.utcoffset(dt)
+
+
+def test_context_from_dict_accepts_z_timestamps():
+    ctx = Context.from_dict(
+        {
+            "uri": "viking://user/default/memories/entities/mem_x.md",
+            "created_at": "2026-03-03T01:26:14.481Z",
+            "updated_at": "2026-03-03T01:27:14.481Z",
+            "is_leaf": True,
+            "context_type": "memory",
+        }
+    )
+    assert ctx.created_at is not None
+    assert ctx.updated_at is not None


### PR DESCRIPTION
## Description
Improve ISO 8601 datetime parsing to accept `Z`-suffix timestamps and trim excessive fractional seconds, then use this parser across core read paths.

## Related Issue
Fixes #<fill-issue-id-if-any>

## Root Cause
Two related parsing gaps caused valid timestamps to fail:

- `datetime.fromisoformat()` does not accept `Z` suffix (e.g., `2026-03-03T01:26:14.481Z`).
- Windows-style timestamps can include more than 6 fractional digits, which `fromisoformat()` rejects.

These inputs appear in stored context/message timestamps, leading to `ValueError` during deserialization.

## Changes Made
| File | Change |
| --- | --- |
| `openviking/utils/time_utils.py` | Normalize `Z` -> `+00:00` and trim excessive fractional seconds before parsing. |
| `openviking/core/context.py` | Use `parse_iso_datetime()` for `created_at` and `updated_at`. |
| `openviking/message/message.py` | Use `parse_iso_datetime()` for message `created_at`. |
| `openviking/retrieve/hierarchical_retriever.py` | Use `parse_iso_datetime()` when parsing `updated_at`. |
| `tests/unit/test_time_utils.py` | Added unit tests for `Z`-suffix parsing and context deserialization. |

## Design Decisions
- Reuse existing utility: `parse_iso_datetime()` already handled excess fractional seconds; the fix extends it to accept `Z`.
- Backward compatible: Inputs already accepted by `fromisoformat()` still parse correctly.
- Minimal surface area: Only the affected parsing call sites were updated.

## Testing
Before:
- `Context.from_dict({"created_at": "2026-03-03T01:26:14.481Z"})` -> `ValueError`

After:
- `parse_iso_datetime("2026-03-03T01:26:14.481Z")` -> timezone-aware `datetime`
- `Context.from_dict(...)` -> parses without error

Tests:
- `python -m pytest tests/unit/test_time_utils.py`

## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
