### PR TITLE
feat: detect embedding model drift and add rebuild tool

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -281,7 +281,7 @@ class OpenVikingService:
         if not self._embedding_compat_check_disabled():
             await ensure_embedding_collection_compatibility(
                 self._vikingdb_manager,
-                config,
+                self._config,
                 config_path=os.environ.get("OPENVIKING_CONFIG_FILE"),
             )
 

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -20,9 +20,11 @@ from openviking.service.relation_service import RelationService
 from openviking.service.resource_service import ResourceService
 from openviking.service.search_service import SearchService
 from openviking.service.session_service import SessionService
+from openviking.service.vector_rebuild import VectorRebuildService
 from openviking.session import SessionCompressor, create_session_compressor
 from openviking.storage import VikingDBManager
 from openviking.storage.collection_schemas import init_context_collection
+from openviking.storage.embedding_compat import ensure_embedding_collection_compatibility
 from openviking.storage.queuefs.queue_manager import QueueManager, init_queue_manager
 from openviking.storage.transaction import LockManager, init_lock_manager
 from openviking.storage.viking_fs import VikingFS, init_viking_fs
@@ -49,6 +51,7 @@ class OpenVikingService:
         self,
         path: Optional[str] = None,
         user: Optional[UserIdentifier] = None,
+        skip_embedding_compat_check: bool = False,
     ):
         """Initialize OpenViking service.
 
@@ -91,6 +94,7 @@ class OpenVikingService:
 
         # State
         self._initialized = False
+        self._skip_embedding_compat_check = skip_embedding_compat_check
 
         # Initialize storage
         self._init_storage(
@@ -163,6 +167,11 @@ class OpenVikingService:
         return self._vikingdb_manager
 
     @property
+    def config(self):
+        """Get the resolved OpenViking config."""
+        return self._config
+
+    @property
     def lock_manager(self) -> Optional[LockManager]:
         """Get LockManager instance."""
         return self._lock_manager
@@ -217,6 +226,19 @@ class OpenVikingService:
         """Get DebugService instance."""
         return self._debug_service
 
+    def create_vector_rebuild_service(self) -> VectorRebuildService:
+        """Build a helper for full vector rebuild operations."""
+        return VectorRebuildService(self)
+
+    def _embedding_compat_check_disabled(self) -> bool:
+        if self._skip_embedding_compat_check:
+            return True
+        return os.environ.get("OPENVIKING_SKIP_EMBEDDING_COMPAT_CHECK", "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+
     async def initialize(self) -> None:
         """Initialize OpenViking storage and indexes."""
         if self._initialized:
@@ -256,6 +278,12 @@ class OpenVikingService:
         if self._vikingdb_manager is None:
             raise RuntimeError("VikingDBManager not initialized")
         await init_context_collection(self._vikingdb_manager)
+        if not self._embedding_compat_check_disabled():
+            await ensure_embedding_collection_compatibility(
+                self._vikingdb_manager,
+                config,
+                config_path=os.environ.get("OPENVIKING_CONFIG_FILE"),
+            )
 
         if self._agfs_client is None:
             raise RuntimeError("AGFS client not initialized")

--- a/openviking/service/vector_rebuild.py
+++ b/openviking/service/vector_rebuild.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Full-account vector rebuild helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+INDEXABLE_SCOPE_ROOTS = (
+    "viking://resources",
+    "viking://user",
+    "viking://agent",
+    "viking://session",
+)
+
+
+@dataclass
+class AccountVectorRebuildReport:
+    """Summary for a rebuilt account."""
+
+    account_id: str
+    deleted_records: int
+    indexed_directories: int
+    queue_status: dict[str, Any]
+
+
+class VectorRebuildService:
+    """Rebuild vectors by deleting account-scoped records and reindexing AGFS content."""
+
+    def __init__(self, service, *, ls_node_limit: int = 100_000):
+        self._service = service
+        self._ls_node_limit = ls_node_limit
+
+    def _root_ctx(self, account_id: str) -> RequestContext:
+        return RequestContext(
+            user=UserIdentifier(account_id, "system", "system"),
+            role=Role.ROOT,
+        )
+
+    async def discover_accounts(self) -> list[str]:
+        """Discover accounts present in the local workspace."""
+        viking_fs = self._service.viking_fs
+        if viking_fs is None:
+            raise RuntimeError("VikingFS not initialized")
+
+        try:
+            entries = await viking_fs.list_account_roots()
+        except AttributeError:
+            entries = viking_fs.agfs.ls("/local")
+
+        accounts = [
+            entry.get("name", "")
+            for entry in entries
+            if entry.get("isDir") and entry.get("name")
+        ]
+        return sorted(set(accounts))
+
+    async def _discover_directories(self, root_uri: str, ctx: RequestContext) -> list[str]:
+        viking_fs = self._service.viking_fs
+        if viking_fs is None:
+            raise RuntimeError("VikingFS not initialized")
+
+        if not await viking_fs.exists(root_uri, ctx=ctx):
+            return []
+
+        discovered: list[str] = []
+        seen: set[str] = set()
+        stack = [root_uri]
+        while stack:
+            current_uri = stack.pop()
+            if current_uri in seen:
+                continue
+            seen.add(current_uri)
+            discovered.append(current_uri)
+
+            try:
+                entries = await viking_fs.ls(
+                    current_uri,
+                    output="original",
+                    show_all_hidden=False,
+                    node_limit=self._ls_node_limit,
+                    ctx=ctx,
+                )
+            except Exception as exc:
+                logger.warning("Failed to enumerate %s during vector rebuild: %s", current_uri, exc)
+                continue
+
+            child_dirs = [
+                entry.get("uri")
+                for entry in entries
+                if entry.get("isDir") and isinstance(entry.get("uri"), str)
+            ]
+            stack.extend(sorted(child_dirs, reverse=True))
+
+        return discovered
+
+    async def rebuild_account(
+        self,
+        account_id: str,
+        *,
+        wait_timeout: Optional[float] = None,
+    ) -> AccountVectorRebuildReport:
+        """Delete all vectors for one account and rebuild from AGFS content."""
+        if self._service.vikingdb_manager is None:
+            raise RuntimeError("VikingDBManager not initialized")
+
+        ctx = self._root_ctx(account_id)
+        deleted_records = await self._service.vikingdb_manager.delete_account_data(
+            account_id, ctx=ctx
+        )
+
+        directories: list[str] = []
+        for root_uri in INDEXABLE_SCOPE_ROOTS:
+            directories.extend(await self._discover_directories(root_uri, ctx))
+
+        ordered_directories = list(dict.fromkeys(directories))
+        for uri in ordered_directories:
+            await self._service.resources.build_index([uri], ctx=ctx)
+
+        queue_status = await self._service.resources.wait_processed(timeout=wait_timeout)
+        return AccountVectorRebuildReport(
+            account_id=account_id,
+            deleted_records=deleted_records,
+            indexed_directories=len(ordered_directories),
+            queue_status=queue_status,
+        )
+
+    async def rebuild_accounts(
+        self,
+        account_ids: Optional[list[str]] = None,
+        *,
+        wait_timeout: Optional[float] = None,
+    ) -> list[AccountVectorRebuildReport]:
+        """Rebuild one or more accounts."""
+        accounts = account_ids or await self.discover_accounts()
+        reports: list[AccountVectorRebuildReport] = []
+        for account_id in accounts:
+            reports.append(await self.rebuild_account(account_id, wait_timeout=wait_timeout))
+        return reports

--- a/openviking/service/vector_rebuild.py
+++ b/openviking/service/vector_rebuild.py
@@ -50,15 +50,9 @@ class VectorRebuildService:
         if viking_fs is None:
             raise RuntimeError("VikingFS not initialized")
 
-        try:
-            entries = await viking_fs.list_account_roots()
-        except AttributeError:
-            entries = viking_fs.agfs.ls("/local")
-
+        entries = await viking_fs.list_account_roots()
         accounts = [
-            entry.get("name", "")
-            for entry in entries
-            if entry.get("isDir") and entry.get("name")
+            entry.get("name", "") for entry in entries if entry.get("isDir") and entry.get("name")
         ]
         return sorted(set(accounts))
 

--- a/openviking/storage/embedding_compat.py
+++ b/openviking/storage/embedding_compat.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Embedding compatibility metadata for vector collections."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from openviking_cli.exceptions import EmbeddingCompatibilityError
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+EMBEDDING_META_FILE = "embedding_meta.json"
+EMBEDDING_META_VERSION = 1
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def resolve_embedding_meta_path(vectordb_config: Any) -> Optional[Path]:
+    """Return the local sidecar metadata path when supported."""
+    if getattr(vectordb_config, "backend", "") != "local":
+        return None
+
+    workspace = getattr(vectordb_config, "path", None)
+    collection_name = getattr(vectordb_config, "name", None) or "context"
+    if not workspace:
+        return None
+
+    return Path(workspace) / "vectordb" / collection_name / EMBEDDING_META_FILE
+
+
+def build_embedding_metadata(config: Any) -> dict[str, Any]:
+    """Build the persisted metadata payload for the active embedding config."""
+    embedding_identity = config.embedding.compatibility_identity()
+    return {
+        "schema_version": EMBEDDING_META_VERSION,
+        "collection_name": config.storage.vectordb.name or "context",
+        "vectordb_backend": config.storage.vectordb.backend,
+        "embedding": embedding_identity,
+        "recorded_at": _utc_now_iso(),
+    }
+
+
+def load_embedding_metadata(vectordb_config: Any) -> Optional[dict[str, Any]]:
+    """Load embedding metadata from the local sidecar file."""
+    meta_path = resolve_embedding_meta_path(vectordb_config)
+    if meta_path is None or not meta_path.exists():
+        return None
+
+    return json.loads(meta_path.read_text(encoding="utf-8"))
+
+
+def persist_embedding_metadata(config: Any, payload: Optional[dict[str, Any]] = None) -> Optional[Path]:
+    """Persist embedding metadata for the active config when backend supports it."""
+    meta_path = resolve_embedding_meta_path(config.storage.vectordb)
+    if meta_path is None:
+        return None
+
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    data = dict(payload or build_embedding_metadata(config))
+    data["recorded_at"] = _utc_now_iso()
+    meta_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return meta_path
+
+
+def _extract_vector_dim(collection_info: Optional[dict[str, Any]]) -> Optional[int]:
+    if not collection_info:
+        return None
+    vector_dim = collection_info.get("vector_dim")
+    if isinstance(vector_dim, int) and vector_dim > 0:
+        return vector_dim
+    return None
+
+
+def _extract_count(collection_info: Optional[dict[str, Any]]) -> int:
+    if not collection_info:
+        return 0
+    count = collection_info.get("count")
+    if isinstance(count, int) and count >= 0:
+        return count
+    return 0
+
+
+def _format_component(component: Optional[dict[str, Any]]) -> str:
+    if not component:
+        return "none"
+    provider = component.get("provider") or "unknown"
+    model = component.get("model") or "unknown"
+    dimension = component.get("dimension")
+    extras: list[str] = []
+    if isinstance(dimension, int) and dimension > 0:
+        extras.append(f"dim={dimension}")
+    if component.get("query_param"):
+        extras.append(f"query={component['query_param']}")
+    if component.get("document_param"):
+        extras.append(f"document={component['document_param']}")
+    if component.get("version"):
+        extras.append(f"version={component['version']}")
+    if component.get("input"):
+        extras.append(f"input={component['input']}")
+    suffix = f" ({', '.join(extras)})" if extras else ""
+    return f"{provider}/{model}{suffix}"
+
+
+def format_embedding_identity(identity: Optional[dict[str, Any]]) -> str:
+    """Render a human-readable embedding identity summary."""
+    if not identity:
+        return "unknown"
+    parts = [identity.get("mode", "unknown")]
+    for key in ("dense", "sparse", "hybrid"):
+        component = identity.get(key)
+        if component:
+            parts.append(f"{key}={_format_component(component)}")
+    text_source = identity.get("text_source")
+    if text_source:
+        parts.append(f"text_source={text_source}")
+    return ", ".join(parts)
+
+
+def _build_rebuild_command(config_path: Optional[str]) -> str:
+    cmd = ["openviking-rebuild-vectors", "--all-accounts"]
+    if config_path:
+        cmd.extend(["--config", config_path])
+    return " ".join(cmd)
+
+
+def _raise_mismatch(
+    *,
+    previous_payload: Optional[dict[str, Any]],
+    current_payload: dict[str, Any],
+    config_path: Optional[str],
+    metadata_path: Optional[Path],
+    reason: str,
+) -> None:
+    previous_identity = (previous_payload or {}).get("embedding")
+    current_identity = current_payload.get("embedding")
+    rebuild_command = _build_rebuild_command(config_path)
+    meta_str = str(metadata_path) if metadata_path else None
+    message = (
+        f"{reason} Existing vectors are incompatible with the current embedding config. "
+        f"Previous: {format_embedding_identity(previous_identity)}. "
+        f"Current: {format_embedding_identity(current_identity)}. "
+        f"Run `{rebuild_command}` and start the server again."
+    )
+    raise EmbeddingCompatibilityError(
+        message,
+        previous=previous_identity,
+        current=current_identity,
+        metadata_path=meta_str,
+        rebuild_command=rebuild_command,
+    )
+
+
+async def ensure_embedding_collection_compatibility(
+    storage: Any,
+    config: Any,
+    *,
+    config_path: Optional[str] = None,
+) -> Optional[Path]:
+    """Validate local vector collection compatibility and persist metadata baseline."""
+    current_payload = build_embedding_metadata(config)
+    meta_path = resolve_embedding_meta_path(config.storage.vectordb)
+
+    if meta_path is None:
+        logger.info(
+            "Skipping embedding compatibility metadata: vectordb backend %s does not support local sidecars",
+            config.storage.vectordb.backend,
+        )
+        return None
+
+    collection_info = await storage.get_collection_info()
+    record_count = _extract_count(collection_info)
+    current_dim = config.embedding.dimension
+
+    try:
+        stored_payload = load_embedding_metadata(config.storage.vectordb)
+    except json.JSONDecodeError as exc:
+        _raise_mismatch(
+            previous_payload=None,
+            current_payload=current_payload,
+            config_path=config_path,
+            metadata_path=meta_path,
+            reason=f"Embedding metadata file is corrupted: {exc}.",
+        )
+    except OSError as exc:
+        raise EmbeddingCompatibilityError(
+            f"Failed to read embedding metadata from {meta_path}: {exc}",
+            metadata_path=str(meta_path),
+        ) from exc
+
+    if stored_payload is None:
+        existing_dim = _extract_vector_dim(collection_info)
+        if record_count > 0 and existing_dim and existing_dim != current_dim:
+            baseline = {
+                "embedding": {
+                    "mode": "unknown",
+                    "dense": {"provider": "unknown", "model": "unknown", "dimension": existing_dim},
+                }
+            }
+            _raise_mismatch(
+                previous_payload=baseline,
+                current_payload=current_payload,
+                config_path=config_path,
+                metadata_path=meta_path,
+                reason=(
+                    "Vector collection dimension does not match the current embedding dimension, "
+                    "and no embedding metadata baseline exists."
+                ),
+            )
+
+        written_path = persist_embedding_metadata(config, current_payload)
+        if record_count > 0:
+            logger.warning(
+                "Vector collection already contains %s records but has no embedding metadata. "
+                "Recorded the current embedding config as the new baseline at %s. "
+                "If this workspace was upgraded after an embedding-model switch, run %s once to rebuild.",
+                record_count,
+                written_path,
+                _build_rebuild_command(config_path),
+            )
+        return written_path
+
+    stored_identity = stored_payload.get("embedding")
+    current_identity = current_payload.get("embedding")
+    if stored_identity != current_identity:
+        _raise_mismatch(
+            previous_payload=stored_payload,
+            current_payload=current_payload,
+            config_path=config_path,
+            metadata_path=meta_path,
+            reason="Embedding configuration changed.",
+        )
+
+    return persist_embedding_metadata(config, current_payload)

--- a/openviking/storage/embedding_compat.py
+++ b/openviking/storage/embedding_compat.py
@@ -56,7 +56,9 @@ def load_embedding_metadata(vectordb_config: Any) -> Optional[dict[str, Any]]:
     return json.loads(meta_path.read_text(encoding="utf-8"))
 
 
-def persist_embedding_metadata(config: Any, payload: Optional[dict[str, Any]] = None) -> Optional[Path]:
+def persist_embedding_metadata(
+    config: Any, payload: Optional[dict[str, Any]] = None
+) -> Optional[Path]:
     """Persist embedding metadata for the active config when backend supports it."""
     meta_path = resolve_embedding_meta_path(config.storage.vectordb)
     if meta_path is None:

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1254,6 +1254,13 @@ class VikingFS:
             return [e for e in entries if e.get("name") in VikingURI.VALID_SCOPES]
         return [e for e in entries if e.get("name") not in self._INTERNAL_NAMES]
 
+    async def list_account_roots(self) -> List[Dict[str, Any]]:
+        """List account directories under the local AGFS root."""
+        try:
+            return self.agfs.ls(self._ROOT_PATH)
+        except Exception:
+            return []
+
     def _path_to_uri(self, path: str, ctx: Optional[RequestContext] = None) -> str:
         """/local/{account}/... -> viking://...
 

--- a/openviking_cli/exceptions.py
+++ b/openviking_cli/exceptions.py
@@ -85,6 +85,30 @@ class FailedPreconditionError(OpenVikingError):
         super().__init__(message, code="FAILED_PRECONDITION", details=details)
 
 
+class EmbeddingCompatibilityError(FailedPreconditionError):
+    """Vector index metadata is incompatible with the current embedding config."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        previous: Optional[dict] = None,
+        current: Optional[dict] = None,
+        metadata_path: Optional[str] = None,
+        rebuild_command: Optional[str] = None,
+    ):
+        details = {}
+        if previous is not None:
+            details["previous"] = previous
+        if current is not None:
+            details["current"] = current
+        if metadata_path is not None:
+            details["metadata_path"] = metadata_path
+        if rebuild_command is not None:
+            details["rebuild_command"] = rebuild_command
+        super().__init__(message, details=details)
+
+
 # ============= Authentication Errors =============
 
 

--- a/openviking_cli/rebuild_vectors.py
+++ b/openviking_cli/rebuild_vectors.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""CLI entry point for rebuilding vectors after embedding changes."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from typing import Sequence
+
+from openviking.service.core import OpenVikingService
+from openviking.storage.embedding_compat import persist_embedding_metadata
+from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Rebuild OpenViking vectors after an embedding configuration change.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to ov.conf config file",
+    )
+    parser.add_argument(
+        "--account",
+        action="append",
+        default=[],
+        help="Only rebuild the specified account_id (repeatable)",
+    )
+    parser.add_argument(
+        "--all-accounts",
+        action="store_true",
+        help="Rebuild every discovered account in the workspace",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Optional queue wait timeout in seconds per account",
+    )
+    return parser
+
+
+def _resolve_account_targets(
+    explicit_accounts: Sequence[str],
+    discovered_accounts: Sequence[str],
+    default_account: str,
+) -> list[str]:
+    if explicit_accounts:
+        return sorted(set(explicit_accounts))
+    if discovered_accounts:
+        return list(discovered_accounts)
+    return [default_account]
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if args.config:
+        os.environ["OPENVIKING_CONFIG_FILE"] = args.config
+
+    OpenVikingConfigSingleton.reset_instance()
+
+    service = OpenVikingService(skip_embedding_compat_check=True)
+    try:
+        await service.initialize()
+        rebuilder = service.create_vector_rebuild_service()
+        discovered_accounts = (
+            await rebuilder.discover_accounts() if args.all_accounts or not args.account else []
+        )
+        target_accounts = _resolve_account_targets(
+            explicit_accounts=args.account,
+            discovered_accounts=discovered_accounts,
+            default_account=service.config.default_account,
+        )
+
+        if not target_accounts:
+            print("No accounts found to rebuild.", file=sys.stderr)
+            return 1
+
+        print("Rebuilding vectors for accounts:", ", ".join(target_accounts))
+        reports = await rebuilder.rebuild_accounts(target_accounts, wait_timeout=args.timeout)
+        meta_path = persist_embedding_metadata(service.config)
+
+        print("")
+        for report in reports:
+            print(
+                f"[{report.account_id}] deleted_records={report.deleted_records} "
+                f"indexed_directories={report.indexed_directories}"
+            )
+            if report.queue_status:
+                for queue_name, queue_data in report.queue_status.items():
+                    processed = queue_data.get("processed", 0)
+                    requeues = queue_data.get("requeue_count", 0)
+                    errors = queue_data.get("error_count", 0)
+                    print(
+                        f"  - {queue_name}: processed={processed} "
+                        f"requeue_count={requeues} error_count={errors}"
+                    )
+
+        if meta_path is not None:
+            print("")
+            print(f"Updated embedding metadata: {meta_path}")
+        print("Vector rebuild completed.")
+        return 0
+    finally:
+        try:
+            await service.close()
+        finally:
+            OpenVikingConfigSingleton.reset_instance()
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    try:
+        raise SystemExit(asyncio.run(_run(args)))
+    except KeyboardInterrupt:
+        raise SystemExit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -605,6 +605,49 @@ class EmbeddingConfig(BaseModel):
 
         raise ValueError("No embedding configuration found (dense, sparse, or hybrid)")
 
+    @staticmethod
+    def _identity_dict_for_model(config: Optional[EmbeddingModelConfig]) -> Optional[dict[str, Any]]:
+        if config is None:
+            return None
+        data: dict[str, Any] = {
+            "provider": EmbeddingConfig._require_provider(config.provider),
+            "model": config.model,
+        }
+        if config.dimension is not None:
+            data["dimension"] = config.get_effective_dimension()
+        elif config.model:
+            try:
+                data["dimension"] = config.get_effective_dimension()
+            except Exception:
+                pass
+        if config.input:
+            data["input"] = config.input
+        if config.query_param:
+            data["query_param"] = config.query_param
+        if config.document_param:
+            data["document_param"] = config.document_param
+        if config.version:
+            data["version"] = config.version
+        return data
+
+    def compatibility_identity(self) -> dict[str, Any]:
+        """Build a stable identity for vector compatibility checks."""
+        mode = "dense"
+        if self.hybrid:
+            mode = "hybrid"
+        elif self.dense and self.sparse:
+            mode = "dense+sparse"
+        elif self.sparse and not self.dense:
+            mode = "sparse"
+
+        return {
+            "mode": mode,
+            "text_source": self.text_source,
+            "dense": self._identity_dict_for_model(self.dense),
+            "sparse": self._identity_dict_for_model(self.sparse),
+            "hybrid": self._identity_dict_for_model(self.hybrid),
+        }
+
     @property
     def dimension(self) -> int:
         """Get dimension from active config."""

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -606,7 +606,9 @@ class EmbeddingConfig(BaseModel):
         raise ValueError("No embedding configuration found (dense, sparse, or hybrid)")
 
     @staticmethod
-    def _identity_dict_for_model(config: Optional[EmbeddingModelConfig]) -> Optional[dict[str, Any]]:
+    def _identity_dict_for_model(
+        config: Optional[EmbeddingModelConfig],
+    ) -> Optional[dict[str, Any]]:
         if config is None:
             return None
         data: dict[str, Any] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ Issues = "https://github.com/volcengine/openviking/issues"
 ov = "openviking_cli.rust_cli:main"  # Rust CLI 入口（极简包装器）
 openviking = "openviking_cli.rust_cli:main"  # Rust CLI 入口（放弃 python CLI）
 openviking-server = "openviking_cli.server_bootstrap:main"
+openviking-rebuild-vectors = "openviking_cli.rebuild_vectors:main"
 vikingbot = "vikingbot.cli.commands:app"
 
 [tool.setuptools_scm]

--- a/tests/service/test_vector_rebuild.py
+++ b/tests/service/test_vector_rebuild.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.server.identity import Role
+from openviking.service.vector_rebuild import VectorRebuildService
+
+
+class _FakeVikingFS:
+    def __init__(self, tree):
+        self._tree = tree
+
+    async def list_account_roots(self):
+        return [{"name": "acme", "isDir": True}]
+
+    async def exists(self, uri, ctx=None):
+        return uri in self._tree
+
+    async def ls(self, uri, **kwargs):
+        return list(self._tree.get(uri, []))
+
+
+class _FakeVikingDBManager:
+    def __init__(self):
+        self.calls = []
+
+    async def delete_account_data(self, account_id, ctx):
+        self.calls.append((account_id, ctx))
+        return 7
+
+
+class _FakeResourceService:
+    def __init__(self):
+        self.build_calls = []
+        self.wait_calls = []
+
+    async def build_index(self, resource_uris, ctx, **kwargs):
+        self.build_calls.append((list(resource_uris), ctx))
+        return {"status": "success"}
+
+    async def wait_processed(self, timeout=None):
+        self.wait_calls.append(timeout)
+        return {
+            "embedding": {
+                "processed": len(self.build_calls),
+                "requeue_count": 0,
+                "error_count": 0,
+                "errors": [],
+            }
+        }
+
+
+@pytest.mark.asyncio
+async def test_vector_rebuild_service_reindexes_all_scope_directories():
+    tree = {
+        "viking://resources": [
+            {"uri": "viking://resources/project", "isDir": True},
+            {"uri": "viking://resources/readme.md", "isDir": False},
+        ],
+        "viking://resources/project": [
+            {"uri": "viking://resources/project/docs", "isDir": True},
+            {"uri": "viking://resources/project/spec.md", "isDir": False},
+        ],
+        "viking://resources/project/docs": [
+            {"uri": "viking://resources/project/docs/notes.md", "isDir": False},
+        ],
+        "viking://user": [
+            {"uri": "viking://user/alice", "isDir": True},
+        ],
+        "viking://user/alice": [
+            {"uri": "viking://user/alice/memories", "isDir": True},
+        ],
+        "viking://user/alice/memories": [
+            {"uri": "viking://user/alice/memories/profile.md", "isDir": False},
+        ],
+    }
+    resources = _FakeResourceService()
+    vikingdb = _FakeVikingDBManager()
+    service = SimpleNamespace(
+        viking_fs=_FakeVikingFS(tree),
+        vikingdb_manager=vikingdb,
+        resources=resources,
+    )
+
+    rebuilder = VectorRebuildService(service)
+    reports = await rebuilder.rebuild_accounts(wait_timeout=12.5)
+
+    assert [report.account_id for report in reports] == ["acme"]
+    assert reports[0].deleted_records == 7
+    assert reports[0].indexed_directories == 6
+    assert resources.wait_calls == [12.5]
+    assert [call[0] for call in resources.build_calls] == [
+        ["viking://resources"],
+        ["viking://resources/project"],
+        ["viking://resources/project/docs"],
+        ["viking://user"],
+        ["viking://user/alice"],
+        ["viking://user/alice/memories"],
+    ]
+    ctx = vikingdb.calls[0][1]
+    assert ctx.role == Role.ROOT
+    assert ctx.account_id == "acme"

--- a/tests/storage/test_embedding_compat.py
+++ b/tests/storage/test_embedding_compat.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.storage.embedding_compat import (
+    ensure_embedding_collection_compatibility,
+    load_embedding_metadata,
+)
+from openviking_cli.exceptions import EmbeddingCompatibilityError
+
+
+class _FakeStorage:
+    def __init__(self, collection_info):
+        self._collection_info = collection_info
+
+    async def get_collection_info(self):
+        return self._collection_info
+
+
+def _make_config(tmp_path, *, model: str, dimension: int = 2048, text_source: str = "summary_first"):
+    vectordb = SimpleNamespace(
+        backend="local",
+        path=str(tmp_path),
+        name="context",
+    )
+    storage = SimpleNamespace(vectordb=vectordb)
+    embedding = SimpleNamespace(
+        dimension=dimension,
+        compatibility_identity=lambda: {
+            "mode": "dense",
+            "text_source": text_source,
+            "dense": {
+                "provider": "openai",
+                "model": model,
+                "dimension": dimension,
+            },
+            "sparse": None,
+            "hybrid": None,
+        },
+    )
+    return SimpleNamespace(storage=storage, embedding=embedding)
+
+
+@pytest.mark.asyncio
+async def test_ensure_embedding_collection_compatibility_writes_baseline(tmp_path):
+    config = _make_config(tmp_path, model="text-embedding-3-small")
+    storage = _FakeStorage({"vector_dim": 2048, "count": 0})
+
+    meta_path = await ensure_embedding_collection_compatibility(
+        storage,
+        config,
+        config_path="/tmp/test-ov.conf",
+    )
+
+    assert meta_path is not None
+    payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert payload["embedding"]["dense"]["model"] == "text-embedding-3-small"
+    assert payload["embedding"]["dense"]["dimension"] == 2048
+    assert load_embedding_metadata(config.storage.vectordb)["embedding"] == payload["embedding"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_embedding_collection_compatibility_raises_on_model_mismatch(tmp_path):
+    initial_config = _make_config(tmp_path, model="text-embedding-3-small")
+    storage = _FakeStorage({"vector_dim": 2048, "count": 12})
+    await ensure_embedding_collection_compatibility(storage, initial_config)
+
+    new_config = _make_config(tmp_path, model="text-embedding-3-large")
+    with pytest.raises(EmbeddingCompatibilityError) as exc_info:
+        await ensure_embedding_collection_compatibility(
+            storage,
+            new_config,
+            config_path="/tmp/test-ov.conf",
+        )
+
+    assert "Embedding configuration changed" in str(exc_info.value)
+    assert "openviking-rebuild-vectors --all-accounts --config /tmp/test-ov.conf" in str(
+        exc_info.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_embedding_collection_compatibility_raises_on_dimension_mismatch_without_metadata(
+    tmp_path,
+):
+    config = _make_config(tmp_path, model="text-embedding-3-small", dimension=2048)
+    storage = _FakeStorage({"vector_dim": 1536, "count": 9})
+
+    with pytest.raises(EmbeddingCompatibilityError) as exc_info:
+        await ensure_embedding_collection_compatibility(
+            storage,
+            config,
+            config_path="/tmp/test-ov.conf",
+        )
+
+    assert "dimension does not match" in str(exc_info.value)

--- a/tests/storage/test_embedding_compat.py
+++ b/tests/storage/test_embedding_compat.py
@@ -21,7 +21,9 @@ class _FakeStorage:
         return self._collection_info
 
 
-def _make_config(tmp_path, *, model: str, dimension: int = 2048, text_source: str = "summary_first"):
+def _make_config(
+    tmp_path, *, model: str, dimension: int = 2048, text_source: str = "summary_first"
+):
     vectordb = SimpleNamespace(
         backend="local",
         path=str(tmp_path),


### PR DESCRIPTION
## Summary
- add persisted embedding compatibility metadata for local vectordb collections
- fail fast on server startup when the configured embedding identity no longer matches stored vectors
- add `openviking-rebuild-vectors` to delete stale per-account vectors and reindex all scopes from AGFS content
- cover metadata mismatch handling and rebuild traversal with targeted tests

Closes #1066.

## Validation
- `ruff check openviking/service/core.py openviking/service/vector_rebuild.py openviking/storage/embedding_compat.py openviking/storage/viking_fs.py openviking_cli/rebuild_vectors.py openviking_cli/utils/config/embedding_config.py openviking_cli/exceptions.py tests/storage/test_embedding_compat.py tests/service/test_vector_rebuild.py`
- `python -m compileall openviking/service/core.py openviking/service/vector_rebuild.py openviking/storage/embedding_compat.py openviking/storage/viking_fs.py openviking_cli/rebuild_vectors.py openviking_cli/utils/config/embedding_config.py tests/storage/test_embedding_compat.py tests/service/test_vector_rebuild.py`
- `python -m openviking_cli.rebuild_vectors --help`
- manual validation harness for the new compatibility + rebuild logic (the repo still has the existing `pytest-asyncio` collection failure: `AttributeError: 'Package' object has no attribute 'obj'`, so direct `pytest` collection is still blocked)
