### PR TITLE
fix: pass explicit node_limit in index_resource to avoid ls truncation

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -351,7 +351,7 @@ async def index_resource(
 
     # 2. Index Files
     try:
-        files = await viking_fs.ls(uri, ctx=ctx)
+        files = await viking_fs.ls(uri, ctx=ctx, node_limit=10000)
         for file_info in files:
             file_name = file_info["name"]
 


### PR DESCRIPTION
## Summary

- `viking_fs.ls()` defaults to `node_limit=1000`, which silently truncates results for directories with more than 1000 entries
- `index_resource` calls `ls()` without specifying `node_limit`, so large memory directories (e.g. 1800+ files) get silently truncated
- Files beyond the 1000 limit are never vectorized, resulting in incomplete vector indexes and missing search results

## Root cause

`viking_fs.ls()` signature (line 1743):
```python
async def ls(self, uri, ..., node_limit=1000)
```

`index_resource` (line 354) calls it with default:
```python
files = await viking_fs.ls(uri, ctx=ctx)  # node_limit defaults to 1000
```

## Fix

Pass `node_limit=10000` explicitly:
```python
files = await viking_fs.ls(uri, ctx=ctx, node_limit=10000)
```

## Impact

Directories with up to 10,000 files will now be fully indexed. This fixes silent data loss during reindexing of large memory stores.

## Test plan

- [ ] Create a directory with >1000 files, run `index_resource`
- [ ] Verify all files are vectorized (not just the first 1000)
- [ ] Check vector count matches file count

🤖 Generated with [Claude Code](https://claude.com/claude-code)