### PR TITLE
fix(openclaw-plugin): preserve existing ov.conf on auto install

### DIFF
--- a/examples/openclaw-plugin/install.sh
+++ b/examples/openclaw-plugin/install.sh
@@ -1669,6 +1669,14 @@ configure_openviking_conf() {
   local embedding_api_key="${OPENVIKING_EMBEDDING_API_KEY:-${OPENVIKING_ARK_API_KEY:-}}"
   local conf_path="${OPENVIKING_DIR}/ov.conf"
 
+  if [[ "$INSTALL_YES" == "1" && -f "${conf_path}" ]]; then
+    SELECTED_SERVER_PORT="$(readPortFromOvConf "${conf_path}" || true)"
+    [[ -z "${SELECTED_SERVER_PORT}" ]] && SELECTED_SERVER_PORT="${DEFAULT_SERVER_PORT}"
+    SELECTED_CONFIG_PATH="${conf_path}"
+    info "$(tr "Preserved existing config: ${conf_path}" "已保留现有配置: ${conf_path}")"
+    return 0
+  fi
+
   if [[ "$INSTALL_YES" != "1" ]]; then
     echo ""
     read -r -p "$(tr "OpenViking workspace path [${workspace}]: " "OpenViking 数据目录 [${workspace}]: ")" _workspace < /dev/tty || true

--- a/examples/openclaw-plugin/setup-helper/install.js
+++ b/examples/openclaw-plugin/setup-helper/install.js
@@ -1106,6 +1106,18 @@ async function installOpenViking() {
 async function configureOvConf() {
   await mkdir(OPENVIKING_DIR, { recursive: true });
 
+  const configPath = join(OPENVIKING_DIR, "ov.conf");
+  if (installYes && existsSync(configPath)) {
+    selectedServerPort = await readPortFromOvConf(configPath) || DEFAULT_SERVER_PORT;
+    info(
+      tr(
+        `Preserved existing config: ${configPath}`,
+        `已保留现有配置: ${configPath}`,
+      ),
+    );
+    return;
+  }
+
   let workspace = join(OPENVIKING_DIR, "data");
   let serverPort = String(DEFAULT_SERVER_PORT);
   let agfsPort = String(DEFAULT_AGFS_PORT);
@@ -1173,7 +1185,6 @@ async function configureOvConf() {
     },
   };
 
-  const configPath = join(OPENVIKING_DIR, "ov.conf");
   await writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf8");
   info(tr(`Config generated: ${configPath}`, `已生成配置: ${configPath}`));
 }


### PR DESCRIPTION
## Description

Preserve an existing `ov.conf` during non-interactive OpenClaw plugin installs so rerunning the installer does not overwrite the user's configured OpenViking workspace and server port.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Skip regenerating `ov.conf` in `install.sh` when `--yes` mode finds an existing config file
- Reuse the configured server port from the preserved config so later setup steps stay aligned
- Mirror the same preserve-existing-config behavior in the Node.js setup helper used by the plugin installer

## Testing

Validated syntax for the updated installer entry points:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- Verified with `bash -n examples/openclaw-plugin/install.sh`
- Verified with `node --check examples/openclaw-plugin/setup-helper/install.js`
- Full installer flow was not executed locally in this pass
