### PR TITLE
fix(cli): upload local files for dockerized localhost servers

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 use std::fs::File;
 use std::path::Path;
 use tempfile::NamedTempFile;
-use url::Url;
 use zip::write::FileOptions;
 use zip::CompressionMethod;
 
@@ -38,16 +37,6 @@ impl HttpClient {
             api_key,
             agent_id,
         }
-    }
-
-    /// Check if the server is localhost or 127.0.0.1
-    fn is_local_server(&self) -> bool {
-        if let Ok(url) = Url::parse(&self.base_url) {
-            if let Some(host) = url.host_str() {
-                return host == "localhost" || host == "127.0.0.1";
-            }
-        }
-        false
     }
 
     /// Zip a directory to a temporary file
@@ -493,7 +482,7 @@ impl HttpClient {
     ) -> Result<serde_json::Value> {
         let path_obj = Path::new(path);
 
-        if path_obj.exists() && !self.is_local_server() {
+        if path_obj.exists() {
             if path_obj.is_dir() {
                 let zip_file = self.zip_directory(path_obj)?;
                 let temp_path = self.upload_temp_file(zip_file.path()).await?;
@@ -583,7 +572,7 @@ impl HttpClient {
     ) -> Result<serde_json::Value> {
         let path_obj = Path::new(data);
 
-        if path_obj.exists() && !self.is_local_server() {
+        if path_obj.exists() {
             if path_obj.is_dir() {
                 let zip_file = self.zip_directory(path_obj)?;
                 let temp_path = self.upload_temp_file(zip_file.path()).await?;

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -282,14 +282,6 @@ class AsyncHTTPClient(BaseClient):
         else:
             raise exc_class(message)
 
-    def _is_local_server(self) -> bool:
-        """Check if the server URL is localhost or 127.0.0.1."""
-        from urllib.parse import urlparse
-
-        parsed_url = urlparse(self._url)
-        hostname = parsed_url.hostname
-        return hostname in ("localhost", "127.0.0.1")
-
     def _zip_directory(self, dir_path: str) -> str:
         """Create a temporary zip file from a directory."""
         dir_path = Path(dir_path)
@@ -361,7 +353,7 @@ class AsyncHTTPClient(BaseClient):
             request_data["preserve_structure"] = preserve_structure
 
         path_obj = Path(path)
-        if path_obj.exists() and not self._is_local_server():
+        if path_obj.exists():
             if path_obj.is_dir():
                 zip_path = self._zip_directory(path)
                 try:
@@ -400,7 +392,7 @@ class AsyncHTTPClient(BaseClient):
 
         if isinstance(data, str):
             path_obj = Path(data)
-            if path_obj.exists() and not self._is_local_server():
+            if path_obj.exists():
                 if path_obj.is_dir():
                     zip_path = self._zip_directory(data)
                     try:
@@ -801,7 +793,7 @@ class AsyncHTTPClient(BaseClient):
         }
 
         file_path_obj = Path(file_path)
-        if file_path_obj.exists() and file_path_obj.is_file() and not self._is_local_server():
+        if file_path_obj.exists() and file_path_obj.is_file():
             temp_path = await self._upload_temp_file(file_path)
             request_data["temp_path"] = temp_path
         else:

--- a/tests/client/test_http_client_local_upload.py
+++ b/tests/client/test_http_client_local_upload.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for client-side temp uploads when using localhost URLs."""
+
+import pytest
+
+from openviking_cli.client.http import AsyncHTTPClient
+
+
+class _FakeHTTPClient:
+    def __init__(self):
+        self.calls = []
+
+    async def post(self, path, json=None, files=None):
+        self.calls.append({"path": path, "json": json, "files": files})
+        return object()
+
+
+@pytest.mark.asyncio
+async def test_add_skill_uploads_local_file_even_when_url_is_localhost(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\nname: demo\ndescription: demo\n---\n\n# Demo\n")
+
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    fake_http = _FakeHTTPClient()
+    client._http = fake_http
+
+    async def fake_upload(_path: str) -> str:
+        return "/tmp/uploaded-skill.md"
+
+    client._upload_temp_file = fake_upload
+    client._handle_response_data = lambda _response: {"result": {"status": "ok"}}
+
+    await client.add_skill(str(skill_file))
+
+    call = fake_http.calls[-1]
+    assert call["path"] == "/api/v1/skills"
+    assert call["json"]["temp_path"] == "/tmp/uploaded-skill.md"
+    assert "data" not in call["json"]
+
+
+@pytest.mark.asyncio
+async def test_add_resource_uploads_local_file_even_when_url_is_localhost(tmp_path):
+    resource_file = tmp_path / "demo.md"
+    resource_file.write_text("# Demo\n")
+
+    client = AsyncHTTPClient(url="http://127.0.0.1:1933")
+    fake_http = _FakeHTTPClient()
+    client._http = fake_http
+
+    async def fake_upload(_path: str) -> str:
+        return "/tmp/uploaded-resource.md"
+
+    client._upload_temp_file = fake_upload
+    client._handle_response_data = lambda _response: {
+        "result": {"root_uri": "viking://resources/demo"}
+    }
+
+    await client.add_resource(str(resource_file), reason="test")
+
+    call = fake_http.calls[-1]
+    assert call["path"] == "/api/v1/resources"
+    assert call["json"]["temp_path"] == "/tmp/uploaded-resource.md"
+    assert "path" not in call["json"]
+
+
+@pytest.mark.asyncio
+async def test_import_ovpack_uploads_local_file_even_when_url_is_localhost(tmp_path):
+    pack_file = tmp_path / "demo.ovpack"
+    pack_file.write_bytes(b"ovpack")
+
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    fake_http = _FakeHTTPClient()
+    client._http = fake_http
+
+    async def fake_upload(_path: str) -> str:
+        return "/tmp/uploaded-pack.ovpack"
+
+    client._upload_temp_file = fake_upload
+    client._handle_response = lambda _response: {"uri": "viking://resources/imported"}
+
+    await client.import_ovpack(str(pack_file), parent="viking://resources/")
+
+    call = fake_http.calls[-1]
+    assert call["path"] == "/api/v1/pack/import"
+    assert call["json"]["temp_path"] == "/tmp/uploaded-pack.ovpack"
+    assert "file_path" not in call["json"]

--- a/tests/server/test_http_client_sdk.py
+++ b/tests/server/test_http_client_sdk.py
@@ -49,6 +49,25 @@ async def test_sdk_add_resource(http_client):
     assert result["root_uri"].startswith("viking://")
 
 
+async def test_sdk_add_skill_from_local_file(http_client):
+    client, _ = http_client
+    f = TEST_TMP_DIR / "sdk_skill.md"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        """---
+name: sdk-skill
+description: SDK localhost upload test
+---
+
+# SDK Skill
+"""
+    )
+
+    result = await client.add_skill(data=str(f), wait=True)
+    assert "uri" in result
+    assert result["uri"].startswith("viking://agent/skills/")
+
+
 async def test_sdk_wait_processed(http_client):
     client, _ = http_client
     result = await client.wait_processed()


### PR DESCRIPTION
## Description

Fix localhost file uploads for Dockerized OpenViking servers.
The CLI no longer assumes that `localhost` or `127.0.0.1` means the server shares the caller filesystem, so local files are uploaded before `add-resource`, `add-skill`, and `import-ovpack` requests.

Background:
A common deployment pattern is running OpenViking server inside Docker while exposing it to the host as `http://localhost:<port>`. In that setup, the CLI runs on the host, but the server process runs inside the container and cannot read host filesystem paths such as `./SKILL.md`. The old localhost heuristic treated this as a shared-filesystem deployment, skipped temp upload, and sent host paths directly to the containerized server.

## Related Issue

Fixes #959

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Remove the localhost hostname heuristic from both Python and Rust CLI HTTP clients.
- Upload client-visible local files whenever the input path exists locally, including `.ovpack` imports.
- Add localhost upload tests in the Python HTTP client layer and a real SDK localhost `add_skill` regression test.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran locally:
- `python -m pytest -o addopts='' tests/client/test_http_client_local_upload.py -q`
- `cargo check -p ov_cli`

Not run locally:
- `python -m pytest -o addopts='' tests/server/test_http_client_sdk.py -q` currently fails in this environment because `argon2` is not installed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This specifically fixes host-CLI to Docker-server localhost deployments where host paths are not visible inside the container.
