### PR TITLE
fix(session): persist cleared messages.jsonl before memory extraction

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -252,11 +252,17 @@ class Session:
         result["archived"] = True
 
         self._messages.clear()
+
+        # 2. Persist cleared messages.jsonl immediately to prevent race condition.
+        # Without this, a concurrent commit could re-read old messages from the
+        # stale file while memory extraction (step 3) is still running.
+        self._write_to_agfs(self._messages)
+
         logger.info(
             f"Archived: {len(messages_to_archive)} messages → history/archive_{self._compression.compression_index:03d}/"
         )
 
-        # 2. Extract long-term memories
+        # 3. Extract long-term memories (may take seconds/minutes with LLM)
         if self._session_compressor:
             logger.info(
                 f"Starting memory extraction from {len(messages_to_archive)} archived messages"
@@ -273,9 +279,6 @@ class Session:
             result["memories_extracted"] = len(memories)
             self._stats.memories_extracted += len(memories)
             get_current_telemetry().set("memory.extracted", len(memories))
-
-        # 3. Write current messages to AGFS
-        self._write_to_agfs(self._messages)
 
         # 4. Create relations
         self._write_relations()
@@ -330,11 +333,17 @@ class Session:
         result["archived"] = True
 
         self._messages.clear()
+
+        # 2. Persist cleared messages.jsonl immediately to prevent race condition.
+        # Without this, a concurrent commit could re-read old messages from the
+        # stale file while memory extraction (step 3) is still running.
+        await self._write_to_agfs_async(self._messages)
+
         logger.info(
             f"Archived: {len(messages_to_archive)} messages → history/archive_{self._compression.compression_index:03d}/"
         )
 
-        # 2. Extract long-term memories
+        # 3. Extract long-term memories (may take seconds/minutes with LLM)
         if self._session_compressor:
             logger.info(
                 f"Starting memory extraction from {len(messages_to_archive)} archived messages"
@@ -349,9 +358,6 @@ class Session:
             result["memories_extracted"] = len(memories)
             self._stats.memories_extracted += len(memories)
             get_current_telemetry().set("memory.extracted", len(memories))
-
-        # 3. Write current messages to AGFS
-        await self._write_to_agfs_async(self._messages)
 
         # 4. Create relations
         await self._write_relations_async()


### PR DESCRIPTION
## Summary
- Fixes race condition where async session commit could re-commit old messages
- Moves the AGFS write of cleared `messages.jsonl` to immediately after `self._messages.clear()`, before memory extraction
- Applied to both `commit()` and `commit_async()` for consistency

Fixes #580

## Root Cause
`commit_async()` cleared `self._messages` in-memory (line 332) but didn't write the empty `messages.jsonl` to AGFS until after memory extraction (line 354). Memory extraction can take seconds/minutes with LLM calls. During that window:
- A concurrent commit could re-read old messages from the stale file
- New messages appended via `add_message()` could be lost when the delayed write overwrites with empty

## Fix
Move `self._write_to_agfs_async(self._messages)` from after memory extraction to immediately after `self._messages.clear()`. This ensures the file is persisted as empty before the long-running LLM step, closing the race window.

## Changes Made
- **`openviking/session/session.py`**: Reordered steps in both `commit()` and `commit_async()` — AGFS write now happens at step 2 (immediately after clear), memory extraction moves to step 3

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Unit tests pass locally (11/11 session tests pass)
- [x] Tested on macOS

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes