### PR TITLE
feat(embedder): add DashScope (Alibaba Tongyi) embedding provider

### DIFF
--- a/openviking/models/embedder/__init__.py
+++ b/openviking/models/embedder/__init__.py
@@ -14,6 +14,7 @@ Supported providers:
 - Jina AI: Dense only
 - Voyage AI: Dense only
 - Cohere: Dense only
+- DashScope (Alibaba Tongyi): Dense only (text + multimodal)
 - Google Gemini: Dense only
 - LiteLLM: Dense only (bridges to OpenRouter, Ollama, vLLM, and many others)
 """
@@ -27,6 +28,7 @@ from openviking.models.embedder.base import (
     SparseEmbedderBase,
 )
 from openviking.models.embedder.cohere_embedders import CohereDenseEmbedder
+from openviking.models.embedder.dashscope_embedders import DashScopeDenseEmbedder
 
 try:
     from openviking.models.embedder.gemini_embedders import GeminiDenseEmbedder
@@ -56,6 +58,8 @@ from openviking.models.embedder.voyage_embedders import VoyageDenseEmbedder
 __all__ = [
     # Cohere implementations
     "CohereDenseEmbedder",
+    # DashScope (Alibaba Tongyi) implementations
+    "DashScopeDenseEmbedder",
     # Base classes
     "EmbedResult",
     "EmbedderBase",

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""DashScope (Alibaba Tongyi) Embedder Implementation"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from openviking.models.embedder.base import (
+    DenseEmbedderBase,
+    EmbedResult,
+    truncate_and_normalize,
+)
+from openviking_cli.utils.logger import default_logger as logger
+
+DEFAULT_CN_ENDPOINT = "https://dashscope.aliyuncs.com"
+DEFAULT_INTL_ENDPOINT = "https://dashscope-intl.aliyuncs.com"
+_TEXT_EMBEDDINGS_PATH = "/compatible-mode/v1/embeddings"
+_MULTIMODAL_EMBEDDINGS_PATH = (
+    "/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding"
+)
+
+DASHSCOPE_MODEL_DIMENSIONS: Dict[str, int] = {
+    "qwen3-vl-embedding": 2560,
+    "qwen2.5-vl-embedding": 1024,
+    "tongyi-embedding-vision-plus-2026-03-06": 1152,
+    "tongyi-embedding-vision-flash-2026-03-06": 768,
+    "tongyi-embedding-vision-plus": 1152,
+    "tongyi-embedding-vision-flash": 768,
+    "text-embedding-v1": 1536,
+    "text-embedding-v2": 1536,
+    "text-embedding-v3": 1024,
+    "text-embedding-v4": 1024,
+}
+
+
+def get_dashscope_model_default_dimension(model_name: Optional[str]) -> int:
+    if not model_name:
+        return 1024
+    return DASHSCOPE_MODEL_DIMENSIONS.get(model_name, 1024)
+
+
+def _resolve_endpoint(endpoint: Optional[str]) -> str:
+    if not endpoint:
+        return DEFAULT_CN_ENDPOINT
+    value = endpoint.strip().lower()
+    if value in ("cn", "china", "default"):
+        return DEFAULT_CN_ENDPOINT
+    if value in ("intl", "international", "global"):
+        return DEFAULT_INTL_ENDPOINT
+    return endpoint.rstrip("/")
+
+
+class DashScopeDenseEmbedder(DenseEmbedderBase):
+    """DashScope (Alibaba Tongyi) Dense Embedder Implementation.
+
+    Supports DashScope embedding models via two routes:
+    - Text mode: OpenAI-compatible endpoint at /compatible-mode/v1/embeddings.
+    - Multimodal mode: native /api/v1/services/embeddings/multimodal-embedding/...
+
+    Multimodal mode is selected via ``input_type="multimodal"`` (default), matching
+    volcengine_embedders. Set ``input_type="text"`` to force the OpenAI-compatible
+    route. Endpoint selection supports the CN (default) and international (``intl``)
+    DashScope hosts.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        dimension: Optional[int] = None,
+        input_type: str = "multimodal",
+        enable_fusion: Optional[bool] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(model_name, config)
+        self.provider = "dashscope"
+
+        self.api_key = api_key
+        self.input_type = input_type
+        self.enable_fusion = enable_fusion
+        self.dimension = dimension
+
+        if not self.api_key:
+            raise ValueError("api_key is required")
+
+        resolved_base = api_base.rstrip("/") if api_base else _resolve_endpoint(endpoint)
+        self.api_base = resolved_base
+        self._text_url = f"{resolved_base}{_TEXT_EMBEDDINGS_PATH}"
+        self._multimodal_url = f"{resolved_base}{_MULTIMODAL_EMBEDDINGS_PATH}"
+
+        self._client: Optional[httpx.Client] = None
+        self._async_client: Optional[httpx.AsyncClient] = None
+
+        self._dimension = dimension or get_dashscope_model_default_dimension(model_name)
+
+    def _get_client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(timeout=60.0, headers=self._build_headers())
+        return self._client
+
+    def _get_async_client(self) -> httpx.AsyncClient:
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(timeout=60.0, headers=self._build_headers())
+        return self._async_client
+
+    def _build_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _is_multimodal(self) -> bool:
+        return (self.input_type or "").lower() == "multimodal"
+
+    def _build_text_payload(self, texts: List[str]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"model": self.model_name, "input": texts}
+        if self.dimension:
+            payload["dimensions"] = self.dimension
+        return payload
+
+    def _build_multimodal_payload(self, texts: List[str]) -> Dict[str, Any]:
+        contents = [{"text": text} for text in texts]
+        parameters: Dict[str, Any] = {}
+        if self.dimension:
+            parameters["dimension"] = self.dimension
+        if self.enable_fusion is not None:
+            parameters["enable_fusion"] = bool(self.enable_fusion)
+        payload: Dict[str, Any] = {
+            "model": self.model_name,
+            "input": {"contents": contents},
+        }
+        if parameters:
+            payload["parameters"] = parameters
+        return payload
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        status = response.status_code
+        try:
+            body = response.json()
+        except Exception:
+            body = response.text
+        if status == 401:
+            raise RuntimeError(f"DashScope API error 401: invalid api_key ({body})")
+        if status == 400:
+            raise RuntimeError(f"DashScope API error 400: bad request ({body})")
+        raise RuntimeError(f"DashScope API error {status}: {body}")
+
+    def _parse_text_response(self, data: Dict[str, Any]) -> List[List[float]]:
+        items = data.get("data")
+        if not items:
+            raise RuntimeError(f"DashScope text response missing 'data': {data}")
+        return [item["embedding"] for item in items]
+
+    def _parse_multimodal_response(self, data: Dict[str, Any]) -> List[List[float]]:
+        output = data.get("output")
+        if output is None:
+            message = data.get("message") or data.get("code") or data
+            raise RuntimeError(f"DashScope multimodal response missing 'output': {message}")
+        embeddings = output.get("embeddings")
+        if not embeddings:
+            raise RuntimeError(f"DashScope multimodal response missing 'embeddings': {output}")
+        vectors: List[List[float]] = []
+        for item in embeddings:
+            vec = item.get("embedding")
+            if vec is None:
+                raise RuntimeError(f"DashScope multimodal embedding entry missing vector: {item}")
+            vectors.append(vec)
+        return vectors
+
+    def _call_text(self, texts: List[str]) -> List[List[float]]:
+        client = self._get_client()
+        response = client.post(self._text_url, json=self._build_text_payload(texts))
+        self._raise_for_status(response)
+        return self._parse_text_response(response.json())
+
+    def _call_multimodal(self, texts: List[str]) -> List[List[float]]:
+        client = self._get_client()
+        response = client.post(
+            self._multimodal_url, json=self._build_multimodal_payload(texts)
+        )
+        self._raise_for_status(response)
+        return self._parse_multimodal_response(response.json())
+
+    async def _call_text_async(self, texts: List[str]) -> List[List[float]]:
+        client = self._get_async_client()
+        response = await client.post(self._text_url, json=self._build_text_payload(texts))
+        self._raise_for_status(response)
+        return self._parse_text_response(response.json())
+
+    async def _call_multimodal_async(self, texts: List[str]) -> List[List[float]]:
+        client = self._get_async_client()
+        response = await client.post(
+            self._multimodal_url, json=self._build_multimodal_payload(texts)
+        )
+        self._raise_for_status(response)
+        return self._parse_multimodal_response(response.json())
+
+    def _normalize(self, vectors: List[List[float]]) -> List[List[float]]:
+        return [truncate_and_normalize(v, self.dimension) for v in vectors]
+
+    def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        def _call() -> EmbedResult:
+            if self._is_multimodal():
+                vectors = self._call_multimodal([text])
+            else:
+                vectors = self._call_text([text])
+            return EmbedResult(dense_vector=self._normalize(vectors)[0])
+
+        try:
+            result = self._run_with_retry(
+                _call,
+                logger=logger,
+                operation_name="DashScope embedding",
+            )
+            self.update_token_usage(
+                model_name=self.model_name,
+                provider="dashscope",
+                prompt_tokens=self._estimate_tokens(text),
+                completion_tokens=0,
+            )
+            return result
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"DashScope embedding failed: {e}") from e
+
+    async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
+        async def _call() -> EmbedResult:
+            if self._is_multimodal():
+                vectors = await self._call_multimodal_async([text])
+            else:
+                vectors = await self._call_text_async([text])
+            return EmbedResult(dense_vector=self._normalize(vectors)[0])
+
+        try:
+            result = await self._run_with_async_retry(
+                _call,
+                logger=logger,
+                operation_name="DashScope async embedding",
+            )
+            self.update_token_usage(
+                model_name=self.model_name,
+                provider="dashscope",
+                prompt_tokens=self._estimate_tokens(text),
+                completion_tokens=0,
+            )
+            return result
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"DashScope embedding failed: {e}") from e
+
+    def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
+        if not texts:
+            return []
+
+        def _call() -> List[EmbedResult]:
+            if self._is_multimodal():
+                return [self.embed(text, is_query=is_query) for text in texts]
+            vectors = self._call_text(texts)
+            return [EmbedResult(dense_vector=v) for v in self._normalize(vectors)]
+
+        try:
+            results = self._run_with_retry(
+                _call,
+                logger=logger,
+                operation_name="DashScope batch embedding",
+            )
+            if not self._is_multimodal():
+                total_tokens = sum(self._estimate_tokens(text) for text in texts)
+                self.update_token_usage(
+                    model_name=self.model_name,
+                    provider="dashscope",
+                    prompt_tokens=total_tokens,
+                    completion_tokens=0,
+                )
+            return results
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"DashScope batch embedding failed: {e}") from e
+
+    async def embed_batch_async(
+        self, texts: List[str], is_query: bool = False
+    ) -> List[EmbedResult]:
+        if not texts:
+            return []
+
+        async def _call() -> List[EmbedResult]:
+            if self._is_multimodal():
+                return list(
+                    await asyncio.gather(
+                        *[self.embed_async(text, is_query=is_query) for text in texts]
+                    )
+                )
+            vectors = await self._call_text_async(texts)
+            return [EmbedResult(dense_vector=v) for v in self._normalize(vectors)]
+
+        try:
+            results = await self._run_with_async_retry(
+                _call,
+                logger=logger,
+                operation_name="DashScope async batch embedding",
+            )
+            if not self._is_multimodal():
+                total_tokens = sum(self._estimate_tokens(text) for text in texts)
+                self.update_token_usage(
+                    model_name=self.model_name,
+                    provider="dashscope",
+                    prompt_tokens=total_tokens,
+                    completion_tokens=0,
+                )
+            return results
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"DashScope batch embedding failed: {e}") from e
+
+    def get_dimension(self) -> int:
+        return self._dimension
+
+    def close(self):
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:
+                pass
+        if self._async_client is not None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop and loop.is_running():
+                loop.create_task(self._async_client.aclose())
+            else:
+                asyncio.run(self._async_client.aclose())

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -37,7 +37,7 @@ class EmbeddingModelConfig(BaseModel):
     provider: Optional[str] = Field(
         default="volcengine",
         description=(
-            "Provider type: 'openai', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'litellm', 'local'. "
+            "Provider type: 'openai', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'litellm', 'local', 'dashscope'. "
             "For OpenRouter or other OpenAI-compatible providers, use 'litellm' with "
             "api_base and api_key, or 'openai' with api_base and extra_headers."
         ),
@@ -112,12 +112,13 @@ class EmbeddingModelConfig(BaseModel):
             "voyage",
             "minimax",
             "cohere",
+            "dashscope",
             "litellm",
             "local",
         ]:
             raise ValueError(
                 f"Invalid embedding provider: '{self.provider}'. Must be one of: "
-                "'openai', 'azure', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'minimax', 'cohere', 'litellm', 'local'"
+                "'openai', 'azure', 'volcengine', 'vikingdb', 'jina', 'ollama', 'gemini', 'voyage', 'minimax', 'cohere', 'dashscope', 'litellm', 'local'"
             )
 
         # Provider-specific validation
@@ -192,6 +193,10 @@ class EmbeddingModelConfig(BaseModel):
         elif self.provider == "cohere":
             if not self.api_key:
                 raise ValueError("Cohere provider requires 'api_key' to be set")
+
+        elif self.provider == "dashscope":
+            if not self.api_key:
+                raise ValueError("DashScope provider requires 'api_key' to be set")
 
         elif self.provider == "litellm":
             # litellm handles auth via env vars or explicit api_key; no strict requirement
@@ -383,6 +388,7 @@ class EmbeddingConfig(BaseModel):
         """
         from openviking.models.embedder import (
             CohereDenseEmbedder,
+            DashScopeDenseEmbedder,
             GeminiDenseEmbedder,
             JinaDenseEmbedder,
             LiteLLMDenseEmbedder,
@@ -582,6 +588,17 @@ class EmbeddingConfig(BaseModel):
                     "api_key": cfg.api_key,
                     "api_base": cfg.api_base,
                     "dimension": cfg.dimension,
+                    "config": dict(runtime_config),
+                },
+            ),
+            ("dashscope", "dense"): (
+                DashScopeDenseEmbedder,
+                lambda cfg: {
+                    "model_name": cfg.model,
+                    "api_key": cfg.api_key,
+                    "api_base": cfg.api_base,
+                    "dimension": cfg.dimension,
+                    "input_type": cfg.input,
                     "config": dict(runtime_config),
                 },
             ),

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for DashScope (Alibaba Tongyi) embedder support."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openviking.models.embedder import DashScopeDenseEmbedder
+from openviking.models.embedder.dashscope_embedders import (
+    DASHSCOPE_MODEL_DIMENSIONS,
+    DEFAULT_CN_ENDPOINT,
+    DEFAULT_INTL_ENDPOINT,
+    get_dashscope_model_default_dimension,
+)
+
+
+class TestDashScopeDenseEmbedder:
+    def test_init_requires_api_key(self):
+        with pytest.raises(ValueError, match="api_key is required"):
+            DashScopeDenseEmbedder(model_name="tongyi-embedding-vision-flash")
+
+    def test_default_cn_endpoint(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+        )
+        assert embedder.api_base == DEFAULT_CN_ENDPOINT
+
+    def test_intl_endpoint_alias(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+            endpoint="intl",
+        )
+        assert embedder.api_base == DEFAULT_INTL_ENDPOINT
+
+    def test_api_base_overrides_endpoint(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+            api_base="https://custom.example.com/",
+            endpoint="intl",
+        )
+        assert embedder.api_base == "https://custom.example.com"
+
+    def test_model_default_dimension(self):
+        assert DASHSCOPE_MODEL_DIMENSIONS["qwen3-vl-embedding"] == 2560
+        assert DASHSCOPE_MODEL_DIMENSIONS["tongyi-embedding-vision-flash"] == 768
+        assert get_dashscope_model_default_dimension("tongyi-embedding-vision-flash") == 768
+        assert get_dashscope_model_default_dimension("unknown") == 1024
+        assert get_dashscope_model_default_dimension(None) == 1024
+
+    def test_text_payload_shape(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="text-embedding-v4",
+            api_key="sk-x",
+            input_type="text",
+            dimension=512,
+        )
+        payload = embedder._build_text_payload(["hello", "world"])
+        assert payload == {
+            "model": "text-embedding-v4",
+            "input": ["hello", "world"],
+            "dimensions": 512,
+        }
+
+    def test_multimodal_payload_shape(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash-2026-03-06",
+            api_key="sk-x",
+            input_type="multimodal",
+            dimension=768,
+            enable_fusion=True,
+        )
+        payload = embedder._build_multimodal_payload(["hi"])
+        assert payload["model"] == "tongyi-embedding-vision-flash-2026-03-06"
+        assert payload["input"] == {"contents": [{"text": "hi"}]}
+        assert payload["parameters"] == {"dimension": 768, "enable_fusion": True}
+
+    def test_multimodal_payload_without_fusion_flag(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+            input_type="multimodal",
+        )
+        payload = embedder._build_multimodal_payload(["hi"])
+        assert "parameters" not in payload or "enable_fusion" not in payload.get(
+            "parameters", {}
+        )
+
+    def test_is_multimodal_routing(self):
+        e1 = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+            input_type="multimodal",
+        )
+        e2 = DashScopeDenseEmbedder(
+            model_name="text-embedding-v4",
+            api_key="sk-x",
+            input_type="text",
+        )
+        assert e1._is_multimodal() is True
+        assert e2._is_multimodal() is False
+
+    def test_raise_for_status_401(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="text-embedding-v4",
+            api_key="sk-x",
+        )
+        resp = MagicMock()
+        resp.status_code = 401
+        resp.json.return_value = {"error": "invalid key"}
+        with pytest.raises(RuntimeError, match="401"):
+            embedder._raise_for_status(resp)
+
+    def test_raise_for_status_400(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="text-embedding-v4",
+            api_key="sk-x",
+        )
+        resp = MagicMock()
+        resp.status_code = 400
+        resp.json.return_value = {"error": "bad input"}
+        with pytest.raises(RuntimeError, match="400"):
+            embedder._raise_for_status(resp)
+
+    def test_parse_text_response(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="text-embedding-v4",
+            api_key="sk-x",
+        )
+        data = {"data": [{"embedding": [0.1, 0.2]}, {"embedding": [0.3, 0.4]}]}
+        assert embedder._parse_text_response(data) == [[0.1, 0.2], [0.3, 0.4]]
+
+    def test_parse_multimodal_response(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+        )
+        data = {"output": {"embeddings": [{"embedding": [0.5, 0.6]}]}}
+        assert embedder._parse_multimodal_response(data) == [[0.5, 0.6]]
+
+    def test_parse_multimodal_response_missing_output(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+        )
+        with pytest.raises(RuntimeError, match="missing 'output'"):
+            embedder._parse_multimodal_response({"message": "err"})
+
+    def test_text_embed_calls_openai_compatible_endpoint(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="text-embedding-v4",
+            api_key="sk-x",
+            input_type="text",
+            dimension=1024,
+        )
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"embedding": [0.1] * 1024}]}
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        with patch.object(embedder, "_get_client", return_value=mock_client):
+            result = embedder.embed("hello")
+        assert len(result.dense_vector) == 1024
+        call_url = mock_client.post.call_args[0][0]
+        assert "/compatible-mode/v1/embeddings" in call_url
+
+    def test_multimodal_embed_calls_native_endpoint(self):
+        embedder = DashScopeDenseEmbedder(
+            model_name="tongyi-embedding-vision-flash",
+            api_key="sk-x",
+            input_type="multimodal",
+            dimension=768,
+        )
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "output": {"embeddings": [{"embedding": [0.2] * 768}]}
+        }
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        with patch.object(embedder, "_get_client", return_value=mock_client):
+            result = embedder.embed("hi")
+        assert len(result.dense_vector) == 768
+        call_url = mock_client.post.call_args[0][0]
+        assert "/multimodal-embedding/multimodal-embedding" in call_url


### PR DESCRIPTION
## Summary

Add a DashScope embedding provider so OpenViking can use Alibaba Cloud Tongyi embedding models alongside the existing Volcengine / OpenAI / Cohere / Ollama options.

`DashScopeDenseEmbedder` talks to DashScope via two routes, matching the pattern used by `volcengine_embedders.py`:

- **Text mode** — OpenAI-compatible endpoint at `/compatible-mode/v1/embeddings` (for `text-embedding-v1..v4`)
- **Multimodal mode** — native `/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding` (for `qwen3-vl-embedding`, `qwen2.5-vl-embedding`, `tongyi-embedding-vision-*`)

Mode is selected via `input_type` (`"multimodal"` by default, consistent with Volcengine). Endpoint selection accepts `"cn"` (default), `"intl"`, or an explicit URL override.

## Changes

- `openviking/models/embedder/dashscope_embedders.py` — new `DashScopeDenseEmbedder` (sync + async, `embed` / `embed_async` / `embed_batch` / `embed_batch_async`), `DASHSCOPE_MODEL_DIMENSIONS` constant, and `get_dashscope_model_default_dimension()` helper.
- `openviking/models/embedder/__init__.py` — export `DashScopeDenseEmbedder`.
- `openviking_cli/utils/config/embedding_config.py` — register `"dashscope"` in the provider allowlist, require `api_key`, and add `("dashscope", "dense")` to the factory.
- `tests/unit/test_dashscope_embedder.py` — 16 unit tests covering init requirements, endpoint resolution, model-dimension defaults, text vs multimodal payload shapes, routing flag, 401 / 400 error raising, response parsing, and end-to-end mocked `embed()` calls verifying correct URLs.

## Config example

```yaml
embedding:
  provider: dashscope
  model_name: tongyi-embedding-vision-flash
  api_key: ${DASHSCOPE_API_KEY}
  endpoint: cn          # or intl, or a full URL
  input_type: multimodal
  dimension: 768
```

## Test plan

- [x] `pytest tests/unit/test_dashscope_embedder.py` — **16 passed**.
- [x] Manual sanity check: payload shapes match DashScope docs for both text and multimodal endpoints.
- [ ] End-to-end call against a live DashScope API key (follow-up — I do not have one available).

## Follow-ups

- Phase 2 of the issue (image / multimodal input support beyond text, per-model config docs) is intentionally out of scope for this PR — wiring up `url` / `image` content types is a natural next step once this baseline lands.

Refs #1518