### PR TITLE
feat(queuefs): Add SQLite backend with ack/recover and unified control-file/config specs

### DIFF
--- a/.github/workflows/_test_full.yml
+++ b/.github/workflows/_test_full.yml
@@ -75,6 +75,9 @@ jobs:
     - name: Install build dependencies
       run: uv pip install setuptools setuptools_scm cmake wheel
 
+    - name: Check ragfs-python workspace build
+      run: cargo check -p ragfs-python
+
     - name: Build C++ extensions
       run: uv run python setup.py build_ext --inplace
 

--- a/.github/workflows/_test_lite.yml
+++ b/.github/workflows/_test_lite.yml
@@ -75,6 +75,9 @@ jobs:
     - name: Install build dependencies
       run: uv pip install setuptools setuptools_scm cmake wheel
 
+    - name: Check ragfs-python workspace build
+      run: cargo check -p ragfs-python
+
     - name: Build C++ extensions
       run: uv run python setup.py build_ext --inplace
 

--- a/crates/ragfs-python/src/lib.rs
+++ b/crates/ragfs-python/src/lib.rs
@@ -170,7 +170,7 @@ impl RAGFSBindingClient {
         rt.block_on(async {
             fs.register_plugin(MemFSPlugin).await;
             fs.register_plugin(KVFSPlugin).await;
-            fs.register_plugin(QueueFSPlugin).await;
+            fs.register_plugin(QueueFSPlugin::new()).await;
             fs.register_plugin(SQLFSPlugin::new()).await;
             fs.register_plugin(LocalFSPlugin::new()).await;
             fs.register_plugin(ServerInfoFSPlugin::new()).await;

--- a/crates/ragfs/src/plugins/queuefs/backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/backend.rs
@@ -5,13 +5,14 @@
 
 use crate::core::errors::{Error, Result};
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection};
+use rusqlite::{params, types::ValueRef, Connection, Row};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
 use std::time::{Duration, UNIX_EPOCH};
 use std::time::SystemTime;
 use uuid::Uuid;
+
 
 /// A message in the queue
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,6 +87,22 @@ fn unix_secs(time: SystemTime) -> i64 {
     time.duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs() as i64
+}
+
+fn read_sqlite_text(row: &Row<'_>, idx: usize) -> rusqlite::Result<String> {
+    match row.get_ref(idx)? {
+        ValueRef::Text(bytes) => Ok(String::from_utf8_lossy(bytes).into_owned()),
+        ValueRef::Blob(bytes) => Ok(String::from_utf8_lossy(bytes).into_owned()),
+        ValueRef::Null => Ok(String::new()),
+        other => Err(rusqlite::Error::InvalidColumnType(
+            idx,
+            row.as_ref()
+                .column_name(idx)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|_| format!("column_{idx}")),
+            other.data_type(),
+        )),
+    }
 }
 
 /// Queue backend trait for pluggable storage implementations
@@ -507,7 +524,7 @@ impl QueueBackend for SQLiteQueueBackend {
              WHERE queue_name = ?1 AND status = 'pending'
              ORDER BY id LIMIT 1",
             params![queue_name],
-            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            |row| Ok((row.get::<_, i64>(0)?, read_sqlite_text(row, 1)?)),
         );
 
         let (id, raw_data) = match row {
@@ -527,7 +544,8 @@ impl QueueBackend for SQLiteQueueBackend {
         tx.commit()
             .map_err(|e| Error::internal(format!("sqlite transaction commit error: {}", e)))?;
 
-        let stored: StoredMessage = serde_json::from_str(&raw_data)?;
+        let stored: StoredMessage =
+            serde_json::from_str(&raw_data).map_err(|e| Error::Serialization(e.to_string()))?;
         Ok(Some(stored.into_message()))
     }
 
@@ -542,7 +560,7 @@ impl QueueBackend for SQLiteQueueBackend {
              WHERE queue_name = ?1 AND status = 'pending'
              ORDER BY id LIMIT 1",
             params![queue_name],
-            |row| row.get::<_, String>(0),
+            |row| read_sqlite_text(row, 0),
         ) {
             Ok(data) => data,
             Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
@@ -803,5 +821,37 @@ mod tests {
         let recovered = reopened.dequeue("test").unwrap().unwrap();
         assert_eq!(recovered.id, msg_id);
         assert_eq!(recovered.data, b"recover me");
+    }
+
+    #[test]
+    fn test_sqlite_backend_dequeue_legacy_go_row() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("queue.db");
+        let db_path_str = db_path.to_str().unwrap().to_string();
+
+        let mut backend =
+            SQLiteQueueBackend::open(&db_path_str, SQLiteQueueOptions::default()).unwrap();
+        backend.create_queue("Semantic").unwrap();
+        drop(backend);
+
+        let conn = Connection::open(&db_path_str).unwrap();
+        conn.execute(
+            "INSERT INTO queue_messages (queue_name, message_id, data, timestamp, status)
+             VALUES (?1, ?2, ?3, ?4, 'pending')",
+            params![
+                "Semantic",
+                "legacy-msg-id",
+                r#"{"id":"legacy-msg-id","data":"{\"id\":\"semantic-inner\",\"uri\":\"viking://resources/demo\",\"context_type\":\"resource\",\"status\":\"pending\",\"timestamp\":1776411350,\"recursive\":true,\"account_id\":\"default\",\"user_id\":\"default\",\"agent_id\":\"default\",\"role\":\"root\",\"skip_vectorization\":false,\"telemetry_id\":\"tm_demo\",\"target_uri\":null,\"lifecycle_lock_handle_id\":\"lock-demo\",\"is_code_repo\":false,\"changes\":null}","timestamp":"2026-04-17T15:37:39.287855+08:00"}"#,
+                1776411459_i64,
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let mut reopened =
+            SQLiteQueueBackend::open(&db_path_str, SQLiteQueueOptions::default()).unwrap();
+        let msg = reopened.dequeue("Semantic").unwrap().unwrap();
+        let payload = String::from_utf8(msg.data).unwrap();
+        assert!(payload.contains("\"uri\":\"viking://resources/demo\""));
     }
 }

--- a/crates/ragfs/src/plugins/queuefs/backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/backend.rs
@@ -363,6 +363,16 @@ impl SQLiteQueueBackend {
             }
         }
 
+        // Backfill queue metadata for legacy databases that only persisted queue_messages.
+        conn.execute(
+            "INSERT OR IGNORE INTO queue_metadata (queue_name)
+             SELECT DISTINCT queue_name
+             FROM queue_messages
+             WHERE queue_name IS NOT NULL AND queue_name != ''",
+            [],
+        )
+        .map_err(|e| Error::internal(format!("sqlite migration backfill queue metadata error: {}", e)))?;
+
         Ok(())
     }
 
@@ -396,6 +406,38 @@ impl SQLiteQueueBackend {
         )
         .map_err(|e| Error::internal(format!("sqlite ensure queue error: {}", e)))?;
         Ok(())
+    }
+
+    fn queue_known(conn: &Connection, queue_name: &str) -> Result<bool> {
+        let metadata_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM queue_metadata WHERE queue_name = ?1",
+                params![queue_name],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::internal(format!("sqlite queue metadata lookup error: {}", e)))?;
+
+        if metadata_count > 0 {
+            return Ok(true);
+        }
+
+        let message_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM queue_messages WHERE queue_name = ?1",
+                params![queue_name],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::internal(format!("sqlite queue messages lookup error: {}", e)))?;
+
+        Ok(message_count > 0)
+    }
+
+    fn require_queue_exists(conn: &Connection, queue_name: &str) -> Result<()> {
+        if Self::queue_known(conn, queue_name)? {
+            Ok(())
+        } else {
+            Err(Error::NotFound(format!("queue '{}' not found", queue_name)))
+        }
     }
 }
 
@@ -449,13 +491,7 @@ impl QueueBackend for SQLiteQueueBackend {
             Ok(conn) => conn,
             Err(_) => return false,
         };
-
-        let count: rusqlite::Result<i64> = conn.query_row(
-            "SELECT COUNT(*) FROM queue_metadata WHERE queue_name = ?1",
-            params![name],
-            |row| row.get(0),
-        );
-        count.unwrap_or(0) > 0
+        Self::queue_known(&conn, name).unwrap_or(false)
     }
 
     fn list_queues(&self, prefix: &str) -> Vec<String> {
@@ -498,7 +534,7 @@ impl QueueBackend for SQLiteQueueBackend {
             .lock()
             .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
 
-        Self::ensure_queue_exists(&conn, queue_name)?;
+        Self::require_queue_exists(&conn, queue_name)?;
         let stored = serde_json::to_string(&StoredMessage::from_message(&msg))?;
         conn.execute(
             "INSERT INTO queue_messages (queue_name, message_id, data, timestamp, status)
@@ -514,6 +550,8 @@ impl QueueBackend for SQLiteQueueBackend {
             .conn
             .lock()
             .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        Self::require_queue_exists(&conn, queue_name)?;
 
         let tx = conn
             .transaction()
@@ -555,6 +593,8 @@ impl QueueBackend for SQLiteQueueBackend {
             .lock()
             .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
 
+        Self::require_queue_exists(&conn, queue_name)?;
+
         let raw_data = match conn.query_row(
             "SELECT data FROM queue_messages
              WHERE queue_name = ?1 AND status = 'pending'
@@ -577,6 +617,8 @@ impl QueueBackend for SQLiteQueueBackend {
             .lock()
             .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
 
+        Self::require_queue_exists(&conn, queue_name)?;
+
         let count: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM queue_messages
@@ -594,6 +636,8 @@ impl QueueBackend for SQLiteQueueBackend {
             .lock()
             .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
 
+        Self::require_queue_exists(&conn, queue_name)?;
+
         conn.execute(
             "DELETE FROM queue_messages WHERE queue_name = ?1",
             params![queue_name],
@@ -607,6 +651,8 @@ impl QueueBackend for SQLiteQueueBackend {
             .conn
             .lock()
             .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        Self::require_queue_exists(&conn, queue_name)?;
 
         let timestamp: Option<i64> = conn
             .query_row(
@@ -630,6 +676,8 @@ impl QueueBackend for SQLiteQueueBackend {
             .conn
             .lock()
             .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        Self::require_queue_exists(&conn, queue_name)?;
 
         let changed = conn
             .execute(
@@ -853,5 +901,56 @@ mod tests {
         let msg = reopened.dequeue("Semantic").unwrap().unwrap();
         let payload = String::from_utf8(msg.data).unwrap();
         assert!(payload.contains("\"uri\":\"viking://resources/demo\""));
+    }
+
+    #[test]
+    fn test_sqlite_backend_backfills_queue_metadata_from_legacy_rows() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("legacy.db");
+        let db_path_str = db_path.to_str().unwrap().to_string();
+
+        let conn = Connection::open(&db_path_str).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE queue_metadata (
+                queue_name TEXT PRIMARY KEY,
+                created_at INTEGER DEFAULT (strftime('%s', 'now')),
+                last_updated INTEGER DEFAULT (strftime('%s', 'now'))
+            );
+            CREATE TABLE queue_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                queue_name TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                timestamp INTEGER NOT NULL
+            );
+            INSERT INTO queue_messages (queue_name, message_id, data, timestamp)
+            VALUES ('legacy/semantic', 'legacy-id', '{"id":"legacy-id","data":"payload"}', 1776411459);
+            "#,
+        )
+        .unwrap();
+        drop(conn);
+
+        let backend =
+            SQLiteQueueBackend::open(&db_path_str, SQLiteQueueOptions::default()).unwrap();
+        assert!(backend.queue_exists("legacy/semantic"));
+        assert_eq!(backend.list_queues("legacy"), vec!["legacy/semantic"]);
+    }
+
+    #[test]
+    fn test_sqlite_backend_operations_on_nonexistent_queue() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("queue.db");
+        let mut backend =
+            SQLiteQueueBackend::open(db_path.to_str().unwrap(), SQLiteQueueOptions::default())
+                .unwrap();
+
+        assert!(backend.enqueue("nonexistent", Message::new(b"data".to_vec())).is_err());
+        assert!(backend.dequeue("nonexistent").is_err());
+        assert!(backend.peek("nonexistent").is_err());
+        assert!(backend.size("nonexistent").is_err());
+        assert!(backend.clear("nonexistent").is_err());
+        assert!(backend.get_last_enqueue_time("nonexistent").is_err());
+        assert!(backend.ack("nonexistent", "msg-id").is_err());
     }
 }

--- a/crates/ragfs/src/plugins/queuefs/backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/backend.rs
@@ -4,8 +4,12 @@
 //! storage implementations (memory, SQLite, etc.) while maintaining a consistent interface.
 
 use crate::core::errors::{Error, Result};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::time::{Duration, UNIX_EPOCH};
 use std::time::SystemTime;
 use uuid::Uuid;
 
@@ -29,6 +33,59 @@ impl Message {
             timestamp: SystemTime::now(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredMessage {
+    id: String,
+    data: String,
+    #[serde(default)]
+    timestamp: Option<serde_json::Value>,
+}
+
+impl StoredMessage {
+    fn from_message(msg: &Message) -> Self {
+        Self {
+            id: msg.id.clone(),
+            data: String::from_utf8_lossy(&msg.data).to_string(),
+            // Prefer unix seconds for compatibility with older queue.db producers.
+            timestamp: Some(serde_json::Value::Number(unix_secs(msg.timestamp).into())),
+        }
+    }
+
+    fn into_message(self) -> Message {
+        Message {
+            id: self.id,
+            data: self.data.into_bytes(),
+            timestamp: parse_stored_timestamp(self.timestamp),
+        }
+    }
+}
+
+fn parse_stored_timestamp(raw: Option<serde_json::Value>) -> SystemTime {
+    match raw {
+        Some(serde_json::Value::String(ts)) => DateTime::parse_from_rfc3339(&ts)
+            .map(|dt| {
+                let secs = dt.timestamp();
+                let secs_u64 = if secs <= 0 { 0 } else { secs as u64 };
+                UNIX_EPOCH + Duration::from_secs(secs_u64)
+            })
+            .unwrap_or_else(|_| SystemTime::now()),
+        Some(serde_json::Value::Number(num)) => num
+            .as_i64()
+            .map(|secs| {
+                let secs_u64 = if secs <= 0 { 0 } else { secs as u64 };
+                UNIX_EPOCH + Duration::from_secs(secs_u64)
+            })
+            .unwrap_or_else(SystemTime::now),
+        _ => SystemTime::now(),
+    }
+}
+
+fn unix_secs(time: SystemTime) -> i64 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
 }
 
 /// Queue backend trait for pluggable storage implementations
@@ -66,6 +123,22 @@ pub trait QueueBackend: Send + Sync {
 
     /// Acknowledge (delete) a message by ID
     fn ack(&mut self, queue_name: &str, msg_id: &str) -> Result<bool>;
+}
+
+/// Options for SQLite queue backend.
+#[derive(Debug, Clone, Copy)]
+pub struct SQLiteQueueOptions {
+    pub recover_stale_sec: i64,
+    pub busy_timeout_ms: u64,
+}
+
+impl Default for SQLiteQueueOptions {
+    fn default() -> Self {
+        Self {
+            recover_stale_sec: 0,
+            busy_timeout_ms: 5_000,
+        }
+    }
 }
 
 /// A single queue with its messages
@@ -192,9 +265,369 @@ impl QueueBackend for MemoryBackend {
     }
 }
 
+/// SQLite queue backend with at-least-once delivery semantics.
+pub struct SQLiteQueueBackend {
+    conn: Mutex<Connection>,
+}
+
+impl SQLiteQueueBackend {
+    pub fn open(db_path: &str, options: SQLiteQueueOptions) -> Result<Self> {
+        let conn = Connection::open(db_path)
+            .map_err(|e| Error::internal(format!("sqlite connection error: {}", e)))?;
+
+        if options.busy_timeout_ms > 0 {
+            conn.busy_timeout(Duration::from_millis(options.busy_timeout_ms))
+                .map_err(|e| Error::internal(format!("sqlite busy_timeout error: {}", e)))?;
+        }
+
+        conn.execute_batch(
+            r#"
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+            "#,
+        )
+        .map_err(|e| Error::internal(format!("sqlite pragma error: {}", e)))?;
+
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS queue_metadata (
+                queue_name TEXT PRIMARY KEY,
+                created_at INTEGER DEFAULT (strftime('%s', 'now')),
+                last_updated INTEGER DEFAULT (strftime('%s', 'now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS queue_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                queue_name TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                processing_started_at INTEGER,
+                created_at INTEGER DEFAULT (strftime('%s', 'now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_queue_status
+                ON queue_messages(queue_name, status, id);
+            CREATE INDEX IF NOT EXISTS idx_queue_message_id
+                ON queue_messages(queue_name, message_id);
+            "#,
+        )
+        .map_err(|e| Error::internal(format!("sqlite schema init error: {}", e)))?;
+
+        let backend = Self {
+            conn: Mutex::new(conn),
+        };
+        backend.run_migrations()?;
+        backend.recover_stale(options.recover_stale_sec)?;
+        Ok(backend)
+    }
+
+    fn run_migrations(&self) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        for stmt in [
+            "ALTER TABLE queue_messages ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'",
+            "ALTER TABLE queue_messages ADD COLUMN processing_started_at INTEGER",
+            "CREATE INDEX IF NOT EXISTS idx_queue_status ON queue_messages(queue_name, status, id)",
+            "CREATE INDEX IF NOT EXISTS idx_queue_message_id ON queue_messages(queue_name, message_id)",
+        ] {
+            if let Err(err) = conn.execute(stmt, []) {
+                let text = err.to_string();
+                if !text.contains("duplicate column name") && !text.contains("already exists") {
+                    return Err(Error::internal(format!(
+                        "sqlite migration failed for '{}': {}",
+                        stmt, text
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn recover_stale(&self, stale_sec: i64) -> Result<usize> {
+        let cutoff = Utc::now().timestamp() - stale_sec.max(0);
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let changed = if stale_sec <= 0 {
+            conn.execute(
+                "UPDATE queue_messages SET status = 'pending', processing_started_at = NULL WHERE status = 'processing'",
+                [],
+            )
+        } else {
+            conn.execute(
+                "UPDATE queue_messages SET status = 'pending', processing_started_at = NULL WHERE status = 'processing' AND processing_started_at <= ?1",
+                params![cutoff],
+            )
+        }
+        .map_err(|e| Error::internal(format!("sqlite recover stale error: {}", e)))?;
+
+        Ok(changed)
+    }
+
+    fn ensure_queue_exists(conn: &Connection, queue_name: &str) -> Result<()> {
+        conn.execute(
+            "INSERT OR IGNORE INTO queue_metadata (queue_name) VALUES (?1)",
+            params![queue_name],
+        )
+        .map_err(|e| Error::internal(format!("sqlite ensure queue error: {}", e)))?;
+        Ok(())
+    }
+}
+
+impl QueueBackend for SQLiteQueueBackend {
+    fn create_queue(&mut self, name: &str) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let changed = conn
+            .execute(
+                "INSERT OR IGNORE INTO queue_metadata (queue_name) VALUES (?1)",
+                params![name],
+            )
+            .map_err(|e| Error::internal(format!("sqlite create queue error: {}", e)))?;
+        if changed == 0 {
+            return Err(Error::AlreadyExists(format!("queue '{}' already exists", name)));
+        }
+        Ok(())
+    }
+
+    fn remove_queue(&mut self, name: &str) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let pattern = format!("{}/%", name);
+        let deleted_messages = conn
+            .execute(
+                "DELETE FROM queue_messages WHERE queue_name = ?1 OR queue_name LIKE ?2",
+                params![name, pattern],
+            )
+            .map_err(|e| Error::internal(format!("sqlite remove messages error: {}", e)))?;
+        let deleted_meta = conn
+            .execute(
+                "DELETE FROM queue_metadata WHERE queue_name = ?1 OR queue_name LIKE ?2",
+                params![name, pattern],
+            )
+            .map_err(|e| Error::internal(format!("sqlite remove metadata error: {}", e)))?;
+
+        if deleted_messages == 0 && deleted_meta == 0 {
+            return Err(Error::NotFound(format!("queue '{}' not found", name)));
+        }
+        Ok(())
+    }
+
+    fn queue_exists(&self, name: &str) -> bool {
+        let conn = match self.conn.lock() {
+            Ok(conn) => conn,
+            Err(_) => return false,
+        };
+
+        let count: rusqlite::Result<i64> = conn.query_row(
+            "SELECT COUNT(*) FROM queue_metadata WHERE queue_name = ?1",
+            params![name],
+            |row| row.get(0),
+        );
+        count.unwrap_or(0) > 0
+    }
+
+    fn list_queues(&self, prefix: &str) -> Vec<String> {
+        let conn = match self.conn.lock() {
+            Ok(conn) => conn,
+            Err(_) => return Vec::new(),
+        };
+
+        if prefix.is_empty() {
+            let mut stmt = match conn.prepare("SELECT queue_name FROM queue_metadata ORDER BY queue_name") {
+                Ok(stmt) => stmt,
+                Err(_) => return Vec::new(),
+            };
+            let rows = match stmt.query_map([], |row| row.get::<_, String>(0)) {
+                Ok(rows) => rows,
+                Err(_) => return Vec::new(),
+            };
+            return rows.filter_map(|row| row.ok()).collect();
+        }
+
+        let mut stmt = match conn.prepare(
+            "SELECT queue_name FROM queue_metadata
+             WHERE queue_name = ?1 OR queue_name LIKE ?2
+             ORDER BY queue_name",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Vec::new(),
+        };
+        let pattern = format!("{}/%", prefix);
+        let rows = match stmt.query_map(params![prefix, pattern], |row| row.get::<_, String>(0)) {
+            Ok(rows) => rows,
+            Err(_) => return Vec::new(),
+        };
+        rows.filter_map(|row| row.ok()).collect()
+    }
+
+    fn enqueue(&mut self, queue_name: &str, msg: Message) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        Self::ensure_queue_exists(&conn, queue_name)?;
+        let stored = serde_json::to_string(&StoredMessage::from_message(&msg))?;
+        conn.execute(
+            "INSERT INTO queue_messages (queue_name, message_id, data, timestamp, status)
+             VALUES (?1, ?2, ?3, ?4, 'pending')",
+            params![queue_name, msg.id, stored, unix_secs(msg.timestamp)],
+        )
+        .map_err(|e| Error::internal(format!("sqlite enqueue error: {}", e)))?;
+        Ok(())
+    }
+
+    fn dequeue(&mut self, queue_name: &str) -> Result<Option<Message>> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let tx = conn
+            .transaction()
+            .map_err(|e| Error::internal(format!("sqlite transaction begin error: {}", e)))?;
+
+        let row = tx.query_row(
+            "SELECT id, data FROM queue_messages
+             WHERE queue_name = ?1 AND status = 'pending'
+             ORDER BY id LIMIT 1",
+            params![queue_name],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        );
+
+        let (id, raw_data) = match row {
+            Ok(row) => row,
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+            Err(e) => return Err(Error::internal(format!("sqlite dequeue query error: {}", e))),
+        };
+
+        tx.execute(
+            "UPDATE queue_messages
+             SET status = 'processing', processing_started_at = ?1
+             WHERE id = ?2",
+            params![Utc::now().timestamp(), id],
+        )
+        .map_err(|e| Error::internal(format!("sqlite mark processing error: {}", e)))?;
+
+        tx.commit()
+            .map_err(|e| Error::internal(format!("sqlite transaction commit error: {}", e)))?;
+
+        let stored: StoredMessage = serde_json::from_str(&raw_data)?;
+        Ok(Some(stored.into_message()))
+    }
+
+    fn peek(&self, queue_name: &str) -> Result<Option<Message>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let raw_data = match conn.query_row(
+            "SELECT data FROM queue_messages
+             WHERE queue_name = ?1 AND status = 'pending'
+             ORDER BY id LIMIT 1",
+            params![queue_name],
+            |row| row.get::<_, String>(0),
+        ) {
+            Ok(data) => data,
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+            Err(e) => return Err(Error::internal(format!("sqlite peek query error: {}", e))),
+        };
+
+        let stored: StoredMessage = serde_json::from_str(&raw_data)?;
+        Ok(Some(stored.into_message()))
+    }
+
+    fn size(&self, queue_name: &str) -> Result<usize> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM queue_messages
+                 WHERE queue_name = ?1 AND status = 'pending'",
+                params![queue_name],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::internal(format!("sqlite size query error: {}", e)))?;
+        Ok(count as usize)
+    }
+
+    fn clear(&mut self, queue_name: &str) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        conn.execute(
+            "DELETE FROM queue_messages WHERE queue_name = ?1",
+            params![queue_name],
+        )
+        .map_err(|e| Error::internal(format!("sqlite clear error: {}", e)))?;
+        Ok(())
+    }
+
+    fn get_last_enqueue_time(&self, queue_name: &str) -> Result<SystemTime> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let timestamp: Option<i64> = conn
+            .query_row(
+                "SELECT MAX(timestamp) FROM queue_messages
+                 WHERE queue_name = ?1 AND status = 'pending'",
+                params![queue_name],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::internal(format!("sqlite last enqueue query error: {}", e)))?;
+
+        Ok(timestamp
+            .map(|secs| {
+                let secs_u64 = if secs <= 0 { 0 } else { secs as u64 };
+                UNIX_EPOCH + Duration::from_secs(secs_u64)
+            })
+            .unwrap_or(SystemTime::UNIX_EPOCH))
+    }
+
+    fn ack(&mut self, queue_name: &str, msg_id: &str) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::internal(format!("sqlite mutex poisoned: {}", e)))?;
+
+        let changed = conn
+            .execute(
+                "DELETE FROM queue_messages
+                 WHERE queue_name = ?1 AND message_id = ?2 AND status = 'processing'",
+                params![queue_name, msg_id],
+            )
+            .map_err(|e| Error::internal(format!("sqlite ack error: {}", e)))?;
+        Ok(changed > 0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_create_queue() {
@@ -320,5 +753,55 @@ mod tests {
         assert!(backend.peek("nonexistent").is_err());
         assert!(backend.size("nonexistent").is_err());
         assert!(backend.clear("nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_sqlite_backend_basic_flow() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("queue.db");
+        let mut backend =
+            SQLiteQueueBackend::open(db_path.to_str().unwrap(), SQLiteQueueOptions::default())
+                .unwrap();
+
+        backend.create_queue("test").unwrap();
+        let msg1 = Message::new(b"message 1".to_vec());
+        let msg2 = Message::new(b"message 2".to_vec());
+        let msg1_id = msg1.id.clone();
+
+        backend.enqueue("test", msg1).unwrap();
+        backend.enqueue("test", msg2).unwrap();
+
+        let first = backend.dequeue("test").unwrap().unwrap();
+        assert_eq!(first.data, b"message 1");
+        assert_eq!(backend.size("test").unwrap(), 1);
+        assert!(backend.ack("test", &msg1_id).unwrap());
+
+        let second = backend.dequeue("test").unwrap().unwrap();
+        assert_eq!(second.data, b"message 2");
+    }
+
+    #[test]
+    fn test_sqlite_backend_recover_stale() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("queue.db");
+        let db_path_str = db_path.to_str().unwrap().to_string();
+
+        let msg_id = {
+            let mut backend =
+                SQLiteQueueBackend::open(&db_path_str, SQLiteQueueOptions::default()).unwrap();
+            backend.create_queue("test").unwrap();
+            let msg = Message::new(b"recover me".to_vec());
+            let msg_id = msg.id.clone();
+            backend.enqueue("test", msg).unwrap();
+            let dequeued = backend.dequeue("test").unwrap().unwrap();
+            assert_eq!(dequeued.id, msg_id);
+            msg_id
+        };
+
+        let mut reopened =
+            SQLiteQueueBackend::open(&db_path_str, SQLiteQueueOptions::default()).unwrap();
+        let recovered = reopened.dequeue("test").unwrap().unwrap();
+        assert_eq!(recovered.id, msg_id);
+        assert_eq!(recovered.data, b"recover me");
     }
 }

--- a/crates/ragfs/src/plugins/queuefs/mod.rs
+++ b/crates/ragfs/src/plugins/queuefs/mod.rs
@@ -18,17 +18,64 @@ use crate::core::{
     types::{ConfigParameter, FileInfo, PluginConfig, WriteFlag},
 };
 use async_trait::async_trait;
-use backend::{MemoryBackend, Message, QueueBackend};
+use backend::{MemoryBackend, Message, QueueBackend, SQLiteQueueBackend, SQLiteQueueOptions};
 use serde::Serialize;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::Mutex;
+
+#[derive(Clone, Copy)]
+struct ControlFileSpec {
+    name: &'static str,
+    mode: u32,
+}
+
+// Single source of truth for control files (names + permissions).
+const CONTROL_FILES: &[ControlFileSpec] = &[
+    ControlFileSpec {
+        name: "enqueue",
+        mode: 0o222,
+    },
+    ControlFileSpec {
+        name: "dequeue",
+        mode: 0o444,
+    },
+    ControlFileSpec {
+        name: "peek",
+        mode: 0o444,
+    },
+    ControlFileSpec {
+        name: "size",
+        mode: 0o444,
+    },
+    ControlFileSpec {
+        name: "clear",
+        mode: 0o222,
+    },
+    ControlFileSpec {
+        name: "ack",
+        mode: 0o222,
+    },
+];
 
 /// Dequeue response format (matches Go libagfsbinding format)
 #[derive(Debug, Serialize)]
 struct QueueMessage {
     id: String,
     data: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BackendKind {
+    Memory,
+    Sqlite,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedBackendConfig {
+    kind: BackendKind,
+    sqlite_db_path: Option<String>,
+    sqlite_options: SQLiteQueueOptions,
 }
 
 /// Parsed path information
@@ -47,14 +94,39 @@ pub struct QueueFileSystem {
 impl QueueFileSystem {
     /// Create a new QueueFileSystem with memory backend
     pub fn new() -> Self {
+        Self::with_backend(Box::new(MemoryBackend::new()))
+    }
+
+    /// Create a QueueFileSystem with a specific backend implementation.
+    pub fn with_backend(backend: Box<dyn QueueBackend>) -> Self {
         Self {
-            backend: Arc::new(Mutex::new(Box::new(MemoryBackend::new()))),
+            backend: Arc::new(Mutex::new(backend)),
         }
     }
 
     /// Check if a name is a control operation
     fn is_control_operation(name: &str) -> bool {
-        matches!(name, "enqueue" | "dequeue" | "peek" | "size" | "clear" | "ack")
+        CONTROL_FILES.iter().any(|spec| spec.name == name)
+    }
+
+    fn control_file_mode(name: &str) -> Option<u32> {
+        CONTROL_FILES
+            .iter()
+            .find(|spec| spec.name == name)
+            .map(|spec| spec.mode)
+    }
+
+    fn leaf_control_files(now: SystemTime) -> Vec<FileInfo> {
+        CONTROL_FILES
+            .iter()
+            .map(|spec| FileInfo {
+                name: spec.name.to_string(),
+                size: 0,
+                mode: spec.mode,
+                mod_time: now,
+                is_dir: false,
+            })
+            .collect()
     }
 
     /// Normalize path by removing trailing slashes and ensuring it starts with /
@@ -154,9 +226,9 @@ impl FileSystem for QueueFileSystem {
 
         match operation.as_str() {
             "dequeue" => {
-                let msg = backend
-                    .dequeue(&queue_name)?
-                    .ok_or_else(|| Error::NotFound("queue is empty".to_string()))?;
+                let Some(msg) = backend.dequeue(&queue_name)? else {
+                    return Ok(b"{}".to_vec());
+                };
                 // Return in Go libagfsbinding format: {"id": "...", "data": "..."}
                 let data_str = String::from_utf8_lossy(&msg.data).to_string();
                 let response = QueueMessage {
@@ -166,9 +238,9 @@ impl FileSystem for QueueFileSystem {
                 Ok(serde_json::to_vec(&response)?)
             }
             "peek" => {
-                let msg = backend
-                    .peek(&queue_name)?
-                    .ok_or_else(|| Error::NotFound("queue is empty".to_string()))?;
+                let Some(msg) = backend.peek(&queue_name)? else {
+                    return Ok(b"{}".to_vec());
+                };
                 // Return in Go libagfsbinding format: {"id": "...", "data": "..."}
                 let data_str = String::from_utf8_lossy(&msg.data).to_string();
                 let response = QueueMessage {
@@ -303,50 +375,7 @@ impl FileSystem for QueueFileSystem {
             )));
         }
 
-        Ok(vec![
-            FileInfo {
-                name: "enqueue".to_string(),
-                size: 0,
-                mode: 0o222,
-                mod_time: now,
-                is_dir: false,
-            },
-            FileInfo {
-                name: "dequeue".to_string(),
-                size: 0,
-                mode: 0o444,
-                mod_time: now,
-                is_dir: false,
-            },
-            FileInfo {
-                name: "peek".to_string(),
-                size: 0,
-                mode: 0o444,
-                mod_time: now,
-                is_dir: false,
-            },
-            FileInfo {
-                name: "size".to_string(),
-                size: 0,
-                mode: 0o444,
-                mod_time: now,
-                is_dir: false,
-            },
-            FileInfo {
-                name: "clear".to_string(),
-                size: 0,
-                mode: 0o222,
-                mod_time: now,
-                is_dir: false,
-            },
-            FileInfo {
-                name: "ack".to_string(),
-                size: 0,
-                mode: 0o222,
-                mod_time: now,
-                is_dir: false,
-            },
-        ])
+        Ok(Self::leaf_control_files(now))
     }
 
     async fn stat(&self, path: &str) -> Result<FileInfo> {
@@ -385,11 +414,8 @@ impl FileSystem for QueueFileSystem {
             Ok(FileInfo {
                 name: operation.clone(),
                 size: 0,
-                mode: if matches!(operation.as_str(), "enqueue" | "clear" | "ack") {
-                    0o222
-                } else {
-                    0o444
-                },
+                mode: Self::control_file_mode(operation)
+                    .ok_or_else(|| Error::NotFound(format!("control file not found: {}", operation)))?,
                 mod_time: SystemTime::now(),
                 is_dir: false,
             })
@@ -441,7 +467,120 @@ impl FileSystem for QueueFileSystem {
 }
 
 /// QueueFS Plugin
-pub struct QueueFSPlugin;
+pub struct QueueFSPlugin {
+    config_params: Vec<ConfigParameter>,
+}
+
+impl QueueFSPlugin {
+    /// Create a new queuefs plugin with supported configuration metadata.
+    pub fn new() -> Self {
+        Self {
+            config_params: vec![
+                ConfigParameter::optional(
+                    "backend",
+                    "string",
+                    "memory",
+                    "Queue backend (memory, sqlite, sqlite3)",
+                ),
+                ConfigParameter::optional(
+                    "db_path",
+                    "string",
+                    "",
+                    "SQLite database file path when backend=sqlite or backend=sqlite3",
+                ),
+                ConfigParameter::optional(
+                    "recover_stale_sec",
+                    "int",
+                    "0",
+                    "Recover processing messages older than this many seconds on startup (0 = recover all)",
+                ),
+                ConfigParameter::optional(
+                    "busy_timeout_ms",
+                    "int",
+                    "5000",
+                    "SQLite busy timeout in milliseconds",
+                ),
+            ],
+        }
+    }
+
+    fn get_string_param<'a>(config: &'a PluginConfig, key: &str) -> Option<&'a str> {
+        config.params.get(key).and_then(|v| v.as_string())
+    }
+
+    fn get_int_param(config: &PluginConfig, key: &str) -> Option<i64> {
+        config.params.get(key).and_then(|v| v.as_int())
+    }
+
+    fn parse_backend_config(config: &PluginConfig) -> Result<ParsedBackendConfig> {
+        let backend_name = Self::get_string_param(config, "backend").unwrap_or("memory");
+        let valid_backends = ["memory", "sqlite", "sqlite3"];
+        if !valid_backends.contains(&backend_name) {
+            return Err(Error::config(format!(
+                "unsupported queue backend: {} (valid: {})",
+                backend_name,
+                valid_backends.join(", ")
+            )));
+        }
+
+        let kind = match backend_name {
+            "memory" => BackendKind::Memory,
+            "sqlite" | "sqlite3" => BackendKind::Sqlite,
+            _ => {
+                return Err(Error::config(format!(
+                    "unsupported queue backend: {}",
+                    backend_name
+                )))
+            }
+        };
+
+        let recover_stale_sec = Self::get_int_param(config, "recover_stale_sec").unwrap_or(0);
+        let busy_timeout_ms = Self::get_int_param(config, "busy_timeout_ms")
+            .unwrap_or(5_000)
+            .max(0) as u64;
+
+        // Ensure typed config values are valid when present (avoid validate/initialize drift).
+        for (key, label) in [
+            ("recover_stale_sec", "recover_stale_sec"),
+            ("busy_timeout_ms", "busy_timeout_ms"),
+        ] {
+            if let Some(value) = config.params.get(key) {
+                value
+                    .as_int()
+                    .ok_or_else(|| Error::config(format!("{} must be an integer", label)))?;
+            }
+        }
+
+        let sqlite_db_path = match kind {
+            BackendKind::Memory => None,
+            BackendKind::Sqlite => {
+                let db_path = Self::get_string_param(config, "db_path").unwrap_or("");
+                if db_path.trim().is_empty() {
+                    return Err(Error::config(format!(
+                        "queuefs db_path is required when backend={} or backend={}",
+                        "sqlite", "sqlite3"
+                    )));
+                }
+                Some(db_path.to_string())
+            }
+        };
+
+        Ok(ParsedBackendConfig {
+            kind,
+            sqlite_db_path,
+            sqlite_options: SQLiteQueueOptions {
+                recover_stale_sec,
+                busy_timeout_ms,
+            },
+        })
+    }
+}
+
+impl Default for QueueFSPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[async_trait]
 impl ServicePlugin for QueueFSPlugin {
@@ -471,29 +610,46 @@ impl ServicePlugin for QueueFSPlugin {
          6. Clear queue:\n\
             echo '' > /queuefs/Embedding/clear\n\
          \n\
+         7. Ack a message:\n\
+            echo '<message_id>' > /queuefs/Embedding/ack\n\
+         \n\
          Control files per queue:\n\
          - enqueue: Write to add a message to the queue\n\
          - dequeue: Read to remove and return the first message\n\
          - peek: Read to view the first message without removing it\n\
          - size: Read to get the current queue size\n\
          - clear: Write to clear all messages from the queue\n\
+         - ack: Write message id to acknowledge and delete it\n\
          \n\
          Supports nested queues:\n\
             mkdir /queuefs/logs/errors\n\
             echo 'error message' > /queuefs/logs/errors/enqueue"
     }
 
-    async fn validate(&self, _config: &PluginConfig) -> Result<()> {
-        // No configuration parameters required
+    async fn validate(&self, config: &PluginConfig) -> Result<()> {
+        Self::parse_backend_config(config)?;
         Ok(())
     }
 
-    async fn initialize(&self, _config: PluginConfig) -> Result<Box<dyn FileSystem>> {
-        Ok(Box::new(QueueFileSystem::new()))
+    async fn initialize(&self, config: PluginConfig) -> Result<Box<dyn FileSystem>> {
+        let parsed = Self::parse_backend_config(&config)?;
+
+        let backend: Box<dyn QueueBackend> = match parsed.kind {
+            BackendKind::Memory => Box::new(MemoryBackend::new()),
+            BackendKind::Sqlite => Box::new(SQLiteQueueBackend::open(
+                parsed
+                    .sqlite_db_path
+                    .as_deref()
+                    .expect("sqlite db_path is validated"),
+                parsed.sqlite_options,
+            )?),
+        };
+
+        Ok(Box::new(QueueFileSystem::with_backend(backend)))
     }
 
     fn config_params(&self) -> &[ConfigParameter] {
-        &[]
+        &self.config_params
     }
 }
 
@@ -530,15 +686,17 @@ mod tests {
         // Dequeue messages
         let result1 = fs.read("/test/dequeue", 0, 0).await.unwrap();
         let msg1: TestQueueMessage = serde_json::from_slice(&result1).unwrap();
+        assert!(!msg1.id.is_empty());
         assert_eq!(msg1.data.as_bytes(), data1);
 
         let result2 = fs.read("/test/dequeue", 0, 0).await.unwrap();
         let msg2: TestQueueMessage = serde_json::from_slice(&result2).unwrap();
+        assert!(!msg2.id.is_empty());
         assert_eq!(msg2.data.as_bytes(), data2);
 
         // Queue should be empty
-        let result = fs.read("/test/dequeue", 0, 0).await;
-        assert!(result.is_err());
+        let result = fs.read("/test/dequeue", 0, 0).await.unwrap();
+        assert_eq!(result, b"{}");
     }
 
     #[tokio::test]
@@ -623,7 +781,7 @@ mod tests {
         assert_eq!(String::from_utf8(size).unwrap(), "0");
 
         let result = fs.read("/test/dequeue", 0, 0).await;
-        assert!(result.is_err());
+        assert_eq!(result.unwrap(), b"{}");
     }
 
     #[tokio::test]
@@ -641,7 +799,7 @@ mod tests {
 
         // Queue directory should list control files
         let entries = fs.read_dir("/test").await.unwrap();
-        assert_eq!(entries.len(), 5);
+        assert_eq!(entries.len(), 6);
 
         let names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
         assert!(names.contains(&"enqueue".to_string()));
@@ -649,6 +807,7 @@ mod tests {
         assert!(names.contains(&"peek".to_string()));
         assert!(names.contains(&"size".to_string()));
         assert!(names.contains(&"clear".to_string()));
+        assert!(names.contains(&"ack".to_string()));
     }
 
     #[tokio::test]
@@ -742,11 +901,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_queuefs_plugin() {
-        let plugin = QueueFSPlugin;
+        let plugin = QueueFSPlugin::new();
 
         assert_eq!(plugin.name(), "queuefs");
         assert!(!plugin.readme().is_empty());
-        assert_eq!(plugin.config_params().len(), 0);
+        assert_eq!(plugin.config_params().len(), 4);
 
         let config = PluginConfig {
             name: "queuefs".to_string(),
@@ -765,7 +924,8 @@ mod tests {
             .await
             .unwrap();
         let result = fs.read("/test/dequeue", 0, 0).await.unwrap();
-        assert_eq!(result, b"test");
+        let msg: TestQueueMessage = serde_json::from_slice(&result).unwrap();
+        assert_eq!(msg.data, "test");
     }
 
     #[tokio::test]
@@ -792,7 +952,8 @@ mod tests {
 
         // Dequeue from specific queue
         let msg = fs.read("/Embedding/dequeue", 0, 0).await.unwrap();
-        assert_eq!(msg, b"embed1");
+        let msg: TestQueueMessage = serde_json::from_slice(&msg).unwrap();
+        assert_eq!(msg.data, "embed1");
 
         // Other queue unaffected
         let size2 = fs.read("/Semantic/size", 0, 0).await.unwrap();
@@ -820,7 +981,8 @@ mod tests {
             .await
             .unwrap();
         let msg = fs.read("/logs/errors/dequeue", 0, 0).await.unwrap();
-        assert_eq!(msg, b"error1");
+        let msg: TestQueueMessage = serde_json::from_slice(&msg).unwrap();
+        assert_eq!(msg.data, "error1");
     }
 
     #[tokio::test]

--- a/crates/ragfs/src/server/main.rs
+++ b/crates/ragfs/src/server/main.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("  - memfs: In-memory file system");
     fs.register_plugin(KVFSPlugin).await;
     tracing::info!("  - kvfs: Key-value file system");
-    fs.register_plugin(QueueFSPlugin).await;
+    fs.register_plugin(QueueFSPlugin::new()).await;
     tracing::info!("  - queuefs: Message queue file system");
     fs.register_plugin(SQLFSPlugin::new()).await;
     tracing::info!("  - sqlfs: Database-backed file system (SQLite)");
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("  POST   /api/v1/unmount");
     tracing::info!("");
     tracing::info!("Example: Mount MemFS");
-    tracing::info!("  curl -X POST http://{}//api/v1/mount \\", addr);
+    tracing::info!("  curl -X POST http://{}/api/v1/mount \\", addr);
     tracing::info!("    -H 'Content-Type: application/json' \\");
     tracing::info!("    -d '{{\"plugin\": \"memfs\", \"path\": \"/memfs\"}}'");
 


### PR DESCRIPTION
## Description
旧版 QueueFS 依赖 Go/SQLite 的 queue.db 做“队列落盘+重启恢复”，而更新后这条链路在 Rust 版 queuefs 里缺失了 SQLite 后端/恢复语义，所以新版重启后任务队列不再天然可恢复。

本 PR 为 `queuefs` 引入 SQLite 持久化后端，用于让队列任务在进程重启后仍可继续消费；并实现与旧版行为一致的 `dequeue -> ack` 两阶段确认（at-least-once）语义：`dequeue` 只把消息标记为 processing 并返回，只有 `ack` 才真正删除。与此同时，补齐 queuefs 的 mount 配置项，并修复一个 server 启动日志示例 URL 的小问题。

## Related Issue
N/A

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made
- 新增 SQLite 队列后端（`SQLiteQueueBackend`）
  - 新增/兼容表结构：`queue_metadata`（记录队列名）与 `queue_messages`（记录消息、状态、时间等）
  - 状态字段：`status`（`pending` / `processing`）与 `processing_started_at`
  - dequeue 行为：从 `pending` 选取一条消息后更新为 `processing` 并返回（保证“取出即锁定”，防止被重复取出）
  - ack 行为：按 `queue_name + message_id + status='processing'` 删除；返回值表示是否真的删到
  - 启动恢复：`recover_stale_sec=0` 时恢复全部 `processing` 为 `pending`；`recover_stale_sec>0` 时仅恢复超过阈值的 `processing`
  - SQLite 运行参数：设置 `busy_timeout_ms`，启用 WAL 相关 pragma（提高并发读写表现）
- QueueFS 插件配置项（mount config）
  - `backend`: `memory | sqlite | sqlite3`
  - `db_path`: sqlite DB 文件路径（当 backend=sqlite/sqlite3 必填）
  - `recover_stale_sec`: 启动时恢复 processing 的阈值（秒，0 表示全部恢复）
  - `busy_timeout_ms`: sqlite busy timeout（毫秒）
- 对外接口与兼容点
  - 控制文件：`enqueue`(写) / `dequeue`(读) / `peek`(读) / `size`(读) / `clear`(写) / `ack`(写 msg_id)
  - 空队列行为：`dequeue/peek` 在无消息时返回 `{}`（用于兼容现有客户端判空逻辑）
  - 文档同步：`readme()` 补齐 `ack` 的用法与控制文件列表
- 杂项修复
  - 修复 server 启动日志 curl 示例 URL 的双斜杠：`http://{}/api/v1/mount`

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

本地验证命令与结果：
- `cargo test -p ragfs queuefs`（23/23 passed）

## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
