### PR TITLE
docs(server): add systemd user-service setup for openviking-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ or you can run in background
 nohup openviking-server > /data/log/openviking.log 2>&1 &
 ```
 
+For long-running environments, prefer a `systemd --user` service instead of `nohup` so restarts and process state are managed consistently. See: [Server Mode (systemd user service)](./docs/en/getting-started/03-quickstart-server.md#run-with-systemd-user-service-recommended-for-linux).
+
 #### Run the CLI
 
 ```bash

--- a/docs/en/getting-started/03-quickstart-server.md
+++ b/docs/en/getting-started/03-quickstart-server.md
@@ -28,6 +28,37 @@ You should see:
 INFO:     Uvicorn running on http://0.0.0.0:1933
 ```
 
+## Run with systemd user service (recommended for Linux)
+
+`openviking-server` runs in the foreground. For persistent Linux sessions, use a user-level systemd unit instead of shell background wrappers.
+
+1. Copy the example unit file:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp docs/en/getting-started/examples/openviking-server.service ~/.config/systemd/user/openviking.service
+```
+
+2. Edit the unit values:
+
+- Set `WorkingDirectory` to your OpenViking workspace
+- Set `Environment=OPENVIKING_CONFIG_FILE=...` to your `ov.conf` path
+- Optionally add `Environment=OPENVIKING_CLI_CONFIG_FILE=...` if needed
+
+3. Enable and start:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now openviking.service
+systemctl --user status openviking.service
+```
+
+4. View logs:
+
+```bash
+journalctl --user -u openviking.service -f
+```
+
 ## Verify
 
 ```bash

--- a/docs/en/getting-started/examples/openviking-server.service
+++ b/docs/en/getting-started/examples/openviking-server.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OpenViking Server (user service)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/openviking
+Environment=OPENVIKING_CONFIG_FILE=%h/.openviking/ov.conf
+ExecStart=/usr/bin/env openviking-server --config ${OPENVIKING_CONFIG_FILE}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- add a ready-to-copy `systemd --user` unit example for `openviking-server`
- document user-service setup/start/log commands in server quickstart docs
- link server startup guidance in root README to the new systemd section

## Problem
Issue #1218 reports that shell background wrappers (like `nohup ... &`) lead to unstable service lifecycle behavior under systemd.

## Why this change
This provides an officially documented, process-manager-native way to run OpenViking in persistent Linux sessions without relying on wrapper/background shell patterns.

## Validation
- `systemd-analyze verify docs/en/getting-started/examples/openviking-server.service`

Closes #1218
