### PR TITLE
feat: make file vectorization strategy configurable

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -220,9 +220,8 @@ async def vectorize_file(
     Vectorize a single file.
 
     Creates Context object for the file and enqueues it.
-    If use_summary=True and summary is available, uses summary for TEXT files (e.g. code scenario).
-    Otherwise reads raw file content for TEXT files, but now respects embedding strategy config
-    to avoid oversize embedding failures on long text files.
+    The effective vectorization strategy is resolved once from either the explicit
+    `use_summary` flag (code path override) or the embedding config.
     """
     enqueued = False
 
@@ -252,13 +251,14 @@ async def vectorize_file(
 
         content_type = get_resource_content_type(file_name)
         embedding_cfg = get_openviking_config().embedding
-        text_source = getattr(embedding_cfg, "text_source", "summary_first")
-        max_text_chars = int(getattr(embedding_cfg, "max_text_chars", 1000) or 1000)
+        configured_text_source = getattr(embedding_cfg, "text_source", "summary_first")
+        effective_text_source = "summary_only" if use_summary else configured_text_source
+        max_input_chars = int(getattr(embedding_cfg, "max_input_chars", 1000) or 1000)
 
         def _truncate_text(value: str) -> str:
-            if len(value) <= max_text_chars:
+            if len(value) <= max_input_chars:
                 return value
-            return value[:max_text_chars] + "\n...(truncated for embedding)"
+            return value[:max_input_chars] + "\n...(truncated for embedding)"
 
         if content_type is None:
             # Unsupported file type: fall back to summary if available
@@ -273,13 +273,10 @@ async def vectorize_file(
                 )
                 return
         elif content_type == ResourceContentType.TEXT:
-            if use_summary and summary:
-                # Explicit code scenario override: use pre-generated summary for embedding
-                context.set_vectorize(Vectorize(text=summary))
-            elif summary and text_source in {"summary_first", "summary_only"}:
+            if summary and effective_text_source in {"summary_first", "summary_only"}:
                 context.set_vectorize(Vectorize(text=summary))
             else:
-                # Default: read raw file content, but apply configured truncation guard
+                # Read raw file content and apply configured truncation guard.
                 try:
                     content = await viking_fs.read_file(file_path, ctx=ctx)
                     if isinstance(content, bytes):

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -224,7 +224,7 @@ class EmbeddingConfig(BaseModel):
         default="summary_first",
         description="Text source for file vectorization: summary_first|summary_only|content_only",
     )
-    max_text_chars: int = Field(
+    max_input_chars: int = Field(
         default=1000,
         ge=100,
         description="Maximum characters sent to embeddings when raw text fallback is used",

--- a/tests/unit/test_embedding_vectorize_strategy.py
+++ b/tests/unit/test_embedding_vectorize_strategy.py
@@ -31,11 +31,11 @@ def test_embedding_text_source_validation_rejects_invalid_values(bad_value):
         _cfg(text_source=bad_value)
 
 
-def test_embedding_max_text_chars_validation_accepts_reasonable_value():
-    cfg = _cfg(max_text_chars=1000)
-    assert cfg.max_text_chars == 1000
+def test_embedding_max_input_chars_validation_accepts_reasonable_value():
+    cfg = _cfg(max_input_chars=1000)
+    assert cfg.max_input_chars == 1000
 
 
-def test_embedding_max_text_chars_validation_rejects_too_small_value():
+def test_embedding_max_input_chars_validation_rejects_too_small_value():
     with pytest.raises(ValueError):
-        _cfg(max_text_chars=10)
+        _cfg(max_input_chars=10)

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -57,7 +57,7 @@ async def test_vectorize_file_uses_summary_first(monkeypatch):
         embedding_utils,
         "get_openviking_config",
         lambda: types.SimpleNamespace(
-            embedding=types.SimpleNamespace(text_source="summary_first", max_text_chars=1000)
+            embedding=types.SimpleNamespace(text_source="summary_first", max_input_chars=1000)
         ),
     )
     monkeypatch.setattr(
@@ -87,7 +87,7 @@ async def test_vectorize_file_truncates_content_when_content_only(monkeypatch):
         embedding_utils,
         "get_openviking_config",
         lambda: types.SimpleNamespace(
-            embedding=types.SimpleNamespace(text_source="content_only", max_text_chars=1000)
+            embedding=types.SimpleNamespace(text_source="content_only", max_input_chars=1000)
         ),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Refs #857.

This PR makes text file vectorization strategy configurable to reduce embedding oversize failures on long text inputs.

### What changed

- add `embedding.text_source` with supported values:
  - `summary_first`
  - `summary_only`
  - `content_only`
- add `embedding.max_text_chars` to cap raw text sent to embeddings
- update `vectorize_file()` to respect the new config
- add minimal validation/unit tests for config and strategy behavior

## Why

Current upstream behavior still defaults to full-text embedding for text files. In real deployments using OpenAI-compatible embedding backends, this can trigger repeated oversize failures like `input (...) is too large to process`, reducing indexing completeness and operational stability.

Making this configurable gives operators a safer, backward-compatible way to balance:

- stability
- indexing completeness
- retrieval quality

## Notes

- This PR intentionally keeps the scope small.
- It does **not** introduce more complex chunking logic yet.
- It focuses on configurable text source selection plus max raw-text length control.

## Validation

- source files and tests pass `py_compile`
- targeted runtime-style validation in the current environment was limited by missing test dependencies for the upstream repo checkout, so this PR includes focused unit tests for the new config/strategy paths
