### PR TITLE
docs: fix commit() examples — session.commit() is async, use get_task() to read memories_extracted

### DIFF
--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -344,10 +344,23 @@ Commit a session by archiving messages and extracting memories.
 session = client.session(session_id="a1b2c3d4")
 session.load()
 
-# Commit archives messages and extracts memories
+# commit returns immediately with a task_id; archiving and memory
+# extraction run asynchronously in the background
 result = session.commit()
-print(f"Status: {result['status']}")
-print(f"Memories extracted: {result['memories_extracted']}")
+print(f"Status: {result['status']}")   # "accepted"
+print(f"Task ID: {result['task_id']}")
+
+# Optional: poll until the background task completes
+import time
+for _ in range(30):
+    task = client.get_task(result["task_id"])
+    if task and task["status"] == "completed":
+        print(f"Memories extracted: {task['result']['memories_extracted']}")
+        break
+    elif task and task["status"] == "failed":
+        print(f"Commit failed: {task['error']}")
+        break
+    time.sleep(1)
 ```
 
 **HTTP API**
@@ -375,10 +388,12 @@ openviking session commit a1b2c3d4
   "status": "ok",
   "result": {
     "session_id": "a1b2c3d4",
-    "status": "committed",
+    "status": "accepted",
+    "task_id": "550e8400-e29b-41d4-a716-446655440000",
+    "archive_uri": "viking://session/a1b2c3d4/history/archive_001",
     "archived": true
   },
-  "time": 0.1
+  "time": 0.05
 }
 ```
 
@@ -467,9 +482,18 @@ session.add_message("assistant", [
 # Track actually used contexts
 session.used(contexts=[results.resources[0].uri])
 
-# Commit session (archive messages, extract memories)
+# Commit session — returns immediately with task_id, extraction runs in background
 result = session.commit()
-print(f"Memories extracted: {result['memories_extracted']}")
+print(f"Task ID: {result['task_id']}")
+
+# Optional: poll until the background task completes
+import time
+for _ in range(30):
+    task = client.get_task(result["task_id"])
+    if task and task["status"] == "completed":
+        print(f"Memories extracted: {task['result']['memories_extracted']}")
+        break
+    time.sleep(1)
 
 client.close()
 ```

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -344,10 +344,22 @@ openviking session add-message a1b2c3d4 --role user --content "How do I authenti
 session = client.session(session_id="a1b2c3d4")
 session.load()
 
-# commit 会归档消息并提取记忆
+# commit 立即返回 task_id，后台异步执行摘要生成和记忆提取
 result = session.commit()
-print(f"Status: {result['status']}")
-print(f"Memories extracted: {result['memories_extracted']}")
+print(f"Status: {result['status']}")   # "accepted"
+print(f"Task ID: {result['task_id']}")
+
+# 可选：轮询后台任务直到完成
+import time
+for _ in range(30):
+    task = client.get_task(result["task_id"])
+    if task and task["status"] == "completed":
+        print(f"Memories extracted: {task['result']['memories_extracted']}")
+        break
+    elif task and task["status"] == "failed":
+        print(f"Commit failed: {task['error']}")
+        break
+    time.sleep(1)
 ```
 
 **HTTP API**
@@ -375,10 +387,12 @@ openviking session commit a1b2c3d4
   "status": "ok",
   "result": {
     "session_id": "a1b2c3d4",
-    "status": "committed",
+    "status": "accepted",
+    "task_id": "550e8400-e29b-41d4-a716-446655440000",
+    "archive_uri": "viking://session/a1b2c3d4/history/archive_001",
     "archived": true
   },
-  "time": 0.1
+  "time": 0.05
 }
 ```
 
@@ -467,9 +481,18 @@ session.add_message("assistant", [
 # 跟踪实际使用的上下文
 session.used(contexts=[results.resources[0].uri])
 
-# 提交会话（归档消息、提取记忆）
+# 提交会话（立即返回，后台执行摘要生成和记忆提取）
 result = session.commit()
-print(f"Memories extracted: {result['memories_extracted']}")
+print(f"Task ID: {result['task_id']}")
+
+# 可选：等待后台任务完成
+import time
+for _ in range(30):
+    task = client.get_task(result["task_id"])
+    if task and task["status"] == "completed":
+        print(f"Memories extracted: {task['result']['memories_extracted']}")
+        break
+    time.sleep(1)
 
 client.close()
 ```


### PR DESCRIPTION
Fixes #1181

## Problem

The `commit()` API examples in `docs/zh/api/05-sessions.md` and `docs/en/api/05-sessions.md` contain two incorrect patterns that cause a `KeyError` when users run the code verbatim:

```python
result = session.commit()
print(f"Memories extracted: {result["memories_extracted"]}")  # KeyError!
```

**Root cause:** The doc was edited to simplify the examples, but the code did not match the simplification:

1. `session.commit()` returns `{"session_id", "status": "accepted", "task_id", "archive_uri", "archived"}` — there is no `memories_extracted` key in the commit response.
2. Memory extraction runs **asynchronously** in the background. The result is only available after polling via `get_task(task_id)`.
3. The response schema incorrectly showed `"status": "committed"` — the actual value is `"accepted"`.

## Fix

**3 locations in each doc (zh + en):**

1. `commit()` API example — replace the incorrect sync pattern with the correct async pattern (poll `get_task()` for the result)
2. Response JSON schema — fix `status: "committed"` → `"accepted"`, add `task_id` and `archive_uri` fields
3. Complete example — same async fix

The corrected pattern:
```python
result = session.commit()
print(f"Task ID: {result['task_id']}")  # "accepted" + task_id

import time
for _ in range(30):
    task = client.get_task(result["task_id"])
    if task and task["status"] == "completed":
        print(f"Memories extracted: {task['result']['memories_extracted']}")
        break
    time.sleep(1)
```

**2 files changed, +61/-14**