### PR TITLE
fix(openclaw-plugin): prevent CONFLICT errors with commit lock

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -10,6 +10,9 @@ import {
 } from "./memory-ranking.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
 
+
+// Simple in-memory lock to prevent concurrent commits
+const commitLocks = new Set<string>();
 type AgentMessage = {
   role?: string;
   content?: unknown;
@@ -572,6 +575,17 @@ export function createMemoryOpenVikingContextEngine(params: {
       }
 
       const OVSessionId = afterTurnParams.sessionId;
+      
+      // Skip if a commit is already in progress for this session
+      if (commitLocks.has(OVSessionId)) {
+        logger.info(`openviking: afterTurn skipped (commit in progress for ${OVSessionId})`);
+        diag("afterTurn_skip", OVSessionId, {
+          reason: "commit_lock_contention",
+        });
+        return;
+      }
+      commitLocks.add(OVSessionId);
+
       try {
         const agentId = resolveAgentId(OVSessionId);
 
@@ -673,6 +687,8 @@ export function createMemoryOpenVikingContextEngine(params: {
         diag("afterTurn_error", OVSessionId, {
           error: String(err),
         });
+      } finally {
+        commitLocks.delete(OVSessionId);
       }
     },
 


### PR DESCRIPTION
## Problem

When using the OpenClaw plugin with auto-capture enabled, we frequently encounter CONFLICT errors:

```
Error: OpenViking request failed [CONFLICT]: Session agent:main:discord:channel:xxx already has a commit in progress
```

This happens when two code paths try to commit to the same OpenViking session simultaneously:
1. `afterTurn` hook auto-capture
2. `memory_store` tool explicit commit

## Solution

Add a simple in-memory lock mechanism in `context-engine.ts`:

```typescript
const commitLocks = new Set<string>();

async afterTurn(afterTurnParams): Promise<void> {
  // ...
  if (commitLocks.has(OVSessionId)) {
    logger.info(`openviking: afterTurn skipped (commit in progress for ${OVSessionId})`);
    return;
  }
  commitLocks.add(OVSessionId);

  try {
    // ... existing commit logic ...
  } catch (err) {
    // ... error handling ...
  } finally {
    commitLocks.delete(OVSessionId);
  }
}
```

## Behavior

- If a commit is already in progress for a session, `afterTurn` skips the auto-capture for that turn
- The lock is released in `finally` block to ensure cleanup even on error
- No data loss - the next turn will capture any missed messages

## Testing

Tested on production OpenClaw instance with OpenViking 0.2.12. CONFLICT errors no longer appear.