### PR TITLE
Refactor(CLI): Centralize ov.conf JSON loading in ov doctor

### DIFF
--- a/openviking_cli/doctor.py
+++ b/openviking_cli/doctor.py
@@ -47,6 +47,14 @@ def _find_config() -> Optional[Path]:
     return resolve_config_path(None, OPENVIKING_CONFIG_ENV, "ov.conf")
 
 
+def _load_config_json(config_path: Path) -> Optional[dict]:
+    """Parse ov.conf as JSON. Returns None if the file is unreadable or not valid JSON."""
+    try:
+        return json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def check_config() -> tuple[bool, str, Optional[str]]:
     """Validate ov.conf exists and is valid JSON with required sections."""
     config_path = _find_config()
@@ -133,9 +141,8 @@ def check_embedding() -> tuple[bool, str, Optional[str]]:
     if config_path is None:
         return False, "Cannot check (no config file)", None
 
-    try:
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-    except Exception:
+    data = _load_config_json(config_path)
+    if data is None:
         return False, "Cannot check (config unreadable)", None
 
     embedding = data.get("embedding", {})
@@ -163,9 +170,8 @@ def check_vlm() -> tuple[bool, str, Optional[str]]:
     if config_path is None:
         return False, "Cannot check (no config file)", None
 
-    try:
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-    except Exception:
+    data = _load_config_json(config_path)
+    if data is None:
         return False, "Cannot check (config unreadable)", None
 
     vlm = data.get("vlm", {})
@@ -192,13 +198,11 @@ def check_disk() -> tuple[bool, str, Optional[str]]:
     workspace = Path.home() / ".openviking"
 
     if config_path:
-        try:
-            data = json.loads(config_path.read_text(encoding="utf-8"))
+        data = _load_config_json(config_path)
+        if data is not None:
             ws = data.get("storage", {}).get("workspace", "")
             if ws:
                 workspace = Path(ws).expanduser()
-        except Exception:
-            pass
 
     check_path = workspace if workspace.exists() else Path.home()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ addopts = "-v --cov=openviking --cov-report=term-missing"
 [tool.ruff]
 line-length = 100
 exclude = ["third_party"]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -167,6 +167,14 @@ class TestCheckEmbedding:
         assert not ok
         assert "no API key" in detail
 
+    def test_fail_invalid_json(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text("{not valid json")
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            ok, detail, fix = check_embedding()
+        assert not ok
+        assert "unreadable" in detail
+
 
 class TestCheckVlm:
     def test_pass_with_config(self, tmp_path: Path):
@@ -186,6 +194,14 @@ class TestCheckVlm:
         with patch("openviking_cli.doctor._find_config", return_value=config):
             ok, detail, fix = check_vlm()
         assert not ok
+
+    def test_fail_invalid_json(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text("{not valid json")
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            ok, detail, fix = check_vlm()
+        assert not ok
+        assert "unreadable" in detail
 
 
 class TestCheckDisk:


### PR DESCRIPTION
## Description

Improves ov doctor by loading ov.conf through a small shared helper that only catches OSError and json.JSONDecodeError, instead of a broad Exception. Aligns Ruff’s target-version with the package’s requires-python (3.10+). Adds unit tests for invalid JSON on embedding and VLM checks.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Added _load_config_json() in openviking_cli/doctor.py and reused it in check_embedding, check_vlm, and check_disk workspace resolution.
- Set tool.ruff target-version from py39 to py310 in pyproject.toml.
- Added test_fail_invalid_json for check_embedding and check_vlm in tests/cli/test_doctor.py.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
N/A — CLI / tooling only.

## Additional Notes

<!-- Add any additional notes or context about the PR -->
check_config still uses explicit JSON error messaging for the primary config validation path; only the secondary reads were deduplicated.