### PR TITLE
Fix: change Role.ROOT to Role.USER, and mirror the HTTP server behavior     (sessions.py:94-95) by calling initialize_user_directories() and     initialize_agent_directories() at the start of create_session().

### DIFF
--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -34,7 +34,7 @@ class LocalClient(BaseClient):
             user=UserIdentifier.the_default_user(),
         )
         self._user = self._service.user
-        self._ctx = RequestContext(user=self._user, role=Role.ROOT)
+        self._ctx = RequestContext(user=self._user, role=Role.USER)
 
     @property
     def service(self) -> OpenVikingService:
@@ -259,6 +259,8 @@ class LocalClient(BaseClient):
 
     async def create_session(self) -> Dict[str, Any]:
         """Create a new session."""
+        await self._service.initialize_user_directories(self._ctx)
+        await self._service.initialize_agent_directories(self._ctx)
         session = await self._service.sessions.create(self._ctx)
         return {
             "session_id": session.session_id,


### PR DESCRIPTION
fix(embedded): LocalClient Role.ROOT and missing agent directory initialization

In embedded mode (LocalClient), two bugs prevented find() from returning
agent memories (cases/patterns) without an explicit target_uri:

1. LocalClient hardcoded Role.ROOT, causing _get_root_uris_for_type() to
   return [] and skip hierarchical traversal entirely.

2. create_session() never called initialize_agent_directories(), so the
   agent memory directory tree (memories/, cases/, patterns/) was never
   initialized with .abstract.md files or vector index entries. Since
   initialization must happen before the first commit, retroactive calls
   had no effect.

Fix: change Role.ROOT to Role.USER, and mirror the HTTP server behavior
(sessions.py:94-95) by calling initialize_user_directories() and
initialize_agent_directories() at the start of create_session().
