### PR TITLE
fix: resolve session-transcript-repair import error in context-engine (fixes #945)

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -8,7 +8,7 @@ import {
   trimForLog,
   toJsonLog,
 } from "./memory-ranking.js";
-import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import { sanitizeToolUseResultPairing } from "./session-transcript-repair";
 
 type AgentMessage = {
   role?: string;


### PR DESCRIPTION
## Problem
Plugin fails to load with:
```
Error: Cannot find module './session-transcript-repair.js'
```

## Root Cause
`context-engine.ts` imports with `.js` extension:
```ts
import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
```
But the actual file is `session-transcript-repair.ts`. When OpenClaw loads the plugin at runtime via TypeScript (tsx/ts-node), Node.js looks for a `.js` file that doesn't exist.

## Fix
Changed to extensionless import:
```ts
import { sanitizeToolUseResultPairing } from "./session-transcript-repair";
```
TypeScript runtimes resolve extensionless imports to `.ts` files correctly.

## Testing
The fix is a single-line import path change. No logic modifications.