### PR TITLE
fix(storage): prevent silent data loss in VikingFS.append_file()

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from openviking.pyagfs.exceptions import AGFSClientError, AGFSHTTPError
 from openviking.server.identity import RequestContext, Role
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
@@ -1667,8 +1668,11 @@ class VikingFS:
                 existing_bytes = self._handle_agfs_read(self.agfs.read(path))
                 existing_bytes = await self._decrypt_content(existing_bytes, ctx=ctx)
                 existing = self._decode_bytes(existing_bytes)
-            except Exception:
-                pass
+            except AGFSHTTPError as e:
+                if e.status_code != 404:
+                    raise
+            except AGFSClientError:
+                raise
 
             await self._ensure_parent_dirs(path)
             final_content = (existing + content).encode("utf-8")


### PR DESCRIPTION
## Summary

`VikingFS.append_file()` catches **all** exceptions when reading existing file content and silently falls back to an empty string. This means any transient AGFS failure (timeout, connection error, decryption failure) causes the subsequent write to **overwrite the entire file** with only the new content — silently losing all previous data.

The only caller is `Session._append_to_jsonl()`, which appends every message to `messages.jsonl`. A single read failure during append wipes the entire message history.

## Changes

- Only suppress `AGFSHTTPError` with status 404 (file not found), which is the expected case on first write
- Let other AGFS errors (`AGFSClientError`: connection refused, timeout, etc.) propagate to the outer handler which logs and raises `IOError`

## Trigger conditions

- AGFS backend temporary I/O error (network flap, S3 timeout)
- Encryption key rotation causing `_decrypt_content` to fail
- File encoding corruption causing `_decode_bytes` to raise

## Test plan

- [x] Verify first-time append still works (file does not exist → 404 → creates new file)
- [x] Verify append to existing file works (read succeeds → content concatenated)
- [x] Verify AGFS timeout during read raises `IOError` instead of silently overwriting