### PR TITLE
fix(parser): resolve PDF bookmark destinations for integer page indices

### DIFF
--- a/openviking/parse/parsers/pdf.py
+++ b/openviking/parse/parsers/pdf.py
@@ -372,7 +372,9 @@ class PDFParser(BaseParser):
                                 page_num = objid_to_num.get(resolved.objid)
                         elif isinstance(page_ref, int):
                             # 0-based integer page index (common in many PDF producers)
-                            page_num = page_ref + 1
+                            candidate = page_ref + 1
+                            if 1 <= candidate <= len(pdf.pages):
+                                page_num = candidate
                 except Exception:
                     pass
 

--- a/tests/parse/test_pdf_bookmark_extraction.py
+++ b/tests/parse/test_pdf_bookmark_extraction.py
@@ -128,6 +128,26 @@ class TestExtractBookmarks:
         assert bookmarks[1]["page_num"] == 2
         assert bookmarks[1]["title"] == "Chapter 2"
 
+    def test_extract_bookmarks_integer_page_index_out_of_range(self):
+        """Out-of-range integer page indices are treated as unresolved."""
+        mock_pdf = MagicMock()
+
+        mock_page1 = MagicMock()
+        mock_page1.page_obj.objid = 100
+        mock_pdf.pages = [mock_page1]  # Only 1 page
+
+        mock_pdf.doc.get_outlines.return_value = [
+            (1, "Valid", [0, "/Fit"], None, None),
+            (1, "Too High", [5, "/Fit"], None, None),
+            (1, "Negative", [-1, "/Fit"], None, None),
+        ]
+
+        bookmarks = self.parser._extract_bookmarks(mock_pdf)
+        assert len(bookmarks) == 3
+        assert bookmarks[0]["page_num"] == 1
+        assert bookmarks[1]["page_num"] is None
+        assert bookmarks[2]["page_num"] is None
+
     def test_extract_bookmarks_exception_returns_empty(self):
         """Returns empty list on unexpected exceptions (best-effort)."""
         mock_pdf = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #522 (related to #386). PDF files with embedded chapter/section outlines were imported as flat content instead of preserving the heading hierarchy.

Three root causes addressed:

- **Integer page indices not handled.** `_extract_bookmarks` only handled `objid` and `.resolve()` destination formats. Many PDF producers encode outline destinations as bare 0-based integer page indices (`[0, "/Fit"]`). These fell through to `page_num = None` and were dropped.
- **Unresolvable bookmarks silently discarded.** Bookmarks where destination resolution fails now fall back to page 1 instead of being excluded from the output entirely.
- **Font heading threshold too aggressive.** `_detect_headings_by_font` filtered out heading font sizes appearing more than 30% as often as body text. For documents with short chapters (where heading sizes naturally repeat on many pages), this excluded valid headings. Threshold raised to 50%.

## Changes

| File | Change |
|------|--------|
| `openviking/parse/parsers/pdf.py` | Add `isinstance(page_ref, int)` branch in `_extract_bookmarks`; fall back to page 1 for unresolvable bookmarks in `_convert_local`; relax font heading frequency threshold from 0.3 to 0.5 |
| `tests/parse/test_pdf_bookmark_extraction.py` | Add `test_extract_bookmarks_integer_page_index` covering the integer destination format |

## Test plan

- [ ] New test `test_extract_bookmarks_integer_page_index` passes
- [ ] All existing `TestExtractBookmarks` tests pass unchanged
- [ ] No ruff/mypy lint errors introduced

This contribution was developed with AI assistance (Claude Code + Codex).