### PR TITLE
fix(prompts): keep semantic summaries in source language

### DIFF
--- a/openviking/prompts/templates/semantic/document_summary.yaml
+++ b/openviking/prompts/templates/semantic/document_summary.yaml
@@ -33,6 +33,12 @@ template: |
   【File Content】
   {{ content }}
 
+  Language requirements:
+  - Write the summary in {{ output_language }}, matching the dominant natural language used in the source content
+  - Do not default to English unless the source content is predominantly English
+  - If the content mixes languages, follow the dominant human-language prose and use it consistently for the whole summary
+  - Keep unavoidable file names, code identifiers, API names, and quoted literals in their original form, but keep all explanatory prose in {{ output_language }}
+
   Output requirements:
   - Length: 60-180 words
   - Focus on the main topics and purpose of this document

--- a/openviking/prompts/templates/semantic/file_summary.yaml
+++ b/openviking/prompts/templates/semantic/file_summary.yaml
@@ -33,6 +33,12 @@ template: |
   【File Content】
   {{ content }}
 
+  Language requirements:
+  - Write the summary in {{ output_language }}, matching the dominant natural language used in the source content
+  - Do not default to English unless the source content is predominantly English
+  - If the content mixes languages, follow the dominant human-language prose and use it consistently for the whole summary
+  - Keep unavoidable file names, code identifiers, API names, and quoted literals in their original form, but keep all explanatory prose in {{ output_language }}
+
   Output requirements:
   - Length: 50-150 words
   - Explain what this file is, what it covers, and what it's used for

--- a/openviking/prompts/templates/semantic/overview_generation.yaml
+++ b/openviking/prompts/templates/semantic/overview_generation.yaml
@@ -45,6 +45,12 @@ template: |
   [Subdirectories and Their Summaries]
   {{ children_abstracts }}
 
+  Language requirements:
+  - Write the entire overview in {{ output_language }}, matching the dominant natural language used across the provided summaries and abstracts
+  - Do not default the title, section headings, navigation text, or descriptions to English unless the dominant source language is English
+  - If the inputs mix languages, follow the dominant human-language prose and use it consistently for the whole overview
+  - Keep unavoidable file names, directory names, code identifiers, API names, and code tokens in their original form, but keep all explanatory prose in {{ output_language }}
+
   Relationship rules:
   - Treat child directories as parts of the same repository unless the summaries clearly show they are independent projects.
   - Do not describe every child directory as an independent project by default.
@@ -68,6 +74,8 @@ template: |
 
   4. **Detailed Description** (H2): One H3 subsection for each file/subdirectory
      - Use the file summaries or subdirectory summaries provided above as description content
+
+  Use headings and navigation labels translated into {{ output_language }} while preserving the markdown hierarchy above.
 
   Total length: 400-800 words
 

--- a/tests/storage/test_semantic_processor_language.py
+++ b/tests/storage/test_semantic_processor_language.py
@@ -164,8 +164,13 @@ class TestSemanticPromptLanguageContract:
         prompt = render_prompt(prompt_id, variables)
 
         assert "matching the dominant natural language used in the source content" in prompt
-        assert "Do not default to English unless the source content is predominantly English" in prompt
-        assert "Keep unavoidable file names, code identifiers, API names, and quoted literals in their original form" in prompt
+        assert (
+            "Do not default to English unless the source content is predominantly English" in prompt
+        )
+        assert (
+            "Keep unavoidable file names, code identifiers, API names, and quoted literals in their original form"
+            in prompt
+        )
 
     def test_overview_prompt_requires_localized_headings_and_navigation(self):
         prompt = render_prompt(

--- a/tests/storage/test_semantic_processor_language.py
+++ b/tests/storage/test_semantic_processor_language.py
@@ -136,6 +136,62 @@ class TestOverviewGenerationFlow:
         )
 
 
+class TestSemanticPromptLanguageContract:
+    """语义摘要模板的语言约束测试。"""
+
+    @pytest.mark.parametrize(
+        "prompt_id,variables",
+        [
+            (
+                "semantic.file_summary",
+                {
+                    "file_name": "notes.txt",
+                    "content": "这是中文说明，API 名称保持英文。",
+                    "output_language": "zh-CN",
+                },
+            ),
+            (
+                "semantic.document_summary",
+                {
+                    "file_name": "guide.md",
+                    "content": "# 中文指南\n\n包含 English API 名称。",
+                    "output_language": "zh-CN",
+                },
+            ),
+        ],
+    )
+    def test_summary_prompts_require_dominant_source_language(self, prompt_id, variables):
+        prompt = render_prompt(prompt_id, variables)
+
+        assert "matching the dominant natural language used in the source content" in prompt
+        assert "Do not default to English unless the source content is predominantly English" in prompt
+        assert "Keep unavoidable file names, code identifiers, API names, and quoted literals in their original form" in prompt
+
+    def test_overview_prompt_requires_localized_headings_and_navigation(self):
+        prompt = render_prompt(
+            "semantic.overview_generation",
+            {
+                "dir_name": "test_dir",
+                "file_summaries": "[1] docs.md: 这是中文文档，包含 API 说明",
+                "children_abstracts": "- api/: 中文接口说明",
+                "output_language": "zh-CN",
+            },
+        )
+
+        assert (
+            "Write the entire overview in zh-CN, matching the dominant natural language used across the provided summaries and abstracts"
+            in prompt
+        )
+        assert (
+            "Do not default the title, section headings, navigation text, or descriptions to English unless the dominant source language is English"
+            in prompt
+        )
+        assert (
+            "Use headings and navigation labels translated into zh-CN while preserving the markdown hierarchy above."
+            in prompt
+        )
+
+
 class LanguageAwareMockVLM:
     """语言感知的 MockVLM，根据 prompt 中的 Output Language 返回对应语言的响应。"""
 


### PR DESCRIPTION
## Summary
- strengthen semantic summary and overview prompts so output follows the dominant source language instead of drifting to English
- keep file names, API names, and identifiers in their original form while requiring explanatory prose to follow `output_language`
- add focused prompt-contract tests for file/document summary and overview generation templates

Closes #1067

## Testing
- `pytest tests/storage/test_semantic_processor_language.py` *(blocked by repo-side `pytest-asyncio` collection issue in this environment)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' tests/storage/test_semantic_processor_language.py::TestSemanticPromptLanguageContract tests/storage/test_semantic_processor_language.py::TestOverviewGenerationFlow`
