### PR TITLE
fix(parse): preserve original filename and extension when importing from URL

### DIFF
--- a/openviking/parse/parsers/html.py
+++ b/openviking/parse/parsers/html.py
@@ -28,6 +28,7 @@ from openviking.parse.base import (
     lazy_import,
 )
 from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.constants import CODE_EXTENSIONS
 from openviking_cli.utils.config import get_openviking_config
 
 
@@ -52,51 +53,11 @@ class URLTypeDetector:
     - A file download link (and what type)
     """
 
-    # Common code/text file extensions that should be downloaded, not parsed as web pages
-    CODE_EXTENSIONS = {
-        ".py",
-        ".js",
-        ".ts",
-        ".jsx",
-        ".tsx",
-        ".rb",
-        ".go",
-        ".rs",
-        ".java",
-        ".c",
-        ".cpp",
-        ".h",
-        ".hpp",
-        ".cs",
-        ".swift",
-        ".kt",
-        ".scala",
-        ".sh",
-        ".bash",
-        ".zsh",
-        ".r",
-        ".lua",
-        ".pl",
-        ".php",
-        ".yaml",
-        ".yml",
-        ".toml",
-        ".ini",
-        ".cfg",
-        ".conf",
-        ".json",
-        ".xml",
-        ".csv",
-        ".sql",
-        ".dockerfile",
-        ".makefile",
-        ".cmake",
-        ".proto",
-        ".graphql",
-    }
-
     # Extension to URL type mapping
+    # CODE_EXTENSIONS spread comes first so explicit entries below override
+    # (e.g., .html/.htm -> DOWNLOAD_HTML instead of DOWNLOAD_TXT)
     EXTENSION_MAP = {
+        **dict.fromkeys(CODE_EXTENSIONS, URLType.DOWNLOAD_TXT),
         ".pdf": URLType.DOWNLOAD_PDF,
         ".md": URLType.DOWNLOAD_MD,
         ".markdown": URLType.DOWNLOAD_MD,
@@ -105,7 +66,6 @@ class URLTypeDetector:
         ".html": URLType.DOWNLOAD_HTML,
         ".htm": URLType.DOWNLOAD_HTML,
         ".git": URLType.CODE_REPOSITORY,
-        **dict.fromkeys(CODE_EXTENSIONS, URLType.DOWNLOAD_TXT),
     }
 
     # Content-Type to URL type mapping

--- a/tests/parse/test_url_filename_preservation.py
+++ b/tests/parse/test_url_filename_preservation.py
@@ -111,3 +111,10 @@ class TestURLTypeDetectorCodeExtensions:
         url = "https://example.com/paper.pdf"
         url_type, meta = await self.detector.detect(url)
         assert url_type == URLType.DOWNLOAD_PDF
+
+    @pytest.mark.asyncio
+    async def test_html_still_routes_to_download_html(self):
+        """Ensure .html overrides CODE_EXTENSIONS mapping to DOWNLOAD_TXT."""
+        url = "https://example.com/page.html"
+        url_type, meta = await self.detector.detect(url)
+        assert url_type == URLType.DOWNLOAD_HTML


### PR DESCRIPTION
## Summary

Fix URL resource import to preserve original filenames and extensions instead of using temp file names and converting everything to `.md`.

## Why this matters

When importing resources via URL (e.g., COS paths), three bugs compound:
1. Temp filename (like `tmptzedil33`) leaks into the final URI as a directory name
2. Code files (`.py`, `.js`, etc.) are converted to `.md` by the markdown parser
3. URL-encoded characters in filenames are not decoded

- [#251](https://github.com/volcengine/OpenViking/issues/251) - Original report with curl repro
- @ZaynJarvis (COLLABORATOR) [confirmed](https://github.com/volcengine/OpenViking/issues/251#issuecomment-1): "good catch. I can reproduce the issue"
- @MaojiaSheng (COLLABORATOR) [confirmed](https://github.com/volcengine/OpenViking/issues/251#issuecomment-2): "The path looks like a url indicated code file, and it hits wrong parser"

Expected: `viking://resources/dir/schemas.py`
Actual: `viking://resources/dir/schemas/schemas.md`

## Changes

In `openviking/parse/parsers/html.py`:
- Added `CODE_EXTENSIONS` set (~40 common code/text extensions) to `URLTypeDetector` so code files route to `DOWNLOAD_TXT` instead of `WEBPAGE` parsing
- Added `_extract_filename_from_url()` to extract and URL-decode the original filename from URLs
- Added `_save_downloaded_text()` to save downloaded text/code files with their original filename and extension, bypassing the MarkdownParser
- Applied `urllib.parse.unquote()` for proper handling of URL-encoded characters

## Testing

Added `tests/parse/test_url_filename_preservation.py` with tests for:
- Filename extraction from various URL formats
- URL decoding of encoded characters
- Code extension detection

Fixes #251

This contribution was developed with AI assistance (Claude Code).