### PR TITLE
fix: protect global watch-task control files from non-root access

### DIFF
--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -14,6 +14,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from openviking.resource.watch_storage import (
+    WATCH_TASK_STORAGE_BAK_URI,
+    WATCH_TASK_STORAGE_TMP_URI,
+    WATCH_TASK_STORAGE_URI,
+)
 from openviking_cli.exceptions import ConflictError, NotFoundError
 from openviking_cli.utils.logger import get_logger
 
@@ -110,9 +115,9 @@ class WatchManager:
     Supports multi-tenant authorization.
     """
 
-    STORAGE_URI = "viking://resources/.watch_tasks.json"
-    STORAGE_BAK_URI = "viking://resources/.watch_tasks.json.bak"
-    STORAGE_TMP_URI = "viking://resources/.watch_tasks.json.tmp"
+    STORAGE_URI = WATCH_TASK_STORAGE_URI
+    STORAGE_BAK_URI = WATCH_TASK_STORAGE_BAK_URI
+    STORAGE_TMP_URI = WATCH_TASK_STORAGE_TMP_URI
 
     def __init__(self, viking_fs: Optional[Any] = None):
         """Initialize WatchManager.

--- a/openviking/resource/watch_storage.py
+++ b/openviking/resource/watch_storage.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Shared constants and helpers for watch-task persistence storage."""
+
+from __future__ import annotations
+
+
+WATCH_TASK_STORAGE_URI = "viking://resources/.watch_tasks.json"
+WATCH_TASK_STORAGE_BAK_URI = "viking://resources/.watch_tasks.json.bak"
+WATCH_TASK_STORAGE_TMP_URI = "viking://resources/.watch_tasks.json.tmp"
+
+WATCH_TASK_CONTROL_URIS = frozenset(
+    {
+        WATCH_TASK_STORAGE_URI,
+        WATCH_TASK_STORAGE_BAK_URI,
+        WATCH_TASK_STORAGE_TMP_URI,
+    }
+)
+
+
+def is_watch_task_control_uri(uri: str) -> bool:
+    """Return True when a URI points at internal watch-task control state."""
+    if not isinstance(uri, str):
+        return False
+    normalized = uri.rstrip("/")
+    return normalized in WATCH_TASK_CONTROL_URIS

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, Optional
 
+from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext
 from openviking.session.memory.utils.content import deserialize_full, serialize_with_metadata
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
@@ -135,6 +136,8 @@ class ContentWriteCoordinator:
         name = uri.rstrip("/").split("/")[-1]
         if name in _DERIVED_FILENAMES:
             raise InvalidArgumentError(f"cannot write derived semantic file directly: {uri}")
+        if is_watch_task_control_uri(uri):
+            raise InvalidArgumentError(f"cannot write watch task control file directly: {uri}")
 
         parsed = VikingURI(uri)
         if parsed.scope not in {"resources", "user", "agent"}:

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -24,6 +24,7 @@ from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSHTTPError
+from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext, Role
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
@@ -1307,6 +1308,8 @@ class VikingFS:
             return True
         if not parts:
             return True
+        if is_watch_task_control_uri(normalized_uri):
+            return False
 
         scope = parts[0]
         if scope in {"resources", "temp"}:

--- a/tests/server/test_watch_task_acl.py
+++ b/tests/server/test_watch_task_acl.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for watch-task control file access boundaries."""
+
+import contextvars
+
+import pytest
+
+from openviking.resource.watch_storage import (
+    WATCH_TASK_STORAGE_BAK_URI,
+    WATCH_TASK_STORAGE_TMP_URI,
+    WATCH_TASK_STORAGE_URI,
+)
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.content_write import ContentWriteCoordinator
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+@pytest.fixture
+def root_ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+
+@pytest.fixture
+def user_ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("default", "alice", "default"), role=Role.USER)
+
+
+@pytest.fixture
+def bare_viking_fs() -> VikingFS:
+    fs = object.__new__(VikingFS)
+    fs._bound_ctx = contextvars.ContextVar("vikingfs_bound_ctx", default=None)
+    return fs
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        WATCH_TASK_STORAGE_URI,
+        WATCH_TASK_STORAGE_BAK_URI,
+        WATCH_TASK_STORAGE_TMP_URI,
+    ],
+)
+def test_watch_task_control_files_are_root_only(bare_viking_fs, root_ctx, user_ctx, uri):
+    assert bare_viking_fs._is_accessible(uri, root_ctx) is True
+    assert bare_viking_fs._is_accessible(uri, user_ctx) is False
+
+    with pytest.raises(PermissionError):
+        bare_viking_fs._ensure_access(uri, user_ctx)
+
+
+@pytest.mark.asyncio
+async def test_hidden_listing_filters_watch_task_control_files_for_non_root(
+    bare_viking_fs, root_ctx, user_ctx
+):
+    bare_viking_fs._uri_to_path = lambda uri, ctx=None: "/fake/resources"
+    bare_viking_fs._ctx_or_default = lambda ctx=None: ctx
+    bare_viking_fs._ls_entries = lambda path: [
+        {"name": ".watch_tasks.json", "isDir": False, "size": 10, "modTime": "2026-01-01T00:00:00+00:00"},
+        {"name": ".watch_tasks.json.bak", "isDir": False, "size": 10, "modTime": "2026-01-01T00:00:00+00:00"},
+        {"name": ".watch_tasks.json.tmp", "isDir": False, "size": 10, "modTime": "2026-01-01T00:00:00+00:00"},
+        {"name": "public.txt", "isDir": False, "size": 5, "modTime": "2026-01-01T00:00:00+00:00"},
+    ]
+    bare_viking_fs._path_to_uri = lambda path, ctx=None: f"viking://resources/{path.split('/')[-1]}"
+
+    root_entries = await bare_viking_fs._ls_original(
+        "viking://resources",
+        show_all_hidden=True,
+        ctx=root_ctx,
+    )
+    root_uris = {entry["uri"] for entry in root_entries}
+    assert root_uris >= {
+        WATCH_TASK_STORAGE_URI,
+        WATCH_TASK_STORAGE_BAK_URI,
+        WATCH_TASK_STORAGE_TMP_URI,
+        "viking://resources/public.txt",
+    }
+
+    user_entries = await bare_viking_fs._ls_original(
+        "viking://resources",
+        show_all_hidden=True,
+        ctx=user_ctx,
+    )
+    user_uris = {entry["uri"] for entry in user_entries}
+    assert "viking://resources/public.txt" in user_uris
+    assert WATCH_TASK_STORAGE_URI not in user_uris
+    assert WATCH_TASK_STORAGE_BAK_URI not in user_uris
+    assert WATCH_TASK_STORAGE_TMP_URI not in user_uris
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        WATCH_TASK_STORAGE_URI,
+        WATCH_TASK_STORAGE_BAK_URI,
+        WATCH_TASK_STORAGE_TMP_URI,
+    ],
+)
+def test_content_write_rejects_watch_task_control_files(uri):
+    coordinator = object.__new__(ContentWriteCoordinator)
+
+    with pytest.raises(InvalidArgumentError, match="watch task control file"):
+        coordinator._validate_target_uri(uri)


### PR DESCRIPTION
# OpenViking global watch-task control file ACL hardening

## Title
fix: protect global watch-task control files from non-root access

## Summary
This PR hardens OpenViking's watch scheduler state boundary by preventing non-root authenticated users from reading, enumerating, or overwriting the global watch-task control files stored under the shared `resources` scope.

- moves internal watch scheduler state out of the broad non-root `resources` access model or explicitly blocks access to the watch control files
- prevents non-root users from discovering hidden watch-task control artifacts through hidden-file listing paths
- blocks direct content writes to watch-task control files and backup/temp variants
- adds regression coverage for read, listing, and write paths affecting internal scheduler state

## Security issues covered

| issue | impact | severity |
| --- | --- | --- |
| Non-root read access to `viking://resources/.watch_tasks.json` and variants | cross-user disclosure of global scheduler metadata | Medium |
| Non-root hidden-file enumeration of watch control artifacts | discovery of internal scheduler control-plane files | Medium |
| Non-root overwrite of global watch-task state | cross-user integrity break against scheduler control state | High |

## Before this PR
- `WatchManager` persists scheduler state in `viking://resources/.watch_tasks.json`, `.bak`, and `.tmp`
- `VikingFS._is_accessible()` allows non-root access to all `resources`-scope URIs
- hidden files under `resources` are omitted from normal listing output but are still enumerable with hidden-file listing enabled
- content writes block derived semantic artifacts like `.abstract.md`, `.overview.md`, and `.relations.json`, but do not block watch-task control files

## After this PR
- watch scheduler control files are treated as internal state rather than general shared resources
- non-root callers cannot read or list the watch-task control file family
- non-root callers cannot write the watch-task control file family through content write paths
- tests lock in the scheduler-state trust boundary across read, listing, and write surfaces

## Why this matters
The watch scheduler stores globally trusted control data in a namespace that the access-control layer currently treats as readable for any non-root authenticated user. That creates a control-plane boundary problem:

- confidentiality: a non-root user can inspect global watch-task metadata
- enumeration: a non-root user can discover internal scheduler files by listing hidden files
- integrity: a non-root user can overwrite the scheduler control file if it already exists

If the scheduler later consumes attacker-modified watch state, this becomes a direct cross-user tampering primitive against global scheduler behavior.

## Attack flow

```text
non-root authenticated request
    -> filesystem/content routes over viking://resources/*
        -> broad resources-scope allow rule + no watch-task control-file denylist
            -> read / enumerate / overwrite scheduler control state
                -> disclosure and integrity impact against global watch metadata
```

## Affected code

| issue | files |
| --- | --- |
| Global watch-task state stored in shared resources scope | `openviking/resource/watch_manager.py` |
| Non-root access allowed for all `resources` URIs | `openviking/storage/viking_fs.py` |
| Write path does not block watch-task control files | `openviking/storage/content_write.py` |

## Root cause

### Shared scheduler state stored in a broad-access namespace
- `WatchManager` stores trusted scheduler metadata in `viking://resources/.watch_tasks.json` and backup/temp siblings
- `resources` is a shared namespace, but these files function as internal control-plane state rather than user-facing shared content

### Access control is too broad for internal resources
- `VikingFS._is_accessible()` currently returns `True` for non-root users on all `resources` scope URIs
- this scope-level allow rule does not distinguish public shared content from internal control files

### Write validation protects some internals but misses watch state
- `ContentWriteCoordinator._validate_target_uri()` blocks only derived semantic files
- watch-task control files are not treated as internal scheduler metadata and remain writable if they already exist

## CVSS assessment

| issue | CVSS v3.1 | vector |
| --- | --- | --- |
| Global watch-task control file read/enumeration | 4.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N` |
| Global watch-task control file overwrite | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:L` |

Rationale:
- attack complexity is low once authenticated access to the normal filesystem/content routes exists
- privileges required are low because the issue is reachable by non-root authenticated users
- the strongest demonstrated impact is integrity on globally trusted scheduler state
- availability impact is kept bounded because scheduler-consumption effects may vary by deployment and validation paths

## Safe reproduction steps
1. Authenticate as a non-root user.
2. Attempt to read:
   - `viking://resources/.watch_tasks.json`
   - `viking://resources/.watch_tasks.json.bak`
   - `viking://resources/.watch_tasks.json.tmp`
3. List `viking://resources` with hidden-file output enabled.
4. Attempt to write replacement JSON to `viking://resources/.watch_tasks.json` through the normal content-write path.
5. Re-read the file and confirm that attacker-controlled content replaced the original scheduler metadata.

## Expected vulnerable behavior
- non-root reads succeed for the watch-task control file family
- hidden-file listing reveals the control files under `resources`
- overwrite succeeds because the file exists and is not blocked by target validation
- derived semantic files like `.abstract.md` are blocked, demonstrating that this is a missing-protection gap rather than a universal no-rules write path

## Validation performed
- confirmed `WatchManager` persists task state at:
  - `viking://resources/.watch_tasks.json`
  - `viking://resources/.watch_tasks.json.bak`
  - `viking://resources/.watch_tasks.json.tmp`
- confirmed `VikingFS._is_accessible()` allows non-root access to `resources` scope URIs
- confirmed hidden-file listing can expose these control files when hidden output is enabled
- confirmed write validation blocks some internal derived files but does not block the watch-task control file family
- reproduced the read / enumerate / overwrite logic path with a source-backed harness that modeled the exact relevant access-control and write-validation logic

## Changes in this PR
- classify watch-task persistence files as internal scheduler state
- deny non-root read and listing access to the watch-task control file family
- deny direct content writes to the watch-task control file family, including backup and temp variants
- add regression tests covering:
  - non-root read denial
  - hidden-file listing denial or filtering
  - non-root write denial
  - root or internal scheduler access preservation

## Files changed

| category | files | what changed |
| --- | --- | --- |
| scheduler state | `openviking/resource/watch_manager.py` | retain internal storage semantics while aligning access expectations |
| access control | `openviking/storage/viking_fs.py` | distinguish internal watch control files from general shared resources |
| content write guard | `openviking/storage/content_write.py` | reject writes to watch-task control artifacts |
| regression tests | `tests/...` | add coverage for read, list, and write boundaries |

## Maintainer impact
- patch scope is narrow and focused on internal watch scheduler state
- user-facing shared resource behavior can remain unchanged for normal resources content
- the fix reduces the risk of future internal-control files being exposed by broad scope-level allow rules
- regression tests make the trust boundary easier to maintain and harder to accidentally reopen

## Fix rationale
The secure default is to keep scheduler control metadata out of the general shared-resource trust model. These files are not ordinary collaborative resources; they are privileged internal state used by the watch subsystem.

A durable fix is to enforce one of these models:
- move watch-task persistence into an internal/root-only namespace, or
- keep the current path but explicitly treat the watch-task control file family as protected internal files across read, list, and write paths

Either approach is better than relying on hidden-file naming alone.

## Type of change
- [x] Security fix
- [x] Bug fix
- [x] Tests
- [ ] Documentation only
- [ ] Refactor only

## Test plan
- [x] Verified storage locations used by `WatchManager`
- [x] Verified non-root `resources` access rule in `VikingFS._is_accessible()`
- [x] Verified hidden-file listing behavior in `VikingFS.ls()`
- [x] Verified content-write validation gap in `ContentWriteCoordinator._validate_target_uri()`
- [x] Reproduced read / enumerate / overwrite behavior with a source-backed harness
- [ ] Full containerized end-to-end reproduction on this host

Executed validation:
- source audit of `openviking/resource/watch_manager.py`
- source audit of `openviking/storage/viking_fs.py`
- source audit of `openviking/storage/content_write.py`
- local harness execution proving non-root access, hidden enumeration, and overwrite against the reproduced policy logic

## Disclosure notes
- claims are bounded to the verified code paths and reproduced policy behavior
- this draft does not overclaim scheduler-side execution impact beyond the demonstrated integrity break on trusted scheduler state
- no unrelated files need to change for the fix
