### PR TITLE
fix(queue): add per-task TTL to prevent indefinitely stuck queue tasks

### DIFF
--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -199,6 +199,9 @@ class QueueManager:
         finally:
             loop.close()
 
+    # Maximum time a single queue task may run before being cancelled.
+    _TASK_TTL_SECONDS: float = 600.0  # 10 minutes
+
     async def _worker_async_concurrent(
         self, queue: NamedQueue, stop_event: threading.Event, max_concurrent: int
     ) -> None:
@@ -213,9 +216,20 @@ class QueueManager:
             async with sem:
                 msg_id = data.get("id", "") if isinstance(data, dict) else ""
                 try:
-                    await queue.process_dequeued(data)
+                    await asyncio.wait_for(
+                        queue.process_dequeued(data),
+                        timeout=self._TASK_TTL_SECONDS,
+                    )
                     # Ack after successful processing (delete from persistent storage).
                     await queue.ack(msg_id)
+                except asyncio.TimeoutError:
+                    queue._on_process_error(
+                        f"Task timed out after {self._TASK_TTL_SECONDS}s", data
+                    )
+                    logger.error(
+                        f"[QueueManager] Task timeout for {queue.name} "
+                        f"(msg_id={msg_id}, TTL={self._TASK_TTL_SECONDS}s)"
+                    )
                 except Exception as e:
                     # Handler did not call report_error; decrement in_progress manually.
                     # Do NOT ack — let RecoverStale re-queue on next startup.


### PR DESCRIPTION
## Summary
- Queue tasks that hang (e.g. due to an unresponsive VLM service or deadlocked event loop) hold a semaphore slot forever, permanently incrementing `in_progress`. The only recovery — `RecoverStale` — runs only at startup, so a stuck task blocks the queue until restart.
- Adds a 10-minute per-task TTL via `asyncio.wait_for` so hung tasks are auto-cancelled.

## Root cause
`_worker_async_concurrent.process_one` awaits `queue.process_dequeued(data)` with no timeout. If the underlying handler (VLM call, embedding call) hangs, the task runs forever:
- Semaphore slot held → reduces effective concurrency
- `_in_progress` counter incremented but never decremented → `QueueStatus.is_complete` never returns True
- SQLite row stays in `processing` state → invisible to `size()` → no retry

## Fix
Wrap `process_dequeued` with `asyncio.wait_for(timeout=600)`. On timeout:
- Task is cancelled
- `_on_process_error` is called (decrements `in_progress`)
- SQLite row stays `processing` → recovered by `RecoverStale` on next restart
- Error is logged with task details for diagnosis

## Test plan
- [ ] Normal queue processing unaffected (tasks complete well within 10 min)
- [ ] Simulated hung handler is cancelled after TTL
- [ ] `in_progress` counter returns to 0 after timeout
- [ ] Service remains responsive during and after timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)