### PR TITLE
fix(tests): align pytest coverage docs with required setup (#1259)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,7 +31,7 @@ See [docs/en/guides/configuration.md](../docs/en/guides/configuration.md) for th
 ### Dependencies
 
 ```bash
-pip install pytest pytest-asyncio
+pip install pytest pytest-asyncio pytest-cov
 ```
 
 ## Running Tests
@@ -43,7 +43,7 @@ pip install pytest pytest-asyncio
 pytest tests/client tests/server tests/session tests/vectordb tests/misc tests/integration -v
 
 # Run with coverage
-pytest tests/client tests/server tests/session tests/vectordb tests/misc tests/integration --cov=openviking --cov-report=html
+pytest tests/client tests/server tests/session tests/vectordb tests/misc tests/integration -v --cov=openviking --cov-report=term-missing
 ```
 
 ### Running Specific Tests


### PR DESCRIPTION
## Summary
- document pytest-cov in the test README dependencies
- keep the coverage command scoped to the intended Python test directories and preserve verbose output
- address review feedback so the README matches actual pytest collection behavior

## Validation
- verified README diff is scoped to tests/README.md
- confirmed documented install command includes pytest-cov
- confirmed coverage command is scoped to tests/client tests/server tests/session tests/vectordb tests/misc tests/integration with term-missing output

Closes #1259
