### PR TITLE
feat(cli): add reindex command to trigger content re-indexing

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -307,6 +307,15 @@ impl HttpClient {
         self.get("/api/v1/content/overview", &params).await
     }
 
+    pub async fn reindex(&self, uri: &str, regenerate: bool, wait: bool) -> Result<serde_json::Value> {
+        let body = serde_json::json!({
+            "uri": uri,
+            "regenerate": regenerate,
+            "wait": wait,
+        });
+        self.post("/api/v1/content/reindex", &body).await
+    }
+
     /// Download file as raw bytes
     pub async fn get_bytes(&self, uri: &str) -> Result<Vec<u8>> {
         let url = format!("{}/api/v1/content/download", self.base_url);

--- a/crates/ov_cli/src/commands/content.rs
+++ b/crates/ov_cli/src/commands/content.rs
@@ -38,6 +38,19 @@ pub async fn overview(
     Ok(())
 }
 
+pub async fn reindex(
+    client: &HttpClient,
+    uri: &str,
+    regenerate: bool,
+    wait: bool,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let result = client.reindex(uri, regenerate, wait).await?;
+    crate::output::output_success(result, output_format, compact);
+    Ok(())
+}
+
 pub async fn get(
     client: &HttpClient,
     uri: &str,

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -264,6 +264,17 @@ enum Commands {
         /// Viking URI
         uri: String,
     },
+    /// Reindex content at URI (regenerates .abstract.md and .overview.md)
+    Reindex {
+        /// Viking URI
+        uri: String,
+        /// Force regenerate summaries even if they exist
+        #[arg(short, long)]
+        regenerate: bool,
+        /// Wait for reindex to complete
+        #[arg(long, default_value = "true")]
+        wait: bool,
+    },
     /// Download file to local path (supports binaries/images)
     Get {
         /// Viking URI
@@ -625,6 +636,9 @@ async fn main() {
         Commands::Read { uri } => handle_read(uri, ctx).await,
         Commands::Abstract { uri } => handle_abstract(uri, ctx).await,
         Commands::Overview { uri } => handle_overview(uri, ctx).await,
+        Commands::Reindex { uri, regenerate, wait } => {
+            handle_reindex(uri, regenerate, wait, ctx).await
+        }
         Commands::Get { uri, local_path } => handle_get(uri, local_path, ctx).await,
         Commands::Find { query, uri, node_limit, threshold } => {
             handle_find(query, uri, node_limit, threshold, ctx).await
@@ -951,6 +965,11 @@ async fn handle_abstract(uri: String, ctx: CliContext) -> Result<()> {
 async fn handle_overview(uri: String, ctx: CliContext) -> Result<()> {
     let client = ctx.get_client();
     commands::content::overview(&client, &uri, ctx.output_format, ctx.compact).await
+}
+
+async fn handle_reindex(uri: String, regenerate: bool, wait: bool, ctx: CliContext) -> Result<()> {
+    let client = ctx.get_client();
+    commands::content::reindex(&client, &uri, regenerate, wait, ctx.output_format, ctx.compact).await
 }
 
 async fn handle_get(uri: String, local_path: String, ctx: CliContext) -> Result<()> {


### PR DESCRIPTION
## Summary

Closes #468. The `POST /api/v1/content/reindex` HTTP endpoint (merged in #631) was never wired to the CLI. This adds the `ov reindex` command.

## Changes

| File | Change |
|------|--------|
| `crates/ov_cli/src/client.rs` | Add `reindex()` method - POSTs to `/api/v1/content/reindex` with `{uri, regenerate, wait}` |
| `crates/ov_cli/src/commands/content.rs` | Add `reindex` handler following the same pattern as `read`/`abstract_content`/`overview` |
| `crates/ov_cli/src/main.rs` | Add `Reindex` subcommand enum variant, match dispatch arm, and `handle_reindex` function |

## Usage

```
ov reindex viking://resources/my-doc/
ov reindex viking://resources/my-doc/ --regenerate
ov reindex viking://resources/my-doc/ --no-wait
```

Flags:
- `--regenerate` / `-r`: Force regenerate `.abstract.md` and `.overview.md` even if they already exist
- `--wait` (default: true) / `--no-wait`: Whether to block until reindexing completes

## Test plan

- [ ] `cargo check` passes with no new warnings
- [ ] `ov reindex --help` shows the command with correct flags
- [ ] HTTP endpoint already has test coverage in `tests/server/test_api_content.py` - this is a passthrough layer

This contribution was developed with AI assistance (Claude Code + Codex).