### PR TITLE
fix: skip hook recall when context-engine active

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -903,6 +903,12 @@ const contextEnginePlugin = {
         );
         return;
       }
+      if (contextEngineRef) {
+        verboseRoutingInfo(
+          `openviking: skipping before_prompt_build auto-recall because context-engine is active (sessionKey=${ctx?.sessionKey ?? "none"}, sessionId=${ctx?.sessionId ?? "none"})`,
+        );
+        return;
+      }
       const agentId = resolveAgentId(ctx?.sessionId, ctx?.sessionKey);
       let client: OpenVikingClient;
       try {

--- a/examples/openclaw-plugin/tests/ut/plugin-bypass-session-patterns.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-bypass-session-patterns.test.ts
@@ -65,6 +65,33 @@ describe("plugin bypass session patterns", () => {
     );
   });
 
+  it("skips before_prompt_build auto-recall once context-engine is active", async () => {
+    const { handlers, logger, registerContextEngine } = setupPlugin();
+
+    const factory = registerContextEngine.mock.calls[0]?.[1] as (() => unknown) | undefined;
+    expect(factory).toBeTruthy();
+    factory!();
+
+    const hook = handlers.get("before_prompt_build");
+    expect(hook).toBeTruthy();
+
+    const result = await hook!(
+      {
+        messages: [{ role: "user", content: "remember the launch checklist" }],
+        prompt: "remember the launch checklist",
+      },
+      {
+        sessionId: "runtime-session",
+        sessionKey: "agent:main:test:1",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed to get client"),
+    );
+  });
+
   it("bypasses before_reset without calling commitOVSession", async () => {
     const { handlers, registerContextEngine } = setupPlugin({
       bypassSessionPatterns: ["agent:*:cron:**"],


### PR DESCRIPTION
## Summary
- skip `before_prompt_build` auto-recall once the OpenViking context-engine has been instantiated
- avoid running the legacy hook-based recall path alongside the active context-engine path
- add a unit test that covers the context-engine-active bypass behavior

## Testing
- git diff --check
