### PR TITLE
fix: use _max_concurrent_semantic for Semantic queue worker instead of hardcoded 1

### DIFF
--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -150,7 +150,11 @@ class QueueManager:
             if thread.is_alive():
                 return
 
-        max_concurrent = self._max_concurrent_embedding if queue.name == self.EMBEDDING else 1
+        max_concurrent = (
+            self._max_concurrent_embedding
+            if queue.name == self.EMBEDDING
+            else self._max_concurrent_semantic
+        )
         stop_event = threading.Event()
         self._queue_stop_events[queue.name] = stop_event
         thread = threading.Thread(


### PR DESCRIPTION
## Summary

Fixes #873

The  variable was stored in `QueueManager.__init__` but never used in `_start_queue_worker`. The Semantic queue worker always ran with `max_concurrent=1`, ignoring the configured `vlm.max_concurrent` value for queue-level task concurrency.

## Change

**Before:**
```python
max_concurrent = self._max_concurrent_embedding if queue.name == self.EMBEDDING else 1
```

**After:**
```python
max_concurrent = self._max_concurrent_embedding if queue.name == self.EMBEDDING else self._max_concurrent_semantic
```

## Impact

- Semantic queue now respects the `max_concurrent_semantic` parameter (default: 100)
- Users can configure Semantic queue concurrency through `ov.conf` via `vlm.max_concurrent`
- Enables parallel processing of multiple pending Semantic tasks