### PR TITLE
fix: reset stale state on plugin re-load to handle double-load by OpenClaw Gateway

### DIFF
--- a/examples/openclaw-plugin/__tests__/plugin-reregister-no-orphan-1214.test.ts
+++ b/examples/openclaw-plugin/__tests__/plugin-reregister-no-orphan-1214.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import contextEnginePlugin from "../index.js";
+import { localClientCache, localClientPendingPromises } from "../client.js";
+
+// Regression for #1214 COLLABORATOR review by Mijamind719:
+// Second register() must preserve the first registration's pending
+// startup entry; otherwise the first registration's captured
+// clientPromise is orphaned and getClient() hangs.
+describe("plugin re-register preserves pending startup entries (#1214)", () => {
+  beforeEach(() => {
+    localClientCache.clear();
+    localClientPendingPromises.clear();
+  });
+
+  const makeStubApi = (pluginConfig: Record<string, unknown>) => ({
+    pluginConfig,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    registerTool: vi.fn(),
+    registerService: vi.fn(),
+    registerContextEngine: vi.fn(),
+    on: vi.fn(),
+  });
+
+  it("keeps the same pending-startup entry after a second register() with the same cacheKey", () => {
+    const cfg = {
+      mode: "local" as const,
+      baseUrl: "http://127.0.0.1:39997",
+      configPath: "/tmp/openviking-test-config-1214",
+      apiKey: "",
+      agentId: "default",
+      logFindRequests: false,
+      timeoutMs: 5000,
+    };
+
+    contextEnginePlugin.register(makeStubApi(cfg) as never);
+
+    expect(localClientPendingPromises.size).toBe(1);
+    const firstEntry = [...localClientPendingPromises.values()][0];
+
+    contextEnginePlugin.register(makeStubApi(cfg) as never);
+
+    // Entry identity must be preserved. The first registration's
+    // `clientPromise` closure was set to `firstEntry.promise` via the
+    // existingPending branch; if a second register() replaced the map
+    // slot with a new entry, service startup would later resolve the
+    // replacement and the first registration's promise would hang.
+    expect(localClientPendingPromises.size).toBe(1);
+    const secondEntry = [...localClientPendingPromises.values()][0];
+    expect(secondEntry).toBe(firstEntry);
+
+    // Behavioral sanity: resolving the preserved entry lets any closure
+    // that captured it settle. Since the second registration reuses the
+    // same promise, both registrations' getClient() would observe the
+    // same resolved client.
+    const fakeClient = { __stub: true };
+    firstEntry!.resolve(fakeClient as never);
+    return expect(firstEntry!.promise).resolves.toBe(fakeClient);
+  });
+
+  it("creates a fresh pending entry on re-register with a different cacheKey (#1210 reload)", () => {
+    const cfgA = {
+      mode: "local" as const,
+      baseUrl: "http://127.0.0.1:39998",
+      configPath: "/tmp/openviking-test-config-1214-a",
+      apiKey: "",
+      agentId: "agent-a",
+      logFindRequests: false,
+      timeoutMs: 5000,
+    };
+    const cfgB = { ...cfgA, agentId: "agent-b" };
+
+    contextEnginePlugin.register(makeStubApi(cfgA) as never);
+    expect(localClientPendingPromises.size).toBe(1);
+
+    contextEnginePlugin.register(makeStubApi(cfgB) as never);
+    // Distinct cacheKeys → each registration owns its own entry; no
+    // cross-contamination and no accidental reuse of the other's promise.
+    expect(localClientPendingPromises.size).toBe(2);
+  });
+});

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -480,11 +480,14 @@ const contextEnginePlugin = {
             ]);
             const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
             const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
-            // 合并两个位置的结果，去重
+            // 合并两个位置的结果，去重 (linear time via Set)
             const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
-            const uniqueMemories = allMemories.filter((memory, index, self) =>
-              index === self.findIndex((m) => m.uri === memory.uri)
-            );
+            const seenUris = new Set<string>();
+            const uniqueMemories = allMemories.filter((memory) => {
+              if (seenUris.has(memory.uri)) return false;
+              seenUris.add(memory.uri);
+              return true;
+            });
             const leafOnly = uniqueMemories.filter((m) => m.level === 2);
             result = {
               memories: leafOnly,
@@ -938,9 +941,12 @@ const contextEnginePlugin = {
                 }
 
                 const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
-                const uniqueMemories = allMemories.filter((memory, index, self) =>
-                  index === self.findIndex((m) => m.uri === memory.uri)
-                );
+                const seenUris = new Set<string>();
+                const uniqueMemories = allMemories.filter((memory) => {
+                  if (seenUris.has(memory.uri)) return false;
+                  seenUris.add(memory.uri);
+                  return true;
+                });
                 const leafOnly = uniqueMemories.filter((m) => m.level === 2);
                 const processed = postProcessMemories(leafOnly, {
                   limit: candidateLimit,

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -262,6 +262,8 @@ function totalCommitMemories(r: CommitSessionResult): number {
   return Object.values(m).reduce((sum, n) => sum + (n ?? 0), 0);
 }
 
+let _registered = false;
+
 const contextEnginePlugin = {
   id: "openviking",
   name: "Context Engine (OpenViking)",
@@ -270,6 +272,17 @@ const contextEnginePlugin = {
   configSchema: memoryOpenVikingConfigSchema,
 
   register(api: OpenClawPluginApi) {
+    // Idempotency guard: when OpenClaw reloads the plugin with a different cacheKey,
+    // module-level state (localClientCache, localClientPendingPromises) persists from
+    // the previous load. Reset stale state so the second registration works cleanly.
+    // See: https://github.com/volcengine/OpenViking/issues/1210
+    if (_registered) {
+      api.logger.info("openviking: plugin re-loaded, resetting stale state");
+      localClientCache.clear();
+      localClientPendingPromises.clear();
+    }
+    _registered = true;
+
     const rawCfg =
       api.pluginConfig && typeof api.pluginConfig === "object" && !Array.isArray(api.pluginConfig)
         ? (api.pluginConfig as Record<string, unknown>)

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -272,14 +272,23 @@ const contextEnginePlugin = {
   configSchema: memoryOpenVikingConfigSchema,
 
   register(api: OpenClawPluginApi) {
-    // Idempotency guard: when OpenClaw reloads the plugin with a different cacheKey,
-    // module-level state (localClientCache, localClientPendingPromises) persists from
-    // the previous load. Reset stale state so the second registration works cleanly.
-    // See: https://github.com/volcengine/OpenViking/issues/1210
+    // Idempotency on re-register: the lookup paths below already handle
+    // both found and not-found states for localClientCache (resolved
+    // client) and localClientPendingPromises (pending startup entry), so
+    // a second register() with the same or a different cacheKey reuses
+    // state correctly for the #1210 reload case.
+    //
+    // Do NOT clear these maps here. The first registration's clientPromise
+    // closure is bound to a specific pending-entry instance; clearing and
+    // letting the second register() install a fresh entry under the same
+    // cacheKey orphans the first closure — service startup resolves the
+    // replacement entry while the first registration's getClient() hangs.
+    // Clearing localClientCache has the same hazard post-startup: the
+    // second registration falls into the pending path even though the
+    // process is already running, so no new resolve() ever fires. See the
+    // review discussion on #1214.
     if (_registered) {
-      api.logger.info("openviking: plugin re-loaded, resetting stale state");
-      localClientCache.clear();
-      localClientPendingPromises.clear();
+      api.logger.info("openviking: plugin re-loaded (cacheKey-keyed state reused)");
     }
     _registered = true;
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -1228,7 +1228,15 @@ const contextEnginePlugin = {
               });
               try {
                 await waitForHealthOrExit(baseUrl, timeoutMs, intervalMs, child);
-                const client = new OpenVikingClient(baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs);
+                const client = new OpenVikingClient(
+                  baseUrl,
+                  cfg.apiKey,
+                  cfg.agentId,
+                  cfg.timeoutMs,
+                  tenantAccount,
+                  tenantUser,
+                  routingDebugLog,
+                );
                 localClientCache.set(localCacheKey, { client, process: child });
                 if (resolveLocalClient) {
                   resolveLocalClient(client);


### PR DESCRIPTION
Closes #1210

## Problem

When OpenClaw Gateway starts, the openviking plugin is loaded twice with different `cacheKey` (first with `preferSetupRuntimeForChannelPlugins: true`, then without). Because the plugin's module-level Maps (`localClientCache`, `localClientPendingPromises`) persist across re-imports, the second `register()` call sees stale state from the first load — causing tool/service/context-engine registration to operate on incorrect cached entries.

## Root Cause

The plugin's `register()` function assumes it's called exactly once per plugin lifecycle. Module-level state is never cleared, so a second registration (triggered by OpenClaw's dual-load startup sequence) inherits stale references.

## Fix

Add an idempotency guard at the beginning of `register()` that detects when the plugin has already been registered. On the second registration call:

1. Log a diagnostic message
2. Clear `localClientCache` and `localClientPendingPromises` Maps
3. Proceed with a clean registration

This ensures tools, service startup, and context-engine are registered correctly even when OpenClaw loads the plugin twice.

## Verification



## Related

- OpenClaw Issue: https://github.com/openclaw/openclaw/issues/60219