### PR TITLE
fix(search): clamp inf/nan scores from vector search to prevent JSON serialization failure

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -8,6 +8,7 @@ and rerank-based relevance scoring.
 """
 
 import heapq
+import math
 import logging
 import time
 from datetime import datetime
@@ -516,6 +517,9 @@ class HierarchicalRetriever:
                             relations.append(RelatedContext(uri=uri, abstract=abstract))
 
             semantic_score = c.get("_final_score", c.get("_score", 0.0))
+            # Fix: clamp inf/nan scores from vector search (#inf-score)
+            if not math.isfinite(semantic_score):
+                semantic_score = 0.0
 
             # --- hotness boost ---
             updated_at_raw = c.get("updated_at")
@@ -536,6 +540,8 @@ class HierarchicalRetriever:
 
             alpha = self.HOTNESS_ALPHA
             final_score = (1 - alpha) * semantic_score + alpha * h_score
+            if not math.isfinite(final_score):
+                final_score = 0.0
             level = c.get("level", 2)
             display_uri = self._append_level_suffix(c.get("uri", ""), level)
 

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Search endpoints for OpenViking HTTP Server."""
 
+import math
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends
@@ -13,6 +14,20 @@ from openviking.server.identity import RequestContext
 from openviking.server.models import Response
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
+
+
+
+def _sanitize_floats(obj: Any) -> Any:
+    """Recursively replace inf/nan with 0.0 to ensure JSON compliance."""
+    if isinstance(obj, float):
+        if math.isinf(obj) or math.isnan(obj):
+            return 0.0
+        return obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_floats(v) for v in obj]
+    return obj
 
 router = APIRouter(prefix="/api/v1/search", tags=["search"])
 
@@ -82,6 +97,7 @@ async def find(
     result = execution.result
     if hasattr(result, "to_dict"):
         result = result.to_dict()
+    result = _sanitize_floats(result)
     return Response(
         status="ok",
         result=result,
@@ -121,6 +137,7 @@ async def search(
     result = execution.result
     if hasattr(result, "to_dict"):
         result = result.to_dict()
+    result = _sanitize_floats(result)
     return Response(
         status="ok",
         result=result,


### PR DESCRIPTION
## Problem

`/api/v1/search/find` and `/api/v1/search/search` return `500 INTERNAL` with:
```
ValueError: Out of range float values are not JSON compliant: inf
```

This happens when local vector search returns `inf` scores (e.g., zero vectors, embedding overflow), which get passed through to the API response. Starlette's `json.dumps(allow_nan=False)` rejects `inf`/`nan`.

## Root Cause

In `hierarchical_retriever.py`, `_convert_to_matched_contexts()` reads `_score` from vector search results and blends it with hotness score. When the source score is `inf`, the blended `final_score` is also `inf`, causing JSON serialization to fail.

## Fix

Two changes:

1. **`openviking/retrieve/hierarchical_retriever.py`**: Clamp `semantic_score` and `final_score` to `0.0` when `math.isfinite()` returns `False`

2. **`openviking/server/routers/search.py`**: Add `_sanitize_floats()` recursive sanitizer as defense-in-depth on `find` and `search` endpoints

## Environment

- OpenViking: v0.2.9
- Local vectorDB (sqlite-vec)
- Local embedding: Ollama `qwen3-embedding:0.6b` (1024d)

## Reproduction

```bash
curl -X POST http://localhost:1933/api/v1/search/find   -H 'Content-Type: application/json'   -d '{"query": "test", "limit": 3}'
# Before: {"status":"error","error":{"message":"Out of range float values are not JSON compliant: inf"}}
# After:  {"status":"ok","result":{"memories":[{"score":0.0802,...}]}}
```