### PR TITLE
fix(storage): persist semantic summary cache by filename

### DIFF
--- a/openviking/storage/queuefs/semantic_cache.py
+++ b/openviking/storage/queuefs/semantic_cache.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Helpers for directory-level semantic summary caches."""
+
+import json
+from typing import Dict, List
+
+SUMMARY_CACHE_FILENAME = ".summary_cache.json"
+MANAGED_HIDDEN_SEMANTIC_FILES = frozenset(
+    {
+        ".abstract.md",
+        ".overview.md",
+        SUMMARY_CACHE_FILENAME,
+    }
+)
+
+
+def build_summary_cache(file_summaries: List[Dict[str, str]]) -> Dict[str, str]:
+    """Build a filename -> summary map from generated file summaries."""
+    cache: Dict[str, str] = {}
+    for item in file_summaries:
+        name = item.get("name", "").strip()
+        if not name:
+            continue
+        summary = item.get("summary", "")
+        cache[name] = summary if isinstance(summary, str) else str(summary)
+    return cache
+
+
+def serialize_summary_cache(file_summaries: List[Dict[str, str]]) -> str:
+    """Serialize summary cache content for storage on disk."""
+    return json.dumps(build_summary_cache(file_summaries), ensure_ascii=False, sort_keys=True)
+
+
+def parse_summary_cache(content: str) -> Dict[str, str]:
+    """Parse a stored summary cache.
+
+    Returns an empty mapping for missing or invalid content.
+    """
+    if not content or not content.strip():
+        return {}
+
+    try:
+        payload = json.loads(content)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+
+    if not isinstance(payload, dict):
+        return {}
+
+    cache: Dict[str, str] = {}
+    for raw_name, raw_summary in payload.items():
+        if not isinstance(raw_name, str):
+            continue
+        name = raw_name.strip()
+        if not name:
+            continue
+        if isinstance(raw_summary, str):
+            cache[name] = raw_summary
+        elif raw_summary is None:
+            cache[name] = ""
+        else:
+            cache[name] = str(raw_summary)
+    return cache

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, List, Optional
 
 from openviking.server.identity import RequestContext
+from openviking.storage.queuefs.semantic_cache import (
+    SUMMARY_CACHE_FILENAME,
+    parse_summary_cache,
+    serialize_summary_cache,
+)
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking_cli.utils import VikingURI
@@ -360,16 +365,27 @@ class SemanticDagExecutor:
                     pass
                 async with self._overview_cache_lock:
                     if parent_uri not in self._overview_cache:
-                        overview_path = f"{parent_uri}/.overview.md"
-                        overview_content = await self._viking_fs.read_file(
-                            overview_path, ctx=self._ctx
-                        )
-                        if overview_content:
-                            self._overview_cache[parent_uri] = self._processor._parse_overview_md(
-                                overview_content
+                        summary_cache: Dict[str, str] = {}
+                        try:
+                            cache_content = await self._viking_fs.read_file(
+                                f"{parent_uri}/{SUMMARY_CACHE_FILENAME}",
+                                ctx=self._ctx,
                             )
-                        else:
-                            self._overview_cache[parent_uri] = {}
+                            summary_cache = parse_summary_cache(cache_content)
+                        except Exception as e:
+                            logger.debug(
+                                f"Failed to read {SUMMARY_CACHE_FILENAME} for {parent_uri}: {e}"
+                            )
+
+                        if not summary_cache:
+                            overview_path = f"{parent_uri}/.overview.md"
+                            overview_content = await self._viking_fs.read_file(
+                                overview_path, ctx=self._ctx
+                            )
+                            if overview_content:
+                                summary_cache = self._processor._parse_overview_md(overview_content)
+
+                        self._overview_cache[parent_uri] = summary_cache
             else:
                 try:
                     from openviking.metrics.datasources.cache import CacheEventDataSource
@@ -578,6 +594,19 @@ class SemanticDagExecutor:
                 await self._viking_fs.write_file(f"{dir_uri}/.abstract.md", abstract, ctx=self._ctx)
             except Exception:
                 logger.info(f"[SemanticDag] {dir_uri} write failed, skipping")
+
+            try:
+                async with node.lock:
+                    file_summaries = self._finalize_file_summaries(node)
+                await self._viking_fs.write_file(
+                    f"{dir_uri}/{SUMMARY_CACHE_FILENAME}",
+                    serialize_summary_cache(file_summaries),
+                    ctx=self._ctx,
+                )
+            except Exception as e:
+                logger.info(
+                    f"[SemanticDag] Failed to write {SUMMARY_CACHE_FILENAME} for {dir_uri}: {e}"
+                )
 
             try:
                 if need_vectorize:

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -28,6 +28,12 @@ from openviking.parse.parsers.media.utils import (
 )
 from openviking.prompts import render_prompt
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.semantic_cache import (
+    MANAGED_HIDDEN_SEMANTIC_FILES,
+    SUMMARY_CACHE_FILENAME,
+    parse_summary_cache,
+    serialize_summary_cache,
+)
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
 from openviking.storage.queuefs.semantic_msg import SemanticMsg
@@ -218,6 +224,22 @@ class SemanticProcessor(DequeueHandlerBase):
             return current_content != target_content
         except Exception:
             return True
+
+    async def _read_directory_summary_cache(
+        self, dir_uri: str, ctx: Optional[RequestContext] = None
+    ) -> Dict[str, str]:
+        """Read cached file summaries for a directory."""
+        viking_fs = get_viking_fs()
+        try:
+            cache_content = await viking_fs.read_file(f"{dir_uri}/{SUMMARY_CACHE_FILENAME}", ctx=ctx)
+        except Exception as e:
+            logger.debug(f"No summary cache found for {dir_uri}: {e}")
+            return {}
+
+        cache = parse_summary_cache(cache_content)
+        if cache:
+            logger.info(f"Loaded {len(cache)} cached summaries from {SUMMARY_CACHE_FILENAME}")
+        return cache
 
     async def _reenqueue_semantic_msg(self, msg: SemanticMsg) -> None:
         """Re-enqueue a semantic message for later processing.
@@ -476,15 +498,17 @@ class SemanticProcessor(DequeueHandlerBase):
         existing_summaries: Dict[str, str] = {}
 
         if msg.changes:
-            try:
-                old_overview = await viking_fs.read_file(f"{dir_uri}/.overview.md", ctx=ctx)
-                if old_overview:
-                    existing_summaries = self._parse_overview_md(old_overview)
-                    logger.info(
-                        f"Parsed {len(existing_summaries)} existing summaries from overview.md"
-                    )
-            except Exception as e:
-                logger.debug(f"No existing overview.md found for {dir_uri}: {e}")
+            existing_summaries = await self._read_directory_summary_cache(dir_uri, ctx=ctx)
+            if not existing_summaries:
+                try:
+                    old_overview = await viking_fs.read_file(f"{dir_uri}/.overview.md", ctx=ctx)
+                    if old_overview:
+                        existing_summaries = self._parse_overview_md(old_overview)
+                        logger.info(
+                            f"Parsed {len(existing_summaries)} existing summaries from overview.md"
+                        )
+                except Exception as e:
+                    logger.debug(f"No existing overview.md found for {dir_uri}: {e}")
 
         changed_files: Set[str] = set()
         if msg.changes:
@@ -575,6 +599,15 @@ class SemanticProcessor(DequeueHandlerBase):
             return
 
         try:
+            await viking_fs.write_file(
+                f"{dir_uri}/{SUMMARY_CACHE_FILENAME}",
+                serialize_summary_cache(file_summaries),
+                ctx=ctx,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to write {SUMMARY_CACHE_FILENAME} for {dir_uri}: {e}")
+
+        try:
             if msg.telemetry_id and msg.id:
                 from openviking.storage.queuefs.embedding_tracker import EmbeddingTaskTracker
 
@@ -641,7 +674,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 name = entry.get("name", "")
                 if not name or name in [".", ".."]:
                     continue
-                if name.startswith(".") and name not in [".abstract.md", ".overview.md"]:
+                if name.startswith(".") and name not in MANAGED_HIDDEN_SEMANTIC_FILES:
                     continue
                 item_uri = VikingURI(dir_uri).join(name).uri
                 if entry.get("isDir", False):

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -28,13 +28,13 @@ from openviking.parse.parsers.media.utils import (
 )
 from openviking.prompts import render_prompt
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_cache import (
     MANAGED_HIDDEN_SEMANTIC_FILES,
     SUMMARY_CACHE_FILENAME,
     parse_summary_cache,
     serialize_summary_cache,
 )
-from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
 from openviking.storage.queuefs.semantic_msg import SemanticMsg
 from openviking.storage.viking_fs import get_viking_fs
@@ -231,7 +231,9 @@ class SemanticProcessor(DequeueHandlerBase):
         """Read cached file summaries for a directory."""
         viking_fs = get_viking_fs()
         try:
-            cache_content = await viking_fs.read_file(f"{dir_uri}/{SUMMARY_CACHE_FILENAME}", ctx=ctx)
+            cache_content = await viking_fs.read_file(
+                f"{dir_uri}/{SUMMARY_CACHE_FILENAME}", ctx=ctx
+            )
         except Exception as e:
             logger.debug(f"No summary cache found for {dir_uri}: {e}")
             return {}

--- a/tests/storage/test_semantic_dag_incremental_missing_summary.py
+++ b/tests/storage/test_semantic_dag_incremental_missing_summary.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import json
 import re
 from unittest.mock import AsyncMock, MagicMock
 
@@ -163,6 +164,45 @@ async def test_incremental_missing_summary_triggers_overview_regen(monkeypatch):
     assert len(processor.summarized_files) == first_run_calls
 
 
+@pytest.mark.asyncio
+async def test_incremental_uses_summary_cache_when_overview_titles_are_descriptive(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+
+    root_uri = "viking://resources/root"
+    target_uri = "viking://resources/target"
+    tree = {
+        root_uri: [{"name": "a.txt", "isDir": False}],
+        target_uri: [{"name": "a.txt", "isDir": False}],
+    }
+
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "hello",
+            f"{target_uri}/a.txt": "hello",
+            f"{target_uri}/.overview.md": "# root\n\n## Detailed Description\n### Session Context Management\nCached summary",
+            f"{target_uri}/.abstract.md": "old-abstract",
+            f"{target_uri}/.summary_cache.json": json.dumps({"a.txt": "Cached summary"}),
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=target_uri,
+    )
+    monkeypatch.setattr(executor, "_add_vectorize_task", AsyncMock())
+    await executor.run(root_uri)
+
+    assert processor.summarized_files == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
-

--- a/tests/storage/test_semantic_processor_summary_cache.py
+++ b/tests/storage/test_semantic_processor_summary_cache.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+
+class _FakeVikingFS:
+    def __init__(self):
+        self.entries = {
+            "viking://user/default/memories/preferences": [
+                {"name": "a.txt", "isDir": False},
+            ],
+        }
+        self.files = {
+            "viking://user/default/memories/preferences/.overview.md": "# preferences\n\n## Detailed Description\n### Session Context Management\nCached summary",
+            "viking://user/default/memories/preferences/.summary_cache.json": json.dumps(
+                {"a.txt": "Cached summary"}
+            ),
+            "viking://user/default/memories/preferences/a.txt": "hello",
+        }
+        self.writes = []
+
+    async def ls(self, uri, ctx=None):
+        return self.entries.get(uri, [])
+
+    async def read_file(self, path, ctx=None):
+        return self.files.get(path, "")
+
+    async def write_file(self, path, content, ctx=None):
+        self.files[path] = content
+        self.writes.append((path, content))
+
+    async def stat(self, path, ctx=None):
+        content = self.files.get(path, "")
+        return {"size": len(content)}
+
+
+@pytest.mark.asyncio
+async def test_process_memory_directory_reuses_summary_cache(monkeypatch):
+    fake_fs = _FakeVikingFS()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+
+    processor = SemanticProcessor(max_concurrent_llm=1)
+    generate_summary = AsyncMock()
+    generate_overview = AsyncMock(return_value="# preferences\n\nCached overview")
+    vectorize_directory = AsyncMock()
+    monkeypatch.setattr(processor, "_generate_single_file_summary", generate_summary)
+    monkeypatch.setattr(processor, "_generate_overview", generate_overview)
+    monkeypatch.setattr(processor, "_vectorize_directory", vectorize_directory)
+    monkeypatch.setattr(processor, "_enforce_size_limits", lambda overview, abstract: (overview, abstract))
+
+    msg = SemanticMsg(
+        uri="viking://user/default/memories/preferences",
+        context_type="memory",
+        recursive=False,
+        changes={"added": [], "modified": [], "deleted": []},
+    )
+
+    await processor._process_memory_directory(msg)
+
+    generate_summary.assert_not_called()
+    generate_overview.assert_awaited_once()
+    file_summaries = generate_overview.await_args.args[1]
+    assert file_summaries == [{"name": "a.txt", "summary": "Cached summary"}]
+    assert any(path.endswith("/.summary_cache.json") for path, _ in fake_fs.writes)

--- a/tests/storage/test_semantic_processor_summary_cache.py
+++ b/tests/storage/test_semantic_processor_summary_cache.py
@@ -56,7 +56,9 @@ async def test_process_memory_directory_reuses_summary_cache(monkeypatch):
     monkeypatch.setattr(processor, "_generate_single_file_summary", generate_summary)
     monkeypatch.setattr(processor, "_generate_overview", generate_overview)
     monkeypatch.setattr(processor, "_vectorize_directory", vectorize_directory)
-    monkeypatch.setattr(processor, "_enforce_size_limits", lambda overview, abstract: (overview, abstract))
+    monkeypatch.setattr(
+        processor, "_enforce_size_limits", lambda overview, abstract: (overview, abstract)
+    )
 
     msg = SemanticMsg(
         uri="viking://user/default/memories/preferences",


### PR DESCRIPTION
## Summary
- add a directory-level  sidecar that stores file summaries by exact filename
- prefer the sidecar cache during incremental semantic refresh, with  parsing kept as a fallback for existing data
- write and sync the cache alongside  / , and cover both DAG incremental and memory-directory flows with regression tests

## Verification
- Listing 'openviking/storage/queuefs'...
- manual async verification of the two new regression tests via direct invocation
- ============================= test session starts ==============================
platform darwin -- Python 3.10.12, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/bytedance/contextgo/OpenViking
configfile: pyproject.toml
plugins: asyncio-0.23.3, cov-4.1.0, anyio-4.10.0
asyncio: mode=auto
collected 0 items / 1 error

==================================== ERRORS ====================================
________________________ ERROR collecting test session _________________________
../../.pyenv/versions/3.10.12/lib/python3.10/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
../../.pyenv/versions/3.10.12/lib/python3.10/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
../../.pyenv/versions/3.10.12/lib/python3.10/site-packages/pytest_asyncio/plugin.py:626: in pytest_collectstart
    pyobject = collector.obj
E   AttributeError: 'Package' object has no attribute 'obj'
=============================== warnings summary ===============================
openviking/resource/watch_manager.py:28
  /Users/bytedance/contextgo/OpenViking/openviking/resource/watch_manager.py:28: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class WatchTask(BaseModel):

../../.pyenv/versions/3.10.12/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py:319
../../.pyenv/versions/3.10.12/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py:319
../../.pyenv/versions/3.10.12/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py:319
  /Users/bytedance/.pyenv/versions/3.10.12/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py:319: PydanticDeprecatedSince20: `json_encoders` is deprecated. See https://docs.pydantic.dev/2.12/concepts/serialization/#custom-serializers for alternatives. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    warnings.warn(

openviking/storage/vectordb/utils/validation.py:137
  /Users/bytedance/contextgo/OpenViking/openviking/storage/vectordb/utils/validation.py:137: PydanticDeprecatedSince212: Using `@model_validator` with mode='after' on a classmethod is deprecated. Instead, use an instance method. See the documentation at https://docs.pydantic.dev/2.12/concepts/validators/#model-after-validator. Deprecated in Pydantic V2.12 to be removed in V3.0.
    def validate_field_logic(cls, m):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

--------- coverage: platform darwin, python 3.10.12-final-0 ----------
Name                                                               Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------------
openviking/__init__.py                                                36     14    61%   21-22, 34-36, 38-40, 42-44, 46-48, 50-52, 54-56
openviking/async_client.py                                           173    112    35%   40-44, 59-70, 76-77, 81-82, 86-90, 95-103, 117, 128-129, 138-139, 143-144, 148-149, 155-156, 160-161, 165-166, 187-188, 196-197, 201-202, 235-240, 257, 261-262, 271-272, 281-282, 297-298, 332-334, 354-355, 368-369, 373-374, 378-379, 391-392, 410-416, 427-428, 439-440, 450-451, 455-456, 460-465, 475-476, 480-481, 487-488, 499-500, 510-511, 526-527, 544-545, 555, 563, 568
openviking/client.py                                                   5      5     0%   8-13
openviking/client/__init__.py                                          6      0   100%
openviking/client/local.py                                           154     99    36%   24-31, 49-54, 59, 65, 69, 89-110, 123-133, 140, 144-146, 150-152, 166, 185, 196, 200, 204, 208, 220, 224, 228, 240-252, 269-281, 298-318, 333, 345, 351, 355, 359, 370-373, 380, 384-387, 393-396, 400-403, 407, 413-418, 425, 446-463, 472, 482, 490, 507-513, 524-525, 533, 541, 546
openviking/client/session.py                                          29     14    52%   34-36, 58-63, 73, 82, 86, 94, 98, 102, 105
openviking/console/__init__.py                                         2      2     0%   9-10
openviking/console/app.py                                            286    286     0%   5-476
openviking/console/bootstrap.py                                       27     27     0%   5-75
openviking/console/config.py                                          25     25     0%   5-69
openviking/core/__init__.py                                            5      0   100%
openviking/core/building_tree.py                                      54     39    28%   26-31, 35-36, 41-43, 48, 52, 56-59, 63, 67-75, 80-98, 101, 104
openviking/core/context.py                                           114     76    33%   48, 80-102, 106-112, 116-121, 125-137, 141, 144, 149, 153-154, 158-191, 196-200, 205-242
openviking/core/directories.py                                       105     80    24%   129-137, 147, 151-169, 173-188, 192-208, 219-243, 254-280, 284-288, 292-299, 309-327, 333-335
openviking/core/mcp_converter.py                                      26     23    12%   10-51, 61
openviking/core/skill_loader.py                                       37     23    38%   20-25, 30-44, 56-59, 64-71
openviking/crypto/__init__.py                                          5      0   100%
openviking/crypto/config.py                                          120    106    12%   31-56, 61-90, 95-105, 110-126, 139-158, 171-211
openviking/crypto/encryptor.py                                        90     71    21%   50-51, 55-68, 82-92, 114-143, 169-185, 195-232, 236-244, 248-258
openviking/crypto/exceptions.py                                       16      0   100%
openviking/crypto/providers.py                                       300    245    18%   44, 49, 54, 59, 76-88, 96-102, 106-114, 127-130, 144-145, 158-159, 163-165, 169-188, 192-193, 228-236, 245-266, 270-281, 285-300, 312-323, 335-345, 354-418, 427, 439-440, 475-485, 494-576, 588-589, 601-602, 611-645, 654, 666-667, 684-732
openviking/eval/__init__.py                                            2      2     0%   7-25
openviking/eval/ragas/__init__.py                                    126    126     0%   7-341
openviking/eval/ragas/analyze_records.py                              36     36     0%   16-127
openviking/eval/ragas/base.py                                         23     23     0%   7-59
openviking/eval/ragas/generator.py                                    33     33     0%   7-134
openviking/eval/ragas/pipeline.py                                     76     76     0%   7-202
openviking/eval/ragas/play_recorder.py                                99     99     0%   16-255
openviking/eval/ragas/playback.py                                    347    347     0%   9-635
openviking/eval/ragas/rag_eval.py                                    226    226     0%   12-488
openviking/eval/ragas/record_analysis.py                             191    191     0%   9-439
openviking/eval/ragas/types.py                                        23     23     0%   7-47
openviking/eval/recorder/__init__.py                                   4      4     0%   9-25
openviking/eval/recorder/async_writer.py                              95     95     0%   9-172
openviking/eval/recorder/playback.py                                   6      6     0%   10-27
openviking/eval/recorder/recorder.py                                 125    125     0%   7-367
openviking/eval/recorder/recording_client.py                         116    116     0%   9-271
openviking/eval/recorder/types.py                                     86     86     0%   7-141
openviking/eval/recorder/wrapper.py                                  236    236     0%   9-473
openviking/message/__init__.py                                         3      0   100%
openviking/message/message.py                                         99     72    27%   28-31, 50-62, 66-73, 81-110, 115-150, 160-162, 178-205, 214, 218, 222-225, 229
openviking/message/part.py                                            35      8    77%   65-88
openviking/models/__init__.py                                          0      0   100%
openviking/models/embedder/__init__.py                                17      2    88%   39-40
openviking/models/embedder/base.py                                   200    123    38%   24-32, 38-42, 47-50, 57-60, 73-82, 100, 105, 110, 126-133, 146, 158, 167, 173-176, 180, 183, 197-223, 233, 238, 243, 260, 273, 277, 288-294, 316, 325, 349, 354, 378, 387, 392, 397, 412-414, 418-421, 427-430, 436-440, 447-451, 457, 460-461, 491-526
openviking/models/embedder/cohere_embedders.py                       126    105    17%   35-37, 55-94, 97-105, 108-111, 114-128, 132-134, 137-155, 158-183, 186-209, 214-246, 250-259, 262
openviking/models/embedder/gemini_embedders.py                       183    180     2%   9-450
openviking/models/embedder/jina_embedders.py                         130    107    18%   34-36, 101-133, 137-148, 151-158, 161-166, 170-171, 192-217, 220-244, 259-286, 291-320, 328
openviking/models/embedder/litellm_embedders.py                      116     99    15%   70-87, 98-100, 104-137, 141-162, 183-200, 203-218, 233-254, 259-276, 284
openviking/models/embedder/minimax_embedders.py                      146    121    17%   58-91, 95-105, 109-110, 114-143, 146-154, 157-160, 163-168, 175-200, 204-214, 217-233, 237-252, 257-276, 280, 283-292
openviking/models/embedder/openai_embedders.py                       171    142    17%   113-149, 153-160, 171-173, 176-197, 213-226, 239-257, 260-267, 272-274, 277-282, 298-317, 320-336, 351-373, 378-402, 410, 420, 426, 436, 442, 445
openviking/models/embedder/vikingdb_embedders.py                     291    258    11%   33-42, 51-74, 82-110, 116-125, 129-144, 162-168, 171-196, 199-226, 229-252, 257-283, 286, 302-306, 312-337, 340-365, 368-393, 398-424, 442-449, 455-486, 489-520, 523-555, 560-596, 599, 602-610
openviking/models/embedder/volcengine_embedders.py                   291    258    11%   22-52, 83-107, 111-115, 118-139, 160-184, 187-189, 192-215, 230-261, 266-299, 302, 329-343, 346-367, 388-407, 410-412, 415-435, 450-452, 457-484, 516-532, 535-556, 577-601, 604-606, 609-633, 648-650, 655-683, 686
openviking/models/embedder/voyage_embedders.py                        98     81    17%   42-44, 62-87, 90-93, 96-101, 106-129, 132-155, 159-184, 189-215, 219
openviking/models/rerank/__init__.py                                   6      0   100%
openviking/models/rerank/base.py                                      34     24    29%   17-21, 33, 37, 54, 74-96, 109, 113
openviking/models/rerank/cohere_rerank.py                             40     29    28%   30-35, 56-91, 94, 107-109
openviking/models/rerank/litellm_rerank.py                            43     34    21%   30-34, 48-98, 111-113
openviking/models/rerank/openai_rerank.py                             49     39    20%   44-49, 63-122, 135-137
openviking/models/rerank/volcengine_rerank.py                         72     57    21%   50-56, 66-85, 99-151, 164-184
openviking/models/vlm/__init__.py                                      6      0   100%
openviking/models/vlm/backends/litellm_vlm.py                        192    159    17%   89-93, 104-115, 119-130, 134-146, 153-167, 171-197, 208-237, 241-251, 255-274, 284-286, 297-307, 318-330, 347-361, 377-388, 404-415, 428-431
openviking/models/vlm/backends/openai_vlm.py                         252    213    15%   18-19, 44-58, 65-68, 72-86, 90-104, 108-122, 126-127, 134-145, 149-159, 163-182, 190-201, 205-226, 230-251, 261-274, 285-307, 310-315, 318-323, 334-346, 363-378, 390-404, 408-434, 445-457, 473-485
openviking/models/vlm/backends/volcengine_vlm.py                     203    179    12%   24-32, 36-46, 50-69, 73-84, 88-99, 110-131, 143-180, 191-246, 250-294, 305-335, 346-376
openviking/models/vlm/base.py                                         95     50    47%   44, 48, 55-67, 90, 113, 138, 163, 167, 171, 191-214, 222, 230-231, 240, 243-245, 265-280, 285-287
openviking/models/vlm/llm.py                                         117    117     0%   9-276
openviking/models/vlm/registry.py                                      7      2    71%   18, 23
openviking/models/vlm/token_usage.py                                  76     43    43%   29-33, 37-41, 49, 58, 83-89, 100, 108-117, 120-126, 133, 146-149, 160, 168, 176-183, 187, 195-203, 206-213
openviking/parse/__init__.py                                          14      0   100%
openviking/parse/base.py                                             178    113    37%   35-40, 54-76, 93-99, 188, 195-200, 204-212, 216-220, 224-226, 230-232, 236-238, 250-255, 267-278, 290-318, 322, 334-344, 370, 374-382, 395-399, 428
openviking/parse/converter.py                                         49     38    22%   19, 23-33, 37-63, 67-83
openviking/parse/custom.py                                            40     17    58%   100-107, 112, 116, 132-137, 159, 201-203, 208, 212, 225, 241
openviking/parse/directory_scan.py                                   153    119    22%   51, 60-69, 85-117, 122-124, 129, 134-136, 145-155, 168-172, 214-298
openviking/parse/parsers/__init__.py                                  12      0   100%
openviking/parse/parsers/base_parser.py                               33     17    48%   33, 51, 57, 69-70, 82-92, 101-103, 115
openviking/parse/parsers/code/__init__.py                              2      0   100%
openviking/parse/parsers/code/ast/__init__.py                          5      5     0%   5-29
openviking/parse/parsers/code/ast/extractor.py                        47     47     0%   5-130
openviking/parse/parsers/code/ast/languages/__init__.py                0      0   100%
openviking/parse/parsers/code/ast/languages/base.py                    5      5     0%   5-12
openviking/parse/parsers/code/ast/languages/cpp.py                   151    151     0%   5-228
openviking/parse/parsers/code/ast/languages/csharp.py                135    135     0%   5-182
openviking/parse/parsers/code/ast/languages/go.py                     84     84     0%   5-110
openviking/parse/parsers/code/ast/languages/java.py                   90     90     0%   5-127
openviking/parse/parsers/code/ast/languages/js_ts.py                 166    166     0%   5-222
openviking/parse/parsers/code/ast/languages/lua.py                   103    103     0%   5-148
openviking/parse/parsers/code/ast/languages/php.py                   248    248     0%   5-327
openviking/parse/parsers/code/ast/languages/python.py                140    140     0%   5-180
openviking/parse/parsers/code/ast/languages/rust.py                   85     85     0%   5-118
openviking/parse/parsers/code/ast/skeleton.py                         60     60     0%   5-99
openviking/parse/parsers/code/code.py                                291    249    14%   66, 78-86, 100-199, 205, 208-217, 225-233, 236-251, 256, 259-275, 284-300, 303-324, 327-331, 336, 351-421, 438-487, 491-549, 553-554
openviking/parse/parsers/constants.py                                 11      0   100%
openviking/parse/parsers/directory.py                                171    142    17%   56, 60, 84-248, 268, 293-305, 322, 351-383, 405-418, 427, 439-453, 462-473
openviking/parse/parsers/epub.py                                      95     74    22%   36-39, 43, 47-60, 66-69, 74-83, 87-105, 109-115, 119-133, 142-173
openviking/parse/parsers/excel.py                                    126    107    15%   39-43, 47, 51-70, 76-79, 83-91, 95-133, 138-171, 175-186, 190-227
openviking/parse/parsers/feishu.py                                   447    447     0%   15-888
openviking/parse/parsers/html.py                                     307    257    16%   98-153, 165-194, 222-224, 228-238, 242-252, 257, 271-278, 292-325, 341-371, 392-396, 413-474, 482-496, 507-528, 550-565, 569-585, 605-636, 651-683, 689-706, 710-725, 743-755, 759-771
openviking/parse/parsers/legacy_doc.py                               193    166    14%   38-41, 45, 49-62, 68-73, 83-97, 102-106, 116-157, 167-187, 203-301, 306, 311-314, 323-360
openviking/parse/parsers/markdown.py                                 293    258    12%   68-84, 89, 103-117, 145-233, 247-262, 275-307, 323-357, 360-372, 400-463, 478-512, 516, 522-527, 531-533, 545-564, 577-591, 599-602, 614-640, 651-664, 683-720, 734-736
openviking/parse/parsers/media/__init__.py                             5      0   100%
openviking/parse/parsers/media/audio.py                              188    166    12%   58, 63, 80-161, 183-225, 246-319, 338-385, 404-430
openviking/parse/parsers/media/constants.py                            4      0   100%
openviking/parse/parsers/media/image.py                              101     77    24%   70, 75, 93-147, 167-192, 205-220, 236-277, 300
openviking/parse/parsers/media/utils.py                               61     45    26%   25, 66-79, 93-97, 118-170, 191-194, 215-218
openviking/parse/parsers/media/video.py                               79     65    18%   49, 54, 71-154, 177, 192-237, 256
openviking/parse/parsers/pdf.py                                      293    269     8%   71-75, 79-83, 88, 105-146, 168-191, 216-336, 343-393, 400-510, 523-541, 557-613, 633-660, 679
openviking/parse/parsers/powerpoint.py                                82     65    21%   39-43, 47, 51-66, 72-75, 79-102, 106-113, 117-135, 139-149
openviking/parse/parsers/text.py                                      19      8    58%   22-24, 28, 32, 38-41
openviking/parse/parsers/upload_utils.py                             162    143    12%   49-58, 63-108, 117-140, 148-149, 162-174, 183-199, 218-307
openviking/parse/parsers/word.py                                      84     67    20%   33-36, 40, 44-59, 65-68, 76-108, 112-120, 124-136, 140-150
openviking/parse/parsers/zip_parser.py                               121    100    17%   37-40, 44, 48-65, 71-74, 86-92, 96-161, 165-173, 177-181, 185-189, 194-226
openviking/parse/registry.py                                         113     80    29%   55-86, 96-100, 132-143, 173-182, 186-191, 195, 207-214, 230-268, 272, 276, 286-288, 302
openviking/parse/resource_detector/__init__.py                         0      0   100%
openviking/parse/resource_detector/detect_info.py                     20     20     0%   10-47
openviking/parse/resource_detector/recursive.py                        0      0   100%
openviking/parse/resource_detector/size.py                             0      0   100%
openviking/parse/resource_detector/visit.py                            0      0   100%
openviking/parse/tree_builder.py                                      84     69    18%   60, 67-76, 84-101, 125-200
openviking/parse/vlm.py                                              234    196    16%   27-28, 50-51, 55-57, 66-91, 103-107, 115-145, 158-184, 197-227, 241-264, 273-311, 326-336, 353-426, 445-509, 525-576, 590-601, 609-666, 677-707
openviking/prompts/__init__.py                                         2      0   100%
openviking/prompts/manager.py                                        123     78    37%   76-79, 84-100, 105, 122-137, 147-160, 182-205, 210-229, 236-237, 249-259, 263-264, 274-276, 291, 304
openviking/pyagfs/__init__.py                                         53     12    77%   38, 43-45, 58-61, 66, 79-80, 90
openviking/pyagfs/client.py                                          436    361    17%   25-31, 35-86, 90-92, 101-115, 119-128, 131, 146-173, 190-269, 273-280, 284-293, 303-319, 323-330, 334-344, 348-358, 362-369, 373-379, 392-401, 405-412, 423-432, 443-452, 460-480, 493-499, 536-561, 565-573, 594-603, 629-639, 647-653, 664-671, 682-689, 702-712, 725-739, 752-762, 773-780, 791-798, 810-819, 849-853, 858, 863, 868, 873, 884-886, 898-900, 911-913, 925-927, 939-941, 949, 953-955, 963-965, 973-975, 986-988, 992-994, 997, 1000, 1003-1004
openviking/pyagfs/exceptions.py                                       12      2    83%   26-27
openviking/pyagfs/helpers.py                                         118    105    11%   37-45, 73-83, 111-119, 128-143, 149-168, 174-192, 200-215, 221-233, 241-256, 261-264, 269-291
openviking/resource/__init__.py                                        2      0   100%
openviking/resource/watch_manager.py                                 343    285    17%   60, 88-96, 100-101, 128-132, 136-145, 149-221, 225-271, 298-308, 322-332, 370-409, 453-522, 547-564, 586-594, 616-624, 646-658, 666-680, 691-705, 708-718, 726-734
openviking/resource/watch_scheduler.py                               173    147    15%   46-60, 65, 73-84, 92-111, 122-140, 147-169, 176-201, 213-307, 313-317, 320-321, 332-341, 346, 351
openviking/resource/watch_storage.py                                  10      4    60%   23-26
openviking/retrieve/__init__.py                                        4      0   100%
openviking/retrieve/hierarchical_retriever.py                        263    222    16%   68-84, 108-219, 236-248, 257-280, 293-323, 332-349, 377-497, 511-572, 577-586, 596-617
openviking/retrieve/intent_analyzer.py                                48     32    33%   36, 56-96, 112-124, 138-140, 148-153
openviking/retrieve/memory_lifecycle.py                               18     13    28%   44-64
openviking/retrieve/retrieval_stats.py                                84     51    39%   37-39, 43-45, 49-51, 55-57, 61, 100-101, 113-148, 152-155, 159-160, 171-175
openviking/server/__init__.py                                          9      7    22%   7-15
openviking/server/api_keys.py                                        292    292     0%   5-559
openviking/server/app.py                                             103    103     0%   5-227
openviking/server/auth.py                                             74     74     0%   5-174
openviking/server/bootstrap.py                                       168    168     0%   5-323
openviking/server/config.py                                           65     65     0%   5-170
openviking/server/dependencies.py                                      9      9     0%   5-33
openviking/server/identity.py                                         35      4    89%   37, 50, 54, 58
openviking/server/local_input_guard.py                                42     30    29%   19, 24-26, 36-42, 47-48, 56-93
openviking/server/models.py                                           12     12     0%   5-28
openviking/server/routers/__init__.py                                 16     16     0%   5-21
openviking/server/routers/admin.py                                   109    109     0%   5-258
openviking/server/routers/bot.py                                      91     91     0%   7-206
openviking/server/routers/content.py                                 107    107     0%   5-263
openviking/server/routers/debug.py                                    48     48     0%   11-102
openviking/server/routers/filesystem.py                               53     53     0%   5-135
openviking/server/routers/metrics.py                                   9      9     0%   5-18
openviking/server/routers/observer.py                                 41     41     0%   13-102
openviking/server/routers/pack.py                                     47     47     0%   5-106
openviking/server/routers/relations.py                                30     30     0%   5-63
openviking/server/routers/resources.py                               107    107     0%   5-253
openviking/server/routers/search.py                                   87     87     0%   5-181
openviking/server/routers/sessions.py                                129    129     0%   5-284
openviking/server/routers/stats.py                                    32     32     0%   5-74
openviking/server/routers/system.py                                   72     72     0%   5-144
openviking/server/routers/tasks.py                                    19     19     0%   10-59
openviking/server/telemetry.py                                         8      8     0%   5-29
openviking/service/__init__.py                                         9      0   100%
openviking/service/core.py                                           207    142    31%   60-102, 113-144, 153, 158, 163, 168, 173, 178, 183, 188, 193, 198, 203, 208, 213, 218, 222-338, 342-370, 374-375, 379-382, 386-389, 393-396
openviking/service/debug_service.py                                   99     56    43%   34-35, 47-55, 66-67, 75-76, 81, 86-96, 105-113, 123-150, 160-170, 180-181, 190-198, 206-208, 219, 227, 232, 236
openviking/service/fs_service.py                                      64     40    38%   24, 28, 32-34, 59-101, 105-106, 110-111, 115-116, 129-130, 142-143, 147-148, 152-153, 157-158, 171-172, 190-191, 195-196, 208-210
openviking/service/pack_service.py                                    23      9    61%   25, 29, 33-35, 47-48, 69-70
openviking/service/relation_service.py                                24     11    54%   23, 27, 31-33, 37-38, 54-55, 64-65
openviking/service/resource_service.py                               173    142    18%   59-63, 74-78, 81-83, 86-93, 97-102, 158-284, 313-367, 376-396, 418-456, 470-471, 485-486, 497-502
openviking/service/search_service.py                                  26     14    46%   26, 30, 34-36, 61-76, 99-108
openviking/service/session_service.py                                 80     57    29%   32-34, 43-45, 49-50, 61-62, 82-88, 101-107, 115-134, 145-154, 167, 182-184, 188-193, 204-210
openviking/service/task_tracker.py                                   173    112    35%   58-62, 74-78, 84, 99-102, 120-123, 133-136, 140-142, 145-152, 156-175, 184-188, 193-194, 207-223, 238-265, 269-273, 277-283, 287-293, 302-306, 318-331, 341-342, 353, 357-358
openviking/session/__init__.py                                        29     17    41%   50-70
openviking/session/compressor.py                                     359    320    11%   68-71, 83-102, 110-146, 161-195, 200-219, 229-265, 271-284, 296-555, 559-566, 580-596, 603-618, 622-633, 642-688, 692-696
openviking/session/compressor_v2.py                                  132    132     0%   10-295
openviking/session/memory/__init__.py                                  9      0   100%
openviking/session/memory/core.py                                     17     17     0%   11-74
openviking/session/memory/dataclass.py                               131     69    47%   80, 84, 104-110, 115-122, 127-136, 141-149, 161-194, 245, 254
openviking/session/memory/extract_loop.py                            240    215    10%   68-90, 99-260, 272-315, 328-346, 363-440, 448-467, 474, 481-518, 527-550, 559-560
openviking/session/memory/memory_type_registry.py                    122    101    17%   29-32, 36-59, 65-66, 70, 81-83, 94-96, 108-117, 126-130, 142-163, 167-180, 201-274, 284
openviking/session/memory/memory_updater.py                          276    234    15%   36, 40-43, 47-50, 54-58, 62-66, 70-74, 85-127, 134, 138-144, 148-156, 160-179, 186-189, 192, 195, 198, 201, 204, 207, 226-229, 233, 237-239, 261-336, 351-412, 416-423, 428-464, 477-530
openviking/session/memory/merge_op/__init__.py                         7      0   100%
openviking/session/memory/merge_op/base.py                            37      7    81%   45, 84-86, 112, 124, 137
openviking/session/memory/merge_op/factory.py                         18      8    56%   32-40, 52
openviking/session/memory/merge_op/immutable.py                       12      5    58%   23, 26, 29-32
openviking/session/memory/merge_op/patch.py                           54     45    17%   28-29, 32-34, 37-39, 56-93, 108-128
openviking/session/memory/merge_op/patch_handler.py                  458    417     9%   48-64, 69-84, 89-101, 112-141, 155-157, 168-173, 178-182, 192, 215-360, 397-398, 420-695, 709-764, 789, 818-834, 838-844, 857-1137
openviking/session/memory/merge_op/sum.py                             19     12    37%   23, 26, 30-39
openviking/session/memory/schema_model_generator.py                  161    134    17%   27-30, 45-50, 54, 69-107, 119-122, 139-160, 172-208, 219, 232-343, 352-353, 362-363, 375, 384-415, 427-435, 444
openviking/session/memory/session_extract_context_provider.py        154    154     0%   9-372
openviking/session/memory/tools.py                                   149     83    44%   28-40, 45-53, 57-63, 74, 95-96, 111, 117, 123, 143, 147, 166, 170, 187-201, 213, 217, 239-256, 261-266, 278, 282, 299-325, 339, 344, 353
openviking/session/memory/utils/__init__.py                            7      0   100%
openviking/session/memory/utils/content.py                            74     60    19%   24-26, 31-39, 62-101, 114-124, 137-154, 167-169, 187-196
openviking/session/memory/utils/json_parser.py                       231    207    10%   55-62, 70-72, 76-80, 96-144, 159, 174-182, 197-206, 221-229, 251-285, 305-382, 407-477
openviking/session/memory/utils/language.py                           31     26    16%   16-46, 55-74
openviking/session/memory/utils/messages.py                           68     58    15%   30-77, 93-123
openviking/session/memory/utils/model.py                              12      9    25%   20-30
openviking/session/memory/utils/uri.py                               183    152    17%   22-27, 50-59, 95-118, 131-148, 169-176, 198-213, 232-249, 269-276, 299-303, 321-329, 358-379, 404-424, 432-437, 440, 467-515, 540-568
openviking/session/memory_archiver.py                                136     96    29%   78-81, 85-89, 112-191, 212-241, 260-273, 283-284, 298-303, 314-320, 325-336
openviking/session/memory_deduplicator.py                            219    166    24%   79-83, 90-92, 96, 107-125, 146-236, 244-309, 318-414, 419-434, 439-449
openviking/session/memory_extractor.py                               713    616    14%   133-134, 143-145, 154-195, 199-223, 238-430, 439, 449-517, 526-558, 572-623, 629-748, 752-760, 764-840, 844-858, 862-875, 878-888, 891-918, 921-924, 927-933, 936-945, 948-958, 963-985, 990-1025, 1028-1037, 1040, 1056, 1075-1118, 1144-1145, 1159-1176, 1182-1318, 1322-1326, 1330-1379, 1383-1391, 1396-1448, 1472-1473, 1487-1504
openviking/session/session.py                                        662    543    18%   93, 107-111, 166-183, 187-228, 232-236, 240-244, 248-251, 259-261, 266, 271, 281-298, 307-324, 334-346, 350, 363-468, 488-650, 659-668, 682-691, 699-711, 715-727, 731-761, 780-789, 798, 802-822, 828-860, 870-896, 903-915, 919-933, 937-941, 945-955, 959-967, 971-985, 992-1007, 1014-1015, 1019-1034, 1039-1042, 1046-1066, 1075-1102, 1106-1115, 1119-1127, 1135-1157, 1165-1187, 1197-1220, 1224-1252, 1262-1284, 1292-1294, 1304-1309, 1325-1344, 1354-1359, 1363-1382, 1386-1395, 1399-1408, 1415, 1420, 1425, 1430, 1435, 1438
openviking/session/tool_skill_utils.py                                72     72     0%   4-127
openviking/storage/__init__.py                                         7      0   100%
openviking/storage/collection_schemas.py                             292    243    17%   63-119, 137-146, 172-188, 192, 196-207, 217-231, 235-238, 243-252, 256-487, 491-495, 499-503
openviking/storage/content_write.py                                  246    208    15%   34, 46-129, 132-133, 136-144, 147-152, 162-180, 191-201, 204-222, 225-231, 243-261, 271-288, 291-296, 304-311, 320-326, 341-354, 369-411, 414-457, 460-464
openviking/storage/errors.py                                          10      0   100%
openviking/storage/expr.py                                            43      0   100%
openviking/storage/local_fs.py                                       195    169    13%   29-46, 51-53, 58-60, 65-72, 78-91, 95-133, 162-253, 272-331
openviking/storage/observers/__init__.py                               8      0   100%
openviking/storage/observers/base_observer.py                         11      3    73%   28, 38, 48
openviking/storage/observers/lock_observer.py                         26     13    50%   19, 23-24, 38, 43-68, 71, 74
openviking/storage/observers/models_observer.py                       90     76    16%   38-40, 49, 58-99, 103-126, 130-158, 162-190, 193, 204, 219
openviking/storage/observers/prometheus_observer.py                  100     71    29%   16-19, 22-26, 30, 40-51, 55, 58, 61, 64-66, 69-71, 74-76, 79-82, 85-88, 91-148, 157-160, 169-177, 189-190, 195
openviking/storage/observers/queue_observer.py                        52     36    31%   28, 31-33, 36, 39, 53-110, 113-119, 122, 125
openviking/storage/observers/retrieval_observer.py                    35     23    34%   30-32, 36, 40-82, 85, 89-92, 96-99
openviking/storage/observers/vikingdb_observer.py                     61     45    26%   28, 31-40, 43, 46, 51-74, 77-112, 121, 130-137
openviking/storage/queuefs/__init__.py                                10      0   100%
openviking/storage/queuefs/embedding_msg.py                           33     15    55%   24-28, 32, 36, 41-48, 53-57
openviking/storage/queuefs/embedding_msg_converter.py                 46     38    17%   26-77
openviking/storage/queuefs/embedding_queue.py                         52     43    17%   21-25, 29-52, 56-75
openviking/storage/queuefs/embedding_tracker.py                       90     63    30%   43-45, 48-52, 57-58, 62, 70-111, 119-121, 138-169, 184-202
openviking/storage/queuefs/named_queue.py                            202    144    29%   40, 44, 57, 74-76, 80-81, 85-86, 90-91, 96-98, 114-131, 139-140, 144-146, 150-151, 155-166, 170-172, 183-188, 192, 196-202, 206-217, 226-232, 239-250, 263-280, 284-289, 297-299, 303-318, 322-337, 341-349
openviking/storage/queuefs/queue_manager.py                          186    151    19%   44-51, 56-59, 81-93, 99-108, 122-144, 148-166, 176-200, 209-266, 271-291, 295, 305-337, 343, 347, 351, 355, 359, 365-369, 373-377, 381-382, 391-397
openviking/storage/queuefs/semantic_cache.py                          37     30    19%   20-27, 32, 40-64
openviking/storage/queuefs/semantic_dag.py                           435    370    15%   89-114, 119-154, 158-230, 234-284, 288-308, 311-322, 325-339, 350-393, 398-419, 424-432, 437-481, 486-499, 502-516, 519-527, 530-537, 540-547, 550-627, 631-636, 640-658, 662-676, 679
openviking/storage/queuefs/semantic_msg.py                            70     40    43%   64-77, 81, 85, 90-125, 130-134
openviking/storage/queuefs/semantic_processor.py                     738    662    10%   94-98, 102-111, 119-127, 137-148, 152-155, 165-170, 174-175, 190-203, 209-221, 227-237, 245-260, 264-412, 415-417, 425-436, 449-609, 613-620, 630-836, 842-849, 859-942, 958-968, 972-991, 995-1000, 1011-1053, 1078-1158, 1169-1200, 1216-1316, 1329-1336, 1356-1359
openviking/storage/queuefs/semantic_queue.py                          60     45    25%   24-26, 30, 34-54, 58-73, 77-90
openviking/storage/stats_aggregator.py                                81     81     0%   9-198
openviking/storage/transaction/__init__.py                             6      0   100%
openviking/storage/transaction/lock_context.py                        46     38    17%   28-36, 39-76, 79-84
openviking/storage/transaction/lock_handle.py                         22      5    77%   33, 36-37, 40-41
openviking/storage/transaction/lock_manager.py                       228    189    17%   30-37, 41, 44, 47-52, 56-58, 62-80, 83-85, 90-95, 100-105, 132-161, 171-180, 183-189, 192-203, 206-207, 210, 214-224, 228-232, 235-242, 249-258, 266-324, 334-356, 372-373, 377-379, 384, 389-392
openviking/storage/transaction/path_lock.py                          378    336    11%   31, 35-57, 62-63, 66-67, 71-87, 90-94, 97-105, 108-112, 115-116, 119-123, 126-130, 135-136, 139-148, 151-156, 159-165, 168-175, 178-187, 190-214, 219-305, 310-413, 436-459, 463-476, 479-487, 490-495
openviking/storage/transaction/redo_log.py                            47     33    30%   24, 27, 30-37, 41-44, 48-51, 55-65, 69-76
openviking/storage/vectordb/__init__.py                                0      0   100%
openviking/storage/vectordb/collection/__init__.py                     5      0   100%
openviking/storage/vectordb/collection/collection.py                 181    103    43%   13-18, 23, 27, 31, 35, 39, 43, 47, 51, 64, 77, 89, 103, 114, 127, 136, 140, 144, 148, 152, 156, 160, 164, 187, 207-210, 217-219, 230-232, 239-241, 251-253, 262-264, 278-280, 292-294, 306-308, 336-338, 371-373, 404-406, 439-441, 469-471, 503-505, 524-526, 538-540, 549-551, 561-563, 578-580, 593-595, 604-606, 613-615, 637-639, 646-648
openviking/storage/vectordb/collection/http_collection.py            225    190    16%   40-51, 67-80, 89-94, 97-116, 119-133, 136, 139-153, 156-171, 174-175, 178, 183-197, 205-225, 228-243, 246-261, 264-280, 283-316, 319-334, 337-352, 364-396, 407-438, 451-484, 494-524, 536-568, 580-612, 622-642, 647-653
openviking/storage/vectordb/collection/local_collection.py           522    445    15%   92-123, 134-162, 165-173, 178, 181-198, 201, 205-213, 216, 219, 222-224, 227, 235-238, 241-244, 247, 259-327, 338-364, 394-404, 416-417, 445-463, 477-511, 515-586, 589-619, 622-636, 650-695, 698-704, 707-714, 717-725, 728-742, 748-763, 776-785, 794-814, 837-875, 879, 888, 899-900, 909-915, 918, 930-936, 939-980, 987, 991-992, 1002-1015, 1024-1035, 1038-1039
openviking/storage/vectordb/collection/result.py                      26      0   100%
openviking/storage/vectordb/collection/vikingdb_clients.py            25     15    40%   53-57, 78-100
openviking/storage/vectordb/collection/vikingdb_collection.py        168    131    22%   32-36, 39-50, 53-66, 69-77, 80-88, 91-100, 103-107, 110, 113, 116, 119-120, 123, 126-130, 138, 141-146, 149, 152-159, 162-169, 172-178, 181-187, 190-203, 206-217, 229-243, 254-266, 279-293, 303-314, 326-339, 351-364, 374-386, 391-397
openviking/storage/vectordb/collection/volcengine_clients.py          71     54    24%   25-32, 35-66, 69-70, 88-95, 98-129, 132-135
openviking/storage/vectordb/collection/volcengine_collection.py      310    252    19%   36-70, 91-107, 111-120, 126-134, 137-148, 151-164, 169-179, 185-191, 197-218, 223-233, 238-242, 247-258, 263-268, 272-281, 284-292, 295-304, 307-311, 314, 317-321, 324-338, 341-342, 345, 348-352, 360-370, 373-378, 381-386, 389-396, 399-407, 410-416, 419-425, 428-441, 444-455, 467-481, 492-504, 517-531, 541-552, 564-577, 589-602, 607-613, 623-635
openviking/storage/vectordb/engine/__init__.py                       139     84    40%   48-62, 73-91, 100-104, 109-119, 123-144, 148-163, 167-180, 189, 192, 195, 198, 207-210, 216
openviking/storage/vectordb/engine/_python_api.py                    328    253    23%   45, 59, 74-119, 122-124, 127, 130, 134-136, 141-142, 145-221, 224, 227-270, 273, 283, 297-302, 309-310, 317-321, 335-338, 342, 354-355, 359, 363-364, 374-376, 380, 384-411, 415-484
openviking/storage/vectordb/index/__init__.py                          0      0   100%
openviking/storage/vectordb/index/index.py                            85     50    41%   42, 67, 88, 128, 167, 190, 210, 227, 243, 256, 274, 293, 307-309, 323-325, 357-368, 386-388, 401-403, 414-417, 425-428, 441-443, 456-458, 480-482
openviking/storage/vectordb/index/local_index.py                     323    271    16%   28-39, 67-68, 78-100, 103-118, 121-137, 140-147, 150-152, 160-163, 171-174, 182, 210-216, 223-230, 233, 236-237, 240-241, 251-265, 271-306, 309, 312-314, 317, 327, 331-333, 336-356, 361-377, 416-433, 447, 455-457, 524-541, 552-576, 590-605, 634-651, 668-678, 696-720, 732-733, 748
openviking/storage/vectordb/meta/__init__.py                           0      0   100%
openviking/storage/vectordb/meta/collection_meta.py                  101     66    35%   27-34, 49-51, 63-108, 120-134, 145-154, 162, 170, 174, 179, 184, 189, 194, 199, 204, 209, 214, 218
openviking/storage/vectordb/meta/dict.py                              38     14    63%   20-21, 33, 37, 45, 53, 61, 68, 77, 86, 99, 104, 113, 122
openviking/storage/vectordb/meta/index_meta.py                        81     63    22%   31-42, 58-61, 76-113, 127-137, 148-163, 171-172, 180, 188
openviking/storage/vectordb/meta/local_dict.py                        48     27    44%   20-21, 29-30, 38, 50, 54, 62, 70, 82, 95-104, 112-113, 121-122, 132-133, 137-138
openviking/storage/vectordb/project/__init__.py                        0      0   100%
openviking/storage/vectordb/project/http_project.py                   70     70     0%   3-233
openviking/storage/vectordb/project/local_project.py                  89     89     0%   3-231
openviking/storage/vectordb/project/project.py                        39     39     0%   3-166
openviking/storage/vectordb/project/project_group.py                  95     95     0%   3-260
openviking/storage/vectordb/project/vikingdb_project.py               92     92     0%   3-208
openviking/storage/vectordb/project/volcengine_project.py             64     64     0%   3-211
openviking/storage/vectordb/service/__init__.py                        0      0   100%
openviking/storage/vectordb/service/api_fastapi.py                   335    335     0%   3-658
openviking/storage/vectordb/service/app_models.py                    124    124     0%   3-184
openviking/storage/vectordb/service/code.py                           10     10     0%   3-14
openviking/storage/vectordb/service/server_fastapi.py                 53     53     0%   10-142
openviking/storage/vectordb/store/__init__.py                          0      0   100%
openviking/storage/vectordb/store/bytes_row.py                       210    147    30%   77, 83, 101-103, 116-208, 211, 214-261, 264-271, 281-283
openviking/storage/vectordb/store/data.py                             40      6    85%   21-29, 32, 51-60, 63
openviking/storage/vectordb/store/file_store.py                       92     81    12%   19-20, 35-50, 62-81, 94-141, 153-171
openviking/storage/vectordb/store/local_store.py                      71     54    24%   23-28, 47-48, 60-64, 74-75, 84-85, 89, 100-104, 120-123, 139-142, 155-167, 176-197
openviking/storage/vectordb/store/serializable.py                     70     28    60%   21, 25, 31, 37, 40-45, 74, 83-89, 101, 112, 116-120, 125-129, 135-137
openviking/storage/vectordb/store/store.py                            59     21    64%   16, 31, 44, 56, 80-82, 106-109, 120, 136, 150, 163, 175, 190, 206, 222, 235, 247
openviking/storage/vectordb/store/store_manager.py                   104     84    19%   25-29, 52, 67-128, 142-180, 191-199, 207-209, 213, 224-229, 240-247, 255-325
openviking/storage/vectordb/utils/__init__.py                          0      0   100%
openviking/storage/vectordb/utils/api_utils.py                         9      9     0%   3-15
openviking/storage/vectordb/utils/config_utils.py                     19     16    16%   23-43
openviking/storage/vectordb/utils/constants.py                        18      0   100%
openviking/storage/vectordb/utils/data_processor.py                  303    269    11%   24-40, 45-47, 77-80, 84-149, 160-163, 167-169, 173-174, 178, 181-200, 203-217, 220-243, 246-263, 266-287, 290-332, 335-339, 342-349, 352-375, 378-394, 397-407, 410-428, 431-438
openviking/storage/vectordb/utils/data_utils.py                       26     26     0%   3-43
openviking/storage/vectordb/utils/dict_utils.py                       73     51    30%   27-28, 32-33, 37-38, 42-43, 47-48, 52-53, 57-58, 62-63, 67-68, 72-73, 81-87, 97, 104-105, 108-109, 112-113, 127-139, 156-172
openviking/storage/vectordb/utils/file_utils.py                        7      7     0%   3-11
openviking/storage/vectordb/utils/id_generator.py                     53     22    58%   53, 55, 65, 71-105, 118
openviking/storage/vectordb/utils/logging_init.py                     34     28    18%   22-41, 48-82
openviking/storage/vectordb/utils/stale_lock.py                       63     51    19%   45, 50, 59-83, 100-137
openviking/storage/vectordb/utils/str_to_uint64.py                     3      1    67%   10
openviking/storage/vectordb/utils/validation.py                      332    182    45%   15-16, 23-34, 80, 84-93, 126, 131-134, 138-144, 162-164, 169-179, 199-205, 210-212, 217-219, 224-226, 242-244, 260-262, 277-279, 284-296, 306-314, 318-321, 325-329, 333-336, 340-344, 348-358, 362-366, 370-379, 383-387, 391-415, 447-473, 477-482, 486-508
openviking/storage/vectordb/vectorize/__init__.py                      0      0   100%
openviking/storage/vectordb/vectorize/base.py                         23     11    52%   21-24, 27, 43-45, 58, 78, 82
openviking/storage/vectordb/vectorize/vectorizer.py                   52     33    37%   40-60, 68, 83-94, 111-119
openviking/storage/vectordb/vectorize/vectorizer_factory.py           21      5    76%   43-52
openviking/storage/vectordb/vectorize/volcengine_vectorizer.py       111     89    20%   18-21, 24-43, 46-49, 78-98, 110-122, 128-146, 156-177, 198-246, 252-260, 264, 268
openviking/storage/vectordb_adapters/__init__.py                       7      0   100%
openviking/storage/vectordb_adapters/base.py                         308    250    19%   35-41, 45-53, 67-69, 73, 77, 93-94, 97-100, 111-135, 138-161, 164-166, 169-171, 178, 189-202, 205-209, 212-216, 220-226, 230-238, 241-265, 268-343, 351, 365, 374, 377, 380-391, 394-412, 426-468, 477-487, 491-501, 504-515, 518-519
openviking/storage/vectordb_adapters/factory.py                       23     15    35%   23-45
openviking/storage/vectordb_adapters/http_adapter.py                  33     20    39%   30-34, 38-41, 50, 56-61, 64-68, 77-79
openviking/storage/vectordb_adapters/local_adapter.py                 35     20    43%   23-25, 29-32, 39-41, 44-51, 54-57
openviking/storage/vectordb_adapters/vikingdb_private_adapter.py      53     36    32%   28-32, 36-38, 47, 50-60, 63-68, 77-80, 87-90, 101-114, 117
openviking/storage/vectordb_adapters/volcengine_adapter.py            55     36    35%   33-40, 44-51, 62, 68, 76, 87-92, 95-97, 107-110, 121-134, 137-144, 147
openviking/storage/viking_fs.py                                     1011    899    11%   57, 66, 96-107, 120-130, 141-143, 148-150, 175-180, 186, 189-192, 196-199, 203-206, 219-221, 234-236, 241-245, 250-252, 257-272, 275-278, 290-321, 330-336, 346-358, 376-416, 430-500, 509-532, 557-627, 640-642, 654-658, 668-678, 692-709, 738-746, 757-785, 797-833, 843-859, 867-883, 894-901, 924-988, 1012-1131, 1143-1159, 1168-1196, 1202-1204, 1214-1222, 1233-1240, 1251-1255, 1263-1279, 1288-1302, 1306-1328, 1332-1343, 1347-1359, 1363-1374, 1378-1386, 1394-1413, 1422-1432, 1446-1465, 1474-1526, 1530, 1534, 1541-1552, 1560-1583, 1590-1598, 1606-1617, 1628-1636, 1655-1684, 1692-1699, 1708-1713, 1722-1744, 1771-1777, 1788-1825, 1835-1857, 1866-1872, 1878, 1882-1895, 1899-1905, 1915-1935, 1948-1973
openviking/storage/viking_vector_index_backend.py                    497    398    20%   103-113, 120, 123-125, 128, 131-137, 141-143, 150-178, 181-189, 192, 195-198, 210-235, 238-245, 248-259, 263-267, 270-273, 276-287, 300-328, 339, 357, 367-386, 389-404, 413-421, 424-437, 440-446, 449-450, 453-459, 462-466, 469-481, 490, 499-517, 523, 527, 535, 539-548, 552, 556-564, 568-569, 576, 579, 582, 585, 588, 595-604, 607-608, 611-612, 615-616, 619-620, 635-636, 658, 679, 690-691, 702-703, 716-720, 723-727, 730, 733-742, 745, 748, 752, 756, 759, 776-782, 802-814, 834-843, 861-872, 888-895, 903-905, 908-922, 931-989, 992-1010, 1019-1043, 1049-1061, 1080-1094
openviking/storage/vikingdb_manager.py                               167     90    46%   48-54, 63, 67-76, 81, 90, 95-99, 104, 120-136, 145-153, 162-169, 203-204, 209, 214, 218, 222, 230, 234, 238, 241, 245, 252, 255, 258, 265, 268, 271, 274, 277, 284, 287, 290, 293, 296, 309, 330, 349, 360, 369, 381, 384, 387, 390, 393, 396, 412, 432, 452, 470, 485, 494, 497, 504, 511
openviking/sync_client.py                                             98     98     0%   7-340
openviking/telemetry/__init__.py                                       8      0   100%
openviking/telemetry/backends/__init__.py                              2      2     0%   5-7
openviking/telemetry/backends/memory.py                                3      3     0%   5-12
openviking/telemetry/context.py                                       19      9    53%   21-25, 31-35
openviking/telemetry/execution.py                                     55     34    38%   32-35, 43-45, 49-51, 63-75, 86-107
openviking/telemetry/operation.py                                    193    147    24%   24, 34-37, 68-73, 77-82, 86-98, 102-117, 123-124, 141-273, 284-293, 296-299, 302, 305-308, 311, 314-327, 331-339, 342, 345, 350-362, 365-370, 373, 376-391
openviking/telemetry/registry.py                                      21     12    43%   16-19, 23-26, 30-33
openviking/telemetry/request.py                                       28     15    46%   24, 31-46
openviking/telemetry/request_wait_tracker.py                         160    117    27%   35-37, 40-43, 47, 50-53, 56, 59-65, 68-74, 77-83, 86-92, 95-103, 111-118, 121-127, 130-139, 147-154, 157-166, 169-175, 183-191, 194-196, 212-215, 219
openviking/telemetry/resource_summary.py                              62     48    23%   15-20, 24-29, 33-38, 43-48, 53, 58, 74-88, 103-133
openviking/telemetry/runtime.py                                       39     15    62%   27-28, 31-33, 38-40, 43-45, 51, 59, 66, 71
openviking/telemetry/snapshot.py                                       2      2     0%   5-7
openviking/telemetry/tracer.py                                       291    216    26%   23-34, 47-48, 55-76, 81-105, 110-118, 144-198, 203, 208, 217-227, 236-241, 253-262, 278, 283, 288, 293, 351-373, 378-404, 409-424, 429-439, 444, 449-460, 465-478, 483-488, 493-509, 516, 519, 522, 525, 528, 531, 534, 537, 552
openviking/utils/__init__.py                                           7      0   100%
openviking/utils/agfs_utils.py                                        58     58     0%   7-157
openviking/utils/circuit_breaker.py                                   66     49    26%   42-50, 54-65, 75-79, 83-88, 92-117
openviking/utils/code_hosting_utils.py                                74     65    12%   27-76, 88-89, 101-102, 114-130, 142-146, 162-190
openviking/utils/embedding_utils.py                                  162    144    11%   26-35, 43-47, 55-128, 144-208, 227-318, 335-387
openviking/utils/media_processor.py                                   92     92     0%   5-189
openviking/utils/model_retry.py                                       54     41    24%   38-52, 57, 67-70, 85-110, 125-150
openviking/utils/network_guard.py                                     59     44    25%   25-34, 38, 42-55, 59-62, 67-86, 96-102
openviking/utils/process_lock.py                                      65     65     0%   9-127
openviking/utils/resource_processor.py                               149    125    16%   52-58, 62-64, 68-72, 76-83, 89-91, 97, 121-297, 302-307
openviking/utils/skill_processor.py                                  111     84    24%   46, 67-138, 151-197, 201-211, 222, 241-258, 262-272
openviking/utils/summarizer.py                                        55     43    22%   31, 45-118
openviking/utils/time_utils.py                                        21     14    33%   15-18, 28-33, 42-47, 56-57
openviking/utils/zip_safe.py                                          39     31    21%   13, 23, 31-56, 65-72
------------------------------------------------------------------------------------------------
TOTAL                                                              34685  28648    17%

=========================== short test summary info ============================
ERROR  - AttributeError: 'Package' object has no attribute 'obj'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 5 warnings, 1 error in 2.33s ========================= still hits the repo's known  collection bug (), so I verified the covered scenarios with a direct Python harness instead

Closes #1261