### PR TITLE
fix(semantic): batch VLM summary generation to prevent event-loop deadlock

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -491,7 +491,18 @@ class SemanticProcessor(DequeueHandlerBase):
                     logger.warning(f"Failed to generate summary for {file_path}: {e}")
                     file_summaries[idx] = {"name": file_name, "summary": ""}
 
-            await asyncio.gather(*[_gen(i, fp) for i, fp in pending_indices])
+            # Process in batches to prevent event-loop starvation when the
+            # pending list is large (e.g. hundreds of files).  Without batching
+            # all coroutines are spawned at once via asyncio.gather, which can
+            # deadlock the event loop even with a semaphore in place.
+            _BATCH_SIZE = 20
+            for _batch_start in range(0, len(pending_indices), _BATCH_SIZE):
+                _batch = pending_indices[_batch_start : _batch_start + _BATCH_SIZE]
+                await asyncio.gather(*[_gen(i, fp) for i, fp in _batch])
+                logger.info(
+                    f"Summary batch {_batch_start // _BATCH_SIZE + 1}/"
+                    f"{(len(pending_indices) + _BATCH_SIZE - 1) // _BATCH_SIZE} done"
+                )
 
         file_summaries = [s for s in file_summaries if s is not None]
 


### PR DESCRIPTION
## Summary
- When a memory directory contains hundreds of files (e.g. 415), `_process_memory_directory` spawns all summary coroutines at once via `asyncio.gather`. Despite the semaphore limiting concurrent LLM calls, the sheer number of coroutines starves the event loop and causes the entire process to hang with zero output.
- Process the pending files in batches of 20 so that only a bounded number of coroutines are alive at any time. Each batch is logged for progress visibility.

## Reproduction
1. Add ~400+ `.md` files to `viking://user/default/memories/entities`
2. Trigger semantic processing (reindex or service restart)
3. Observe log: `Generating summaries for 415 changed files concurrently` followed by zero progress for 8+ minutes until killed

## Root cause
`asyncio.gather(*[_gen(i, fp) for i, fp in pending_indices])` creates all 415 coroutines simultaneously. Even though `llm_sem` limits concurrency, the event loop gets overwhelmed scheduling 415 tasks and never yields back to process completions.

## Fix
Replace the single `asyncio.gather` with batched processing (batch size = 20). Each batch completes before the next starts, and progress is logged per-batch.

## Test plan
- [ ] Test with small directory (< 20 files) — should behave identically to before
- [ ] Test with large directory (400+ files) — should process in batches with progress logs
- [ ] Verify no regression in summary quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)