### PR TITLE
feat(bot): expose channel status via HTTP endpoint

### DIFF
--- a/bot/tests/test_channel_status.py
+++ b/bot/tests/test_channel_status.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for GET /bot/v1/channels/status endpoint."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from vikingbot.bus.queue import MessageBus
+from vikingbot.channels.openapi import OpenAPIChannel, OpenAPIChannelConfig
+
+
+def _make_channel(
+    app: FastAPI,
+    *,
+    api_key: str = "",
+    status_provider=None,
+) -> OpenAPIChannel:
+    config = OpenAPIChannelConfig(enabled=True, api_key=api_key)
+    channel = OpenAPIChannel(config, MessageBus(), app=app, status_provider=status_provider)
+    channel._setup_routes()
+    return channel
+
+
+def _make_app() -> FastAPI:
+    return FastAPI()
+
+
+def _fake_status():
+    return {
+        "openapi": {"enabled": True, "running": True},
+        "telegram": {"enabled": True, "running": False},
+    }
+
+
+@pytest.fixture()
+def app_with_status():
+    app = _make_app()
+    _make_channel(app, status_provider=_fake_status)
+    return app
+
+
+@pytest.fixture()
+def app_without_status():
+    app = _make_app()
+    _make_channel(app, status_provider=None)
+    return app
+
+
+@pytest.fixture()
+def app_with_auth():
+    app = _make_app()
+    _make_channel(app, api_key="test-secret", status_provider=_fake_status)
+    return app
+
+
+class TestChannelStatusEndpoint:
+    """GET /bot/v1/channels/status tests."""
+
+    async def test_returns_channel_status(self, app_with_status):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_status), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/bot/v1/channels/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["result"]["openapi"]["running"] is True
+        assert body["result"]["telegram"]["running"] is False
+
+    async def test_returns_503_when_provider_missing(self, app_without_status):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_without_status), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/bot/v1/channels/status")
+
+        assert resp.status_code == 503
+
+    async def test_requires_api_key_when_configured(self, app_with_auth):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as ac:
+            # No key -> 401
+            resp = await ac.get("/bot/v1/channels/status")
+            assert resp.status_code == 401
+
+            # Wrong key -> 403
+            resp = await ac.get(
+                "/bot/v1/channels/status",
+                headers={"X-API-Key": "wrong-key"},
+            )
+            assert resp.status_code == 403
+
+            # Correct key -> 200
+            resp = await ac.get(
+                "/bot/v1/channels/status",
+                headers={"X-API-Key": "test-secret"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"

--- a/bot/vikingbot/channels/openapi.py
+++ b/bot/vikingbot/channels/openapi.py
@@ -5,7 +5,7 @@ import secrets
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException
 from fastapi.responses import StreamingResponse
@@ -15,6 +15,7 @@ from vikingbot.bus.events import InboundMessage, OutboundEventType, OutboundMess
 from vikingbot.bus.queue import MessageBus
 from vikingbot.channels.base import BaseChannel
 from vikingbot.channels.openapi_models import (
+    ChannelsStatusResponse,
     ChatRequest,
     ChatResponse,
     ChatStreamEvent,
@@ -83,6 +84,7 @@ class OpenAPIChannel(BaseChannel):
         bus: MessageBus,
         workspace_path: Path | None = None,
         app: "FastAPI | None" = None,
+        status_provider: "Callable[[], Dict[str, Any]] | None" = None,
     ):
         super().__init__(config, bus, workspace_path)
         self.config = config
@@ -91,6 +93,7 @@ class OpenAPIChannel(BaseChannel):
         self._router: Optional[APIRouter] = None
         self._app = app  # External FastAPI app to register routes on
         self._server: Optional[asyncio.Task] = None  # Server task
+        self._status_provider = status_provider
 
     async def start(self) -> None:
         """Start the channel - register routes to external FastAPI app if provided."""
@@ -165,6 +168,15 @@ class OpenAPIChannel(BaseChannel):
                 status="healthy" if channel._running else "unhealthy",
                 version=__version__,
             )
+
+        @router.get("/channels/status", response_model=ChannelsStatusResponse)
+        async def channels_status(
+            authorized: bool = Depends(verify_api_key),
+        ):
+            """Get running status of all registered channels."""
+            if channel._status_provider is None:
+                raise HTTPException(status_code=503, detail="Channel status provider not available")
+            return ChannelsStatusResponse(status="ok", result=channel._status_provider())
 
         @router.post("/chat", response_model=ChatResponse)
         async def chat(

--- a/bot/vikingbot/channels/openapi_models.py
+++ b/bot/vikingbot/channels/openapi_models.py
@@ -116,6 +116,22 @@ class HealthResponse(BaseModel):
     timestamp: datetime = Field(default_factory=datetime.now, description="Check timestamp")
 
 
+class ChannelStatusInfo(BaseModel):
+    """Status of a single channel."""
+
+    enabled: bool = Field(..., description="Whether the channel is enabled")
+    running: bool = Field(..., description="Whether the channel is currently running")
+
+
+class ChannelsStatusResponse(BaseModel):
+    """Response for channels status endpoint."""
+
+    status: str = Field(default="ok")
+    result: Dict[str, ChannelStatusInfo] = Field(
+        ..., description="Per-channel status keyed by channel name"
+    )
+
+
 class ErrorResponse(BaseModel):
     """Error response."""
 

--- a/bot/vikingbot/cli/commands.py
+++ b/bot/vikingbot/cli/commands.py
@@ -428,7 +428,8 @@ def prepare_channel(
         openapi_channel = OpenAPIChannel(
             openapi_config,
             bus,
-            app=fastapi_app,  # Pass the external FastAPI app
+            app=fastapi_app,
+            status_provider=channels.get_status,
         )
         channels.add_channel(openapi_channel)
         logger.info(f"OpenAPI channel enabled on port {openapi_port}")


### PR DESCRIPTION
## Summary

Add `GET /bot/v1/channels/status` endpoint that returns the enabled/running
state of every registered channel. `ChannelManager.get_status()` already tracks
this internally — this change exposes it over HTTP via a callback injected into
`OpenAPIChannel`.

- Uses `response_model=ChannelsStatusResponse` for auto-validation and OpenAPI docs
- Returns 503 if status provider is not configured (runtime dependency)
- Follows existing auth pattern (`X-API-Key` via `verify_api_key`)

## Type of Change

- [x] New feature (feat)
- [ ] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Testing

- [x] Unit tests pass
  ```
  PYTHONPATH=bot pytest bot/tests/test_channel_status.py -v
  ```
- [x] Manual testing completed

Test cases:
1. `status_provider` present → 200, validates `ChannelsStatusResponse` structure
2. `status_provider` absent → 503
3. API key auth: no key → 401, wrong key → 403, correct key → 200

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [ ] Documentation updated — bot has no API reference docs yet; endpoint is self-documented via OpenAPI schema
- [x] All tests pass