### PR TITLE
feat(embedding): add DashScope dense text provider

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -119,7 +119,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 |-----------|------|-------------|
 | `max_concurrent` | int | Maximum concurrent embedding requests (`embedding.max_concurrent`, default: `10`) |
 | `max_retries` | int | Maximum retry attempts for transient embedding provider errors (`embedding.max_retries`, default: `3`; `0` disables retry) |
-| `provider` | str | `"volcengine"`, `"openai"`, `"vikingdb"`, `"jina"`, `"voyage"`, or `"gemini"` |
+| `provider` | str | `"volcengine"`, `"openai"`, `"dashscope"`, `"vikingdb"`, `"jina"`, `"voyage"`, or `"gemini"` |
 | `api_key` | str | API key |
 | `model` | str | Model name |
 | `dimension` | int | Vector dimension. For Voyage, this maps to `output_dimension` |
@@ -127,6 +127,8 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 | `batch_size` | int | Batch size for embedding requests |
 
 `embedding.max_retries` only applies to transient errors such as `429`, `5xx`, timeouts, and connection failures. Permanent errors such as `400`, `401`, `403`, and `AccountOverdue` are not retried automatically. The backoff strategy is exponential backoff with jitter, starting at `0.5s` and capped at `8s`.
+
+When `provider` is `dashscope`, OpenViking currently supports dense text embeddings only. If `input` is omitted, it defaults to `"text"`. Setting `input: "multimodal"` is rejected in this PR.
 
 #### Embedding Circuit Breaker
 
@@ -161,12 +163,28 @@ With `input: "multimodal"`, OpenViking can embed text, images (PNG, JPG, etc.), 
 
 **Supported providers:**
 - `openai`: OpenAI Embedding API
+- `dashscope`: DashScope OpenAI-compatible Embedding API (dense text only in this PR)
 - `volcengine`: Volcengine Embedding API
 - `vikingdb`: VikingDB Embedding API
 - `jina`: Jina AI Embedding API
 - `voyage`: Voyage AI Embedding API
 - `minimax`: MiniMax Embedding API
 - `gemini`: Google Gemini Embedding API (text-only; requires `google-genai>=1.0.0`)
+
+**dashscope provider example:**
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "provider": "dashscope",
+      "api_key": "your-dashscope-api-key",
+      "model": "text-embedding-v4",
+      "dimension": 1024
+    }
+  }
+}
+```
 
 **minimax provider example:**
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -121,7 +121,7 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 |------|------|------|
 | `max_concurrent` | int | 最大并发 Embedding 请求数（`embedding.max_concurrent`，默认：`10`） |
 | `max_retries` | int | Embedding provider 瞬时错误的最大重试次数（`embedding.max_retries`，默认：`3`；`0` 表示禁用重试） |
-| `provider` | str | `"volcengine"`、`"openai"`、`"vikingdb"`、`"jina"`、`"voyage"`、`"minimax"` 或 `"gemini"` |
+| `provider` | str | `"volcengine"`、`"openai"`、`"dashscope"`、`"vikingdb"`、`"jina"`、`"voyage"`、`"minimax"` 或 `"gemini"` |
 | `api_key` | str | API Key |
 | `model` | str | 模型名称 |
 | `dimension` | int | 向量维度 |
@@ -129,6 +129,8 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 | `batch_size` | int | 批量请求大小 |
 
 `embedding.max_retries` 仅对瞬时错误生效，例如 `429`、`5xx`、超时和连接错误；`400`、`401`、`403`、`AccountOverdue` 这类永久错误不会自动重试。退避策略为指数退避，初始延迟 `0.5s`，上限 `8s`，并带随机抖动。
+
+当 `provider` 为 `dashscope` 时，当前 PR 只支持 dense 文本 embedding。若省略 `input`，会默认使用 `"text"`；显式设置 `input: "multimodal"` 会被拒绝。
 
 #### Embedding 熔断（Circuit Breaker）
 
@@ -163,12 +165,28 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 
 **支持的 provider:**
 - `openai`: OpenAI Embedding API
+- `dashscope`: DashScope OpenAI 兼容 Embedding API（当前 PR 仅支持 dense 文本）
 - `volcengine`: 火山引擎 Embedding API
 - `vikingdb`: VikingDB Embedding API
 - `jina`: Jina AI Embedding API
 - `voyage`: Voyage AI Embedding API
 - `minimax`: MiniMax Embedding API
 - `gemini`: Google Gemini Embedding API（仅文本；需安装 `google-genai>=1.0.0`）
+
+**dashscope provider 配置示例:**
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "provider": "dashscope",
+      "api_key": "your-dashscope-api-key",
+      "model": "text-embedding-v4",
+      "dimension": 1024
+    }
+  }
+}
+```
 
 **minimax provider 配置示例:**
 

--- a/openviking/models/embedder/__init__.py
+++ b/openviking/models/embedder/__init__.py
@@ -10,6 +10,7 @@ Provides three embedder abstractions:
 
 Supported providers:
 - OpenAI: Dense only
+- DashScope: Dense only (text-only in this PR)
 - Volcengine: Dense, Sparse, Hybrid
 - Jina AI: Dense only
 - Voyage AI: Dense only
@@ -27,6 +28,7 @@ from openviking.models.embedder.base import (
     SparseEmbedderBase,
 )
 from openviking.models.embedder.cohere_embedders import CohereDenseEmbedder
+from openviking.models.embedder.dashscope_embedders import DashScopeDenseEmbedder
 
 try:
     from openviking.models.embedder.gemini_embedders import GeminiDenseEmbedder
@@ -56,6 +58,8 @@ from openviking.models.embedder.voyage_embedders import VoyageDenseEmbedder
 __all__ = [
     # Cohere implementations
     "CohereDenseEmbedder",
+    # DashScope implementations
+    "DashScopeDenseEmbedder",
     # Base classes
     "EmbedResult",
     "EmbedderBase",

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""DashScope embedding implementations.
+
+This PR intentionally supports only dense text embeddings through DashScope's
+OpenAI-compatible endpoint. Native multimodal embedding support is deferred.
+"""
+
+from typing import Any, Dict, Optional
+
+from openviking.models.embedder.openai_embedders import OpenAIDenseEmbedder
+
+
+class DashScopeDenseEmbedder(OpenAIDenseEmbedder):
+    """DashScope dense embedder via the OpenAI-compatible embeddings API."""
+
+    DEFAULT_API_BASE = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    supports_multimodal: bool = False
+
+    def __init__(
+        self,
+        model_name: str,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        dimension: Optional[int] = None,
+        query_param: Optional[str] = None,
+        document_param: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        input_type: Optional[str] = "text",
+    ):
+        normalized_input_type = (input_type or "text").lower()
+        if normalized_input_type != "text":
+            raise ValueError(
+                "DashScope currently supports dense text embeddings only. "
+                "input='multimodal' is not supported in this PR."
+            )
+
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            api_base=api_base or self.DEFAULT_API_BASE,
+            dimension=dimension,
+            query_param=query_param,
+            document_param=document_param,
+            config=config,
+            extra_headers=extra_headers,
+            provider="openai",
+            configured_provider="dashscope",
+        )
+
+        # Keep transport behavior OpenAI-compatible while reporting the configured provider.
+        self._provider = "dashscope"
+        self.provider = "dashscope"
+        self.input_type = normalized_input_type
+
+    def _should_send_dimensions(self) -> bool:
+        # Stay conservative with DashScope's compatible endpoint and preserve the same
+        # request shape as the existing provider='openai' workaround.
+        return False

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -37,14 +37,14 @@ class EmbeddingModelConfig(BaseModel):
     provider: Optional[str] = Field(
         default="volcengine",
         description=(
-            "Provider type: 'openai', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'litellm', 'local'. "
+            "Provider type: 'openai', 'dashscope', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'litellm', 'local'. "
             "For OpenRouter or other OpenAI-compatible providers, use 'litellm' with "
             "api_base and api_key, or 'openai' with api_base and extra_headers."
         ),
     )
     backend: Optional[str] = Field(
         default="volcengine",
-        description="Backend type (Deprecated, use 'provider' instead): 'openai', 'volcengine', 'vikingdb', 'voyage', 'local'",
+        description="Backend type (Deprecated, use 'provider' instead): 'openai', 'dashscope', 'volcengine', 'vikingdb', 'voyage', 'local'",
     )
     version: Optional[str] = Field(default=None, description="Model version")
     ak: Optional[str] = Field(default=None, description="Access Key ID for VikingDB API")
@@ -80,9 +80,23 @@ class EmbeddingModelConfig(BaseModel):
         if isinstance(data, dict):
             provider = data.get("provider")
             backend = data.get("backend")
+            provider_name = provider.lower() if isinstance(provider, str) else None
+            backend_name = backend.lower() if isinstance(backend, str) else None
 
             if backend is not None and provider is None:
                 data["provider"] = backend
+                provider_name = backend_name
+
+            input_type = data.get("input")
+            if isinstance(input_type, str):
+                data["input"] = input_type.lower()
+
+            # DashScope support in this PR is text-only. When input is omitted, default to
+            # text so users can discover provider='dashscope' without needing an OpenAI
+            # compatibility workaround or an extra input override.
+            if (provider_name or backend_name) == "dashscope" and "input" not in data:
+                data["input"] = "text"
+
             for key in ("query_param", "document_param"):
                 value = data.get(key)
                 if isinstance(value, str):
@@ -103,6 +117,7 @@ class EmbeddingModelConfig(BaseModel):
 
         if self.provider not in [
             "openai",
+            "dashscope",
             "azure",
             "volcengine",
             "vikingdb",
@@ -117,7 +132,7 @@ class EmbeddingModelConfig(BaseModel):
         ]:
             raise ValueError(
                 f"Invalid embedding provider: '{self.provider}'. Must be one of: "
-                "'openai', 'azure', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'minimax', 'cohere', 'litellm', 'local'"
+                "'openai', 'dashscope', 'azure', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'minimax', 'cohere', 'litellm', 'local'"
             )
 
         # Provider-specific validation
@@ -131,6 +146,15 @@ class EmbeddingModelConfig(BaseModel):
                 raise ValueError("Azure provider requires 'api_key' to be set")
             if not self.api_base:
                 raise ValueError("Azure provider requires 'api_base' (Azure endpoint) to be set")
+
+        elif self.provider == "dashscope":
+            if not self.api_key:
+                raise ValueError("DashScope provider requires 'api_key' to be set")
+            if self.input != "text":
+                raise ValueError(
+                    "DashScope provider currently supports dense text embeddings only. "
+                    "Set 'input' to 'text'; 'multimodal' is not supported in this PR."
+                )
 
         elif self.provider == "ollama":
             # Ollama runs locally, no API key required
@@ -297,7 +321,8 @@ class EmbeddingCircuitBreakerConfig(BaseModel):
 
 class EmbeddingConfig(BaseModel):
     """
-    Embedding configuration, supports OpenAI, VolcEngine, VikingDB, Jina, Gemini, Voyage, or LiteLLM APIs.
+    Embedding configuration, supports OpenAI, DashScope, VolcEngine, VikingDB, Jina,
+    Gemini, Voyage, or LiteLLM APIs.
 
     Structure:
     - dense: Configuration for dense embedder
@@ -371,7 +396,7 @@ class EmbeddingConfig(BaseModel):
         """Factory method to create embedder instance based on provider and type.
 
         Args:
-            provider: Provider type ('openai', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'litellm')
+            provider: Provider type ('openai', 'dashscope', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'litellm')
             embedder_type: Embedder type ('dense', 'sparse', 'hybrid')
             config: EmbeddingModelConfig instance
 
@@ -383,6 +408,7 @@ class EmbeddingConfig(BaseModel):
         """
         from openviking.models.embedder import (
             CohereDenseEmbedder,
+            DashScopeDenseEmbedder,
             GeminiDenseEmbedder,
             JinaDenseEmbedder,
             LiteLLMDenseEmbedder,
@@ -435,6 +461,20 @@ class EmbeddingConfig(BaseModel):
                     "dimension": cfg.dimension,
                     "provider": "azure",
                     "configured_provider": "azure",
+                    "config": dict(runtime_config),
+                    **({"query_param": cfg.query_param} if cfg.query_param else {}),
+                    **({"document_param": cfg.document_param} if cfg.document_param else {}),
+                    **({"extra_headers": cfg.extra_headers} if cfg.extra_headers else {}),
+                },
+            ),
+            ("dashscope", "dense"): (
+                DashScopeDenseEmbedder,
+                lambda cfg: {
+                    "model_name": cfg.model,
+                    "api_key": cfg.api_key,
+                    "api_base": cfg.api_base,
+                    "dimension": cfg.dimension,
+                    "input_type": cfg.input,
                     "config": dict(runtime_config),
                     **({"query_param": cfg.query_param} if cfg.query_param else {}),
                     **({"document_param": cfg.document_param} if cfg.document_param else {}),

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the DashScope dense embedder wrapper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openviking.models.embedder import DashScopeDenseEmbedder
+
+
+def _make_mock_client(vector_size: int = 8):
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = MagicMock(
+        data=[MagicMock(embedding=[0.1] * vector_size)],
+        usage=None,
+    )
+    return mock_client
+
+
+@patch("openviking.models.embedder.openai_embedders.openai.OpenAI")
+def test_dashscope_embedder_uses_default_api_base_and_is_text_only(mock_openai_class):
+    mock_openai_class.return_value = _make_mock_client()
+
+    embedder = DashScopeDenseEmbedder(
+        model_name="text-embedding-v4",
+        api_key="dash-key",
+        dimension=8,
+    )
+
+    assert embedder.provider == "dashscope"
+    assert embedder._provider == "dashscope"
+    assert embedder.supports_multimodal is False
+    assert embedder.input_type == "text"
+
+    mock_openai_class.assert_called_once()
+    call_kwargs = mock_openai_class.call_args[1]
+    assert call_kwargs["base_url"] == DashScopeDenseEmbedder.DEFAULT_API_BASE
+
+
+def test_dashscope_embedder_rejects_multimodal_input():
+    with pytest.raises(ValueError, match="multimodal"):
+        DashScopeDenseEmbedder(
+            model_name="text-embedding-v4",
+            api_key="dash-key",
+            dimension=8,
+            input_type="multimodal",
+        )
+
+
+@patch("openviking.models.embedder.openai_embedders.openai.OpenAI")
+def test_dashscope_embed_does_not_send_dimensions_and_truncates_locally(mock_openai_class):
+    mock_client = _make_mock_client(vector_size=12)
+    mock_openai_class.return_value = mock_client
+
+    embedder = DashScopeDenseEmbedder(
+        model_name="text-embedding-v4",
+        api_key="dash-key",
+        dimension=8,
+    )
+    result = embedder.embed("hello dashscope")
+
+    assert len(result.dense_vector) == 8
+
+    mock_client.embeddings.create.assert_called_once()
+    call_kwargs = mock_client.embeddings.create.call_args[1]
+    assert call_kwargs["input"] == "hello dashscope"
+    assert call_kwargs["model"] == "text-embedding-v4"
+    assert "dimensions" not in call_kwargs

--- a/tests/unit/test_embedding_config_dashscope.py
+++ b/tests/unit/test_embedding_config_dashscope.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for DashScope embedding config and factory wiring."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openviking.models.embedder import DashScopeDenseEmbedder
+from openviking_cli.utils.config.embedding_config import EmbeddingConfig, EmbeddingModelConfig
+
+
+def _make_mock_client():
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = MagicMock(
+        data=[MagicMock(embedding=[0.1] * 8)],
+        usage=None,
+    )
+    return mock_client
+
+
+def test_dashscope_config_defaults_input_to_text():
+    cfg = EmbeddingModelConfig(
+        provider="dashscope",
+        model="text-embedding-v4",
+        api_key="dash-key",
+    )
+
+    assert cfg.provider == "dashscope"
+    assert cfg.input == "text"
+
+
+def test_dashscope_backend_sync_defaults_input_to_text():
+    cfg = EmbeddingModelConfig(
+        backend="dashscope",
+        model="text-embedding-v4",
+        api_key="dash-key",
+    )
+
+    assert cfg.provider == "dashscope"
+    assert cfg.input == "text"
+
+
+def test_dashscope_config_rejects_multimodal_input():
+    with pytest.raises(ValueError, match="dense text embeddings only"):
+        EmbeddingModelConfig(
+            provider="dashscope",
+            model="text-embedding-v4",
+            api_key="dash-key",
+            input="multimodal",
+        )
+
+
+def test_dashscope_config_requires_api_key():
+    with pytest.raises(ValueError, match="DashScope provider requires 'api_key'"):
+        EmbeddingModelConfig(
+            provider="dashscope",
+            model="text-embedding-v4",
+        )
+
+
+@patch("openviking.models.embedder.openai_embedders.openai.OpenAI")
+def test_dashscope_factory_creates_dashscope_embedder_with_default_api_base(mock_openai_class):
+    mock_openai_class.return_value = _make_mock_client()
+
+    cfg = EmbeddingModelConfig(
+        provider="dashscope",
+        model="text-embedding-v4",
+        api_key="dash-key",
+        dimension=8,
+    )
+    embedder = EmbeddingConfig(dense=cfg)._create_embedder("dashscope", "dense", cfg)
+
+    assert isinstance(embedder, DashScopeDenseEmbedder)
+    assert embedder.provider == "dashscope"
+    assert embedder.input_type == "text"
+
+    mock_openai_class.assert_called_once()
+    call_kwargs = mock_openai_class.call_args[1]
+    assert call_kwargs["api_key"] == "dash-key"
+    assert call_kwargs["base_url"] == DashScopeDenseEmbedder.DEFAULT_API_BASE


### PR DESCRIPTION
## Summary
- add first-class `provider: "dashscope"` support for dense text embeddings via DashScope's OpenAI-compatible endpoint
- explicitly default omitted DashScope `input` to `text` and reject `input: "multimodal"` in this bounded first step
- document the provider in the configuration guide and add focused config/embedder tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts= tests/unit/test_embedding_config_dashscope.py tests/unit/test_dashscope_embedder.py tests/misc/test_embedding_input_type.py -q`\n\n## Notes\n- this PR intentionally does **not** implement native DashScope image/video embedding support across the queue/vectorizer stack\n- it removes the need for the current `provider: "openai"` workaround for DashScope text embeddings\n\nRefs #1518