### PR TITLE
fix(plugin): sanitize prompt fallback in before_prompt_build to preve…

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -1443,7 +1443,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
       const latestUserText = extractLatestUserText(eventObj.messages);
       const rawRecallQuery =
         latestUserText ||
-        (typeof eventObj.prompt === "string" ? eventObj.prompt.trim() : "");
+        (typeof eventObj.prompt === "string" ? sanitizeUserTextForCapture(eventObj.prompt) : "");
       const recallQuery = prepareRecallQuery(rawRecallQuery);
       const queryText = recallQuery.query;
       if (!queryText) {


### PR DESCRIPTION
…nt query pollution

The prompt fallback path bypassed sanitizeUserTextForCapture, allowing Sender metadata blocks and timestamps to be sent as search queries to the OpenViking API, causing irrelevant memories to rank highly.

Made-with: Cursor

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
