### PR TITLE
Feat(ovpack): recursively vectorize all imported docs

### DIFF
--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -92,7 +92,7 @@ def get_viking_rel_path_from_zip(zip_path: str) -> str:
 
 
 async def _enqueue_direct_vectorization(viking_fs, uri: str, ctx: RequestContext) -> None:
-    entries = await viking_fs.tree(uri, output="original", node_limit=100000, level_limit=1000, ctx=ctx)
+    entries = await viking_fs.tree(uri, node_limit=100000, level_limit=1000, ctx=ctx)
     dir_uris = {uri}
     file_entries: list[tuple[str, str, str]] = []
     for entry in entries:

--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
+import asyncio
 import json
 import os
 import re
@@ -89,38 +90,52 @@ def get_viking_rel_path_from_zip(zip_path: str) -> str:
     return "/".join(new_parts)
 
 
-# TODO: Consider recursive vectorization
 async def _enqueue_direct_vectorization(viking_fs, uri: str, ctx: RequestContext) -> None:
     queue_manager = get_queue_manager()
     embedding_queue = cast(
         EmbeddingQueue, queue_manager.get_queue(queue_manager.EMBEDDING, allow_create=True)
     )
 
-    parent_uri = VikingURI(uri).parent.uri
-    abstract = await viking_fs.abstract(uri, ctx=ctx)
-    resource = Context(
-        uri=uri,
-        parent_uri=parent_uri,
-        is_leaf=False,
-        abstract=abstract,
-        level=0,
-        created_at=datetime.now(),
-        active_count=0,
-        related_uri=[],
-        user=ctx.user,
-        account_id=ctx.account_id,
-        owner_space=(
-            ctx.user.agent_space_name()
-            if uri.startswith("viking://agent/")
-            else ctx.user.user_space_name()
-            if uri.startswith("viking://user/") or uri.startswith("viking://session/")
-            else ""
-        ),
-        meta={"semantic_name": uri.split("/")[-1]},
-    )
+    entries = await viking_fs.tree(uri, output="original", node_limit=65536, level_limit=1000, ctx=ctx)
+    dir_uris = {uri}
+    for entry in entries:
+        if entry.get("isDir") and entry.get("uri"):
+            dir_uris.add(entry["uri"])
 
-    embedding_msg = EmbeddingMsgConverter.from_context(resource)
-    await embedding_queue.enqueue(embedding_msg)
+    sem = asyncio.Semaphore(16)
+
+    async def process_one(target_uri: str) -> None:
+        async with sem:
+            try:
+                abstract = await viking_fs.abstract(target_uri, ctx=ctx)
+            except Exception:
+                return
+            parent_uri = VikingURI(target_uri).parent.uri
+            resource = Context(
+                uri=target_uri,
+                parent_uri=parent_uri,
+                is_leaf=False,
+                abstract=abstract,
+                level=0,
+                created_at=datetime.now(),
+                active_count=0,
+                related_uri=[],
+                user=ctx.user,
+                account_id=ctx.account_id,
+                owner_space=(
+                    ctx.user.agent_space_name()
+                    if target_uri.startswith("viking://agent/")
+                    else ctx.user.user_space_name()
+                    if target_uri.startswith("viking://user/") or target_uri.startswith("viking://session/")
+                    else ""
+                ),
+                meta={"semantic_name": target_uri.split("/")[-1]},
+            )
+            embedding_msg = EmbeddingMsgConverter.from_context(resource)
+            if embedding_msg:
+                await embedding_queue.enqueue(embedding_msg)
+
+    await asyncio.gather(*(process_one(d) for d in dir_uris))
 
 
 async def import_ovpack(

--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -108,28 +108,26 @@ async def _enqueue_direct_vectorization(viking_fs, uri: str, ctx: RequestContext
         parent_uri = VikingURI(entry_uri).parent.uri
         file_entries.append((entry_uri, parent_uri, name))
 
-    sem = asyncio.Semaphore(16)
-
     async def index_dir(dir_uri: str) -> None:
-        async with sem:
-            abstract_uri = f"{dir_uri}/.abstract.md"
-            overview_uri = f"{dir_uri}/.overview.md"
-            abstract = ""
-            overview = ""
-            try:
-                if await viking_fs.exists(abstract_uri, ctx=ctx):
-                    content = await viking_fs.read_file(abstract_uri, ctx=ctx)
-                    abstract = content.decode("utf-8") if isinstance(content, bytes) else content
-                if await viking_fs.exists(overview_uri, ctx=ctx):
-                    content = await viking_fs.read_file(overview_uri, ctx=ctx)
-                    overview = content.decode("utf-8") if isinstance(content, bytes) else content
-            except Exception:
-                return
-            await vectorize_directory_meta(dir_uri, abstract, overview, ctx=ctx)
+        abstract_uri = f"{dir_uri}/.abstract.md"
+        overview_uri = f"{dir_uri}/.overview.md"
+        abstract = ""
+        overview = ""
+        try:
+            if await viking_fs.exists(abstract_uri, ctx=ctx):
+                content = await viking_fs.read_file(abstract_uri, ctx=ctx)
+                abstract = content.decode("utf-8") if isinstance(content, bytes) else content
+            if await viking_fs.exists(overview_uri, ctx=ctx):
+                content = await viking_fs.read_file(overview_uri, ctx=ctx)
+                overview = content.decode("utf-8") if isinstance(content, bytes) else content
+        except Exception:
+            return
+        await vectorize_directory_meta(dir_uri, abstract, overview, ctx=ctx)
 
     async def index_file(file_uri: str, parent_uri: str, name: str) -> None:
-        async with sem:
-            await vectorize_file(file_path=file_uri, summary_dict={"name": name}, parent_uri=parent_uri, ctx=ctx)
+        await vectorize_file(
+            file_path=file_uri, summary_dict={"name": name}, parent_uri=parent_uri, ctx=ctx
+        )
 
     work_queue: asyncio.Queue[tuple[str, tuple]] = asyncio.Queue()
     for dir_uri in dir_uris:

--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -129,32 +129,13 @@ async def _enqueue_direct_vectorization(viking_fs, uri: str, ctx: RequestContext
             file_path=file_uri, summary_dict={"name": name}, parent_uri=parent_uri, ctx=ctx
         )
 
-    work_queue: asyncio.Queue[tuple[str, tuple]] = asyncio.Queue()
-    for dir_uri in dir_uris:
-        work_queue.put_nowait(("dir", (dir_uri,)))
-    for file_uri, parent_uri, file_name in file_entries:
-        work_queue.put_nowait(("file", (file_uri, parent_uri, file_name)))
-
-    worker_count = 10
-    for _ in range(worker_count):
-        work_queue.put_nowait(("stop", ()))
-
-    async def worker() -> None:
-        while True:
-            kind, payload = await work_queue.get()
-            try:
-                if kind == "stop":
-                    return
-                if kind == "dir":
-                    (dir_uri,) = payload
-                    await index_dir(dir_uri)
-                elif kind == "file":
-                    file_uri, parent_uri, file_name = payload
-                    await index_file(file_uri, parent_uri, file_name)
-            finally:
-                work_queue.task_done()
-
-    await asyncio.gather(*(worker() for _ in range(worker_count)))
+    await asyncio.gather(*(index_dir(dir_uri) for dir_uri in dir_uris))
+    await asyncio.gather(
+        *(
+            index_file(file_uri, parent_uri, file_name)
+            for file_uri, parent_uri, file_name in file_entries
+        )
+    )
 
 
 async def import_ovpack(

--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -12,6 +12,7 @@ from openviking.core.context import Context
 from openviking.server.identity import RequestContext
 from openviking.storage.queuefs import EmbeddingQueue, get_queue_manager
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
+from openviking.utils.embedding_utils import vectorize_directory_meta, vectorize_file
 from openviking_cli.exceptions import NotFoundError
 from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
@@ -91,51 +92,71 @@ def get_viking_rel_path_from_zip(zip_path: str) -> str:
 
 
 async def _enqueue_direct_vectorization(viking_fs, uri: str, ctx: RequestContext) -> None:
-    queue_manager = get_queue_manager()
-    embedding_queue = cast(
-        EmbeddingQueue, queue_manager.get_queue(queue_manager.EMBEDDING, allow_create=True)
-    )
-
-    entries = await viking_fs.tree(uri, output="original", node_limit=65536, level_limit=1000, ctx=ctx)
+    entries = await viking_fs.tree(uri, output="original", node_limit=100000, level_limit=1000, ctx=ctx)
     dir_uris = {uri}
+    file_entries: list[tuple[str, str, str]] = []
     for entry in entries:
-        if entry.get("isDir") and entry.get("uri"):
-            dir_uris.add(entry["uri"])
+        entry_uri = entry.get("uri")
+        if not entry_uri:
+            continue
+        if entry.get("isDir"):
+            dir_uris.add(entry_uri)
+            continue
+        name = entry.get("name", "")
+        if name.startswith("."):
+            continue
+        parent_uri = VikingURI(entry_uri).parent.uri
+        file_entries.append((entry_uri, parent_uri, name))
 
     sem = asyncio.Semaphore(16)
 
-    async def process_one(target_uri: str) -> None:
+    async def index_dir(dir_uri: str) -> None:
         async with sem:
+            abstract_uri = f"{dir_uri}/.abstract.md"
+            overview_uri = f"{dir_uri}/.overview.md"
+            abstract = ""
+            overview = ""
             try:
-                abstract = await viking_fs.abstract(target_uri, ctx=ctx)
+                if await viking_fs.exists(abstract_uri, ctx=ctx):
+                    content = await viking_fs.read_file(abstract_uri, ctx=ctx)
+                    abstract = content.decode("utf-8") if isinstance(content, bytes) else content
+                if await viking_fs.exists(overview_uri, ctx=ctx):
+                    content = await viking_fs.read_file(overview_uri, ctx=ctx)
+                    overview = content.decode("utf-8") if isinstance(content, bytes) else content
             except Exception:
                 return
-            parent_uri = VikingURI(target_uri).parent.uri
-            resource = Context(
-                uri=target_uri,
-                parent_uri=parent_uri,
-                is_leaf=False,
-                abstract=abstract,
-                level=0,
-                created_at=datetime.now(),
-                active_count=0,
-                related_uri=[],
-                user=ctx.user,
-                account_id=ctx.account_id,
-                owner_space=(
-                    ctx.user.agent_space_name()
-                    if target_uri.startswith("viking://agent/")
-                    else ctx.user.user_space_name()
-                    if target_uri.startswith("viking://user/") or target_uri.startswith("viking://session/")
-                    else ""
-                ),
-                meta={"semantic_name": target_uri.split("/")[-1]},
-            )
-            embedding_msg = EmbeddingMsgConverter.from_context(resource)
-            if embedding_msg:
-                await embedding_queue.enqueue(embedding_msg)
+            await vectorize_directory_meta(dir_uri, abstract, overview, ctx=ctx)
 
-    await asyncio.gather(*(process_one(d) for d in dir_uris))
+    async def index_file(file_uri: str, parent_uri: str, name: str) -> None:
+        async with sem:
+            await vectorize_file(file_path=file_uri, summary_dict={"name": name}, parent_uri=parent_uri, ctx=ctx)
+
+    work_queue: asyncio.Queue[tuple[str, tuple]] = asyncio.Queue()
+    for dir_uri in dir_uris:
+        work_queue.put_nowait(("dir", (dir_uri,)))
+    for file_uri, parent_uri, file_name in file_entries:
+        work_queue.put_nowait(("file", (file_uri, parent_uri, file_name)))
+
+    worker_count = 10
+    for _ in range(worker_count):
+        work_queue.put_nowait(("stop", ()))
+
+    async def worker() -> None:
+        while True:
+            kind, payload = await work_queue.get()
+            try:
+                if kind == "stop":
+                    return
+                if kind == "dir":
+                    (dir_uri,) = payload
+                    await index_dir(dir_uri)
+                elif kind == "file":
+                    file_uri, parent_uri, file_name = payload
+                    await index_file(file_uri, parent_uri, file_name)
+            finally:
+                work_queue.task_done()
+
+    await asyncio.gather(*(worker() for _ in range(worker_count)))
 
 
 async def import_ovpack(


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
修复/添加 ovpack 导入后的“直接向量化入队”逻辑：导入完成后递归遍历整棵目录树，把子目录和内部文件都加入向量化入队，避免导入后在子目录范围内检索不到内容。同时使用固定 worker 池，降低大pack场景的协程创建与调度压力。


## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
现状： import_ovpack(..., vectorize=True) 会触发“导入后向量化入队”，但原逻辑只对导入根目录做一次入队，导致：
- 限定 --uri=viking://resources/<import_root>/<subdir>   时检索经常为空
- 导入后的子目录/内部文件无法被召回（因为没有向量索引）
## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- ovpack 导入 import_ovpack(..., vectorize=True) 后的向量化入队从“仅入队根目录”改为“递归覆盖导入树（目录 + 文件）”，导入后子目录检索可命中。
- 向量化标准对齐 add-resource：
  - 目录：读取并向量化该目录下存在的 .abstract.md / .overview.md （通过 vectorize_directory_meta 入队）。
  - 文件：通过 vectorize_file 对文件内容向量化（包含 max_input_chars 截断/格式处理等既有逻辑）。
- 并发模型优化：用 asyncio.Queue + 固定 worker_count 处理入队任务，避免一次性 gather(N) 创建海量 coroutine（对大 ovpack 更稳定）。

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

手动验证：
- 导入一个包含多级目录的 ovpack（ vectorize=True ），导入完成后执行：
- ov search --uri=viking://resources/<import_root>/<subdir> -n 10 "<关键词>"
- 预期：修改前子目录命中为空/很少；修改后子目录能命中（目录 .abstract/.overview 以及内部文件内容）。

提取root目录后再导入
<img width="741" height="279" alt="image" src="https://github.com/user-attachments/assets/b7fd3c99-5c77-4419-9117-3d6ac25c868a" />

修改前导入到了imports，修改后导入到了imports_fix
<img width="740" height="234" alt="image" src="https://github.com/user-attachments/assets/3fa4fcc7-a007-4f6a-82fc-b55518c3966b" />


验证修改前
<img width="711" height="107" alt="image" src="https://github.com/user-attachments/assets/6b3f1250-1699-4dc2-b9e2-cb984bff9aa0" />
验证修改后
<img width="748" height="364" alt="image" src="https://github.com/user-attachments/assets/c51cea9f-cd3e-4389-b2c2-5fe163558770" />


## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
