### PR TITLE
fix: fall back to prefix filters for volcengine path scope

### DIFF
--- a/openviking/storage/vectordb_adapters/volcengine_adapter.py
+++ b/openviking/storage/vectordb_adapters/volcengine_adapter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from openviking.storage.expr import PathScope
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb.collection.volcengine_collection import (
     VolcengineCollection,
@@ -131,6 +132,16 @@ class VolcengineCollectionAdapter(CollectionAdapter):
             index_meta["VectorIndex"]["EnableSparse"] = True
             index_meta["VectorIndex"]["SearchWithSparseLogitAlpha"] = sparse_weight
         return index_meta
+
+    def _compile_filter(self, expr):
+        if isinstance(expr, PathScope):
+            path = (
+                self._encode_uri_field_value(expr.path)
+                if expr.field in self._URI_FIELD_NAMES
+                else expr.path
+            )
+            return {"op": "prefix", "field": expr.field, "prefix": path}
+        return super()._compile_filter(expr)
 
     def _normalize_record_for_read(self, record: Dict[str, Any]) -> Dict[str, Any]:
         return super()._normalize_record_for_read(record)

--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -1,5 +1,6 @@
 from volcengine.base.Request import Request
 
+from openviking.storage.expr import PathScope
 from openviking.storage.vectordb.collection.volcengine_clients import (
     ClientForConsoleApi,
     ClientForDataApi,
@@ -178,3 +179,21 @@ def test_volcengine_collection_get_meta_data_returns_empty_on_collection_not_fou
     monkeypatch.setattr(collection.console_client, "do_req", lambda *args, **kwargs: _Response())
 
     assert collection.get_meta_data() == {}
+
+
+def test_volcengine_adapter_compiles_pathscope_to_prefix_filter():
+    config = VectorDBBackendConfig(
+        backend="volcengine",
+        name="context",
+        volcengine=VolcengineConfig(
+            ak="test-ak",
+            sk="test-sk",
+            region="cn-beijing",
+        ),
+    )
+
+    adapter = VolcengineCollectionAdapter.from_config(config)
+
+    compiled = adapter.compile_filter(PathScope("uri", "viking://resources/demo", depth=-1))
+
+    assert compiled == {"op": "prefix", "field": "uri", "prefix": "viking://resources/demo"}


### PR DESCRIPTION
## Summary
- compile `PathScope` as a `prefix` filter in the Volcengine adapter instead of emitting the generic `must + para=-d` DSL
- keep the generic PathScope compilation unchanged for other backends
- add a focused regression test for Volcengine adapter filter compilation

## Why
Volcengine backend users reported that `target_uri` scoped search returns zero results because the cloud backend does not honor the generic `para=-d` path filter form. This change uses the backend's existing `prefix` filter support for URI scoping.

## Testing
- `ruff check openviking/storage/vectordb_adapters/volcengine_adapter.py tests/storage/test_volcengine_clients.py`
- `ruff format --check openviking/storage/vectordb_adapters/volcengine_adapter.py tests/storage/test_volcengine_clients.py`
- `git diff --check`

## Notes
- Full local `pytest` validation was blocked by repository-specific AGFS build requirements and optional dependency imports during test bootstrap, so this PR keeps scope tight and locks behavior with a focused adapter regression test.
