### PR TITLE
feat(parse): add support for .inl file extension

### DIFF
--- a/openviking/parse/parsers/constants.py
+++ b/openviking/parse/parsers/constants.py
@@ -101,6 +101,7 @@ CODE_EXTENSIONS = {
     ".c",
     ".h",
     ".hpp",
+    ".inl",
     ".cs",
     ".js",
     ".ts",

--- a/tests/parse/test_directory_scan.py
+++ b/tests/parse/test_directory_scan.py
@@ -36,6 +36,7 @@ def tmp_tree(tmp_path: Path) -> Path:
     # text (code/config, no dedicated parser or text parser only): .py, .yaml
     (tmp_path / "main.py").write_text("print(1)", encoding="utf-8")
     (tmp_path / "engine.cc").write_text("int main() { return 0; }", encoding="utf-8")
+    (tmp_path / "inline.inl").write_text("inline impl", encoding="utf-8")
     (tmp_path / "config.yaml").write_text("key: value", encoding="utf-8")
 
     # unsupported: unknown extension
@@ -138,6 +139,7 @@ class TestScanDirectoryClassification:
         processable_rel = [f.rel_path for f in result.processable]
         assert "main.py" in processable_rel
         assert "engine.cc" in processable_rel
+        assert "inline.inl" in processable_rel
         assert "config.yaml" in processable_rel
         assert "src/app.py" in processable_rel
 


### PR DESCRIPTION
Add .inl to CODE_EXTENSIONS and include test case for directory scanning

## Description

<!-- Provide a brief description of the changes in this PR -->
Fix unnecessary directory overview regeneration during incremental updates when a C/C++ codebase contains `.inl` files.

Root cause: inconsistent “file included/excluded” rules across import paths. `.inl` is treated as a normal text/code file in one path, but may be excluded in another, making directory children sets differ and triggering `children_changed=True`, which causes redundant overview regeneration and extra VLM/token usage.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
https://github.com/volcengine/OpenViking/issues/1164

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Add `.inl` to `CODE_EXTENSIONS` so `.inl` is consistently recognized as text/code during directory scan and upload.
## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
