### PR TITLE
fix(session): skip messages.jsonl in semantic file summary generation

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -13,6 +13,11 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Session-internal files that should never be summarized by the semantic pipeline.
+# These are canonical archives (e.g. session transcripts) whose content provides
+# no additional retrieval value and would only waste tokens and add latency.
+_SKIP_FILENAMES = frozenset({"messages.jsonl"})
+
 
 @dataclass
 class DirNode:
@@ -130,7 +135,7 @@ class SemanticDagExecutor:
 
         for entry in entries:
             name = entry.get("name", "")
-            if not name or name.startswith(".") or name in [".", ".."]:
+            if not name or name.startswith(".") or name in [".", ".."] or name in _SKIP_FILENAMES:
                 continue
 
             item_uri = VikingURI(uri).join(name).uri

--- a/tests/storage/test_semantic_dag_skip_files.py
+++ b/tests/storage/test_semantic_dag_skip_files.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeVikingFS:
+    def __init__(self, tree):
+        self._tree = tree
+        self.writes = []
+
+    async def ls(self, uri, ctx=None):
+        return self._tree.get(uri, [])
+
+    async def write_file(self, path, content, ctx=None):
+        self.writes.append((path, content))
+
+
+class _FakeProcessor:
+    def __init__(self):
+        self.summarized_files = []
+        self.vectorized_files = []
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.summarized_files.append(file_path)
+        return {"name": file_path.split("/")[-1], "summary": "summary"}
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        return "overview"
+
+    def _extract_abstract_from_overview(self, overview):
+        return "abstract"
+
+    async def _vectorize_directory_simple(self, uri, context_type, abstract, overview, ctx=None):
+        pass
+
+    async def _vectorize_single_file(
+        self, parent_uri, context_type, file_path, summary_dict, ctx=None
+    ):
+        self.vectorized_files.append(file_path)
+
+
+@pytest.mark.asyncio
+async def test_messages_jsonl_excluded_from_summary(monkeypatch):
+    """messages.jsonl should be skipped by _list_dir and never summarized."""
+    root_uri = "viking://sessions/test-session"
+    tree = {
+        root_uri: [
+            {"name": "messages.jsonl", "isDir": False},
+            {"name": "notes.txt", "isDir": False},
+            {"name": "document.pdf", "isDir": False},
+        ],
+    }
+    fake_fs = _FakeVikingFS(tree)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="session",
+        max_concurrent_llm=2,
+        ctx=ctx,
+    )
+    await executor.run(root_uri)
+
+    summarized_names = [p.split("/")[-1] for p in processor.summarized_files]
+    assert "messages.jsonl" not in summarized_names
+    assert "notes.txt" in summarized_names
+    assert "document.pdf" in summarized_names
+
+
+@pytest.mark.asyncio
+async def test_messages_jsonl_excluded_in_subdirectory(monkeypatch):
+    """messages.jsonl in a subdirectory should also be skipped."""
+    root_uri = "viking://sessions/test-session"
+    tree = {
+        root_uri: [
+            {"name": "subdir", "isDir": True},
+        ],
+        f"{root_uri}/subdir": [
+            {"name": "messages.jsonl", "isDir": False},
+            {"name": "data.csv", "isDir": False},
+        ],
+    }
+    fake_fs = _FakeVikingFS(tree)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="session",
+        max_concurrent_llm=2,
+        ctx=ctx,
+    )
+    await executor.run(root_uri)
+
+    summarized_names = [p.split("/")[-1] for p in processor.summarized_files]
+    assert "messages.jsonl" not in summarized_names
+    assert "data.csv" in summarized_names
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

Skip `messages.jsonl` from the semantic file summary pipeline during session commit. This file is the canonical session transcript archive and should not be re-summarized as a generic document.

## Why this matters

During `session.commit()`, the session temp directory is enqueued into `SemanticQueue` with `recursive=True`. `SemanticDagExecutor` processes all files uniformly, so `messages.jsonl` goes through VLM-based file summary generation and vectorization - wasting tokens, adding latency, and providing no retrieval value.

- [#564](https://github.com/volcengine/OpenViking/issues/564) - Original report with root cause analysis
- Collaborator @qin-ctx [confirmed](https://github.com/volcengine/OpenViking/issues/564#issuecomment-1) the issue: "Traced through the code and confirmed the issue"
- @yash27-lab traced the code path to `SemanticDagExecutor._file_summary_task()` in `semantic_dag.py`

## Changes

- Added `_SKIP_FILENAMES` frozenset in `semantic_dag.py` containing `messages.jsonl`
- Added filtering in `_list_dir()` to exclude these files from the DAG before they reach `_file_summary_task()`
- The filter sits alongside the existing dotfile skip logic for consistency

## Testing

- Added `tests/storage/test_semantic_dag_skip_files.py` with 2 test cases:
  - `messages.jsonl` excluded at root level while other files are still processed
  - `messages.jsonl` excluded in nested subdirectories

Fixes #564

This contribution was developed with AI assistance (Claude Code).