### PR TITLE
fix(vlm): pass thinking flag to dashscope openai backend

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -8,6 +8,7 @@ import json
 import logging
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Any, Dict, List, Optional, Union
 
 from ..base import VLMBase, VLMResponse, ToolCall
@@ -15,6 +16,11 @@ from ..registry import DEFAULT_AZURE_API_VERSION
 
 logger = logging.getLogger(__name__)
 
+
+_DASHSCOPE_HOSTS = {
+    "dashscope.aliyuncs.com",
+    "dashscope-intl.aliyuncs.com",
+}
 
 def _build_openai_client_kwargs(
     provider: str,
@@ -81,6 +87,31 @@ class OpenAIVLM(VLMBase):
             else:
                 self._async_client = openai.AsyncOpenAI(**kwargs)
         return self._async_client
+
+    def _supports_enable_thinking(self) -> bool:
+        """Return True for OpenAI-compatible DashScope endpoints that accept enable_thinking."""
+        if self.provider != "openai":
+            return False
+
+        if isinstance(self.model, str) and self.model.lower().startswith("dashscope/"):
+            return True
+
+        if not self.api_base:
+            return False
+
+        try:
+            host = urlparse(self.api_base).hostname or ""
+        except ValueError:
+            return False
+
+        return host.lower() in _DASHSCOPE_HOSTS
+
+    def _apply_provider_specific_extra_body(
+        self, kwargs: Dict[str, Any], thinking: bool
+    ) -> None:
+        """Attach provider-specific raw body parameters understood by compatible APIs."""
+        if self._supports_enable_thinking():
+            kwargs["extra_body"] = {"enable_thinking": bool(thinking)}
 
     def _update_token_usage_from_response(
         self, response, duration_seconds: float = 0.0,
@@ -247,6 +278,7 @@ class OpenAIVLM(VLMBase):
             "temperature": self.temperature,
             "stream": self.stream,
         }
+        self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
 
@@ -292,6 +324,7 @@ class OpenAIVLM(VLMBase):
             "temperature": self.temperature,
             "stream": self.stream,
         }
+        self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
 
@@ -409,6 +442,7 @@ class OpenAIVLM(VLMBase):
             "temperature": self.temperature,
             "stream": self.stream,
         }
+        self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
 
@@ -460,6 +494,7 @@ class OpenAIVLM(VLMBase):
             "temperature": self.temperature,
             "stream": self.stream,
         }
+        self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
 

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for VLM extra_headers support."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
 from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
@@ -96,6 +96,110 @@ class TestVLMExtraHeaders:
         call_kwargs = mock_openai_class.call_args[1]
         # Empty dict is falsy, so default_headers should not be set
         assert "default_headers" not in call_kwargs
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
+    def test_dashscope_text_completion_passes_enable_thinking_in_extra_body(
+        self, mock_openai_class
+    ):
+        """DashScope-compatible OpenAI backends should pass thinking via extra_body."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+        mock_response.usage = None
+        mock_client.chat.completions.create.return_value = mock_response
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                "model": "dashscope/qwen3.5-plus",
+            }
+        )
+
+        vlm.get_completion("hello", thinking=False)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"enable_thinking": False}
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
+    async def test_dashscope_async_vision_completion_passes_enable_thinking_in_extra_body(
+        self, mock_async_openai_class
+    ):
+        """DashScope-compatible async vision calls should pass thinking via extra_body."""
+        mock_client = MagicMock()
+        mock_async_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+        mock_response.usage = None
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+                "model": "qwen3.5-flash",
+            }
+        )
+
+        await vlm.get_vision_completion_async(
+            prompt="describe",
+            images=[b"\x89PNG\r\n\x1a\n0000"],
+            thinking=True,
+        )
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"enable_thinking": True}
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
+    def test_official_openai_text_completion_does_not_set_enable_thinking(
+        self, mock_openai_class
+    ):
+        """Official OpenAI API should not receive DashScope-specific extra_body flags."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+        mock_response.usage = None
+        mock_client.chat.completions.create.return_value = mock_response
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+                "model": "gpt-4o-mini",
+            }
+        )
+
+        vlm.get_completion("hello", thinking=False)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert "extra_body" not in call_kwargs
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.AzureOpenAI")
+    def test_azure_text_completion_does_not_set_enable_thinking(self, mock_azure_openai_class):
+        """Azure OpenAI should not receive DashScope-specific extra_body flags."""
+        mock_client = MagicMock()
+        mock_azure_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+        mock_response.usage = None
+        mock_client.chat.completions.create.return_value = mock_response
+
+        vlm = OpenAIVLM(
+            {
+                "provider": "azure",
+                "api_key": "sk-test",
+                "api_base": "https://example-resource.openai.azure.com",
+                "api_version": "2025-01-01-preview",
+                "model": "gpt-4o-mini",
+            }
+        )
+
+        vlm.get_completion("hello", thinking=False)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert "extra_body" not in call_kwargs
 
 
 class TestVLMBaseExtraHeaders:


### PR DESCRIPTION
## Description

This PR fixes the OpenAI-compatible VLM backend so the `thinking` flag is propagated to DashScope-compatible endpoints via `extra_body.enable_thinking`.

The change is scoped to DashScope detection only, so official OpenAI and Azure requests keep their existing behavior.

## Related Issue

Fixes #923

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Detect DashScope-compatible OpenAI backends from the configured model prefix and `api_base` host.
- Pass `extra_body={"enable_thinking": <bool>}` through all four OpenAI VLM completion paths.
- Add regression tests covering DashScope text/async vision calls and non-DashScope guard rails for official OpenAI and Azure.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated with:
- `python3 -m py_compile openviking/models/vlm/backends/openai_vlm.py tests/unit/test_extra_headers_vlm.py`
- Isolated behavior verification for DashScope sync text, DashScope async vision, official OpenAI, and Azure.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A
