### PR TITLE
fix: derive context_type from URI in index_resource

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import Dict, Optional
 
 from openviking.core.context import Context, ContextLevel, ResourceContentType, Vectorize
+from openviking.core.directories import get_context_type_for_uri
 from openviking.server.identity import RequestContext
 from openviking.storage.queuefs import get_queue_manager
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
@@ -326,8 +327,13 @@ async def index_resource(
 
     1. Reads .abstract.md and .overview.md and vectorizes them.
     2. Scans files in the directory and vectorizes them.
+
+    The context_type is derived from the URI so that memory directories
+    (``/memories/``) are indexed as ``"memory"`` rather than the default
+    ``"resource"``.
     """
     viking_fs = get_viking_fs()
+    context_type = get_context_type_for_uri(uri)
 
     # 1. Index Directory Metadata
     abstract_uri = f"{uri}/.abstract.md"
@@ -347,7 +353,9 @@ async def index_resource(
             overview = content.decode("utf-8")
 
     if abstract or overview:
-        await vectorize_directory_meta(uri, abstract, overview, ctx=ctx)
+        await vectorize_directory_meta(
+            uri, abstract, overview, context_type=context_type, ctx=ctx
+        )
 
     # 2. Index Files
     try:
@@ -368,7 +376,11 @@ async def index_resource(
             # For direct indexing, we might not have summaries.
             # We pass empty summary_dict, vectorize_file will try to read content for text files.
             await vectorize_file(
-                file_path=file_uri, summary_dict={"name": file_name}, parent_uri=uri, ctx=ctx
+                file_path=file_uri,
+                summary_dict={"name": file_name},
+                parent_uri=uri,
+                context_type=context_type,
+                ctx=ctx,
             )
 
     except Exception as e:


### PR DESCRIPTION
## Summary

- `index_resource()` always used the default `context_type="resource"` when calling `vectorize_directory_meta()` and `vectorize_file()`, even for memory directories (`/memories/` URIs)
- This caused all records created via `/api/v1/content/reindex` to be tagged as `"resource"` instead of `"memory"`, breaking `StatsAggregator` (which filters `Eq("context_type", "memory")`) and hierarchical search scoping
- Fix: use the existing `get_context_type_for_uri()` helper to derive the correct `context_type` from the URI

## Root cause

`vectorize_file` and `vectorize_directory_meta` both default their `context_type` parameter to `"resource"`. The `SemanticProcessor._process_memory_directory()` path correctly hardcodes `context_type="memory"`, but `index_resource()` (used by the reindex API) did not — it relied on the default.

## Test plan

- [ ] Reindex a memory directory via `/api/v1/content/reindex`
- [ ] Verify new records have `context_type="memory"` (not `"resource"`)
- [ ] Verify `/api/v1/stats/memories` correctly counts reindexed records
- [ ] Verify search scoping returns results from reindexed memory directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)