### PR TITLE
feat(embedding): add Voyage text embedding support

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -115,11 +115,13 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `max_concurrent` | int | Maximum concurrent embedding requests (`embedding.max_concurrent`, default: `10`) |
-| `provider` | str | `"volcengine"`, `"openai"`, `"vikingdb"`, or `"jina"` |
+| `provider` | str | `"volcengine"`, `"openai"`, `"vikingdb"`, `"jina"`, or `"voyage"` |
 | `api_key` | str | API key |
 | `model` | str | Model name |
-| `dimension` | int | Vector dimension |
+| `dimension` | int | Vector dimension. For Voyage, this maps to `output_dimension` |
 | `input` | str | Input type: `"text"` or `"multimodal"` |
+| `input_type` | str | Provider-specific text input mode such as `"query"` or `"document"` (Voyage) |
+| `output_dtype` | str | Provider-specific output dtype (Voyage) |
 | `batch_size` | int | Batch size for embedding requests |
 
 **Available Models**
@@ -136,6 +138,7 @@ With `input: "multimodal"`, OpenViking can embed text, images (PNG, JPG, etc.), 
 - `volcengine`: Volcengine Embedding API
 - `vikingdb`: VikingDB Embedding API
 - `jina`: Jina AI Embedding API
+- `voyage`: Voyage AI Embedding API
 
 **vikingdb provider example:**
 
@@ -190,6 +193,35 @@ Get your API key at https://jina.ai
   }
 }
 ```
+
+**voyage provider example:**
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "provider": "voyage",
+      "api_key": "pa-xxx",
+      "api_base": "https://api.voyageai.com/v1",
+      "model": "voyage-4-lite",
+      "dimension": 1024,
+      "input_type": "document",
+      "output_dtype": "float"
+    }
+  }
+}
+```
+
+Supported Voyage text embedding models include:
+- `voyage-4-lite`
+- `voyage-4`
+- `voyage-4-large`
+- `voyage-code-3`
+- `voyage-3`
+- `voyage-3.5`
+- `voyage-3.5-lite`
+
+If `dimension` is omitted, OpenViking uses the model's default output dimension when creating the vector schema.
 
 #### Sparse Embedding
 

--- a/openviking/models/embedder/__init__.py
+++ b/openviking/models/embedder/__init__.py
@@ -12,6 +12,7 @@ Supported providers:
 - OpenAI: Dense only
 - Volcengine: Dense, Sparse, Hybrid
 - Jina AI: Dense only
+- Voyage AI: Dense only
 """
 
 from openviking.models.embedder.base import (
@@ -24,6 +25,7 @@ from openviking.models.embedder.base import (
 )
 from openviking.models.embedder.jina_embedders import JinaDenseEmbedder
 from openviking.models.embedder.openai_embedders import OpenAIDenseEmbedder
+from openviking.models.embedder.voyage_embedders import VoyageDenseEmbedder
 from openviking.models.embedder.vikingdb_embedders import (
     VikingDBDenseEmbedder,
     VikingDBHybridEmbedder,
@@ -47,6 +49,8 @@ __all__ = [
     "JinaDenseEmbedder",
     # OpenAI implementations
     "OpenAIDenseEmbedder",
+    # Voyage implementations
+    "VoyageDenseEmbedder",
     # Volcengine implementations
     "VolcengineDenseEmbedder",
     "VolcengineSparseEmbedder",

--- a/openviking/models/embedder/voyage_embedders.py
+++ b/openviking/models/embedder/voyage_embedders.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Voyage AI embedder implementation."""
+
+from typing import Any, Dict, List, Optional
+
+import openai
+
+from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult
+
+VOYAGE_MODEL_DIMENSIONS = {
+    "voyage-3": 1024,
+    "voyage-3-large": 1024,
+    "voyage-3.5": 1024,
+    "voyage-3.5-lite": 1024,
+    "voyage-4": 1024,
+    "voyage-4-lite": 1024,
+    "voyage-4-large": 1024,
+    "voyage-code-3": 1024,
+    "voyage-context-3": 1024,
+    "voyage-finance-2": 1024,
+    "voyage-law-2": 1024,
+}
+
+VOYAGE_MODEL_ALLOWED_DIMENSIONS = {
+    "voyage-3": {256, 512, 1024, 2048},
+    "voyage-3-large": {256, 512, 1024, 2048},
+    "voyage-3.5": {256, 512, 1024, 2048},
+    "voyage-3.5-lite": {256, 512, 1024, 2048},
+    "voyage-4": {256, 512, 1024, 2048},
+    "voyage-4-lite": {256, 512, 1024, 2048},
+    "voyage-4-large": {256, 512, 1024, 2048},
+    "voyage-code-3": {256, 512, 1024, 2048},
+}
+
+
+def get_voyage_model_default_dimension(model_name: Optional[str]) -> int:
+    """Get the default output dimension for a Voyage text embedding model."""
+    if not model_name:
+        return 1024
+    return VOYAGE_MODEL_DIMENSIONS.get(model_name.lower(), 1024)
+
+
+class VoyageDenseEmbedder(DenseEmbedderBase):
+    """Voyage AI dense embedder.
+
+    Uses Voyage's OpenAI-compatible embeddings endpoint while sending Voyage-specific
+    request fields through ``extra_body``.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "voyage-4-lite",
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        dimension: Optional[int] = None,
+        input_type: Optional[str] = None,
+        output_dtype: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(model_name, config)
+
+        self.api_key = api_key
+        self.api_base = api_base or "https://api.voyageai.com/v1"
+        self.dimension = dimension
+        self.input_type = input_type
+        self.output_dtype = output_dtype
+
+        if not self.api_key:
+            raise ValueError("api_key is required")
+
+        normalized_model_name = model_name.lower()
+        supported_dimensions = VOYAGE_MODEL_ALLOWED_DIMENSIONS.get(normalized_model_name)
+        if supported_dimensions and dimension is not None and dimension not in supported_dimensions:
+            supported = ", ".join(str(value) for value in sorted(supported_dimensions))
+            raise ValueError(
+                f"Requested dimension {dimension} is not supported for model '{model_name}'. "
+                f"Supported dimensions: {supported}."
+            )
+
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url=self.api_base,
+        )
+
+        self._dimension = dimension or get_voyage_model_default_dimension(normalized_model_name)
+
+    def _build_extra_body(self) -> Optional[Dict[str, Any]]:
+        """Build Voyage-specific request fields."""
+        extra_body: Dict[str, Any] = {}
+        if self.input_type:
+            extra_body["input_type"] = self.input_type
+        if self.output_dtype:
+            extra_body["output_dtype"] = self.output_dtype
+        if self.dimension is not None:
+            extra_body["output_dimension"] = self.dimension
+        return extra_body or None
+
+    def embed(self, text: str) -> EmbedResult:
+        """Perform dense embedding on text."""
+        try:
+            kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
+            extra_body = self._build_extra_body()
+            if extra_body:
+                kwargs["extra_body"] = extra_body
+
+            response = self.client.embeddings.create(**kwargs)
+            vector = response.data[0].embedding
+            return EmbedResult(dense_vector=vector)
+        except openai.APIError as e:
+            raise RuntimeError(f"Voyage API error: {e.message}") from e
+        except Exception as e:
+            raise RuntimeError(f"Embedding failed: {str(e)}") from e
+
+    def embed_batch(self, texts: List[str]) -> List[EmbedResult]:
+        """Batch embedding."""
+        if not texts:
+            return []
+
+        try:
+            kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
+            extra_body = self._build_extra_body()
+            if extra_body:
+                kwargs["extra_body"] = extra_body
+
+            response = self.client.embeddings.create(**kwargs)
+            return [EmbedResult(dense_vector=item.embedding) for item in response.data]
+        except openai.APIError as e:
+            raise RuntimeError(f"Voyage API error: {e.message}") from e
+        except Exception as e:
+            raise RuntimeError(f"Batch embedding failed: {str(e)}") from e
+
+    def get_dimension(self) -> int:
+        """Get embedding dimension."""
+        return self._dimension

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -14,13 +14,21 @@ class EmbeddingModelConfig(BaseModel):
     dimension: Optional[int] = Field(default=None, description="Embedding dimension")
     batch_size: int = Field(default=32, description="Batch size for embedding generation")
     input: str = Field(default="multimodal", description="Input type: 'text' or 'multimodal'")
+    input_type: Optional[str] = Field(
+        default=None,
+        description="Provider-specific text embedding input type (for example 'query' or 'document')",
+    )
+    output_dtype: Optional[str] = Field(
+        default=None,
+        description="Provider-specific output dtype for embedding vectors",
+    )
     provider: Optional[str] = Field(
         default="volcengine",
-        description="Provider type: 'openai', 'volcengine', 'vikingdb', 'jina'",
+        description="Provider type: 'openai', 'volcengine', 'vikingdb', 'jina', 'voyage'",
     )
     backend: Optional[str] = Field(
         default="volcengine",
-        description="Backend type (Deprecated, use 'provider' instead): 'openai', 'volcengine', 'vikingdb'",
+        description="Backend type (Deprecated, use 'provider' instead): 'openai', 'volcengine', 'vikingdb', 'voyage'",
     )
     version: Optional[str] = Field(default=None, description="Model version")
     ak: Optional[str] = Field(default=None, description="Access Key ID for VikingDB API")
@@ -53,9 +61,9 @@ class EmbeddingModelConfig(BaseModel):
         if not self.provider:
             raise ValueError("Embedding provider is required")
 
-        if self.provider not in ["openai", "volcengine", "vikingdb", "jina"]:
+        if self.provider not in ["openai", "volcengine", "vikingdb", "jina", "voyage"]:
             raise ValueError(
-                f"Invalid embedding provider: '{self.provider}'. Must be one of: 'openai', 'volcengine', 'vikingdb', 'jina'"
+                f"Invalid embedding provider: '{self.provider}'. Must be one of: 'openai', 'volcengine', 'vikingdb', 'jina', 'voyage'"
             )
 
         # Provider-specific validation
@@ -85,7 +93,27 @@ class EmbeddingModelConfig(BaseModel):
             if not self.api_key:
                 raise ValueError("Jina provider requires 'api_key' to be set")
 
+        elif self.provider == "voyage":
+            if not self.api_key:
+                raise ValueError("Voyage provider requires 'api_key' to be set")
+
         return self
+
+    def get_effective_dimension(self) -> int:
+        """Resolve the dimension used for schema creation and validation."""
+        if self.dimension is not None:
+            return self.dimension
+
+        provider = (self.provider or "").lower()
+
+        if provider == "voyage":
+            from openviking.models.embedder.voyage_embedders import (
+                get_voyage_model_default_dimension,
+            )
+
+            return get_voyage_model_default_dimension(self.model)
+
+        return 2048
 
 
 class EmbeddingConfig(BaseModel):
@@ -136,6 +164,7 @@ class EmbeddingConfig(BaseModel):
         from openviking.models.embedder import (
             JinaDenseEmbedder,
             OpenAIDenseEmbedder,
+            VoyageDenseEmbedder,
             VikingDBDenseEmbedder,
             VikingDBHybridEmbedder,
             VikingDBSparseEmbedder,
@@ -229,6 +258,17 @@ class EmbeddingConfig(BaseModel):
                     "dimension": cfg.dimension,
                 },
             ),
+            ("voyage", "dense"): (
+                VoyageDenseEmbedder,
+                lambda cfg: {
+                    "model_name": cfg.model,
+                    "api_key": cfg.api_key,
+                    "api_base": cfg.api_base,
+                    "dimension": cfg.dimension,
+                    "input_type": cfg.input_type,
+                    "output_dtype": cfg.output_dtype,
+                },
+            ),
         }
 
         key = (provider, embedder_type)
@@ -276,7 +316,7 @@ class EmbeddingConfig(BaseModel):
     def get_dimension(self) -> int:
         """Helper to get dimension from active config"""
         if self.hybrid:
-            return self.hybrid.dimension or 2048
+            return self.hybrid.get_effective_dimension()
         if self.dense:
-            return self.dense.dimension or 2048
+            return self.dense.get_effective_dimension()
         return 2048

--- a/tests/unit/test_embedding_config_voyage.py
+++ b/tests/unit/test_embedding_config_voyage.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Voyage embedding configuration."""
+
+import pytest
+
+from openviking.models.embedder import VoyageDenseEmbedder
+from openviking_cli.utils.config.embedding_config import EmbeddingConfig, EmbeddingModelConfig
+
+
+def test_voyage_provider_requires_api_key():
+    with pytest.raises(ValueError, match="Voyage provider requires 'api_key'"):
+        EmbeddingModelConfig(provider="voyage", model="voyage-4-lite")
+
+
+def test_voyage_dense_dimension_defaults_to_model_dimension():
+    config = EmbeddingConfig(
+        dense=EmbeddingModelConfig(
+            provider="voyage",
+            model="voyage-4-lite",
+            api_key="voyage-key",
+        )
+    )
+
+    assert config.dimension == 1024
+
+
+def test_voyage_dense_dimension_honors_explicit_output_dimension():
+    config = EmbeddingConfig(
+        dense=EmbeddingModelConfig(
+            provider="voyage",
+            model="voyage-4-lite",
+            api_key="voyage-key",
+            dimension=512,
+        )
+    )
+
+    assert config.dimension == 512
+
+
+def test_voyage_get_embedder_returns_voyage_dense_embedder():
+    config = EmbeddingConfig(
+        dense=EmbeddingModelConfig(
+            provider="voyage",
+            model="voyage-4-lite",
+            api_key="voyage-key",
+            input_type="query",
+            output_dtype="float",
+        )
+    )
+
+    embedder = config.get_embedder()
+    assert isinstance(embedder, VoyageDenseEmbedder)
+    assert embedder.input_type == "query"
+    assert embedder.output_dtype == "float"

--- a/tests/unit/test_voyage_embedder.py
+++ b/tests/unit/test_voyage_embedder.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Voyage AI embedder support."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openviking.models.embedder import VoyageDenseEmbedder
+from openviking.models.embedder.voyage_embedders import (
+    VOYAGE_MODEL_DIMENSIONS,
+)
+
+
+class TestVoyageDenseEmbedder:
+    """Test cases for VoyageDenseEmbedder."""
+
+    def test_init_requires_api_key(self):
+        with pytest.raises(ValueError, match="api_key is required"):
+            VoyageDenseEmbedder(model_name="voyage-4-lite")
+
+    def test_init_with_defaults(self):
+        embedder = VoyageDenseEmbedder(
+            model_name="voyage-4-lite",
+            api_key="voyage-key",
+        )
+        assert embedder.api_key == "voyage-key"
+        assert embedder.api_base == "https://api.voyageai.com/v1"
+        assert embedder.get_dimension() == 1024
+
+    def test_model_dimensions_constant(self):
+        assert VOYAGE_MODEL_DIMENSIONS["voyage-4-lite"] == 1024
+        assert VOYAGE_MODEL_DIMENSIONS["voyage-4"] == 1024
+        assert VOYAGE_MODEL_DIMENSIONS["voyage-4-large"] == 1024
+        assert VOYAGE_MODEL_DIMENSIONS["voyage-code-3"] == 1024
+
+    def test_custom_dimension(self):
+        embedder = VoyageDenseEmbedder(
+            model_name="voyage-4-lite",
+            api_key="voyage-key",
+            dimension=256,
+        )
+        assert embedder.get_dimension() == 256
+
+    def test_invalid_dimension_for_supported_model(self):
+        with pytest.raises(ValueError, match="Supported dimensions"):
+            VoyageDenseEmbedder(
+                model_name="voyage-4-lite",
+                api_key="voyage-key",
+                dimension=1536,
+            )
+
+    @patch("openviking.models.embedder.voyage_embedders.openai.OpenAI")
+    def test_embed_single_text(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = [0.1] * 1024
+
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embedder = VoyageDenseEmbedder(
+            model_name="voyage-4-lite",
+            api_key="voyage-key",
+        )
+        result = embedder.embed("Hello world")
+
+        assert result.dense_vector is not None
+        assert len(result.dense_vector) == 1024
+        call_kwargs = mock_client.embeddings.create.call_args[1]
+        assert call_kwargs["model"] == "voyage-4-lite"
+        assert "dimensions" not in call_kwargs
+        assert "extra_body" not in call_kwargs
+
+    @patch("openviking.models.embedder.voyage_embedders.openai.OpenAI")
+    def test_embed_uses_voyage_specific_fields(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = [0.1] * 512
+
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embedder = VoyageDenseEmbedder(
+            model_name="voyage-4-lite",
+            api_key="voyage-key",
+            dimension=512,
+            input_type="document",
+            output_dtype="float",
+        )
+        embedder.embed("Hello world")
+
+        call_kwargs = mock_client.embeddings.create.call_args[1]
+        assert "extra_body" in call_kwargs
+        assert call_kwargs["extra_body"]["input_type"] == "document"
+        assert call_kwargs["extra_body"]["output_dtype"] == "float"
+        assert call_kwargs["extra_body"]["output_dimension"] == 512
+        assert "dimensions" not in call_kwargs
+
+    @patch("openviking.models.embedder.voyage_embedders.openai.OpenAI")
+    def test_embed_batch(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.data = [
+            MagicMock(embedding=[0.1] * 1024),
+            MagicMock(embedding=[0.2] * 1024),
+        ]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embedder = VoyageDenseEmbedder(
+            model_name="voyage-4-lite",
+            api_key="voyage-key",
+        )
+        results = embedder.embed_batch(["Hello", "World"])
+
+        assert len(results) == 2
+        assert len(results[0].dense_vector) == 1024
+        assert len(results[1].dense_vector) == 1024
+
+    @patch("openviking.models.embedder.voyage_embedders.openai.OpenAI")
+    def test_embed_batch_empty(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        embedder = VoyageDenseEmbedder(
+            model_name="voyage-4-lite",
+            api_key="voyage-key",
+        )
+        assert embedder.embed_batch([]) == []
+        mock_client.embeddings.create.assert_not_called()
+
+    @patch("openviking.models.embedder.voyage_embedders.openai.OpenAI")
+    def test_embed_api_error(self, mock_openai_class):
+        import openai
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.embeddings.create.side_effect = openai.APIError(
+            message="Voyage error",
+            request=MagicMock(),
+            body=None,
+        )
+
+        embedder = VoyageDenseEmbedder(
+            model_name="voyage-4-lite",
+            api_key="voyage-key",
+        )
+
+        with pytest.raises(RuntimeError, match="Voyage API error"):
+            embedder.embed("Hello world")


### PR DESCRIPTION
## Summary
- add first-class `voyage` dense embedding support
- resolve Voyage model defaults when deriving embedding dimension from config
- document the Voyage configuration surface and add focused tests

## Problem
OpenViking's embedding configuration currently supports a fixed set of providers and does not expose Voyage AI as a first-class dense embedding backend.

That creates two concrete issues for Voyage usage:
- there is no supported provider path for Voyage text embedding models
- when no explicit `dimension` is configured, schema creation falls back to a generic default instead of the Voyage model's actual output dimension

For Voyage, that second point is important because collection schema creation happens from configuration before embeddings are written. If the configured dimension does not match the vectors returned by the provider, writes fail later with a vector dimension mismatch.

## What This PR Changes
### 1. Add a dedicated Voyage dense embedder
This PR adds `VoyageDenseEmbedder` and wires it into the embedding factory as a new `provider: "voyage"` option.

The embedder uses Voyage's embeddings API shape and supports provider-specific request fields:
- `input_type`
- `output_dtype`
- `output_dimension` (mapped from `dimension` in config)

### 2. Resolve Voyage dimensions from config
This PR adds provider-specific effective dimension resolution for Voyage so that:
- an explicit `dimension` is honored when provided
- otherwise, the configured Voyage model's default output dimension is used

That keeps vector schema creation aligned with the actual vectors returned by Voyage models.

### 3. Document the supported config shape
The configuration guide now includes:
- `provider: "voyage"`
- Voyage-specific embedding fields
- a concrete dense embedding example
- supported Voyage text embedding models

## Why This Design
This PR keeps the change narrow and provider-specific.

Instead of broadening existing providers, it introduces Voyage support only where Voyage behavior is materially different:
- provider validation
- embedder construction
- Voyage-specific request payload fields
- Voyage-specific default dimension resolution

That keeps existing provider behavior unchanged while making Voyage configuration explicit and maintainable.

## Verification
Ran:

```bash
.venv/bin/python -m pytest tests/unit/test_voyage_embedder.py tests/unit/test_embedding_config_voyage.py --noconftest -q
```

Result:
- `14 passed`

Coverage of the added tests includes:
- provider validation for `voyage`
- default and explicit dimension handling
- embedder factory wiring
- Voyage request payload construction
- batch behavior and API error handling

## Scope
This PR is intentionally limited to Voyage **text embedding** support.
It does not change sparse embeddings, hybrid embeddings, reranking, or non-Voyage providers.
