### PR TITLE
fix(embedder): initialize async client state in VolcengineSparseEmbedder

### DIFF
--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -337,6 +337,8 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
         self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
+        self._ark_kwargs = ark_kwargs
+        self._async_client = None
 
     def _update_telemetry_token_usage(self, response) -> None:
         usage = getattr(response, "usage", None)


### PR DESCRIPTION
## Description

Fix a crash in `VolcengineSparseEmbedder` when OpenViking uses the async sparse embedding path during search/retrieval.

The root cause was that `VolcengineSparseEmbedder.__init__()` did not initialize the async client state (`self._ark_kwargs` and `self._async_client`), while `_get_async_client()` assumes both fields already exist. This caused runtime failures such as:

```text
AttributeError: 'VolcengineSparseEmbedder' object has no attribute '_async_client'
```

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Initialize `self._ark_kwargs` in `VolcengineSparseEmbedder.__init__()`
- Initialize `self._async_client = None` in `VolcengineSparseEmbedder.__init__()`
- Align sparse embedder initialization with the existing dense and hybrid Volcengine embedder implementations

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This is a minimal fix intended to restore the async sparse embedding path without changing public behavior.

The failure was reproduced from OpenViking runtime logs during search execution, where the async retrieval path called `_get_async_client()` on `VolcengineSparseEmbedder` before `_async_client` had ever been defined.