### PR TITLE
docs: add Feishu/Lark cloud document parser documentation

### DIFF
--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -16,6 +16,7 @@ Resources are external knowledge that agents can reference. This guide covers ho
 | Video | `.mp4`, `.mov`, `.avi` | Frame extraction + VLM |
 | Audio | `.mp3`, `.wav`, `.m4a` | Transcription |
 | Documents | `.docx` | Text extraction |
+| Feishu/Lark | URL (`*.feishu.cn`, `*.larksuite.com`) | Cloud document parsing via `lark-oapi` |
 
 ## Processing Pipeline
 
@@ -139,6 +140,57 @@ curl -X POST http://localhost:1933/api/v1/resources \
 
 ```bash
 openviking add-resource https://example.com/api-docs.md --to viking://resources/external/ --reason "External API documentation"
+```
+
+**Example: Add Feishu/Lark Cloud Documents**
+
+[Feishu](https://www.feishu.cn) (飞书) and its international version [Lark](https://www.larksuite.com) are widely used for documentation in Chinese tech companies. OpenViking can directly import cloud documents by URL.
+
+Supported document types:
+
+| Type | URL Pattern |
+|------|-------------|
+| Documents | `https://*.feishu.cn/docx/{id}` |
+| Wiki pages | `https://*.feishu.cn/wiki/{token}` |
+| Spreadsheets | `https://*.feishu.cn/sheets/{token}` |
+| Bitable | `https://*.feishu.cn/base/{token}` |
+
+> **Setup**: Install the optional dependency: `pip install 'openviking[bot-feishu]'`
+>
+> Configure credentials via `ov.conf` (see [Configuration](../../guides/01-configuration.md#feishu)) or environment variables:
+> ```bash
+> export FEISHU_APP_ID="cli_xxx"
+> export FEISHU_APP_SECRET="xxx"
+> ```
+
+**Python SDK (Embedded / HTTP)**
+
+```python
+# Import a Feishu document
+result = client.add_resource(
+    "https://example.feishu.cn/docx/doxcnABC123",
+    reason="Project design document"
+)
+client.wait_processed()
+
+# Import a wiki page (auto-resolves to underlying type)
+client.add_resource("https://example.feishu.cn/wiki/wikiXYZ")
+
+# Import a spreadsheet
+client.add_resource("https://example.feishu.cn/sheets/shtcn456")
+```
+
+**CLI**
+
+```bash
+# Import a Feishu document
+openviking add-resource "https://example.feishu.cn/docx/doxcnABC123" --reason "Project design document"
+
+# Import a wiki page
+openviking add-resource "https://example.feishu.cn/wiki/wikiXYZ"
+
+# Incremental update to an existing target
+openviking add-resource "https://example.feishu.cn/docx/doxcnABC123" --to viking://resources/design-doc
 ```
 
 **Example: Wait for Processing**

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -428,6 +428,34 @@ For OpenAI-compatible providers that return SSE (Server-Sent Events) format resp
 
 > **Note**: The OpenAI SDK requires `stream=true` to properly parse SSE responses. When using providers that force SSE format, you must set this option to `true`.
 
+### feishu
+
+Configuration for Feishu/Lark cloud document parsing. See [Resources](../api/02-resources.md) for supported URL patterns.
+
+```json
+{
+  "feishu": {
+    "app_id": "",
+    "app_secret": "",
+    "domain": "https://open.feishu.cn",
+    "max_rows_per_sheet": 1000,
+    "max_records_per_table": 1000
+  }
+}
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `app_id` | str | Feishu app ID (can also be set via `FEISHU_APP_ID` env var) |
+| `app_secret` | str | Feishu app secret (can also be set via `FEISHU_APP_SECRET` env var) |
+| `domain` | str | Feishu API domain. Use `https://open.larksuite.com` for Lark international |
+| `max_rows_per_sheet` | int | Maximum rows to import per spreadsheet sheet (default: `1000`) |
+| `max_records_per_table` | int | Maximum records to import per bitable table (default: `1000`) |
+
+**Dependency**: `pip install 'openviking[bot-feishu]'`
+
+**Lark international**: For Lark URLs (`*.larksuite.com`), set `domain` to `https://open.larksuite.com`.
+
 ### code
 
 Controls how code files are summarized via `code_summary_mode`. Both config formats are equivalent:

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -16,6 +16,7 @@
 | 视频 | `.mp4`, `.mov`, `.avi` | 帧提取 + VLM |
 | 音频 | `.mp3`, `.wav`, `.m4a` | 语音转录 |
 | 文档 | `.docx` | 文本提取 |
+| 飞书/Lark | URL（`*.feishu.cn`、`*.larksuite.com`） | 云端文档解析（`lark-oapi`） |
 
 ## 处理流程
 
@@ -139,6 +140,57 @@ curl -X POST http://localhost:1933/api/v1/resources \
 
 ```bash
 openviking add-resource https://example.com/api-docs.md --to viking://resources/external/ --reason "External API documentation"
+```
+
+**示例：添加飞书/Lark 云端文档**
+
+[飞书](https://www.feishu.cn)及其国际版 [Lark](https://www.larksuite.com) 是国内科技公司广泛使用的协作平台。OpenViking 可以通过 URL 直接导入飞书云端文档。
+
+支持的文档类型：
+
+| 类型 | URL 格式 |
+|------|----------|
+| 文档 | `https://*.feishu.cn/docx/{id}` |
+| 知识库 | `https://*.feishu.cn/wiki/{token}` |
+| 电子表格 | `https://*.feishu.cn/sheets/{token}` |
+| 多维表格 | `https://*.feishu.cn/base/{token}` |
+
+> **前置配置**：安装可选依赖 `pip install 'openviking[bot-feishu]'`
+>
+> 通过 `ov.conf` 配置凭据（详见[配置文档](../../zh/guides/01-configuration.md#feishu)），或设置环境变量：
+> ```bash
+> export FEISHU_APP_ID="cli_xxx"
+> export FEISHU_APP_SECRET="xxx"
+> ```
+
+**Python SDK (Embedded / HTTP)**
+
+```python
+# 导入飞书文档
+result = client.add_resource(
+    "https://example.feishu.cn/docx/doxcnABC123",
+    reason="项目设计文档"
+)
+client.wait_processed()
+
+# 导入知识库页面（自动解析为底层文档类型）
+client.add_resource("https://example.feishu.cn/wiki/wikiXYZ")
+
+# 导入电子表格
+client.add_resource("https://example.feishu.cn/sheets/shtcn456")
+```
+
+**CLI**
+
+```bash
+# 导入飞书文档
+openviking add-resource "https://example.feishu.cn/docx/doxcnABC123" --reason "项目设计文档"
+
+# 导入知识库页面
+openviking add-resource "https://example.feishu.cn/wiki/wikiXYZ"
+
+# 增量更新到已有 target
+openviking add-resource "https://example.feishu.cn/docx/doxcnABC123" --to viking://resources/design-doc
 ```
 
 **示例：等待处理完成**

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -403,6 +403,34 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 
 > **注意**: OpenAI SDK 需要 `stream=true` 才能正确解析 SSE 响应。使用强制返回 SSE 格式的 provider 时，必须将此选项设置为 `true`。
 
+### feishu
+
+飞书/Lark 云端文档解析配置。支持的 URL 格式详见[资源管理](../api/02-resources.md)。
+
+```json
+{
+  "feishu": {
+    "app_id": "",
+    "app_secret": "",
+    "domain": "https://open.feishu.cn",
+    "max_rows_per_sheet": 1000,
+    "max_records_per_table": 1000
+  }
+}
+```
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `app_id` | str | 飞书应用 ID（也可通过 `FEISHU_APP_ID` 环境变量设置） |
+| `app_secret` | str | 飞书应用密钥（也可通过 `FEISHU_APP_SECRET` 环境变量设置） |
+| `domain` | str | 飞书 API 域名。Lark 国际版请设为 `https://open.larksuite.com` |
+| `max_rows_per_sheet` | int | 电子表格每个 sheet 最大导入行数（默认 `1000`） |
+| `max_records_per_table` | int | 多维表格每个表最大导入记录数（默认 `1000`） |
+
+**依赖**：`pip install 'openviking[bot-feishu]'`
+
+**Lark 国际版**：对于 Lark URL（`*.larksuite.com`），请将 `domain` 设为 `https://open.larksuite.com`。
+
 ### code
 
 通过 `code_summary_mode` 控制代码文件的摘要生成方式。以下两种写法等价：


### PR DESCRIPTION
## Summary

- Add documentation for the Feishu/Lark cloud document parser added in PR #831
- Covers both English and Chinese docs (resources + configuration)

## Changes

### Resources docs ()
- Added Feishu/Lark row to "Supported Formats" table
- Added usage example section with:
  - Supported document types table (docx, wiki, sheets, bitable)
  - Setup instructions (dependency + credential configuration)
  - Python SDK examples for all document types
  - CLI examples including incremental update
  - Cross-link to configuration docs

### Configuration docs ()
- Added `feishu` config section documenting all parameters:
  - `app_id` / `app_secret` (with env var alternatives)
  - `domain` (with Lark international note)
  - `max_rows_per_sheet` / `max_records_per_table`
- Added dependency install instruction

Closes #859