### PR TITLE
fix(openclaw-plugin): use plugin-sdk exports for compaction delegation (fixes #833) openclaw ≥ v2026.3.22

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -41,6 +41,17 @@ type CompactResult = {
   result?: unknown;
 };
 
+type CompactDelegate = (arg: {
+  sessionId: string;
+  sessionFile: string;
+  tokenBudget?: number;
+  force?: boolean;
+  currentTokenCount?: number;
+  compactionTarget?: "budget" | "threshold";
+  customInstructions?: string;
+  runtimeContext?: Record<string, unknown>;
+}) => Promise<CompactResult>;
+
 type ContextEngine = {
   info: ContextEngineInfo;
   ingest: (params: { sessionId: string; message: AgentMessage; isHeartbeat?: boolean }) => Promise<IngestResult>;
@@ -113,7 +124,7 @@ function isModuleResolutionError(err: unknown): boolean {
   );
 }
 
-async function tryLegacyCompact(
+async function tryDelegatedCompact(
   params: {
     sessionId: string;
     sessionFile: string;
@@ -126,55 +137,78 @@ async function tryLegacyCompact(
   },
   logger: Logger,
 ): Promise<CompactResult | null> {
+  let delegateCompactionToRuntime: CompactDelegate | null;
+  try {
+    delegateCompactionToRuntime = await loadCompactDelegate(logger);
+  } catch (err) {
+    return {
+      ok: false,
+      compacted: false,
+      reason: `delegate_compact_import_failed:${describeError(err)}`,
+    };
+  }
+
+  if (!delegateCompactionToRuntime) {
+    if (cachedCompactUnavailableReason) {
+      warnOrInfo(
+        logger,
+        `openviking: delegated compaction unavailable (${cachedCompactUnavailableReason})`,
+      );
+    }
+    return null;
+  }
+
+  try {
+    return await delegateCompactionToRuntime(params);
+  } catch (err) {
+    logger.error(`openviking: delegated compaction failed: ${describeError(err)}`);
+    return {
+      ok: false,
+      compacted: false,
+      reason: `delegate_compact_failed:${describeError(err)}`,
+    };
+  }
+}
+
+let cachedCompactDelegate: CompactDelegate | null | undefined;
+let cachedCompactUnavailableReason: string | undefined;
+
+async function loadCompactDelegate(logger: Logger): Promise<CompactDelegate | null> {
+  if (cachedCompactDelegate !== undefined) {
+    return cachedCompactDelegate;
+  }
+
   const candidates = [
-    "openclaw/context-engine/legacy",
-    "openclaw/dist/context-engine/legacy.js",
+    "openclaw/plugin-sdk/core",
+    "openclaw/plugin-sdk",
   ];
   const importErrors: string[] = [];
 
   for (const path of candidates) {
     try {
       const mod = (await import(path)) as {
-        LegacyContextEngine?: new () => {
-          compact: (arg: typeof params) => Promise<CompactResult>;
-        };
+        delegateCompactionToRuntime?: CompactDelegate;
       };
-      if (!mod?.LegacyContextEngine) {
-        importErrors.push(`${path}: LegacyContextEngine export missing`);
+      if (!mod?.delegateCompactionToRuntime) {
+        importErrors.push(`${path}: delegateCompactionToRuntime export missing`);
         continue;
       }
-      const legacy = new mod.LegacyContextEngine();
-      try {
-        return await legacy.compact(params);
-      } catch (err) {
-        warnOrInfo(
-          logger,
-          `openviking: delegated legacy compact failed via ${path}: ${describeError(err)}`,
-        );
-        return {
-          ok: false,
-          compacted: false,
-          reason: `legacy_compact_failed:${path}`,
-        };
-      }
+      cachedCompactDelegate = mod.delegateCompactionToRuntime;
+      cachedCompactUnavailableReason = undefined;
+      return cachedCompactDelegate;
     } catch (err) {
       const detail = `${path}: ${describeError(err)}`;
       importErrors.push(detail);
       if (!isModuleResolutionError(err)) {
-        warnOrInfo(logger, `openviking: legacy compact import failed: ${detail}`);
-        return {
-          ok: false,
-          compacted: false,
-          reason: `legacy_compact_import_failed:${path}`,
-        };
+        logger.error(`openviking: delegated compaction import failed: ${detail}`);
+        throw err;
       }
     }
   }
 
-  if (importErrors.length > 0) {
-    warnOrInfo(logger, `openviking: legacy compact unavailable (${importErrors.join("; ")})`);
-  }
-
+  cachedCompactUnavailableReason =
+    `failed to load compact delegate from candidates: ${importErrors.join(" | ")}`;
+  cachedCompactDelegate = null;
   return null;
 }
 
@@ -318,20 +352,20 @@ export function createMemoryOpenVikingContextEngine(params: {
     },
 
     async compact(compactParams): Promise<CompactResult> {
-      const delegated = await tryLegacyCompact(compactParams, logger);
+      const delegated = await tryDelegatedCompact(compactParams, logger);
       if (delegated) {
         return delegated;
       }
 
       warnOrInfo(
         logger,
-        "openviking: legacy compaction delegation unavailable; skipping compact",
+        "openviking: delegated compaction unavailable; skipping compact",
       );
 
       return {
         ok: true,
         compacted: false,
-        reason: "legacy_compact_unavailable",
+        reason: "delegate_compact_unavailable",
       };
     },
   };


### PR DESCRIPTION
## 变更说明

继续委托 OpenClaw context engine 中的 compact 逻辑，不过从旧的内部模块路径切换为 OpenClaw 当前公开导出的 plugin-sdk 入口。

原来尝试导入的是：
- `openclaw/context-engine/legacy`
- `openclaw/dist/context-engine/legacy.js`

现在改为：
- `openclaw/plugin-sdk/core`
- `openclaw/plugin-sdk`

## 版本兼容说明
仅支持openclaw ≥ v2026.3.22，后续正式接管compact后可实现全版本支持

## 相关ISSUE
Fixes https://github.com/volcengine/OpenViking/issues/833

## 主要修改

- 将 compact 委托入口切换到 `plugin-sdk` 导出
- 将辅助函数 `tryLegacyCompact` 重命名为 `tryDelegatedCompact`
- 更新 compact 相关日志和 reason：
  - `legacy_compact_*` -> `delegate_compact_*`
- 优化 delegate 不可用时的原因提示文案

## 修改原因

原来的实现依赖 OpenClaw 的内部模块路径，在当前运行时下可能因为 package `exports` 限制导致导入失败。  
改为使用 `plugin-sdk` 的公开导出，可以减少对内部实现路径的依赖，兼容当前 OpenClaw 版本。