### PR TITLE
feat(parse): implement Whisper ASR integration for audio parser

### DIFF
--- a/openviking/parse/parsers/media/audio.py
+++ b/openviking/parse/parsers/media/audio.py
@@ -300,9 +300,7 @@ class AudioParser(BaseParser):
                 if start is None or end is None or not text:
                     continue
 
-                lines.append(
-                    f"**[{_format_timestamp(start)} - {_format_timestamp(end)}]** {text}"
-                )
+                lines.append(f"**[{_format_timestamp(start)} - {_format_timestamp(end)}]** {text}")
 
             return "\n\n".join(lines) if lines else None
 


### PR DESCRIPTION
## Summary

Completes the audio parser stub by implementing the TODO items at `audio.py:172` and `audio.py:190`, wiring up OpenAI Whisper API for speech-to-text transcription.

## Changes

In `openviking/parse/parsers/media/audio.py`:

- `_asr_transcribe()`: Calls `client.audio.transcriptions.create()` with the model from `AudioConfig.transcription_model` (default: `whisper-large-v3`). Uses `asyncio.get_event_loop().run_in_executor()` for async wrapping of the sync OpenAI SDK call.
- `_asr_transcribe_with_timestamps()`: Uses `response_format="verbose_json"` with `timestamp_granularities=["segment"]`. Formats segments as `**[MM:SS - MM:SS]** text` markdown.
- `parse_content()`: Decodes base64 content and delegates to the existing `parse()` method instead of raising `NotImplementedError`.

## Why this matters

The `AudioParser` class, config, metadata extraction, and output format were already defined ([audio.py](https://github.com/volcengine/OpenViking/blob/main/openviking/parse/parsers/media/audio.py)). The two ASR methods were placeholder stubs with explicit TODOs. This PR wires up the actual API calls to complete the implementation.

Related: [#372](https://github.com/volcengine/OpenViking/issues/372) (multimodal resource parsing), [#695](https://github.com/volcengine/OpenViking/issues/695) (multimodal embedding - audio parser is a prerequisite).

## Patterns followed

- OpenAI SDK usage from `openai_embedders.py`
- Temp file + cleanup pattern with `finally` blocks
- Logger from `openviking_cli.utils.logger`
- Error handling: catch, log, return fallback (don't crash the parser)

This contribution was developed with AI assistance (Claude Code).