### PR TITLE
fix: clear live messages.jsonl during async commit to prevent duplicate commits

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -484,6 +484,25 @@ class Session:
             # 2.5 Update active_count
             active_count_updated = await self._update_active_counts_async()
             result["active_count_updated"] = active_count_updated
+
+            # 2.6 Clear live session's messages.jsonl immediately.
+            #
+            # The atomic temp→live switch (Phase 3) is handled asynchronously
+            # by SemanticProcessor and may complete much later.  If the session
+            # object is evicted from memory and reloaded from disk before that
+            # switch happens, the old messages.jsonl in the live directory would
+            # be read back — causing duplicate commits on a subsequent call.
+            #
+            # Writing an empty messages.jsonl to the *live* directory here
+            # closes this race window: even if the session is reloaded before
+            # the semantic switch, it will find no messages to re-commit.
+            await self._viking_fs.write_file(
+                f"{self._session_uri}/messages.jsonl", "", ctx=self.ctx
+            )
+            logger.info(
+                f"Cleared live messages.jsonl for session {self.session_id} "
+                "to prevent duplicate commits before semantic switch"
+            )
         except Exception as e:
             logger.error(f"Failed to write changes to temp: {e}")
             await self._cleanup_temp_uris()


### PR DESCRIPTION
## Summary

Fixes #580 — async session commit can re-commit old messages before live session switch completes.

## Root cause

`commit_async()` uses a Copy-on-Write pattern:
1. **Phase 1 (Copy):** Copy live session to temp directory
2. **Phase 2 (Write):** Archive messages + extract memories in temp, clear `self._messages` in memory
3. **Phase 3 (Switch):** Enqueue to `SemanticProcessor` for atomic temp→live directory switch

The problem: after Phase 2 clears the in-memory message list, the **live session directory** still contains the original `messages.jsonl`. The atomic switch only happens later when `SemanticProcessor` processes the queue. If the session object is evicted from memory and reloaded from disk before that switch (or if the process restarts), the old `messages.jsonl` is read back — causing a subsequent commit to re-archive the same messages.

## Fix

Write an empty `messages.jsonl` to the **live** session directory immediately after Phase 2 completes (step 2.6), before enqueuing to the semantic queue. This closes the race window:

- In-memory: `self._messages` is already cleared (step 2.1)
- On-disk: `messages.jsonl` is now also cleared (step 2.6)
- Even if the session is reloaded before the semantic switch, it finds no messages to re-commit

The fix is intentionally minimal — one `write_file` call + logging. It uses the existing `_viking_fs.write_file()` API that is already used during session initialization (line 151).

## What about the task completion semantics?

The issue also mentions that `task.status=completed` should imply the live session has been switched. This PR addresses the data safety concern (no duplicate commits) but does **not** change the task tracking semantics. A follow-up could defer `tracker.complete()` until the semantic switch finishes, if stricter task completion guarantees are desired.