### PR TITLE
fix(openclaw-plugin): add defensive re-spawn for OpenViking subproces…

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -22,6 +22,7 @@ import {
 import {
   IS_WIN,
   waitForHealth,
+  quickHealthCheck,
   quickRecallPrecheck,
   withTimeout,
   resolvePythonCommand,
@@ -460,14 +461,17 @@ const contextEnginePlugin = {
       }),
       async execute(_toolCallId: string, params: Record<string, unknown>) {
         const archiveId = String((params as { archiveId?: string }).archiveId ?? "").trim();
+        const sessionId = ctx.sessionId ?? "";
+        api.logger.info?.(`openviking: ov_archive_expand invoked (archiveId=${archiveId || "(empty)"}, sessionId=${sessionId || "(empty)"})`);
+
         if (!archiveId) {
+          api.logger.warn?.(`openviking: ov_archive_expand missing archiveId`);
           return {
             content: [{ type: "text", text: "Error: archiveId is required." }],
             details: { error: "missing_param", param: "archiveId" },
           };
         }
 
-        const sessionId = ctx.sessionId ?? "";
         if (!sessionId) {
           return {
             content: [{ type: "text", text: "Error: no active session." }],
@@ -495,6 +499,7 @@ const contextEnginePlugin = {
             .map((m: OVMessage) => formatMessageFaithful(m))
             .join("\n\n");
 
+          api.logger.info?.(`openviking: ov_archive_expand expanded ${detail.archive_id}, messages=${detail.messages.length}, chars=${body.length}, sessionId=${sessionId}`);
           return {
             content: [{ type: "text", text: `${header}\n${body}` }],
             details: {
@@ -506,6 +511,7 @@ const contextEnginePlugin = {
           };
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
+          api.logger.warn?.(`openviking: ov_archive_expand failed (archiveId=${archiveId}, sessionId=${sessionId}): ${msg}`);
           return {
             content: [{ type: "text", text: `Failed to expand ${archiveId}: ${msg}` }],
             details: { error: msg, archiveId, sessionId },
@@ -705,7 +711,7 @@ const contextEnginePlugin = {
         return contextEngineRef;
       });
       api.logger.info(
-        "openviking: registered context-engine (before_prompt_build=auto-recall, afterTurn=auto-capture, assemble=archive+active, sessionId=1:1 mapping)",
+        "openviking: registered context-engine (before_prompt_build=auto-recall, afterTurn=auto-capture, assemble=archive+active)",
       );
     } else {
       api.logger.warn(
@@ -794,10 +800,8 @@ const contextEnginePlugin = {
               localProcess = null;
               localClientCache.delete(localCacheKey);
             }
-            if (code != null && code !== 0 || signal) {
-              const out = formatStderrOutput();
-              api.logger.warn(`openviking: subprocess exited (code=${code}, signal=${signal})${out}`);
-            }
+            const out = formatStderrOutput();
+            api.logger.warn(`openviking: subprocess exited (code=${code}, signal=${signal})${out}`);
           });
           try {
             await waitForHealth(baseUrl, timeoutMs, intervalMs);
@@ -818,6 +822,82 @@ const contextEnginePlugin = {
               );
             }
             throw err;
+          }
+        } else if (cfg.mode === "local") {
+          // Defensive re-spawn: if we're not the designated spawner but there's
+          // no valid local process, trigger a fresh spawn to recover from
+          // scenarios like Gateway force-restart where the child process was
+          // orphaned or exited silently.
+          const cached = localClientCache.get(localCacheKey);
+          const processAlive = cached?.process && cached.process.exitCode === null && !cached.process.killed;
+          if (!processAlive) {
+            const healthOk = await quickHealthCheck(`http://127.0.0.1:${cfg.port}`, 2000);
+            if (!healthOk) {
+              api.logger.warn(
+                `openviking: no valid local process detected (isSpawner=false), triggering defensive re-spawn`,
+              );
+              const timeoutMs = 60_000;
+              const intervalMs = 500;
+              const actualPort = await prepareLocalPort(cfg.port, api.logger);
+              const baseUrl = `http://127.0.0.1:${actualPort}`;
+              const pythonCmd = resolvePythonCommand(api.logger);
+              const pathSep = IS_WIN ? ";" : ":";
+              const env = {
+                ...process.env,
+                PYTHONUNBUFFERED: "1",
+                PYTHONWARNINGS: "ignore::RuntimeWarning",
+                OPENVIKING_CONFIG_FILE: cfg.configPath,
+                OPENVIKING_START_CONFIG: cfg.configPath,
+                OPENVIKING_START_HOST: "127.0.0.1",
+                OPENVIKING_START_PORT: String(actualPort),
+                ...(process.env.OPENVIKING_GO_PATH && { PATH: `${process.env.OPENVIKING_GO_PATH}${pathSep}${process.env.PATH || ""}` }),
+                ...(process.env.OPENVIKING_GOPATH && { GOPATH: process.env.OPENVIKING_GOPATH }),
+                ...(process.env.OPENVIKING_GOPROXY && { GOPROXY: process.env.OPENVIKING_GOPROXY }),
+              };
+              const runpyCode = `import sys,os,warnings; warnings.filterwarnings('ignore', category=RuntimeWarning, message='.*sys.modules.*'); sys.argv=['openviking.server.bootstrap','--config',os.environ['OPENVIKING_START_CONFIG'],'--host',os.environ.get('OPENVIKING_START_HOST','127.0.0.1'),'--port',os.environ['OPENVIKING_START_PORT']]; import runpy, importlib.util; spec=importlib.util.find_spec('openviking.server.bootstrap'); (runpy.run_path(spec.origin, run_name='__main__') if spec and getattr(spec,'origin',None) else runpy.run_module('openviking.server.bootstrap', run_name='__main__', alter_sys=True))`;
+              const child = spawn(
+                pythonCmd,
+                ["-c", runpyCode],
+                { env, cwd: IS_WIN ? tmpdir() : "/tmp", stdio: ["ignore", "pipe", "pipe"] },
+              );
+              localProcess = child;
+              child.on("error", (err: Error) => api.logger.warn(`openviking: local server error (re-spawn): ${String(err)}`));
+              child.stderr?.on("data", (chunk: Buffer) => {
+                api.logger.debug?.(`[openviking-respawn] ${String(chunk).trim()}`);
+              });
+              child.on("exit", (code: number | null, signal: string | null) => {
+                if (localProcess === child) {
+                  localProcess = null;
+                  localClientCache.delete(localCacheKey);
+                }
+                api.logger.warn(`openviking: re-spawned subprocess exited (code=${code}, signal=${signal})`);
+              });
+              try {
+                await waitForHealth(baseUrl, timeoutMs, intervalMs);
+                const client = new OpenVikingClient(baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs);
+                localClientCache.set(localCacheKey, { client, process: child });
+                if (resolveLocalClient) {
+                  resolveLocalClient(client);
+                  rejectLocalClient = null;
+                }
+                api.logger.info(
+                  `openviking: local server re-spawned successfully (${baseUrl}, config: ${cfg.configPath})`,
+                );
+              } catch (err) {
+                localProcess = null;
+                child.kill("SIGTERM");
+                markLocalUnavailable("re-spawn failed", err);
+                api.logger.warn(`openviking: defensive re-spawn failed: ${String(err)}`);
+                throw err;
+              }
+            } else {
+              api.logger.info(`openviking: local process healthy on port ${cfg.port} (isSpawner=false)`);
+            }
+          } else {
+            await (await getClient()).healthCheck().catch(() => {});
+            api.logger.info(
+              `openviking: initialized via cache (url: ${cfg.baseUrl}, targetUri: ${cfg.targetUri})`,
+            );
           }
         } else {
           await (await getClient()).healthCheck().catch(() => {});


### PR DESCRIPTION
…s after Gateway restart

## Description
Fix OpenViking subprocess not recovering after Gateway force-restart, causing all memory-dependent requests to time out indefinitely. Always log subprocess exit events (including code=0) for better diagnostics. Add diagnostic logging to ov_archive_expand tool invocations.
<!-- Provide a brief description of the changes in this PR -->

## Related Issue
input long text → restart Gateway → query → timeout with no response.
<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made
Always log subprocess exit: Removed the code !== 0 guard in the exit handler so exits with code=0 are also logged, preventing silent process disappearance
Defensive re-spawn: When isSpawner=false in local mode, check if a valid process actually exists (via cache + health check); if not, trigger a fresh spawn using the same env/config as the primary spawn path
ov_archive_expand diagnostics: Added structured logging for tool invocations (archiveId, sessionId), successful expansions (message count, char count), and failures (error details)
<!-- List the main changes made in this PR -->

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes
Root cause: The plugin is registered multiple times per Gateway startup (gateway subsystem + per-session). Only the first start() call to find a pending entry in localClientPendingPromises becomes the spawner. After a force-restart, race conditions in module loading can cause all start() calls to miss the pending entry, leaving isSpawner=false for every call. The original else branch silently swallowed health-check failures, so the system entered a permanently broken state. The defensive re-spawn acts as a self-healing fallback that detects "no valid process" and recovers automatically.
<!-- Add any additional notes or context about the PR -->
