### PR TITLE
Use uv sync --locked in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,10 @@ COPY src/ src/
 COPY third_party/ third_party/
 
 # Install project and dependencies (triggers setup.py artifact builds + build_extension).
+# --locked ensures the lockfile is used and is consistent with pyproject.toml,
+# preventing silent re-resolution that could pull unexpected package versions.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
-    uv sync --no-editable
+    uv sync --locked --no-editable
 
 # Stage 4: runtime
 FROM python:3.13-slim-trixie


### PR DESCRIPTION
## Summary

- Adds `--locked` flag to `uv sync` in the Dockerfile build stage, following [uv's recommended Docker practice](https://docs.astral.sh/uv/guides/integration/docker/)

## Why

Without `--locked`, `uv sync` will silently re-resolve dependencies if `pyproject.toml` has drifted from `uv.lock`. In a Docker build this means a stale lockfile could cause unexpected package versions to be installed — a supply chain risk highlighted by the [recent litellm incident](https://docs.litellm.ai/blog/security-update-march-2026).

With `--locked`, the build fails fast if the lockfile is inconsistent with `pyproject.toml`, ensuring Docker images are always built from the committed lockfile.

## Change

```diff
-    uv sync --no-editable
+    uv sync --locked --no-editable
```