### PR TITLE
fix(embed): give warning when embeder and vectoerdb are not the same.

### DIFF
--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -21,6 +21,7 @@ from .consts import (
 from .embedding_config import EmbeddingConfig
 from .encryption_config import EncryptionConfig
 from .log_config import LogConfig
+from .memory_config import MemoryConfig
 from .parser_config import (
     AudioConfig,
     CodeConfig,
@@ -37,7 +38,6 @@ from .parser_config import (
 from .rerank_config import RerankConfig
 from .storage_config import StorageConfig
 from .vlm_config import VLMConfig
-from .memory_config import MemoryConfig
 
 
 class OpenVikingConfig(BaseModel):
@@ -224,6 +224,22 @@ class OpenVikingConfig(BaseModel):
                     config_class = getattr(instance, parser_type).__class__
                     setattr(instance, parser_type, config_class.from_dict(parser_data))
 
+            # Check dimension consistency
+            if (
+                getattr(instance, "storage", None)
+                and getattr(instance.storage, "vectordb", None)
+                and getattr(instance, "embedding", None)
+            ):
+                db_dim = instance.storage.vectordb.dimension
+                emb_dim = instance.embedding.dimension
+                if db_dim > 0 and emb_dim > 0 and db_dim != emb_dim:
+                    import logging
+
+                    logging.warning(
+                        f"Dimension mismatch: VectorDB dimension is {db_dim}, "
+                        f"but Embedding dimension is {emb_dim}. "
+                        "This may cause errors during vector search."
+                    )
             return instance
         except ValidationError as e:
             raise ValueError(format_validation_error(root_model=cls, error=e)) from e


### PR DESCRIPTION
## Description 
 
This PR adds a configuration validation step to check the consistency of vector dimensions. It compares the `dimension` specified for `storage.vectordb` with the `dimension` configured for `embedding`. If both values are greater than 0 but do not match, the system will log a warning to help users catch potential vector search errors early.
 
## Related Issue 
 
N/A
 
## Type of Change 
 
- [ ] Bug fix (non-breaking change that fixes an issue) 
- [x] New feature (non-breaking change that adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 
- [ ] Documentation update 
- [ ] Refactoring (no functional changes) 
- [ ] Performance improvement 
- [ ] Test update 
 
## Changes Made 
 
- Added a dimension consistency check in `OpenVikingConfig.from_dict` (`openviking_cli/utils/config/open_viking_config.py`).
- Added a standard `logging.warning` output to notify users of dimension mismatches.
- Applied `ruff` formatting to the modified code blocks to ensure styling compliance.
 
## Testing 
 
- [ ] I have added tests that prove my fix is effective or that my feature works 
- [x] New and existing unit tests pass locally with my changes 
- [x] I have tested this on the following platforms: 
  - [ ] Linux 
  - [x] macOS 
  - [ ] Windows 
 
## Checklist 
 
- [x] My code follows the project's coding style 
- [x] I have performed a self-review of my code 
- [x] I have commented my code, particularly in hard-to-understand areas 
- [ ] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings (Note: Added an intentional runtime warning for invalid configs)
- [x] Any dependent changes have been merged and published 
 
## Screenshots (if applicable) 
 
N/A
 
## Additional Notes 
 
The warning uses the standard `logging` module directly to avoid infinite recursion that could occur if `get_logger` triggers config initialization before the config object is fully loaded.