### PR TITLE
fix: prevent intent analyzer from over-rewriting retrieval queries

### DIFF
--- a/openviking/prompts/templates/retrieval/intent_analysis.yaml
+++ b/openviking/prompts/templates/retrieval/intent_analysis.yaml
@@ -190,7 +190,13 @@ template: |
      - Queries should be short, specific, and retrievable
      - Avoid lengthy descriptions
 
-  5. **Priority setting**:
+  5. **Do not leak conversation transcript into query text**:
+     - Query text must stay close to the user's current message and the concrete retrieval target
+     - Do not include speaker roles, chat history summaries, review workflow narration, or multi-step task decomposition in query text
+     - Recent conversation is for disambiguation only, not for copying into the final query
+     - If the current message is already a focused search intent, prefer minimal rewrite or keep it unchanged
+
+  6. **Priority setting**:
      - 1 = Highest priority (core requirement)
      - 3 = Medium priority (helpful)
      - 5 = Lowest priority (optional)

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1047,6 +1047,22 @@ class VikingFS:
                 target_abstract=target_abstract,
             )
             typed_queries = query_plan.queries
+
+            # Guardrail: keep retrieval queries semantically anchored to the current
+            # user query. Intent analysis may expand into task-planning language
+            # using recent conversation context, which hurts retrieval precision and
+            # can pollute rerank inputs with session-level narration.
+            original_query = (query or "").strip()
+            if original_query:
+                for tq in typed_queries:
+                    rewritten = (tq.query or "").strip()
+                    if not rewritten:
+                        tq.query = original_query
+                        continue
+                    token_overlap = set(original_query.lower().split()) & set(rewritten.lower().split())
+                    if len(token_overlap) < 2 and len(original_query) <= 200:
+                        tq.query = original_query
+
             # Set target_directories
             if target_uri_list:
                 for tq in typed_queries:


### PR DESCRIPTION
## Summary
- add guardrail in `viking_fs.search()` to keep retrieval queries semantically anchored to the original user query
- update intent analysis prompt to discourage leaking conversation transcript into query text

## Motivation
When using `search(session_id=...)` with recent messages, IntentAnalyzer may rewrite the query into task-planning language that includes conversation context, speaker roles, and multi-step decomposition. This hurts retrieval precision and can pollute rerank inputs with session-level narration instead of focused search intent.

Observed examples of over-rewritten queries:
- `Monitor GitHub PR status and review progress`
- `Analyze rerank query pollution root cause`
- `OpenViking retrieval query processing flow code`

These are not good retrieval queries; they are planning statements derived from conversation context.

## Changes
1. **viking_fs.py guardrail**:
   - After IntentAnalyzer generates typed queries, check if each rewritten query maintains sufficient token overlap with the original
   - If overlap is too low and original query is reasonably short, revert to the original query
   - This ensures retrieval queries stay focused on what the user actually asked

2. **intent_analysis.yaml prompt update**:
   - Explicitly instruct not to leak conversation transcript into query text
   - Emphasize that recent conversation is for disambiguation only, not for copying into the final query
   - Encourage minimal rewrite when current message is already a focused search intent

## Validation
- Tested on a local OpenViking 0.3.3 deployment with real session data
- Before fix: queries like "Monitor GitHub PR status..." were generated
- After fix: queries stay close to the original user input
- All 5 test queries remained clean (0 pollution)

## Notes
- This fix is conservative: it only guards against queries that drift too far from the original
- IntentAnalyzer can still use conversation context for disambiguation
- The threshold (token overlap < 2) is intentionally simple to keep the change minimal
