### PR TITLE
fix: backfill abstract from file content in vectorize_file

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -282,6 +282,8 @@ async def vectorize_file(
                     if isinstance(content, bytes):
                         content = content.decode("utf-8", errors="replace")
                     content = _truncate_text(content)
+                    if not context.abstract and content:
+                        context.abstract = content[:200]
                     context.set_vectorize(Vectorize(text=content))
                 except Exception as e:
                     logger.warning(


### PR DESCRIPTION
## Summary

- When `index_resource` calls `vectorize_file` without a summary in `summary_dict`, the `abstract` field on the `Context` is set to an empty string
- This means L2 (leaf) records in the vector database have empty `abstract` fields
- Downstream, `hierarchical_retriever` passes these empty abstracts as documents to the rerank API, causing rerank providers (e.g. DashScope qwen3-rerank) to return **HTTP 400** because they reject empty document strings

## Root cause

`index_resource` (line 371) calls `vectorize_file(summary_dict={"name": file_name})` — no `"summary"` key. Inside `vectorize_file`, `summary = summary_dict.get("summary", "")` resolves to `""`, which becomes `Context(abstract="")`. The file content IS read for embedding but never used to populate `abstract`.

## Fix

When `vectorize_file` reads raw file content for embedding and the abstract is still empty, backfill it with the first 200 characters of the file content:

```python
content = _truncate_text(content)
if not context.abstract and content:
    context.abstract = content[:200]
context.set_vectorize(Vectorize(text=content))
```

## Impact

Every L2 record created via `index_resource` will now have a non-empty `abstract`, preventing rerank 400 errors.

## Test plan

- [ ] Run `index_resource` on a directory with text files
- [ ] Verify L2 records in vectordb have non-empty `abstract`
- [ ] Run a search query that triggers rerank — confirm no 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)