### PR TITLE
fix(parser): use GITHUB_TOKEN for ZIP downloads if available

### DIFF
--- a/openviking/parse/parsers/code/code.py
+++ b/openviking/parse/parsers/code/code.py
@@ -371,7 +371,12 @@ class CodeRepositoryParser(BaseParser):
 
         # Download (blocking HTTP; run in thread pool to avoid stalling event loop).
         def _download() -> None:
-            req = urllib.request.Request(zip_url, headers={"User-Agent": "OpenViking"})
+            headers = {"User-Agent": "OpenViking"}
+            github_token = os.environ.get("GITHUB_TOKEN")
+            if github_token:
+                headers["Authorization"] = f"token {github_token}"
+
+            req = urllib.request.Request(zip_url, headers=headers)
             with urllib.request.urlopen(req, timeout=1800) as resp, open(zip_path, "wb") as f:
                 shutil.copyfileobj(resp, f)
 


### PR DESCRIPTION
## Description

This PR adds support for authenticating GitHub ZIP downloads using the `GITHUB_TOKEN` environment variable if it is available. This enables OpenViking to ingest private GitHub repositories when using the `ov add-resource https://github.com/...` command via the ZIP API.

## Related Issue

<!-- Link to the related issue (if applicable) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Read `GITHUB_TOKEN` from environment variables in `code.py`'s `_download` method.
- Attach the token to the `Authorization` header when making the request to the GitHub archive API.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published