### PR TITLE
修复: VikingFS append_file 处理 missing messages

### DIFF
--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -84,7 +84,7 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
         raise FileNotFoundError(
             f"OpenViking configuration file not found.\n"
             f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-            f"See: https://openviking.dev/docs/guides/configuration"
+            f"See: https://openviking.ai/docs"
         )
 
     data = load_json_config(path)

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1722,8 +1722,12 @@ class VikingFS:
             except AGFSHTTPError as e:
                 if e.status_code != 404:
                     raise
-            except AGFSClientError:
-                raise
+            except AGFSClientError as e:
+                if "not found" not in (str(e) or "").lower():
+                    raise
+            except RuntimeError as e:
+                if "not found" not in (str(e) or "").lower():
+                    raise
 
             await self._ensure_parent_dirs(path)
             final_content = (existing + content).encode("utf-8")

--- a/openviking_cli/utils/config/config_loader.py
+++ b/openviking_cli/utils/config/config_loader.py
@@ -121,6 +121,6 @@ def require_config(
         raise FileNotFoundError(
             f"OpenViking {purpose} configuration file not found.\n"
             f"Please create {default_path_user} or {default_path_system}, or set {env_var}.\n"
-            f"See: https://openviking.dev/docs/guides/configuration"
+            f"See: https://openviking.ai/docs"
         )
     return load_json_config(path)

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -287,7 +287,7 @@ class OpenVikingConfigSingleton:
                         raise FileNotFoundError(
                             f"OpenViking configuration file not found.\n"
                             f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-                            f"See: https://openviking.dev/docs/guides/configuration"
+                            f"See: https://openviking.ai/docs"
                         )
         return cls._instance
 
@@ -316,7 +316,7 @@ class OpenVikingConfigSingleton:
                     raise FileNotFoundError(
                         f"OpenViking configuration file not found.\n"
                         f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-                        f"See: https://openviking.dev/docs/guides/configuration"
+                        f"See: https://openviking.ai/docs"
                     )
         return cls._instance
 

--- a/tests/misc/test_append_file_missing.py
+++ b/tests/misc/test_append_file_missing.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Ensures VikingFS.append_file treats missing files as empty content Before writing."""
+
+import contextvars
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.pyagfs.exceptions import AGFSClientError
+
+
+def _make_viking_fs():
+    """Create a VikingFS instance with all required hooks mocked."""
+    from openviking.storage.viking_fs import VikingFS
+
+    fs = VikingFS.__new__(VikingFS)
+    fs.agfs = MagicMock()
+    fs.query_embedder = None
+    fs.vector_store = None
+    fs._bound_ctx = contextvars.ContextVar("vikingfs_bound_ctx", default=None)
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_append_file_missing_runtime_error():
+    """Missing file should not crash when append_file reads a RuntimeError 'not found'."""
+    fs = _make_viking_fs()
+    fs._ensure_parent_dirs = AsyncMock()
+    fs.agfs.read.side_effect = RuntimeError("not found: /default/session/.../messages.jsonl")
+    fs.agfs.write = MagicMock()
+
+    await fs.append_file("viking://session/default/foo/messages.jsonl", "hello\n")
+
+    fs.agfs.write.assert_called_once()
+    path, payload = fs.agfs.write.call_args[0]
+    assert "messages.jsonl" in path
+    assert payload == b"hello\n"
+
+
+@pytest.mark.asyncio
+async def test_append_file_missing_client_error():
+    """AGFSClientError carrying 'not found' should also be treated as empty existing content."""
+    fs = _make_viking_fs()
+    fs._ensure_parent_dirs = AsyncMock()
+    fs.agfs.read.side_effect = AGFSClientError("not found: /default/session/default/messages.jsonl")
+    fs.agfs.write = MagicMock()
+
+    await fs.append_file("viking://session/default/bar/messages.jsonl", "line\n")
+
+    fs.agfs.write.assert_called_once()
+    _, payload = fs.agfs.write.call_args[0]
+    assert payload.endswith(b"line\n")
+
+
+@pytest.mark.asyncio
+async def test_append_file_other_runtime_error_bubbles():
+    """RuntimeErrors without 'not found' should still propagate."""
+    fs = _make_viking_fs()
+    fs._ensure_parent_dirs = AsyncMock()
+    fs.agfs.read.side_effect = RuntimeError("permission denied")
+
+    with pytest.raises(RuntimeError):
+        await fs.append_file("viking://session/default/bad/messages.jsonl", "x\n")

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -218,3 +218,19 @@ def test_openviking_config_singleton_missing_message_uses_openviking_ai_docs(tmp
             OpenVikingConfigSingleton.get_instance()
     finally:
         OpenVikingConfigSingleton.reset_instance()
+
+
+def test_openviking_config_singleton_initialize_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.open_viking_config as config_module
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(config_module, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    OpenVikingConfigSingleton.reset_instance()
+    try:
+        with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+            OpenVikingConfigSingleton.initialize()
+    finally:
+        OpenVikingConfigSingleton.reset_instance()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -180,3 +180,41 @@ def test_openviking_config_singleton_preserves_value_error_for_bad_config(tmp_pa
     with pytest.raises(ValueError, match="server"):
         OpenVikingConfigSingleton.initialize(config_path=str(config_path))
     OpenVikingConfigSingleton.reset_instance()
+
+
+def test_require_config_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.config_loader as loader
+
+    monkeypatch.delenv("TEST_MISSING_ENV", raising=False)
+    monkeypatch.setattr(loader, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(loader, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+        loader.require_config(None, "TEST_MISSING_ENV", "missing.conf", "test")
+
+
+def test_load_server_config_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking.server.config as server_config
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(server_config, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(server_config, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+        server_config.load_server_config()
+
+
+def test_openviking_config_singleton_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.open_viking_config as config_module
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(config_module, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    OpenVikingConfigSingleton.reset_instance()
+    try:
+        with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+            OpenVikingConfigSingleton.get_instance()
+    finally:
+        OpenVikingConfigSingleton.reset_instance()


### PR DESCRIPTION
### Summary
- avoid rethrowing AGFS "not found" errors when appending messages so the file is created automatically
- add a regression test that ensures missing file still allows append while other runtime errors still surface

### Testing
- python3 -m pytest tests/misc/test_append_file_missing.py *(blocked: openviking/__init__.py raises `ImportError: Bundled OpenViking AGFS client is unavailable`. Building the client requires `pip install -e .`, which currently fails because the in-tree ov CLI needs Cargo with edition2024.)*

Fixes #1358
