### PR TITLE
docs: add guidance for creating user matching OpenClaw agentId

### DIFF
--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -477,3 +477,9 @@ python3 -m pip uninstall openviking -y && rm -rf ~/.openviking
 ---
 
 **See also:** [INSTALL-ZH.md](./INSTALL-ZH.md) (中文详细安装指南) · [INSTALL.md](./INSTALL.md) (English Install Guide) · [INSTALL-AGENT.md](./INSTALL-AGENT.md) (Agent Install Guide)
+
+> **Note: Agent Scope Limitation**
+>
+> The user API key can only access `viking://user/*` scope. If you see `Access denied for viking://agent/xxx/memories`, this is expected behavior. The plugin currently defaults to user scope only for memory search.
+>
+> If you need agent scope access, use the root API key with `X-OpenViking-Account` and `X-OpenViking-User` headers.


### PR DESCRIPTION
## Problem

When using the OpenClaw plugin with OpenViking, users may encounter these errors:

1. `Access denied for viking://agent/xxx/memories`
2. `INVALID_ARGUMENT: ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers`

These occur because:
- OpenClaw defaults to using `main` as the `agentId`
- The plugin creates a user-specific memory space based on `userId:agentId` hash
- If the user does not exist in OpenViking, access is denied
- Using the root API key without proper headers causes authentication failures

## Solution

This PR adds documentation to help users:

1. **Added warning box in Step 2: Create Team & Users** — Explains the agentId requirement with commands to:
   - Check current agentId
   - Create the user in OpenViking
   - Generate a user API key

2. **Added troubleshooting entries** — Two new rows in the troubleshooting table:
   - `Access denied for viking://agent/xxx/memories` → Create user matching agentId
   - `INVALID_ARGUMENT: ROOT requests...` → Use user API key instead of root key

## Testing

These steps were verified on a production OpenClaw + OpenViking setup. Creating the `main` user and using its API key resolved both error types.