### PR TITLE
fix(openclaw): sanitize and cap recall queries

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -11,6 +11,7 @@ import {
   compileSessionPatterns,
   isTranscriptLikeIngest,
   extractLatestUserText,
+  sanitizeUserTextForCapture,
   shouldBypassSession,
 } from "./text-utils.js";
 import {
@@ -110,6 +111,7 @@ type OpenClawPluginApi = {
 const MAX_OPENVIKING_STDERR_LINES = 200;
 const MAX_OPENVIKING_STDERR_CHARS = 256_000;
 const AUTO_RECALL_TIMEOUT_MS = 5_000;
+const RECALL_QUERY_MAX_CHARS = 4_000;
 
 /**
  * OpenViking `UserIdentifier` allows only [a-zA-Z0-9_-] for agent_id
@@ -126,6 +128,39 @@ export function sanitizeOpenVikingAgentIdHeader(raw: string): string {
     .replace(/_+/g, "_")
     .replace(/^_|_$/g, "");
   return normalized.length > 0 ? normalized : "ov_agent";
+}
+
+export type PreparedRecallQuery = {
+  query: string;
+  truncated: boolean;
+  originalChars: number;
+  finalChars: number;
+};
+
+export function prepareRecallQuery(rawText: string): PreparedRecallQuery {
+  const sanitized = sanitizeUserTextForCapture(rawText).trim();
+  const originalChars = sanitized.length;
+
+  if (!sanitized) {
+    return {
+      query: "",
+      truncated: false,
+      originalChars: 0,
+      finalChars: 0,
+    };
+  }
+
+  const query =
+    sanitized.length > RECALL_QUERY_MAX_CHARS
+      ? sanitized.slice(0, RECALL_QUERY_MAX_CHARS).trim()
+      : sanitized;
+
+  return {
+    query,
+    truncated: sanitized.length > RECALL_QUERY_MAX_CHARS,
+    originalChars,
+    finalChars: query.length,
+  };
 }
 
 function extractAgentIdFromSessionKey(sessionKey?: string): string | undefined {
@@ -882,11 +917,20 @@ const contextEnginePlugin = {
       }
 
       const eventObj = (event ?? {}) as { messages?: unknown[]; prompt?: string };
-      const queryText =
-        extractLatestUserText(eventObj.messages) ||
+      const latestUserText = extractLatestUserText(eventObj.messages);
+      const rawRecallQuery =
+        latestUserText ||
         (typeof eventObj.prompt === "string" ? eventObj.prompt.trim() : "");
+      const recallQuery = prepareRecallQuery(rawRecallQuery);
+      const queryText = recallQuery.query;
       if (!queryText) {
         return;
+      }
+      if (recallQuery.truncated) {
+        verboseRoutingInfo(
+          `openviking: recall query truncated (` +
+            `chars=${recallQuery.originalChars}->${recallQuery.finalChars})`,
+        );
       }
 
       const prependContextParts: string[] = [];

--- a/examples/openclaw-plugin/tests/ut/index-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/index-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  prepareRecallQuery,
   sanitizeOpenVikingAgentIdHeader,
   createSessionAgentResolver,
 } from "../../index.js";
@@ -95,5 +96,31 @@ describe("createSessionAgentResolver", () => {
     const r1 = resolver.resolve("s1");
     const r2 = resolver.resolve("s1");
     expect(r1.resolved).toBe(r2.resolved);
+  });
+});
+
+describe("prepareRecallQuery", () => {
+  it("sanitizes the recall query before returning it", () => {
+    const result = prepareRecallQuery(
+      "  <relevant-memories>stale</relevant-memories>\nhello   world\u0000  ",
+    );
+
+    expect(result).toEqual({
+      query: "hello world",
+      truncated: false,
+      originalChars: 11,
+      finalChars: 11,
+    });
+  });
+
+  it("truncates overly long recall queries after sanitization", () => {
+    const rawQuery = "x".repeat(4100);
+
+    const result = prepareRecallQuery(rawQuery);
+
+    expect(result.query).toBe("x".repeat(4000));
+    expect(result.truncated).toBe(true);
+    expect(result.originalChars).toBe(4100);
+    expect(result.finalChars).toBe(4000);
   });
 });


### PR DESCRIPTION
## Description

Sanitize the OpenClaw recall query before retrieval and cap oversized queries so auto-recall does not send noisy or excessively long prompts to OpenViking.

## Related Issue

Fixes #1298

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Sanitize the latest user text or prompt before building the recall query.
- Truncate recall queries above 4000 characters and emit a verbose log when truncation happens.
- Add unit coverage for sanitized and truncated recall-query behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Ran `npm test -- tests/ut/index-utils.test.ts` in `examples/openclaw-plugin`.
