### PR TITLE
fix: update observer test to use /models endpoint instead of non-exis…

### DIFF
--- a/tests/api_test/api/client.py
+++ b/tests/api_test/api/client.py
@@ -490,8 +490,8 @@ class OpenVikingAPIClient:
         url = self._build_url(self.server_url, endpoint)
         return self._request_with_retry("GET", url)
 
-    def observer_vlm(self) -> requests.Response:
-        endpoint = "/api/v1/observer/vlm"
+    def observer_models(self) -> requests.Response:
+        endpoint = "/api/v1/observer/models"
         url = self._build_url(self.server_url, endpoint)
         return self._request_with_retry("GET", url)
 
@@ -510,20 +510,23 @@ class OpenVikingAPIClient:
         url = self._build_url(self.server_url, endpoint)
         return self._request_with_retry("GET", url)
 
-    def wait_for_task(self, task_id: str, timeout: float = 60.0, poll_interval: float = 1.0) -> dict:
+    def wait_for_task(
+        self, task_id: str, timeout: float = 60.0, poll_interval: float = 1.0
+    ) -> dict:
         import time
+
         start_time = time.time()
         while time.time() - start_time < timeout:
             response = self.get_task(task_id)
             if response.status_code == 200:
                 data = response.json()
-                if data.get('status') == 'ok':
-                    result = data.get('result', {})
-                    task_status = result.get('status')
-                    if task_status in ['completed', 'failed']:
+                if data.get("status") == "ok":
+                    result = data.get("result", {})
+                    task_status = result.get("status")
+                    if task_status in ["completed", "failed"]:
                         return result
             time.sleep(poll_interval)
-        return {'status': 'timeout', 'task_id': task_id}
+        return {"status": "timeout", "task_id": task_id}
 
     def admin_create_account(self, account_id: str, admin_user_id: str) -> requests.Response:
         endpoint = "/api/v1/admin/accounts"

--- a/tests/api_test/system/test_observer.py
+++ b/tests/api_test/system/test_observer.py
@@ -62,14 +62,14 @@ class TestObserver:
             print(f"Error: {e}")
             raise
 
-    def test_observer_vlm(self, api_client):
+    def test_observer_models(self, api_client):
         try:
-            response = api_client.observer_vlm()
-            print(f"\nObserver VLM API status code: {response.status_code}")
+            response = api_client.observer_models()
+            print(f"\nObserver Models API status code: {response.status_code}")
 
             data = response.json()
             print("\n" + "=" * 80)
-            print("Observer VLM API Response:")
+            print("Observer Models API Response:")
             print("=" * 80)
             print(json.dumps(data, indent=2, ensure_ascii=False))
             print("=" * 80 + "\n")

--- a/tests/server/test_api_observer.py
+++ b/tests/server/test_api_observer.py
@@ -30,9 +30,9 @@ async def test_observer_vikingdb(client: httpx.AsyncClient):
     assert "is_healthy" in result
 
 
-async def test_observer_vlm(client: httpx.AsyncClient):
-    """GET /api/v1/observer/vlm should return VLM status."""
-    resp = await client.get("/api/v1/observer/vlm")
+async def test_observer_models(client: httpx.AsyncClient):
+    """GET /api/v1/observer/models should return models status."""
+    resp = await client.get("/api/v1/observer/models")
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"


### PR DESCRIPTION
…tent /vlm

The /api/v1/observer/vlm endpoint does not exist in the server router. The correct endpoint for VLM status is /api/v1/observer/models which returns status for VLM, Embedding, and Rerank models.

Changes:
- client.py: rename observer_vlm() to observer_models(), update endpoint
- test_observer.py: rename test_observer_vlm to test_observer_models
- test_api_observer.py: rename test_observer_vlm to test_observer_models

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
