### PR TITLE
fix: preserve existing abstract during reindex

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -333,6 +333,7 @@ async def index_resource(
     ``"resource"``.
     """
     viking_fs = get_viking_fs()
+    vector_store = viking_fs.vector_store
     context_type = get_context_type_for_uri(uri)
 
     # 1. Index Directory Metadata
@@ -373,11 +374,21 @@ async def index_resource(
 
             file_uri = file_info.get("uri") or f"{uri}/{file_name}"
 
-            # For direct indexing, we might not have summaries.
-            # We pass empty summary_dict, vectorize_file will try to read content for text files.
+            # Preserve existing abstract from vector index during reindex.
+            # Without this, reindex overwrites VLM-generated abstracts with empty
+            # strings, causing rerank to lose document differentiation ability.
+            existing_abstract = ""
+            if vector_store:
+                try:
+                    existing = await vector_store.fetch_by_uri(file_uri, ctx=ctx)
+                    if existing:
+                        existing_abstract = existing.get("abstract", "") or ""
+                except Exception:
+                    pass
+
             await vectorize_file(
                 file_path=file_uri,
-                summary_dict={"name": file_name},
+                summary_dict={"name": file_name, "summary": existing_abstract},
                 parent_uri=uri,
                 context_type=context_type,
                 ctx=ctx,


### PR DESCRIPTION
## Problem

When `index_resource()` rebuilds the vector index (e.g. after switching embedding models via `reindex` with `regenerate=False`), it passes an empty `summary_dict` to `vectorize_file`:

```python
await vectorize_file(
    file_path=file_uri,
    summary_dict={"name": file_name},  # no "summary" key
    ...
)
```

This causes `Context(abstract="")`, which overwrites the existing VLM-generated abstract in the vector index with an empty string.

**Impact**: Rerank relies on the `abstract` field to differentiate documents. With empty abstracts, all documents sent to the rerank API are identical (`"[empty]"` after the DashScope safety filter), resulting in uniform scores and no meaningful ranking.

## Root Cause

`index_resource` and the normal write path use different code paths for the `abstract` field:

- **Normal write**: semantic processor (VLM) generates summary → passed as `summary_dict["summary"]` → stored as `abstract` in vector index
- **Reindex**: no summary available → `summary_dict` has no `"summary"` key → `abstract=""` → overwrites old value via upsert

Reindex and VLM summary generation are independent concerns, but the current implementation couples them by discarding the old abstract during reindex.

## Fix

Before calling `vectorize_file`, query the existing vector index entry via `fetch_by_uri` (which already includes `abstract` in its output fields) and carry forward the old value:

```python
existing_abstract = ""
if vector_store:
    try:
        existing = await vector_store.fetch_by_uri(file_uri, ctx=ctx)
        if existing:
            existing_abstract = existing.get("abstract", "") or ""
    except Exception:
        pass

await vectorize_file(
    file_path=file_uri,
    summary_dict={"name": file_name, "summary": existing_abstract},
    ...
)
```

## Test Plan

- [x] Verified on OpenViking 0.3.5 with 8600+ vectors
- [x] Reindex with new embedding model (BGE-M3 → text-embedding-v4) preserves all VLM abstracts
- [x] Rerank scores show proper differentiation after reindex (10 unique scores vs all-identical before fix)
- [x] No impact on `regenerate=True` path (which uses `summarize()` instead of `build_index()`)