### PR TITLE
fix(plugin): propagate toolCallId and handle user-role tool parts in …

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -267,9 +267,10 @@ export function openClawSessionRefToOvStorageId(ref: string): string {
  * 1. The assistant message with toolUse blocks in its content array
  * 2. A separate toolResult message per ToolPart (carrying tool_output)
  */
-function convertToAgentMessages(msg: { role: string; parts: unknown[] }): AgentMessage[] {
+export function convertToAgentMessages(msg: { role: string; parts: unknown[] }): AgentMessage[] {
   const parts = msg.parts ?? [];
   const contentBlocks: Record<string, unknown>[] = [];
+  const toolUseBlocks: Record<string, unknown>[] = [];
   const toolResults: AgentMessage[] = [];
 
   for (const part of parts) {
@@ -282,43 +283,33 @@ function convertToAgentMessages(msg: { role: string; parts: unknown[] }): AgentM
       if (typeof p.abstract === "string" && p.abstract) {
         contentBlocks.push({ type: "text", text: p.abstract });
       }
-    } else if (p.type === "tool" && msg.role === "assistant") {
+    } else if (p.type === "tool") {
       const toolId = typeof p.tool_id === "string" ? p.tool_id : "";
       const toolName = typeof p.tool_name === "string" ? p.tool_name : "unknown";
+      const status = typeof p.tool_status === "string" ? p.tool_status : "unknown";
+      const output = typeof p.tool_output === "string" ? p.tool_output : "";
 
       if (toolId) {
-        contentBlocks.push({
+        // Structured path: emit toolUse + toolResult pair (works for any role)
+        toolUseBlocks.push({
           type: "toolUse",
           id: toolId,
           name: toolName,
           input: p.tool_input ?? {},
         });
 
-        const status = typeof p.tool_status === "string" ? p.tool_status : "";
-        const output = typeof p.tool_output === "string" ? p.tool_output : "";
-
-        if (status === "completed" || status === "error") {
-          toolResults.push({
-            role: "toolResult",
-            toolCallId: toolId,
-            toolName,
-            content: [{ type: "text", text: output || "(no output)" }],
-            isError: status === "error",
-          } as unknown as AgentMessage);
-        } else {
-          toolResults.push({
-            role: "toolResult",
-            toolCallId: toolId,
-            toolName,
-            content: [{ type: "text", text: "(interrupted — tool did not complete)" }],
-            isError: false,
-          } as unknown as AgentMessage);
-        }
+        const resultText = (status === "completed" || status === "error")
+          ? (output || "(no output)")
+          : "(interrupted — tool did not complete)";
+        toolResults.push({
+          role: "toolResult",
+          toolCallId: toolId,
+          toolName,
+          content: [{ type: "text", text: resultText }],
+          isError: status === "error",
+        } as unknown as AgentMessage);
       } else {
-        // No tool_id: degrade to text block to preserve information.
-        // Cannot emit toolUse/toolResult without a valid id.
-        const status = typeof p.tool_status === "string" ? p.tool_status : "unknown";
-        const output = typeof p.tool_output === "string" ? p.tool_output : "";
+        // No tool_id: degrade to text block
         const segments = [`[${toolName}] (${status})`];
         if (p.tool_input) {
           try {
@@ -338,13 +329,21 @@ function convertToAgentMessages(msg: { role: string; parts: unknown[] }): AgentM
   const result: AgentMessage[] = [];
 
   if (msg.role === "assistant") {
-    result.push({ role: msg.role, content: contentBlocks });
+    // Assistant: text + toolUse in one message, then toolResults
+    result.push({ role: "assistant", content: [...contentBlocks, ...toolUseBlocks] });
     result.push(...toolResults);
   } else {
+    // Non-assistant: emit text as original role, then synthesize assistant(toolUse) + toolResult
     const texts = contentBlocks
       .filter((b) => b.type === "text")
       .map((b) => b.text as string);
-    result.push({ role: msg.role, content: texts.join("\n") || "" });
+    if (texts.length > 0 || toolUseBlocks.length === 0) {
+      result.push({ role: msg.role, content: texts.join("\n") || "" });
+    }
+    if (toolUseBlocks.length > 0) {
+      result.push({ role: "assistant", content: toolUseBlocks });
+      result.push(...toolResults);
+    }
   }
 
   return result;
@@ -487,11 +486,28 @@ function buildArchiveMemory(
   return { messages: trimmedMessages, tokens };
 }
 
+/** Merge consecutive assistant messages by concatenating their content arrays. */
+export function mergeConsecutiveAssistants(messages: AgentMessage[]): AgentMessage[] {
+  const result: AgentMessage[] = [];
+  for (const msg of messages) {
+    const prev = result[result.length - 1];
+    if (msg.role === "assistant" && prev?.role === "assistant") {
+      const prevContent = Array.isArray(prev.content) ? prev.content : [{ type: "text", text: prev.content }];
+      const currContent = Array.isArray(msg.content) ? msg.content : [{ type: "text", text: msg.content }];
+      prev.content = [...prevContent, ...currContent] as typeof prev.content;
+    } else {
+      result.push({ ...msg });
+    }
+  }
+  return result;
+}
+
 function buildSessionContext(
   ovMessages: OVMessage[],
   budget: number,
 ): { messages: AgentMessage[]; tokens: number } {
-  const messages = ovMessages.flatMap((m) => convertToAgentMessages(m));
+  const raw = ovMessages.flatMap((m) => convertToAgentMessages(m));
+  const messages = mergeConsecutiveAssistants(raw);
   const tokens = roughEstimate(messages);
   if (budget === BUDGET_UNLIMITED || tokens <= budget) {
     return { messages, tokens };
@@ -967,6 +983,7 @@ export function createMemoryOpenVikingContextEngine(params: {
             } else {
               return {
                 type: "tool" as const,
+                tool_id: part.toolCallId,
                 tool_name: part.toolName,
                 tool_input: part.toolInput,
                 tool_output: part.toolOutput,

--- a/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "vitest";
+
+import { extractNewTurnMessages } from "../../text-utils.js";
+import { convertToAgentMessages, mergeConsecutiveAssistants } from "../../context-engine.js";
+
+describe("extractNewTurnMessages: toolCallId propagation", () => {
+  it("propagates toolCallId from toolResult to extracted tool part", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "toolCall", id: "call_abc123", name: "exec", arguments: { command: "ls" } },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_abc123",
+        toolName: "exec",
+        content: [{ type: "text", text: "file1.txt\nfile2.txt" }],
+      },
+    ];
+
+    const { messages: extracted } = extractNewTurnMessages(messages, 0);
+
+    const toolMsg = extracted.find(
+      (m) => m.parts.some((p) => p.type === "tool"),
+    );
+    expect(toolMsg).toBeDefined();
+
+    const toolPart = toolMsg!.parts.find((p) => p.type === "tool");
+    expect(toolPart).toBeDefined();
+    expect(toolPart!.type).toBe("tool");
+    if (toolPart!.type === "tool") {
+      expect(toolPart!.toolCallId).toBe("call_abc123");
+      expect(toolPart!.toolName).toBe("exec");
+      expect(toolPart!.toolInput).toEqual({ command: "ls" });
+      expect(toolPart!.toolOutput).toContain("file1.txt");
+    }
+  });
+
+  it("sets toolCallId to undefined when original message has no toolCallId", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolName: "search",
+        content: [{ type: "text", text: "no results" }],
+      },
+    ];
+
+    const { messages: extracted } = extractNewTurnMessages(messages, 0);
+    const toolPart = extracted[0]!.parts[0]!;
+    expect(toolPart.type).toBe("tool");
+    if (toolPart.type === "tool") {
+      expect(toolPart.toolCallId).toBeUndefined();
+    }
+  });
+
+  it("maps toolResult to role=user", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "call_xyz",
+        toolName: "exec",
+        content: [{ type: "text", text: "hello" }],
+      },
+    ];
+
+    const { messages: extracted } = extractNewTurnMessages(messages, 0);
+    expect(extracted[0]!.role).toBe("user");
+  });
+});
+
+describe("convertToAgentMessages: structured tool round-trip", () => {
+  it("user-role tool with tool_id → assistant(toolUse) + toolResult", () => {
+    const msg = {
+      role: "user",
+      parts: [
+        {
+          type: "tool",
+          tool_id: "call_abc123",
+          tool_name: "read",
+          tool_status: "completed",
+          tool_input: { path: "/tmp/test.txt" },
+          tool_output: "file content here",
+        },
+      ],
+    };
+
+    const result = convertToAgentMessages(msg);
+    expect(result).toHaveLength(2);
+
+    const assistantMsg = result[0]!;
+    expect(assistantMsg.role).toBe("assistant");
+    const blocks = assistantMsg.content as Array<Record<string, unknown>>;
+    expect(blocks[0]!.type).toBe("toolUse");
+    expect(blocks[0]!.id).toBe("call_abc123");
+    expect(blocks[0]!.name).toBe("read");
+    expect(blocks[0]!.input).toEqual({ path: "/tmp/test.txt" });
+
+    const toolResult = result[1]!;
+    expect(toolResult.role).toBe("toolResult");
+    expect((toolResult as Record<string, unknown>).toolCallId).toBe("call_abc123");
+    expect((toolResult as Record<string, unknown>).isError).toBe(false);
+  });
+
+  it("assistant-role tool with tool_id → toolUse + toolResult (unchanged)", () => {
+    const msg = {
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Let me check." },
+        {
+          type: "tool",
+          tool_id: "call_abc123",
+          tool_name: "read",
+          tool_status: "completed",
+          tool_input: { path: "/tmp/test.txt" },
+          tool_output: "file content here",
+        },
+      ],
+    };
+
+    const result = convertToAgentMessages(msg);
+    expect(result).toHaveLength(2);
+
+    const assistantMsg = result[0]!;
+    expect(assistantMsg.role).toBe("assistant");
+    const blocks = assistantMsg.content as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.type).toBe("text");
+    expect(blocks[1]!.type).toBe("toolUse");
+    expect(blocks[1]!.id).toBe("call_abc123");
+
+    expect(result[1]!.role).toBe("toolResult");
+  });
+
+  it("no tool_id → degrade to text (user role)", () => {
+    const msg = {
+      role: "user",
+      parts: [
+        {
+          type: "tool",
+          tool_id: "",
+          tool_name: "exec",
+          tool_status: "completed",
+          tool_input: { command: "echo hello" },
+          tool_output: "hello",
+        },
+      ],
+    };
+
+    const result = convertToAgentMessages(msg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.role).toBe("user");
+
+    const content = result[0]!.content as string;
+    expect(content).toContain("[exec]");
+    expect(content).toContain("hello");
+  });
+
+  it("no tool_id → degrade to text (assistant role)", () => {
+    const msg = {
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          tool_id: "",
+          tool_name: "exec",
+          tool_status: "error",
+          tool_input: { command: "bad-cmd" },
+          tool_output: "command not found",
+        },
+      ],
+    };
+
+    const result = convertToAgentMessages(msg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.role).toBe("assistant");
+
+    const blocks = result[0]!.content as Array<Record<string, unknown>>;
+    expect(blocks[0]!.type).toBe("text");
+    const text = blocks[0]!.text as string;
+    expect(text).toContain("[exec]");
+    expect(text).toContain("command not found");
+  });
+
+  it("user message with text + tool(tool_id) → user(text) + assistant(toolUse) + toolResult", () => {
+    const msg = {
+      role: "user",
+      parts: [
+        { type: "text", text: "User said something" },
+        {
+          type: "tool",
+          tool_id: "call_xyz",
+          tool_name: "exec",
+          tool_status: "completed",
+          tool_input: { command: "ls" },
+          tool_output: "file.txt",
+        },
+      ],
+    };
+
+    const result = convertToAgentMessages(msg);
+    expect(result).toHaveLength(3);
+
+    expect(result[0]!.role).toBe("user");
+    expect(result[0]!.content).toBe("User said something");
+
+    expect(result[1]!.role).toBe("assistant");
+    const blocks = result[1]!.content as Array<Record<string, unknown>>;
+    expect(blocks[0]!.type).toBe("toolUse");
+
+    expect(result[2]!.role).toBe("toolResult");
+  });
+
+  it("user message with text + tool(no tool_id) → single user message", () => {
+    const msg = {
+      role: "user",
+      parts: [
+        { type: "text", text: "User said something" },
+        {
+          type: "tool",
+          tool_id: "",
+          tool_name: "exec",
+          tool_status: "completed",
+          tool_input: { command: "ls" },
+          tool_output: "file.txt",
+        },
+      ],
+    };
+
+    const result = convertToAgentMessages(msg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.role).toBe("user");
+
+    const content = result[0]!.content as string;
+    expect(content).toContain("User said something");
+    expect(content).toContain("[exec]");
+  });
+
+  it("tool with error status sets isError=true", () => {
+    const msg = {
+      role: "user",
+      parts: [
+        {
+          type: "tool",
+          tool_id: "call_err",
+          tool_name: "exec",
+          tool_status: "error",
+          tool_input: { command: "bad" },
+          tool_output: "not found",
+        },
+      ],
+    };
+
+    const result = convertToAgentMessages(msg);
+    const toolResult = result[1]!;
+    expect((toolResult as Record<string, unknown>).isError).toBe(true);
+  });
+});
+
+describe("mergeConsecutiveAssistants", () => {
+  it("merges two consecutive assistant messages", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "toolUse", id: "c1", name: "read", input: {} }] },
+    ] as Array<{ role: string; content: unknown }>;
+
+    const merged = mergeConsecutiveAssistants(messages);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.role).toBe("assistant");
+
+    const blocks = merged[0]!.content as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.type).toBe("text");
+    expect(blocks[1]!.type).toBe("toolUse");
+  });
+
+  it("does not merge non-consecutive assistants", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: "A" }] },
+      { role: "toolResult", toolCallId: "c1", content: [{ type: "text", text: "result" }] },
+      { role: "assistant", content: [{ type: "text", text: "B" }] },
+    ] as Array<{ role: string; content: unknown }>;
+
+    const merged = mergeConsecutiveAssistants(messages);
+    expect(merged).toHaveLength(3);
+  });
+
+  it("handles string content in assistant messages", () => {
+    const messages = [
+      { role: "assistant", content: "Hello" },
+      { role: "assistant", content: [{ type: "toolUse", id: "c1", name: "read", input: {} }] },
+    ] as Array<{ role: string; content: unknown }>;
+
+    const merged = mergeConsecutiveAssistants(messages);
+    expect(merged).toHaveLength(1);
+
+    const blocks = merged[0]!.content as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.text).toBe("Hello");
+    expect(blocks[1]!.type).toBe("toolUse");
+  });
+
+  it("simulates real OV sequence: assistant(text) + user(tool→assistant+toolResult)", () => {
+    const ovAssistant = { role: "assistant", parts: [{ type: "text", text: "Let me check." }] };
+    const ovUserTool = {
+      role: "user",
+      parts: [{
+        type: "tool",
+        tool_id: "call_abc",
+        tool_name: "read",
+        tool_status: "completed",
+        tool_input: { path: "/tmp/f.txt" },
+        tool_output: "content",
+      }],
+    };
+
+    const raw = [
+      ...convertToAgentMessages(ovAssistant),
+      ...convertToAgentMessages(ovUserTool),
+    ];
+    const merged = mergeConsecutiveAssistants(raw);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0]!.role).toBe("assistant");
+    const blocks = merged[0]!.content as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.type).toBe("text");
+    expect(blocks[0]!.text).toBe("Let me check.");
+    expect(blocks[1]!.type).toBe("toolUse");
+    expect(blocks[1]!.id).toBe("call_abc");
+
+    expect(merged[1]!.role).toBe("toolResult");
+    expect((merged[1] as Record<string, unknown>).toolCallId).toBe("call_abc");
+  });
+});

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -490,6 +490,7 @@ export type ExtractedMessage = {
     text: string;
   } | {
     type: "tool";
+    toolCallId?: string;
     toolName: string;
     toolInput?: Record<string, unknown>;
     toolOutput: string;
@@ -562,6 +563,7 @@ export function extractNewTurnMessages(
           role: "user",
           parts: [{
             type: "tool",
+            toolCallId: toolCallId || undefined,
             toolName,
             toolInput,
             toolOutput: output,


### PR DESCRIPTION
…convertToAgentMessages

Tool call information (input, output, status) was lost when messages round-tripped through OpenViking. Two bugs contributed:

1. extractNewTurnMessages extracted toolCallId but never included it in ExtractedMessage, so OV stored tool_id as empty string.

2. convertToAgentMessages only handled tool parts when msg.role was "assistant", but toolResult messages are stored as role "user" with type "tool" parts — these were silently dropped, producing empty content strings.

Fix: propagate toolCallId through the pipeline (ExtractedMessage → afterTurn → OV), and handle user-role tool parts by degrading them to a text representation that preserves tool name, input, and output.

Made-with: Cursor

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
