### PR TITLE
fix(resource): resolve 'file exists' errors on resource add

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -325,13 +325,13 @@ async def index_resource(
     abstract = ""
     overview = ""
 
-    if await viking_fs.exists(abstract_uri):
-        content = await viking_fs.read_file(abstract_uri)
+    if await viking_fs.exists(abstract_uri, ctx=ctx):
+        content = await viking_fs.read_file(abstract_uri, ctx=ctx)
         if isinstance(content, bytes):
             abstract = content.decode("utf-8")
 
-    if await viking_fs.exists(overview_uri):
-        content = await viking_fs.read_file(overview_uri)
+    if await viking_fs.exists(overview_uri, ctx=ctx):
+        content = await viking_fs.read_file(overview_uri, ctx=ctx)
         if isinstance(content, bytes):
             overview = content.decode("utf-8")
 

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -228,13 +228,16 @@ class ResourceProcessor:
                     dst_path = viking_fs._uri_to_path(root_uri, ctx=ctx)
                     parent_path = dst_path.rsplit("/", 1)[0] if "/" in dst_path else dst_path
 
-                    parent_uri = "/".join(root_uri.rsplit("/", 1)[:-1])
+                    parent_uri = "/".join(root_uri.rstrip("/").rsplit("/", 1)[:-1])
                     if parent_uri:
                         await viking_fs.mkdir(parent_uri, exist_ok=True, ctx=ctx)
 
                     async with LockContext(lock_manager, [parent_path], lock_mode="point"):
                         if candidate_uri:
-                            root_uri = await self.tree_builder._resolve_unique_uri(candidate_uri)
+                            with viking_fs.bind_request_context(ctx):
+                                root_uri = await self.tree_builder._resolve_unique_uri(
+                                    candidate_uri
+                                )
                             result["root_uri"] = root_uri
                             dst_path = viking_fs._uri_to_path(root_uri, ctx=ctx)
 


### PR DESCRIPTION
## Description

Fix two bugs in `resource_processor.py` Phase 3.5 that caused `mv` to fail with "file exists" when adding resources, plus a minor ctx propagation fix in `embedding_utils.py`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- **Trailing slash in `to` URI**: When `to` parameter ends with `/`, `parent_uri` was incorrectly computed as the target directory itself (instead of its parent). `mkdir` then pre-created the exact path that `mv` was about to rename into, causing 100% failure. Fixed by stripping trailing slash before `rsplit`.
- **Missing request context in `_resolve_unique_uri`**: The Phase 3.5 call to `_resolve_unique_uri` ran outside `bind_request_context`, so `stat` checked the default account (`/local/default/`) instead of the actual account (e.g., `/local/coral/`). On repeated adds of the same resource name, it failed to detect the existing resource and returned the original URI, colliding with the existing path. Fixed by wrapping in `bind_request_context(ctx)`.
- **`embedding_utils.py`**: `index_resource` had `ctx` available but didn't pass it to `viking_fs.exists()` and `viking_fs.read_file()` calls for `.abstract.md` / `.overview.md`.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

**Reproduction (Bug 1 - trailing slash):** Call `add_resource` with `to="viking://resources/foo/"` — first add fails immediately.

**Reproduction (Bug 2 - missing context):** On a non-default account, run `ov add-resource file.md` twice — second add fails with "file exists".
