### PR TITLE
fix vikingbot grep/glob/add_resource get response issue

### DIFF
--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -218,7 +218,7 @@ class VikingAddResourceTool(OVFileTool):
             )
 
             if result:
-                root_uri = result.get("result", {}).get("root_uri", "unknown")
+                root_uri = result.get("root_uri", "unknown")
                 return f"Successfully added resource: {root_uri}"
             else:
                 return "Failed to add resource"
@@ -272,8 +272,8 @@ class VikingGrepTool(OVFileTool):
             result = await client.grep(uri, pattern, case_insensitive=case_insensitive)
 
             if isinstance(result, dict):
-                matches = result.get("result", {}).get("matches", [])
-                count = result.get("result", {}).get("count", 0)
+                matches = result.get("matches", [])
+                count = result.get("count", 0)
             else:
                 matches = getattr(result, "matches", [])
                 count = getattr(result, "count", 0)
@@ -336,8 +336,8 @@ class VikingGlobTool(OVFileTool):
             result = await client.glob(pattern, uri=uri or None)
 
             if isinstance(result, dict):
-                matches = result.get("result", {}).get("matches", [])
-                count = result.get("result", {}).get("count", 0)
+                matches = result.get("matches", [])
+                count = result.get("count", 0)
             else:
                 matches = getattr(result, "matches", [])
                 count = getattr(result, "count", 0)


### PR DESCRIPTION
## Description

Fix: vikingbot grep/glob/add-resource tools Remove redundant result field access since SDK already extracts it from API responses.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

vikingbot grep/glob/add-resource tools 

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

