### PR TITLE
[security] fix(pack): block ovpack import writes to forbidden control-plane targets

### DIFF
--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -5,20 +5,17 @@ import json
 import os
 import re
 import zipfile
-from datetime import datetime
-from typing import cast
 
-from openviking.core.context import Context
+from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext
-from openviking.storage.queuefs import EmbeddingQueue, get_queue_manager
-from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking.utils.embedding_utils import vectorize_directory_meta, vectorize_file
-from openviking_cli.exceptions import NotFoundError
+from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
 from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
 
 logger = get_logger(__name__)
 
+_DERIVED_FILENAMES = frozenset({".abstract.md", ".overview.md", ".relations.json"})
 
 _UNSAFE_PATH_RE = re.compile(r"(^|[\\/])\.\.($|[\\/])")
 _DRIVE_RE = re.compile(r"^[A-Za-z]:")
@@ -89,6 +86,19 @@ def get_viking_rel_path_from_zip(zip_path: str) -> str:
             new_parts.append(p)
 
     return "/".join(new_parts)
+
+
+def _validate_import_target_uri(uri: str) -> None:
+    """Enforce the same target-policy boundary as direct content writes."""
+    parsed = VikingURI(uri)
+    if parsed.scope not in {"resources", "user", "agent"}:
+        raise InvalidArgumentError(f"ovpack import is not supported for scope: {parsed.scope}")
+
+    name = uri.rstrip("/").split("/")[-1]
+    if name in _DERIVED_FILENAMES:
+        raise InvalidArgumentError(f"cannot import derived semantic file: {uri}")
+    if is_watch_task_control_uri(uri):
+        raise InvalidArgumentError(f"cannot import watch task control file: {uri}")
 
 
 async def _enqueue_direct_vectorization(viking_fs, uri: str, ctx: RequestContext) -> None:
@@ -185,6 +195,7 @@ async def import_ovpack(
             raise ValueError("Could not determine root directory name from ovpack")
 
         root_uri = f"{parent}/{base_name}"
+        _validate_import_target_uri(root_uri)
 
         # 2. Conflict check
         try:
@@ -235,6 +246,7 @@ async def import_ovpack(
             # Handle file entries
             rel_path = get_viking_rel_path_from_zip(safe_zip_path)
             target_file_uri = f"{root_uri}/{rel_path}" if rel_path else root_uri
+            _validate_import_target_uri(target_file_uri)
 
             try:
                 data = zf.read(safe_zip_path)

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Security regression tests for ovpack import target-policy enforcement."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.local_fs import import_ovpack
+from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class FakeVikingFS:
+    def __init__(self) -> None:
+        self.written_files: list[str] = []
+        self.created_dirs: list[str] = []
+
+    async def stat(self, uri: str, ctx=None):
+        return {"uri": uri, "isDir": True}
+
+    async def mkdir(self, uri: str, exist_ok: bool = False, ctx=None):
+        self.created_dirs.append(uri)
+
+    async def ls(self, uri: str, ctx=None):
+        raise NotFoundError(uri, "file")
+
+    async def write_file_bytes(self, uri: str, data: bytes, ctx=None):
+        self.written_files.append(uri)
+
+    async def tree(self, uri: str, node_limit: int = 100000, level_limit: int = 1000, ctx=None):
+        return []
+
+    async def exists(self, uri: str, ctx=None):
+        return False
+
+    async def read_file(self, uri: str, ctx=None):
+        raise FileNotFoundError(uri)
+
+
+@pytest.fixture
+def request_ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("acct", "alice", "agent1"), role=Role.USER)
+
+
+@pytest.fixture
+def temp_ovpack_path() -> Path:
+    fd, path = tempfile.mkstemp(suffix=".ovpack")
+    os.close(fd)
+    ovpack_path = Path(path)
+    try:
+        yield ovpack_path
+    finally:
+        ovpack_path.unlink(missing_ok=True)
+
+
+def _write_ovpack(path: Path, entries: dict[str, str]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+
+
+@pytest.mark.asyncio
+async def test_import_ovpack_rejects_derived_semantic_files(
+    temp_ovpack_path: Path, request_ctx: RequestContext
+):
+    _write_ovpack(
+        temp_ovpack_path,
+        {
+            "demo/_._overview.md": "ATTACKER_OVERVIEW",
+            "demo/notes.txt": "hello",
+        },
+    )
+    fake_fs = FakeVikingFS()
+
+    with pytest.raises(
+        InvalidArgumentError,
+        match=r"cannot import derived semantic file: viking://resources/demo/\.overview\.md",
+    ):
+        await import_ovpack(
+            fake_fs, str(temp_ovpack_path), "viking://resources", request_ctx, vectorize=False
+        )
+
+    assert fake_fs.written_files == []
+
+
+@pytest.mark.asyncio
+async def test_import_ovpack_rejects_session_scope_targets(
+    temp_ovpack_path: Path, request_ctx: RequestContext
+):
+    _write_ovpack(
+        temp_ovpack_path,
+        {
+            "victim/_._meta.json": json.dumps({"session_id": "victim"}),
+            "victim/messages.jsonl": '{"id":"msg_attacker","role":"user","parts":[{"type":"text","text":"forged"}],"created_at":"2026-01-01T00:00:00Z"}\n',
+        },
+    )
+    fake_fs = FakeVikingFS()
+
+    with pytest.raises(
+        InvalidArgumentError,
+        match=r"ovpack import is not supported for scope: session",
+    ):
+        await import_ovpack(
+            fake_fs, str(temp_ovpack_path), "viking://session/default", request_ctx, vectorize=False
+        )
+
+    assert fake_fs.written_files == []


### PR DESCRIPTION
## Summary

This PR hardens ovpack import so package extraction can no longer bypass the normal write-policy boundary and plant trusted control-plane files in forbidden targets.

- reject ovpack imports into unsupported scopes such as `session`
- reject ovpack members that would write derived semantic files such as `.overview.md`, `.abstract.md`, or `.relations.json`
- preserve normal resource/user/agent imports for ordinary files
- add focused regression tests covering the two verified bypass paths

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Ovpack import could write forbidden derived semantic files | Retrieval / metadata poisoning through attacker-controlled trusted summary files | High |
| Ovpack import could write directly into session scope | Forged persisted session messages and metadata through import | High |

## Before this PR

- direct content writes explicitly rejected derived semantic files and unsupported scopes like `session`
- ovpack import validated ZIP path safety but did not enforce the same semantic target policy
- a crafted ovpack could write `.overview.md` and sibling trusted files directly into imported trees
- a crafted ovpack could import directly into `viking://session/...` and plant `messages.jsonl` / `.meta.json`

## After this PR

- ovpack import rejects unsupported target scopes up front
- ovpack import rejects per-file targets that would land on derived semantic files
- the import path now aligns with the existing direct-write trust boundary
- regression tests lock in both forbidden-target cases

## Why this matters

OpenViking already distinguishes ordinary user-editable files from trusted control-plane artifacts. Derived semantic files and session persistence files are consumed differently from ordinary content and should not become writable through an alternate import path when the main write path intentionally forbids them.

## Attack flow

```text
attacker-crafted ovpack
    -> pack import route
        -> local_fs.import_ovpack writes ZIP members directly
            -> trusted derived/session state planted in forbidden targets
```

## Affected code

| Area | Files |
| --- | --- |
| Ovpack import target-policy enforcement | `openviking/storage/local_fs.py` |
| Regression coverage | `tests/misc/test_ovpack_import_policy.py` |

## Root cause

- ovpack import enforced archive path traversal safety but not semantic target safety
- the import path did not reuse or mirror the direct-write restrictions for forbidden file types and scopes

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
| --- | --- | --- |
| Import writes trusted derived/session control-plane files | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L` |

Rationale:
- requires authenticated access to the import surface
- no user interaction required once the attacker can import a package
- allows integrity compromise of trusted persisted metadata and session state
- can also expose or influence subsequent processing of imported artifacts

## Safe reproduction steps

1. Create an ovpack containing a derived semantic file such as `demo/_._overview.md`.
2. Import it under `viking://resources`.
3. Observe pre-patch behavior writes `viking://resources/demo/.overview.md` even though direct writes forbid that target.
4. Create an ovpack containing `victim/messages.jsonl` and `victim/_._meta.json`.
5. Import it under `viking://session/default`.
6. Observe pre-patch behavior writes directly into `viking://session/default/victim` even though direct writes reject session scope.

## Expected vulnerable behavior

- ovpack import accepts member paths that land on `.overview.md`, `.abstract.md`, or `.relations.json`
- ovpack import accepts parent targets in `session` scope and writes `messages.jsonl` / `.meta.json`
- these writes occur despite the normal direct-write path rejecting the same targets

## Changes in this PR

- add ovpack import target-policy validation in `local_fs.import_ovpack`
- reject unsupported scopes for import targets (`session` and any other non resource/user/agent scope)
- reject imports that would land on derived semantic files
- reject imports that would land on watch-task control files
- add focused regression tests using the real import path with a narrow fake filesystem

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Import hardening | `openviking/storage/local_fs.py` | Added target-policy checks for root and per-file import targets |
| Tests | `tests/misc/test_ovpack_import_policy.py` | Added regressions for derived-file and session-scope import bypasses |

## Maintainer impact

- patch scope is narrow and isolated to ovpack import behavior
- ordinary resource/user/agent imports for non-forbidden files continue to work
- the change aligns import with an already-existing direct-write policy instead of inventing a new restriction model

## Suggested fix rationale

If direct writes intentionally forbid a target because it is trusted control-plane state, import should not reopen that target through a different write path. Reusing the same trust boundary keeps the model easier to reason about and harder to regress.

## Type of change

- [x] Bug fix (non-breaking security hardening)
- [x] Security hardening
- [x] Test update
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test plan

- [x] Added regression test for derived semantic file import rejection
- [x] Added regression test for session-scope import rejection
- [x] Ran targeted format and lint checks on touched files

Executed:
```bash
PYTHONPATH=. /Users/lennon/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/misc/test_ovpack_import_policy.py -q
uvx ruff format --check openviking/storage/local_fs.py tests/misc/test_ovpack_import_policy.py
uvx ruff check openviking/storage/local_fs.py tests/misc/test_ovpack_import_policy.py
```

Result:
- `2 passed`
- `ruff format --check`: passed
- `ruff check`: passed

## Disclosure notes

- claims in this PR are bounded to the reviewed ovpack import and session-loading code paths
- this PR does not claim cross-account compromise; it fixes a verified control-plane import bypass
- no unrelated files were modified
