### PR TITLE
fix(config): point missing-config help messages to openviking.ai docs

### DIFF
--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -84,7 +84,7 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
         raise FileNotFoundError(
             f"OpenViking configuration file not found.\n"
             f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-            f"See: https://openviking.dev/docs/guides/configuration"
+            f"See: https://openviking.ai/docs"
         )
 
     data = load_json_config(path)

--- a/openviking_cli/utils/config/config_loader.py
+++ b/openviking_cli/utils/config/config_loader.py
@@ -121,6 +121,6 @@ def require_config(
         raise FileNotFoundError(
             f"OpenViking {purpose} configuration file not found.\n"
             f"Please create {default_path_user} or {default_path_system}, or set {env_var}.\n"
-            f"See: https://openviking.dev/docs/guides/configuration"
+            f"See: https://openviking.ai/docs"
         )
     return load_json_config(path)

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -287,7 +287,7 @@ class OpenVikingConfigSingleton:
                         raise FileNotFoundError(
                             f"OpenViking configuration file not found.\n"
                             f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-                            f"See: https://openviking.dev/docs/guides/configuration"
+                            f"See: https://openviking.ai/docs"
                         )
         return cls._instance
 
@@ -316,7 +316,7 @@ class OpenVikingConfigSingleton:
                     raise FileNotFoundError(
                         f"OpenViking configuration file not found.\n"
                         f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-                        f"See: https://openviking.dev/docs/guides/configuration"
+                        f"See: https://openviking.ai/docs"
                     )
         return cls._instance
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -218,3 +218,19 @@ def test_openviking_config_singleton_missing_message_uses_openviking_ai_docs(tmp
             OpenVikingConfigSingleton.get_instance()
     finally:
         OpenVikingConfigSingleton.reset_instance()
+
+
+def test_openviking_config_singleton_initialize_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.open_viking_config as config_module
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(config_module, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    OpenVikingConfigSingleton.reset_instance()
+    try:
+        with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+            OpenVikingConfigSingleton.initialize()
+    finally:
+        OpenVikingConfigSingleton.reset_instance()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -180,3 +180,41 @@ def test_openviking_config_singleton_preserves_value_error_for_bad_config(tmp_pa
     with pytest.raises(ValueError, match="server"):
         OpenVikingConfigSingleton.initialize(config_path=str(config_path))
     OpenVikingConfigSingleton.reset_instance()
+
+
+def test_require_config_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.config_loader as loader
+
+    monkeypatch.delenv("TEST_MISSING_ENV", raising=False)
+    monkeypatch.setattr(loader, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(loader, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+        loader.require_config(None, "TEST_MISSING_ENV", "missing.conf", "test")
+
+
+def test_load_server_config_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking.server.config as server_config
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(server_config, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(server_config, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+        server_config.load_server_config()
+
+
+def test_openviking_config_singleton_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.open_viking_config as config_module
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(config_module, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    OpenVikingConfigSingleton.reset_instance()
+    try:
+        with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+            OpenVikingConfigSingleton.get_instance()
+    finally:
+        OpenVikingConfigSingleton.reset_instance()


### PR DESCRIPTION
## Summary

- replace the stale `https://openviking.dev/docs/guides/configuration` help URL with `https://openviking.ai/docs` in the missing-config error paths
- update all current config entry points that emit the same guidance so `openviking-server`, the generic config loader, and the singleton bootstrap stay consistent
- add focused regression tests that pin the docs URL used in those missing-config error messages

## Validation

- `python3 -m py_compile openviking/server/config.py openviking_cli/utils/config/config_loader.py openviking_cli/utils/config/open_viking_config.py tests/test_config_loader.py`
- `rg -n "openviking\.dev" openviking openviking_cli tests/test_config_loader.py -S` -> no matches

## Notes

- fixes `#1363`
- targeted `pytest tests/test_config_loader.py -q` is currently blocked in this environment by repo-level test prerequisites outside this patch (`tests/conftest.py` imports `AsyncOpenViking`, which requires bundled AGFS artifacts, and `uv run --extra test` additionally hits the repo's local Rust/Cargo toolchain mismatch while building `ov_cli`)
