### PR TITLE
fix(claude-code-memory-plugin): improve Windows compatibility

### DIFF
--- a/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
+++ b/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Long-term semantic memory for Claude Code, powered by OpenViking. Auto-recall relevant memories at session start and capture important information during conversations.",
   "author": {
     "name": "OpenViking",

--- a/examples/claude-code-memory-plugin/.mcp.json
+++ b/examples/claude-code-memory-plugin/.mcp.json
@@ -3,7 +3,7 @@
     "command": "node",
     "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/start-memory-server.mjs"],
     "env": {
-      "OPENVIKING_CONFIG_FILE": "${OPENVIKING_CONFIG_FILE:-}"
+      "OPENVIKING_CONFIG_FILE": "${OPENVIKING_CONFIG_FILE}"
     }
   }
 }

--- a/examples/claude-code-memory-plugin/README.md
+++ b/examples/claude-code-memory-plugin/README.md
@@ -1,8 +1,9 @@
 # OpenViking Memory Plugin for Claude Code
 
 Long-term semantic memory for Claude Code, powered by [OpenViking](https://github.com/volcengine/OpenViking).
+Provide a plugin marketplace repository for one-click installation: [openviking-plugins](https://github.com/Castor6/openviking-plugins)
 
-> Ported from the [OpenClaw context-engine plugin](../openclaw-plugin/) and adapted for Claude Code's plugin architecture (MCP + hooks).
+> Ported from the [OpenClaw context-engine plugin](https://github.com/volcengine/OpenViking/tree/main/examples/openclaw-plugin) and adapted for Claude Code's plugin architecture (MCP + hooks).
 
 ## Architecture
 
@@ -117,7 +118,7 @@ pipx install openviking
 
 ### 2. Create Config
 
-If you don't already have `~/.openviking/ov.conf`, create it:
+If you don't already have `~/.openviking/ov.conf`(Can override the default path via the environment variable `OPENVIKING_CONFIG_FILE`), create it:
 
 ```bash
 mkdir -p ~/.openviking
@@ -154,7 +155,8 @@ vim ~/.openviking/ov.conf
 }
 ```
 
-> `root_api_key`: Once set, all HTTP requests must carry the `X-API-Key` header. Defaults to `null` in local mode (authentication disabled).
+> `root_api_key`: Once set, all HTTP requests must carry the `X-API-Key` header. Defaults to `null` in local mode (authentication disabled).  
+> For Windows system paths in the workspace, use / instead of \, for example: `D:/.openviking/data`
 
 Optionally add a `claude_code` section for plugin-specific overrides:
 

--- a/examples/claude-code-memory-plugin/README.md
+++ b/examples/claude-code-memory-plugin/README.md
@@ -1,6 +1,7 @@
 # OpenViking Memory Plugin for Claude Code
 
 Long-term semantic memory for Claude Code, powered by [OpenViking](https://github.com/volcengine/OpenViking).
+
 Provide a plugin marketplace repository for one-click installation: [openviking-plugins](https://github.com/Castor6/openviking-plugins)
 
 > Ported from the [OpenClaw context-engine plugin](https://github.com/volcengine/OpenViking/tree/main/examples/openclaw-plugin) and adapted for Claude Code's plugin architecture (MCP + hooks).

--- a/examples/claude-code-memory-plugin/README_CN.md
+++ b/examples/claude-code-memory-plugin/README_CN.md
@@ -1,8 +1,9 @@
 # OpenViking Memory Plugin for Claude Code
 
 为 Claude Code 提供长期语义记忆功能，基于 [OpenViking](https://github.com/volcengine/OpenViking) 构建。
+提供一键安装的插件市场仓库：[openviking-plugins](https://github.com/Castor6/openviking-plugins)
 
-> 移植自 [OpenClaw context-engine plugin](../openclaw-plugin/)，并适配 Claude Code 的插件架构（MCP + hooks）。
+> 移植自 [OpenClaw context-engine plugin](https://github.com/volcengine/OpenViking/tree/main/examples/openclaw-plugin)，并适配 Claude Code 的插件架构（MCP + hooks）。
 
 ## 架构
 
@@ -114,7 +115,7 @@ pipx install openviking
 
 ### 2. 创建配置
 
-如果还没有 `~/.openviking/ov.conf`，请创建：
+如果还没有 `~/.openviking/ov.conf`（可通过环境变量 `OPENVIKING_CONFIG_FILE` 覆盖默认路径），请创建：
 
 ```bash
 mkdir -p ~/.openviking
@@ -151,7 +152,8 @@ vim ~/.openviking/ov.conf
 }
 ```
 
-> `root_api_key`：设置后，所有 HTTP 请求必须携带 `X-API-Key` 头。本地模式默认为 `null`（禁用认证）。
+> `root_api_key`：设置后，所有 HTTP 请求必须携带 `X-API-Key` 头。本地模式默认为 `null`（禁用认证）。  
+> windows 系统的 workspace 路径分隔请用 / ，不要用 \ ，如 `D:/.openviking/data`
 
 可选添加 `claude_code` 部分用于插件特定覆盖：
 

--- a/examples/claude-code-memory-plugin/README_CN.md
+++ b/examples/claude-code-memory-plugin/README_CN.md
@@ -1,6 +1,7 @@
 # OpenViking Memory Plugin for Claude Code
 
 为 Claude Code 提供长期语义记忆功能，基于 [OpenViking](https://github.com/volcengine/OpenViking) 构建。
+
 提供一键安装的插件市场仓库：[openviking-plugins](https://github.com/Castor6/openviking-plugins)
 
 > 移植自 [OpenClaw context-engine plugin](https://github.com/volcengine/OpenViking/tree/main/examples/openclaw-plugin)，并适配 Claude Code 的插件架构（MCP + hooks）。

--- a/examples/claude-code-memory-plugin/scripts/runtime-common.mjs
+++ b/examples/claude-code-memory-plugin/scripts/runtime-common.mjs
@@ -190,6 +190,7 @@ export async function ensureRuntimeInstalled(paths, expectedState) {
       cwd: paths.runtimeRoot,
       encoding: "utf8",
       stdio: "pipe",
+      shell: process.platform === "win32",
     });
 
     if (result.error) throw result.error;


### PR DESCRIPTION
## Summary
- enable shell mode for runtime bootstrap commands on Windows so `npm ci` runs correctly during plugin setup
- replace `${OPENVIKING_CONFIG_FILE:-}` with `${OPENVIKING_CONFIG_FILE}` in `.mcp.json` because the default-value syntax is not portable to the Windows environment expansion used by Claude Code
- document the config override and Windows path separator expectations in both English and Chinese READMEs
- bump the Claude plugin manifest version to `0.1.2`

## Validation
- Static check: `node --check examples/claude-code-memory-plugin/scripts/runtime-common.mjs`
- Static check: `node -e "JSON.parse(require('fs').readFileSync('examples/claude-code-memory-plugin/.claude-plugin/plugin.json','utf8')); JSON.parse(require('fs').readFileSync('examples/claude-code-memory-plugin/.mcp.json','utf8')); console.log('json ok')"`
- Manual verification: validated successfully in a real Windows environment after applying this change
