### PR TITLE
fix(plugin): add skills to autoRecall search scope

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
@@ -222,13 +222,15 @@ async function searchScope(query, targetUri, limit) {
 }
 
 async function searchBothScopes(query, limit) {
-  const [userMems, agentMems] = await Promise.all([
+  const [userMems, agentMems, agentSkills] = await Promise.all([
     searchScope(query, "viking://user/memories", limit),
     searchScope(query, "viking://agent/memories", limit),
+    searchScope(query, "viking://agent/skills", limit),
   ]);
   log("search_complete", { scope: "user", rawCount: userMems.length, topScores: userMems.slice(0, 3).map(m => m.score) });
   log("search_complete", { scope: "agent", rawCount: agentMems.length, topScores: agentMems.slice(0, 3).map(m => m.score) });
-  const all = [...userMems, ...agentMems];
+  log("search_complete", { scope: "skills", rawCount: agentSkills.length, topScores: agentSkills.slice(0, 3).map(m => m.score) });
+  const all = [...userMems, ...agentMems, ...agentSkills];
   const uriSet = new Set();
   return all.filter(m => {
     if (uriSet.has(m.uri)) return false;


### PR DESCRIPTION
## Description

The autoRecall feature in the Claude Code memory plugin only searches two scopes: \`viking://user/memories\` and \`viking://agent/memories\`. Skills stored at \`viking://agent/skills\` are never searched, so they're never auto-injected into conversation context even when relevant.

This adds \`viking://agent/skills\` as a third parallel search scope in \`searchBothScopes()\`, with the same deduplication and logging as the existing scopes.

## Related Issue

Fixes #1089

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added \`searchScope(query, "viking://agent/skills", limit)\` to the parallel search in \`searchBothScopes()\`
- Added \`search_complete\` log entry for the skills scope
- Merged skills results into the dedup list alongside memories

## Testing

- [x] Unit tests pass
- [ ] Platform testing (Linux)

## Checklist

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

This contribution was developed with AI assistance (Codex).