### PR TITLE
feat(memory): bundle #533 + #549 — facet guard, length limits, concise extraction

### DIFF
--- a/openviking/prompts/templates/compression/memory_extraction.yaml
+++ b/openviking/prompts/templates/compression/memory_extraction.yaml
@@ -204,25 +204,57 @@ template: |
 
   # Three-Level Structure
 
-  Each memory contains three levels, each serving a purpose:
+  Each memory contains three levels. **Keep all levels concise — memories are sticky notes, not essays.**
 
-  **abstract (L0)**: Index layer, plain text one-liner
+  **abstract (L0)**: Index layer, plain text one-liner. **Target: 1 sentence, ~50-80 characters.**
+  - This is the PRIMARY retrieval key — it MUST be specific enough to distinguish this memory from others.
   - Merge types (preferences/entities/profile/patterns): `[Merge key]: [Description]`
     - preferences: `Python code style: No type hints, concise and direct`
-    - entities: `OpenViking project: AI Agent long-term memory management system`
-    - profile: `User basic info: AI development engineer, 3 years experience`
+    - entities: `OpenViking: AI Agent 长期记忆系统，Python+AGFS，本地 oMLX embedding`
+    - profile: `AI 开发工程师，3年 LLM 应用经验，专注 Agent 架构`
     - patterns: `Teaching topic handling: Outline→Plan→Generate PPT`
   - Independent types (events/cases): Specific description
-    - events: `Decided to refactor memory system: Simplify to 5 categories`
+    - events: `2026-03-10 禁用 Lossless-Claw：CJK token 低估 3x + 预算失控`
     - cases: `Band not recognized → Request member/album/style details`
 
-  **overview (L1)**: Structured summary layer, organized with Markdown headings
+  **overview (L1)**: Structured summary layer, organized with Markdown headings. **Target: 3-5 bullet points.**
   - preferences: `## Preference Domain` / `## Specific Preferences`
   - entities: `## Basic Info` / `## Core Attributes`
   - events: `## Decision Content` / `## Reason` / `## Result`
   - cases: `## Problem` / `## Solution`
 
-  **content (L2)**: Detailed expansion layer, free Markdown, includes background, timeline, complete narrative
+  **content (L2)**: Core facts layer. **Target: 2-4 sentences with all essential specifics.**
+  - Capture ONLY the facts that would be lost if this memory were deleted.
+  - Include: names, versions, numbers, configurations, error messages, solutions.
+  - Exclude: background narratives, general explanations, elaboration of obvious points.
+  - Think: "What would I write on a sticky note to remind myself?"
+
+  **❌ BAD content** (too long, narrative-heavy):
+  ```
+  OpenViking is a long-term memory management system for AI Agents, originally open-sourced by
+  Volcengine, with the user currently maintaining a local instance and developing it as a
+  memory-openviking plugin compatible with the OpenClaw environment. The system employs a
+  front-end/back-end separated architecture built around an AGFS foundation... [1200+ chars]
+  ```
+
+  **✅ GOOD content** (concise, fact-dense):
+  ```
+  OpenViking (OV): 火山引擎开源 AI Agent 长期记忆系统，用户本地维护。Python+AGFS，viking:// URI，
+  L0-L4 分层上下文。本地 oMLX 4bit-DWQ embedding，dashscope/qwen3.5-plus VLM。
+  296 记忆文件，2872 向量，34MB vectordb。
+  ```
+
+  **❌ BAD content** (single memory with too many topics):
+  ```
+  Lossless-Claw (LCM v0.2.8) was a third-party LLM context auto-compression plugin...
+  The disablement resulted from fatal defects... The Meridian project now serves as
+  the successor... [1400+ chars mixing entity + cause + successor]
+  ```
+
+  **✅ GOOD** (split into separate memories):
+  Memory 1 [entities]: `Lossless-Claw (LCM v0.2.8): OpenClaw LLM 压缩插件，Martian-Engineering 开发，2026-03-10 已禁用。`
+  Memory 2 [cases]: `LCM 禁用原因：estimateTokens 对 CJK 低估 3x；assemble() 无预算控制致注入膨胀。`
+  Memory 3 [entities]: `Meridian: LCM 后继，复用~1200行。SQLite+FTS5、tiktoken、三区预算硬分配。`
 
   # Few-shot Examples
 

--- a/openviking/prompts/templates/compression/memory_extraction.yaml
+++ b/openviking/prompts/templates/compression/memory_extraction.yaml
@@ -210,11 +210,11 @@ template: |
   - This is the PRIMARY retrieval key — it MUST be specific enough to distinguish this memory from others.
   - Merge types (preferences/entities/profile/patterns): `[Merge key]: [Description]`
     - preferences: `Python code style: No type hints, concise and direct`
-    - entities: `OpenViking: AI Agent 长期记忆系统，Python+AGFS，本地 oMLX embedding`
-    - profile: `AI 开发工程师，3年 LLM 应用经验，专注 Agent 架构`
+    - entities: `OpenViking project: AI Agent long-term memory management system`
+    - profile: `User basic info: AI development engineer, 3 years experience`
     - patterns: `Teaching topic handling: Outline→Plan→Generate PPT`
   - Independent types (events/cases): Specific description
-    - events: `2026-03-10 禁用 Lossless-Claw：CJK token 低估 3x + 预算失控`
+    - events: `Decided to refactor memory system: Simplify to 5 categories`
     - cases: `Band not recognized → Request member/album/style details`
 
   **overview (L1)**: Structured summary layer, organized with Markdown headings. **Target: 3-5 bullet points.**
@@ -227,34 +227,6 @@ template: |
   - Capture ONLY the facts that would be lost if this memory were deleted.
   - Include: names, versions, numbers, configurations, error messages, solutions.
   - Exclude: background narratives, general explanations, elaboration of obvious points.
-  - Think: "What would I write on a sticky note to remind myself?"
-
-  **❌ BAD content** (too long, narrative-heavy):
-  ```
-  OpenViking is a long-term memory management system for AI Agents, originally open-sourced by
-  Volcengine, with the user currently maintaining a local instance and developing it as a
-  memory-openviking plugin compatible with the OpenClaw environment. The system employs a
-  front-end/back-end separated architecture built around an AGFS foundation... [1200+ chars]
-  ```
-
-  **✅ GOOD content** (concise, fact-dense):
-  ```
-  OpenViking (OV): 火山引擎开源 AI Agent 长期记忆系统，用户本地维护。Python+AGFS，viking:// URI，
-  L0-L4 分层上下文。本地 oMLX 4bit-DWQ embedding，dashscope/qwen3.5-plus VLM。
-  296 记忆文件，2872 向量，34MB vectordb。
-  ```
-
-  **❌ BAD content** (single memory with too many topics):
-  ```
-  Lossless-Claw (LCM v0.2.8) was a third-party LLM context auto-compression plugin...
-  The disablement resulted from fatal defects... The Meridian project now serves as
-  the successor... [1400+ chars mixing entity + cause + successor]
-  ```
-
-  **✅ GOOD** (split into separate memories):
-  Memory 1 [entities]: `Lossless-Claw (LCM v0.2.8): OpenClaw LLM 压缩插件，Martian-Engineering 开发，2026-03-10 已禁用。`
-  Memory 2 [cases]: `LCM 禁用原因：estimateTokens 对 CJK 低估 3x；assemble() 无预算控制致注入膨胀。`
-  Memory 3 [entities]: `Meridian: LCM 后继，复用~1200行。SQLite+FTS5、tiktoken、三区预算硬分配。`
 
   # Few-shot Examples
 

--- a/openviking/prompts/templates/compression/memory_merge_bundle.yaml
+++ b/openviking/prompts/templates/compression/memory_merge_bundle.yaml
@@ -1,8 +1,8 @@
 metadata:
   id: "compression.memory_merge_bundle"
   name: "Memory Merge Bundle"
-  description: "Merge memory and return L0/L1/L2 in one structured response"
-  version: "1.0.0"
+  description: "Merge memory and return L0/L1/L2 in one structured response, with facet guard and length limits"
+  version: "2.0.0"
   language: "en"
   category: "compression"
 
@@ -46,7 +46,7 @@ variables:
     default: "auto"
 
 template: |
-  You are merging one existing memory with one new memory update.
+  You are deciding whether to merge two memories of the same category, or skip (keep them separate).
 
   Category: {{ category }}
   Target Output Language: {{ output_language }}
@@ -61,26 +61,62 @@ template: |
   - Overview (L1): {{ new_overview }}
   - Content (L2): {{ new_content }}
 
-  Requirements:
-  - Merge into a single coherent memory.
-  - Keep non-conflicting details from existing memory.
-  - Update conflicting details to reflect the newer fact.
-  - Output language must be {{ output_language }}.
-  - Return JSON only.
+  ## Step 1: Facet coherence check
 
-  Output JSON schema:
+  Before merging, determine whether the two memories describe the SAME specific facet/topic.
+
+  Same facet examples (should merge):
+  - "Python code style: no type hints" + "Python code style: concise comments" → same facet (Python code style)
+  - "OpenViking project: memory extraction" + "OpenViking project: added dedup" → same facet (OpenViking project)
+
+  Different facet examples (should skip):
+  - "Python code style: no type hints" + "Food preference: likes apples" → different facets
+  - "Server 192.168.2.75: runs agent-helper" + "OpenViking project: memory extraction" → different facets
+  - "Git commit style: zh-CN verbs" + "Exit code semantics: 0/1/2" → different facets
+
+  If the two memories cover DIFFERENT facets, you MUST output decision "skip".
+  Do NOT merge unrelated information just because they share the same category.
+
+  ## Step 2: Merge (only if same facet)
+
+  If merging:
+  - When facts conflict, keep the NEWER version only.
+  - Condense to essential facts. Do NOT accumulate every historical detail.
+  - The merged memory should read as a clean, up-to-date snapshot — not a changelog.
+
+  ## Hard length limits
+
+  - `abstract`: ≤ 80 characters
+  - `overview`: ≤ 200 characters
+  - `content`: ≤ 300 characters
+
+  If the merged result would exceed these limits, aggressively summarize.
+  Drop older, less important details first. Preserve specific values (names, numbers, versions) over narrative.
+
+  ## Output
+
+  Return JSON only. Two possible decisions:
+
+  When merging:
   {
     "decision": "merge",
-    "abstract": "one-line L0 summary",
-    "overview": "structured markdown L1 summary",
-    "content": "full merged L2 content",
+    "abstract": "one-line L0 (≤80 chars)",
+    "overview": "structured L1 (≤200 chars)",
+    "content": "condensed L2 (≤300 chars)",
     "reason": "short reason"
+  }
+
+  When skipping (different facets):
+  {
+    "decision": "skip",
+    "reason": "short reason why these are different facets"
   }
 
   Constraints:
   - `abstract` must be concise and specific.
-  - `overview` and `content` must be non-empty.
+  - `overview` and `content` must be non-empty when decision is "merge".
   - Do not output any text outside JSON.
+  - Output language must be {{ output_language }}.
 
 llm_config:
   temperature: 0.0

--- a/openviking/session/memory_extractor.py
+++ b/openviking/session/memory_extractor.py
@@ -474,7 +474,8 @@ class MemoryExtractor:
                 owner_space=owner_space,
             )
             logger.info(f"uri {memory_uri} abstract: {payload.abstract} content: {payload.content}")
-            memory.set_vectorize(Vectorize(text=payload.content))
+            # Use abstract for vectorization — shorter text produces more discriminative embeddings
+            memory.set_vectorize(Vectorize(text=payload.abstract or payload.content))
             return memory
 
         # Determine parent URI based on category
@@ -514,7 +515,8 @@ class MemoryExtractor:
             owner_space=owner_space,
         )
         logger.info(f"uri {memory_uri} abstract: {candidate.abstract} content: {candidate.content}")
-        memory.set_vectorize(Vectorize(text=candidate.content))
+        # Use abstract for vectorization — shorter text produces more discriminative embeddings
+        memory.set_vectorize(Vectorize(text=candidate.abstract or candidate.content))
         return memory
 
     async def _append_to_profile(


### PR DESCRIPTION
Cherry-picked bundle of two in-flight prompt-quality PRs from @lishixiang0705. **Original commits preserved** — authorship is unchanged; my only new commit is a fixup addressing the inline review feedback.

## Commits

| SHA | Author | Source | Change |
|---|---|---|---|
| 1c98e28 | @lishixiang0705 | #533 | facet guard + length limits in `memory_merge_bundle.yaml` |
| 2566355 | @lishixiang0705 | #549 | length targets + vectorize-on-abstract |
| 508576a | @ZaynJarvis | review fixup | drop BAD/GOOD blocks, restore English examples |

## What each piece does

**#533 — memory_merge_bundle.yaml v1 → v2**
- Facet coherence check: even within the same category, don't merge memories covering different facets (Python code style + food preferences stay separate). `decision: skip` added.
- Hard length limits: abstract ≤ 80, overview ≤ 200, content ≤ 300.
- Condensed snapshot strategy: on conflict keep newer value, do not accumulate superseded details.

**#549 — memory_extraction.yaml + memory_extractor.py**
- Explicit length targets on the Three-Level Structure section (~50-80 / 3-5 bullets / 2-4 sentences).
- `set_vectorize(abstract or content)` — shorter, keyword-dense text produces more discriminative embeddings.

**Fixup — addresses inline review on #549**
- Drop the BAD/GOOD content example blocks. They duplicate the Few-shot Examples section below (my comment on #549).
- Restore English values in the L0 bullet examples; the Chinese values would bias `output_language: auto` for non-Chinese users (@yangxinxin-7's point).
- Did **not** update the existing Few-shot Examples to match the new length targets (yangxinxin-7's first point) — separate scope, follow-up.

## Memory-quality effect
Pending eval. Will run retrieval precision / embedding score-spread numbers before merge.

## Not in this PR
The queue stall fix from #951 is kept standalone — see its own companion PR (unrelated code path).

## Test plan
- [x] Both YAML templates parse with `yaml.safe_load`
- [ ] Retrieval precision / embedding score-spread eval on a real memory corpus