### PR TITLE
fix(session): auto-create missing sessions on first add

### DIFF
--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -249,10 +249,10 @@ async def add_message(
        ]}
 
     If both `content` and `parts` are provided, `parts` takes precedence.
+    Missing sessions are auto-created on first add.
     """
     service = get_service()
-    session = service.sessions.session(_ctx, session_id)
-    await session.load()
+    session = await service.sessions.get(session_id, _ctx, auto_create=True)
 
     if request.parts is not None:
         parts = [part_from_dict(p) for p in request.parts]


### PR DESCRIPTION
## Description

Auto-create a missing session when `POST /api/v1/sessions/{session_id}/messages` receives the first message, so plugins can append the initial turn without an explicit create call.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Route session message writes through `SessionService.get(..., auto_create=True)`
- Materialize a missing session before loading it on the add-message path
- Keep the change scoped to the add-message API instead of archive/context reads

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

Unit tests were not run as part of this PR workflow.
