### PR TITLE
fix(memory): tolerate Python 3.10 ISO timestamps in extraction paths

### DIFF
--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -24,6 +24,7 @@ from openviking.session.memory.utils import (
 )
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import tracer
+from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.exceptions import NotFoundError
 from openviking_cli.utils import get_logger
 
@@ -146,20 +147,16 @@ class MessageRange:
 
     def _first_message_time(self) -> str | None:
         """获取第一条消息的时间（内部方法）"""
-        from datetime import datetime
-
         for elem in self.elements:
             if isinstance(elem, str):
                 continue
             if hasattr(elem, "created_at") and elem.created_at:
-                dt = datetime.fromisoformat(elem.created_at)
+                dt = parse_iso_datetime(elem.created_at)
                 return dt.strftime("%Y-%m-%d")
         return None
 
     def _first_message_time_with_weekday(self) -> str | None:
         """获取第一条消息的时间，带周几（内部方法）"""
-        from datetime import datetime
-
         for elem in self.elements:
             if isinstance(elem, str):
                 continue
@@ -174,7 +171,7 @@ class MessageRange:
                     "Saturday",
                     "Sunday",
                 ]
-                dt = datetime.fromisoformat(elem.created_at)
+                dt = parse_iso_datetime(elem.created_at)
                 weekday = weekday_en[dt.weekday()]
                 return f"{dt.strftime('%Y-%m-%d')} ({weekday})"
         return None

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -19,6 +19,7 @@ from openviking.session.memory.tools import (
 )
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import tracer
+from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
 
@@ -109,7 +110,7 @@ The system automatically generates URIs based on memory_type and fields. Just pr
             last_msg_time = None
 
         if first_msg_time:
-            session_time = datetime.fromisoformat(first_msg_time)
+            session_time = parse_iso_datetime(first_msg_time)
         else:
             session_time = datetime.now()
 
@@ -118,7 +119,7 @@ The system automatically generates URIs based on memory_type and fields. Just pr
 
         # 检查是否需要显示范围
         if last_msg_time and last_msg_time != first_msg_time:
-            last_time = datetime.fromisoformat(last_msg_time)
+            last_time = parse_iso_datetime(last_msg_time)
             time_display = f"{session_time_str} - {last_time.strftime('%Y-%m-%d %H:%M')}"
         else:
             time_display = session_time_str

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -19,15 +19,14 @@ from openviking.session.memory.tools import (
     get_tool,
 )
 from openviking.storage.viking_fs import VikingFS
-from openviking.telemetry import tracer
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
 
-logger = get_logger(__name__)
-
 if TYPE_CHECKING:
     from openviking.session.memory.memory_updater import ExtractContext
+
+logger = get_logger(__name__)
 
 
 class SessionExtractContextProvider(ExtractContextProvider):

--- a/openviking/session/memory/utils/content.py
+++ b/openviking/session/memory/utils/content.py
@@ -12,6 +12,8 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
 
+from openviking.utils.time_utils import parse_iso_datetime
+
 # Regex pattern to match the MEMORY_FIELDS HTML comment
 MEMORY_FIELDS_PATTERN = re.compile(r"\n\n<!--\s*MEMORY_FIELDS\s*\n(.*?)\n-->", re.DOTALL)
 
@@ -32,7 +34,7 @@ def _deserialize_datetime(metadata: Dict[str, Any]) -> Dict[str, Any]:
     for key in ["created_at", "updated_at"]:
         if key in result and isinstance(result[key], str):
             try:
-                result[key] = datetime.fromisoformat(result[key])
+                result[key] = parse_iso_datetime(result[key])
             except (ValueError, TypeError):
                 # Keep as string if parsing fails
                 pass

--- a/tests/session/memory/test_memory_timestamp_parsing.py
+++ b/tests/session/memory/test_memory_timestamp_parsing.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.message import Message
+from openviking.message.part import TextPart
+from openviking.session.memory.memory_updater import MessageRange
+from openviking.session.memory.session_extract_context_provider import (
+    SessionExtractContextProvider,
+)
+from openviking.session.memory.utils import deserialize_full, serialize_with_metadata
+
+
+def _message(*, created_at: str, role: str = "user", text: str = "hello") -> Message:
+    return Message(
+        id=f"msg-{role}",
+        role=role,
+        parts=[TextPart(text=text)],
+        created_at=created_at,
+    )
+
+
+@pytest.fixture
+def stub_provider_config(monkeypatch):
+    config = SimpleNamespace(
+        memory=SimpleNamespace(eager_prefetch=False),
+        language_fallback="en",
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: config,
+    )
+
+
+def test_conversation_message_accepts_z_suffix_timestamps(stub_provider_config):
+    provider = SessionExtractContextProvider(
+        messages=[
+            _message(created_at="2026-04-17T01:26:14.481Z", text="first"),
+            _message(
+                created_at="2026-04-17T02:31:09.000Z",
+                role="assistant",
+                text="second",
+            ),
+        ]
+    )
+
+    message = provider._build_conversation_message()
+
+    assert "Session Time:** 2026-04-17 01:26 - 2026-04-17 02:31" in message["content"]
+    assert "(Friday)" in message["content"]
+
+
+def test_message_range_accepts_extended_fractional_seconds():
+    msg_range = MessageRange(
+        [
+            _message(created_at="2026-04-17T09:10:11.1234567+08:00"),
+            _message(
+                created_at="2026-04-17T09:12:13.7654321+08:00",
+                role="assistant",
+            ),
+        ]
+    )
+
+    assert msg_range._first_message_time() == "2026-04-17"
+    assert msg_range._first_message_time_with_weekday() == "2026-04-17 (Friday)"
+
+
+def test_deserialize_full_parses_memory_metadata_timestamps_with_z_suffix():
+    full_content = serialize_with_metadata(
+        {
+            "content": "memory body",
+            "created_at": "2026-04-17T01:26:14.481Z",
+            "updated_at": "2026-04-17T09:10:11.1234567+08:00",
+        }
+    )
+
+    body, metadata = deserialize_full(full_content)
+
+    assert body == "memory body"
+    assert metadata is not None
+    assert metadata["created_at"].isoformat() == "2026-04-17T01:26:14.481000+00:00"
+    assert metadata["updated_at"].isoformat() == "2026-04-17T09:10:11.123456+08:00"


### PR DESCRIPTION
## Summary
- replace direct `datetime.fromisoformat(...)` calls in extraction-related memory paths with the existing tolerant `parse_iso_datetime(...)` helper
- cover session extract prompt rendering, message-range date helpers, and metadata deserialization for `Z` suffix / >6 fractional second timestamps
- keep the fix bounded to memory extraction and related formatting paths

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts= tests/session/memory/test_memory_timestamp_parsing.py`\n\nRefs #1510