### PR TITLE
docs: document openviking-server init/doctor in README (#1454)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,29 @@ For complete model support, see [LiteLLM Providers Documentation](https://docs.l
 
 ### 3. Environment Configuration
 
+#### Quick Setup for Local Models (Ollama)
+
+If you want to run OpenViking with local models via [Ollama](https://ollama.ai), the interactive setup wizard handles everything automatically:
+
+```bash
+openviking-server init
+```
+
+The wizard will:
+- Detect and install Ollama if needed
+- Recommend and pull suitable embedding and VLM models for your hardware
+- Generate a ready-to-use `ov.conf` configuration file
+
+To validate your setup at any time:
+
+```bash
+openviking-server doctor
+```
+
+`doctor` checks local prerequisites (config file, Python version, embedding/VLM provider connectivity, disk space) without requiring a running server.
+
+> For cloud API providers (Volcengine, OpenAI, Gemini, etc.), continue with the manual configuration below.
+
 #### Server Configuration Template
 
 Create a configuration file `~/.openviking/ov.conf`, remove the comments before copy:

--- a/README_CN.md
+++ b/README_CN.md
@@ -267,6 +267,29 @@ ollama serve
 
 ### 3. 环境配置
 
+#### 本地模型快速配置 (Ollama)
+
+如果你想通过 [Ollama](https://ollama.ai) 使用本地模型运行 OpenViking，交互式向导会自动完成所有配置：
+
+```bash
+openviking-server init
+```
+
+向导会：
+- 检测并安装 Ollama（如需要）
+- 根据你的硬件推荐并拉取合适的 embedding 和 VLM 模型
+- 生成可直接使用的 `ov.conf` 配置文件
+
+随时验证配置是否正确：
+
+```bash
+openviking-server doctor
+```
+
+`doctor` 会检查本地环境（配置文件、Python 版本、embedding/VLM 服务连通性、磁盘空间），无需启动服务器。
+
+> 如果使用云端 API（火山引擎、OpenAI、Gemini 等），请继续下方的手动配置。
+
 #### 服务器配置模板
 
 创建配置文件 `~/.openviking/ov.conf`，复制前请删除注释：


### PR DESCRIPTION
## Summary

Fixes #1454.

v0.3.6 (#1353) introduced `openviking-server init` (interactive Ollama setup wizard) and `openviking-server doctor` (offline prerequisites validator), but neither README.md nor README_CN.md mentions them.

Adds a "Quick Setup for Local Models (Ollama)" subsection under "3. Environment Configuration" in both READMEs, showing:
- `openviking-server init` for automated Ollama model detection/pull/config
- `openviking-server doctor` for setup validation

This gives local-first users a clear fast path while preserving the existing manual configuration docs for cloud API users.

## Type of Change

- [x] Documentation update