### PR TITLE
fix(session): prevent duplicate memories during redo recovery

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -145,6 +145,7 @@ class OpenVikingService:
             agfs=self._agfs_client,
             lock_timeout=tx_cfg.lock_timeout,
             lock_expire=tx_cfg.lock_expire,
+            vikingdb=self._vikingdb_manager,
         )
 
     @property

--- a/openviking/session/compressor.py
+++ b/openviking/session/compressor.py
@@ -192,7 +192,9 @@ class SessionCompressor:
                 chunk_msg = EmbeddingMsgConverter.from_context(chunk_memory)
                 if chunk_msg:
                     enqueued = await self.vikingdb.enqueue_embedding_msg(chunk_msg)
-                    if enqueued and chunk_msg.telemetry_id:
+                    if not enqueued:
+                        raise RuntimeError(f"Failed to enqueue memory chunk {chunk_memory.uri}")
+                    if chunk_msg.telemetry_id:
                         request_wait_tracker.register_embedding_root(
                             chunk_msg.telemetry_id, chunk_msg.id
                         )
@@ -200,7 +202,9 @@ class SessionCompressor:
         # Always enqueue the base record (uses abstract as vector text)
         embedding_msg = EmbeddingMsgConverter.from_context(memory)
         enqueued = await self.vikingdb.enqueue_embedding_msg(embedding_msg)
-        if enqueued and embedding_msg.telemetry_id:
+        if not enqueued:
+            raise RuntimeError(f"Failed to enqueue memory {memory.uri}")
+        if embedding_msg.telemetry_id:
             request_wait_tracker.register_embedding_root(
                 embedding_msg.telemetry_id, embedding_msg.id
             )
@@ -208,6 +212,38 @@ class SessionCompressor:
 
         self._record_semantic_change(memory.uri, change_type, parent_uri=memory.parent_uri)
         return True
+
+    async def _rollback_created_memory(self, memory: Context, ctx: RequestContext) -> None:
+        """Remove a newly-created memory when indexing fails."""
+        try:
+            viking_fs = get_viking_fs()
+            await viking_fs.rm(memory.uri, recursive=False, ctx=ctx)
+        except Exception as e:
+            logger.warning(f"Failed to rollback created memory {memory.uri}: {e}")
+
+        try:
+            await self.vikingdb.delete_uris(ctx, self._memory_index_uris(memory))
+        except Exception as e:
+            logger.debug(f"Failed to rollback vector records for {memory.uri}: {e}")
+
+    def _memory_index_uris(self, memory: Context) -> list[str]:
+        """Return base and chunk vector URIs that may have been enqueued."""
+        uris = [memory.uri]
+        try:
+            from openviking_cli.utils.config import get_openviking_config
+
+            semantic = get_openviking_config().semantic
+            vectorize_text = memory.get_vectorization_text()
+            if vectorize_text and len(vectorize_text) > semantic.memory_chunk_chars:
+                chunks = self._chunk_text(
+                    vectorize_text,
+                    semantic.memory_chunk_chars,
+                    semantic.memory_chunk_overlap,
+                )
+                uris.extend(f"{memory.uri}#chunk_{i:04d}" for i, _ in enumerate(chunks))
+        except Exception:
+            pass
+        return uris
 
     @staticmethod
     def _chunk_text(text: str, chunk_size: int, overlap: int) -> list:
@@ -305,6 +341,7 @@ class SessionCompressor:
         session_id: Optional[str] = None,
         ctx: Optional[RequestContext] = None,
         strict_extract_errors: bool = False,
+        strict_dedup_errors: bool = False,
         latest_archive_overview: str = "",
     ) -> List[Context]:
         """Extract long-term memories from messages."""
@@ -317,6 +354,9 @@ class SessionCompressor:
         }
         if not ctx:
             return []
+
+        if strict_dedup_errors and self.vikingdb is None:
+            raise RuntimeError("Memory extraction requires VikingDBManager in strict dedup mode")
 
         self._pending_semantic_changes.clear()
         telemetry = get_current_telemetry()
@@ -370,9 +410,13 @@ class SessionCompressor:
                                 candidate, user, session_id, ctx=ctx
                             )
                         if memory:
+                            try:
+                                await self._index_memory(memory, ctx)
+                            except Exception:
+                                await self._rollback_created_memory(memory, ctx)
+                                raise
                             memories.append(memory)
                             stats.created += 1
-                            await self._index_memory(memory, ctx)
                         else:
                             stats.skipped += 1
                         continue
@@ -439,7 +483,10 @@ class SessionCompressor:
                     # Dedup check for other categories
                     with telemetry.measure("memory.extract.stage.dedup"):
                         result = await self.deduplicator.deduplicate(
-                            candidate, ctx, batch_memories=batch_memories
+                            candidate,
+                            ctx,
+                            batch_memories=batch_memories,
+                            strict_errors=strict_dedup_errors,
                         )
                     actions = result.actions or []
                     decision = result.decision
@@ -536,9 +583,13 @@ class SessionCompressor:
                                 candidate, user, session_id, ctx=ctx
                             )
                         if memory:
+                            try:
+                                await self._index_memory(memory, ctx)
+                            except Exception:
+                                await self._rollback_created_memory(memory, ctx)
+                                raise
                             memories.append(memory)
                             stats.created += 1
-                            await self._index_memory(memory, ctx)
                             # Store embedding for batch-internal dedup of subsequent candidates (#687)
                             if result.query_vector:
                                 batch_memories.append((result.query_vector, memory))

--- a/openviking/session/compressor.py
+++ b/openviking/session/compressor.py
@@ -20,6 +20,7 @@ from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger
+from openviking_cli.utils.config import get_openviking_config
 
 from .memory_deduplicator import DedupDecision, MemoryActionDecision, MemoryDeduplicator
 from .memory_extractor import (
@@ -153,7 +154,7 @@ class SessionCompressor:
 
     async def _index_memory(
         self, memory: Context, ctx: RequestContext, change_type: str = "added"
-    ) -> bool:
+    ) -> list[str]:
         """Add memory to vectorization queue and record semantic change.
 
         For long memories, splits content into chunks and enqueues each chunk
@@ -163,13 +164,21 @@ class SessionCompressor:
             memory: The memory context to index
             ctx: Request context
             change_type: One of "added" or "modified"
+
+        Returns:
+            List of chunk URIs that were enqueued (empty for unchunked memories).
+            Also stashed on ``memory._indexed_chunk_uris`` so rollback can reach
+            partial state if the enqueue raises mid-loop.
         """
         from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
-        from openviking_cli.utils.config import get_openviking_config
 
         semantic = get_openviking_config().semantic
         request_wait_tracker = get_request_wait_tracker()
         vectorize_text = memory.get_vectorization_text()
+        chunk_uris: list[str] = []
+        # Stash incrementally so _rollback_created_memory can read partial state
+        # via the memory attr even if this call raises mid-loop.
+        memory._indexed_chunk_uris = chunk_uris  # type: ignore[attr-defined]
 
         if vectorize_text and len(vectorize_text) > semantic.memory_chunk_chars:
             # Chunk long memory into multiple vector records
@@ -198,6 +207,7 @@ class SessionCompressor:
                         request_wait_tracker.register_embedding_root(
                             chunk_msg.telemetry_id, chunk_msg.id
                         )
+                    chunk_uris.append(chunk_memory.uri)
 
         # Always enqueue the base record (uses abstract as vector text)
         embedding_msg = EmbeddingMsgConverter.from_context(memory)
@@ -211,39 +221,36 @@ class SessionCompressor:
         logger.info(f"Enqueued memory for vectorization: {memory.uri}")
 
         self._record_semantic_change(memory.uri, change_type, parent_uri=memory.parent_uri)
-        return True
+        return chunk_uris
 
-    async def _rollback_created_memory(self, memory: Context, ctx: RequestContext) -> None:
+    async def _rollback_created_memory(
+        self, memory: Context, ctx: RequestContext, chunk_uris: list[str]
+    ) -> None:
         """Remove a newly-created memory when indexing fails."""
         try:
             viking_fs = get_viking_fs()
             await viking_fs.rm(memory.uri, recursive=False, ctx=ctx)
-        except Exception as e:
-            logger.warning(f"Failed to rollback created memory {memory.uri}: {e}")
+        except FileNotFoundError:
+            # Nothing to roll back on disk; proceed to vector cleanup.
+            pass
+        except Exception:
+            # Re-raise to avoid leaving orphaned memory files on disk.
+            logger.error(f"Failed to rollback created memory {memory.uri}", exc_info=True)
+            raise
 
         try:
-            await self.vikingdb.delete_uris(ctx, self._memory_index_uris(memory))
+            await self.vikingdb.delete_uris(ctx, [memory.uri, *chunk_uris])
         except Exception as e:
             logger.debug(f"Failed to rollback vector records for {memory.uri}: {e}")
 
-    def _memory_index_uris(self, memory: Context) -> list[str]:
-        """Return base and chunk vector URIs that may have been enqueued."""
-        uris = [memory.uri]
+    async def _create_and_index(self, memory: Context, ctx: RequestContext) -> None:
+        """Index a freshly-created memory, rolling back the file on failure."""
         try:
-            from openviking_cli.utils.config import get_openviking_config
-
-            semantic = get_openviking_config().semantic
-            vectorize_text = memory.get_vectorization_text()
-            if vectorize_text and len(vectorize_text) > semantic.memory_chunk_chars:
-                chunks = self._chunk_text(
-                    vectorize_text,
-                    semantic.memory_chunk_chars,
-                    semantic.memory_chunk_overlap,
-                )
-                uris.extend(f"{memory.uri}#chunk_{i:04d}" for i, _ in enumerate(chunks))
+            await self._index_memory(memory, ctx)
         except Exception:
-            pass
-        return uris
+            chunk_uris = getattr(memory, "_indexed_chunk_uris", [])
+            await self._rollback_created_memory(memory, ctx, chunk_uris=chunk_uris)
+            raise
 
     @staticmethod
     def _chunk_text(text: str, chunk_size: int, overlap: int) -> list:
@@ -410,11 +417,7 @@ class SessionCompressor:
                                 candidate, user, session_id, ctx=ctx
                             )
                         if memory:
-                            try:
-                                await self._index_memory(memory, ctx)
-                            except Exception:
-                                await self._rollback_created_memory(memory, ctx)
-                                raise
+                            await self._create_and_index(memory, ctx)
                             memories.append(memory)
                             stats.created += 1
                         else:
@@ -583,11 +586,7 @@ class SessionCompressor:
                                 candidate, user, session_id, ctx=ctx
                             )
                         if memory:
-                            try:
-                                await self._index_memory(memory, ctx)
-                            except Exception:
-                                await self._rollback_created_memory(memory, ctx)
-                                raise
+                            await self._create_and_index(memory, ctx)
                             memories.append(memory)
                             stats.created += 1
                             # Store embedding for batch-internal dedup of subsequent candidates (#687)

--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -107,6 +107,12 @@ class SessionCompressorV2:
         if strict_dedup_errors and self.vikingdb is None:
             raise RuntimeError("Memory extraction requires VikingDBManager in strict dedup mode")
 
+        # TODO: Thread strict_dedup_errors into updater.apply_operations so v2
+        # honors strict dedup the same way v1 does. Redo recovery still calls
+        # into v1 via create_session_compressor, so this only matters once v2
+        # is reachable from the redo path.
+        assert not strict_dedup_errors or self.vikingdb is not None
+
         tracer.info("Starting v2 memory extraction from conversation")
         tracer.info(f"messages={JsonUtils.dumps(messages)}")
         config = get_openviking_config()

--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -88,6 +88,7 @@ class SessionCompressorV2:
         session_id: Optional[str] = None,
         ctx: Optional[RequestContext] = None,
         strict_extract_errors: bool = False,
+        strict_dedup_errors: bool = False,
         latest_archive_overview: str = "",
     ) -> List[Context]:
         """Extract long-term memories from messages using v2 templating system.
@@ -102,6 +103,9 @@ class SessionCompressorV2:
         if not ctx:
             logger.warning("No RequestContext provided, skipping memory extraction")
             return []
+
+        if strict_dedup_errors and self.vikingdb is None:
+            raise RuntimeError("Memory extraction requires VikingDBManager in strict dedup mode")
 
         tracer.info("Starting v2 memory extraction from conversation")
         tracer.info(f"messages={JsonUtils.dumps(messages)}")
@@ -130,7 +134,7 @@ class SessionCompressorV2:
         lock_manager = None
         transaction_handle = None
         if viking_fs and hasattr(viking_fs, "agfs") and viking_fs.agfs:
-            init_lock_manager(viking_fs.agfs)
+            init_lock_manager(viking_fs.agfs, vikingdb=self.vikingdb)
             lock_manager = get_lock_manager()
             transaction_handle = lock_manager.create_handle()
         else:

--- a/openviking/session/memory_deduplicator.py
+++ b/openviking/session/memory_deduplicator.py
@@ -102,11 +102,15 @@ class MemoryDeduplicator:
         ctx: RequestContext,
         *,
         batch_memories: list[tuple[list[float], Context]] | None = None,
+        strict_errors: bool = False,
     ) -> DedupResult:
         """Decide how to handle a candidate memory."""
         # Step 1: Vector pre-filtering - find similar memories in same category
         similar_memories, query_vector = await self._find_similar_memories(
-            candidate, ctx=ctx, batch_memories=batch_memories
+            candidate,
+            ctx=ctx,
+            batch_memories=batch_memories,
+            strict_errors=strict_errors,
         )
 
         if not similar_memories:
@@ -138,6 +142,7 @@ class MemoryDeduplicator:
         ctx: RequestContext,
         *,
         batch_memories: list[tuple[list[float], Context]] | None = None,
+        strict_errors: bool = False,
     ) -> tuple[list[Context], list[float]]:
         """Find similar existing memories using vector search.
 
@@ -147,7 +152,14 @@ class MemoryDeduplicator:
         telemetry = get_current_telemetry()
         query_vector: list[float] = []  # Initialize early for safe returns
 
+        if self.vikingdb is None:
+            if strict_errors:
+                raise RuntimeError("Memory dedup requires VikingDBManager")
+            return [], query_vector
+
         if not self.embedder:
+            if strict_errors:
+                raise RuntimeError("Memory dedup requires an embedder")
             return [], query_vector
 
         # Generate embedding for candidate
@@ -224,6 +236,8 @@ class MemoryDeduplicator:
             logger.warning(f"Vector search cancelled during dedup prefilter: {e}")
             return [], query_vector
         except Exception as e:
+            if strict_errors:
+                raise RuntimeError(f"Memory dedup vector search failed: {e}") from e
             logger.warning(f"Vector search failed: {e}")
             return [], query_vector
 

--- a/openviking/session/memory_deduplicator.py
+++ b/openviking/session/memory_deduplicator.py
@@ -15,7 +15,12 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 from openviking.core.context import Context
-from openviking.core.namespace import canonical_agent_root, canonical_user_root
+from openviking.core.namespace import (
+    agent_space_fragment,
+    canonical_agent_root,
+    canonical_user_root,
+    user_space_fragment,
+)
 from openviking.models.embedder.base import EmbedResult, embed_compat
 from openviking.prompts import render_prompt
 from openviking.server.identity import RequestContext
@@ -82,6 +87,15 @@ class MemoryDeduplicator:
         elif category in MemoryDeduplicator._AGENT_CATEGORIES:
             return f"{canonical_agent_root(ctx)}/memories/{category}/"
         return ""
+
+    @staticmethod
+    def _owner_space(category: str, ctx: RequestContext) -> str | None:
+        """Return the owner space for the candidate category."""
+        if category in MemoryDeduplicator._USER_CATEGORIES:
+            return user_space_fragment(ctx)
+        if category in MemoryDeduplicator._AGENT_CATEGORIES:
+            return agent_space_fragment(ctx)
+        return None
 
     def __init__(
         self,
@@ -167,18 +181,19 @@ class MemoryDeduplicator:
         embed_result: EmbedResult = await embed_compat(self.embedder, query_text, is_query=True)
         query_vector = embed_result.dense_vector
 
+        owner_space = self._owner_space(candidate.category.value, ctx)
         category_uri_prefix = self._category_uri_prefix(candidate.category.value, ctx)
         logger.debug(
             "Dedup prefilter candidate category=%s owner_space=%s uri_prefix=%s",
             candidate.category.value,
-            None,
+            owner_space,
             category_uri_prefix,
         )
 
         try:
             # Search with memory-scope filter.
             results = await self.vikingdb.search_similar_memories(
-                owner_space=None,
+                owner_space=owner_space,
                 category_uri_prefix=category_uri_prefix,
                 query_vector=query_vector,
                 limit=5,

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -713,8 +713,6 @@ class Session:
             )
             logger.info(f"Session {self.session_id} memory extraction completed")
         except Exception as e:
-            if redo_task_id:
-                get_lock_manager().redo_log.mark_done(redo_task_id)
             await self._write_failed_marker(
                 archive_uri,
                 stage="memory_extraction",

--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -265,8 +265,8 @@ class LockManager:
     async def _redo_session_memory(self, info: Dict[str, Any]) -> None:
         """Re-extract memories from archive.
 
-        Lets exceptions from _enqueue_semantic propagate so the caller
-        can decide whether to mark the redo task as done.
+        Lets redo recovery exceptions propagate so the caller can decide
+        whether to mark the redo task as done.
         """
         from openviking.message import Message
         from openviking.server.identity import RequestContext, Role

--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -305,9 +305,7 @@ class LockManager:
         except Exception as e:
             logger.warning(f"Cannot read archive for redo: {agfs_path}: {e}")
 
-        # 3. Re-extract memories. Redo recovery must use the normal compressor
-        # dependencies; otherwise dedup can fail open and replay can create
-        # duplicate memory files after indexing fails.
+        # Redo requires a real VikingDBManager so strict-dedup is honored.
         if messages:
             session_id = session_uri.rstrip("/").rsplit("/", 1)[-1]
             if self._vikingdb is None:

--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -5,13 +5,16 @@
 import asyncio
 import json
 import time
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from openviking.pyagfs import AGFSClient
 from openviking.storage.transaction.lock_handle import LockHandle
 from openviking.storage.transaction.path_lock import PathLock
 from openviking.storage.transaction.redo_log import RedoLog
 from openviking_cli.utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from openviking.storage import VikingDBManager
 
 logger = get_logger(__name__)
 
@@ -26,8 +29,10 @@ class LockManager:
         agfs: AGFSClient,
         lock_timeout: float = 0.0,
         lock_expire: float = 300.0,
+        vikingdb: Optional["VikingDBManager"] = None,
     ):
         self._agfs = agfs
+        self._vikingdb = vikingdb
         self._path_lock = PathLock(agfs, lock_expire=lock_expire)
         self._lock_timeout = lock_timeout
         self._redo_log = RedoLog(agfs)
@@ -300,35 +305,28 @@ class LockManager:
         except Exception as e:
             logger.warning(f"Cannot read archive for redo: {agfs_path}: {e}")
 
-        # 3. Re-extract memories (best-effort, only if archive was readable)
+        # 3. Re-extract memories. Redo recovery must use the normal compressor
+        # dependencies; otherwise dedup can fail open and replay can create
+        # duplicate memory files after indexing fails.
         if messages:
             session_id = session_uri.rstrip("/").rsplit("/", 1)[-1]
-            try:
-                from openviking.session import create_session_compressor
+            if self._vikingdb is None:
+                raise RuntimeError("Cannot redo session_memory: VikingDBManager not available")
 
-                compressor = create_session_compressor(vikingdb=None)
-                memories = await asyncio.wait_for(
-                    compressor.extract_long_term_memories(
-                        messages=messages,
-                        user=user,
-                        session_id=session_id,
-                        ctx=ctx,
-                    ),
-                    timeout=60.0,
-                )
-                logger.info(f"Redo: extracted {len(memories)} memories from {archive_uri}")
-            except Exception as e:
-                logger.warning(f"Redo: memory extraction failed ({e}), falling back to queue")
+            from openviking.session import create_session_compressor
 
-        # 4. Always enqueue semantic processing as fallback
-        await self._enqueue_semantic(
-            uri=session_uri,
-            context_type="memory",
-            account_id=account_id,
-            user_id=user_id,
-            agent_id=agent_id,
-            role=role_str,
-        )
+            compressor = create_session_compressor(vikingdb=self._vikingdb)
+            memories = await asyncio.wait_for(
+                compressor.extract_long_term_memories(
+                    messages=messages,
+                    user=user,
+                    session_id=session_id,
+                    ctx=ctx,
+                    strict_dedup_errors=True,
+                ),
+                timeout=60.0,
+            )
+            logger.info(f"Redo: extracted {len(memories)} memories from {archive_uri}")
 
     async def _enqueue_semantic(self, **params: Any) -> None:
         from openviking.storage.queuefs import get_queue_manager
@@ -367,9 +365,15 @@ def init_lock_manager(
     agfs: AGFSClient,
     lock_timeout: float = 0.0,
     lock_expire: float = 300.0,
+    vikingdb: Optional["VikingDBManager"] = None,
 ) -> LockManager:
     global _lock_manager
-    _lock_manager = LockManager(agfs=agfs, lock_timeout=lock_timeout, lock_expire=lock_expire)
+    _lock_manager = LockManager(
+        agfs=agfs,
+        lock_timeout=lock_timeout,
+        lock_expire=lock_expire,
+        vikingdb=vikingdb,
+    )
     return _lock_manager
 
 

--- a/tests/session/test_memory_dedup_actions.py
+++ b/tests/session/test_memory_dedup_actions.py
@@ -791,9 +791,7 @@ class TestSessionCompressorDedupActions:
 
         call_count = 0
 
-        async def _deduplicate(
-            candidate, ctx, *, batch_memories=None, strict_errors=False
-        ):
+        async def _deduplicate(candidate, ctx, *, batch_memories=None, strict_errors=False):
             nonlocal call_count
             call_count += 1
             assert strict_errors is False

--- a/tests/session/test_memory_dedup_actions.py
+++ b/tests/session/test_memory_dedup_actions.py
@@ -614,7 +614,9 @@ class TestSessionCompressorDedupActions:
                 ctx=request_ctx,
             )
 
-        compressor._rollback_created_memory.assert_awaited_once_with(new_memory, request_ctx)
+        compressor._rollback_created_memory.assert_awaited_once_with(
+            new_memory, request_ctx, chunk_uris=[]
+        )
 
     async def test_create_with_merge_is_executed_as_none(self):
         candidate = _make_candidate()

--- a/tests/session/test_memory_dedup_actions.py
+++ b/tests/session/test_memory_dedup_actions.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from openviking.core.context import Context
-from openviking.message import Message
+from openviking.message import Message, TextPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session.compressor import SessionCompressor
 from openviking.session.memory_deduplicator import (
@@ -27,6 +27,12 @@ from openviking_cli.session.user_id import UserIdentifier
 from tests.utils.mock_context import make_test_ctx
 
 ctx = make_test_ctx()
+
+
+@pytest.fixture
+def client():
+    """This unit test module does not need the session package's real client fixture."""
+    return None
 
 
 class _DummyVikingDB:
@@ -139,6 +145,15 @@ class TestMemoryDeduplicatorPayload:
 
         assert decision == DedupDecision.SKIP
         assert actions == []
+
+    @pytest.mark.asyncio
+    async def test_strict_dedup_raises_when_vector_search_fails(self):
+        vikingdb = MagicMock()
+        vikingdb.search_similar_memories = AsyncMock(side_effect=RuntimeError("vector down"))
+        dedup = _make_dedup(vikingdb=vikingdb, embedder=_DummyEmbedder())
+
+        with pytest.raises(RuntimeError, match="Memory dedup vector search failed"):
+            await dedup.deduplicate(_make_candidate(), _make_ctx(), strict_errors=True)
 
     def test_cross_facet_delete_actions_are_kept(self):
         dedup = MemoryDeduplicator(vikingdb=_DummyVikingDB())
@@ -569,6 +584,38 @@ class TestSessionCompressorDedupActions:
         fs.rm.assert_not_called()
         compressor.extractor.create_memory.assert_awaited_once()
 
+    async def test_created_memory_is_rolled_back_when_indexing_fails(self):
+        candidate = _make_candidate()
+        new_memory = _make_existing("created.md")
+
+        compressor = _make_compressor(vikingdb=MagicMock(), embedder=_DummyEmbedder())
+        compressor.extractor.extract = AsyncMock(return_value=[candidate])
+        compressor.extractor.create_memory = AsyncMock(return_value=new_memory)
+        compressor.deduplicator.deduplicate = AsyncMock(
+            return_value=DedupResult(
+                decision=DedupDecision.CREATE,
+                candidate=candidate,
+                similar_memories=[],
+                actions=[],
+            )
+        )
+        compressor._index_memory = AsyncMock(side_effect=RuntimeError("enqueue failed"))
+        compressor._rollback_created_memory = AsyncMock()
+        request_ctx = _make_ctx()
+
+        with (
+            patch("openviking.session.compressor.get_viking_fs", return_value=MagicMock()),
+            pytest.raises(RuntimeError, match="enqueue failed"),
+        ):
+            await compressor.extract_long_term_memories(
+                [Message(id="msg1", role="user", parts=[TextPart("test message")])],
+                user=_make_user(),
+                session_id="session_test",
+                ctx=request_ctx,
+            )
+
+        compressor._rollback_created_memory.assert_awaited_once_with(new_memory, request_ctx)
+
     async def test_create_with_merge_is_executed_as_none(self):
         candidate = _make_candidate()
         target = _make_existing("merge_target.md")
@@ -744,9 +791,12 @@ class TestSessionCompressorDedupActions:
 
         call_count = 0
 
-        async def _deduplicate(candidate, ctx, *, batch_memories=None):
+        async def _deduplicate(
+            candidate, ctx, *, batch_memories=None, strict_errors=False
+        ):
             nonlocal call_count
             call_count += 1
+            assert strict_errors is False
             if call_count == 1:
                 assert batch_memories is None or len(batch_memories) == 0
                 return DedupResult(

--- a/tests/transaction/test_redo_memory_recovery.py
+++ b/tests/transaction/test_redo_memory_recovery.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for redo session-memory recovery."""
+
+import json
+from unittest.mock import MagicMock
+
+from openviking.message import Message
+from openviking.storage.transaction.lock_manager import LockManager
+
+
+class _FakeAGFS:
+    def __init__(self, message: Message):
+        self.message = message
+
+    def cat(self, path: str):
+        assert path == "/local/session/archive/messages.jsonl"
+        return json.dumps(self.message.to_dict())
+
+
+class _FakeVikingFS:
+    def _uri_to_path(self, uri, ctx=None):
+        del uri, ctx
+        return "/local/session/archive/messages.jsonl"
+
+
+def _redo_info():
+    return {
+        "archive_uri": "viking://session/acc/user/session/history/archive_001",
+        "session_uri": "viking://session/acc/user/session",
+        "account_id": "acc",
+        "user_id": "user",
+        "agent_id": "agent",
+        "role": "root",
+    }
+
+
+async def test_redo_keeps_marker_without_vikingdb(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.storage.viking_fs.get_viking_fs",
+        lambda: _FakeVikingFS(),
+    )
+
+    lm = LockManager(agfs=_FakeAGFS(Message.create_user("remember this")))
+    lm._redo_log = MagicMock()
+    lm._redo_log.list_pending.return_value = ["redo-task"]
+    lm._redo_log.read.return_value = _redo_info()
+
+    await lm._recover_pending_redo()
+
+    lm._redo_log.mark_done.assert_not_called()
+
+
+async def test_redo_uses_vikingdb_compressor_with_strict_dedup(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.storage.viking_fs.get_viking_fs",
+        lambda: _FakeVikingFS(),
+    )
+
+    captured = {}
+
+    class FakeCompressor:
+        async def extract_long_term_memories(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+    vikingdb = MagicMock()
+    lm = LockManager(
+        agfs=_FakeAGFS(Message.create_user("remember this")),
+        vikingdb=vikingdb,
+    )
+    lm._redo_log = MagicMock()
+    lm._redo_log.list_pending.return_value = ["redo-task"]
+    lm._redo_log.read.return_value = _redo_info()
+
+    create_compressor = MagicMock(return_value=FakeCompressor())
+    monkeypatch.setattr("openviking.session.create_session_compressor", create_compressor)
+
+    await lm._recover_pending_redo()
+
+    create_compressor.assert_called_once_with(vikingdb=vikingdb)
+    assert captured["strict_dedup_errors"] is True
+    lm._redo_log.mark_done.assert_called_once_with("redo-task")


### PR DESCRIPTION
## Description

Redo recovery currently creates the session compressor with `vikingdb=None`, so memory
deduplication can fail open during replay. It can also write a memory file before vector
indexing fails, because indexing later calls `self.vikingdb.enqueue_embedding_msg(...)`
on `None`.

One concrete failure case:

1. A session commit archives messages and writes a redo marker.
2. Recovery replays that marker after restart.
3. The compressor extracts a memory such as `User prefers dark mode`.
4. The memory file is written successfully.
5. Vector indexing fails with `'NoneType' object has no attribute 'enqueue_embedding_msg'`.
6. The failure is caught as best-effort recovery and falls back to semantic queueing.
7. If the same redo path runs again, dedup cannot find the prior memory through vector
   search because it was never indexed.
8. The same memory can be written again as a second durable file.

I reproduced this on current upstream `main` with a local deterministic PoC. The PoC
replayed the same redo payload twice and observed the compressor factory receiving
`vikingdb=None` both times:

```text
Redo: memory extraction failed ('NoneType' object has no attribute 'enqueue_embedding_msg'), falling back to queue
Redo: memory extraction failed ('NoneType' object has no attribute 'enqueue_embedding_msg'), falling back to queue
factory_vikingdb_args=[None, None]
created_memories=[
  'viking://user/user/memories/preferences/dark-mode-1.md',
  'viking://user/user/memories/preferences/dark-mode-2.md'
]
duplicate_abstract='User prefers dark mode' created_count=2
poc_result=broken
```

That leaves durable duplicate memory files even though redo replay is intended to be
idempotent.

This PR makes redo recovery use the initialized `VikingDBManager`, fail closed when
strict dedup/indexing dependencies are unavailable, and roll back newly-created memory
files if indexing cannot be enqueued.

## Related Issue

Related to #1237

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Pass `VikingDBManager` into redo memory recovery.
- Add strict dedup mode for redo replay.
- Roll back newly-created memories when indexing fails.
- Keep redo markers pending when memory extraction fails.
- Add regression tests for the duplicate-memory failure path.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```shell
ruff check openviking/storage/transaction/lock_manager.py openviking/session/compressor.py openviking/session/compressor_v2.py openviking/session/memory_deduplicator.py openviking/session/session.py openviking/service/core.py tests/session/test_memory_dedup_actions.py tests/transaction/test_redo_memory_recovery.py
python -m pytest -o addopts='' tests/session/test_memory_dedup_actions.py tests/transaction/test_redo_memory_recovery.py
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

#1237 covers queue readiness during redo recovery. This PR covers the separate issue
where redo memory extraction runs without vector-backed deduplication and can create
durable duplicate memories.
