### PR TITLE
feat: add account namespace policy phase 1

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -11,8 +11,10 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from openviking.core.context import Context, ContextType, Vectorize
+from openviking.core.namespace import NamespacePolicy, persist_namespace_policy
 from openviking.server.identity import RequestContext
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
+from openviking_cli.utils.uri import VikingURI
 
 if TYPE_CHECKING:
     from openviking.storage import VikingDBManager
@@ -145,9 +147,15 @@ class DirectoryInitializer:
         vikingdb: "VikingDBManager",
     ):
         self.vikingdb = vikingdb
+        self._namespace_policy_overrides: Dict[str, NamespacePolicy] = {}
+
+    def set_namespace_policy(self, account_id: str, policy: NamespacePolicy) -> None:
+        """Pin a policy override for the next initialization pass of an account."""
+        self._namespace_policy_overrides[account_id] = policy
 
     async def initialize_account_directories(self, ctx: RequestContext) -> int:
         """Initialize account-shared scope roots."""
+        await self._ensure_namespace_policy(ctx)
         count = 0
         scope_roots = {
             "user": PRESET_DIRECTORIES["user"],
@@ -172,11 +180,13 @@ class DirectoryInitializer:
         """Initialize user-space tree lazily for the current user."""
         if "user" not in PRESET_DIRECTORIES:
             return 0
-        user_space_root = f"viking://user/{ctx.user.user_space_name()}"
+        policy = self._load_namespace_policy(ctx)
+        user_space_root = ctx.user.canonical_user_root(policy)
+        user_parent = VikingURI(user_space_root).parent
         user_tree = PRESET_DIRECTORIES["user"]
         created = await self._ensure_directory(
             uri=user_space_root,
-            parent_uri="viking://user",
+            parent_uri=user_parent.uri if user_parent else "viking://user",
             defn=user_tree,
             scope="user",
             ctx=ctx,
@@ -191,11 +201,13 @@ class DirectoryInitializer:
         """Initialize agent-space tree lazily for the current user+agent."""
         if "agent" not in PRESET_DIRECTORIES:
             return 0
-        agent_space_root = f"viking://agent/{ctx.user.agent_space_name()}"
+        policy = self._load_namespace_policy(ctx)
+        agent_space_root = ctx.user.canonical_agent_root(policy)
+        agent_parent = VikingURI(agent_space_root).parent
         agent_tree = PRESET_DIRECTORIES["agent"]
         created = await self._ensure_directory(
             uri=agent_space_root,
-            parent_uri="viking://agent",
+            parent_uri=agent_parent.uri if agent_parent else "viking://agent",
             defn=agent_tree,
             scope="agent",
             ctx=ctx,
@@ -339,3 +351,18 @@ class DirectoryInitializer:
             is_leaf=False,  # Preset directories can continue traversing downward
             ctx=ctx,
         )
+
+    async def _ensure_namespace_policy(self, ctx: RequestContext) -> NamespacePolicy:
+        from openviking.storage.viking_fs import get_viking_fs
+
+        viking_fs = get_viking_fs()
+        policy = self._namespace_policy_overrides.pop(ctx.account_id, None)
+        if policy is None:
+            policy = viking_fs.get_namespace_resolver(ctx).policy
+        return await persist_namespace_policy(viking_fs, ctx.account_id, policy)
+
+    @staticmethod
+    def _load_namespace_policy(ctx: RequestContext) -> NamespacePolicy:
+        from openviking.storage.viking_fs import get_viking_fs
+
+        return get_viking_fs().get_namespace_resolver(ctx).policy

--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -180,7 +180,7 @@ class DirectoryInitializer:
         """Initialize user-space tree lazily for the current user."""
         if "user" not in PRESET_DIRECTORIES:
             return 0
-        policy = self._load_namespace_policy(ctx)
+        policy = await self._load_namespace_policy(ctx)
         user_space_root = ctx.user.canonical_user_root(policy)
         user_parent = VikingURI(user_space_root).parent
         user_tree = PRESET_DIRECTORIES["user"]
@@ -201,7 +201,7 @@ class DirectoryInitializer:
         """Initialize agent-space tree lazily for the current user+agent."""
         if "agent" not in PRESET_DIRECTORIES:
             return 0
-        policy = self._load_namespace_policy(ctx)
+        policy = await self._load_namespace_policy(ctx)
         agent_space_root = ctx.user.canonical_agent_root(policy)
         agent_parent = VikingURI(agent_space_root).parent
         agent_tree = PRESET_DIRECTORIES["agent"]
@@ -358,11 +358,11 @@ class DirectoryInitializer:
         viking_fs = get_viking_fs()
         policy = self._namespace_policy_overrides.pop(ctx.account_id, None)
         if policy is None:
-            policy = viking_fs.get_namespace_resolver(ctx).policy
+            policy = (await viking_fs.get_namespace_resolver(ctx)).policy
         return await persist_namespace_policy(viking_fs, ctx.account_id, policy)
 
     @staticmethod
-    def _load_namespace_policy(ctx: RequestContext) -> NamespacePolicy:
+    async def _load_namespace_policy(ctx: RequestContext) -> NamespacePolicy:
         from openviking.storage.viking_fs import get_viking_fs
 
-        return get_viking_fs().get_namespace_resolver(ctx).policy
+        return (await get_viking_fs().get_namespace_resolver(ctx)).policy

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
 """Account-scoped namespace policy and canonical URI resolution helpers."""
 
 from __future__ import annotations
@@ -6,9 +8,12 @@ import json
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from openviking_cli.utils import run_async
+from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
 
 NAMESPACE_POLICY_PATH_TEMPLATE = "/local/{account_id}/_system/setting.json"
+logger = get_logger(__name__)
 
 _ROOT_METADATA_FILES = {".abstract.md", ".overview.md"}
 _USER_STRUCTURE_DIRS = {"memories", "profile.md"}
@@ -195,8 +200,10 @@ def _ensure_parent_dirs(viking_fs: Any, path: str) -> None:
         parent = "/" + "/".join(parts[:index])
         try:
             viking_fs.agfs.mkdir(parent)
-        except Exception:
-            pass
+        except FileExistsError:
+            continue
+        except Exception as exc:
+            logger.debug("Failed to create parent directory %s: %s", parent, exc)
 
 
 def _coerce_bytes(viking_fs: Any, result: Any) -> bytes:
@@ -223,7 +230,36 @@ async def load_namespace_policy(viking_fs: Any, account_id: str) -> NamespacePol
         payload = await viking_fs.decrypt_bytes(account_id, payload)
         data = json.loads(payload.decode("utf-8"))
         return NamespacePolicy.from_dict(data)
-    except Exception:
+    except Exception as exc:
+        logger.debug(
+            "Falling back to default namespace policy for account %s from %s: %s",
+            account_id,
+            path,
+            exc,
+        )
+        return NamespacePolicy()
+
+
+def load_namespace_policy_sync(viking_fs: Any, account_id: str) -> NamespacePolicy:
+    """Synchronously read the persisted account policy for sync-only call sites."""
+    path = namespace_policy_path(account_id)
+    try:
+        try:
+            raw = viking_fs.agfs.read(path, 0, -1)
+        except TypeError:
+            raw = viking_fs.agfs.read(path)
+        payload = _coerce_bytes(viking_fs, raw)
+        if getattr(viking_fs, "_encryptor", None):
+            payload = run_async(viking_fs.decrypt_bytes(account_id, payload))
+        data = json.loads(payload.decode("utf-8"))
+        return NamespacePolicy.from_dict(data)
+    except Exception as exc:
+        logger.debug(
+            "Synchronously falling back to default namespace policy for account %s from %s: %s",
+            account_id,
+            path,
+            exc,
+        )
         return NamespacePolicy()
 
 
@@ -239,7 +275,11 @@ async def persist_namespace_policy(
     content = await viking_fs.encrypt_bytes(account_id, content)
     _ensure_parent_dirs(viking_fs, path)
     viking_fs.agfs.write(path, content)
-    cache = getattr(viking_fs, "_namespace_policy_cache", None)
-    if isinstance(cache, dict):
-        cache[account_id] = resolved
+    cache_setter = getattr(viking_fs, "_set_cached_namespace_policy", None)
+    if callable(cache_setter):
+        cache_setter(account_id, resolved)
+    else:
+        cache = getattr(viking_fs, "_namespace_policy_cache", None)
+        if isinstance(cache, dict):
+            cache[account_id] = resolved
     return resolved

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -1,0 +1,245 @@
+"""Account-scoped namespace policy and canonical URI resolution helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from openviking_cli.utils.uri import VikingURI
+
+NAMESPACE_POLICY_PATH_TEMPLATE = "/local/{account_id}/_system/setting.json"
+
+_ROOT_METADATA_FILES = {".abstract.md", ".overview.md"}
+_USER_STRUCTURE_DIRS = {"memories", "profile.md"}
+_AGENT_STRUCTURE_DIRS = {"memories", "skills", "instructions", "workspaces"}
+_SESSION_STRUCTURE_DIRS = {"messages.jsonl", "history", "tools", ".meta.json"}
+
+
+@dataclass(frozen=True)
+class NamespacePolicy:
+    """Persisted account-level namespace isolation policy."""
+
+    isolate_user_scope_by_agent: bool = False
+    isolate_agent_scope_by_user: bool = False
+
+    def to_dict(self) -> dict[str, bool]:
+        return {
+            "isolate_user_scope_by_agent": self.isolate_user_scope_by_agent,
+            "isolate_agent_scope_by_user": self.isolate_agent_scope_by_user,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict[str, Any]]) -> "NamespacePolicy":
+        if not isinstance(data, dict):
+            return cls()
+        return cls(
+            isolate_user_scope_by_agent=bool(data.get("isolate_user_scope_by_agent", False)),
+            isolate_agent_scope_by_user=bool(data.get("isolate_agent_scope_by_user", False)),
+        )
+
+
+def namespace_policy_path(account_id: str) -> str:
+    """Return the AGFS path for the persisted namespace policy."""
+    return NAMESPACE_POLICY_PATH_TEMPLATE.format(account_id=account_id)
+
+
+class NamespaceResolver:
+    """Resolve canonical user/agent/session URIs for a request identity."""
+
+    def __init__(self, policy: Optional[NamespacePolicy] = None):
+        self.policy = policy or NamespacePolicy()
+
+    @staticmethod
+    def _join_uri(base_uri: str, *parts: str) -> str:
+        suffix = "/".join(part.strip("/") for part in parts if part and part.strip("/"))
+        if not suffix:
+            return base_uri
+        return f"{base_uri.rstrip('/')}/{suffix}"
+
+    def user_root(self, user: Any) -> str:
+        parts = [user.user_id]
+        if self.policy.isolate_user_scope_by_agent:
+            parts.extend(["agent", user.agent_id])
+        return VikingURI.build("user", *parts)
+
+    def agent_root(self, user: Any) -> str:
+        parts = [user.agent_id]
+        if self.policy.isolate_agent_scope_by_user:
+            parts.extend(["user", user.user_id])
+        return VikingURI.build("agent", *parts)
+
+    @staticmethod
+    def session_root(session_id: Optional[str] = None) -> str:
+        if session_id:
+            return VikingURI.build("session", session_id)
+        return VikingURI.build("session")
+
+    def canonicalize_uri(self, uri: str, user: Any) -> str:
+        """Canonicalize shorthand and legacy URIs for the given user."""
+        normalized = VikingURI.normalize(uri)
+        parts = [part for part in normalized[len("viking://") :].strip("/").split("/") if part]
+        if not parts:
+            return normalized
+
+        scope = parts[0]
+        if scope == "user":
+            return self._canonicalize_user_uri(normalized, parts, user)
+        if scope == "agent":
+            return self._canonicalize_agent_uri(normalized, parts, user)
+        if scope == "session":
+            return self._canonicalize_session_uri(normalized, parts, user)
+        return normalized
+
+    def is_visible(self, uri: str, user: Any) -> bool:
+        """Check whether a canonicalized URI is visible to the given user."""
+        canonical = self.canonicalize_uri(uri, user)
+        parts = [part for part in canonical[len("viking://") :].strip("/").split("/") if part]
+        if not parts:
+            return True
+
+        scope = parts[0]
+        if scope in {"resources", "temp", "queue"}:
+            return True
+        if scope == "session":
+            return True
+        if len(parts) == 1:
+            return True
+        if len(parts) == 2 and parts[1] in _ROOT_METADATA_FILES:
+            return True
+        if scope == "user":
+            expected_root = self.user_root(user)
+            return canonical == expected_root or canonical.startswith(f"{expected_root}/")
+        if scope == "agent":
+            expected_root = self.agent_root(user)
+            return canonical == expected_root or canonical.startswith(f"{expected_root}/")
+        return True
+
+    def _canonicalize_user_uri(self, normalized: str, parts: list[str], user: Any) -> str:
+        if len(parts) == 1:
+            return normalized
+
+        second = parts[1]
+        if second in _ROOT_METADATA_FILES:
+            return normalized
+
+        canonical_root = self.user_root(user)
+        if second in _USER_STRUCTURE_DIRS:
+            return self._join_uri(canonical_root, *parts[1:])
+
+        if second != user.user_id:
+            return normalized
+
+        remainder = parts[2:]
+        if self.policy.isolate_user_scope_by_agent:
+            if len(remainder) >= 2 and remainder[0] == "agent" and remainder[1] == user.agent_id:
+                return normalized
+            return self._join_uri(canonical_root, *remainder)
+
+        if len(remainder) >= 2 and remainder[0] == "agent" and remainder[1] == user.agent_id:
+            return self._join_uri(canonical_root, *remainder[2:])
+        return normalized
+
+    def _canonicalize_agent_uri(self, normalized: str, parts: list[str], user: Any) -> str:
+        if len(parts) == 1:
+            return normalized
+
+        second = parts[1]
+        if second in _ROOT_METADATA_FILES:
+            return normalized
+
+        canonical_root = self.agent_root(user)
+        if second in _AGENT_STRUCTURE_DIRS:
+            return self._join_uri(canonical_root, *parts[1:])
+
+        current_aliases = {user.agent_id}
+        agent_space_name = getattr(user, "agent_space_name", None)
+        if callable(agent_space_name):
+            current_aliases.add(agent_space_name())
+        if second not in current_aliases:
+            return normalized
+
+        remainder = parts[2:]
+        if self.policy.isolate_agent_scope_by_user:
+            if len(remainder) >= 2 and remainder[0] == "user" and remainder[1] == user.user_id:
+                return self._join_uri(canonical_root, *remainder[2:])
+            return self._join_uri(canonical_root, *remainder)
+
+        if len(remainder) >= 2 and remainder[0] == "user" and remainder[1] == user.user_id:
+            return self._join_uri(canonical_root, *remainder[2:])
+        if second == user.agent_id:
+            return normalized
+        return self._join_uri(canonical_root, *remainder)
+
+    def _canonicalize_session_uri(self, normalized: str, parts: list[str], user: Any) -> str:
+        if len(parts) <= 1:
+            return normalized
+
+        if len(parts) >= 4 and parts[1] == user.user_id:
+            return self._join_uri(self.session_root(parts[2]), *parts[3:])
+
+        if (
+            len(parts) == 3
+            and parts[1] == user.user_id
+            and parts[2] not in _SESSION_STRUCTURE_DIRS
+            and parts[2] not in _ROOT_METADATA_FILES
+        ):
+            return self.session_root(parts[2])
+
+        return normalized
+
+
+def _ensure_parent_dirs(viking_fs: Any, path: str) -> None:
+    parts = [part for part in path.lstrip("/").split("/") if part]
+    for index in range(1, len(parts)):
+        parent = "/" + "/".join(parts[:index])
+        try:
+            viking_fs.agfs.mkdir(parent)
+        except Exception:
+            pass
+
+
+def _coerce_bytes(viking_fs: Any, result: Any) -> bytes:
+    if hasattr(viking_fs, "_handle_agfs_read"):
+        return viking_fs._handle_agfs_read(result)
+    if isinstance(result, bytes):
+        return result
+    if result is None:
+        return b""
+    if hasattr(result, "content") and result.content is not None:
+        return result.content
+    return str(result).encode("utf-8")
+
+
+async def load_namespace_policy(viking_fs: Any, account_id: str) -> NamespacePolicy:
+    """Read the persisted account policy, falling back to defaults."""
+    path = namespace_policy_path(account_id)
+    try:
+        try:
+            raw = viking_fs.agfs.read(path, 0, -1)
+        except TypeError:
+            raw = viking_fs.agfs.read(path)
+        payload = _coerce_bytes(viking_fs, raw)
+        payload = await viking_fs.decrypt_bytes(account_id, payload)
+        data = json.loads(payload.decode("utf-8"))
+        return NamespacePolicy.from_dict(data)
+    except Exception:
+        return NamespacePolicy()
+
+
+async def persist_namespace_policy(
+    viking_fs: Any,
+    account_id: str,
+    policy: Optional[NamespacePolicy] = None,
+) -> NamespacePolicy:
+    """Persist an account's namespace policy, creating the settings file if needed."""
+    resolved = policy or NamespacePolicy()
+    path = namespace_policy_path(account_id)
+    content = json.dumps(resolved.to_dict(), ensure_ascii=False, indent=2).encode("utf-8")
+    content = await viking_fs.encrypt_bytes(account_id, content)
+    _ensure_parent_dirs(viking_fs, path)
+    viking_fs.agfs.write(path, content)
+    cache = getattr(viking_fs, "_namespace_policy_cache", None)
+    if isinstance(cache, dict):
+        cache[account_id] = resolved
+    return resolved

--- a/openviking/message/part.py
+++ b/openviking/message/part.py
@@ -40,7 +40,7 @@ class ToolPart:
     type: Literal["tool"] = "tool"
     tool_id: str = ""
     tool_name: str = ""
-    tool_uri: str = ""  # viking://session/{user_space_name}/{session_id}/tools/{tool_id}
+    tool_uri: str = ""  # viking://session/{session_id}/tools/{tool_id}
     skill_uri: str = ""  # viking://agent/{agent_space_name}/skills/{skill_name}
     tool_input: Optional[dict] = None
     tool_output: str = ""

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -5,6 +5,7 @@
 from fastapi import APIRouter, Depends, Path, Request
 from pydantic import BaseModel
 
+from openviking.core.namespace import NamespacePolicy
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext, Role
@@ -33,6 +34,8 @@ _DEV_MODE_ADMIN_API_MESSAGE = (
 class CreateAccountRequest(BaseModel):
     account_id: str
     admin_user_id: str
+    isolate_user_scope_by_agent: bool = False
+    isolate_agent_scope_by_user: bool = False
 
 
 class RegisterUserRequest(BaseModel):
@@ -100,7 +103,11 @@ async def create_account(
         user=UserIdentifier(body.account_id, body.admin_user_id, "default"),
         role=Role.ADMIN,
     )
-    await service.initialize_account_directories(account_ctx)
+    namespace_policy = NamespacePolicy(
+        isolate_user_scope_by_agent=body.isolate_user_scope_by_agent,
+        isolate_agent_scope_by_user=body.isolate_agent_scope_by_user,
+    )
+    await service.initialize_account_directories(account_ctx, namespace_policy=namespace_policy)
     await service.initialize_user_directories(account_ctx)
     return Response(
         status="ok",
@@ -108,6 +115,7 @@ async def create_account(
             "account_id": body.account_id,
             "admin_user_id": body.admin_user_id,
             "user_key": user_key,
+            **namespace_policy.to_dict(),
         },
     )
 

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -10,6 +10,7 @@ import os
 from typing import Any, Optional
 
 from openviking.core.directories import DirectoryInitializer
+from openviking.core.namespace import NamespacePolicy
 from openviking.crypto.config import bootstrap_encryption
 from openviking.resource.watch_scheduler import WatchScheduler
 from openviking.server.identity import RequestContext, Role
@@ -374,11 +375,17 @@ class OpenVikingService:
         if not self._initialized:
             raise NotInitializedError("OpenVikingService")
 
-    async def initialize_account_directories(self, ctx: RequestContext) -> int:
+    async def initialize_account_directories(
+        self,
+        ctx: RequestContext,
+        namespace_policy: NamespacePolicy | None = None,
+    ) -> int:
         """Initialize account-shared preset roots."""
         self._ensure_initialized()
         if not self._directory_initializer:
             return 0
+        if namespace_policy is not None:
+            self._directory_initializer.set_namespace_policy(ctx.account_id, namespace_policy)
         return await self._directory_initializer.initialize_account_directories(ctx)
 
     async def initialize_user_directories(self, ctx: RequestContext) -> int:

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -8,13 +8,18 @@ Provides session management operations: session, sessions, add_message, commit, 
 
 from typing import Any, Dict, List, Optional
 
-from openviking.server.identity import RequestContext
+from openviking.server.identity import RequestContext, Role
 from openviking.service.task_tracker import get_task_tracker
 from openviking.session import Session
 from openviking.session.compressor import SessionCompressor
 from openviking.storage import VikingDBManager
 from openviking.storage.viking_fs import VikingFS
-from openviking_cli.exceptions import AlreadyExistsError, NotFoundError, NotInitializedError
+from openviking_cli.exceptions import (
+    AlreadyExistsError,
+    NotFoundError,
+    NotInitializedError,
+    PermissionDeniedError,
+)
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -143,13 +148,13 @@ class SessionService:
             raise
 
     async def sessions(self, ctx: RequestContext) -> List[Dict[str, Any]]:
-        """Get all sessions for the current user.
+        """Get all sessions for the current account.
 
         Returns:
             List of session info dicts
         """
         self._ensure_initialized()
-        session_base_uri = f"viking://session/{ctx.user.user_space_name()}"
+        session_base_uri = "viking://session"
 
         try:
             entries = await self._viking_fs.ls(session_base_uri, ctx=ctx)
@@ -179,7 +184,10 @@ class SessionService:
             True if deleted successfully
         """
         self._ensure_initialized()
-        session_uri = f"viking://session/{ctx.user.user_space_name()}/{session_id}"
+        if ctx.role not in {Role.ROOT, Role.ADMIN}:
+            raise PermissionDeniedError("Deleting sessions requires admin or root access")
+
+        session_uri = f"viking://session/{session_id}"
 
         try:
             await self._viking_fs.rm(session_uri, recursive=True, ctx=ctx)

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -171,7 +171,7 @@ class Session:
         self.session_id = session_id or str(uuid4())
         self.created_at = int(datetime.now(timezone.utc).timestamp() * 1000)
         self._auto_commit_threshold = auto_commit_threshold
-        self._session_uri = f"viking://session/{self.user.user_space_name()}/{self.session_id}"
+        self._session_uri = f"viking://session/{self.session_id}"
 
         self._messages: List[Message] = []
         self._usage_records: List[Usage] = []

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -17,13 +17,19 @@ import contextvars
 import hashlib
 import json
 import re
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from openviking.core.namespace import NamespaceResolver, load_namespace_policy
+from openviking.core.namespace import (
+    NamespacePolicy,
+    NamespaceResolver,
+    load_namespace_policy,
+    load_namespace_policy_sync,
+)
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSDirectoryNotEmptyError, AGFSHTTPError
 from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext, Role
@@ -31,7 +37,6 @@ from openviking.telemetry import get_current_telemetry
 from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
 from openviking_cli.exceptions import FailedPreconditionError, NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
-from openviking_cli.utils import run_async
 from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
 
@@ -198,7 +203,8 @@ class VikingFS:
         self._bound_ctx: contextvars.ContextVar[Optional[RequestContext]] = contextvars.ContextVar(
             "vikingfs_bound_ctx", default=None
         )
-        self._namespace_policy_cache: Dict[str, Any] = {}
+        self._namespace_policy_cache: Dict[str, NamespacePolicy] = {}
+        self._namespace_policy_cache_lock = threading.Lock()
 
     @staticmethod
     def _default_ctx() -> RequestContext:
@@ -270,22 +276,38 @@ class VikingFS:
             return uri
         return VikingURI.normalize(uri)
 
+    def _get_cached_namespace_policy(self, account_id: str) -> Optional[NamespacePolicy]:
+        with self._namespace_policy_cache_lock:
+            return self._namespace_policy_cache.get(account_id)
+
+    def _set_cached_namespace_policy(self, account_id: str, policy: NamespacePolicy) -> None:
+        with self._namespace_policy_cache_lock:
+            self._namespace_policy_cache[account_id] = policy
+
+    async def _load_namespace_policy_cached(
+        self, ctx: Optional[RequestContext]
+    ) -> NamespacePolicy:
+        real_ctx = self._ctx_or_default(ctx)
+        cached = self._get_cached_namespace_policy(real_ctx.account_id)
+        if cached is not None:
+            return cached
+
+        policy = await load_namespace_policy(self, real_ctx.account_id)
+        self._set_cached_namespace_policy(real_ctx.account_id, policy)
+        return policy
+
     def _get_namespace_resolver(self, ctx: Optional[RequestContext]) -> NamespaceResolver:
         real_ctx = self._ctx_or_default(ctx)
-        cache = getattr(self, "_namespace_policy_cache", None)
-        if cache is None:
-            cache = {}
-            self._namespace_policy_cache = cache
-
-        policy = cache.get(real_ctx.account_id)
+        policy = self._get_cached_namespace_policy(real_ctx.account_id)
         if policy is None:
-            policy = run_async(load_namespace_policy(self, real_ctx.account_id))
-            cache[real_ctx.account_id] = policy
+            policy = load_namespace_policy_sync(self, real_ctx.account_id)
+            self._set_cached_namespace_policy(real_ctx.account_id, policy)
         return NamespaceResolver(policy)
 
-    def get_namespace_resolver(self, ctx: Optional[RequestContext]) -> NamespaceResolver:
+    async def get_namespace_resolver(self, ctx: Optional[RequestContext]) -> NamespaceResolver:
         """Expose the per-account namespace resolver for callers that need canonical roots."""
-        return self._get_namespace_resolver(ctx)
+        policy = await self._load_namespace_policy_cached(ctx)
+        return NamespaceResolver(policy)
 
     def _canonicalize_uri(self, uri: str, ctx: Optional[RequestContext]) -> str:
         normalized = self._normalize_uri(uri)
@@ -326,6 +348,14 @@ class VikingFS:
         if real_ctx.role != Role.ROOT and normalized_uri.rstrip("/") == "viking://temp":
             raise PermissionError("Temp root is read-only for non-root users")
 
+    async def _ensure_access_async(self, uri: str, ctx: Optional[RequestContext]) -> None:
+        await self._load_namespace_policy_cached(ctx)
+        self._ensure_access(uri, ctx)
+
+    async def _ensure_mutable_access_async(self, uri: str, ctx: Optional[RequestContext]) -> None:
+        await self._load_namespace_policy_cached(ctx)
+        self._ensure_mutable_access(uri, ctx)
+
     # ========== AGFS Basic Commands ==========
 
     async def read(
@@ -336,7 +366,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> bytes:
         """Read file"""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
 
         if self._encryptor:
@@ -376,7 +406,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> str:
         """Write file"""
-        self._ensure_mutable_access(uri, ctx)
+        await self._ensure_mutable_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         if isinstance(data, str):
             data = data.encode("utf-8")
@@ -392,7 +422,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Create directory."""
-        self._ensure_mutable_access(uri, ctx)
+        await self._ensure_mutable_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         # Always ensure parent directories exist before creating this directory
         await self._ensure_parent_dirs(path)
@@ -425,7 +455,7 @@ class VikingFS:
         from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
         from openviking.storage.transaction import LockContext, get_lock_manager
 
-        self._ensure_mutable_access(uri, ctx)
+        await self._ensure_mutable_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         target_uri = self._path_to_uri(path, ctx=ctx)
 
@@ -491,8 +521,8 @@ class VikingFS:
         from openviking.pyagfs.helpers import cp as agfs_cp
         from openviking.storage.transaction import LockContext, get_lock_manager
 
-        self._ensure_mutable_access(old_uri, ctx)
-        self._ensure_mutable_access(new_uri, ctx)
+        await self._ensure_mutable_access_async(old_uri, ctx)
+        await self._ensure_mutable_access_async(new_uri, ctx)
         old_path = self._uri_to_path(old_uri, ctx=ctx)
         new_path = self._uri_to_path(new_uri, ctx=ctx)
         target_uri = self._path_to_uri(old_path, ctx=ctx)
@@ -615,14 +645,14 @@ class VikingFS:
             level_limit: Maximum depth level to traverse (default: 5)
             ctx: Request context
         """
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
 
         flags = re.IGNORECASE if case_insensitive else 0
         compiled_pattern = re.compile(pattern, flags)
         excluded_prefix = None
         if exclude_uri:
             excluded_prefix = self._normalize_uri(exclude_uri).rstrip("/")
-            self._ensure_access(excluded_prefix, ctx)
+            await self._ensure_access_async(excluded_prefix, ctx)
 
         results = []
         files_scanned = 0
@@ -698,7 +728,7 @@ class VikingFS:
 
         example: {'name': 'resources', 'size': 128, 'mode': 2147484141, 'modTime': '2026-02-10T21:26:02.934376379+08:00', 'isDir': True, 'meta': {'Name': 'localfs', 'Type': 'local', 'Content': {'local_path': '...'}}}
         """
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         return self.agfs.stat(path)
 
@@ -796,7 +826,7 @@ class VikingFS:
         output="agent"
         [{'name': '.abstract.md', 'size': 100, 'modTime': '2026-02-11 16:52:16', 'isDir': False, 'rel_path': '.abstract.md', 'uri': 'viking://resources...', 'abstract': "..."}]
         """
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         if output == "original":
             return await self._tree_original(uri, show_all_hidden, node_limit, level_limit, ctx=ctx)
         elif output == "agent":
@@ -901,7 +931,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> str:
         """Read directory's L0 summary (.abstract.md)."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         info = self.agfs.stat(path)
         if not info.get("isDir", info.get("is_dir")):
@@ -925,7 +955,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> str:
         """Read directory's L1 overview (.overview.md)."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         info = self.agfs.stat(path)
         if not info.get("isDir", info.get("is_dir")):
@@ -952,7 +982,7 @@ class VikingFS:
 
         Returns: [{"uri": "...", "reason": "..."}, ...]
         """
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         entries = await self.get_relation_table(uri, ctx=ctx)
         result = []
         for entry in entries:
@@ -991,7 +1021,7 @@ class VikingFS:
         )
 
         if target_uri and target_uri not in {"/", "viking://"}:
-            self._ensure_access(target_uri, ctx)
+            await self._ensure_access_async(target_uri, ctx)
 
         storage = self._get_vector_store()
         if not storage:
@@ -1092,7 +1122,7 @@ class VikingFS:
 
         query_plan: Optional[QueryPlan] = None
         if primary_target_uri and primary_target_uri not in {"/", "viking://"}:
-            self._ensure_access(primary_target_uri, ctx)
+            await self._ensure_access_async(primary_target_uri, ctx)
 
         # When target_uri exists: read abstract, infer context_type
         target_context_type: Optional[ContextType] = None
@@ -1203,9 +1233,9 @@ class VikingFS:
         """Create relation (maintained in .relations.json)."""
         if isinstance(uris, str):
             uris = [uris]
-        self._ensure_access(from_uri, ctx)
+        await self._ensure_access_async(from_uri, ctx)
         for uri in uris:
-            self._ensure_access(uri, ctx)
+            await self._ensure_access_async(uri, ctx)
 
         from_path = self._uri_to_path(from_uri, ctx=ctx)
 
@@ -1226,8 +1256,8 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Delete relation."""
-        self._ensure_access(from_uri, ctx)
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(from_uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         from_path = self._uri_to_path(from_uri, ctx=ctx)
 
         try:
@@ -1260,7 +1290,7 @@ class VikingFS:
         self, uri: str, ctx: Optional[RequestContext] = None
     ) -> List[RelationEntry]:
         """Get relation table."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         return await self._read_relation_table(path, ctx=ctx)
 
@@ -1552,8 +1582,8 @@ class VikingFS:
         from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
         from openviking.storage.transaction import LockContext, get_lock_manager
 
-        self._ensure_access(old_uri, ctx)
-        self._ensure_access(new_uri, ctx)
+        await self._ensure_access_async(old_uri, ctx)
+        await self._ensure_access_async(new_uri, ctx)
 
         real_ctx = self._ctx_or_default(ctx)
         old_dir = VikingURI.normalize(old_uri).rstrip("/")
@@ -1703,7 +1733,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Write file directly."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         await self._ensure_parent_dirs(path)
 
@@ -1730,7 +1760,7 @@ class VikingFS:
         Raises:
             FileNotFoundError: If the file does not exist.
         """
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         # Verify the file exists before reading, because AGFS read returns
         # empty bytes for non-existent files instead of raising an error.
@@ -1767,7 +1797,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> bytes:
         """Read single binary file."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         try:
             raw = self._handle_agfs_read(self.agfs.read(path))
@@ -1783,7 +1813,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Write single binary file."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         await self._ensure_parent_dirs(path)
 
@@ -1797,7 +1827,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Append content to file."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
 
         try:
@@ -1846,7 +1876,7 @@ class VikingFS:
         output="agent"
         [{'name': '.abstract.md', 'size': 100, 'modTime': '2026-02-11(or 16:52:16 for today)', 'isDir': False, 'uri': 'viking://resources/.abstract.md', 'abstract': "..."}]
         """
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         if output == "original":
             return await self._ls_original(uri, show_all_hidden, node_limit, ctx=ctx)
         elif output == "agent":
@@ -1941,8 +1971,8 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Move file."""
-        self._ensure_mutable_access(from_uri, ctx)
-        self._ensure_mutable_access(to_uri, ctx)
+        await self._ensure_mutable_access_async(from_uri, ctx)
+        await self._ensure_mutable_access_async(to_uri, ctx)
         from_path = self._uri_to_path(from_uri, ctx=ctx)
 
         content_bytes = await self.read_file_bytes(from_uri, ctx=ctx)
@@ -1964,7 +1994,7 @@ class VikingFS:
 
     async def delete_temp(self, temp_uri: str, ctx: Optional[RequestContext] = None) -> None:
         """Delete temp directory and its contents."""
-        self._ensure_mutable_access(temp_uri, ctx)
+        await self._ensure_mutable_access_async(temp_uri, ctx)
         path = self._uri_to_path(temp_uri, ctx=ctx)
         try:
             for entry in self._ls_entries(path):
@@ -2031,7 +2061,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Write context to AGFS (L0/L1/L2)."""
-        self._ensure_access(uri, ctx)
+        await self._ensure_access_async(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
 
         try:

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from openviking.core.namespace import NamespaceResolver, load_namespace_policy
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSDirectoryNotEmptyError, AGFSHTTPError
 from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext, Role
@@ -30,6 +31,7 @@ from openviking.telemetry import get_current_telemetry
 from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
 from openviking_cli.exceptions import FailedPreconditionError, NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils import run_async
 from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
 
@@ -196,6 +198,7 @@ class VikingFS:
         self._bound_ctx: contextvars.ContextVar[Optional[RequestContext]] = contextvars.ContextVar(
             "vikingfs_bound_ctx", default=None
         )
+        self._namespace_policy_cache: Dict[str, Any] = {}
 
     @staticmethod
     def _default_ctx() -> RequestContext:
@@ -266,6 +269,29 @@ class VikingFS:
         if uri.startswith("viking://"):
             return uri
         return VikingURI.normalize(uri)
+
+    def _get_namespace_resolver(self, ctx: Optional[RequestContext]) -> NamespaceResolver:
+        real_ctx = self._ctx_or_default(ctx)
+        cache = getattr(self, "_namespace_policy_cache", None)
+        if cache is None:
+            cache = {}
+            self._namespace_policy_cache = cache
+
+        policy = cache.get(real_ctx.account_id)
+        if policy is None:
+            policy = run_async(load_namespace_policy(self, real_ctx.account_id))
+            cache[real_ctx.account_id] = policy
+        return NamespaceResolver(policy)
+
+    def get_namespace_resolver(self, ctx: Optional[RequestContext]) -> NamespaceResolver:
+        """Expose the per-account namespace resolver for callers that need canonical roots."""
+        return self._get_namespace_resolver(ctx)
+
+    def _canonicalize_uri(self, uri: str, ctx: Optional[RequestContext]) -> str:
+        normalized = self._normalize_uri(uri)
+        real_ctx = self._ctx_or_default(ctx)
+        resolver = self._get_namespace_resolver(real_ctx)
+        return resolver.canonicalize_uri(normalized, real_ctx.user)
 
     @classmethod
     def _normalized_uri_parts(cls, uri: str) -> tuple[str, List[str]]:
@@ -1267,7 +1293,8 @@ class VikingFS:
         """
         real_ctx = self._ctx_or_default(ctx)
         account_id = real_ctx.account_id
-        _, parts = self._normalized_uri_parts(uri)
+        canonical_uri = self._canonicalize_uri(uri, real_ctx)
+        _, parts = self._normalized_uri_parts(canonical_uri)
         if not parts:
             return f"/local/{account_id}"
 
@@ -1295,23 +1322,23 @@ class VikingFS:
         Pure prefix replacement: strips /local/{account_id}/ and prepends viking://.
         No implicit space stripping.
         """
+        real_ctx = self._ctx_or_default(ctx)
         if path.startswith("viking://"):
-            return path
+            return self._canonicalize_uri(path, real_ctx)
         elif path.startswith("/local/"):
             inner = path[7:].strip("/")
             if not inner:
                 return "viking://"
-            real_ctx = self._ctx_or_default(ctx)
             parts = [p for p in inner.split("/") if p]
             if parts and parts[0] == real_ctx.account_id:
                 parts = parts[1:]
             if not parts:
                 return "viking://"
-            return f"viking://{'/'.join(parts)}"
+            return self._canonicalize_uri(f"viking://{'/'.join(parts)}", real_ctx)
         elif path.startswith("/"):
             return f"viking:/{path}"
         else:
-            return f"viking://{path}"
+            return self._canonicalize_uri(f"viking://{path}", real_ctx)
 
     def _looks_like_legacy_temp_leaf(self, value: str) -> bool:
         return bool(re.match(r"^\d{8}_[0-9a-f]{6}$", value or ""))
@@ -1371,15 +1398,11 @@ class VikingFS:
             return self._is_legacy_temp_uri_parts(parts)
         if scope == "_system":
             return False
-
-        space = self._extract_space_from_uri(normalized_uri)
-        if space is None:
+        if scope == "session":
             return True
-
-        if scope in {"user", "session"}:
-            return space == ctx.user.user_space_name()
-        if scope == "agent":
-            return space == ctx.user.agent_space_name()
+        if scope in {"user", "agent"}:
+            resolver = self._get_namespace_resolver(ctx)
+            return resolver.is_visible(normalized_uri, ctx.user)
         return True
 
     def _handle_agfs_read(self, result: Union[bytes, Any, None]) -> bytes:

--- a/openviking_cli/session/user_id.py
+++ b/openviking_cli/session/user_id.py
@@ -1,5 +1,9 @@
 import hashlib
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openviking.core.namespace import NamespacePolicy
 
 
 class UserIdentifier(object):
@@ -67,6 +71,18 @@ class UserIdentifier(object):
     def agent_space_name(self) -> str:
         """Agent-level space name derived from memory.agent_scope_mode."""
         return hashlib.md5(self._agent_space_source().encode()).hexdigest()[:12]
+
+    def canonical_user_root(self, policy: "NamespacePolicy | None" = None) -> str:
+        """Canonical user-root URI under the account namespace policy."""
+        from openviking.core.namespace import NamespaceResolver
+
+        return NamespaceResolver(policy).user_root(self)
+
+    def canonical_agent_root(self, policy: "NamespacePolicy | None" = None) -> str:
+        """Canonical agent-root URI under the account namespace policy."""
+        from openviking.core.namespace import NamespaceResolver
+
+        return NamespaceResolver(policy).agent_root(self)
 
     def memory_space_uri(self) -> str:
         return f"viking://agent/{self.agent_space_name()}/memories"

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -3,6 +3,7 @@
 
 """Tests for Admin API endpoints (openviking/server/routers/admin.py)."""
 
+import json
 import uuid
 
 import httpx
@@ -73,6 +74,34 @@ async def test_create_account(admin_client: httpx.AsyncClient):
     assert body["result"]["account_id"] == acct
     assert body["result"]["admin_user_id"] == "alice"
     assert "user_key" in body["result"]
+
+
+async def test_create_account_persists_namespace_policy(
+    admin_client: httpx.AsyncClient, admin_app
+):
+    """Account creation should persist and echo namespace policy fields."""
+    acct = _uid()
+    resp = await admin_client.post(
+        "/api/v1/admin/accounts",
+        json={
+            "account_id": acct,
+            "admin_user_id": "alice",
+            "isolate_user_scope_by_agent": True,
+            "isolate_agent_scope_by_user": True,
+        },
+        headers=root_headers(),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["isolate_user_scope_by_agent"] is True
+    assert body["result"]["isolate_agent_scope_by_user"] is True
+
+    raw = admin_app.state.api_key_manager._viking_fs.agfs.read(f"/local/{acct}/_system/setting.json")
+    persisted = json.loads(raw.decode("utf-8"))
+    assert persisted == {
+        "isolate_user_scope_by_agent": True,
+        "isolate_agent_scope_by_user": True,
+    }
 
 
 async def test_list_accounts(admin_client: httpx.AsyncClient):

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -219,6 +219,68 @@ async def test_user_key_access(auth_client: httpx.AsyncClient, user_key: str):
     assert resp.status_code == 200
 
 
+async def test_same_account_users_can_access_shared_session(
+    auth_client: httpx.AsyncClient, auth_app
+):
+    """Sessions should be visible across users within the same account."""
+    manager = auth_app.state.api_key_manager
+    account_id = _uid()
+    alice_key = await manager.create_account(account_id, "alice")
+    bob_key = await manager.register_user(account_id, "bob")
+
+    create_resp = await auth_client.post(
+        "/api/v1/sessions",
+        json={"session_id": "shared-session"},
+        headers={"X-API-Key": alice_key},
+    )
+    assert create_resp.status_code == 200
+
+    await auth_client.post(
+        "/api/v1/sessions/shared-session/messages",
+        json={"role": "user", "content": "hello from alice"},
+        headers={"X-API-Key": alice_key},
+    )
+
+    list_resp = await auth_client.get("/api/v1/sessions", headers={"X-API-Key": bob_key})
+    assert list_resp.status_code == 200
+    session_ids = {item["session_id"] for item in list_resp.json()["result"]}
+    assert "shared-session" in session_ids
+
+    get_resp = await auth_client.get(
+        "/api/v1/sessions/shared-session",
+        headers={"X-API-Key": bob_key},
+    )
+    assert get_resp.status_code == 200
+    assert get_resp.json()["result"]["session_id"] == "shared-session"
+
+
+async def test_user_key_cannot_delete_shared_session(auth_client: httpx.AsyncClient, auth_app):
+    """Deleting a session should require admin or root access."""
+    manager = auth_app.state.api_key_manager
+    account_id = _uid()
+    admin_key = await manager.create_account(account_id, "alice")
+    bob_key = await manager.register_user(account_id, "bob")
+
+    create_resp = await auth_client.post(
+        "/api/v1/sessions",
+        json={"session_id": "shared-session"},
+        headers={"X-API-Key": admin_key},
+    )
+    assert create_resp.status_code == 200
+
+    deny_resp = await auth_client.delete(
+        "/api/v1/sessions/shared-session",
+        headers={"X-API-Key": bob_key},
+    )
+    assert deny_resp.status_code == 403
+
+    allow_resp = await auth_client.delete(
+        "/api/v1/sessions/shared-session",
+        headers={"X-API-Key": admin_key},
+    )
+    assert allow_resp.status_code == 200
+
+
 async def test_missing_key_returns_401(auth_client: httpx.AsyncClient):
     """Request without API key should return 401."""
     resp = await auth_client.get("/api/v1/system/status")

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -36,9 +36,7 @@ class TestSessionCreate:
         """Test session URI"""
         uri = session.uri
 
-        assert uri.startswith("viking://")
-        assert "session" in uri
-        assert session.session_id in uri
+        assert uri == f"viking://session/{session.session_id}"
 
 
 class TestSessionLoad:

--- a/tests/test_session_task_tracking.py
+++ b/tests/test_session_task_tracking.py
@@ -72,7 +72,7 @@ def _make_tracked_commit(behavior="instant", result_overrides=None, gate=None, s
             owner_account_id=_ctx.account_id,
             owner_user_id=_ctx.user.user_id,
         )
-        archive_uri = f"viking://session/test/{_sid}/history/archive_001"
+        archive_uri = f"viking://session/{_sid}/history/archive_001"
 
         async def _background():
             tracker.start(task.task_id)

--- a/tests/unit/test_namespace_resolver.py
+++ b/tests/unit/test_namespace_resolver.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for account namespace policy and canonical URI resolution."""
+
+from openviking.core.namespace import NamespacePolicy, NamespaceResolver
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _user() -> UserIdentifier:
+    return UserIdentifier("acct", "alice", "bot")
+
+
+def test_default_namespace_roots_are_account_shared_for_session() -> None:
+    user = _user()
+    resolver = NamespaceResolver(NamespacePolicy())
+
+    assert user.canonical_user_root(resolver.policy) == "viking://user/alice"
+    assert user.canonical_agent_root(resolver.policy) == "viking://agent/bot"
+    assert resolver.session_root("sess-001") == "viking://session/sess-001"
+
+
+def test_user_scope_can_nest_by_agent() -> None:
+    user = _user()
+    resolver = NamespaceResolver(NamespacePolicy(isolate_user_scope_by_agent=True))
+
+    assert resolver.canonicalize_uri("viking://user/memories/preferences", user) == (
+        "viking://user/alice/agent/bot/memories/preferences"
+    )
+    assert resolver.canonicalize_uri("viking://user/alice", user) == "viking://user/alice/agent/bot"
+
+
+def test_agent_scope_canonicalizes_legacy_hash_root() -> None:
+    user = _user()
+    resolver = NamespaceResolver(NamespacePolicy())
+
+    legacy_uri = f"viking://agent/{user.agent_space_name()}/memories/cases"
+    assert resolver.canonicalize_uri(legacy_uri, user) == "viking://agent/bot/memories/cases"
+
+
+def test_agent_scope_can_nest_by_user() -> None:
+    user = _user()
+    resolver = NamespaceResolver(NamespacePolicy(isolate_agent_scope_by_user=True))
+
+    assert resolver.canonicalize_uri("viking://agent/skills", user) == (
+        "viking://agent/bot/user/alice/skills"
+    )
+    assert resolver.canonicalize_uri("viking://agent/bot", user) == "viking://agent/bot/user/alice"
+
+
+def test_session_legacy_user_scoped_uri_is_canonicalized() -> None:
+    user = _user()
+    resolver = NamespaceResolver(NamespacePolicy())
+
+    assert resolver.canonicalize_uri(
+        "viking://session/alice/sess-001/history/archive_001",
+        user,
+    ) == "viking://session/sess-001/history/archive_001"
+
+
+def test_session_scope_is_account_visible() -> None:
+    alice = UserIdentifier("acct", "alice", "bot")
+    bob = UserIdentifier("acct", "bob", "bot")
+    resolver = NamespaceResolver(NamespacePolicy())
+
+    assert resolver.is_visible("viking://session/shared-001", alice) is True
+    assert resolver.is_visible("viking://session/shared-001", bob) is True
+    assert resolver.is_visible("viking://user/alice/memories/preferences", bob) is False

--- a/tests/unit/test_summarizer_context_type.py
+++ b/tests/unit/test_summarizer_context_type.py
@@ -6,8 +6,6 @@ Verifies that the summarizer uses get_context_type_for_uri() to correctly
 classify memory, skill, and resource URIs (fixes #1060).
 """
 
-import pytest
-
 from openviking.core.directories import get_context_type_for_uri
 
 
@@ -46,7 +44,7 @@ class TestSummarizerContextType:
 
     def test_session_uri(self):
         """Session URIs should classify as 'memory'."""
-        uri = "viking://session/default/sess_001/history/archive_001"
+        uri = "viking://session/sess_001/history/archive_001"
         assert get_context_type_for_uri(uri) == "memory"
 
     def test_unknown_uri_defaults_to_resource(self):


### PR DESCRIPTION
## Summary
- implement `#1351` Phase 1 account namespace policy persistence under `/local/{account_id}/_system/setting.json`
- add a namespace resolver to canonicalize user/agent/session URIs and move sessions to account-level `viking://session/{session_id}`
- enforce shared-session visibility within an account and restrict session deletion to `ADMIN` / `ROOT`

## What Changed
- add `NamespacePolicy` + `NamespaceResolver` and cache policy loading inside `VikingFS`
- add canonical user/agent root helpers on `UserIdentifier`
- persist namespace policy during account initialization and accept the policy fields in the admin create-account API
- switch session create/list/delete/storage paths to account-level session roots
- add regression coverage for namespace canonicalization, account policy persistence, shared-session visibility, and delete permissions

## Phase 1 Scope
Included in this PR:
- account-level namespace policy persistence
- canonical URI/root resolution for user/agent/session
- account-level shared session root
- delete-session permission tightening

Explicitly left for follow-up:
- retrieval/vector ownership redesign
- message `role_id` identity model
- participant metadata / ACL
- legacy agent-data migration
- online policy mutation

## Validation
- `ruff check openviking/core/namespace.py openviking/storage/viking_fs.py openviking/core/directories.py openviking/service/core.py openviking/server/routers/admin.py openviking/service/session_service.py openviking/session/session.py openviking/message/part.py openviking_cli/session/user_id.py tests/unit/test_namespace_resolver.py tests/server/test_admin_api.py tests/server/test_auth.py tests/session/test_session_lifecycle.py tests/test_session_task_tracking.py tests/unit/test_summarizer_context_type.py`
- `python -m compileall openviking/core/namespace.py openviking/core/directories.py openviking/storage/viking_fs.py openviking/service/core.py openviking/server/routers/admin.py openviking/service/session_service.py openviking/session/session.py openviking/message/part.py openviking_cli/session/user_id.py tests/unit/test_namespace_resolver.py tests/server/test_admin_api.py tests/server/test_auth.py tests/session/test_session_lifecycle.py tests/test_session_task_tracking.py tests/unit/test_summarizer_context_type.py`
- manual end-to-end validation script covering:
  - admin account creation with namespace policy persistence
  - shared session visibility across users in one account
  - `USER` delete denied / `ADMIN` delete allowed

## Notes
`pytest` collection is currently blocked by the repo's existing `pytest-asyncio` package-collection error (`AttributeError: 'Package' object has no attribute 'obj'`), so I used compile/lint plus a direct integration harness for this PR.
