### PR TITLE
fix(bot): when used as bot provider, minimax not support role: system, avoid the role

### DIFF
--- a/bot/vikingbot/providers/litellm_provider.py
+++ b/bot/vikingbot/providers/litellm_provider.py
@@ -4,9 +4,9 @@ import json
 import os
 from typing import Any
 
-from loguru import logger
 import litellm
 from litellm import acompletion
+from loguru import logger
 
 from vikingbot.integrations.langfuse import LangfuseClient
 from vikingbot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
@@ -104,6 +104,64 @@ class LiteLLMProvider(LLMProvider):
                     kwargs.update(overrides)
                     return
 
+    def _handle_system_message(
+        self, model: str, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """
+        Handle system message for providers that don't support it (e.g. MiniMax).
+        Merges system message into the first user message or converts to user role.
+        """
+        # Check for MiniMax
+        if model.startswith("minimax/") or "/minimax/" in model:
+            # Create a copy to avoid modifying the original list
+            new_messages = []
+
+            # Helper to merge content
+            def merge_content(base_content, new_content):
+                if isinstance(base_content, str) and isinstance(new_content, str):
+                    return f"{new_content}\n\n{base_content}"
+                if isinstance(base_content, list):
+                    base_content = list(base_content)
+                    base_content.insert(0, {"type": "text", "text": f"{new_content}\n\n"})
+                    return base_content
+                return f"{new_content}\n\n{str(base_content)}"
+
+            # First pass: identify system messages
+            system_contents = []
+            cleaned_messages = []
+
+            for msg in messages:
+                if msg.get("role") == "system":
+                    system_contents.append(msg.get("content", ""))
+                else:
+                    cleaned_messages.append(msg)
+
+            # If no system messages, return as is
+            if not system_contents:
+                return messages
+
+            # Combine all system prompts
+            full_system_prompt = "\n\n".join([str(c) for c in system_contents])
+
+            # Merge into the first user message if available
+            merged = False
+            for msg in cleaned_messages:
+                if not merged and msg.get("role") == "user":
+                    msg = msg.copy()
+                    msg["content"] = merge_content(msg.get("content", ""), full_system_prompt)
+                    new_messages.append(msg)
+                    merged = True
+                else:
+                    new_messages.append(msg)
+
+            # If no user message found, create one at the beginning
+            if not merged:
+                new_messages.insert(0, {"role": "user", "content": full_system_prompt})
+
+            return new_messages
+
+        return messages
+
     async def chat(
         self,
         messages: list[dict[str, Any]],
@@ -128,6 +186,9 @@ class LiteLLMProvider(LLMProvider):
             LLMResponse with content and/or tool calls.
         """
         model = self._resolve_model(model or self.default_model)
+
+        # Handle system message for MiniMax and others that don't support it
+        messages = self._handle_system_message(model, messages)
 
         kwargs: dict[str, Any] = {
             "model": model,


### PR DESCRIPTION
## Description


MiniMax API Limitations
The MiniMax Chat Completion API (specifically v1) does not support the role: "system" attribute within the messages list. It typically only accepts user, assistant, and function roles.

LiteLLM Default Behavior
Vikingbot utilizes LiteLLM as an abstraction layer. By default, LiteLLM passes system messages directly through to the downstream provider.

The Conflict
Vikingbot (AgentLoop) generates a System Prompt (e.g., "You are a helpful assistant...") based on the configured Skill and Profile at the start of a conversation. This is placed as the first message in the list with role: system.

When this request containing a system role is sent directly to MiniMax, the MiniMax server fails validation and returns Error Code 2013.

{
  "error": {
    "message": "MinimaxException - invalid params, chat content has invalid message role: system (2013)",
    "type": "None",
    "param": "None",
    "code": "2013"
  }
}


## Related Issue



## Type of Change



- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- remove the system role message and merge it into normal message
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)


## Additional Notes
