### PR TITLE
fix(docker): copy build_support/ into container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /app
 # Copy source required for setup.py artifact builds and native extension build.
 COPY Cargo.toml Cargo.lock ./
 COPY pyproject.toml uv.lock setup.py README.md ./
+COPY build_support/ build_support/
 COPY crates/ crates/
 COPY openviking/ openviking/
 COPY openviking_cli/ openviking_cli/


### PR DESCRIPTION
## Description

Add the missing `COPY build_support/ build_support/` instruction to the Dockerfile so that the `build_support` Python module is available during Docker image builds.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Added `COPY build_support/ build_support/` to the Dockerfile, placed before the existing `COPY crates/ crates/` line to maintain logical ordering of source copy instructions.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The `build_support/` directory contains `x86_profiles.py` and other helpers used by `setup.py` during native extension builds. Without this COPY instruction, Docker builds fail because the module cannot be imported.

Generated with [Claude Code](https://claude.com/claude-code)
