### PR TITLE
fix(add-resource): improve directory import UX and correctness

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -563,11 +563,16 @@ impl HttpClient {
 
         if path_obj.exists() {
             if path_obj.is_dir() {
+                let source_name = path_obj
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.to_string());
                 let zip_file = self.zip_directory(path_obj)?;
                 let temp_file_id = self.upload_temp_file(zip_file.path()).await?;
 
                 let body = serde_json::json!({
                     "temp_file_id": temp_file_id,
+                    "source_name": source_name,
                     "to": to,
                     "parent": parent,
                     "reason": reason,

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -6,7 +6,7 @@ mod output;
 mod tui;
 mod utils;
 
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 use config::Config;
 use error::{Error, Result};
 use output::OutputFormat;
@@ -128,9 +128,9 @@ enum Commands {
         /// Wait timeout in seconds (only used with --wait)
         #[arg(long)]
         timeout: Option<f64>,
-        /// No strict mode for directory scanning
-        #[arg(long = "no-strict", default_value_t = false)]
-        no_strict: bool,
+        /// Enable strict mode for directory scanning (fail if any unsupported files found)
+        #[arg(long = "strict", action = ArgAction::SetTrue)]
+        strict_mode: bool,
         /// Ignore directories, e.g. --ignore-dirs "node_modules,dist"
         #[arg(long)]
         ignore_dirs: Option<String>,
@@ -657,7 +657,7 @@ async fn main() {
             instruction,
             wait,
             timeout,
-            no_strict,
+            strict_mode,
             ignore_dirs,
             include,
             exclude,
@@ -672,7 +672,7 @@ async fn main() {
                 instruction,
                 wait,
                 timeout,
-                no_strict,
+                strict_mode,
                 ignore_dirs,
                 include,
                 exclude,
@@ -827,7 +827,7 @@ async fn handle_add_resource(
     instruction: String,
     wait: bool,
     timeout: Option<f64>,
-    no_strict: bool,
+    strict_mode: bool,
     ignore_dirs: Option<String>,
     include: Option<String>,
     exclude: Option<String>,
@@ -875,7 +875,7 @@ async fn handle_add_resource(
         std::process::exit(1);
     }
 
-    let strict = !no_strict;
+    let strict = strict_mode;
     let directly_upload_media = !no_directly_upload_media;
 
     let effective_timeout = if wait {

--- a/openviking/parse/directory_scan.py
+++ b/openviking/parse/directory_scan.py
@@ -289,9 +289,6 @@ def scan_directory(
             raise UnsupportedDirectoryFilesError(msg, unsupported_paths)
         else:
             logger.warning(msg)
-        result.warnings.append(msg)
-        for rel in unsupported_paths:
-            result.warnings.append(f"  - {rel}")
 
     result.processable.sort(key=lambda x: x.rel_path)
     result.unsupported.sort(key=lambda x: x.rel_path)

--- a/openviking/parse/parsers/constants.py
+++ b/openviking/parse/parsers/constants.py
@@ -95,6 +95,7 @@ IGNORE_EXTENSIONS = {
 # Code file extensions for file type detection
 CODE_EXTENSIONS = {
     ".py",
+    ".pyi",
     ".java",
     ".cpp",
     ".cc",
@@ -226,6 +227,8 @@ ADDITIONAL_TEXT_EXTENSIONS = {
     ".yarnrc",
     ".env",
     ".env.example",
+    ".lock",
+    ".in",
 }
 
 # Common text encodings to try for encoding detection (in order of likelihood)

--- a/openviking/parse/parsers/directory.py
+++ b/openviking/parse/parsers/directory.py
@@ -87,7 +87,7 @@ class DirectoryParser(BaseParser):
         if not source_path.is_dir():
             raise NotADirectoryError(f"Not a directory: {source_path}")
 
-        dir_name = source_path.name
+        dir_name = kwargs.get("source_name") or source_path.name
         warnings: List[str] = []
 
         try:

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -73,7 +73,8 @@ class AddResourceRequest(BaseModel):
     instruction: str = ""
     wait: bool = False
     timeout: Optional[float] = None
-    strict: bool = True
+    strict: bool = False
+    source_name: Optional[str] = None
     ignore_dirs: Optional[str] = None
     include: Optional[str] = None
     exclude: Optional[str] = None
@@ -190,6 +191,7 @@ async def add_resource(
 
     kwargs = {
         "strict": request.strict,
+        "source_name": request.source_name,
         "ignore_dirs": request.ignore_dirs,
         "include": request.include,
         "exclude": request.exclude,

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -153,7 +153,7 @@ class ResourceProcessor:
                     return result
 
                 if parse_result.warnings:
-                    result["errors"].extend(parse_result.warnings)
+                    result.setdefault("warnings", []).extend(parse_result.warnings)
 
                 telemetry.set(
                     "resource.parse.duration_ms",


### PR DESCRIPTION
## Summary

- **Preserve original directory name**: CLI now sends `source_name` (the original directory name) to the server so the resource URI reflects the real directory name instead of a temp dir name like `tmp4zzggd7w`
- **Non-strict by default**: changed default from `strict=true` to `strict=false` so unsupported files are silently skipped instead of failing the entire import; replaced `--no-strict` flag (which required `=true` to work) with `--strict` opt-in flag using `ArgAction::SetTrue`
- **Cleaner output**: unsupported-file warnings are no longer forwarded to the API response in non-strict mode (still logged server-side); parse warnings moved from `result["errors"]` to `result["warnings"]` to avoid misleading `error` column header on successful imports
- **Extended file support**: added `.pyi` (Python type stubs), `.lock` (uv.lock, Cargo.lock), `.in` (MANIFEST.in) to supported text extensions