### PR TITLE
feat: add reindex command for new/modified resources

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -607,6 +607,22 @@ impl HttpClient {
         }
     }
 
+    pub async fn reindex(
+        &self,
+        uri: &str,
+        force: bool,
+        wait: bool,
+        timeout: Option<f64>,
+    ) -> Result<serde_json::Value> {
+        let body = serde_json::json!({
+            "uri": uri,
+            "force": force,
+            "wait": wait,
+            "timeout": timeout,
+        });
+        self.post("/api/v1/resources/reindex", &body).await
+    }
+
     // ============ Relation Methods ============
 
     pub async fn relations(&self, uri: &str) -> Result<serde_json::Value> {

--- a/crates/ov_cli/src/commands/resources.rs
+++ b/crates/ov_cli/src/commands/resources.rs
@@ -39,6 +39,20 @@ pub async fn add_resource(
     Ok(())
 }
 
+pub async fn reindex(
+    client: &HttpClient,
+    uri: &str,
+    force: bool,
+    wait: bool,
+    timeout: Option<f64>,
+    format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let result = client.reindex(uri, force, wait, timeout).await?;
+    output_success(&result, format, compact);
+    Ok(())
+}
+
 pub async fn add_skill(
     client: &HttpClient,
     data: &str,

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -108,6 +108,21 @@ enum Commands {
         #[arg(long)]
         timeout: Option<f64>,
     },
+    /// Re-generate L0/L1 and rebuild vector index for new or modified resources
+    Reindex {
+        /// Root URI to scan (default: all resources)
+        #[arg(default_value = "viking://resources/")]
+        uri: String,
+        /// Re-process even if content appears up-to-date
+        #[arg(long)]
+        force: bool,
+        /// Wait until processing is complete
+        #[arg(long)]
+        wait: bool,
+        /// Wait timeout in seconds (only used with --wait)
+        #[arg(long)]
+        timeout: Option<f64>,
+    },
     /// List relations of a resource
     Relations {
         /// Viking URI
@@ -546,6 +561,9 @@ async fn main() {
         Commands::AddSkill { data, wait, timeout } => {
             handle_add_skill(data, wait, timeout, ctx).await
         }
+        Commands::Reindex { uri, force, wait, timeout } => {
+            handle_reindex(uri, force, wait, timeout, ctx).await
+        }
         Commands::Relations { uri } => {
             handle_relations(uri, ctx).await
         }
@@ -726,6 +744,19 @@ async fn handle_add_skill(
     let client = ctx.get_client();
     commands::resources::add_skill(
         &client, &data, wait, timeout, ctx.output_format, ctx.compact
+    ).await
+}
+
+async fn handle_reindex(
+    uri: String,
+    force: bool,
+    wait: bool,
+    timeout: Option<f64>,
+    ctx: CliContext,
+) -> Result<()> {
+    let client = ctx.get_client();
+    commands::resources::reindex(
+        &client, &uri, force, wait, timeout, ctx.output_format, ctx.compact
     ).await
 }
 

--- a/examples/mcp-query/server.py
+++ b/examples/mcp-query/server.py
@@ -211,6 +211,49 @@ def create_server(host: str = "127.0.0.1", port: int = 2033) -> FastMCP:
 
         return await asyncio.to_thread(_add_sync)
 
+    @mcp.tool()
+    async def reindex(
+        uri: str = "viking://resources/",
+        force: bool = False,
+    ) -> str:
+        """
+        Re-generate L0/L1 summaries and rebuild the vector index for new or modified resources.
+
+        Scans AGFS under the given URI and detects:
+        - New files (no .abstract.md yet)
+        - Modified files (L2 content newer than .abstract.md)
+
+        Use force=True to unconditionally re-process everything.
+
+        Args:
+            uri: Root URI to scan (default: all resources).
+            force: Re-process even if content appears up-to-date.
+        """
+        config_path = _config_path
+        data_path = _data_path
+
+        def _reindex_sync():
+            with open(config_path, "r") as f:
+                config_dict = json.load(f)
+
+            config = OpenVikingConfig.from_dict(config_dict)
+            client = ov.SyncOpenViking(path=data_path, config=config)
+
+            try:
+                client.initialize()
+                result = client.reindex(uri=uri, force=force, wait=True, timeout=600)
+                new = result.get("new", 0)
+                modified = result.get("modified", 0)
+                skipped = result.get("skipped", 0)
+                return (
+                    f"Reindex complete: {new} new, {modified} modified, "
+                    f"{skipped} skipped (unchanged)."
+                )
+            finally:
+                client.close()
+
+        return await asyncio.to_thread(_reindex_sync)
+
     @mcp.resource("openviking://status")
     def server_status() -> str:
         """Get the current server status and configuration."""

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -216,6 +216,17 @@ class AsyncOpenViking:
             **kwargs,
         )
 
+    async def reindex(
+        self,
+        uri: str = "viking://resources/",
+        force: bool = False,
+        wait: bool = False,
+        timeout: float = None,
+    ) -> Dict[str, Any]:
+        """Re-generate L0/L1 and rebuild vector index for new or modified resources."""
+        await self._ensure_initialized()
+        return await self._client.reindex(uri=uri, force=force, wait=wait, timeout=timeout)
+
     async def wait_processed(self, timeout: float = None) -> Dict[str, Any]:
         """Wait for all queued processing to complete."""
         await self._ensure_initialized()

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -99,6 +99,22 @@ class LocalClient(BaseClient):
         """Wait for all processing to complete."""
         return await self._service.resources.wait_processed(timeout=timeout)
 
+    async def reindex(
+        self,
+        uri: str = "viking://resources/",
+        force: bool = False,
+        wait: bool = False,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Re-generate L0/L1 and rebuild vector index for new or modified resources."""
+        return await self._service.resources.reindex(
+            uri=uri,
+            ctx=self._ctx,
+            force=force,
+            wait=wait,
+            timeout=timeout,
+        )
+
     async def build_index(self, resource_uris: Union[str, List[str]], **kwargs) -> Dict[str, Any]:
         """Manually trigger index building."""
         if isinstance(resource_uris, str):

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -134,6 +134,32 @@ async def add_resource(
     return Response(status="ok", result=result)
 
 
+class ReindexRequest(BaseModel):
+    """Request model for reindex."""
+
+    uri: str = "viking://resources/"
+    force: bool = False
+    wait: bool = False
+    timeout: Optional[float] = None
+
+
+@router.post("/resources/reindex")
+async def reindex(
+    request: ReindexRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Re-generate L0/L1 and rebuild vector index for new or modified resources."""
+    service = get_service()
+    result = await service.resources.reindex(
+        uri=request.uri,
+        ctx=_ctx,
+        force=request.force,
+        wait=request.wait,
+        timeout=request.timeout,
+    )
+    return Response(status="ok", result=result)
+
+
 @router.post("/skills")
 async def add_skill(
     request: AddSkillRequest,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from openviking.server.identity import RequestContext
 from openviking.storage import VikingDBManager
-from openviking.storage.queuefs import get_queue_manager
+from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.storage.viking_fs import VikingFS
 from openviking.utils.resource_processor import ResourceProcessor
 from openviking.utils.skill_processor import SkillProcessor
@@ -209,6 +209,172 @@ class ResourceService:
         """
         self._ensure_initialized()
         return await self._resource_processor.summarize(resource_uris, ctx, **kwargs)
+
+    async def reindex(
+        self,
+        uri: str = "viking://resources/",
+        ctx: Optional["RequestContext"] = None,
+        force: bool = False,
+        wait: bool = False,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Re-generate L0/L1 summaries and rebuild vector index for stale or new entries.
+
+        Scans the AGFS tree under *uri*.  For every leaf directory that
+        contains L2 content files:
+
+        * **New** – no ``.abstract.md`` exists → enqueue for semantic processing.
+        * **Modified** – L2 file ``modTime`` is newer than ``.abstract.md`` →
+          delete old vectors, enqueue for re-processing.
+        * **force=True** – unconditionally re-process everything.
+
+        Args:
+            uri: Root URI to scan (default: all resources).
+            ctx: Request context.
+            force: Re-process even if L0/L1 appear up-to-date.
+            wait: Block until all queued processing finishes.
+            timeout: Maximum seconds to wait (only when *wait* is True).
+
+        Returns:
+            Summary dict with counts of *skipped*, *new*, *modified*, and
+            *enqueued* entries.
+        """
+        self._ensure_initialized()
+
+        viking_fs = self._viking_fs
+        vikingdb = self._vikingdb
+
+        stats: Dict[str, int] = {"scanned": 0, "skipped": 0, "new": 0, "modified": 0, "enqueued": 0}
+        dirs_to_reindex: list[str] = []
+
+        # Walk the tree and decide which directories need re-processing.
+        entries = await viking_fs.ls(uri, show_all_hidden=True, node_limit=100000, ctx=ctx)
+        await self._collect_stale_dirs(viking_fs, uri, entries, force, dirs_to_reindex, stats, ctx)
+
+        # Delete existing vectors and enqueue semantic processing for each stale dir.
+        if dirs_to_reindex:
+            queue_manager = get_queue_manager()
+            semantic_queue = queue_manager.get_queue(queue_manager.SEMANTIC, allow_create=True)
+
+            for dir_uri in dirs_to_reindex:
+                # Remove old vectors so they get rebuilt
+                if vikingdb:
+                    try:
+                        await vikingdb.remove_by_uri(dir_uri, ctx=ctx)
+                    except Exception as e:
+                        logger.warning(f"Failed to remove old vectors for {dir_uri}: {e}")
+
+                msg = SemanticMsg(
+                    uri=dir_uri,
+                    context_type=self._context_type_for_uri(dir_uri),
+                    recursive=False,  # we already collected individual dirs
+                    account_id=ctx.account_id if ctx else "default",
+                    user_id=ctx.user.user_id if ctx else "default",
+                    agent_id=ctx.user.agent_id if ctx else "default",
+                    role=ctx.role.value if ctx else "root",
+                )
+                await semantic_queue.enqueue(msg)
+                stats["enqueued"] += 1
+
+            logger.info(f"Reindex enqueued {stats['enqueued']} directories under {uri}")
+
+        if wait:
+            qm = get_queue_manager()
+            try:
+                status = await qm.wait_complete(timeout=timeout)
+            except TimeoutError as exc:
+                raise DeadlineExceededError("queue processing", timeout) from exc
+            stats["queue_status"] = {
+                name: {
+                    "processed": s.processed,
+                    "error_count": s.error_count,
+                    "errors": [{"message": e.message} for e in s.errors],
+                }
+                for name, s in status.items()
+            }
+
+        return stats
+
+    async def _collect_stale_dirs(
+        self,
+        viking_fs: "VikingFS",
+        parent_uri: str,
+        entries: List[Dict[str, Any]],
+        force: bool,
+        result: list[str],
+        stats: Dict[str, int],
+        ctx: Optional["RequestContext"] = None,
+    ) -> None:
+        """Recursively collect directory URIs that need re-indexing."""
+        from datetime import datetime
+
+        abstract_mtime = None
+        has_l2_files = False
+        max_l2_mtime = None
+
+        for entry in entries:
+            name = entry.get("name", "")
+            is_dir = entry.get("isDir", False)
+            entry_uri = entry.get("uri", f"{parent_uri}/{name}")
+
+            if is_dir and not name.startswith("."):
+                # Recurse into subdirectories
+                sub_entries = await viking_fs.ls(entry_uri, show_all_hidden=True, node_limit=100000, ctx=ctx)
+                await self._collect_stale_dirs(viking_fs, entry_uri, sub_entries, force, result, stats, ctx)
+                continue
+
+            mod_time_str = entry.get("modTime", "")
+
+            if name == ".abstract.md" and mod_time_str:
+                try:
+                    abstract_mtime = datetime.fromisoformat(mod_time_str)
+                except (ValueError, TypeError):
+                    pass
+                continue
+
+            # Skip other hidden/meta files
+            if name.startswith("."):
+                continue
+
+            # This is an L2 content file
+            if not is_dir:
+                has_l2_files = True
+                if mod_time_str:
+                    try:
+                        file_mtime = datetime.fromisoformat(mod_time_str)
+                        if max_l2_mtime is None or file_mtime > max_l2_mtime:
+                            max_l2_mtime = file_mtime
+                    except (ValueError, TypeError):
+                        pass
+
+        stats["scanned"] += 1
+
+        if not has_l2_files:
+            stats["skipped"] += 1
+            return
+
+        if force:
+            stats["modified"] += 1
+            result.append(parent_uri)
+        elif abstract_mtime is None:
+            # No .abstract.md → new, never indexed
+            stats["new"] += 1
+            result.append(parent_uri)
+        elif max_l2_mtime and max_l2_mtime > abstract_mtime:
+            # L2 files modified after last indexing
+            stats["modified"] += 1
+            result.append(parent_uri)
+        else:
+            stats["skipped"] += 1
+
+    @staticmethod
+    def _context_type_for_uri(uri: str) -> str:
+        """Derive context_type from URI scope."""
+        if "memory" in uri or "memories" in uri:
+            return "memory"
+        if "skill" in uri:
+            return "skill"
+        return "resource"
 
     async def wait_processed(self, timeout: Optional[float] = None) -> Dict[str, Any]:
         """Wait for all queued processing to complete.

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -113,6 +113,18 @@ class SyncOpenViking:
             )
         )
 
+    def reindex(
+        self,
+        uri: str = "viking://resources/",
+        force: bool = False,
+        wait: bool = False,
+        timeout: float = None,
+    ) -> Dict[str, Any]:
+        """Re-generate L0/L1 and rebuild vector index for new or modified resources."""
+        return run_async(
+            self._async_client.reindex(uri=uri, force=force, wait=wait, timeout=timeout)
+        )
+
     def add_skill(
         self,
         data: Any,


### PR DESCRIPTION
## Summary

- Adds `reindex` command that scans AGFS and detects new or modified resources by comparing L2 file `modTime` against `.abstract.md` `modTime`
- Stale entries are re-enqueued for L0/L1 regeneration and vector index rebuild
- Supports `--force` flag to unconditionally re-process all entries
- Implemented across all layers: service, HTTP API, client chain (sync/async), Rust CLI, and MCP tool

## Motivation

Currently, if files are manually added to the AGFS workspace directory or modified externally after `add_resource()`, there is no way to detect and re-index them. Users must manually `rm` + `add_resource` each changed file.

This PR adds a single `reindex` command that handles both cases:
- **New files** — no `.abstract.md` exists → enqueue for semantic processing
- **Modified files** — L2 content `modTime` is newer than `.abstract.md` → delete old vectors, re-process

## Usage

```bash
# CLI
ov reindex                                    # scan all resources
ov reindex viking://resources/docs/ --force   # force re-process specific subtree
ov reindex --wait --timeout 300               # wait for completion

# HTTP API
POST /api/v1/resources/reindex
{"uri": "viking://resources/", "force": false, "wait": true}

# Python SDK
client.reindex(uri="viking://resources/", force=False, wait=True)

# MCP tool
reindex(uri="viking://resources/", force=False)
```

## Files changed

| File | Change |
|------|--------|
| `openviking/service/resource_service.py` | Core `reindex()` with mtime-based staleness detection |
| `openviking/server/routers/resources.py` | `POST /api/v1/resources/reindex` endpoint |
| `openviking/client/local.py` | `LocalClient.reindex()` |
| `openviking/async_client.py` | `AsyncOpenViking.reindex()` |
| `openviking/sync_client.py` | `SyncOpenViking.reindex()` |
| `crates/ov_cli/src/main.rs` | `ov reindex` CLI command |
| `crates/ov_cli/src/commands/resources.rs` | CLI handler |
| `crates/ov_cli/src/client.rs` | HTTP client method |
| `examples/mcp-query/server.py` | MCP `reindex` tool |

## Test plan

- [ ] Add new files directly to AGFS workspace → `ov reindex` detects and indexes them
- [ ] Modify existing L2 files → `ov reindex` detects mtime change and re-processes
- [ ] Unchanged files are skipped (no unnecessary LLM calls)
- [ ] `--force` flag re-processes everything regardless of mtime
- [ ] `--wait` blocks until queue processing completes
- [ ] HTTP endpoint returns correct stats (scanned/new/modified/skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)