### PR TITLE
feat(openclaw-plugin): support multi-agent memory isolation via hook context agentId

### DIFF
--- a/examples/openclaw-memory-plugin/client.ts
+++ b/examples/openclaw-memory-plugin/client.ts
@@ -47,15 +47,35 @@ export function isMemoryUri(uri: string): boolean {
 }
 
 export class OpenVikingClient {
-  private readonly resolvedSpaceByScope: Partial<Record<ScopeName, string>> = {};
+  private resolvedSpaceByScope: Partial<Record<ScopeName, string>> = {};
   private runtimeIdentity: RuntimeIdentity | null = null;
 
   constructor(
     private readonly baseUrl: string,
     private readonly apiKey: string,
-    private readonly agentId: string,
+    private agentId: string,
     private readonly timeoutMs: number,
   ) {}
+
+  /**
+   * Dynamically switch the agent identity for multi-agent memory isolation.
+   * When a shared client serves multiple agents (e.g. in OpenClaw multi-agent
+   * gateway), call this before each agent's recall/capture to route memories
+   * to the correct agent_space = md5(user_id + agent_id)[:12].
+   * Clears cached space resolution so the next request re-derives agent_space.
+   */
+  setAgentId(newAgentId: string): void {
+    if (newAgentId && newAgentId !== this.agentId) {
+      this.agentId = newAgentId;
+      // Clear cached identity and spaces — they depend on agentId
+      this.runtimeIdentity = null;
+      this.resolvedSpaceByScope = {};
+    }
+  }
+
+  getAgentId(): string {
+    return this.agentId;
+  }
 
   private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
     const controller = new AbortController();

--- a/examples/openclaw-memory-plugin/index.ts
+++ b/examples/openclaw-memory-plugin/index.ts
@@ -354,7 +354,16 @@ const memoryPlugin = {
     );
 
     if (cfg.autoRecall || cfg.ingestReplyAssist) {
-      api.on("before_agent_start", async (event: { messages?: unknown[]; prompt: string }) => {
+      api.on("before_agent_start", async (event: { messages?: unknown[]; prompt: string }, ctx?: { agentId?: string }) => {
+        // Dynamically switch agent identity for multi-agent memory isolation.
+        // In multi-agent gateway deployments, the hook context carries the current
+        // agent's ID so we route memory operations to the correct agent_space.
+        const hookAgentId = ctx?.agentId;
+        if (hookAgentId) {
+          const client = await getClient();
+          client.setAgentId(hookAgentId);
+          api.logger.info?.(`memory-openviking: switched to agentId=${hookAgentId} for recall`);
+        }
         const queryText = extractLatestUserText(event.messages) || event.prompt.trim();
         if (!queryText) {
           return;
@@ -474,7 +483,14 @@ const memoryPlugin = {
     if (cfg.autoCapture) {
       let lastProcessedMsgCount = 0;
 
-      api.on("agent_end", async (event: { success?: boolean; messages?: unknown[] }) => {
+      api.on("agent_end", async (event: { success?: boolean; messages?: unknown[] }, ctx?: { agentId?: string }) => {
+        // Dynamically switch agent identity for multi-agent memory isolation
+        const hookAgentId = ctx?.agentId;
+        if (hookAgentId) {
+          const client = await getClient();
+          client.setAgentId(hookAgentId);
+          api.logger.info?.(`memory-openviking: switched to agentId=${hookAgentId} for capture`);
+        }
         if (!event.success || !event.messages || event.messages.length === 0) {
           api.logger.info(
             `memory-openviking: auto-capture skipped (success=${String(event.success)}, messages=${event.messages?.length ?? 0})`,


### PR DESCRIPTION
## Summary

When OpenClaw gateway serves multiple agents, each agent's `before_agent_start` and `agent_end` hooks carry the agent's ID in the second parameter (`PluginHookAgentContext`). This PR makes the memory plugin dynamically switch the client's `agentId` before each recall/capture operation, ensuring memories are routed to the correct `agent_space` (`md5(user_id + agent_id)[:12]`).

## Problem

In a multi-agent deployment (e.g., 9 agents sharing one OpenClaw gateway), all agents stored and retrieved memories from the **same** default agent space (`md5('default' + 'default')[:12]`), causing memory cross-contamination between agents.

## Changes

### `client.ts`
- Add `setAgentId()` / `getAgentId()` methods to `OpenVikingClient`
- `setAgentId()` clears cached `runtimeIdentity` and `resolvedSpaceByScope` to force re-derivation of the agent_space for the new agent

### `index.ts`
- `before_agent_start` handler: accept 2nd `ctx` parameter, extract `ctx.agentId`, call `client.setAgentId()` before memory recall
- `agent_end` handler: same pattern before memory capture

## Backward Compatibility

Fully backward compatible. If `ctx?.agentId` is absent (single-agent setup or older OpenClaw versions), the plugin falls back to the static `config.agentId` as before.

## Tested

Verified on OpenClaw v2026.3.13 multi-agent gateway with 9 agents. Gateway logs confirm different agentIds for different agents:
```
memory-openviking: switched to agentId=main for recall
memory-openviking: switched to agentId=main for capture
memory-openviking: switched to agentId=r3-2 for recall
memory-openviking: switched to agentId=r3-2 for capture
```