### PR TITLE
fix(reindex): use get_context_type_for_uri for correct memory/skill classification

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, List, Optional
 
+from openviking.core.directories import get_context_type_for_uri
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils import VikingURI
@@ -440,7 +441,7 @@ class SemanticDagExecutor:
                 task = VectorizeTask(
                     task_type="file",
                     uri=file_path,
-                    context_type=self._context_type,
+                    context_type=get_context_type_for_uri(file_path),
                     ctx=self._ctx,
                     semantic_msg_id=self._semantic_msg_id,
                     file_path=file_path,
@@ -560,7 +561,7 @@ class SemanticDagExecutor:
                     task = VectorizeTask(
                         task_type="directory",
                         uri=dir_uri,
-                        context_type=self._context_type,
+                        context_type=get_context_type_for_uri(dir_uri),
                         ctx=self._ctx,
                         semantic_msg_id=self._semantic_msg_id,
                         abstract=abstract,

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -7,6 +7,7 @@ Handles summarization and key information extraction.
 
 from typing import TYPE_CHECKING, Any, Dict, List
 
+from openviking.core.directories import get_context_type_for_uri
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.telemetry import get_current_telemetry
 from openviking_cli.utils import get_logger
@@ -57,11 +58,7 @@ class Summarizer:
         telemetry = get_current_telemetry()
         for uri, temp_uri in zip(resource_uris, temp_uris):
             # Determine context_type based on URI
-            context_type = "resource"
-            if uri.startswith("viking://memory/"):
-                context_type = "memory"
-            elif uri.startswith("viking://agent/skills/"):
-                context_type = "skill"
+            context_type = get_context_type_for_uri(uri)
 
             msg = SemanticMsg(
                 uri=temp_uri,


### PR DESCRIPTION
## Problem

During `reindex` (via `/api/v1/content/reindex`), all memory files under `viking://user/memories/` and `viking://agent/*/memories/` are incorrectly tagged with `context_type = "resource"` instead of `"memory"`.

This causes downstream consumers (e.g. OpenClaw's auto-recall plugin) that filter by `context_type == "memory"` to miss all reindexed memories.

## Root Cause

Two bugs in the reindex code path:

### Bug 1: `summarizer.py` (line 61)

```python
# Broken — 'viking://memory/' never matches real URIs
if uri.startswith("viking://memory/"):
    context_type = "memory"
```

Real memory URIs look like `viking://user/memories/entities/mem_xxx.md` or `viking://agent/<id>/memories/cases/mem_xxx.md` — none start with `viking://memory/`.

### Bug 2: `semantic_dag.py` (lines 443, 563)

`SemanticDagExecutor` receives `context_type` from the root URI and propagates it to **all** child nodes via `self._context_type`. When reindexing from `viking://` (root), the root has no `/memories` substring, so `context_type` defaults to `"resource"` for everything — including actual memories.

## Fix

Both files now use the existing `get_context_type_for_uri()` from `core/directories.py`, which already handles all URI patterns correctly:

```python
def get_context_type_for_uri(uri: str) -> str:
    if "/memories" in uri:
        return "memory"
    elif "/resources" in uri:
        return "resource"
    elif "/skills" in uri:
        return "skill"
    elif uri.startswith("viking://session"):
        return "memory"
    return "resource"
```

This is consistent with how `DirectoryInitializer` (line 269 in `directories.py`) already determines context types.

## Changes

| File | Change |
|------|--------|
| `summarizer.py` | Replace broken `startswith` checks with `get_context_type_for_uri(uri)` |
| `semantic_dag.py` | Replace `self._context_type` with per-node `get_context_type_for_uri(file_path/dir_uri)` |

## Impact

- **Auto-capture** memories are **unaffected** (different code path via `memory_updater.py`)
- **Reindex** operations will now correctly classify memories, skills, and resources
- No breaking changes — reindex simply becomes correct

Fixes #1060