### PR TITLE
fix(server): add --workers flag to prevent single blocking request stalling HTTP server

### DIFF
--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -80,6 +80,19 @@ def main():
         help="Vikingbot OpenAPIChannel URL (default: http://localhost:18790)",
     )
     parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Number of uvicorn worker processes (default: 1). "
+            "Use N > 1 in production to prevent a single slow request from "
+            "stalling the entire HTTP server. "
+            "When N > 1 the app is loaded independently in each worker "
+            "process; --bot is not supported in this mode."
+        ),
+    )
+    parser.add_argument(
         "--enable-bot-logging",
         action="store_true",
         dest="enable_bot_logging",
@@ -118,15 +131,46 @@ def main():
         config.with_bot = True
     if args.bot_url:
         config.bot_api_url = args.bot_url
+    if args.workers is not None:
+        config.workers = args.workers
 
     # Configure logging for Uvicorn
     configure_uvicorn_logging()
 
-    # Create and run app
-    app = create_app(config)
     print(f"OpenViking HTTP Server is running on {config.host}:{config.port}")
+    if config.workers > 1:
+        print(f"Workers: {config.workers} (multi-process mode)")
     if config.with_bot:
         print(f"Bot API proxy enabled, forwarding to {config.bot_api_url}")
+
+    if config.workers > 1:
+        # Multi-process mode: pass the app as an import string so each worker
+        # process can independently import and initialise it.  The config file
+        # path is propagated via the OPENVIKING_CONFIG_FILE environment
+        # variable that was set earlier in this function.
+        #
+        # --bot / vikingbot gateway is not supported with workers > 1 because
+        # the bot subprocess is managed by the parent process only.
+        if config.with_bot:
+            print(
+                "Warning: --with-bot is not supported when --workers > 1; "
+                "bot proxy will be disabled.  Run a separate openviking-server "
+                "instance with workers=1 if you need the bot proxy."
+            )
+        uvicorn.run(
+            "openviking.server.app:create_app",
+            factory=True,
+            host=config.host,
+            port=config.port,
+            workers=config.workers,
+            log_config=None,
+        )
+        return
+
+    # Single-worker mode (default): create the app in this process and hand it
+    # directly to uvicorn.  This is the original behaviour and supports the
+    # vikingbot gateway subprocess.
+    app = create_app(config)
 
     # Determine if bot logging should be enabled
     enable_bot_logging = args.enable_bot_logging

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -29,6 +29,7 @@ class ServerConfig:
     port: int = 1933
     root_api_key: Optional[str] = None
     cors_origins: List[str] = field(default_factory=lambda: ["*"])
+    workers: int = 1  # Number of uvicorn worker processes
     with_bot: bool = False  # Enable Bot API proxy to Vikingbot
     bot_api_url: str = "http://localhost:18790"  # Vikingbot OpenAPIChannel URL (default port)
 
@@ -72,6 +73,7 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
         port=server_data.get("port", 1933),
         root_api_key=server_data.get("root_api_key"),
         cors_origins=server_data.get("cors_origins", ["*"]),
+        workers=server_data.get("workers", 1),
     )
 
     return config
@@ -96,6 +98,14 @@ def validate_server_config(config: ServerConfig) -> None:
     Raises:
         SystemExit: If the configuration is unsafe.
     """
+    if config.workers < 1:
+        logger.error(
+            "server.workers must be >= 1, got %d. "
+            "Set server.workers >= 1 in ov.conf or use --workers >= 1.",
+            config.workers,
+        )
+        sys.exit(1)
+
     if config.root_api_key:
         return
 

--- a/tests/server/test_server_workers_config.py
+++ b/tests/server/test_server_workers_config.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for server workers configuration (issue #464).
+
+Verifies that:
+- ServerConfig defaults to workers=1
+- workers can be overridden via ov.conf ``server.workers``
+- validate_server_config rejects workers < 1
+- valid workers values (1, N > 1) pass validation
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openviking.server.config import ServerConfig, validate_server_config
+
+
+# ---------------------------------------------------------------------------
+# ServerConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_server_config_default_workers():
+    """ServerConfig should default to a single worker."""
+    config = ServerConfig()
+    assert config.workers == 1
+
+
+def test_server_config_custom_workers():
+    """ServerConfig workers field should accept any positive integer."""
+    config = ServerConfig(workers=4)
+    assert config.workers == 4
+
+
+# ---------------------------------------------------------------------------
+# validate_server_config – workers validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rejects_zero_workers():
+    """workers=0 should cause sys.exit(1)."""
+    config = ServerConfig(workers=0, root_api_key="test-key")
+    with pytest.raises(SystemExit) as exc_info:
+        validate_server_config(config)
+    assert exc_info.value.code == 1
+
+
+def test_validate_rejects_negative_workers():
+    """workers=-1 should cause sys.exit(1)."""
+    config = ServerConfig(workers=-1, root_api_key="test-key")
+    with pytest.raises(SystemExit) as exc_info:
+        validate_server_config(config)
+    assert exc_info.value.code == 1
+
+
+def test_validate_accepts_single_worker():
+    """workers=1 (default) should pass validation."""
+    config = ServerConfig(workers=1, root_api_key="test-key")
+    # Should not raise
+    validate_server_config(config)
+
+
+def test_validate_accepts_multiple_workers():
+    """workers=4 should pass validation."""
+    config = ServerConfig(workers=4, root_api_key="test-key")
+    # Should not raise
+    validate_server_config(config)
+
+
+# ---------------------------------------------------------------------------
+# load_server_config – reads workers from config dict
+# ---------------------------------------------------------------------------
+
+
+def test_load_server_config_reads_workers(tmp_path):
+    """load_server_config should populate workers from the server section."""
+    import json
+
+    conf = tmp_path / "ov.conf"
+    conf.write_text(json.dumps({"server": {"workers": 8, "root_api_key": "test-key"}}))
+
+    import os
+
+    with patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(conf)}):
+        from openviking.server.config import load_server_config
+
+        config = load_server_config(str(conf))
+        assert config.workers == 8
+
+
+def test_load_server_config_defaults_workers_to_one(tmp_path):
+    """load_server_config should default workers to 1 when not in config."""
+    import json
+
+    conf = tmp_path / "ov.conf"
+    conf.write_text(json.dumps({"server": {"root_api_key": "test-key"}}))
+
+    import os
+
+    with patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(conf)}):
+        from openviking.server.config import load_server_config
+
+        config = load_server_config(str(conf))
+        assert config.workers == 1


### PR DESCRIPTION
## Summary

Fixes #464

OpenViking started uvicorn with no `workers` argument (defaulting to 1), which means one slow or blocking request can stall the entire HTTP server process — including lightweight probes like `/health`.

This PR adds a `workers` configuration knob so operators can run multiple uvicorn worker processes and prevent this availability issue.

## Changes

### `openviking/server/config.py`
- Add `workers: int = 1` field to `ServerConfig`
- Load `server.workers` from `ov.conf`
- Add validation in `validate_server_config`: reject `workers < 1` with a clear error and `sys.exit(1)`

### `openviking/server/bootstrap.py`
- Add `--workers N` CLI argument
- When `workers == 1` (default): existing behaviour unchanged, app object passed directly to `uvicorn.run()`
- When `workers > 1`: use `uvicorn.run('openviking.server.app:create_app', factory=True, workers=N)` so each worker process independently imports and initialises its own `OpenVikingService`. The config file path is propagated via the `OPENVIKING_CONFIG_FILE` env var already set in `main()`

### `tests/server/test_server_workers_config.py` (new)
- `ServerConfig` defaults to `workers=1`
- Custom workers value stored correctly
- `validate_server_config` rejects `workers=0` and `workers=-1`
- `validate_server_config` accepts `workers=1` and `workers=4`
- `load_server_config` reads `workers` from config file
- `load_server_config` defaults `workers` to `1` when absent

## Usage

```bash
# CLI flag
openviking-server --workers 4

# ov.conf
{
  "server": {
    "workers": 4
  }
}
```

## Limitations

- `--with-bot` is not supported with `--workers > 1` (warning emitted, bot proxy disabled). Bot mode requires a separate single-worker instance.
- Multiple workers each hold independent in-memory state. For local SQLite backends, concurrent writes may cause contention; a networked backend is recommended for production multi-worker deployments.

## Backward Compatibility

Default is `workers=1`, so all existing deployments are unaffected.