### PR TITLE
fix(healthcheck): clean synthetic probe data

### DIFF
--- a/examples/openclaw-plugin/health_check_tools/ov-healthcheck.py
+++ b/examples/openclaw-plugin/health_check_tools/ov-healthcheck.py
@@ -188,6 +188,11 @@ def parse_args() -> argparse.Namespace:
         help="Disable SSL certificate verification (useful for self-signed certs in remote mode).",
     )
     parser.add_argument("--json-out", default="", help="Optional JSON report output path.")
+    parser.add_argument(
+        "--keep-test-data",
+        action="store_true",
+        help="Keep synthetic sessions and memories for debugging instead of cleaning them up automatically.",
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="Print extra debug information.")
     return parser.parse_args()
 
@@ -629,6 +634,18 @@ class OpenVikingInspector:
         result = extract_result(payload)
         return result if isinstance(result, dict) else None
 
+    def delete_session(self, session_id: str) -> bool:
+        payload = http_json(
+            self.base_url,
+            f"/api/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
+            method="DELETE",
+            headers=self.headers(),
+            timeout=20.0,
+            insecure=self.insecure,
+        )
+        result = extract_result(payload)
+        return isinstance(result, dict)
+
     def commit(self, session_id: str) -> dict[str, Any] | None:
         payload = http_json(
             self.base_url,
@@ -670,6 +687,103 @@ class OpenVikingInspector:
             if isinstance(memories, list):
                 return [item for item in memories if isinstance(item, dict)]
         return []
+
+    def delete_uri(self, uri: str, recursive: bool = False) -> bool:
+        payload = http_json(
+            self.base_url,
+            f"/api/v1/fs?uri={urllib.parse.quote(uri, safe='')}&recursive={'true' if recursive else 'false'}",
+            method="DELETE",
+            headers=self.headers(),
+            timeout=20.0,
+            insecure=self.insecure,
+        )
+        result = extract_result(payload)
+        return isinstance(result, dict)
+
+
+def collect_cleanup_session_ids(
+    inspector: OpenVikingInspector,
+    hints: list[str],
+) -> list[str]:
+    hint_set = {item.strip() for item in hints if item and item.strip()}
+    matched = set(hint_set)
+    try:
+        sessions = inspector.list_sessions()
+    except Exception:
+        return sorted(matched)
+    for item in sessions:
+        session_id = str(item.get("session_id", "")).strip()
+        if not session_id:
+            continue
+        if any(hint in session_id for hint in hint_set):
+            matched.add(session_id)
+    return sorted(matched)
+
+
+def cleanup_healthcheck_artifacts(
+    recorder: Recorder,
+    inspector: OpenVikingInspector,
+    *,
+    generated_user_id: bool,
+    user_id: str,
+    fresh_user_id: str | None,
+    probe: str,
+    discovered_session_id: str | None,
+    keep_test_data: bool,
+) -> None:
+    if keep_test_data:
+        recorder.add("INFO", "Synthetic cleanup skipped", "--keep-test-data enabled")
+        return
+
+    if not generated_user_id:
+        recorder.add(
+            "WARN",
+            "Synthetic cleanup skipped",
+            "explicit --user-id provided; refusing to auto-delete potentially real user data",
+        )
+        return
+
+    session_hints = [user_id]
+    if fresh_user_id:
+        session_hints.append(fresh_user_id)
+    if discovered_session_id:
+        session_hints.append(discovered_session_id)
+    session_ids = collect_cleanup_session_ids(inspector, session_hints)
+
+    deleted_sessions = 0
+    session_errors: list[str] = []
+    for session_id in session_ids:
+        try:
+            if inspector.delete_session(session_id):
+                deleted_sessions += 1
+        except Exception as exc:
+            session_errors.append(f"{session_id}: {exc}")
+
+    memory_uris: set[str] = set()
+    for query in (probe, MEMORY_QUERY):
+        try:
+            for item in inspector.search_memories(query, limit=20):
+                uri = item.get("uri")
+                if isinstance(uri, str) and uri.strip():
+                    memory_uris.add(uri.strip())
+        except Exception:
+            continue
+
+    deleted_memories = 0
+    memory_errors: list[str] = []
+    for uri in sorted(memory_uris):
+        try:
+            if inspector.delete_uri(uri, recursive=False):
+                deleted_memories += 1
+        except Exception as exc:
+            memory_errors.append(f"{uri}: {exc}")
+
+    detail = f"sessions={deleted_sessions} memories={deleted_memories}"
+    if session_errors or memory_errors:
+        error_detail = "; ".join((session_errors + memory_errors)[:3])
+        recorder.add("WARN", "Synthetic cleanup completed with partial failures", f"{detail}; {error_detail}")
+    else:
+        recorder.add("PASS", "Synthetic cleanup completed", detail)
 
 
 def send_gateway_message(
@@ -777,8 +891,12 @@ def main() -> int:
         or str(os.environ.get("OPENVIKING_API_KEY", "")).strip()
     )
     agent_id = (args.agent_id or str(plugin_config.get("agentId", "")).strip() or DEFAULT_AGENT_ID)
+    generated_user_id = not bool(args.user_id)
     user_id = args.user_id or f"ov-healthcheck-{uuid.uuid4().hex[:8]}"
     probe = f"probe-{uuid.uuid4().hex[:8]}"
+    fresh_user_id: str | None = None
+    discovered_session_id: str | None = None
+    synthetic_data_created = False
     ov_log_path = openviking_log_path(ov_config)
 
     print(bold("OpenViking Plugin Healthcheck"))
@@ -858,6 +976,7 @@ def main() -> int:
             payload = send_gateway_message(gateway_url, token, user_id, message, timeout=args.chat_timeout, insecure=args.insecure)
             reply = extract_reply_text(payload)
             if reply:
+                synthetic_data_created = True
                 recorder.add("PASS", f"Chat turn {index} succeeded", f"reply_len={len(reply)}")
                 if args.verbose:
                     print(f"  reply preview: {reply[:180]}")
@@ -872,6 +991,17 @@ def main() -> int:
             time.sleep(max(0.0, args.delay))
 
     if recorder.has_failures():
+        if synthetic_data_created:
+            cleanup_healthcheck_artifacts(
+                recorder,
+                inspector,
+                generated_user_id=generated_user_id,
+                user_id=user_id,
+                fresh_user_id=fresh_user_id,
+                probe=probe,
+                discovered_session_id=discovered_session_id,
+                keep_test_data=args.keep_test_data,
+            )
         print()
         print(red("Stopping because the real conversation flow did not complete."))
         return 1
@@ -896,6 +1026,7 @@ def main() -> int:
         session_context = None
 
     if session_id:
+        discovered_session_id = session_id
         recorder.add("PASS", "Probe session located in OpenViking", session_id)
     else:
         recorder.add("FAIL", "Probe session not found in OpenViking", "afterTurn capture may be broken")
@@ -916,6 +1047,17 @@ def main() -> int:
         recorder.add("FAIL", "Failed to read OpenViking session context")
 
     if not session_id:
+        if synthetic_data_created:
+            cleanup_healthcheck_artifacts(
+                recorder,
+                inspector,
+                generated_user_id=generated_user_id,
+                user_id=user_id,
+                fresh_user_id=fresh_user_id,
+                probe=probe,
+                discovered_session_id=discovered_session_id,
+                keep_test_data=args.keep_test_data,
+            )
         print()
         print(red("Stopping because no matching OpenViking session was found."))
         return 1
@@ -1008,6 +1150,7 @@ def main() -> int:
             recall_payload = send_gateway_message(gateway_url, token, fresh_user_id, RECALL_QUESTION, timeout=args.chat_timeout, insecure=args.insecure)
             recall_reply = extract_reply_text(recall_payload)
             if recall_reply:
+                synthetic_data_created = True
                 hit_count, hits = count_keyword_hits(recall_reply, RECALL_KEYWORDS)
                 if hit_count >= 2:
                     recorder.add("PASS", "Fresh-session recall returned seeded stack facts", ",".join(hits))
@@ -1019,6 +1162,18 @@ def main() -> int:
             recorder.add("WARN", "Fresh-session recall request failed", str(exc))
     else:
         recorder.add("SKIP", "Fresh-session recall skipped", "autoRecall is disabled in plugin config")
+
+    if synthetic_data_created:
+        cleanup_healthcheck_artifacts(
+            recorder,
+            inspector,
+            generated_user_id=generated_user_id,
+            user_id=user_id,
+            fresh_user_id=fresh_user_id,
+            probe=probe,
+            discovered_session_id=discovered_session_id,
+            keep_test_data=args.keep_test_data,
+        )
 
     print()
     print(bold("Summary"))

--- a/examples/openclaw-plugin/health_check_tools/ov-healthcheck.py
+++ b/examples/openclaw-plugin/health_check_tools/ov-healthcheck.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 import ssl
+import sys
 import time
-import uuid
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -27,8 +27,7 @@ HEALTHCHECK_PREFIX = (
 
 SEED_MESSAGES = [
     (
-        HEALTHCHECK_PREFIX
-        + "Please remember the following SYNTHETIC test data: "
+        HEALTHCHECK_PREFIX + "Please remember the following SYNTHETIC test data: "
         "my name is Lin Zhou, I am rebuilding an order platform, "
         "my backend stack is Go, PostgreSQL, and Redis, and the current project progress is 70 percent. "
         "Reply briefly."
@@ -133,26 +132,34 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="End-to-end healthcheck for the OpenClaw OpenViking plugin.",
     )
-    parser.add_argument("--gateway", default="", help=f"Gateway base URL (default: {DEFAULT_GATEWAY_URL})")
+    parser.add_argument(
+        "--gateway", default="", help=f"Gateway base URL (default: {DEFAULT_GATEWAY_URL})"
+    )
     parser.add_argument(
         "--openviking",
         default="",
         help=f"OpenViking base URL (default: {DEFAULT_OPENVIKING_URL})",
     )
-    parser.add_argument("--token", default="", help="Gateway bearer token. Auto-discovered when possible.")
+    parser.add_argument(
+        "--token", default="", help="Gateway bearer token. Auto-discovered when possible."
+    )
     parser.add_argument(
         "--openviking-api-key",
         default="",
         help="OpenViking API key. Auto-discovered from plugin config when possible.",
     )
-    parser.add_argument("--agent-id", default="", help=f"OpenViking agent id (default: {DEFAULT_AGENT_ID})")
+    parser.add_argument(
+        "--agent-id", default="", help=f"OpenViking agent id (default: {DEFAULT_AGENT_ID})"
+    )
     parser.add_argument("--user-id", default="", help="User id for the real conversation session.")
     parser.add_argument(
         "--openclaw-config",
         default="",
         help="Path to openclaw.json. Auto-discovered when omitted.",
     )
-    parser.add_argument("--delay", type=float, default=1.0, help="Delay between chat turns in seconds.")
+    parser.add_argument(
+        "--delay", type=float, default=1.0, help="Delay between chat turns in seconds."
+    )
     parser.add_argument(
         "--capture-wait",
         type=float,
@@ -193,7 +200,9 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Keep synthetic sessions and memories for debugging instead of cleaning them up automatically.",
     )
-    parser.add_argument("--verbose", "-v", action="store_true", help="Print extra debug information.")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print extra debug information."
+    )
     return parser.parse_args()
 
 
@@ -275,7 +284,9 @@ def extract_openviking_config_path(plugin_config: dict[str, Any]) -> Path | None
     return path if path.exists() else None
 
 
-def load_openviking_config(plugin_config: dict[str, Any]) -> tuple[Path | None, dict[str, Any] | None]:
+def load_openviking_config(
+    plugin_config: dict[str, Any],
+) -> tuple[Path | None, dict[str, Any] | None]:
     path = extract_openviking_config_path(plugin_config)
     if not path:
         return None, None
@@ -375,11 +386,11 @@ def resolve_env_placeholders(value: str) -> str:
         end = resolved.find("}", start + 2)
         if end < 0:
             return resolved
-        name = resolved[start + 2:end]
+        name = resolved[start + 2 : end]
         env_value = os.environ.get(name)
         if env_value is None:
             return resolved
-        resolved = resolved[:start] + env_value + resolved[end + 1:]
+        resolved = resolved[:start] + env_value + resolved[end + 1 :]
 
 
 def openviking_log_path(ov_config: dict[str, Any] | None) -> Path:
@@ -544,8 +555,7 @@ def extract_memory_total(payload: dict[str, Any] | None) -> int:
     if isinstance(memories.get("total"), int):
         return memories["total"]
     return sum(
-        value for key, value in memories.items()
-        if key != "total" and isinstance(value, int)
+        value for key, value in memories.items() if key != "total" and isinstance(value, int)
     )
 
 
@@ -566,8 +576,16 @@ def wait_for_commit_visibility(
         latest_detail = detail
         latest_context = context
 
-        commit_ok = isinstance(detail, dict) and isinstance(detail.get("commit_count"), int) and detail["commit_count"] > 0
-        overview_ok = isinstance(context, dict) and isinstance(context.get("latest_archive_overview"), str) and bool(context["latest_archive_overview"].strip())
+        commit_ok = (
+            isinstance(detail, dict)
+            and isinstance(detail.get("commit_count"), int)
+            and detail["commit_count"] > 0
+        )
+        overview_ok = (
+            isinstance(context, dict)
+            and isinstance(context.get("latest_archive_overview"), str)
+            and bool(context["latest_archive_overview"].strip())
+        )
         memory_ok = extract_memory_total(detail) > 0
 
         status = f"commit={'yes' if commit_ok else 'no'} overview={'yes' if overview_ok else 'no'} memory={'yes' if memory_ok else 'no'}"
@@ -583,7 +601,9 @@ def wait_for_commit_visibility(
 
 
 class OpenVikingInspector:
-    def __init__(self, base_url: str, api_key: str, agent_id: str, *, insecure: bool = False) -> None:
+    def __init__(
+        self, base_url: str, api_key: str, agent_id: str, *, insecure: bool = False
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.agent_id = agent_id or DEFAULT_AGENT_ID
@@ -599,14 +619,26 @@ class OpenVikingInspector:
 
     def health(self) -> bool:
         try:
-            payload = http_json(self.base_url, "/health", headers=self.headers(), timeout=5.0, insecure=self.insecure)
+            payload = http_json(
+                self.base_url,
+                "/health",
+                headers=self.headers(),
+                timeout=5.0,
+                insecure=self.insecure,
+            )
         except Exception:
             return False
         result = extract_result(payload)
         return isinstance(result, dict) and result.get("status") == "ok"
 
     def list_sessions(self) -> list[dict[str, Any]]:
-        payload = http_json(self.base_url, "/api/v1/sessions", headers=self.headers(), timeout=15.0, insecure=self.insecure)
+        payload = http_json(
+            self.base_url,
+            "/api/v1/sessions",
+            headers=self.headers(),
+            timeout=15.0,
+            insecure=self.insecure,
+        )
         result = extract_result(payload)
         if isinstance(result, list):
             return [item for item in result if isinstance(item, dict)]
@@ -781,7 +813,9 @@ def cleanup_healthcheck_artifacts(
     detail = f"sessions={deleted_sessions} memories={deleted_memories}"
     if session_errors or memory_errors:
         error_detail = "; ".join((session_errors + memory_errors)[:3])
-        recorder.add("WARN", "Synthetic cleanup completed with partial failures", f"{detail}; {error_detail}")
+        recorder.add(
+            "WARN", "Synthetic cleanup completed with partial failures", f"{detail}; {error_detail}"
+        )
     else:
         recorder.add("PASS", "Synthetic cleanup completed", detail)
 
@@ -834,14 +868,13 @@ def find_session_with_probe(
 ) -> tuple[str | None, dict[str, Any] | None, dict[str, Any] | None]:
     sessions = inspector.list_sessions()
     candidates = [
-        item for item in sessions
-        if not str(item.get("session_id", "")).startswith("memory-store-")
+        item for item in sessions if not str(item.get("session_id", "")).startswith("memory-store-")
     ]
     candidates.sort(
         key=lambda item: str(item.get("updated_at", "") or item.get("created_at", "")),
         reverse=True,
     )
-    scan = candidates if session_scan_limit <= 0 else candidates[: session_scan_limit]
+    scan = candidates if session_scan_limit <= 0 else candidates[:session_scan_limit]
     for item in scan:
         session_id = str(item.get("session_id", "")).strip()
         if not session_id:
@@ -890,7 +923,7 @@ def main() -> int:
         )
         or str(os.environ.get("OPENVIKING_API_KEY", "")).strip()
     )
-    agent_id = (args.agent_id or str(plugin_config.get("agentId", "")).strip() or DEFAULT_AGENT_ID)
+    agent_id = args.agent_id or str(plugin_config.get("agentId", "")).strip() or DEFAULT_AGENT_ID
     generated_user_id = not bool(args.user_id)
     user_id = args.user_id or f"ov-healthcheck-{uuid.uuid4().hex[:8]}"
     probe = f"probe-{uuid.uuid4().hex[:8]}"
@@ -913,7 +946,11 @@ def main() -> int:
     if config_path and config:
         recorder.add("PASS", "OpenClaw config discovered", str(config_path))
     else:
-        recorder.add("WARN", "OpenClaw config not discovered", "falling back to defaults and explicit arguments")
+        recorder.add(
+            "WARN",
+            "OpenClaw config not discovered",
+            "falling back to defaults and explicit arguments",
+        )
 
     if config:
         slot = extract_context_slot(config)
@@ -938,9 +975,13 @@ def main() -> int:
             if ov_config_path:
                 recorder.add("INFO", "OpenViking config discovered", str(ov_config_path))
             if plugin_config.get("autoCapture") is False:
-                recorder.add("WARN", "autoCapture is disabled", "afterTurn capture checks are likely to fail")
+                recorder.add(
+                    "WARN", "autoCapture is disabled", "afterTurn capture checks are likely to fail"
+                )
             if plugin_config.get("autoRecall") is False:
-                recorder.add("WARN", "autoRecall is disabled", "fresh-session recall check will be skipped")
+                recorder.add(
+                    "WARN", "autoRecall is disabled", "fresh-session recall check will be skipped"
+                )
         else:
             recorder.add("WARN", "Plugin config missing", "using detected defaults")
 
@@ -951,7 +992,9 @@ def main() -> int:
     else:
         recorder.add("WARN", "Gateway token not found", "continuing without Authorization header")
 
-    inspector = OpenVikingInspector(openviking_url, openviking_api_key, agent_id, insecure=args.insecure)
+    inspector = OpenVikingInspector(
+        openviking_url, openviking_api_key, agent_id, insecure=args.insecure
+    )
 
     if gateway_health(gateway_url, token, insecure=args.insecure):
         recorder.add("PASS", "Gateway health check succeeded")
@@ -973,7 +1016,14 @@ def main() -> int:
     for index, template in enumerate(SEED_MESSAGES, start=1):
         message = template.format(probe=probe)
         try:
-            payload = send_gateway_message(gateway_url, token, user_id, message, timeout=args.chat_timeout, insecure=args.insecure)
+            payload = send_gateway_message(
+                gateway_url,
+                token,
+                user_id,
+                message,
+                timeout=args.chat_timeout,
+                insecure=args.insecure,
+            )
             reply = extract_reply_text(payload)
             if reply:
                 synthetic_data_created = True
@@ -1029,7 +1079,9 @@ def main() -> int:
         discovered_session_id = session_id
         recorder.add("PASS", "Probe session located in OpenViking", session_id)
     else:
-        recorder.add("FAIL", "Probe session not found in OpenViking", "afterTurn capture may be broken")
+        recorder.add(
+            "FAIL", "Probe session not found in OpenViking", "afterTurn capture may be broken"
+        )
 
     if session_context:
         flattened = flatten_context_text(session_context)
@@ -1042,7 +1094,9 @@ def main() -> int:
         if len(hits) >= 2:
             recorder.add("PASS", "Captured session context contains seeded facts", ",".join(hits))
         else:
-            recorder.add("WARN", "Captured session context contains too few seeded facts", ",".join(hits))
+            recorder.add(
+                "WARN", "Captured session context contains too few seeded facts", ",".join(hits)
+            )
     else:
         recorder.add("FAIL", "Failed to read OpenViking session context")
 
@@ -1064,7 +1118,6 @@ def main() -> int:
 
     print()
     print(bold("Phase 3: commit, context, and memory checks"))
-    memory_extraction_confirmed = False
     try:
         commit_result = inspector.commit(session_id)
     except Exception as exc:
@@ -1074,7 +1127,11 @@ def main() -> int:
     if isinstance(commit_result, dict):
         status = str(commit_result.get("status", ""))
         if status == "failed":
-            recorder.add("FAIL", "OpenViking commit finished with failure", str(commit_result.get("error", "")))
+            recorder.add(
+                "FAIL",
+                "OpenViking commit finished with failure",
+                str(commit_result.get("error", "")),
+            )
         elif status:
             recorder.add("PASS", "OpenViking commit accepted", status)
         else:
@@ -1085,7 +1142,10 @@ def main() -> int:
     print(f"Waiting up to {args.commit_wait:.0f}s for commit, archive, and memory extraction...")
     try:
         latest_session_detail, latest_context = wait_for_commit_visibility(
-            inspector, session_id, timeout_seconds=args.commit_wait, verbose=args.verbose,
+            inspector,
+            session_id,
+            timeout_seconds=args.commit_wait,
+            verbose=args.verbose,
         )
     except Exception as exc:
         latest_session_detail = None
@@ -1097,12 +1157,13 @@ def main() -> int:
         if isinstance(commit_count, int) and commit_count > 0:
             recorder.add("PASS", "Session commit_count is greater than zero", str(commit_count))
         else:
-            recorder.add("FAIL", "Session commit_count is still zero after waiting", str(commit_count))
+            recorder.add(
+                "FAIL", "Session commit_count is still zero after waiting", str(commit_count)
+            )
 
         total_memories = extract_memory_total(latest_session_detail)
         if total_memories > 0:
             recorder.add("PASS", "Memory extraction produced results", f"total={total_memories}")
-            memory_extraction_confirmed = True
         else:
             recorder.add("FAIL", "Memory extraction produced no results after waiting")
 
@@ -1130,14 +1191,27 @@ def main() -> int:
     print()
     print(bold("Phase 4: follow-up through Gateway"))
     try:
-        follow_up_payload = send_gateway_message(gateway_url, token, user_id, FOLLOW_UP_QUESTION, timeout=args.chat_timeout, insecure=args.insecure)
+        follow_up_payload = send_gateway_message(
+            gateway_url,
+            token,
+            user_id,
+            FOLLOW_UP_QUESTION,
+            timeout=args.chat_timeout,
+            insecure=args.insecure,
+        )
         follow_up_reply = extract_reply_text(follow_up_payload)
         if follow_up_reply:
             hit_count, hits = count_keyword_hits(follow_up_reply, FOLLOW_UP_KEYWORDS)
             if hit_count >= 2:
-                recorder.add("PASS", "Same-session follow-up recalled earlier facts", ",".join(hits))
+                recorder.add(
+                    "PASS", "Same-session follow-up recalled earlier facts", ",".join(hits)
+                )
             else:
-                recorder.add("WARN", "Same-session follow-up did not recall enough facts", maybe_detail(follow_up_reply[:220], args.verbose))
+                recorder.add(
+                    "WARN",
+                    "Same-session follow-up did not recall enough facts",
+                    maybe_detail(follow_up_reply[:220], args.verbose),
+                )
         else:
             recorder.add("WARN", "Same-session follow-up returned no assistant text")
     except Exception as exc:
@@ -1147,21 +1221,36 @@ def main() -> int:
     if auto_recall_enabled:
         fresh_user_id = f"{user_id}-fresh-{uuid.uuid4().hex[:4]}"
         try:
-            recall_payload = send_gateway_message(gateway_url, token, fresh_user_id, RECALL_QUESTION, timeout=args.chat_timeout, insecure=args.insecure)
+            recall_payload = send_gateway_message(
+                gateway_url,
+                token,
+                fresh_user_id,
+                RECALL_QUESTION,
+                timeout=args.chat_timeout,
+                insecure=args.insecure,
+            )
             recall_reply = extract_reply_text(recall_payload)
             if recall_reply:
                 synthetic_data_created = True
                 hit_count, hits = count_keyword_hits(recall_reply, RECALL_KEYWORDS)
                 if hit_count >= 2:
-                    recorder.add("PASS", "Fresh-session recall returned seeded stack facts", ",".join(hits))
+                    recorder.add(
+                        "PASS", "Fresh-session recall returned seeded stack facts", ",".join(hits)
+                    )
                 else:
-                    recorder.add("WARN", "Fresh-session recall was inconclusive", maybe_detail(recall_reply[:220], args.verbose))
+                    recorder.add(
+                        "WARN",
+                        "Fresh-session recall was inconclusive",
+                        maybe_detail(recall_reply[:220], args.verbose),
+                    )
             else:
                 recorder.add("WARN", "Fresh-session recall returned no assistant text")
         except Exception as exc:
             recorder.add("WARN", "Fresh-session recall request failed", str(exc))
     else:
-        recorder.add("SKIP", "Fresh-session recall skipped", "autoRecall is disabled in plugin config")
+        recorder.add(
+            "SKIP", "Fresh-session recall skipped", "autoRecall is disabled in plugin config"
+        )
 
     if synthetic_data_created:
         cleanup_healthcheck_artifacts(
@@ -1179,10 +1268,7 @@ def main() -> int:
     print(bold("Summary"))
     counts = recorder.counts()
     print(
-        f"PASS={counts['PASS']} "
-        f"WARN={counts['WARN']} "
-        f"FAIL={counts['FAIL']} "
-        f"SKIP={counts['SKIP']}"
+        f"PASS={counts['PASS']} WARN={counts['WARN']} FAIL={counts['FAIL']} SKIP={counts['SKIP']}"
     )
 
     if args.json_out:
@@ -1194,7 +1280,9 @@ def main() -> int:
     if recorder.has_failures():
         print(red("Healthcheck failed."))
         print("Suggested next steps:")
-        print("  1. Confirm `openclaw config get plugins.slots.contextEngine` returns `openviking`.")
+        print(
+            "  1. Confirm `openclaw config get plugins.slots.contextEngine` returns `openviking`."
+        )
         print("  2. Confirm both `/health` endpoints are reachable.")
         print("  3. Inspect `openclaw logs --follow` for `openviking:` lines.")
         print(f"  4. Inspect `{ov_log_path}` for backend errors.")


### PR DESCRIPTION
## Summary
- add automatic cleanup for synthetic sessions and extracted memories created by `ov-healthcheck`
- add `--keep-test-data` for debugging and skip destructive cleanup when an explicit `--user-id` is provided
- report cleanup status in the healthcheck output so leftover synthetic data is visible

Closes #1462

## Testing
- `python -m py_compile examples/openclaw-plugin/health_check_tools/ov-healthcheck.py`
- inline import/harness validation for cleanup session and URI deletion flow *(passed)*
