### PR TITLE
fix: PersistentIndex.need_rebuild() should trigger rebuild when index is empty

### DIFF
--- a/openviking/storage/vectordb/index/local_index.py
+++ b/openviking/storage/vectordb/index/local_index.py
@@ -735,14 +735,18 @@ class PersistentIndex(LocalIndex):
     def need_rebuild(self) -> bool:
         """Determine if the index needs rebuilding.
 
-        For persistent indexes, rebuilding is typically not needed as
-        persistence handles compaction. Returns False to avoid unnecessary rebuilds.
+        When the index has no data entries but the store contains data,
+        a rebuild is needed to populate the index from the store.
+        This handles the case where upsert_to_index silently fails
+        for persistent indexes, leaving the store growing but the
+        index empty.
 
         Returns:
-            bool: False (persistent indexes don't require periodic rebuilds)
-
-        Note:
-            Subclasses could override this to implement deletion-ratio-based
-            rebuild triggers if needed for space reclamation.
+            bool: True if index has 0 data entries, False otherwise.
         """
+        try:
+            if self.get_data_count() == 0:
+                return True
+        except Exception:
+            pass
         return False


### PR DESCRIPTION
## Bug Description

`PersistentIndex.need_rebuild()` always returns `False`, which prevents the index maintenance scheduler from ever rebuilding the index, even when the index is empty but the store contains data.

## Root Cause

When `upsert_data()` is called, it writes to both the store (LevelDB) and attempts to update the FAISS index via `upsert_to_index()`. However, for persistent indexes, the C++ FAISS engine can silently fail to write data, resulting in:

- Store growing with data (e.g., 8.4MB, 1002 entries)
- FAISS index remaining empty (0 vectors)
- `vector/count` API returning 0

The index maintenance scheduler runs every 30 seconds and calls `_rebuild_indexes_if_needed()`, which checks `index.need_rebuild()`. Since `PersistentIndex.need_rebuild()` always returns `False`, the scheduler never triggers a rebuild, and the index stays permanently empty.

## Impact

- Memory search returns no results even after successful embedding/vectorization
- `ov reindex --regenerate` completes but vectors are not searchable
- The only workaround is manual source code patching

## Fix

Change `PersistentIndex.need_rebuild()` to check if the index has zero data entries. When the index is empty, return `True` to trigger the maintenance scheduler to rebuild from the store.

```python
# Before
def need_rebuild(self) -> bool:
    return False

# After
def need_rebuild(self) -> bool:
    try:
        if self.get_data_count() == 0:
            return True
    except Exception:
        pass
    return False
```

## Testing

1. Import memories via `ov reindex --regenerate`
2. Verify store has data: `curl http://127.0.0.1:1933/api/v1/stats/memories`
3. Wait 30 seconds for maintenance scheduler
4. Verify index is populated: search API returns results (previously returned 0)

## Environment

- OV Version: 0.3.3
- Backend: local (FAISS)
- OS: Linux