### PR TITLE
fix(embedder): auto-retry with smaller chunks when input exceeds model limit

### DIFF
--- a/openviking/models/embedder/base.py
+++ b/openviking/models/embedder/base.py
@@ -118,18 +118,19 @@ class EmbedderBase(ABC):
             # CJK text (3 bytes per char in UTF-8) is not underestimated.
             return max(len(text) // 3, len(text.encode("utf-8")) // 4)
 
-    def _chunk_text(self, text: str) -> List[str]:
+    def _chunk_text(self, text: str, override_max_tokens: Optional[int] = None) -> List[str]:
         """Split text into chunks, each within max_tokens.
 
         Splitting priority: paragraphs (\\n\\n) > sentences (。.!?\\n) > fixed length.
 
         Args:
             text: Input text
+            override_max_tokens: If set, use this instead of self.max_tokens
 
         Returns:
             List of text chunks
         """
-        max_tok = self.max_tokens
+        max_tok = override_max_tokens if override_max_tokens is not None else self.max_tokens
         if self._estimate_tokens(text) <= max_tok:
             return [text]
 
@@ -188,7 +189,12 @@ class EmbedderBase(ABC):
             start = end
         return chunks
 
-    def _chunk_and_embed(self, text: str, is_query: bool = False) -> EmbedResult:
+    def _chunk_and_embed(
+        self,
+        text: str,
+        is_query: bool = False,
+        override_max_tokens: Optional[int] = None,
+    ) -> EmbedResult:
         """Chunk text if it exceeds max_tokens, embed each chunk, and merge results.
 
         For text within limits, delegates to _embed_single directly.
@@ -198,15 +204,17 @@ class EmbedderBase(ABC):
         Args:
             text: Input text
             is_query: Flag to indicate if this is a query embedding
+            override_max_tokens: If set, use this instead of self.max_tokens
 
         Returns:
             EmbedResult with merged embedding
         """
+        max_tok = override_max_tokens if override_max_tokens is not None else self.max_tokens
         estimated = self._estimate_tokens(text)
-        if estimated <= self.max_tokens:
+        if estimated <= max_tok:
             return self._embed_single(text, is_query=is_query)
 
-        chunks = self._chunk_text(text)
+        chunks = self._chunk_text(text, override_max_tokens=override_max_tokens)
         logger.debug(
             "Chunking text: original ~%d tokens -> %d chunks",
             estimated,

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -301,25 +301,21 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         except RuntimeError as e:
             error_msg = str(e).lower()
             if (
-                "too large" in error_msg
-                or "too long" in error_msg
-                or "maximum context length" in error_msg
+                ("input" in error_msg and "too large" in error_msg)
+                or ("token" in error_msg and ("too long" in error_msg or "too many" in error_msg))
+                or "context length" in error_msg
             ):
                 # Token estimation was wrong (common with non-OpenAI models).
                 # Retry with chunking at half the current max_tokens.
                 reduced = max(self.max_tokens // 2, 128)
                 logger.warning(
-                    f"Embedding failed due to input length. "
-                    f"Retrying with chunk size {reduced} tokens. "
-                    f"Set embedding.dense.max_tokens in ov.conf to match "
-                    f"your model's actual limit."
+                    "Embedding failed due to input length. "
+                    "Retrying with chunk size %d tokens. "
+                    "Set embedding.dense.max_tokens in ov.conf to match "
+                    "your model's actual limit.",
+                    reduced,
                 )
-                saved = self._max_tokens
-                self._max_tokens = reduced
-                try:
-                    return self._chunk_and_embed(text, is_query=is_query)
-                finally:
-                    self._max_tokens = saved
+                return self._chunk_and_embed(text, is_query=is_query, override_max_tokens=reduced)
             raise
 
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:


### PR DESCRIPTION
## Summary
- When the embedding API rejects input as too large, automatically retry with chunking at half the current `max_tokens` instead of crashing
- Logs a warning guiding users to set `embedding.dense.max_tokens` in `ov.conf`

Fixes #731

## Root Cause
The default `max_tokens` is 8000 (designed for OpenAI models). Users with models that have smaller limits (e.g., `bce-embedding-base_v1` with 512 max tokens) hit errors because:
1. Token estimation uses `len(text) // 3` for non-OpenAI models (no tiktoken), which underestimates CJK text
2. `_chunk_and_embed()` creates chunks of `max_tokens` size, but each chunk still exceeds the model's actual limit
3. The API returns "input too large" and the embedder crashes

## Fix
In `OpenAIDenseEmbedder.embed()`, catch "too large/too long/maximum context length" errors from `_embed_single()` and retry with `_chunk_and_embed()` at half the `max_tokens`. This handles both:
- Text that passes the estimation check but fails at the API
- Models with smaller limits than the 8000 default

## Changes Made
- **`openviking/models/embedder/openai_embedders.py`**: Added error-driven retry in `embed()` with reduced chunk size and user-facing warning

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Unit tests pass locally (11/11 embedder tests)
- [x] Tested on macOS