### PR TITLE
fix(openclaw-plugin): harden local server lifecycle

### DIFF
--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -23,6 +23,7 @@ export type MemoryOpenVikingConfig = {
   recallMaxContentChars?: number;
   recallPreferAbstract?: boolean;
   recallTokenBudget?: number;
+  autoRecallTimeoutMs?: number;
   ingestReplyAssist?: boolean;
   ingestReplyAssistMinSpeakerTurns?: number;
   ingestReplyAssistMinChars?: number;
@@ -42,6 +43,7 @@ const DEFAULT_RECALL_TOKEN_BUDGET = 2000;
 const DEFAULT_INGEST_REPLY_ASSIST = true;
 const DEFAULT_INGEST_REPLY_ASSIST_MIN_SPEAKER_TURNS = 2;
 const DEFAULT_INGEST_REPLY_ASSIST_MIN_CHARS = 120;
+const DEFAULT_AUTO_RECALL_TIMEOUT_MS = 5000;
 const DEFAULT_LOCAL_CONFIG_PATH = join(homedir(), ".openviking", "ov.conf");
 
 const DEFAULT_AGENT_ID = "default";
@@ -118,6 +120,7 @@ export const memoryOpenVikingConfigSchema = {
         "recallMaxContentChars",
         "recallPreferAbstract",
         "recallTokenBudget",
+        "autoRecallTimeoutMs",
         "ingestReplyAssist",
         "ingestReplyAssistMinSpeakerTurns",
         "ingestReplyAssistMinChars",
@@ -181,6 +184,7 @@ export const memoryOpenVikingConfigSchema = {
         100,
         Math.min(50000, Math.floor(toNumber(cfg.recallTokenBudget, DEFAULT_RECALL_TOKEN_BUDGET))),
       ),
+      autoRecallTimeoutMs: Math.max(1000, Math.min(30000, Math.floor(toNumber(cfg.autoRecallTimeoutMs, DEFAULT_AUTO_RECALL_TIMEOUT_MS)))),
       ingestReplyAssist: cfg.ingestReplyAssist !== false,
       ingestReplyAssistMinSpeakerTurns: Math.max(
         1,
@@ -291,6 +295,12 @@ export const memoryOpenVikingConfigSchema = {
       placeholder: String(DEFAULT_RECALL_TOKEN_BUDGET),
       advanced: true,
       help: "Maximum estimated tokens for auto-recall memory injection. Injection stops when budget is exhausted.",
+    },
+    autoRecallTimeoutMs: {
+      label: "Auto-Recall Timeout (ms)",
+      placeholder: String(DEFAULT_AUTO_RECALL_TIMEOUT_MS),
+      advanced: true,
+      help: "Timeout in milliseconds for auto-recall memory search. Clamped to 1000–30000.",
     },
     ingestReplyAssist: {
       label: "Ingest Reply Assist",

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -70,7 +70,6 @@ type OpenClawPluginApi = {
 
 const MAX_OPENVIKING_STDERR_LINES = 200;
 const MAX_OPENVIKING_STDERR_CHARS = 256_000;
-const AUTO_RECALL_TIMEOUT_MS = 5_000;
 
 const contextEnginePlugin = {
   id: "openviking",
@@ -522,7 +521,7 @@ const contextEnginePlugin = {
                   );
                 }
               })(),
-              AUTO_RECALL_TIMEOUT_MS,
+              cfg.autoRecallTimeoutMs,
               "openviking: auto-recall search timeout",
             );
           } catch (err) {
@@ -622,6 +621,16 @@ const contextEnginePlugin = {
           // Inherit system environment; optionally override Go/Python paths via env vars
           const pathSep = IS_WIN ? ";" : ":";
 	  const { ALL_PROXY, all_proxy, HTTP_PROXY, http_proxy, HTTPS_PROXY, https_proxy, ...filteredEnv } = process.env;
+          const strippedProxies = [
+            ALL_PROXY && "ALL_PROXY", all_proxy && "all_proxy",
+            HTTP_PROXY && "HTTP_PROXY", http_proxy && "http_proxy",
+            HTTPS_PROXY && "HTTPS_PROXY", https_proxy && "https_proxy",
+          ].filter(Boolean);
+          if (strippedProxies.length > 0) {
+            api.logger.info(
+              `openviking: stripped proxy env vars for local server: ${strippedProxies.join(", ")} (local server connects to 127.0.0.1 only)`,
+            );
+          }
           const env = {
             ...filteredEnv,
             PYTHONUNBUFFERED: "1",

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -90,6 +90,12 @@
       "advanced": true,
       "help": "Maximum estimated tokens for auto-recall memory injection"
     },
+    "autoRecallTimeoutMs": {
+      "label": "Auto-Recall Timeout (ms)",
+      "placeholder": "5000",
+      "advanced": true,
+      "help": "Timeout in milliseconds for auto-recall memory search. Clamped to 1000-30000."
+    },
     "ingestReplyAssist": {
       "label": "Ingest Reply Assist",
       "help": "When transcript-like memory ingestion is detected, add a lightweight reply instruction to reduce NO_REPLY.",
@@ -161,6 +167,9 @@
         "type": "boolean"
       },
       "recallTokenBudget": {
+        "type": "number"
+      },
+      "autoRecallTimeoutMs": {
         "type": "number"
       },
       "ingestReplyAssist": {

--- a/examples/openclaw-plugin/process-manager.ts
+++ b/examples/openclaw-plugin/process-manager.ts
@@ -225,10 +225,20 @@ async function killProcessOnPortUnix(port: number, logger: ProcessLogger): Promi
       } catch { /* ss not available */ }
     }
     for (const pid of pids) {
-      logger.info?.(`openviking: killing pid ${pid} on port ${port}`);
-      try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
+      logger.info?.(`openviking: sending SIGTERM to pid ${pid} on port ${port}`);
+      try { process.kill(pid, "SIGTERM"); } catch { /* already gone */ }
     }
-    if (pids.length) await new Promise((r) => setTimeout(r, 500));
+    if (pids.length) {
+      await new Promise((r) => setTimeout(r, 1000));
+      for (const pid of pids) {
+        try {
+          process.kill(pid, 0); // check if still alive
+          logger.info?.(`openviking: pid ${pid} still alive, sending SIGKILL`);
+          try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
+        } catch { /* already exited from SIGTERM */ }
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
   } catch { /* port check failed */ }
 }
 


### PR DESCRIPTION
## Summary

- **SIGTERM before SIGKILL**: `killProcessOnPortUnix` now sends SIGTERM first, waits 1 second for graceful shutdown, then only escalates to SIGKILL if the process is still alive. Fixes hard-kill without cleanup.
- **Configurable auto-recall timeout**: The hardcoded 5-second `AUTO_RECALL_TIMEOUT_MS` is now exposed as `autoRecallTimeoutMs` in plugin config (clamped 1000–30000ms), with defaults, validation, schema, and UI hints.
- **Log stripped proxy vars**: When proxy environment variables (ALL_PROXY, HTTP_PROXY, HTTPS_PROXY and lowercase variants) are removed from the local server environment, they are now logged so users can diagnose connectivity issues.

Closes #964