### PR TITLE
fix: clamp inf/nan similarity scores at source to prevent JSON crash

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -295,7 +295,10 @@ class HierarchicalRetriever:
         global_results = [r for r in global_results if r.get("level", 2) != 2]
 
         # Results from global search
-        default_scores = [r.get("_score", 0.0) for r in global_results]
+        default_scores = [
+            s if math.isfinite(s) else 0.0
+            for s in (r.get("_score", 0.0) for r in global_results)
+        ]
         if self._rerank_client and mode == RetrieverMode.THINKING:
             docs = [str(r.get("abstract", "")) for r in global_results]
             query_scores = self._rerank_scores(query, docs, default_scores)
@@ -330,7 +333,10 @@ class HierarchicalRetriever:
         if not initial_candidates:
             return []
 
-        default_scores = [r.get("_score", 0.0) for r in initial_candidates]
+        default_scores = [
+            s if math.isfinite(s) else 0.0
+            for s in (r.get("_score", 0.0) for r in initial_candidates)
+        ]
         if self._rerank_client and mode == RetrieverMode.THINKING:
             docs = [str(r.get("abstract", "")) for r in initial_candidates]
             query_scores = self._rerank_scores(query, docs, default_scores)
@@ -431,7 +437,10 @@ class HierarchicalRetriever:
             if not results:
                 continue
 
-            query_scores = [r.get("_score", 0.0) for r in results]
+            query_scores = [
+                s if math.isfinite(s) else 0.0
+                for s in (r.get("_score", 0.0) for r in results)
+            ]
             if self._rerank_client and mode == RetrieverMode.THINKING:
                 documents = [str(r.get("abstract", "")) for r in results]
                 query_scores = self._rerank_scores(query, documents, query_scores)

--- a/openviking/storage/vectordb_adapters/base.py
+++ b/openviking/storage/vectordb_adapters/base.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import math
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, Optional
@@ -458,7 +459,10 @@ class CollectionAdapter(ABC):
         for item in result.data:
             record = dict(item.fields) if item.fields else {}
             record["id"] = item.id
-            record["_score"] = item.score if item.score is not None else 0.0
+            raw_score = item.score if item.score is not None else 0.0
+            if not math.isfinite(raw_score):
+                raw_score = 0.0
+            record["_score"] = raw_score
             record = self._normalize_record_for_read(record)
             records.append(record)
         return records


### PR DESCRIPTION
## Problem

Closes #871

The C++ vector engine (`bruteforce.h`) can produce `inf` float values when computing inner product similarity on non-normalized vectors (`distance_type=ip` with `NormalizeVector=False`). The raw dot product of high-dimensional vectors with large component values overflows `float32` to `+inf`.

These `inf` scores propagate through the Python adapter and retriever layers untouched, until JSON serialization fails:

```
ValueError: Out of range float values are not JSON compliant: inf
```

This crashes the entire server process, requiring a manual restart.

## Root Cause

1. **`CollectionAdapter.query()`** reads `item.score` from the C++ engine result and assigns it directly to `record["_score"]` — no finite check
2. **`HierarchicalRetriever._recursive_search()`** reads `_score` and applies score propagation: `alpha * inf + (1 - alpha) * current_score = inf` — amplifying the problem
3. The existing `isfinite` guard in `_convert_to_matched_contexts()` catches scores only at the final conversion step — too late, because `inf` already reaches JSON serialization in intermediate API responses

## Fix

Clamp non-finite scores to `0.0` at the two layers where they enter the Python pipeline:

**Layer 1 — `openviking/storage/vectordb_adapters/base.py`**
- `CollectionAdapter.query()`: check `math.isfinite()` immediately after reading from engine result, before the score enters any JSON-serializable record

**Layer 2 — `openviking/retrieve/hierarchical_retriever.py`**
- Clamp `_score` at all three entry points where scores are read from search results:
  - `_merge_starting_points()` — global search scores
  - `_prepare_initial_candidates()` — initial candidate scores
  - `_recursive_search()` — per-directory search scores

This ensures `inf` values never propagate into score arithmetic or JSON responses.

## Why not PR #880?

PR #880 applies `SafeJSONResponse` only to error handlers. This prevents the server crash, but the search endpoint still returns an HTTP 500 error instead of results — the user gets nothing. This PR fixes the actual scores so search returns correct results.

## Changes

- `openviking/storage/vectordb_adapters/base.py` — 1 import, 3 lines changed
- `openviking/retrieve/hierarchical_retriever.py` — 9 lines changed (3 locations)