### PR TITLE
fix(language): add threshold for ko/ru/ar detection to avoid misclass…

### DIFF
--- a/openviking/session/memory_extractor.py
+++ b/openviking/session/memory_extractor.py
@@ -161,7 +161,13 @@ class MemoryExtractor:
         if not user_text:
             return fallback
 
-        # Detect scripts that are largely language-unique first.
+        # Detect scripts that are largely language-unique.
+        # Require threshold to avoid misclassifying mixed-language texts
+        # (e.g., Chinese with a single Cyrillic letter).
+        total_chars = len(re.findall(r"\S", user_text))
+        if total_chars == 0:
+            return fallback
+
         counts = {
             "ko": len(re.findall(r"[\uac00-\ud7af]", user_text)),
             "ru": len(re.findall(r"[\u0400-\u04ff]", user_text)),
@@ -169,7 +175,8 @@ class MemoryExtractor:
         }
 
         detected, score = max(counts.items(), key=lambda item: item[1])
-        if score > 0:
+        # Threshold: at least 2 chars AND at least 10% of non-whitespace chars
+        if score >= 2 and score / total_chars >= 0.10:
             return detected
 
         # CJK disambiguation:

--- a/tests/session/test_memory_extractor_language.py
+++ b/tests/session/test_memory_extractor_language.py
@@ -86,3 +86,31 @@ def test_detect_output_language_japanese_with_more_han_than_kana():
     ]
     language = MemoryExtractor._detect_output_language(messages, fallback_language="en")
     assert language == "ja"
+
+
+def test_detect_output_language_chinese_with_single_cyrillic():
+    """Mixed Chinese with single Cyrillic char should be detected as Chinese, not Russian."""
+    messages = [_msg("user", "\u8fd9\u662f\u4e2d\u6587 \u0414 \u518d\u7ee7\u7eed")]
+    language = MemoryExtractor._detect_output_language(messages, fallback_language="en")
+    assert language == "zh-CN"
+
+
+def test_detect_output_language_japanese_with_single_cyrillic():
+    """Mixed Japanese with single Cyrillic char should be detected as Japanese, not Russian."""
+    messages = [_msg("user", "\u3053\u308c\u306f\u65e5\u672c\u8a9e \u042f ")]
+    language = MemoryExtractor._detect_output_language(messages, fallback_language="en")
+    assert language == "ja"
+
+
+def test_detect_output_language_russian_with_threshold():
+    """Russian text with sufficient Cyrillic chars should be detected as Russian."""
+    messages = [_msg("user", "\u042d\u0442\u043e \u0440\u0443\u0441\u0441\u043a\u0438\u0439 \u0442\u0435\u043a\u0441\u0442")]
+    language = MemoryExtractor._detect_output_language(messages, fallback_language="en")
+    assert language == "ru"
+
+
+def test_detect_output_language_insufficient_cyrillic_fallback():
+    """Text with only 1 Cyrillic char among Latin should fallback, not Russian."""
+    messages = [_msg("user", "Hello \u0424 world")]
+    language = MemoryExtractor._detect_output_language(messages, fallback_language="en")
+    assert language == "en"


### PR DESCRIPTION

The old logic detected Korean/Russian/Arabic with just 1 character, causing mixed CJK+Cyrillic text to be misclassified.

  Changes:
  - Require >=2 chars AND >=10% of text for ko/ru/ar detection
  - Keep original detection order (ko/ru/ar first, then CJK)
  - Add test cases for mixed-language scenarios

  Fixes issue where Chinese text with a single Cyrillic letter such as  (｡>д<) was incorrectly detected as Russian.

  ## Description

  Fix language detection logic in `memory_extractor.py` to prevent misclassification of CJK text containing isolated Cyrillic/Arabic characters.

 The original logic detected Korean/Russian/Arabic as long as there was
  at least 1 matching character, causing mixed-language text like
  "这是中文 Д 再继续" to be incorrectly classified as Russian.

  以及 Testing 部分：

  Tested with the following scenarios:
  - "这是中文 Д 再继续" → correctly detected as `zh-CN` (was `ru`)
  - "これは日本語 Я " → correctly detected as `ja` (was `ru`)
  - "Это русский текст" → correctly detected as `ru` (unchanged)
  - "Hello Ф world" → correctly falls back to `en` (was `ru`)

  This PR adds a threshold requirement: ko/ru/ar detection now requires at least 2 characters AND those characters must constitute at least 10% of the
   non-whitespace text.

  ## Related Issue

  <!-- Link to the related issue (if applicable) -->
  <!-- Fixes #(issue number) -->

  ## Type of Change

  <!-- Mark the relevant option with an "x" -->

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Test update

  ## Changes Made

  <!-- List the main changes made in this PR -->

  - Modified `_detect_output_language()` in `openviking/session/memory_extractor.py`:
    - Added `total_chars` calculation for threshold comparison
    - Changed detection threshold from `score > 0` to `score >= 2 and score / total_chars >= 0.10`
    - Added clarifying comment about the threshold purpose

  - Added test cases in `tests/session/test_memory_extractor_language.py`:
    - `test_detect_output_language_chinese_with_single_cyrillic()` - Chinese with 1 Cyrillic char → zh-CN
    - `test_detect_output_language_japanese_with_single_cyrillic()` - Japanese with 1 Cyrillic char → ja
    - `test_detect_output_language_russian_with_threshold()` - Russian text meeting threshold → ru
    - `test_detect_output_language_insufficient_cyrillic_fallback()` - 1 Cyrillic char among Latin → en

  ## Testing

  <!-- Describe how you tested your changes -->

  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] I have tested this on the following platforms:
    - [ ] Linux
    - [x] macOS
    - [ ] Windows (or use your actual platform)


  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published

  ## Screenshots (if applicable)

  <!-- Add screenshots to help explain your changes -->

  ## Additional Notes

  <!-- Add any additional notes or context about the PR -->

  The detection order remains unchanged: ko/ru/ar are still checked before CJK, but now require meeting the threshold to return early. This preserves
  the original design intent while fixing the false positive issue.