### PR TITLE
fix(openclaw-plugin): Use OpenViking-owned compaction instead of legacy delegation

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -19,6 +19,7 @@ type ContextEngineInfo = {
   id: string;
   name: string;
   version?: string;
+  ownsCompaction: true;
 };
 
 type AssembleResult = {
@@ -416,6 +417,7 @@ export function createMemoryOpenVikingContextEngine(params: {
       id,
       name,
       version,
+      ownsCompaction: true,
     },
 
     commitOVSession: doCommitOVSession,
@@ -436,7 +438,7 @@ export function createMemoryOpenVikingContextEngine(params: {
 
       const originalTokens = roughEstimate(messages);
       logger.info(`openviking: assemble input msgs=${messages.length} ~${originalTokens} tokens, budget=${validTokenBudget(assembleParams.tokenBudget) ?? 128_000}`);
-
+      
       const OVSessionId = assembleParams.sessionId;
       diag("assemble_entry", OVSessionId, {
         messagesCount: messages.length,


### PR DESCRIPTION
## Description

This PR makes the OpenViking context engine explicitly own the compaction flow and replaces the previous legacy compaction delegation path with a `commitSession`-based implementation.  In addition, this change is intended to address message loss across multi-turn conversations by aligning compaction ownership and session commit behavior with the OpenViking-managed session flow.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `ownsCompaction: true` to `ContextEngineInfo` and expose it from the OpenViking context engine
- Remove the legacy compact delegation path and handle compaction directly through `commitSession(..., { wait: true })`
- Add clearer compact diagnostics and result handling for success, timeout, failure, no-archive, and unexpected error cases

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

- This change is intended to align compaction ownership with the OpenViking context engine instead of relying on unstable legacy import paths.