### PR TITLE
fix(text-utils): exclude cron/maintenance prompts from ingest-reply-assist injection

### DIFF
--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -171,6 +171,37 @@ describe("isTranscriptLikeIngest", () => {
     expect(result.shouldAssist).toBe(false);
     expect(result.reason).toBe("speaker_turns_below_threshold");
   });
+
+  it("daily maintenance prompt → shouldAssist=false (issue #982)", () => {
+    const text =
+      "Daily memory maintenance. Read skills/opencortex/references/distillation.md for full instructions and follow them. Workspace: /Users/neo/.openclaw/workspace";
+    const result = isTranscriptLikeIngest(text, { minSpeakerTurns: 2, minChars: 50 });
+    expect(result.shouldAssist).toBe(false);
+    expect(result.reason).toBe("cron_maintenance_task");
+  });
+
+  it("weekly synthesis prompt → shouldAssist=false", () => {
+    const text =
+      "Weekly memory synthesis. Read skills/opencortex/references/synthesis.md for full instructions and follow them. Workspace: /home/user/.openclaw/workspace";
+    const result = isTranscriptLikeIngest(text, { minSpeakerTurns: 2, minChars: 50 });
+    expect(result.shouldAssist).toBe(false);
+    expect(result.reason).toBe("cron_maintenance_task");
+  });
+
+  it("nightly distillation prompt → shouldAssist=false", () => {
+    const text =
+      "Nightly distillation task. Read skills/memory/distillation.md and execute full workflow. lockfile at /tmp/distill.lock. Workspace: /data/openclaw/workspace";
+    const result = isTranscriptLikeIngest(text, { minSpeakerTurns: 2, minChars: 50 });
+    expect(result.shouldAssist).toBe(false);
+    expect(result.reason).toBe("cron_maintenance_task");
+  });
+
+  it("genuine multi-speaker transcript still triggers assist", () => {
+    const text = "Alice: 今天的会议主要讨论Q2目标\nBob: 我觉得我们应该把重点放在用户增长上\nAlice: 同意，那我们就定下来吧";
+    const result = isTranscriptLikeIngest(text, { minSpeakerTurns: 2, minChars: 50 });
+    expect(result.shouldAssist).toBe(true);
+    expect(result.reason).toBe("transcript_like_ingest");
+  });
 });
 
 describe("extractNewTurnTexts", () => {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -24,6 +24,10 @@ const COMPACTED_SYSTEM_MSG_RE = /^System:\s*\[.*?\]\s*Compacted\s*(.+)$/i;
 const COMMAND_TEXT_RE = /^\/[a-z0-9_-]{1,64}\b/i;
 const NON_CONTENT_TEXT_RE = /^[\p{P}\p{S}\s]+$/u;
 const SUBAGENT_CONTEXT_RE = /^\s*\[Subagent Context\]/i;
+// Matches cron/maintenance task prompts that should never be treated as transcript ingestion.
+// These are autonomous maintenance jobs (distillation, synthesis, workspace ops), not user transcripts.
+const CRON_MAINTENANCE_RE =
+  /(?:daily|weekly|monthly|nightly)\s+(?:memory\s+)?(?:maintenance|distillation|synthesis|digest|cleanup|summary)|(?:read\s+skills\/[^\s]+\/references\/|workspace:\s*\/[^\s]+|\.openviking\/workspace|lockfile|debrief\s+to\s+archived)/i;
 const MEMORY_INTENT_RE = /记住|记下|remember|save|store|偏好|preference|规则|rule|事实|fact/i;
 const QUESTION_CUE_RE =
   /[?？]|\b(?:what|when|where|who|why|how|which|can|could|would|did|does|is|are)\b|^(?:请问|能否|可否|怎么|如何|什么时候|谁|什么|哪|是否)/i;
@@ -192,6 +196,16 @@ export function isTranscriptLikeIngest(
     return {
       shouldAssist: false,
       reason: "subagent_context",
+      normalizedText,
+      speakerTurns: 0,
+      chars: normalizedText.length,
+    };
+  }
+
+  if (CRON_MAINTENANCE_RE.test(normalizedText)) {
+    return {
+      shouldAssist: false,
+      reason: "cron_maintenance_task",
       normalizedText,
       speakerTurns: 0,
       chars: normalizedText.length,


### PR DESCRIPTION
## Summary

Autonomous cron tasks (daily distillation, weekly synthesis, nightly cleanup) can contain structured text that accidentally triggers the speaker-turn heuristic in `isTranscriptLikeIngest`, causing `<ingest-reply-assist>` to be injected into maintenance runs.

- Two failure modes were reported: hard failure (maintenance run produces only one opening line, zero tool calls) and residual degraded mode (workflow completes but receives incorrect prompt augmentation)
- Root cause: `isTranscriptLikeIngest` checks content shape but has no awareness of cron/maintenance task context
- Fix: add `CRON_MAINTENANCE_RE` to detect these prompts by characteristic keywords — `daily/weekly/nightly maintenance/distillation/synthesis`, `skills/` reference paths, workspace paths, lockfile references — and short-circuit with `shouldAssist=false, reason="cron_maintenance_task"` before the speaker-turn check

## Changes

- `text-utils.ts`: add `CRON_MAINTENANCE_RE` constant and early-exit guard in `isTranscriptLikeIngest`
- `tests/ut/text-utils.test.ts`: four new regression tests — daily maintenance, weekly synthesis, nightly distillation, and a positive control confirming genuine transcripts still trigger the assist path

Fixes #982

## Test plan

- [ ] `npx vitest run tests/ut/text-utils.test.ts` — new tests pass, no regression in existing suite
- [ ] Daily/weekly maintenance cron prompts no longer receive `ingest-reply-assist` injection
- [ ] Genuine multi-speaker transcripts still correctly trigger `shouldAssist=true`