### PR TITLE
fix(opencode-plugin): recover stale commit state on current main

### DIFF
--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -611,6 +611,31 @@ function upsertBufferedMessage(
   sessionMessageBuffer.set(sessionId, freshBuffer)
 }
 
+function cleanupOrphanedMessageBuffers(now: number): void {
+  for (const [sessionId, buffer] of sessionMessageBuffer.entries()) {
+    if (sessionMap.has(sessionId)) {
+      continue
+    }
+
+    const oldestMessage = buffer[0]
+    if (!oldestMessage) {
+      sessionMessageBuffer.delete(sessionId)
+      continue
+    }
+
+    if (now - oldestMessage.timestamp <= BUFFERED_MESSAGE_TTL_MS * 2) {
+      continue
+    }
+
+    log("INFO", "buffer", "Cleaning up orphaned message buffer", {
+      session_id: sessionId,
+      buffer_age_ms: now - oldestMessage.timestamp,
+      message_count: buffer.length,
+    })
+    sessionMessageBuffer.delete(sessionId)
+  }
+}
+
 function getAutoCommitIntervalMinutes(config: OpenVikingConfig): number {
   const configured = Number(config.autoCommit?.intervalMinutes ?? DEFAULT_CONFIG.autoCommit?.intervalMinutes ?? 10)
   if (!Number.isFinite(configured)) {
@@ -728,6 +753,15 @@ function clearCommitState(mapping: SessionMapping): void {
   mapping.commitInFlight = false
   mapping.commitTaskId = undefined
   mapping.commitStartedAt = undefined
+}
+
+function isMissingCommitTaskError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return message.includes("resource not found") || message.includes("not found")
 }
 
 let backgroundCommitSupported: boolean | null = null
@@ -988,7 +1022,19 @@ async function pollCommitTaskOnce(
   }
 
   if (!mapping.commitTaskId) {
-    return "running"
+    const recoveredTaskId = await findRunningCommitTaskId(mapping.ovSessionId, config)
+    if (!recoveredTaskId) {
+      log("INFO", "session", "Clearing stale in-flight commit without task id", {
+        openviking_session: mapping.ovSessionId,
+        opencode_session: opencodeSessionId,
+      })
+      clearCommitState(mapping)
+      debouncedSaveSessionMap()
+      return "unknown"
+    }
+
+    mapping.commitTaskId = recoveredTaskId
+    debouncedSaveSessionMap()
   }
 
   try {
@@ -1041,12 +1087,23 @@ async function pollCommitTaskOnce(
     }
 
     return task.status
-  } catch (error: any) {
+  } catch (error: unknown) {
+    if (isMissingCommitTaskError(error)) {
+      log("INFO", "session", "Commit task disappeared; clearing stale state", {
+        openviking_session: mapping.ovSessionId,
+        opencode_session: opencodeSessionId,
+        task_id: mapping.commitTaskId,
+      })
+      clearCommitState(mapping)
+      debouncedSaveSessionMap()
+      return "unknown"
+    }
+
     log("ERROR", "session", "Failed to poll OpenViking background commit", {
       openviking_session: mapping.ovSessionId,
       opencode_session: opencodeSessionId,
       task_id: mapping.commitTaskId,
-      error: error.message,
+      error: error instanceof Error ? error.message : String(error),
     })
     return "unknown"
   }
@@ -1070,41 +1127,63 @@ async function waitForCommitCompletion(
       return null
     }
     if (!mapping.commitTaskId) {
-      await sleep(500, abortSignal)
-      continue
-    }
+      const recoveredTaskId = await findRunningCommitTaskId(mapping.ovSessionId, config)
+      if (!recoveredTaskId) {
+        clearCommitState(mapping)
+        debouncedSaveSessionMap()
+        return null
+      }
 
-    const response = await makeRequest<OpenVikingResponse<TaskResult>>(config, {
-      method: "GET",
-      endpoint: `/api/v1/tasks/${mapping.commitTaskId}`,
-      timeoutMs: 5000,
-      abortSignal,
-    })
-    const task = unwrapResponse(response)
-
-    if (task.status === "completed") {
-      const memoriesExtracted = totalMemoriesFromResult(task.result)
-      const archived = task.result?.archived ?? false
-
-      await finalizeCommitSuccess(mapping, opencodeSessionId, config)
-
-      log("INFO", "memcommit", "Background commit completed while waiting", {
-        openviking_session: mapping.ovSessionId,
-        opencode_session: opencodeSessionId,
-        task_id: task.task_id,
-        memories_extracted: memoriesExtracted,
-        archived,
-      })
-      return task
-    }
-
-    if (task.status === "failed") {
-      clearCommitState(mapping)
+      mapping.commitTaskId = recoveredTaskId
       debouncedSaveSessionMap()
-      throw new Error(task.error || "Background commit failed")
     }
 
-    await sleep(2000, abortSignal)
+    try {
+      const response = await makeRequest<OpenVikingResponse<TaskResult>>(config, {
+        method: "GET",
+        endpoint: `/api/v1/tasks/${mapping.commitTaskId}`,
+        timeoutMs: 5000,
+        abortSignal,
+      })
+      const task = unwrapResponse(response)
+
+      if (task.status === "completed") {
+        const memoriesExtracted = totalMemoriesFromResult(task.result)
+        const archived = task.result?.archived ?? false
+
+        await finalizeCommitSuccess(mapping, opencodeSessionId, config)
+
+        log("INFO", "memcommit", "Background commit completed while waiting", {
+          openviking_session: mapping.ovSessionId,
+          opencode_session: opencodeSessionId,
+          task_id: task.task_id,
+          memories_extracted: memoriesExtracted,
+          archived,
+        })
+        return task
+      }
+
+      if (task.status === "failed") {
+        clearCommitState(mapping)
+        debouncedSaveSessionMap()
+        throw new Error(task.error || "Background commit failed")
+      }
+
+      await sleep(2000, abortSignal)
+    } catch (error: unknown) {
+      if (isMissingCommitTaskError(error)) {
+        log("INFO", "session", "Commit task disappeared while waiting; clearing stale state", {
+          openviking_session: mapping.ovSessionId,
+          opencode_session: opencodeSessionId,
+          task_id: mapping.commitTaskId,
+        })
+        clearCommitState(mapping)
+        debouncedSaveSessionMap()
+        return null
+      }
+
+      throw error
+    }
   }
 
   return null
@@ -1117,6 +1196,11 @@ async function waitForCommitCompletion(
 let autoCommitTimer: NodeJS.Timeout | null = null
 
 function startAutoCommit(config: OpenVikingConfig) {
+  if (autoCommitTimer) {
+    log("INFO", "auto-commit", "Auto-commit scheduler already running")
+    return
+  }
+
   if (!config.autoCommit?.enabled) {
     log("INFO", "auto-commit", "Auto-commit disabled in config")
     return
@@ -1145,6 +1229,8 @@ function stopAutoCommit() {
 async function checkAndCommitSessions(config: OpenVikingConfig): Promise<void> {
   const intervalMs = getAutoCommitIntervalMinutes(config) * 60 * 1000
   const now = Date.now()
+
+  cleanupOrphanedMessageBuffers(now)
 
   for (const [opencodeSessionId, mapping] of sessionMap.entries()) {
     if (mapping.commitInFlight) {


### PR DESCRIPTION
## Summary
This is a focused follow-up to the reliability portions of `#715`, rebased onto the current `main` implementation of `examples/opencode-memory-plugin/openviking-memory.ts`.

`#715` is based on an older version of the plugin and removes compatibility behavior that now exists on `main` for older OpenViking servers, including background-task detection and synchronous commit fallback. This PR intentionally keeps the current `main` compatibility path and only carries forward the low-risk operational fixes that still apply cleanly.

Supersedes the salvageable runtime pieces of `#715`.

## What changed
- recover a missing `commitTaskId` by querying the task list before treating the commit as still running forever
- clear stale in-flight commit state when the task disappears from OpenViking, which can happen after a restart or task expiry
- prevent duplicate auto-commit timers from being started on repeated plugin initialization
- clean up long-lived orphaned message buffers for sessions that no longer exist in `sessionMap`

## Why this is a better option than reviving `#715`
- starts from the current `main` file instead of the stale pre-compatibility version
- avoids the blocking regressions called out in review on `#715`
- keeps the shared finalization helper and synchronous fallback already present on `main`
- limits review surface to the parts that are still useful and do not require a large semantic re-review

## Validation
- `npx -y esbuild examples/opencode-memory-plugin/openviking-memory.ts --bundle --format=esm --platform=node --external:@opencode-ai/plugin --outfile=/tmp/openviking-memory.js`

## Follow-up
If maintainers prefer, `#715` can be closed in favor of this narrower current-main follow-up.
