### PR TITLE
fix(dedup): detect intra-batch duplicates via in-memory batch contexts

### DIFF
--- a/openviking/session/compressor.py
+++ b/openviking/session/compressor.py
@@ -247,6 +247,7 @@ class SessionCompressor:
                 return []
 
             memories: List[Context] = []
+            batch_contexts: List[Context] = []
             stats = ExtractionStats()
             viking_fs = get_viking_fs()
 
@@ -323,7 +324,9 @@ class SessionCompressor:
                     continue
 
                 # Dedup check for other categories
-                result = await self.deduplicator.deduplicate(candidate, ctx)
+                result = await self.deduplicator.deduplicate(
+                    candidate, ctx, batch_contexts=batch_contexts,
+                )
                 actions = result.actions or []
                 decision = result.decision
 
@@ -360,6 +363,8 @@ class SessionCompressor:
                                     candidate, action.memory, viking_fs, ctx=ctx
                                 ):
                                     stats.merged += 1
+                                    self._tag_batch_vector(action.memory, candidate)
+                                    batch_contexts.append(action.memory)
                                 else:
                                     stats.skipped += 1
                             else:
@@ -385,6 +390,8 @@ class SessionCompressor:
                         memories.append(memory)
                         stats.created += 1
                         await self._index_memory(memory, ctx)
+                        self._tag_batch_vector(memory, candidate)
+                        batch_contexts.append(memory)
                     else:
                         stats.skipped += 1
 
@@ -404,6 +411,22 @@ class SessionCompressor:
         except Exception:
             self._pending_semantic_changes.clear()
             raise
+
+    def _tag_batch_vector(self, memory: Context, candidate: CandidateMemory) -> None:
+        """Attach embedding vector to memory for intra-batch dedup.
+
+        Non-critical: failures are silently ignored since dedup still works
+        via vector search for previously indexed memories.
+        """
+        if not self.deduplicator.embedder:
+            return
+        try:
+            query_text = f"{candidate.abstract} {candidate.content}"
+            embed_result = self.deduplicator.embedder.embed(query_text)
+            if embed_result.dense_vector:
+                memory.meta = {**(memory.meta or {}), "_batch_vector": embed_result.dense_vector}
+        except Exception:
+            pass
 
     def _extract_tool_parts(self, messages: List[Message]) -> List:
         """Extract all ToolPart from messages."""

--- a/openviking/session/memory_deduplicator.py
+++ b/openviking/session/memory_deduplicator.py
@@ -92,10 +92,13 @@ class MemoryDeduplicator:
         self,
         candidate: CandidateMemory,
         ctx: RequestContext,
+        batch_contexts: Optional[List[Context]] = None,
     ) -> DedupResult:
         """Decide how to handle a candidate memory."""
         # Step 1: Vector pre-filtering - find similar memories in same category
-        similar_memories = await self._find_similar_memories(candidate, ctx=ctx)
+        similar_memories = await self._find_similar_memories(
+            candidate, ctx=ctx, batch_contexts=batch_contexts,
+        )
 
         if not similar_memories:
             # No similar memories, create directly
@@ -122,6 +125,7 @@ class MemoryDeduplicator:
         self,
         candidate: CandidateMemory,
         ctx: RequestContext,
+        batch_contexts: Optional[List[Context]] = None,
     ) -> List[Context]:
         """Find similar existing memories using vector search."""
         telemetry = get_current_telemetry()
@@ -186,6 +190,26 @@ class MemoryDeduplicator:
                         # Keep retrieval score for later destructive-action guardrails.
                         context.meta = {**(context.meta or {}), "_dedup_score": score}
                         similar.append(context)
+            # Supplement with in-memory batch contexts (covers async vectorization gap)
+            if batch_contexts and query_vector:
+                seen_uris = {c.uri for c in similar}
+                for bc in batch_contexts:
+                    if bc.uri in seen_uris:
+                        continue
+                    bc_vector = (bc.meta or {}).get("_batch_vector")
+                    if bc_vector:
+                        score = self._cosine_similarity(query_vector, bc_vector)
+                        if score >= self.SIMILARITY_THRESHOLD:
+                            bc_copy = Context.from_dict(bc.to_dict())
+                            if bc_copy:
+                                bc_copy.meta = {**(bc_copy.meta or {}), "_dedup_score": score}
+                                similar.append(bc_copy)
+                                logger.debug(
+                                    "Batch intra-dedup hit score=%.4f uri=%s",
+                                    score,
+                                    bc.uri,
+                                )
+
             logger.debug("Dedup similar memories after threshold=%d", len(similar))
             return similar
 

--- a/tests/session/test_memory_dedup_actions.py
+++ b/tests/session/test_memory_dedup_actions.py
@@ -368,6 +368,129 @@ class TestProfileMergeSafety:
 
 
 @pytest.mark.asyncio
+class TestBatchIntraDedup:
+    async def test_batch_context_is_included_in_similar_memories(self):
+        """When vector search returns nothing but batch_contexts has a similar memory,
+        dedup should still find it and NOT default to CREATE with 'No similar'."""
+        vikingdb = MagicMock()
+        vikingdb.get_embedder.return_value = _DummyEmbedder()
+        # Vector search returns empty — simulates async vectorization gap
+        vikingdb.search_similar_memories = AsyncMock(return_value=[])
+
+        dedup = MemoryDeduplicator(vikingdb=vikingdb)
+        candidate = _make_candidate()
+
+        # Simulate a previously processed memory in this batch
+        batch_mem = _make_existing("batch_prev.md")
+        batch_mem.meta = {**(batch_mem.meta or {}), "_batch_vector": [0.1, 0.2, 0.3]}
+
+        result = await dedup.deduplicate(candidate, ctx, batch_contexts=[batch_mem])
+
+        # Should find the batch context as similar, not default to CREATE with "No similar"
+        assert result.similar_memories, "batch context should appear as similar memory"
+        assert any(m.uri == batch_mem.uri for m in result.similar_memories)
+
+    async def test_batch_context_not_duplicated_with_vector_results(self):
+        """If vector search already returns a memory, batch_contexts should not add it again."""
+        existing = _make_existing("already_found.md")
+        vikingdb = MagicMock()
+        vikingdb.get_embedder.return_value = _DummyEmbedder()
+        vikingdb.search_similar_memories = AsyncMock(
+            return_value=[
+                {
+                    "id": "found",
+                    "uri": existing.uri,
+                    "context_type": "memory",
+                    "level": 2,
+                    "account_id": "acc1",
+                    "owner_space": _make_user().user_space_name(),
+                    "abstract": existing.abstract,
+                    "category": "preferences",
+                    "_score": 0.9,
+                }
+            ]
+        )
+
+        dedup = MemoryDeduplicator(vikingdb=vikingdb)
+        candidate = _make_candidate()
+
+        # Same URI in batch_contexts
+        batch_mem = _make_existing("already_found.md")
+        batch_mem.meta = {**(batch_mem.meta or {}), "_batch_vector": [0.1, 0.2, 0.3]}
+
+        result = await dedup.deduplicate(candidate, ctx, batch_contexts=[batch_mem])
+
+        # Should not have duplicates
+        uris = [m.uri for m in result.similar_memories]
+        assert len(uris) == len(set(uris)), "no duplicate URIs in similar_memories"
+
+    async def test_empty_batch_contexts_has_no_effect(self):
+        """Passing empty batch_contexts should behave identically to not passing it."""
+        vikingdb = MagicMock()
+        vikingdb.get_embedder.return_value = _DummyEmbedder()
+        vikingdb.search_similar_memories = AsyncMock(return_value=[])
+
+        dedup = MemoryDeduplicator(vikingdb=vikingdb)
+        candidate = _make_candidate()
+
+        result = await dedup.deduplicate(candidate, ctx, batch_contexts=[])
+
+        assert result.decision == DedupDecision.CREATE
+        assert result.reason == "No similar memories found"
+
+
+@pytest.mark.asyncio
+class TestCompressorBatchDedup:
+    async def test_second_candidate_receives_first_as_batch_context(self):
+        """When two candidates are extracted, the second should receive
+        the first's Context in batch_contexts."""
+        candidate1 = _make_candidate()
+        candidate1.abstract = "Company X org structure"
+        candidate2 = _make_candidate()
+        candidate2.abstract = "Company X business model"
+
+        new_memory1 = _make_existing("created1.md")
+
+        vikingdb = MagicMock()
+        vikingdb.get_embedder.return_value = _DummyEmbedder()
+        vikingdb.delete_uris = AsyncMock(return_value=None)
+        vikingdb.enqueue_embedding_msg = AsyncMock()
+
+        compressor = SessionCompressor(vikingdb=vikingdb)
+        compressor.extractor.extract = AsyncMock(return_value=[candidate1, candidate2])
+        compressor.extractor.create_memory = AsyncMock(return_value=new_memory1)
+
+        dedup_calls = []
+
+        async def _capture_dedup(candidate, ctx, batch_contexts=None):
+            dedup_calls.append({"candidate": candidate, "batch_contexts": batch_contexts or []})
+            return DedupResult(
+                decision=DedupDecision.CREATE,
+                candidate=candidate,
+                similar_memories=[],
+                actions=[],
+            )
+
+        compressor.deduplicator.deduplicate = AsyncMock(side_effect=_capture_dedup)
+        compressor._index_memory = AsyncMock(return_value=True)
+
+        fs = MagicMock()
+        with patch("openviking.session.compressor.get_viking_fs", return_value=fs):
+            await compressor.extract_long_term_memories(
+                [Message.create_user("test message")],
+                user=_make_user(),
+                session_id="session_test",
+                ctx=_make_ctx(),
+            )
+
+        assert len(dedup_calls) == 2
+        # First candidate: no batch contexts
+        assert dedup_calls[0]["batch_contexts"] == []
+        # Second candidate: should have batch contexts from the first
+        assert len(dedup_calls[1]["batch_contexts"]) >= 1
+
+
+@pytest.mark.asyncio
 class TestSessionCompressorDedupActions:
     async def test_create_with_empty_list_only_creates_new_memory(self):
         candidate = _make_candidate()


### PR DESCRIPTION
## Summary

Fixes #687. When a single `session.commit()` produces multiple candidates about the same entity, async vectorization means earlier candidates are not yet indexed when later ones run dedup. This causes near-duplicate memories to be created.

## Changes

- Add `batch_contexts` parameter to `MemoryDeduplicator.deduplicate()` and `_find_similar_memories()`
- Compute cosine similarity against batch contexts using the existing `_cosine_similarity()` method
- Maintain `batch_contexts` list in `SessionCompressor.extract_long_term_memories()` loop
- Add `_tag_batch_vector()` helper to store transient embedding on processed memories
- Deduplicate URIs between vector search results and batch contexts

## Design

- **Purely additive**: vector search behavior is unchanged; batch contexts only supplement its blind spot during the async vectorization gap
- **Embedding reuse**: uses the same embedder instance already available on the deduplicator
- **Transient metadata**: `_batch_vector` is stored in `Context.meta` but never persisted to storage
- **Graceful degradation**: embedding failures in `_tag_batch_vector()` are silently ignored; dedup still works via vector search for previously indexed memories

## Test plan

- [x] `test_batch_context_is_included_in_similar_memories` — batch context appears when vector search returns empty
- [x] `test_batch_context_not_duplicated_with_vector_results` — no duplicate URIs when vector search already found the memory
- [x] `test_empty_batch_contexts_has_no_effect` — empty list behaves same as before
- [x] `test_second_candidate_receives_first_as_batch_context` — compressor passes batch contexts through the loop
- [x] All 14 existing dedup/compressor tests pass without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)