### PR TITLE
feat(examples): mark recalled memories as used

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
@@ -208,6 +208,38 @@ async function resolveTargetUri(targetUri) {
   return `viking://${scope}/${space}/${parts.join("/")}`;
 }
 
+function markRecalledMemoriesUsed(contexts) {
+  const uniqueContexts = [...new Set(contexts.filter(uri => typeof uri === "string" && uri.length > 0))];
+  if (uniqueContexts.length === 0) return;
+
+  void (async () => {
+    const sessionResult = await fetchJSON("/api/v1/sessions", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    if (!sessionResult?.session_id) return;
+
+    const sessionId = sessionResult.session_id;
+    try {
+      await fetchJSON(`/api/v1/sessions/${encodeURIComponent(sessionId)}/used`, {
+        method: "POST",
+        body: JSON.stringify({ contexts: uniqueContexts }),
+      });
+      await fetchJSON(`/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+      log("used_signal", { sessionId, count: uniqueContexts.length, uris: uniqueContexts });
+    } catch (err) {
+      logError("used_signal_failed", err);
+    } finally {
+      await fetchJSON(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, {
+        method: "DELETE",
+      }).catch(() => {});
+    }
+  })();
+}
+
 // ---------------------------------------------------------------------------
 // Search OpenViking
 // ---------------------------------------------------------------------------
@@ -331,6 +363,7 @@ async function main() {
   }
 
   log("picked", { pickedCount: memories.length, uris: memories.map(m => m.uri) });
+  markRecalledMemoriesUsed(memories.map(memory => memory.uri));
 
   // Read full content for leaf memories
   const lines = await Promise.all(

--- a/examples/claude-code-memory-plugin/servers/memory-server.js
+++ b/examples/claude-code-memory-plugin/servers/memory-server.js
@@ -228,6 +228,17 @@ class OpenVikingClient {
     async extractSessionMemories(sessionId) {
         return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/extract`, { method: "POST", body: JSON.stringify({}) });
     }
+    async sessionUsed(sessionId, contexts) {
+        if (contexts.length === 0)
+            return;
+        await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/used`, {
+            method: "POST",
+            body: JSON.stringify({ contexts }),
+        });
+    }
+    async commitSession(sessionId) {
+        return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`, { method: "POST", body: JSON.stringify({}) });
+    }
     async deleteSession(sessionId) {
         await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
     }
@@ -366,6 +377,27 @@ async function searchBothScopes(client, query, limit) {
     const unique = all.filter((m, i, self) => i === self.findIndex((o) => o.uri === m.uri));
     return unique.filter((m) => m.level === 2);
 }
+function markRecalledMemoriesUsed(client, contexts) {
+    const uniqueContexts = [...new Set(contexts.filter((uri) => typeof uri === "string" && uri.length > 0))];
+    if (uniqueContexts.length === 0)
+        return;
+    void (async () => {
+        let sessionId;
+        try {
+            sessionId = await client.createSession();
+            await client.sessionUsed(sessionId, uniqueContexts);
+            await client.commitSession(sessionId);
+        }
+        catch {
+            // Fire-and-forget usage tracking must never block or fail the caller.
+        }
+        finally {
+            if (sessionId) {
+                await client.deleteSession(sessionId).catch(() => { });
+            }
+        }
+    })();
+}
 // ---------------------------------------------------------------------------
 // MCP Server
 // ---------------------------------------------------------------------------
@@ -397,6 +429,7 @@ server.tool("memory_recall", "Search long-term memories from OpenViking. Use whe
     if (memories.length === 0) {
         return { content: [{ type: "text", text: "No relevant memories found in OpenViking." }] };
     }
+    markRecalledMemoriesUsed(client, memories.map((memory) => memory.uri));
     // Read full content for leaf memories
     const lines = await Promise.all(memories.map(async (item) => {
         if (item.level === 2) {

--- a/examples/claude-code-memory-plugin/src/memory-server.ts
+++ b/examples/claude-code-memory-plugin/src/memory-server.ts
@@ -36,6 +36,14 @@ type FindResult = {
   total?: number;
 };
 
+type CommitSessionResult = {
+  task_id?: string;
+  status?: string;
+  memories_extracted?: Record<string, number>;
+  active_count_updated?: number;
+  error?: unknown;
+};
+
 type ScopeName = "user" | "agent";
 
 // ---------------------------------------------------------------------------
@@ -284,6 +292,21 @@ class OpenVikingClient {
     );
   }
 
+  async sessionUsed(sessionId: string, contexts: string[]): Promise<void> {
+    if (contexts.length === 0) return;
+    await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/used`, {
+      method: "POST",
+      body: JSON.stringify({ contexts }),
+    });
+  }
+
+  async commitSession(sessionId: string): Promise<CommitSessionResult> {
+    return this.request<CommitSessionResult>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
+      { method: "POST", body: JSON.stringify({}) },
+    );
+  }
+
   async deleteSession(sessionId: string): Promise<void> {
     await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
   }
@@ -437,6 +460,26 @@ async function searchBothScopes(
   return unique.filter((m) => m.level === 2);
 }
 
+function markRecalledMemoriesUsed(client: OpenVikingClient, contexts: string[]): void {
+  const uniqueContexts = [...new Set(contexts.filter((uri) => typeof uri === "string" && uri.length > 0))];
+  if (uniqueContexts.length === 0) return;
+
+  void (async () => {
+    let sessionId: string | undefined;
+    try {
+      sessionId = await client.createSession();
+      await client.sessionUsed(sessionId, uniqueContexts);
+      await client.commitSession(sessionId);
+    } catch {
+      // Fire-and-forget usage tracking must never block or fail the caller.
+    } finally {
+      if (sessionId) {
+        await client.deleteSession(sessionId).catch(() => {});
+      }
+    }
+  })();
+}
+
 // ---------------------------------------------------------------------------
 // MCP Server
 // ---------------------------------------------------------------------------
@@ -478,6 +521,8 @@ server.tool(
     if (memories.length === 0) {
       return { content: [{ type: "text" as const, text: "No relevant memories found in OpenViking." }] };
     }
+
+    markRecalledMemoriesUsed(client, memories.map((memory) => memory.uri));
 
     // Read full content for leaf memories
     const lines = await Promise.all(

--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -512,4 +512,17 @@ export class OpenVikingClient {
       method: "DELETE",
     }, agentId);
   }
+
+  async sessionUsed(
+    sessionId: string,
+    contexts: string[],
+    agentId?: string,
+  ): Promise<void> {
+    if (contexts.length === 0) return;
+    await this.request(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/used`,
+      { method: "POST", body: JSON.stringify({ contexts }) },
+      agentId,
+    );
+  }
 }

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -708,8 +708,8 @@ const contextEnginePlugin = {
       async execute(_toolCallId: string, params: Record<string, unknown>) {
         rememberSessionAgentId(ctx);
         const archiveId = String((params as { archiveId?: string }).archiveId ?? "").trim();
-        const sessionId = ctx.sessionId ?? "";
-        api.logger.info?.(`openviking: ov_archive_expand invoked (archiveId=${archiveId || "(empty)"}, sessionId=${sessionId || "(empty)"})`);
+        const activeSessionId = ctx.sessionId ?? "";
+        api.logger.info?.(`openviking: ov_archive_expand invoked (archiveId=${archiveId || "(empty)"}, sessionId=${activeSessionId || "(empty)"})`);
 
         if (!archiveId) {
           api.logger.warn?.(`openviking: ov_archive_expand missing archiveId`);
@@ -892,6 +892,17 @@ const contextEnginePlugin = {
                 const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
 
                 if (memories.length > 0) {
+                  const recalledUris = memories
+                    .map((memory) => memory.uri)
+                    .filter((uri): uri is string => typeof uri === "string" && uri.length > 0);
+                  const ovSessionId = openClawSessionToOvStorageId(
+                    ctx?.sessionId,
+                    ctx?.sessionKey,
+                  );
+                  void client.sessionUsed(ovSessionId, recalledUris, agentId).catch((err) => {
+                    api.logger.warn(`openviking: sessionUsed failed: ${String(err)}`);
+                  });
+
                   const { lines: memoryLines, estimatedTokens } = await buildMemoryLinesWithBudget(
                     memories,
                     (uri) => client.read(uri, agentId),


### PR DESCRIPTION
## Description

Mark recalled memories as `used()` in the existing Claude Code and OpenClaw examples so retrieval feedback feeds back into OpenViking hotness/ranking.

This keeps the change narrowly scoped to the example integrations that already perform recall.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `sessionUsed()` support to the OpenClaw example client.
- Mark recalled memory URIs as `used()` during OpenClaw recall before continuing with normal injection flow.
- Add the same fire-and-forget `session.used()` plus `commit()` feedback loop to the Claude Code memory example and auto-recall script.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Verified locally with:

```bash
cd examples/claude-code-memory-plugin
npm ci
npm run build

cd ../openclaw-plugin
npm ci
npm test
```

OpenClaw plugin tests are currently red on upstream `main` before this patch as well. The same two failures reproduce on a clean upstream-based worktree:

- `context-engine-assemble.test.ts > assembles summary archive and completed tool parts into agent messages`
- `context-engine-assemble.test.ts > emits a non-error toolResult for a running tool`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- This PR intentionally stays at the example layer and does not change core retrieval APIs.
- The OpenClaw-side diff is limited to marking recalled URIs as used; unrelated local-only runtime wiring is excluded.
