### PR TITLE
fix(openclaw-plugin): remove duplicate `const sessionId` declaration in ov_archive_expand

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -719,7 +719,6 @@ const contextEnginePlugin = {
           };
         }
 
-        const sessionId = ctx.sessionId ?? "";
         const sessionKey = ctx.sessionKey ?? "";
         if (!sessionId && !sessionKey) {
           return {


### PR DESCRIPTION
## Problem

`index.ts` line 722 re-declares `const sessionId = ctx.sessionId ?? ""` which was already declared on line 711 within the same `execute()` scope of the `ov_archive_expand` tool handler.

This causes a `ParseError` when OpenClaw loads the plugin:

```
ParseError: Identifier 'sessionId' has already been declared.
 /home/…/.openclaw/extensions/openviking/index.ts:722:14
```

## Fix

Removed the duplicate declaration on line 722. The existing `sessionId` from line 711 is reused for the subsequent `!sessionId && !sessionKey` guard.

## Diff

```diff
-        const sessionId = ctx.sessionId ?? "";
         const sessionKey = ctx.sessionKey ?? "";
```

One line removed, no behavior change.