### PR TITLE
fix(openclaw-plugin): stop writing gateway.mode from installers

### DIFF
--- a/examples/openclaw-plugin/install.sh
+++ b/examples/openclaw-plugin/install.sh
@@ -2021,11 +2021,6 @@ configure_openclaw_plugin() {
     return 0
   fi
 
-  # Set gateway mode
-  if [[ "${skip_gateway_mode}" != "1" ]]; then
-    "${oc_env[@]}" openclaw config set gateway.mode "${SELECTED_MODE}"
-  fi
-
   # Set plugin config for the selected mode
   if [[ "$SELECTED_MODE" == "local" ]]; then
     local ov_conf_path="${SELECTED_CONFIG_PATH:-${OPENVIKING_DIR}/ov.conf}"

--- a/examples/openclaw-plugin/setup-helper/install.js
+++ b/examples/openclaw-plugin/setup-helper/install.js
@@ -2094,10 +2094,6 @@ async function configureOpenClawPlugin({
       : { mode: "local", configPath: join(OPENVIKING_DIR, "ov.conf"), port: selectedServerPort }
   );
 
-  if (!skipGatewayMode) {
-    await oc(["config", "set", "gateway.mode", effectiveRuntimeConfig.mode === "remote" ? "remote" : "local"]);
-  }
-
   // Set plugin config for the selected mode
   if (effectiveRuntimeConfig.mode === "local") {
     const ovConfPath = effectiveRuntimeConfig.configPath || join(OPENVIKING_DIR, "ov.conf");

--- a/examples/openclaw-plugin/setup-helper/package.json
+++ b/examples/openclaw-plugin/setup-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-openviking-setup-helper",
-  "version": "0.2.11",
+  "version": "0.2.15",
   "description": "Setup helper for installing OpenViking memory plugin into OpenClaw",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Remove openclaw config set gateway.mode from install.sh and setup-helper/install.js; OpenViking plugin local/remote is unrelated to OpenClaw gateway.mode. Bump setup-helper to 0.2.15.

Made-with: Cursor

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
