### PR TITLE
fix(semantic): normalize overview section titles for file parsing

### DIFF
--- a/openviking/prompts/templates/semantic/overview_generation.yaml
+++ b/openviking/prompts/templates/semantic/overview_generation.yaml
@@ -62,6 +62,7 @@ template: |
      - Concise keyword descriptions
 
   4. **Detailed Description** (H2): One H3 subsection for each file/subdirectory
+     - **H3 title MUST be the exact file or directory name only, with no additional description**
      - Use the file summaries or subdirectory summaries provided above as description content
 
   Total length: 400-800 words

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -975,7 +975,7 @@ class SemanticProcessor(DequeueHandlerBase):
 
                 file_name = header_match.group(1).strip()
                 parts = file_name.split()
-                if len(parts) >= 2 and parts[0] == parts[1]:
+                if len(parts) >= 2 and parts[1].startswith(parts[0]):
                     file_name = parts[0]
 
                 current_file = file_name


### PR DESCRIPTION
## Summary
- require H3 titles in semantic overview generation to use the exact file or directory name only
- align the prompt contract with the parser so generated overview sections map back to files more reliably
- tolerate descriptive suffixes during parsing to avoid mismatches when headers contain repeated filename prefixes

## Test plan
- generate semantic overviews for directories containing multiple files and subdirectories
- verify H3 section titles match exact file or directory names
- verify overview parsing still maps sections correctly when a title includes an additional descriptive suffix
