### PR TITLE
ci: add timeout and SMTP failure notification

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -42,6 +42,7 @@ jobs:
   api-tests:
     name: API Integration Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -468,3 +469,29 @@ jobs:
         run: |
           Write-Host "API tests failed!"
           exit 1
+
+  notify-failure:
+    name: Notify on Failure
+    needs: [api-tests]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure email
+        uses: dawidd6/action-send-mail@v4
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "❌ CI Failed: ${{ github.workflow }} - ${{ github.ref_name }}"
+          to: likaisong@bytedance.com
+          from: GitHub Actions
+          body: |
+            Workflow: ${{ github.workflow }}
+            Repository: ${{ github.repository }}
+            Branch: ${{ github.ref_name }}
+            Commit: ${{ github.sha }}
+            Actor: ${{ github.actor }}
+            Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            
+            Please check the workflow run for details.

--- a/.github/workflows/oc2ov_test.yml
+++ b/.github/workflows/oc2ov_test.yml
@@ -30,6 +30,7 @@ jobs:
   p0-tests:
     name: P0 Memory Tests
     runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 50
     if: inputs.skip_tests != true
     
     steps:
@@ -196,3 +197,29 @@ jobs:
         run: |
           echo "::notice::P0 tests passed. Release can proceed."
           echo "Release ${{ github.event.release.tag_name }} has been validated by P0 tests."
+
+  notify-failure:
+    name: Notify on Failure
+    needs: [p0-tests]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure email
+        uses: dawidd6/action-send-mail@v4
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "❌ CI Failed: ${{ github.workflow }} - ${{ github.ref_name }}"
+          to: likaisong@bytedance.com
+          from: GitHub Actions
+          body: |
+            Workflow: ${{ github.workflow }}
+            Repository: ${{ github.repository }}
+            Branch: ${{ github.ref_name }}
+            Commit: ${{ github.sha }}
+            Actor: ${{ github.actor }}
+            Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            
+            Please check the workflow run for details.


### PR DESCRIPTION
- Add 50 minutes timeout for api_test and oc2ov_test workflows
- Add SMTP email notification on workflow failure
- Email will be sent to likaisong@bytedance.com

Required secrets:
- SMTP_USERNAME: SMTP email username
- SMTP_PASSWORD: SMTP email password/app password

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
