### PR TITLE
fix(openclaw-plugin): resolve agentId shadowing and deduplicate utilities

### DIFF
--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -49,7 +49,7 @@ const MEMORY_URI_PATTERNS = [
 const USER_STRUCTURE_DIRS = new Set(["memories"]);
 const AGENT_STRUCTURE_DIRS = new Set(["memories", "skills", "instructions", "workspaces"]);
 
-function md5Short(input: string): string {
+export function md5Short(input: string): string {
   return createHash("md5").update(input).digest("hex").slice(0, 12);
 }
 

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -1,5 +1,4 @@
-import { createHash } from "node:crypto";
-
+import { md5Short } from "./client.js";
 import type { OpenVikingClient } from "./client.js";
 import type { MemoryOpenVikingConfig } from "./config.js";
 import {
@@ -222,9 +221,6 @@ function warnOrInfo(logger: Logger, message: string): void {
   logger.info(message);
 }
 
-function md5Short(input: string): string {
-  return createHash("md5").update(input).digest("hex").slice(0, 12);
-}
 
 const SAFE_SESSION_KEY_RE = /^[A-Za-z0-9_-]+$/;
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -256,7 +256,7 @@ const contextEnginePlugin = {
 
           let sessionId = sessionIdIn;
           let usedMappedSession = false;
-          const storeAgentId = sessionKeyIn ? resolveAgentId(sessionKeyIn) : undefined;
+          const storeAgentId = sessionKeyIn ? resolveSessionAgentId(sessionKeyIn) : undefined;
           try {
             const c = await getClient();
             if (!sessionId && sessionKeyIn && contextEngineRef) {
@@ -418,7 +418,7 @@ const contextEnginePlugin = {
         sessionAgentIds.set(ctx.sessionKey, ctx.agentId);
       }
     };
-    const resolveAgentId = (sessionId: string): string =>
+    const resolveSessionAgentId = (sessionId: string): string =>
       sessionAgentIds.get(sessionId) ?? cfg.agentId;
 
     api.on("session_start", async (_event: unknown, ctx?: HookAgentContext) => {
@@ -431,7 +431,7 @@ const contextEnginePlugin = {
       rememberSessionAgentId(ctx ?? {});
 
       const hookSessionId = ctx?.sessionId ?? ctx?.sessionKey ?? "";
-      const agentId = resolveAgentId(hookSessionId);
+      const agentId = resolveSessionAgentId(hookSessionId);
       let client: OpenVikingClient;
       try {
         client = await withTimeout(
@@ -584,7 +584,7 @@ const contextEnginePlugin = {
           cfg,
           logger: api.logger,
           getClient,
-          resolveAgentId,
+          resolveAgentId: resolveSessionAgentId,
         });
         return contextEngineRef;
       });

--- a/examples/openclaw-plugin/memory-ranking.ts
+++ b/examples/openclaw-plugin/memory-ranking.ts
@@ -1,4 +1,5 @@
 import type { FindResultItem } from "./client.js";
+import { normalizeDedupeText } from "./text-utils.js";
 
 export function clampScore(value: number | undefined): number {
   if (typeof value !== "number" || Number.isNaN(value)) {
@@ -7,9 +8,6 @@ export function clampScore(value: number | undefined): number {
   return Math.max(0, Math.min(1, value));
 }
 
-function normalizeDedupeText(text: string): string {
-  return text.toLowerCase().replace(/\s+/g, " ").trim();
-}
 
 function isEventOrCaseMemory(item: FindResultItem): boolean {
   const category = (item.category ?? "").toLowerCase();

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -24,8 +24,8 @@
     },
     "agentId": {
       "label": "Agent ID",
-      "placeholder": "random unique ID",
-      "help": "Identifies this agent to OpenViking. A random unique ID is generated if not set."
+      "placeholder": "default",
+      "help": "Identifies this agent to OpenViking (sent as X-OpenViking-Agent header). Defaults to \"default\" if not set."
     },
     "apiKey": {
       "label": "OpenViking API Key",

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -177,7 +177,7 @@ export function isTranscriptLikeIngest(
   };
 }
 
-function normalizeDedupeText(text: string): string {
+export function normalizeDedupeText(text: string): string {
   return text.toLowerCase().replace(/\s+/g, " ").trim();
 }
 


### PR DESCRIPTION
## Summary

- Rename the inner `resolveAgentId` closure in `index.ts` to `resolveSessionAgentId` to prevent shadowing the module-level `resolveAgentId` from `config.ts`
- Fix misleading `agentId` placeholder/help text in `openclaw.plugin.json` — the actual default is `"default"`, not a random unique ID
- Deduplicate `md5Short` (keep exported in `client.ts`, import in `context-engine.ts`)
- Deduplicate `normalizeDedupeText` (keep exported in `text-utils.ts`, import in `memory-ranking.ts`)

Refs #948

## Test plan

- [ ] Verify TypeScript compilation passes with no errors
- [ ] Confirm `resolveSessionAgentId` is called correctly in `before_prompt_build`, `memory_store`, and `createMemoryOpenVikingContextEngine`
- [ ] Confirm `md5Short` import in `context-engine.ts` resolves correctly
- [ ] Confirm `normalizeDedupeText` import in `memory-ranking.ts` resolves correctly
- [ ] Verify plugin JSON schema renders correct placeholder/help for agentId