### PR TITLE
fix(observer): pass RequestContext through vikingdb observer for tenant-scoped vector count

### DIFF
--- a/docs/en/api/07-system.md
+++ b/docs/en/api/07-system.md
@@ -49,7 +49,7 @@ Get system status including initialization state and user info.
 **Python SDK (Embedded / HTTP)**
 
 ```python
-print(client.observer.system)
+print(client.observer.system())
 ```
 
 **HTTP API**
@@ -204,16 +204,16 @@ Get VikingDB status (collections, indexes, vector counts).
 **Python SDK (Embedded / HTTP)**
 
 ```python
-print(client.observer.vikingdb)
+print(client.observer.vikingdb())
 # Output:
 # [vikingdb] (healthy)
 # Collection  Index Count  Vector Count  Status
 # context     1            55            OK
 # TOTAL       1            55
 
-# Access specific properties
-print(client.observer.vikingdb.is_healthy)  # True
-print(client.observer.vikingdb.status)      # Status table string
+# Access specific attributes
+print(client.observer.vikingdb().is_healthy)  # True
+print(client.observer.vikingdb().status)      # Status table string
 ```
 
 **HTTP API**
@@ -306,7 +306,7 @@ Get overall system status including all components.
 **Python SDK (Embedded / HTTP)**
 
 ```python
-print(client.observer.system)
+print(client.observer.system())
 # Output:
 # [queue] (healthy)
 # ...
@@ -382,7 +382,7 @@ Quick health check for the entire system.
 if client.observer.is_healthy():
     print("System OK")
 else:
-    print(client.observer.system)
+    print(client.observer.system())
 ```
 
 **HTTP API**

--- a/docs/zh/api/07-system.md
+++ b/docs/zh/api/07-system.md
@@ -49,7 +49,7 @@ openviking health
 **Python SDK (Embedded / HTTP)**
 
 ```python
-print(client.observer.system)
+print(client.observer.system())
 ```
 
 **HTTP API**
@@ -204,7 +204,7 @@ openviking observer queue
 **Python SDK (Embedded / HTTP)**
 
 ```python
-print(client.observer.vikingdb)
+print(client.observer.vikingdb())
 # Output:
 # [vikingdb] (healthy)
 # Collection  Index Count  Vector Count  Status
@@ -212,8 +212,8 @@ print(client.observer.vikingdb)
 # TOTAL       1            55
 
 # 访问特定属性
-print(client.observer.vikingdb.is_healthy)  # True
-print(client.observer.vikingdb.status)      # Status table string
+print(client.observer.vikingdb().is_healthy)  # True
+print(client.observer.vikingdb().status)      # Status table string
 ```
 
 **HTTP API**
@@ -306,7 +306,7 @@ openviking observer vlm
 **Python SDK (Embedded / HTTP)**
 
 ```python
-print(client.observer.system)
+print(client.observer.system())
 # Output:
 # [queue] (healthy)
 # ...
@@ -382,7 +382,7 @@ openviking observer system
 if client.observer.is_healthy():
     print("System OK")
 else:
-    print(client.observer.system)
+    print(client.observer.system())
 ```
 
 **HTTP API**

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -449,7 +449,7 @@ class LocalClient(BaseClient):
         Returns:
             SystemStatus containing health status of all components.
         """
-        return self._service.debug.observer.system
+        return self._service.debug.observer.system()
 
     def is_healthy(self) -> bool:
         """Quick health check (synchronous).

--- a/openviking/server/routers/observer.py
+++ b/openviking/server/routers/observer.py
@@ -54,11 +54,11 @@ async def observer_queue(
 
 @router.get("/vikingdb")
 async def observer_vikingdb(
-    _ctx: RequestContext = Depends(get_request_context),
+    ctx: RequestContext = Depends(get_request_context),
 ):
     """Get VikingDB status."""
     service = get_service()
-    component = service.debug.observer.vikingdb
+    component = service.debug.observer.vikingdb(ctx=ctx)
     return Response(status="ok", result=_component_to_dict(component))
 
 
@@ -94,9 +94,9 @@ async def observer_retrieval(
 
 @router.get("/system")
 async def observer_system(
-    _ctx: RequestContext = Depends(get_request_context),
+    ctx: RequestContext = Depends(get_request_context),
 ):
     """Get system overall status (includes all components)."""
     service = get_service()
-    status = service.debug.observer.system
+    status = service.debug.observer.system(ctx=ctx)
     return Response(status="ok", result=_system_to_dict(status))

--- a/openviking/service/debug_service.py
+++ b/openviking/service/debug_service.py
@@ -7,6 +7,7 @@ Debug Service - provides system status query and health check.
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+from openviking.server.identity import RequestContext
 from openviking.storage import VikingDBManager
 from openviking.storage.observers import (
     LockObserver,
@@ -99,8 +100,7 @@ class ObserverService:
             status=observer.get_status_table(),
         )
 
-    @property
-    def vikingdb(self) -> ComponentStatus:
+    def vikingdb(self, ctx: Optional[RequestContext] = None) -> ComponentStatus:
         """Get VikingDB status."""
         if self._vikingdb is None:
             return ComponentStatus(
@@ -114,7 +114,7 @@ class ObserverService:
             name="vikingdb",
             is_healthy=observer.is_healthy(),
             has_errors=observer.has_errors(),
-            status=observer.get_status_table(),
+            status=observer.get_status_table(ctx=ctx),
         )
 
     @property
@@ -166,12 +166,11 @@ class ObserverService:
             status=observer.get_status_table(),
         )
 
-    @property
-    def system(self) -> SystemStatus:
+    def system(self, ctx: Optional[RequestContext] = None) -> SystemStatus:
         """Get system overall status."""
         components = {
             "queue": self.queue,
-            "vikingdb": self.vikingdb,
+            "vikingdb": self.vikingdb(ctx=ctx),
             "vlm": self.vlm,
             "lock": self.lock,
             "retrieval": self.retrieval,
@@ -187,7 +186,7 @@ class ObserverService:
         """Quick health check."""
         if not self._dependencies_ready:
             return False
-        return self.system.is_healthy
+        return self.system().is_healthy
 
 
 class DebugService:

--- a/openviking/storage/observers/README.md
+++ b/openviking/storage/observers/README.md
@@ -58,7 +58,7 @@ Monitors VikingDB collection status (index count and vector count per collection
 import openviking as ov
 
 client = ov.OpenViking(path="./data")
-print(client.observer.vikingdb)
+print(client.observer.vikingdb())
 # Output:
 #    Collection  Index Count  Vector Count Status
 #    context            1            69     OK

--- a/openviking/storage/observers/vikingdb_observer.py
+++ b/openviking/storage/observers/vikingdb_observer.py
@@ -6,8 +6,9 @@ VikingDBObserver: VikingDB storage observability tool.
 Provides methods to observe and report VikingDB collection status.
 """
 
-from typing import Dict
+from typing import Dict, Optional
 
+from openviking.server.identity import RequestContext
 from openviking.storage.observers.base_observer import BaseObserver
 from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking_cli.utils import run_async
@@ -26,23 +27,27 @@ class VikingDBObserver(BaseObserver):
     def __init__(self, vikingdb_manager: VikingDBManager):
         self._vikingdb_manager = vikingdb_manager
 
-    async def get_status_table_async(self) -> str:
+    async def get_status_table_async(self, ctx: Optional[RequestContext] = None) -> str:
         if not self._vikingdb_manager:
             return "VikingDB manager not initialized."
 
         if not await self._vikingdb_manager.collection_exists():
             return "No collections found."
 
-        statuses = await self._get_collection_statuses([self._vikingdb_manager.collection_name])
+        statuses = await self._get_collection_statuses(
+            [self._vikingdb_manager.collection_name], ctx=ctx
+        )
         return self._format_status_as_table(statuses)
 
-    def get_status_table(self) -> str:
-        return run_async(self.get_status_table_async())
+    def get_status_table(self, ctx: Optional[RequestContext] = None) -> str:
+        return run_async(self.get_status_table_async(ctx=ctx))
 
     def __str__(self) -> str:
         return self.get_status_table()
 
-    async def _get_collection_statuses(self, collection_names: list) -> Dict[str, Dict]:
+    async def _get_collection_statuses(
+        self, collection_names: list, *, ctx: Optional[RequestContext] = None
+    ) -> Dict[str, Dict]:
         statuses = {}
 
         for name in collection_names:
@@ -52,7 +57,7 @@ class VikingDBObserver(BaseObserver):
 
                 # Current OpenViking flow uses one managed default index per collection.
                 index_count = 1
-                vector_count = await self._vikingdb_manager.count()
+                vector_count = await self._vikingdb_manager.count(ctx=ctx)
 
                 statuses[name] = {
                     "index_count": index_count,

--- a/tests/misc/test_debug_service.py
+++ b/tests/misc/test_debug_service.py
@@ -166,7 +166,7 @@ class TestObserverService:
         mock_observer_cls.return_value = mock_observer
 
         service = ObserverService(vikingdb=mock_vikingdb)
-        status = service.vikingdb
+        status = service.vikingdb()
 
         assert isinstance(status, ComponentStatus)
         assert status.name == "vikingdb"
@@ -216,7 +216,7 @@ class TestObserverService:
 
         mock_config = MagicMock()
         service = ObserverService(vikingdb=MagicMock(), config=mock_config)
-        status = service.system
+        status = service.system()
 
         assert isinstance(status, SystemStatus)
         for name in ("queue", "vikingdb", "vlm"):
@@ -255,7 +255,7 @@ class TestObserverService:
 
         mock_config = MagicMock()
         service = ObserverService(vikingdb=MagicMock(), config=mock_config)
-        status = service.system
+        status = service.system()
 
         assert isinstance(status, SystemStatus)
         assert status.is_healthy is False
@@ -281,7 +281,7 @@ class TestObserverService:
 
         mock_config = MagicMock()
         service = ObserverService(vikingdb=MagicMock(), config=mock_config)
-        status = service.system
+        status = service.system()
         assert all(c.is_healthy for name, c in status.components.items() if name != "transaction")
 
     def test_is_healthy_without_dependencies(self):
@@ -292,7 +292,7 @@ class TestObserverService:
     def test_vikingdb_property_without_dependency(self):
         """Test vikingdb property returns unhealthy ComponentStatus when vikingdb is None."""
         service = ObserverService()
-        status = service.vikingdb
+        status = service.vikingdb()
         assert isinstance(status, ComponentStatus)
         assert status.name == "vikingdb"
         assert status.is_healthy is False
@@ -312,7 +312,7 @@ class TestObserverService:
     def test_system_property_without_dependencies(self):
         """Test system property returns unhealthy SystemStatus when dependencies not set."""
         service = ObserverService()
-        status = service.system
+        status = service.system()
         assert isinstance(status, SystemStatus)
         assert status.is_healthy is False
 

--- a/tests/misc/test_vikingdb_observer.py
+++ b/tests/misc/test_vikingdb_observer.py
@@ -42,7 +42,7 @@ async def test_vikingdb_observer():
 
         # Test VikingDBObserver
         print("\n4. Test VikingDBObserver:")
-        vikingdb_status = client.observer.vikingdb
+        vikingdb_status = client.observer.vikingdb()
         print(f"Type: {type(vikingdb_status)}")
         print(f"Is healthy: {vikingdb_status.is_healthy}")
         print(f"Has errors: {vikingdb_status.has_errors}")
@@ -58,7 +58,7 @@ async def test_vikingdb_observer():
 
         # Test system status
         print("\n7. Test system status:")
-        system_status = client.observer.system
+        system_status = client.observer.system()
         print(f"System is_healthy: {system_status.is_healthy}")
         for name, component in system_status.components.items():
             print(f"\n{name}:")
@@ -102,7 +102,7 @@ async def test_sync_client():
 
         # Test VikingDBObserver
         print("\nVikingDBObserver status:")
-        print(client.observer.vikingdb)
+        print(client.observer.vikingdb())
 
         print("\n=== Sync client test completed ===")
 


### PR DESCRIPTION
## Description

The VikingDB observer and `/api/v1/observer/vikingdb` endpoint always returned `vector_count: 0` for non-default tenants. The root cause is that `VikingDBObserver.count()` was called without `RequestContext`, falling back to `account_id="default"` which filters out vectors belonging to other tenants.

This PR threads `RequestContext` from the HTTP router all the way through `ObserverService` → `VikingDBObserver` → `VikingVectorIndexBackend.count(ctx=ctx)`, so each tenant only sees their own vector count.

## Related Issue

Fixes #786

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- **`vikingdb_observer.py`** — Add `ctx: Optional[RequestContext]` parameter to `get_status_table_async()`, `get_status_table()`, and `_get_collection_statuses()`. Pass `ctx` to `vikingdb_manager.count(ctx=ctx)`.
- **`debug_service.py`** — Change `vikingdb` and `system` from `@property` to methods accepting `ctx` parameter. Update `is_healthy()` to call `system()`.
- **`observer.py`** — Pass `ctx` from router to `ObserverService.vikingdb(ctx=ctx)` and `ObserverService.system(ctx=ctx)` for `/vikingdb` and `/system` endpoints.
- **`local.py`** — Adapt `get_status()` to call `system()` as a method.
- **`tests/`** — Update `test_debug_service.py` and `test_vikingdb_observer.py` to use method calls instead of property access.
- **`docs/`** — Update SDK examples in `docs/zh/api/07-system.md`, `docs/en/api/07-system.md`, and `openviking/storage/observers/README.md` to reflect the property-to-method change.

## Testing

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

**Breaking change for local SDK users**: `client.observer.vikingdb` and `client.observer.system` are now methods instead of properties. Users need to add parentheses: `client.observer.vikingdb()`, `client.observer.system()`. The HTTP SDK client (`_HTTPObserver`) is not affected as it has its own independent property-based interface.

This is an alternative approach to PR #802, which used `include_all_accounts=True` to bypass tenant isolation. That approach has two issues:
1. It violates multi-tenant isolation by exposing all tenants' vector counts
2. It has a runtime bug — `_SingleAccountBackend.get_collection_info()` calls `self.count(include_all_accounts=True)` but `_SingleAccountBackend.count()` doesn't accept that parameter, causing a `TypeError`

Credit-To: jackjin1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)
