### PR TITLE
fix: use _max_concurrent_semantic in Semantic queue worker

### DIFF
--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -150,7 +150,7 @@ class QueueManager:
             if thread.is_alive():
                 return
 
-        max_concurrent = self._max_concurrent_embedding if queue.name == self.EMBEDDING else 1
+        max_concurrent = self._max_concurrent_embedding if queue.name == self.EMBEDDING else self._max_concurrent_semantic
         stop_event = threading.Event()
         self._queue_stop_events[queue.name] = stop_event
         thread = threading.Thread(


### PR DESCRIPTION
## Summary

Fixes #873

The `_max_concurrent_semantic` variable was stored in `QueueManager.__init__` and passed to `SemanticProcessor`, but it was **not used** when starting the Semantic queue worker thread.

## Problem

In `_start_queue_worker`:
```python
max_concurrent = self._max_concurrent_embedding if queue.name == self.EMBEDDING else 1  # Hardcoded to 1!
```

This caused the Semantic queue to always have `max_concurrent = 1`, ignoring the configured `vlm.max_concurrent` value for queue-level concurrency.

## Solution

```python
max_concurrent = self._max_concurrent_embedding if queue.name == self.EMBEDDING else self._max_concurrent_semantic
```

## Impact

Users can now configure Semantic queue concurrency through `ov.conf`, enabling faster processing when there are many pending Semantic tasks.

Thanks for the great bug report! 👍