### PR TITLE
fix(content): pass tenant context to reindex existence check

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -112,7 +112,7 @@ async def reindex(
     viking_fs = get_viking_fs()
 
     # Validate URI exists
-    if not await viking_fs.exists(uri):
+    if not await viking_fs.exists(uri, ctx=_ctx):
         return Response(
             status="error",
             error=ErrorInfo(code="NOT_FOUND", message=f"URI not found: {uri}"),

--- a/tests/server/test_api_content.py
+++ b/tests/server/test_api_content.py
@@ -3,6 +3,14 @@
 
 """Tests for content endpoints: read, abstract, overview."""
 
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers.content import ReindexRequest, reindex
+from openviking_cli.session.user_id import UserIdentifier
+
 
 async def test_read_content(client_with_resource):
     client, uri = client_with_resource
@@ -83,3 +91,45 @@ async def test_reindex_wait_parameter_schema(client):
     # Pydantic coerces or rejects — either way, not a 404/405
     assert resp.status_code != 404
     assert resp.status_code != 405
+
+
+@pytest.mark.asyncio
+async def test_reindex_uses_request_tenant_for_exists(monkeypatch):
+    """Reindex must validate URI existence inside the caller's tenant."""
+    seen = {}
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            seen["uri"] = uri
+            seen["ctx"] = ctx
+            return True
+
+    class FakeTracker:
+        def has_running(self, task_type, uri):
+            return False
+
+    async def fake_do_reindex(service, uri, regenerate, ctx):
+        return {"status": "success", "message": "Indexed 1 resources"}
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice", agent_id="default"),
+        role=Role.ADMIN,
+    )
+    request = ReindexRequest(uri="viking://resources/demo/demo-note.md", wait=True)
+
+    monkeypatch.setattr("openviking.storage.viking_fs.get_viking_fs", lambda: FakeVikingFS())
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.content.get_service",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr("openviking.server.routers.content._do_reindex", fake_do_reindex)
+
+    response = await reindex(request=request, _ctx=ctx)
+
+    assert response.status == "ok"
+    assert seen["uri"] == "viking://resources/demo/demo-note.md"
+    assert seen["ctx"] == ctx


### PR DESCRIPTION
## Description

Fix an issue where `/api/v1/content/reindex` incorrectly returned `NOT_FOUND` for non-default accounts.

Previously, the URI existence check inside `reindex` did not use the request's tenant context, causing it to fall back to the default account. As a result, resources created under other accounts could not be reindexed.

This PR ensures the existence check is executed within the correct tenant context.

## Related Issue

<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Pass request `ctx` into `viking_fs.exists(...)` in `reindex` to ensure tenant-scoped validation
- Add a regression test to verify existence checks are performed with the caller's tenant context
- Keep the change minimal and limited to the validation path

## Testing

- Reproduced the issue:
  - Works correctly under the default account
  - Returns `NOT_FOUND` under non-default accounts before the fix
- Verified the fix:
  - Reindex works correctly under both default and non-default accounts
- Added unit test to assert `exists()` is called with the correct `ctx`

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This bug only affects multi-tenant scenarios. Single-tenant (default account) usage remains unaffected, which made the issue less obvious without explicit cross-account testing.