### PR TITLE
pref(retrieve): Optimize the search performance of larger directories by skipping redundant target_directories scope

### DIFF
--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -831,9 +831,11 @@ class VikingVectorIndexBackend:
         extra_filter: Optional[FilterExpr | Dict[str, Any]] = None,
         limit: int = 10,
     ) -> List[Dict[str, Any]]:
-        # If parent_uri is already under the requested target_directories, adding a redundant
-        # scope prefix filter can slow down the backend. Keep tenant/context filters but skip
-        # target_directories in that case.
+        # TODO：Better Alternative to Current Temporary Fix
+        
+        # If parent_uri is already under the requested target_directories, 
+        # adding a redundant scope prefix filter can slow down the backend. 
+        # Keep tenant/context filters but skip target_directories in that case.
         effective_target_directories = target_directories
         if target_directories:
             parent_norm = parent_uri.rstrip("/")

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -831,12 +831,26 @@ class VikingVectorIndexBackend:
         extra_filter: Optional[FilterExpr | Dict[str, Any]] = None,
         limit: int = 10,
     ) -> List[Dict[str, Any]]:
+        # If parent_uri is already under the requested target_directories, adding a redundant
+        # scope prefix filter can slow down the backend. Keep tenant/context filters but skip
+        # target_directories in that case.
+        effective_target_directories = target_directories
+        if target_directories:
+            parent_norm = parent_uri.rstrip("/")
+            for target_dir in target_directories:
+                if not target_dir:
+                    continue
+                target_norm = target_dir.rstrip("/")
+                if parent_norm == target_norm or parent_norm.startswith(target_norm + "/"):
+                    effective_target_directories = None
+                    break
+
         merged_filter = self._merge_filters(
             PathScope("uri", parent_uri, depth=1),
             self._build_scope_filter(
                 ctx=ctx,
                 context_type=context_type,
-                target_directories=target_directories,
+                target_directories=effective_target_directories,
                 extra_filter=extra_filter,
             ),
         )


### PR DESCRIPTION
## Description

当使用较大的目录 例如 --uri viking://resources （根目录）检索时，单步 search_children_in_tenant() 调用耗时显著更高（约 10–15ms），而使用更窄的子目录检索同一parent_uri 时用时仅约 2ms。

原因是在递归展开时， search_children_in_tenant() 总是同时合并两个 scope 约束传给向量后端：
1. PathScope(parent_uri, depth=1) — 只查直接子节点
2. PathScope(target_dir, depth=-1) — 来自命令行 --uri 的子树约束
当 parent_uri 已经在 target_directories 子树下时，第 2 个约束是冗余的，但会改变后端执行路径，导致宽范围（如根目录）下的高延迟。

本 PR 在 search_children_in_tenant() 中增加前置判断：如果 parent_uri 已在任意 target_directories 子树下，则跳过传入 target_directories 给 _build_scope_filter() ，从而避免冗余约束带来的额外执行开销。
<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

openviking/storage/viking_vector_index_backend.py : 在 VikingVectorIndexBackend.search_children_in_tenant() 中增加 effective_target_directories 冗余判断逻辑，当 parent_uri 位于任意 target_directories 子树下时，将 effective_target_directories 设为 None 以跳过额外子树约束。

## Testing

验证结果：
- 性能 ：根目录 -n 600 检索时延从约 2.5s 降至约 0.5s；同一 parent_uri 下单步 took_ms 从 ~12ms 降至 <1ms。
- 质量 ：Top-K 结果保持稳定（跨版本 Top-100 重叠率 > 98%，Top-600 重叠率 > 94%）。
<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes
- 本修复为临时方案，TODO：后续还需研究传入target_directories约束导致检索变慢的具体原因。

<!-- Add any additional notes or context about the PR -->
