### PR TITLE
fix: remove misdirected SemanticMsg enqueue causing O(n²) reprocessing

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -306,23 +306,6 @@ class Session:
         await self._write_to_agfs_async(self._messages)
         await self._write_relations_async()
 
-        # Enqueue semantic processing directly
-        from openviking.storage.queuefs import get_queue_manager
-        from openviking.storage.queuefs.semantic_msg import SemanticMsg
-
-        queue_manager = get_queue_manager()
-        if queue_manager:
-            msg = SemanticMsg(
-                uri=self._session_uri,
-                context_type="memory",
-                account_id=self.ctx.account_id,
-                user_id=self.ctx.user.user_id,
-                agent_id=self.ctx.user.agent_id,
-                role=self.ctx.role.value,
-            )
-            semantic_queue = queue_manager.get_queue(queue_manager.SEMANTIC)
-            await semantic_queue.enqueue(msg)
-
         redo_log.mark_done(task_id)
 
         # Update active_count

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -365,16 +365,13 @@ class SemanticProcessor(DequeueHandlerBase):
         file_summaries: List[Dict[str, str]] = []
         existing_summaries: Dict[str, str] = {}
 
-        if msg.changes:
-            try:
-                old_overview = await viking_fs.read_file(f"{dir_uri}/.overview.md", ctx=ctx)
-                if old_overview:
-                    existing_summaries = self._parse_overview_md(old_overview)
-                    logger.info(
-                        f"Parsed {len(existing_summaries)} existing summaries from overview.md"
-                    )
-            except Exception as e:
-                logger.debug(f"No existing overview.md found for {dir_uri}: {e}")
+        try:
+            old_overview = await viking_fs.read_file(f"{dir_uri}/.overview.md", ctx=ctx)
+            if old_overview:
+                existing_summaries = self._parse_overview_md(old_overview)
+                logger.info(f"Parsed {len(existing_summaries)} existing summaries from overview.md")
+        except Exception as e:
+            logger.debug(f"No existing overview.md found for {dir_uri}: {e}")
 
         changed_files: Set[str] = set()
         if msg.changes:

--- a/tests/session/test_fix_505_duplicate_semantic_enqueue.py
+++ b/tests/session/test_fix_505_duplicate_semantic_enqueue.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #505: misdirected SemanticMsg enqueue."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openviking.message import TextPart
+from openviking.session import Session
+
+
+@pytest.mark.asyncio
+async def test_no_misdirected_semantic_enqueue_after_flush():
+    """After _flush_semantic_operations() enqueues proper SemanticMsg with changes dict,
+    commit_async() must NOT enqueue a second SemanticMsg targeting the session URI.
+
+    Regression test for https://github.com/volcengine/OpenViking/issues/505
+    """
+    # Construct a Session directly with mocks (avoids full client init)
+    mock_fs = AsyncMock()
+    mock_compressor = AsyncMock()
+    mock_compressor.extract_long_term_memories = AsyncMock(return_value=[])
+
+    session = Session(
+        viking_fs=mock_fs,
+        session_compressor=mock_compressor,
+        session_id="test_505_regression",
+    )
+    session.add_message("user", [TextPart("Hello")])
+    session.add_message("assistant", [TextPart("Hi there")])
+
+    # Mock the queue manager to track enqueue calls
+    mock_queue = AsyncMock()
+    mock_queue_manager = MagicMock()
+    mock_queue_manager.SEMANTIC = "semantic"
+    mock_queue_manager.get_queue.return_value = mock_queue
+
+    # Mock redo log
+    mock_redo_log = MagicMock()
+    mock_lock_manager = MagicMock()
+    mock_lock_manager.redo_log = mock_redo_log
+
+    with (
+        patch("openviking.storage.queuefs.get_queue_manager", return_value=mock_queue_manager),
+        patch("openviking.storage.transaction.get_lock_manager", return_value=mock_lock_manager),
+        patch("openviking.telemetry.get_current_telemetry", return_value=MagicMock()),
+        patch.object(
+            session,
+            "_generate_archive_summary_async",
+            new_callable=AsyncMock,
+            return_value="summary",
+        ),
+        patch.object(session, "_extract_abstract_from_summary", return_value="abstract"),
+        patch.object(session, "_write_archive_async", new_callable=AsyncMock),
+        patch.object(session, "_write_to_agfs_async", new_callable=AsyncMock),
+        patch.object(session, "_write_relations_async", new_callable=AsyncMock),
+        patch.object(
+            session, "_update_active_counts_async", new_callable=AsyncMock, return_value=True
+        ),
+    ):
+        await session.commit_async()
+
+    # The compressor's _flush_semantic_operations() handles semantic enqueue.
+    # session.py must NOT enqueue an additional misdirected SemanticMsg.
+    assert mock_queue.enqueue.await_count == 0, (
+        f"Expected 0 enqueue calls from session.py (compressor handles this), "
+        f"got {mock_queue.enqueue.await_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_memory_directory_loads_cache_when_changes_none():
+    """_process_memory_directory() must load cached summaries from .overview.md
+    even when msg.changes is None. Without this, every file triggers a VLM call.
+
+    Regression test for https://github.com/volcengine/OpenViking/issues/505
+    """
+    from openviking.storage.queuefs.semantic_msg import SemanticMsg
+    from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+    processor = SemanticProcessor.__new__(SemanticProcessor)
+    processor.max_concurrent_llm = 1
+    processor._current_ctx = MagicMock()
+    processor._current_msg = None
+
+    msg = SemanticMsg(
+        uri="viking://test/memories/dir1",
+        context_type="memory",
+    )
+    assert msg.changes is None  # Precondition: no changes dict
+
+    mock_fs = AsyncMock()
+    # ls returns 2 files
+    mock_fs.ls = AsyncMock(
+        return_value=[
+            {"name": "file1.md", "isDir": False},
+            {"name": "file2.md", "isDir": False},
+        ]
+    )
+    # read_file returns cached overview
+    mock_fs.read_file = AsyncMock(return_value="cached overview content")
+    # write_file for saving new overview
+    mock_fs.write_file = AsyncMock()
+
+    mock_generate_summary = AsyncMock()
+    mock_generate_overview = AsyncMock(return_value="overview content")
+    mock_extract_abstract = MagicMock(return_value="abstract")
+    mock_enforce_limits = MagicMock(return_value=("overview content", "abstract"))
+
+    # Mock VikingURI to return predictable URIs
+    mock_viking_uri_instance = MagicMock()
+    mock_viking_uri_instance.join.side_effect = lambda name: MagicMock(
+        uri=f"viking://test/memories/dir1/{name}"
+    )
+    mock_viking_uri_cls = MagicMock(return_value=mock_viking_uri_instance)
+
+    with (
+        patch("openviking.storage.queuefs.semantic_processor.get_viking_fs", return_value=mock_fs),
+        patch("openviking.storage.queuefs.semantic_processor.VikingURI", mock_viking_uri_cls),
+        patch.object(processor, "_generate_single_file_summary", mock_generate_summary),
+        patch.object(processor, "_generate_overview", mock_generate_overview),
+        patch.object(processor, "_extract_abstract_from_overview", mock_extract_abstract),
+        patch.object(processor, "_enforce_size_limits", mock_enforce_limits),
+        patch.object(
+            processor,
+            "_parse_overview_md",
+            return_value={
+                "file1.md": "Summary of file 1.",
+                "file2.md": "Summary of file 2.",
+            },
+        ),
+        patch.object(processor, "_vectorize_directory", new_callable=AsyncMock),
+    ):
+        await processor._process_memory_directory(msg)
+
+    # With cache loaded, NO VLM calls should be made for unchanged files
+    assert mock_generate_summary.await_count == 0, (
+        f"Expected 0 VLM calls (cache should serve both files), "
+        f"got {mock_generate_summary.await_count}"
+    )


### PR DESCRIPTION
## Summary

- **Removed misdirected SemanticMsg enqueue** in `session.py` (lines 309-324): After `_flush_semantic_operations()` already enqueued correct messages with change-tracking dicts, `commit_async()` was enqueuing a second `SemanticMsg` targeting the session URI (not a memory directory) with `changes=None`
- **Hardened cache loading** in `semantic_processor.py`: `_process_memory_directory()` now always loads cached summaries from `.overview.md` regardless of `msg.changes` value (defense-in-depth against other `changes=None` callers like `lock_manager.py` and `summarizer.py`)
- **Added 2 regression tests** verifying both the enqueue removal and the cache guard

## Problem

On every commit, `session.py:309-324` enqueued a `SemanticMsg` with `changes=None` after the compressor had already correctly enqueued messages with proper change-tracking dicts. This misdirected message bypassed the cache guard in `_process_memory_directory()` (which only loaded cached summaries when `msg.changes` was truthy), causing unconditional VLM API calls for every memory file — O(n²) reprocessing. At 500 memories this wasted 100K+ tokens/day.

The timeline on each commit

1. commit_async() starts
2. → compressor.extract_long_term_memories()
3.   → compressor._flush_semantic_operations()
4.   → enqueues SemanticMsg(uri=memory_dir, changes={added: [...]})  ✓ CORRECT
5. → session.py lines 309-324
6.   → enqueues SemanticMsg(uri=session_dir, changes=None)           ✗ MISDIRECTED
7. Processor handles msg from step 4: loads cache, only regenerates changed files
8. Processor handles msg from step 6: no cache, VLM call for EVERY file

Step 6-8 is waste. Removing lines 309-324 eliminates step 6, so step 8 never happens.

## Fix

1. **`session.py`**: Removed 16-line block that enqueued the misdirected `SemanticMsg` — the compressor's `_flush_semantic_operations()` already handles this correctly
2. **`semantic_processor.py`**: Removed `if msg.changes:` guard on cache loading so `.overview.md` is always consulted
Closes #505

## Testing

- 2 regression tests added (`test_fix_505_duplicate_semantic_enqueue.py`)
  - `test_no_misdirected_semantic_enqueue_after_flush` — verifies `commit_async()` doesn't enqueue after compressor flush
  - `test_process_memory_directory_loads_cache_when_changes_none` — verifies cache is loaded even when `msg.changes is None`
- Both tests confirmed RED before fix, GREEN after fix (TDD cycle)
- Full test suite: no regressions (pre-existing config errors unrelated)

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
