### PR TITLE
fix(ci): use pull_request_target so Qodo review runs on fork PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,7 @@
 name: PR Review (Qodo)
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
 


### PR DESCRIPTION
## Description

将 `pr-review.yml` 的触发事件从 `pull_request` 改为 `pull_request_target`，使 Qodo PR Review 能在所有 fork PR 上自动运行。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 将 `pr-review.yml` 的 `pull_request` 事件改为 `pull_request_target`

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

### 问题

当前 `pull_request` 事件下，来自外部贡献者的 fork PR 会被 GitHub 拦截（`action_required`），需要 maintainer 手动批准。即使批准后，`secrets.DOUBAO_API_KEY` 在 fork PR 的 `pull_request` 事件中也不可用，导致 Qodo review 无法调用 Doubao API。

最近 100 次 workflow 运行中，有 13 次 fork PR 全部卡在 `action_required` 状态。

### 方案

`pull_request_target` 在 base repo（main 分支）的上下文中运行 workflow，因此：
1. 不受 fork PR 审批策略限制，自动触发
2. 可以访问 `secrets.DOUBAO_API_KEY`

### 安全性

- workflow YAML 来自 main 分支，fork 无法修改
- `actions/checkout@v4` 在 `pull_request_target` 下默认 checkout base branch，`.pr_agent.toml` 也来自 main
- pr-agent 通过 GitHub API 读取 PR diff，不执行 fork 提交的代码

🤖 Generated with [Claude Code](https://claude.com/claude-code)
