### PR TITLE
fix(plugin): restore bug fixes from #681 and #688 lost during #662 merge

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -4,8 +4,8 @@ import { tmpdir } from "node:os";
 import { Type } from "@sinclair/typebox";
 import { memoryOpenVikingConfigSchema } from "./config.js";
 
-import { OpenVikingClient, localClientCache, isMemoryUri } from "./client.js";
-import type { FindResultItem } from "./client.js";
+import { OpenVikingClient, localClientCache, localClientPendingPromises, isMemoryUri } from "./client.js";
+import type { FindResultItem, PendingClientEntry } from "./client.js";
 import {
   isTranscriptLikeIngest,
   extractLatestUserText,
@@ -69,6 +69,7 @@ type OpenClawPluginApi = {
 
 const MAX_OPENVIKING_STDERR_LINES = 200;
 const MAX_OPENVIKING_STDERR_CHARS = 256_000;
+const AUTO_RECALL_TIMEOUT_MS = 5_000;
 
 const contextEnginePlugin = {
   id: "openviking",
@@ -108,10 +109,18 @@ const contextEnginePlugin = {
         localProcess = cached.process;
         clientPromise = Promise.resolve(cached.client);
       } else {
-        clientPromise = new Promise<OpenVikingClient>((resolve, reject) => {
-          resolveLocalClient = resolve;
-          rejectLocalClient = reject;
-        });
+        const existingPending = localClientPendingPromises.get(localCacheKey);
+        if (existingPending) {
+          clientPromise = existingPending.promise;
+        } else {
+          const entry = {} as PendingClientEntry;
+          entry.promise = new Promise<OpenVikingClient>((resolve, reject) => {
+            entry.resolve = resolve;
+            entry.reject = reject;
+          });
+          clientPromise = entry.promise;
+          localClientPendingPromises.set(localCacheKey, entry);
+        }
       }
     } else {
       clientPromise = Promise.resolve(new OpenVikingClient(cfg.baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs));
@@ -449,67 +458,73 @@ const contextEnginePlugin = {
           );
         } else {
           try {
-            const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
-            const [userSettled, agentSettled] = await Promise.allSettled([
-              client.find(queryText, {
-                targetUri: "viking://user/memories",
-                limit: candidateLimit,
-                scoreThreshold: 0,
-              }),
-              client.find(queryText, {
-                targetUri: "viking://agent/memories",
-                limit: candidateLimit,
-                scoreThreshold: 0,
-              }),
-            ]);
+            await withTimeout(
+              (async () => {
+                const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
+                const [userSettled, agentSettled] = await Promise.allSettled([
+                  client.find(queryText, {
+                    targetUri: "viking://user/memories",
+                    limit: candidateLimit,
+                    scoreThreshold: 0,
+                  }),
+                  client.find(queryText, {
+                    targetUri: "viking://agent/memories",
+                    limit: candidateLimit,
+                    scoreThreshold: 0,
+                  }),
+                ]);
 
-            const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
-            const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
-            if (userSettled.status === "rejected") {
-              api.logger.warn(`openviking: user memories search failed: ${String(userSettled.reason)}`);
-            }
-            if (agentSettled.status === "rejected") {
-              api.logger.warn(`openviking: agent memories search failed: ${String(agentSettled.reason)}`);
-            }
+                const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
+                const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
+                if (userSettled.status === "rejected") {
+                  api.logger.warn(`openviking: user memories search failed: ${String(userSettled.reason)}`);
+                }
+                if (agentSettled.status === "rejected") {
+                  api.logger.warn(`openviking: agent memories search failed: ${String(agentSettled.reason)}`);
+                }
 
-            const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
-            const uniqueMemories = allMemories.filter((memory, index, self) =>
-              index === self.findIndex((m) => m.uri === memory.uri)
-            );
-            const leafOnly = uniqueMemories.filter((m) => m.level === 2);
-            const processed = postProcessMemories(leafOnly, {
-              limit: candidateLimit,
-              scoreThreshold: cfg.recallScoreThreshold,
-            });
-            const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
+                const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
+                const uniqueMemories = allMemories.filter((memory, index, self) =>
+                  index === self.findIndex((m) => m.uri === memory.uri)
+                );
+                const leafOnly = uniqueMemories.filter((m) => m.level === 2);
+                const processed = postProcessMemories(leafOnly, {
+                  limit: candidateLimit,
+                  scoreThreshold: cfg.recallScoreThreshold,
+                });
+                const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
 
-            if (memories.length > 0) {
-              const memoryLines = await Promise.all(
-                memories.map(async (item: FindResultItem) => {
-                  if (item.level === 2) {
-                    try {
-                      const content = await client.read(item.uri);
-                      if (content && typeof content === "string" && content.trim()) {
-                        return `- [${item.category ?? "memory"}] ${content.trim()}`;
+                if (memories.length > 0) {
+                  const memoryLines = await Promise.all(
+                    memories.map(async (item: FindResultItem) => {
+                      if (item.level === 2) {
+                        try {
+                          const content = await client.read(item.uri);
+                          if (content && typeof content === "string" && content.trim()) {
+                            return `- [${item.category ?? "memory"}] ${content.trim()}`;
+                          }
+                        } catch {
+                          // fallback to abstract
+                        }
                       }
-                    } catch {
-                      // fallback to abstract
-                    }
-                  }
-                  return `- [${item.category ?? "memory"}] ${item.abstract ?? item.uri}`;
-                }),
-              );
-              const memoryContext = memoryLines.join("\n");
-              api.logger.info(`openviking: injecting ${memories.length} memories into context`);
-              api.logger.info(
-                `openviking: inject-detail ${toJsonLog({ count: memories.length, memories: summarizeInjectionMemories(memories) })}`,
-              );
-              prependContextParts.push(
-                "<relevant-memories>\nThe following OpenViking memories may be relevant:\n" +
-                  `${memoryContext}\n` +
-                "</relevant-memories>",
-              );
-            }
+                      return `- [${item.category ?? "memory"}] ${item.abstract ?? item.uri}`;
+                    }),
+                  );
+                  const memoryContext = memoryLines.join("\n");
+                  api.logger.info(`openviking: injecting ${memories.length} memories into context`);
+                  api.logger.info(
+                    `openviking: inject-detail ${toJsonLog({ count: memories.length, memories: summarizeInjectionMemories(memories) })}`,
+                  );
+                  prependContextParts.push(
+                    "<relevant-memories>\nThe following OpenViking memories may be relevant:\n" +
+                      `${memoryContext}\n` +
+                    "</relevant-memories>",
+                  );
+                }
+              })(),
+              AUTO_RECALL_TIMEOUT_MS,
+              "openviking: auto-recall search timeout",
+            );
           } catch (err) {
             api.logger.warn(`openviking: auto-recall failed: ${String(err)}`);
           }
@@ -576,7 +591,16 @@ const contextEnginePlugin = {
     api.registerService({
       id: "openviking",
       start: async () => {
-        if (cfg.mode === "local" && resolveLocalClient) {
+        // Claim the pending entry — only the first start() call to claim it spawns the process.
+        // Subsequent start() calls (from other registrations sharing the same promise) fall through.
+        const pendingEntry = localClientPendingPromises.get(localCacheKey);
+        const isSpawner = cfg.mode === "local" && !!pendingEntry;
+        if (isSpawner) {
+          localClientPendingPromises.delete(localCacheKey);
+          resolveLocalClient = pendingEntry!.resolve;
+          rejectLocalClient = pendingEntry!.reject;
+        }
+        if (isSpawner) {
           const timeoutMs = 60_000;
           const intervalMs = 500;
 
@@ -654,7 +678,7 @@ const contextEnginePlugin = {
             await waitForHealth(baseUrl, timeoutMs, intervalMs);
             const client = new OpenVikingClient(baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs);
             localClientCache.set(localCacheKey, { client, process: child });
-            resolveLocalClient(client);
+            resolveLocalClient!(client);
             rejectLocalClient = null;
             api.logger.info(
               `openviking: local server started (${baseUrl}, config: ${cfg.configPath})`,
@@ -681,6 +705,7 @@ const contextEnginePlugin = {
         if (localProcess) {
           localProcess.kill("SIGTERM");
           localClientCache.delete(localCacheKey);
+          localClientPendingPromises.delete(localCacheKey);
           localProcess = null;
           api.logger.info("openviking: local server stopped");
         } else {


### PR DESCRIPTION
## Description

PR #662 renamed the plugin directory from `openclaw-memory-plugin` to `openclaw-plugin` and rewrote `index.ts`, but was based on a stale branch that predated two important bug fixes (#681 and #688). This PR restores those lost fixes, adapted to the current context-engine code.

## Related Issue

Restores fixes from:
- #681 — fix(memory-openviking): share pending clientPromise across dual-context registrations
- #688 — fix(plugin): wrap auto-recall in withTimeout to prevent indefinite agent hang

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Restore #681: import and use `localClientPendingPromises` shared map so that dual-context plugin registrations (gateway + plugins) share the same pending client promise instead of creating independent ones that never resolve
- Restore #681: `start()` claims the pending entry from the map — only the first caller spawns the process; `stop()` clears the map to prevent stale entries across hot-reloads
- Restore #688: wrap the entire auto-recall flow (`find()` + post-processing + `read()`) in `withTimeout(5s)` to prevent the `before_prompt_build` hook from blocking the agent indefinitely

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The `PendingClientEntry` type and `localClientPendingPromises` map were already present in `client.ts` (from #681), but unused — `index.ts` never imported them after #662's rewrite. This PR reconnects the wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
