### PR TITLE
fix(stats): fall back to memory filesystem scan

### DIFF
--- a/openviking/storage/stats_aggregator.py
+++ b/openviking/storage/stats_aggregator.py
@@ -190,11 +190,10 @@ class StatsAggregator:
             if isinstance(uri, str) and uri:
                 records_by_uri[uri] = record
 
-        if not records_by_uri:
-            for record in await self._scan_memory_filesystem(ctx):
-                uri = record.get("uri", "")
-                if isinstance(uri, str) and uri and uri not in records_by_uri:
-                    records_by_uri[uri] = record
+        for record in await self._scan_memory_filesystem(ctx):
+            uri = record.get("uri", "")
+            if isinstance(uri, str) and uri and uri not in records_by_uri:
+                records_by_uri[uri] = record
 
         return list(records_by_uri.values())
 
@@ -220,7 +219,8 @@ class StatsAggregator:
             seen_dirs.add(dir_uri)
             try:
                 entries = await viking_fs.ls(dir_uri, show_all_hidden=True, ctx=ctx)
-            except Exception:
+            except Exception as e:
+                logger.debug("Failed to list memory directory %s: %s", dir_uri, e)
                 return
 
             for entry in entries:
@@ -268,8 +268,8 @@ class StatsAggregator:
             created_at = metadata.get("created_at")
             updated_at = metadata.get("updated_at")
             active_count = int(metadata.get("active_count", 0) or 0)
-        except Exception:
-            metadata = {}
+        except Exception as e:
+            logger.debug("Failed to read memory metadata for %s: %s", uri, e)
 
         if created_at is None or updated_at is None:
             try:
@@ -279,7 +279,8 @@ class StatsAggregator:
                     created_at = mod_time
                 if updated_at is None:
                     updated_at = mod_time
-            except Exception:
+            except Exception as e:
+                logger.debug("Failed to stat memory file %s: %s", uri, e)
                 pass
 
         return {

--- a/openviking/storage/stats_aggregator.py
+++ b/openviking/storage/stats_aggregator.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from openviking.retrieve.memory_lifecycle import hotness_score
 from openviking.server.identity import RequestContext
 from openviking.storage.expr import Eq
+from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -71,15 +72,15 @@ class StatsAggregator:
             "oldest_memory_age_days": 0,
         }
 
-        # Fetch all memories once and group by category in Python
-        all_records = await self._query_all_memories(ctx)
+        # Fetch vector-indexed memories first, then supplement from the
+        # filesystem so stats still work when extracted memory leaf files have
+        # not been individually indexed into VikingDB.
+        all_records = await self._get_memory_records(ctx)
         grouped: Dict[str, List[Dict[str, Any]]] = {cat: [] for cat in categories}
         for record in all_records:
-            uri = record.get("uri", "")
-            for cat in categories:
-                if f"/{cat}/" in uri:
-                    grouped[cat].append(record)
-                    break
+            cat = _category_from_uri(record.get("uri", ""))
+            if cat in grouped:
+                grouped[cat].append(record)
 
         for cat in categories:
             records = grouped[cat]
@@ -177,6 +178,131 @@ class StatsAggregator:
         except Exception as e:
             logger.error("Error querying memories: %s", e)
             return []
+
+    async def _get_memory_records(
+        self,
+        ctx: RequestContext,
+    ) -> List[Dict[str, Any]]:
+        """Return memory records from VikingDB, supplemented by filesystem scan."""
+        records_by_uri: Dict[str, Dict[str, Any]] = {}
+        for record in await self._query_all_memories(ctx):
+            uri = record.get("uri", "")
+            if isinstance(uri, str) and uri:
+                records_by_uri[uri] = record
+
+        if not records_by_uri:
+            for record in await self._scan_memory_filesystem(ctx):
+                uri = record.get("uri", "")
+                if isinstance(uri, str) and uri and uri not in records_by_uri:
+                    records_by_uri[uri] = record
+
+        return list(records_by_uri.values())
+
+    async def _scan_memory_filesystem(
+        self,
+        ctx: RequestContext,
+    ) -> List[Dict[str, Any]]:
+        """Scan memory roots directly from VikingFS as a stats fallback."""
+        viking_fs = get_viking_fs()
+        if viking_fs is None:
+            return []
+
+        memory_roots = [
+            f"viking://user/{ctx.user.user_space_name()}/memories",
+            f"viking://agent/{ctx.user.agent_space_name()}/memories",
+        ]
+        seen_dirs = set()
+        scanned: Dict[str, Dict[str, Any]] = {}
+
+        async def walk(dir_uri: str) -> None:
+            if dir_uri in seen_dirs:
+                return
+            seen_dirs.add(dir_uri)
+            try:
+                entries = await viking_fs.ls(dir_uri, show_all_hidden=True, ctx=ctx)
+            except Exception:
+                return
+
+            for entry in entries:
+                name = entry.get("name", "")
+                if not name or name in {".", ".."}:
+                    continue
+                if name.startswith(".") or name in {"_archive", ".relations.json"}:
+                    continue
+
+                uri = entry.get("uri") or f"{dir_uri.rstrip('/')}/{name}"
+                if entry.get("isDir", False):
+                    await walk(uri)
+                    continue
+
+                if not uri.endswith(".md"):
+                    continue
+                if name in {".overview.md", ".abstract.md"}:
+                    continue
+                if _category_from_uri(uri) is None:
+                    continue
+
+                scanned[uri] = await self._build_filesystem_record(viking_fs, uri, ctx)
+
+        for root in memory_roots:
+            await walk(root)
+
+        return list(scanned.values())
+
+    async def _build_filesystem_record(
+        self,
+        viking_fs,
+        uri: str,
+        ctx: RequestContext,
+    ) -> Dict[str, Any]:
+        """Build a lightweight stats record from a memory file on VikingFS."""
+        created_at = None
+        updated_at = None
+        active_count = 0
+
+        try:
+            from openviking.session.memory.utils.content import deserialize_metadata
+
+            raw = await viking_fs.read_file(uri, ctx=ctx)
+            metadata = deserialize_metadata(raw) or {}
+            created_at = metadata.get("created_at")
+            updated_at = metadata.get("updated_at")
+            active_count = int(metadata.get("active_count", 0) or 0)
+        except Exception:
+            metadata = {}
+
+        if created_at is None or updated_at is None:
+            try:
+                stat = await viking_fs.stat(uri, ctx=ctx)
+                mod_time = stat.get("modTime")
+                if created_at is None:
+                    created_at = mod_time
+                if updated_at is None:
+                    updated_at = mod_time
+            except Exception:
+                pass
+
+        return {
+            "uri": uri,
+            "active_count": active_count,
+            "updated_at": updated_at,
+            "created_at": created_at,
+            "context_type": "memory",
+        }
+
+
+def _category_from_uri(uri: str) -> Optional[str]:
+    """Infer memory category from a memory URI."""
+    if not isinstance(uri, str) or not uri:
+        return None
+    if uri.endswith("/memories/profile.md"):
+        return "profile"
+    for cat in MEMORY_CATEGORIES:
+        if cat == "profile":
+            continue
+        if f"/{cat}/" in uri:
+            return cat
+    return None
 
 
 def _parse_datetime(value) -> Optional[datetime]:

--- a/tests/unit/stats/test_stats_aggregator.py
+++ b/tests/unit/stats/test_stats_aggregator.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from openviking.storage.stats_aggregator import StatsAggregator, _parse_datetime
+from openviking.storage.stats_aggregator import (
+    StatsAggregator,
+    _category_from_uri,
+    _parse_datetime,
+)
 
 
 @pytest.fixture
@@ -132,6 +136,72 @@ class TestStatsAggregator:
 
         assert result["by_category"]["cases"] == 0
         assert result["total_memories"] == 0
+
+    @pytest.mark.asyncio
+    async def test_profile_uri_is_counted(self, aggregator, mock_vikingdb, mock_ctx):
+        """profile.md lives directly under /memories and still counts as profile."""
+        now = datetime.now(timezone.utc)
+        mock_vikingdb.query = AsyncMock(
+            return_value=[
+                {
+                    "uri": "viking://user/default/memories/profile.md",
+                    "context_type": "memory",
+                    "active_count": 1,
+                    "updated_at": now.isoformat(),
+                    "created_at": now.isoformat(),
+                }
+            ]
+        )
+
+        result = await aggregator.get_memory_stats(mock_ctx)
+
+        assert result["by_category"]["profile"] == 1
+        assert result["total_memories"] == 1
+
+    @pytest.mark.asyncio
+    async def test_filesystem_fallback_when_vector_records_missing(self, aggregator, mock_vikingdb, mock_ctx, monkeypatch):
+        """Filesystem scan should supplement stats when VikingDB has no memory leaf records."""
+        mock_vikingdb.query = AsyncMock(return_value=[])
+
+        fake_fs = MagicMock()
+        fake_fs.ls = AsyncMock(
+            side_effect=lambda uri, show_all_hidden=False, ctx=None: {
+                "viking://user/default/memories": [
+                    {"name": "preferences", "isDir": True, "uri": "viking://user/default/memories/preferences"},
+                    {"name": "profile.md", "isDir": False, "uri": "viking://user/default/memories/profile.md"},
+                ],
+                "viking://user/default/memories/preferences": [
+                    {"name": "mem_a.md", "isDir": False, "uri": "viking://user/default/memories/preferences/mem_a.md"},
+                    {"name": ".overview.md", "isDir": False, "uri": "viking://user/default/memories/preferences/.overview.md"},
+                ],
+                "viking://agent/8e1f7e6e4d1d/memories": [],
+            }.get(uri, [])
+        )
+        fake_fs.read_file = AsyncMock(return_value="")
+        fake_fs.stat = AsyncMock(
+            return_value={"modTime": "2026-04-07T00:00:00+00:00"}
+        )
+        monkeypatch.setattr("openviking.storage.stats_aggregator.get_viking_fs", lambda: fake_fs)
+        mock_ctx.user = MagicMock()
+        mock_ctx.user.user_space_name.return_value = "default"
+        mock_ctx.user.agent_space_name.return_value = "8e1f7e6e4d1d"
+
+        result = await aggregator.get_memory_stats(mock_ctx)
+
+        assert result["by_category"]["preferences"] == 1
+        assert result["by_category"]["profile"] == 1
+        assert result["total_memories"] == 2
+
+
+class TestCategoryFromUri:
+    def test_profile_file(self):
+        assert _category_from_uri("viking://user/default/memories/profile.md") == "profile"
+
+    def test_category_directory(self):
+        assert _category_from_uri("viking://user/default/memories/preferences/mem_x.md") == "preferences"
+
+    def test_unknown(self):
+        assert _category_from_uri("viking://resources/docs/readme.md") is None
 
 
 class TestParseDatetime:

--- a/tests/unit/stats/test_stats_aggregator.py
+++ b/tests/unit/stats/test_stats_aggregator.py
@@ -192,6 +192,62 @@ class TestStatsAggregator:
         assert result["by_category"]["profile"] == 1
         assert result["total_memories"] == 2
 
+    @pytest.mark.asyncio
+    async def test_filesystem_fallback_supplements_partial_vector_results(
+        self, aggregator, mock_vikingdb, mock_ctx, monkeypatch
+    ):
+        """Filesystem scan should backfill memories that are missing from VikingDB."""
+        now = datetime.now(timezone.utc).isoformat()
+        mock_vikingdb.query = AsyncMock(
+            return_value=[
+                {
+                    "uri": "viking://user/default/memories/profile.md",
+                    "context_type": "memory",
+                    "active_count": 1,
+                    "updated_at": now,
+                    "created_at": now,
+                }
+            ]
+        )
+
+        fake_fs = MagicMock()
+        fake_fs.ls = AsyncMock(
+            side_effect=lambda uri, show_all_hidden=False, ctx=None: {
+                "viking://user/default/memories": [
+                    {
+                        "name": "preferences",
+                        "isDir": True,
+                        "uri": "viking://user/default/memories/preferences",
+                    },
+                    {
+                        "name": "profile.md",
+                        "isDir": False,
+                        "uri": "viking://user/default/memories/profile.md",
+                    },
+                ],
+                "viking://user/default/memories/preferences": [
+                    {
+                        "name": "mem_a.md",
+                        "isDir": False,
+                        "uri": "viking://user/default/memories/preferences/mem_a.md",
+                    },
+                ],
+                "viking://agent/8e1f7e6e4d1d/memories": [],
+            }.get(uri, [])
+        )
+        fake_fs.read_file = AsyncMock(return_value="")
+        fake_fs.stat = AsyncMock(return_value={"modTime": "2026-04-07T00:00:00+00:00"})
+        monkeypatch.setattr("openviking.storage.stats_aggregator.get_viking_fs", lambda: fake_fs)
+        mock_ctx.user = MagicMock()
+        mock_ctx.user.user_space_name.return_value = "default"
+        mock_ctx.user.agent_space_name.return_value = "8e1f7e6e4d1d"
+
+        result = await aggregator.get_memory_stats(mock_ctx)
+
+        assert result["by_category"]["profile"] == 1
+        assert result["by_category"]["preferences"] == 1
+        assert result["total_memories"] == 2
+
 
 class TestCategoryFromUri:
     def test_profile_file(self):


### PR DESCRIPTION
## Summary
- fix stats category detection for `viking://.../memories/profile.md`
- keep VikingDB as the primary source for `/api/v1/stats/memories`, but fall back to scanning the memory filesystem when no memory records are indexed
- add regression coverage for both the profile URI case and the filesystem fallback path

## Verification
- `python -m compileall openviking/storage/stats_aggregator.py tests/unit/stats/test_stats_aggregator.py tests/unit/stats/test_stats_api.py`
- manual async verification of `StatsAggregator.get_memory_stats()` for both profile classification and VikingFS fallback scenarios
- `pytest tests/unit/stats/test_stats_aggregator.py tests/unit/stats/test_stats_api.py -q` is still blocked by the repo's known `pytest-asyncio` collection bug: `AttributeError: 'Package' object has no attribute 'obj'`

Closes #1255
