### PR TITLE
fix: block CI when OpenViking server fails to start

### DIFF
--- a/tests/oc2ov_test/upgrade_openviking.sh
+++ b/tests/oc2ov_test/upgrade_openviking.sh
@@ -504,11 +504,11 @@ except Exception as e:
     > /tmp/openviking.log
 
     if [ -n "$OV_CONF" ]; then
-        nohup $OV_PYTHON -m openviking.server.bootstrap --config "$OV_CONF" > /tmp/openviking.log 2>&1 &
+        nohup $OV_PYTHON -u -m openviking.server.bootstrap --config "$OV_CONF" > /tmp/openviking.log 2>&1 &
         OV_SERVER_PID=$!
         log "Started OpenViking server with config: $OV_CONF (PID: $OV_SERVER_PID)"
     else
-        nohup $OV_PYTHON -m openviking.server.bootstrap > /tmp/openviking.log 2>&1 &
+        nohup $OV_PYTHON -u -m openviking.server.bootstrap > /tmp/openviking.log 2>&1 &
         OV_SERVER_PID=$!
         log "Started OpenViking server without explicit config (PID: $OV_SERVER_PID)"
     fi
@@ -535,9 +535,15 @@ except Exception as e:
     done
 
     if [ "$OV_SERVER_RUNNING" = false ]; then
-        log "⚠️  WARNING: OpenViking server failed to start on port 1933"
+        log "❌ ERROR: OpenViking server failed to start on port 1933"
         log "   Server log:"
         cat /tmp/openviking.log 2>/dev/null | tee -a "$LOG_FILE" || true
+        log ""
+        log "This likely indicates a data compatibility issue between the new code"
+        log "and existing vectordb data. Check the error above for details."
+        log "Do NOT delete /root/.openviking/data/ - this error should be reported and fixed."
+        log "Caches, build artifacts, and temp files are safe to clean."
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
- Server startup failure now exits with error instead of just warning
- Use python -u for unbuffered output to capture crash traceback
- Print clear message about data compatibility issues
- Do NOT auto-clean data - let CI surface compatibility problems

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
