### PR TITLE
fix(session): add timeout to _wait_for_previous_archive_done to prevent infinite hang

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _ARCHIVE_WAIT_POLL_SECONDS = 0.1
+_ARCHIVE_WAIT_TIMEOUT_SECONDS = 300.0  # 5 minutes max wait for previous archive
 
 
 @dataclass
@@ -1034,11 +1035,18 @@ class Session:
         return int(match.group(1))
 
     async def _wait_for_previous_archive_done(self, archive_index: int) -> bool:
-        """Wait until the previous archive is done, or report dependency failure."""
+        """Wait until the previous archive is done, or report dependency failure.
+
+        Returns True if the previous archive completed successfully, False if it
+        failed or timed out.  A timeout is treated as a failure so that the
+        current archive does not hang indefinitely when the previous archive's
+        Phase 2 crashed without writing either .done or .failed.json.
+        """
         if archive_index <= 1 or not self._viking_fs:
             return True
 
         previous_archive_uri = f"{self._session_uri}/history/archive_{archive_index - 1:03d}"
+        deadline = asyncio.get_event_loop().time() + _ARCHIVE_WAIT_TIMEOUT_SECONDS
         while True:
             try:
                 await self._viking_fs.read_file(f"{previous_archive_uri}/.done", ctx=self.ctx)
@@ -1054,6 +1062,13 @@ class Session:
                 return False
             except Exception:
                 pass
+
+            if asyncio.get_event_loop().time() >= deadline:
+                logger.error(
+                    f"Timed out waiting for previous archive archive_{archive_index - 1:03d} "
+                    f"after {_ARCHIVE_WAIT_TIMEOUT_SECONDS}s — treating as failed"
+                )
+                return False
 
             await asyncio.sleep(_ARCHIVE_WAIT_POLL_SECONDS)
 


### PR DESCRIPTION
## Summary

- `_wait_for_previous_archive_done()` has an infinite `while True` loop with no timeout. When a previous archive's Phase 2 crashes after writing `messages.jsonl` but before writing `.done` or `.failed.json`, all subsequent archives for that session hang forever in this loop.
- Added a 5-minute deadline (`_ARCHIVE_WAIT_TIMEOUT_SECONDS = 300.0`). On timeout, the method returns `False`, which causes the caller to write `.failed.json` and unblocks the session.

## Root Cause

When `commit_async()` runs Phase 2 (memory extraction) in a background `asyncio.create_task`, a crash at the right moment can leave an archive without either a `.done` or `.failed.json` marker. The next archive's Phase 2 then polls indefinitely for a marker that will never appear.

## Test plan

- [ ] Manually verify: create a session, add messages, commit twice in quick succession — second commit should complete within 5 minutes even if the first Phase 2 is killed
- [ ] Verify existing tests pass: `pytest tests/session/`
- [ ] Edge case: confirm that `archive_index <= 1` still returns immediately (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)