### PR TITLE
fix: reduce rerank payload size and timeout

### DIFF
--- a/openviking/models/rerank/openai_rerank.py
+++ b/openviking/models/rerank/openai_rerank.py
@@ -9,6 +9,7 @@ via api_key + api_base configuration.
 
 # For logging, use Python's built-in logging
 import logging
+import os
 from typing import List, Optional
 
 import requests
@@ -16,6 +17,8 @@ import requests
 from openviking.models.rerank.base import RerankBase
 
 logger = logging.getLogger(__name__)
+
+OPENAI_RERANK_TIMEOUT = max(1, int(os.getenv("OPENVIKING_RERANK_TIMEOUT_SEC", "12")))
 
 
 class OpenAIRerankClient(RerankBase):
@@ -69,7 +72,7 @@ class OpenAIRerankClient(RerankBase):
                     "Content-Type": "application/json",
                 },
                 json=req_body,
-                timeout=30,
+                timeout=OPENAI_RERANK_TIMEOUT,
             )
             response.raise_for_status()
             result = response.json()

--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -10,6 +10,7 @@ and rerank-based relevance scoring.
 import heapq
 import logging
 import math
+import os
 import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
@@ -48,7 +49,13 @@ class HierarchicalRetriever:
     MAX_RELATIONS = 5  # Maximum relations per resource
     SCORE_PROPAGATION_ALPHA = 0.5  # Score propagation coefficient
     DIRECTORY_DOMINANCE_RATIO = 1.2  # Directory score must exceed max child score
-    GLOBAL_SEARCH_TOPK = 10  # Global retrieval count (more candidates = better rerank precision)
+    GLOBAL_SEARCH_TOPK = max(1, int(os.getenv("OPENVIKING_GLOBAL_SEARCH_TOPK", "6")))
+    RECURSIVE_PREFILTER_MULTIPLIER = max(
+        1, int(os.getenv("OPENVIKING_RECURSIVE_PREFILTER_MULTIPLIER", "2"))
+    )
+    RECURSIVE_PREFILTER_MIN = max(1, int(os.getenv("OPENVIKING_RECURSIVE_PREFILTER_MIN", "8")))
+    RERANK_MAX_DOC_CHARS = max(128, int(os.getenv("OPENVIKING_RERANK_MAX_DOC_CHARS", "600")))
+    RERANK_MAX_QUERY_CHARS = max(64, int(os.getenv("OPENVIKING_RERANK_MAX_QUERY_CHARS", "500")))
     HOTNESS_ALPHA = 0.2  # Weight for hotness score in final ranking (0 = disabled)
     LEVEL_URI_SUFFIX = {0: ".abstract.md", 1: ".overview.md"}
 
@@ -247,6 +254,13 @@ class HierarchicalRetriever:
         telemetry.count("vector.scanned", len(results))
         return results
 
+    @classmethod
+    def _truncate_rerank_text(cls, text: str, max_chars: int) -> str:
+        text = str(text or "").strip()
+        if len(text) <= max_chars:
+            return text
+        return text[:max_chars].rstrip()
+
     def _rerank_scores(
         self,
         query: str,
@@ -257,8 +271,13 @@ class HierarchicalRetriever:
         if not self._rerank_client or not documents:
             return fallback_scores
 
+        truncated_query = self._truncate_rerank_text(query, self.RERANK_MAX_QUERY_CHARS)
+        truncated_documents = [
+            self._truncate_rerank_text(doc, self.RERANK_MAX_DOC_CHARS) for doc in documents
+        ]
+
         try:
-            scores = self._rerank_client.rerank_batch(query, documents)
+            scores = self._rerank_client.rerank_batch(truncated_query, truncated_documents)
         except Exception as e:
             logger.warning(
                 "[HierarchicalRetriever] Rerank failed, fallback to vector scores: %s", e
@@ -418,7 +437,10 @@ class HierarchicalRetriever:
             visited.add(current_uri)
             logger.info(f"[RecursiveSearch] Entering URI: {current_uri}")
 
-            pre_filter_limit = max(limit * 2, 20)
+            pre_filter_limit = max(
+                limit * self.RECURSIVE_PREFILTER_MULTIPLIER,
+                self.RECURSIVE_PREFILTER_MIN,
+            )
 
             results = await vector_proxy.search_children_in_tenant(
                 parent_uri=current_uri,


### PR DESCRIPTION
## Summary
- reduce default rerank candidate fan-out to shrink payload size before reranking
- truncate rerank query and document payloads before sending them to OpenAI-compatible rerank backends
- make rerank timeout configurable and lower the default to fail fast under oversized requests

## Motivation
In real OpenViking deployments with OpenAI-compatible rerank adapters, rerank latency can become dominated by oversized payloads. We observed:
- hardcoded global rerank candidate counts producing too many long candidates
- recursive prefilter fan-out keeping too many documents alive for rerank
- no truncation before rerank requests
- a fixed 30s rerank timeout that delays fallback when the backend is already overloaded

This patch keeps the change surface small while making the critical knobs configurable by environment variables.

## Changes
- `OPENVIKING_GLOBAL_SEARCH_TOPK` default `6`
- `OPENVIKING_RECURSIVE_PREFILTER_MULTIPLIER` default `2`
- `OPENVIKING_RECURSIVE_PREFILTER_MIN` default `8`
- `OPENVIKING_RERANK_MAX_DOC_CHARS` default `600`
- `OPENVIKING_RERANK_MAX_QUERY_CHARS` default `500`
- `OPENVIKING_RERANK_TIMEOUT_SEC` default `12`

## Validation
- reproduced the hotfix against a live OpenViking 0.3.3 deployment using an OpenAI-compatible rerank adapter
- verified service restart and `/health` returned `200`
- verified search endpoint returned successfully after the change with latency reduced from roughly 10s to 23s down to about 1.85s in the tested query
- ran Python compile checks for the modified files

## Notes
- this PR intentionally does not change any local startup scripts
- operators can keep previous behavior by overriding the environment variables back to larger values if needed
