### PR TITLE
fix(vlm): strip <think> reasoning tags from model responses

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -224,7 +224,7 @@ class LiteLLMVLMProvider(VLMBase):
 
         response = completion(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")
 
     async def get_completion_async(
         self, prompt: str, thinking: bool = False, max_retries: int = 0
@@ -239,7 +239,7 @@ class LiteLLMVLMProvider(VLMBase):
             try:
                 response = await acompletion(**kwargs)
                 self._update_token_usage_from_response(response)
-                return response.choices[0].message.content or ""
+                return self._clean_response(response.choices[0].message.content or "")
             except Exception as e:
                 last_error = e
                 if attempt < max_retries:
@@ -268,7 +268,7 @@ class LiteLLMVLMProvider(VLMBase):
 
         response = completion(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")
 
     async def get_vision_completion_async(
         self,
@@ -289,7 +289,7 @@ class LiteLLMVLMProvider(VLMBase):
 
         response = await acompletion(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")
 
     def _update_token_usage_from_response(self, response) -> None:
         """Update token usage from response."""

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -65,7 +65,7 @@ class OpenAIVLM(VLMBase):
 
         response = client.chat.completions.create(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")
 
     async def get_completion_async(
         self, prompt: str, thinking: bool = False, max_retries: int = 0
@@ -83,7 +83,7 @@ class OpenAIVLM(VLMBase):
             try:
                 response = await client.chat.completions.create(**kwargs)
                 self._update_token_usage_from_response(response)
-                return response.choices[0].message.content or ""
+                return self._clean_response(response.choices[0].message.content or "")
             except Exception as e:
                 last_error = e
                 if attempt < max_retries:
@@ -168,7 +168,7 @@ class OpenAIVLM(VLMBase):
 
         response = client.chat.completions.create(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")
 
     async def get_vision_completion_async(
         self,
@@ -192,4 +192,4 @@ class OpenAIVLM(VLMBase):
 
         response = await client.chat.completions.create(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -71,7 +71,7 @@ class VolcEngineVLM(OpenAIVLM):
 
         response = client.chat.completions.create(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")
 
     async def get_completion_async(
         self, prompt: str, thinking: bool = False, max_retries: int = 0
@@ -90,7 +90,7 @@ class VolcEngineVLM(OpenAIVLM):
             try:
                 response = await client.chat.completions.create(**kwargs)
                 self._update_token_usage_from_response(response)
-                return response.choices[0].message.content or ""
+                return self._clean_response(response.choices[0].message.content or "")
             except Exception as e:
                 last_error = e
                 if attempt < max_retries:
@@ -238,7 +238,7 @@ class VolcEngineVLM(OpenAIVLM):
 
         response = client.chat.completions.create(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")
 
     async def get_vision_completion_async(
         self,
@@ -263,4 +263,4 @@ class VolcEngineVLM(OpenAIVLM):
 
         response = await client.chat.completions.create(**kwargs)
         self._update_token_usage_from_response(response)
-        return response.choices[0].message.content or ""
+        return self._clean_response(response.choices[0].message.content or "")

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """VLM base interface and abstract classes"""
 
+import re
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Union
@@ -9,6 +10,8 @@ from typing import Any, Dict, List, Union
 from openviking.utils.time_utils import format_iso8601
 
 from .token_usage import TokenUsageTracker
+
+_THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>")
 
 
 class VLMBase(ABC):
@@ -57,6 +60,10 @@ class VLMBase(ABC):
     ) -> str:
         """Get vision completion asynchronously"""
         pass
+
+    def _clean_response(self, content: str) -> str:
+        """Strip reasoning tags (e.g. ``<think>...</think>``) from model output."""
+        return _THINK_TAG_RE.sub("", content).strip()
 
     def is_available(self) -> bool:
         """Check if available"""

--- a/tests/models/test_vlm_strip_think_tags.py
+++ b/tests/models/test_vlm_strip_think_tags.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for stripping <think> reasoning tags from VLM responses."""
+
+import pytest
+
+from openviking.models.vlm.base import _THINK_TAG_RE, VLMBase
+
+
+class TestStripThinkTags:
+    """Test _clean_response strips <think> blocks correctly."""
+
+    @pytest.fixture()
+    def vlm(self):
+        """Create a minimal concrete VLMBase for testing."""
+
+        class _Stub(VLMBase):
+            def get_completion(self, prompt, thinking=False):
+                return ""
+
+            async def get_completion_async(self, prompt, thinking=False, max_retries=0):
+                return ""
+
+            def get_vision_completion(self, prompt, images, thinking=False):
+                return ""
+
+            async def get_vision_completion_async(self, prompt, images, thinking=False):
+                return ""
+
+        return _Stub({"api_key": "test"})
+
+    def test_no_think_tags(self, vlm):
+        text = "This is a normal response."
+        assert vlm._clean_response(text) == "This is a normal response."
+
+    def test_single_think_block(self, vlm):
+        text = "<think>\nI need to analyze this.\n</think>\nThe actual summary."
+        assert vlm._clean_response(text) == "The actual summary."
+
+    def test_think_block_at_end(self, vlm):
+        text = "Summary text.\n<think>some reasoning</think>"
+        assert vlm._clean_response(text) == "Summary text."
+
+    def test_think_block_in_middle(self, vlm):
+        text = "Start.<think>reasoning here</think>End."
+        assert vlm._clean_response(text) == "Start.End."
+
+    def test_multiple_think_blocks(self, vlm):
+        text = "<think>first</think>Hello<think>second</think> world"
+        assert vlm._clean_response(text) == "Hello world"
+
+    def test_multiline_think_block(self, vlm):
+        text = (
+            "<think>\nStep 1: analyze the document\n"
+            "Step 2: summarize\nStep 3: output\n</think>\n"
+            "# Directory Overview\n\nThis directory contains..."
+        )
+        result = vlm._clean_response(text)
+        assert result.startswith("# Directory Overview")
+        assert "<think>" not in result
+
+    def test_empty_string(self, vlm):
+        assert vlm._clean_response("") == ""
+
+    def test_only_think_block(self, vlm):
+        text = "<think>all reasoning, no output</think>"
+        assert vlm._clean_response(text) == ""
+
+    def test_nested_angle_brackets_preserved(self, vlm):
+        text = "Use <b>bold</b> and <i>italic</i> formatting."
+        assert vlm._clean_response(text) == text
+
+    def test_json_with_think_prefix(self, vlm):
+        text = '<think>let me think</think>\n{"abstract": "summary", "overview": "details"}'
+        result = vlm._clean_response(text)
+        assert result == '{"abstract": "summary", "overview": "details"}'
+
+
+class TestThinkTagRegex:
+    """Test the compiled regex pattern directly."""
+
+    def test_greedy_minimal(self):
+        """Ensure non-greedy matching: each <think>...</think> is matched individually."""
+        text = "<think>a</think>KEEP<think>b</think>"
+        assert _THINK_TAG_RE.sub("", text) == "KEEP"


### PR DESCRIPTION
## Description

When reasoning-capable LLMs (e.g. MiniMax-M2.5, DeepSeek-R1, QwQ) are used as the VLM backend via vLLM, `<think>...</think>` reasoning blocks in `message.content` are stored verbatim into file summaries, directory overviews, and abstracts. This pollutes semantic search results and wastes token budget during L0/L1 context loading.

This PR adds a centralized `_clean_response()` method in `VLMBase` that strips `<think>` tags from all VLM responses before they are returned to callers.

## Related Issue

Closes #685

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added `_clean_response()` method in `VLMBase` (base.py) with a compiled regex to strip `<think>...</think>` blocks
- Applied `_clean_response()` at all return points in OpenAI, VolcEngine, and LiteLLM backends (12 call sites total)
- Added regression test suite (`tests/models/test_vlm_strip_think_tags.py`) covering: single/multiple/multiline think blocks, empty input, JSON with think prefix, and ensuring non-think HTML tags are preserved

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The fix is applied at the VLM backend layer so all downstream consumers (semantic processor, media summary generator, JSON parser, etc.) receive clean content without needing individual fixes. For responses that don't contain `<think>` tags, the overhead is a single no-match regex scan which is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)