### PR TITLE
fix(vectordb): share single adapter across account backends to prevent RocksDB lock contention

### DIFF
--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -21,16 +21,26 @@ logger = get_logger(__name__)
 class _SingleAccountBackend:
     """绑定单个 account 的后端实现（内部类）"""
 
-    def __init__(self, config: VectorDBBackendConfig, bound_account_id: Optional[str]):
+    def __init__(
+        self,
+        config: VectorDBBackendConfig,
+        bound_account_id: Optional[str],
+        shared_adapter=None,
+    ):
         """
         初始化单 account 后端。
 
         Args:
             config: VectorDB 配置
             bound_account_id: 绑定的 account_id，None 表示 root 特权模式
+            shared_adapter: Optional pre-created adapter to share across backends.
+                If provided, reuses the existing adapter (and its underlying
+                PersistStore) instead of creating a new one. This avoids
+                RocksDB LOCK contention when multiple account backends point
+                to the same storage path.
         """
         self._bound_account_id = bound_account_id
-        self._adapter = create_collection_adapter(config)
+        self._adapter = shared_adapter or create_collection_adapter(config)
         self._collection_config: Dict[str, Any] = {}
         self._meta_data_cache: Dict[str, Any] = {}
         self._mode = self._adapter.mode
@@ -429,6 +439,9 @@ class VikingVectorIndexBackend:
 
         self._account_backends: Dict[str, _SingleAccountBackend] = {}
         self._root_backend: Optional[_SingleAccountBackend] = None
+        # Share a single adapter (and its underlying PersistStore/RocksDB instance)
+        # across all account backends to avoid LOCK contention.
+        self._shared_adapter = create_collection_adapter(config)
 
         logger.info(
             "VikingVectorIndexBackend facade initialized",
@@ -453,7 +466,7 @@ class VikingVectorIndexBackend:
     def _get_backend_for_account(self, account_id: str) -> _SingleAccountBackend:
         """获取指定 account 的 backend，懒创建"""
         if account_id not in self._account_backends:
-            backend = _SingleAccountBackend(self._config, bound_account_id=account_id)
+            backend = _SingleAccountBackend(self._config, bound_account_id=account_id, shared_adapter=self._shared_adapter)
             backend._distance_metric = self.distance_metric
             backend._sparse_weight = self.sparse_weight
             backend._collection_name = self._collection_name
@@ -467,7 +480,7 @@ class VikingVectorIndexBackend:
     def _get_root_backend(self) -> _SingleAccountBackend:
         """获取 root 特权 backend"""
         if not self._root_backend:
-            self._root_backend = _SingleAccountBackend(self._config, bound_account_id=None)
+            self._root_backend = _SingleAccountBackend(self._config, bound_account_id=None, shared_adapter=self._shared_adapter)
             self._root_backend._distance_metric = self.distance_metric
             self._root_backend._sparse_weight = self.sparse_weight
             self._root_backend._collection_name = self._collection_name


### PR DESCRIPTION
## Description

Fix RocksDB lock contention in the `local` vectordb backend when running in multi-tenant mode. Every call to `_get_backend_for_account()` or `_get_root_backend()` was creating a new `_SingleAccountBackend` with its own `PersistStore` instance, all pointing to the same on-disk RocksDB directory. Since RocksDB enforces single-process exclusive locking, only the first opener succeeds — all subsequent ones fail with `RuntimeError: IO error: lock ... already held by process`.

The fix creates the adapter once in `VikingVectorIndexBackend.__init__()` and passes it as a `shared_adapter` to every `_SingleAccountBackend`, eliminating lock contention entirely.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Create the collection adapter once in `VikingVectorIndexBackend.__init__()` instead of per-account
- Add optional `shared_adapter` parameter to `_SingleAccountBackend` constructor
- Pass the shared adapter to every `_SingleAccountBackend` created by `_get_backend_for_account()` and `_get_root_backend()`
- Preserve backward compatibility: when `shared_adapter` is not provided, fall back to `create_collection_adapter(config)`

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- No behavioral change for single-account setups or non-local backends (e.g. Qdrant, Weaviate)
- The shared adapter pattern only applies when `VikingVectorIndexBackend` manages multiple account backends; standalone `_SingleAccountBackend` usage is unaffected

