### PR TITLE
fix(embedder): add unified input truncation to prevent token limit errors

### DIFF
--- a/openviking/models/embedder/base.py
+++ b/openviking/models/embedder/base.py
@@ -1,12 +1,68 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import random
+import re
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 T = TypeVar("T")
+
+
+_tiktoken_encoder = None
+
+
+def _get_tiktoken_encoder():
+    """Get cached tiktoken encoder (module-level singleton, downloaded once)."""
+    global _tiktoken_encoder
+    if _tiktoken_encoder is None:
+        try:
+            import tiktoken
+
+            _tiktoken_encoder = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            pass
+    return _tiktoken_encoder
+
+
+def truncate_text_by_tokens(text: str, max_tokens: int) -> str:
+    """Truncate text to at most max_tokens tokens. Returns original text if within limit.
+
+    Guarantees: len(tiktoken.encode(result)) <= max_tokens for cl100k_base.
+    Falls back to UTF-8 byte truncation if tiktoken is unavailable.
+
+    Args:
+        text: Input text to truncate
+        max_tokens: Maximum number of tokens allowed
+
+    Returns:
+        Truncated text (or original text if already within limit)
+    """
+    # Fast path: tiktoken never produces more tokens than UTF-8 bytes,
+    # so byte count <= max_tokens guarantees token count <= max_tokens.
+    if len(text.encode("utf-8")) <= max_tokens:
+        return text
+
+    enc = _get_tiktoken_encoder()
+    if enc is not None:
+        try:
+            # disallowed_special=() avoids ValueError when text contains special token strings
+            tokens = enc.encode(text, disallowed_special=())
+            if len(tokens) <= max_tokens:
+                return text
+            return enc.decode(tokens[:max_tokens])
+        except Exception:
+            pass  # Fall through to byte-based truncation
+
+    # Fallback: UTF-8 byte truncation (tiktoken unavailable).
+    # Guaranteed safe: token_count <= utf8_bytes, truncating to max_tokens bytes
+    # ensures token_count <= max_tokens.
+    encoded = text.encode("utf-8")
+    truncated = encoded[:max_tokens].decode("utf-8", errors="ignore")
+    return truncated
+
 
 
 def truncate_and_normalize(embedding: List[float], dimension: Optional[int]) -> List[float]:
@@ -99,6 +155,20 @@ class EmbedderBase(ABC):
             List[EmbedResult]: List of embedding results
         """
         return [self.embed(text, is_query=is_query) for text in texts]
+
+    @property
+    def max_input_tokens(self) -> int:
+        """Maximum number of tokens allowed as input. Subclasses can override."""
+        return 8000
+
+    def _truncate_input(self, text: str) -> str:
+        """Truncate input text to max_input_tokens. Logs a warning if truncation occurs."""
+        truncated = truncate_text_by_tokens(text, self.max_input_tokens)
+        if truncated != text:
+            logging.getLogger(__name__).warning(
+                f"[{self.__class__.__name__}] Input truncated to {self.max_input_tokens} tokens"
+            )
+        return truncated
 
     def close(self):
         """Release resources, subclasses can override as needed"""

--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -17,6 +17,12 @@ JINA_MODEL_DIMENSIONS = {
     "jina-embeddings-v5-text-nano": 768,  # 239M params, max seq 8192
 }
 
+# Max input tokens for Jina embedding models (with ~200 token buffer for tokenizer differences)
+JINA_MODEL_MAX_TOKENS = {
+    "jina-embeddings-v5-text-small": 32000,
+    "jina-embeddings-v5-text-nano": 8000,
+}
+
 
 class JinaDenseEmbedder(DenseEmbedderBase):
     """Jina AI Dense Embedder Implementation
@@ -106,6 +112,11 @@ class JinaDenseEmbedder(DenseEmbedderBase):
                 f"Jina models support Matryoshka dimension reduction up to {max_dim}."
             )
         self._dimension = dimension if dimension is not None else max_dim
+        self._max_input_tokens = JINA_MODEL_MAX_TOKENS.get(model_name, 8192)
+
+    @property
+    def max_input_tokens(self) -> int:
+        return self._max_input_tokens
 
     def _build_extra_body(self, is_query: bool = False) -> Optional[Dict[str, Any]]:
         """Build extra_body dict for Jina-specific parameters"""
@@ -136,6 +147,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             RuntimeError: When API call fails
         """
         try:
+            text = self._truncate_input(text)
             kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
             if self.dimension:
                 kwargs["dimensions"] = self.dimension
@@ -170,6 +182,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._truncate_input(t) for t in texts]
             kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
             if self.dimension:
                 kwargs["dimensions"] = self.dimension

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -225,6 +225,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             RuntimeError: When API call fails
         """
         try:
+            text = self._truncate_input(text)
             kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
 
             extra_body = self._build_extra_body(is_query=is_query)
@@ -258,6 +259,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._truncate_input(t) for t in texts]
             kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
             if self.dimension:
                 kwargs["dimensions"] = self.dimension

--- a/openviking/models/embedder/vikingdb_embedders.py
+++ b/openviking/models/embedder/vikingdb_embedders.py
@@ -13,6 +13,16 @@ from openviking.models.embedder.base import (
 from openviking.storage.vectordb.collection.volcengine_clients import ClientForDataApi
 from openviking_cli.utils.logger import default_logger as logger
 
+# Max input tokens per VikingDB model (文本截断长度, with small buffer)
+VIKINGDB_MODEL_MAX_TOKENS = {
+    "bge-large-zh": 500,
+    "bge-m3": 8000,
+    "bge-visualized-m3": 8000,
+    "doubao-embedding-large": 4000,
+    "doubao-embedding-vision": 8000,
+    "doubao-embedding": 4000,
+}
+
 
 class VikingDBClientMixin:
     """Mixin to handle VikingDB Client initialization and API calls."""
@@ -81,6 +91,14 @@ class VikingDBClientMixin:
             embedding = [x / norm for x in embedding]
         return embedding
 
+    def _get_max_input_tokens(self) -> int:
+        """Resolve max input tokens based on model name."""
+        name = self.model_name.lower()
+        for key, limit in VIKINGDB_MODEL_MAX_TOKENS.items():
+            if key in name:
+                return limit
+        return 4000  # conservative default
+
     def _process_sparse_embedding(self, sparse_data: Any) -> Dict[str, float]:
         """Process sparse embedding data"""
         if not sparse_data:
@@ -104,6 +122,10 @@ class VikingDBClientMixin:
 class VikingDBDenseEmbedder(DenseEmbedderBase, VikingDBClientMixin):
     """VikingDB Dense Embedder"""
 
+    @property
+    def max_input_tokens(self) -> int:
+        return self._get_max_input_tokens()
+
     def __init__(
         self,
         model_name: str,
@@ -124,6 +146,7 @@ class VikingDBDenseEmbedder(DenseEmbedderBase, VikingDBClientMixin):
         self.dense_model = {"name": model_name, "version": model_version, "dim": dimension}
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        text = self._truncate_input(text)
         results = self._call_api([text], dense_model=self.dense_model)
         if not results:
             return EmbedResult(dense_vector=[])
@@ -138,6 +161,7 @@ class VikingDBDenseEmbedder(DenseEmbedderBase, VikingDBClientMixin):
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
         if not texts:
             return []
+        texts = [self._truncate_input(t) for t in texts]
         raw_results = self._call_api(texts, dense_model=self.dense_model)
         return [
             EmbedResult(
@@ -154,6 +178,10 @@ class VikingDBDenseEmbedder(DenseEmbedderBase, VikingDBClientMixin):
 
 class VikingDBSparseEmbedder(SparseEmbedderBase, VikingDBClientMixin):
     """VikingDB Sparse Embedder"""
+
+    @property
+    def max_input_tokens(self) -> int:
+        return self._get_max_input_tokens()
 
     def __init__(
         self,
@@ -174,6 +202,7 @@ class VikingDBSparseEmbedder(SparseEmbedderBase, VikingDBClientMixin):
         }
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        text = self._truncate_input(text)
         results = self._call_api([text], sparse_model=self.sparse_model)
         if not results:
             return EmbedResult(sparse_vector={})
@@ -188,6 +217,7 @@ class VikingDBSparseEmbedder(SparseEmbedderBase, VikingDBClientMixin):
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
         if not texts:
             return []
+        texts = [self._truncate_input(t) for t in texts]
         raw_results = self._call_api(texts, sparse_model=self.sparse_model)
         return [
             EmbedResult(
@@ -199,6 +229,10 @@ class VikingDBSparseEmbedder(SparseEmbedderBase, VikingDBClientMixin):
 
 class VikingDBHybridEmbedder(HybridEmbedderBase, VikingDBClientMixin):
     """VikingDB Hybrid Embedder"""
+
+    @property
+    def max_input_tokens(self) -> int:
+        return self._get_max_input_tokens()
 
     def __init__(
         self,
@@ -224,6 +258,7 @@ class VikingDBHybridEmbedder(HybridEmbedderBase, VikingDBClientMixin):
         }
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        text = self._truncate_input(text)
         results = self._call_api(
             [text], dense_model=self.dense_model, sparse_model=self.sparse_model
         )
@@ -244,6 +279,7 @@ class VikingDBHybridEmbedder(HybridEmbedderBase, VikingDBClientMixin):
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
         if not texts:
             return []
+        texts = [self._truncate_input(t) for t in texts]
         raw_results = self._call_api(
             texts, dense_model=self.dense_model, sparse_model=self.sparse_model
         )

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -75,6 +75,10 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
     Supports Volcengine embedding models such as doubao-embedding.
     """
 
+    @property
+    def max_input_tokens(self) -> int:
+        return 8000 if "vision" in self.model_name.lower() else 4000
+
     def __init__(
         self,
         model_name: str,
@@ -159,6 +163,8 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
             RuntimeError: When API call fails
         """
 
+        text = self._truncate_input(text)
+
         def _embed_call():
             if self.input_type == "multimodal":
                 # Use multimodal embeddings API
@@ -206,6 +212,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._truncate_input(t) for t in texts]
             if self.input_type == "multimodal":
                 multimodal_inputs = [{"type": "text", "text": text} for text in texts]
                 response = self.client.multimodal_embeddings.create(
@@ -237,6 +244,10 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
 
     Generates sparse embeddings using Volcengine's multimodal embedding API.
     """
+
+    @property
+    def max_input_tokens(self) -> int:
+        return 8000 if "vision" in self.model_name.lower() else 4000
 
     def __init__(
         self,
@@ -282,6 +293,8 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         Raises:
             RuntimeError: When API call fails
         """
+
+        text = self._truncate_input(text)
 
         def _embed_call():
             # Must use multimodal endpoint for sparse
@@ -331,6 +344,10 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
     Generates both dense and sparse embeddings simultaneously using Volcengine's
     multimodal embedding API.
     """
+
+    @property
+    def max_input_tokens(self) -> int:
+        return 8000 if "vision" in self.model_name.lower() else 4000
 
     def __init__(
         self,
@@ -382,6 +399,8 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         Raises:
             RuntimeError: When API call fails
         """
+
+        text = self._truncate_input(text)
 
         def _embed_call():
             # Always use multimodal for hybrid to get both

--- a/openviking/models/embedder/voyage_embedders.py
+++ b/openviking/models/embedder/voyage_embedders.py
@@ -84,6 +84,7 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         """Perform dense embedding on text."""
         try:
+            text = self._truncate_input(text)
             kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
             if self.dimension is not None:
                 kwargs["extra_body"] = {"output_dimension": self.dimension}
@@ -102,6 +103,7 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._truncate_input(t) for t in texts]
             kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
             if self.dimension is not None:
                 kwargs["extra_body"] = {"output_dimension": self.dimension}

--- a/tests/unit/test_truncate_input.py
+++ b/tests/unit/test_truncate_input.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for truncate_text_by_tokens and EmbedderBase._truncate_input"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openviking.models.embedder.base import (
+    EmbedderBase,
+    EmbedResult,
+    truncate_text_by_tokens,
+)
+
+
+# ---------------------------------------------------------------------------
+# truncate_text_by_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateTextByTokens:
+    def test_short_text_returned_unchanged(self):
+        text = "hello world"
+        result = truncate_text_by_tokens(text, max_tokens=100)
+        assert result == text
+
+    def test_empty_string(self):
+        assert truncate_text_by_tokens("", max_tokens=10) == ""
+
+    def test_exact_limit_not_truncated(self):
+        # 10 ASCII chars → 10 utf-8 bytes → fast path allows it through
+        text = "a" * 10
+        result = truncate_text_by_tokens(text, max_tokens=10)
+        assert result == text
+
+    def test_ascii_truncated_by_tiktoken(self):
+        # Each ASCII word is ~1 token; build a text that exceeds max_tokens
+        words = ["word"] * 200  # ~200 tokens
+        text = " ".join(words)
+        max_tokens = 50
+        result = truncate_text_by_tokens(text, max_tokens=max_tokens)
+        assert len(result) < len(text)
+        # Verify the result is within the token limit (requires tiktoken)
+        try:
+            import tiktoken
+
+            enc = tiktoken.get_encoding("cl100k_base")
+            assert len(enc.encode(result, disallowed_special=())) <= max_tokens
+        except ImportError:
+            pass  # tiktoken not installed; byte-based fallback used
+
+    def test_cjk_text_truncated(self):
+        # Chinese text: each CJK char is 3 utf-8 bytes, typically 1-2 tokens
+        text = "你好世界" * 500  # 2000 CJK chars, ~6000 utf-8 bytes
+        max_tokens = 100
+        result = truncate_text_by_tokens(text, max_tokens=max_tokens)
+        assert len(result) < len(text)
+        try:
+            import tiktoken
+
+            enc = tiktoken.get_encoding("cl100k_base")
+            assert len(enc.encode(result, disallowed_special=())) <= max_tokens
+        except ImportError:
+            pass
+
+    def test_special_tokens_do_not_raise(self):
+        # Text containing OpenAI special token strings should not raise
+        text = "<|endoftext|>" * 100
+        result = truncate_text_by_tokens(text, max_tokens=10)
+        assert isinstance(result, str)
+
+    def test_returns_str_not_tuple(self):
+        result = truncate_text_by_tokens("hello", max_tokens=100)
+        assert isinstance(result, str)
+
+    def test_tiktoken_unavailable_fallback(self):
+        # Simulate tiktoken import failure → byte-based fallback
+        long_text = "x" * 10000
+        max_tokens = 100
+        with patch(
+            "openviking.models.embedder.base._get_tiktoken_encoder", return_value=None
+        ):
+            result = truncate_text_by_tokens(long_text, max_tokens=max_tokens)
+        assert len(result.encode("utf-8")) <= max_tokens
+
+    def test_utf8_fast_path_skips_tokenization(self):
+        # text whose utf-8 byte count <= max_tokens → returned unchanged without tiktoken
+        text = "hi"  # 2 utf-8 bytes
+        called = []
+
+        original_get_encoder = __import__(
+            "openviking.models.embedder.base", fromlist=["_get_tiktoken_encoder"]
+        )._get_tiktoken_encoder
+
+        def tracking_get_encoder():
+            called.append(True)
+            return original_get_encoder()
+
+        with patch(
+            "openviking.models.embedder.base._get_tiktoken_encoder",
+            side_effect=tracking_get_encoder,
+        ):
+            result = truncate_text_by_tokens(text, max_tokens=100)
+
+        assert result == text
+        assert not called, "tiktoken encoder should not be called for short text"
+
+
+# ---------------------------------------------------------------------------
+# EmbedderBase._truncate_input (via a concrete stub)
+# ---------------------------------------------------------------------------
+
+
+class _StubEmbedder(EmbedderBase):
+    """Minimal concrete embedder for testing _truncate_input."""
+
+    def __init__(self, max_tokens: int):
+        super().__init__(model_name="stub", config={})
+        self._max_tokens = max_tokens
+
+    @property
+    def max_input_tokens(self) -> int:
+        return self._max_tokens
+
+    def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        return EmbedResult(dense_vector=[])
+
+
+class TestTruncateInput:
+    def test_short_text_returned_unchanged(self):
+        embedder = _StubEmbedder(max_tokens=4000)
+        text = "short text"
+        assert embedder._truncate_input(text) == text
+
+    def test_long_text_is_truncated(self):
+        embedder = _StubEmbedder(max_tokens=50)
+        long_text = "word " * 200
+        result = embedder._truncate_input(long_text)
+        assert len(result) < len(long_text)
+
+    def test_warning_logged_on_truncation(self):
+        import logging as _logging
+
+        embedder = _StubEmbedder(max_tokens=20)
+        long_text = "token " * 100
+
+        records = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        logger = _logging.getLogger("openviking.models.embedder.base")
+        handler = _Capture()
+        logger.addHandler(handler)
+        old_level = logger.level
+        logger.setLevel(_logging.WARNING)
+        try:
+            result = embedder._truncate_input(long_text)
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(old_level)
+
+        assert len(result) < len(long_text)
+        assert any("truncated" in r.getMessage().lower() for r in records)
+
+    def test_no_warning_for_short_text(self, caplog):
+        embedder = _StubEmbedder(max_tokens=4000)
+        with caplog.at_level(logging.WARNING, logger="openviking.models.embedder.base"):
+            embedder._truncate_input("hello")
+        assert not caplog.records
+
+    def test_cjk_truncated_within_limit(self):
+        max_tokens = 50
+        embedder = _StubEmbedder(max_tokens=max_tokens)
+        text = "中文测试" * 300
+        result = embedder._truncate_input(text)
+        try:
+            import tiktoken
+
+            enc = tiktoken.get_encoding("cl100k_base")
+            assert len(enc.encode(result, disallowed_special=())) <= max_tokens
+        except ImportError:
+            assert len(result.encode("utf-8")) <= max_tokens
+
+    def test_truncated_result_is_valid_utf8(self):
+        embedder = _StubEmbedder(max_tokens=30)
+        # Mixed ASCII + CJK to exercise multi-byte boundary handling
+        text = "hello " * 10 + "世界" * 100
+        result = embedder._truncate_input(text)
+        # Should not raise when encoding
+        result.encode("utf-8")


### PR DESCRIPTION
## Summary

Fixes #616 and #686: embedding requests fail when input text exceeds model token limits.

- Add `truncate_text_by_tokens(text, max_tokens)` to `base.py` with three-layer truncation:
  1. **Fast path**: if utf-8 byte count ≤ max_tokens, return immediately (provably safe: token count ≤ utf-8 bytes for BPE)
  2. **tiktoken path**: encode with cl100k_base, slice to max_tokens, decode
  3. **Fallback**: byte-based truncation when tiktoken is unavailable
- Add `max_input_tokens` property and `_truncate_input()` to `EmbedderBase`; all embedders call it at `embed()` / `embed_batch()` entry

### Per-model token limits

| Embedder | Limit |
|----------|-------|
| OpenAI | 8000 (default) |
| Jina v5-text-small | 32000 |
| Jina v5-text-nano | 8000 |
| Voyage | 8000 (default) |
| Volcengine (vision) | 8000 |
| Volcengine (non-vision) | 4000 |
| VikingDB bge-large-zh | 500 |
| VikingDB bge-m3 / bge-visualized-m3 | 8000 |
| VikingDB doubao-embedding-large | 4000 |
| VikingDB doubao-embedding-vision | 8000 |
| VikingDB doubao-embedding | 4000 |

## Test plan

- [ ] New test file `tests/unit/test_truncate_input.py` — 15 cases (all passing):
  - ASCII and CJK text truncated within token limit
  - Special token strings (e.g. `<|endoftext|>`) do not raise
  - tiktoken unavailable → byte-based fallback
  - Short text takes utf-8 fast path without calling tiktoken
  - Warning logged when truncation occurs
  - Truncated result is always valid UTF-8

Closes #616
Closes #686