### PR TITLE
fix(openclaw-plugin): enforce assemble token budgets

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -117,10 +117,12 @@ const RESERVED_MIN = 20_000;
 const RESERVED_RATIO = 0.15;
 const ARCHIVE_INDEX_TRIM_LIMIT = 10;
 
-function allocateContextBudget(totalBudget: number): ContextBudgets {
-  const reserved = Math.max(totalBudget * RESERVED_RATIO, RESERVED_MIN);
-  const archiveMemory = Math.min(totalBudget * ARCHIVE_BUDGET_RATIO, ARCHIVE_BUDGET_CAP);
-  const sessionContext = Math.max(totalBudget - archiveMemory - reserved, 0);
+function allocateContextBudget(totalBudget: number, instructionTokens = 0): ContextBudgets {
+  const reserveFloor = totalBudget >= RESERVED_MIN * 2 ? RESERVED_MIN : 0;
+  const reserved = Math.min(totalBudget, Math.max(totalBudget * RESERVED_RATIO, reserveFloor));
+  const usableBudget = Math.max(totalBudget - reserved - instructionTokens, 0);
+  const archiveMemory = Math.min(usableBudget * ARCHIVE_BUDGET_RATIO, ARCHIVE_BUDGET_CAP);
+  const sessionContext = Math.max(usableBudget - archiveMemory, 0);
   return { archiveMemory, sessionContext, reserved };
 }
 
@@ -715,15 +717,21 @@ export function createMemoryOpenVikingContextEngine(params: {
     budgets: ContextBudgets;
     instruction: { text: string; tokens: number };
   } {
-    // 4-layer context partitioning (budget computed for diag; BUDGET_UNLIMITED bypasses limits):
+    const hasArchives = Boolean(overview) || preAbstracts.length > 0;
+    const instruction = hasArchives ? buildInstructionPrompt() : { text: "", tokens: 0 };
+
+    // 4-layer context partitioning:
     //   Instruction — system prompt guide (Archive Index / Session History usage)
     //   Archive     — session history summary + per-archive one-line abstracts
     //   Session     — active OV messages converted to AgentMessage format
     //   Reserved    — headroom for model output (not consumed here)
-    const budgets = allocateContextBudget(tokenBudget);
-    const instruction = buildInstructionPrompt();
-    const archive = buildArchiveMemory(overview, preAbstracts, BUDGET_UNLIMITED);
-    const session = buildSessionContext(ovMessages, BUDGET_UNLIMITED);
+    const budgets = allocateContextBudget(tokenBudget, instruction.tokens);
+    const archive = buildArchiveMemory(overview, preAbstracts, budgets.archiveMemory);
+    const sessionBudget = Math.max(
+      tokenBudget - budgets.reserved - instruction.tokens - archive.tokens,
+      0,
+    );
+    const session = buildSessionContext(ovMessages, sessionBudget);
     const assembled = [...archive.messages, ...session.messages];
 
     logger.info(
@@ -824,7 +832,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           });
         }
 
-        const assembledTokens = roughEstimate(sanitized);
+        const assembledTokens = roughEstimate(sanitized) + instruction.tokens;
         const tokensSaved = originalTokens - assembledTokens;
         const savingPct = originalTokens > 0 ? Math.round((tokensSaved / originalTokens) * 100) : 0;
 
@@ -848,7 +856,7 @@ export function createMemoryOpenVikingContextEngine(params: {
         return {
           messages: sanitized,
           estimatedTokens: assembledTokens,
-          ...(hasArchives ? { systemPromptAddition: instruction.text } : {}),
+          ...(instruction.text ? { systemPromptAddition: instruction.text } : {}),
         };
       } catch (err) {
         logger.warn?.(

--- a/examples/openclaw-plugin/tests/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/context-engine-assemble.test.ts
@@ -16,6 +16,10 @@ function roughEstimate(messages: unknown[]): number {
   return Math.ceil(JSON.stringify(messages).length / 4);
 }
 
+function systemPromptTokens(text?: string): number {
+  return text ? Math.ceil(text.length / 4) : 0;
+}
+
 function makeLogger() {
   return {
     info: vi.fn(),
@@ -110,7 +114,9 @@ describe("context-engine assemble()", () => {
 
     expect(resolveAgentId).toHaveBeenCalledWith("session-1", undefined, "session-1");
     expect(client.getSessionContext).toHaveBeenCalledWith("session-1", 4096, "agent:session-1");
-    expect(result.estimatedTokens).toBe(roughEstimate(result.messages));
+    expect(result.estimatedTokens).toBe(
+      roughEstimate(result.messages) + systemPromptTokens(result.systemPromptAddition),
+    );
     expect(result.systemPromptAddition).toContain("Session Context Guide");
     expect(result.messages).toEqual([
       {
@@ -285,5 +291,45 @@ describe("context-engine assemble()", () => {
       messages: liveMessages,
       estimatedTokens: roughEstimate(liveMessages),
     });
+  });
+
+  it("keeps assembled output within the requested token budget", async () => {
+    const longText = "A".repeat(2500);
+    const { engine } = makeEngine({
+      latest_archive_overview: "# Session Summary\nA short overview",
+      pre_archive_abstracts: [],
+      messages: [
+        {
+          id: "msg_long_1",
+          role: "user",
+          created_at: "2026-03-24T00:00:00Z",
+          parts: [{ type: "text", text: longText }],
+        },
+        {
+          id: "msg_long_2",
+          role: "assistant",
+          created_at: "2026-03-24T00:00:01Z",
+          parts: [{ type: "text", text: longText }],
+        },
+      ],
+      estimatedTokens: 2000,
+      stats: {
+        ...makeStats(),
+        totalArchives: 1,
+        includedArchives: 1,
+        activeTokens: 2000,
+        archiveTokens: 10,
+      },
+    });
+
+    const result = await engine.assemble({
+      sessionId: "session-budgeted",
+      messages: [],
+      tokenBudget: 1024,
+    });
+
+    expect(result.estimatedTokens).toBeLessThanOrEqual(1024);
+    expect(result.messages.length).toBeGreaterThan(0);
+    expect(result.systemPromptAddition).toContain("Session Context Guide");
   });
 });

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -16,6 +16,10 @@ function roughEstimate(messages: unknown[]): number {
   return Math.ceil(JSON.stringify(messages).length / 4);
 }
 
+function systemPromptTokens(text?: string): number {
+  return text ? Math.ceil(text.length / 4) : 0;
+}
+
 function makeLogger() {
   return {
     info: vi.fn(),
@@ -123,7 +127,9 @@ describe("context-engine assemble()", () => {
 
     expect(resolveAgentId).toHaveBeenCalledWith("session-1", undefined, "session-1");
     expect(client.getSessionContext).toHaveBeenCalledWith("session-1", 4096, "agent:session-1");
-    expect(result.estimatedTokens).toBe(roughEstimate(result.messages));
+    expect(result.estimatedTokens).toBe(
+      roughEstimate(result.messages) + systemPromptTokens(result.systemPromptAddition),
+    );
     expect(result.systemPromptAddition).toContain("Session Context Guide");
     expect(result.messages[0]).toEqual({
       role: "user",
@@ -432,6 +438,46 @@ describe("context-engine assemble()", () => {
       role: "user",
       content: expect.stringContaining("Session History Summary"),
     });
+    expect(result.systemPromptAddition).toContain("Session Context Guide");
+  });
+
+  it("keeps assembled output within the requested token budget", async () => {
+    const longText = "A".repeat(2500);
+    const { engine } = makeEngine({
+      latest_archive_overview: "# Session Summary\nA short overview",
+      pre_archive_abstracts: [],
+      messages: [
+        {
+          id: "msg_long_1",
+          role: "user",
+          created_at: "2026-03-24T00:00:00Z",
+          parts: [{ type: "text", text: longText }],
+        },
+        {
+          id: "msg_long_2",
+          role: "assistant",
+          created_at: "2026-03-24T00:00:01Z",
+          parts: [{ type: "text", text: longText }],
+        },
+      ],
+      estimatedTokens: 2000,
+      stats: {
+        ...makeStats(),
+        totalArchives: 1,
+        includedArchives: 1,
+        activeTokens: 2000,
+        archiveTokens: 10,
+      },
+    });
+
+    const result = await engine.assemble({
+      sessionId: "session-budgeted",
+      messages: [],
+      tokenBudget: 1024,
+    });
+
+    expect(result.estimatedTokens).toBeLessThanOrEqual(1024);
+    expect(result.messages.length).toBeGreaterThan(0);
     expect(result.systemPromptAddition).toContain("Session Context Guide");
   });
 


### PR DESCRIPTION
## Summary
- enforce `assemble()` token budgeting in the OpenClaw plugin instead of building archive/session context with unlimited budgets
- include instruction/system prompt tokens in `estimatedTokens` so OpenClaw no longer underestimates the true prompt size
- add regression coverage for token accounting and budget-bounded assemble output

## Root Cause
Issue #1364 is caused by the OpenViking OpenClaw plugin computing a context budget but not actually applying it when building assembled context:
- `archive` and `session` content were assembled with effectively unlimited budgets
- `estimatedTokens` did not include `systemPromptAddition` / instruction tokens

That combination lets the plugin return a prompt estimate that is smaller than the real prompt. OpenClaw therefore delays compaction and can end up surfacing `Context limit exceeded` / overflow errors even though the plugin believed the assembled context was still within budget.

This change makes the budget real:
- reserve headroom before composing archive/session content
- subtract instruction tokens from usable budget
- bound archive/session slices to the remaining budget
- report `estimatedTokens` including instruction tokens

## Validation
### Automated
- `cd examples/openclaw-plugin && npm test -- --run tests/ut/context-engine-assemble.test.ts tests/context-engine-assemble.test.ts`

### Real E2E / reproduction notes
Validated against the issue's version pairing:
- OpenClaw `2026.4.10`
- OpenViking `0.3.5`
- OpenViking launched with the repo `ov.conf`

A direct “long prompt” E2E is noisy because the currently available real model hits its own context ceiling sharply. To isolate the plugin bug, I also compared `assemble()` on the same real OpenViking session before and after the fix.

Using a real OV session with archived history plus active messages:
- session state: `totalArchives=10`, `activeMessages=20`
- at `tokenBudget=8192`
  - baseline: `estimatedTokens=9328`, `messages=20`
  - fixed: `estimatedTokens=6810`, `messages=14`
- at `tokenBudget=6144`
  - baseline: `estimatedTokens=9328`
  - fixed: `estimatedTokens=4987`

So the same OV context that exceeded budget before the patch is brought back under budget after the patch, which is the exact failure mode behind #1364.

## Notes
- Extremely large single-turn payloads can still exceed the model's actual context window even after this fix. That is a separate provider/window limit, not the plugin budgeting bug fixed here.
