### PR TITLE
fix(queue): preserve embedding message ids across serialization

### DIFF
--- a/openviking/storage/queuefs/embedding_msg.py
+++ b/openviking/storage/queuefs/embedding_msg.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Union
 from uuid import uuid4
 
@@ -10,6 +10,7 @@ from uuid import uuid4
 class EmbeddingMsg:
     message: Union[str, List[Dict[str, Any]]]
     context_data: Dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid4()))
     telemetry_id: str = ""
     semantic_msg_id: Optional[str] = None
 

--- a/tests/storage/test_embedding_msg.py
+++ b/tests/storage/test_embedding_msg.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from uuid import uuid4
+
+from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
+from openviking.telemetry.request_wait_tracker import RequestWaitTracker
+
+
+def test_embedding_msg_roundtrip_preserves_id_for_request_wait_tracker():
+    telemetry_id = f"tm_{uuid4().hex}"
+    tracker = RequestWaitTracker.get_instance()
+    tracker.register_request(telemetry_id)
+
+    try:
+        msg = EmbeddingMsg(
+            "hello",
+            {"uri": "viking://agent/skills/demo"},
+            telemetry_id=telemetry_id,
+        )
+        tracker.register_embedding_root(telemetry_id, msg.id)
+
+        restored = EmbeddingMsg.from_dict(msg.to_dict())
+
+        assert restored.id == msg.id
+        tracker.mark_embedding_done(telemetry_id, restored.id)
+        assert tracker.is_complete(telemetry_id)
+    finally:
+        tracker.cleanup(telemetry_id)


### PR DESCRIPTION
## Description

Preserve `EmbeddingMsg.id` when embedding queue messages are serialized and later deserialized by the worker. Direct embedding waits register this id with `RequestWaitTracker`; losing it can leave `wait=True` requests pending until timeout even after the embedding job succeeds.

## Related Issue

Fixes #1379

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Declared `EmbeddingMsg.id` as a dataclass field so `asdict()` includes it in queued payloads.
- Kept the existing constructor signature unchanged.
- Added a regression test covering queue-style round trip deserialization and request wait completion.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands run:

```bash
ruff format --check openviking/storage/queuefs/embedding_msg.py tests/storage/test_embedding_msg.py
ruff check openviking/storage/queuefs/embedding_msg.py tests/storage/test_embedding_msg.py
git diff --check
PYTHONPATH=. /tmp/openviking-test-venv/bin/pytest -o addopts='' --confcutdir=tests/storage tests/storage/test_embedding_msg.py -q
PYTHONPATH=. /tmp/openviking-test-venv/bin/pytest -o addopts='' --confcutdir=tests/telemetry tests/telemetry/test_request_wait_tracker.py -q
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The temporary validation environment was removed after running the tests.