### PR TITLE
fix(cli): support git@ SSH URL format in add-resource

### DIFF
--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -603,8 +603,11 @@ async fn handle_add_resource(
     no_directly_upload_media: bool,
     ctx: CliContext,
 ) -> Result<()> {
-    // Validate path: if it's a local path, check if it exists
-    if !path.starts_with("http://") && !path.starts_with("https://") {
+    let is_url = path.starts_with("http://") 
+        || path.starts_with("https://")
+        || path.starts_with("git@");
+    
+    if !is_url {
         use std::path::Path;
         
         // Unescape path: replace backslash followed by space with just space


### PR DESCRIPTION
- CLI: Add git@ URL recognition in path validation

This fixes the error when using git@ SSH URLs like:
  ov add-resource 'git@github.com:user/repo.git'

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue
[Bug]: Error when using git@ SSH URLs #412

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->


## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
