### PR TITLE
fix(mcp): add api_key support and configurable defaults to MCP query server

### DIFF
--- a/examples/mcp-query/server.py
+++ b/examples/mcp-query/server.py
@@ -45,6 +45,8 @@ def _get_recipe() -> Recipe:
     global _recipe
     if _recipe is None:
         _recipe = Recipe(config_path=_config_path, data_path=_data_path)
+        if _api_key:
+            _recipe.api_key = _api_key
     return _recipe
 
 


### PR DESCRIPTION
## Summary

The in-repo MCP server at `examples/mcp-query/server.py` had three gaps reported in #606:

1. **No API key pass-through** - no mechanism to pass authentication credentials when the OpenViking server has `root_api_key` configured. Added `--api-key` / `OV_API_KEY`.

2. **No configurable search scope** - the `search` tool accepted `target_uri` per-call but had no server-level default, requiring every MCP client to specify the scope. Added `--default-uri` / `OV_DEFAULT_URI` as a fallback when the client does not provide `target_uri`.

3. **Windows localhost failure** - the epilog examples used `localhost` which resolves to `::1` on Windows while the server binds to `127.0.0.1`. Fixed to use `127.0.0.1`.

Note: The external `openviking-mcp` PyPI package referenced in #606 is out of scope for this repo. This PR improves the official in-repo MCP example to prevent the same issues.

## Changes

- Added `--api-key` / `OV_API_KEY` CLI flag (empty string default = no auth)
- Added `--default-uri` / `OV_DEFAULT_URI` CLI flag (empty string default = search all)
- Search tool uses `_default_uri` as fallback when `target_uri` is not provided by the client
- Fixed `localhost` to `127.0.0.1` in argparse epilog examples
- Added environment variable documentation for new flags

All new flags have backward-compatible defaults - existing deployments are unaffected.

Fixes #606

This contribution was developed with AI assistance (Claude Code).

## Test plan

- [ ] `uv run server.py` starts without errors (backward compatible)
- [ ] `uv run server.py --default-uri viking://user/memories` - search tool uses default URI
- [ ] `uv run server.py --api-key sk-test` - API key stored for future use
- [ ] `uv run server.py --help` shows new flags and updated examples
- [ ] `ruff format --check` and `ruff check` pass