### PR TITLE
fix(docker): set OPENVIKING_CLI_CONFIG_FILE so CLI finds /app/ovcli.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ COPY docker/openviking-console-entrypoint.sh /usr/local/bin/openviking-console-e
 RUN chmod +x /usr/local/bin/openviking-console-entrypoint
 ENV PATH="/app/.venv/bin:$PATH"
 ENV OPENVIKING_CONFIG_FILE="/app/ov.conf"
+ENV OPENVIKING_CLI_CONFIG_FILE="/app/ovcli.conf"
 
 EXPOSE 1933 8020
 
@@ -121,5 +122,5 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD curl -fsS http://127.0.0.1:1933/health || exit 1
 
 # Default runs server + console; override command to run CLI, e.g.:
-# docker run --rm <image> -v "$HOME/.openviking/ovcli.conf:/root/.openviking/ovcli.conf" openviking --help
+# docker run --rm -v "$HOME/.openviking/ovcli.conf:/app/ovcli.conf" <image> openviking --help
 ENTRYPOINT ["openviking-console-entrypoint"]


### PR DESCRIPTION
## Summary

Docker image already sets `OPENVIKING_CONFIG_FILE=/app/ov.conf` but had no CLI counterpart, so users exec'ing into the container found `ov` falling back to `~/.openviking/ovcli.conf` instead of the mounted `/app/ovcli.conf`.

Mirrors the existing server-side env with `OPENVIKING_CLI_CONFIG_FILE=/app/ovcli.conf` — the env var is already honored by both the Rust CLI (`crates/ov_cli/src/config.rs`) and the Python CLI (`openviking_cli/utils/config/config_loader.py`), so no resolver changes are needed.

Also updates the usage comment in the Dockerfile to mount to `/app/ovcli.conf` instead of `/root/.openviking/ovcli.conf`.

## Test plan

- [ ] `docker run --rm -v "\$HOME/.openviking/ovcli.conf:/app/ovcli.conf" <image> openviking --help` picks up the mounted config
- [ ] Exec'ing into a running container, `ov` commands use `/app/ovcli.conf` rather than falling back to `~/.openviking/`