### PR TITLE
fix(embedding): add dimension resolution for Ollama embedding provider

### DIFF
--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -207,6 +207,30 @@ class EmbeddingModelConfig(BaseModel):
 
             return GeminiDenseEmbedder._default_dimension(self.model)
 
+        if provider == "ollama":
+            # Common Ollama embedding models and their dimensions
+            # Users should set dimension explicitly for other models
+            ollama_model_dimensions = {
+                "nomic-embed-text": 768,
+                "nomic-embed-text-v1": 768,
+                "nomic-embed-text-v1.5": 768,
+                "mxbai-embed-large": 1024,
+                "mxbai-embed-large-v1": 1024,
+                "all-minilm": 384,
+                "all-minilm-l6-v2": 384,
+                "snowflake-arctic-embed": 1024,
+                "snowflake-arctic-embed-l": 1024,
+            }
+            model_lower = (self.model or "").lower()
+            if model_lower in ollama_model_dimensions:
+                return ollama_model_dimensions[model_lower]
+            # For unknown Ollama models, require explicit dimension
+            raise ValueError(
+                f"Unknown dimension for Ollama model '{self.model}'. "
+                f"Please set 'dimension' explicitly in your embedding config. "
+                f"Known models: {list(ollama_model_dimensions.keys())}"
+            )
+
         return 2048
 
 


### PR DESCRIPTION
## Summary

Fixes #865 (Bug 1)

## Problem

When using Ollama as embedding provider with models like `nomic-embed-text`, `get_effective_dimension()` would fallback to 2048 (default). This caused:

1. Collection created with `Dim: 2048`
2. Ollama returns 768-dim vectors
3. Qdrant similarity scores become `inf`
4. JSON serialization fails: `Out of range float values are not JSON compliant: inf`

## Solution

Added Ollama-specific dimension resolution in `get_effective_dimension()`:

- Known Ollama models return their correct dimension
- Unknown models raise clear error requiring explicit `dimension` config

```python
ollama_model_dimensions = {
    "nomic-embed-text": 768,
    "mxbai-embed-large": 1024,
    "all-minilm": 384,
    "snowflake-arctic-embed": 1024,
    # ...
}
```

## Testing

```yaml
# ov.conf
embedding:
  dense:
    provider: ollama
    model: nomic-embed-text
    api_base: http://localhost:11434/v1
```

- Before: `inf` similarity scores, JSON error
- After: Collection created with 768-dim, search works correctly