### PR TITLE
fix(redo): wait for queue manager before recovery, prevent silent task loss

### DIFF
--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -246,6 +246,21 @@ class LockManager:
     # ------------------------------------------------------------------
 
     async def _recover_pending_redo(self) -> None:
+        # Wait for the queue manager to become available so that
+        # _enqueue_semantic does not silently discard work.
+        from openviking.storage.queuefs import get_queue_manager
+
+        for _ in range(30):  # up to 30 s
+            if get_queue_manager() is not None:
+                break
+            await asyncio.sleep(1)
+        else:
+            logger.warning(
+                "Queue manager not available after 30 s — "
+                "deferring redo recovery to next restart"
+            )
+            return
+
         pending_ids = self._redo_log.list_pending()
         for task_id in pending_ids:
             logger.info(f"Recovering pending redo task: {task_id}")
@@ -314,7 +329,7 @@ class LockManager:
                         session_id=session_id,
                         ctx=ctx,
                     ),
-                    timeout=60.0,
+                    timeout=15.0,  # short timeout during recovery to avoid blocking startup
                 )
                 logger.info(f"Redo: extracted {len(memories)} memories from {archive_uri}")
             except Exception as e:
@@ -337,8 +352,9 @@ class LockManager:
 
         queue_manager = get_queue_manager()
         if queue_manager is None:
-            logger.debug("No queue manager available, skipping enqueue_semantic")
-            return
+            raise RuntimeError(
+                "Queue manager not available — cannot enqueue semantic processing"
+            )
 
         uri = params.get("uri")
         if not uri:


### PR DESCRIPTION
## Summary
- Redo recovery runs immediately at `start()` but the queue manager may not be initialized yet. `_enqueue_semantic` silently returns when `queue_manager is None`, then `mark_done` removes the redo marker — **the task is permanently lost and memories are never extracted**.
- VLM timeout during recovery is 60s, wasting minutes when VLM is down.

## Root cause
Three issues compound:
1. `_recover_pending_redo` starts before queue manager is ready
2. `_enqueue_semantic` silently drops work when `queue_manager is None`
3. `mark_done` runs after the silent drop → redo marker deleted → task lost forever

Log evidence:
```
21:44:24 - Recovering pending redo task: 36bfde37-...
21:44:45 - Redo: memory extraction failed ('NoneType' object has no attribute 'enqueue_embedding_msg'), falling back to queue
```

## Fix
- Wait up to 30s for queue manager to become available before starting redo recovery
- Reduce VLM timeout from 60s → 15s during recovery (best-effort, not critical path)
- Make `_enqueue_semantic` raise `RuntimeError` instead of silently returning when queue_manager is `None`

## Test plan
- [ ] Verify service starts normally with no pending redo tasks
- [ ] Verify redo recovery waits for queue manager and succeeds
- [ ] Verify redo task is NOT marked done when enqueue fails
- [ ] Verify service starts within 30s even with unreachable VLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)