### PR TITLE
feat(content): add reindex endpoint for re-embedding after manual edits

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Content endpoints for OpenViking HTTP Server."""
 
+import asyncio
 from urllib.parse import quote
 
 from fastapi import APIRouter, Body, Depends, Query
@@ -12,6 +13,11 @@ from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.models import ErrorInfo, Response
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+REINDEX_TASK_TYPE = "resource_reindex"
 
 
 class ReindexRequest(BaseModel):
@@ -19,6 +25,7 @@ class ReindexRequest(BaseModel):
 
     uri: str
     regenerate: bool = False
+    wait: bool = True
 
 
 router = APIRouter(prefix="/api/v1/content", tags=["content"])
@@ -94,7 +101,11 @@ async def reindex(
     Re-embeds existing .abstract.md/.overview.md content into the vector
     database. If regenerate=True, also regenerates L0/L1 summaries via LLM
     before re-embedding.
+
+    Uses transaction locking to prevent concurrent reindexes on the same URI.
+    Set wait=False to run in the background and track progress via task API.
     """
+    from openviking.service.task_tracker import get_task_tracker
     from openviking.storage.viking_fs import get_viking_fs
 
     uri = request.uri
@@ -108,11 +119,90 @@ async def reindex(
         )
 
     service = get_service()
-    if request.regenerate:
-        # Regenerate L0/L1 via LLM, then auto-enqueue for embedding
-        result = await service.resources.summarize([uri], ctx=_ctx)
+    tracker = get_task_tracker()
+
+    if request.wait:
+        # Synchronous path: block until reindex completes
+        if tracker.has_running(REINDEX_TASK_TYPE, uri):
+            return Response(
+                status="error",
+                error=ErrorInfo(
+                    code="CONFLICT",
+                    message=f"URI {uri} already has a reindex in progress",
+                ),
+            )
+        result = await _do_reindex(service, uri, request.regenerate, _ctx)
         return Response(status="ok", result=result)
     else:
-        # Re-embed existing content only
-        result = await service.resources.build_index([uri], ctx=_ctx)
-        return Response(status="ok", result=result)
+        # Async path: run in background, return task_id for polling
+        task = tracker.create_if_no_running(REINDEX_TASK_TYPE, uri)
+        if task is None:
+            return Response(
+                status="error",
+                error=ErrorInfo(
+                    code="CONFLICT",
+                    message=f"URI {uri} already has a reindex in progress",
+                ),
+            )
+        asyncio.create_task(
+            _background_reindex_tracked(service, uri, request.regenerate, _ctx, task.task_id)
+        )
+        return Response(
+            status="ok",
+            result={
+                "uri": uri,
+                "status": "accepted",
+                "task_id": task.task_id,
+                "message": "Reindex is processing in the background",
+            },
+        )
+
+
+async def _do_reindex(
+    service,
+    uri: str,
+    regenerate: bool,
+    ctx: RequestContext,
+) -> dict:
+    """Execute reindex within a transaction."""
+    from openviking.storage.transaction import get_transaction_manager
+
+    tm = get_transaction_manager()
+    tx = tm.create_transaction(init_info={"uri": uri, "regenerate": regenerate})
+    await tm.begin(tx.id)
+
+    try:
+        await tm.acquire_lock_normal(tx.id, uri)
+        if regenerate:
+            result = await service.resources.summarize([uri], ctx=ctx)
+        else:
+            result = await service.resources.build_index([uri], ctx=ctx)
+        await tm.commit(tx.id)
+        return result
+    except Exception:
+        try:
+            await tm.rollback(tx.id)
+        except Exception:
+            pass
+        raise
+
+
+async def _background_reindex_tracked(
+    service,
+    uri: str,
+    regenerate: bool,
+    ctx: RequestContext,
+    task_id: str,
+) -> None:
+    """Run reindex in background with task tracking."""
+    from openviking.service.task_tracker import get_task_tracker
+
+    tracker = get_task_tracker()
+    tracker.start(task_id)
+    try:
+        result = await _do_reindex(service, uri, regenerate, ctx)
+        tracker.complete(task_id, {"uri": uri, **result})
+        logger.info("Background reindex completed: uri=%s task=%s", uri, task_id)
+    except Exception as exc:
+        tracker.fail(task_id, str(exc))
+        logger.exception("Background reindex failed: uri=%s task=%s", uri, task_id)

--- a/tests/server/test_api_content.py
+++ b/tests/server/test_api_content.py
@@ -60,7 +60,7 @@ async def test_reindex_endpoint_registered(client):
 
 async def test_reindex_request_validation(client):
     """Test reindex validates the request body schema."""
-    # Empty body
+    # Empty body — uri is required
     resp = await client.post("/api/v1/content/reindex", json={})
     assert resp.status_code == 422
 
@@ -71,3 +71,15 @@ async def test_reindex_request_validation(client):
     )
     # Pydantic coerces strings to bool, so this may or may not fail
     assert resp.status_code in (200, 422, 500)
+
+
+async def test_reindex_wait_parameter_schema(client):
+    """Test reindex accepts wait parameter in request schema."""
+    # Invalid wait type should be coerced or rejected, not crash
+    resp = await client.post(
+        "/api/v1/content/reindex",
+        json={"uri": "viking://resources/test", "wait": "invalid"},
+    )
+    # Pydantic coerces or rejects — either way, not a 404/405
+    assert resp.status_code != 404
+    assert resp.status_code != 405


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/content/reindex` endpoint that re-embeds existing `.abstract.md`/`.overview.md` content into the vector database after manual edits
- Supports optional `regenerate=true` mode that regenerates L0/L1 summaries via LLM before re-embedding
- Includes request validation (URI existence check, schema validation) and tests

Addresses #468

## Changes Made
- **`openviking/server/routers/content.py`**: Added `ReindexRequest` model and `POST /reindex` endpoint. Uses existing `ResourceService.build_index()` for re-embed and `ResourceService.summarize()` for regenerate mode.
- **`tests/server/test_api_content.py`**: Added 3 tests — request validation (missing uri → 422), endpoint registration (GET → 405), and schema validation.

## API

```bash
# Re-embed existing content (after manual edit to .overview.md)
curl -X POST http://localhost:1933/api/v1/content/reindex \
  -H "Content-Type: application/json" \
  -d '{"uri": "viking://resources/my_project/doc_dir"}'

# Regenerate L0/L1 via LLM + re-embed
curl -X POST http://localhost:1933/api/v1/content/reindex \
  -H "Content-Type: application/json" \
  -d '{"uri": "viking://resources/my_project/doc_dir", "regenerate": true}'
```

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Tests added
- [x] Unit tests pass locally (`pytest tests/server/test_api_content.py` — 6/6 pass)
- [x] Tested on macOS

## Checklist
- [x] My code follows the code style of this project (ruff check + format pass)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)