### PR TITLE
Fix JsonUtils typed loads validation

### DIFF
--- a/openviking/session/memory/utils/__init__.py
+++ b/openviking/session/memory/utils/__init__.py
@@ -12,6 +12,7 @@ from openviking.session.memory.utils.content import (
     truncate_content,
 )
 from openviking.session.memory.utils.json_parser import (
+    JsonUtils,
     _any_to_str,
     _get_arg_type,
     _get_origin_type,
@@ -78,6 +79,7 @@ __all__ = [
     "parse_json_with_stability",
     "value_fault_tolerance",
     "parse_value_with_tolerance",
+    "JsonUtils",
     "_get_origin_type",
     "_get_arg_type",
     "_any_to_str",

--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -47,23 +47,17 @@ __all__ = [
 ]
 
 
-
-
 class PydanticEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, BaseModel) :
+        if isinstance(obj, BaseModel):
             # 保存类名和属性值
-            return {
-                **obj.model_dump(mode='python')
-            }
+            return {**obj.model_dump(mode="python")}
         elif is_dataclass(obj):
             return asdict(obj)
         return super().default(obj)
 
 
-
 class JsonUtils:
-
     @staticmethod
     def dumps(obj, indent=4, ensure_ascii=False):
         if obj is None:
@@ -174,7 +168,7 @@ def _get_origin_type(annotation) -> Type:
     if origin is Union or origin is UnionType:
         args = get_args(annotation)
         # Handle Optional[T] which is Union[T, None]
-        if len(args) == 2 and args[1] == type(None):
+        if len(args) == 2 and args[1] is type(None):
             return _get_origin_type(args[0])
     elif origin is list:
         return list
@@ -196,7 +190,7 @@ def _get_arg_type(annotation) -> Optional[Type]:
     origin = get_origin(annotation)
     if origin is Union or origin is UnionType:
         args = get_args(annotation)
-        if len(args) == 2 and args[1] == type(None):
+        if len(args) == 2 and args[1] is type(None):
             return _get_arg_type(args[0])
     elif origin is list:
         args = get_args(annotation)

--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -11,7 +11,7 @@ Layer 5: Validation Tolerance - TypeAdapter(strict=False) + list item filtering
 """
 
 import json
-from dataclasses import is_dataclass, asdict
+from dataclasses import asdict, is_dataclass
 from types import UnionType
 from typing import (
     Any,
@@ -26,8 +26,7 @@ from typing import (
 )
 
 import json_repair
-from pydantic import TypeAdapter, BaseModel, parse_obj_as
-
+from pydantic import BaseModel, TypeAdapter
 
 from openviking_cli.utils import get_logger
 
@@ -76,7 +75,7 @@ class JsonUtils:
         if not json_str:
             return None
         if clazz:
-            return TypeAdapter.validate_python(clazz, json_repair.loads(json_str))
+            return TypeAdapter(clazz).validate_python(json_repair.loads(json_str), strict=False)
         return json_repair.loads(json_str)
 
 
@@ -475,5 +474,3 @@ def parse_json_with_stability(
             return model_class.model_validate(tolerant_data), None
         except Exception as e2:
             return None, f"Model validation failed even after tolerance: {e} (fallback: {e2})"
-
-

--- a/tests/session/memory/test_json_stability.py
+++ b/tests/session/memory/test_json_stability.py
@@ -141,17 +141,17 @@ class TestTypeHelpers:
 
     def test_get_origin_type_from_optional(self):
         """Test extracts type from Optional[T]."""
-        assert _get_origin_type(Optional[str]) == str
-        assert _get_origin_type(Optional[int]) == int
+        assert _get_origin_type(Optional[str]) is str
+        assert _get_origin_type(Optional[int]) is int
 
     def test_get_origin_type_from_list(self):
         """Test returns list for List[T]."""
-        assert _get_origin_type(List[str]) == list
+        assert _get_origin_type(List[str]) is list
 
     def test_get_arg_type_from_list(self):
         """Test extracts item type from List[T]."""
-        assert _get_arg_type(List[str]) == str
-        assert _get_arg_type(List[int]) == int
+        assert _get_arg_type(List[str]) is str
+        assert _get_arg_type(List[int]) is int
 
 
 class TestParseJsonWithStability:

--- a/tests/session/memory/test_json_stability.py
+++ b/tests/session/memory/test_json_stability.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 from openviking.session.memory.utils import (
+    JsonUtils,
     _get_arg_type,
     _get_origin_type,
     extract_json_content,
@@ -222,6 +223,26 @@ Please be careful with the output."""
         data, error = parse_json_with_stability(content)
         assert data is None
         assert error is not None
+
+
+class TestJsonUtilsLoads:
+    """Tests for JsonUtils.loads convenience parsing."""
+
+    class TestModel(BaseModel):
+        reasonning: str
+        count: Optional[int] = None
+
+    def test_loads_returns_raw_dict_without_model(self):
+        """Test raw JSON loading still returns a dict without a model class."""
+        data = JsonUtils.loads('{"reasonning": "test", "count": 42}')
+        assert data == {"reasonning": "test", "count": 42}
+
+    def test_loads_validates_pydantic_model(self):
+        """Test model class loading uses a TypeAdapter instance."""
+        data = JsonUtils.loads('{"reasonning": "test", "count": "42"}', self.TestModel)
+        assert isinstance(data, self.TestModel)
+        assert data.reasonning == "test"
+        assert data.count == 42
 
 
 class TestMemoryOperationsIntegration:


### PR DESCRIPTION
## Summary\n- instantiate TypeAdapter before validating typed JsonUtils.loads input\n- export JsonUtils from memory utils\n- add regression coverage for raw dict and Pydantic model loading\n\n## Validation\n- python3 -m py_compile openviking/session/memory/utils/json_parser.py openviking/session/memory/utils/__init__.py tests/session/memory/test_json_stability.py\n- PYTHONPATH=. uv run --no-project --with ruff python -m ruff check --select I,F401 openviking/session/memory/utils/json_parser.py openviking/session/memory/utils/__init__.py tests/session/memory/test_json_stability.py\n- PYTHONPATH=. uv run --no-project --with pydantic --with json-repair python - <<'PY' ... direct JsonUtils.loads regression check\n\nNote: full pytest through uv run is blocked in this local environment because editable install builds the bundled Rust AGFS/CLI and the installed CommandLineTools libxcrun.dylib has an incompatible architecture. Running pytest without installing the project then fails in tests/conftest.py because the bundled AGFS client is unavailable.