### PR TITLE
fix(content): support recursive reindex

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -29,6 +29,7 @@ class ReindexRequest(BaseModel):
 
     uri: str
     regenerate: bool = False
+    recursive: bool = False
     wait: bool = True
 
 
@@ -229,7 +230,7 @@ async def reindex(
                     message=f"URI {uri} already has a reindex in progress",
                 ),
             )
-        result = await _do_reindex(service, uri, request.regenerate, _ctx)
+        result = await _do_reindex(service, uri, request.regenerate, request.recursive, _ctx)
         return Response(status="ok", result=result)
     else:
         # Async path: run in background, return task_id for polling
@@ -248,7 +249,14 @@ async def reindex(
                 ),
             )
         asyncio.create_task(
-            _background_reindex_tracked(service, uri, request.regenerate, _ctx, task.task_id)
+            _background_reindex_tracked(
+                service,
+                uri,
+                request.regenerate,
+                request.recursive,
+                _ctx,
+                task.task_id,
+            )
         )
         return Response(
             status="ok",
@@ -265,6 +273,7 @@ async def _do_reindex(
     service,
     uri: str,
     regenerate: bool,
+    recursive: bool,
     ctx: RequestContext,
 ) -> dict:
     """Execute reindex within a lock scope."""
@@ -275,15 +284,16 @@ async def _do_reindex(
 
     async with LockContext(get_lock_manager(), [path], lock_mode="point"):
         if regenerate:
-            return await service.resources.summarize([uri], ctx=ctx)
+            return await service.resources.summarize([uri], ctx=ctx, recursive=recursive)
         else:
-            return await service.resources.build_index([uri], ctx=ctx)
+            return await service.resources.build_index([uri], ctx=ctx, recursive=recursive)
 
 
 async def _background_reindex_tracked(
     service,
     uri: str,
     regenerate: bool,
+    recursive: bool,
     ctx: RequestContext,
     task_id: str,
 ) -> None:
@@ -293,7 +303,7 @@ async def _background_reindex_tracked(
     tracker = get_task_tracker()
     tracker.start(task_id)
     try:
-        result = await _do_reindex(service, uri, regenerate, ctx)
+        result = await _do_reindex(service, uri, regenerate, recursive, ctx)
         tracker.complete(task_id, {"uri": uri, **result})
         logger.info("Background reindex completed: uri=%s task=%s", uri, task_id)
     except Exception as exc:

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -394,6 +394,7 @@ async def vectorize_file(
 async def index_resource(
     uri: str,
     ctx: RequestContext,
+    recursive: bool = False,
 ) -> None:
     """
     Build vector index for a resource directory.
@@ -406,53 +407,62 @@ async def index_resource(
     ``"resource"``.
     """
     viking_fs = get_viking_fs()
-    context_type = get_context_type_for_uri(uri)
 
-    # 1. Index Directory Metadata
-    abstract_uri = f"{uri}/.abstract.md"
-    overview_uri = f"{uri}/.overview.md"
+    async def _index_directory(directory_uri: str) -> None:
+        context_type = get_context_type_for_uri(directory_uri)
 
-    abstract = ""
-    overview = ""
+        abstract_uri = f"{directory_uri}/.abstract.md"
+        overview_uri = f"{directory_uri}/.overview.md"
 
-    if await viking_fs.exists(abstract_uri, ctx=ctx):
-        content = await viking_fs.read_file(abstract_uri, ctx=ctx)
-        if isinstance(content, bytes):
-            abstract = content.decode("utf-8")
+        abstract = ""
+        overview = ""
 
-    if await viking_fs.exists(overview_uri, ctx=ctx):
-        content = await viking_fs.read_file(overview_uri, ctx=ctx)
-        if isinstance(content, bytes):
-            overview = content.decode("utf-8")
+        if await viking_fs.exists(abstract_uri, ctx=ctx):
+            content = await viking_fs.read_file(abstract_uri, ctx=ctx)
+            if isinstance(content, bytes):
+                abstract = content.decode("utf-8")
 
-    if abstract or overview:
-        await vectorize_directory_meta(uri, abstract, overview, context_type=context_type, ctx=ctx)
+        if await viking_fs.exists(overview_uri, ctx=ctx):
+            content = await viking_fs.read_file(overview_uri, ctx=ctx)
+            if isinstance(content, bytes):
+                overview = content.decode("utf-8")
 
-    # 2. Index Files
-    try:
-        files = await viking_fs.ls(uri, ctx=ctx)
-        for file_info in files:
-            file_name = file_info["name"]
-
-            # Skip hidden files (like .abstract.md)
-            if file_name.startswith("."):
-                continue
-
-            if file_info.get("type") == "directory" or file_info.get("isDir"):
-                # TODO: Recursive indexing? For now, skip subdirectories to match previous behavior
-                continue
-
-            file_uri = file_info.get("uri") or f"{uri}/{file_name}"
-
-            # For direct indexing, we might not have summaries.
-            # We pass empty summary_dict, vectorize_file will try to read content for text files.
-            await vectorize_file(
-                file_path=file_uri,
-                summary_dict={"name": file_name},
-                parent_uri=uri,
+        if abstract or overview:
+            await vectorize_directory_meta(
+                directory_uri,
+                abstract,
+                overview,
                 context_type=context_type,
                 ctx=ctx,
             )
 
-    except Exception as e:
-        logger.error(f"Failed to scan directory {uri} for indexing: {e}")
+        try:
+            files = await viking_fs.ls(directory_uri, ctx=ctx)
+            for file_info in files:
+                file_name = file_info["name"]
+
+                # Skip hidden files and directories (like .abstract.md).
+                if file_name.startswith("."):
+                    continue
+
+                file_uri = file_info.get("uri") or f"{directory_uri}/{file_name}"
+                is_directory = file_info.get("type") == "directory" or file_info.get("isDir")
+                if is_directory:
+                    if recursive:
+                        await _index_directory(file_uri)
+                    continue
+
+                # For direct indexing, we might not have summaries.
+                # We pass empty summary_dict, vectorize_file will try to read content for text files.
+                await vectorize_file(
+                    file_path=file_uri,
+                    summary_dict={"name": file_name},
+                    parent_uri=directory_uri,
+                    context_type=context_type,
+                    ctx=ctx,
+                )
+
+        except Exception as e:
+            logger.error(f"Failed to scan directory {directory_uri} for indexing: {e}")
+
+    await _index_directory(uri)

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -86,8 +86,9 @@ class ResourceProcessor:
         self, resource_uris: List[str], ctx: RequestContext, **kwargs
     ) -> Dict[str, Any]:
         """Expose index building as a standalone method."""
+        recursive = kwargs.get("recursive", False)
         for uri in resource_uris:
-            await index_resource(uri, ctx)
+            await index_resource(uri, ctx, recursive=recursive)
         return {"status": "success", "message": f"Indexed {len(resource_uris)} resources"}
 
     async def summarize(

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -57,6 +57,7 @@ class Summarizer:
                 "message": "temp_uris length must match resource_uris length",
             }
         enqueued_count = 0
+        recursive = kwargs.get("recursive", True)
 
         telemetry = get_current_telemetry()
 
@@ -97,6 +98,7 @@ class Summarizer:
                 msg = SemanticMsg(
                     uri=source_uri,
                     context_type=context_type,
+                    recursive=recursive,
                     account_id=ctx.account_id,
                     user_id=ctx.user.user_id,
                     agent_id=ctx.user.agent_id,

--- a/tests/server/test_api_content.py
+++ b/tests/server/test_api_content.py
@@ -129,7 +129,7 @@ async def test_reindex_uses_request_tenant_for_exists(monkeypatch):
         def has_running(self, task_type, uri, owner_account_id=None, owner_user_id=None):
             return False
 
-    async def fake_do_reindex(service, uri, regenerate, ctx):
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
         return {"status": "success", "message": "Indexed 1 resources"}
 
     ctx = RequestContext(
@@ -154,3 +154,52 @@ async def test_reindex_uses_request_tenant_for_exists(monkeypatch):
     assert response.status == "ok"
     assert seen["uri"] == "viking://resources/demo/demo-note.md"
     assert seen["ctx"] == ctx
+    assert request.recursive is False
+
+
+@pytest.mark.asyncio
+async def test_reindex_forwards_recursive_flag(monkeypatch):
+    """Reindex should forward the recursive flag to the execution layer."""
+    seen = {}
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return True
+
+    class FakeTracker:
+        def has_running(self, task_type, uri, owner_account_id=None, owner_user_id=None):
+            return False
+
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
+        seen["recursive"] = recursive
+        seen["uri"] = uri
+        return {"status": "success", "message": "Indexed recursively"}
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice", agent_id="default"),
+        role=Role.ADMIN,
+    )
+    request = ReindexRequest(
+        uri="viking://resources/demo",
+        wait=True,
+        recursive=True,
+    )
+
+    monkeypatch.setattr("openviking.storage.viking_fs.get_viking_fs", lambda: FakeVikingFS())
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.content.get_service",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr("openviking.server.routers.content._do_reindex", fake_do_reindex)
+
+    response = await reindex(request=request, _ctx=ctx)
+
+    assert response.status == "ok"
+    assert seen == {
+        "recursive": True,
+        "uri": "viking://resources/demo",
+    }

--- a/tests/unit/test_embedding_index_resource_recursive.py
+++ b/tests/unit/test_embedding_index_resource_recursive.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.utils.embedding_utils import index_resource
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _DummyVikingFS:
+    def __init__(self, entries_by_uri, files_by_uri):
+        self.entries_by_uri = entries_by_uri
+        self.files_by_uri = files_by_uri
+
+    async def exists(self, uri, ctx=None):
+        return uri in self.files_by_uri
+
+    async def read_file(self, uri, ctx=None):
+        return self.files_by_uri[uri]
+
+    async def ls(self, uri, ctx=None):
+        return self.entries_by_uri.get(uri, [])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("recursive", "expected_dirs", "expected_files"),
+    [
+        (
+            False,
+            ["viking://resources/root"],
+            [("viking://resources/root/top.md", "viking://resources/root")],
+        ),
+        (
+            True,
+            [
+                "viking://resources/root",
+                "viking://resources/root/nested",
+            ],
+            [
+                ("viking://resources/root/top.md", "viking://resources/root"),
+                ("viking://resources/root/nested/child.md", "viking://resources/root/nested"),
+            ],
+        ),
+    ],
+)
+async def test_index_resource_recursive_traversal(recursive, expected_dirs, expected_files):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    vfs = _DummyVikingFS(
+        entries_by_uri={
+            "viking://resources/root": [
+                {"name": ".abstract.md", "uri": "viking://resources/root/.abstract.md", "isDir": False},
+                {"name": "top.md", "uri": "viking://resources/root/top.md", "isDir": False},
+                {"name": "nested", "uri": "viking://resources/root/nested", "isDir": True},
+            ],
+            "viking://resources/root/nested": [
+                {
+                    "name": ".abstract.md",
+                    "uri": "viking://resources/root/nested/.abstract.md",
+                    "isDir": False,
+                },
+                {
+                    "name": "child.md",
+                    "uri": "viking://resources/root/nested/child.md",
+                    "isDir": False,
+                },
+            ],
+        },
+        files_by_uri={
+            "viking://resources/root/.abstract.md": b"root abstract",
+            "viking://resources/root/nested/.abstract.md": b"nested abstract",
+        },
+    )
+    seen_dirs = []
+    seen_files = []
+
+    async def fake_vectorize_directory_meta(uri, abstract, overview, context_type, ctx):
+        seen_dirs.append(uri)
+
+    async def fake_vectorize_file(file_path, summary_dict, parent_uri, context_type, ctx):
+        seen_files.append((file_path, parent_uri))
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=vfs),
+        patch(
+            "openviking.utils.embedding_utils.vectorize_directory_meta",
+            side_effect=fake_vectorize_directory_meta,
+        ),
+        patch("openviking.utils.embedding_utils.vectorize_file", side_effect=fake_vectorize_file),
+    ):
+        await index_resource("viking://resources/root", ctx, recursive=recursive)
+
+    assert seen_dirs == expected_dirs
+    assert seen_files == expected_files

--- a/tests/unit/test_embedding_index_resource_recursive.py
+++ b/tests/unit/test_embedding_index_resource_recursive.py
@@ -52,7 +52,11 @@ async def test_index_resource_recursive_traversal(recursive, expected_dirs, expe
     vfs = _DummyVikingFS(
         entries_by_uri={
             "viking://resources/root": [
-                {"name": ".abstract.md", "uri": "viking://resources/root/.abstract.md", "isDir": False},
+                {
+                    "name": ".abstract.md",
+                    "uri": "viking://resources/root/.abstract.md",
+                    "isDir": False,
+                },
                 {"name": "top.md", "uri": "viking://resources/root/top.md", "isDir": False},
                 {"name": "nested", "uri": "viking://resources/root/nested", "isDir": True},
             ],

--- a/tests/unit/test_summarizer_resources_root_split.py
+++ b/tests/unit/test_summarizer_resources_root_split.py
@@ -152,6 +152,37 @@ async def test_explicit_subpath_not_split():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("recursive", [False, True])
+async def test_recursive_flag_is_forwarded_to_semantic_msg(recursive):
+    queue = _DummyQueue()
+    qm = _DummyQueueManager(queue)
+    vfs = _DummyVikingFS({})
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+    with (
+        patch("openviking.utils.summarizer.get_queue_manager", return_value=qm),
+        patch(
+            "openviking.utils.summarizer.get_current_telemetry",
+            return_value=SimpleNamespace(telemetry_id="tid"),
+        ),
+        patch(
+            "openviking.utils.summarizer.get_request_wait_tracker", return_value=_DummyWaitTracker()
+        ),
+        patch("openviking.utils.summarizer.get_viking_fs", return_value=vfs),
+    ):
+        summarizer = Summarizer(vlm_processor=None)
+        res = await summarizer.summarize(
+            resource_uris=["viking://resources/foo"],
+            ctx=ctx,
+            recursive=recursive,
+        )
+
+    assert res["status"] == "success"
+    assert res["enqueued_count"] == 1
+    assert queue.msgs[0].recursive is recursive
+
+
+@pytest.mark.asyncio
 async def test_resources_root_empty_import_is_error():
     queue = _DummyQueue()
     qm = _DummyQueueManager(queue)


### PR DESCRIPTION
## Summary
- add a backward-compatible `recursive` flag to `/api/v1/content/reindex`
- thread the flag through reindex execution, direct indexing, and semantic queue enqueueing
- add focused coverage for request forwarding, summarizer propagation, and recursive directory indexing

Closes #1073

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' -q tests/server/test_api_content.py tests/unit/test_summarizer_resources_root_split.py tests/unit/test_embedding_index_resource_recursive.py` *(blocked by repo `pytest-asyncio` collection issue in this environment)*
- `python - <<'PY' ...` manual async harness covering reindex forwarding, summarizer recursive propagation, and recursive indexing *(passed)*
