### PR TITLE
fix(vlm): extend enable_thinking support to ZhiPu/GLM providers

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -196,7 +196,30 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             return {"type": "image_url", "image_url": {"url": image}}
 
-    def _build_kwargs(self, model: str, messages: list, tools: Optional[List[Dict[str, Any]]] = None, tool_choice: Optional[str] = None) -> dict[str, Any]:
+    _THINKING_PROVIDERS = frozenset({"dashscope", "zhipu"})
+
+    def _apply_provider_specific_extra_body(
+        self, kwargs: dict[str, Any], thinking: bool | None = None,
+    ) -> None:
+        """Attach enable_thinking for providers that support it (DashScope, ZhiPu).
+
+        Args:
+            kwargs: The kwargs dict to mutate.
+            thinking: Call-site override; falls back to ``self._thinking`` from config.
+        """
+        provider = self._detected_provider or detect_provider_by_model(self.model or "")
+        if provider in self._THINKING_PROVIDERS:
+            value = thinking if thinking is not None else self._thinking
+            kwargs["enable_thinking"] = bool(value)
+
+    def _build_kwargs(
+        self,
+        model: str,
+        messages: list,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str] = None,
+        thinking: bool | None = None,
+    ) -> dict[str, Any]:
         """Build kwargs for LiteLLM call."""
         kwargs: dict[str, Any] = {
             "model": model,
@@ -223,6 +246,7 @@ class LiteLLMVLMProvider(VLMBase):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
+        self._apply_provider_specific_extra_body(kwargs, thinking)
         return kwargs
 
     def _parse_tool_calls(self, message) -> List[ToolCall]:
@@ -282,7 +306,7 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             kwargs_messages = [{"role": "user", "content": prompt}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice, thinking=thinking)
 
         t0 = time.perf_counter()
         response = completion(**kwargs)
@@ -306,7 +330,7 @@ class LiteLLMVLMProvider(VLMBase):
         else:
             kwargs_messages = [{"role": "user", "content": prompt}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, tool_choice, thinking=thinking)
 
         last_error = None
         for attempt in range(max_retries + 1):
@@ -349,7 +373,7 @@ class LiteLLMVLMProvider(VLMBase):
                 content.append({"type": "text", "text": prompt})
             kwargs_messages = [{"role": "user", "content": content}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, thinking=thinking)
 
         t0 = time.perf_counter()
         response = completion(**kwargs)
@@ -379,7 +403,7 @@ class LiteLLMVLMProvider(VLMBase):
                 content.append({"type": "text", "text": prompt})
             kwargs_messages = [{"role": "user", "content": content}]
 
-        kwargs = self._build_kwargs(model, kwargs_messages, tools)
+        kwargs = self._build_kwargs(model, kwargs_messages, tools, thinking=thinking)
 
         t0 = time.perf_counter()
         response = await acompletion(**kwargs)

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -17,9 +17,10 @@ from ..registry import DEFAULT_AZURE_API_VERSION
 logger = logging.getLogger(__name__)
 
 
-_DASHSCOPE_HOSTS = {
+_THINKING_HOSTS = {
     "dashscope.aliyuncs.com",
     "dashscope-intl.aliyuncs.com",
+    "open.bigmodel.cn",
 }
 
 def _build_openai_client_kwargs(
@@ -88,12 +89,19 @@ class OpenAIVLM(VLMBase):
                 self._async_client = openai.AsyncOpenAI(**kwargs)
         return self._async_client
 
+    _THINKING_MODEL_PREFIXES = ("dashscope/", "zhipu/")
+
     def _supports_enable_thinking(self) -> bool:
-        """Return True for OpenAI-compatible DashScope endpoints that accept enable_thinking."""
+        """Return True for OpenAI-compatible endpoints that accept enable_thinking.
+
+        Recognized providers: DashScope (Alibaba Cloud) and ZhiPu (GLM).
+        """
         if self.provider != "openai":
             return False
 
-        if isinstance(self.model, str) and self.model.lower().startswith("dashscope/"):
+        if isinstance(self.model, str) and self.model.lower().startswith(
+            self._THINKING_MODEL_PREFIXES
+        ):
             return True
 
         if not self.api_base:
@@ -104,7 +112,7 @@ class OpenAIVLM(VLMBase):
         except ValueError:
             return False
 
-        return host.lower() in _DASHSCOPE_HOSTS
+        return host.lower() in _THINKING_HOSTS
 
     def _apply_provider_specific_extra_body(
         self, kwargs: Dict[str, Any], thinking: bool

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -349,3 +349,153 @@ class TestLiteLLMVLMModelResolution:
         )
 
         assert vlm._resolve_model("zai/custom-model") == "gemini/zai/custom-model"
+
+
+class TestOpenAIVLMEnableThinkingZhiPu:
+    """Test enable_thinking support for ZhiPu/GLM providers in OpenAI backend."""
+
+    def test_supports_enable_thinking_zhipu_host(self):
+        """ZhiPu open.bigmodel.cn host should be recognised as thinking-capable."""
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
+                "model": "glm-5",
+            }
+        )
+        assert vlm._supports_enable_thinking() is True
+
+    def test_supports_enable_thinking_zhipu_model_prefix(self):
+        """Model names starting with 'zhipu/' should be recognised as thinking-capable."""
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "zhipu/glm-5",
+            }
+        )
+        assert vlm._supports_enable_thinking() is True
+
+    def test_dashscope_host_still_supported(self):
+        """DashScope hosts must continue to be recognised (regression guard)."""
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                "model": "qwen3.5-plus",
+            }
+        )
+        assert vlm._supports_enable_thinking() is True
+
+    def test_dashscope_model_prefix_still_supported(self):
+        """Model names starting with 'dashscope/' must continue to work."""
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "dashscope/qwen3.5-plus",
+            }
+        )
+        assert vlm._supports_enable_thinking() is True
+
+    def test_generic_openai_host_not_thinking(self):
+        """Standard OpenAI API should not be flagged as thinking-capable."""
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+                "model": "gpt-4o-mini",
+            }
+        )
+        assert vlm._supports_enable_thinking() is False
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
+    def test_zhipu_completion_passes_enable_thinking_in_extra_body(
+        self, mock_openai_class
+    ):
+        """ZhiPu GLM via OpenAI backend should send enable_thinking in extra_body."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+        mock_response.usage = None
+        mock_client.chat.completions.create.return_value = mock_response
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
+                "model": "glm-5",
+            }
+        )
+
+        vlm.get_completion("hello", thinking=False)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"enable_thinking": False}
+
+
+class TestLiteLLMVLMEnableThinking:
+    """Test enable_thinking support for DashScope and ZhiPu providers in LiteLLM backend."""
+
+    def test_dashscope_provider_gets_enable_thinking(self):
+        """DashScope provider should have enable_thinking in built kwargs."""
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "qwen3.5-plus",
+                "provider": "litellm",
+                "api_key": "sk-test",
+                "thinking": False,
+            }
+        )
+        kwargs = vlm._build_kwargs(
+            "dashscope/qwen3.5-plus",
+            [{"role": "user", "content": "hi"}],
+        )
+        assert kwargs["enable_thinking"] is False
+
+    def test_zhipu_provider_gets_enable_thinking(self):
+        """ZhiPu provider should have enable_thinking in built kwargs."""
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "glm-5",
+                "provider": "litellm",
+                "api_key": "sk-test",
+                "thinking": True,
+            }
+        )
+        kwargs = vlm._build_kwargs(
+            "zhipu/glm-5",
+            [{"role": "user", "content": "hi"}],
+        )
+        assert kwargs["enable_thinking"] is True
+
+    def test_openai_provider_no_enable_thinking(self):
+        """Standard OpenAI provider should NOT have enable_thinking in kwargs."""
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "gpt-4o-mini",
+                "provider": "openai",
+                "api_key": "sk-test",
+            }
+        )
+        kwargs = vlm._build_kwargs(
+            "gpt-4o-mini",
+            [{"role": "user", "content": "hi"}],
+        )
+        assert "enable_thinking" not in kwargs
+
+    def test_call_site_thinking_overrides_config(self):
+        """The thinking param from the call site should override config-level _thinking."""
+        vlm = LiteLLMVLMProvider(
+            {
+                "model": "qwen3.5-plus",
+                "provider": "litellm",
+                "api_key": "sk-test",
+                "thinking": False,
+            }
+        )
+        kwargs = vlm._build_kwargs(
+            "dashscope/qwen3.5-plus",
+            [{"role": "user", "content": "hi"}],
+            thinking=True,
+        )
+        assert kwargs["enable_thinking"] is True


### PR DESCRIPTION
## Summary

- Extends `enable_thinking` parameter support beyond DashScope to also cover ZhiPu (GLM-5, GLM-Z1) reasoning models
- **OpenAI backend**: Added `open.bigmodel.cn` to thinking-capable hosts, added `"zhipu/"` to model prefix detection in `_supports_enable_thinking()`
- **LiteLLM backend**: Added `_THINKING_PROVIDERS` frozenset (`dashscope`, `zhipu`) with `_apply_provider_specific_extra_body()` helper for clean provider gating
- 12 new tests: ZhiPu host/prefix detection, DashScope regression guards, LiteLLM provider routing, negative cases for OpenAI/Azure

GLM-5 defaults to thinking mode and returns empty `content` with all tokens going to `reasoning_content`. Without `enable_thinking: false`, every memory extraction call produces empty results.

Fixes #983.

## Test plan

- [x] 11/12 new tests pass (1 failure is pre-existing `openai` mock env issue affecting all OpenAI tests)
- [x] ZhiPu host (`open.bigmodel.cn`) detected correctly
- [x] ZhiPu model prefix (`zhipu/`) detected correctly  
- [x] DashScope still works (regression tests)
- [x] Non-thinking providers (OpenAI, Azure, Ollama) do NOT get enable_thinking
- [x] Ruff clean