### PR TITLE
fix(windows): handle stale PID locks and TUI console input

### DIFF
--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -42,6 +42,12 @@ def _is_pid_alive(pid: int) -> bool:
     except PermissionError:
         # Process exists but we can't signal it.
         return True
+    except OSError:
+        # On Windows, os.kill(pid, 0) raises OSError (WinError 87 "The
+        # parameter is incorrect") for stale or invalid PIDs instead of
+        # ProcessLookupError.  Treat this as "not alive" so stale lock
+        # files are correctly reclaimed.
+        return False
 
 
 def acquire_data_dir_lock(data_dir: str) -> str:

--- a/openviking_cli/rust_cli.py
+++ b/openviking_cli/rust_cli.py
@@ -18,9 +18,25 @@ Rust CLI 独立发布能力完全保留，用户可通过以下方式获取：
 """
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 from shutil import which
+
+
+def _exec_binary(binary: str, argv: list[str]) -> None:
+    """Execute a binary, replacing the current process on Unix.
+
+    On Windows, ``os.execv`` does not truly replace the process — CPython's
+    MSVC implementation spawns a child process instead.  This breaks console
+    handle inheritance and prevents the Rust TUI from receiving keyboard
+    input (see #587).  We use ``subprocess.call`` on Windows to work around
+    this.
+    """
+    if sys.platform == "win32":
+        sys.exit(subprocess.call([binary] + argv))
+    else:
+        os.execv(binary, [binary] + argv)
 
 
 def main():
@@ -37,9 +53,7 @@ def main():
         # __file__ is openviking_cli/rust_cli.py, so parent is openviking_cli directory
         dev_binary = Path(__file__).parent.parent / "target" / "release" / "ov"
         if dev_binary.exists() and os.access(dev_binary, os.X_OK):
-            # 找到后立即 execv，不返回
-            args = [str(dev_binary)] + sys.argv[1:]
-            os.execv(str(dev_binary), args)
+            _exec_binary(str(dev_binary), sys.argv[1:])
     except Exception:
         pass
 
@@ -51,9 +65,7 @@ def main():
         for binary_name in ["ov", "ov.exe"]:
             binary = package_bin / binary_name
             if binary.exists() and os.access(binary, os.X_OK):
-                # 找到后立即 execv，不返回
-                args = [str(binary)] + sys.argv[1:]
-                os.execv(str(binary), args)
+                _exec_binary(str(binary), sys.argv[1:])
     except Exception:
         pass
 
@@ -67,8 +79,7 @@ def main():
                 first_bytes = f.read(2)
             # Skip if it starts with #! (shebang, likely Python script)
             if first_bytes != b"#!":
-                args = [path_binary] + sys.argv[1:]
-                os.execv(path_binary, args)
+                _exec_binary(path_binary, sys.argv[1:])
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

Fix two Windows-specific issues that prevent normal operation on Windows:

1. **Stale PID lock recovery** (`process_lock.py`): `os.kill(pid, 0)` raises `OSError` (`WinError 87: "The parameter is incorrect"`) on Windows for stale or invalid PIDs, instead of `ProcessLookupError` as on Unix. This prevented the server from reclaiming lock files left by crashed processes, blocking startup with no recovery path other than manually deleting the `.openviking.pid` file. Fixes #650.

2. **TUI console input** (`rust_cli.py`): `os.execv()` on Windows does not truly replace the current process — CPython's MSVC implementation spawns a child process instead. This breaks console handle inheritance, which prevents the Rust TUI (crossterm) from receiving keyboard input. Replaced all three `os.execv()` call sites with a helper that uses `subprocess.call()` on Windows to properly inherit console handles. Fixes #587.

## Changes

- `openviking/utils/process_lock.py`: Add `except OSError` clause to `_is_pid_alive()` to handle Windows-specific error codes for stale PIDs.
- `openviking_cli/rust_cli.py`: Extract `_exec_binary()` helper that dispatches to `subprocess.call()` on Windows and `os.execv()` on Unix.

## Testing

- **PID lock fix**: Reproduced on Windows 11 (Python 3.12) — server crashed, left stale `.openviking.pid`, subsequent startup failed with `OSError: [WinError 87]`. After fix, stale lock is correctly reclaimed.
- **TUI fix**: The `os.execv()` → `subprocess.call()` pattern is a well-known Windows workaround for console applications ([CPython docs](https://docs.python.org/3/library/os.html#os.execv)).
- `ruff check` passes on both files.