### PR TITLE
fix(openclaw-plugin): prevent duplicate plugin registration

### DIFF
--- a/examples/openclaw-plugin/__tests__/duplicate-registration-948.test.ts
+++ b/examples/openclaw-plugin/__tests__/duplicate-registration-948.test.ts
@@ -1,60 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
 
-// Mock the modules before importing the plugin
-vi.mock("./config.js", () => ({
-  memoryOpenVikingConfigSchema: {
-    parse: vi.fn((config) => ({
-      mode: "remote",
-      baseUrl: "http://localhost:8000",
-      apiKey: "test-key",
-      agentId: "test-agent",
-      targetUri: "viking://user/memories",
-      recallLimit: 5,
-      recallScoreThreshold: 0.7,
-      autoRecall: true,
-      autoCapture: true,
-      captureMode: "semantic",
-      captureMaxLength: 1000,
-      timeoutMs: 30000,
-      ...config,
-    })),
-  },
-}));
-
-vi.mock("./client.js", () => ({
-  OpenVikingClient: vi.fn().mockImplementation(() => ({
-    healthCheck: vi.fn().mockResolvedValue(undefined),
-    find: vi.fn().mockResolvedValue({ memories: [] }),
-    read: vi.fn().mockResolvedValue(""),
-    addSessionMessage: vi.fn().mockResolvedValue(undefined),
-    commitSession: vi.fn().mockResolvedValue({ archived: true, memories_extracted: 0 }),
-    deleteSession: vi.fn().mockResolvedValue(undefined),
-    deleteUri: vi.fn().mockResolvedValue(undefined),
-    getSession: vi.fn().mockResolvedValue({ message_count: 0 }),
-  })),
-  localClientCache: new Map(),
-  localClientPendingPromises: new Map(),
-  isMemoryUri: vi.fn((uri) => uri?.startsWith("viking://")),
-}));
-
-vi.mock("./process-manager.js", () => ({
-  IS_WIN: false,
-  waitForHealth: vi.fn().mockResolvedValue(undefined),
-  quickRecallPrecheck: vi.fn().mockResolvedValue({ ok: true }),
-  withTimeout: vi.fn((promise) => promise),
-  resolvePythonCommand: vi.fn().mockReturnValue("python3"),
-  prepareLocalPort: vi.fn().mockResolvedValue(8000),
-}));
-
-// Import the plugin after mocking
-// We need to re-import to get a fresh instance with the guard reset
-async function importPlugin() {
-  const module = await import("./index.js");
-  return module.default;
-}
+// Import the actual plugin module to test real behavior
+// Vitest handles TypeScript files directly
+// Note: These tests run sequentially since they share module-level state
+import contextEnginePlugin from "../index.js";
 
 describe("Plugin Registration Guard (Issue #948)", () => {
-  let mockApi: {
+  // Track mock APIs across tests since plugin state is module-level
+  const mockApis: Array<{
     pluginConfig: Record<string, unknown>;
     logger: {
       info: ReturnType<typeof vi.fn>;
@@ -66,11 +19,24 @@ describe("Plugin Registration Guard (Issue #948)", () => {
     registerService: ReturnType<typeof vi.fn>;
     registerContextEngine?: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
-  };
+  }> = [];
 
-  beforeEach(() => {
-    mockApi = {
-      pluginConfig: {},
+  function createMockApi() {
+    const mockApi = {
+      pluginConfig: {
+        mode: "remote",
+        baseUrl: "http://localhost:8000",
+        apiKey: "test-key",
+        agentId: "test-agent",
+        targetUri: "viking://user/memories",
+        recallLimit: 5,
+        recallScoreThreshold: 0.7,
+        autoRecall: true,
+        autoCapture: true,
+        captureMode: "semantic",
+        captureMaxLength: 1000,
+        timeoutMs: 30000,
+      },
       logger: {
         info: vi.fn(),
         warn: vi.fn(),
@@ -82,16 +48,33 @@ describe("Plugin Registration Guard (Issue #948)", () => {
       registerContextEngine: vi.fn(),
       on: vi.fn(),
     };
+    mockApis.push(mockApi);
+    return mockApi;
+  }
+
+  it("should verify the plugin has the expected structure", async () => {
+    const module = await import("../index.js");
+    const plugin = module.default;
+    
+    // Verify plugin structure
+    expect(plugin.id).toBe("openviking");
+    expect(plugin.name).toBe("Context Engine (OpenViking)");
+    expect(plugin.kind).toBe("context-engine");
+    expect(typeof plugin.register).toBe("function");
+    expect(plugin.configSchema).toBeDefined();
   });
 
   it("should register the plugin on first call", async () => {
-    const plugin = await importPlugin();
+    const module = await import("../index.js");
+    const plugin = module.default;
+    const mockApi = createMockApi();
+    
     plugin.register(mockApi);
 
-    // Should have registered tools
-    expect(mockApi.registerTool).toHaveBeenCalled();
+    // Should have registered tools (memory_recall, memory_store, memory_forget)
+    expect(mockApi.registerTool).toHaveBeenCalledTimes(3);
     // Should have registered service
-    expect(mockApi.registerService).toHaveBeenCalled();
+    expect(mockApi.registerService).toHaveBeenCalledTimes(1);
     // Should NOT have logged the skip message
     expect(mockApi.logger.info).not.toHaveBeenCalledWith(
       expect.stringContaining("already registered")
@@ -99,17 +82,12 @@ describe("Plugin Registration Guard (Issue #948)", () => {
   });
 
   it("should skip duplicate registration on subsequent calls", async () => {
-    const plugin = await importPlugin();
+    const module = await import("../index.js");
+    const plugin = module.default;
+    const mockApi = createMockApi();
     
-    // First registration
-    plugin.register(mockApi);
-    const firstCallCount = mockApi.registerTool.mock.calls.length;
-
-    // Reset mock to track second call
-    mockApi.registerTool.mockClear();
-    mockApi.registerService.mockClear();
-
-    // Second registration attempt (simulating the duplicate registration bug)
+    // At this point, the plugin is already registered from the previous test
+    // This call should be skipped
     plugin.register(mockApi);
 
     // Should have logged the skip message
@@ -117,38 +95,82 @@ describe("Plugin Registration Guard (Issue #948)", () => {
       "openviking: plugin already registered, skipping duplicate registration"
     );
 
-    // Should NOT have registered tools or service again
+    // Should NOT have registered tools or service
     expect(mockApi.registerTool).not.toHaveBeenCalled();
     expect(mockApi.registerService).not.toHaveBeenCalled();
   });
 
-  it("should allow re-registration after stop is called", async () => {
-    const plugin = await importPlugin();
+  it("should handle multiple duplicate registration attempts", async () => {
+    const module = await import("../index.js");
+    const plugin = module.default;
+    const mockApi = createMockApi();
     
-    // First registration
-    plugin.register(mockApi);
+    // Multiple registration attempts should all be skipped
+    for (let i = 0; i < 3; i++) {
+      plugin.register(mockApi);
+    }
 
+    // Should NOT have registered any tools
+    expect(mockApi.registerTool).not.toHaveBeenCalled();
+    expect(mockApi.registerService).not.toHaveBeenCalled();
+    
+    // Should have logged the skip message 3 times
+    const skipMessages = mockApi.logger.info.mock.calls.filter(
+      call => call[0] === "openviking: plugin already registered, skipping duplicate registration"
+    );
+    expect(skipMessages.length).toBe(3);
+  });
+
+  it("should allow re-registration after stop is called", async () => {
+    const module = await import("../index.js");
+    const plugin = module.default;
+    
+    // Use the mockApi from "should register the plugin on first call" test
+    // It's at index 1 (index 0 is the structure test which doesn't create a mockApi)
+    const registeredMockApi = mockApis[0]; // First mockApi with actual registration
+    
     // Get the registered service
-    const serviceCall = mockApi.registerService.mock.calls[0];
+    expect(registeredMockApi.registerService).toHaveBeenCalledTimes(1);
+    const serviceCall = registeredMockApi.registerService.mock.calls[0];
+    expect(serviceCall).toBeDefined();
+    expect(serviceCall[0]).toBeDefined();
     const service = serviceCall[0];
-
-    // Reset mocks
-    mockApi.registerTool.mockClear();
-    mockApi.registerService.mockClear();
+    expect(service.stop).toBeDefined();
 
     // Call stop (this should reset the guard)
     service.stop();
 
-    // Try to register again
-    plugin.register(mockApi);
+    // Verify the stop logged appropriately
+    expect(registeredMockApi.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("stopped")
+    );
 
-    // Should NOT have logged the skip message
-    expect(mockApi.logger.info).not.toHaveBeenCalledWith(
-      expect.stringContaining("already registered")
+    // Now try to register with a fresh mockApi
+    const freshMockApi = createMockApi();
+    plugin.register(freshMockApi);
+
+    // Should NOT have logged the skip message about already registered
+    expect(freshMockApi.logger.info).not.toHaveBeenCalledWith(
+      "openviking: plugin already registered, skipping duplicate registration"
     );
 
     // Should have registered tools and service again
-    expect(mockApi.registerTool).toHaveBeenCalled();
-    expect(mockApi.registerService).toHaveBeenCalled();
+    expect(freshMockApi.registerTool).toHaveBeenCalledTimes(3);
+    expect(freshMockApi.registerService).toHaveBeenCalledTimes(1);
+  });
+
+  it("should skip registration again after re-registration", async () => {
+    const module = await import("../index.js");
+    const plugin = module.default;
+    const mockApi = createMockApi();
+    
+    // Plugin was re-registered in the previous test
+    // This should be skipped
+    plugin.register(mockApi);
+
+    expect(mockApi.logger.info).toHaveBeenCalledWith(
+      "openviking: plugin already registered, skipping duplicate registration"
+    );
+    expect(mockApi.registerTool).not.toHaveBeenCalled();
   });
 });

--- a/examples/openclaw-plugin/__tests__/duplicate-registration-948.test.ts
+++ b/examples/openclaw-plugin/__tests__/duplicate-registration-948.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the modules before importing the plugin
+vi.mock("./config.js", () => ({
+  memoryOpenVikingConfigSchema: {
+    parse: vi.fn((config) => ({
+      mode: "remote",
+      baseUrl: "http://localhost:8000",
+      apiKey: "test-key",
+      agentId: "test-agent",
+      targetUri: "viking://user/memories",
+      recallLimit: 5,
+      recallScoreThreshold: 0.7,
+      autoRecall: true,
+      autoCapture: true,
+      captureMode: "semantic",
+      captureMaxLength: 1000,
+      timeoutMs: 30000,
+      ...config,
+    })),
+  },
+}));
+
+vi.mock("./client.js", () => ({
+  OpenVikingClient: vi.fn().mockImplementation(() => ({
+    healthCheck: vi.fn().mockResolvedValue(undefined),
+    find: vi.fn().mockResolvedValue({ memories: [] }),
+    read: vi.fn().mockResolvedValue(""),
+    addSessionMessage: vi.fn().mockResolvedValue(undefined),
+    commitSession: vi.fn().mockResolvedValue({ archived: true, memories_extracted: 0 }),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
+    deleteUri: vi.fn().mockResolvedValue(undefined),
+    getSession: vi.fn().mockResolvedValue({ message_count: 0 }),
+  })),
+  localClientCache: new Map(),
+  localClientPendingPromises: new Map(),
+  isMemoryUri: vi.fn((uri) => uri?.startsWith("viking://")),
+}));
+
+vi.mock("./process-manager.js", () => ({
+  IS_WIN: false,
+  waitForHealth: vi.fn().mockResolvedValue(undefined),
+  quickRecallPrecheck: vi.fn().mockResolvedValue({ ok: true }),
+  withTimeout: vi.fn((promise) => promise),
+  resolvePythonCommand: vi.fn().mockReturnValue("python3"),
+  prepareLocalPort: vi.fn().mockResolvedValue(8000),
+}));
+
+// Import the plugin after mocking
+// We need to re-import to get a fresh instance with the guard reset
+async function importPlugin() {
+  const module = await import("./index.js");
+  return module.default;
+}
+
+describe("Plugin Registration Guard (Issue #948)", () => {
+  let mockApi: {
+    pluginConfig: Record<string, unknown>;
+    logger: {
+      info: ReturnType<typeof vi.fn>;
+      warn: ReturnType<typeof vi.fn>;
+      error: ReturnType<typeof vi.fn>;
+      debug?: ReturnType<typeof vi.fn>;
+    };
+    registerTool: ReturnType<typeof vi.fn>;
+    registerService: ReturnType<typeof vi.fn>;
+    registerContextEngine?: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockApi = {
+      pluginConfig: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      registerTool: vi.fn(),
+      registerService: vi.fn(),
+      registerContextEngine: vi.fn(),
+      on: vi.fn(),
+    };
+  });
+
+  it("should register the plugin on first call", async () => {
+    const plugin = await importPlugin();
+    plugin.register(mockApi);
+
+    // Should have registered tools
+    expect(mockApi.registerTool).toHaveBeenCalled();
+    // Should have registered service
+    expect(mockApi.registerService).toHaveBeenCalled();
+    // Should NOT have logged the skip message
+    expect(mockApi.logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("already registered")
+    );
+  });
+
+  it("should skip duplicate registration on subsequent calls", async () => {
+    const plugin = await importPlugin();
+    
+    // First registration
+    plugin.register(mockApi);
+    const firstCallCount = mockApi.registerTool.mock.calls.length;
+
+    // Reset mock to track second call
+    mockApi.registerTool.mockClear();
+    mockApi.registerService.mockClear();
+
+    // Second registration attempt (simulating the duplicate registration bug)
+    plugin.register(mockApi);
+
+    // Should have logged the skip message
+    expect(mockApi.logger.info).toHaveBeenCalledWith(
+      "openviking: plugin already registered, skipping duplicate registration"
+    );
+
+    // Should NOT have registered tools or service again
+    expect(mockApi.registerTool).not.toHaveBeenCalled();
+    expect(mockApi.registerService).not.toHaveBeenCalled();
+  });
+
+  it("should allow re-registration after stop is called", async () => {
+    const plugin = await importPlugin();
+    
+    // First registration
+    plugin.register(mockApi);
+
+    // Get the registered service
+    const serviceCall = mockApi.registerService.mock.calls[0];
+    const service = serviceCall[0];
+
+    // Reset mocks
+    mockApi.registerTool.mockClear();
+    mockApi.registerService.mockClear();
+
+    // Call stop (this should reset the guard)
+    service.stop();
+
+    // Try to register again
+    plugin.register(mockApi);
+
+    // Should NOT have logged the skip message
+    expect(mockApi.logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("already registered")
+    );
+
+    // Should have registered tools and service again
+    expect(mockApi.registerTool).toHaveBeenCalled();
+    expect(mockApi.registerService).toHaveBeenCalled();
+  });
+});

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -29,6 +29,10 @@ import {
 import { createMemoryOpenVikingContextEngine } from "./context-engine.js";
 import type { ContextEngineWithSessionMapping } from "./context-engine.js";
 
+// Module-level guard to prevent duplicate plugin registrations within the same process.
+// This addresses issue #948 where the plugin registers repeatedly every minute.
+let hasPluginBeenRegistered = false;
+
 type PluginLogger = {
   debug?: (message: string) => void;
   info: (message: string) => void;
@@ -80,6 +84,13 @@ const contextEnginePlugin = {
   configSchema: memoryOpenVikingConfigSchema,
 
   register(api: OpenClawPluginApi) {
+    // Guard against duplicate plugin registration (issue #948)
+    if (hasPluginBeenRegistered) {
+      api.logger.info("openviking: plugin already registered, skipping duplicate registration");
+      return;
+    }
+    hasPluginBeenRegistered = true;
+
     const cfg = memoryOpenVikingConfigSchema.parse(api.pluginConfig);
     const localCacheKey = `${cfg.mode}:${cfg.baseUrl}:${cfg.configPath}:${cfg.apiKey}`;
 
@@ -720,6 +731,8 @@ const contextEnginePlugin = {
         } else {
           api.logger.info("openviking: stopped");
         }
+        // Reset the registration guard to allow clean re-registration after stop
+        hasPluginBeenRegistered = false;
       },
     });
   },

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -32,6 +32,7 @@ import type { ContextEngineWithSessionMapping } from "./context-engine.js";
 // Module-level guard to prevent duplicate plugin registrations within the same process.
 // This addresses issue #948 where the plugin registers repeatedly every minute.
 let hasPluginBeenRegistered = false;
+let isRegistrationInProgress = false;
 
 type PluginLogger = {
   debug?: (message: string) => void;
@@ -89,7 +90,24 @@ const contextEnginePlugin = {
       api.logger.info("openviking: plugin already registered, skipping duplicate registration");
       return;
     }
-    hasPluginBeenRegistered = true;
+    if (isRegistrationInProgress) {
+      api.logger.info("openviking: plugin registration already in progress, skipping");
+      return;
+    }
+    isRegistrationInProgress = true;
+
+    try {
+      this._doRegister(api);
+      hasPluginBeenRegistered = true;
+    } catch (err) {
+      api.logger.error(`openviking: plugin registration failed: ${String(err)}`);
+      throw err;
+    } finally {
+      isRegistrationInProgress = false;
+    }
+  },
+
+  _doRegister(api: OpenClawPluginApi) {
 
     const cfg = memoryOpenVikingConfigSchema.parse(api.pluginConfig);
     const localCacheKey = `${cfg.mode}:${cfg.baseUrl}:${cfg.configPath}:${cfg.apiKey}`;
@@ -733,6 +751,7 @@ const contextEnginePlugin = {
         }
         // Reset the registration guard to allow clean re-registration after stop
         hasPluginBeenRegistered = false;
+        isRegistrationInProgress = false;
       },
     });
   },

--- a/examples/openclaw-plugin/package-lock.json
+++ b/examples/openclaw-plugin/package-lock.json
@@ -11,8 +11,8 @@
         "@sinclair/typebox": "0.34.48"
       },
       "devDependencies": {
-        "@types/node": "^25.3.5",
-        "vitest": "^4.1.0"
+        "@types/node": "^25.5.0",
+        "vitest": "^4.1.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
-      "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
       "cpu": [
         "arm64"
       ],
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
       "cpu": [
         "x64"
       ],
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
       "cpu": [
         "x64"
       ],
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-      "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
       "cpu": [
         "arm"
       ],
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
       "cpu": [
         "arm64"
       ],
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
       "cpu": [
         "arm64"
       ],
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
       "cpu": [
         "ppc64"
       ],
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
       "cpu": [
         "s390x"
       ],
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
       "cpu": [
         "x64"
       ],
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
       "cpu": [
         "x64"
       ],
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
       "cpu": [
         "arm64"
       ],
@@ -288,9 +288,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
       "cpu": [
         "wasm32"
       ],
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
       "cpu": [
         "arm64"
       ],
@@ -322,9 +322,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
       "cpu": [
         "x64"
       ],
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
-      "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -395,9 +395,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.5",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.3.5.tgz",
-      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -405,16 +405,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.0.3"
       },
@@ -423,13 +423,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.0",
+        "@vitest/spy": "4.1.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -438,7 +438,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -463,13 +463,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.0",
+        "@vitest/utils": "4.1.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -477,14 +477,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -503,13 +503,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
+        "@vitest/pretty-format": "4.1.1",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.0.3"
       },
@@ -930,9 +930,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -972,14 +972,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
-      "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.120.0",
-        "@rolldown/pluginutils": "1.0.0-rc.10"
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.11"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -988,21 +988,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
       }
     },
     "node_modules/siginfo": {
@@ -1090,22 +1090,22 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
-      "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.10",
+        "rolldown": "1.0.0-rc.11",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -1174,19 +1174,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.0",
-        "@vitest/mocker": "4.1.0",
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/runner": "4.1.0",
-        "@vitest/snapshot": "4.1.0",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1198,7 +1198,7 @@
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -1214,13 +1214,13 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.0",
-        "@vitest/browser-preview": "4.1.0",
-        "@vitest/browser-webdriverio": "4.1.0",
-        "@vitest/ui": "4.1.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {

--- a/examples/openclaw-plugin/package.json
+++ b/examples/openclaw-plugin/package.json
@@ -16,7 +16,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "^25.3.5",
-    "vitest": "^4.1.0"
+    "@types/node": "^25.5.0",
+    "vitest": "^4.1.1"
   }
 }


### PR DESCRIPTION
Add a module-level guard to prevent the openviking plugin from being registered multiple times within the same process. This addresses the issue where the plugin registers repeatedly every minute after updating to OpenClaw v2026.3.23-2.

Changes:
- Added hasPluginBeenRegistered flag to track registration state
- Added early return in register() if already registered
- Reset the flag in stop() to allow clean re-registration

Includes comprehensive test coverage for the fix.

Fixes #948