### PR TITLE
fix(summarizer): use correct URI matching for memory context_type during reindex

### DIFF
--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -7,6 +7,7 @@ Handles summarization and key information extraction.
 
 from typing import TYPE_CHECKING, Any, Dict, List
 
+from openviking.core.directories import get_context_type_for_uri
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.telemetry import get_current_telemetry
 from openviking_cli.utils import get_logger
@@ -57,11 +58,7 @@ class Summarizer:
         telemetry = get_current_telemetry()
         for uri, temp_uri in zip(resource_uris, temp_uris):
             # Determine context_type based on URI
-            context_type = "resource"
-            if uri.startswith("viking://memory/"):
-                context_type = "memory"
-            elif uri.startswith("viking://agent/skills/"):
-                context_type = "skill"
+            context_type = get_context_type_for_uri(uri)
 
             msg = SemanticMsg(
                 uri=temp_uri,

--- a/tests/unit/test_summarizer_context_type.py
+++ b/tests/unit/test_summarizer_context_type.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for context_type classification in Summarizer.
+
+Verifies that the summarizer uses get_context_type_for_uri() to correctly
+classify memory, skill, and resource URIs (fixes #1060).
+"""
+
+import pytest
+
+from openviking.core.directories import get_context_type_for_uri
+
+
+class TestSummarizerContextType:
+    """Verify URI → context_type mapping used by Summarizer."""
+
+    def test_user_memory_uri(self):
+        """User memory URIs should classify as 'memory'."""
+        uri = "viking://user/default/memories/entities/mem_abc123.md"
+        assert get_context_type_for_uri(uri) == "memory"
+
+    def test_agent_memory_uri(self):
+        """Agent memory URIs should classify as 'memory'."""
+        uri = "viking://agent/default/memories/cases/mem_xyz789.md"
+        assert get_context_type_for_uri(uri) == "memory"
+
+    def test_memory_profile_uri(self):
+        """Profile memory URI should classify as 'memory'."""
+        uri = "viking://user/default/memories/profile.md"
+        assert get_context_type_for_uri(uri) == "memory"
+
+    def test_memory_preferences_uri(self):
+        """Preferences memory URI should classify as 'memory'."""
+        uri = "viking://user/default/memories/preferences/coding-style.md"
+        assert get_context_type_for_uri(uri) == "memory"
+
+    def test_skill_uri(self):
+        """Skill URIs should classify as 'skill'."""
+        uri = "viking://agent/default/skills/search.md"
+        assert get_context_type_for_uri(uri) == "skill"
+
+    def test_resource_uri(self):
+        """Resource URIs should classify as 'resource'."""
+        uri = "viking://resources/docs/readme.md"
+        assert get_context_type_for_uri(uri) == "resource"
+
+    def test_session_uri(self):
+        """Session URIs should classify as 'memory'."""
+        uri = "viking://session/default/sess_001/history/archive_001"
+        assert get_context_type_for_uri(uri) == "memory"
+
+    def test_unknown_uri_defaults_to_resource(self):
+        """Unknown URIs should default to 'resource'."""
+        uri = "viking://unknown/something"
+        assert get_context_type_for_uri(uri) == "resource"
+
+    def test_old_broken_prefix_would_fail(self):
+        """Regression: the old startswith('viking://memory/') check would miss real URIs."""
+        # These real memory URIs do NOT start with "viking://memory/"
+        real_uris = [
+            "viking://user/default/memories/entities/mem_001.md",
+            "viking://agent/default/memories/patterns/mem_002.md",
+            "viking://user/john/memories/events/mem_003.md",
+        ]
+        for uri in real_uris:
+            assert not uri.startswith("viking://memory/"), f"URI unexpectedly matches old prefix: {uri}"
+            assert get_context_type_for_uri(uri) == "memory", f"URI should classify as memory: {uri}"


### PR DESCRIPTION
## Summary

- Replace broken `uri.startswith("viking://memory/")` prefix check in `summarizer.py` with a call to the existing `get_context_type_for_uri()` from `core/directories.py`
- The old prefix never matched real memory URIs (`viking://user/{space}/memories/...`), causing all memories to be misclassified as `context_type="resource"` during reindex
- This broke OpenClaw auto-recall which filters `context_type == "memory"`

## Root Cause

`summarizer.py:61` checked `uri.startswith("viking://memory/")` but actual memory URIs use the pattern `viking://user/{space}/memories/...` or `viking://agent/{space}/memories/...` — the prefix never matches.

The correct logic already existed in `core/directories.py:get_context_type_for_uri()` using `"/memories" in uri`. The fix simply wires it up.

## Changes

- `openviking/utils/summarizer.py`: Replace 4-line inline check with 1-line call to `get_context_type_for_uri(uri)`
- `tests/unit/test_summarizer_context_type.py`: 9 tests covering all URI types + regression test for the old broken pattern

## Test plan

- [x] 9 new tests pass: user memory, agent memory, profile, preferences, skill, resource, session, unknown, regression
- [x] 58 existing `test_context.py` tests pass (no regression)
- [x] Verified no other `startswith("viking://memory")` patterns remain in codebase

Fixes #1060