### PR TITLE
feat(session): add chunked vectorization for long memories

### DIFF
--- a/openviking/session/compressor.py
+++ b/openviking/session/compressor.py
@@ -148,19 +148,73 @@ class SessionCompressor:
     ) -> bool:
         """Add memory to vectorization queue and record semantic change.
 
+        For long memories, splits content into chunks and enqueues each chunk
+        as a separate vector record for better retrieval precision.
+
         Args:
             memory: The memory context to index
             ctx: Request context
             change_type: One of "added" or "modified"
         """
         from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
+        from openviking_cli.utils.config import get_openviking_config
 
+        semantic = get_openviking_config().semantic
+        vectorize_text = memory.get_vectorization_text()
+
+        if vectorize_text and len(vectorize_text) > semantic.memory_chunk_chars:
+            # Chunk long memory into multiple vector records
+            chunks = self._chunk_text(
+                vectorize_text,
+                semantic.memory_chunk_chars,
+                semantic.memory_chunk_overlap,
+            )
+            logger.info(
+                f"Chunking memory {memory.uri} into {len(chunks)} chunks "
+                f"({len(vectorize_text)} chars)"
+            )
+            import copy
+
+            for i, chunk in enumerate(chunks):
+                chunk_memory = copy.deepcopy(memory)
+                chunk_memory.uri = f"{memory.uri}#chunk_{i:04d}"
+                chunk_memory.parent_uri = memory.uri
+                chunk_memory.set_vectorize(Vectorize(text=chunk))
+                chunk_msg = EmbeddingMsgConverter.from_context(chunk_memory)
+                if chunk_msg:
+                    await self.vikingdb.enqueue_embedding_msg(chunk_msg)
+
+        # Always enqueue the base record (uses abstract as vector text)
         embedding_msg = EmbeddingMsgConverter.from_context(memory)
         await self.vikingdb.enqueue_embedding_msg(embedding_msg)
         logger.info(f"Enqueued memory for vectorization: {memory.uri}")
 
         self._record_semantic_change(memory.uri, change_type, parent_uri=memory.parent_uri)
         return True
+
+    @staticmethod
+    def _chunk_text(text: str, chunk_size: int, overlap: int) -> list:
+        """Split text into overlapping chunks, preferring paragraph boundaries."""
+        if len(text) <= chunk_size:
+            return [text]
+
+        chunks = []
+        start = 0
+        while start < len(text):
+            end = start + chunk_size
+
+            # Try to break at paragraph boundary
+            if end < len(text):
+                boundary = text.rfind("\n\n", start, end)
+                if boundary > start + chunk_size // 2:
+                    end = boundary + 2  # Include the double newline
+
+            chunks.append(text[start:end].strip())
+            start = end - overlap
+            if start >= len(text):
+                break
+
+        return [c for c in chunks if c]
 
     async def _merge_into_existing(
         self,
@@ -379,9 +433,7 @@ class SessionCompressor:
                                         merged_text = (
                                             f"{action.memory.abstract} {candidate.content}"
                                         )
-                                        merged_embed = self.deduplicator.embedder.embed(
-                                            merged_text
-                                        )
+                                        merged_embed = self.deduplicator.embedder.embed(merged_text)
                                         batch_memories.append(
                                             (merged_embed.dense_vector, action.memory)
                                         )

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -505,6 +505,13 @@ class SemanticConfig:
     overview_max_chars: int = 4000
     """Maximum characters for generated overviews."""
 
+    memory_chunk_chars: int = 2000
+    """Maximum characters per chunk when splitting long memories for vectorization.
+    Memories shorter than this are vectorized as a single record."""
+
+    memory_chunk_overlap: int = 200
+    """Character overlap between adjacent memory chunks for context continuity."""
+
 
 # Configuration registry for dynamic loading
 PARSER_CONFIG_REGISTRY = {

--- a/tests/misc/test_semantic_config.py
+++ b/tests/misc/test_semantic_config.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for SemanticConfig and overview budget estimation."""
+"""Tests for SemanticConfig, overview budget estimation, and memory chunking."""
 
+from openviking.session.compressor import SessionCompressor
 from openviking_cli.utils.config.parser_config import SemanticConfig
 
 
@@ -14,6 +15,8 @@ def test_semantic_config_defaults():
     assert config.overview_batch_size == 50
     assert config.abstract_max_chars == 256
     assert config.overview_max_chars == 4000
+    assert config.memory_chunk_chars == 2000
+    assert config.memory_chunk_overlap == 200
 
 
 def test_semantic_config_custom_values():
@@ -80,3 +83,54 @@ def test_batch_splitting():
     assert len(batches[0]) == 50
     assert len(batches[1]) == 50
     assert len(batches[2]) == 20
+
+
+# --- Memory chunking tests ---
+
+
+def test_chunk_text_short_text_no_split():
+    """Short text below chunk_size returns single chunk."""
+    text = "Short memory content."
+    chunks = SessionCompressor._chunk_text(text, chunk_size=2000, overlap=200)
+    assert len(chunks) == 1
+    assert chunks[0] == text
+
+
+def test_chunk_text_long_text_splits():
+    """Long text is split into multiple chunks."""
+    text = "A" * 5000
+    chunks = SessionCompressor._chunk_text(text, chunk_size=2000, overlap=200)
+    assert len(chunks) >= 3
+    # Each chunk should be at most chunk_size
+    for chunk in chunks:
+        assert len(chunk) <= 2000
+
+
+def test_chunk_text_overlap():
+    """Chunks should overlap by the specified amount."""
+    # Create text with clear markers every 500 chars
+    text = "".join(f"[BLOCK{i:03d}]" + "x" * 490 for i in range(10))
+    chunks = SessionCompressor._chunk_text(text, chunk_size=2000, overlap=200)
+    assert len(chunks) >= 2
+    # The end of chunk N should overlap with the start of chunk N+1
+    for i in range(len(chunks) - 1):
+        tail = chunks[i][-200:]
+        assert tail in chunks[i + 1] or chunks[i + 1].startswith(tail[:50])
+
+
+def test_chunk_text_prefers_paragraph_boundaries():
+    """Chunking should prefer splitting at paragraph boundaries."""
+    paragraphs = ["Paragraph about topic " + str(i) + ". " * 50 for i in range(10)]
+    text = "\n\n".join(paragraphs)
+    chunks = SessionCompressor._chunk_text(text, chunk_size=500, overlap=50)
+    # Chunks should tend to start at paragraph beginnings
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        assert len(chunk) > 0
+
+
+def test_memory_chunk_config_custom():
+    """Custom memory chunk config values work."""
+    config = SemanticConfig(memory_chunk_chars=500, memory_chunk_overlap=50)
+    assert config.memory_chunk_chars == 500
+    assert config.memory_chunk_overlap == 50


### PR DESCRIPTION
## Summary
- Long memories are now split into multiple independent vector records for better retrieval precision
- Each chunk is independently searchable, replacing the current approach of averaging chunks into a single lossy vector
- Configurable via `SemanticConfig.memory_chunk_chars` and `memory_chunk_overlap`
- Short memories behave identically to before

Fixes #530

## Problem
When a memory exceeds the embedder's max token limit, the current code chunks it internally but merges all chunks into a **single averaged vector** (via `_chunk_and_embed` in `base.py`). This averaging is lossy — a long memory covering "Python debugging" AND "Docker networking" becomes one blended vector that matches neither topic precisely. Retrieval quality degrades as memories grow.

## Solution
Chunk long memories **before** enqueuing to the EmbeddingQueue. Each chunk becomes a separate vector record:
- Chunk URIs: `memory_uri#chunk_0001`, `memory_uri#chunk_0002`, etc.
- Each chunk's `parent_uri` points to the original memory for deduplication
- The base memory record is still enqueued with its abstract as the vector text
- Chunking prefers paragraph boundaries (`\n\n`) with configurable overlap

## Changes Made
- **`openviking_cli/utils/config/parser_config.py`**: Added `memory_chunk_chars` (2000) and `memory_chunk_overlap` (200) to `SemanticConfig`
- **`openviking/session/compressor.py`**: Modified `_index_memory()` to chunk long memories before enqueuing. Added `_chunk_text()` static method with paragraph-aware splitting.
- **`tests/misc/test_semantic_config.py`**: 5 new tests for chunking logic (short text, long text, overlap, paragraph boundaries, custom config)

## Configuration
```json
{
  "semantic": {
    "memory_chunk_chars": 2000,
    "memory_chunk_overlap": 200
  }
}
```

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Tests added (5 new chunking tests, 12 total pass)
- [x] Tested on macOS
- [x] Short memories unchanged (backward compatible)

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes