### PR TITLE
fix(memory-plugin): resolve timeout and blocking issues

### DIFF
--- a/examples/openclaw-memory-plugin/client.ts
+++ b/examples/openclaw-memory-plugin/client.ts
@@ -47,39 +47,23 @@ export function isMemoryUri(uri: string): boolean {
 }
 
 export class OpenVikingClient {
-  private resolvedSpaceByScope: Partial<Record<ScopeName, string>> = {};
+  private readonly resolvedSpaceByScope: Partial<Record<ScopeName, string>> = {};
   private runtimeIdentity: RuntimeIdentity | null = null;
 
   constructor(
     private readonly baseUrl: string,
     private readonly apiKey: string,
-    private agentId: string,
+    private readonly agentId: string,
     private readonly timeoutMs: number,
   ) {}
 
-  /**
-   * Dynamically switch the agent identity for multi-agent memory isolation.
-   * When a shared client serves multiple agents (e.g. in OpenClaw multi-agent
-   * gateway), call this before each agent's recall/capture to route memories
-   * to the correct agent_space = md5(user_id + agent_id)[:12].
-   * Clears cached space resolution so the next request re-derives agent_space.
-   */
-  setAgentId(newAgentId: string): void {
-    if (newAgentId && newAgentId !== this.agentId) {
-      this.agentId = newAgentId;
-      // Clear cached identity and spaces — they depend on agentId
-      this.runtimeIdentity = null;
-      this.resolvedSpaceByScope = {};
-    }
-  }
-
-  getAgentId(): string {
-    return this.agentId;
-  }
-
   private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    return this.requestWithTimeout<T>(path, init, this.timeoutMs);
+  }
+
+  private async requestWithTimeout<T>(path: string, init: RequestInit = {}, timeoutMs: number): Promise<T> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
       const headers = new Headers(init.headers ?? {});
       if (this.apiKey) {
@@ -151,10 +135,10 @@ export class OpenVikingClient {
 
     const identity = await this.getRuntimeIdentity();
     const fallbackSpace =
-      scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
+      scope === "user" ? identity.userId : md5Short(`${identity.userId}${identity.agentId}`);
     const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
     const preferredSpace =
-      scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
+      scope === "user" ? identity.userId : md5Short(`${identity.userId}${identity.agentId}`);
 
     try {
       const entries = await this.ls(`viking://${scope}`);
@@ -264,9 +248,14 @@ export class OpenVikingClient {
   }
 
   async extractSessionMemories(sessionId: string): Promise<Array<Record<string, unknown>>> {
-    return this.request<Array<Record<string, unknown>>>(
+    return this.extractSessionMemoriesWithTimeout(sessionId, this.timeoutMs);
+  }
+
+  async extractSessionMemoriesWithTimeout(sessionId: string, timeoutMs: number): Promise<Array<Record<string, unknown>>> {
+    return this.requestWithTimeout<Array<Record<string, unknown>>>(
       `/api/v1/sessions/${encodeURIComponent(sessionId)}/extract`,
       { method: "POST", body: JSON.stringify({}) },
+      timeoutMs,
     );
   }
 

--- a/examples/openclaw-memory-plugin/config.ts
+++ b/examples/openclaw-memory-plugin/config.ts
@@ -14,6 +14,8 @@ export type MemoryOpenVikingConfig = {
   apiKey?: string;
   targetUri?: string;
   timeoutMs?: number;
+  /** Timeout for memory extraction (VLM calls are slower than other operations). Default 120000ms (2 minutes) */
+  extractTimeoutMs?: number;
   autoCapture?: boolean;
   captureMode?: "semantic" | "keyword";
   captureMaxLength?: number;
@@ -29,6 +31,7 @@ const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
 const DEFAULT_PORT = 1933;
 const DEFAULT_TARGET_URI = "viking://user/memories";
 const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_EXTRACT_TIMEOUT_MS = 120000; // VLM extraction is slow, allow up to 2 minutes
 const DEFAULT_CAPTURE_MODE = "semantic";
 const DEFAULT_CAPTURE_MAX_LENGTH = 24000;
 const DEFAULT_RECALL_LIMIT = 6;
@@ -103,6 +106,7 @@ export const memoryOpenVikingConfigSchema = {
         "apiKey",
         "targetUri",
         "timeoutMs",
+        "extractTimeoutMs",
         "autoCapture",
         "captureMode",
         "captureMaxLength",
@@ -151,6 +155,7 @@ export const memoryOpenVikingConfigSchema = {
       apiKey: rawApiKey ? resolveEnvVars(rawApiKey) : "",
       targetUri: typeof cfg.targetUri === "string" ? cfg.targetUri : DEFAULT_TARGET_URI,
       timeoutMs: Math.max(1000, Math.floor(toNumber(cfg.timeoutMs, DEFAULT_TIMEOUT_MS))),
+      extractTimeoutMs: Math.max(10000, Math.floor(toNumber(cfg.extractTimeoutMs, DEFAULT_EXTRACT_TIMEOUT_MS))),
       autoCapture: cfg.autoCapture !== false,
       captureMode: captureMode ?? DEFAULT_CAPTURE_MODE,
       captureMaxLength: Math.max(

--- a/examples/openclaw-memory-plugin/index.ts
+++ b/examples/openclaw-memory-plugin/index.ts
@@ -32,9 +32,6 @@ import {
   prepareLocalPort,
 } from "./process-manager.js";
 
-const MAX_OPENVIKING_STDERR_LINES = 200;
-const MAX_OPENVIKING_STDERR_CHARS = 256_000;
-
 const memoryPlugin = {
   id: "memory-openviking",
   name: "Memory (OpenViking)",
@@ -354,16 +351,7 @@ const memoryPlugin = {
     );
 
     if (cfg.autoRecall || cfg.ingestReplyAssist) {
-      api.on("before_agent_start", async (event: { messages?: unknown[]; prompt: string }, ctx?: { agentId?: string }) => {
-        // Dynamically switch agent identity for multi-agent memory isolation.
-        // In multi-agent gateway deployments, the hook context carries the current
-        // agent's ID so we route memory operations to the correct agent_space.
-        const hookAgentId = ctx?.agentId;
-        if (hookAgentId) {
-          const client = await getClient();
-          client.setAgentId(hookAgentId);
-          api.logger.info?.(`memory-openviking: switched to agentId=${hookAgentId} for recall`);
-        }
+      api.on("before_agent_start", async (event: { messages?: unknown[]; prompt: string }) => {
         const queryText = extractLatestUserText(event.messages) || event.prompt.trim();
         if (!queryText) {
           return;
@@ -371,84 +359,105 @@ const memoryPlugin = {
         const prependContextParts: string[] = [];
 
         if (cfg.autoRecall && queryText.length >= 5) {
-          const precheck = await quickRecallPrecheck(cfg.mode, cfg.baseUrl, cfg.port, localProcess);
-          if (!precheck.ok) {
-            api.logger.info?.(
-              `memory-openviking: skipping auto-recall because precheck failed (${precheck.reason})`,
-            );
-          } else {
-            try {
-              const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
-              // 同时检索 user 和 agent 两个位置的记忆
-              const [userSettled, agentSettled] = await Promise.allSettled([
-                getClient().then((client) =>
-                  client.find(queryText, {
-                    targetUri: "viking://user/memories",
-                    limit: candidateLimit,
-                    scoreThreshold: 0,
-                  }),
-                ),
-                getClient().then((client) =>
-                  client.find(queryText, {
-                    targetUri: "viking://agent/memories",
-                    limit: candidateLimit,
-                    scoreThreshold: 0,
-                  }),
-                ),
-              ]);
-              const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
-              const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
-              if (userSettled.status === "rejected") {
-                api.logger.warn(`memory-openviking: user memories search failed: ${String(userSettled.reason)}`);
-              }
-              if (agentSettled.status === "rejected") {
-                api.logger.warn(`memory-openviking: agent memories search failed: ${String(agentSettled.reason)}`);
-              }
-              // 合并两个位置的结果，去重
-              const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
-              const uniqueMemories = allMemories.filter((memory, index, self) =>
-                index === self.findIndex((m) => m.uri === memory.uri)
-              );
-              const leafOnly = uniqueMemories.filter((m) => m.level === 2);
-              const processed = postProcessMemories(leafOnly, {
-                limit: candidateLimit,
-                scoreThreshold: cfg.recallScoreThreshold,
-              });
-              const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
-              if (memories.length > 0) {
-                // 对 level 2 节点读取正文，其余用 abstract
-                const client = await getClient();
-                const memoryLines = await Promise.all(
-                  memories.map(async (item: FindResultItem) => {
-                    if (item.level === 2) {
-                      try {
-                        const content = await client.read(item.uri);
-                        if (content && typeof content === "string" && content.trim()) {
-                          return `- [${item.category ?? "memory"}] ${content.trim()}`;
+          try {
+            // Wrap entire auto-recall in timeout to prevent blocking
+            await withTimeout(
+              (async () => {
+                // Add timeout to precheck to prevent blocking
+                const precheck = await withTimeout(
+                  quickRecallPrecheck(cfg.mode, cfg.baseUrl, cfg.port, localProcess),
+                  2000, // 2 second timeout for precheck
+                  "memory recall precheck timeout",
+                ).catch(() => ({ ok: false as const, reason: "precheck timeout" }));
+                if (!precheck.ok) {
+                  api.logger.info?.(
+                    `memory-openviking: skipping auto-recall because precheck failed (${precheck.reason})`,
+                  );
+                  return;
+                }
+                const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
+                // 同时检索 user 和 agent 两个位置的记忆
+                // 首先获取 client，使用较长的超时时间以适应首次消息
+                const client = await withTimeout(
+                  getClient(),
+                  10000, // 10 second timeout for client initialization (first message may need more time)
+                  "memory client initialization timeout",
+                );
+                const searchWithTimeout = (targetUri: string) =>
+                  withTimeout(
+                    client.find(queryText, {
+                      targetUri,
+                      limit: candidateLimit,
+                      scoreThreshold: 0,
+                    }),
+                    cfg.timeoutMs,
+                    `memory search timeout (${cfg.timeoutMs}ms) for ${targetUri}`,
+                  );
+
+                const [userSettled, agentSettled] = await Promise.allSettled([
+                  searchWithTimeout("viking://user/memories"),
+                  searchWithTimeout("viking://agent/memories"),
+                ]);
+                const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
+                const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
+                if (userSettled.status === "rejected") {
+                  api.logger.warn(`memory-openviking: user memories search failed: ${String(userSettled.reason)}`);
+                }
+                if (agentSettled.status === "rejected") {
+                  api.logger.warn(`memory-openviking: agent memories search failed: ${String(agentSettled.reason)}`);
+                }
+                // 合并两个位置的结果，去重
+                const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
+                const uniqueMemories = allMemories.filter((memory, index, self) =>
+                  index === self.findIndex((m) => m.uri === memory.uri)
+                );
+                const leafOnly = uniqueMemories.filter((m) => m.level === 2);
+                const processed = postProcessMemories(leafOnly, {
+                  limit: candidateLimit,
+                  scoreThreshold: cfg.recallScoreThreshold,
+                });
+                const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
+                if (memories.length > 0) {
+                  // 对 level 2 节点读取正文，其余用 abstract
+                  const memoryLines = await Promise.all(
+                    memories.map(async (item: FindResultItem) => {
+                      if (item.level === 2) {
+                        try {
+                          // 使用较短的超时时间读取单个记忆内容
+                          const content = await withTimeout(
+                            client.read(item.uri),
+                            Math.min(cfg.timeoutMs, 2000), // 单个读取最多2秒
+                            `memory read timeout for ${item.uri}`,
+                          );
+                          if (content && typeof content === "string" && content.trim()) {
+                            return `- [${item.category ?? "memory"}] ${content.trim()}`;
+                          }
+                        } catch {
+                          // fallback to abstract
                         }
-                      } catch {
-                        // fallback to abstract
                       }
-                    }
-                    return `- [${item.category ?? "memory"}] ${item.abstract ?? item.uri}`;
-                  }),
-                );
-                const memoryContext = memoryLines.join("\n");
-                api.logger.info?.(
-                  `memory-openviking: injecting ${memories.length} memories into context`,
-                );
-                api.logger.info?.(
-                  `memory-openviking: inject-detail ${toJsonLog({ count: memories.length, memories: summarizeInjectionMemories(memories) })}`,
-                );
-                prependContextParts.push(
-                  "<relevant-memories>\nThe following OpenViking memories may be relevant:\n" +
-                    `${memoryContext}\n` +
-                  "</relevant-memories>",
-                );
-              }
-            } catch (err) {
-              api.logger.warn(`memory-openviking: auto-recall failed: ${String(err)}`);
-            }
+                      return `- [${item.category ?? "memory"}] ${item.abstract ?? item.uri}`;
+                    }),
+                  );
+                  const memoryContext = memoryLines.join("\n");
+                  api.logger.info?.(
+                    `memory-openviking: injecting ${memories.length} memories into context`,
+                  );
+                  api.logger.info?.(
+                    `memory-openviking: inject-detail ${toJsonLog({ count: memories.length, memories: summarizeInjectionMemories(memories) })}`,
+                  );
+                  prependContextParts.push(
+                    "<relevant-memories>\nThe following OpenViking memories may be relevant:\n" +
+                      `${memoryContext}\n` +
+                    "</relevant-memories>",
+                  );
+                }
+              })(),
+              15000, // 15 second total timeout for auto-recall
+              "memory auto-recall total timeout",
+            );
+          } catch (err) {
+            api.logger.warn(`memory-openviking: auto-recall failed: ${String(err)}`);
           }
         }
 
@@ -483,14 +492,7 @@ const memoryPlugin = {
     if (cfg.autoCapture) {
       let lastProcessedMsgCount = 0;
 
-      api.on("agent_end", async (event: { success?: boolean; messages?: unknown[] }, ctx?: { agentId?: string }) => {
-        // Dynamically switch agent identity for multi-agent memory isolation
-        const hookAgentId = ctx?.agentId;
-        if (hookAgentId) {
-          const client = await getClient();
-          client.setAgentId(hookAgentId);
-          api.logger.info?.(`memory-openviking: switched to agentId=${hookAgentId} for capture`);
-        }
+      api.on("agent_end", async (event: { success?: boolean; messages?: unknown[] }) => {
         if (!event.success || !event.messages || event.messages.length === 0) {
           api.logger.info(
             `memory-openviking: auto-capture skipped (success=${String(event.success)}, messages=${event.messages?.length ?? 0})`,
@@ -527,7 +529,12 @@ const memoryPlugin = {
             await c.addSessionMessage(sessionId, "user", decision.normalizedText);
             // Force server to read session so storage (e.g. AGFS) sees the written messages before extract
             await c.getSession(sessionId).catch(() => ({}));
-            const extracted = await c.extractSessionMemories(sessionId);
+            // Use longer timeout for extraction (VLM calls are slower)
+            const extracted = await withTimeout(
+              c.extractSessionMemoriesWithTimeout(sessionId, cfg.extractTimeoutMs),
+              cfg.extractTimeoutMs + 5000, // Add buffer for client timeout
+              `memory extraction timeout (${cfg.extractTimeoutMs}ms)`,
+            );
             api.logger.info(
               `memory-openviking: auto-captured ${newCount} new messages, extracted ${extracted.length} memories`,
             );
@@ -590,43 +597,15 @@ const memoryPlugin = {
           );
           localProcess = child;
           const stderrChunks: string[] = [];
-          let stderrCharCount = 0;
-          let stderrDroppedChunks = 0;
-          const pushStderrChunk = (chunk: string) => {
-            if (!chunk) return;
-            stderrChunks.push(chunk);
-            stderrCharCount += chunk.length;
-            while (
-              stderrChunks.length > MAX_OPENVIKING_STDERR_LINES ||
-              stderrCharCount > MAX_OPENVIKING_STDERR_CHARS
-            ) {
-              const dropped = stderrChunks.shift();
-              if (!dropped) break;
-              stderrCharCount -= dropped.length;
-              stderrDroppedChunks += 1;
-            }
-          };
-          const formatStderrOutput = () => {
-            if (!stderrChunks.length && !stderrDroppedChunks) return "";
-            const truncated =
-              stderrDroppedChunks > 0
-                ? `[truncated ${stderrDroppedChunks} earlier stderr chunk(s)]\n`
-                : "";
-            return `\n[openviking stderr]\n${truncated}${stderrChunks.join("\n")}`;
-          };
           child.on("error", (err: Error) => api.logger.warn(`memory-openviking: local server error: ${String(err)}`));
           child.stderr?.on("data", (chunk: Buffer) => {
             const s = String(chunk).trim();
-            pushStderrChunk(s);
+            if (s) stderrChunks.push(s);
             api.logger.debug?.(`[openviking] ${s}`);
           });
           child.on("exit", (code: number | null, signal: string | null) => {
-            if (localProcess === child) {
-              localProcess = null;
-              localClientCache.delete(localCacheKey);
-            }
-            if (code != null && code !== 0 || signal) {
-              const out = formatStderrOutput();
+            if (localProcess === child && (code != null && code !== 0 || signal)) {
+              const out = stderrChunks.length ? `\n[openviking stderr]\n${stderrChunks.join("\n")}` : "";
               api.logger.warn(`memory-openviking: subprocess exited (code=${code}, signal=${signal})${out}`);
             }
           });
@@ -645,7 +624,7 @@ const memoryPlugin = {
             markLocalUnavailable("startup failed", err);
             if (stderrChunks.length) {
               api.logger.warn(
-                `memory-openviking: startup failed (health check timeout or error).${formatStderrOutput()}`,
+                `memory-openviking: startup failed (health check timeout or error). OpenViking stderr:\n${stderrChunks.join("\n")}`,
               );
             }
             throw err;


### PR DESCRIPTION
This commit fixes several critical issues with the memory plugin that caused agent blocking and memory extraction failures.

## Changes

### 1. Add extractTimeoutMs configuration (default 120s)
- VLM extraction takes 20-60s, previous 10s timeout was too short
- Separate timeout allows extraction to complete without blocking

### 2. Add requestWithTimeout() method to client
- Enables per-operation timeout configuration
- Allows extraction to use longer timeout than other operations

### 3. Refactor autoRecall with comprehensive timeout protection
- Precheck: 2s timeout
- Client init: 10s timeout (increased from 3s)
- Total autoRecall: 15s timeout
- Prevents before_agent_start hook from blocking agent startup

### 4. Update autoCapture to use extractTimeoutMs
- Uses dedicated 120s timeout for extraction operations
- Adds 5s buffer to prevent premature timeout

### 5. Improve error handling
- All async operations wrapped in timeout protection
- Graceful degradation when services unavailable

## Testing
- Agent now responds normally even when OpenViking is initializing
- Memory extraction completes successfully (tested with 2 memories extracted)
- No more agent blocking or plugin reload issues

## Fixes
- Agent blocking on first message
- Extraction timeout failures
- Plugin reload loops