### PR TITLE
fix: resolve commitInFlight 404 bug and assistant role data loss

### DIFF
--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -1019,6 +1019,19 @@ async function pollCommitTaskOnce(
 
     return task.status
   } catch (error: any) {
+    // If task not found (404/expired), clear commit state so new commits can proceed
+    if (error.message?.includes("not found") || error.message?.includes("404")) {
+      log("INFO", "session", "Commit task expired or not found, clearing commit state", {
+        openviking_session: mapping.ovSessionId,
+        opencode_session: opencodeSessionId,
+        task_id: mapping.commitTaskId,
+        error: error.message,
+      })
+      clearCommitState(mapping)
+      debouncedSaveSessionMap()
+      return "completed"
+    }
+
     log("ERROR", "session", "Failed to poll OpenViking background commit", {
       openviking_session: mapping.ovSessionId,
       opencode_session: opencodeSessionId,
@@ -1454,7 +1467,7 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
               role: role,
             })
           }
-        } else if (role === "assistant" && finish === "stop") {
+        } else if (role === "assistant") {
           mapping.messageRoles.set(messageId, role)
 
           log("DEBUG", "message", `${role} message completed and role stored`, {
@@ -1463,6 +1476,15 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
             role: role,
             finish: finish,
           })
+
+          if (finish && finish !== "stop") {
+            log("INFO", "message", `assistant message role stored with non-stop finish`, {
+              session_id: sessionId,
+              message_id: messageId,
+              role: role,
+              finish: finish,
+            })
+          }
         }
 
         await flushPendingMessages(sessionId, mapping, config)


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs in the OpenCode memory plugin that affect session memory integrity.

## Fix #1: commitInFlight not cleared on 404

**Issue:** When `pollCommitTaskOnce()` receives a 404 response (commit task not found), the error is caught but `commitInFlight` is never cleared. This causes auto-commit to stop working permanently for the session.

**Fix:** Added 404/expired task detection in the catch block to clear commit state via `clearCommitState(mapping)` so new commits can proceed normally.

## Fix #2: Assistant role conditional on finish='stop' causes data loss

**Issue:** Assistant message roles were only stored when `finish === "stop"`. However, assistant messages with tool calls complete with other finish types (e.g., "tool_calls"). This caused content to be captured in `pendingMessages` but never flushed to the OpenViking server because `flushPendingMessages()` requires both content AND role.

**Fix:** Removed the `finish === "stop"` condition - assistant roles are now stored regardless of finish value. Added logging for non-stop finish values for debugging.

## Impact

- **Fix #1:** Auto-commit was silently breaking after OV server restart or task expiry
- **Fix #2:** 15-16 messages per session were being orphaned in pendingMessages, never sent to OpenViking

## Testing

Both fixes have been tested in a live OpenCode environment with OpenViking. The session-map.json showed 15-16 orphaned pendingMessages which were cleared after applying fix #2.