### PR TITLE
feat(embedding): enable recursive directory indexing for nested resource trees

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -320,12 +320,23 @@ async def vectorize_file(
 async def index_resource(
     uri: str,
     ctx: RequestContext,
+    recursive: bool = True,
+    max_depth: int = 10,
+    _current_depth: int = 0,
 ) -> None:
     """
     Build vector index for a resource directory.
 
     1. Reads .abstract.md and .overview.md and vectorizes them.
     2. Scans files in the directory and vectorizes them.
+    3. Optionally recurses into subdirectories.
+
+    Args:
+        uri: Resource directory URI to index.
+        ctx: Request context for tenant scoping.
+        recursive: Whether to recurse into subdirectories (default True).
+        max_depth: Maximum recursion depth to prevent runaway traversal (default 10).
+        _current_depth: Internal depth tracker, do not set manually.
     """
     viking_fs = get_viking_fs()
 
@@ -360,7 +371,15 @@ async def index_resource(
                 continue
 
             if file_info.get("type") == "directory" or file_info.get("isDir"):
-                # TODO: Recursive indexing? For now, skip subdirectories to match previous behavior
+                if recursive and _current_depth < max_depth:
+                    subdir_uri = file_info.get("uri") or f"{uri}/{file_name}"
+                    await index_resource(
+                        subdir_uri,
+                        ctx=ctx,
+                        recursive=True,
+                        max_depth=max_depth,
+                        _current_depth=_current_depth + 1,
+                    )
                 continue
 
             file_uri = file_info.get("uri") or f"{uri}/{file_name}"

--- a/tests/unit/test_index_resource_recursive.py
+++ b/tests/unit/test_index_resource_recursive.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for recursive directory indexing in index_resource()."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_index_resource_recurses_into_subdirectories():
+    """index_resource traverses subdirectories when recursive=True."""
+    mock_ctx = MagicMock()
+    mock_fs = AsyncMock()
+
+    # Root dir has one file and one subdir
+    mock_fs.exists.return_value = False  # no .abstract.md/.overview.md
+    mock_fs.ls.side_effect = [
+        # Root listing
+        [
+            {"name": "readme.md", "type": "file"},
+            {"name": "subdir", "type": "directory", "uri": "viking://test/subdir"},
+        ],
+        # Subdir listing
+        [
+            {"name": "nested.md", "type": "file"},
+        ],
+    ]
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=mock_fs),
+        patch("openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock) as mock_vf,
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://test/", ctx=mock_ctx, recursive=True)
+
+        # Should have vectorized both files (root + subdir)
+        assert mock_vf.call_count == 2
+        vectorized_paths = [
+            call.kwargs.get("file_path", call.args[0] if call.args else "")
+            for call in mock_vf.call_args_list
+        ]
+        # Check that paths include files from both levels
+        assert any("readme" in str(p) for p in vectorized_paths)
+        assert any("nested" in str(p) for p in vectorized_paths)
+
+
+@pytest.mark.asyncio
+async def test_index_resource_skips_subdirs_when_not_recursive():
+    """index_resource skips subdirectories when recursive=False."""
+    mock_ctx = MagicMock()
+    mock_fs = AsyncMock()
+
+    mock_fs.exists.return_value = False
+    mock_fs.ls.return_value = [
+        {"name": "readme.md", "type": "file"},
+        {"name": "subdir", "type": "directory"},
+    ]
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=mock_fs),
+        patch("openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock) as mock_vf,
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://test/", ctx=mock_ctx, recursive=False)
+
+        # Should only vectorize the file, not recurse into subdir
+        assert mock_vf.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_index_resource_respects_max_depth():
+    """index_resource stops recursing at max_depth."""
+    mock_ctx = MagicMock()
+    mock_fs = AsyncMock()
+
+    mock_fs.exists.return_value = False
+    # Each directory contains one subdir - infinite nesting
+    mock_fs.ls.return_value = [
+        {"name": "deep", "type": "directory", "uri": "viking://test/deep"},
+    ]
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=mock_fs),
+        patch("openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock),
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://test/", ctx=mock_ctx, recursive=True, max_depth=2)
+
+        # ls should be called for depth 0, 1, and 2 (3 calls total), then stop
+        assert mock_fs.ls.call_count == 3


### PR DESCRIPTION
## Description

Replace the TODO at `embedding_utils.py:362` with recursive directory traversal. When `index_resource()` encounters a subdirectory, it now recurses to index nested files instead of skipping them.

Before this change, only top-level files in a resource directory got vector-indexed. Files in subdirectories were invisible to semantic search, which was a problem for nested resource trees (code repos, documentation hierarchies).

## Related Issue

No existing issue - addresses an explicit TODO in the codebase.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `recursive` parameter (default `True`) and `max_depth` parameter (default `10`) to `index_resource()` in `embedding_utils.py`
- Replace the `continue` on subdirectories with a recursive `index_resource()` call when `recursive=True` and depth limit not reached
- Add 3 tests in `tests/unit/test_index_resource_recursive.py`: recursive traversal, skip-when-disabled, max-depth enforcement

## Testing

- Tests mock `viking_fs.ls()` and `vectorize_file()` to verify traversal behavior
- `ruff format` and `ruff check` pass
- `max_depth=2` test verifies that `ls` is called exactly 3 times (depth 0, 1, 2) then stops

## Design decisions

- **Default recursive=True**: the old behavior (skipping subdirs) was the TODO-acknowledged limitation, not an intentional choice. Enabling recursion by default matches user expectation when adding a directory resource.
- **max_depth=10**: prevents runaway traversal on deeply nested or symlink-cycled trees. 10 levels covers any real resource hierarchy.
- **Backward compatible**: new parameters are optional with sensible defaults. Existing callers of `index_resource(uri, ctx)` work identically but now get subdirectory coverage.

This contribution was developed with AI assistance (Claude Code).