### PR TITLE
fix(search): use session summaries in search and cap intent summary l…

### DIFF
--- a/openviking/retrieve/intent_analyzer.py
+++ b/openviking/retrieve/intent_analyzer.py
@@ -28,6 +28,9 @@ class IntentAnalyzer:
     3. Generate multiple TypedQueries for memory/resources/skill
     """
 
+    # Limit content length (about 10000 tokens)
+    MAX_COMPRESSION_SUMMARY_CHARS = 30000
+
     def __init__(self, max_recent_messages: int = 5):
         """Initialize intent analyzer."""
         self.max_recent_messages = max_recent_messages
@@ -106,7 +109,8 @@ class IntentAnalyzer:
     ) -> str:
         """Build prompt for intent analysis."""
         # Format compression info
-        summary = compression_summary if compression_summary else "None"
+        summary = self._truncate_text(compression_summary, self.MAX_COMPRESSION_SUMMARY_CHARS)
+        summary = summary if summary else "None"
 
         # Format recent messages
         recent = messages[-self.max_recent_messages :] if messages else []
@@ -127,6 +131,13 @@ class IntentAnalyzer:
                 "target_abstract": target_abstract,
             },
         )
+
+    @staticmethod
+    def _truncate_text(text: str, max_chars: int) -> str:
+        """Truncate text to avoid oversized prompt context."""
+        if not text or len(text) <= max_chars:
+            return text
+        return text[: max_chars - 15] + "\n...(truncated)"
 
     def _summarize_context(
         self,

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -669,7 +669,11 @@ class VikingFS:
             TypedQuery,
         )
 
-        session_summary = session_info.get("summary") if session_info else None
+        summary_list = session_info.get("summaries") if session_info else None
+        if isinstance(summary_list, list):
+            session_summary = "\n\n".join(str(item) for item in summary_list if item)
+        else:
+            session_summary = ""
         recent_messages = session_info.get("recent_messages") if session_info else None
 
         query_plan: Optional[QueryPlan] = None


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes the session context contract mismatch in search and adds prompt-safety truncation for session summaries.

Specifically:

Session.get_context_for_search() provides summaries (list), but VikingFS.search() was reading summary (singular).
After aligning to summaries, the list is normalized into a single string before passing to intent analysis.
IntentAnalyzer now truncates overly long compression_summary to avoid oversized prompts.
Related Issue

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
Fixes #493 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Updated VikingFS.search() to consume session_info["summaries"] and normalize List[str] via "\n\n".join(...).
- Added compression summary truncation in IntentAnalyzer (MAX_COMPRESSION_SUMMARY_CHARS) before prompt rendering.


## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
