### PR TITLE
feat(memory): concise extraction/merge prompts + semantic queue stall fix

### DIFF
--- a/openviking/prompts/templates/compression/memory_extraction.yaml
+++ b/openviking/prompts/templates/compression/memory_extraction.yaml
@@ -204,9 +204,10 @@ template: |
 
   # Three-Level Structure
 
-  Each memory contains three levels, each serving a purpose:
+  Each memory contains three levels. **Keep all levels concise — memories are sticky notes, not essays.**
 
-  **abstract (L0)**: Index layer, plain text one-liner
+  **abstract (L0)**: Index layer, plain text one-liner. **Target: 1 sentence, ~50-80 characters.**
+  - This is the PRIMARY retrieval key — it MUST be specific enough to distinguish this memory from others.
   - Merge types (preferences/entities/profile/patterns): `[Merge key]: [Description]`
     - preferences: `Python code style: No type hints, concise and direct`
     - entities: `OpenViking project: AI Agent long-term memory management system`
@@ -216,13 +217,16 @@ template: |
     - events: `Decided to refactor memory system: Simplify to 5 categories`
     - cases: `Band not recognized → Request member/album/style details`
 
-  **overview (L1)**: Structured summary layer, organized with Markdown headings
+  **overview (L1)**: Structured summary layer, organized with Markdown headings. **Target: 3-5 bullet points.**
   - preferences: `## Preference Domain` / `## Specific Preferences`
   - entities: `## Basic Info` / `## Core Attributes`
   - events: `## Decision Content` / `## Reason` / `## Result`
   - cases: `## Problem` / `## Solution`
 
-  **content (L2)**: Detailed expansion layer, free Markdown, includes background, timeline, complete narrative
+  **content (L2)**: Core facts layer. **Target: 2-4 sentences with all essential specifics.**
+  - Capture ONLY the facts that would be lost if this memory were deleted.
+  - Include: names, versions, numbers, configurations, error messages, solutions.
+  - Exclude: background narratives, general explanations, elaboration of obvious points.
 
   # Few-shot Examples
 

--- a/openviking/prompts/templates/compression/memory_merge_bundle.yaml
+++ b/openviking/prompts/templates/compression/memory_merge_bundle.yaml
@@ -1,8 +1,8 @@
 metadata:
   id: "compression.memory_merge_bundle"
   name: "Memory Merge Bundle"
-  description: "Merge memory and return L0/L1/L2 in one structured response"
-  version: "1.0.0"
+  description: "Merge memory and return L0/L1/L2 in one structured response, with facet guard and length limits"
+  version: "2.0.0"
   language: "en"
   category: "compression"
 
@@ -46,7 +46,7 @@ variables:
     default: "auto"
 
 template: |
-  You are merging one existing memory with one new memory update.
+  You are deciding whether to merge two memories of the same category, or skip (keep them separate).
 
   Category: {{ category }}
   Target Output Language: {{ output_language }}
@@ -61,25 +61,28 @@ template: |
   - Overview (L1): {{ new_overview }}
   - Content (L2): {{ new_content }}
 
-  Requirements:
-  - Merge into a single coherent memory.
-  - Keep non-conflicting details from existing memory.
-  - Update conflicting details to reflect the newer fact.
-  - Output language must be {{ output_language }}.
-  - Return JSON only.
+  Step 1 — Facet check:
+  - The two memories share a category, but may describe different facets (e.g. both `preferences` but
+    one is "Python code style" and the other is "food preference"). If the facets differ, output
+    `{"decision": "skip", "reason": "..."}` and do NOT merge.
+  - Only merge when both memories describe the same specific facet/topic.
 
-  Output JSON schema:
-  {
-    "decision": "merge",
-    "abstract": "one-line L0 summary",
-    "overview": "structured markdown L1 summary",
-    "content": "full merged L2 content",
-    "reason": "short reason"
-  }
+  Step 2 — Merge (same facet only):
+  - Keep the NEWER value when facts conflict; do not retain superseded details.
+  - Condense to a clean up-to-date snapshot — not an accumulating changelog.
+
+  Length limits (hard): `abstract` ≤ 80 chars, `overview` ≤ 200 chars, `content` ≤ 300 chars.
+  If a limit would be exceeded, drop older/less important details first and preserve specific
+  values (names, numbers, versions) over narrative.
+
+  Output JSON only, one of:
+  {"decision": "merge", "abstract": "...", "overview": "...", "content": "...", "reason": "..."}
+  {"decision": "skip", "reason": "..."}
 
   Constraints:
   - `abstract` must be concise and specific.
-  - `overview` and `content` must be non-empty.
+  - `overview` and `content` must be non-empty when decision is "merge".
+  - Output language must be {{ output_language }}.
   - Do not output any text outside JSON.
 
 llm_config:

--- a/openviking/session/memory_extractor.py
+++ b/openviking/session/memory_extractor.py
@@ -474,7 +474,7 @@ class MemoryExtractor:
                 owner_space=owner_space,
             )
             logger.info(f"uri {memory_uri} abstract: {payload.abstract} content: {payload.content}")
-            memory.set_vectorize(Vectorize(text=payload.content))
+            memory.set_vectorize(Vectorize(text=payload.abstract or payload.content))
             return memory
 
         # Determine parent URI based on category
@@ -514,7 +514,7 @@ class MemoryExtractor:
             owner_space=owner_space,
         )
         logger.info(f"uri {memory_uri} abstract: {candidate.abstract} content: {candidate.content}")
-        memory.set_vectorize(Vectorize(text=candidate.content))
+        memory.set_vectorize(Vectorize(text=candidate.abstract or candidate.content))
         return memory
 
     async def _append_to_profile(

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -449,11 +449,8 @@ class SemanticProcessor(DequeueHandlerBase):
         try:
             entries = await viking_fs.ls(dir_uri, ctx=ctx)
         except Exception as e:
-            logger.warning(f"Failed to list memory directory {dir_uri}: {e}")
             _mark_failed(str(e))
-            if msg.lifecycle_lock_handle_id:
-                await self._release_memory_lifecycle_lock(msg.lifecycle_lock_handle_id)
-            return
+            raise RuntimeError(f"Failed to list memory directory {dir_uri}: {e}") from e
 
         file_paths: List[str] = []
         for entry in entries:
@@ -567,11 +564,8 @@ class SemanticProcessor(DequeueHandlerBase):
             await viking_fs.write_file(f"{dir_uri}/.abstract.md", abstract, ctx=ctx)
             logger.info(f"Generated abstract.md and overview.md for {dir_uri}")
         except Exception as e:
-            logger.error(f"Failed to write abstract/overview for {dir_uri}: {e}")
             _mark_failed(str(e))
-            if msg.lifecycle_lock_handle_id:
-                await self._release_memory_lifecycle_lock(msg.lifecycle_lock_handle_id)
-            return
+            raise RuntimeError(f"Failed to write abstract/overview for {dir_uri}: {e}") from e
 
         try:
             if msg.telemetry_id and msg.id:

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -16,6 +16,8 @@ PERMANENT_API_ERROR_PATTERNS = (
     "AccountOverdue",
 )
 
+_PERMANENT_IO_ERRORS = (FileNotFoundError, PermissionError, IsADirectoryError, NotADirectoryError)
+
 TRANSIENT_API_ERROR_PATTERNS = (
     "429",
     "500",
@@ -35,6 +37,12 @@ TRANSIENT_API_ERROR_PATTERNS = (
 
 def classify_api_error(error: Exception) -> str:
     """Classify an API error as permanent, transient, or unknown."""
+    # Local filesystem errors (including wrapped causes) are always permanent —
+    # retrying never heals a missing path or denied permission.
+    for exc in (error, error.__cause__):
+        if exc is not None and isinstance(exc, _PERMANENT_IO_ERRORS):
+            return "permanent"
+
     texts = [str(error)]
     if error.__cause__ is not None:
         texts.append(str(error.__cause__))

--- a/tests/storage/test_memory_semantic_stall.py
+++ b/tests/storage/test_memory_semantic_stall.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for memory semantic queue stall fix.
+
+_process_memory_directory() previously had silent early-return paths for ls
+and write_file failures, which bypassed on_dequeue()'s completion callbacks
+and left the queue's in_progress counter stuck. These tests pin the fixed
+behaviour: error paths propagate and on_dequeue reports error (not success)
+through the real classify_api_error path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+
+def _make_msg(**kwargs) -> SemanticMsg:
+    defaults = {
+        "uri": "viking://user/default/memories/preferences",
+        "context_type": "memory",
+        "recursive": False,
+    }
+    defaults.update(kwargs)
+    return SemanticMsg(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_ls_filesystem_error_reports_error(monkeypatch):
+    """FileNotFoundError from ls must reach on_error (not on_success)."""
+    processor = SemanticProcessor()
+
+    fake_fs = MagicMock()
+    fake_fs.ls = AsyncMock(side_effect=FileNotFoundError("/memories"))
+
+    success_called = False
+    error_called = False
+
+    def on_success():
+        nonlocal success_called
+        success_called = True
+
+    def on_error(msg, data=None):
+        nonlocal error_called
+        error_called = True
+
+    processor.set_callbacks(on_success, lambda: None, on_error)
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.resolve_telemetry",
+        lambda _tid: None,
+    )
+
+    await processor.on_dequeue(_make_msg().to_dict())
+
+    assert error_called, "FileNotFoundError should be classified permanent and reach on_error"
+    assert not success_called, "on_success must NOT be called when ls fails"
+
+
+@pytest.mark.asyncio
+async def test_empty_memory_dir_reports_success(monkeypatch):
+    """Empty directory still completes successfully — no regression."""
+    processor = SemanticProcessor()
+
+    fake_fs = MagicMock()
+    fake_fs.ls = AsyncMock(return_value=[])
+
+    success_called = False
+
+    def on_success():
+        nonlocal success_called
+        success_called = True
+
+    processor.set_callbacks(on_success, lambda: None, lambda msg, data=None: None)
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.resolve_telemetry",
+        lambda _tid: None,
+    )
+
+    await processor.on_dequeue(_make_msg().to_dict())
+
+    assert success_called, "empty memory directory should still report success"

--- a/tests/utils/test_circuit_breaker.py
+++ b/tests/utils/test_circuit_breaker.py
@@ -194,3 +194,21 @@ def test_classify_chained_exception():
     wrapper = RuntimeError("API call failed")
     wrapper.__cause__ = cause
     assert classify_api_error(wrapper) == "permanent"
+
+
+def test_classify_filesystem_errors_as_permanent():
+    from openviking.utils.circuit_breaker import classify_api_error
+
+    assert classify_api_error(FileNotFoundError("/path/not/found")) == "permanent"
+    assert classify_api_error(PermissionError("Permission denied")) == "permanent"
+    assert classify_api_error(IsADirectoryError("Is a directory")) == "permanent"
+    assert classify_api_error(NotADirectoryError("Not a directory")) == "permanent"
+
+
+def test_classify_chained_filesystem_error_as_permanent():
+    from openviking.utils.circuit_breaker import classify_api_error
+
+    cause = FileNotFoundError("/missing")
+    wrapper = RuntimeError("storage layer failed")
+    wrapper.__cause__ = cause
+    assert classify_api_error(wrapper) == "permanent"


### PR DESCRIPTION
Bundles three in-flight contributor PRs (#533, #549, #951) into one focused change set. Each piece has had reviewer feedback applied; diffs were re-tightened to the essentials so the review surface stays small.

## What this PR does

### 1. `memory_extraction.yaml` — concise L0/L1/L2 targets (from #549)
Adds explicit length targets so the LLM stops producing 500–2000-char L2 blobs that dilute embeddings and bloat retrieval cost:

- `abstract` ~50–80 chars
- `overview` 3–5 bullet points
- `content` 2–4 sentences with the essential specifics only

Dropped vs. #549: the BAD/GOOD content example blocks. They duplicated the Few-shot Examples section immediately below (Zayn's review), and mixing Chinese text into an otherwise-English prompt risked biasing `output_language: auto` for non-Chinese users (yangxinxin-7's review).

### 2. `memory_extractor.py` — vectorize on abstract (from #549)
Use `payload.abstract or payload.content` instead of full content for `Vectorize(text=...)`. Shorter, keyword-dense text produces more discriminative embeddings — relevant/irrelevant score separation widens meaningfully with the shorter prompts above.

### 3. `memory_merge_bundle.yaml` — facet guard + length limits (from #533)
Template v1 → v2. Three coordinated changes:

- **Facet guard**: shared category ≠ safe to merge. "Python code style" and "food preferences" are both `preferences` but cover different facets; force `{"decision": "skip"}` in that case.
- **Hard length limits**: abstract ≤ 80, overview ≤ 200, content ≤ 300. Merged memories were growing unbounded (1000+ chars), which caused the same embedding-dilution problem as #549 on the write path.
- **Condensed snapshot strategy**: on conflict, keep the newer value; do not retain superseded details. Merge output reads as an up-to-date snapshot, not a changelog.

**Breaking change**: `decision` now accepts `"skip"` in addition to `"merge"`. Callers must handle the new value (the existing memory merge pipeline already does).

### 4. `semantic_processor.py` + `model_retry.py` — queue stall fix (from #951, fixes #864)
`_process_memory_directory()` had two silent early-return paths for ls and write_file failures. Telemetry was `mark_failed`'d, but on return `on_dequeue()` still hit `report_success()` — so the queue's `in_progress` counter and `processed` count treated the failed message as done. Symptom: `pending` grew while `processed` stayed at 0.

Fix:
- Re-raise as `RuntimeError(... ) from e` in both error paths so `on_dequeue()` routes to `report_error()`.
- Classify local filesystem errors (`FileNotFoundError`, `PermissionError`, `IsADirectoryError`, `NotADirectoryError`, plus chained `__cause__`) as `"permanent"` in `classify_api_error()`. Without this, on-prem I/O failures land in the `unknown` bucket and get re-enqueued forever — the original #951 reviewer (qin-ctx) flagged this and it's the blocking piece.

## Test plan

- [x] `uv run pytest tests/utils/test_circuit_breaker.py tests/storage/test_memory_semantic_stall.py` — 20 passed
- [x] `uv run ruff check` + `ruff format --check` on all changed files — clean
- [x] Both YAML templates parse with `yaml.safe_load`
- [ ] Smoke test on a real memory directory after merge

## Credits

- #533: @lishixiang0705 — facet guard + length limits design
- #549: @lishixiang0705 — extraction length targets + vectorize-on-abstract
- #951: @deepakdevp — queue stall root cause + permanent-IO classification

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>