### PR TITLE
feature(memory): improve memory v2 lock retry controls in compressor

### DIFF
--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -7,6 +7,7 @@ Uses the new Memory Templating System with ReAct orchestrator.
 Maintains the same interface as compressor.py for backward compatibility.
 """
 
+import asyncio
 from typing import List, Optional
 
 from openviking.core.context import Context
@@ -158,8 +159,11 @@ class SessionCompressorV2:
                         memory_schema_dirs.append(dir_path)
                 logger.debug(f"Memory schema directories to lock: {memory_schema_dirs}")
 
-                # 循环等待获取锁（机制确保不会死锁）
-                # 由于使用有序加锁法，可以安全地无限等待
+                retry_interval = config.memory.v2_lock_retry_interval_seconds
+                max_retries = config.memory.v2_lock_max_retries
+                retry_count = 0
+
+                # 循环重试获取锁（机制确保不会死锁）
                 while True:
                     lock_acquired = await lock_manager.acquire_subtree_batch(
                         transaction_handle,
@@ -168,7 +172,19 @@ class SessionCompressorV2:
                     )
                     if lock_acquired:
                         break
-                    logger.warning("Failed to acquire memory locks, retrying...")
+                    retry_count += 1
+                    if max_retries > 0 and retry_count >= max_retries:
+                        raise TimeoutError(
+                            "Failed to acquire memory locks after "
+                            f"{retry_count} retries (max={max_retries})"
+                        )
+
+                    logger.warning(
+                        "Failed to acquire memory locks, retrying "
+                        f"(attempt={retry_count}, max={max_retries or 'unlimited'})..."
+                    )
+                    if retry_interval > 0:
+                        await asyncio.sleep(retry_interval)
 
             orchestrator._transaction_handle = transaction_handle  # 传递给 ExtractLoop
 

--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -24,6 +24,22 @@ class MemoryConfig(BaseModel):
         default="",
         description="Custom memory templates directory. If set, templates from this directory will be loaded in addition to built-in templates",
     )
+    v2_lock_retry_interval_seconds: float = Field(
+        default=0.2,
+        ge=0.0,
+        description=(
+            "Retry interval (seconds) when SessionCompressorV2 fails to acquire memory subtree "
+            "locks. Set to 0 for immediate retries."
+        ),
+    )
+    v2_lock_max_retries: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Maximum retries for SessionCompressorV2 memory lock acquisition. "
+            "0 means unlimited retries."
+        ),
+    )
 
     model_config = {"extra": "forbid"}
 

--- a/tests/session/memory/test_compressor_v2.py
+++ b/tests/session/memory/test_compressor_v2.py
@@ -9,7 +9,7 @@ Uses MockVikingFS and real VLM (from config).
 import logging
 from types import SimpleNamespace
 from typing import Any, Dict, List
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -420,3 +420,65 @@ class TestCompressorV2:
         assert isinstance(memories, list)
 
         logger.info("Test completed successfully!")
+
+    @pytest.mark.asyncio
+    async def test_v2_lock_acquire_respects_max_retries(self):
+        """v2 memory extraction should stop after configured lock retry limit."""
+        compressor = SessionCompressorV2(vikingdb=None)
+        user = UserIdentifier.the_default_user()
+        ctx = RequestContext(user=user, role=Role.ROOT)
+        messages = [Message.create_user("test")]
+
+        class DummySchema:
+            directory = "viking://user/{{ user_space }}/memories/events"
+
+        class DummyProvider:
+            def get_memory_schemas(self, _ctx):
+                return [DummySchema()]
+
+            def _get_registry(self):
+                return object()
+
+        class DummyOrchestrator:
+            context_provider = DummyProvider()
+
+            async def run(self):
+                return (
+                    SimpleNamespace(
+                        write_uris=[],
+                        edit_uris=[],
+                        edit_overview_uris=[],
+                        delete_uris=[],
+                    ),
+                    [],
+                )
+
+        lock_manager = SimpleNamespace(
+            create_handle=lambda: object(),
+            acquire_subtree_batch=AsyncMock(return_value=False),
+            release=AsyncMock(),
+        )
+
+        with (
+            patch("openviking.session.compressor_v2.get_viking_fs", return_value=MockVikingFS()),
+            patch("openviking.storage.transaction.init_lock_manager"),
+            patch("openviking.storage.transaction.get_lock_manager", return_value=lock_manager),
+            patch(
+                "openviking.session.memory.memory_type_registry.create_default_registry",
+                return_value=SimpleNamespace(initialize_memory_files=AsyncMock()),
+            ),
+            patch.object(compressor, "_get_or_create_react", return_value=DummyOrchestrator()),
+            patch("openviking.session.compressor_v2.asyncio.sleep", new=AsyncMock()),
+        ):
+            initialize_openviking_config()
+            config = get_openviking_config()
+            config.memory.v2_lock_max_retries = 2
+            config.memory.v2_lock_retry_interval_seconds = 0.0
+            result = await compressor.extract_long_term_memories(
+                messages=messages,
+                ctx=ctx,
+                strict_extract_errors=False,
+            )
+
+        assert result == []
+        assert lock_manager.acquire_subtree_batch.await_count == 2


### PR DESCRIPTION
## Description

This PR improves the reliability and operability of long-term memory extraction in SessionCompressorV2 by adding configurable lock retry controls and preventing unbounded lock wait loops under contention.

Previously, the extractor used an unbounded retry loop (while True) for subtree lock acquisition, which could block session commit flows indefinitely when lock contention occurred. This PR introduces configurable retry pacing and retry limits so deployments can tune behavior based on their workload and SLO requirements.

## Related Issue

Fixes #1274 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made
- Added two new memory config options in MemoryConfig:
  - v2_lock_retry_interval_seconds (retry interval in seconds, default 0.2)

  - v2_lock_max_retries (max retries, default 0 = unlimited)

- Updated SessionCompressorV2.extract_long_term_memories lock-acquisition flow to:

  - apply configurable retry interval

  - enforce max retry bound

  - raise TimeoutError when retry limit is reached

- Added unit test:

  - test_v2_lock_acquire_respects_max_retries

  - validates retry loop exits after configured max retries

- Preserved existing ordered batch-locking strategy to avoid deadlocks.


## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- This change is backward compatible: default behavior remains effectively unlimited retries (v2_lock_max_retries=0) unless explicitly configured.

- Operators can now tune retry behavior to trade off throughput vs. latency under contention.

- In strict_extract_errors=True mode, lock-timeout failure now surfaces promptly (via TimeoutError) rather than potentially waiting forever.


