### PR TITLE
feat(openclaw): support ratio-based commit threshold

### DIFF
--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -112,7 +112,7 @@ That means OpenClaw sees “compressed history summary + archive index + active 
 - it strips injected `<relevant-memories>` blocks and metadata noise before capture
 - it appends the sanitized turn text into the OpenViking session
 
-After that, the plugin checks `pending_tokens`. Once the session crosses `commitTokenThreshold`, it triggers `commit(wait=false)`:
+After that, the plugin checks `pending_tokens`. If `commitTokenThresholdRatio` is configured, the plugin first derives an effective threshold from the current token budget or model context window; otherwise it uses the fixed `commitTokenThreshold`. Once the session crosses that effective threshold, it triggers `commit(wait=false)`:
 
 - archive generation and Phase 2 memory extraction continue asynchronously on the server
 - the current turn is not blocked waiting for extraction

--- a/examples/openclaw-plugin/README_CN.md
+++ b/examples/openclaw-plugin/README_CN.md
@@ -112,7 +112,7 @@ Session 是这套设计的主轴。当前实现里，它覆盖了“历史组装
 - 会先剥掉注入过的 `<relevant-memories>` 和元数据噪音
 - 最终把清洗后的增量内容追加到 OpenViking session
 
-之后插件会读取 session 的 `pending_tokens`。当它超过 `commitTokenThreshold` 时，会触发一次 `commit(wait=false)`：
+之后插件会读取 session 的 `pending_tokens`。如果配置了 `commitTokenThresholdRatio`，插件会优先基于当前 token budget 或模型上下文窗口计算出一个生效阈值；否则继续使用固定的 `commitTokenThreshold`。当 `pending_tokens` 超过这个生效阈值时，就会触发一次 `commit(wait=false)`：
 
 - archive 和 Phase 2 记忆抽取在服务端异步继续跑
 - 当前 turn 不会因为等待抽取而阻塞

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -23,6 +23,7 @@ export type MemoryOpenVikingConfig = {
   recallMaxContentChars?: number;
   recallPreferAbstract?: boolean;
   recallTokenBudget?: number;
+  commitTokenThresholdRatio?: number;
   commitTokenThreshold?: number;
   bypassSessionPatterns?: string[];
   ingestReplyAssist?: boolean;
@@ -51,6 +52,7 @@ const DEFAULT_RECALL_MAX_CONTENT_CHARS = 500;
 const DEFAULT_RECALL_PREFER_ABSTRACT = true;
 const DEFAULT_RECALL_TOKEN_BUDGET = 2000;
 const DEFAULT_COMMIT_TOKEN_THRESHOLD = 20000;
+const MAX_COMMIT_TOKEN_THRESHOLD_RATIO = 0.49;
 const DEFAULT_BYPASS_SESSION_PATTERNS: string[] = [];
 const DEFAULT_INGEST_REPLY_ASSIST = true;
 const DEFAULT_INGEST_REPLY_ASSIST_MIN_SPEAKER_TURNS = 2;
@@ -89,6 +91,17 @@ function toNumber(value: unknown, fallback: number): number {
     }
   }
   return fallback;
+}
+
+function toOptionalRatio(value: unknown): number | undefined {
+  if (typeof value === "undefined" || value === null || value === "") {
+    return undefined;
+  }
+  const parsed = toNumber(value, Number.NaN);
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+  return Math.max(0, Math.min(MAX_COMMIT_TOKEN_THRESHOLD_RATIO, parsed));
 }
 
 function toStringArray(value: unknown, fallback: string[]): string[] {
@@ -159,6 +172,7 @@ export const memoryOpenVikingConfigSchema = {
         "recallMaxContentChars",
         "recallPreferAbstract",
         "recallTokenBudget",
+        "commitTokenThresholdRatio",
         "commitTokenThreshold",
         "bypassSessionPatterns",
         "ingestReplyAssist",
@@ -227,6 +241,7 @@ export const memoryOpenVikingConfigSchema = {
         100,
         Math.min(50000, Math.floor(toNumber(cfg.recallTokenBudget, DEFAULT_RECALL_TOKEN_BUDGET))),
       ),
+      commitTokenThresholdRatio: toOptionalRatio(cfg.commitTokenThresholdRatio),
       commitTokenThreshold: Math.max(
         0,
         Math.min(100_000, Math.floor(toNumber(cfg.commitTokenThreshold, DEFAULT_COMMIT_TOKEN_THRESHOLD))),
@@ -360,6 +375,13 @@ export const memoryOpenVikingConfigSchema = {
       placeholder: String(DEFAULT_RECALL_TOKEN_BUDGET),
       advanced: true,
       help: "Maximum estimated tokens for auto-recall memory injection. Injection stops when budget is exhausted.",
+    },
+    commitTokenThresholdRatio: {
+      label: "Commit Threshold Ratio",
+      placeholder: "0.38",
+      advanced: true,
+      help:
+        "Preferred over Commit Token Threshold when set. Uses up to 49% of the current token budget/context window to decide when auto-commit should trigger.",
     },
     bypassSessionPatterns: {
       label: "Bypass Session Patterns",

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -190,6 +190,102 @@ function validTokenBudget(raw: unknown): number | undefined {
   return undefined;
 }
 
+function pickNumericField(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = validTokenBudget(record[key]);
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function extractCommitContextWindow(runtimeContext: Record<string, unknown> | undefined): number | undefined {
+  if (!runtimeContext) {
+    return undefined;
+  }
+
+  const direct = pickNumericField(runtimeContext, [
+    "contextWindow",
+    "context_window",
+    "maxInputTokens",
+    "max_input_tokens",
+    "modelContextWindow",
+    "model_context_window",
+  ]);
+  if (typeof direct === "number") {
+    return direct;
+  }
+
+  const nestedCandidates = [
+    runtimeContext.model,
+    runtimeContext.activeModel,
+    runtimeContext.gatewayModel,
+    runtimeContext.modelInfo,
+  ];
+  for (const candidate of nestedCandidates) {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+      continue;
+    }
+    const nested = pickNumericField(candidate as Record<string, unknown>, [
+      "contextWindow",
+      "context_window",
+      "maxInputTokens",
+      "max_input_tokens",
+    ]);
+    if (typeof nested === "number") {
+      return nested;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveCommitTokenThreshold(
+  cfg: Required<MemoryOpenVikingConfig>,
+  tokenBudget: unknown,
+  runtimeContext?: Record<string, unknown>,
+): {
+  value: number;
+  source: "fixed" | "ratio_runtime_context" | "ratio_token_budget" | "fixed_fallback";
+  ratio?: number;
+  basis?: number;
+} {
+  const ratio = cfg.commitTokenThresholdRatio;
+  if (typeof ratio !== "number") {
+    return {
+      value: cfg.commitTokenThreshold,
+      source: "fixed",
+    };
+  }
+
+  const runtimeContextWindow = extractCommitContextWindow(runtimeContext);
+  if (typeof runtimeContextWindow === "number") {
+    return {
+      value: Math.max(0, Math.floor(runtimeContextWindow * ratio)),
+      source: "ratio_runtime_context",
+      ratio,
+      basis: runtimeContextWindow,
+    };
+  }
+
+  const resolvedTokenBudget = validTokenBudget(tokenBudget);
+  if (typeof resolvedTokenBudget === "number") {
+    return {
+      value: Math.max(0, Math.floor(resolvedTokenBudget * ratio)),
+      source: "ratio_token_budget",
+      ratio,
+      basis: resolvedTokenBudget,
+    };
+  }
+
+  return {
+    value: cfg.commitTokenThreshold,
+    source: "fixed_fallback",
+    ratio,
+  };
+}
+
 /** OpenClaw session UUID (path-safe on Windows). */
 const OPENVIKING_OV_SESSION_UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -904,12 +1000,20 @@ export function createMemoryOpenVikingContextEngine(params: {
 
         const session = await client.getSession(OVSessionId, agentId);
         const pendingTokens = session.pending_tokens ?? 0;
+        const commitThreshold = resolveCommitTokenThreshold(
+          cfg,
+          afterTurnParams.tokenBudget,
+          afterTurnParams.runtimeContext,
+        );
 
-        if (pendingTokens < cfg.commitTokenThreshold) {
+        if (pendingTokens < commitThreshold.value) {
           diag("afterTurn_skip", OVSessionId, {
             reason: "below_threshold",
             pendingTokens,
-            commitTokenThreshold: cfg.commitTokenThreshold,
+            commitTokenThreshold: commitThreshold.value,
+            commitTokenThresholdSource: commitThreshold.source,
+            commitTokenThresholdRatio: commitThreshold.ratio ?? null,
+            commitTokenThresholdBasis: commitThreshold.basis ?? null,
           });
           return;
         }
@@ -927,7 +1031,10 @@ export function createMemoryOpenVikingContextEngine(params: {
 
         diag("afterTurn_commit", OVSessionId, {
           pendingTokens,
-          commitTokenThreshold: cfg.commitTokenThreshold,
+          commitTokenThreshold: commitThreshold.value,
+          commitTokenThresholdSource: commitThreshold.source,
+          commitTokenThresholdRatio: commitThreshold.ratio ?? null,
+          commitTokenThresholdBasis: commitThreshold.basis ?? null,
           status: commitResult.status,
           archived: commitResult.archived ?? false,
           taskId: commitResult.task_id ?? null,

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -96,9 +96,15 @@
       "help": "Completely bypass OpenViking for matching session keys. Use * within one segment and ** across segments.",
       "advanced": true
     },
+    "commitTokenThresholdRatio": {
+      "label": "Commit Threshold Ratio",
+      "placeholder": "0.38",
+      "advanced": true,
+      "help": "Preferred over Commit Token Threshold when set. Uses up to 49% of the current token budget/context window to decide when auto-commit should trigger."
+    },
     "commitTokenThreshold": {
       "label": "Commit Token Threshold",
-      "placeholder": "2000",
+      "placeholder": "20000",
       "advanced": true,
       "help": "Minimum estimated pending tokens before auto-commit triggers. Set to 0 to commit every turn."
     },
@@ -189,6 +195,9 @@
         "type": "boolean"
       },
       "recallTokenBudget": {
+        "type": "number"
+      },
+      "commitTokenThresholdRatio": {
         "type": "number"
       },
       "commitTokenThreshold": {

--- a/examples/openclaw-plugin/tests/ut/config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/config.test.ts
@@ -21,6 +21,7 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
     expect(cfg.autoRecall).toBe(true);
     expect(cfg.recallPreferAbstract).toBe(false);
     expect(cfg.recallTokenBudget).toBe(2000);
+    expect(cfg.commitTokenThresholdRatio).toBeUndefined();
     expect(cfg.commitTokenThreshold).toBe(20000);
     expect(cfg.ingestReplyAssist).toBe(false);
     expect(cfg.captureMode).toBe("semantic");
@@ -153,6 +154,19 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
     expect(cfgLow.recallMaxContentChars).toBe(50);
     const cfgHigh = memoryOpenVikingConfigSchema.parse({ recallMaxContentChars: 99999 });
     expect(cfgHigh.recallMaxContentChars).toBe(10000);
+  });
+
+  it("accepts commitTokenThresholdRatio within bounds", () => {
+    const cfg = memoryOpenVikingConfigSchema.parse({ commitTokenThresholdRatio: 0.38 });
+    expect(cfg.commitTokenThresholdRatio).toBe(0.38);
+  });
+
+  it("clamps commitTokenThresholdRatio to the supported range", () => {
+    const cfgLow = memoryOpenVikingConfigSchema.parse({ commitTokenThresholdRatio: -1 });
+    expect(cfgLow.commitTokenThresholdRatio).toBe(0);
+
+    const cfgHigh = memoryOpenVikingConfigSchema.parse({ commitTokenThresholdRatio: 0.9 });
+    expect(cfgHigh.commitTokenThresholdRatio).toBe(0.49);
   });
 
   it("resolves agentId from configured value", () => {

--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -15,6 +15,7 @@ function makeLogger() {
 function makeEngine(opts?: {
   autoCapture?: boolean;
   commitTokenThreshold?: number;
+  commitTokenThresholdRatio?: number;
   getSession?: Record<string, unknown>;
   addSessionMessageError?: Error;
   cfgOverrides?: Record<string, unknown>;
@@ -26,6 +27,7 @@ function makeEngine(opts?: {
     autoCapture: opts?.autoCapture ?? true,
     autoRecall: false,
     ingestReplyAssist: false,
+    commitTokenThresholdRatio: opts?.commitTokenThresholdRatio,
     commitTokenThreshold: opts?.commitTokenThreshold ?? 20000,
     emitStandardDiagnostics: true,
     ...(opts?.cfgOverrides ?? {}),
@@ -297,6 +299,70 @@ describe("context-engine afterTurn()", () => {
     expect(client.commitSession).toHaveBeenCalledTimes(1);
     const commitCall = client.commitSession.mock.calls[0];
     expect(commitCall[1]).toMatchObject({ wait: false });
+  });
+
+  it("uses commitTokenThresholdRatio with tokenBudget when configured", async () => {
+    const { engine, client } = makeEngine({
+      commitTokenThresholdRatio: 0.38,
+      commitTokenThreshold: 20000,
+      getSession: { pending_tokens: 300000 },
+    });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      tokenBudget: 1_000_000,
+      messages: [{ role: "user", content: "long-context model turn" }],
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.commitSession).not.toHaveBeenCalled();
+  });
+
+  it("prefers runtimeContext contextWindow over tokenBudget for ratio threshold", async () => {
+    const { engine, client, logger } = makeEngine({
+      commitTokenThresholdRatio: 0.38,
+      commitTokenThreshold: 20000,
+      getSession: { pending_tokens: 300000 },
+    });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      tokenBudget: 200000,
+      runtimeContext: {
+        model: {
+          contextWindow: 1_000_000,
+        },
+      },
+      messages: [{ role: "user", content: "prefer model context window over token budget" }],
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.commitSession).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("\"commitTokenThresholdSource\":\"ratio_runtime_context\""),
+    );
+  });
+
+  it("falls back to fixed threshold when ratio is set but no budget signal is available", async () => {
+    const { engine, client, logger } = makeEngine({
+      commitTokenThresholdRatio: 0.38,
+      commitTokenThreshold: 20000,
+      getSession: { pending_tokens: 25000 },
+    });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages: [{ role: "user", content: "fallback to fixed threshold" }],
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.commitSession).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("\"commitTokenThresholdSource\":\"fixed_fallback\""),
+    );
   });
 
   it("catches errors without throwing", async () => {


### PR DESCRIPTION
## Summary
- add `commitTokenThresholdRatio` to the OpenClaw plugin config and manifest
- derive the effective auto-commit threshold from runtime model context window or token budget when ratio is set
- keep fixed `commitTokenThreshold` as the fallback and document/test the precedence

## Testing
- npm test -- tests/ut/config.test.ts tests/ut/context-engine-afterTurn.test.ts
- npm test

Closes #1172
