### PR TITLE
fix: correct context_type classification for memories during reindex

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, List, Optional
 
+from openviking.core.directories import get_context_type_for_uri
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils import VikingURI
@@ -440,7 +441,7 @@ class SemanticDagExecutor:
                 task = VectorizeTask(
                     task_type="file",
                     uri=file_path,
-                    context_type=self._context_type,
+                    context_type=get_context_type_for_uri(file_path),
                     ctx=self._ctx,
                     semantic_msg_id=self._semantic_msg_id,
                     file_path=file_path,
@@ -560,7 +561,7 @@ class SemanticDagExecutor:
                     task = VectorizeTask(
                         task_type="directory",
                         uri=dir_uri,
-                        context_type=self._context_type,
+                        context_type=get_context_type_for_uri(dir_uri),
                         ctx=self._ctx,
                         semantic_msg_id=self._semantic_msg_id,
                         abstract=abstract,

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -57,10 +57,11 @@ class Summarizer:
         telemetry = get_current_telemetry()
         for uri, temp_uri in zip(resource_uris, temp_uris):
             # Determine context_type based on URI
+            # Use the same logic as core/directories.get_context_type_for_uri()
             context_type = "resource"
-            if uri.startswith("viking://memory/"):
+            if "/memories" in uri:
                 context_type = "memory"
-            elif uri.startswith("viking://agent/skills/"):
+            elif "/skills" in uri:
                 context_type = "skill"
 
             msg = SemanticMsg(


### PR DESCRIPTION
## Summary

Fixes #1060

When reindexing via `/api/v1/content/reindex`, all memories under `viking://user/*/memories/*` and `viking://agent/*/memories/*` are incorrectly classified as `context_type="resource"` instead of `"memory"`. This causes downstream consumers (e.g. OpenClaw's auto-recall plugin) that filter by `context_type == "memory"` to miss all reindexed memories.

## Root Cause

Two bugs in the reindex code path:

### Bug 1: `summarizer.py` — wrong URI prefix check

```python
# Before (never matches — no URI uses this path)
if uri.startswith("viking://memory/"):

# After (matches actual memory URIs like viking://user/default/memories/...)
if "/memories" in uri:
```

The fix uses the same substring matching logic as `core/directories.get_context_type_for_uri()`.

### Bug 2: `semantic_dag.py` — root context_type propagated to all children

`SemanticDagExecutor` stored the root URI's `context_type` as `self._context_type` and used it for every child node during recursive traversal. When reindexing from `viking://` (root), the root has no `/memories/` segment, so `context_type` defaults to `"resource"` and propagates to all descendants.

Fixed by calling `get_context_type_for_uri()` per node instead of inheriting from root.

## Why this was hidden

Normal memory creation via `auto-capture` uses a completely different code path (`memory_updater.py` → embedding queue, which hardcodes `"memory"`). It never touches `Summarizer` or `SemanticDagExecutor`. This bug only manifests during `reindex` operations — typically after switching embedding models.

## Changes

- `openviking/utils/summarizer.py`: Fix URI matching to use `"/memories" in uri` and `"/skills" in uri`
- `openviking/storage/queuefs/semantic_dag.py`: Use `get_context_type_for_uri()` per node instead of `self._context_type`

## Test Plan

1. Populate memories via normal auto-capture flow
2. Run `POST /api/v1/content/reindex` with `{"uri": "viking://", "regenerate": true}`
3. Verify via `GET /api/v1/debug/vector/scroll` that records under `/memories/` have `context_type="memory"`
4. Verify OpenClaw auto-recall (which filters by `context_type=="memory"`) can find reindexed memories