### PR TITLE
fix(openclaw-plugin): capture user turn at assistant boundary

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -941,18 +941,23 @@ export function createMemoryOpenVikingContextEngine(params: {
             ? afterTurnParams.prePromptMessageCount
             : 0;
 
-        const { messages: extractedMessages, newCount } = extractNewTurnMessages(messages, start);
+        const {
+          messages: extractedMessages,
+          newCount,
+          effectiveStartIndex,
+        } = extractNewTurnMessages(messages, start);
 
         if (extractedMessages.length === 0) {
           diag("afterTurn_skip", OVSessionId, {
             reason: "no_new_turn_messages",
             totalMessages: messages.length,
             prePromptMessageCount: start,
+            captureStartIndex: effectiveStartIndex,
           });
           return;
         }
 
-        const turnMessages = messages.slice(start) as AgentMessage[];
+        const turnMessages = messages.slice(effectiveStartIndex) as AgentMessage[];
         const newMessages = turnMessages.filter((m: any) => {
           const r = (m as Record<string, unknown>).role as string;
           return r === "user" || r === "assistant";
@@ -964,6 +969,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           totalMessages: messages.length,
           newMessageCount: newCount,
           prePromptMessageCount: start,
+          captureStartIndex: effectiveStartIndex,
           newTurnTokens,
           messages: newMsgFull,
         });
@@ -972,6 +978,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           totalMessages: messages.length,
           newMessageCount: newCount,
           prePromptMessageCount: start,
+          captureStartIndex: effectiveStartIndex,
         }))) {
           return;
         }
@@ -982,11 +989,13 @@ export function createMemoryOpenVikingContextEngine(params: {
         for (const msg of extractedMessages) {
           const ovParts = msg.parts.map((part) => {
             if (part.type === "text") {
-              // 清理 relevant-memories 块
-              const cleaned = part.text
-                .replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>/gi, " ")
-                .replace(/\s+/g, " ")
-                .trim();
+              const cleaned =
+                msg.role === "user"
+                  ? part.text
+                      .replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>/gi, " ")
+                      .replace(/\s+/g, " ")
+                      .trim()
+                  : part.text;
               return { type: "text" as const, text: cleaned };
             } else {
               return {

--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -207,6 +207,60 @@ describe("context-engine afterTurn()", () => {
     expect(client.addSessionMessage.mock.calls[1][2][0].text).toContain("hi there");
   });
 
+  it("rescues the current-turn user message when prePromptMessageCount starts at the assistant reply", async () => {
+    const { engine, client } = makeEngine();
+
+    const messages = [
+      { role: "user", content: "old message" },
+      { role: "assistant", content: "old reply" },
+      { role: "user", content: "current message that must still be captured" },
+      { role: "assistant", content: "current reply" },
+    ];
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages,
+      prePromptMessageCount: 3,
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("user");
+    expect(client.addSessionMessage.mock.calls[0][2][0].text).toContain("current message");
+    expect(client.addSessionMessage.mock.calls[0][2][0].text).not.toContain("old message");
+    expect(client.addSessionMessage.mock.calls[1][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[1][2][0].text).toContain("current reply");
+  });
+
+  it("rescues grouped user messages across a system gap when prePromptMessageCount starts at the assistant reply", async () => {
+    const { engine, client } = makeEngine();
+
+    const messages = [
+      { role: "user", content: "old message" },
+      { role: "assistant", content: "old reply" },
+      { role: "user", content: "current first question" },
+      { role: "user", content: "current second question" },
+      { role: "system", content: "system prompt injection" },
+      { role: "assistant", content: "current answer" },
+    ];
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages,
+      prePromptMessageCount: 5,
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("user");
+    const userParts = client.addSessionMessage.mock.calls[0][2] as Array<{ text?: string }>;
+    expect(userParts.map((part) => part.text).join(" ")).toContain("current first question");
+    expect(userParts.map((part) => part.text).join(" ")).toContain("current second question");
+    expect(userParts.map((part) => part.text).join(" ")).not.toContain("old message");
+    expect(client.addSessionMessage.mock.calls[1][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[1][2][0].text).toContain("current answer");
+  });
+
   it("passes the latest non-system message timestamp to addSessionMessage as ISO string", async () => {
     const { engine, client } = makeEngine();
 

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -498,6 +498,80 @@ export type ExtractedMessage = {
   }>;
 };
 
+function findEffectiveTurnStartIndex(messages: unknown[], startIndex: number): number {
+  const clampedStart = Math.max(0, Math.min(startIndex, messages.length));
+
+  let firstRelevantIndex = -1;
+  for (let i = clampedStart; i < messages.length; i += 1) {
+    const msg = messages[i] as Record<string, unknown>;
+    const role = typeof msg?.role === "string" ? msg.role : "";
+    if (role && role !== "system") {
+      firstRelevantIndex = i;
+      break;
+    }
+  }
+
+  if (firstRelevantIndex < 0) {
+    return clampedStart;
+  }
+
+  const firstRelevant = messages[firstRelevantIndex] as Record<string, unknown>;
+  const firstRole = typeof firstRelevant?.role === "string" ? firstRelevant.role : "";
+  if (firstRole !== "assistant" && firstRole !== "toolResult") {
+    return clampedStart;
+  }
+
+  for (let i = firstRelevantIndex - 1; i >= 0; i -= 1) {
+    const msg = messages[i] as Record<string, unknown>;
+    const role = typeof msg?.role === "string" ? msg.role : "";
+    if (!role || role === "system") {
+      continue;
+    }
+    if (role === "user") {
+      let earliestUserIndex = i;
+      for (let j = i - 1; j >= 0; j -= 1) {
+        const prev = messages[j] as Record<string, unknown>;
+        const prevRole = typeof prev?.role === "string" ? prev.role : "";
+        if (!prevRole || prevRole === "system") {
+          continue;
+        }
+        if (prevRole !== "user") {
+          break;
+        }
+        earliestUserIndex = j;
+      }
+      return earliestUserIndex;
+    }
+  }
+
+  return clampedStart;
+}
+
+function pushExtractedPart(
+  result: ExtractedMessage[],
+  role: "user" | "assistant",
+  part:
+    | {
+        type: "text";
+        text: string;
+      }
+    | {
+        type: "tool";
+        toolCallId?: string;
+        toolName: string;
+        toolInput?: Record<string, unknown>;
+        toolOutput: string;
+        toolStatus: string;
+      },
+): void {
+  const last = result[result.length - 1];
+  if (last?.role === role) {
+    last.parts.push(part);
+    return;
+  }
+  result.push({ role, parts: [part] });
+}
+
 /**
  * 提取从 startIndex 开始的新消息，返回结构化消息。
  * - 用户输入 → type: "text"
@@ -508,9 +582,10 @@ export type ExtractedMessage = {
 export function extractNewTurnMessages(
   messages: unknown[],
   startIndex: number,
-): { messages: ExtractedMessage[]; newCount: number } {
+): { messages: ExtractedMessage[]; newCount: number; effectiveStartIndex: number } {
   const result: ExtractedMessage[] = [];
   let count = 0;
+  const effectiveStartIndex = findEffectiveTurnStartIndex(messages, startIndex);
 
   // First pass: collect toolUse inputs indexed by toolCallId/toolUseId
   // Scan all messages (including after startIndex) to find toolUse before each toolResult
@@ -538,7 +613,7 @@ export function extractNewTurnMessages(
     }
   }
 
-  for (let i = startIndex; i < messages.length; i++) {
+  for (let i = effectiveStartIndex; i < messages.length; i++) {
     const msg = messages[i] as Record<string, unknown>;
     if (!msg || typeof msg !== "object") continue;
 
@@ -559,44 +634,37 @@ export function extractNewTurnMessages(
           ? msg.toolInput as Record<string, unknown>
           : undefined);
       if (output) {
-        result.push({
-          role: "user",
-          parts: [{
-            type: "tool",
-            toolCallId: toolCallId || undefined,
-            toolName,
-            toolInput,
-            toolOutput: output,
-            toolStatus: "completed",
-          }],
+        pushExtractedPart(result, "user", {
+          type: "tool",
+          toolCallId: toolCallId || undefined,
+          toolName,
+          toolInput,
+          toolOutput: `[${toolName} result]: ${output}`,
+          toolStatus: "completed",
         });
       }
       continue;
     }
 
     // user/assistant -> type: "text"
-    // 统一 role 为 user
-    const content = msg.content;
-    const text = extractPartText(content);
+    const text = extractSingleMessageText(msg);
 
     if (text) {
-      // 使用 sanitizeUserTextForCapture 清理所有噪音（Sender 元数据、时间戳等）
-      const cleanedText = sanitizeUserTextForCapture(text);
+      const cleanedText =
+        role === "assistant"
+          ? (HEARTBEAT_RE.test(text) ? "" : text.trim())
+          : sanitizeUserTextForCapture(text);
       if (cleanedText) {
-        // 保持原始 role，assistant 保持 assistant，user 保持 user
         const ovRole: "user" | "assistant" = role === "assistant" ? "assistant" : "user";
-        result.push({
-          role: ovRole,
-          parts: [{
-            type: "text",
-            text: cleanedText,
-          }],
+        pushExtractedPart(result, ovRole, {
+          type: "text",
+          text: cleanedText,
         });
       }
     }
   }
 
-  return { messages: result, newCount: count };
+  return { messages: result, newCount: count, effectiveStartIndex };
 }
 
 export function extractLatestUserText(messages: unknown[] | undefined): string {


### PR DESCRIPTION
## Summary
- backtrack the effective afterTurn capture window when `prePromptMessageCount` starts on the assistant side of the turn
- keep user-only `<relevant-memories>` stripping while preserving assistant text
- add regression coverage for assistant-boundary and grouped-user cases

Closes #1248

## Testing
- `pnpm vitest run tests/ut/context-engine-afterTurn.test.ts`
