### PR TITLE
fix: handle None data in skill_processor._parse_skill()

### DIFF
--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -58,6 +58,9 @@ class SkillProcessor:
             Processing result with status and metadata
         """
 
+        if data is None:
+            raise ValueError("Skill data cannot be None")
+
         config = get_openviking_config()
 
         skill_dict, auxiliary_files, base_path = self._parse_skill(data)
@@ -115,6 +118,9 @@ class SkillProcessor:
 
     def _parse_skill(self, data: Any) -> tuple[Dict[str, Any], List[Path], Optional[Path]]:
         """Parse skill data from various formats."""
+        if data is None:
+            raise ValueError("Skill data cannot be None")
+
         auxiliary_files = []
         base_path = None
 

--- a/tests/unit/test_skill_processor_none.py
+++ b/tests/unit/test_skill_processor_none.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SkillProcessor None data handling.
+
+Verifies that SkillProcessor raises a clear ValueError when
+skill data is None, instead of falling through to the generic
+'Unsupported data type' error.
+"""
+
+import pytest
+
+from openviking.utils.skill_processor import SkillProcessor
+
+
+class TestParseSkillNoneData:
+    """SkillProcessor._parse_skill should reject None with a clear message."""
+
+    def test_parse_skill_none_raises_value_error(self):
+        """None data should raise ValueError with explicit message."""
+        processor = SkillProcessor(vikingdb=None)
+        with pytest.raises(ValueError, match="Skill data cannot be None"):
+            processor._parse_skill(None)
+
+    def test_parse_skill_none_not_unsupported_type(self):
+        """None should NOT produce the generic 'Unsupported data type' message."""
+        processor = SkillProcessor(vikingdb=None)
+        with pytest.raises(ValueError) as exc_info:
+            processor._parse_skill(None)
+        assert "Unsupported data type" not in str(exc_info.value)
+
+    def test_parse_skill_valid_dict_passes(self):
+        """A valid dict should not raise."""
+        processor = SkillProcessor(vikingdb=None)
+        skill_dict, aux_files, base_path = processor._parse_skill(
+            {"name": "test-skill", "description": "A test skill"}
+        )
+        assert skill_dict["name"] == "test-skill"
+        assert aux_files == []
+        assert base_path is None
+
+    def test_parse_skill_unsupported_type_still_raises(self):
+        """Non-None unsupported types should still raise with type info."""
+        processor = SkillProcessor(vikingdb=None)
+        with pytest.raises(ValueError, match="Unsupported data type"):
+            processor._parse_skill(12345)


### PR DESCRIPTION
## Problem

`_parse_skill()` raises `ValueError: Unsupported data type: <class 'NoneType'>` when `data` is `None`. This causes confusing 500 errors on the `/api/v1/skills` endpoint when called with empty/null data.

The `None` value falls through all `isinstance` checks and hits the generic `else` branch, producing an unhelpful error message.

## Fix

Add an explicit `None` guard at the beginning of both:
- `process_skill()` (public API, defense in depth)
- `_parse_skill()` (where the actual parsing happens)

Both raise `ValueError("Skill data cannot be None")` with a clear, actionable message.

## Tests

Added `tests/unit/test_skill_processor_none.py` with 4 tests:
- `test_parse_skill_none_raises_value_error` — None raises ValueError with explicit message
- `test_parse_skill_none_not_unsupported_type` — error message is NOT the generic one
- `test_parse_skill_valid_dict_passes` — valid dict input still works
- `test_parse_skill_unsupported_type_still_raises` — other invalid types still get the generic error

All tests pass.