### PR TITLE
fix: prevent Zip Slip path traversal in ZIP extraction

### DIFF
--- a/openviking/utils/media_processor.py
+++ b/openviking/utils/media_processor.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Optional
 
 from openviking.parse import DocumentConverter, parse
 from openviking.parse.base import ParseResult
+from openviking.utils.zip_safe import safe_extract_zip
 from openviking_cli.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -152,7 +153,7 @@ class UnifiedResourceProcessor:
             temp_dir = Path(tempfile.mkdtemp())
             try:
                 with zipfile.ZipFile(file_path, "r") as zipf:
-                    zipf.extractall(temp_dir)
+                    safe_extract_zip(zipf, temp_dir)
                 return await self._process_directory(temp_dir, instruction, **kwargs)
             finally:
                 pass  # Don't delete temp_dir yet, it will be used by TreeBuilder

--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -19,6 +19,7 @@ from openviking.server.identity import RequestContext
 from openviking.storage import VikingDBManager
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking.storage.viking_fs import VikingFS
+from openviking.utils.zip_safe import safe_extract_zip
 from openviking.telemetry import get_current_telemetry
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
@@ -149,7 +150,7 @@ class SkillProcessor:
                 if zipfile.is_zipfile(path_obj):
                     temp_dir = Path(tempfile.mkdtemp())
                     with zipfile.ZipFile(path_obj, "r") as zipf:
-                        zipf.extractall(temp_dir)
+                        safe_extract_zip(zipf, temp_dir)
                     data = temp_dir
                 else:
                     data = path_obj

--- a/openviking/utils/zip_safe.py
+++ b/openviking/utils/zip_safe.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Safe ZIP extraction with Zip Slip protection."""
+
+import os
+import zipfile
+from pathlib import Path
+
+
+def safe_extract_zip(zipf: zipfile.ZipFile, dest_dir: Path) -> None:
+    """Extract ZIP archive with Zip Slip protection.
+
+    Validates every member path stays within dest_dir before extraction.
+    Rejects absolute paths and parent-directory traversal (..).
+    """
+    dest_dir = Path(dest_dir).resolve()
+    for member in zipf.infolist():
+        member_path = (dest_dir / member.filename).resolve()
+        # Ensure the resolved path is inside dest_dir
+        if not str(member_path).startswith(str(dest_dir) + os.sep):
+            raise ValueError(f"Zip Slip attempt detected: {member.filename}")
+        zipf.extract(member, dest_dir)


### PR DESCRIPTION
## Summary

Replaces unsafe `zipf.extractall()` calls with a validated extraction helper `safe_extract_zip()` that checks each archive member's resolved path stays within the target directory before writing.

## Changes

- **New file**: `openviking/utils/zip_safe.py` — shared `safe_extract_zip()` helper that validates per-member paths
- **Modified**: `openviking/utils/skill_processor.py` — replaced `extractall()` with `safe_extract_zip()`
- **Modified**: `openviking/utils/media_processor.py` — replaced `extractall()` with `safe_extract_zip()`

## Security

This prevents **Zip Slip** (path traversal) attacks where a malicious ZIP archive contains entries with `../` or absolute paths to write files outside the intended extraction directory.

Fixes #878
Fixes #866