### PR TITLE
feat(session): add used() endpoint for context/skill tracking

### DIFF
--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -328,6 +328,71 @@ openviking session add-message a1b2c3d4 --role user --content "How do I authenti
 
 ---
 
+### used()
+
+Record actually used contexts and skills in the session. When `commit()` is called, `active_count` is updated based on this usage data.
+
+**Parameters**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| contexts | List[str] | No | None | List of context URIs that were actually used |
+| skill | Dict[str, Any] | No | None | Skill usage record with keys: `uri`, `input`, `output`, `success` |
+
+**Python SDK (Embedded / HTTP)**
+
+```python
+session = client.session(session_id="a1b2c3d4")
+session.load()
+
+# Record used contexts
+session.used(contexts=["viking://resources/docs/auth/"])
+
+# Record used skill
+session.used(skill={
+    "uri": "viking://skills/search-web/",
+    "input": {"query": "OAuth"},
+    "output": "Results...",
+    "success": True
+})
+```
+
+**HTTP API**
+
+```
+POST /api/v1/sessions/{session_id}/used
+```
+
+```bash
+# Record used contexts
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"contexts": ["viking://resources/docs/auth/"]}'
+
+# Record used skill
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"skill": {"uri": "viking://skills/search-web/", "input": {"query": "OAuth"}, "output": "Results...", "success": true}}'
+```
+
+**Response**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "session_id": "a1b2c3d4",
+    "contexts_used": 1,
+    "skills_used": 0
+  },
+  "time": 0.1
+}
+```
+
+---
+
 ### commit()
 
 Commit a session by archiving messages and extracting memories.
@@ -501,7 +566,13 @@ curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/messages \
   -H "X-API-Key: your-key" \
   -d '{"role": "assistant", "content": "Based on the documentation, you can configure embedding..."}'
 
-# Step 5: Commit session
+# Step 5: Record used contexts
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"contexts": ["viking://resources/docs/embedding/"]}'
+
+# Step 6: Commit session
 curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/commit \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key"

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -328,6 +328,71 @@ openviking session add-message a1b2c3d4 --role user --content "How do I authenti
 
 ---
 
+### used()
+
+记录会话中实际使用的上下文和技能。调用 `commit()` 时，会根据此使用数据更新 `active_count`。
+
+**参数**
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| contexts | List[str] | 否 | None | 实际使用的上下文 URI 列表 |
+| skill | Dict[str, Any] | 否 | None | 技能使用记录，包含 `uri`、`input`、`output`、`success` 字段 |
+
+**Python SDK (Embedded / HTTP)**
+
+```python
+session = client.session(session_id="a1b2c3d4")
+session.load()
+
+# 记录使用的上下文
+session.used(contexts=["viking://resources/docs/auth/"])
+
+# 记录使用的技能
+session.used(skill={
+    "uri": "viking://skills/search-web/",
+    "input": {"query": "OAuth"},
+    "output": "Results...",
+    "success": True
+})
+```
+
+**HTTP API**
+
+```
+POST /api/v1/sessions/{session_id}/used
+```
+
+```bash
+# 记录使用的上下文
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"contexts": ["viking://resources/docs/auth/"]}'
+
+# 记录使用的技能
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"skill": {"uri": "viking://skills/search-web/", "input": {"query": "OAuth"}, "output": "Results...", "success": true}}'
+```
+
+**响应**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "session_id": "a1b2c3d4",
+    "contexts_used": 1,
+    "skills_used": 0
+  },
+  "time": 0.1
+}
+```
+
+---
+
 ### commit()
 
 提交会话，归档消息并提取记忆。
@@ -501,7 +566,13 @@ curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/messages \
   -H "X-API-Key: your-key" \
   -d '{"role": "assistant", "content": "Based on the documentation, you can configure embedding..."}'
 
-# 步骤 5：提交会话
+# 步骤 5：记录使用的上下文
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"contexts": ["viking://resources/docs/embedding/"]}'
+
+# 步骤 6：提交会话
 curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/commit \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key"

--- a/examples/openclaw-memory-plugin/INSTALL-AGENT.md
+++ b/examples/openclaw-memory-plugin/INSTALL-AGENT.md
@@ -104,24 +104,11 @@ Check if `~/.openviking/ov.conf` already exists:
 > "Please provide your Volcengine Ark API Key (used for Embedding and VLM model calls).
 > Get one at https://console.volcengine.com/ark if you don't have one."
 
-Check if the OpenViking repo is available locally:
-
-```bash
-ls examples/openclaw-memory-plugin/setup-helper/package.json 2>/dev/null
-```
-
-- In repo: Run setup helper directly
-- Not in repo: Clone first
-
-```bash
-git clone https://github.com/volcengine/OpenViking.git /tmp/OpenViking
-cd /tmp/OpenViking
-```
-
 Run the setup helper:
 
 ```bash
-npx ./examples/openclaw-memory-plugin/setup-helper
+npm install -g openclaw-openviking-setup-helper
+ov-install
 ```
 
 At the interactive prompts:
@@ -194,18 +181,15 @@ openclaw --version
 
 > Remote mode does **not** require Python — OpenViking runs on the remote server.
 
-### Step R3: Deploy Plugin and Configure
-
-Get the plugin code:
+### Step R3: Install Plugin and Configure
 
 ```bash
-git clone https://github.com/volcengine/OpenViking.git /tmp/OpenViking
-cd /tmp/OpenViking/examples/openclaw-memory-plugin
-npm install
-openclaw plugin link .
+npm install -g openclaw-openviking-setup-helper
+ov-install
+# Select remote mode, enter OpenViking server URL and API Key
 ```
 
-Configure remote connection (substitute user-provided values). If targeting a non-default instance, prefix each command with `OPENCLAW_STATE_DIR=<workdir>`:
+Alternatively, configure manually (substitute user-provided values). If targeting a non-default instance, prefix each command with `OPENCLAW_STATE_DIR=<workdir>`:
 
 ```bash
 openclaw config set plugins.enabled true --json

--- a/examples/openclaw-memory-plugin/INSTALL-ZH.md
+++ b/examples/openclaw-memory-plugin/INSTALL-ZH.md
@@ -1,6 +1,24 @@
 # 为 OpenClaw 安装 OpenViking 记忆功能
 
-通过 [OpenViking](https://github.com/volcengine/OpenViking) 为 [OpenClaw](https://github.com/openclaw/openclaw) 提供长效记忆能力。安装完成后，OpenClaw 将自动**记住**对话中的重要信息，并在回复前**回忆**相关内容。OpenViking最新版本发布[WebConsole](https://github.com/volcengine/OpenViking/tree/main/openviking/console),方便调试和运维。文档方式三也为大家提供了如何在WebConsole界面验证记忆被写入，提供好用易懂的使用说明，欢迎大家试用和反馈。
+通过 [OpenViking](https://github.com/volcengine/OpenViking) 为 [OpenClaw](https://github.com/openclaw/openclaw) 提供长效记忆能力。安装完成后，OpenClaw 将自动**记住**对话中的重要信息，并在回复前**回忆**相关内容。OpenViking 最新版本发布了 [WebConsole](https://github.com/volcengine/OpenViking/tree/main/openviking/console)，方便调试和运维。文档方式三也提供了如何在 WebConsole 界面验证记忆写入的说明，欢迎试用和反馈。
+
+> **⚠️ OpenClaw >= 2026.3.12 兼容性问题**
+>
+> OpenClaw `2026.3.12` 及更高版本存在已知兼容性问题，会导致加载插件后对话卡死无响应。
+> 这不是本插件的 bug——根因是 OpenClaw 3.12 的 slug generator（会话自动命名）有硬编码 15s 超时，
+> 当 LLM provider 响应较慢时会逐个 profile 超时重试，阻塞整个会话初始化管线。
+> 此外 3.12 新增的插件信任机制也可能影响本地插件的加载时序。
+> 另一个已知问题：`before_agent_start` 中的 auto-recall 缺少超时保护，可能导致 agent 静默挂起（[#673](https://github.com/volcengine/OpenViking/issues/673)）。
+>
+> **临时方案：** 回退到 `2026.3.11`：`npm install -g openclaw@2026.3.11`
+>
+> 上游修复 PR：openclaw/openclaw#34673、openclaw/openclaw#33547。
+> 详见 [#591](https://github.com/volcengine/OpenViking/issues/591)。
+
+> **🚀 插件 2.0 设计中**
+>
+> 我们正在设计基于 context-engine 架构重构的插件 2.0 版本，将作为 OpenViking 接入 AI 编程助手的最佳实践。
+> 欢迎参与讨论：https://github.com/volcengine/OpenViking/discussions/525
 
 ---
 
@@ -88,19 +106,13 @@ python3 -m pip install openviking --upgrade
 
 ### Step 2: 运行安装助手
 
-#### 方式 A：npm 全局安装（推荐）
-
 ```bash
+# 方式 A：npm 安装（推荐，全平台）
 npm install -g openclaw-openviking-setup-helper
 ov-install
-```
 
-#### 方式 B：从仓库运行
-
-```bash
-git clone https://github.com/volcengine/OpenViking.git
-cd OpenViking
-npx ./examples/openclaw-memory-plugin/setup-helper
+# 方式 B：curl 一键安装（Linux / macOS）
+curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/openclaw-memory-plugin/install.sh | bash
 ```
 
 安装助手会提示输入 Ark API Key 并自动生成配置文件。
@@ -128,16 +140,23 @@ openclaw status
 
 **前置：** 已有 OpenViking 服务地址 + API Key（如服务端启用了认证）。
 
-### Step 1: 部署插件代码
+### Step 1: 安装插件
 
 ```bash
-git clone https://github.com/volcengine/OpenViking.git
-cd OpenViking/examples/openclaw-memory-plugin
-npm install
-openclaw plugin link .
+npm install -g openclaw-openviking-setup-helper
+ov-install
+# 选择 remote 模式，填入 OpenViking 服务地址和 API Key
 ```
 
-### Step 2: 配置远端连接
+### Step 2: 启动并验证
+
+```bash
+openclaw gateway restart
+openclaw status
+```
+
+<details>
+<summary>手动配置（不使用安装助手）</summary>
 
 ```bash
 openclaw config set plugins.enabled true --json
@@ -145,16 +164,12 @@ openclaw config set plugins.slots.memory memory-openviking
 openclaw config set plugins.entries.memory-openviking.config.mode remote
 openclaw config set plugins.entries.memory-openviking.config.baseUrl "http://your-server:1933"
 openclaw config set plugins.entries.memory-openviking.config.apiKey "your-api-key"
+openclaw config set plugins.entries.memory-openviking.config.agentId "your-agent-id"
 openclaw config set plugins.entries.memory-openviking.config.autoRecall true --json
 openclaw config set plugins.entries.memory-openviking.config.autoCapture true --json
 ```
 
-### Step 3: 启动并验证
-
-```bash
-openclaw gateway
-openclaw status
-```
+</details>
 ## 方式三 火山引擎 ECS 版 Openclaw 接入 OpenViking
 
 本部分主要介绍如何在火山引擎ECS上接入OpenViking，并使用WebConsole验证写入。详情可见[文档](https://www.volcengine.com/docs/6396/2249500?lang=zh)。

--- a/examples/openclaw-memory-plugin/INSTALL.md
+++ b/examples/openclaw-memory-plugin/INSTALL.md
@@ -1,6 +1,26 @@
 # Installing OpenViking for OpenClaw
 
-Provide long-term memory capabilities for [OpenClaw](https://github.com/openclaw/openclaw) via [OpenViking](https://github.com/volcengine/OpenViking). After installing, OpenClaw will automatically **remember** important information from conversations and **recall** relevant content before replying. The latest version of OpenViking releases the [WebConsole](https://www.google.com/search?q=https://github.com/volcengine/OpenViking/tree/main/openviking/console) to facilitate debugging and operations. Method 3 in this document also provides instructions on how to verify that memories are written via the WebConsole interface, offering user-friendly and easy-to-understand usage guidelines. We welcome you to try it out and provide feedback.
+Provide long-term memory capabilities for [OpenClaw](https://github.com/openclaw/openclaw) via [OpenViking](https://github.com/volcengine/OpenViking). After installing, OpenClaw will automatically **remember** important information from conversations and **recall** relevant content before replying. The latest version of OpenViking includes a [WebConsole](https://github.com/volcengine/OpenViking/tree/main/openviking/console) for debugging and operations. Method 3 in this document also provides instructions on how to verify that memories are written via the WebConsole interface. We welcome you to try it out and provide feedback.
+
+> **⚠️ OpenClaw >= 2026.3.12 Compatibility Issue**
+>
+> OpenClaw `2026.3.12` and later have a known issue that causes conversations to hang after loading the plugin.
+> This is not a bug in our plugin — the root cause is OpenClaw 3.12's slug generator (automatic conversation naming),
+> which has a hardcoded 15s timeout that cascades when the LLM provider responds slowly, blocking the entire
+> session initialization pipeline. Additionally, 3.12's new plugin trust mechanism may affect loading order for
+> locally installed plugins. A separate issue: the `before_agent_start` auto-recall hook lacks timeout protection,
+> which can cause the agent to hang silently ([#673](https://github.com/volcengine/OpenViking/issues/673)).
+>
+> **Workaround:** Downgrade to `2026.3.11`: `npm install -g openclaw@2026.3.11`
+>
+> Upstream fix PRs: openclaw/openclaw#34673, openclaw/openclaw#33547.
+> See [#591](https://github.com/volcengine/OpenViking/issues/591) for details.
+
+> **🚀 Plugin 2.0 In Design**
+>
+> We are designing Plugin 2.0, rebuilt on the context-engine architecture — the best practice for integrating
+> OpenViking with AI coding assistants. Join the discussion:
+> https://github.com/volcengine/OpenViking/discussions/525
 
 ---
 
@@ -96,21 +116,13 @@ Verification: `python3 -c "import openviking; print('ok')"`
 
 ### Step 2: Run the Setup Helper
 
-#### Method A: Global npm Installation (Recommended)
-
 ```bash
+# Method A: npm install (recommended, cross-platform)
 npm install -g openclaw-openviking-setup-helper
 ov-install
 
-```
-
-#### Method B: Run from Repository
-
-```bash
-git clone https://github.com/volcengine/OpenViking.git
-cd OpenViking
-npx ./examples/openclaw-memory-plugin/setup-helper
-
+# Method B: curl one-click (Linux / macOS)
+curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/openclaw-memory-plugin/install.sh | bash
 ```
 
 The setup helper will prompt you to enter your Ark API Key and automatically generate a configuration file.
@@ -140,17 +152,23 @@ Already have a running OpenViking service? Simply configure the OpenClaw plugin 
 
 **Prerequisites:** An existing OpenViking service address + API Key (if authentication is enabled on the server side).
 
-### Step 1: Deploy Plugin Code
+### Step 1: Install Plugin
 
 ```bash
-git clone https://github.com/volcengine/OpenViking.git
-cd OpenViking/examples/openclaw-memory-plugin
-npm install
-openclaw plugin link .
-
+npm install -g openclaw-openviking-setup-helper
+ov-install
+# Select remote mode, enter your OpenViking server URL and API Key
 ```
 
-### Step 2: Configure Remote Connection
+### Step 2: Start and Verify
+
+```bash
+openclaw gateway restart
+openclaw status
+```
+
+<details>
+<summary>Manual configuration (without setup helper)</summary>
 
 ```bash
 openclaw config set plugins.enabled true --json
@@ -158,18 +176,12 @@ openclaw config set plugins.slots.memory memory-openviking
 openclaw config set plugins.entries.memory-openviking.config.mode remote
 openclaw config set plugins.entries.memory-openviking.config.baseUrl "http://your-server:1933"
 openclaw config set plugins.entries.memory-openviking.config.apiKey "your-api-key"
+openclaw config set plugins.entries.memory-openviking.config.agentId "your-agent-id"
 openclaw config set plugins.entries.memory-openviking.config.autoRecall true --json
 openclaw config set plugins.entries.memory-openviking.config.autoCapture true --json
-
 ```
 
-### Step 3: Start and Verify
-
-```bash
-openclaw gateway
-openclaw status
-
-```
+</details>
 
 ## Method 3: Integrating Openclaw with OpenViking on Volcengine ECS
 

--- a/examples/openclaw-memory-plugin/README.md
+++ b/examples/openclaw-memory-plugin/README.md
@@ -1,63 +1,75 @@
 # OpenClaw + OpenViking Memory Plugin
 
-Use OpenViking as the long-term memory backend for [OpenClaw](https://github.com/openclaw/openclaw).
+Use [OpenViking](https://github.com/volcengine/OpenViking) as the long-term memory backend for [OpenClaw](https://github.com/openclaw/openclaw). Once installed, OpenClaw will automatically **remember** important information from conversations and **recall** relevant context before responding.
 
-## Quick Start
+> **⚠️ OpenClaw >= 2026.3.12 Compatibility Issue**
+>
+> OpenClaw `2026.3.12` and later have a known issue that causes conversations to hang after loading the plugin.
+> This is not a bug in our plugin — the root cause is OpenClaw 3.12's slug generator (automatic conversation naming),
+> which has a hardcoded 15s timeout that cascades when the LLM provider responds slowly, blocking the entire
+> session initialization pipeline. Additionally, 3.12's new plugin trust mechanism may affect loading order for
+> locally installed plugins. A separate issue: the `before_agent_start` auto-recall hook lacks timeout protection,
+> which can cause the agent to hang silently ([#673](https://github.com/volcengine/OpenViking/issues/673)).
+>
+> **Workaround:** Downgrade to `2026.3.11`: `npm install -g openclaw@2026.3.11`
+>
+> Upstream fix PRs: openclaw/openclaw#34673, openclaw/openclaw#33547.
+> See [#591](https://github.com/volcengine/OpenViking/issues/591) for details.
+
+> **🚀 Plugin 2.0 In Design**
+>
+> We are designing Plugin 2.0, rebuilt on the context-engine architecture — the best practice for integrating
+> OpenViking with AI coding assistants. Join the discussion:
+> https://github.com/volcengine/OpenViking/discussions/525
+
+---
+
+## Table of Contents
+
+- [One-Click Installation](#one-click-installation)
+- [Manual Setup](#manual-setup)
+  - [Prerequisites](#prerequisites)
+  - [Local Mode (Personal Use)](#local-mode-personal-use)
+  - [Remote Mode (Team Sharing)](#remote-mode-team-sharing)
+  - [Volcengine ECS Deployment](#volcengine-ecs-deployment)
+- [Starting & Verification](#starting--verification)
+- [Configuration Reference](#configuration-reference)
+- [Daily Usage](#daily-usage)
+- [Web Console (Visualization)](#web-console-visualization)
+- [Troubleshooting](#troubleshooting)
+- [Uninstallation](#uninstallation)
+
+---
+
+## One-Click Installation
+
+For users who want a quick local experience. The setup helper handles environment detection, dependency installation, and config file generation automatically.
+
+### Method A: npm Install (Recommended, Cross-platform)
 
 ```bash
-cd /path/to/OpenViking
-npx ./examples/openclaw-memory-plugin/setup-helper
-openclaw gateway
+npm install -g openclaw-openviking-setup-helper
+ov-install
 ```
 
-The setup helper checks the environment, creates `~/.openviking/ov.conf`, deploys the plugin, and configures OpenClaw automatically. It supports both **local** and **remote** modes and auto-detects multiple OpenClaw instances.
-
-## Manual Setup
-
-### Local Mode
-
-Prerequisites: **OpenClaw** (`npm install -g openclaw`), **Python >= 3.10** with `openviking` (`pip install openviking --upgrade --force-reinstall`).
+### Method B: curl One-Click (Linux / macOS)
 
 ```bash
-# Install plugin
-mkdir -p ~/.openclaw/extensions/memory-openviking
-cp examples/openclaw-memory-plugin/{index.ts,config.ts,client.ts,process-manager.ts,memory-ranking.ts,text-utils.ts,openclaw.plugin.json,package.json,.gitignore} \
-   ~/.openclaw/extensions/memory-openviking/
-cd ~/.openclaw/extensions/memory-openviking && npm install
-
-# Configure (local mode — plugin auto-starts OpenViking)
-openclaw config set plugins.enabled true
-openclaw config set plugins.slots.memory memory-openviking
-openclaw config set plugins.entries.memory-openviking.config.mode "local"
-openclaw config set plugins.entries.memory-openviking.config.configPath "~/.openviking/ov.conf"
-openclaw config set plugins.entries.memory-openviking.config.targetUri "viking://user/memories"
-openclaw config set plugins.entries.memory-openviking.config.autoRecall true --json
-openclaw config set plugins.entries.memory-openviking.config.autoCapture true --json
-
-# Start
-source ~/.openclaw/openviking.env && openclaw gateway
+curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/openclaw-memory-plugin/install.sh | bash
 ```
 
-### Remote Mode
+The setup helper will walk you through:
 
-Prerequisites: **OpenClaw** only. No Python/OpenViking needed.
+1. **Environment check** — Detects Python >= 3.10, Node.js, cmake, etc.
+2. **Select OpenClaw instance** — If multiple instances are installed locally, lists them for you to choose
+3. **Select deployment mode** — Local or Remote (see below)
+4. **Generate config** — Writes `~/.openviking/ov.conf` and `~/.openclaw/openviking.env` automatically
 
-```bash
-openclaw config set plugins.enabled true
-openclaw config set plugins.slots.memory memory-openviking
-openclaw config set plugins.entries.memory-openviking.config.mode "remote"
-openclaw config set plugins.entries.memory-openviking.config.baseUrl "http://your-server:1933"
-openclaw config set plugins.entries.memory-openviking.config.apiKey "your-api-key"  # optional
-openclaw config set plugins.entries.memory-openviking.config.autoRecall true --json
-openclaw config set plugins.entries.memory-openviking.config.autoCapture true --json
-
-openclaw gateway
-```
-
-## Setup Helper Options
+<details>
+<summary>Setup helper options</summary>
 
 ```
-npx openclaw-openviking-setup-helper [options]
+ov-install [options]
 
   -y, --yes              Non-interactive, use defaults
   --workdir <path>       OpenClaw config directory (default: ~/.openclaw)
@@ -70,36 +82,380 @@ Env vars:
   OPENVIKING_ARK_API_KEY  Volcengine API Key (skip prompt in -y mode)
 ```
 
-## ov.conf Example
+</details>
+
+---
+
+## Manual Setup
+
+### Prerequisites
+
+| Component | Version | Purpose |
+|-----------|---------|---------|
+| **Python** | >= 3.10 | OpenViking runtime (Local mode) |
+| **Node.js** | >= 22 | OpenClaw runtime |
+| **Volcengine Ark API Key** | — | Embedding + VLM model calls |
+
+```bash
+python3 --version   # >= 3.10
+node -v              # >= v22
+openclaw --version   # installed
+```
+
+- Python: https://www.python.org/downloads/
+- Node.js: https://nodejs.org/
+- OpenClaw: `npm install -g openclaw@2026.3.11 && openclaw onboard`
+
+---
+
+### Local Mode (Personal Use)
+
+The simplest option — nearly zero configuration. The memory service runs alongside your OpenClaw agent locally. You only need a Volcengine Ark API Key.
+
+#### Step 1: Install OpenViking
+
+```bash
+python3 -m pip install openviking --upgrade
+```
+
+Verify: `python3 -c "import openviking; print('ok')"`
+
+> Hit `externally-managed-environment`? Use the one-click installer (handles venv automatically) or create one manually:
+> ```bash
+> python3 -m venv ~/.openviking/venv && ~/.openviking/venv/bin/pip install openviking
+> ```
+
+#### Step 2: Run the Setup Helper
+
+```bash
+# Method A: npm install (recommended, cross-platform)
+npm install -g openclaw-openviking-setup-helper
+ov-install
+
+# Method B: curl one-click (Linux / macOS)
+curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/openclaw-memory-plugin/install.sh | bash
+```
+
+Select **local** mode, keep defaults, and enter your Ark API Key.
+
+Generated config files:
+- `~/.openviking/ov.conf` — OpenViking service config
+- `~/.openclaw/openviking.env` — Environment variables (Python path, etc.)
+
+#### Step 3: Start
+
+```bash
+source ~/.openclaw/openviking.env && openclaw gateway restart
+```
+
+> In Local mode you must `source` the env file first — the plugin auto-starts an OpenViking subprocess.
+
+#### Step 4: Verify
+
+```bash
+openclaw status
+# Memory row should show: enabled (plugin memory-openviking)
+```
+
+---
+
+### Remote Mode (Team Sharing)
+
+For multiple OpenClaw instances or team use. Deploy a standalone OpenViking service that is shared across agents. **No Python/OpenViking needed on the client side.**
+
+#### Step 1: Deploy the OpenViking Service
+
+Edit `~/.openviking/ov.conf` — set `root_api_key` to enable multi-tenancy:
 
 ```json
 {
-  "vlm": {
-    "provider": "volcengine",
-    "api_key": "<your-api-key>",
-    "model": "doubao-seed-2-0-pro-260215",
-    "api_base": "https://ark.cn-beijing.volces.com/api/v3",
-    "temperature": 0.1,
-    "max_retries": 3
+  "server": {
+    "host": "127.0.0.1",
+    "port": 1933,
+    "root_api_key": "<your-root-api-key>",
+    "cors_origins": ["*"]
+  },
+  "storage": {
+    "workspace": "~/.openviking/data",
+    "vectordb": {
+      "name": "context",
+      "backend": "local"
+    },
+    "agfs": {
+      "log_level": "warn",
+      "backend": "local"
+    }
   },
   "embedding": {
     "dense": {
       "provider": "volcengine",
-      "api_key": "<your-api-key>",
+      "api_key": "<your-ark-api-key>",
       "model": "doubao-embedding-vision-251215",
       "api_base": "https://ark.cn-beijing.volces.com/api/v3",
       "dimension": 1024,
       "input": "multimodal"
     }
+  },
+  "vlm": {
+    "provider": "volcengine",
+    "api_key": "<your-ark-api-key>",
+    "model": "doubao-seed-2-0-pro-260215",
+    "api_base": "https://ark.cn-beijing.volces.com/api/v3",
+    "temperature": 0.1,
+    "max_retries": 3
   }
 }
 ```
 
+Start the service:
+
+```bash
+openviking-server
+```
+
+#### Step 2: Create Team & Users
+
+```bash
+# Create team + admin
+curl -X POST http://localhost:1933/api/v1/admin/accounts \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <root-api-key>" \
+  -d '{
+    "account_id": "my-team",
+    "admin_user_id": "admin"
+  }'
+
+# Add member
+curl -X POST http://localhost:1933/api/v1/admin/accounts/my-team/users \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <root-or-admin-key>" \
+  -d '{
+    "user_id": "xiaomei",
+    "role": "user"
+  }'
+```
+
+#### Step 3: Configure the OpenClaw Plugin
+
+```bash
+openclaw config set plugins.enabled true --json
+openclaw config set plugins.slots.memory memory-openviking
+openclaw config set plugins.entries.memory-openviking.config.mode remote
+openclaw config set plugins.entries.memory-openviking.config.baseUrl "http://your-server:1933"
+openclaw config set plugins.entries.memory-openviking.config.apiKey "<user-api-key>"
+openclaw config set plugins.entries.memory-openviking.config.agentId "<agent-id>"
+openclaw config set plugins.entries.memory-openviking.config.autoRecall true --json
+openclaw config set plugins.entries.memory-openviking.config.autoCapture true --json
+```
+
+#### Step 4: Start & Verify
+
+```bash
+# Remote mode — no env sourcing needed
+openclaw gateway restart
+openclaw status
+```
+
+---
+
+### Volcengine ECS Deployment
+
+Deploy OpenClaw + OpenViking on Volcengine ECS. See [Volcengine docs](https://www.volcengine.com/docs/6396/2249500?lang=zh) for details.
+
+> ECS instances restrict global pip installs under root to protect system Python. Create a venv first.
+
+```bash
+# 1. Install
+npm install -g openclaw-openviking-setup-helper
+ov-install
+
+# 2. Load environment
+source /root/.openclaw/openviking.env
+
+# 3. Start OpenViking server
+python -m openviking.server.bootstrap
+
+# 4. Start Web Console (ensure security group allows TCP 8020 inbound)
+python -m openviking.console.bootstrap --host 0.0.0.0 --port 8020 --openviking-url http://127.0.0.1:1933
+```
+
+Access `http://<public-ip>:8020` to use the Web Console.
+
+---
+
+## Starting & Verification
+
+### Local Mode
+
+```bash
+source ~/.openclaw/openviking.env && openclaw gateway restart
+```
+
+### Remote Mode
+
+```bash
+openclaw gateway restart
+```
+
+### Check Plugin Status
+
+```bash
+openclaw status
+# Memory row should show: enabled (plugin memory-openviking)
+```
+
+### View Plugin Config
+
+```bash
+openclaw config get plugins.entries.memory-openviking.config
+```
+
+---
+
+## Configuration Reference
+
+### `~/.openviking/ov.conf` (Local Mode)
+
+```json
+{
+  "root_api_key": null,
+  "server": { "host": "127.0.0.1", "port": 1933 },
+  "storage": {
+    "workspace": "~/.openviking/data",
+    "vectordb": { "backend": "local" },
+    "agfs": { "backend": "local", "port": 1833 }
+  },
+  "embedding": {
+    "dense": {
+      "provider": "volcengine",
+      "api_key": "<your-ark-api-key>",
+      "model": "doubao-embedding-vision-251215",
+      "api_base": "https://ark.cn-beijing.volces.com/api/v3",
+      "dimension": 1024,
+      "input": "multimodal"
+    }
+  },
+  "vlm": {
+    "provider": "volcengine",
+    "api_key": "<your-ark-api-key>",
+    "model": "doubao-seed-2-0-pro-260215",
+    "api_base": "https://ark.cn-beijing.volces.com/api/v3"
+  }
+}
+```
+
+> `root_api_key`: When set, all HTTP requests must include the `X-API-Key` header. Defaults to `null` in Local mode (auth disabled).
+
+### Plugin Config Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `mode` | `remote` | `local` (start local server) or `remote` (connect to remote) |
+| `baseUrl` | `http://127.0.0.1:1933` | OpenViking server URL (Remote mode) |
+| `apiKey` | — | OpenViking API Key (optional) |
+| `agentId` | auto-generated | Agent identifier, distinguishes OpenClaw instances. Auto-generates `openclaw-<hostname>-<random>` if unset |
+| `configPath` | `~/.openviking/ov.conf` | Config file path (Local mode) |
+| `port` | `1933` | Local server port (Local mode) |
+| `targetUri` | `viking://user/memories` | Default memory search scope |
+| `autoCapture` | `true` | Auto-extract memories after conversations |
+| `captureMode` | `semantic` | Extraction mode: `semantic` (full semantic) / `keyword` (trigger-word only) |
+| `captureMaxLength` | `24000` | Max text length per capture |
+| `autoRecall` | `true` | Auto-recall relevant memories before conversations |
+| `recallLimit` | `6` | Max memories injected during auto-recall |
+| `recallScoreThreshold` | `0.01` | Minimum relevance score for recall |
+| `ingestReplyAssist` | `true` | Add reply guidance when multi-party conversation text is detected |
+
+### `~/.openclaw/openviking.env`
+
+Auto-generated by the setup helper, stores environment variables like the Python path:
+
+```bash
+export OPENVIKING_PYTHON='/usr/local/bin/python3'
+```
+
+---
+
+## Daily Usage
+
+```bash
+# Start (Local mode — source env first)
+source ~/.openclaw/openviking.env && openclaw gateway
+
+# Start (Remote mode — no env needed)
+openclaw gateway
+
+# Disable memory
+openclaw config set plugins.slots.memory none
+
+# Re-enable memory
+openclaw config set plugins.slots.memory memory-openviking
+```
+
+> Restart the gateway after changing the memory slot.
+
+---
+
+## Web Console (Visualization)
+
+OpenViking provides a Web Console for debugging and inspecting stored memories.
+
+```bash
+python -m openviking.console.bootstrap \
+  --host 127.0.0.1 \
+  --port 8020 \
+  --openviking-url http://127.0.0.1:1933 \
+  --write-enabled
+```
+
+Open http://127.0.0.1:8020 in your browser.
+
+---
+
 ## Troubleshooting
 
-| Symptom | Fix |
-|---------|-----|
-| Memory shows `disabled` / `memory-core` | `openclaw config set plugins.slots.memory memory-openviking` |
-| `memory_store failed: fetch failed` | Check OpenViking is running; verify `ov.conf` and Python path |
-| `health check timeout` | `lsof -ti tcp:1933 \| xargs kill -9` then restart |
-| `extracted 0 memories` | Ensure `ov.conf` has valid `vlm` and `embedding.dense` with API key |
+### Common Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Conversation hangs, no response | OpenClaw >= 2026.3.12 compatibility issue | Downgrade to `2026.3.11`: `npm install -g openclaw@2026.3.11`. See [#591](https://github.com/volcengine/OpenViking/issues/591) |
+| Agent hangs silently, no output | auto-recall missing timeout protection | Disable auto-recall temporarily: `openclaw config set plugins.entries.memory-openviking.config.autoRecall false --json`, or apply the patch in [#673](https://github.com/volcengine/OpenViking/issues/673) |
+| Memory shows `disabled` / `memory-core` | Plugin slot not configured | `openclaw config set plugins.slots.memory memory-openviking` |
+| `memory_store failed: fetch failed` | OpenViking not running | Check `ov.conf` and Python path; verify service is up |
+| `health check timeout` | Port held by stale process | `lsof -ti tcp:1933 \| xargs kill -9`, then restart |
+| `extracted 0 memories` | Wrong API Key or model name | Check `api_key` and `model` in `ov.conf` |
+| `port occupied` | Port used by another process | Change port: `openclaw config set plugins.entries.memory-openviking.config.port 1934` |
+| Plugin not loaded | Env file not sourced | Run `source ~/.openclaw/openviking.env` before starting |
+| `externally-managed-environment` | Python PEP 668 restriction | Use venv or the one-click installer |
+| `TypeError: unsupported operand type(s) for \|` | Python < 3.10 | Upgrade Python to 3.10+ |
+
+### Viewing Logs
+
+```bash
+# OpenViking logs
+cat ~/.openviking/data/log/openviking.log
+
+# OpenClaw gateway logs
+cat ~/.openclaw/logs/gateway.log
+cat ~/.openclaw/logs/gateway.err.log
+
+# Check if OpenViking process is alive
+lsof -i:1933
+
+# Quick connectivity check
+curl http://localhost:1933
+# Expected: {"detail":"Not Found"}
+```
+
+---
+
+## Uninstallation
+
+```bash
+lsof -ti tcp:1933 tcp:1833 tcp:18789 | xargs kill -9
+npm uninstall -g openclaw && rm -rf ~/.openclaw
+python3 -m pip uninstall openviking -y && rm -rf ~/.openviking
+```
+
+---
+
+**See also:** [INSTALL-ZH.md](./INSTALL-ZH.md) (中文详细安装指南) · [INSTALL.md](./INSTALL.md) (English Install Guide) · [INSTALL-AGENT.md](./INSTALL-AGENT.md) (Agent Install Guide)

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -76,6 +76,13 @@ class AddMessageRequest(BaseModel):
         return self
 
 
+class UsedRequest(BaseModel):
+    """Request model for recording usage."""
+
+    contexts: Optional[List[str]] = None
+    skill: Optional[Dict[str, Any]] = None
+
+
 class CommitSessionRequest(BaseModel):
     """Request model for session commit."""
 
@@ -294,5 +301,26 @@ async def add_message(
         result={
             "session_id": session_id,
             "message_count": len(session.messages),
+        },
+    )
+
+
+@router.post("/{session_id}/used")
+async def record_used(
+    request: UsedRequest,
+    session_id: str = Path(..., description="Session ID"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Record actually used contexts and skills in a session."""
+    service = get_service()
+    session = service.sessions.session(_ctx, session_id)
+    await session.load()
+    session.used(contexts=request.contexts, skill=request.skill)
+    return Response(
+        status="ok",
+        result={
+            "session_id": session_id,
+            "contexts_used": session.stats.contexts_used,
+            "skills_used": session.stats.skills_used,
         },
     )


### PR DESCRIPTION
## Description

Add a new `POST /api/v1/sessions/{session_id}/used` endpoint that records actually used contexts and skills during a session. When `commit()` is called, `active_count` is updated based on this usage data. Also overhauls all plugin installation documentation with simplified flows, compatibility warnings, and expanded troubleshooting.

## Related Issue

<!-- N/A -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `POST /{session_id}/used` API endpoint in `sessions.py` with `UsedRequest` model (accepts `contexts` and `skill` fields)
- Add `used()` API documentation in both English and Chinese session docs
- Update session workflow examples to include the new usage recording step
- Overhaul `README.md`: restructure with table of contents, one-click installation, configuration reference, daily usage, web console, troubleshooting, and uninstallation sections
- Overhaul `INSTALL.md` and `INSTALL-ZH.md`: simplify to npm global package, add curl one-click method, add OpenClaw >= 2026.3.12 compatibility warning, add Plugin 2.0 announcement, expand troubleshooting
- Simplify `INSTALL-AGENT.md`: replace repo-clone workflow with npm global install

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The `used()` endpoint is designed to be called between `add-message()` and `commit()` in the session lifecycle, allowing clients to report which loaded contexts and skills were actually consumed during the conversation turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
