### PR TITLE
fix(zip): Fix garbled characters

### DIFF
--- a/openviking/utils/zip_safe.py
+++ b/openviking/utils/zip_safe.py
@@ -6,6 +6,55 @@ import os
 import zipfile
 from pathlib import Path
 
+_UTF8_FLAG = 0x800
+
+
+def _contains_cjk(text: str) -> bool:
+    return any(
+        "\u3400" <= ch <= "\u4dbf"
+        or "\u4e00" <= ch <= "\u9fff"
+        or "\u3000" <= ch <= "\u303f"
+        or "\uff00" <= ch <= "\uffef"
+        for ch in text
+    )
+
+
+def _contains_common_mojibake(text: str) -> bool:
+    return any(
+        "\u0370" <= ch <= "\u03ff" or "\u2200" <= ch <= "\u22ff" or "\u2500" <= ch <= "\u257f"
+        for ch in text
+    )
+
+
+def normalize_zip_filenames(zipf: zipfile.ZipFile) -> None:
+    """Repair UTF-8 member names when archives forgot to set the UTF-8 flag."""
+    repaired_any = False
+    for member in zipf.infolist():
+        if member.flag_bits & _UTF8_FLAG:
+            continue
+
+        try:
+            raw_name = member.filename.encode("cp437")
+            repaired_name = raw_name.decode("utf-8")
+        except UnicodeError:
+            continue
+
+        if repaired_name == member.filename:
+            continue
+        if _contains_cjk(member.filename):
+            continue
+        if not _contains_cjk(repaired_name):
+            continue
+        if not _contains_common_mojibake(member.filename):
+            continue
+
+        member.filename = repaired_name
+        member.orig_filename = repaired_name
+        repaired_any = True
+
+    if repaired_any:
+        zipf.metadata_encoding = "utf-8"
+
 
 def safe_extract_zip(zipf: zipfile.ZipFile, dest_dir: Path) -> None:
     """Extract ZIP archive with Zip Slip protection.
@@ -14,6 +63,7 @@ def safe_extract_zip(zipf: zipfile.ZipFile, dest_dir: Path) -> None:
     Rejects absolute paths and parent-directory traversal (..).
     """
     dest_dir = Path(dest_dir).resolve()
+    normalize_zip_filenames(zipf)
     for member in zipf.infolist():
         member_path = (dest_dir / member.filename).resolve()
         # Ensure the resolved path is inside dest_dir


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
  修复了上传 zip 资源时中文路径被解析成乱码的问题。根因是部分 zip 文件虽然成员名实际是 UTF-8
  编码，但没有正确设置 ZIP 的 UTF-8 flag，Python zipfile 默认按 cp437 解码，导致 业务域/ 这类
  目录名被读成乱码。

  这次改动在 openviking/utils/zip_safe.py 增加了 zip 成员名规范化逻辑：对“未设置 UTF-8 flag
  且明显是 UTF-8 误解码”的文件名进行修复，并在修复后将 ZipFile.metadata_encoding 切换为 utf-
  8，保证后续安全解压和路径校验使用正确文件名。还新增了回归测试 tests/utils/
  test_zip_safe.py，覆盖“UTF-8 文件名但缺失 UTF-8 flag”的异常 zip 场景，验证解压后中文路径能
  正确恢复。
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
