### PR TITLE
fix: skip ingest-reply-assist for cron maintenance tasks

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -532,22 +532,39 @@ const contextEnginePlugin = {
       }
 
       if (cfg.ingestReplyAssist) {
-        const decision = isTranscriptLikeIngest(queryText, {
-          minSpeakerTurns: cfg.ingestReplyAssistMinSpeakerTurns,
-          minChars: cfg.ingestReplyAssistMinChars,
-        });
-        if (decision.shouldAssist) {
+        // Skip ingest-reply-assist for cron maintenance tasks
+        // These tasks have their own prompts and should not be treated as transcripts
+        const cronMaintenancePatterns = [
+          /^\[cron:/,                                    // [cron:xxx] prefix
+          /Daily memory maintenance/i,                   // Distillation task
+          /Weekly synthesis/i,                           // Weekly synthesis task
+          /Read .*references\/(distillation|weekly-synthesis)\.md/i,  // Task instruction
+          /^Workspace:\s*\//m,                           // Workspace line
+        ];
+        const isCronMaintenance = cronMaintenancePatterns.some(p => p.test(queryText));
+        
+        if (isCronMaintenance) {
           api.logger.info(
-            `openviking: ingest-reply-assist applied (reason=${decision.reason}, speakerTurns=${decision.speakerTurns}, chars=${decision.chars})`,
+            `openviking: skipping ingest-reply-assist for cron maintenance task`,
           );
-          prependContextParts.push(
-            "<ingest-reply-assist>\n" +
-              "The latest user input looks like a multi-speaker transcript used for memory ingestion.\n" +
-              "Reply with 1-2 concise sentences to acknowledge or summarize key points.\n" +
-              "Do not output NO_REPLY or an empty reply.\n" +
-              "Do not fabricate facts beyond the provided transcript and recalled memories.\n" +
-              "</ingest-reply-assist>",
-          );
+        } else {
+          const decision = isTranscriptLikeIngest(queryText, {
+            minSpeakerTurns: cfg.ingestReplyAssistMinSpeakerTurns,
+            minChars: cfg.ingestReplyAssistMinChars,
+          });
+          if (decision.shouldAssist) {
+            api.logger.info(
+              `openviking: ingest-reply-assist applied (reason=${decision.reason}, speakerTurns=${decision.speakerTurns}, chars=${decision.chars})`,
+            );
+            prependContextParts.push(
+              "<ingest-reply-assist>\n" +
+                "The latest user input looks like a multi-speaker transcript used for memory ingestion.\n" +
+                "Reply with 1-2 concise sentences to acknowledge or summarize key points.\n" +
+                "Do not output NO_REPLY or an empty reply.\n" +
+                "Do not fabricate facts beyond the provided transcript and recalled memories.\n" +
+                "</ingest-reply-assist>",
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes #982

Cron maintenance tasks (Daily Memory Distillation, Weekly Synthesis) were being misclassified as transcript-like ingestion and receiving unwanted `ingest-reply-assist` prompt augmentation.

## Problem

When running cron maintenance tasks like:
```
Daily memory maintenance. Read skills/opencortex/references/distillation.md for full instructions and follow them. Workspace: /path/to/workspace
```

The plugin would:
1. Misclassify this as a multi-speaker transcript
2. Inject the `ingest-reply-assist` prompt block
3. Cause the cron task to deviate from its intended behavior

## Solution

Added pattern detection in `index.ts` to identify cron maintenance tasks and skip the `ingest-reply-assist` injection. The detection checks for:

- `[cron:xxx]` prefix
- `Daily memory maintenance` / `Weekly synthesis` phrases  
- References to `distillation` or `weekly-synthesis` instruction files
- `Workspace:` lines

When a cron maintenance task is detected, the plugin logs:
```
openviking: skipping ingest-reply-assist for cron maintenance task
```

## Testing

Verified in production environment:
- Before fix: `ingest-reply-assist applied (reason=transcript_like_ingest, speakerTurns=2, chars=452)`
- After fix: `skipping ingest-reply-assist for cron maintenance task`

The cron tasks now execute correctly without prompt injection.

## Changes

- `examples/openclaw-plugin/index.ts`: Added cron maintenance task detection before `isTranscriptLikeIngest()` call
