### PR TITLE
Support vlm.base_url legacy config

### DIFF
--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -11,6 +11,10 @@ class VLMConfig(BaseModel):
     model: Optional[str] = Field(default=None, description="Model name")
     api_key: Optional[str] = Field(default=None, description="API key")
     api_base: Optional[str] = Field(default=None, description="API base URL")
+    base_url: Optional[str] = Field(
+        default=None,
+        description="Legacy alias for `api_base` (accepted for backward compatibility)",
+    )
     temperature: float = Field(default=0.0, description="Generation temperature")
     max_retries: int = Field(default=3, description="Maximum retry attempts")
 
@@ -79,6 +83,9 @@ class VLMConfig(BaseModel):
 
     def _migrate_legacy_config(self):
         """Migrate legacy config to providers structure."""
+        if self.base_url and not self.api_base:
+            self.api_base = self.base_url
+
         if self.api_key and self.provider:
             if self.provider not in self.providers:
                 self.providers[self.provider] = {}

--- a/tests/misc/test_config_validation.py
+++ b/tests/misc/test_config_validation.py
@@ -164,6 +164,22 @@ def test_embedding_validation():
     else:
         print(f"   Fail (provider='volcengine' should have priority, got '{config_b.provider}')")
 
+    # Test 5: VLM legacy base_url alias
+    print("\n5. Test VLM base_url alias...")
+    try:
+        config_c = VLMConfig(
+            base_url="https://example.com/api",
+            model="gpt-4",
+            api_key="test-key",
+            provider="openai",
+        )
+        if config_c.api_base == "https://example.com/api":
+            print("   Pass (base_url accepted as api_base)")
+        else:
+            print("   Fail (base_url not mapped to api_base)")
+    except ValueError as e:
+        print(f"   Fail: {e}")
+
     # Test 5: Ollama provider (no API key required)
     print("\n5. Test Ollama provider (no API key required)...")
     try:


### PR DESCRIPTION
## Summary
- allow the legacy `vlm.base_url` key to populate `api_base` so Docker + ov.conf fragments that still use base_url will pass validation
- add a config regression test that verifies the alias is accepted

## Testing
- PYTHONPATH=. python tests/misc/test_config_validation.py
