### PR TITLE
fix(ci): publish wheels for Python 3.14 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ on:
         description: 'JSON string of Python versions (Manual only)'
         required: false
         type: string
-        default: '["3.10", "3.11", "3.12", "3.13"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
 permissions:
   contents: write
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       os_json: ${{ inputs.os_json || '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15-intel", "windows-latest"]' }}
-      python_json: ${{ inputs.python_json || '["3.10", "3.11", "3.12", "3.13"]' }}
+      python_json: ${{ inputs.python_json || '["3.10", "3.11", "3.12", "3.13", "3.14"]' }}
       build_sdist: ${{ github.event_name == 'release' || inputs.build_sdist != false }}
       build_wheels: ${{ github.event_name == 'release' || inputs.build_wheels != false }}
 


### PR DESCRIPTION
## Summary
- Add Python 3.14 to the release workflow's default `python_json` parameter
- `_build.yml` already supports 3.14, but `release.yml` was missing it — so no pre-built wheels were published for 3.14

Closes #719