### PR TITLE
fix(session): add commit_async for client.Session

### DIFF
--- a/openviking/client/session.py
+++ b/openviking/client/session.py
@@ -66,6 +66,15 @@ class Session:
         """
         return await self._client.commit_session(self.session_id, telemetry=telemetry)
 
+    async def commit_async(self, telemetry: TelemetryRequest = False) -> Dict[str, Any]:
+        """Commit the session asynchronously (archive messages and extract memories).
+           Used in viking bot for committing.
+
+        Returns:
+            Commit result
+        """
+        return await self.commit(telemetry)
+
     async def delete(self) -> None:
         """Delete the session."""
         await self._client.delete_session(self.session_id)


### PR DESCRIPTION
## Problem
When start the server in --with-bot model and trigger memory commit in `ov chat`, there is an error after calling the `openviking_memory_commit` tool.

> Error committing to Viking: 'Session' object has no attribute 'commit_async'

## Root Cause
In the commit 87ee8752d40007fe4f74e1a211fac3a46c18f164, `await session.commit()` has been modified to `await session.commit_async()`. In the `openviking.client.Session`, `commit_async` was not implemented.

## Solution
`commit` has been implemented in the file and it is async method. Just add the `commit_async` in the class and call `self.commit`.

## Test
```
Calling: openviking_memory_commit({"messages": [{"role": "user", "content": "......"}]})
  └─ Result: Successfully committed to session cli__default__00DF0727-DBBE-5DF0-AB0D-E33C3EC67AA1
```
