### PR TITLE
fix(session): pass ctx/user/session_id into async commit memory extraction

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -337,6 +337,9 @@ class Session:
             )
             memories = await self._session_compressor.extract_long_term_memories(
                 messages=messages_to_archive,
+                user=self.user,
+                session_id=self.session_id,
+                ctx=self.ctx,
             )
             logger.info(f"Extracted {len(memories)} memories")
             result["memories_extracted"] = len(memories)


### PR DESCRIPTION
## Summary

`Session.commit_async()` calls `extract_long_term_memories()` without passing `user`, `session_id`, or `ctx`. Because the compressor returns early when `ctx is None`, async session commits always produce `memories_extracted = 0` even when the archived messages contain extractable memories.

## Why this matters

- [#602](https://github.com/volcengine/OpenViking/issues/602) documents the regression with reproduction steps and commit evidence
- The sync `commit()` path correctly passes all three parameters (session.py:263-267)
- The async path lost them after the COW pattern revert ([#584](https://github.com/volcengine/OpenViking/pull/584))
- This breaks memory extraction for integrations using the async commit endpoint (OpenClaw / memory-openviking)

## Changes

`openviking/session/session.py` line 338: Added the three missing keyword arguments to match the sync path:

```python
# Before (broken):
memories = await self._session_compressor.extract_long_term_memories(
    messages=messages_to_archive,
)

# After (fixed):
memories = await self._session_compressor.extract_long_term_memories(
    messages=messages_to_archive,
    user=self.user,
    session_id=self.session_id,
    ctx=self.ctx,
)
```

## Testing

- Verified the sync path (line 263) passes `user`, `session_id`, `ctx`
- Verified the compressor guard (`if not ctx: return []`) at `compressor.py:134` is the root cause
- `ruff format --check` and `ruff check` pass

Fixes #602

This contribution was developed with AI assistance (Claude Code).