### PR TITLE
fix: add timeout parameter to OpenAIVLM client

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -35,6 +35,7 @@ def _build_openai_client_kwargs(
     api_base: str,
     api_version: str | None,
     extra_headers: Dict[str, str] | None,
+    timeout: float = 60.0,
 ) -> Dict[str, Any]:
     """Build kwargs dict shared by sync and async OpenAI/Azure client constructors."""
     if provider == "azure":
@@ -44,9 +45,11 @@ def _build_openai_client_kwargs(
             "api_key": api_key,
             "azure_endpoint": api_base,
             "api_version": api_version or DEFAULT_AZURE_API_VERSION,
+            "timeout": timeout,
         }
     else:
         kwargs = {"api_key": api_key, "base_url": api_base}
+    kwargs["timeout"] = timeout
     if extra_headers:
         kwargs["default_headers"] = extra_headers
     return kwargs


### PR DESCRIPTION
## Problem

- OpenAI Python SDK uses `DEFAULT_TIMEOUT` with `connect=5.0` seconds
- Some API endpoints (like DashScope) require >5s to establish connection
- This causes `ConnectTimeout` errors with retries, taking ~15-16 seconds

## Solution

- Add `timeout` parameter (default=60.0) to `_build_openai_client_kwargs`
- Pass timeout to both Azure and non-Azure OpenAI client constructors

## Testing

Verified on DashScope endpoint:
- Before fix: VLM requests timeout after ~16 seconds
- After fix: VLM requests complete successfully in ~13-14 seconds

```python
# Test result
MemoryExtractor.extract - completed in 13.74s with 1 memory extracted
Session memory extraction - prompt_tokens: 6386, completion_tokens: 4751, memories: 1
```

## Changes

```diff
+    timeout: float = 60.0,
     extra_headers: Dict[str, str] | None,
 ) -> Dict[str, Any]:
@@ -44,9 +45,11 @@ def _build_openai_client_kwargs(
             "api_key": api_key,
             "azure_endpoint": api_base,
             "api_version": api_version or DEFAULT_AZURE_API_VERSION,
+            "timeout": timeout,
         }
     else:
         kwargs = {"api_key": api_key, "base_url": api_base}
+    kwargs["timeout"] = timeout
```

Fixes VLM timeout issues when connecting to slow-response endpoints.