### PR TITLE
fix(storage): detect and clear stale RocksDB LOCK files on Windows

### DIFF
--- a/openviking/storage/vectordb/store/local_store.py
+++ b/openviking/storage/vectordb/store/local_store.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
+import glob
+import logging
+import os
+import sys
+from pathlib import Path
 from typing import List, Tuple, Union
 
 import openviking.storage.vectordb.engine as engine
@@ -7,6 +12,58 @@ from openviking.storage.vectordb.store.store import BatchOp, IMutiTableStore, Op
 
 # Constant for the maximum Unicode character, used for range queries to cover all possible keys
 MAX_UNICODE_CHAR = "\U0010ffff"
+
+_log = logging.getLogger("openviking.storage.vectordb.store")
+
+
+def _clear_stale_rocksdb_locks(data_path: str) -> None:
+    """Remove stale RocksDB LOCK files left behind by crashed or exited processes.
+
+    RocksDB creates a LOCK file when opening a database.  On Windows, the
+    OS file handle may persist even after ``client.close()`` until the Python
+    process fully exits, and a crash or kill leaves the LOCK forever.
+    Subsequent processes then fail with:
+
+        IO error: .../LOCK: The process cannot access the file because it
+        is being used by another process
+
+    This is especially common with hook-based architectures (Claude Code hooks,
+    MCP stdio servers) where many short-lived Python processes repeatedly open
+    and close the same database.
+
+    Safety: RocksDB LOCK files are purely advisory (0-byte, no data).  All
+    actual data lives in SST files, WAL logs, and MANIFEST.  On Windows,
+    ``os.remove()`` on a file held by a live process raises ``PermissionError``,
+    giving us an atomic staleness check:
+
+    - ``os.remove()`` succeeds → no process holds the file → stale, safe to remove
+    - ``os.remove()`` raises ``PermissionError`` → live process → leave it alone
+
+    On Unix, ``os.remove()`` succeeds even when a process holds the file
+    (inode stays alive), so we only run this on Windows where the issue
+    actually manifests.
+
+    See: https://github.com/volcengine/OpenViking/issues/650
+    """
+    if sys.platform != "win32":
+        return
+
+    base = Path(data_path)
+    # Search for LOCK files in the vectordb subdirectory tree
+    lock_patterns = [
+        str(base / "**" / "LOCK"),
+    ]
+
+    for pattern in lock_patterns:
+        for lock_path in glob.glob(pattern, recursive=True):
+            try:
+                os.remove(lock_path)
+                _log.info("Removed stale RocksDB LOCK: %s", lock_path)
+            except PermissionError:
+                # Active process holds this lock — leave it alone.
+                _log.debug("LOCK held by live process, skipping: %s", lock_path)
+            except OSError as exc:
+                _log.debug("Could not remove LOCK %s: %s", lock_path, exc)
 
 
 def create_store_engine_proxy(path: str = "") -> "StoreEngineProxy":
@@ -19,6 +76,8 @@ def create_store_engine_proxy(path: str = "") -> "StoreEngineProxy":
     Returns:
         StoreEngineProxy: Proxy instance wrapping the underlying storage engine.
     """
+    if path:
+        _clear_stale_rocksdb_locks(path)
     date_engine = engine.PersistStore(path) if path else engine.VolatileStore()
     return StoreEngineProxy(date_engine)
 

--- a/tests/storage/test_stale_rocksdb_lock.py
+++ b/tests/storage/test_stale_rocksdb_lock.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for stale RocksDB LOCK detection.
+
+Verifies the fix for https://github.com/volcengine/OpenViking/issues/650:
+On Windows, crashed or exited processes leave behind stale RocksDB LOCK
+files that block subsequent sessions.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from openviking.storage.vectordb.store.local_store import _clear_stale_rocksdb_locks
+
+
+@pytest.fixture
+def fake_vectordb(tmp_path):
+    """Create a fake vectordb directory tree with LOCK files."""
+    store_dir = tmp_path / "vectordb" / "default" / "store"
+    store_dir.mkdir(parents=True)
+    lock_file = store_dir / "LOCK"
+    lock_file.touch()
+
+    store_dir2 = tmp_path / "vectordb" / "account2" / "store"
+    store_dir2.mkdir(parents=True)
+    lock_file2 = store_dir2 / "LOCK"
+    lock_file2.touch()
+
+    return tmp_path
+
+
+@patch("sys.platform", "win32")
+def test_removes_stale_locks_on_windows(fake_vectordb):
+    """Stale LOCK files should be removed on Windows."""
+    lock1 = fake_vectordb / "vectordb" / "default" / "store" / "LOCK"
+    lock2 = fake_vectordb / "vectordb" / "account2" / "store" / "LOCK"
+
+    assert lock1.exists()
+    assert lock2.exists()
+
+    _clear_stale_rocksdb_locks(str(fake_vectordb))
+
+    assert not lock1.exists(), "Stale LOCK should be removed"
+    assert not lock2.exists(), "Stale LOCK should be removed"
+
+
+@patch("sys.platform", "darwin")
+def test_skips_on_non_windows(fake_vectordb):
+    """LOCK cleanup should be skipped on non-Windows platforms."""
+    lock1 = fake_vectordb / "vectordb" / "default" / "store" / "LOCK"
+    assert lock1.exists()
+
+    _clear_stale_rocksdb_locks(str(fake_vectordb))
+
+    assert lock1.exists(), "LOCK should not be removed on non-Windows"
+
+
+@patch("sys.platform", "win32")
+def test_handles_permission_error_gracefully(fake_vectordb):
+    """When a live process holds the LOCK, PermissionError should be caught."""
+    lock1 = fake_vectordb / "vectordb" / "default" / "store" / "LOCK"
+
+    with patch("os.remove", side_effect=PermissionError("locked by live process")):
+        # Should not raise
+        _clear_stale_rocksdb_locks(str(fake_vectordb))
+
+    assert lock1.exists(), "LOCK held by live process should be kept"
+
+
+@patch("sys.platform", "win32")
+def test_handles_empty_directory(tmp_path):
+    """No LOCK files should result in a no-op."""
+    # Should not raise
+    _clear_stale_rocksdb_locks(str(tmp_path))
+
+
+@patch("sys.platform", "win32")
+def test_handles_nonexistent_path():
+    """Non-existent path should be handled gracefully."""
+    _clear_stale_rocksdb_locks("/nonexistent/path/that/does/not/exist")


### PR DESCRIPTION
## Problem

On Windows, when using OpenViking in local mode (`SyncOpenViking` with `PersistStore`), crashed or exited processes leave behind stale RocksDB LOCK files.  All subsequent sessions fail with:

```
IO error: .../LOCK: The process cannot access the file because it is being used by another process
```

This is especially common with hook-based architectures (Claude Code hooks, MCP stdio servers) where many short-lived Python processes repeatedly open and close the same database.  Even calling `client.close()` may not release the OS file handle until the Python process fully exits.

## Root Cause

RocksDB creates a LOCK file when opening a database.  On Windows:
1. Even after `client.close()`, the OS file handle may persist until process exit
2. If the process crashes/is killed/times out, LOCK is never released
3. Next process trying to open the same DB gets a `PermissionError`

## Solution

Add `_clear_stale_rocksdb_locks()` in `local_store.py`, called before creating `PersistStore`.  The function leverages Windows file semantics for an atomic staleness check:

- `os.remove()` **succeeds** → no process holds the file → stale lock → safe to remove
- `os.remove()` raises `PermissionError` → live process holds the file → leave it alone

On non-Windows platforms, the function is a no-op (Unix inode semantics mean the issue doesn't manifest).

**Safety**: RocksDB LOCK files are purely advisory (0-byte, contain no data).  All actual data lives in SST files, WAL logs, and MANIFEST.

## Tests

Added 5 tests in `tests/storage/test_stale_rocksdb_lock.py`:
- `test_removes_stale_locks_on_windows` — verifies cleanup on Windows
- `test_skips_on_non_windows` — verifies no-op on macOS/Linux  
- `test_handles_permission_error_gracefully` — verifies live locks are kept
- `test_handles_empty_directory` — edge case
- `test_handles_nonexistent_path` — edge case

Closes #650
Ref #473, #576