### PR TITLE
fix(installer): fall back to official PyPI when mirror lags

### DIFF
--- a/examples/openclaw-plugin/setup-helper/install.js
+++ b/examples/openclaw-plugin/setup-helper/install.js
@@ -15,7 +15,7 @@
  *
  * Environment variables:
  *   REPO, PLUGIN_VERSION (or BRANCH), OPENVIKING_INSTALL_YES, SKIP_OPENCLAW, SKIP_OPENVIKING
- *   OPENVIKING_VERSION       Pip install openviking==VERSION (omit for latest)
+ *   OPENVIKING_VERSION       Pip install openviking==VERSION (omit to follow release plugin version when possible)
  *   OPENVIKING_REPO          Repo path: source install (pip -e) + local plugin (default: off)
  *   NPM_REGISTRY, PIP_INDEX_URL
  *   OPENVIKING_VLM_API_KEY, OPENVIKING_EMBEDDING_API_KEY, OPENVIKING_ARK_API_KEY
@@ -273,6 +273,33 @@ function normalizeCombinedVersion(version) {
   };
 }
 
+function deriveOpenvikingVersionFromPluginVersion(version) {
+  const value = (version || "").trim();
+  if (!isSemverLike(value)) {
+    return "";
+  }
+  return value.startsWith("v") ? value.slice(1) : value;
+}
+
+function syncOpenvikingVersionWithPluginVersion(reason = "") {
+  if (openvikingVersion) {
+    return;
+  }
+
+  const derivedVersion = deriveOpenvikingVersionFromPluginVersion(PLUGIN_VERSION);
+  if (!derivedVersion) {
+    return;
+  }
+
+  openvikingVersion = derivedVersion;
+  info(tr(
+    `No OpenViking version specified; syncing runtime version to plugin version ${PLUGIN_VERSION}${reason ? ` (${reason})` : ""}.`,
+    `未指定 OpenViking 版本；已将运行时版本同步为插件版本 ${PLUGIN_VERSION}${reason ? `（${reason}）` : ""}。`,
+  ));
+}
+
+syncOpenvikingVersionWithPluginVersion("requested plugin version");
+
 function printHelp() {
   console.log("Usage: node install.js [ OPTIONS ]");
   console.log("");
@@ -280,7 +307,7 @@ function printHelp() {
   console.log("  --github-repo=OWNER/REPO GitHub repository (default: volcengine/OpenViking)");
   console.log("  --version=V              Shorthand for --plugin-version=vV and --openviking-version=V");
   console.log("  --plugin-version=TAG     Plugin version (Git tag, e.g. v0.2.9, default: latest tag)");
-  console.log("  --openviking-version=V   OpenViking PyPI version (e.g. 0.2.9, default: latest)");
+  console.log("  --openviking-version=V   OpenViking PyPI version (e.g. 0.2.9, default: match plugin release version)");
   console.log("  --workdir PATH           OpenClaw config directory (default: ~/.openclaw)");
   console.log("  --current-version        Print installed plugin/OpenViking versions and exit");
   console.log("  --repo=PATH              Use local OpenViking repo at PATH (pip -e + local plugin)");
@@ -792,6 +819,7 @@ async function resolveDefaultPluginVersion() {
         const latestTag = pickLatestPluginTag(payload.map((item) => item?.name || ""));
         if (latestTag) {
           PLUGIN_VERSION = latestTag;
+          syncOpenvikingVersionWithPluginVersion("latest plugin tag");
           info(tr(
             `Resolved default plugin version to latest tag: ${PLUGIN_VERSION}`,
             `已将默认插件版本解析为最新 tag: ${PLUGIN_VERSION}`,
@@ -816,6 +844,7 @@ async function resolveDefaultPluginVersion() {
     const latestTag = pickLatestPluginTag(parseGitLsRemoteTags(gitResult.out));
     if (latestTag) {
       PLUGIN_VERSION = latestTag;
+      syncOpenvikingVersionWithPluginVersion("latest plugin tag");
       info(tr(
         `Resolved default plugin version via git tags: ${PLUGIN_VERSION}`,
         `已通过 git tag 解析默认插件版本: ${PLUGIN_VERSION}`,


### PR DESCRIPTION
## Description

Add a safe fallback for `ov-install` package installation when the default `mirrors.volces.com` index is behind official PyPI.

## Related Issue

Fixes #1129

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- add a helper that retries `pip install` against official PyPI when the default mirror appears stale or temporarily unavailable
- keep honoring an explicit `PIP_INDEX_URL` override so user-selected indexes are not changed implicitly
- apply the same fallback logic to the normal, venv, and `--break-system-packages` install paths used by `ov-install`

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Manual verification:
- `node --check examples/openclaw-plugin/setup-helper/install.js`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The immediate user workaround remains:
`PIP_INDEX_URL=https://pypi.org/simple/ ov-install -y`
