### PR TITLE
feat(parse): add phase-1 builtin parser provider layer

### DIFF
--- a/openviking/parse/__init__.py
+++ b/openviking/parse/__init__.py
@@ -17,6 +17,8 @@ from openviking.parse.parsers.html import HTMLParser
 from openviking.parse.parsers.markdown import MarkdownParser
 from openviking.parse.parsers.pdf import PDFParser
 from openviking.parse.parsers.text import TextParser
+from openviking.parse.plugin_base import ParserProvider
+from openviking.parse.plugin_manager import ParserPluginManager
 from openviking.parse.registry import ParserRegistry, get_registry, parse
 from openviking.parse.tree_builder import TreeBuilder
 from openviking.parse.vlm import VLMProcessor
@@ -34,6 +36,8 @@ __all__ = [
     "PDFParser",
     "HTMLParser",
     "DocumentConverter",
+    "ParserProvider",
+    "ParserPluginManager",
     # Custom parser support
     "CustomParserProtocol",
     "CustomParserWrapper",

--- a/openviking/parse/plugin_base.py
+++ b/openviking/parse/plugin_base.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Base contracts for parser providers."""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from openviking.parse.parsers.base_parser import BaseParser
+from openviking_cli.utils.config.parser_config import ParserConfig
+
+
+class ParserProvider(ABC):
+    """Factory contract for parser plugins."""
+
+    name: str
+
+    @property
+    @abstractmethod
+    def supported_extensions(self) -> List[str]:
+        """List of extensions exposed by this provider."""
+
+    def is_available(self) -> bool:
+        """Whether this provider can create a parser in the current environment."""
+        return True
+
+    @abstractmethod
+    def create_parser(self, config: Optional[ParserConfig] = None) -> BaseParser:
+        """Build a parser instance for registry registration."""

--- a/openviking/parse/plugin_manager.py
+++ b/openviking/parse/plugin_manager.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Discovery and loading helpers for parser providers."""
+
+import importlib
+import logging
+import pkgutil
+from types import ModuleType
+from typing import Dict, Mapping, Optional
+
+from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.plugin_base import ParserProvider
+from openviking_cli.utils.config.parser_config import ParserConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ParserPluginManager:
+    """Discover parser providers from an in-package plugin directory."""
+
+    def __init__(
+        self,
+        plugin_package: str = "openviking.parse.plugins",
+        parser_configs: Optional[Mapping[str, ParserConfig]] = None,
+    ):
+        self._plugin_package = plugin_package
+        self._parser_configs = dict(parser_configs or {})
+        self._providers: Optional[Dict[str, ParserProvider]] = None
+
+    def discover_providers(self) -> Dict[str, ParserProvider]:
+        """Discover providers exposed by the configured plugin package."""
+        if self._providers is not None:
+            return dict(self._providers)
+
+        discovered: Dict[str, ParserProvider] = {}
+
+        try:
+            package = importlib.import_module(self._plugin_package)
+        except Exception:
+            logger.warning("Failed to import parser plugin package %s", self._plugin_package)
+            self._providers = discovered
+            return dict(discovered)
+
+        package_path = getattr(package, "__path__", None)
+        if package_path is None:
+            self._providers = discovered
+            return dict(discovered)
+
+        for module_info in pkgutil.iter_modules(package_path, f"{package.__name__}."):
+            provider = self._load_provider_from_module(module_info.name)
+            if provider is None:
+                continue
+            discovered[provider.name] = provider
+
+        self._providers = discovered
+        return dict(discovered)
+
+    def get_provider(self, name: str) -> Optional[ParserProvider]:
+        """Return a discovered provider by name."""
+        return self.discover_providers().get(name)
+
+    def is_provider_available(self, name: str) -> bool:
+        """Return whether a discovered provider is available for use."""
+        provider = self.get_provider(name)
+        return bool(provider and provider.is_available())
+
+    def list_available_providers(self) -> list[str]:
+        """List names of available providers."""
+        return sorted(
+            name
+            for name, provider in self.discover_providers().items()
+            if provider.is_available()
+        )
+
+    def create_parser(self, name: str) -> Optional[BaseParser]:
+        """Create a parser from a discovered provider."""
+        provider = self.get_provider(name)
+        if provider is None or not provider.is_available():
+            return None
+        return provider.create_parser(config=self._parser_configs.get(name))
+
+    def _load_provider_from_module(self, module_name: str) -> Optional[ParserProvider]:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            logger.warning("Failed to import parser provider module %s", module_name, exc_info=True)
+            return None
+
+        candidate = self._resolve_provider_candidate(module)
+        if candidate is None:
+            return None
+        if isinstance(candidate, type):
+            candidate = candidate()
+        if not isinstance(candidate, ParserProvider):
+            logger.warning(
+                "Skipping parser provider module %s: unsupported provider object %r",
+                module_name,
+                candidate,
+            )
+            return None
+        return candidate
+
+    @staticmethod
+    def _resolve_provider_candidate(module: ModuleType) -> Optional[object]:
+        if hasattr(module, "PROVIDER"):
+            return getattr(module, "PROVIDER")
+        if hasattr(module, "get_provider"):
+            return module.get_provider()
+        return None

--- a/openviking/parse/plugins/__init__.py
+++ b/openviking/parse/plugins/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Builtin parser provider modules."""

--- a/openviking/parse/plugins/markdown_provider.py
+++ b/openviking/parse/plugins/markdown_provider.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Builtin provider for the markdown parser."""
+
+from typing import List, Optional
+
+from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.markdown import MarkdownParser
+from openviking.parse.plugin_base import ParserProvider
+from openviking_cli.utils.config.parser_config import ParserConfig
+
+
+class MarkdownParserProvider(ParserProvider):
+    """Create markdown parser instances for the registry."""
+
+    name = "markdown"
+
+    @property
+    def supported_extensions(self) -> List[str]:
+        return [".md", ".markdown", ".mdown", ".mkd"]
+
+    def create_parser(self, config: Optional[ParserConfig] = None) -> BaseParser:
+        return MarkdownParser(config=config)
+
+
+PROVIDER = MarkdownParserProvider()
+
+
+def get_provider() -> ParserProvider:
+    return PROVIDER

--- a/openviking/parse/plugins/text_provider.py
+++ b/openviking/parse/plugins/text_provider.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Builtin provider for the text parser."""
+
+from typing import List, Optional
+
+from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.text import TextParser
+from openviking.parse.plugin_base import ParserProvider
+from openviking_cli.utils.config.parser_config import ParserConfig
+
+
+class TextParserProvider(ParserProvider):
+    """Create text parser instances for the registry."""
+
+    name = "text"
+
+    @property
+    def supported_extensions(self) -> List[str]:
+        return [".txt", ".text"]
+
+    def create_parser(self, config: Optional[ParserConfig] = None) -> BaseParser:
+        return TextParser(config=config)
+
+
+PROVIDER = TextParserProvider()
+
+
+def get_provider() -> ParserProvider:
+    return PROVIDER

--- a/openviking/parse/registry.py
+++ b/openviking/parse/registry.py
@@ -15,6 +15,7 @@ from openviking.parse.parsers.base_parser import BaseParser
 from openviking.parse.parsers.directory import DirectoryParser
 from openviking.parse.parsers.epub import EPubParser
 from openviking.parse.parsers.excel import ExcelParser
+from openviking.parse.plugin_manager import ParserPluginManager
 
 # Import will be handled dynamically to avoid dependency issues
 from openviking.parse.parsers.html import HTMLParser
@@ -47,6 +48,7 @@ class ParserRegistry:
         self,
         register_optional: bool = True,
         parser_configs: Optional[Dict[str, ParserConfig]] = None,
+        plugin_manager: Optional[ParserPluginManager] = None,
     ):
         """
         Initialize registry with default parsers.
@@ -55,14 +57,22 @@ class ParserRegistry:
             register_optional: Whether to register optional parsers
                               that require extra dependencies
             parser_configs: Dictionary of parser configurations (from load_parser_configs_from_dict)
+            plugin_manager: Optional provider manager override for builtin parser loading
         """
         self._parsers: Dict[str, BaseParser] = {}
         self._extension_map: Dict[str, str] = {}
         self._parser_configs = parser_configs or {}
+        self._plugin_manager = plugin_manager or ParserPluginManager(
+            parser_configs=self._parser_configs
+        )
 
-        # Register core parsers
-        self.register("text", TextParser(config=self._parser_configs.get("text")))
-        self.register("markdown", MarkdownParser(config=self._parser_configs.get("markdown")))
+        # Register provider-backed core parsers with direct-instantiation fallback.
+        self._register_builtin_parser(
+            "text", lambda: TextParser(config=self._parser_configs.get("text"))
+        )
+        self._register_builtin_parser(
+            "markdown", lambda: MarkdownParser(config=self._parser_configs.get("markdown"))
+        )
         self.register("pdf", PDFParser(config=self._parser_configs.get("pdf")))
         self.register("html", HTMLParser(config=self._parser_configs.get("html")))
 
@@ -78,6 +88,13 @@ class ParserRegistry:
         self.register("image", ImageParser())
         self.register("audio", AudioParser())
         self.register("video", VideoParser())
+
+    def _register_builtin_parser(self, name: str, legacy_factory: Callable[[], BaseParser]) -> None:
+        """Register a builtin parser from a provider, with legacy fallback."""
+        parser = self._plugin_manager.create_parser(name)
+        if parser is None:
+            parser = legacy_factory()
+        self.register(name, parser)
 
     def register(self, name: str, parser: BaseParser) -> None:
         """

--- a/tests/parse/test_plugin_manager.py
+++ b/tests/parse/test_plugin_manager.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for parser provider discovery and registry compatibility."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from openviking.parse.base import NodeType, ResourceNode, create_parse_result
+from openviking.parse.parsers.markdown import MarkdownParser
+from openviking.parse.parsers.text import TextParser
+from openviking.parse.plugin_manager import ParserPluginManager
+from openviking.parse.registry import ParserRegistry
+
+
+class NullPluginManager:
+    """Plugin manager stub that forces the legacy registration path."""
+
+    def create_parser(self, name: str):
+        return None
+
+
+def test_builtin_provider_discovery_finds_text_and_markdown():
+    manager = ParserPluginManager()
+
+    providers = manager.discover_providers()
+
+    assert {"markdown", "text"}.issubset(providers)
+    assert providers["markdown"].supported_extensions == [".md", ".markdown", ".mdown", ".mkd"]
+    assert providers["text"].supported_extensions == [".txt", ".text"]
+    assert "markdown" in manager.list_available_providers()
+    assert "text" in manager.list_available_providers()
+
+
+def test_registry_resolves_provider_backed_builtin_extensions():
+    registry = ParserRegistry(register_optional=False)
+
+    markdown_parser = registry.get_parser_for_file(Path("notes.md"))
+    text_parser = registry.get_parser_for_file(Path("notes.txt"))
+
+    assert isinstance(markdown_parser, MarkdownParser)
+    assert isinstance(text_parser, TextParser)
+
+
+def test_registry_parse_keeps_text_fallback_for_unknown_extensions(tmp_path: Path):
+    registry = ParserRegistry(register_optional=False)
+    source = tmp_path / "notes.custom"
+    source.write_text("plain text fallback", encoding="utf-8")
+
+    result = create_parse_result(
+        root=ResourceNode(type=NodeType.ROOT),
+        source_path=str(source),
+        source_format="text",
+        parser_name="TextParser",
+    )
+    text_parser = registry.get_parser("text")
+    assert text_parser is not None
+    text_parser.parse = AsyncMock(return_value=result)  # type: ignore[method-assign]
+
+    parsed = asyncio.run(registry.parse(source))
+
+    assert parsed is result
+    text_parser.parse.assert_awaited_once_with(source)
+
+
+def test_registry_falls_back_to_legacy_builtin_factories_when_provider_unavailable():
+    registry = ParserRegistry(register_optional=False, plugin_manager=NullPluginManager())
+
+    assert isinstance(registry.get_parser("markdown"), MarkdownParser)
+    assert isinstance(registry.get_parser("text"), TextParser)
+    assert isinstance(registry.get_parser_for_file(Path("legacy.md")), MarkdownParser)
+    assert isinstance(registry.get_parser_for_file(Path("legacy.txt")), TextParser)


### PR DESCRIPTION
## Summary
- add a `ParserProvider` contract and in-package `ParserPluginManager` for builtin parser discovery
- register builtin `text` and `markdown` parsers through the provider layer with legacy direct-instantiation fallback
- add focused tests for provider discovery, registry routing, fallback behavior, and parser config propagation

Refs #1142.

Scope is limited to the phase-1 builtin provider layer; external parser plugin loading is not included.
