### PR TITLE
fix(openclaw-plugin): extend default Phase 2 commit wait timeout

### DIFF
--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -155,6 +155,7 @@ export type AddSkillResult = {
 };
 
 const DEFAULT_WAIT_REQUEST_TIMEOUT_MS = 120_000;
+export const DEFAULT_PHASE2_POLL_TIMEOUT_MS = 300_000;
 const WAIT_REQUEST_TIMEOUT_BUFFER_MS = 5_000;
 
 function sleep(ms: number): Promise<void> {
@@ -714,7 +715,7 @@ export class OpenVikingClient {
     }
 
     // Client-side poll until Phase 2 finishes
-    const deadline = Date.now() + (options.timeoutMs ?? 120_000);
+    const deadline = Date.now() + (options.timeoutMs ?? DEFAULT_PHASE2_POLL_TIMEOUT_MS);
     const pollInterval = 500;
     while (Date.now() < deadline) {
       await sleep(pollInterval);

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { DEFAULT_PHASE2_POLL_TIMEOUT_MS } from "./client.js";
 import type { OpenVikingClient, OVMessage } from "./client.js";
 import type { MemoryOpenVikingConfig } from "./config.js";
 import {
@@ -431,7 +432,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 const PHASE2_POLL_INTERVAL_MS = 800;
-const PHASE2_POLL_MAX_MS = 120_000;
+const PHASE2_POLL_MAX_MS = DEFAULT_PHASE2_POLL_TIMEOUT_MS;
 
 /**
  * After wait=false commit, Phase2 runs on the server. Poll task until completed/failed/timeout

--- a/examples/openclaw-plugin/tests/ut/client.test.ts
+++ b/examples/openclaw-plugin/tests/ut/client.test.ts
@@ -284,4 +284,43 @@ describe("OpenVikingClient resource and skill import", () => {
 
     await assertion;
   });
+
+  it("keeps polling wait=true commit long enough for slow Phase 2 completion", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/api/v1/sessions/slow-session/commit")) {
+        return Promise.resolve(okResponse({
+          session_id: "slow-session",
+          status: "accepted",
+          task_id: "task-slow",
+          archived: true,
+        }));
+      }
+      if (url.endsWith("/api/v1/tasks/task-slow")) {
+        const completed = Date.now() >= 200_000;
+        return Promise.resolve(okResponse({
+          task_id: "task-slow",
+          task_type: "session_commit",
+          status: completed ? "completed" : "running",
+          created_at: 0,
+          updated_at: 0,
+          result: completed ? { memories_extracted: { core: 1 } } : {},
+        }));
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OpenVikingClient("http://127.0.0.1:1933", "", "agent", 5_000);
+    const pending = client.commitSession("slow-session", { wait: true });
+
+    await vi.advanceTimersByTimeAsync(200_500);
+
+    await expect(pending).resolves.toMatchObject({
+      status: "completed",
+      archived: true,
+      task_id: "task-slow",
+      memories_extracted: { core: 1 },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- increase the default client-side Phase 2 commit wait timeout from 120s to 300s for `commitSession(wait=true)`
- reuse the same 300s default for the plugin's background Phase 2 polling logs
- add a regression test proving slow Phase 2 completion after ~200s no longer gets reported as timeout

## Testing
- `npm test -- --run tests/ut/client.test.ts tests/ut/context-engine-compact.test.ts`
- `npm test`

Closes #1405
