### PR TITLE
fix(plugin): add timeout protection to getClient() in before_prompt_build hook

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -22,6 +22,7 @@ import {
   IS_WIN,
   waitForHealth,
   quickRecallPrecheck,
+  withTimeout,
   resolvePythonCommand,
   prepareLocalPort,
 } from "./process-manager.js";
@@ -414,7 +415,17 @@ const contextEnginePlugin = {
 
       const hookSessionId = ctx?.sessionId ?? ctx?.sessionKey ?? "";
       const resolvedAgentId = resolveAgentId(hookSessionId);
-      const client = await getClient();
+      let client: OpenVikingClient;
+      try {
+        client = await withTimeout(
+          getClient(),
+          5000,
+          "openviking: client initialization timeout (OpenViking service not ready yet)"
+        );
+      } catch (err) {
+        api.logger.warn?.(`openviking: failed to get client: ${String(err)}`);
+        return;
+      }
       if (resolvedAgentId && client.getAgentId() !== resolvedAgentId) {
         client.setAgentId(resolvedAgentId);
         api.logger.info(`openviking: switched to agentId=${resolvedAgentId} for before_prompt_build`);


### PR DESCRIPTION
## Problem

The `before_prompt_build` hook calls `await getClient()` without timeout protection. If the OpenViking client hasn't finished initializing when the hook is triggered, the agent will hang indefinitely waiting for the client Promise to resolve.

This happens because:
1. Plugin loads and registers the `before_prompt_build` hook
2. User sends a message before `start()` function completes OpenViking server startup
3. Hook triggers and calls `await getClient()`
4. `getClient()` waits for `clientPromise` to resolve
5. But `clientPromise` only resolves after `start()` finishes starting the OpenViking service
6. **Deadlock**: hook blocks agent → agent can't complete → `start()` can't finish

## Solution

Wrap `getClient()` call with `withTimeout()` (5 seconds):
- If client initializes in time, proceed normally with memory recall
- If timeout, log warning and skip recall gracefully
- Agent continues without blocking

## Testing

Tested locally with OpenClaw + OpenViking plugin:
- **Before fix**: Agent hangs on first message if OpenViking service not ready
- **After fix**: Agent responds normally, recall skipped gracefully if timeout

## Related Issues

- Similar to #673 (which fixed `auto-recall` timeout but not the initial `getClient()` call in hook)
- Addresses #748 (directory refactor bug where timeout fix wasn't synchronized to new plugin location)