### PR TITLE
fix(vlm): scope LiteLLM thinking param to DashScope providers only

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Union
 import litellm
 from litellm import acompletion, completion
 
-from ..base import VLMBase, VLMResponse, ToolCall
+from ..base import ToolCall, VLMBase, VLMResponse
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +196,14 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             return {"type": "image_url", "image_url": {"url": image}}
 
-    def _build_kwargs(self, model: str, messages: list, tools: Optional[List[Dict[str, Any]]] = None, tool_choice: Optional[str] = None) -> dict[str, Any]:
+    def _build_kwargs(
+        self,
+        model: str,
+        messages: list,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str] = None,
+        thinking: bool = False,
+    ) -> dict[str, Any]:
         """Build kwargs for LiteLLM call."""
         kwargs: dict[str, Any] = {
             "model": model,
@@ -223,6 +230,13 @@ class LiteLLMVLMProvider(VLMBase):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
+        # Only send enable_thinking to DashScope-compatible providers
+        provider = self._detected_provider or detect_provider_by_model(model)
+        if provider == "dashscope":
+            extra = kwargs.get("extra_body", {})
+            extra["enable_thinking"] = thinking
+            kwargs["extra_body"] = extra
+
         return kwargs
 
     def _parse_tool_calls(self, message) -> List[ToolCall]:
@@ -236,11 +250,7 @@ class LiteLLMVLMProvider(VLMBase):
                         args = json.loads(args)
                     except json.JSONDecodeError:
                         args = {"raw": args}
-                tool_calls.append(ToolCall(
-                    id=tc.id,
-                    name=tc.function.name,
-                    arguments=args
-                ))
+                tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
         return tool_calls
 
     def _build_vlm_response(self, response, has_tools: bool) -> Union[str, VLMResponse]:
@@ -282,7 +292,7 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             kwargs_messages = [{"role": "user", "content": prompt}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice, thinking=thinking)
 
         t0 = time.perf_counter()
         response = completion(**kwargs)
@@ -306,7 +316,7 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             kwargs_messages = [{"role": "user", "content": prompt}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice, thinking=thinking)
 
         last_error = None
         for attempt in range(max_retries + 1):
@@ -315,7 +325,8 @@ class LiteLLMVLMProvider(VLMBase):
                 response = await acompletion(**kwargs)
                 elapsed = time.perf_counter() - t0
                 self._update_token_usage_from_response(
-                    response, duration_seconds=elapsed,
+                    response,
+                    duration_seconds=elapsed,
                 )
                 return self._build_vlm_response(response, has_tools=bool(tools))
             except Exception as e:
@@ -349,7 +360,7 @@ class LiteLLMVLMProvider(VLMBase):
                 content.append({"type": "text", "text": prompt})
             kwargs_messages = [{"role": "user", "content": content}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, thinking=thinking)
 
         t0 = time.perf_counter()
         response = completion(**kwargs)
@@ -379,7 +390,7 @@ class LiteLLMVLMProvider(VLMBase):
                 content.append({"type": "text", "text": prompt})
             kwargs_messages = [{"role": "user", "content": content}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, thinking=thinking)
 
         t0 = time.perf_counter()
         response = await acompletion(**kwargs)
@@ -388,7 +399,9 @@ class LiteLLMVLMProvider(VLMBase):
         return self._build_vlm_response(response, has_tools=bool(tools))
 
     def _update_token_usage_from_response(
-        self, response, duration_seconds: float = 0.0,
+        self,
+        response,
+        duration_seconds: float = 0.0,
     ) -> None:
         """Update token usage from response."""
         if hasattr(response, "usage") and response.usage:

--- a/tests/unit/test_vlm_thinking_param.py
+++ b/tests/unit/test_vlm_thinking_param.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for LiteLLM thinking parameter scoping to DashScope providers."""
+
+from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
+
+
+class TestLiteLLMThinkingParam:
+    """Test that enable_thinking is only sent to DashScope-compatible providers."""
+
+    def _make_provider(self, model: str, **extra_config) -> LiteLLMVLMProvider:
+        config = {"model": model, "provider": "litellm", **extra_config}
+        return LiteLLMVLMProvider(config)
+
+    def test_litellm_dashscope_thinking_disabled(self):
+        """DashScope model with thinking=False should set enable_thinking=False in extra_body."""
+        vlm = self._make_provider("qwen-plus")
+        model = vlm._resolve_model("qwen-plus")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=False)
+
+        assert "extra_body" in kwargs
+        assert kwargs["extra_body"]["enable_thinking"] is False
+
+    def test_litellm_dashscope_thinking_enabled(self):
+        """DashScope model with thinking=True should set enable_thinking=True in extra_body."""
+        vlm = self._make_provider("qwen-plus")
+        model = vlm._resolve_model("qwen-plus")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=True)
+
+        assert "extra_body" in kwargs
+        assert kwargs["extra_body"]["enable_thinking"] is True
+
+    def test_litellm_non_dashscope_no_thinking_field(self):
+        """Non-DashScope model should NOT have enable_thinking in extra_body."""
+        vlm = self._make_provider("gpt-4o")
+        model = vlm._resolve_model("gpt-4o")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=False)
+
+        extra_body = kwargs.get("extra_body", {})
+        assert "enable_thinking" not in extra_body
+
+    def test_litellm_non_dashscope_thinking_true_no_field(self):
+        """Non-DashScope model with thinking=True should still NOT have enable_thinking."""
+        vlm = self._make_provider("gpt-4o")
+        model = vlm._resolve_model("gpt-4o")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=True)
+
+        extra_body = kwargs.get("extra_body", {})
+        assert "enable_thinking" not in extra_body
+
+    def test_litellm_anthropic_no_thinking_field(self):
+        """Anthropic model should NOT have enable_thinking in extra_body."""
+        vlm = self._make_provider("claude-3-opus")
+        model = vlm._resolve_model("claude-3-opus")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=False)
+
+        extra_body = kwargs.get("extra_body", {})
+        assert "enable_thinking" not in extra_body
+
+    def test_litellm_ollama_no_thinking_field(self):
+        """Ollama model should NOT have enable_thinking in extra_body."""
+        vlm = self._make_provider("ollama/llama3")
+        model = vlm._resolve_model("ollama/llama3")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=True)
+
+        extra_body = kwargs.get("extra_body", {})
+        assert "enable_thinking" not in extra_body
+
+    def test_dashscope_detected_via_model_name(self):
+        """Provider detection via model name 'dashscope' keyword should trigger enable_thinking."""
+        vlm = self._make_provider("dashscope/custom-model")
+        model = vlm._resolve_model("dashscope/custom-model")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=True)
+
+        assert "extra_body" in kwargs
+        assert kwargs["extra_body"]["enable_thinking"] is True


### PR DESCRIPTION
## Summary

Follow-up to #939 (which fixed OpenAI backends). This PR narrows the LiteLLM thinking parameter to DashScope providers only:

- `_build_kwargs()` now detects the provider via `self._detected_provider` or `detect_provider_by_model(model)` and only sets `extra_body["enable_thinking"]` when provider is `"dashscope"`
- Non-DashScope providers (OpenAI, Azure, Ollama, Anthropic) never receive this vendor-specific field
- 7 tests: positive (DashScope enabled/disabled), negative (GPT-4o, Claude, Ollama, model-name detection)

Addresses feedback from closed PR #949. Fixes #923.

## Test plan

- [x] 7 tests pass (`pytest tests/unit/test_vlm_thinking_param.py`)
- [x] DashScope model gets `enable_thinking` in extra_body
- [x] Non-DashScope models do NOT get `enable_thinking`
- [x] Ruff clean