### PR TITLE
fix(markdownparser): ensure merged filenames unique

### DIFF
--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -590,9 +590,8 @@ class MarkdownParser(BaseParser):
 
         Strategy:
         - Single section: Use directly (truncated with hash if needed)
-        - Multiple sections: {first_section}_{count}more (e.g., Intro_3more)
+        - Multiple sections: {first_section}_{count}more_{hash} (e.g., Intro_3more_a1b2c3d4)
         - Total length strictly limited: MAX_MERGED_FILENAME_LENGTH characters
-        - Hash suffix ensures uniqueness when truncation occurs
         """
         if not sections:
             return "merged"
@@ -604,7 +603,9 @@ class MarkdownParser(BaseParser):
         if count == 1:
             name = names[0]
         else:
-            suffix = f"_{count}more"
+            merged_content = "\n\n".join(c for _, c, _ in sections)
+            hash_suffix = hashlib.sha256(merged_content.encode("utf-8")).hexdigest()[:8]
+            suffix = f"_{count}more_{hash_suffix}"
             max_first_len = max_len - len(suffix)
             first_name = names[0][: max(max_first_len, 1)]
             name = f"{first_name}{suffix}"


### PR DESCRIPTION
## Description
导入 Markdown（ ov add-resource ）时，若文档中存在大量重复同名标题（例如重复的顶级 # ... ）， MarkdownParser 会把多个“小节”合并输出为 *_Nmore.md

旧的合并命名策略在 count > 1 时仅使用 {first}_{count}more ，在“重复标题 + 多次 merge 批次”场景下会产生同名文件，导致解析阶段写入覆盖/内容丢失
<!-- Provide a brief description of the changes in this PR -->

## Related Issue

Closes #1004 
<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

仅调整合并文件命名逻辑： count > 1 时在  {first}\_{count}more 后追加基于合并内容的短 hash（8 位），生成 {first}\_{count}more\_{hash8} ，确保不同合并批次的输出文件名稳定且唯一。
<!-- List the main changes made in this PR -->


## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
