### PR TITLE
fix(config): handle UTF-8 BOM in config files on Windows (#499)

### DIFF
--- a/openviking_cli/utils/config/config_loader.py
+++ b/openviking_cli/utils/config/config_loader.py
@@ -80,7 +80,7 @@ def load_json_config(path: Path) -> Dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(f"Config file does not exist: {path}")
 
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, "r", encoding="utf-8-sig") as f:
         try:
             print(f"Loading config file: {path}")
             return json.load(f)


### PR DESCRIPTION
## Problem

Windows text editors (Notepad, VS Code with certain settings) save UTF-8 files with a **Byte Order Mark (BOM, `\xef\xbb\xbf`)**. When `load_json_config()` opens such a file with `encoding='utf-8'`, the BOM appears as the first character, causing `json.load()` to fail with a JSON parse error.

Reported in #499 (Windows 11 startup crash).

## Fix

Change `encoding='utf-8'` → `encoding='utf-8-sig'` in `config_loader.py`.

Python's `utf-8-sig` codec **automatically strips the BOM** when present, and behaves identically to `utf-8` for BOM-less files — so this is a zero-risk, backward-compatible change.

## Change

```python
# Before
with open(path, "r", encoding="utf-8") as f:

# After  
with open(path, "r", encoding="utf-8-sig") as f:
```

Fixes #499