### PR TITLE
Follow up to #569: add attribution notice to OpenCode memory plugin example

### DIFF
--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -3,6 +3,12 @@
  *
  * Exposes OpenViking's semantic memory capabilities as tools for AI agents.
  * Supports user profiles, preferences, entities, events, cases, and patterns.
+ * 
+ * Contributed by: littlelory@convolens.net
+ * GitHub: https://github.com/convolens
+ * We are building Enterprise AI assistant for consumer brands，with process awareness and memory,
+ * Serving product development to pre-launch lifecycle
+ * Copyright 2026 Convolens.
  */
 
 import type { Hooks, PluginInput } from "@opencode-ai/plugin"


### PR DESCRIPTION
## Summary

This PR is a small follow-up to #569.

It adds an attribution notice to the OpenCode memory plugin example source file.

## Changes

- add an attribution header to `examples/opencode-memory-plugin/openviking-memory.ts`

## Notes

This change does not affect functionality. It is intended to clarify the contribution origin at the source level.
