### PR TITLE
fix(vlm): wire thinking parameter to OpenAI and LiteLLM backends

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Union
 import litellm
 from litellm import acompletion, completion
 
-from ..base import VLMBase, VLMResponse, ToolCall
+from ..base import ToolCall, VLMBase, VLMResponse
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +196,14 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             return {"type": "image_url", "image_url": {"url": image}}
 
-    def _build_kwargs(self, model: str, messages: list, tools: Optional[List[Dict[str, Any]]] = None, tool_choice: Optional[str] = None) -> dict[str, Any]:
+    def _build_kwargs(
+        self,
+        model: str,
+        messages: list,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str] = None,
+        thinking: bool = False,
+    ) -> dict[str, Any]:
         """Build kwargs for LiteLLM call."""
         kwargs: dict[str, Any] = {
             "model": model,
@@ -205,6 +212,10 @@ class LiteLLMVLMProvider(VLMBase):
         }
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
+        if not thinking:
+            extra = kwargs.get("extra_body", {})
+            extra["enable_thinking"] = False
+            kwargs["extra_body"] = extra
 
         if self.api_key:
             kwargs["api_key"] = self.api_key
@@ -236,11 +247,7 @@ class LiteLLMVLMProvider(VLMBase):
                         args = json.loads(args)
                     except json.JSONDecodeError:
                         args = {"raw": args}
-                tool_calls.append(ToolCall(
-                    id=tc.id,
-                    name=tc.function.name,
-                    arguments=args
-                ))
+                tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
         return tool_calls
 
     def _build_vlm_response(self, response, has_tools: bool) -> Union[str, VLMResponse]:
@@ -282,7 +289,7 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             kwargs_messages = [{"role": "user", "content": prompt}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice, thinking=thinking)
 
         t0 = time.perf_counter()
         response = completion(**kwargs)
@@ -306,7 +313,7 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             kwargs_messages = [{"role": "user", "content": prompt}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice, thinking=thinking)
 
         last_error = None
         for attempt in range(max_retries + 1):
@@ -315,7 +322,8 @@ class LiteLLMVLMProvider(VLMBase):
                 response = await acompletion(**kwargs)
                 elapsed = time.perf_counter() - t0
                 self._update_token_usage_from_response(
-                    response, duration_seconds=elapsed,
+                    response,
+                    duration_seconds=elapsed,
                 )
                 return self._build_vlm_response(response, has_tools=bool(tools))
             except Exception as e:
@@ -349,7 +357,7 @@ class LiteLLMVLMProvider(VLMBase):
                 content.append({"type": "text", "text": prompt})
             kwargs_messages = [{"role": "user", "content": content}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, thinking=thinking)
 
         t0 = time.perf_counter()
         response = completion(**kwargs)
@@ -379,7 +387,7 @@ class LiteLLMVLMProvider(VLMBase):
                 content.append({"type": "text", "text": prompt})
             kwargs_messages = [{"role": "user", "content": content}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, thinking=thinking)
 
         t0 = time.perf_counter()
         response = await acompletion(**kwargs)
@@ -388,7 +396,9 @@ class LiteLLMVLMProvider(VLMBase):
         return self._build_vlm_response(response, has_tools=bool(tools))
 
     def _update_token_usage_from_response(
-        self, response, duration_seconds: float = 0.0,
+        self,
+        response,
+        duration_seconds: float = 0.0,
     ) -> None:
         """Update token usage from response."""
         if hasattr(response, "usage") and response.usage:

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from ..base import VLMBase, VLMResponse, ToolCall
+from ..base import ToolCall, VLMBase, VLMResponse
 from ..registry import DEFAULT_AZURE_API_VERSION
 
 logger = logging.getLogger(__name__)
@@ -56,8 +56,11 @@ class OpenAIVLM(VLMBase):
             except ImportError:
                 raise ImportError("Please install openai: pip install openai")
             kwargs = _build_openai_client_kwargs(
-                self.provider, self.api_key, self.api_base,
-                self.api_version, self.extra_headers,
+                self.provider,
+                self.api_key,
+                self.api_base,
+                self.api_version,
+                self.extra_headers,
             )
             if self.provider == "azure":
                 self._sync_client = openai.AzureOpenAI(**kwargs)
@@ -73,8 +76,11 @@ class OpenAIVLM(VLMBase):
             except ImportError:
                 raise ImportError("Please install openai: pip install openai")
             kwargs = _build_openai_client_kwargs(
-                self.provider, self.api_key, self.api_base,
-                self.api_version, self.extra_headers,
+                self.provider,
+                self.api_key,
+                self.api_base,
+                self.api_version,
+                self.extra_headers,
             )
             if self.provider == "azure":
                 self._async_client = openai.AsyncAzureOpenAI(**kwargs)
@@ -83,7 +89,9 @@ class OpenAIVLM(VLMBase):
         return self._async_client
 
     def _update_token_usage_from_response(
-        self, response, duration_seconds: float = 0.0,
+        self,
+        response,
+        duration_seconds: float = 0.0,
     ):
         if hasattr(response, "usage") and response.usage:
             prompt_tokens = response.usage.prompt_tokens
@@ -108,11 +116,7 @@ class OpenAIVLM(VLMBase):
                         args = json.loads(args)
                     except json.JSONDecodeError:
                         args = {"raw": args}
-                tool_calls.append(ToolCall(
-                    id=tc.id,
-                    name=tc.function.name,
-                    arguments=args
-                ))
+                tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
         return tool_calls
 
     def _build_vlm_response(self, response, has_tools: bool) -> Union[str, VLMResponse]:
@@ -249,6 +253,10 @@ class OpenAIVLM(VLMBase):
         }
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
+        if not thinking:
+            extra = kwargs.get("extra_body", {})
+            extra["enable_thinking"] = False
+            kwargs["extra_body"] = extra
 
         if tools:
             kwargs["tools"] = tools
@@ -294,6 +302,10 @@ class OpenAIVLM(VLMBase):
         }
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
+        if not thinking:
+            extra = kwargs.get("extra_body", {})
+            extra["enable_thinking"] = False
+            kwargs["extra_body"] = extra
 
         if tools:
             kwargs["tools"] = tools
@@ -314,7 +326,8 @@ class OpenAIVLM(VLMBase):
                     content = await self._process_streaming_response_async(response)
                 else:
                     self._update_token_usage_from_response(
-                        response, duration_seconds=elapsed,
+                        response,
+                        duration_seconds=elapsed,
                     )
                     content = self._extract_content_from_response(response)
 
@@ -411,6 +424,10 @@ class OpenAIVLM(VLMBase):
         }
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
+        if not thinking:
+            extra = kwargs.get("extra_body", {})
+            extra["enable_thinking"] = False
+            kwargs["extra_body"] = extra
 
         if tools:
             kwargs["tools"] = tools
@@ -462,6 +479,10 @@ class OpenAIVLM(VLMBase):
         }
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
+        if not thinking:
+            extra = kwargs.get("extra_body", {})
+            extra["enable_thinking"] = False
+            kwargs["extra_body"] = extra
 
         if tools:
             kwargs["tools"] = tools

--- a/tests/unit/test_vlm_thinking_param.py
+++ b/tests/unit/test_vlm_thinking_param.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for VLM thinking parameter support."""
+
+from unittest.mock import MagicMock, patch
+
+from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+
+
+def _make_mock_response():
+    """Create a mock OpenAI-style response."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "test response"
+    mock_response.choices[0].message.tool_calls = None
+    mock_response.choices[0].finish_reason = "stop"
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 5
+    mock_response.usage.total_tokens = 15
+    mock_response.usage.prompt_tokens_details = None
+    return mock_response
+
+
+class TestOpenAIThinkingParam:
+    """Test thinking parameter is wired to OpenAI API calls."""
+
+    def _make_vlm_with_mock_client(self):
+        """Create an OpenAIVLM with a mocked sync client."""
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_mock_response()
+        vlm._sync_client = mock_client
+        return vlm, mock_client
+
+    def test_openai_thinking_disabled_passes_extra_body(self):
+        """When thinking=False, extra_body should contain enable_thinking=False."""
+        vlm, mock_client = self._make_vlm_with_mock_client()
+
+        vlm.get_completion(prompt="hello", thinking=False)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "extra_body" in call_kwargs
+        assert call_kwargs["extra_body"]["enable_thinking"] is False
+
+    def test_openai_thinking_enabled_no_extra_body(self):
+        """When thinking=True, enable_thinking should NOT be set to False."""
+        vlm, mock_client = self._make_vlm_with_mock_client()
+
+        vlm.get_completion(prompt="hello", thinking=True)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        extra_body = call_kwargs.get("extra_body", {})
+        assert extra_body.get("enable_thinking") is not False
+
+    def test_openai_vision_thinking_disabled_passes_extra_body(self):
+        """Vision completion with thinking=False should pass enable_thinking=False."""
+        vlm, mock_client = self._make_vlm_with_mock_client()
+
+        vlm.get_vision_completion(
+            prompt="describe this",
+            images=["https://example.com/img.png"],
+            thinking=False,
+        )
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "extra_body" in call_kwargs
+        assert call_kwargs["extra_body"]["enable_thinking"] is False
+
+
+class TestLiteLLMThinkingParam:
+    """Test thinking parameter is wired to LiteLLM API calls."""
+
+    @patch("openviking.models.vlm.backends.litellm_vlm.completion")
+    def test_litellm_thinking_disabled_passes_extra_body(self, mock_completion):
+        """When thinking=False, extra_body should contain enable_thinking=False."""
+        mock_completion.return_value = _make_mock_response()
+
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "qwen3.5-plus",
+                "provider": "dashscope",
+                "api_key": "sk-test",
+            }
+        )
+
+        vlm.get_completion(prompt="hello", thinking=False)
+
+        call_kwargs = mock_completion.call_args[1]
+        assert "extra_body" in call_kwargs
+        assert call_kwargs["extra_body"]["enable_thinking"] is False
+
+    @patch("openviking.models.vlm.backends.litellm_vlm.completion")
+    def test_litellm_thinking_enabled_no_extra_body(self, mock_completion):
+        """When thinking=True, enable_thinking should NOT be set to False."""
+        mock_completion.return_value = _make_mock_response()
+
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "qwen3.5-plus",
+                "provider": "dashscope",
+                "api_key": "sk-test",
+            }
+        )
+
+        vlm.get_completion(prompt="hello", thinking=True)
+
+        call_kwargs = mock_completion.call_args[1]
+        extra_body = call_kwargs.get("extra_body", {})
+        assert extra_body.get("enable_thinking") is not False


### PR DESCRIPTION
## Summary

- Wire the unused `thinking` parameter to the OpenAI and LiteLLM VLM backends by passing `enable_thinking: False` via `extra_body` when `thinking=False`
- Models like `qwen3.5-plus` (DashScope) default to thinking mode, causing 60+ second timeouts on every memory extraction call because thinking was never explicitly disabled
- The VolcEngine backend already handles this correctly — this fix brings OpenAI and LiteLLM backends to parity

## Changes

- **`openai_vlm.py`**: All 4 completion methods now pass `extra_body={"enable_thinking": False}` when `thinking=False`
- **`litellm_vlm.py`**: `_build_kwargs()` now accepts `thinking` param; all 4 callers pass it through
- **5 new tests** covering both backends

Fixes #923.

## Test plan

- [x] 5 new tests pass (`pytest tests/unit/test_vlm_thinking_param.py`)
- [x] Ruff check and format clean
- [x] VolcEngine backend unchanged (already correct)