### PR TITLE
fix: include user message in auto-capture when prePromptMessageCount excludes it (#1248)

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -806,7 +806,7 @@ export function createMemoryOpenVikingContextEngine(params: {
             ? afterTurnParams.prePromptMessageCount
             : 0;
 
-        const { texts: newTexts, newCount } = extractNewTurnTexts(messages, start);
+        const { texts: newTexts, newCount } = extractNewTurnTexts(messages, start, true);
 
         if (newTexts.length === 0) {
           diag("afterTurn_skip", OVSessionId, {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -419,6 +419,7 @@ function formatToolResultContent(content: unknown): string {
 export function extractNewTurnTexts(
   messages: unknown[],
   startIndex: number,
+  ensureLastUserMessage?: boolean,
 ): { texts: string[]; newCount: number } {
   const texts: string[] = [];
   let count = 0;
@@ -452,6 +453,36 @@ export function extractNewTurnTexts(
       }
     }
   }
+  // Defensive fix: ensure the last user message is included even if
+  // startIndex skipped it (OpenClaw prePromptMessageCount off-by-one)
+  // See: https://github.com/volcengine/OpenViking/issues/1248
+  if (ensureLastUserMessage && messages.length > 0) {
+    let lastUserText: string | null = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i] as Record<string, unknown>;
+      if (!msg || typeof msg !== "object") continue;
+      if (msg.role === "user") {
+        const content = msg.content;
+        if (typeof content === "string" && content.trim()) {
+          lastUserText = `[user]: ${content.trim()}`;
+        } else if (Array.isArray(content)) {
+          for (const block of content) {
+            const b = block as Record<string, unknown>;
+            if (b?.type === "text" && typeof b.text === "string" && b.text.trim()) {
+              lastUserText = `[user]: ${b.text.trim()}`;
+              break;
+            }
+          }
+        }
+        break;
+      }
+    }
+    if (lastUserText && !texts.some((t) => t.startsWith("[user]:"))) {
+      texts.unshift(lastUserText);
+      count++;
+    }
+  }
+
   return { texts, newCount: count };
 }
 


### PR DESCRIPTION
## Problem

The  hook's auto-capture only captures the assistant reply, not the user's original message. This causes the VLM extractor to receive text with only an [assistant] role message (a recap/acknowledgment), which yields 0 extractable memories.

## Root Cause

OpenClaw's  (used as  in ) points to an index that may exclude the current turn's user message. When  is too high, the user message falls outside the extraction window.

## Fix

1. **text-utils.ts**: Add optional  parameter to . When true, after normal extraction, check if any user message exists in the extracted results. If not, find the last user message in the full transcript and prepend it.

2. **index.ts**: Pass  when calling  from the  handler.

This is a defensive fix — it ensures the user message is always captured even if the OpenClaw host passes an incorrect  value.

## Testing

Verified the logic:
- Normal case (user msg already captured): no duplicate, behavior unchanged
- Bug case (user msg before startIndex): last user msg prepended to results
- Edge case (no user msg in transcript): no crash, returns existing results

Fixes #1248