### PR TITLE
fix(embedder): add code model dimensions and actionable 422 error for Jina

### DIFF
--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -15,6 +15,8 @@ from openviking.models.embedder.base import (
 JINA_MODEL_DIMENSIONS = {
     "jina-embeddings-v5-text-small": 1024,  # 677M params, max seq 32768
     "jina-embeddings-v5-text-nano": 768,  # 239M params, max seq 8192
+    "jina-code-embeddings-1.5b": 1024,  # code model, max seq 8192
+    "jina-code-embeddings-0.5b": 768,  # code model, max seq 8192
 }
 
 DEFAULT_JINA_QUERY_TASK = "retrieval.query"
@@ -140,6 +142,16 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             extra_body["late_chunking"] = self.late_chunking
         return extra_body if extra_body else None
 
+    def _raise_task_error(self, error: openai.APIError) -> None:
+        """Raise an actionable error if a 422 indicates an invalid task type."""
+        if getattr(error, "status_code", None) == 422 and "task" in str(error.body):
+            raise RuntimeError(
+                f"Jina API rejected task type for model '{self.model_name}'. "
+                f"This usually means the model requires a different task prefix. "
+                f"Set 'query_param' and 'document_param' in your embedding config "
+                f"to a valid task type for this model. API details: {error.message}"
+            ) from error
+
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         """Perform dense embedding on text
 
@@ -167,6 +179,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
 
             return EmbedResult(dense_vector=vector)
         except openai.APIError as e:
+            self._raise_task_error(e)
             raise RuntimeError(f"Jina API error: {e.message}") from e
         except Exception as e:
             raise RuntimeError(f"Embedding failed: {str(e)}") from e
@@ -200,6 +213,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
 
             return [EmbedResult(dense_vector=item.embedding) for item in response.data]
         except openai.APIError as e:
+            self._raise_task_error(e)
             raise RuntimeError(f"Jina API error: {e.message}") from e
         except Exception as e:
             raise RuntimeError(f"Batch embedding failed: {str(e)}") from e

--- a/tests/unit/test_jina_embedder.py
+++ b/tests/unit/test_jina_embedder.py
@@ -324,3 +324,63 @@ class TestJinaDenseEmbedder:
             dimension=256,
         )
         assert embedder.get_dimension() == 256
+
+    @patch("openviking.models.embedder.jina_embedders.openai.OpenAI")
+    def test_422_task_error_actionable_message(self, mock_openai_class):
+        """422 error mentioning 'task' should produce actionable RuntimeError."""
+        import openai
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        error = openai.BadRequestError(
+            message="Validation error",
+            response=MagicMock(status_code=422, headers={}),
+            body={"detail": "Input should be 'nl2code.query' ... task"},
+        )
+        mock_client.embeddings.create.side_effect = error
+
+        embedder = JinaDenseEmbedder(
+            model_name="jina-code-embeddings-1.5b",
+            api_key="test-key",
+        )
+
+        with pytest.raises(RuntimeError, match="query_param.*document_param"):
+            embedder.embed("hello")
+
+    @patch("openviking.models.embedder.jina_embedders.openai.OpenAI")
+    def test_non_422_error_passthrough(self, mock_openai_class):
+        """Non-422 API errors should use the generic 'Jina API error' message."""
+        import openai
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        error = openai.APIError(
+            message="Internal server error",
+            request=MagicMock(),
+            body=None,
+        )
+        mock_client.embeddings.create.side_effect = error
+
+        embedder = JinaDenseEmbedder(
+            model_name="jina-embeddings-v5-text-small",
+            api_key="test-key",
+        )
+
+        with pytest.raises(RuntimeError, match="Jina API error"):
+            embedder.embed("hello")
+
+    def test_code_model_dimensions(self):
+        """Code models should have correct default dimensions."""
+        embedder_1_5b = JinaDenseEmbedder(
+            model_name="jina-code-embeddings-1.5b",
+            api_key="test-key",
+        )
+        assert embedder_1_5b.get_dimension() == 1024
+
+        embedder_0_5b = JinaDenseEmbedder(
+            model_name="jina-code-embeddings-0.5b",
+            api_key="test-key",
+        )
+        assert embedder_0_5b.get_dimension() == 768


### PR DESCRIPTION
## Summary

- Adds `jina-code-embeddings-1.5b` (1024) and `jina-code-embeddings-0.5b` (768) to `JINA_MODEL_DIMENSIONS` so dimension validation works correctly for code models
- Adds `_raise_task_error()` helper that intercepts 422 validation errors mentioning `task` and produces a user-friendly error message guiding users to set `query_param` and `document_param` in their embedding config
- Adds 3 new tests: 422 actionable error, non-422 passthrough, code model dimensions

Builds on the model-aware task defaults already merged in main. This PR completes the fix by adding the missing dimensions and improving the error experience when task types are misconfigured.

Fixes #912.

## Test plan

- [x] All 23 Jina embedder tests pass (`pytest tests/unit/test_jina_embedder.py`)
- [x] `test_422_task_error_actionable_message` — verifies 422 with "task" in body produces actionable RuntimeError
- [x] `test_non_422_error_passthrough` — verifies non-422 errors use generic message
- [x] `test_code_model_dimensions` — verifies both code models resolve correct default dimensions
- [x] Ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)