### PR TITLE
feat(parse): implement Whisper ASR integration for audio parser

### DIFF
--- a/openviking/parse/parsers/media/audio.py
+++ b/openviking/parse/parsers/media/audio.py
@@ -1,21 +1,19 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 """
-Audio parser - Future implementation.
+Audio parser with Whisper ASR integration.
 
-Planned Features:
-1. Speech-to-text transcription using ASR models
+Features:
+1. Speech-to-text transcription using OpenAI Whisper API
 2. Audio metadata extraction (duration, sample rate, channels)
-3. Speaker diarization (identify different speakers)
-4. Timestamp alignment for transcribed text
-5. Generate structured ResourceNode with transcript
+3. Timestamp alignment for transcribed text
+4. Generate structured ResourceNode with transcript
 
 Example workflow:
     1. Load audio file
     2. Extract metadata (duration, format, sample rate)
-    3. Transcribe speech to text using Whisper or similar
-    4. (Optional) Perform speaker diarization
-    5. Create ResourceNode with:
+    3. Transcribe speech to text using Whisper
+    4. Create ResourceNode with:
        - type: NodeType.ROOT
        - children: sections for each speaker/timestamp
        - meta: audio metadata and timestamps
@@ -24,6 +22,8 @@ Example workflow:
 Supported formats: MP3, WAV, OGG, FLAC, AAC, M4A
 """
 
+import os
+import tempfile
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -31,6 +31,30 @@ from openviking.parse.base import NodeType, ParseResult, ResourceNode
 from openviking.parse.parsers.base_parser import BaseParser
 from openviking.parse.parsers.media.constants import AUDIO_EXTENSIONS
 from openviking_cli.utils.config.parser_config import AudioConfig
+from openviking_cli.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Map audio extensions to MIME suffixes for the Whisper API
+_EXT_TO_SUFFIX = {
+    ".mp3": ".mp3",
+    ".wav": ".wav",
+    ".ogg": ".ogg",
+    ".flac": ".flac",
+    ".aac": ".aac",
+    ".m4a": ".m4a",
+    ".opus": ".opus",
+}
+
+
+def _format_timestamp(seconds: float) -> str:
+    """Format seconds as MM:SS or HH:MM:SS."""
+    total = int(seconds)
+    hrs, remainder = divmod(total, 3600)
+    mins, secs = divmod(remainder, 60)
+    if hrs > 0:
+        return f"{hrs:02d}:{mins:02d}:{secs:02d}"
+    return f"{mins:02d}:{secs:02d}"
 
 
 class AudioParser(BaseParser):
@@ -128,14 +152,72 @@ class AudioParser(BaseParser):
         channels = 0
         format_str = ext[1:].upper()
 
-        # Create ResourceNode - metadata only, no content understanding yet
+        # Phase 2: ASR transcription (when enabled)
+        transcript_text = None
+        timestamp_text = None
+        has_transcript = False
+
+        if self.config.enable_transcription:
+            logger.info(
+                f"[AudioParser.parse] Starting ASR transcription for {file_path.name} "
+                f"with model={self.config.transcription_model}"
+            )
+            transcript_text = await self._asr_transcribe(
+                audio_bytes, model=self.config.transcription_model
+            )
+            timestamp_text = await self._asr_transcribe_with_timestamps(
+                audio_bytes, model=self.config.transcription_model
+            )
+
+            if transcript_text and not transcript_text.startswith("Audio transcription failed"):
+                has_transcript = True
+                # Save transcript as markdown file
+                transcript_md = f"# Transcript\n\n{transcript_text}\n"
+                await viking_fs.write_file(
+                    f"{root_dir_uri}/transcript.md",
+                    transcript_md,
+                )
+
+            if timestamp_text:
+                await viking_fs.write_file(
+                    f"{root_dir_uri}/transcript_timestamps.md",
+                    timestamp_text,
+                )
+
+        # Create ResourceNode
+        children = []
+        if has_transcript and transcript_text:
+            children.append(
+                ResourceNode(
+                    type=NodeType.SECTION,
+                    title="Transcript",
+                    level=1,
+                    detail_file="transcript.md",
+                    content_path=f"{root_dir_uri}/transcript.md",
+                    children=[],
+                    meta={"content_type": "transcript"},
+                )
+            )
+        if timestamp_text:
+            children.append(
+                ResourceNode(
+                    type=NodeType.SECTION,
+                    title="Transcript with Timestamps",
+                    level=1,
+                    detail_file="transcript_timestamps.md",
+                    content_path=f"{root_dir_uri}/transcript_timestamps.md",
+                    children=[],
+                    meta={"content_type": "transcript_timestamps"},
+                )
+            )
+
         root_node = ResourceNode(
             type=NodeType.ROOT,
             title=file_path.stem,
             level=0,
             detail_file=None,
             content_path=None,
-            children=[],
+            children=children,
             meta={
                 "duration": duration,
                 "sample_rate": sample_rate,
@@ -145,6 +227,7 @@ class AudioParser(BaseParser):
                 "source_title": file_path.stem,
                 "semantic_name": file_path.stem,
                 "original_filename": original_filename,
+                "has_transcript": has_transcript,
             },
         )
 
@@ -155,42 +238,170 @@ class AudioParser(BaseParser):
             temp_dir_path=temp_uri,
             source_format="audio",
             parser_name="AudioParser",
-            meta={"content_type": "audio", "format": format_str.lower()},
+            meta={
+                "content_type": "audio",
+                "format": format_str.lower(),
+                "has_transcript": has_transcript,
+            },
         )
+
+    def _get_openai_client(self):
+        """
+        Get an OpenAI client for Whisper ASR calls.
+
+        Uses the VLM config's API key/base when the provider is OpenAI-compatible,
+        otherwise falls back to OPENAI_API_KEY from the environment.
+
+        Returns:
+            openai.OpenAI client instance
+        """
+        try:
+            import openai
+        except ImportError:
+            raise ImportError("Please install openai: pip install openai")
+
+        from openviking_cli.utils.config import get_openviking_config
+
+        client_kwargs = {}
+        try:
+            vlm_config = get_openviking_config().vlm_config
+            if vlm_config and vlm_config.api_key:
+                client_kwargs["api_key"] = vlm_config.api_key
+            if vlm_config and vlm_config.api_base:
+                client_kwargs["base_url"] = vlm_config.api_base
+        except Exception:
+            pass
+
+        if "api_key" not in client_kwargs:
+            api_key = os.environ.get("OPENAI_API_KEY")
+            if api_key:
+                client_kwargs["api_key"] = api_key
+
+        return openai.OpenAI(**client_kwargs)
 
     async def _asr_transcribe(self, audio_bytes: bytes, model: Optional[str]) -> str:
         """
-        Generate audio transcription using ASR.
+        Generate audio transcription using OpenAI Whisper API.
 
         Args:
             audio_bytes: Audio binary data
-            model: ASR model name
+            model: ASR model name (defaults to config.transcription_model)
 
         Returns:
             Audio transcription in markdown format
-
-        TODO: Integrate with actual ASR API (Whisper, etc.)
         """
-        # Fallback implementation - returns basic placeholder
-        return "Audio transcription (ASR integration pending)\n\nThis is an audio. ASR transcription feature has not yet integrated external API."
+        import asyncio
+
+        model = model or self.config.transcription_model or "whisper-1"
+
+        def _transcribe_sync() -> str:
+            client = self._get_openai_client()
+            suffix = ".mp3"
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+                tmp.write(audio_bytes)
+                tmp_path = tmp.name
+            try:
+                with open(tmp_path, "rb") as audio_file:
+                    transcript = client.audio.transcriptions.create(
+                        model=model,
+                        file=audio_file,
+                    )
+                return transcript.text
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+
+        try:
+            text = await asyncio.get_event_loop().run_in_executor(None, _transcribe_sync)
+            logger.info(
+                f"[AudioParser._asr_transcribe] Whisper transcription received, "
+                f"length: {len(text)}, preview: {text[:256]}"
+            )
+            return text.strip()
+        except Exception as e:
+            logger.error(
+                f"[AudioParser._asr_transcribe] Whisper transcription failed: {e}",
+                exc_info=True,
+            )
+            return (
+                "Audio transcription failed\n\n"
+                f"ASR transcription using model '{model}' encountered an error: {e}"
+            )
 
     async def _asr_transcribe_with_timestamps(
         self, audio_bytes: bytes, model: Optional[str]
     ) -> Optional[str]:
         """
-        Extract transcription with timestamps from audio using ASR.
+        Extract transcription with timestamps from audio using OpenAI Whisper API.
+
+        Uses the verbose_json response format to obtain word-level or segment-level
+        timestamps, then formats them as a markdown transcript.
 
         Args:
             audio_bytes: Audio binary data
-            model: ASR model name
+            model: ASR model name (defaults to config.transcription_model)
 
         Returns:
             Transcript with timestamps in markdown format, or None if not available
-
-        TODO: Integrate with ASR API
         """
-        # Not implemented - return None
-        return None
+        import asyncio
+
+        model = model or self.config.transcription_model or "whisper-1"
+
+        def _transcribe_verbose_sync() -> Optional[str]:
+            client = self._get_openai_client()
+            suffix = ".mp3"
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+                tmp.write(audio_bytes)
+                tmp_path = tmp.name
+            try:
+                with open(tmp_path, "rb") as audio_file:
+                    transcript = client.audio.transcriptions.create(
+                        model=model,
+                        file=audio_file,
+                        response_format="verbose_json",
+                        timestamp_granularities=["segment"],
+                    )
+
+                segments = getattr(transcript, "segments", None)
+                if not segments:
+                    return None
+
+                lines = ["## Transcript with Timestamps\n"]
+                for seg in segments:
+                    start = seg.get("start", 0) if isinstance(seg, dict) else getattr(seg, "start", 0)
+                    end = seg.get("end", 0) if isinstance(seg, dict) else getattr(seg, "end", 0)
+                    text = seg.get("text", "") if isinstance(seg, dict) else getattr(seg, "text", "")
+                    start_fmt = _format_timestamp(start)
+                    end_fmt = _format_timestamp(end)
+                    lines.append(f"**[{start_fmt} - {end_fmt}]** {text.strip()}\n")
+
+                return "\n".join(lines)
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None, _transcribe_verbose_sync
+            )
+            if result:
+                logger.info(
+                    f"[AudioParser._asr_transcribe_with_timestamps] "
+                    f"Timestamped transcript received, length: {len(result)}"
+                )
+            return result
+        except Exception as e:
+            logger.error(
+                f"[AudioParser._asr_transcribe_with_timestamps] "
+                f"Whisper timestamp transcription failed: {e}",
+                exc_info=True,
+            )
+            return None
 
     async def _generate_semantic_info(
         self, node: ResourceNode, description: str, viking_fs, has_transcript: bool
@@ -258,17 +469,37 @@ class AudioParser(BaseParser):
         self, content: str, source_path: Optional[str] = None, instruction: str = "", **kwargs
     ) -> ParseResult:
         """
-        Parse audio from content string - Not yet implemented.
+        Parse audio from base64-encoded content string.
+
+        Decodes the base64 content, writes it to a temporary file, and
+        delegates to the file-based ``parse()`` method.
 
         Args:
-            content: Audio content (base64 or binary string)
+            content: Base64-encoded audio content
             source_path: Optional source path for metadata
             **kwargs: Additional parsing parameters
 
         Returns:
             ParseResult with audio content
-
-        Raises:
-            NotImplementedError: This feature is not yet implemented
         """
-        raise NotImplementedError("Audio parsing from content not yet implemented")
+        import base64
+
+        audio_bytes = base64.b64decode(content)
+
+        suffix = ".mp3"
+        if source_path:
+            p = Path(source_path)
+            if p.suffix.lower() in _EXT_TO_SUFFIX:
+                suffix = p.suffix.lower()
+
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(audio_bytes)
+            tmp_path = tmp.name
+
+        try:
+            return await self.parse(tmp_path, instruction=instruction, **kwargs)
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
Completes the audio parser stub by implementing the TODO items at lines 172 and 190.

- Integrates OpenAI Whisper API for `_asr_transcribe()` and `_asr_transcribe_with_timestamps()`
- Follows the existing OpenAI SDK pattern used in `openai_vlm.py` and `agfs-shell/commands/llm.py`
- Output format matches the pre-defined ResourceNode structure in the stub
- `parse_content()` now accepts base64-encoded audio and delegates to `parse()`
- `parse()` now produces transcribed text with optional timestamps when `enable_transcription` is set

## Context
The audio parser class, config, metadata extraction, and output format were already defined by the maintainers. This PR wires up the actual ASR API calls to complete the implementation.

## Test plan
- [ ] Verify `_asr_transcribe()` produces plain text from an audio file via Whisper API
- [ ] Verify `_asr_transcribe_with_timestamps()` returns segment-level timestamps in markdown
- [ ] Verify `parse()` saves `transcript.md` and `transcript_timestamps.md` to VikingFS
- [ ] Verify `parse_content()` decodes base64 audio and delegates to `parse()`
- [ ] Verify graceful fallback when OPENAI_API_KEY is not set or API returns error


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>