### PR TITLE
feat(server): add trusted auth mode for tenant headers

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -72,7 +72,7 @@ def create_app(
         set_service(service)
 
         # Initialize APIKeyManager after service (needs VikingFS)
-        if config.root_api_key:
+        if config.auth_mode == "api_key" and config.root_api_key:
             api_key_manager = APIKeyManager(
                 root_key=config.root_api_key,
                 viking_fs=service.viking_fs,
@@ -82,6 +82,13 @@ def create_app(
             app.state.api_key_manager = api_key_manager
             logger.info(
                 "APIKeyManager initialized with encryption_enabled=%s", config.encryption_enabled
+            )
+        elif config.auth_mode == "trusted":
+            app.state.api_key_manager = None
+            logger.warning(
+                "Trusted mode enabled: authentication uses X-OpenViking-Account/User/Agent "
+                "headers without API keys. Only expose this server behind a trusted "
+                "network boundary or identity-injecting gateway."
             )
         else:
             app.state.api_key_manager = None

--- a/openviking/server/auth.py
+++ b/openviking/server/auth.py
@@ -25,6 +25,11 @@ _ROOT_IMPLICIT_TENANT_ALLOWED_PREFIXES = (
 )
 
 
+def _auth_mode(request: Request) -> str:
+    config = getattr(request.app.state, "config", None)
+    return getattr(config, "auth_mode", "api_key")
+
+
 def _root_request_requires_explicit_tenant(path: str) -> bool:
     """Return True when a ROOT request targets tenant-scoped data APIs.
 
@@ -50,10 +55,24 @@ async def resolve_identity(
     """Resolve API key to identity.
 
     Strategy:
-    - If api_key_manager is None (dev mode): return ROOT with default identity
-    - Otherwise: resolve via APIKeyManager (root key first, then user key index)
+    - trusted mode: trust explicit account/user headers and return USER identity
+    - api_key mode without manager: dev mode, return implicit ROOT/default identity
+    - api_key mode with manager: resolve via APIKeyManager (root key first, then user key index)
     """
+    auth_mode = _auth_mode(request)
     api_key_manager = getattr(request.app.state, "api_key_manager", None)
+
+    if auth_mode == "trusted":
+        if not x_openviking_account or not x_openviking_user:
+            raise InvalidArgumentError(
+                "Trusted mode requests must include X-OpenViking-Account and X-OpenViking-User."
+            )
+        return ResolvedIdentity(
+            role=Role.USER,
+            account_id=x_openviking_account,
+            user_id=x_openviking_user,
+            agent_id=x_openviking_agent or "default",
+        )
 
     if api_key_manager is None:
         return ResolvedIdentity(
@@ -86,9 +105,11 @@ async def get_request_context(
 ) -> RequestContext:
     """Convert ResolvedIdentity to RequestContext."""
     path = request.url.path
+    auth_mode = _auth_mode(request)
     api_key_manager = getattr(request.app.state, "api_key_manager", None)
     if (
-        api_key_manager is not None
+        auth_mode == "api_key"
+        and api_key_manager is not None
         and identity.role == Role.ROOT
         and _root_request_requires_explicit_tenant(path)
     ):
@@ -99,6 +120,11 @@ async def get_request_context(
                 "ROOT requests to tenant-scoped APIs must include X-OpenViking-Account "
                 "and X-OpenViking-User headers. Use a user key for regular data access."
             )
+
+    if auth_mode == "trusted" and not identity.account_id:
+        raise InvalidArgumentError("Trusted mode requests must include X-OpenViking-Account.")
+    if auth_mode == "trusted" and not identity.user_id:
+        raise InvalidArgumentError("Trusted mode requests must include X-OpenViking-User.")
 
     return RequestContext(
         user=UserIdentifier(

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -42,6 +42,7 @@ class ServerConfig:
     host: str = "127.0.0.1"
     port: int = 1933
     workers: int = 1
+    auth_mode: str = "api_key"
     root_api_key: Optional[str] = None
     cors_origins: List[str] = field(default_factory=lambda: ["*"])
     with_bot: bool = False  # Enable Bot API proxy to Vikingbot
@@ -93,6 +94,7 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
         host=server_data.get("host", "127.0.0.1"),
         port=server_data.get("port", 1933),
         workers=server_data.get("workers", 1),
+        auth_mode=server_data.get("auth_mode", "api_key"),
         root_api_key=server_data.get("root_api_key"),
         cors_origins=server_data.get("cors_origins", ["*"]),
         encryption_enabled=encryption_enabled,
@@ -117,14 +119,30 @@ def _is_localhost(host: str) -> bool:
 def validate_server_config(config: ServerConfig) -> None:
     """Validate server config for safe startup.
 
-    When ``root_api_key`` is not set, authentication is disabled (dev mode).
-    This is only acceptable when the server binds to localhost.  Binding to a
-    non-loopback address without authentication exposes an unauthenticated ROOT
-    endpoint to the network.
+    In ``api_key`` mode, when ``root_api_key`` is not set, authentication is
+    disabled (dev mode). This is only acceptable when the server binds to
+    localhost. Binding to a non-loopback address without authentication
+    exposes an unauthenticated ROOT endpoint to the network.
 
     Raises:
         SystemExit: If the configuration is unsafe.
     """
+    if config.auth_mode not in {"api_key", "trusted"}:
+        logger.error(
+            "Invalid server.auth_mode=%r. Expected one of: 'api_key', 'trusted'.",
+            config.auth_mode,
+        )
+        sys.exit(1)
+
+    if config.auth_mode == "trusted":
+        if not _is_localhost(config.host):
+            logger.warning(
+                "SECURITY: server.auth_mode='trusted' on non-localhost host '%s'. "
+                "Only use this behind a trusted network boundary or identity-injecting gateway.",
+                config.host,
+            )
+        return
+
     if config.root_api_key:
         return
 

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -35,12 +35,14 @@ def _make_request(
     path: str,
     headers: dict[str, str] | None = None,
     auth_enabled: bool = True,
+    auth_mode: str = "api_key",
 ) -> Request:
     """Create a minimal Starlette request for auth dependency tests."""
     raw_headers = []
     for key, value in (headers or {}).items():
         raw_headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
     app = FastAPI()
+    app.state.config = ServerConfig(auth_mode=auth_mode)
     if auth_enabled:
         # Non-empty api_key_manager means the server is in authenticated mode.
         app.state.api_key_manager = object()
@@ -54,8 +56,9 @@ def _make_request(
 
 
 def _build_auth_http_test_app(
-    identity: ResolvedIdentity,
+    identity: ResolvedIdentity | None,
     auth_enabled: bool = True,
+    auth_mode: str = "api_key",
 ) -> FastAPI:
     """Create a lightweight app that exercises auth dependency wiring.
 
@@ -63,6 +66,7 @@ def _build_auth_http_test_app(
     the test focused on request auth behavior and the structured HTTP error body.
     """
     app = FastAPI()
+    app.state.config = ServerConfig(auth_mode=auth_mode)
     if auth_enabled:
         # Match production auth mode so get_request_context enters the guard path.
         app.state.api_key_manager = object()
@@ -87,7 +91,8 @@ def _build_auth_http_test_app(
         """Return a fixed identity so tests can isolate request header behavior."""
         return identity
 
-    app.dependency_overrides[resolve_identity] = _resolve_identity_override
+    if identity is not None:
+        app.dependency_overrides[resolve_identity] = _resolve_identity_override
 
     @app.get("/api/v1/fs/ls")
     async def fs_ls(ctx=Depends(get_request_context)):
@@ -480,6 +485,71 @@ async def test_dev_mode_root_tenant_scoped_requests_keep_200_via_http():
     assert response.json()["status"] == "ok"
 
 
+async def test_trusted_mode_allows_header_identity_without_api_key():
+    """Trusted mode should accept explicit tenant headers without API key."""
+    request = _make_request(
+        "/api/v1/resources",
+        headers={
+            "X-OpenViking-Account": "acme",
+            "X-OpenViking-User": "alice",
+            "X-OpenViking-Agent": "assistant-1",
+        },
+        auth_enabled=False,
+        auth_mode="trusted",
+    )
+
+    identity = await resolve_identity(
+        request,
+        x_openviking_account="acme",
+        x_openviking_user="alice",
+        x_openviking_agent="assistant-1",
+    )
+
+    assert identity.role == Role.USER
+    assert identity.account_id == "acme"
+    assert identity.user_id == "alice"
+    assert identity.agent_id == "assistant-1"
+
+
+async def test_trusted_mode_tenant_http_routes_require_explicit_identity_headers():
+    """Trusted mode should reject tenant-scoped routes without account/user headers."""
+    app = _build_auth_http_test_app(
+        identity=None,
+        auth_enabled=False,
+        auth_mode="trusted",
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/api/v1/fs/ls")
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+async def test_trusted_mode_tenant_http_routes_accept_explicit_identity_headers():
+    """Trusted mode should allow tenant-scoped routes with account/user headers."""
+    app = _build_auth_http_test_app(
+        identity=None,
+        auth_enabled=False,
+        auth_mode="trusted",
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(
+            "/api/v1/fs/ls",
+            headers={
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "alice",
+                "X-OpenViking-Agent": "assistant-1",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["result"] == {"account_id": "acme", "user_id": "alice"}
+
+
 # ---- _is_localhost tests ----
 
 
@@ -515,3 +585,9 @@ def test_validate_with_key_any_host_passes():
     for host in ("0.0.0.0", "::", "192.168.1.1", "127.0.0.1"):
         config = ServerConfig(host=host, root_api_key="some-secret-key")
         validate_server_config(config)  # should not raise
+
+
+def test_validate_trusted_mode_without_key_non_localhost_passes():
+    """Trusted mode should bypass the localhost-only dev-mode restriction."""
+    config = ServerConfig(host="0.0.0.0", root_api_key=None, auth_mode="trusted")
+    validate_server_config(config)


### PR DESCRIPTION
  # Trusted 模式多租户访问设计方案

  ## Summary

  新增一个独立于现有 dev 模式和 api_key 模式的 trusted 认证模式，用于“受信任网络中的无 key 多
  租户访问”。在该模式下，服务端不要求 X-API-Key，而是要求请求显式携带 X-OpenViking-Account、
  X-OpenViking-User，并可选携带 X-OpenViking-Agent。服务端直接基于这些请求头构造
  RequestContext，从而复用现有的数据隔离、文件系统路径隔离、VectorDB tenant filter 和
  session/resource/search 等业务链路。

  v1 明确不做 account/user 自动创建，不写 accounts.json、users.json，也不让 trusted 模式承担
  Admin 管理面职责。这样可以避免引入创建竞态、分布式一致性、缓存失效和注册表膨胀问题，同时满
  足“无需显式创建 account/user，也无需传 api key”的核心目标。

  ## Key Changes

  ### 1. 认证模式与配置

  - 在 server 配置中新增认证模式字段，替代当前“通过是否配置 root_api_key 推断模式”的单一路
    径。
  - 建议新增：
      - server.auth_mode: "api_key" | "trusted"
  - 模式语义：
      - api_key：保持现有行为不变
      - trusted：不要求 X-API-Key，改为信任 X-OpenViking-* 身份头
  - root_api_key 仅在 api_key 模式下生效；trusted 模式下可忽略或禁止同时配置，避免语义混乱。
  - 启动校验中新增 trusted 模式专属提示：
      - 明确声明这是“受信任网络模式”，不是公网匿名模式
      - 若绑定到非 localhost 地址，不报“未配置 root_api_key 的 dev 模式错误”，但输出高风险告
        警日志

  ### 2. 身份解析与 RequestContext

  - 修改 openviking/server/auth.py 的身份解析流程：
      - 按 auth_mode 分支解析身份
      - trusted 模式下：
          - 强制要求 X-OpenViking-Account
          - 强制要求 X-OpenViking-User
          - X-OpenViking-Agent 可选，默认 "default"
          - 缺失 account/user 时，对 tenant-scoped API 直接返回参数错误
  - trusted 模式下构造的身份：
      - role = USER
      - account_id = X-OpenViking-Account
      - user_id = X-OpenViking-User
      - agent_id = X-OpenViking-Agent or "default"
  - 禁止任何隐式回退到 default/default
  - 保持 RequestContext(UserIdentifier(account_id, user_id, agent_id), role) 结构不变，确保后
    续链路无需改动

  ### 3. 数据面行为

  - 不修改 VikingFS、VectorDB、Session、Resource、Search 的 tenant 行为
  - 依赖现有 RequestContext 继续完成：
      - AGFS 路径映射到对应 account/user/agent 作用域
      - VectorDB 基于 ctx.account_id、owner_space 做过滤
      - session / resource / search / fs / relations / pack 等接口按现有多租户逻辑工作
  - 因为 trusted 模式下不自动创建注册表实体，所以“数据面可用”与“控制面登记”解耦
  - 首次访问某个新 account/user 时，只要业务链路本身支持按路径懒创建目录，就允许直接使用；不
    要求存在于 accounts.json/users.json

  ### 4. Admin 与权限边界

  - trusted 模式默认只面向数据面，不承担控制面
  - 默认角色固定为 USER
  - 因此：
      - 普通接口可访问：fs、search/find、resources、sessions、relations、pack、content 等依赖
        get_request_context 的接口
      - 管理接口不可访问：/api/v1/admin/**
  - admin 路由现有 require_role(Role.ROOT / ADMIN) 逻辑保持不变
  - 文档中明确声明：
      - trusted 模式适合“由调用方或网关提供租户身份”的访问场景
      - 若需要账号列表、用户列表、角色管理、发 key、删账号等控制面能力，仍应使用现有 api_key
        模式

  ### 5. 客户端与 HTTP 约定

  - 复用现有请求头，不新增 wire format：
      - X-OpenViking-Account
      - X-OpenViking-User
      - X-OpenViking-Agent
  - CLI/ovcli.conf 暂不纳入本次设计范围；v1 先保证 direct HTTP / SDK 可用
  - 文档中给出典型 curl 示例：
      - add-resource
      - find
      - sessions -> messages -> commit
  - 若后续要支持 CLI，可作为单独后续计划，新增：
      - ovcli.conf.account_id
      - ovcli.conf.user_id
      - client.rs 自动发送 X-OpenViking-Account/User

  ## Test Plan

  ### 配置与启动

  - auth_mode=api_key 时，现有行为完全不变
  - auth_mode=trusted 时，服务启动成功且不要求 root_api_key
  - trusted 模式绑定非 localhost 地址时，打印明确风险警告
  - 非法 auth_mode 配置启动失败

  ### 身份解析

  - trusted 模式下，带 X-OpenViking-Account/User 且不带 X-API-Key 的请求成功
  - 缺失 X-OpenViking-Account 请求失败
  - 缺失 X-OpenViking-User 请求失败
  - 缺失 X-OpenViking-Agent 时，agent_id 默认为 "default"
  - trusted 模式下不会回退到 default/default

  ### 数据面接口

  - POST /api/v1/resources 在 trusted 模式下可正常写入租户资源
  - POST /api/v1/search/find 只能检索到对应 account/user 可见的数据
  - POST /api/v1/sessions、/messages、/commit 可正常工作
  - 不同 account/user 头之间保持隔离
  - 同一 account 不同 user 下的 user/agent/session scope 保持隔离
  - resources 共享范围行为与现有 tenant filter 保持一致

  ### 权限边界

  - 失败码与错误信息清晰表明“当前模式/角色无权访问管理接口”
  ### 回归验证

  - 现有 api_key 多租户测试全部保持通过

  ## Assumptions and Defaults

  - trusted 模式用于受信任内网、服务网格、反向代理后或受控调用方，不面向公网匿名调用
  - v1 不做 Auto-provision
  - v1 不写 accounts.json/users.json
  - v1 默认角色固定为 USER
  - v1 不支持通过 trusted 模式访问 Admin 控制面
  - v1 只复用现有 X-OpenViking-* 头，不引入可配置上游头名映射