### PR TITLE
fix(session): trigger semantic indexing for parent directory after memory extraction

### DIFF
--- a/openviking/session/compressor.py
+++ b/openviking/session/compressor.py
@@ -67,13 +67,15 @@ class SessionCompressor:
         self.extractor = MemoryExtractor()
         self.deduplicator = MemoryDeduplicator(vikingdb=vikingdb)
 
-    async def _index_memory(self, memory: Context) -> bool:
-        """Add memory to vectorization queue."""
+    async def _index_memory(self, memory: Context, ctx: RequestContext) -> bool:
+        """Add memory to vectorization queue and trigger parent directory semantic generation."""
         from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 
         embedding_msg = EmbeddingMsgConverter.from_context(memory)
         await self.vikingdb.enqueue_embedding_msg(embedding_msg)
         logger.info(f"Enqueued memory for vectorization: {memory.uri}")
+
+        await self.extractor._enqueue_semantic_for_parent(memory.uri, ctx)
         return True
 
     async def _merge_into_existing(
@@ -106,7 +108,7 @@ class SessionCompressor:
                 "Merged memory %s with abstract %s", target_memory.uri, target_memory.abstract
             )
             target_memory.set_vectorize(Vectorize(text=payload.content))
-            await self._index_memory(target_memory)
+            await self._index_memory(target_memory, ctx)
             return True
         except Exception as e:
             logger.error(f"Failed to merge memory {target_memory.uri}: {e}")
@@ -162,7 +164,7 @@ class SessionCompressor:
                 if memory:
                     memories.append(memory)
                     stats.created += 1
-                    await self._index_memory(memory)
+                    await self._index_memory(memory, ctx)
                 else:
                     stats.skipped += 1
                 continue
@@ -170,7 +172,9 @@ class SessionCompressor:
             # Tool/Skill Memory: 特殊合并逻辑
             if candidate.category in TOOL_SKILL_CATEGORIES:
                 if isinstance(candidate, ToolSkillCandidateMemory):
-                    tool_name, skill_name, tool_status = self._get_tool_skill_info(candidate, tool_parts)
+                    tool_name, skill_name, tool_status = self._get_tool_skill_info(
+                        candidate, tool_parts
+                    )
                     candidate.tool_status = tool_status
                     if skill_name:
                         memory = await self.extractor._merge_skill_memory(
@@ -187,7 +191,7 @@ class SessionCompressor:
                     if memory:
                         memories.append(memory)
                         stats.merged += 1
-                        await self._index_memory(memory)
+                        await self._index_memory(memory, ctx)
                 continue
 
             # Dedup check for other categories
@@ -250,7 +254,7 @@ class SessionCompressor:
                 if memory:
                     memories.append(memory)
                     stats.created += 1
-                    await self._index_memory(memory)
+                    await self._index_memory(memory, ctx)
                 else:
                     stats.skipped += 1
 
@@ -316,7 +320,6 @@ class SessionCompressor:
                         calibrated_tool = candidate_tool
                 else:
                     calibrated_tool = part.tool_name
-                
 
         if calibrated_skill:
             return ("", calibrated_skill, tool_status)
@@ -346,6 +349,7 @@ class SessionCompressor:
             return True
 
         from difflib import SequenceMatcher
+
         ratio = SequenceMatcher(None, n1, n2).ratio()
         return ratio >= 0.7
 

--- a/openviking/session/memory_extractor.py
+++ b/openviking/session/memory_extractor.py
@@ -66,8 +66,8 @@ class ToolSkillCandidateMemory(CandidateMemory):
     duration_ms: int = 0  # 执行耗时（毫秒）
     prompt_tokens: int = 0  # 输入 Token
     completion_tokens: int = 0  # 输出 Token
-    call_time: int = 0 # 调用次数
-    success_time: int = 0 # 成功调用次数
+    call_time: int = 0  # 调用次数
+    success_time: int = 0  # 成功调用次数
 
 
 @dataclass
@@ -241,7 +241,6 @@ class MemoryExtractor:
 
         messages = context["messages"]
 
-
         tool_stats_map = self._collect_tool_stats_from_messages(messages)
 
         # logger.warning(f"tool_stats_map={tool_stats_map}")
@@ -315,8 +314,8 @@ class MemoryExtractor:
                             language=output_language,
                             tool_name=tool_name,
                             skill_name=skill_name,
-                            call_time=stats.get("call_count",0),
-                            success_time=stats.get("success_time",0),
+                            call_time=stats.get("call_count", 0),
+                            success_time=stats.get("success_time", 0),
                             duration_ms=stats.get("duration_ms", 0),
                             prompt_tokens=stats.get("prompt_tokens", 0),
                             completion_tokens=stats.get("completion_tokens", 0),
@@ -563,7 +562,7 @@ class MemoryExtractor:
             new_stats = self._parse_tool_statistics(candidate.content)
             if new_stats["total_calls"] == 0:
                 new_stats["total_calls"] = 1
-                tool_status = getattr(candidate, 'tool_status', 'completed')
+                tool_status = getattr(candidate, "tool_status", "completed")
                 if tool_status == "error":
                     new_stats["fail_count"] = 1
                     new_stats["success_count"] = 0
@@ -575,14 +574,12 @@ class MemoryExtractor:
             merged_stats = self._compute_statistics_derived(new_stats)
             merged_content = self._generate_tool_memory_content(tool_name, merged_stats, candidate)
             await viking_fs.write_file(uri=uri, content=merged_content, ctx=ctx)
-            await self._enqueue_semantic_for_parent(uri, ctx)
             return self._create_tool_context(uri, candidate, ctx)
 
         existing_stats = self._parse_tool_statistics(existing)
         merged_stats = self._merge_tool_statistics(existing_stats, new_stats)
         merged_content = self._generate_tool_memory_content(tool_name, merged_stats, candidate)
         await viking_fs.write_file(uri=uri, content=merged_content, ctx=ctx)
-        await self._enqueue_semantic_for_parent(uri, ctx)
         return self._create_tool_context(uri, candidate, ctx)
 
     async def _enqueue_semantic_for_parent(self, file_uri: str, ctx: "RequestContext") -> None:
@@ -680,11 +677,11 @@ class MemoryExtractor:
             first_nonzero = -1
             s = f"{value_ms:.20f}"
             for i, c in enumerate(s):
-                if c not in ('0', '.'):
+                if c not in ("0", "."):
                     first_nonzero = i
                     break
             if first_nonzero > 0:
-                decimals_needed = first_nonzero - s.index('.') + 1
+                decimals_needed = first_nonzero - s.index(".") + 1
                 formatted = f"{value_ms:.{decimals_needed}f}"
         return f"{formatted}ms"
 
@@ -760,14 +757,12 @@ class MemoryExtractor:
                 skill_name, merged_stats, candidate
             )
             await viking_fs.write_file(uri=uri, content=merged_content, ctx=ctx)
-            await self._enqueue_semantic_for_parent(uri, ctx)
             return self._create_skill_context(uri, candidate, ctx)
 
         existing_stats = self._parse_skill_statistics(existing)
         merged_stats = self._merge_skill_statistics(existing_stats, new_stats)
         merged_content = self._generate_skill_memory_content(skill_name, merged_stats, candidate)
         await viking_fs.write_file(uri=uri, content=merged_content, ctx=ctx)
-        await self._enqueue_semantic_for_parent(uri, ctx)
         return self._create_skill_context(uri, candidate, ctx)
 
     def _compute_skill_statistics_derived(self, stats: dict) -> dict:


### PR DESCRIPTION
## Description

Extracted memories were not searchable via vector search because the parent directory's `.abstract.md`/`.overview.md` (level 0/1) were never generated after memory extraction, making them invisible to the hierarchical retriever's global search phase.

## Related Issue

Fixes #422

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`openviking/session/compressor.py`**: Add `_enqueue_semantic_for_parent()` call in `_index_memory()` to trigger parent directory semantic generation (`.abstract.md`/`.overview.md`) after every memory indexing operation. This ensures the hierarchical retriever can discover the directory at level 0/1 and then drill into level-2 memory files.
- **`openviking/session/memory_extractor.py`**: Remove duplicate `_enqueue_semantic_for_parent()` calls from `_merge_tool_memory()` and `_merge_skill_memory()`, since `_index_memory()` in the compressor now handles this uniformly for all memory types.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

**Root cause**: The search system uses hierarchical retrieval -- it first searches directory-level summaries (`.abstract.md` at level 0/1), then drills into matched directories to find actual files (level 2). Resource ingestion correctly triggers the full `SemanticQueue -> SemanticProcessor` pipeline, but memory extraction only enqueued the memory file itself (level 2) to `EmbeddingQueue`, skipping the parent directory semantic generation step.
<img width="1404" height="471" alt="image" src="https://github.com/user-attachments/assets/d6dbe3c6-09c5-49c7-a85b-6f3abd6457c7" />

