### PR TITLE
feat(memory): default to memory v2

### DIFF
--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -9,7 +9,7 @@ class MemoryConfig(BaseModel):
     """Memory configuration for OpenViking."""
 
     version: str = Field(
-        default="v1",
+        default="v2",
         description="Memory implementation version: 'v1' (legacy) or 'v2' (new templating system)",
     )
     agent_scope_mode: str = Field(


### PR DESCRIPTION
## Summary
- Set default memory version from v1 to v2 in MemoryConfig

## Changes
开启 v2 后的主要变化：

1. **记忆模板化系统** - 支持自定义添加记忆类型，无需修改核心代码
2. **ReAct 模式** - 采用 Reasoning + Action 模式，一次 LLM 调用更新所有记忆
3. **语义化文件名** - 记忆文件名使用语义化命名，提升导航价值
4. **Patch 增量更新** - 采用 patch 增量更新机制（包含 abstract 和 overview），减少 LLM 调用次数
5. **保持向后兼容** - 现有的 8 个记忆类别（profile, preferences, entities, events, cases, patterns, tools, skills）继续正常工作

## Test plan
- [ ] Verify memory v2 is enabled by default
- [ ] Test existing memory functionality works

🤖 Generated with [Claude Code](https://claude.com/claude-code)