### PR TITLE
fix(ci): add macos-15 (ARM64) to wheel build matrix

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       os_json:
-        description: 'JSON string of runner labels to build on (ubuntu-24.04=x86_64, ubuntu-24.04-arm=aarch64, macos-14=arm64, macos-15-intel=x86_64, windows-latest=x86_64)'
+        description: 'JSON string of runner labels to build on (ubuntu-24.04=x86_64, ubuntu-24.04-arm=aarch64, macos-14=arm64, macos-15=arm64, macos-15-intel=x86_64, windows-latest=x86_64)'
         required: false
         type: string
-        default: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15-intel", "windows-latest"]'
+        default: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15", "macos-15-intel", "windows-latest"]'
       python_json:
         description: 'JSON string of Python versions'
         required: false
@@ -36,9 +36,9 @@ on:
         type: boolean
         default: true
       os_json:
-        description: 'JSON string of runner labels to build on (ubuntu-24.04=x86_64, ubuntu-24.04-arm=aarch64, macos-14=arm64, macos-15-intel=x86_64, windows-latest=x86_64)'
+        description: 'JSON string of runner labels to build on (ubuntu-24.04=x86_64, ubuntu-24.04-arm=aarch64, macos-14=arm64, macos-15=arm64, macos-15-intel=x86_64, windows-latest=x86_64)'
         required: false
-        default: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15-intel", "windows-latest"]'
+        default: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15", "macos-15-intel", "windows-latest"]'
       python_json:
         description: 'JSON string of Python versions'
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ on:
         type: boolean
         default: true
       os_json:
-        description: 'JSON string of runner labels to build on (Manual only; ubuntu-24.04=x86_64, ubuntu-24.04-arm=aarch64, macos-14=arm64, macos-15-intel=x86_64, windows-latest=x86_64)'
+        description: 'JSON string of runner labels to build on (Manual only; ubuntu-24.04=x86_64, ubuntu-24.04-arm=aarch64, macos-14=arm64, macos-15=arm64, macos-15-intel=x86_64, windows-latest=x86_64)'
         required: false
         type: string
-        default: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15-intel", "windows-latest"]'
+        default: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15", "macos-15-intel", "windows-latest"]'
       python_json:
         description: 'JSON string of Python versions (Manual only)'
         required: false
@@ -47,7 +47,7 @@ jobs:
     if: "!startsWith(github.event.release.tag_name, 'cli-')"
     uses: ./.github/workflows/_build.yml
     with:
-      os_json: ${{ inputs.os_json || '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15-intel", "windows-latest"]' }}
+      os_json: ${{ inputs.os_json || '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15", "macos-15-intel", "windows-latest"]' }}
       python_json: ${{ inputs.python_json || '["3.10", "3.11", "3.12", "3.13"]' }}
       build_sdist: ${{ github.event_name == 'release' || inputs.build_sdist != false }}
       build_wheels: ${{ github.event_name == 'release' || inputs.build_wheels != false }}


### PR DESCRIPTION
## Problem

The current wheel build matrix only includes:
- `macos-14` (ARM64) - builds for macOS 14 ARM64
- `macos-15-intel` (x86_64) - builds for macOS 15 Intel

But it's missing `macos-15` (ARM64), causing **macOS 15 ARM64 users to trigger wheel rebuild from source** when installing openviking.

## Root Cause

According to GitHub's official runner-images roadmap:

> `macos-latest` label will be migrated to `macOS 15` runner image beginning **August 4, 2025** and will complete by **September 1, 2025**.

- Source: https://github.com/actions/runner-images/issues/12520

Currently (`macos-latest` -> `macos-14`), there's no automatic way to get macOS 15 ARM64 wheels without explicitly adding the `macos-15` label.

## Changes

Added `macos-15` to the default OS matrix in:
1. `.github/workflows/_build.yml`
2. `.github/workflows/release.yml`

### Before
```yaml
["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15-intel", "windows-latest"]
```

### After
```yaml
["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15", "macos-15-intel", "windows-latest"]
```

## Verification

Once merged, the next release build will produce wheels for:
| Platform | Architecture | Runner Label |
|----------|-------------|--------------|
| Linux | x86_64 | ubuntu-24.04 |
| Linux | ARM64 | ubuntu-24.04-arm |
| macOS 14 | ARM64 | macos-14 |
| **macOS 15** | **ARM64** | **macos-15** <- NEW |
| macOS 15 | x86_64 | macos-15-intel |
| Windows | x86_64 | windows-latest |

This ensures macOS 15 ARM64 users get pre-built wheels instead of triggering source builds.
