### PR TITLE
fix(ci): Update build files

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -209,16 +209,13 @@ jobs:
         enable-cache: true
 
     - name: Create venv (Linux)
-      run: uv venv --python "$PYTHON_BIN"
-
-    - name: Seed pip (Linux)
-      run: uv run python -m ensurepip --upgrade
+      run: uv venv --python "$PYTHON_BIN" --seed
 
     - name: Install dependencies
       run: uv sync --frozen
 
     - name: Install build dependencies
-      run: uv pip install setuptools setuptools_scm cmake wheel build
+      run: uv pip install setuptools setuptools_scm cmake wheel build maturin
 
     - name: Resolve OpenViking version for Rust CLI (Linux)
       shell: bash
@@ -404,7 +401,7 @@ jobs:
       run: uv sync --frozen
 
     - name: Install build dependencies
-      run: uv pip install setuptools setuptools_scm cmake wheel build
+      run: uv pip install setuptools setuptools_scm cmake wheel build maturin
 
     - name: Require ragfs native artifact for wheel builds
       shell: bash

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -27,14 +27,14 @@ jobs:
     - name: Install dependencies
       run: uv sync --frozen --extra dev
 
-    # --- NEW STEP: Get the list of changed files ---
+    - name: Fetch base branch
+      run: git fetch origin "${{ github.base_ref }}" --depth=1
+
     - name: Get changed files
       id: files
       run: |
-        # Compare the PR head to the base branch
-        echo "changed_files=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }} HEAD | grep '\.py$' | xargs)" >> $GITHUB_OUTPUT
+        echo "changed_files=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD -- '*.py' | xargs)" >> $GITHUB_OUTPUT
 
-    # --- UPDATED STEPS: Use the file list ---
     - name: List files
       run: echo "The changed files are ${{ steps.files.outputs.changed_files }}"
 

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install build dependencies (system pip)
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=70.1" setuptools_scm cmake wheel
+          pip install "setuptools>=70.1" setuptools_scm cmake wheel maturin
           echo "---"
           python -c "import setuptools; print(f'setuptools version: {setuptools.__version__}')"
 
@@ -113,12 +113,13 @@ jobs:
       - name: Install build dependencies (uv pip)
         run: |
           echo "Installing build dependencies to uv environment..."
-          uv pip install setuptools setuptools_scm cmake wheel
+          uv pip install setuptools setuptools_scm cmake wheel maturin
 
       - name: Build C++ extensions
         shell: bash
         run: |
           export OV_SKIP_OV_BUILD=1
+          export OV_REQUIRE_RAGFS_BUILD=1
           mkdir -p openviking/bin
           touch openviking/bin/ov
           chmod +x openviking/bin/ov
@@ -131,6 +132,7 @@ jobs:
           fi
           
           uv run python setup.py build_ext --inplace
+          uv run python -c "from openviking.pyagfs import get_binding_client; get_binding_client()"
 
       - name: Install API test dependencies
         run: |
@@ -312,7 +314,7 @@ jobs:
           echo "Starting OpenViking Server on port $SERVER_PORT..."
           export ROOT_API_KEY=test-root-api-key
           export SERVER_PORT=$SERVER_PORT
-          nohup uv run python -m openviking.server.bootstrap > openviking-server.log 2>&1 &
+          nohup uv run python -m openviking.server.bootstrap --port "$SERVER_PORT" > openviking-server.log 2>&1 &
           echo $! > openviking-server.pid
           echo "SERVER_PID=$(cat openviking-server.pid)" >> $GITHUB_ENV
           
@@ -348,7 +350,7 @@ jobs:
           $errFile = Join-Path $PWD "openviking-server-error.log"
           $batchFile = Join-Path $PWD "start-server.bat"
           
-          $batchContent = "@echo off`r`nset ROOT_API_KEY=test-root-api-key`r`nset SERVER_PORT=$port`r`nuv run python -m openviking.server.bootstrap`r`n"
+          $batchContent = "@echo off`r`nset ROOT_API_KEY=test-root-api-key`r`nset SERVER_PORT=$port`r`nuv run python -m openviking.server.bootstrap --port $port`r`n"
           Set-Content -Path $batchFile -Value $batchContent -Encoding ASCII
           
           Write-Host "Batch file created at: $batchFile"

--- a/crates/ragfs-python/pyproject.toml
+++ b/crates/ragfs-python/pyproject.toml
@@ -10,4 +10,3 @@ requires-python = ">=3.10"
 [tool.maturin]
 features = ["s3"]
 abi3 = true
-python-source = "3.10"


### PR DESCRIPTION
## Summary
- fix changed-file detection in lint so PR diffs are computed against the fetched base branch
- make Linux and wheel build jobs install the required build tooling and seed the venv safely
- make API integration startup verify ragfs_python is built and pass the selected port explicitly
- remove the invalid maturin `python-source` setting from `crates/ragfs-python`

## Why
These changes address the CI failures surfaced while validating the VLM provider work for Kimi, GLM, and Codex.

## Validation
- verified the changed-file diff command used by lint
- verified `setup.py build_ext --inplace` with `OV_REQUIRE_RAGFS_BUILD=1`
- verified `get_binding_client()` after the native build
- verified wheel build via `uv build --wheel`