### PR TITLE
fix: prevent startup hang from blocking VLM call in redo recovery

### DIFF
--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -33,6 +33,7 @@ class LockManager:
         self._redo_log = RedoLog(agfs)
         self._handles: Dict[str, LockHandle] = {}
         self._cleanup_task: Optional[asyncio.Task] = None
+        self._redo_task: Optional[asyncio.Task] = None
         self._running = False
 
     @property
@@ -54,11 +55,18 @@ class LockManager:
         """Start background cleanup and redo recovery."""
         self._running = True
         self._cleanup_task = asyncio.create_task(self._stale_cleanup_loop())
-        await self._recover_pending_redo()
+        self._redo_task = asyncio.create_task(self._recover_pending_redo())
 
     async def stop(self) -> None:
         """Stop cleanup and release all active locks."""
         self._running = False
+        if self._redo_task:
+            self._redo_task.cancel()
+            try:
+                await self._redo_task
+            except asyncio.CancelledError:
+                pass
+            self._redo_task = None
         if self._cleanup_task:
             self._cleanup_task.cancel()
             try:
@@ -299,11 +307,14 @@ class LockManager:
                 from openviking.session import create_session_compressor
 
                 compressor = create_session_compressor(vikingdb=None)
-                memories = await compressor.extract_long_term_memories(
-                    messages=messages,
-                    user=user,
-                    session_id=session_id,
-                    ctx=ctx,
+                memories = await asyncio.wait_for(
+                    compressor.extract_long_term_memories(
+                        messages=messages,
+                        user=user,
+                        session_id=session_id,
+                        ctx=ctx,
+                    ),
+                    timeout=60.0,
                 )
                 logger.info(f"Redo: extracted {len(memories)} memories from {archive_uri}")
             except Exception as e:


### PR DESCRIPTION
## Description

Server startup can hang indefinitely when crash-recovery redo includes session_memory extraction. The LockManager.start() method awaits _recover_pending_redo() synchronously, which calls extract_long_term_memories() (a VLM call). If the VLM service is slow or unresponsive, the server never finishes starting and /health remains unavailable.

Two changes:
1. Move redo recovery to a background task via asyncio.create_task() so startup completes immediately
2. Add 60s timeout to extract_long_term_memories via asyncio.wait_for() to prevent indefinite hangs on individual redo tasks

## Related Issue

Fixes #1222

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `__init__`: initialize `self._redo_task`
- `start()`: launch `_recover_pending_redo()` as background task instead of awaiting it
- `stop()`: cancel and await the redo task on shutdown
- `_redo_session_memory()`: wrap VLM call with `asyncio.wait_for(timeout=60.0)`

## Testing

- [x] Unit tests pass
- [ ] Platform testing (Linux)

## Checklist

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

This contribution was developed with AI assistance (Codex).