### PR TITLE
fix(vlm): skip zhipu prefix when model already uses zai/ (LiteLLM)

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -132,7 +132,8 @@ class LiteLLMVLMProvider(VLMBase):
         if provider and provider in PROVIDER_CONFIGS:
             prefix = PROVIDER_CONFIGS[provider]["litellm_prefix"]
             # LiteLLM uses the `zai/` prefix for Zhipu GLM; do not prepend `zhipu/` (see #784).
-            if prefix and not model.startswith(f"{prefix}/") and not model.startswith("zai/"):
+            is_zhipu_zai_model = provider == "zhipu" and model.startswith("zai/")
+            if prefix and not model.startswith(f"{prefix}/") and not is_zhipu_zai_model:
                 return f"{prefix}/{model}"
             return model
 

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -4,6 +4,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
 from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
 
 
@@ -219,3 +220,30 @@ class TestVLMConfigExtraHeaders:
             "HTTP-Referer": "https://example.com",
             "X-Title": "My App",
         }
+
+
+class TestLiteLLMVLMModelResolution:
+    """Regression tests for LiteLLM model prefix resolution."""
+
+    def test_zhipu_zai_model_keeps_existing_zai_prefix(self):
+        """Zhipu GLM models already using LiteLLM's zai/ prefix must not be double-prefixed."""
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "zai/glm-4.5",
+                "provider": "litellm",
+            }
+        )
+
+        assert vlm._resolve_model("zai/glm-4.5") == "zai/glm-4.5"
+
+    def test_non_zhipu_provider_still_applies_prefix(self):
+        """The zai/ exception should not affect other providers."""
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "zai/custom-model",
+                "provider": "gemini",
+                "api_key": "sk-test",
+            }
+        )
+
+        assert vlm._resolve_model("zai/custom-model") == "gemini/zai/custom-model"


### PR DESCRIPTION
## Summary
Fixes incorrect LiteLLM model rewriting: when the configured model already uses LiteLLM's `zai/` prefix (e.g. `zai/glm-4.5`), the VLM backend no longer prepends `zhipu/`, which produced invalid names like `zhipu/zai/glm-4.5`.

## Context
- Closes #784

## Change
In `_resolve_model`, skip adding the zhipu prefix if the model string already starts with `zai/`.

Made with [Cursor](https://cursor.com)