### PR TITLE
fix: vector count returns 0 due to account_id mismatch in observer

### DIFF
--- a/openviking/storage/observers/vikingdb_observer.py
+++ b/openviking/storage/observers/vikingdb_observer.py
@@ -52,7 +52,7 @@ class VikingDBObserver(BaseObserver):
 
                 # Current OpenViking flow uses one managed default index per collection.
                 index_count = 1
-                vector_count = await self._vikingdb_manager.count()
+                vector_count = await self._vikingdb_manager.count(include_all_accounts=True)
 
                 statuses[name] = {
                     "index_count": index_count,

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -130,7 +130,7 @@ class _SingleAccountBackend:
         return {
             "name": self._collection_name,
             "vector_dim": config.get("vector_dim"),
-            "count": await self.count(),
+            "count": await self.count(include_all_accounts=True),
             "status": "active",
         }
 
@@ -635,8 +635,11 @@ class VikingVectorIndexBackend:
         filter: Optional[Dict[str, Any] | FilterExpr] = None,
         *,
         ctx: Optional[RequestContext] = None,
+        include_all_accounts: bool = False,
     ) -> int:
-        if ctx:
+        if include_all_accounts:
+            backend = self._get_root_backend()
+        elif ctx:
             backend = self._get_backend_for_context(ctx)
         else:
             backend = self._get_default_backend()


### PR DESCRIPTION
## Summary

Fixes #786

## Root Cause

`VikingDBObserver.count()` calls `VikingVectorIndexBackend.count(ctx=None)`, which defaults to `_get_default_backend()` — a backend bound to `account_id="default"`.

When vectors are written with a **different** `account_id` (derived from the user's `RequestContext` in `TextEmbeddingHandler`), the count query filters them out, returning 0 even though vectors are properly persisted in LevelDB.

**Code path:**

```
Observer → VikingDBManager.count()
         → VikingVectorIndexBackend.count(ctx=None)
         → _get_default_backend()  ← bound to account_id="default"
         → _SingleAccountBackend.count()
         → Eq("account_id", "default")  ← misses non-default accounts
```

## Fix

- Add `include_all_accounts: bool` parameter to `VikingVectorIndexBackend.count()`
- When `True`, uses `_get_root_backend()` (no `account_id` filter) to count all vectors
- Update `VikingDBObserver` and `get_collection_info()` to use `include_all_accounts=True`
- Backward compatible — existing callers with `ctx` or default behavior unchanged

## Changes

- `openviking/storage/viking_vector_index_backend.py` — add `include_all_accounts` param to `count()`, fix `get_collection_info`
- `openviking/storage/observers/vikingdb_observer.py` — use `include_all_accounts=True`