### PR TITLE
docs(docker): use latest image tag in examples

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openviking:
-    image: ghcr.io/volcengine/openviking:main
+    image: ghcr.io/volcengine/openviking:latest
     container_name: openviking
     ports:
       - "1933:1933"

--- a/docs/en/getting-started/02-quickstart.md
+++ b/docs/en/getting-started/02-quickstart.md
@@ -36,7 +36,7 @@ If you prefer to run OpenViking as a standalone service, Docker is recommended.
    ```yaml
    services:
      openviking:
-       image: ghcr.io/volcengine/openviking:main
+       image: ghcr.io/volcengine/openviking:latest
        container_name: openviking
        ports:
          - "1933:1933"
@@ -59,7 +59,7 @@ If you prefer to run OpenViking as a standalone service, Docker is recommended.
 > ```yaml
 > services:
 >   openviking:
->     image: ghcr.io/volcengine/openviking:main
+>     image: ghcr.io/volcengine/openviking:latest
 >     ports:
 >       - "1933:1934" # Map host 1933 to container 1934
 >     volumes:

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -202,7 +202,7 @@ docker run -d \
   -v ~/.openviking/ov.conf:/app/ov.conf \
   -v /var/lib/openviking/data:/app/data \
   --restart unless-stopped \
-  ghcr.io/volcengine/openviking:main
+  ghcr.io/volcengine/openviking:latest
 ```
 
 You can also use Docker Compose with the `docker-compose.yml` provided in the project root:

--- a/docs/zh/getting-started/02-quickstart.md
+++ b/docs/zh/getting-started/02-quickstart.md
@@ -36,7 +36,7 @@ pip install openviking --upgrade --force-reinstall
    ```yaml
    services:
      openviking:
-       image: ghcr.io/volcengine/openviking:main
+       image: ghcr.io/volcengine/openviking:latest
        container_name: openviking
        ports:
          - "1933:1933"
@@ -59,7 +59,7 @@ pip install openviking --upgrade --force-reinstall
 > ```yaml
 > services:
 >   openviking:
->     image: ghcr.io/volcengine/openviking:main
+>     image: ghcr.io/volcengine/openviking:latest
 >     ports:
 >       - "1933:1934" # 将宿主机 1933 映射到容器 1934
 >     volumes:

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -200,7 +200,7 @@ docker run -d \
   -v ~/.openviking/ov.conf:/app/ov.conf \
   -v /var/lib/openviking/data:/app/data \
   --restart unless-stopped \
-  ghcr.io/volcengine/openviking:main
+  ghcr.io/volcengine/openviking:latest
 ```
 
 也可以使用 Docker Compose，项目根目录提供了 `docker-compose.yml`：

--- a/examples/cloud/GUIDE.md
+++ b/examples/cloud/GUIDE.md
@@ -258,7 +258,7 @@ docker run -d \
   -v ~/.openviking/ov.conf:/app/ov.conf \
   -v /var/lib/openviking/data:/app/data \
   --restart unless-stopped \
-  ghcr.io/volcengine/openviking:main
+  ghcr.io/volcengine/openviking:latest
 ```
 
 > 将 `~/.openviking/ov.conf` 替换为你实际的配置文件路径。


### PR DESCRIPTION
## Description

Update Docker examples and deployment docs to use `ghcr.io/volcengine/openviking:latest` instead of the stale `:main` tag.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Replace `ghcr.io/volcengine/openviking:main` with `:latest` in the root `docker-compose.yml`
- Update English quickstart and deployment guides to match the currently published image tag
- Update Chinese quickstart, deployment, and cloud guides with the same image tag change

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

No runtime code changed. This PR only updates image tag references in docs and examples.
