### PR TITLE
feat(vlm): add configurable enable_thinking flag

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -397,12 +397,15 @@ Vision Language Model for semantic extraction (L0/L1 generation).
 | `model` | str | Model name |
 | `api_base` | str | API endpoint (optional) |
 | `thinking` | bool | Enable thinking mode for VolcEngine models (default: `false`) |
+| `enable_thinking` | bool\|null | Control whether OpenAI-compatible and LiteLLM backends send `extra_body.enable_thinking`; `null` keeps the backend default allowlist behavior |
 | `max_concurrent` | int | Maximum concurrent semantic LLM calls (default: `100`) |
 | `max_retries` | int | Maximum retry attempts for transient VLM provider errors (default: `3`; `0` disables retry) |
 | `extra_headers` | object | Custom HTTP headers (for OpenAI-compatible providers, optional) |
 | `stream` | bool | Enable streaming mode (for OpenAI-compatible providers, default: `false`) |
 
 `vlm.max_retries` only applies to transient errors such as `429`, `5xx`, timeouts, and connection failures. Permanent authentication, authorization, and billing errors are not retried automatically. The backoff strategy is exponential backoff with jitter, starting at `0.5s` and capped at `8s`.
+
+Set `vlm.enable_thinking` to `true` to force sending `extra_body.enable_thinking` on OpenAI-compatible or LiteLLM backends, or to `false` to suppress that field entirely. Leaving it unset preserves the existing provider-detection behavior.
 
 **Available Models**
 
@@ -997,6 +1000,7 @@ For detailed encryption explanations, see [Data Encryption](../concepts/10-encry
     "model": "string",
     "api_base": "string",
     "thinking": false,
+    "enable_thinking": null,
     "max_concurrent": 100,
     "max_retries": 3,
     "extra_headers": {},

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -368,12 +368,15 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 | `model` | str | 模型名称 |
 | `api_base` | str | API 端点（可选） |
 | `thinking` | bool | 启用思考模式（仅对部分火山模型生效，默认：`false`） |
+| `enable_thinking` | bool\|null | 控制 OpenAI 兼容和 LiteLLM backend 是否发送 `extra_body.enable_thinking`；`null` 表示保持 backend 默认的 provider 判定行为 |
 | `max_concurrent` | int | 语义处理阶段 LLM 最大并发调用数（默认：`100`） |
 | `max_retries` | int | VLM provider 瞬时错误的最大重试次数（默认：`3`；`0` 表示禁用重试） |
 | `extra_headers` | object | 自定义 HTTP 请求头（OpenAI 兼容 provider 可用，可选） |
 | `stream` | bool | 启用流式模式（OpenAI 兼容 provider 可用，默认：`false`） |
 
 `vlm.max_retries` 仅对瞬时错误生效，例如 `429`、`5xx`、超时和连接错误；认证、鉴权、欠费等永久错误不会自动重试。退避策略为指数退避，初始延迟 `0.5s`，上限 `8s`，并带随机抖动。
+
+将 `vlm.enable_thinking` 设为 `true` 可强制在 OpenAI 兼容或 LiteLLM backend 上发送 `extra_body.enable_thinking`，设为 `false` 则完全禁止发送该字段。不设置时会保持现有的 provider 自动判定逻辑。
 
 **可用模型**
 
@@ -970,6 +973,7 @@ openviking add-resource ./docs --exclude "*.tmp"
     "model": "string",
     "api_base": "string",
     "thinking": false,
+    "enable_thinking": null,
     "max_concurrent": 100,
     "max_retries": 3,
     "extra_headers": {},

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -227,11 +227,14 @@ class LiteLLMVLMProvider(VLMBase):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
-        # Only send enable_thinking to DashScope-compatible providers
         provider = self._detected_provider or detect_provider_by_model(model)
-        if provider == "dashscope":
-            extra = kwargs.get("extra_body", {})
-            extra["enable_thinking"] = thinking
+        enable_thinking = self._resolve_enable_thinking_value(
+            thinking=thinking,
+            auto_supported=provider == "dashscope",
+        )
+        if enable_thinking is not None:
+            extra = dict(kwargs.get("extra_body", {}))
+            extra["enable_thinking"] = enable_thinking
             kwargs["extra_body"] = extra
 
         return kwargs

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -15,11 +15,8 @@ os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 import litellm
 from litellm import acompletion, completion
 
-
 from openviking.telemetry import tracer
-
 from openviking.utils.model_retry import retry_async, retry_sync
-
 
 from ..base import ToolCall, VLMBase, VLMResponse
 
@@ -325,7 +322,7 @@ class LiteLLMVLMProvider(VLMBase):
             response = completion(**kwargs)
             elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))
@@ -356,7 +353,7 @@ class LiteLLMVLMProvider(VLMBase):
             response = await acompletion(**kwargs)
             elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -123,8 +123,16 @@ class OpenAIVLM(VLMBase):
 
     def _apply_provider_specific_extra_body(self, kwargs: Dict[str, Any], thinking: bool) -> None:
         """Attach provider-specific raw body parameters understood by compatible APIs."""
-        if self._supports_enable_thinking():
-            kwargs["extra_body"] = {"enable_thinking": bool(thinking)}
+        enable_thinking = self._resolve_enable_thinking_value(
+            thinking=thinking,
+            auto_supported=self._supports_enable_thinking(),
+        )
+        if enable_thinking is None:
+            return
+
+        extra_body = dict(kwargs.get("extra_body", {}))
+        extra_body["enable_thinking"] = enable_thinking
+        kwargs["extra_body"] = extra_body
 
     def _update_token_usage_from_response(
         self,

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -64,6 +64,7 @@ class VLMBase(ABC):
         self.max_tokens = config.get("max_tokens")
         self.extra_headers = config.get("extra_headers")
         self.stream = config.get("stream", False)
+        self.enable_thinking = config.get("enable_thinking")
 
         # Token usage tracking
         self._token_tracker = TokenUsageTracker()
@@ -270,6 +271,18 @@ class VLMBase(ABC):
         if isinstance(response, str):
             return response
         return response.choices[0].message.content or ""
+
+    def _resolve_enable_thinking_value(
+        self, thinking: bool, auto_supported: bool
+    ) -> Optional[bool]:
+        """Return the enable_thinking payload value, or None to omit the field."""
+        if self.enable_thinking is True:
+            return bool(thinking)
+        if self.enable_thinking is False:
+            return None
+        if auto_supported:
+            return bool(thinking)
+        return None
 
 
 class VLMFactory:

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -32,6 +32,13 @@ class VLMConfig(BaseModel):
     )
 
     thinking: bool = Field(default=False, description="Enable thinking mode for VolcEngine models")
+    enable_thinking: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Control whether OpenAI-compatible and LiteLLM backends send "
+            "extra_body.enable_thinking (None = backend default behavior)"
+        ),
+    )
 
     max_concurrent: int = Field(
         default=100, description="Maximum number of concurrent LLM calls for semantic processing"
@@ -90,6 +97,11 @@ class VLMConfig(BaseModel):
                 self.providers[self.provider]["extra_headers"] = self.extra_headers
             if self.stream and "stream" not in self.providers[self.provider]:
                 self.providers[self.provider]["stream"] = self.stream
+            if (
+                self.enable_thinking is not None
+                and "enable_thinking" not in self.providers[self.provider]
+            ):
+                self.providers[self.provider]["enable_thinking"] = self.enable_thinking
 
     def _has_any_config(self) -> bool:
         """Check if any config is provided."""
@@ -154,6 +166,11 @@ class VLMConfig(BaseModel):
         stream = (
             config.get("stream") if config and config.get("stream") is not None else self.stream
         )
+        enable_thinking = (
+            config.get("enable_thinking")
+            if config and "enable_thinking" in config
+            else self.enable_thinking
+        )
 
         result = {
             "model": self.model,
@@ -161,6 +178,7 @@ class VLMConfig(BaseModel):
             "max_retries": self.max_retries,
             "provider": name,
             "thinking": self.thinking,
+            "enable_thinking": enable_thinking,
             "max_tokens": self.max_tokens,
             "stream": stream,
             "api_version": self.api_version,

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -175,9 +175,7 @@ class TestVLMExtraHeaders:
         assert "extra_body" not in call_kwargs
 
     @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_explicit_enable_thinking_forces_extra_body_on_openai_backend(
-        self, mock_openai_class
-    ):
+    def test_explicit_enable_thinking_forces_extra_body_on_openai_backend(self, mock_openai_class):
         """Explicit config should force enable_thinking even without a legacy allowlist match."""
         mock_client = MagicMock()
         mock_openai_class.return_value = mock_client

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -174,6 +174,32 @@ class TestVLMExtraHeaders:
         call_kwargs = mock_client.chat.completions.create.call_args.kwargs
         assert "extra_body" not in call_kwargs
 
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
+    def test_explicit_enable_thinking_forces_extra_body_on_openai_backend(
+        self, mock_openai_class
+    ):
+        """Explicit config should force enable_thinking even without a legacy allowlist match."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+        mock_response.usage = None
+        mock_client.chat.completions.create.return_value = mock_response
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+                "model": "gpt-4o-mini",
+                "enable_thinking": True,
+            }
+        )
+
+        vlm.get_completion("hello", thinking=True)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"enable_thinking": True}
+
     @patch("openviking.models.vlm.backends.openai_vlm.openai.AzureOpenAI")
     def test_azure_text_completion_does_not_set_enable_thinking(self, mock_azure_openai_class):
         """Azure OpenAI should not receive DashScope-specific extra_body flags."""
@@ -195,6 +221,30 @@ class TestVLMExtraHeaders:
         )
 
         vlm.get_completion("hello", thinking=False)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert "extra_body" not in call_kwargs
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
+    def test_explicit_disable_thinking_suppresses_dashscope_extra_body(self, mock_openai_class):
+        """Explicit config should suppress enable_thinking for legacy-supported backends."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+        mock_response.usage = None
+        mock_client.chat.completions.create.return_value = mock_response
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                "model": "dashscope/qwen3.5-plus",
+                "enable_thinking": False,
+            }
+        )
+
+        vlm.get_completion("hello", thinking=True)
 
         call_kwargs = mock_client.chat.completions.create.call_args.kwargs
         assert "extra_body" not in call_kwargs

--- a/tests/unit/test_vlm_thinking_param.py
+++ b/tests/unit/test_vlm_thinking_param.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Tests for LiteLLM thinking parameter scoping to DashScope providers."""
 
+from openviking_cli.utils.config.vlm_config import VLMConfig
 from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
 
 
@@ -88,3 +89,73 @@ class TestLiteLLMThinkingParam:
 
         assert "extra_body" in kwargs
         assert kwargs["extra_body"]["enable_thinking"] is True
+
+    def test_litellm_explicit_enable_thinking_for_non_dashscope_model(self):
+        """Explicit config should force enable_thinking on unsupported-by-default models."""
+        vlm = self._make_provider("gpt-4o", enable_thinking=True)
+        model = vlm._resolve_model("gpt-4o")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=True)
+
+        assert kwargs["extra_body"]["enable_thinking"] is True
+
+    def test_litellm_explicit_disable_thinking_for_dashscope_model(self):
+        """Explicit config should suppress enable_thinking even for DashScope models."""
+        vlm = self._make_provider("qwen-plus", enable_thinking=False)
+        model = vlm._resolve_model("qwen-plus")
+        messages = [{"role": "user", "content": "hello"}]
+
+        kwargs = vlm._build_kwargs(model, messages, thinking=True)
+
+        assert "enable_thinking" not in kwargs.get("extra_body", {})
+
+
+class TestVLMConfigEnableThinking:
+    """Test VLMConfig passes enable_thinking controls to VLM instances."""
+
+    def test_vlm_config_enable_thinking_defaults_to_none(self):
+        """VLMConfig should default enable_thinking to provider-specific behavior."""
+        config = VLMConfig(
+            model="gpt-4o",
+            provider="openai",
+            providers={
+                "openai": {
+                    "api_key": "sk-test",
+                }
+            },
+        )
+
+        assert config.enable_thinking is None
+        assert config._build_vlm_config_dict()["enable_thinking"] is None
+
+    def test_vlm_config_enable_thinking_passed_to_vlm_dict(self):
+        """VLMConfig should pass explicit enable_thinking to the VLM config dict."""
+        config = VLMConfig(
+            model="gpt-4o",
+            provider="openai",
+            enable_thinking=True,
+            providers={
+                "openai": {
+                    "api_key": "sk-test",
+                }
+            },
+        )
+
+        assert config._build_vlm_config_dict()["enable_thinking"] is True
+
+    def test_vlm_config_provider_enable_thinking_takes_precedence(self):
+        """Provider-level enable_thinking should override the flat VLM setting."""
+        config = VLMConfig(
+            model="gpt-4o",
+            provider="openai",
+            enable_thinking=True,
+            providers={
+                "openai": {
+                    "api_key": "sk-test",
+                    "enable_thinking": False,
+                }
+            },
+        )
+
+        assert config._build_vlm_config_dict()["enable_thinking"] is False


### PR DESCRIPTION
## Summary
- add tri-state `vlm.enable_thinking` config so callers can force, suppress, or defer backend-specific `extra_body.enable_thinking`
- share the resolution logic across OpenAI-compatible and LiteLLM VLM backends
- document the new config and add focused config/backend tests

Closes #983

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' -q tests/unit/test_vlm_thinking_param.py tests/unit/test_extra_headers_vlm.py::TestVLMExtraHeaders::test_dashscope_text_completion_passes_enable_thinking_in_extra_body tests/unit/test_extra_headers_vlm.py::TestVLMExtraHeaders::test_official_openai_text_completion_does_not_set_enable_thinking tests/unit/test_extra_headers_vlm.py::TestVLMExtraHeaders::test_explicit_enable_thinking_forces_extra_body_on_openai_backend tests/unit/test_extra_headers_vlm.py::TestVLMExtraHeaders::test_azure_text_completion_does_not_set_enable_thinking tests/unit/test_extra_headers_vlm.py::TestVLMExtraHeaders::test_explicit_disable_thinking_suppresses_dashscope_extra_body tests/misc/test_config_validation.py`
