### PR TITLE
fix(embedding): truncate input exceeding model max token limit

### DIFF
--- a/openviking/models/embedder/base.py
+++ b/openviking/models/embedder/base.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import random
 import time
 from abc import ABC, abstractmethod
@@ -7,6 +8,33 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 T = TypeVar("T")
+
+_logger = logging.getLogger(__name__)
+
+# Rough heuristic: many embedding APIs document ~4 characters per token for Latin text.
+EMBEDDING_CHARS_PER_TOKEN_HEURISTIC = 4
+
+
+def truncate_embedding_input_text(
+    text: str,
+    max_input_tokens: Optional[int],
+    *,
+    model_name: str,
+) -> str:
+    """Truncate raw text before sending to an embedding API when a token limit is configured."""
+    if max_input_tokens is None or max_input_tokens <= 0:
+        return text
+    max_chars = max_input_tokens * EMBEDDING_CHARS_PER_TOKEN_HEURISTIC
+    if len(text) <= max_chars:
+        return text
+    _logger.warning(
+        "Truncating embedding input from %d to %d characters (~%d token limit, model=%s)",
+        len(text),
+        max_chars,
+        max_input_tokens,
+        model_name,
+    )
+    return text[:max_chars]
 
 
 def truncate_and_normalize(embedding: List[float], dimension: Optional[int]) -> List[float]:
@@ -65,15 +93,29 @@ class EmbedderBase(ABC):
     Provides unified embedding interface supporting dense, sparse, and hybrid modes.
     """
 
-    def __init__(self, model_name: str, config: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        model_name: str,
+        config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
+    ):
         """Initialize embedder
 
         Args:
             model_name: Model name
             config: Configuration dict containing api_key, api_base, etc.
+            max_input_tokens: When set, input text is truncated to roughly this many tokens
+                before calling the provider (see EMBEDDING_CHARS_PER_TOKEN_HEURISTIC).
         """
         self.model_name = model_name
         self.config = config or {}
+        self.max_input_tokens = max_input_tokens
+
+    def _prepare_embedding_text(self, text: str) -> str:
+        """Apply optional max-input truncation configured for this embedder."""
+        return truncate_embedding_input_text(
+            text, self.max_input_tokens, model_name=self.model_name
+        )
 
     @abstractmethod
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:

--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -61,6 +61,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
         late_chunking: Optional[bool] = None,
         config: Optional[Dict[str, Any]] = None,
         task: Optional[str] = None,
+        max_input_tokens: Optional[int] = None,
     ):
         """Initialize Jina AI Dense Embedder
 
@@ -80,7 +81,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
         Raises:
             ValueError: If api_key is not provided
         """
-        super().__init__(model_name, config)
+        super().__init__(model_name, config, max_input_tokens=max_input_tokens)
 
         self.api_key = api_key
         self.api_base = api_base or "https://api.jina.ai/v1"
@@ -136,6 +137,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             RuntimeError: When API call fails
         """
         try:
+            text = self._prepare_embedding_text(text)
             kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
             if self.dimension:
                 kwargs["dimensions"] = self.dimension
@@ -170,6 +172,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._prepare_embedding_text(t) for t in texts]
             kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
             if self.dimension:
                 kwargs["dimensions"] = self.dimension

--- a/openviking/models/embedder/minimax_embedders.py
+++ b/openviking/models/embedder/minimax_embedders.py
@@ -40,6 +40,7 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
         document_param: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
         extra_headers: Optional[Dict[str, str]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
         """Initialize MiniMax Dense Embedder
 
@@ -53,7 +54,7 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
             config: Additional configuration dict
             extra_headers: Extra headers, useful for passing GroupId for MiniMax API
         """
-        super().__init__(model_name, config)
+        super().__init__(model_name, config, max_input_tokens=max_input_tokens)
 
         self.api_key = api_key
         self.api_base = api_base or self.DEFAULT_API_BASE
@@ -163,6 +164,7 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         """Perform dense embedding on text"""
+        text = self._prepare_embedding_text(text)
         vectors = self._call_api([text], is_query=is_query)
         return EmbedResult(dense_vector=vectors[0])
 
@@ -173,6 +175,7 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
 
         # MiniMax might have batch size limits, but let's assume the caller handles batching or use safe defaults
         # For now, we pass through. If needed, we can implement internal chunking.
+        texts = [self._prepare_embedding_text(t) for t in texts]
         vectors = self._call_api(texts, is_query=is_query)
         return [EmbedResult(dense_vector=v) for v in vectors]
 

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -69,6 +69,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         config: Optional[Dict[str, Any]] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         input_type: Optional[str] = None,
+        max_input_tokens: Optional[int] = None,
     ):
         """Initialize OpenAI-Compatible Dense Embedder
 
@@ -91,6 +92,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             config: Additional configuration dict
             extra_headers: Extra HTTP headers to include in API requests (e.g., for OpenRouter:
                           {'HTTP-Referer': 'https://your-site.com', 'X-Title': 'Your App'})
+            max_input_tokens: When set, truncate input text to roughly this many tokens before the API call.
 
         Raises:
             ValueError: If api_key is not provided and env vars are not set
@@ -101,7 +103,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             supported by OpenAI-compatible third-party models (e.g., BGE-M3, Jina, Cohere) that
             implement the input_type parameter.
         """
-        super().__init__(model_name, config)
+        super().__init__(model_name, config, max_input_tokens=max_input_tokens)
 
         self.api_key = api_key
         self.api_base = api_base
@@ -225,6 +227,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             RuntimeError: When API call fails
         """
         try:
+            text = self._prepare_embedding_text(text)
             kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
 
             extra_body = self._build_extra_body(is_query=is_query)
@@ -258,6 +261,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._prepare_embedding_text(t) for t in texts]
             kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
             if self.dimension:
                 kwargs["dimensions"] = self.dimension

--- a/openviking/models/embedder/vikingdb_embedders.py
+++ b/openviking/models/embedder/vikingdb_embedders.py
@@ -115,8 +115,11 @@ class VikingDBDenseEmbedder(DenseEmbedderBase, VikingDBClientMixin):
         dimension: Optional[int] = None,
         embedding_type: str = "text",
         config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
-        DenseEmbedderBase.__init__(self, model_name, config)
+        DenseEmbedderBase.__init__(
+            self, model_name, config, max_input_tokens=max_input_tokens
+        )
         self._init_vikingdb_client(ak, sk, region, host)
         self.model_version = model_version
         self.dimension = dimension
@@ -124,6 +127,7 @@ class VikingDBDenseEmbedder(DenseEmbedderBase, VikingDBClientMixin):
         self.dense_model = {"name": model_name, "version": model_version, "dim": dimension}
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        text = self._prepare_embedding_text(text)
         results = self._call_api([text], dense_model=self.dense_model)
         if not results:
             return EmbedResult(dense_vector=[])
@@ -138,6 +142,7 @@ class VikingDBDenseEmbedder(DenseEmbedderBase, VikingDBClientMixin):
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
         if not texts:
             return []
+        texts = [self._prepare_embedding_text(t) for t in texts]
         raw_results = self._call_api(texts, dense_model=self.dense_model)
         return [
             EmbedResult(
@@ -164,8 +169,11 @@ class VikingDBSparseEmbedder(SparseEmbedderBase, VikingDBClientMixin):
         region: Optional[str] = None,
         host: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
-        SparseEmbedderBase.__init__(self, model_name, config)
+        SparseEmbedderBase.__init__(
+            self, model_name, config, max_input_tokens=max_input_tokens
+        )
         self._init_vikingdb_client(ak, sk, region, host)
         self.model_version = model_version
         self.sparse_model = {
@@ -174,6 +182,7 @@ class VikingDBSparseEmbedder(SparseEmbedderBase, VikingDBClientMixin):
         }
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        text = self._prepare_embedding_text(text)
         results = self._call_api([text], sparse_model=self.sparse_model)
         if not results:
             return EmbedResult(sparse_vector={})
@@ -188,6 +197,7 @@ class VikingDBSparseEmbedder(SparseEmbedderBase, VikingDBClientMixin):
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
         if not texts:
             return []
+        texts = [self._prepare_embedding_text(t) for t in texts]
         raw_results = self._call_api(texts, sparse_model=self.sparse_model)
         return [
             EmbedResult(
@@ -211,8 +221,11 @@ class VikingDBHybridEmbedder(HybridEmbedderBase, VikingDBClientMixin):
         dimension: Optional[int] = None,
         embedding_type: str = "text",
         config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
-        HybridEmbedderBase.__init__(self, model_name, config)
+        HybridEmbedderBase.__init__(
+            self, model_name, config, max_input_tokens=max_input_tokens
+        )
         self._init_vikingdb_client(ak, sk, region, host)
         self.model_version = model_version
         self.dimension = dimension
@@ -224,6 +237,7 @@ class VikingDBHybridEmbedder(HybridEmbedderBase, VikingDBClientMixin):
         }
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        text = self._prepare_embedding_text(text)
         results = self._call_api(
             [text], dense_model=self.dense_model, sparse_model=self.sparse_model
         )
@@ -244,6 +258,7 @@ class VikingDBHybridEmbedder(HybridEmbedderBase, VikingDBClientMixin):
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
         if not texts:
             return []
+        texts = [self._prepare_embedding_text(t) for t in texts]
         raw_results = self._call_api(
             texts, dense_model=self.dense_model, sparse_model=self.sparse_model
         )

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -83,6 +83,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
         dimension: Optional[int] = None,
         input_type: str = "multimodal",
         config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
         """Initialize Volcengine Dense Embedder
 
@@ -97,7 +98,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
         Raises:
             ValueError: If api_key is not provided
         """
-        super().__init__(model_name, config)
+        super().__init__(model_name, config, max_input_tokens=max_input_tokens)
 
         self.api_key = api_key
         self.api_base = api_base or "https://ark.cn-beijing.volces.com/api/v3"
@@ -158,6 +159,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
         Raises:
             RuntimeError: When API call fails
         """
+        text = self._prepare_embedding_text(text)
 
         def _embed_call():
             if self.input_type == "multimodal":
@@ -206,6 +208,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._prepare_embedding_text(t) for t in texts]
             if self.input_type == "multimodal":
                 multimodal_inputs = [{"type": "text", "text": text} for text in texts]
                 response = self.client.multimodal_embeddings.create(
@@ -244,6 +247,7 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
         """Initialize Volcengine Sparse Embedder
 
@@ -256,7 +260,7 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         Raises:
             ValueError: If api_key is not provided
         """
-        super().__init__(model_name, config)
+        super().__init__(model_name, config, max_input_tokens=max_input_tokens)
 
         self.api_key = api_key
         self.api_base = api_base
@@ -282,6 +286,7 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         Raises:
             RuntimeError: When API call fails
         """
+        text = self._prepare_embedding_text(text)
 
         def _embed_call():
             # Must use multimodal endpoint for sparse
@@ -340,6 +345,7 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         dimension: Optional[int] = None,
         input_type: str = "multimodal",
         config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
         """Initialize Volcengine Hybrid Embedder
 
@@ -354,7 +360,7 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         Raises:
             ValueError: If api_key is not provided
         """
-        super().__init__(model_name, config)
+        super().__init__(model_name, config, max_input_tokens=max_input_tokens)
         self.api_key = api_key
         self.api_base = api_base
         self.dimension = dimension
@@ -382,6 +388,7 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         Raises:
             RuntimeError: When API call fails
         """
+        text = self._prepare_embedding_text(text)
 
         def _embed_call():
             # Always use multimodal for hybrid to get both

--- a/openviking/models/embedder/voyage_embedders.py
+++ b/openviking/models/embedder/voyage_embedders.py
@@ -55,8 +55,9 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
         api_base: Optional[str] = None,
         dimension: Optional[int] = None,
         config: Optional[Dict[str, Any]] = None,
+        max_input_tokens: Optional[int] = None,
     ):
-        super().__init__(model_name, config)
+        super().__init__(model_name, config, max_input_tokens=max_input_tokens)
 
         self.api_key = api_key
         self.api_base = api_base or "https://api.voyageai.com/v1"
@@ -84,6 +85,7 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         """Perform dense embedding on text."""
         try:
+            text = self._prepare_embedding_text(text)
             kwargs: Dict[str, Any] = {"input": text, "model": self.model_name}
             if self.dimension is not None:
                 kwargs["extra_body"] = {"output_dimension": self.dimension}
@@ -102,6 +104,7 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
             return []
 
         try:
+            texts = [self._prepare_embedding_text(t) for t in texts]
             kwargs: Dict[str, Any] = {"input": texts, "model": self.model_name}
             if self.dimension is not None:
                 kwargs["extra_body"] = {"output_dimension": self.dimension}

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -13,6 +13,14 @@ class EmbeddingModelConfig(BaseModel):
     api_base: Optional[str] = Field(default=None, description="API base URL")
     dimension: Optional[int] = Field(default=None, description="Embedding dimension")
     batch_size: int = Field(default=32, description="Batch size for embedding generation")
+    max_input_tokens: Optional[int] = Field(
+        default=None,
+        description=(
+            "Optional maximum input length in tokens for this embedding model. When set, text is "
+            "truncated before API calls using a ~4 characters/token heuristic to avoid provider "
+            "errors (e.g. HTTP 500) on models with small context windows such as 512 tokens."
+        ),
+    )
     input: str = Field(default="multimodal", description="Input type: 'text' or 'multimodal'")
     query_param: Optional[str] = Field(
         default=None,
@@ -234,6 +242,7 @@ class EmbeddingConfig(BaseModel):
                     or "no-key",  # Placeholder for local OpenAI-compatible servers
                     "api_base": cfg.api_base,
                     "dimension": cfg.dimension,
+                    "max_input_tokens": cfg.max_input_tokens,
                     **({"query_param": cfg.query_param} if cfg.query_param else {}),
                     **({"document_param": cfg.document_param} if cfg.document_param else {}),
                     **({"extra_headers": cfg.extra_headers} if cfg.extra_headers else {}),
@@ -247,6 +256,7 @@ class EmbeddingConfig(BaseModel):
                     "api_base": cfg.api_base,
                     "dimension": cfg.dimension,
                     "input_type": cfg.input,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("volcengine", "sparse"): (
@@ -255,6 +265,7 @@ class EmbeddingConfig(BaseModel):
                     "model_name": cfg.model,
                     "api_key": cfg.api_key,
                     "api_base": cfg.api_base,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("volcengine", "hybrid"): (
@@ -265,6 +276,7 @@ class EmbeddingConfig(BaseModel):
                     "api_base": cfg.api_base,
                     "dimension": cfg.dimension,
                     "input_type": cfg.input,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("vikingdb", "dense"): (
@@ -278,6 +290,7 @@ class EmbeddingConfig(BaseModel):
                     "host": cfg.host,
                     "dimension": cfg.dimension,
                     "input_type": cfg.input,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("vikingdb", "sparse"): (
@@ -289,6 +302,7 @@ class EmbeddingConfig(BaseModel):
                     "sk": cfg.sk,
                     "region": cfg.region,
                     "host": cfg.host,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("vikingdb", "hybrid"): (
@@ -302,6 +316,7 @@ class EmbeddingConfig(BaseModel):
                     "host": cfg.host,
                     "dimension": cfg.dimension,
                     "input_type": cfg.input,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("jina", "dense"): (
@@ -311,6 +326,7 @@ class EmbeddingConfig(BaseModel):
                     "api_key": cfg.api_key,
                     "api_base": cfg.api_base,
                     "dimension": cfg.dimension,
+                    "max_input_tokens": cfg.max_input_tokens,
                     **({"query_param": cfg.query_param} if cfg.query_param else {}),
                     **({"document_param": cfg.document_param} if cfg.document_param else {}),
                 },
@@ -324,6 +340,7 @@ class EmbeddingConfig(BaseModel):
                     or "no-key",  # Ollama ignores the key, but client requires non-empty
                     "api_base": cfg.api_base or "http://localhost:11434/v1",
                     "dimension": cfg.dimension,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("voyage", "dense"): (
@@ -333,6 +350,7 @@ class EmbeddingConfig(BaseModel):
                     "api_key": cfg.api_key,
                     "api_base": cfg.api_base,
                     "dimension": cfg.dimension,
+                    "max_input_tokens": cfg.max_input_tokens,
                 },
             ),
             ("minimax", "dense"): (
@@ -342,6 +360,7 @@ class EmbeddingConfig(BaseModel):
                     "api_key": cfg.api_key,
                     "api_base": cfg.api_base,
                     "dimension": cfg.dimension,
+                    "max_input_tokens": cfg.max_input_tokens,
                     **({"query_param": cfg.query_param} if cfg.query_param else {}),
                     **({"document_param": cfg.document_param} if cfg.document_param else {}),
                     **({"extra_headers": cfg.extra_headers} if cfg.extra_headers else {}),

--- a/tests/unit/test_embedding_input_truncation.py
+++ b/tests/unit/test_embedding_input_truncation.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for optional max_input_tokens truncation before embedding API calls."""
+
+from unittest.mock import MagicMock, patch
+
+from openviking.models.embedder.base import (
+    EMBEDDING_CHARS_PER_TOKEN_HEURISTIC,
+    truncate_embedding_input_text,
+)
+from openviking.models.embedder import OpenAIDenseEmbedder
+
+
+def test_truncate_embedding_input_text_respects_limit():
+    limit = 10
+    long = "a" * (limit * EMBEDDING_CHARS_PER_TOKEN_HEURISTIC + 5)
+    out = truncate_embedding_input_text(long, limit, model_name="m")
+    assert len(out) == limit * EMBEDDING_CHARS_PER_TOKEN_HEURISTIC
+
+
+def test_truncate_embedding_input_text_none_means_no_truncation():
+    long = "x" * 1000
+    assert truncate_embedding_input_text(long, None, model_name="m") == long
+
+
+@patch("openviking.models.embedder.openai_embedders.openai.OpenAI")
+def test_openai_embed_truncates_when_max_input_tokens_set(mock_openai_class):
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_embedding = MagicMock()
+    mock_embedding.embedding = [0.1] * 8
+    mock_response = MagicMock()
+    mock_response.data = [mock_embedding]
+    mock_client.embeddings.create.return_value = mock_response
+
+    limit = 2
+    max_chars = limit * EMBEDDING_CHARS_PER_TOKEN_HEURISTIC
+    long_text = "b" * (max_chars + 20)
+
+    embedder = OpenAIDenseEmbedder(
+        model_name="text-embedding-3-small",
+        api_key="k",
+        max_input_tokens=limit,
+    )
+    embedder.embed(long_text)
+
+    sent = mock_client.embeddings.create.call_args[1]["input"]
+    assert len(sent) == max_chars


### PR DESCRIPTION
## Summary
When using embedding models with limited context windows (e.g. 512 tokens for bce-embedding-base), input text can exceed the model's max input length, causing HTTP 500 errors.

## Changes
- Added optional `max_input_tokens` config field for embedding models
- Added truncation logic before calling embed to prevent oversized inputs
- Logs a warning when truncation occurs

Fixes #731

Made with [Cursor](https://cursor.com)