### PR TITLE
fix(semantic_dag): handle missing summary case in incremental update

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -421,7 +421,10 @@ class SemanticDagExecutor:
 
                 if not content_changed:
                     summary_dict = await self._read_existing_summary(file_path)
-                    need_vectorize = False
+                    if summary_dict is not None:
+                        need_vectorize = False
+                    else:
+                        self._file_change_status[file_path] = True
             else:
                 self._file_change_status[file_path] = True
             if summary_dict is None:

--- a/tests/storage/test_semantic_dag_incremental_missing_summary.py
+++ b/tests/storage/test_semantic_dag_incremental_missing_summary.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import re
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _mock_transaction_layer(monkeypatch):
+    mock_handle = MagicMock()
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aenter__",
+        AsyncMock(return_value=mock_handle),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aexit__",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: MagicMock(),
+    )
+
+
+class _FakeVikingFS:
+    def __init__(self, tree, file_contents):
+        self._tree = {self._norm(k): v for k, v in tree.items()}
+        self._file_contents = {self._norm(k): v for k, v in file_contents.items()}
+        self.writes = []
+
+    def _norm(self, path):
+        if "://" not in path:
+            return path
+        scheme, rest = path.split("://", 1)
+        rest = re.sub(r"/{2,}", "/", rest)
+        return f"{scheme}://{rest}"
+
+    async def ls(self, uri, ctx=None):
+        return self._tree.get(self._norm(uri), [])
+
+    async def stat(self, uri, ctx=None):
+        content = self._file_contents.get(self._norm(uri), "")
+        return {"size": len(content)}
+
+    async def read_file(self, path, ctx=None):
+        return self._file_contents.get(self._norm(path), "")
+
+    async def write_file(self, path, content, ctx=None):
+        norm_path = self._norm(path)
+        self._file_contents[norm_path] = content
+        self.writes.append((norm_path, content))
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri.replace("viking://", "/local/acc1/")
+
+
+class _FakeProcessor:
+    def __init__(self, viking_fs):
+        self._fs = viking_fs
+        self.summarized_files = []
+
+    def _parse_overview_md(self, overview_content):
+        results = {}
+        for line in overview_content.splitlines():
+            m = re.match(r"^-\s*(?P<name>[^:]+):\s*(?P<summary>.*)$", line.strip())
+            if not m:
+                continue
+            results[m.group("name").strip()] = m.group("summary").strip()
+        return results
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.summarized_files.append(file_path)
+        return {"name": file_path.split("/")[-1], "summary": "summary"}
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        lines = ["FILES:"]
+        for item in file_summaries:
+            name = item.get("name", "")
+            summary = item.get("summary", "")
+            lines.append(f"- {name}: {summary}")
+        return "\n".join(lines)
+
+    def _extract_abstract_from_overview(self, overview):
+        return "abstract"
+
+    def _enforce_size_limits(self, overview, abstract):
+        return overview, abstract
+
+    async def _sync_topdown_recursive(
+        self, root_uri, target_uri, ctx=None, file_change_status=None, lifecycle_lock_handle_id=""
+    ):
+        root_uri = self._fs._norm(root_uri)
+        target_uri = self._fs._norm(target_uri)
+        for path, content in list(self._fs._file_contents.items()):
+            if path.startswith(root_uri + "/"):
+                mapped = target_uri + path[len(root_uri) :]
+                self._fs._file_contents[mapped] = content
+        return MagicMock(
+            added_files=[],
+            deleted_files=[],
+            updated_files=[],
+            added_dirs=[],
+            deleted_dirs=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_incremental_missing_summary_triggers_overview_regen(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+
+    root_uri = "viking://resources/root"
+    target_uri = "viking://resources/target"
+    tree = {
+        root_uri: [{"name": "a.txt", "isDir": False}],
+        target_uri: [{"name": "a.txt", "isDir": False}],
+    }
+
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "hello",
+            f"{target_uri}/a.txt": "hello",
+            f"{target_uri}/.overview.md": "FILES:\n",
+            f"{target_uri}/.abstract.md": "old-abstract",
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+
+    executor1 = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=target_uri,
+    )
+    monkeypatch.setattr(executor1, "_add_vectorize_task", AsyncMock())
+    await executor1.run(root_uri)
+
+    assert "- a.txt:" in fake_fs._file_contents[f"{root_uri}/.overview.md"]
+    assert "- a.txt:" in fake_fs._file_contents[f"{target_uri}/.overview.md"]
+    first_run_calls = len(processor.summarized_files)
+
+    executor2 = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=target_uri,
+    )
+    monkeypatch.setattr(executor2, "_add_vectorize_task", AsyncMock())
+    await executor2.run(root_uri)
+
+    assert len(processor.summarized_files) == first_run_calls
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])
+


### PR DESCRIPTION
Add condition to check if summary_dict exists before setting need_vectorize flag Add test case for incremental update with missing summary

## Description

<!-- Provide a brief description of the changes in this PR -->
Fixes an infinite LLM/VLM consumption loop during incremental sync ( incremental_update=True ) when a parent directory’s existing .overview.md is missing a file entry (often due to truncated overview output in large directories). In this case, the system repeatedly regenerates the same unchanged file summary on every incremental run because the directory overview is never regenerated to persist the missing entry.

This PR makes the incremental pipeline “self-heal” by forcing the parent directory overview to be regenerated when the summary cannot be reused from the existing .overview.md .

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
Fixes #1169

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Update incremental logic in _file_summary_task so that we only disable downstream updates/vectorization when an existing summary is successfully reused; if the existing .overview.md does not contain the summary entry, mark the file as changed to force parent directory overview regeneration (so the missing entry is persisted).
- Code: semantic_dag.py
- Add a regression test that simulates “target .overview.md missing entry + file content unchanged” and verifies:
- first incremental run regenerates and writes back the missing overview entry
- second incremental run does not regenerate the same file summary again
- Test: test_semantic_dag_incremental_missing_summary.py

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
