### PR TITLE
feat(parse): add multimodal parser semantic artifact MVP

### DIFF
--- a/openviking/parse/parsers/media/audio.py
+++ b/openviking/parse/parsers/media/audio.py
@@ -1,112 +1,162 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""
-Audio parser - Future implementation.
-
-Planned Features:
-1. Speech-to-text transcription using ASR models
-2. Audio metadata extraction (duration, sample rate, channels)
-3. Speaker diarization (identify different speakers)
-4. Timestamp alignment for transcribed text
-5. Generate structured ResourceNode with transcript
-
-Example workflow:
-    1. Load audio file
-    2. Extract metadata (duration, format, sample rate)
-    3. Transcribe speech to text using Whisper or similar
-    4. (Optional) Perform speaker diarization
-    5. Create ResourceNode with:
-       - type: NodeType.ROOT
-       - children: sections for each speaker/timestamp
-       - meta: audio metadata and timestamps
-    6. Return ParseResult
-
-Supported formats: MP3, WAV, OGG, FLAC, AAC, M4A
-"""
+"""Audio parser with bounded semantic artifact generation."""
 
 import asyncio
 import base64
+import io
 import os
+import re
 import tempfile
+import time
+import wave
 from pathlib import Path
 from typing import List, Optional, Union
 
 import openai
 
-from openviking.parse.base import NodeType, ParseResult, ResourceNode
+from openviking.parse.base import NodeType, ResourceNode, create_parse_result
 from openviking.parse.parsers.base_parser import BaseParser
 from openviking.parse.parsers.media.constants import AUDIO_EXTENSIONS
 from openviking_cli.utils.config.parser_config import AudioConfig
 from openviking_cli.utils.logger import get_logger
+from openviking_cli.utils.uri import VikingURI
 
 logger = get_logger(__name__)
 
 
+def _clean_text(value: str) -> str:
+    """Normalize whitespace for sidecar content."""
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def _truncate_text(value: str, limit: int) -> str:
+    """Truncate text without leaving trailing whitespace."""
+    text = _clean_text(value)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def _format_optional_number(value, *, digits: int = 2, suffix: str = "") -> str:
+    """Format metadata fields consistently."""
+    if value in (None, 0, 0.0, ""):
+        return "unknown"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}{suffix}"
+    return f"{value}{suffix}"
+
+
+def _transcript_success(text: Optional[str]) -> bool:
+    """Return True when transcript text contains actual recognized speech."""
+    if not text:
+        return False
+    lowered = text.lower().strip()
+    return not lowered.startswith(
+        (
+            "audio transcription unavailable:",
+            "audio transcription failed:",
+            "audio transcription returned empty result.",
+            "transcription disabled",
+            "audio track extraction unavailable:",
+        )
+    )
+
+
 class AudioParser(BaseParser):
-    """
-    Audio parser for audio files.
-    """
+    """Parser for standalone audio resources."""
 
     def __init__(self, config: Optional[AudioConfig] = None, **kwargs):
-        """
-        Initialize AudioParser.
-
-        Args:
-            config: Audio parsing configuration
-            **kwargs: Additional configuration parameters
-        """
         self.config = config or AudioConfig()
 
     @property
     def supported_extensions(self) -> List[str]:
-        """Return supported audio file extensions."""
         return AUDIO_EXTENSIONS
 
-    async def parse(self, source: Union[str, Path], instruction: str = "", **kwargs) -> ParseResult:
-        """
-        Parse audio file - only copy original file and extract basic metadata, no content understanding.
-
-        Args:
-            source: Audio file path
-            **kwargs: Additional parsing parameters
-
-        Returns:
-            ParseResult with audio content
-
-        Raises:
-            FileNotFoundError: If source file does not exist
-            IOError: If audio processing fails
-        """
-        from openviking.storage.viking_fs import get_viking_fs
-
-        # Convert to Path object
+    async def parse(self, source: Union[str, Path], instruction: str = "", **kwargs):
+        start_time = time.time()
         file_path = Path(source) if isinstance(source, str) else source
         if not file_path.exists():
             raise FileNotFoundError(f"Audio file not found: {source}")
 
-        viking_fs = get_viking_fs()
-        temp_uri = viking_fs.create_temp_uri()
-
-        # Phase 1: Generate temporary files
         audio_bytes = file_path.read_bytes()
-        ext = file_path.suffix
-
-        from openviking_cli.utils.uri import VikingURI
-
-        # Sanitize original filename (replace spaces with underscores)
+        ext = file_path.suffix.lower()
         original_filename = file_path.name.replace(" ", "_")
-        # Root directory name: filename stem + _ + extension (without dot)
         stem = file_path.stem.replace(" ", "_")
-        ext_no_dot = ext[1:] if ext else ""
+        ext_no_dot = ext[1:] if ext else "audio"
         root_dir_name = VikingURI.sanitize_segment(f"{stem}_{ext_no_dot}")
-        root_dir_uri = f"{temp_uri}/{root_dir_name}"
-        await viking_fs.mkdir(root_dir_uri, exist_ok=True)
 
-        # 1.1 Save original audio with original filename (sanitized)
+        viking_fs = self._get_viking_fs()
+        temp_uri = self._create_temp_uri()
+        root_dir_uri = f"{temp_uri}/{root_dir_name}"
+        await viking_fs.mkdir(temp_uri, exist_ok=True)
+        await viking_fs.mkdir(root_dir_uri, exist_ok=True)
         await viking_fs.write_file_bytes(f"{root_dir_uri}/{original_filename}", audio_bytes)
 
-        # 1.2 Validate audio file using magic bytes
-        # Define magic bytes for supported audio formats
+        self._validate_audio_signature(file_path, audio_bytes)
+        metadata = self._extract_audio_metadata(file_path, audio_bytes)
+
+        transcript_status = "disabled"
+        transcript_text = "Transcription disabled by parser configuration."
+        if self.config.enable_transcription:
+            transcript_status, transcript_text = await self._build_transcript(audio_bytes)
+        await viking_fs.write_file(f"{root_dir_uri}/transcript.md", transcript_text)
+
+        description = self._build_description(
+            original_filename=original_filename,
+            metadata=metadata,
+            transcript_status=transcript_status,
+            transcript_text=transcript_text,
+        )
+        await viking_fs.write_file(f"{root_dir_uri}/description.md", description)
+
+        node = ResourceNode(
+            type=NodeType.ROOT,
+            title=file_path.stem,
+            level=0,
+            content_type="audio",
+            auxiliary_files={
+                "original": original_filename,
+                "description": "description.md",
+                "transcript": "transcript.md",
+            },
+            meta={
+                **metadata,
+                "content_type": "audio",
+                "source_title": file_path.stem,
+                "semantic_name": file_path.stem,
+                "original_filename": original_filename,
+                "file_size_bytes": len(audio_bytes),
+                "transcript_status": transcript_status,
+                "description_file": "description.md",
+                "transcript_file": "transcript.md",
+            },
+        )
+        await self._generate_semantic_info(
+            node=node,
+            description=description,
+            viking_fs=viking_fs,
+            has_transcript=_transcript_success(transcript_text),
+            root_dir_uri=root_dir_uri,
+        )
+
+        result = create_parse_result(
+            root=node,
+            source_path=str(file_path),
+            source_format="audio",
+            parser_name="AudioParser",
+            parse_time=time.time() - start_time,
+            meta={
+                "content_type": "audio",
+                "format": metadata["format"],
+                "transcript_status": transcript_status,
+            },
+        )
+        result.temp_dir_path = temp_uri
+        return result
+
+    def _validate_audio_signature(self, file_path: Path, audio_bytes: bytes) -> None:
+        """Validate common audio containers using lightweight signature checks."""
         audio_magic_bytes = {
             ".mp3": [b"ID3", b"\xff\xfb", b"\xff\xf3", b"\xff\xf2"],
             ".wav": [b"RIFF"],
@@ -117,69 +167,131 @@ class AudioParser(BaseParser):
             ".opus": [b"OggS"],
         }
 
-        # Check magic bytes
-        valid = False
-        ext_lower = ext.lower()
+        ext_lower = file_path.suffix.lower()
         magic_list = audio_magic_bytes.get(ext_lower, [])
-        for magic in magic_list:
-            if len(audio_bytes) >= len(magic) and audio_bytes.startswith(magic):
-                valid = True
-                break
-
-        if not valid:
+        if not any(
+            len(audio_bytes) >= len(magic) and audio_bytes.startswith(magic) for magic in magic_list
+        ):
             raise ValueError(
-                f"Invalid audio file: {file_path}. File signature does not match expected format {ext_lower}"
+                f"Invalid audio file: {file_path}. "
+                f"File signature does not match expected format {ext_lower}"
             )
 
-        # Extract audio metadata (placeholder)
-        duration = 0
-        sample_rate = 0
-        channels = 0
-        format_str = ext[1:].upper()
+    def _extract_audio_metadata(self, file_path: Path, audio_bytes: bytes) -> dict:
+        """Collect lightweight audio metadata with standard-library fallbacks."""
+        metadata = {
+            "duration": None,
+            "sample_rate": None,
+            "channels": None,
+            "bitrate": None,
+            "format": (file_path.suffix.lstrip(".") or "audio").lower(),
+            "metadata_source": "extension",
+        }
 
-        # Create ResourceNode - metadata only, no content understanding yet
-        root_node = ResourceNode(
-            type=NodeType.ROOT,
-            title=file_path.stem,
-            level=0,
-            detail_file=None,
-            content_path=None,
-            children=[],
-            meta={
-                "duration": duration,
-                "sample_rate": sample_rate,
-                "channels": channels,
-                "format": format_str.lower(),
-                "content_type": "audio",
-                "source_title": file_path.stem,
-                "semantic_name": file_path.stem,
-                "original_filename": original_filename,
-            },
-        )
+        if file_path.suffix.lower() == ".wav":
+            try:
+                with wave.open(io.BytesIO(audio_bytes), "rb") as wav_file:
+                    frame_rate = wav_file.getframerate()
+                    frame_count = wav_file.getnframes()
+                    channels = wav_file.getnchannels()
+                    sample_width = wav_file.getsampwidth()
+                    metadata.update(
+                        {
+                            "duration": frame_count / frame_rate if frame_rate else None,
+                            "sample_rate": frame_rate or None,
+                            "channels": channels or None,
+                            "bitrate": frame_rate * channels * sample_width * 8
+                            if frame_rate and channels and sample_width
+                            else None,
+                            "metadata_source": "wave",
+                        }
+                    )
+            except Exception as exc:
+                logger.debug("Failed to read WAV metadata for %s: %s", file_path, exc)
 
-        # Phase 3: Build directory structure (handled by TreeBuilder)
-        return ParseResult(
-            root=root_node,
-            source_path=str(file_path),
-            temp_dir_path=temp_uri,
-            source_format="audio",
-            parser_name="AudioParser",
-            meta={"content_type": "audio", "format": format_str.lower()},
+        try:
+            from mutagen import File as MutagenFile
+
+            audio_info = MutagenFile(file_path)
+            info = getattr(audio_info, "info", None)
+            if info is not None:
+                metadata.update(
+                    {
+                        "duration": metadata["duration"] or getattr(info, "length", None),
+                        "sample_rate": metadata["sample_rate"]
+                        or getattr(info, "sample_rate", None),
+                        "channels": metadata["channels"] or getattr(info, "channels", None),
+                        "bitrate": metadata["bitrate"] or getattr(info, "bitrate", None),
+                        "metadata_source": "mutagen",
+                    }
+                )
+        except ImportError:
+            pass
+        except Exception as exc:
+            logger.debug("Failed to read Mutagen metadata for %s: %s", file_path, exc)
+
+        return metadata
+
+    async def _build_transcript(self, audio_bytes: bytes) -> tuple[str, str]:
+        """Generate the best available transcript artifact."""
+        timestamped = await self._asr_transcribe_with_timestamps(
+            audio_bytes, self.config.transcription_model
         )
+        if _transcript_success(timestamped):
+            return "timestamped", timestamped
+
+        plain = await self._asr_transcribe(audio_bytes, self.config.transcription_model)
+        if _transcript_success(plain):
+            return "plain", plain
+
+        return "unavailable", plain
+
+    def _build_description(
+        self,
+        *,
+        original_filename: str,
+        metadata: dict,
+        transcript_status: str,
+        transcript_text: str,
+    ) -> str:
+        """Build markdown summary for the audio resource."""
+        if _transcript_success(transcript_text):
+            summary = (
+                f"Audio transcript generated with `{transcript_status}` detail. "
+                f"Excerpt: {_truncate_text(transcript_text, 320)}"
+            )
+        else:
+            summary = (
+                f"Audio file `{original_filename}` in {metadata['format'].upper()} format. "
+                f"Automatic transcription is {transcript_status}."
+            )
+
+        parts = ["# Audio Summary", "", summary, "", "## Metadata"]
+        parts.append(
+            f"- Duration: {_format_optional_number(metadata.get('duration'), suffix='s')}"
+        )
+        parts.append(
+            f"- Sample rate: {_format_optional_number(metadata.get('sample_rate'), suffix=' Hz')}"
+        )
+        parts.append(f"- Channels: {_format_optional_number(metadata.get('channels'))}")
+        parts.append(f"- Bitrate: {_format_optional_number(metadata.get('bitrate'), suffix=' bps')}")
+        parts.append(f"- Format: {metadata['format'].upper()}")
+        parts.append(f"- Metadata source: {metadata.get('metadata_source', 'unknown')}")
+
+        parts.extend(
+            [
+                "",
+                "## Transcript Status",
+                transcript_status,
+                "",
+                "## Transcript",
+                transcript_text.strip(),
+            ]
+        )
+        return "\n".join(parts).strip() + "\n"
 
     async def _asr_transcribe(self, audio_bytes: bytes, model: Optional[str]) -> str:
-        """
-        Generate audio transcription using ASR.
-
-        Args:
-            audio_bytes: Audio binary data
-            model: ASR model name
-
-        Returns:
-            Audio transcription in markdown format
-
-        TODO: Integrate with actual ASR API (Whisper, etc.)
-        """
+        """Generate audio transcription using an OpenAI-compatible ASR backend."""
         model_name = model or self.config.transcription_model
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
@@ -200,10 +312,10 @@ class AudioParser(BaseParser):
                 temp_file.write(audio_bytes)
                 temp_file_path = temp_file.name
 
-            with open(temp_file_path, "rb") as f:
+            with open(temp_file_path, "rb") as audio_file:
                 response = client.audio.transcriptions.create(
                     model=model_name,
-                    file=f,
+                    file=audio_file,
                     language=self.config.language,
                 )
 
@@ -214,9 +326,9 @@ class AudioParser(BaseParser):
         try:
             text = await asyncio.get_event_loop().run_in_executor(None, _sync_transcribe)
             return text or "Audio transcription returned empty result."
-        except Exception as e:
-            logger.exception("Audio transcription failed: %s", e)
-            return f"Audio transcription failed: {str(e)}"
+        except Exception as exc:
+            logger.exception("Audio transcription failed: %s", exc)
+            return f"Audio transcription failed: {exc}"
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
                 try:
@@ -231,18 +343,7 @@ class AudioParser(BaseParser):
     async def _asr_transcribe_with_timestamps(
         self, audio_bytes: bytes, model: Optional[str]
     ) -> Optional[str]:
-        """
-        Extract transcription with timestamps from audio using ASR.
-
-        Args:
-            audio_bytes: Audio binary data
-            model: ASR model name
-
-        Returns:
-            Transcript with timestamps in markdown format, or None if not available
-
-        TODO: Integrate with ASR API
-        """
+        """Extract transcription with timestamps from audio using ASR."""
         model_name = model or self.config.transcription_model
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
@@ -268,21 +369,18 @@ class AudioParser(BaseParser):
                 temp_file.write(audio_bytes)
                 temp_file_path = temp_file.name
 
-            with open(temp_file_path, "rb") as f:
+            with open(temp_file_path, "rb") as audio_file:
                 response = client.audio.transcriptions.create(
                     model=model_name,
-                    file=f,
+                    file=audio_file,
                     language=self.config.language,
                     response_format="verbose_json",
                     timestamp_granularities=["segment"],
                 )
 
-            segments = None
-            if isinstance(response, dict):
-                segments = response.get("segments")
-            else:
-                segments = getattr(response, "segments", None)
-
+            segments = response.get("segments") if isinstance(response, dict) else getattr(
+                response, "segments", None
+            )
             if not segments:
                 return None
 
@@ -299,7 +397,6 @@ class AudioParser(BaseParser):
 
                 if start is None or end is None or not text:
                     continue
-
                 lines.append(f"**[{_format_timestamp(start)} - {_format_timestamp(end)}]** {text}")
 
             return "\n\n".join(lines) if lines else None
@@ -308,8 +405,8 @@ class AudioParser(BaseParser):
             return await asyncio.get_event_loop().run_in_executor(
                 None, _sync_transcribe_with_timestamps
             )
-        except Exception as e:
-            logger.exception("Timestamp transcription failed: %s", e)
+        except Exception as exc:
+            logger.exception("Timestamp transcription failed: %s", exc)
             return None
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
@@ -323,84 +420,56 @@ class AudioParser(BaseParser):
                     )
 
     async def _generate_semantic_info(
-        self, node: ResourceNode, description: str, viking_fs, has_transcript: bool
-    ):
-        """
-        Phase 2: Generate abstract and overview.
+        self,
+        node: ResourceNode,
+        description: str,
+        viking_fs,
+        has_transcript: bool,
+        root_dir_uri: str,
+    ) -> None:
+        """Populate and persist the audio L0/L1 summaries."""
+        if has_transcript:
+            abstract = _truncate_text(description, 220)
+        else:
+            abstract = (
+                f"Audio file {node.meta['original_filename']} "
+                f"({_format_optional_number(node.meta.get('duration'), suffix='s')})"
+            )
 
-        Args:
-            node: ResourceNode to update
-            description: Audio description
-            viking_fs: VikingFS instance
-            has_transcript: Whether transcript file exists
-        """
-        # Generate abstract (short summary, < 100 tokens)
-        abstract = description[:200] if len(description) > 200 else description
-
-        # Generate overview (content summary + file list + usage instructions)
         overview_parts = [
-            "## Content Summary\n",
-            description,
-            "\n\n## Available Files\n",
-            f"- {node.meta['original_filename']}: Original audio file ({node.meta['duration']}s, {node.meta['sample_rate']}Hz, {node.meta['channels']}ch, {node.meta['format'].upper()} format)\n",
+            "## Content Summary",
+            "",
+            _truncate_text(description, 1800),
+            "",
+            "## Available Files",
+            f"- {node.meta['original_filename']}: Original audio file",
+            "- description.md: Semantic markdown summary for the audio",
+            "- transcript.md: Transcript or fallback status for the audio track",
+            "",
+            "## Metadata",
+            f"- Duration: {_format_optional_number(node.meta.get('duration'), suffix='s')}",
+            f"- Sample rate: {_format_optional_number(node.meta.get('sample_rate'), suffix=' Hz')}",
+            f"- Channels: {_format_optional_number(node.meta.get('channels'))}",
+            f"- Bitrate: {_format_optional_number(node.meta.get('bitrate'), suffix=' bps')}",
+            f"- Format: {node.meta['format'].upper()}",
+            f"- Transcript status: {node.meta['transcript_status']}",
         ]
+        overview = "\n".join(overview_parts).strip() + "\n"
 
-        if has_transcript:
-            overview_parts.append("- transcript.md: Transcript with timestamps from the audio\n")
-
-        overview_parts.append("\n## Usage\n")
-        overview_parts.append("### Play Audio\n")
-        overview_parts.append("```python\n")
-        overview_parts.append("audio_bytes = await audio_resource.play()\n")
-        overview_parts.append("# Returns: Audio file binary data\n")
-        overview_parts.append("# Purpose: Play or save the audio\n")
-        overview_parts.append("```\n\n")
-
-        if has_transcript:
-            overview_parts.append("### Get Timestamps Transcript\n")
-            overview_parts.append("```python\n")
-            overview_parts.append("timestamps = await audio_resource.timestamps()\n")
-            overview_parts.append("# Returns: FileContent object or None\n")
-            overview_parts.append("# Purpose: Extract timestamped transcript from the audio\n")
-            overview_parts.append("```\n\n")
-
-        overview_parts.append("### Get Audio Metadata\n")
-        overview_parts.append("```python\n")
-        overview_parts.append(
-            f"duration = audio_resource.get_duration()  # {node.meta['duration']}s\n"
-        )
-        overview_parts.append(
-            f"sample_rate = audio_resource.get_sample_rate()  # {node.meta['sample_rate']}Hz\n"
-        )
-        overview_parts.append(
-            f"channels = audio_resource.get_channels()  # {node.meta['channels']}\n"
-        )
-        overview_parts.append(f'format = audio_resource.get_format()  # "{node.meta["format"]}"\n')
-        overview_parts.append("```\n")
-
-        overview = "".join(overview_parts)
-
-        # Store in node meta
         node.meta["abstract"] = abstract
         node.meta["overview"] = overview
 
+        await viking_fs.write_file(f"{root_dir_uri}/.abstract.md", abstract)
+        await viking_fs.write_file(f"{root_dir_uri}/.overview.md", overview)
+
     async def parse_content(
-        self, content: str, source_path: Optional[str] = None, instruction: str = "", **kwargs
-    ) -> ParseResult:
-        """
-        Parse audio from base64 content string.
-
-        Args:
-            content: Audio content (base64 or binary string)
-            source_path: Optional source path for metadata
-            **kwargs: Additional parsing parameters
-
-        Returns:
-            ParseResult with audio content
-
-        Raises:
-            ValueError: If content is not valid base64 audio data
-        """
+        self,
+        content: str,
+        source_path: Optional[str] = None,
+        instruction: str = "",
+        **kwargs,
+    ):
+        """Parse audio from base64 content string."""
         temp_file_path = None
         try:
             if content.startswith("data:") and "," in content:
@@ -419,9 +488,9 @@ class AudioParser(BaseParser):
             if source_path:
                 result.source_path = source_path
             return result
-        except Exception as e:
-            logger.exception("Failed to parse audio content: %s", e)
-            raise ValueError(f"Invalid audio content: {str(e)}") from e
+        except Exception as exc:
+            logger.exception("Failed to parse audio content: %s", exc)
+            raise ValueError(f"Invalid audio content: {exc}") from exc
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
                 try:

--- a/openviking/parse/parsers/media/image.py
+++ b/openviking/parse/parsers/media/image.py
@@ -1,27 +1,20 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""
-Media parser interfaces for OpenViking - Future expansion.
-
-This module defines parser interfaces for media types (image, audio, video).
-These are placeholder implementations that raise NotImplementedError.
-They serve as a design reference for future media parsing capabilities.
-
-For current document parsing (PDF, Markdown, HTML, Text), see other parser modules.
-"""
+"""Image parser with lightweight semantic artifact generation."""
 
 import asyncio
 import io
+import re
+import time
 from pathlib import Path
 from typing import List, Optional, Union
 
 from PIL import Image
 
-from openviking.parse.base import NodeType, ParseResult, ResourceNode
+from openviking.parse.base import NodeType, ResourceNode, create_parse_result
 from openviking.parse.parsers.base_parser import BaseParser
 from openviking.parse.parsers.media.constants import IMAGE_EXTENSIONS
 from openviking.prompts import render_prompt
-from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.config.parser_config import ImageConfig
 from openviking_cli.utils.logger import get_logger
@@ -29,149 +22,199 @@ from openviking_cli.utils.uri import VikingURI
 
 logger = get_logger(__name__)
 
-# =============================================================================
-# Configuration Classes
-# =============================================================================
+
+def _clean_text(value: str) -> str:
+    """Collapse whitespace so semantic sidecars stay compact."""
+    return re.sub(r"\s+", " ", value or "").strip()
 
 
-# =============================================================================
-# Parser Classes
-# =============================================================================
+def _truncate_text(value: str, limit: int) -> str:
+    """Truncate text without returning empty placeholders."""
+    text = _clean_text(value)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
 
 
 class ImageParser(BaseParser):
-    """
-    Image parser - Future implementation.
-
-    Planned Features:
-    1. Visual content understanding using VLM (Vision Language Model)
-    2. OCR text extraction for images containing text
-    3. Metadata extraction (dimensions, format, EXIF data)
-    4. Generate semantic description and structured ResourceNode
-
-    Example workflow:
-        1. Load image file
-        2. (Optional) Perform OCR to extract text
-        3. (Optional) Use VLM to generate visual description
-        4. Create ResourceNode with image metadata and descriptions
-        5. Return ParseResult
-
-    Supported formats: PNG, JPG, JPEG, GIF, BMP, WEBP, SVG
-    """
+    """Parser for standalone image resources."""
 
     def __init__(self, config: Optional[ImageConfig] = None, **kwargs):
-        """
-        Initialize ImageParser.
-
-        Args:
-            config: Image parsing configuration
-            **kwargs: Additional configuration parameters
-        """
         self.config = config or ImageConfig()
 
     @property
     def supported_extensions(self) -> List[str]:
-        """Return supported image file extensions."""
         return IMAGE_EXTENSIONS
 
-    async def parse(self, source: Union[str, Path], instruction: str = "", **kwargs) -> ParseResult:
-        """
-        Parse image file - only copy original file and extract basic metadata, no content understanding.
-
-        Args:
-            source: Image file path
-            **kwargs: Additional parsing parameters
-
-        Returns:
-            ParseResult with image content
-
-        Raises:
-            FileNotFoundError: If source file does not exist
-            IOError: If image processing fails
-        """
-        # Convert to Path object
+    async def parse(self, source: Union[str, Path], instruction: str = "", **kwargs):
+        start_time = time.time()
         file_path = Path(source) if isinstance(source, str) else source
         if not file_path.exists():
             raise FileNotFoundError(f"Image file not found: {source}")
 
-        viking_fs = get_viking_fs()
-        temp_uri = viking_fs.create_temp_uri()
-
-        # Phase 1: Generate temporary files
         image_bytes = file_path.read_bytes()
-        ext = file_path.suffix
-
-        # Sanitize original filename (replace spaces with underscores)
+        ext = file_path.suffix.lower()
         original_filename = file_path.name.replace(" ", "_")
-        # Root directory name: filename stem + _ + extension (without dot)
         stem = file_path.stem.replace(" ", "_")
-        ext_no_dot = ext[1:] if ext else ""
+        ext_no_dot = ext[1:] if ext else "image"
         root_dir_name = VikingURI.sanitize_segment(f"{stem}_{ext_no_dot}")
-        root_dir_uri = f"{temp_uri}/{root_dir_name}"
-        await viking_fs.mkdir(root_dir_uri, exist_ok=True)
 
-        # 1.1 Save original image with original filename (sanitized)
+        viking_fs = self._get_viking_fs()
+        temp_uri = self._create_temp_uri()
+        root_dir_uri = f"{temp_uri}/{root_dir_name}"
+        await viking_fs.mkdir(temp_uri, exist_ok=True)
+        await viking_fs.mkdir(root_dir_uri, exist_ok=True)
         await viking_fs.write_file_bytes(f"{root_dir_uri}/{original_filename}", image_bytes)
 
-        # 1.2 Validate and extract image metadata
-        try:
-            img = Image.open(file_path)
-            img.verify()  # Verify that it's a valid image
-            img.close()  # Close and reopen to reset after verify()
-            img = Image.open(file_path)
-            width, height = img.size
-            format_str = img.format or ext[1:].upper()
-        except Exception as e:
-            raise ValueError(f"Invalid image file: {file_path}. Error: {e}") from e
+        metadata = self._extract_image_metadata(file_path)
 
-        # Create ResourceNode - metadata only, no content understanding yet
-        root_node = ResourceNode(
+        ocr_text = None
+        if self.config.enable_ocr:
+            ocr_text = await self._ocr_extract(image_bytes, lang=self.config.ocr_lang)
+            if ocr_text:
+                await viking_fs.write_file(f"{root_dir_uri}/ocr.md", ocr_text)
+
+        visual_description = None
+        if self.config.enable_vlm and self._is_vlm_available() and ext != ".svg":
+            visual_description = await self._vlm_describe(
+                image_bytes,
+                model=self.config.vlm_model,
+                instruction=instruction,
+            )
+
+        description = self._build_description(
+            original_filename=original_filename,
+            metadata=metadata,
+            visual_description=visual_description,
+            ocr_text=ocr_text,
+        )
+        await viking_fs.write_file(f"{root_dir_uri}/description.md", description)
+
+        node = ResourceNode(
             type=NodeType.ROOT,
             title=file_path.stem,
             level=0,
-            detail_file=None,
-            content_path=None,
-            children=[],
+            content_type="image",
+            auxiliary_files={
+                "original": original_filename,
+                "description": "description.md",
+                **({"ocr": "ocr.md"} if ocr_text else {}),
+            },
             meta={
-                "width": width,
-                "height": height,
-                "format": format_str.lower(),
+                **metadata,
                 "content_type": "image",
                 "source_title": file_path.stem,
                 "semantic_name": file_path.stem,
                 "original_filename": original_filename,
+                "file_size_bytes": len(image_bytes),
+                "has_ocr": bool(ocr_text),
+                "has_visual_description": bool(visual_description),
+                "description_file": "description.md",
+                "ocr_file": "ocr.md" if ocr_text else None,
             },
         )
-
-        # Phase 3: Build directory structure (handled by TreeBuilder)
-        return ParseResult(
-            root=root_node,
-            source_path=str(file_path),
-            temp_dir_path=temp_uri,
-            source_format="image",
-            parser_name="ImageParser",
-            meta={"content_type": "image", "format": format_str.lower()},
+        await self._generate_semantic_info(
+            node=node,
+            description=description,
+            viking_fs=viking_fs,
+            has_ocr=bool(ocr_text),
+            root_dir_uri=root_dir_uri,
         )
 
-    async def _vlm_describe(self, image_bytes: bytes, model: Optional[str]) -> str:
-        """
-        Generate image description using VLM.
+        result = create_parse_result(
+            root=node,
+            source_path=str(file_path),
+            source_format="image",
+            parser_name="ImageParser",
+            parse_time=time.time() - start_time,
+            meta={
+                "content_type": "image",
+                "format": metadata["format"],
+                "has_ocr": bool(ocr_text),
+                "has_visual_description": bool(visual_description),
+            },
+        )
+        result.temp_dir_path = temp_uri
+        return result
 
-        Args:
-            image_bytes: Image binary data
-            model: VLM model name
+    def _extract_image_metadata(self, file_path: Path) -> dict:
+        """Validate the image and collect basic metadata."""
+        try:
+            with Image.open(file_path) as img:
+                img.verify()
+            with Image.open(file_path) as img:
+                width, height = img.size
+                format_str = (img.format or file_path.suffix.lstrip(".") or "image").lower()
+                mode = img.mode or "unknown"
+        except Exception as exc:
+            raise ValueError(f"Invalid image file: {file_path}. Error: {exc}") from exc
 
-        Returns:
-            Image description in markdown format
-        """
+        return {
+            "width": width,
+            "height": height,
+            "format": format_str,
+            "mode": mode,
+        }
+
+    def _is_vlm_available(self) -> bool:
+        """Return True when VLM config is present and usable."""
+        try:
+            return get_openviking_config().vlm.is_available()
+        except Exception:
+            return False
+
+    def _build_description(
+        self,
+        *,
+        original_filename: str,
+        metadata: dict,
+        visual_description: Optional[str],
+        ocr_text: Optional[str],
+    ) -> str:
+        """Assemble a semantic markdown description for the image."""
+        summary = _clean_text(visual_description or "")
+        if not summary and ocr_text:
+            summary = (
+                "Image content inferred from OCR-recognized text because VLM analysis "
+                "was unavailable."
+            )
+        if not summary:
+            summary = (
+                f"Image file `{original_filename}` in {metadata['format'].upper()} format "
+                f"with resolution {metadata['width']}x{metadata['height']}."
+            )
+
+        parts = ["# Image Summary", "", summary, "", "## Metadata"]
+        parts.append(f"- Format: {metadata['format'].upper()}")
+        parts.append(f"- Resolution: {metadata['width']}x{metadata['height']}")
+        parts.append(f"- Color mode: {metadata['mode']}")
+
+        if ocr_text:
+            parts.extend(
+                [
+                    "",
+                    "## OCR Text",
+                    ocr_text.strip(),
+                ]
+            )
+        elif self.config.enable_ocr:
+            parts.extend(["", "## OCR Text", "No OCR text was detected in the image."])
+
+        return "\n".join(parts).strip() + "\n"
+
+    async def _vlm_describe(
+        self,
+        image_bytes: bytes,
+        model: Optional[str],
+        instruction: str = "",
+    ) -> str:
+        """Generate image description using VLM when configured."""
         try:
             vlm = get_openviking_config().vlm
-
-            # Render prompt
             prompt = render_prompt(
                 "parsing.image_summary",
                 {
-                    "context": "No additional context",
+                    "context": instruction.strip() or "No additional context",
                 },
             )
             response = await vlm.get_vision_completion_async(
@@ -179,29 +222,20 @@ class ImageParser(BaseParser):
                 images=[image_bytes],
             )
             logger.info(
-                f"[ImageParser._vlm_describe] VLM response received, length: {len(response)}, content: {response[:256]}"
+                "[ImageParser._vlm_describe] VLM response received, length=%s",
+                len(response),
             )
-
-            return response.strip()
-
-        except Exception as e:
+            return str(response).strip()
+        except Exception as exc:
             logger.error(
-                f"[ImageParser._vlm_describe] Error in VLM image description: {e}", exc_info=True
+                "[ImageParser._vlm_describe] Error in VLM image description: %s",
+                exc,
+                exc_info=True,
             )
-            # Fallback to basic description
-            return "Image description (VLM integration failed)\n\nThis is an image file."
+            return ""
 
     async def _ocr_extract(self, image_bytes: bytes, lang: str) -> Optional[str]:
-        """
-        Extract text from image using OCR via Tesseract.
-
-        Args:
-            image_bytes: Image binary data
-            lang: OCR language code (e.g., "eng", "chi_sim")
-
-        Returns:
-            Extracted text as a string, or None if no text found
-        """
+        """Extract text from image using OCR via Tesseract."""
         try:
             import pytesseract
         except ImportError:
@@ -215,86 +249,56 @@ class ImageParser(BaseParser):
 
         try:
             return await asyncio.get_event_loop().run_in_executor(None, _sync_ocr)
-        except Exception as e:
-            logger.error(f"[ImageParser._ocr_extract] OCR extraction failed: {e}", exc_info=True)
+        except Exception as exc:
+            logger.error("[ImageParser._ocr_extract] OCR extraction failed: %s", exc, exc_info=True)
             return None
 
     async def _generate_semantic_info(
-        self, node: ResourceNode, description: str, viking_fs, has_ocr: bool, root_dir_uri: str
-    ):
-        """
-        Phase 2: Generate abstract and overview and write to .abstract.md and .overview.md.
+        self,
+        node: ResourceNode,
+        description: str,
+        viking_fs,
+        has_ocr: bool,
+        root_dir_uri: str,
+    ) -> None:
+        """Populate and persist the image L0/L1 summaries."""
+        abstract = _truncate_text(description, 220) or f"Image: {node.meta['original_filename']}"
 
-        Args:
-            node: ResourceNode to update
-            description: Image description
-            viking_fs: VikingFS instance
-            has_ocr: Whether OCR file exists
-            root_dir_uri: Root directory URI to write semantic files
-        """
-        # Generate abstract (short summary, < 100 tokens)
-        abstract = description[:253] + "..." if len(description) > 256 else description
-
-        # Generate overview (content summary + file list + usage instructions)
         overview_parts = [
-            "## Content Summary\n",
-            description,
-            "\n\n## Available Files\n",
-            f"- {node.meta['original_filename']}: Original image file ({node.meta['width']}x{node.meta['height']}, {node.meta['format'].upper()} format)\n",
+            "## Content Summary",
+            "",
+            _truncate_text(description, 1800),
+            "",
+            "## Available Files",
+            f"- {node.meta['original_filename']}: Original image file",
+            "- description.md: Semantic markdown summary for the image",
         ]
-
         if has_ocr:
-            overview_parts.append("- ocr.md: OCR text recognition result from the image\n")
+            overview_parts.append("- ocr.md: OCR-recognized text extracted from the image")
 
-        overview_parts.append("\n## Usage\n")
-        overview_parts.append("### View Image\n")
-        overview_parts.append("```python\n")
-        overview_parts.append("image_bytes = await image_resource.view()\n")
-        overview_parts.append("# Returns: PNG/JPG format image binary data\n")
-        overview_parts.append("# Purpose: Display or save the image\n")
-        overview_parts.append("```\n\n")
-
-        if has_ocr:
-            overview_parts.append("### Get OCR-recognized Text\n")
-            overview_parts.append("```python\n")
-            overview_parts.append("ocr_text = await image_resource.ocr()\n")
-            overview_parts.append("# Returns: FileContent object or None\n")
-            overview_parts.append("# Purpose: Extract text information from the image\n")
-            overview_parts.append("```\n\n")
-
-        overview_parts.append("### Get Image Metadata\n")
-        overview_parts.append("```python\n")
-        overview_parts.append(
-            f"size = image_resource.get_size()  # ({node.meta['width']}, {node.meta['height']})\n"
+        overview_parts.extend(
+            [
+                "",
+                "## Metadata",
+                f"- Format: {node.meta['format'].upper()}",
+                f"- Resolution: {node.meta['width']}x{node.meta['height']}",
+                f"- Color mode: {node.meta['mode']}",
+            ]
         )
-        overview_parts.append(f'format = image_resource.get_format()  # "{node.meta["format"]}"\n')
-        overview_parts.append("```\n")
 
-        overview = "".join(overview_parts)
+        overview = "\n".join(overview_parts).strip() + "\n"
 
-        # Store in node meta
         node.meta["abstract"] = abstract
         node.meta["overview"] = overview
 
-        # Write to files in temp directory
-        # await viking_fs.write_file(f"{root_dir_uri}/.abstract.md", abstract)
-        # await viking_fs.write_file(f"{root_dir_uri}/.overview.md", overview)
+        await viking_fs.write_file(f"{root_dir_uri}/.abstract.md", abstract)
+        await viking_fs.write_file(f"{root_dir_uri}/.overview.md", overview)
 
     async def parse_content(
-        self, content: str, source_path: Optional[str] = None, instruction: str = "", **kwargs
-    ) -> ParseResult:
-        """
-        Parse image from content string - Not yet implemented.
-
-        Args:
-            content: Image content (base64 or binary string)
-            source_path: Optional source path for metadata
-            **kwargs: Additional parsing parameters
-
-        Returns:
-            ParseResult with image content
-
-        Raises:
-            NotImplementedError: This feature is not yet implemented
-        """
+        self,
+        content: str,
+        source_path: Optional[str] = None,
+        instruction: str = "",
+        **kwargs,
+    ):
         raise NotImplementedError("Image parsing not yet implemented")

--- a/openviking/parse/parsers/media/video.py
+++ b/openviking/parse/parsers/media/video.py
@@ -1,103 +1,140 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""
-Video parser - Future implementation.
+"""Video parser with bounded preview and transcript support."""
 
-Planned Features:
-1. Key frame extraction at regular intervals
-2. Audio track transcription using ASR
-3. VLM-based scene description for key frames
-4. Video metadata extraction (duration, resolution, codec)
-5. Generate structured ResourceNode combining visual and audio
-
-Example workflow:
-    1. Load video file
-    2. Extract metadata (duration, resolution, fps)
-    3. Extract audio track → transcribe using AudioParser
-    4. Extract key frames at specified intervals
-    5. For each frame: generate VLM description
-    6. Create ResourceNode tree:
-       - Root: video metadata
-       - Children: timeline nodes (each with frame + transcript)
-    7. Return ParseResult
-
-Supported formats: MP4, AVI, MOV, MKV, WEBM
-"""
-
+import asyncio
+import json
+import shutil
+import subprocess
+import tempfile
+import time
 from pathlib import Path
 from typing import List, Optional, Union
 
-from openviking.parse.base import NodeType, ParseResult, ResourceNode
+from openviking.parse.base import NodeType, ResourceNode, create_parse_result
 from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.media.audio import AudioParser, _format_optional_number, _truncate_text
 from openviking.parse.parsers.media.constants import VIDEO_EXTENSIONS
+from openviking.parse.parsers.media.image import ImageParser
 from openviking_cli.utils.config.parser_config import VideoConfig
+from openviking_cli.utils.logger import get_logger
+from openviking_cli.utils.uri import VikingURI
+
+logger = get_logger(__name__)
 
 
 class VideoParser(BaseParser):
-    """
-    Video parser for video files.
-    """
+    """Parser for standalone video resources."""
 
     def __init__(self, config: Optional[VideoConfig] = None, **kwargs):
-        """
-        Initialize VideoParser.
-
-        Args:
-            config: Video parsing configuration
-            **kwargs: Additional configuration parameters
-        """
         self.config = config or VideoConfig()
 
     @property
     def supported_extensions(self) -> List[str]:
-        """Return supported video file extensions."""
         return VIDEO_EXTENSIONS
 
-    async def parse(self, source: Union[str, Path], instruction: str = "", **kwargs) -> ParseResult:
-        """
-        Parse video file - only copy original file and extract basic metadata, no content understanding.
-
-        Args:
-            source: Video file path
-            **kwargs: Additional parsing parameters
-
-        Returns:
-            ParseResult with video content
-
-        Raises:
-            FileNotFoundError: If source file does not exist
-            IOError: If video processing fails
-        """
-        from openviking.storage.viking_fs import get_viking_fs
-
-        # Convert to Path object
+    async def parse(self, source: Union[str, Path], instruction: str = "", **kwargs):
+        start_time = time.time()
         file_path = Path(source) if isinstance(source, str) else source
         if not file_path.exists():
             raise FileNotFoundError(f"Video file not found: {source}")
 
-        viking_fs = get_viking_fs()
-        temp_uri = viking_fs.create_temp_uri()
-
-        # Phase 1: Generate temporary files
         video_bytes = file_path.read_bytes()
-        ext = file_path.suffix
-
-        from openviking_cli.utils.uri import VikingURI
-
-        # Sanitize original filename (replace spaces with underscores)
+        ext = file_path.suffix.lower()
         original_filename = file_path.name.replace(" ", "_")
-        # Root directory name: filename stem + _ + extension (without dot)
         stem = file_path.stem.replace(" ", "_")
-        ext_no_dot = ext[1:] if ext else ""
+        ext_no_dot = ext[1:] if ext else "video"
         root_dir_name = VikingURI.sanitize_segment(f"{stem}_{ext_no_dot}")
-        root_dir_uri = f"{temp_uri}/{root_dir_name}"
-        await viking_fs.mkdir(root_dir_uri, exist_ok=True)
 
-        # 1.1 Save original video with original filename (sanitized)
+        viking_fs = self._get_viking_fs()
+        temp_uri = self._create_temp_uri()
+        root_dir_uri = f"{temp_uri}/{root_dir_name}"
+        await viking_fs.mkdir(temp_uri, exist_ok=True)
+        await viking_fs.mkdir(root_dir_uri, exist_ok=True)
         await viking_fs.write_file_bytes(f"{root_dir_uri}/{original_filename}", video_bytes)
 
-        # 1.2 Validate video file using magic bytes
-        # Define magic bytes for supported video formats
+        self._validate_video_signature(file_path, video_bytes)
+        metadata = await self._extract_video_metadata(file_path)
+
+        preview_bytes = None
+        if self.config.extract_frames:
+            preview_bytes = await self._extract_preview_frame(file_path)
+            if preview_bytes:
+                await viking_fs.write_file_bytes(f"{root_dir_uri}/preview.png", preview_bytes)
+
+        transcript_status = "disabled"
+        transcript_text = "Transcription disabled by parser configuration."
+        if self.config.enable_transcription:
+            transcript_status, transcript_text = await self._build_video_transcript(file_path)
+        await viking_fs.write_file(f"{root_dir_uri}/transcript.md", transcript_text)
+
+        preview_description = None
+        if preview_bytes:
+            preview_description = await self._describe_preview_frame(
+                preview_bytes, instruction=instruction
+            )
+
+        description = self._build_description(
+            original_filename=original_filename,
+            metadata=metadata,
+            preview_description=preview_description,
+            transcript_status=transcript_status,
+            transcript_text=transcript_text,
+            has_preview=bool(preview_bytes),
+        )
+        await viking_fs.write_file(f"{root_dir_uri}/description.md", description)
+
+        node = ResourceNode(
+            type=NodeType.ROOT,
+            title=file_path.stem,
+            level=0,
+            content_type="video",
+            auxiliary_files={
+                "original": original_filename,
+                "description": "description.md",
+                "transcript": "transcript.md",
+                **({"preview": "preview.png"} if preview_bytes else {}),
+            },
+            meta={
+                **metadata,
+                "content_type": "video",
+                "source_title": file_path.stem,
+                "semantic_name": file_path.stem,
+                "original_filename": original_filename,
+                "file_size_bytes": len(video_bytes),
+                "has_preview_frame": bool(preview_bytes),
+                "transcript_status": transcript_status,
+                "description_file": "description.md",
+                "transcript_file": "transcript.md",
+                "preview_file": "preview.png" if preview_bytes else None,
+            },
+        )
+        await self._generate_semantic_info(
+            node=node,
+            description=description,
+            viking_fs=viking_fs,
+            has_key_frames=bool(preview_bytes),
+            root_dir_uri=root_dir_uri,
+        )
+
+        result = create_parse_result(
+            root=node,
+            source_path=str(file_path),
+            source_format="video",
+            parser_name="VideoParser",
+            parse_time=time.time() - start_time,
+            meta={
+                "content_type": "video",
+                "format": metadata["format"],
+                "has_preview_frame": bool(preview_bytes),
+                "transcript_status": transcript_status,
+            },
+        )
+        result.temp_dir_path = temp_uri
+        return result
+
+    def _validate_video_signature(self, file_path: Path, video_bytes: bytes) -> None:
+        """Validate common video containers with simple signature checks."""
         video_magic_bytes = {
             ".mp4": [b"\x00\x00\x00", b"ftyp"],
             ".avi": [b"RIFF"],
@@ -108,149 +145,326 @@ class VideoParser(BaseParser):
             ".wmv": [b"\x30\x26\xb2\x75\x8e\x66\xcf\x11"],
         }
 
-        # Check magic bytes
-        valid = False
-        ext_lower = ext.lower()
+        ext_lower = file_path.suffix.lower()
         magic_list = video_magic_bytes.get(ext_lower, [])
-        for magic in magic_list:
-            if len(video_bytes) >= len(magic) and video_bytes.startswith(magic):
-                valid = True
-                break
-
-        if not valid:
+        if not any(
+            len(video_bytes) >= len(magic) and video_bytes.startswith(magic) for magic in magic_list
+        ):
             raise ValueError(
-                f"Invalid video file: {file_path}. File signature does not match expected format {ext_lower}"
+                f"Invalid video file: {file_path}. "
+                f"File signature does not match expected format {ext_lower}"
             )
 
-        # Extract video metadata (placeholder)
-        duration = 0
-        width = 0
-        height = 0
-        fps = 0
-        format_str = ext[1:].upper()
+    async def _extract_video_metadata(self, file_path: Path) -> dict:
+        """Probe video metadata with ffprobe or cv2 when available."""
+        metadata = {
+            "duration": None,
+            "width": None,
+            "height": None,
+            "fps": None,
+            "frame_count": None,
+            "format": (file_path.suffix.lstrip(".") or "video").lower(),
+            "metadata_source": "extension",
+        }
 
-        # Create ResourceNode - metadata only, no content understanding yet
-        root_node = ResourceNode(
-            type=NodeType.ROOT,
-            title=file_path.stem,
-            level=0,
-            detail_file=None,
-            content_path=None,
-            children=[],
-            meta={
-                "duration": duration,
-                "width": width,
-                "height": height,
-                "fps": fps,
-                "format": format_str.lower(),
-                "content_type": "video",
-                "source_title": file_path.stem,
-                "semantic_name": file_path.stem,
-                "original_filename": original_filename,
-            },
+        ffprobe_path = shutil.which("ffprobe")
+        if ffprobe_path:
+            try:
+                probed = await asyncio.to_thread(self._probe_with_ffprobe, ffprobe_path, file_path)
+                metadata.update({k: v for k, v in probed.items() if v not in (None, "", 0, 0.0)})
+                metadata["metadata_source"] = "ffprobe"
+                return metadata
+            except Exception as exc:
+                logger.debug("ffprobe metadata extraction failed for %s: %s", file_path, exc)
+
+        try:
+            import cv2
+
+            def _probe_with_cv2() -> dict:
+                cap = cv2.VideoCapture(str(file_path))
+                if not cap.isOpened():
+                    return {}
+                fps = cap.get(cv2.CAP_PROP_FPS) or None
+                frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT) or None
+                width = cap.get(cv2.CAP_PROP_FRAME_WIDTH) or None
+                height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or None
+                cap.release()
+                return {
+                    "fps": fps,
+                    "frame_count": frame_count,
+                    "width": int(width) if width else None,
+                    "height": int(height) if height else None,
+                    "duration": (frame_count / fps) if fps and frame_count else None,
+                }
+
+            probed = await asyncio.to_thread(_probe_with_cv2)
+            if probed:
+                metadata.update({k: v for k, v in probed.items() if v not in (None, "", 0, 0.0)})
+                metadata["metadata_source"] = "cv2"
+        except ImportError:
+            pass
+        except Exception as exc:
+            logger.debug("cv2 metadata extraction failed for %s: %s", file_path, exc)
+
+        return metadata
+
+    def _probe_with_ffprobe(self, ffprobe_path: str, file_path: Path) -> dict:
+        """Probe metadata using ffprobe JSON output."""
+        result = subprocess.run(
+            [
+                ffprobe_path,
+                "-v",
+                "error",
+                "-print_format",
+                "json",
+                "-show_streams",
+                "-show_format",
+                str(file_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
         )
-
-        # Phase 3: Build directory structure (handled by TreeBuilder)
-        return ParseResult(
-            root=root_node,
-            source_path=str(file_path),
-            temp_dir_path=temp_uri,
-            source_format="video",
-            parser_name="VideoParser",
-            meta={"content_type": "video", "format": format_str.lower()},
+        payload = json.loads(result.stdout or "{}")
+        video_stream = next(
+            (stream for stream in payload.get("streams", []) if stream.get("codec_type") == "video"),
+            {},
         )
+        frame_rate_raw = video_stream.get("avg_frame_rate") or video_stream.get("r_frame_rate")
+        fps = None
+        if frame_rate_raw and frame_rate_raw not in {"0/0", "0"}:
+            num, _, den = frame_rate_raw.partition("/")
+            fps = float(num) / float(den or "1")
 
-    async def _generate_video_description(self, file_path: Path, config: VideoConfig) -> str:
-        """
-        Generate video description using key frames and audio transcription.
+        duration = video_stream.get("duration") or payload.get("format", {}).get("duration")
+        frame_count = video_stream.get("nb_frames")
+        return {
+            "width": video_stream.get("width"),
+            "height": video_stream.get("height"),
+            "fps": fps,
+            "duration": float(duration) if duration else None,
+            "frame_count": int(frame_count) if frame_count and str(frame_count).isdigit() else None,
+        }
 
-        Args:
-            file_path: Video file path
-            config: Video parsing configuration
+    async def _extract_preview_frame(self, file_path: Path) -> Optional[bytes]:
+        """Extract a single preview frame without a heavy video pipeline."""
+        ffmpeg_path = shutil.which("ffmpeg")
+        if ffmpeg_path:
+            try:
+                return await asyncio.to_thread(self._extract_preview_with_ffmpeg, ffmpeg_path, file_path)
+            except Exception as exc:
+                logger.debug("ffmpeg preview extraction failed for %s: %s", file_path, exc)
 
-        Returns:
-            Video description in markdown format
+        try:
+            import cv2
 
-        TODO: Integrate with actual video processing libraries
-        """
-        # Fallback implementation - returns basic placeholder
-        return "Video description (video processing integration pending)\n\nThis is a video. Video processing feature has not yet integrated external libraries."
+            def _extract_with_cv2() -> Optional[bytes]:
+                cap = cv2.VideoCapture(str(file_path))
+                if not cap.isOpened():
+                    return None
+                ok, frame = cap.read()
+                cap.release()
+                if not ok:
+                    return None
+                ok, encoded = cv2.imencode(".png", frame)
+                return bytes(encoded) if ok else None
+
+            return await asyncio.to_thread(_extract_with_cv2)
+        except ImportError:
+            return None
+        except Exception as exc:
+            logger.debug("cv2 preview extraction failed for %s: %s", file_path, exc)
+            return None
+
+    def _extract_preview_with_ffmpeg(self, ffmpeg_path: str, file_path: Path) -> Optional[bytes]:
+        """Extract one PNG frame using ffmpeg."""
+        result = subprocess.run(
+            [
+                ffmpeg_path,
+                "-y",
+                "-i",
+                str(file_path),
+                "-frames:v",
+                "1",
+                "-f",
+                "image2pipe",
+                "-vcodec",
+                "png",
+                "pipe:1",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        return result.stdout or None
+
+    async def _build_video_transcript(self, file_path: Path) -> tuple[str, str]:
+        """Extract the audio track when possible and reuse AudioParser ASR helpers."""
+        audio_bytes = await self._extract_audio_track(file_path)
+        if not audio_bytes:
+            return "unavailable", "Audio track extraction unavailable: ffmpeg is not installed or failed."
+
+        audio_parser = AudioParser()
+        timestamped = await audio_parser._asr_transcribe_with_timestamps(audio_bytes, None)
+        if timestamped:
+            return "timestamped", timestamped
+
+        plain = await audio_parser._asr_transcribe(audio_bytes, None)
+        if plain:
+            return ("plain" if "unavailable" not in plain.lower() and "failed" not in plain.lower() else "unavailable"), plain
+        return "unavailable", "Audio transcription unavailable: extracted audio track produced no transcript."
+
+    async def _extract_audio_track(self, file_path: Path) -> Optional[bytes]:
+        """Extract a WAV audio track using ffmpeg when available."""
+        ffmpeg_path = shutil.which("ffmpeg")
+        if not ffmpeg_path:
+            return None
+
+        def _extract() -> Optional[bytes]:
+            result = subprocess.run(
+                [
+                    ffmpeg_path,
+                    "-y",
+                    "-i",
+                    str(file_path),
+                    "-vn",
+                    "-acodec",
+                    "pcm_s16le",
+                    "-ar",
+                    "16000",
+                    "-ac",
+                    "1",
+                    "-f",
+                    "wav",
+                    "pipe:1",
+                ],
+                capture_output=True,
+                check=True,
+            )
+            return result.stdout or None
+
+        try:
+            return await asyncio.to_thread(_extract)
+        except Exception as exc:
+            logger.debug("ffmpeg audio extraction failed for %s: %s", file_path, exc)
+            return None
+
+    async def _describe_preview_frame(
+        self,
+        preview_bytes: bytes,
+        instruction: str = "",
+    ) -> Optional[str]:
+        """Describe the preview frame through the existing image VLM helper."""
+        image_parser = ImageParser()
+        if not image_parser._is_vlm_available():
+            return None
+        description = await image_parser._vlm_describe(
+            preview_bytes,
+            model=None,
+            instruction=instruction,
+        )
+        return description or None
+
+    def _build_description(
+        self,
+        *,
+        original_filename: str,
+        metadata: dict,
+        preview_description: Optional[str],
+        transcript_status: str,
+        transcript_text: str,
+        has_preview: bool,
+    ) -> str:
+        """Build markdown summary for the video resource."""
+        if preview_description:
+            summary = f"Preview-frame description: {_truncate_text(preview_description, 320)}"
+        elif transcript_text and "unavailable" not in transcript_text.lower():
+            summary = f"Video audio transcript excerpt: {_truncate_text(transcript_text, 320)}"
+        else:
+            summary = (
+                f"Video file `{original_filename}` in {metadata['format'].upper()} format "
+                "with lightweight metadata-only analysis."
+            )
+
+        parts = ["# Video Summary", "", summary, "", "## Metadata"]
+        parts.append(f"- Duration: {_format_optional_number(metadata.get('duration'), suffix='s')}")
+        resolution = (
+            f"{metadata.get('width')}x{metadata.get('height')}"
+            if metadata.get("width") and metadata.get("height")
+            else "unknown"
+        )
+        parts.append(f"- Resolution: {resolution}")
+        parts.append(f"- FPS: {_format_optional_number(metadata.get('fps'))}")
+        parts.append(f"- Frame count: {_format_optional_number(metadata.get('frame_count'))}")
+        parts.append(f"- Format: {metadata['format'].upper()}")
+        parts.append(f"- Metadata source: {metadata.get('metadata_source', 'unknown')}")
+        parts.append(f"- Preview frame extracted: {'yes' if has_preview else 'no'}")
+
+        parts.extend(
+            [
+                "",
+                "## Audio Transcript Status",
+                transcript_status,
+                "",
+                "## Audio Transcript",
+                transcript_text.strip(),
+            ]
+        )
+        if preview_description:
+            parts.extend(["", "## Preview Frame Description", preview_description.strip()])
+        return "\n".join(parts).strip() + "\n"
 
     async def _generate_semantic_info(
-        self, node: ResourceNode, description: str, viking_fs, has_key_frames: bool
-    ):
-        """
-        Phase 2: Generate abstract and overview.
-
-        Args:
-            node: ResourceNode to update
-            description: Video description
-            viking_fs: VikingFS instance
-            has_key_frames: Whether key frames directory exists
-        """
-        # Generate abstract (short summary, < 100 tokens)
-        abstract = description[:200] if len(description) > 200 else description
-
-        # Generate overview (content summary + file list + usage instructions)
+        self,
+        node: ResourceNode,
+        description: str,
+        viking_fs,
+        has_key_frames: bool,
+        root_dir_uri: str,
+    ) -> None:
+        """Populate and persist the video L0/L1 summaries."""
+        abstract = _truncate_text(description, 220) or f"Video: {node.meta['original_filename']}"
         overview_parts = [
-            "## Content Summary\n",
-            description,
-            "\n\n## Available Files\n",
-            f"- {node.meta['original_filename']}: Original video file ({node.meta['duration']}s, {node.meta['width']}x{node.meta['height']}, {node.meta['fps']}fps, {node.meta['format'].upper()} format)\n",
+            "## Content Summary",
+            "",
+            _truncate_text(description, 1800),
+            "",
+            "## Available Files",
+            f"- {node.meta['original_filename']}: Original video file",
+            "- description.md: Semantic markdown summary for the video",
+            "- transcript.md: Transcript or fallback status for the audio track",
         ]
-
         if has_key_frames:
-            overview_parts.append("- keyframes/: Directory containing extracted key frames\n")
-
-        overview_parts.append("\n## Usage\n")
-        overview_parts.append("### Play Video\n")
-        overview_parts.append("```python\n")
-        overview_parts.append("video_bytes = await video_resource.play()\n")
-        overview_parts.append("# Returns: Video file binary data\n")
-        overview_parts.append("# Purpose: Play or save the video\n")
-        overview_parts.append("```\n\n")
-
-        if has_key_frames:
-            overview_parts.append("### Get Key Frames\n")
-            overview_parts.append("```python\n")
-            overview_parts.append("keyframes = await video_resource.keyframes()\n")
-            overview_parts.append("# Returns: List of key frame resources\n")
-            overview_parts.append("# Purpose: Analyze video scenes\n")
-            overview_parts.append("```\n\n")
-
-        overview_parts.append("### Get Video Metadata\n")
-        overview_parts.append("```python\n")
-        overview_parts.append(
-            f"duration = video_resource.get_duration()  # {node.meta['duration']}s\n"
+            overview_parts.append("- preview.png: Single extracted preview frame")
+        overview_parts.extend(
+            [
+                "",
+                "## Metadata",
+                f"- Duration: {_format_optional_number(node.meta.get('duration'), suffix='s')}",
+                "- Resolution: "
+                + (
+                    f"{node.meta.get('width')}x{node.meta.get('height')}"
+                    if node.meta.get("width") and node.meta.get("height")
+                    else "unknown"
+                ),
+                f"- FPS: {_format_optional_number(node.meta.get('fps'))}",
+                f"- Frame count: {_format_optional_number(node.meta.get('frame_count'))}",
+                f"- Format: {node.meta['format'].upper()}",
+                f"- Transcript status: {node.meta['transcript_status']}",
+            ]
         )
-        overview_parts.append(
-            f"resolution = video_resource.get_resolution()  # ({node.meta['width']}, {node.meta['height']})\n"
-        )
-        overview_parts.append(f"fps = video_resource.get_fps()  # {node.meta['fps']}\n")
-        overview_parts.append(f'format = video_resource.get_format()  # "{node.meta["format"]}"\n')
-        overview_parts.append("```\n")
+        overview = "\n".join(overview_parts).strip() + "\n"
 
-        overview = "".join(overview_parts)
-
-        # Store in node meta
         node.meta["abstract"] = abstract
         node.meta["overview"] = overview
 
+        await viking_fs.write_file(f"{root_dir_uri}/.abstract.md", abstract)
+        await viking_fs.write_file(f"{root_dir_uri}/.overview.md", overview)
+
     async def parse_content(
-        self, content: str, source_path: Optional[str] = None, instruction: str = "", **kwargs
-    ) -> ParseResult:
-        """
-        Parse video from content string - Not yet implemented.
-
-        Args:
-            content: Video content (base64 or binary string)
-            source_path: Optional source path for metadata
-            **kwargs: Additional parsing parameters
-
-        Returns:
-            ParseResult with video content
-
-        Raises:
-            NotImplementedError: This feature is not yet implemented
-        """
+        self,
+        content: str,
+        source_path: Optional[str] = None,
+        instruction: str = "",
+        **kwargs,
+    ):
         raise NotImplementedError("Video parsing from content not yet implemented")

--- a/tests/parse/test_media_parser_semantics.py
+++ b/tests/parse/test_media_parser_semantics.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Focused tests for multimodal parser semantic artifact generation."""
+
+import asyncio
+import io
+import wave
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, patch
+
+from PIL import Image
+
+from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.media.audio import AudioParser
+from openviking.parse.parsers.media.image import ImageParser
+from openviking.parse.parsers.media.video import VideoParser
+from openviking_cli.utils.config.parser_config import AudioConfig, ImageConfig, VideoConfig
+
+
+class FakeVikingFS:
+    """Minimal VikingFS mock for parser temp outputs."""
+
+    def __init__(self):
+        self.dirs: List[str] = []
+        self.files: Dict[str, bytes] = {}
+        self._temp_counter = 0
+
+    async def mkdir(self, uri: str, exist_ok: bool = False, **kwargs) -> None:
+        if uri not in self.dirs:
+            self.dirs.append(uri)
+
+    async def write_file(self, uri: str, content: Any) -> None:
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        self.files[uri] = content
+
+    async def write_file_bytes(self, uri: str, content: bytes) -> None:
+        self.files[uri] = content
+
+    def create_temp_uri(self) -> str:
+        self._temp_counter += 1
+        return f"viking://temp/media_{self._temp_counter}"
+
+
+def _create_png_bytes(width: int = 48, height: int = 24) -> bytes:
+    """Create a simple PNG fixture."""
+    img = Image.new("RGB", (width, height), color="white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _create_wav_bytes(duration_seconds: float = 0.2, sample_rate: int = 8000) -> bytes:
+    """Create a small valid WAV file in memory."""
+    frame_count = int(duration_seconds * sample_rate)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * frame_count)
+    return buf.getvalue()
+
+
+def _decode(fake_fs: FakeVikingFS, uri: str) -> str:
+    """Decode UTF-8 content stored in the fake FS."""
+    return fake_fs.files[uri].decode("utf-8")
+
+
+def test_image_parser_writes_semantic_artifacts(tmp_path: Path) -> None:
+    """Image parsing should emit semantic sidecars and OCR output."""
+    file_path = tmp_path / "receipt.png"
+    file_path.write_bytes(_create_png_bytes())
+    fake_fs = FakeVikingFS()
+
+    with patch.object(BaseParser, "_get_viking_fs", return_value=fake_fs):
+        parser = ImageParser(config=ImageConfig(enable_ocr=True, enable_vlm=False))
+        with patch.object(
+            parser,
+            "_ocr_extract",
+            new=AsyncMock(return_value="Store receipt total: $42.00"),
+        ):
+            result = asyncio.run(parser.parse(file_path))
+
+    base_uri = f"{result.temp_dir_path}/receipt_png"
+    assert f"{base_uri}/receipt.png" in fake_fs.files
+    assert f"{base_uri}/description.md" in fake_fs.files
+    assert f"{base_uri}/ocr.md" in fake_fs.files
+    assert f"{base_uri}/.abstract.md" in fake_fs.files
+    assert f"{base_uri}/.overview.md" in fake_fs.files
+    assert result.root.meta["has_ocr"] is True
+
+    description = _decode(fake_fs, f"{base_uri}/description.md")
+    overview = _decode(fake_fs, f"{base_uri}/.overview.md")
+
+    assert "OCR Text" in description
+    assert "Store receipt total: $42.00" in description
+    assert "description.md" in overview
+    assert "ocr.md" in overview
+
+
+def test_audio_parser_writes_transcript_fallback_artifacts(tmp_path: Path) -> None:
+    """Audio parsing should write transcript sidecars even when ASR is unavailable."""
+    file_path = tmp_path / "meeting.wav"
+    file_path.write_bytes(_create_wav_bytes())
+    fake_fs = FakeVikingFS()
+
+    with patch.object(BaseParser, "_get_viking_fs", return_value=fake_fs):
+        parser = AudioParser(config=AudioConfig(enable_transcription=True))
+        with patch.object(
+            parser,
+            "_build_transcript",
+            new=AsyncMock(
+                return_value=("unavailable", "Audio transcription unavailable: OPENAI_API_KEY is not set.")
+            ),
+        ):
+            result = asyncio.run(parser.parse(file_path))
+
+    base_uri = f"{result.temp_dir_path}/meeting_wav"
+    assert f"{base_uri}/meeting.wav" in fake_fs.files
+    assert f"{base_uri}/transcript.md" in fake_fs.files
+    assert f"{base_uri}/description.md" in fake_fs.files
+    assert f"{base_uri}/.abstract.md" in fake_fs.files
+    assert f"{base_uri}/.overview.md" in fake_fs.files
+    assert result.root.meta["transcript_status"] == "unavailable"
+    assert result.root.meta["metadata_source"] == "wave"
+
+    description = _decode(fake_fs, f"{base_uri}/description.md")
+    abstract = _decode(fake_fs, f"{base_uri}/.abstract.md")
+
+    assert "Automatic transcription is unavailable." in description
+    assert "meeting.wav" in abstract
+    assert "placeholder" not in description.lower()
+
+
+def test_video_parser_writes_preview_and_semantic_artifacts(tmp_path: Path) -> None:
+    """Video parsing should emit preview, transcript, and semantic sidecars."""
+    file_path = tmp_path / "demo.mp4"
+    file_path.write_bytes(b"\x00\x00\x00\x18ftypisom")
+    fake_fs = FakeVikingFS()
+    preview_bytes = _create_png_bytes(32, 32)
+
+    with patch.object(BaseParser, "_get_viking_fs", return_value=fake_fs):
+        parser = VideoParser(
+            config=VideoConfig(extract_frames=True, enable_transcription=True)
+        )
+        with patch.object(
+            parser,
+            "_extract_video_metadata",
+            new=AsyncMock(
+                return_value={
+                    "duration": 12.5,
+                    "width": 1280,
+                    "height": 720,
+                    "fps": 30.0,
+                    "frame_count": 375,
+                    "format": "mp4",
+                    "metadata_source": "mock",
+                }
+            ),
+        ), patch.object(
+            parser,
+            "_extract_preview_frame",
+            new=AsyncMock(return_value=preview_bytes),
+        ), patch.object(
+            parser,
+            "_build_video_transcript",
+            new=AsyncMock(return_value=("plain", "Speaker says hello from the demo video.")),
+        ), patch.object(
+            parser,
+            "_describe_preview_frame",
+            new=AsyncMock(return_value="A presenter stands beside a slide with a chart."),
+        ):
+            result = asyncio.run(parser.parse(file_path))
+
+    base_uri = f"{result.temp_dir_path}/demo_mp4"
+    assert f"{base_uri}/demo.mp4" in fake_fs.files
+    assert f"{base_uri}/preview.png" in fake_fs.files
+    assert f"{base_uri}/transcript.md" in fake_fs.files
+    assert f"{base_uri}/description.md" in fake_fs.files
+    assert f"{base_uri}/.abstract.md" in fake_fs.files
+    assert f"{base_uri}/.overview.md" in fake_fs.files
+    assert result.root.meta["has_preview_frame"] is True
+
+    description = _decode(fake_fs, f"{base_uri}/description.md")
+    overview = _decode(fake_fs, f"{base_uri}/.overview.md")
+
+    assert "A presenter stands beside a slide with a chart." in description
+    assert "preview.png" in overview
+    assert "Transcript status: plain" in overview


### PR DESCRIPTION
## Summary
- upgrade image/audio/video parsers to write semantic sidecars instead of metadata-only placeholder roots
- reuse lightweight OCR/VLM/ASR-style helpers when available and emit graceful fallback text when they are not
- add focused parser tests covering semantic artifacts and fallback outputs for multimodal media

## Testing
- python -m py_compile openviking/parse/parsers/media/image.py openviking/parse/parsers/media/audio.py openviking/parse/parsers/media/video.py tests/parse/test_media_parser_semantics.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --noconftest -q -o addopts= tests/parse/test_media_parser_semantics.py