### PR TITLE
[security] fix(prompts,installer): require explicit prompt opt-in and disable plugin lifecycle scripts

### DIFF
--- a/bot/scripts/install_local_openclaw_plugin.sh
+++ b/bot/scripts/install_local_openclaw_plugin.sh
@@ -44,7 +44,7 @@ if [[ "$REBUILD" == "false" ]]; then
   # 安装依赖
   echo "安装依赖..."
   cd "$OPENCLAW_PLUGIN_DIR"
-  npm install --include=dev
+  npm install --ignore-scripts --include=dev
 fi
 
 # 编译 TypeScript

--- a/docs/en/guides/10-prompt-guide.md
+++ b/docs/en/guides/10-prompt-guide.md
@@ -449,10 +449,17 @@ Applicable when:
 
 Available configuration:
 
+- `prompts.enable_custom_templates`
 - `prompts.templates_dir`
 - environment variable `OPENVIKING_PROMPT_TEMPLATES_DIR`
 
-Load priority:
+Secure default:
+
+- custom prompt templates are disabled by default
+- OpenViking only loads bundled templates unless a trusted operator sets `prompts.enable_custom_templates: true`
+- `OPENVIKING_PROMPT_TEMPLATES_DIR` is ignored unless that setting is enabled
+
+Load priority after opt-in:
 
 1. Explicitly provided template directory
 2. Environment variable `OPENVIKING_PROMPT_TEMPLATES_DIR`
@@ -485,6 +492,7 @@ Example configuration:
 ```json
 {
   "prompts": {
+    "enable_custom_templates": true,
     "templates_dir": "/path/to/custom-prompts"
   }
 }

--- a/docs/zh/guides/10-prompt-guide.md
+++ b/docs/zh/guides/10-prompt-guide.md
@@ -449,10 +449,17 @@ OpenViking 支持两种主要的自定义方式：
 
 可用配置：
 
+- `prompts.enable_custom_templates`
 - `prompts.templates_dir`
 - 环境变量 `OPENVIKING_PROMPT_TEMPLATES_DIR`
 
-加载优先级：
+安全默认值：
+
+- 自定义 prompt 模板默认禁用
+- 只有受信任运维显式设置 `prompts.enable_custom_templates: true` 时，OpenViking 才会加载外部模板目录
+- 在未开启该设置时，`OPENVIKING_PROMPT_TEMPLATES_DIR` 会被忽略
+
+开启后的加载优先级：
 
 1. 显式传入的模板目录
 2. 环境变量 `OPENVIKING_PROMPT_TEMPLATES_DIR`
@@ -485,6 +492,7 @@ custom-prompts/
 ```json
 {
   "prompts": {
+    "enable_custom_templates": true,
     "templates_dir": "/path/to/custom-prompts"
   }
 }

--- a/examples/openclaw-plugin/setup-helper/install.js
+++ b/examples/openclaw-plugin/setup-helper/install.js
@@ -1324,8 +1324,8 @@ async function downloadPlugin(destDir) {
   // npm install
   info(tr("Installing plugin npm dependencies...", "正在安装插件 npm 依赖..."));
   const npmArgs = resolvedNpmOmitDev
-    ? ["install", "--omit=dev", "--no-audit", "--no-fund", "--registry", NPM_REGISTRY]
-    : ["install", "--no-audit", "--no-fund", "--registry", NPM_REGISTRY];
+    ? ["install", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund", "--registry", NPM_REGISTRY]
+    : ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--registry", NPM_REGISTRY];
   await run("npm", npmArgs, { cwd: destDir, silent: false });
   info(tr(`Plugin deployed: ${PLUGIN_DEST}`, `插件部署完成: ${PLUGIN_DEST}`));
 }

--- a/openviking/prompts/manager.py
+++ b/openviking/prompts/manager.py
@@ -70,7 +70,10 @@ class PromptManager:
 
         Args:
             templates_dir: Directory containing YAML templates.
-                          If None, uses bundled templates.
+                          If provided explicitly, this trusted in-process override
+                          takes precedence over config-based custom template loading.
+                          If None, PromptManager uses bundled templates unless
+                          prompts.enable_custom_templates is enabled.
             enable_caching: Enable prompt template caching
         """
         self.templates_dir = self._resolve_templates_dir(templates_dir)
@@ -84,14 +87,17 @@ class PromptManager:
         if templates_dir is not None:
             return Path(templates_dir)
 
-        env_dir = os.environ.get(OPENVIKING_PROMPT_TEMPLATES_DIR_ENV)
-        if env_dir:
-            return Path(env_dir).expanduser()
-
         try:
             config = get_openviking_config()
         except FileNotFoundError:
             return cls._get_bundled_templates_dir()
+
+        if not config.prompts.enable_custom_templates:
+            return cls._get_bundled_templates_dir()
+
+        env_dir = os.environ.get(OPENVIKING_PROMPT_TEMPLATES_DIR_ENV)
+        if env_dir:
+            return Path(env_dir).expanduser()
 
         config_dir = config.prompts.templates_dir.strip()
         if config_dir:

--- a/openviking/prompts/manager.py
+++ b/openviking/prompts/manager.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 from pydantic import BaseModel, Field
 
 from openviking_cli.utils.config import (
@@ -200,8 +200,8 @@ class PromptManager:
             ):
                 variables[var_def.name] = variables[var_def.name][: var_def.max_length]
 
-        # Render template with Jinja2
-        jinja_template = Template(template.template)
+        # Render template with sandboxed Jinja2
+        jinja_template = SandboxedEnvironment(autoescape=False).from_string(template.template)
         return jinja_template.render(**variables)
 
     def _validate_variables(self, template: PromptTemplate, variables: Dict[str, Any]) -> None:

--- a/openviking_cli/utils/config/prompts_config.py
+++ b/openviking_cli/utils/config/prompts_config.py
@@ -8,11 +8,19 @@ from pydantic import BaseModel, Field
 class PromptsConfig(BaseModel):
     """Prompt template configuration for OpenViking."""
 
+    enable_custom_templates: bool = Field(
+        default=False,
+        description=(
+            "Enable loading prompt templates from operator-configured external directories. "
+            "Disabled by default so PromptManager only uses bundled templates unless a "
+            "trusted operator explicitly opts in."
+        ),
+    )
     templates_dir: str = Field(
         default="",
         description=(
-            "Custom prompt templates directory. If set, PromptManager loads prompt "
-            "templates from this directory instead of the bundled templates."
+            "Custom prompt templates directory. Only used when "
+            "prompts.enable_custom_templates is true."
         ),
     )
 

--- a/tests/misc/test_prompt_manager_security.py
+++ b/tests/misc/test_prompt_manager_security.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import pytest
+from jinja2.exceptions import SecurityError
+
+from openviking.prompts.manager import PromptManager
+
+
+def _write_template(base: Path, body: str) -> None:
+    target = base / "memory"
+    target.mkdir(parents=True, exist_ok=True)
+    indented_body = "\n".join(f"  {line}" for line in body.splitlines()) or "  "
+    (target / "profile.yaml").write_text(
+        """
+metadata:
+  id: memory.profile
+  name: Profile
+  description: Test template
+  version: "1.0"
+  language: en
+  category: memory
+variables:
+  - name: user_name
+    type: string
+    description: user name
+    required: false
+template: |
+""".lstrip()
+        + indented_body
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_prompt_manager_renders_safe_template(tmp_path: Path) -> None:
+    _write_template(tmp_path, "Hello {{ user_name }}")
+    manager = PromptManager(templates_dir=tmp_path, enable_caching=False)
+
+    rendered = manager.render("memory.profile", {"user_name": "alice"})
+
+    assert rendered.strip() == "Hello alice"
+
+
+def test_prompt_manager_blocks_unsafe_jinja_attribute_access(tmp_path: Path) -> None:
+    _write_template(
+        tmp_path,
+        '{{ cycler.__init__.__globals__.os.system("echo should_not_run") }}',
+    )
+    manager = PromptManager(templates_dir=tmp_path, enable_caching=False)
+
+    with pytest.raises(SecurityError):
+        manager.render("memory.profile")

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -139,12 +139,12 @@ def test_prompt_manager_ignores_custom_templates_from_config_when_not_enabled(
     assert manager.templates_dir == PromptManager._get_bundled_templates_dir()
     bundled_template = manager.load_template("vision.image_understanding")
     assert bundled_template.metadata.id == "vision.image_understanding"
-    assert manager._resolve_template_path("memory.profile") != custom_dir / "memory" / "profile.yaml"
+    assert (
+        manager._resolve_template_path("memory.profile") != custom_dir / "memory" / "profile.yaml"
+    )
 
 
-def test_prompt_manager_ignores_environment_templates_dir_when_not_enabled(
-    tmp_path, monkeypatch
-):
+def test_prompt_manager_ignores_environment_templates_dir_when_not_enabled(tmp_path, monkeypatch):
     env_dir = tmp_path / "env-prompts"
     config_dir = tmp_path / "config-prompts"
     config_path = tmp_path / "ov.conf"
@@ -228,11 +228,17 @@ def test_context_provider_schema_directories_use_prompt_manager_resolved_templat
         "_resolve_templates_dir",
         classmethod(lambda cls, templates_dir=None: resolved_templates_dir),
     )
+    config = SimpleNamespace(
+        memory=SimpleNamespace(custom_templates_dir="", eager_prefetch=False),
+        output_language_override="",
+    )
     monkeypatch.setattr(
         "openviking.session.memory.session_extract_context_provider.get_openviking_config",
-        lambda: SimpleNamespace(
-            memory=SimpleNamespace(custom_templates_dir="", eager_prefetch=False)
-        ),
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.utils.language.get_openviking_config",
+        lambda: config,
     )
 
     provider = SessionExtractContextProvider(messages=[])

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -38,7 +38,12 @@ def _write_template(templates_dir: Path, content: str) -> None:
     )
 
 
-def _write_config(config_path: Path, templates_dir: Path) -> None:
+def _write_config(
+    config_path: Path,
+    templates_dir: Path,
+    *,
+    enable_custom_templates: bool = False,
+) -> None:
     config_path.write_text(
         json.dumps(
             {
@@ -51,10 +56,11 @@ def _write_config(config_path: Path, templates_dir: Path) -> None:
                     "dense": {
                         "provider": "openai",
                         "model": "text-embedding-3-small",
-                        "api_key": "test-key",
+                        "api_key": "***",
                     }
                 },
                 "prompts": {
+                    "enable_custom_templates": enable_custom_templates,
                     "templates_dir": str(templates_dir),
                 },
             }
@@ -74,7 +80,7 @@ def test_prompt_manager_prefers_environment_templates_dir(tmp_path, monkeypatch)
 
     _write_template(env_dir, "env-template")
     _write_template(config_dir, "config-template")
-    _write_config(config_path, config_dir)
+    _write_config(config_path, config_dir, enable_custom_templates=True)
 
     OpenVikingConfigSingleton.reset_instance()
     monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))
@@ -91,7 +97,7 @@ def test_prompt_manager_uses_ov_conf_templates_dir_when_env_is_unset(tmp_path, m
     config_path = tmp_path / "ov.conf"
 
     _write_template(config_dir, "config-template")
-    _write_config(config_path, config_dir)
+    _write_config(config_path, config_dir, enable_custom_templates=True)
 
     OpenVikingConfigSingleton.reset_instance()
     monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))
@@ -103,14 +109,58 @@ def test_prompt_manager_uses_ov_conf_templates_dir_when_env_is_unset(tmp_path, m
     assert manager.render("memory.profile") == "config-template"
 
 
-def test_prompt_manager_falls_back_to_bundled_templates_dir(monkeypatch):
+def test_prompt_manager_falls_back_to_bundled_templates_dir(tmp_path, monkeypatch):
+    missing_config = tmp_path / "missing-ov.conf"
+
     OpenVikingConfigSingleton.reset_instance()
-    monkeypatch.delenv(OPENVIKING_CONFIG_ENV, raising=False)
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(missing_config))
     monkeypatch.delenv(OPENVIKING_PROMPT_TEMPLATES_DIR_ENV, raising=False)
 
     manager = PromptManager(enable_caching=False)
 
     assert manager.templates_dir == PromptManager._get_bundled_templates_dir()
+
+
+def test_prompt_manager_ignores_custom_templates_from_config_when_not_enabled(
+    tmp_path, monkeypatch
+):
+    custom_dir = tmp_path / "custom-prompts"
+    config_path = tmp_path / "ov.conf"
+
+    _write_template(custom_dir, "custom-profile-template")
+    _write_config(config_path, custom_dir, enable_custom_templates=False)
+
+    OpenVikingConfigSingleton.reset_instance()
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))
+    monkeypatch.delenv(OPENVIKING_PROMPT_TEMPLATES_DIR_ENV, raising=False)
+
+    manager = PromptManager(enable_caching=False)
+
+    assert manager.templates_dir == PromptManager._get_bundled_templates_dir()
+    bundled_template = manager.load_template("vision.image_understanding")
+    assert bundled_template.metadata.id == "vision.image_understanding"
+    assert manager._resolve_template_path("memory.profile") != custom_dir / "memory" / "profile.yaml"
+
+
+def test_prompt_manager_ignores_environment_templates_dir_when_not_enabled(
+    tmp_path, monkeypatch
+):
+    env_dir = tmp_path / "env-prompts"
+    config_dir = tmp_path / "config-prompts"
+    config_path = tmp_path / "ov.conf"
+
+    _write_template(env_dir, "env-template")
+    _write_template(config_dir, "config-template")
+    _write_config(config_path, config_dir, enable_custom_templates=False)
+
+    OpenVikingConfigSingleton.reset_instance()
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))
+    monkeypatch.setenv(OPENVIKING_PROMPT_TEMPLATES_DIR_ENV, str(env_dir))
+
+    manager = PromptManager(enable_caching=False)
+
+    assert manager.templates_dir == PromptManager._get_bundled_templates_dir()
+    assert manager._resolve_template_path("memory.profile") != env_dir / "memory" / "profile.yaml"
 
 
 def test_prompt_manager_falls_back_to_bundled_template_when_custom_dir_is_partial(
@@ -120,7 +170,7 @@ def test_prompt_manager_falls_back_to_bundled_template_when_custom_dir_is_partia
     config_path = tmp_path / "ov.conf"
 
     _write_template(custom_dir, "custom-profile-template")
-    _write_config(config_path, custom_dir)
+    _write_config(config_path, custom_dir, enable_custom_templates=True)
 
     OpenVikingConfigSingleton.reset_instance()
     monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))


### PR DESCRIPTION
## Summary
This PR hardens two execution-capable trust boundaries in OpenViking.

- disable config- and environment-driven custom prompt template loading by default behind `prompts.enable_custom_templates`
- sandbox prompt rendering so enabled custom templates cannot execute unsafe Jinja attribute traversal during `PromptManager.render()`
- disable npm lifecycle scripts in the OpenClaw plugin installer and local install helper so attacker-controlled plugin content cannot execute during dependency installation
- add focused regression coverage for the prompt-template opt-in gate and sandboxing behavior, and update prompt customization docs to match the new secure default

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Config/env-driven custom prompt templates loaded by default | Writable/imported template content could become executable Jinja when operators pointed `prompts.templates_dir` at writable storage-backed paths | High |
| Unsandboxed custom prompt template rendering | Enabled custom templates could execute unsafe Jinja expressions during `PromptManager.render()` | High |
| Plugin installer lifecycle-script execution | Attacker-controlled plugin content could execute during plugin install/update when `npm install` ran lifecycle hooks | High |

## Before this PR
- `prompts.templates_dir` and `OPENVIKING_PROMPT_TEMPLATES_DIR` were honored automatically once present.
- `PromptManager.render()` used raw Jinja rendering, so custom prompt content was treated as executable template code.
- OpenClaw installer/update flows ran `npm install` inside plugin directories without disabling lifecycle scripts.
- There was no focused regression coverage proving that custom prompt templates are disabled by default.

## After this PR
- OpenViking uses bundled prompt templates by default.
- Operators must explicitly set `prompts.enable_custom_templates: true` before config- or environment-based custom prompt directories are used.
- Prompt rendering uses a sandboxed Jinja environment.
- OpenClaw installer/update flows and the local plugin install helper disable npm lifecycle scripts during dependency installation.
- Focused tests lock in both the prompt opt-in gate and the sandboxed rendering behavior.

## Explicit operator choice
Secure default configuration:

```json
{
  "prompts": {
    "enable_custom_templates": false
  }
}
```

Explicit opt-in configuration:

```json
{
  "prompts": {
    "enable_custom_templates": true,
    "templates_dir": "/path/to/custom-prompts"
  }
}
```

Disabled state:
- bundled templates are used
- `prompts.templates_dir` is ignored
- `OPENVIKING_PROMPT_TEMPLATES_DIR` is ignored

Enabled state:
- trusted operators can load custom templates from a configured directory
- environment variable override works again
- rendering still stays inside a sandboxed Jinja environment

## Why this matters
These issues cross a content-to-execution boundary.

In the prompt path, writable template content could move from configuration/storage into executable Jinja at render time. In the installer path, plugin package metadata could move from plugin content into code execution through npm lifecycle hooks. Both should require an explicit trust boundary instead of happening implicitly.

## Attack flow
```text
attacker-controlled imported prompt template
    -> operator points prompts.templates_dir at writable/imported storage
        -> PromptManager loads the imported YAML template
            -> vulnerable code executes attacker-controlled Jinja during render
```

```text
attacker-controlled plugin package content
    -> installer copies plugin into staging/plugin directory
        -> npm install runs in that attacker-controlled directory
            -> lifecycle scripts execute during install/update
```

## Affected code
| Issue | Files |
|-------|-------|
| Prompt custom-template opt-in gate + sandboxing | `openviking/prompts/manager.py`, `openviking_cli/utils/config/prompts_config.py`, `tests/test_prompt_manager.py`, `tests/misc/test_prompt_manager_security.py`, `docs/en/guides/10-prompt-guide.md`, `docs/zh/guides/10-prompt-guide.md` |
| Plugin installer lifecycle-script execution | `examples/openclaw-plugin/setup-helper/install.js`, `examples/openclaw-plugin/install.sh`, `bot/scripts/install_local_openclaw_plugin.sh` |

## Root cause
Issue 1: Config/env-driven custom prompt template loading by default
- PromptManager trusted config and environment overrides for external template directories with no explicit opt-in.
- The trust boundary failed because external template sources were treated as normal runtime configuration instead of privileged operator-controlled behavior.

Issue 2: Unsandboxed custom prompt template rendering
- PromptManager rendered template content with raw Jinja rendering.
- The trust boundary failed because custom prompt files were treated as safe executable templates rather than untrusted content.

Issue 3: Plugin installer lifecycle-script execution
- Installer/update flows ran `npm install` directly inside attacker-controlled plugin directories.
- The trust boundary failed because plugin package lifecycle hooks were treated as trusted during installation.

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Config/env-driven custom prompt template loading by default | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` |
| Unsandboxed custom prompt template rendering | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` |
| Plugin installer lifecycle-script execution | 7.8 High | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H` |

Rationale:
- The prompt issue becomes process-level code execution when operators enable custom template loading from writable/imported storage-backed paths; this PR now requires explicit opt-in and keeps rendering sandboxed even after opt-in.
- The installer issue requires an operator to install/update attacker-controlled plugin content, but code executes immediately once that installation occurs.

## Safe reproduction steps
### 1. Prompt custom-template execution
1. Configure a deployment to use a writable/imported directory for `prompts.templates_dir`.
2. Import a custom prompt template into that directory through the existing import path.
3. Put a safe Jinja payload in the template body that only writes a harmless marker file.
4. Trigger `PromptManager.render()` for that template.
5. Observe marker-file creation on vulnerable code.
6. After this PR, the same config-driven path is ignored unless `prompts.enable_custom_templates: true`, and unsafe Jinja attribute traversal is blocked even when opt-in is enabled.

### 2. OpenClaw plugin installer lifecycle execution
1. Create a local OpenViking repo copy with a plugin `package.json` containing a safe `postinstall` payload that only writes a harmless marker file.
2. Run the documented OpenClaw OpenViking installer against that local repo.
3. Observe that vulnerable code runs `npm install` in the plugin staging/deploy directory.
4. Observe marker-file creation during install and again during update.
5. After this PR, the same install path uses `npm install --ignore-scripts`, so the marker file is not created.

## Expected vulnerable behavior
- External prompt template directories configured through settings or environment are honored implicitly.
- Enabled custom templates can execute unsafe Jinja expressions during render.
- Plugin package lifecycle hooks execute during installer dependency installation.

## Changes in this PR
- add `prompts.enable_custom_templates` with a secure default of `false`
- make `PromptManager` ignore config- and environment-driven external template directories unless that setting is enabled
- replace raw Jinja rendering in `PromptManager` with a sandboxed Jinja environment
- add regression tests for the secure-default gate, env/config override behavior after opt-in, and blocked unsafe Jinja attribute traversal
- document the new prompt customization opt-in flow in the English and Chinese prompt guides
- add `--ignore-scripts` to the OpenClaw plugin installer and local install helper npm install flows

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| Prompt config hardening | `openviking_cli/utils/config/prompts_config.py` | Add `enable_custom_templates` with a default-secure opt-in model |
| Prompt resolution hardening | `openviking/prompts/manager.py` | Gate config/env custom template loading behind the new setting and keep Jinja sandboxed |
| Prompt regression tests | `tests/test_prompt_manager.py`, `tests/misc/test_prompt_manager_security.py` | Verify disabled-by-default behavior, enabled override behavior, and blocked unsafe rendering |
| Prompt docs | `docs/en/guides/10-prompt-guide.md`, `docs/zh/guides/10-prompt-guide.md` | Document the secure default and explicit opt-in configuration |
| Plugin installer hardening | `examples/openclaw-plugin/setup-helper/install.js`, `examples/openclaw-plugin/install.sh`, `bot/scripts/install_local_openclaw_plugin.sh` | Disable npm lifecycle scripts during dependency installation |

## Maintainer impact
- This patch is intentionally narrow and does not redesign prompt loading or plugin installation.
- Bundled prompt behavior remains the default.
- Trusted operators still have a supported way to use custom prompt templates, but it is now explicit and sandboxed.
- Plugin dependency installation still works, but installer-time lifecycle hooks no longer execute.
- No unrelated server/router/storage behavior is changed by this patch.

## Fix rationale
- External prompt template loading is a privileged control-plane behavior and should require explicit operator intent.
- Sandboxing prompt rendering is the narrowest durable fix for the validated `PromptManager.render()` execution path.
- Disabling npm lifecycle scripts is the narrowest durable fix for installer-time execution from attacker-controlled plugin content.
- The focused tests make the secure default, opt-in path, and sandbox behavior hard to regress.

## Reference patterns from other software
- GitHub Actions requires explicit maintainer approval before untrusted fork content can reach privileged workflow execution.
- GitLab protects sensitive runners/variables behind explicit authorization boundaries.
- This PR follows the same principle: untrusted content should not reach execution-capable paths without an explicit operator decision.

## Type of change
- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `cd /tmp/OpenViking-pr && python3 -m pytest -o addopts='' tests/test_prompt_manager.py tests/misc/test_prompt_manager_security.py -q`
- [x] `cd /tmp/OpenViking-pr && ruff check openviking/prompts/manager.py openviking_cli/utils/config/prompts_config.py tests/test_prompt_manager.py tests/misc/test_prompt_manager_security.py`
- [x] `cd /tmp/OpenViking-pr && node --check examples/openclaw-plugin/setup-helper/install.js`
- [x] `cd /tmp/OpenViking-pr && bash -n examples/openclaw-plugin/install.sh`
- [x] `cd /tmp/OpenViking-pr && bash -n bot/scripts/install_local_openclaw_plugin.sh`
- [x] safe local validation that patched `PromptManager` blocks unsafe Jinja attribute traversal without creating the marker file
- [x] safe local validation that patched installer logic no longer executes a malicious `postinstall` payload during install

Executed with:
- `cd /tmp/OpenViking-pr && python3 -m pytest -o addopts='' tests/test_prompt_manager.py tests/misc/test_prompt_manager_security.py -q`
- `cd /tmp/OpenViking-pr && ruff check openviking/prompts/manager.py openviking_cli/utils/config/prompts_config.py tests/test_prompt_manager.py tests/misc/test_prompt_manager_security.py`
- `cd /tmp/OpenViking-pr && node --check examples/openclaw-plugin/setup-helper/install.js`
- `cd /tmp/OpenViking-pr && bash -n examples/openclaw-plugin/install.sh`
- `cd /tmp/OpenViking-pr && bash -n bot/scripts/install_local_openclaw_plugin.sh`
- safe local PromptManager marker-file validation after patch
- safe local installer marker-file validation after patch

## Disclosure notes
- This PR is intentionally bounded to the validated prompt-template and installer execution-capable surfaces above.
- It does not claim a new unauthenticated remote HTTP RCE path.
- Prompt-template exploitability depends on operator opt-in to custom template loading; the secure default in this PR removes the implicit config/env exposure.
- The plugin-installer issue is installer/supply-chain scoped: exploitability depends on attacker-controlled plugin content reaching the installer.
- No unrelated repo files were changed.
