### PR TITLE
docs(process_lock): clarify Windows error handling for _is_pid_alive

### DIFF
--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -43,10 +43,13 @@ def _is_pid_alive(pid: int) -> bool:
         # Process exists but we can't signal it.
         return True
     except OSError:
-        # On Windows, os.kill(pid, 0) raises OSError (WinError 87 "The
-        # parameter is incorrect") for stale or invalid PIDs instead of
-        # ProcessLookupError.  Treat this as "not alive" so stale lock
-        # files are correctly reclaimed.
+        # On Windows, os.kill(pid, 0) raises OSError for stale or invalid
+        # PIDs instead of ProcessLookupError. Common errors include:
+        # - WinError 87 "The parameter is incorrect"
+        # - WinError 11 "An attempt was made to load a program with an
+        #   incorrect format"
+        # Treat any OSError as "not alive" so stale lock files are
+        # correctly reclaimed on Windows.
         return False
 
 


### PR DESCRIPTION
## Summary
Update the comment in `_is_pid_alive()` to document additional Windows error codes that can be raised by `os.kill(pid, 0)` for stale or invalid PIDs. The previous comment only mentioned WinError 87, but users have reported WinError 11 (ERROR_BAD_FORMAT) as well in issue #842.

## Changes
- Expand the comment to document multiple Windows error codes:
  - WinError 87 "The parameter is incorrect"
  - WinError 11 "An attempt was made to load a program with an incorrect format"
- Clarify that any OSError should be treated as "not alive"

## Why
This documentation improvement helps future maintainers understand why the broad OSError catch is necessary and prevents confusion when different Windows error codes are encountered.

## Related Issue
Related to #842