### PR TITLE
fix(config): validate ov.conf and ovcli.conf strictly

### DIFF
--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -112,8 +112,15 @@ def main():
     if args.config is not None:
         os.environ["OPENVIKING_CONFIG_FILE"] = args.config
 
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
     # Load server config from ov.conf
-    config = load_server_config(args.config)
+    try:
+        config = load_server_config(args.config)
+        OpenVikingConfigSingleton.initialize(config_path=args.config)
+    except (FileNotFoundError, ValueError) as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
     # Override with command line arguments
     if args.host is not None:

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -3,14 +3,16 @@
 """Server configuration for OpenViking HTTP Server."""
 
 import sys
-from dataclasses import dataclass, field
 from typing import List, Optional
+
+from pydantic import BaseModel, Field, ValidationError
 
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config.config_loader import (
     load_json_config,
     resolve_config_path,
 )
+from openviking_cli.utils.config.config_utils import format_validation_error
 from openviking_cli.utils.config.consts import (
     DEFAULT_CONFIG_DIR,
     DEFAULT_OV_CONF,
@@ -21,22 +23,23 @@ from openviking_cli.utils.config.consts import (
 logger = get_logger(__name__)
 
 
-@dataclass
-class PrometheusConfig:
+class PrometheusConfig(BaseModel):
     """Prometheus exporter configuration."""
 
     enabled: bool = False
 
+    model_config = {"extra": "forbid"}
 
-@dataclass
-class TelemetryConfig:
+
+class TelemetryConfig(BaseModel):
     """Telemetry configuration."""
 
-    prometheus: PrometheusConfig = field(default_factory=PrometheusConfig)
+    prometheus: PrometheusConfig = Field(default_factory=PrometheusConfig)
+
+    model_config = {"extra": "forbid"}
 
 
-@dataclass
-class ServerConfig:
+class ServerConfig(BaseModel):
     """Server configuration (from the ``server`` section of ov.conf)."""
 
     host: str = "127.0.0.1"
@@ -44,11 +47,13 @@ class ServerConfig:
     workers: int = 1
     auth_mode: str = "api_key"
     root_api_key: Optional[str] = None
-    cors_origins: List[str] = field(default_factory=lambda: ["*"])
+    cors_origins: List[str] = Field(default_factory=lambda: ["*"])
     with_bot: bool = False  # Enable Bot API proxy to Vikingbot
     bot_api_url: str = "http://localhost:18790"  # Vikingbot OpenAPIChannel URL (default port)
     encryption_enabled: bool = False  # Whether API key hashing is enabled
-    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
+    telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
+
+    model_config = {"extra": "forbid"}
 
 
 def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
@@ -84,28 +89,23 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
 
     data = load_json_config(path)
     server_data = data.get("server", {})
-    telemetry_data = server_data.get("telemetry", {}) or {}
-    prometheus_data = telemetry_data.get("prometheus", {}) or {}
+    if server_data is None:
+        server_data = {}
+    if not isinstance(server_data, dict):
+        raise ValueError("Invalid server config: 'server' section must be an object")
 
     # Get encryption enabled from config data directly (for test compatibility)
     encryption_enabled = data.get("encryption", {}).get("enabled", False)
 
-    config = ServerConfig(
-        host=server_data.get("host", "127.0.0.1"),
-        port=server_data.get("port", 1933),
-        workers=server_data.get("workers", 1),
-        auth_mode=server_data.get("auth_mode", "api_key"),
-        root_api_key=server_data.get("root_api_key"),
-        cors_origins=server_data.get("cors_origins", ["*"]),
-        encryption_enabled=encryption_enabled,
-        telemetry=TelemetryConfig(
-            prometheus=PrometheusConfig(
-                enabled=prometheus_data.get("enabled", False),
-            )
-        ),
-    )
+    try:
+        config = ServerConfig.model_validate(server_data)
+    except ValidationError as e:
+        raise ValueError(
+            f"Invalid server config in {path}:\n"
+            f"{format_validation_error(root_model=ServerConfig, error=e, path_prefix='server')}"
+        ) from e
 
-    return config
+    return config.model_copy(update={"encryption_enabled": encryption_enabled})
 
 
 _LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -35,14 +35,7 @@ from openviking_cli.exceptions import (
 from openviking_cli.retrieve.types import FindResult
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import run_async
-from openviking_cli.utils.config.config_loader import (
-    load_json_config,
-    resolve_config_path,
-)
-from openviking_cli.utils.config.consts import (
-    DEFAULT_OVCLI_CONF,
-    OPENVIKING_CLI_CONFIG_ENV,
-)
+from openviking_cli.utils.config.ovcli_config import load_ovcli_config
 from openviking_cli.utils.uri import VikingURI
 
 # Error code to exception class mapping
@@ -151,20 +144,24 @@ class AsyncHTTPClient(BaseClient):
                   to access tenant-scoped APIs. If not provided, reads from ovcli.conf.
             timeout: HTTP request timeout in seconds. Default 60.0.
         """
-        if url is None:
-            # print(f"OPENVIKING_CLI_CONFIG_ENV={OPENVIKING_CLI_CONFIG_ENV}")
-            # print(f"DEFAULT_OVCLI_CONF={DEFAULT_OVCLI_CONF}")
-            config_path = resolve_config_path(None, OPENVIKING_CLI_CONFIG_ENV, DEFAULT_OVCLI_CONF)
-            if config_path:
-                cfg = load_json_config(config_path)
-
-                url = cfg.get("url")
-                api_key = api_key or cfg.get("api_key")
-                agent_id = agent_id or cfg.get("agent_id")
-                account = account or cfg.get("account")
-                user = user or cfg.get("user")
+        should_load_cli_config = (
+            url is None
+            or api_key is None
+            or agent_id is None
+            or account is None
+            or user is None
+            or timeout == 60.0
+        )
+        if should_load_cli_config:
+            cli_config = load_ovcli_config()
+            if cli_config is not None:
+                url = url or cli_config.url
+                api_key = api_key or cli_config.api_key
+                agent_id = agent_id or cli_config.agent_id
+                account = account or cli_config.account
+                user = user or cli_config.user
                 if timeout == 60.0:  # only override default with config value
-                    timeout = cfg.get("timeout", 60.0)
+                    timeout = cli_config.timeout
         if not url:
             raise ValueError(
                 "url is required. Pass it explicitly or configure in "

--- a/openviking_cli/utils/config/__init__.py
+++ b/openviking_cli/utils/config/__init__.py
@@ -24,6 +24,7 @@ from .open_viking_config import (
     is_valid_openviking_config,
     set_openviking_config,
 )
+from .ovcli_config import OVCLIConfig, load_ovcli_config
 from .parser_config import (
     PARSER_CONFIG_REGISTRY,
     AudioConfig,
@@ -54,6 +55,7 @@ __all__ = [
     "OPENVIKING_CONFIG_ENV",
     "OpenVikingConfig",
     "OpenVikingConfigSingleton",
+    "OVCLIConfig",
     "RerankConfig",
     "StorageConfig",
     "VectorDBBackendConfig",
@@ -73,6 +75,7 @@ __all__ = [
     "get_openviking_config",
     "initialize_openviking_config",
     "load_json_config",
+    "load_ovcli_config",
     "require_config",
     "resolve_config_path",
     "set_openviking_config",

--- a/openviking_cli/utils/config/config_utils.py
+++ b/openviking_cli/utils/config/config_utils.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for config validation and error formatting."""
+
+import difflib
+from typing import Any, Optional, get_args, get_origin
+
+from pydantic import BaseModel, ValidationError
+
+
+def suggest_closest_field(field_name: str, valid_fields: set[str]) -> Optional[str]:
+    """Return the closest matching field name when it is similar enough."""
+    close_matches = difflib.get_close_matches(field_name, sorted(valid_fields), n=1, cutoff=0.6)
+    if close_matches:
+        return close_matches[0]
+    return None
+
+
+def raise_unknown_config_fields(
+    *,
+    data: dict[str, Any],
+    valid_fields: set[str],
+    context_name: str,
+) -> None:
+    """Raise a user-friendly error for unexpected config fields."""
+    unknown_fields = [key for key in data if key not in valid_fields]
+    if not unknown_fields:
+        return
+
+    errors = []
+    for field_name in unknown_fields:
+        suggestion = suggest_closest_field(field_name, valid_fields)
+        if suggestion:
+            errors.append(
+                f"Unknown config field '{field_name}' in {context_name} "
+                f"(did you mean '{suggestion}'?)"
+            )
+        else:
+            errors.append(f"Unknown config field '{field_name}' in {context_name}")
+
+    raise ValueError("\n".join(errors))
+
+
+def _unwrap_model_type(annotation: Any) -> Optional[type[BaseModel]]:
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+
+    origin = get_origin(annotation)
+    if origin is None:
+        return None
+
+    for arg in get_args(annotation):
+        model_type = _unwrap_model_type(arg)
+        if model_type is not None:
+            return model_type
+    return None
+
+
+def _get_model_at_path(
+    root_model: type[BaseModel], path: tuple[Any, ...]
+) -> Optional[type[BaseModel]]:
+    current_model = root_model
+    for part in path:
+        field = current_model.model_fields.get(str(part))
+        if field is None:
+            return None
+        next_model = _unwrap_model_type(field.annotation)
+        if next_model is None:
+            return None
+        current_model = next_model
+    return current_model
+
+
+def format_validation_error(
+    *,
+    root_model: type[BaseModel],
+    error: ValidationError,
+    path_prefix: str = "",
+) -> str:
+    """Render a pydantic ValidationError as a concise config error message."""
+    formatted_errors = []
+
+    for item in error.errors():
+        loc = tuple(item.get("loc", ()))
+        path_parts = [path_prefix] if path_prefix else []
+        path_parts.extend(str(part) for part in loc)
+        path = ".".join(path_parts)
+        error_type = item.get("type", "")
+
+        if error_type == "extra_forbidden" and loc:
+            parent_model = _get_model_at_path(root_model, loc[:-1])
+            invalid_field = str(loc[-1])
+            message = f"Unknown config field '{path}'" if path else "Unknown config field"
+
+            if parent_model is not None:
+                suggestion = suggest_closest_field(
+                    invalid_field,
+                    set(parent_model.model_fields.keys()),
+                )
+                if suggestion:
+                    suggested_parts = [path_prefix] if path_prefix else []
+                    suggested_parts.extend(str(part) for part in loc[:-1])
+                    suggested_parts.append(suggestion)
+                    message += f" (did you mean '{'.'.join(suggested_parts)}'?)"
+
+            formatted_errors.append(message)
+            continue
+
+        if path:
+            formatted_errors.append(
+                f"Invalid value for '{path}': {item.get('msg', 'validation failed')}"
+            )
+        else:
+            formatted_errors.append(f"Invalid config value: {item.get('msg', 'validation failed')}")
+
+    return "\n".join(formatted_errors)

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -5,11 +5,12 @@ from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from openviking_cli.session.user_id import UserIdentifier
 
 from .config_loader import resolve_config_path
+from .config_utils import format_validation_error, raise_unknown_config_fields
 from .consts import (
     DEFAULT_CONFIG_DIR,
     DEFAULT_OV_CONF,
@@ -103,7 +104,8 @@ class OpenVikingConfig(BaseModel):
     )
 
     feishu: FeishuConfig = Field(
-        default_factory=lambda: FeishuConfig(), description="Feishu/Lark document parsing configuration"
+        default_factory=lambda: FeishuConfig(),
+        description="Feishu/Lark document parsing configuration",
     )
 
     semantic: SemanticConfig = Field(
@@ -147,49 +149,67 @@ class OpenVikingConfig(BaseModel):
     @classmethod
     def from_dict(cls, config: Dict[str, Any]) -> "OpenVikingConfig":
         """Create configuration from dictionary."""
-        # Make a copy to avoid modifying the original
-        config_copy = config.copy()
+        try:
+            # Make a copy to avoid modifying the original
+            config_copy = config.copy()
 
-        # Remove sections managed by other loaders (e.g. server config)
-        config_copy.pop("server", None)
-        config_copy.pop("bot", None)
+            parser_types = [
+                "pdf",
+                "code",
+                "image",
+                "audio",
+                "video",
+                "markdown",
+                "html",
+                "text",
+                "directory",
+                "feishu",
+            ]
+            raise_unknown_config_fields(
+                data=config_copy,
+                valid_fields=set(cls.model_fields.keys()) | {"server", "bot", "parsers"},
+                context_name="OpenVikingConfig",
+            )
 
-        # Handle parser configurations from nested "parsers" section
-        parser_configs = {}
-        if "parsers" in config_copy:
-            parser_configs = config_copy.pop("parsers")
-        parser_types = [
-            "pdf",
-            "code",
-            "image",
-            "audio",
-            "video",
-            "markdown",
-            "html",
-            "text",
-            "directory",
-            "feishu",
-        ]
-        for parser_type in parser_types:
-            if parser_type in config_copy:
-                parser_configs[parser_type] = config_copy.pop(parser_type)
-        # Handle log configuration from nested "log" section
-        log_config_data = None
-        if "log" in config_copy:
-            log_config_data = config_copy.pop("log")
+            # Remove sections managed by other loaders (e.g. server config)
+            config_copy.pop("server", None)
+            config_copy.pop("bot", None)
 
-        instance = cls(**config_copy)
-        # Apply log configuration
-        if log_config_data is not None:
-            instance.log = LogConfig.from_dict(log_config_data)
+            # Handle parser configurations from nested "parsers" section
+            parser_configs = {}
+            if "parsers" in config_copy:
+                parser_configs = config_copy.pop("parsers")
+                if parser_configs is None:
+                    parser_configs = {}
+                if not isinstance(parser_configs, dict):
+                    raise ValueError("Invalid parsers config: 'parsers' section must be an object")
+            raise_unknown_config_fields(
+                data=parser_configs,
+                valid_fields=set(parser_types),
+                context_name="parsers",
+            )
+            for parser_type in parser_types:
+                if parser_type in config_copy:
+                    parser_configs[parser_type] = config_copy.pop(parser_type)
+            # Handle log configuration from nested "log" section
+            log_config_data = None
+            if "log" in config_copy:
+                log_config_data = config_copy.pop("log")
 
-        # Apply parser configurations
-        for parser_type, parser_data in parser_configs.items():
-            if hasattr(instance, parser_type):
-                config_class = getattr(instance, parser_type).__class__
-                setattr(instance, parser_type, config_class.from_dict(parser_data))
+            instance = cls(**config_copy)
+            # Apply log configuration
+            if log_config_data is not None:
+                instance.log = LogConfig.from_dict(log_config_data)
 
-        return instance
+            # Apply parser configurations
+            for parser_type, parser_data in parser_configs.items():
+                if hasattr(instance, parser_type):
+                    config_class = getattr(instance, parser_type).__class__
+                    setattr(instance, parser_type, config_class.from_dict(parser_data))
+
+            return instance
+        except ValidationError as e:
+            raise ValueError(format_validation_error(root_model=cls, error=e)) from e
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert configuration to dictionary."""
@@ -275,6 +295,8 @@ class OpenVikingConfigSingleton:
             return OpenVikingConfig.from_dict(config_data)
         except json.JSONDecodeError as e:
             raise ValueError(f"Config file JSON format error: {e}")
+        except ValueError:
+            raise
         except Exception as e:
             raise RuntimeError(f"Failed to load config file: {e}")
 

--- a/openviking_cli/utils/config/ovcli_config.py
+++ b/openviking_cli/utils/config/ovcli_config.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration schema and loader for ovcli.conf."""
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, ValidationError
+
+from .config_loader import resolve_config_path
+from .config_utils import format_validation_error
+from .consts import DEFAULT_OVCLI_CONF, OPENVIKING_CLI_CONFIG_ENV
+
+
+class OVCLIConfig(BaseModel):
+    """Client configuration loaded from ovcli.conf."""
+
+    url: Optional[str] = None
+    api_key: Optional[str] = None
+    agent_id: Optional[str] = None
+    account: Optional[str] = None
+    user: Optional[str] = None
+    timeout: float = 60.0
+
+    model_config = {"extra": "forbid"}
+
+
+def load_ovcli_config(config_path: Optional[str] = None) -> Optional[OVCLIConfig]:
+    """Load ovcli.conf if present and validate it strictly."""
+    path = resolve_config_path(config_path, OPENVIKING_CLI_CONFIG_ENV, DEFAULT_OVCLI_CONF)
+    if path is None:
+        return None
+
+    try:
+        from .config_loader import load_json_config
+
+        data = load_json_config(Path(path))
+        return OVCLIConfig.model_validate(data)
+    except ValidationError as e:
+        raise ValueError(
+            f"Invalid CLI config in {path}:\n"
+            f"{format_validation_error(root_model=OVCLIConfig, error=e, path_prefix='ovcli')}"
+        ) from e

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
+from .config_utils import raise_unknown_config_fields
+
 
 @dataclass
 class ParserConfig:
@@ -58,33 +60,9 @@ class ParserConfig:
         Examples:
             >>> config = ParserConfig.from_dict({"max_content_length": 50000})
         """
-        import logging
-        import difflib
-
-        logger = logging.getLogger(__name__)
-
-        # Filter only fields that belong to this class
         valid_fields = {f.name for f in cls.__dataclass_fields__.values()}
-        unknown_fields = {k: v for k, v in data.items() if k not in valid_fields}
-
-        if unknown_fields:
-            warnings = []
-            for field_name in unknown_fields:
-                close_matches = difflib.get_close_matches(field_name, valid_fields, n=1, cutoff=0.6)
-                if close_matches:
-                    warnings.append(
-                        f"Unknown config field '{field_name}' in {cls.__name__} — "
-                        f"did you mean '{close_matches[0]}'?"
-                    )
-                else:
-                    warnings.append(
-                        f"Unknown config field '{field_name}' in {cls.__name__} — ignoring"
-                    )
-            for w in warnings:
-                logger.warning(w)
-
-        filtered_data = {k: v for k, v in data.items() if k in valid_fields}
-        return cls(**filtered_data)
+        raise_unknown_config_fields(data=data, valid_fields=valid_fields, context_name=cls.__name__)
+        return cls(**data)
 
     @classmethod
     def from_yaml(cls, yaml_path: Union[str, Path]) -> "ParserConfig":
@@ -518,8 +496,12 @@ class FeishuConfig(ParserConfig):
     domain: str = "https://open.feishu.cn"
     max_rows_per_sheet: int = 1000
     max_records_per_table: int = 1000
-    download_images: bool = True  # TODO: not yet implemented, reserved for future image download support
-    request_timeout: float = 30.0  # TODO: not yet passed to lark-oapi client, reserved for future use
+    download_images: bool = (
+        True  # TODO: not yet implemented, reserved for future image download support
+    )
+    request_timeout: float = (
+        30.0  # TODO: not yet passed to lark-oapi client, reserved for future use
+    )
 
 
 @dataclass
@@ -644,6 +626,12 @@ def load_parser_configs_from_dict(config_dict: Dict[str, Any]) -> Dict[str, Pars
         >>> pdf_config = configs["pdf"]
         >>> code_config = configs["code"]
     """
+    raise_unknown_config_fields(
+        data=config_dict,
+        valid_fields=set(PARSER_CONFIG_REGISTRY.keys()),
+        context_name="parsers",
+    )
+
     configs = {}
 
     for parser_type, config_class in PARSER_CONFIG_REGISTRY.items():

--- a/tests/client/test_http_client_config.py
+++ b/tests/client/test_http_client_config.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from openviking_cli.client.http import AsyncHTTPClient
+
+
+def test_async_http_client_loads_missing_fields_from_ovcli_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "url": "http://config-host:1933",
+                "api_key": "config-key",
+                "agent_id": "config-agent",
+                "account": "config-account",
+                "user": "config-user",
+                "timeout": 12.5,
+            }
+        )
+    )
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(config_path))
+
+    client = AsyncHTTPClient(url="http://explicit-host:1933")
+
+    assert client._url == "http://explicit-host:1933"
+    assert client._api_key == "config-key"
+    assert client._agent_id == "config-agent"
+    assert client._account == "config-account"
+    assert client._user_id == "config-user"
+    assert client._timeout == 12.5
+
+
+def test_async_http_client_explicit_values_override_ovcli_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "url": "http://config-host:1933",
+                "api_key": "config-key",
+                "account": "config-account",
+                "timeout": 12.5,
+            }
+        )
+    )
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(config_path))
+
+    client = AsyncHTTPClient(
+        url="http://explicit-host:1933",
+        api_key="explicit-key",
+        account="explicit-account",
+        timeout=33.0,
+    )
+
+    assert client._url == "http://explicit-host:1933"
+    assert client._api_key == "explicit-key"
+    assert client._account == "explicit-account"
+    assert client._timeout == 33.0
+
+
+def test_async_http_client_rejects_unknown_ovcli_field(tmp_path, monkeypatch):
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(json.dumps({"ur": "http://localhost:1933"}))
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(config_path))
+
+    with pytest.raises(ValueError, match=r"ovcli\.ur'.*ovcli\.url"):
+        AsyncHTTPClient()
+
+
+def test_async_http_client_reports_invalid_ovcli_value_path(tmp_path, monkeypatch):
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(json.dumps({"url": "http://localhost:1933", "timeout": "fast"}))
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(config_path))
+
+    with pytest.raises(ValueError, match=r"Invalid value for 'ovcli\.timeout'"):
+        AsyncHTTPClient()

--- a/tests/parse/test_markdown_char_limit.py
+++ b/tests/parse/test_markdown_char_limit.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from openviking.parse.parsers.markdown import MarkdownParser
-from openviking_cli.utils.config.parser_config import ParserConfig
+from openviking_cli.utils.config.parser_config import ParserConfig, load_parser_configs_from_dict
 
 # ---------------------------------------------------------------------------
 # ParserConfig
@@ -30,6 +30,14 @@ class TestParserConfigMaxSectionChars:
     def test_from_dict_missing_key_uses_default(self):
         config = ParserConfig.from_dict({})
         assert config.max_section_chars == 6000
+
+    def test_from_dict_rejects_unknown_key(self):
+        with pytest.raises(ValueError, match="max_section_chars"):
+            ParserConfig.from_dict({"max_section_chras": 2000})
+
+    def test_load_parser_configs_rejects_unknown_parser_section(self):
+        with pytest.raises(ValueError, match="markdown"):
+            load_parser_configs_from_dict({"markdwon": {}})
 
     def test_validate_rejects_zero(self):
         config = ParserConfig(max_section_chars=0)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -98,3 +98,76 @@ class TestRequireConfig:
         monkeypatch.delenv("TEST_MISSING_ENV", raising=False)
         with pytest.raises(FileNotFoundError, match="configuration file not found"):
             require_config(None, "TEST_MISSING_ENV", "nonexistent_file.conf", "test")
+
+
+def test_openviking_config_rejects_unknown_nested_parser_section(monkeypatch):
+    monkeypatch.setenv("OPENVIKING_CONFIG_FILE", "/tmp/codex-no-config.json")
+
+    from openviking_cli.utils.config.open_viking_config import (
+        OpenVikingConfig,
+        OpenVikingConfigSingleton,
+    )
+
+    with pytest.raises(ValueError, match="markdown"):
+        OpenVikingConfig.from_dict(
+            {
+                "embedding": {
+                    "dense": {
+                        "provider": "openai",
+                        "api_key": "test-key",
+                        "model": "text-embedding-3-small",
+                    }
+                },
+                "parsers": {"markdwon": {}},
+            }
+        )
+
+    OpenVikingConfigSingleton.reset_instance()
+
+
+def test_openviking_config_rejects_unknown_top_level_section_with_suggestion(monkeypatch):
+    monkeypatch.setenv("OPENVIKING_CONFIG_FILE", "/tmp/codex-no-config.json")
+
+    from openviking_cli.utils.config.open_viking_config import (
+        OpenVikingConfig,
+        OpenVikingConfigSingleton,
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Unknown config field 'erver' in OpenVikingConfig .*'server'"
+    ):
+        OpenVikingConfig.from_dict(
+            {
+                "erver": {
+                    "host": "127.0.0.1",
+                    "port": 1933,
+                    "root_api_key": "test",
+                    "cors_origins": ["*"],
+                },
+                "embedding": {
+                    "dense": {
+                        "provider": "openai",
+                        "api_key": "test-key",
+                        "model": "text-embedding-3-small",
+                    }
+                },
+            }
+        )
+
+    OpenVikingConfigSingleton.reset_instance()
+
+
+def test_openviking_config_singleton_preserves_value_error_for_bad_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENVIKING_CONFIG_FILE", "/tmp/codex-no-config.json")
+
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        '{"erver": {"host": "127.0.0.1"}, "embedding": {"dense": {"provider": "openai", "api_key": "x", "model": "m"}}}'
+    )
+
+    OpenVikingConfigSingleton.reset_instance()
+    with pytest.raises(ValueError, match="server"):
+        OpenVikingConfigSingleton.initialize(config_path=str(config_path))
+    OpenVikingConfigSingleton.reset_instance()

--- a/tests/test_server_config_loader.py
+++ b/tests/test_server_config_loader.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from openviking.server.config import load_server_config
+
+
+def test_load_server_config_rejects_unknown_field(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(json.dumps({"server": {"host": "0.0.0.0", "prt": 9999}}))
+
+    with pytest.raises(
+        ValueError,
+        match=r"server\.prt'.*server\.port",
+    ):
+        load_server_config(str(config_path))
+
+
+def test_load_server_config_rejects_unknown_nested_field(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(json.dumps({"server": {"telemetry": {"prometheus": {"enabld": True}}}}))
+
+    with pytest.raises(
+        ValueError,
+        match=r"server\.telemetry\.prometheus\.enabld'.*server\.telemetry\.prometheus\.enabled",
+    ):
+        load_server_config(str(config_path))
+
+
+def test_load_server_config_reports_invalid_value_path(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(json.dumps({"server": {"port": "abc"}}))
+
+    with pytest.raises(ValueError, match=r"Invalid value for 'server\.port'"):
+        load_server_config(str(config_path))
+
+
+def test_load_server_config_preserves_supported_fields(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "host": "0.0.0.0",
+                    "port": 1944,
+                    "workers": 2,
+                    "auth_mode": "trusted",
+                    "with_bot": True,
+                    "bot_api_url": "http://localhost:19999",
+                    "telemetry": {"prometheus": {"enabled": True}},
+                },
+                "encryption": {"enabled": True},
+            }
+        )
+    )
+
+    config = load_server_config(str(config_path))
+
+    assert config.host == "0.0.0.0"
+    assert config.port == 1944
+    assert config.workers == 2
+    assert config.auth_mode == "trusted"
+    assert config.with_bot is True
+    assert config.bot_api_url == "http://localhost:19999"
+    assert config.telemetry.prometheus.enabled is True
+    assert config.encryption_enabled is True


### PR DESCRIPTION
## Description

Tighten config validation across `ov.conf` and `ovcli.conf` so unknown fields fail fast with readable error messages instead of being silently ignored. This also prevalidates the full config during `openviking-server --config ...` startup and consolidates shared validation/error-formatting helpers into one utility module.

## Related Issue

Fixes #855
Related prior PRs: #856, #881

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added shared config validation helpers for typo suggestions and friendly Pydantic error formatting, and reused them across server, parser, and top-level OpenViking config loaders
- Made `server`, `parser`, top-level `ov.conf`, and `ovcli.conf` reject unknown fields with explicit error paths instead of silently ignoring them
- Validated the full config during `openviking-server --config ...` startup and added regression tests for friendly error messages and config precedence behavior

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- This PR intentionally chooses strict validation for unknown fields, because warning-only behavior still leaves misconfigurations easy to miss.
- `ovcli.conf` now also supports filling in missing auth/context fields even when `url` is passed explicitly, while keeping explicit arguments higher priority than config values.
- Local verification command:
  `env OPENVIKING_CONFIG_FILE=/tmp/codex-no-config.json .venv/bin/python -m pytest tests/client/test_http_client_config.py tests/test_config_loader.py tests/test_server_config_loader.py tests/parse/test_markdown_char_limit.py -q`
