### PR TITLE
test(crypto): add regression tests for decrypting short plaintext files

### DIFF
--- a/tests/unit/crypto/test_encryptor.py
+++ b/tests/unit/crypto/test_encryptor.py
@@ -86,6 +86,45 @@ async def test_encrypt_empty_data(encryptor):
 
 
 @pytest.mark.asyncio
+async def test_decrypt_empty_plaintext(encryptor):
+    """Test decrypting empty plaintext bytes (not encrypted-empty, but raw b'').
+
+    Regression test: decrypt() used to raise 'Ciphertext too short' on empty
+    files because it checked length before the magic header.
+    """
+    account_id = "test_account"
+    decrypted = await encryptor.decrypt(account_id, b"")
+    assert decrypted == b""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data", [b"X", b"AB", b"ABC"])
+async def test_decrypt_short_plaintext_less_than_4_bytes(encryptor, data):
+    """Test decrypting plaintext shorter than 4 bytes (magic length).
+
+    Regression test: these used to raise InvalidMagicError('Ciphertext too short')
+    because length was checked before the magic prefix.
+    """
+    account_id = "test_account"
+    decrypted = await encryptor.decrypt(account_id, data)
+    assert decrypted == data
+
+
+@pytest.mark.asyncio
+async def test_decrypt_magic_prefix_without_full_header(encryptor):
+    """Test decrypting data that starts with 'OVE1' but has no valid envelope.
+
+    Should raise CorruptedCiphertextError because the envelope header is
+    incomplete (needs at least 12 bytes).
+    """
+    account_id = "test_account"
+    from openviking.crypto.exceptions import CorruptedCiphertextError
+
+    with pytest.raises(CorruptedCiphertextError):
+        await encryptor.decrypt(account_id, b"OVE1")
+
+
+@pytest.mark.asyncio
 async def test_different_accounts(encryptor):
     """Test encryption/decryption across different accounts."""
     account1 = "account1"


### PR DESCRIPTION
## Summary

Add regression tests for the fix in [#1163](https://github.com/volcengine/OpenViking/pull/1163) where `decrypt()` raised `"Ciphertext too short"` on plaintext files shorter than 4 bytes.

## Tests Added

- `test_decrypt_empty_plaintext` — raw `b""` returns `b""` (not an error)
- `test_decrypt_short_plaintext_less_than_4_bytes` — `b"X"`, `b"AB"`, `b"ABC"` returned as-is
- `test_decrypt_magic_prefix_without_full_header` — `b"OVE1"` raises `CorruptedCiphertextError` (valid magic but incomplete envelope)

All 10 tests pass.

## Related

Closes the unit test request from @baojun-zhang in [#1163 comments](https://github.com/volcengine/OpenViking/pull/1163#issuecomment-4186593567).