### PR TITLE
fix: treat only .zip as archive; avoid unzipping ZIP-based container …

### DIFF
--- a/openviking/utils/media_processor.py
+++ b/openviking/utils/media_processor.py
@@ -119,8 +119,9 @@ class UnifiedResourceProcessor:
         **kwargs,
     ) -> ParseResult:
         """Process file with unified parsing."""
-        # Check if it's a zip file
-        if zipfile.is_zipfile(file_path):
+        ext = file_path.suffix.lower()
+        # Only treat .zip files as archives to extract.
+        if ext == ".zip" and zipfile.is_zipfile(file_path):
             temp_dir = Path(tempfile.mkdtemp())
             try:
                 with zipfile.ZipFile(file_path, "r") as zipf:


### PR DESCRIPTION
fix: treat only .zip as archive; avoid unzipping ZIP-based container formats (OOXML)

## Description

**English:**
This PR fixes an issue where ZIP-based container formats (such as `.docx`, `.xlsx`, `.pptx`) were incorrectly identified as generic ZIP archives and unzipped, bypassing their dedicated parsers. The fix introduces a specific check for the `.zip` file extension before attempting to unzip, ensuring that only true ZIP archives are treated as compressed directories. This allows Office documents (which are technically ZIP files) to fall through to their specialized parsers (e.g., via `registry.get_parser_for_file`).

**中文:**
本 PR 修复了一个问题：基于 ZIP 容器格式的文件（如 `.docx`, `.xlsx`, `.pptx`）被错误地识别为普通 ZIP 压缩包并被解压，从而绕过了它们专用的解析器。该修复在尝试解压之前引入了针对 `.zip` 文件扩展名的特定检查，确保只有真正的 ZIP 归档文件才会被作为压缩目录处理。这使得 Office 文档（本质上是 ZIP 文件）能够正确地传递给它们专门的解析器（例如通过 `registry.get_parser_for_file`）。

## Related Issue

Fixes #407

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

**English:**
- Added a check for `.zip` extension combined with `zipfile.is_zipfile` in `openviking/utils/media_processor.py`.
- Prioritized explicit `.zip` handling to prevent generic ZIP detection from intercepting OOXML files.

**中文:**
- 在 `openviking/utils/media_processor.py` 中添加了结合 `.zip` 扩展名和 `zipfile.is_zipfile` 的检查。
- 优先处理显式的 `.zip` 文件，防止通用的 ZIP 检测逻辑拦截 OOXML 文件。

## Testing

- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->