### PR TITLE
fix(openclaw-plugin): resolve sessionKey in memory_store without contextEngineRef

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -26,7 +26,7 @@ import {
   resolvePythonCommand,
   prepareLocalPort,
 } from "./process-manager.js";
-import { createMemoryOpenVikingContextEngine } from "./context-engine.js";
+import { createMemoryOpenVikingContextEngine, mapSessionKeyToOVSessionId } from "./context-engine.js";
 import type { ContextEngineWithSessionMapping } from "./context-engine.js";
 
 type PluginLogger = {
@@ -261,6 +261,12 @@ const contextEnginePlugin = {
             const c = await getClient();
             if (!sessionId && sessionKeyIn && contextEngineRef) {
               sessionId = await contextEngineRef.resolveOVSession(sessionKeyIn);
+              usedMappedSession = true;
+            }
+            if (!sessionId && sessionKeyIn) {
+              // Fallback: resolve directly without contextEngineRef (covers cases
+              // where registerContextEngine is unavailable or factory not yet called)
+              sessionId = mapSessionKeyToOVSessionId(sessionKeyIn);
               usedMappedSession = true;
             }
             if (!sessionId) {


### PR DESCRIPTION
## Summary
- `memory_store` tool throws "Either sessionKey or sessionId is required" even when `sessionKey` is passed, because the session mapping depends on `contextEngineRef` being non-null
- `contextEngineRef` is null when `registerContextEngine` is unavailable on the OpenClaw API or when the factory hasn't been called yet
- Adds a direct fallback to `mapSessionKeyToOVSessionId()` so session mapping works regardless of context engine state

## Test plan
- [ ] Call `memory_store` with `sessionKey` on an OpenClaw version that does not expose `registerContextEngine` — should succeed instead of rejecting
- [ ] Call `memory_store` with `sessionKey` immediately after plugin load (before context engine factory is invoked) — should succeed
- [ ] Existing `memory_store` with `sessionId` path unchanged
- [ ] TypeScript check and vitest pass