### PR TITLE
feat(opencode-memory-plugin): add agentId support for per-agent memory isolation

### DIFF
--- a/examples/opencode-memory-plugin/openviking-config.example.json
+++ b/examples/opencode-memory-plugin/openviking-config.example.json
@@ -3,6 +3,7 @@
   "apiKey": "your-api-key-here",
   "enabled": true,
   "timeoutMs": 30000,
+  "agentId": "",
   "autoCommit": {
     "enabled": true,
     "intervalMinutes": 10

--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -279,6 +279,8 @@ interface OpenVikingConfig {
   apiKey: string
   enabled: boolean
   timeoutMs: number
+  /** Identifies this agent to OpenViking (sent as X-OpenViking-Agent header). Enables per-agent memory isolation. */
+  agentId?: string
   autoCommit?: {
     enabled: boolean
     intervalMinutes: number
@@ -345,6 +347,7 @@ const DEFAULT_CONFIG: OpenVikingConfig = {
   apiKey: "",
   enabled: true,
   timeoutMs: 30000,
+  agentId: "",
   autoCommit: {
     enabled: true,
     intervalMinutes: 10
@@ -378,6 +381,9 @@ function loadConfig(): OpenVikingConfig {
       if (process.env.OPENVIKING_API_KEY) {
         config.apiKey = process.env.OPENVIKING_API_KEY
       }
+      if (process.env.OPENVIKING_AGENT_ID) {
+        config.agentId = process.env.OPENVIKING_AGENT_ID
+      }
 
       return config
     }
@@ -394,6 +400,9 @@ function loadConfig(): OpenVikingConfig {
   }
   if (process.env.OPENVIKING_API_KEY) {
     config.apiKey = process.env.OPENVIKING_API_KEY
+  }
+  if (process.env.OPENVIKING_AGENT_ID) {
+    config.agentId = process.env.OPENVIKING_AGENT_ID
   }
   if (config.autoCommit) {
     config.autoCommit.intervalMinutes = getAutoCommitIntervalMinutes(config)
@@ -422,6 +431,9 @@ async function makeRequest<T = any>(config: OpenVikingConfig, options: HttpReque
 
   if (config.apiKey) {
     headers["X-API-Key"] = config.apiKey
+  }
+  if (config.agentId) {
+    headers["X-OpenViking-Agent"] = config.agentId
   }
 
   const controller = new AbortController()


### PR DESCRIPTION
## Summary

Add `X-OpenViking-Agent` header support to the opencode-memory-plugin, enabling multi-agent setups to maintain isolated memory spaces via OpenViking's built-in agent scope mechanism.

## Motivation

When running multiple agents (e.g. main, blog, psy-mate, proj-mate) against a single OpenViking server, all agents currently share the same memory space. OpenViking already supports per-agent memory isolation via the `X-OpenViking-Agent` header at the server level, but the plugin does not expose a way to set this header.

## Changes

- Add `agentId` field to `OpenVikingConfig` interface with JSDoc
- Send `X-OpenViking-Agent` header in `makeRequest()` when `agentId` is configured
- Support `OPENVIKING_AGENT_ID` env var override (consistent with existing `OPENVIKING_API_KEY` pattern)
- Update `openviking-config.example.json` with the new field

## Usage

**Via config file** (`openviking-config.json`):
```json
{
  "endpoint": "http://localhost:1933",
  "agentId": "my-agent-name"
}
```

**Via environment variable**:
```bash
OPENVIKING_AGENT_ID=my-agent-name
```

When `agentId` is set, memories are written to and read from an agent-scoped namespace (`viking://agent/{hash}/memories`) instead of the shared user scope. Different agents with different `agentId` values will have completely isolated memory spaces.

## Backward Compatibility

- `agentId` defaults to empty string (no header sent) — existing behavior unchanged
- No breaking changes to the plugin API or config schema