### PR TITLE
fix(core): add separator to agent_space_name to prevent hash collisions

### DIFF
--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -91,7 +91,7 @@ class VikingClient:
         }
 
     def get_agent_space_name(self, user_id: str) -> str:
-        return hashlib.md5((user_id + self.agent_id).encode()).hexdigest()[:12]
+        return hashlib.md5(f"{user_id}:{self.agent_id}".encode()).hexdigest()[:12]
 
     async def find(self, query: str, target_uri: Optional[str] = None):
         """搜索资源"""

--- a/examples/openclaw-memory-plugin/client.ts
+++ b/examples/openclaw-memory-plugin/client.ts
@@ -131,10 +131,10 @@ export class OpenVikingClient {
 
     const identity = await this.getRuntimeIdentity();
     const fallbackSpace =
-      scope === "user" ? identity.userId : md5Short(`${identity.userId}${identity.agentId}`);
+      scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
     const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
     const preferredSpace =
-      scope === "user" ? identity.userId : md5Short(`${identity.userId}${identity.agentId}`);
+      scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
 
     try {
       const entries = await this.ls(`viking://${scope}`);

--- a/openviking_cli/session/user_id.py
+++ b/openviking_cli/session/user_id.py
@@ -51,7 +51,7 @@ class UserIdentifier(object):
 
     def agent_space_name(self) -> str:
         """Agent-level space name (user + agent)."""
-        return hashlib.md5((self._user_id + self._agent_id).encode()).hexdigest()[:12]
+        return hashlib.md5(f"{self._user_id}:{self._agent_id}".encode()).hexdigest()[:12]
 
     def memory_space_uri(self) -> str:
         return f"viking://agent/{self.agent_space_name()}/memories"

--- a/tests/cli/test_user_identifier.py
+++ b/tests/cli/test_user_identifier.py
@@ -1,0 +1,32 @@
+"""Tests for UserIdentifier, specifically agent_space_name collision safety."""
+
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class TestAgentSpaceNameCollision:
+    """Verify that agent_space_name uses a separator to prevent hash collisions."""
+
+    def test_different_pairs_produce_different_hashes(self):
+        """Pairs like (alice, bot) vs (aliceb, ot) must not collide."""
+        u1 = UserIdentifier("acct", "alice", "bot")
+        u2 = UserIdentifier("acct", "aliceb", "ot")
+        assert u1.agent_space_name() != u2.agent_space_name()
+
+    def test_same_pair_produces_same_hash(self):
+        """Same (user_id, agent_id) must always produce the same hash."""
+        u1 = UserIdentifier("acct", "alice", "bot")
+        u2 = UserIdentifier("acct", "alice", "bot")
+        assert u1.agent_space_name() == u2.agent_space_name()
+
+    def test_swapped_ids_produce_different_hashes(self):
+        """(user_id=a, agent_id=b) vs (user_id=b, agent_id=a) must differ."""
+        u1 = UserIdentifier("acct", "alpha", "beta")
+        u2 = UserIdentifier("acct", "beta", "alpha")
+        assert u1.agent_space_name() != u2.agent_space_name()
+
+    def test_hash_length(self):
+        """agent_space_name must return a 12-character hex string."""
+        u = UserIdentifier("acct", "user1", "agent1")
+        name = u.agent_space_name()
+        assert len(name) == 12
+        assert all(c in "0123456789abcdef" for c in name)


### PR DESCRIPTION
## Summary

`agent_space_name()` computed `md5(user_id + agent_id)` without a separator, allowing different `(user_id, agent_id)` pairs to collide when their concatenation matched. For example, `("alice", "bot")` and `("aliceb", "ot")` both produce `md5("alicebot")`, mapping to the same agent space.

This adds `:` as a separator in the hash input across all three implementations (Python SDK, bot server, TypeScript example).

## Why this matters

- [#595](https://github.com/volcengine/OpenViking/issues/595) documents the collision risk with a clear reproduction case
- @qin-ctx [confirmed](https://github.com/volcengine/OpenViking/issues/595#issuecomment-4059652826) the issue and invited a PR fix
- Hash collisions cause unintended data sharing across agent spaces (memories, skills, workspaces)

## Changes

- `openviking_cli/session/user_id.py`: `md5(user_id + agent_id)` -> `md5(f"{user_id}:{agent_id}")`
- `bot/vikingbot/openviking_mount/ov_server.py`: same fix
- `examples/openclaw-memory-plugin/client.ts`: same fix (two occurrences)
- `tests/cli/test_user_identifier.py`: new test covering collision scenario, hash stability, swapped IDs, and format

The `:` separator is safe because the validation regex `[a-zA-Z0-9_-]` prevents either field from containing it.

## Breaking Change

This changes the hash output for all existing agent spaces. Data stored under the old hash will not be found with the new hash. Options for migration:
1. A one-time migration script that rehashes existing space directories
2. A fallback lookup that checks both old and new hashes during a transition period

## Testing

- New test `tests/cli/test_user_identifier.py` verifies:
  - Previously-colliding pairs now produce different hashes
  - Same pairs still produce identical hashes
  - Swapped `(user_id, agent_id)` pairs produce different hashes
  - Hash format is 12 hex characters
- `ruff format --check` and `ruff check` pass on all changed files

Fixes #595

This contribution was developed with AI assistance (Claude Code).