### PR TITLE
Revert "fix(session): add timeout to _wait_for_previous_archive_done to prevent infinite hang"

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _ARCHIVE_WAIT_POLL_SECONDS = 0.1
-_ARCHIVE_WAIT_TIMEOUT_SECONDS = 300.0  # 5 minutes max wait for previous archive
 
 
 @dataclass
@@ -1043,18 +1042,11 @@ class Session:
         return int(match.group(1))
 
     async def _wait_for_previous_archive_done(self, archive_index: int) -> bool:
-        """Wait until the previous archive is done, or report dependency failure.
-
-        Returns True if the previous archive completed successfully, False if it
-        failed or timed out.  A timeout is treated as a failure so that the
-        current archive does not hang indefinitely when the previous archive's
-        Phase 2 crashed without writing either .done or .failed.json.
-        """
+        """Wait until the previous archive is done, or report dependency failure."""
         if archive_index <= 1 or not self._viking_fs:
             return True
 
         previous_archive_uri = f"{self._session_uri}/history/archive_{archive_index - 1:03d}"
-        deadline = asyncio.get_event_loop().time() + _ARCHIVE_WAIT_TIMEOUT_SECONDS
         while True:
             try:
                 await self._viking_fs.read_file(f"{previous_archive_uri}/.done", ctx=self.ctx)
@@ -1070,13 +1062,6 @@ class Session:
                 return False
             except Exception:
                 pass
-
-            if asyncio.get_event_loop().time() >= deadline:
-                logger.error(
-                    f"Timed out waiting for previous archive archive_{archive_index - 1:03d} "
-                    f"after {_ARCHIVE_WAIT_TIMEOUT_SECONDS}s — treating as failed"
-                )
-                return False
 
             await asyncio.sleep(_ARCHIVE_WAIT_POLL_SECONDS)
 


### PR DESCRIPTION
Reverts volcengine/OpenViking#1235

related bug reported