### PR TITLE
Include gemini optional dependency in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,13 +51,13 @@ COPY third_party/ third_party/
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
     case "${UV_LOCK_STRATEGY}" in \
         locked) \
-            uv sync --locked --no-editable --extra bot \
+            uv sync --locked --no-editable --extra bot --extra gemini \
             ;; \
         auto) \
             if ! uv lock --check; then \
                 uv lock; \
             fi; \
-            uv sync --locked --no-editable --extra bot \
+            uv sync --locked --no-editable --extra bot --extra gemini \
             ;; \
         *) \
             echo "Unsupported UV_LOCK_STRATEGY: ${UV_LOCK_STRATEGY}" >&2; \


### PR DESCRIPTION
## Summary

- The Dockerfile only includes `--extra bot` in the `uv sync` commands, so the `google-genai` package is missing from the Docker image
- This causes a crash (`TypeError: 'NoneType' object is not callable`) when users configure the `gemini` embedding provider
- Adds `--extra gemini` to both `uv sync` invocations in the Dockerfile

Fixes #1253