### PR TITLE
Use code-specific Jina task defaults for code embedding models

### DIFF
--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -17,6 +17,19 @@ JINA_MODEL_DIMENSIONS = {
     "jina-embeddings-v5-text-nano": 768,  # 239M params, max seq 8192
 }
 
+DEFAULT_JINA_QUERY_TASK = "retrieval.query"
+DEFAULT_JINA_DOCUMENT_TASK = "retrieval.passage"
+DEFAULT_JINA_CODE_QUERY_TASK = "nl2code.query"
+DEFAULT_JINA_CODE_DOCUMENT_TASK = "nl2code.passage"
+_UNSET = object()
+
+
+def _get_default_task_params(model_name: str) -> tuple[str, str]:
+    """Return the default Jina task names for the selected model."""
+    if model_name.startswith("jina-code-embeddings-"):
+        return DEFAULT_JINA_CODE_QUERY_TASK, DEFAULT_JINA_CODE_DOCUMENT_TASK
+    return DEFAULT_JINA_QUERY_TASK, DEFAULT_JINA_DOCUMENT_TASK
+
 
 class JinaDenseEmbedder(DenseEmbedderBase):
     """Jina AI Dense Embedder Implementation
@@ -56,8 +69,8 @@ class JinaDenseEmbedder(DenseEmbedderBase):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         dimension: Optional[int] = None,
-        query_param: Optional[str] = "retrieval.query",
-        document_param: Optional[str] = "retrieval.passage",
+        query_param: Any = _UNSET,
+        document_param: Any = _UNSET,
         late_chunking: Optional[bool] = None,
         config: Optional[Dict[str, Any]] = None,
         task: Optional[str] = None,
@@ -85,6 +98,11 @@ class JinaDenseEmbedder(DenseEmbedderBase):
         self.api_key = api_key
         self.api_base = api_base or "https://api.jina.ai/v1"
         self.dimension = dimension
+        default_query_param, default_document_param = _get_default_task_params(model_name)
+        if query_param is _UNSET:
+            query_param = default_query_param
+        if document_param is _UNSET:
+            document_param = default_document_param
         self.query_param = query_param
         self.document_param = document_param
         self.late_chunking = late_chunking

--- a/tests/unit/test_jina_embedder.py
+++ b/tests/unit/test_jina_embedder.py
@@ -148,6 +148,54 @@ class TestJinaDenseEmbedder:
         assert call_kwargs["extra_body"]["task"] == "retrieval.query"
 
     @patch("openviking.models.embedder.jina_embedders.openai.OpenAI")
+    def test_code_model_uses_code_task_defaults(self, mock_openai_class):
+        """Jina code models should use code-specific default task names."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = [0.1] * 1024
+
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embedder = JinaDenseEmbedder(
+            model_name="jina-code-embeddings-1.5b",
+            api_key="test-api-key",
+        )
+
+        embedder.embed("Write a binary search in Python", is_query=True)
+
+        call_kwargs = mock_client.embeddings.create.call_args[1]
+        assert call_kwargs["extra_body"]["task"] == "nl2code.query"
+
+    @patch("openviking.models.embedder.jina_embedders.openai.OpenAI")
+    def test_code_model_keeps_explicit_task_override(self, mock_openai_class):
+        """Explicit task params should override the model-specific defaults."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = [0.1] * 1024
+
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embedder = JinaDenseEmbedder(
+            model_name="jina-code-embeddings-1.5b",
+            api_key="test-api-key",
+            query_param="custom.query",
+            document_param="custom.passage",
+        )
+
+        embedder.embed("Write a binary search in Python", is_query=True)
+
+        call_kwargs = mock_client.embeddings.create.call_args[1]
+        assert call_kwargs["extra_body"]["task"] == "custom.query"
+
+    @patch("openviking.models.embedder.jina_embedders.openai.OpenAI")
     def test_embed_with_late_chunking(self, mock_openai_class):
         """Test embedding with late_chunking parameter"""
         mock_client = MagicMock()


### PR DESCRIPTION
This updates the Jina embedder defaults for `jina-code-embeddings-*` models so code queries use the code-specific task names.

It also keeps explicit task overrides unchanged and adds tests for both cases.

Tested with:
- targeted unit tests for `JinaDenseEmbedder`

Closes #912
