### PR TITLE
fix: expand tilde (~) in storage workspace paths

### DIFF
--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -358,7 +358,7 @@ def initialize_openviking_config(
         config.storage.vectordb.backend = config.storage.vectordb.backend or "local"
         # Resolve and update workspace + dependent paths (model_validator won't
         # re-run on attribute assignment, so sync agfs.path / vectordb.path here).
-        workspace_path = Path(path).resolve()
+        workspace_path = Path(path).expanduser().resolve()
         workspace_path.mkdir(parents=True, exist_ok=True)
         resolved = str(workspace_path)
         config.storage.workspace = resolved

--- a/openviking_cli/utils/config/storage_config.py
+++ b/openviking_cli/utils/config/storage_config.py
@@ -50,8 +50,8 @@ class StorageConfig(BaseModel):
                 f"Using '{self.workspace}' from workspace instead of '{self.vectordb.path}'"
             )
 
-        # Update paths to use workspace
-        workspace_path = Path(self.workspace).resolve()
+        # Update paths to use workspace (expand ~ first)
+        workspace_path = Path(self.workspace).expanduser().resolve()
         workspace_path.mkdir(parents=True, exist_ok=True)
         self.workspace = str(workspace_path)
         self.agfs.path = self.workspace
@@ -65,7 +65,7 @@ class StorageConfig(BaseModel):
         Returns:
             Path to {workspace}/temp/upload directory
         """
-        workspace_path = Path(self.workspace).resolve()
+        workspace_path = Path(self.workspace).expanduser().resolve()
         upload_temp_dir = workspace_path / "temp" / "upload"
         upload_temp_dir.mkdir(parents=True, exist_ok=True)
         return upload_temp_dir


### PR DESCRIPTION
This PR fixes an issue where tilde expansion (~) doesn't work properly in the ov.conf storage workspace configuration.

**Problem:**
When configuring storage workspace as "~/.openviking/data" in ov.conf, the path was treated literally instead of expanding ~ to the user's home directory. This caused the application to create directories named "~" instead of using the actual home directory.

**Root Cause:**
The storage configuration code was using Path(workspace).resolve() without first calling expanduser() to handle the ~ character.

**Solution:**
- Added .expanduser() before .resolve() in storage_config.py's resolve_paths() method
- Added .expanduser() before .resolve() in open_viking_config.py's initialize_openviking_config() function
- Added .expanduser() before .resolve() in storage_config.py's get_upload_temp_dir() method for consistency

**Files Changed:**
- openviking_cli/utils/config/storage_config.py
- openviking_cli/utils/config/open_viking_config.py

**Testing:**
The fix ensures that workspace paths like "~/.openviking/data" are properly expanded to "/Users/username/.openviking/data" before being resolved and used.