### PR TITLE
feat(examples): add Claude Code context engine plugin

### DIFF
--- a/examples/claude-code-context-engine/.claude-plugin/plugin.json
+++ b/examples/claude-code-context-engine/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "openviking-context-engine",
+  "version": "0.2.0",
+  "description": "Full OpenViking context pipeline for Claude Code: persistent sessions, archive compression, auto-recall, context assembly, and memory extraction.",
+  "author": {
+    "name": "OpenViking",
+    "url": "https://github.com/volcengine/OpenViking"
+  },
+  "repository": "https://github.com/volcengine/OpenViking",
+  "license": "Apache-2.0",
+  "keywords": [
+    "context-engine",
+    "memory",
+    "openviking",
+    "session",
+    "archive",
+    "compaction"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/examples/claude-code-context-engine/.gitignore
+++ b/examples/claude-code-context-engine/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/claude-code-context-engine/.mcp.json
+++ b/examples/claude-code-context-engine/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "openviking-context-engine": {
+    "command": "node",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/start-context-server.mjs"],
+    "env": {
+      "OPENVIKING_CONFIG_FILE": "${OPENVIKING_CONFIG_FILE:-}"
+    }
+  }
+}

--- a/examples/claude-code-context-engine/hooks/hooks.json
+++ b/examples/claude-code-context-engine/hooks/hooks.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-runtime.mjs",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/assemble.mjs",
+            "timeout": 8
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/after-turn.mjs",
+            "timeout": 45
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/claude-code-context-engine/package-lock.json
+++ b/examples/claude-code-context-engine/package-lock.json
@@ -1,0 +1,1174 @@
+{
+  "name": "claude-code-openviking-context-engine",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-code-openviking-context-engine",
+      "version": "0.2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "zod": "^4.3.6"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/claude-code-context-engine/package.json
+++ b/examples/claude-code-context-engine/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-code-openviking-context-engine",
+  "version": "0.2.0",
+  "description": "OpenViking context engine plugin for Claude Code — full session pipeline with archive compression and memory extraction",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/claude-code-context-engine/scripts/after-turn.mjs
+++ b/examples/claude-code-context-engine/scripts/after-turn.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+/**
+ * Stop hook (afterTurn): read transcript, capture new turns to persistent OV session,
+ * evaluate compact thresholds, trigger session.commit() when needed.
+ *
+ * Key difference from old auto-capture.mjs:
+ * - Maintains PERSISTENT session (not temp sessions)
+ * - Messages accumulate; commit triggers server-side archiving + memory extraction
+ * - Evaluates multiple compact thresholds (tokens, turns, interval, tokens-added)
+ */
+
+import { readFile } from "node:fs/promises";
+import { loadConfig } from "./config.mjs";
+import { createClient } from "./http-client.mjs";
+import { loadState, saveState, deriveOvSessionId } from "./state.mjs";
+import { createLogger } from "./debug-log.mjs";
+import { parseTranscript, extractAllTurns, sanitize, estimateTokens, groupTurns } from "./text-utils.mjs";
+
+const cfg = loadConfig();
+const { log, logError } = createLogger("after-turn");
+
+function output(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+function approve(msg) {
+  const out = { decision: "approve" };
+  if (msg) out.systemMessage = msg;
+  output(out);
+}
+
+async function main() {
+  if (!cfg.autoCapture) {
+    log("skip", { reason: "autoCapture disabled" });
+    approve();
+    return;
+  }
+
+  // Read stdin
+  let input;
+  try {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    input = JSON.parse(Buffer.concat(chunks).toString());
+  } catch {
+    log("skip", { reason: "invalid stdin" });
+    approve();
+    return;
+  }
+
+  const transcriptPath = input.transcript_path;
+  const ccSessionId = input.session_id || "unknown";
+  log("start", { ccSessionId, transcriptPath });
+
+  // Health check
+  const client = createClient(cfg);
+  const healthy = await client.healthCheck();
+  if (!healthy) {
+    logError("health_check", "server unreachable");
+    approve();
+    return;
+  }
+
+  if (!transcriptPath) {
+    log("skip", { reason: "no transcript_path" });
+    approve();
+    return;
+  }
+
+  // Read transcript
+  let transcriptContent;
+  try {
+    transcriptContent = await readFile(transcriptPath, "utf-8");
+  } catch (err) {
+    logError("transcript_read", err);
+    approve();
+    return;
+  }
+
+  if (!transcriptContent.trim()) {
+    log("skip", { reason: "empty transcript" });
+    approve();
+    return;
+  }
+
+  // Parse and extract all turns
+  const messages = parseTranscript(transcriptContent);
+  const allTurns = extractAllTurns(messages);
+  if (allTurns.length === 0) {
+    log("skip", { reason: "no turns" });
+    approve();
+    return;
+  }
+
+  // Load state
+  const state = await loadState(ccSessionId);
+  if (!state.ovSessionId) {
+    state.ovSessionId = deriveOvSessionId(ccSessionId);
+  }
+  const ovSessionId = state.ovSessionId;
+
+  // Incremental: only new turns
+  const newTurns = allTurns.slice(state.capturedTurnCount);
+  log("transcript_parse", {
+    totalTurns: allTurns.length,
+    previouslyCaptured: state.capturedTurnCount,
+    newTurns: newTurns.length,
+  });
+
+  if (newTurns.length === 0) {
+    approve();
+    return;
+  }
+
+  // Ensure OV session exists
+  const session = await client.getSession(ovSessionId);
+  if (!session) {
+    const created = await client.createSession(ovSessionId);
+    if (!created) {
+      logError("session_create", "failed to create OV session");
+      approve();
+      return;
+    }
+  }
+
+  // Send new turns to OV session
+  // Group adjacent same-role messages
+  const groups = groupTurns(newTurns);
+  let tokensAdded = 0;
+
+  for (const group of groups) {
+    const text = sanitize(group.texts.join("\n"));
+    if (!text) continue;
+
+    const result = await client.addSessionMessage(ovSessionId, group.role, text);
+    if (result) {
+      tokensAdded += estimateTokens(text);
+    }
+  }
+
+  // Update state
+  state.capturedTurnCount = allTurns.length;
+  state.totalTokensAdded += tokensAdded;
+  state.turnsSinceCommit += newTurns.length;
+
+  log("capture_done", {
+    groupsSent: groups.length,
+    tokensAdded,
+    totalTokensAdded: state.totalTokensAdded,
+    turnsSinceCommit: state.turnsSinceCommit,
+  });
+
+  // Evaluate compact thresholds
+  const now = Date.now();
+  const intervalSinceCommit = now - (state.lastCommitAt || state.createdAt || now);
+  let commitReason = null;
+
+  if (state.totalTokensAdded >= cfg.commitTokensAddedThreshold) {
+    commitReason = `tokensAdded(${state.totalTokensAdded} >= ${cfg.commitTokensAddedThreshold})`;
+  } else if (state.turnsSinceCommit >= cfg.commitTurnThreshold) {
+    commitReason = `turns(${state.turnsSinceCommit} >= ${cfg.commitTurnThreshold})`;
+  } else if (intervalSinceCommit >= cfg.commitIntervalMs && state.turnsSinceCommit >= 1) {
+    commitReason = `interval(${Math.floor(intervalSinceCommit / 60000)}min >= ${Math.floor(cfg.commitIntervalMs / 60000)}min)`;
+  }
+
+  // Also check server-side pending tokens
+  if (!commitReason) {
+    const sessionInfo = await client.getSession(ovSessionId);
+    const pendingTokens = sessionInfo?.pending_tokens || sessionInfo?.message_count * 250 || 0;
+    if (pendingTokens >= cfg.commitTokenThreshold) {
+      commitReason = `pendingTokens(${pendingTokens} >= ${cfg.commitTokenThreshold})`;
+    }
+  }
+
+  if (commitReason) {
+    log("compact_trigger", { reason: commitReason });
+
+    const commitResult = await client.commitSession(ovSessionId);
+    if (commitResult) {
+      log("compact_done", {
+        taskId: commitResult.task_id,
+        archived: commitResult.archived,
+        archiveUri: commitResult.archive_uri,
+      });
+
+      state.lastCommitAt = now;
+      state.totalTokensAdded = 0;
+      state.turnsSinceCommit = 0;
+      state.commitCount++;
+    } else {
+      logError("compact_failed", "commitSession returned null");
+    }
+  }
+
+  await saveState(ccSessionId, state);
+  approve();
+}
+
+main().catch((err) => { logError("uncaught", err); approve(); });

--- a/examples/claude-code-context-engine/scripts/assemble.mjs
+++ b/examples/claude-code-context-engine/scripts/assemble.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+/**
+ * UserPromptSubmit hook (assemble): full context assembly.
+ * 1. Fetches session context (archive summaries) from OV
+ * 2. Searches memories (user + agent) with query-aware ranking
+ * 3. Injects assembled context as systemMessage
+ *
+ * Runs session context fetch + memory search in PARALLEL to fit 8s timeout.
+ */
+
+import { loadConfig } from "./config.mjs";
+import { createClient } from "./http-client.mjs";
+import { loadState, deriveOvSessionId } from "./state.mjs";
+import { createLogger } from "./debug-log.mjs";
+import { postProcess, pickMemories } from "./ranking.mjs";
+
+const cfg = loadConfig();
+const { log, logError } = createLogger("assemble");
+
+function output(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+function approve(msg) {
+  const out = { decision: "approve" };
+  if (msg) out.hookSpecificOutput = { hookEventName: "UserPromptSubmit", additionalContext: msg };
+  output(out);
+}
+
+// Deadline: abort everything if we're close to the 8s hook timeout
+const DEADLINE_MS = 6500;
+const startTime = Date.now();
+function timeLeft() { return DEADLINE_MS - (Date.now() - startTime); }
+
+async function withDeadline(promise) {
+  const remaining = timeLeft();
+  if (remaining <= 0) return null;
+  return Promise.race([
+    promise,
+    new Promise(resolve => setTimeout(() => resolve(null), remaining)),
+  ]);
+}
+
+async function searchBothScopes(client, query, limit) {
+  const [userMems, agentMems, agentSkills] = await Promise.allSettled([
+    client.find(query, "viking://user/memories", limit),
+    client.find(query, "viking://agent/memories", limit),
+    client.find(query, "viking://agent/skills", limit),
+  ]);
+
+  const user = userMems.status === "fulfilled" ? userMems.value : [];
+  const agent = agentMems.status === "fulfilled" ? agentMems.value : [];
+  const skills = agentSkills.status === "fulfilled" ? agentSkills.value : [];
+
+  const all = [...user, ...agent, ...skills];
+  const uriSet = new Set();
+  return all.filter(m => {
+    if (uriSet.has(m.uri)) return false;
+    uriSet.add(m.uri);
+    return true;
+  });
+}
+
+async function main() {
+  if (!cfg.autoRecall) {
+    log("skip", { reason: "autoRecall disabled" });
+    approve();
+    return;
+  }
+
+  // Read stdin
+  let input;
+  try {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    input = JSON.parse(Buffer.concat(chunks).toString());
+  } catch {
+    log("skip", { reason: "invalid stdin" });
+    approve();
+    return;
+  }
+
+  const userPrompt = (input.prompt || "").trim();
+  log("start", { queryLength: userPrompt.length });
+
+  if (!userPrompt || userPrompt.length < cfg.minQueryLength) {
+    log("skip", { reason: "query too short" });
+    approve();
+    return;
+  }
+
+  // Health check
+  const client = createClient(cfg);
+  const healthy = await withDeadline(client.healthCheck());
+  if (!healthy) {
+    logError("health_check", "server unreachable");
+    approve();
+    return;
+  }
+
+  // Load state for session context
+  // Try to get session_id from env or use a default
+  const ccSessionId = process.env.CLAUDE_SESSION_ID || "unknown";
+  const state = { ovSessionId: deriveOvSessionId(ccSessionId) };
+
+  // Run in parallel: session context + memory search
+  const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
+  const [sessionCtx, allMemories] = await Promise.all([
+    withDeadline(client.getSessionContext(state.ovSessionId, cfg.contextTokenBudget)),
+    withDeadline(searchBothScopes(client, userPrompt, candidateLimit)),
+  ]);
+
+  const sections = [];
+
+  // --- Session Context (archive summaries) ---
+  if (sessionCtx) {
+    const parts = [];
+
+    if (sessionCtx.latest_archive_overview) {
+      parts.push(`[Session History Summary]\n${sessionCtx.latest_archive_overview}`);
+    }
+
+    if (sessionCtx.pre_archive_abstracts && sessionCtx.pre_archive_abstracts.length > 0) {
+      const archiveLines = sessionCtx.pre_archive_abstracts
+        .map(a => `${a.archive_id}: ${a.abstract || "..."}`)
+        .join("\n");
+      parts.push(`[Archive Index]\n${archiveLines}`);
+    }
+
+    if (parts.length > 0) {
+      parts.push(
+        "\n## Session Context Guide\n" +
+        "The above shows compressed history from earlier in this conversation. " +
+        "If you need original details from a specific archive, use the `ov_archive_expand` tool with the archive_id."
+      );
+
+      sections.push(
+        "<openviking-context>\n" + parts.join("\n\n") + "\n</openviking-context>"
+      );
+
+      log("session_context", {
+        hasOverview: !!sessionCtx.latest_archive_overview,
+        archiveCount: sessionCtx.pre_archive_abstracts?.length || 0,
+        estimatedTokens: sessionCtx.estimatedTokens,
+      });
+    }
+  }
+
+  // --- Memory Recall ---
+  if (allMemories && allMemories.length > 0) {
+    const processed = postProcess(allMemories, candidateLimit, cfg.scoreThreshold);
+    const memories = pickMemories(processed, cfg.recallLimit, userPrompt);
+
+    log("recall", {
+      rawCount: allMemories.length,
+      processedCount: processed.length,
+      pickedCount: memories.length,
+    });
+
+    if (memories.length > 0) {
+      // Read full content for leaf memories (with deadline)
+      const lines = await Promise.all(
+        memories.map(async (item) => {
+          if (item.level === 2 && timeLeft() > 500) {
+            const content = await withDeadline(client.read(item.uri));
+            if (content) return `- [${item.category || "memory"}] ${content}`;
+          }
+          return `- [${item.category || "memory"}] ${(item.abstract || item.overview || item.uri).trim()}`;
+        })
+      );
+
+      sections.push(
+        "<relevant-memories>\n" +
+        "The following long-term memories from OpenViking may be relevant to this conversation:\n" +
+        lines.join("\n") + "\n" +
+        "</relevant-memories>"
+      );
+    }
+  }
+
+  if (sections.length === 0) {
+    log("skip", { reason: "no context to inject" });
+    approve();
+    return;
+  }
+
+  approve(sections.join("\n\n"));
+}
+
+main().catch((err) => { logError("uncaught", err); approve(); });

--- a/examples/claude-code-context-engine/scripts/bootstrap-runtime.mjs
+++ b/examples/claude-code-context-engine/scripts/bootstrap-runtime.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/**
+ * SessionStart hook: install MCP runtime dependencies + create OV session.
+ */
+
+import {
+  computeSourceState,
+  ensureRuntimeInstalled,
+  getRuntimePaths,
+} from "./runtime-common.mjs";
+import { loadConfig } from "./config.mjs";
+import { createClient } from "./http-client.mjs";
+import { deriveOvSessionId, loadState, saveState } from "./state.mjs";
+import { createLogger } from "./debug-log.mjs";
+
+const cfg = loadConfig();
+const { log, logError } = createLogger("bootstrap");
+
+async function main() {
+  // 1. Ensure MCP server runtime is installed
+  const paths = getRuntimePaths();
+  const expectedState = await computeSourceState(paths);
+  try {
+    await ensureRuntimeInstalled(paths, expectedState);
+  } catch (err) {
+    process.stderr.write(
+      `[openviking-context-engine] Failed to prepare MCP runtime: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+
+  // 2. Create/touch OV session
+  try {
+    const client = createClient(cfg);
+    const healthy = await client.healthCheck();
+    if (healthy) {
+      // Read stdin for session_id if available
+      let ccSessionId = "unknown";
+      try {
+        const chunks = [];
+        process.stdin.resume();
+        process.stdin.setTimeout?.(500);
+        for await (const chunk of process.stdin) chunks.push(chunk);
+        const input = JSON.parse(Buffer.concat(chunks).toString());
+        ccSessionId = input.session_id || "unknown";
+      } catch { /* no stdin or timeout — use default */ }
+
+      const ovSessionId = deriveOvSessionId(ccSessionId);
+      const result = await client.createSession(ovSessionId);
+      log("session_created", { ccSessionId, ovSessionId, result });
+
+      // Initialize state
+      const state = await loadState(ccSessionId);
+      state.ovSessionId = ovSessionId;
+      state.createdAt = Date.now();
+      await saveState(ccSessionId, state);
+    } else {
+      log("skip", { reason: "server_unhealthy" });
+    }
+  } catch (err) {
+    logError("session_create", err);
+  }
+}
+
+main().catch((err) => {
+  logError("uncaught", err);
+  process.exit(0);
+});

--- a/examples/claude-code-context-engine/scripts/config.mjs
+++ b/examples/claude-code-context-engine/scripts/config.mjs
@@ -1,0 +1,107 @@
+/**
+ * Shared configuration loader for the Claude Code OpenViking context engine.
+ * Reads from ~/.openviking/ov.conf (JSON), shared with OpenClaw and other clients.
+ * Plugin-specific overrides in optional "claude_code" section.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+
+const DEFAULT_CONFIG_PATH = join(homedir(), ".openviking", "ov.conf");
+
+function num(val, fallback) {
+  if (typeof val === "number" && Number.isFinite(val)) return val;
+  if (typeof val === "string" && val.trim()) {
+    const n = Number(val);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+function str(val, fallback) {
+  if (typeof val === "string" && val.trim()) return val.trim();
+  return fallback;
+}
+
+export function loadConfig() {
+  const configPath = resolvePath(
+    (process.env.OPENVIKING_CONFIG_FILE || DEFAULT_CONFIG_PATH).replace(/^~/, homedir()),
+  );
+
+  let raw;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch (err) {
+    const msg = err?.code === "ENOENT"
+      ? `Config file not found: ${configPath}\n  Create it from the example: cp ov.conf.example ~/.openviking/ov.conf`
+      : `Failed to read config file: ${configPath} — ${err?.message || err}`;
+    process.stderr.write(`[openviking-context-engine] ${msg}\n`);
+    process.exit(1);
+  }
+
+  let file;
+  try {
+    file = JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write(`[openviking-context-engine] Invalid JSON in ${configPath}: ${err?.message || err}\n`);
+    process.exit(1);
+  }
+
+  const server = file.server || {};
+  const host = str(server.host, "127.0.0.1").replace("0.0.0.0", "127.0.0.1");
+  const port = Math.floor(num(server.port, 1933));
+  const baseUrl = `http://${host}:${port}`;
+  const apiKey = str(server.root_api_key, "") || "";
+  const account = str(server.account, "default");
+  const user = str(server.user, "default");
+
+  const cc = file.claude_code || {};
+
+  const debug = cc.debug === true || process.env.OPENVIKING_DEBUG === "1";
+  const defaultLogPath = join(homedir(), ".openviking", "logs", "cc-hooks.log");
+  const debugLogPath = str(process.env.OPENVIKING_DEBUG_LOG, defaultLogPath);
+
+  const timeoutMs = Math.max(1000, Math.floor(num(cc.timeoutMs, 15000)));
+  const captureTimeoutMs = Math.max(
+    1000,
+    Math.floor(num(cc.captureTimeoutMs, Math.max(timeoutMs * 2, 30000))),
+  );
+
+  return {
+    configPath,
+    baseUrl,
+    apiKey,
+    account,
+    user,
+    agentId: str(cc.agentId, "claude-code"),
+    timeoutMs,
+
+    // Recall
+    autoRecall: cc.autoRecall !== false,
+    recallLimit: Math.max(1, Math.floor(num(cc.recallLimit, 6))),
+    scoreThreshold: Math.min(1, Math.max(0, num(cc.scoreThreshold, 0.01))),
+    minQueryLength: Math.max(1, Math.floor(num(cc.minQueryLength, 3))),
+    logRankingDetails: cc.logRankingDetails === true,
+
+    // Capture
+    autoCapture: cc.autoCapture !== false,
+    captureMode: cc.captureMode === "keyword" ? "keyword" : "semantic",
+    captureMaxLength: Math.max(200, Math.floor(num(cc.captureMaxLength, 24000))),
+    captureTimeoutMs,
+    captureAssistantTurns: cc.captureAssistantTurns !== false, // default true for context engine
+
+    // Compact thresholds
+    commitTokenThreshold: Math.max(0, Math.floor(num(cc.commitTokenThreshold, 20000))),
+    commitTurnThreshold: Math.max(1, Math.floor(num(cc.commitTurnThreshold, 20))),
+    commitIntervalMs: Math.max(60000, Math.floor(num(cc.commitIntervalMs, 30 * 60 * 1000))),
+    commitTokensAddedThreshold: Math.max(1000, Math.floor(num(cc.commitTokensAddedThreshold, 30000))),
+    contextTokenBudget: Math.max(1000, Math.floor(num(cc.contextTokenBudget, 128000))),
+    recallTokenBudget: Math.max(100, Math.floor(num(cc.recallTokenBudget, 2000))),
+    recallMaxContentChars: Math.max(50, Math.floor(num(cc.recallMaxContentChars, 500))),
+
+    // Debug
+    debug,
+    debugLogPath,
+  };
+}

--- a/examples/claude-code-context-engine/scripts/debug-log.mjs
+++ b/examples/claude-code-context-engine/scripts/debug-log.mjs
@@ -1,0 +1,60 @@
+/**
+ * Shared structured debug logger for Claude Code hook scripts.
+ * Activation: OPENVIKING_DEBUG=1 env var OR claude_code.debug: true in ov.conf.
+ * Format: JSON Lines — { ts, hook, stage, data } | { ts, hook, stage, error }.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { loadConfig } from "./config.mjs";
+
+let _cfg;
+function cfg() {
+  if (!_cfg) _cfg = loadConfig();
+  return _cfg;
+}
+
+function ensureDir(filePath) {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+  } catch { /* already exists or no permission */ }
+}
+
+function writeLine(filePath, obj) {
+  try {
+    appendFileSync(filePath, JSON.stringify(obj) + "\n");
+  } catch { /* best effort */ }
+}
+
+function localISO() {
+  const d = new Date();
+  const off = d.getTimezoneOffset();
+  const sign = off <= 0 ? "+" : "-";
+  const abs = Math.abs(off);
+  const local = new Date(d.getTime() - off * 60000);
+  return local.toISOString().replace("Z",
+    `${sign}${String(Math.floor(abs / 60)).padStart(2, "0")}:${String(abs % 60).padStart(2, "0")}`);
+}
+
+const noop = () => {};
+
+export function createLogger(hookName, overrideCfg) {
+  const c = overrideCfg || cfg();
+  if (!c.debug) return { log: noop, logError: noop };
+
+  const logPath = c.debugLogPath;
+  ensureDir(logPath);
+
+  function log(stage, data) {
+    writeLine(logPath, { ts: localISO(), hook: hookName, stage, data });
+  }
+
+  function logError(stage, err) {
+    const error = err instanceof Error
+      ? { message: err.message, stack: err.stack }
+      : String(err);
+    writeLine(logPath, { ts: localISO(), hook: hookName, stage, error });
+  }
+
+  return { log, logError };
+}

--- a/examples/claude-code-context-engine/scripts/http-client.mjs
+++ b/examples/claude-code-context-engine/scripts/http-client.mjs
@@ -1,0 +1,172 @@
+/**
+ * Shared OpenViking HTTP client for hook scripts.
+ * Provides session management, search, and content read methods.
+ */
+
+export function createClient(config) {
+  const { baseUrl, apiKey, account, user, agentId, timeoutMs, captureTimeoutMs } = config;
+
+  function headers() {
+    const h = { "Content-Type": "application/json" };
+    if (apiKey) h["X-API-Key"] = apiKey;
+    if (account) h["X-OpenViking-Account"] = account;
+    if (user) h["X-OpenViking-User"] = user;
+    if (agentId) h["X-OpenViking-Agent"] = agentId;
+    return h;
+  }
+
+  async function request(path, init = {}, timeout = timeoutMs) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    try {
+      const res = await fetch(`${baseUrl}${path}`, {
+        ...init,
+        headers: { ...headers(), ...(init.headers || {}) },
+        signal: controller.signal,
+      });
+      const body = await res.json();
+      if (!res.ok || body.status === "error") return null;
+      return body.result ?? body;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  // URI space resolution (mirrors MCP server normalizeTargetUri logic)
+  const USER_RESERVED = new Set(["memories"]);
+  const AGENT_RESERVED = new Set(["memories", "skills", "instructions", "workspaces"]);
+  const spaceCache = {};
+
+  async function resolveScopeSpace(scope) {
+    if (spaceCache[scope]) return spaceCache[scope];
+    let fallbackSpace = "default";
+    try {
+      const status = await request("/api/v1/system/status");
+      if (status && typeof status.user === "string" && status.user.trim()) {
+        fallbackSpace = status.user.trim();
+      }
+    } catch { /* use fallback */ }
+    const reserved = scope === "user" ? USER_RESERVED : AGENT_RESERVED;
+    try {
+      const entries = await request(`/api/v1/fs/ls?uri=${encodeURIComponent(`viking://${scope}`)}&output=original`);
+      if (Array.isArray(entries)) {
+        const spaces = entries
+          .filter(e => e?.isDir)
+          .map(e => (typeof e.name === "string" ? e.name.trim() : ""))
+          .filter(n => n && !n.startsWith(".") && !reserved.has(n));
+        if (spaces.length > 0) {
+          if (spaces.includes(fallbackSpace)) { spaceCache[scope] = fallbackSpace; return fallbackSpace; }
+          if (scope === "user" && spaces.includes("default")) { spaceCache[scope] = "default"; return "default"; }
+          if (spaces.length === 1) { spaceCache[scope] = spaces[0]; return spaces[0]; }
+        }
+      }
+    } catch { /* use fallback */ }
+    spaceCache[scope] = fallbackSpace;
+    return fallbackSpace;
+  }
+
+  async function resolveTargetUri(targetUri) {
+    const trimmed = targetUri.trim().replace(/\/+$/, "");
+    const m = trimmed.match(/^viking:\/\/(user|agent)(?:\/(.*))?$/);
+    if (!m) return trimmed;
+    const scope = m[1];
+    const rawRest = (m[2] ?? "").trim();
+    if (!rawRest) return trimmed;
+    const parts = rawRest.split("/").filter(Boolean);
+    if (parts.length === 0) return trimmed;
+    const reserved = scope === "user" ? USER_RESERVED : AGENT_RESERVED;
+    if (!reserved.has(parts[0])) return trimmed;
+    const space = await resolveScopeSpace(scope);
+    return `viking://${scope}/${space}/${parts.join("/")}`;
+  }
+
+  return {
+    async healthCheck() {
+      const result = await request("/health");
+      return !!result;
+    },
+
+    async find(query, targetUri, limit = 24) {
+      const resolved = await resolveTargetUri(targetUri);
+      const result = await request("/api/v1/search/find", {
+        method: "POST",
+        body: JSON.stringify({ query, target_uri: resolved, limit, score_threshold: 0 }),
+      });
+      return result?.memories || [];
+    },
+
+    async read(uri) {
+      const result = await request(`/api/v1/content/read?uri=${encodeURIComponent(uri)}`);
+      if (result && typeof result === "string" && result.trim()) return result.trim();
+      return null;
+    },
+
+    async createSession(sessionId) {
+      const body = sessionId ? { session_id: sessionId } : {};
+      const result = await request("/api/v1/sessions", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }, captureTimeoutMs);
+      return result?.session_id || null;
+    },
+
+    async getSession(sessionId) {
+      return await request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, {}, captureTimeoutMs);
+    },
+
+    async addSessionMessage(sessionId, role, content) {
+      return await request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`, {
+        method: "POST",
+        body: JSON.stringify({ role, content }),
+      }, captureTimeoutMs);
+    },
+
+    async commitSession(sessionId) {
+      return await request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }, captureTimeoutMs);
+    },
+
+    async getSessionContext(sessionId, tokenBudget = 128000) {
+      return await request(
+        `/api/v1/sessions/${encodeURIComponent(sessionId)}/context?token_budget=${tokenBudget}`,
+        {},
+        captureTimeoutMs,
+      );
+    },
+
+    async getSessionArchive(sessionId, archiveId) {
+      return await request(
+        `/api/v1/sessions/${encodeURIComponent(sessionId)}/archives/${encodeURIComponent(archiveId)}`,
+        {},
+        captureTimeoutMs,
+      );
+    },
+
+    async extractSessionMemories(sessionId) {
+      return await request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/extract`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }, captureTimeoutMs);
+    },
+
+    async deleteSession(sessionId) {
+      return await request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, {
+        method: "DELETE",
+      }, captureTimeoutMs);
+    },
+
+    async deleteUri(uri) {
+      return await request(`/api/v1/fs?uri=${encodeURIComponent(uri)}&recursive=false`, {
+        method: "DELETE",
+      });
+    },
+
+    async getTask(taskId) {
+      return await request(`/api/v1/tasks/${encodeURIComponent(taskId)}`);
+    },
+  };
+}

--- a/examples/claude-code-context-engine/scripts/ranking.mjs
+++ b/examples/claude-code-context-engine/scripts/ranking.mjs
@@ -1,0 +1,97 @@
+/**
+ * Memory ranking, dedup, and query-aware boosting.
+ * Ported from auto-recall.mjs / memory-ranking.ts.
+ */
+
+function clampScore(v) {
+  if (typeof v !== "number" || Number.isNaN(v)) return 0;
+  return Math.max(0, Math.min(1, v));
+}
+
+const PREFERENCE_QUERY_RE = /prefer|preference|favorite|favourite|like|偏好|喜欢|爱好|更倾向/i;
+const TEMPORAL_QUERY_RE = /when|what time|date|day|month|year|yesterday|today|tomorrow|last|next|什么时候|何时|哪天|几月|几年|昨天|今天|明天/i;
+const QUERY_TOKEN_RE = /[a-z0-9\u4e00-\u9fa5]{2,}/gi;
+const STOPWORDS = new Set([
+  "what","when","where","which","who","whom","whose","why","how","did","does",
+  "is","are","was","were","the","and","for","with","from","that","this","your","you",
+]);
+
+export function buildQueryProfile(query) {
+  const text = query.trim();
+  const allTokens = text.toLowerCase().match(QUERY_TOKEN_RE) || [];
+  const tokens = allTokens.filter(t => !STOPWORDS.has(t));
+  return {
+    tokens,
+    wantsPreference: PREFERENCE_QUERY_RE.test(text),
+    wantsTemporal: TEMPORAL_QUERY_RE.test(text),
+  };
+}
+
+function lexicalOverlapBoost(tokens, text) {
+  if (tokens.length === 0 || !text) return 0;
+  const haystack = ` ${text.toLowerCase()} `;
+  let matched = 0;
+  for (const token of tokens.slice(0, 8)) {
+    if (haystack.includes(token)) matched += 1;
+  }
+  return Math.min(0.2, (matched / Math.min(tokens.length, 4)) * 0.2);
+}
+
+function rankForInjection(item, profile) {
+  const base = clampScore(item.score);
+  const abstract = (item.abstract || item.overview || "").trim();
+  const cat = (item.category || "").toLowerCase();
+  const uri = item.uri.toLowerCase();
+  const leafBoost = (item.level === 2 || uri.endsWith(".md")) ? 0.12 : 0;
+  const eventBoost = profile.wantsTemporal && (cat === "events" || uri.includes("/events/")) ? 0.1 : 0;
+  const prefBoost = profile.wantsPreference && (cat === "preferences" || uri.includes("/preferences/")) ? 0.08 : 0;
+  const overlapBoost = lexicalOverlapBoost(profile.tokens, `${item.uri} ${abstract}`);
+  return base + leafBoost + eventBoost + prefBoost + overlapBoost;
+}
+
+/** Post-process: filter leaf-only, apply threshold, dedup by abstract. */
+export function postProcess(items, limit, threshold) {
+  const seen = new Set();
+  const sorted = [...items].sort((a, b) => clampScore(b.score) - clampScore(a.score));
+  const result = [];
+  for (const item of sorted) {
+    if (item.level !== 2) continue;
+    if (clampScore(item.score) < threshold) continue;
+    const cat = (item.category || "").toLowerCase() || "unknown";
+    const abs = (item.abstract || item.overview || "").trim().toLowerCase();
+    const key = abs ? `${cat}:${abs}` : `uri:${item.uri}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+    if (result.length >= limit) break;
+  }
+  return result;
+}
+
+/** Pick best memories for injection with query-aware ranking. */
+export function pickMemories(items, limit, queryText) {
+  if (items.length === 0 || limit <= 0) return [];
+  const profile = buildQueryProfile(queryText);
+  const sorted = [...items].sort((a, b) => rankForInjection(b, profile) - rankForInjection(a, profile));
+
+  // Dedup by abstract
+  const seen = new Set();
+  const deduped = sorted.filter(item => {
+    const key = (item.abstract || item.overview || "").trim().toLowerCase() || item.uri;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const leaves = deduped.filter(m => m.level === 2 || m.uri.endsWith(".md"));
+  if (leaves.length >= limit) return leaves.slice(0, limit);
+
+  const picked = [...leaves];
+  const used = new Set(picked.map(m => m.uri));
+  for (const item of deduped) {
+    if (picked.length >= limit) break;
+    if (used.has(item.uri)) continue;
+    picked.push(item);
+  }
+  return picked;
+}

--- a/examples/claude-code-context-engine/scripts/runtime-common.mjs
+++ b/examples/claude-code-context-engine/scripts/runtime-common.mjs
@@ -1,0 +1,211 @@
+/**
+ * Runtime installation management — ensures MCP server dependencies are installed.
+ * Adapted from claude-code-memory-plugin with paths updated for context-engine.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { access, copyFile, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const INSTALL_TIMEOUT_MS = 120000;
+
+const LOCK_STALE_MS = 10 * 60 * 1000;
+const FALLBACK_PLUGIN_DATA_ROOT = join(homedir(), ".openviking", "claude-code-context-engine");
+
+export function getRuntimePaths() {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const pluginDataRoot = process.env.CLAUDE_PLUGIN_DATA || FALLBACK_PLUGIN_DATA_ROOT;
+
+  if (!pluginRoot) throw new Error("CLAUDE_PLUGIN_ROOT is not set");
+
+  const runtimeRoot = join(pluginDataRoot, "runtime");
+
+  return {
+    pluginRoot,
+    pluginDataRoot,
+    runtimeRoot,
+    sourcePackagePath: join(pluginRoot, "package.json"),
+    sourceLockPath: join(pluginRoot, "package-lock.json"),
+    sourceServerPath: join(pluginRoot, "servers", "context-server.js"),
+    runtimePackagePath: join(runtimeRoot, "package.json"),
+    runtimeLockPath: join(runtimeRoot, "package-lock.json"),
+    runtimeServerPath: join(runtimeRoot, "servers", "context-server.js"),
+    runtimeNodeModulesPath: join(runtimeRoot, "node_modules"),
+    statePath: join(runtimeRoot, "install-state.json"),
+    lockDir: join(runtimeRoot, ".install-lock"),
+    envMetaPath: join(runtimeRoot, ".runtime-env.json"),
+    usingFallbackPluginData: !process.env.CLAUDE_PLUGIN_DATA,
+  };
+}
+
+export async function computeSourceState(paths) {
+  const [pkgRaw, lockRaw, serverRaw] = await Promise.all([
+    readFile(paths.sourcePackagePath),
+    readFile(paths.sourceLockPath),
+    readFile(paths.sourceServerPath),
+  ]);
+  const pkg = JSON.parse(pkgRaw.toString("utf8"));
+  return {
+    pluginVersion: typeof pkg.version === "string" ? pkg.version : "0.0.0",
+    manifestHash: sha256(pkgRaw, lockRaw),
+    serverHash: sha256(serverRaw),
+  };
+}
+
+export async function loadInstallState(paths) {
+  try {
+    return JSON.parse(await readFile(paths.statePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function writeInstallState(paths, state) {
+  await mkdir(paths.runtimeRoot, { recursive: true });
+  await writeFile(
+    paths.statePath,
+    JSON.stringify({ ...state, updatedAt: new Date().toISOString() }, null, 2) + "\n",
+  );
+}
+
+async function writeRuntimeEnvMeta(paths) {
+  await mkdir(paths.runtimeRoot, { recursive: true });
+  await writeFile(
+    paths.envMetaPath,
+    JSON.stringify({
+      pluginDataRoot: paths.pluginDataRoot,
+      runtimeRoot: paths.runtimeRoot,
+      usingFallbackPluginData: paths.usingFallbackPluginData,
+      updatedAt: new Date().toISOString(),
+    }, null, 2) + "\n",
+  );
+}
+
+async function runtimeIsReady(paths, expectedState) {
+  const state = await loadInstallState(paths);
+  if (!state || state.status !== "ready") return false;
+  if (state.manifestHash !== expectedState.manifestHash) return false;
+  if (state.serverHash !== expectedState.serverHash) return false;
+  for (const target of [
+    paths.runtimePackagePath, paths.runtimeLockPath,
+    paths.runtimeServerPath, paths.runtimeNodeModulesPath,
+  ]) {
+    if (!(await pathExists(target))) return false;
+  }
+  return true;
+}
+
+async function syncRuntimeFiles(paths) {
+  await mkdir(join(paths.runtimeRoot, "servers"), { recursive: true });
+  await copyFile(paths.sourcePackagePath, paths.runtimePackagePath);
+  await copyFile(paths.sourceLockPath, paths.runtimeLockPath);
+  await copyFile(paths.sourceServerPath, paths.runtimeServerPath);
+  await writeRuntimeEnvMeta(paths);
+}
+
+async function acquireInstallLock(paths, timeoutMs = INSTALL_TIMEOUT_MS) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    await mkdir(paths.runtimeRoot, { recursive: true });
+    try {
+      await mkdir(paths.lockDir);
+      await writeFile(
+        join(paths.lockDir, "owner.json"),
+        JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }) + "\n",
+      );
+      return async () => { await rm(paths.lockDir, { recursive: true, force: true }); };
+    } catch (err) {
+      if (err?.code !== "EEXIST") throw err;
+      if (await isStaleLock(paths.lockDir)) {
+        await rm(paths.lockDir, { recursive: true, force: true });
+        continue;
+      }
+      await wait(500);
+    }
+  }
+  throw new Error(`Timed out waiting for install lock in ${paths.runtimeRoot}`);
+}
+
+export async function ensureRuntimeInstalled(paths, expectedState) {
+  if (await runtimeIsReady(paths, expectedState)) return false;
+  const releaseLock = await acquireInstallLock(paths, INSTALL_TIMEOUT_MS);
+  try {
+    if (await runtimeIsReady(paths, expectedState)) return false;
+    await syncRuntimeFiles(paths);
+    const result = spawnSync(getNpmCommand(), installArgs(), {
+      cwd: paths.runtimeRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) throw new Error(formatInstallFailure(result));
+    await writeInstallState(paths, {
+      status: "ready",
+      pluginVersion: expectedState.pluginVersion,
+      manifestHash: expectedState.manifestHash,
+      serverHash: expectedState.serverHash,
+      pluginDataRoot: paths.pluginDataRoot,
+      usingFallbackPluginData: paths.usingFallbackPluginData,
+    });
+    return true;
+  } catch (err) {
+    await rm(paths.runtimeNodeModulesPath, { recursive: true, force: true });
+    await writeInstallState(paths, {
+      status: "error",
+      pluginVersion: expectedState.pluginVersion,
+      manifestHash: expectedState.manifestHash,
+      serverHash: expectedState.serverHash,
+      pluginDataRoot: paths.pluginDataRoot,
+      usingFallbackPluginData: paths.usingFallbackPluginData,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  } finally {
+    await releaseLock();
+  }
+}
+
+async function pathExists(target) {
+  try { await access(target, fsConstants.F_OK); return true; } catch { return false; }
+}
+
+async function isStaleLock(lockDir) {
+  try { const info = await stat(lockDir); return Date.now() - info.mtimeMs > LOCK_STALE_MS; } catch { return false; }
+}
+
+function sha256(...buffers) {
+  const hash = createHash("sha256");
+  for (const buf of buffers) hash.update(buf);
+  return hash.digest("hex");
+}
+
+function getNpmCommand() {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function installArgs() {
+  return ["ci", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"];
+}
+
+function formatInstallFailure(result) {
+  const lines = [
+    `npm ci exited with status ${result.status ?? "unknown"}`,
+    trimOutput(result.stderr),
+    trimOutput(result.stdout),
+  ].filter(Boolean);
+  return lines.join("\n");
+}
+
+function trimOutput(output) {
+  if (!output) return "";
+  const text = output.trim();
+  if (!text || text.length <= 4000) return text;
+  return text.slice(-4000);
+}
+
+export function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/examples/claude-code-context-engine/scripts/start-context-server.mjs
+++ b/examples/claude-code-context-engine/scripts/start-context-server.mjs
@@ -1,0 +1,54 @@
+import { spawn } from "node:child_process";
+import {
+  computeSourceState,
+  ensureRuntimeInstalled,
+  getRuntimePaths,
+  loadInstallState,
+} from "./runtime-common.mjs";
+
+async function main() {
+  const paths = getRuntimePaths();
+  const expectedState = await computeSourceState(paths);
+
+  try {
+    await ensureRuntimeInstalled(paths, expectedState);
+  } catch (err) {
+    const state = await loadInstallState(paths);
+    const detail = state?.error ? ` Last install error: ${state.error}` : "";
+    process.stderr.write(
+      `[openviking-context-engine] MCP runtime is not ready in ${paths.runtimeRoot}.${detail}\n`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const child = spawn(process.execPath, [paths.runtimeServerPath], {
+    cwd: paths.runtimeRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, () => {
+      if (!child.killed) child.kill(signal);
+    });
+  }
+
+  child.on("error", (err) => {
+    process.stderr.write(
+      `[openviking-context-engine] Failed to start MCP server: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  });
+
+  child.on("exit", (code) => {
+    process.exit(code ?? 1);
+  });
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `[openviking-context-engine] MCP launcher failed: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/examples/claude-code-context-engine/scripts/state.mjs
+++ b/examples/claude-code-context-engine/scripts/state.mjs
@@ -1,0 +1,57 @@
+/**
+ * Persistent state management for context engine.
+ * Tracks OV session ID, captured turn count, compact timing.
+ * State persisted in $TMPDIR/openviking-cc-context-state/<safe-session-id>.json
+ */
+
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+
+const STATE_DIR = join(tmpdir(), "openviking-cc-context-state");
+
+function safeId(sessionId) {
+  return sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function stateFilePath(sessionId) {
+  return join(STATE_DIR, `${safeId(sessionId)}.json`);
+}
+
+/** Derive a deterministic OV session ID from Claude Code session_id. */
+export function deriveOvSessionId(ccSessionId) {
+  const trimmed = (ccSessionId || "unknown").trim();
+  // If already a UUID, use as-is
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  return createHash("sha256").update(`cc-session:${trimmed}`).digest("hex");
+}
+
+export async function loadState(sessionId) {
+  try {
+    const data = await readFile(stateFilePath(sessionId), "utf-8");
+    return JSON.parse(data);
+  } catch {
+    return {
+      ovSessionId: deriveOvSessionId(sessionId),
+      capturedTurnCount: 0,
+      totalTokensAdded: 0,
+      turnsSinceCommit: 0,
+      lastCommitAt: 0,
+      commitCount: 0,
+      createdAt: Date.now(),
+    };
+  }
+}
+
+export async function saveState(sessionId, state) {
+  try {
+    await mkdir(STATE_DIR, { recursive: true });
+    const path = stateFilePath(sessionId);
+    const tmpPath = path + ".tmp";
+    await writeFile(tmpPath, JSON.stringify(state));
+    await rename(tmpPath, path);
+  } catch { /* best effort */ }
+}

--- a/examples/claude-code-context-engine/scripts/text-utils.mjs
+++ b/examples/claude-code-context-engine/scripts/text-utils.mjs
@@ -1,0 +1,89 @@
+/**
+ * Text processing utilities for transcript parsing and capture decisions.
+ */
+
+const RELEVANT_MEMORIES_BLOCK_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>/gi;
+const OPENVIKING_CONTEXT_BLOCK_RE = /<openviking-context>[\s\S]*?<\/openviking-context>/gi;
+const CJK_CHAR_RE = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\uac00-\ud7af]/;
+
+export function sanitize(text) {
+  return text
+    .replace(RELEVANT_MEMORIES_BLOCK_RE, " ")
+    .replace(OPENVIKING_CONTEXT_BLOCK_RE, " ")
+    .replace(/\u0000/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function parseTranscript(content) {
+  try {
+    const data = JSON.parse(content);
+    if (Array.isArray(data)) return data;
+  } catch { /* not a JSON array */ }
+
+  const lines = content.split("\n").filter(l => l.trim());
+  const messages = [];
+  for (const line of lines) {
+    try { messages.push(JSON.parse(line)); } catch { /* skip */ }
+  }
+  return messages;
+}
+
+export function extractAllTurns(messages) {
+  const turns = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+
+    let role = msg.role;
+    let text = "";
+
+    if (typeof msg.content === "string") {
+      text = msg.content;
+    } else if (Array.isArray(msg.content)) {
+      const textParts = msg.content
+        .filter(b => b && b.type === "text" && typeof b.text === "string")
+        .map(b => b.text);
+      text = textParts.join("\n");
+    } else if (typeof msg.message === "object" && msg.message) {
+      const inner = msg.message;
+      role = inner.role || role;
+      if (typeof inner.content === "string") {
+        text = inner.content;
+      } else if (Array.isArray(inner.content)) {
+        const textParts = inner.content
+          .filter(b => b && b.type === "text" && typeof b.text === "string")
+          .map(b => b.text);
+        text = textParts.join("\n");
+      }
+    }
+
+    if (role !== "user" && role !== "assistant") continue;
+    if (text.trim()) {
+      turns.push({ role, text: text.trim() });
+    }
+  }
+  return turns;
+}
+
+/** Estimate tokens from text (rough: chars / 4). */
+export function estimateTokens(text) {
+  return Math.ceil((text || "").length / 4);
+}
+
+/** Group adjacent same-role turns. */
+export function groupTurns(turns) {
+  if (turns.length === 0) return [];
+  const groups = [];
+  let current = { role: turns[0].role, texts: [turns[0].text] };
+
+  for (let i = 1; i < turns.length; i++) {
+    if (turns[i].role === current.role) {
+      current.texts.push(turns[i].text);
+    } else {
+      groups.push(current);
+      current = { role: turns[i].role, texts: [turns[i].text] };
+    }
+  }
+  groups.push(current);
+  return groups;
+}

--- a/examples/claude-code-context-engine/servers/context-server.js
+++ b/examples/claude-code-context-engine/servers/context-server.js
@@ -1,0 +1,507 @@
+/**
+ * OpenViking Context Engine MCP Server for Claude Code
+ *
+ * Tools:
+ *   - memory_recall   : semantic search across memories
+ *   - memory_store    : extract and persist new memories
+ *   - memory_forget   : delete memories by URI or query
+ *   - memory_health   : health check
+ *   - ov_archive_expand : expand compressed archive to original turns
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+function loadOvConf() {
+    const defaultPath = join(homedir(), ".openviking", "ov.conf");
+    const configPath = resolvePath((process.env.OPENVIKING_CONFIG_FILE || defaultPath).replace(/^~/, homedir()));
+    try {
+        return JSON.parse(readFileSync(configPath, "utf-8"));
+    }
+    catch (err) {
+        const code = err?.code;
+        const msg = code === "ENOENT"
+            ? `Config file not found: ${configPath}`
+            : `Failed to read config: ${configPath}`;
+        process.stderr.write(`[openviking-context-engine] ${msg}\n`);
+        process.exit(1);
+    }
+}
+function num(val, fallback) {
+    if (typeof val === "number" && Number.isFinite(val))
+        return val;
+    if (typeof val === "string" && val.trim()) {
+        const n = Number(val);
+        if (Number.isFinite(n))
+            return n;
+    }
+    return fallback;
+}
+function str(val, fallback) {
+    if (typeof val === "string" && val.trim())
+        return val.trim();
+    return fallback;
+}
+const file = loadOvConf();
+const serverCfg = (file.server ?? {});
+const cc = (file.claude_code ?? {});
+const host = str(serverCfg.host, "127.0.0.1").replace("0.0.0.0", "127.0.0.1");
+const port = Math.floor(num(serverCfg.port, 1933));
+const config = {
+    baseUrl: `http://${host}:${port}`,
+    apiKey: str(serverCfg.root_api_key, ""),
+    account: str(serverCfg.account, "default"),
+    user: str(serverCfg.user, "default"),
+    agentId: str(cc.agentId, "claude-code"),
+    timeoutMs: Math.max(1000, Math.floor(num(cc.timeoutMs, 15000))),
+    recallLimit: Math.max(1, Math.floor(num(cc.recallLimit, 6))),
+    scoreThreshold: Math.min(1, Math.max(0, num(cc.scoreThreshold, 0.01))),
+};
+// ---------------------------------------------------------------------------
+// OpenViking HTTP Client
+// ---------------------------------------------------------------------------
+const MEMORY_URI_PATTERNS = [
+    /^viking:\/\/user\/(?:[^/]+\/)?memories(?:\/|$)/,
+    /^viking:\/\/agent\/(?:[^/]+\/)?memories(?:\/|$)/,
+];
+const USER_STRUCTURE_DIRS = new Set(["memories"]);
+const AGENT_STRUCTURE_DIRS = new Set(["memories", "skills", "instructions", "workspaces"]);
+function md5Short(input) {
+    return createHash("md5").update(input).digest("hex").slice(0, 12);
+}
+function isMemoryUri(uri) {
+    return MEMORY_URI_PATTERNS.some((p) => p.test(uri));
+}
+class OpenVikingClient {
+    baseUrl;
+    apiKey;
+    account;
+    user;
+    agentId;
+    timeoutMs;
+    resolvedSpaceByScope = {};
+    runtimeIdentity = null;
+    constructor(baseUrl, apiKey, account, user, agentId, timeoutMs) {
+        this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+        this.account = account;
+        this.user = user;
+        this.agentId = agentId;
+        this.timeoutMs = timeoutMs;
+    }
+    async request(path, init = {}) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+        try {
+            const headers = new Headers(init.headers ?? {});
+            if (this.apiKey)
+                headers.set("X-API-Key", this.apiKey);
+            if (this.account)
+                headers.set("X-OpenViking-Account", this.account);
+            if (this.user)
+                headers.set("X-OpenViking-User", this.user);
+            if (this.agentId)
+                headers.set("X-OpenViking-Agent", this.agentId);
+            if (init.body && !headers.has("Content-Type"))
+                headers.set("Content-Type", "application/json");
+            const response = await fetch(`${this.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
+            const payload = (await response.json().catch(() => ({})));
+            if (!response.ok || payload.status === "error") {
+                const code = payload.error?.code ? ` [${payload.error.code}]` : "";
+                const message = payload.error?.message ?? `HTTP ${response.status}`;
+                throw new Error(`OpenViking request failed${code}: ${message}`);
+            }
+            return (payload.result ?? payload);
+        }
+        finally {
+            clearTimeout(timer);
+        }
+    }
+    async healthCheck() {
+        try {
+            await this.request("/health");
+            return true;
+        }
+        catch {
+            return false;
+        }
+    }
+    async ls(uri) {
+        return this.request(`/api/v1/fs/ls?uri=${encodeURIComponent(uri)}&output=original`);
+    }
+    async getRuntimeIdentity() {
+        if (this.runtimeIdentity)
+            return this.runtimeIdentity;
+        const fallback = { userId: "default", agentId: this.agentId || "default" };
+        try {
+            const status = await this.request("/api/v1/system/status");
+            const userId = typeof status.user === "string" && status.user.trim() ? status.user.trim() : "default";
+            this.runtimeIdentity = { userId, agentId: this.agentId || "default" };
+            return this.runtimeIdentity;
+        }
+        catch {
+            this.runtimeIdentity = fallback;
+            return fallback;
+        }
+    }
+    async resolveScopeSpace(scope) {
+        const cached = this.resolvedSpaceByScope[scope];
+        if (cached)
+            return cached;
+        const identity = await this.getRuntimeIdentity();
+        const fallbackSpace = scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
+        const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
+        try {
+            const entries = await this.ls(`viking://${scope}`);
+            const spaces = entries.filter((e) => e?.isDir === true).map((e) => (typeof e.name === "string" ? e.name.trim() : "")).filter((n) => n && !n.startsWith(".") && !reservedDirs.has(n));
+            if (spaces.length > 0) {
+                if (spaces.includes(fallbackSpace)) {
+                    this.resolvedSpaceByScope[scope] = fallbackSpace;
+                    return fallbackSpace;
+                }
+                if (scope === "user" && spaces.includes("default")) {
+                    this.resolvedSpaceByScope[scope] = "default";
+                    return "default";
+                }
+                if (spaces.length === 1) {
+                    this.resolvedSpaceByScope[scope] = spaces[0];
+                    return spaces[0];
+                }
+            }
+        }
+        catch { /* fall through */ }
+        this.resolvedSpaceByScope[scope] = fallbackSpace;
+        return fallbackSpace;
+    }
+    async normalizeTargetUri(targetUri) {
+        const trimmed = targetUri.trim().replace(/\/+$/, "");
+        const match = trimmed.match(/^viking:\/\/(user|agent)(?:\/(.*))?$/);
+        if (!match)
+            return trimmed;
+        const scope = match[1];
+        const rawRest = (match[2] ?? "").trim();
+        if (!rawRest)
+            return trimmed;
+        const parts = rawRest.split("/").filter(Boolean);
+        if (parts.length === 0)
+            return trimmed;
+        const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
+        if (!reservedDirs.has(parts[0]))
+            return trimmed;
+        const space = await this.resolveScopeSpace(scope);
+        return `viking://${scope}/${space}/${parts.join("/")}`;
+    }
+    async find(query, options) {
+        const normalizedTargetUri = await this.normalizeTargetUri(options.targetUri);
+        return this.request("/api/v1/search/find", {
+            method: "POST",
+            body: JSON.stringify({ query, target_uri: normalizedTargetUri, limit: options.limit, score_threshold: options.scoreThreshold }),
+        });
+    }
+    async read(uri) {
+        return this.request(`/api/v1/content/read?uri=${encodeURIComponent(uri)}`);
+    }
+    async createSession() {
+        const result = await this.request("/api/v1/sessions", { method: "POST", body: JSON.stringify({}) });
+        return result.session_id;
+    }
+    async addSessionMessage(sessionId, role, content) {
+        await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`, { method: "POST", body: JSON.stringify({ role, content }) });
+    }
+    async extractSessionMemories(sessionId) {
+        return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/extract`, { method: "POST", body: JSON.stringify({}) });
+    }
+    async deleteSession(sessionId) {
+        await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
+    }
+    async deleteUri(uri) {
+        await this.request(`/api/v1/fs?uri=${encodeURIComponent(uri)}&recursive=false`, { method: "DELETE" });
+    }
+    async getSessionArchive(sessionId, archiveId) {
+        return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/archives/${encodeURIComponent(archiveId)}`);
+    }
+}
+// ---------------------------------------------------------------------------
+// Ranking helpers
+// ---------------------------------------------------------------------------
+function clampScore(value) {
+    if (typeof value !== "number" || Number.isNaN(value))
+        return 0;
+    return Math.max(0, Math.min(1, value));
+}
+function getMemoryDedupeKey(item) {
+    const abstract = (item.abstract ?? item.overview ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+    const category = (item.category ?? "").toLowerCase() || "unknown";
+    if (abstract)
+        return `abstract:${category}:${abstract}`;
+    return `uri:${item.uri}`;
+}
+function postProcessMemories(items, options) {
+    const deduped = [];
+    const seen = new Set();
+    const sorted = [...items].sort((a, b) => clampScore(b.score) - clampScore(a.score));
+    for (const item of sorted) {
+        if (options.leafOnly && item.level !== 2)
+            continue;
+        if (clampScore(item.score) < options.scoreThreshold)
+            continue;
+        const key = getMemoryDedupeKey(item);
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        deduped.push(item);
+        if (deduped.length >= options.limit)
+            break;
+    }
+    return deduped;
+}
+function formatMemoryLines(items) {
+    return items.map((item, i) => {
+        const score = clampScore(item.score);
+        const abstract = item.abstract?.trim() || item.overview?.trim() || item.uri;
+        const category = item.category ?? "memory";
+        return `${i + 1}. [${category}] ${abstract} (${(score * 100).toFixed(0)}%)`;
+    }).join("\n");
+}
+const PREFERENCE_QUERY_RE = /prefer|preference|favorite|favourite|like|偏好|喜欢|爱好|更倾向/i;
+const TEMPORAL_QUERY_RE = /when|what time|date|day|month|year|yesterday|today|tomorrow|last|next|什么时候|何时|哪天|几月|几年|昨天|今天|明天/i;
+const QUERY_TOKEN_RE = /[a-z0-9]{2,}/gi;
+const QUERY_TOKEN_STOPWORDS = new Set(["what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does", "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you"]);
+function buildQueryProfile(query) {
+    const text = query.trim();
+    const allTokens = text.toLowerCase().match(QUERY_TOKEN_RE) ?? [];
+    const tokens = allTokens.filter((t) => !QUERY_TOKEN_STOPWORDS.has(t));
+    return { tokens, wantsPreference: PREFERENCE_QUERY_RE.test(text), wantsTemporal: TEMPORAL_QUERY_RE.test(text) };
+}
+function lexicalOverlapBoost(tokens, text) {
+    if (tokens.length === 0 || !text)
+        return 0;
+    const haystack = ` ${text.toLowerCase()} `;
+    let matched = 0;
+    for (const token of tokens.slice(0, 8)) {
+        if (haystack.includes(token))
+            matched += 1;
+    }
+    return Math.min(0.2, (matched / Math.min(tokens.length, 4)) * 0.2);
+}
+function rankForInjection(item, query) {
+    const baseScore = clampScore(item.score);
+    const abstract = (item.abstract ?? item.overview ?? "").trim();
+    const leafBoost = item.level === 2 ? 0.12 : 0;
+    const cat = (item.category ?? "").toLowerCase();
+    const eventBoost = query.wantsTemporal && (cat === "events" || item.uri.includes("/events/")) ? 0.1 : 0;
+    const prefBoost = query.wantsPreference && (cat === "preferences" || item.uri.includes("/preferences/")) ? 0.08 : 0;
+    const overlapBoost = lexicalOverlapBoost(query.tokens, `${item.uri} ${abstract}`);
+    return baseScore + leafBoost + eventBoost + prefBoost + overlapBoost;
+}
+function pickMemoriesForInjection(items, limit, queryText) {
+    if (items.length === 0 || limit <= 0)
+        return [];
+    const query = buildQueryProfile(queryText);
+    const sorted = [...items].sort((a, b) => rankForInjection(b, query) - rankForInjection(a, query));
+    const deduped = [];
+    const seen = new Set();
+    for (const item of sorted) {
+        const key = (item.abstract ?? item.overview ?? "").trim().toLowerCase() || item.uri;
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        deduped.push(item);
+    }
+    const leaves = deduped.filter((item) => item.level === 2);
+    if (leaves.length >= limit)
+        return leaves.slice(0, limit);
+    const picked = [...leaves];
+    const used = new Set(leaves.map((item) => item.uri));
+    for (const item of deduped) {
+        if (picked.length >= limit)
+            break;
+        if (used.has(item.uri))
+            continue;
+        picked.push(item);
+    }
+    return picked;
+}
+// ---------------------------------------------------------------------------
+// Shared search
+// ---------------------------------------------------------------------------
+async function searchBothScopes(client, query, limit) {
+    const [userSettled, agentSettled] = await Promise.allSettled([
+        client.find(query, { targetUri: "viking://user/memories", limit, scoreThreshold: 0 }),
+        client.find(query, { targetUri: "viking://agent/memories", limit, scoreThreshold: 0 }),
+    ]);
+    const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
+    const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
+    const all = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
+    return all.filter((m, i, self) => i === self.findIndex((o) => o.uri === m.uri)).filter((m) => m.level === 2);
+}
+// ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+const client = new OpenVikingClient(config.baseUrl, config.apiKey, config.account, config.user, config.agentId, config.timeoutMs);
+const server = new McpServer({ name: "openviking-context-engine", version: "0.2.0" });
+// -- Tool: memory_recall --
+server.tool("memory_recall", "Search long-term memories from OpenViking. Use when you need past user preferences, facts, decisions, or any previously stored information.", {
+    query: z.string().describe("Search query - describe what you want to recall"),
+    limit: z.number().optional().describe("Max results to return (default: 6)"),
+    score_threshold: z.number().optional().describe("Min relevance score 0-1 (default: 0.01)"),
+    target_uri: z.string().optional().describe("Search scope URI, e.g. viking://user/memories"),
+}, async ({ query, limit, score_threshold, target_uri }) => {
+    const recallLimit = limit ?? config.recallLimit;
+    const threshold = score_threshold ?? config.scoreThreshold;
+    const candidateLimit = Math.max(recallLimit * 4, 20);
+    let leafMemories;
+    if (target_uri) {
+        const result = await client.find(query, { targetUri: target_uri, limit: candidateLimit, scoreThreshold: 0 });
+        leafMemories = (result.memories ?? []).filter((m) => m.level === 2);
+    }
+    else {
+        leafMemories = await searchBothScopes(client, query, candidateLimit);
+    }
+    const processed = postProcessMemories(leafMemories, { limit: candidateLimit, scoreThreshold: threshold });
+    const memories = pickMemoriesForInjection(processed, recallLimit, query);
+    if (memories.length === 0) {
+        return { content: [{ type: "text", text: "No relevant memories found in OpenViking." }] };
+    }
+    const lines = await Promise.all(memories.map(async (item) => {
+        if (item.level === 2) {
+            try {
+                const content = await client.read(item.uri);
+                if (content?.trim())
+                    return `- [${item.category ?? "memory"}] ${content.trim()}`;
+            }
+            catch { /* fallback */ }
+        }
+        return `- [${item.category ?? "memory"}] ${item.abstract ?? item.uri}`;
+    }));
+    return {
+        content: [{
+                type: "text",
+                text: `Found ${memories.length} relevant memories:\n\n${lines.join("\n")}\n\n---\n${formatMemoryLines(memories)}`,
+            }],
+    };
+});
+// -- Tool: memory_store --
+server.tool("memory_store", "Store information into OpenViking long-term memory. Use when the user says 'remember this', shares preferences, important facts, decisions, or any information worth persisting across sessions.", {
+    text: z.string().describe("The information to store as memory"),
+    role: z.string().optional().describe("Message role: 'user' (default) or 'assistant'"),
+}, async ({ text, role }) => {
+    const msgRole = role || "user";
+    let sessionId;
+    try {
+        sessionId = await client.createSession();
+        await client.addSessionMessage(sessionId, msgRole, text);
+        const extracted = await client.extractSessionMemories(sessionId);
+        if (extracted.length === 0) {
+            return { content: [{ type: "text", text: "Memory stored but extraction returned 0 memories." }] };
+        }
+        return { content: [{ type: "text", text: `Successfully extracted ${extracted.length} memory/memories and stored them in OpenViking.` }] };
+    }
+    finally {
+        if (sessionId) {
+            await client.deleteSession(sessionId).catch(() => { });
+        }
+    }
+});
+// -- Tool: memory_forget --
+server.tool("memory_forget", "Delete a memory from OpenViking. Provide an exact URI for direct deletion, or a search query to find and delete matching memories.", {
+    uri: z.string().optional().describe("Exact viking:// memory URI to delete"),
+    query: z.string().optional().describe("Search query to find the memory to delete"),
+    target_uri: z.string().optional().describe("Search scope URI (default: viking://user/memories)"),
+}, async ({ uri, query, target_uri }) => {
+    if (uri) {
+        if (!isMemoryUri(uri)) {
+            return { content: [{ type: "text", text: `Refusing to delete non-memory URI: ${uri}` }] };
+        }
+        await client.deleteUri(uri);
+        return { content: [{ type: "text", text: `Deleted memory: ${uri}` }] };
+    }
+    if (!query) {
+        return { content: [{ type: "text", text: "Please provide either a uri or query parameter." }] };
+    }
+    const candidateLimit = 20;
+    let candidates;
+    if (target_uri) {
+        const result = await client.find(query, { targetUri: target_uri, limit: candidateLimit, scoreThreshold: 0 });
+        candidates = postProcessMemories(result.memories ?? [], { limit: candidateLimit, scoreThreshold: config.scoreThreshold, leafOnly: true }).filter((item) => isMemoryUri(item.uri));
+    }
+    else {
+        const leafMemories = await searchBothScopes(client, query, candidateLimit);
+        candidates = postProcessMemories(leafMemories, { limit: candidateLimit, scoreThreshold: config.scoreThreshold, leafOnly: true }).filter((item) => isMemoryUri(item.uri));
+    }
+    if (candidates.length === 0) {
+        return { content: [{ type: "text", text: "No matching memories found. Try a more specific query." }] };
+    }
+    const top = candidates[0];
+    if (candidates.length === 1 && clampScore(top.score) >= 0.85) {
+        await client.deleteUri(top.uri);
+        return { content: [{ type: "text", text: `Deleted memory: ${top.uri}` }] };
+    }
+    const list = candidates.map((item) => `- ${item.uri} — ${item.abstract?.trim() || "?"} (${(clampScore(item.score) * 100).toFixed(0)}%)`).join("\n");
+    return { content: [{ type: "text", text: `Found ${candidates.length} candidate memories. Please specify the exact URI to delete:\n\n${list}` }] };
+});
+// -- Tool: memory_health --
+server.tool("memory_health", "Check whether the OpenViking memory server is reachable and healthy.", {}, async () => {
+    const ok = await client.healthCheck();
+    return {
+        content: [{
+                type: "text",
+                text: ok
+                    ? `OpenViking is healthy (${config.baseUrl})`
+                    : `OpenViking is unreachable at ${config.baseUrl}. Please check if the server is running.`,
+            }],
+    };
+});
+// -- Tool: ov_archive_expand -- (NEW)
+server.tool("ov_archive_expand", "Expand a compressed session archive to retrieve original conversation turns. Use this when you see an Archive Index in the context and need original details from a specific archive.", {
+    session_id: z.string().describe("The OV session ID (shown in session context)"),
+    archive_id: z.string().describe("The archive ID to expand (e.g. 'archive_001' from the Archive Index)"),
+}, async ({ session_id, archive_id }) => {
+    try {
+        const archive = await client.getSessionArchive(session_id, archive_id);
+        if (!archive) {
+            return { content: [{ type: "text", text: `Archive '${archive_id}' not found in session '${session_id}'.` }] };
+        }
+        // Format archive content
+        const messages = archive.messages;
+        if (!messages || messages.length === 0) {
+            return { content: [{ type: "text", text: `Archive '${archive_id}' is empty.` }] };
+        }
+        const lines = messages.map((msg, i) => {
+            const role = msg.role || "unknown";
+            const parts = msg.parts || [];
+            const textParts = parts
+                .map((p) => {
+                if (p.type === "text")
+                    return p.text || "";
+                if (p.type === "tool")
+                    return `[tool: ${p.tool_name}] input=${JSON.stringify(p.tool_input)} output=${(p.tool_output || "").slice(0, 500)}`;
+                return "";
+            })
+                .filter(Boolean)
+                .join("\n");
+            return `--- Message ${i + 1} [${role}] ---\n${textParts}`;
+        });
+        return {
+            content: [{
+                    type: "text",
+                    text: `Archive '${archive_id}' contains ${messages.length} messages:\n\n${lines.join("\n\n")}`,
+                }],
+        };
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Failed to expand archive: ${message}` }] };
+    }
+});
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/examples/claude-code-context-engine/src/context-server.ts
+++ b/examples/claude-code-context-engine/src/context-server.ts
@@ -1,0 +1,548 @@
+/**
+ * OpenViking Context Engine MCP Server for Claude Code
+ *
+ * Tools:
+ *   - memory_recall   : semantic search across memories
+ *   - memory_store    : extract and persist new memories
+ *   - memory_forget   : delete memories by URI or query
+ *   - memory_health   : health check
+ *   - ov_archive_expand : expand compressed archive to original turns
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+function loadOvConf(): Record<string, unknown> {
+  const defaultPath = join(homedir(), ".openviking", "ov.conf");
+  const configPath = resolvePath(
+    (process.env.OPENVIKING_CONFIG_FILE || defaultPath).replace(/^~/, homedir()),
+  );
+  try {
+    return JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err: unknown) {
+    const code = (err as { code?: string })?.code;
+    const msg = code === "ENOENT"
+      ? `Config file not found: ${configPath}`
+      : `Failed to read config: ${configPath}`;
+    process.stderr.write(`[openviking-context-engine] ${msg}\n`);
+    process.exit(1);
+  }
+}
+
+function num(val: unknown, fallback: number): number {
+  if (typeof val === "number" && Number.isFinite(val)) return val;
+  if (typeof val === "string" && val.trim()) {
+    const n = Number(val);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+function str(val: unknown, fallback: string): string {
+  if (typeof val === "string" && val.trim()) return val.trim();
+  return fallback;
+}
+
+const file = loadOvConf();
+const serverCfg = (file.server ?? {}) as Record<string, unknown>;
+const cc = (file.claude_code ?? {}) as Record<string, unknown>;
+
+const host = str(serverCfg.host, "127.0.0.1").replace("0.0.0.0", "127.0.0.1");
+const port = Math.floor(num(serverCfg.port, 1933));
+
+const config = {
+  baseUrl: `http://${host}:${port}`,
+  apiKey: str(serverCfg.root_api_key, ""),
+  account: str(serverCfg.account, "default"),
+  user: str(serverCfg.user, "default"),
+  agentId: str(cc.agentId, "claude-code"),
+  timeoutMs: Math.max(1000, Math.floor(num(cc.timeoutMs, 15000))),
+  recallLimit: Math.max(1, Math.floor(num(cc.recallLimit, 6))),
+  scoreThreshold: Math.min(1, Math.max(0, num(cc.scoreThreshold, 0.01))),
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type FindResultItem = {
+  uri: string;
+  level?: number;
+  abstract?: string;
+  overview?: string;
+  category?: string;
+  score?: number;
+};
+
+type ScopeName = "user" | "agent";
+
+// ---------------------------------------------------------------------------
+// OpenViking HTTP Client
+// ---------------------------------------------------------------------------
+
+const MEMORY_URI_PATTERNS = [
+  /^viking:\/\/user\/(?:[^/]+\/)?memories(?:\/|$)/,
+  /^viking:\/\/agent\/(?:[^/]+\/)?memories(?:\/|$)/,
+];
+const USER_STRUCTURE_DIRS = new Set(["memories"]);
+const AGENT_STRUCTURE_DIRS = new Set(["memories", "skills", "instructions", "workspaces"]);
+
+function md5Short(input: string): string {
+  return createHash("md5").update(input).digest("hex").slice(0, 12);
+}
+
+function isMemoryUri(uri: string): boolean {
+  return MEMORY_URI_PATTERNS.some((p) => p.test(uri));
+}
+
+class OpenVikingClient {
+  private resolvedSpaceByScope: Partial<Record<ScopeName, string>> = {};
+  private runtimeIdentity: { userId: string; agentId: string } | null = null;
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+    private readonly account: string,
+    private readonly user: string,
+    private readonly agentId: string,
+    private readonly timeoutMs: number,
+  ) {}
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const headers = new Headers(init.headers ?? {});
+      if (this.apiKey) headers.set("X-API-Key", this.apiKey);
+      if (this.account) headers.set("X-OpenViking-Account", this.account);
+      if (this.user) headers.set("X-OpenViking-User", this.user);
+      if (this.agentId) headers.set("X-OpenViking-Agent", this.agentId);
+      if (init.body && !headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+      const response = await fetch(`${this.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
+      const payload = (await response.json().catch(() => ({}))) as {
+        status?: string; result?: T; error?: { code?: string; message?: string };
+      };
+      if (!response.ok || payload.status === "error") {
+        const code = payload.error?.code ? ` [${payload.error.code}]` : "";
+        const message = payload.error?.message ?? `HTTP ${response.status}`;
+        throw new Error(`OpenViking request failed${code}: ${message}`);
+      }
+      return (payload.result ?? payload) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try { await this.request<{ status: string }>("/health"); return true; } catch { return false; }
+  }
+
+  private async ls(uri: string): Promise<Array<Record<string, unknown>>> {
+    return this.request<Array<Record<string, unknown>>>(`/api/v1/fs/ls?uri=${encodeURIComponent(uri)}&output=original`);
+  }
+
+  private async getRuntimeIdentity(): Promise<{ userId: string; agentId: string }> {
+    if (this.runtimeIdentity) return this.runtimeIdentity;
+    const fallback = { userId: "default", agentId: this.agentId || "default" };
+    try {
+      const status = await this.request<{ user?: unknown }>("/api/v1/system/status");
+      const userId = typeof status.user === "string" && status.user.trim() ? status.user.trim() : "default";
+      this.runtimeIdentity = { userId, agentId: this.agentId || "default" };
+      return this.runtimeIdentity;
+    } catch {
+      this.runtimeIdentity = fallback;
+      return fallback;
+    }
+  }
+
+  private async resolveScopeSpace(scope: ScopeName): Promise<string> {
+    const cached = this.resolvedSpaceByScope[scope];
+    if (cached) return cached;
+    const identity = await this.getRuntimeIdentity();
+    const fallbackSpace = scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
+    const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
+    try {
+      const entries = await this.ls(`viking://${scope}`);
+      const spaces = entries.filter((e) => e?.isDir === true).map((e) => (typeof e.name === "string" ? e.name.trim() : "")).filter((n) => n && !n.startsWith(".") && !reservedDirs.has(n));
+      if (spaces.length > 0) {
+        if (spaces.includes(fallbackSpace)) { this.resolvedSpaceByScope[scope] = fallbackSpace; return fallbackSpace; }
+        if (scope === "user" && spaces.includes("default")) { this.resolvedSpaceByScope[scope] = "default"; return "default"; }
+        if (spaces.length === 1) { this.resolvedSpaceByScope[scope] = spaces[0]!; return spaces[0]!; }
+      }
+    } catch { /* fall through */ }
+    this.resolvedSpaceByScope[scope] = fallbackSpace;
+    return fallbackSpace;
+  }
+
+  private async normalizeTargetUri(targetUri: string): Promise<string> {
+    const trimmed = targetUri.trim().replace(/\/+$/, "");
+    const match = trimmed.match(/^viking:\/\/(user|agent)(?:\/(.*))?$/);
+    if (!match) return trimmed;
+    const scope = match[1] as ScopeName;
+    const rawRest = (match[2] ?? "").trim();
+    if (!rawRest) return trimmed;
+    const parts = rawRest.split("/").filter(Boolean);
+    if (parts.length === 0) return trimmed;
+    const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
+    if (!reservedDirs.has(parts[0]!)) return trimmed;
+    const space = await this.resolveScopeSpace(scope);
+    return `viking://${scope}/${space}/${parts.join("/")}`;
+  }
+
+  async find(query: string, options: { targetUri: string; limit: number; scoreThreshold?: number }): Promise<{ memories?: FindResultItem[] }> {
+    const normalizedTargetUri = await this.normalizeTargetUri(options.targetUri);
+    return this.request("/api/v1/search/find", {
+      method: "POST",
+      body: JSON.stringify({ query, target_uri: normalizedTargetUri, limit: options.limit, score_threshold: options.scoreThreshold }),
+    });
+  }
+
+  async read(uri: string): Promise<string> {
+    return this.request<string>(`/api/v1/content/read?uri=${encodeURIComponent(uri)}`);
+  }
+
+  async createSession(): Promise<string> {
+    const result = await this.request<{ session_id: string }>("/api/v1/sessions", { method: "POST", body: JSON.stringify({}) });
+    return result.session_id;
+  }
+
+  async addSessionMessage(sessionId: string, role: string, content: string): Promise<void> {
+    await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`, { method: "POST", body: JSON.stringify({ role, content }) });
+  }
+
+  async extractSessionMemories(sessionId: string): Promise<Array<Record<string, unknown>>> {
+    return this.request<Array<Record<string, unknown>>>(`/api/v1/sessions/${encodeURIComponent(sessionId)}/extract`, { method: "POST", body: JSON.stringify({}) });
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
+  }
+
+  async deleteUri(uri: string): Promise<void> {
+    await this.request(`/api/v1/fs?uri=${encodeURIComponent(uri)}&recursive=false`, { method: "DELETE" });
+  }
+
+  async getSessionArchive(sessionId: string, archiveId: string): Promise<Record<string, unknown>> {
+    return this.request<Record<string, unknown>>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/archives/${encodeURIComponent(archiveId)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ranking helpers
+// ---------------------------------------------------------------------------
+
+function clampScore(value: number | undefined): number {
+  if (typeof value !== "number" || Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function getMemoryDedupeKey(item: FindResultItem): string {
+  const abstract = (item.abstract ?? item.overview ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+  const category = (item.category ?? "").toLowerCase() || "unknown";
+  if (abstract) return `abstract:${category}:${abstract}`;
+  return `uri:${item.uri}`;
+}
+
+function postProcessMemories(items: FindResultItem[], options: { limit: number; scoreThreshold: number; leafOnly?: boolean }): FindResultItem[] {
+  const deduped: FindResultItem[] = [];
+  const seen = new Set<string>();
+  const sorted = [...items].sort((a, b) => clampScore(b.score) - clampScore(a.score));
+  for (const item of sorted) {
+    if (options.leafOnly && item.level !== 2) continue;
+    if (clampScore(item.score) < options.scoreThreshold) continue;
+    const key = getMemoryDedupeKey(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(item);
+    if (deduped.length >= options.limit) break;
+  }
+  return deduped;
+}
+
+function formatMemoryLines(items: FindResultItem[]): string {
+  return items.map((item, i) => {
+    const score = clampScore(item.score);
+    const abstract = item.abstract?.trim() || item.overview?.trim() || item.uri;
+    const category = item.category ?? "memory";
+    return `${i + 1}. [${category}] ${abstract} (${(score * 100).toFixed(0)}%)`;
+  }).join("\n");
+}
+
+const PREFERENCE_QUERY_RE = /prefer|preference|favorite|favourite|like|偏好|喜欢|爱好|更倾向/i;
+const TEMPORAL_QUERY_RE = /when|what time|date|day|month|year|yesterday|today|tomorrow|last|next|什么时候|何时|哪天|几月|几年|昨天|今天|明天/i;
+const QUERY_TOKEN_RE = /[a-z0-9]{2,}/gi;
+const QUERY_TOKEN_STOPWORDS = new Set(["what","when","where","which","who","whom","whose","why","how","did","does","is","are","was","were","the","and","for","with","from","that","this","your","you"]);
+
+function buildQueryProfile(query: string) {
+  const text = query.trim();
+  const allTokens = text.toLowerCase().match(QUERY_TOKEN_RE) ?? [];
+  const tokens = allTokens.filter((t) => !QUERY_TOKEN_STOPWORDS.has(t));
+  return { tokens, wantsPreference: PREFERENCE_QUERY_RE.test(text), wantsTemporal: TEMPORAL_QUERY_RE.test(text) };
+}
+
+function lexicalOverlapBoost(tokens: string[], text: string): number {
+  if (tokens.length === 0 || !text) return 0;
+  const haystack = ` ${text.toLowerCase()} `;
+  let matched = 0;
+  for (const token of tokens.slice(0, 8)) { if (haystack.includes(token)) matched += 1; }
+  return Math.min(0.2, (matched / Math.min(tokens.length, 4)) * 0.2);
+}
+
+function rankForInjection(item: FindResultItem, query: ReturnType<typeof buildQueryProfile>): number {
+  const baseScore = clampScore(item.score);
+  const abstract = (item.abstract ?? item.overview ?? "").trim();
+  const leafBoost = item.level === 2 ? 0.12 : 0;
+  const cat = (item.category ?? "").toLowerCase();
+  const eventBoost = query.wantsTemporal && (cat === "events" || item.uri.includes("/events/")) ? 0.1 : 0;
+  const prefBoost = query.wantsPreference && (cat === "preferences" || item.uri.includes("/preferences/")) ? 0.08 : 0;
+  const overlapBoost = lexicalOverlapBoost(query.tokens, `${item.uri} ${abstract}`);
+  return baseScore + leafBoost + eventBoost + prefBoost + overlapBoost;
+}
+
+function pickMemoriesForInjection(items: FindResultItem[], limit: number, queryText: string): FindResultItem[] {
+  if (items.length === 0 || limit <= 0) return [];
+  const query = buildQueryProfile(queryText);
+  const sorted = [...items].sort((a, b) => rankForInjection(b, query) - rankForInjection(a, query));
+  const deduped: FindResultItem[] = [];
+  const seen = new Set<string>();
+  for (const item of sorted) {
+    const key = (item.abstract ?? item.overview ?? "").trim().toLowerCase() || item.uri;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(item);
+  }
+  const leaves = deduped.filter((item) => item.level === 2);
+  if (leaves.length >= limit) return leaves.slice(0, limit);
+  const picked = [...leaves];
+  const used = new Set(leaves.map((item) => item.uri));
+  for (const item of deduped) {
+    if (picked.length >= limit) break;
+    if (used.has(item.uri)) continue;
+    picked.push(item);
+  }
+  return picked;
+}
+
+// ---------------------------------------------------------------------------
+// Shared search
+// ---------------------------------------------------------------------------
+
+async function searchBothScopes(client: OpenVikingClient, query: string, limit: number): Promise<FindResultItem[]> {
+  const [userSettled, agentSettled] = await Promise.allSettled([
+    client.find(query, { targetUri: "viking://user/memories", limit, scoreThreshold: 0 }),
+    client.find(query, { targetUri: "viking://agent/memories", limit, scoreThreshold: 0 }),
+  ]);
+  const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
+  const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
+  const all = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
+  return all.filter((m, i, self) => i === self.findIndex((o) => o.uri === m.uri)).filter((m) => m.level === 2);
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+
+const client = new OpenVikingClient(config.baseUrl, config.apiKey, config.account, config.user, config.agentId, config.timeoutMs);
+const server = new McpServer({ name: "openviking-context-engine", version: "0.2.0" });
+
+// -- Tool: memory_recall --
+server.tool(
+  "memory_recall",
+  "Search long-term memories from OpenViking. Use when you need past user preferences, facts, decisions, or any previously stored information.",
+  {
+    query: z.string().describe("Search query - describe what you want to recall"),
+    limit: z.number().optional().describe("Max results to return (default: 6)"),
+    score_threshold: z.number().optional().describe("Min relevance score 0-1 (default: 0.01)"),
+    target_uri: z.string().optional().describe("Search scope URI, e.g. viking://user/memories"),
+  },
+  async ({ query, limit, score_threshold, target_uri }) => {
+    const recallLimit = limit ?? config.recallLimit;
+    const threshold = score_threshold ?? config.scoreThreshold;
+    const candidateLimit = Math.max(recallLimit * 4, 20);
+
+    let leafMemories: FindResultItem[];
+    if (target_uri) {
+      const result = await client.find(query, { targetUri: target_uri, limit: candidateLimit, scoreThreshold: 0 });
+      leafMemories = (result.memories ?? []).filter((m) => m.level === 2);
+    } else {
+      leafMemories = await searchBothScopes(client, query, candidateLimit);
+    }
+
+    const processed = postProcessMemories(leafMemories, { limit: candidateLimit, scoreThreshold: threshold });
+    const memories = pickMemoriesForInjection(processed, recallLimit, query);
+
+    if (memories.length === 0) {
+      return { content: [{ type: "text" as const, text: "No relevant memories found in OpenViking." }] };
+    }
+
+    const lines = await Promise.all(
+      memories.map(async (item) => {
+        if (item.level === 2) {
+          try {
+            const content = await client.read(item.uri);
+            if (content?.trim()) return `- [${item.category ?? "memory"}] ${content.trim()}`;
+          } catch { /* fallback */ }
+        }
+        return `- [${item.category ?? "memory"}] ${item.abstract ?? item.uri}`;
+      }),
+    );
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Found ${memories.length} relevant memories:\n\n${lines.join("\n")}\n\n---\n${formatMemoryLines(memories)}`,
+      }],
+    };
+  },
+);
+
+// -- Tool: memory_store --
+server.tool(
+  "memory_store",
+  "Store information into OpenViking long-term memory. Use when the user says 'remember this', shares preferences, important facts, decisions, or any information worth persisting across sessions.",
+  {
+    text: z.string().describe("The information to store as memory"),
+    role: z.string().optional().describe("Message role: 'user' (default) or 'assistant'"),
+  },
+  async ({ text, role }) => {
+    const msgRole = role || "user";
+    let sessionId: string | undefined;
+    try {
+      sessionId = await client.createSession();
+      await client.addSessionMessage(sessionId, msgRole, text);
+      const extracted = await client.extractSessionMemories(sessionId);
+      if (extracted.length === 0) {
+        return { content: [{ type: "text" as const, text: "Memory stored but extraction returned 0 memories." }] };
+      }
+      return { content: [{ type: "text" as const, text: `Successfully extracted ${extracted.length} memory/memories and stored them in OpenViking.` }] };
+    } finally {
+      if (sessionId) { await client.deleteSession(sessionId).catch(() => {}); }
+    }
+  },
+);
+
+// -- Tool: memory_forget --
+server.tool(
+  "memory_forget",
+  "Delete a memory from OpenViking. Provide an exact URI for direct deletion, or a search query to find and delete matching memories.",
+  {
+    uri: z.string().optional().describe("Exact viking:// memory URI to delete"),
+    query: z.string().optional().describe("Search query to find the memory to delete"),
+    target_uri: z.string().optional().describe("Search scope URI (default: viking://user/memories)"),
+  },
+  async ({ uri, query, target_uri }) => {
+    if (uri) {
+      if (!isMemoryUri(uri)) {
+        return { content: [{ type: "text" as const, text: `Refusing to delete non-memory URI: ${uri}` }] };
+      }
+      await client.deleteUri(uri);
+      return { content: [{ type: "text" as const, text: `Deleted memory: ${uri}` }] };
+    }
+    if (!query) {
+      return { content: [{ type: "text" as const, text: "Please provide either a uri or query parameter." }] };
+    }
+    const candidateLimit = 20;
+    let candidates: FindResultItem[];
+    if (target_uri) {
+      const result = await client.find(query, { targetUri: target_uri, limit: candidateLimit, scoreThreshold: 0 });
+      candidates = postProcessMemories(result.memories ?? [], { limit: candidateLimit, scoreThreshold: config.scoreThreshold, leafOnly: true }).filter((item) => isMemoryUri(item.uri));
+    } else {
+      const leafMemories = await searchBothScopes(client, query, candidateLimit);
+      candidates = postProcessMemories(leafMemories, { limit: candidateLimit, scoreThreshold: config.scoreThreshold, leafOnly: true }).filter((item) => isMemoryUri(item.uri));
+    }
+    if (candidates.length === 0) {
+      return { content: [{ type: "text" as const, text: "No matching memories found. Try a more specific query." }] };
+    }
+    const top = candidates[0]!;
+    if (candidates.length === 1 && clampScore(top.score) >= 0.85) {
+      await client.deleteUri(top.uri);
+      return { content: [{ type: "text" as const, text: `Deleted memory: ${top.uri}` }] };
+    }
+    const list = candidates.map((item) => `- ${item.uri} — ${item.abstract?.trim() || "?"} (${(clampScore(item.score) * 100).toFixed(0)}%)`).join("\n");
+    return { content: [{ type: "text" as const, text: `Found ${candidates.length} candidate memories. Please specify the exact URI to delete:\n\n${list}` }] };
+  },
+);
+
+// -- Tool: memory_health --
+server.tool(
+  "memory_health",
+  "Check whether the OpenViking memory server is reachable and healthy.",
+  {},
+  async () => {
+    const ok = await client.healthCheck();
+    return {
+      content: [{
+        type: "text" as const,
+        text: ok
+          ? `OpenViking is healthy (${config.baseUrl})`
+          : `OpenViking is unreachable at ${config.baseUrl}. Please check if the server is running.`,
+      }],
+    };
+  },
+);
+
+// -- Tool: ov_archive_expand -- (NEW)
+server.tool(
+  "ov_archive_expand",
+  "Expand a compressed session archive to retrieve original conversation turns. Use this when you see an Archive Index in the context and need original details from a specific archive.",
+  {
+    session_id: z.string().describe("The OV session ID (shown in session context)"),
+    archive_id: z.string().describe("The archive ID to expand (e.g. 'archive_001' from the Archive Index)"),
+  },
+  async ({ session_id, archive_id }) => {
+    try {
+      const archive = await client.getSessionArchive(session_id, archive_id);
+      if (!archive) {
+        return { content: [{ type: "text" as const, text: `Archive '${archive_id}' not found in session '${session_id}'.` }] };
+      }
+
+      // Format archive content
+      const messages = (archive as { messages?: Array<{ role?: string; parts?: Array<{ type?: string; text?: string; tool_name?: string; tool_input?: unknown; tool_output?: string }> }> }).messages;
+      if (!messages || messages.length === 0) {
+        return { content: [{ type: "text" as const, text: `Archive '${archive_id}' is empty.` }] };
+      }
+
+      const lines = messages.map((msg, i) => {
+        const role = msg.role || "unknown";
+        const parts = msg.parts || [];
+        const textParts = parts
+          .map((p) => {
+            if (p.type === "text") return p.text || "";
+            if (p.type === "tool") return `[tool: ${p.tool_name}] input=${JSON.stringify(p.tool_input)} output=${(p.tool_output || "").slice(0, 500)}`;
+            return "";
+          })
+          .filter(Boolean)
+          .join("\n");
+        return `--- Message ${i + 1} [${role}] ---\n${textParts}`;
+      });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: `Archive '${archive_id}' contains ${messages.length} messages:\n\n${lines.join("\n\n")}`,
+        }],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text" as const, text: `Failed to expand archive: ${message}` }] };
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/examples/claude-code-context-engine/tsconfig.json
+++ b/examples/claude-code-context-engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./servers",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- New plugin `examples/claude-code-context-engine/` implementing the full OpenViking session pipeline for Claude Code
- Persistent sessions with incremental turn capture (afterTurn via Stop hook)
- Context assembly with archive summaries + memory recall (assemble via UserPromptSubmit hook)
- Compact thresholds: tokens >= 20k, turns >= 20, interval >= 30min, tokensAdded >= 30k
- MCP server with 5 tools: memory_recall, memory_store, memory_forget, memory_health, ov_archive_expand (new)

## Test plan
- [x] API calls verified against running OpenViking server
- [x] `assemble.mjs` tested: finds memories, returns context
- [x] `after-turn.mjs` tested: captures turns incrementally to persistent OV session
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)