### PR TITLE
fix(memory-openviking): share pending clientPromise across dual-context registrations

### DIFF
--- a/examples/openclaw-memory-plugin/client.ts
+++ b/examples/openclaw-memory-plugin/client.ts
@@ -29,7 +29,18 @@ export type LocalClientCacheEntry = {
   process: ReturnType<typeof spawn> | null;
 };
 
+export type PendingClientEntry = {
+  promise: Promise<OpenVikingClient>;
+  resolve: (c: OpenVikingClient) => void;
+  reject: (err: unknown) => void;
+};
+
 export const localClientCache = new Map<string, LocalClientCacheEntry>();
+
+// Module-level pending promise map: shared across all plugin registrations so
+// that both [gateway] and [plugins] contexts await the same promise and
+// don't create duplicate pending promises that never resolve.
+export const localClientPendingPromises = new Map<string, PendingClientEntry>();
 
 const MEMORY_URI_PATTERNS = [
   /^viking:\/\/user\/(?:[^/]+\/)?memories(?:\/|$)/,

--- a/examples/openclaw-memory-plugin/index.ts
+++ b/examples/openclaw-memory-plugin/index.ts
@@ -5,7 +5,8 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import { memoryOpenVikingConfigSchema } from "./config.js";
 
-import { OpenVikingClient, localClientCache, isMemoryUri } from "./client.js";
+import { OpenVikingClient, localClientCache, localClientPendingPromises, isMemoryUri } from "./client.js";
+import type { PendingClientEntry } from "./client.js";
 import type { FindResultItem } from "./client.js";
 import {
   getCaptureDecision,
@@ -51,7 +52,6 @@ const memoryPlugin = {
     let resolveLocalClient: ((c: OpenVikingClient) => void) | null = null;
     let rejectLocalClient: ((err: unknown) => void) | null = null;
     let localUnavailableReason: string | null = null;
-    const autoRecallTimeoutMs = 5_000;
 
     const markLocalUnavailable = (reason: string, err?: unknown) => {
       if (!localUnavailableReason) {
@@ -75,10 +75,18 @@ const memoryPlugin = {
         localProcess = cached.process;
         clientPromise = Promise.resolve(cached.client);
       } else {
-        clientPromise = new Promise<OpenVikingClient>((resolve, reject) => {
-          resolveLocalClient = resolve;
-          rejectLocalClient = reject;
-        });
+        const existingPending = localClientPendingPromises.get(localCacheKey);
+        if (existingPending) {
+          clientPromise = existingPending.promise;
+        } else {
+          const entry = {} as PendingClientEntry;
+          entry.promise = new Promise<OpenVikingClient>((resolve, reject) => {
+            entry.resolve = resolve;
+            entry.reject = reject;
+          });
+          clientPromise = entry.promise;
+          localClientPendingPromises.set(localCacheKey, entry);
+        }
       }
     } else {
       clientPromise = Promise.resolve(new OpenVikingClient(cfg.baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs));
@@ -379,6 +387,7 @@ const memoryPlugin = {
           } else {
             try {
               const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
+              api.logger.info?.(`memory-openviking: autoRecall searching (query="${queryText.slice(0, 80)}", limit=${candidateLimit})`);
               // 同时检索 user 和 agent 两个位置的记忆
               const [userSettled, agentSettled] = await Promise.allSettled([
                 getClient().then((client) =>
@@ -398,6 +407,8 @@ const memoryPlugin = {
               ]);
               const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
               const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
+              api.logger.info?.(`memory-openviking: autoRecall done (user=${userResult.memories?.length ?? 0}, agent=${agentResult.memories?.length ?? 0})`);
+
               if (userSettled.status === "rejected") {
                 api.logger.warn(`memory-openviking: user memories search failed: ${String(userSettled.reason)}`);
               }
@@ -556,7 +567,16 @@ const memoryPlugin = {
     api.registerService({
       id: "memory-openviking",
       start: async () => {
-        if (cfg.mode === "local" && resolveLocalClient) {
+        // Claim the pending entry — only the first start() call to claim it spawns the process.
+        // Subsequent start() calls (from other registrations sharing the same promise) fall through.
+        const pendingEntry = localClientPendingPromises.get(localCacheKey);
+        const isSpawner = cfg.mode === "local" && !!pendingEntry;
+        if (isSpawner) {
+          localClientPendingPromises.delete(localCacheKey);
+          resolveLocalClient = pendingEntry!.resolve;
+          rejectLocalClient = pendingEntry!.reject;
+        }
+        if (isSpawner) {
           const timeoutMs = 60_000;
           const intervalMs = 500;
 
@@ -636,12 +656,14 @@ const memoryPlugin = {
             localClientCache.set(localCacheKey, { client, process: child });
             resolveLocalClient(client);
             rejectLocalClient = null;
+            localClientPendingPromises.delete(localCacheKey);
             api.logger.info(
               `memory-openviking: local server started (${baseUrl}, config: ${cfg.configPath})`,
             );
           } catch (err) {
             localProcess = null;
             child.kill("SIGTERM");
+            localClientPendingPromises.delete(localCacheKey);
             markLocalUnavailable("startup failed", err);
             if (stderrChunks.length) {
               api.logger.warn(
@@ -658,6 +680,7 @@ const memoryPlugin = {
         }
       },
       stop: () => {
+        localClientPendingPromises.delete(localCacheKey);
         if (localProcess) {
           localProcess.kill("SIGTERM");
           localClientCache.delete(localCacheKey);


### PR DESCRIPTION
## Problem

OpenClaw loads the `memory-openviking` plugin in **two separate contexts** (`[gateway]` and `[plugins]`), each calling `register()` independently. Each call creates its own local `clientPromise`. However, `start()` only runs in **one** context — leaving the other context's promise permanently pending.

This causes the `before_agent_start` hook to **hang forever** on `await getClient()` whenever `hookAgentId` is set (i.e. always in a standard gateway deployment), because the hook runs in the context whose `clientPromise` was never resolved.

**Symptoms:**
- Bot receives message, typing indicator starts, never gets a response
- Gateway log shows `running before_agent_start (1 handlers, sequential)` with nothing after
- `autoRecall` and `autoCapture` appear completely broken

## Fix

Introduce a **module-level `localClientPendingPromises` map** in `client.ts`:

- `register()` checks the map first. If an entry exists, it shares that promise instead of creating a new pending one.
- `start()` atomically claims the entry (deletes it from the map) — only the **first** `start()` call spawns the process and resolves the shared promise. Subsequent `start()` calls fall through to `await getClient()` which waits for the spawner.
- `stop()` clears the map entry to prevent stale promises persisting across hot-reloads.

## Test plan

- [ ] Send a message via Telegram with `autoRecall: true` — confirm `autoRecall done` appears in logs within ~2 seconds
- [ ] Restart gateway — confirm subsequent messages still work (no stale promise from previous run)
- [ ] Confirm `before_agent_start` hook no longer hangs indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)