### PR TITLE
feat(resource): improve incremental summary reuse and diff observability

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -46,6 +46,20 @@ class DagStats:
 
 
 @dataclass
+class IncrementalReuseStats:
+    reused_file_summaries: int = 0
+    regenerated_file_summaries: int = 0
+    missing_cached_file_summaries: int = 0
+    reused_directory_summaries: int = 0
+    regenerated_directory_summaries: int = 0
+    extracted_directory_abstracts: int = 0
+    skipped_file_vectorizations: int = 0
+    enqueued_file_vectorizations: int = 0
+    skipped_directory_vectorizations: int = 0
+    enqueued_directory_vectorizations: int = 0
+
+
+@dataclass
 class VectorizeTask:
     """Vectorize task information."""
 
@@ -107,6 +121,7 @@ class SemanticDagExecutor:
         self._overview_cache: Dict[str, Dict[str, str]] = {}
         self._overview_cache_lock = asyncio.Lock()
         self._refresh_task: Optional[asyncio.Task] = None
+        self._incremental_reuse_stats = IncrementalReuseStats()
 
     def _create_on_complete_callback(self) -> Callable[[], Awaitable[None]]:
         """Create on_complete callback for incremental update or full update."""
@@ -135,8 +150,10 @@ class SemanticDagExecutor:
                     f"added_files={len(diff.added_files)}, "
                     f"deleted_files={len(diff.deleted_files)}, "
                     f"updated_files={len(diff.updated_files)}, "
+                    f"unchanged_files={len(diff.unchanged_files)}, "
                     f"added_dirs={len(diff.added_dirs)}, "
-                    f"deleted_dirs={len(diff.deleted_dirs)}"
+                    f"deleted_dirs={len(diff.deleted_dirs)}, "
+                    f"unchanged_dirs={len(diff.unchanged_dirs)}"
                 )
             except Exception as e:
                 logger.error(
@@ -181,6 +198,8 @@ class SemanticDagExecutor:
         async with self._vectorize_lock:
             task_count = self._vectorize_task_count
             tasks = list(self._pending_vectorize_tasks)
+
+        self._log_incremental_reuse_stats()
 
         if task_count > 0:
             from .embedding_tracker import EmbeddingTaskTracker
@@ -421,12 +440,22 @@ class SemanticDagExecutor:
         target_path = self._get_target_file_path(dir_uri)
         if not target_path:
             return None, None
+        overview = None
+        abstract = None
         try:
             overview = await self._viking_fs.read_file(f"{target_path}/.overview.md", ctx=self._ctx)
-            abstract = await self._viking_fs.read_file(f"{target_path}/.abstract.md", ctx=self._ctx)
-            return overview, abstract
         except Exception:
-            return None, None
+            overview = None
+        try:
+            abstract = await self._viking_fs.read_file(f"{target_path}/.abstract.md", ctx=self._ctx)
+        except Exception:
+            abstract = None
+
+        if overview and not abstract:
+            abstract = self._processor._extract_abstract_from_overview(overview)
+            if abstract:
+                self._incremental_reuse_stats.extracted_directory_abstracts += 1
+        return overview, abstract
 
     async def _file_summary_task(self, parent_uri: str, file_path: str) -> None:
         """Generate file summary and notify parent completion."""
@@ -443,14 +472,18 @@ class SemanticDagExecutor:
                     summary_dict = await self._read_existing_summary(file_path)
                     if summary_dict is not None:
                         need_vectorize = False
+                        self._incremental_reuse_stats.reused_file_summaries += 1
                     else:
                         self._file_change_status[file_path] = True
+                        self._incremental_reuse_stats.missing_cached_file_summaries += 1
             else:
                 self._file_change_status[file_path] = True
             if summary_dict is None:
                 summary_dict = await self._processor._generate_single_file_summary(
                     file_path, llm_sem=self._llm_sem, ctx=self._ctx
                 )
+                if self._incremental_update:
+                    self._incremental_reuse_stats.regenerated_file_summaries += 1
         except Exception as e:
             logger.warning(f"Failed to generate summary for {file_path}: {e}")
             summary_dict = {"name": file_name, "summary": ""}
@@ -473,6 +506,10 @@ class SemanticDagExecutor:
                     use_summary=use_summary,
                 )
                 await self._add_vectorize_task(task)
+                if self._incremental_update:
+                    self._incremental_reuse_stats.enqueued_file_vectorizations += 1
+            elif self._incremental_update:
+                self._incremental_reuse_stats.skipped_file_vectorizations += 1
         except Exception as e:
             logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
         await self._on_file_done(parent_uri, file_path, summary_dict)
@@ -559,8 +596,10 @@ class SemanticDagExecutor:
                 )
 
                 if not children_changed:
-                    need_vectorize = False
                     overview, abstract = await self._read_existing_overview_abstract(dir_uri)
+                    if overview is not None and abstract is not None:
+                        need_vectorize = False
+                        self._incremental_reuse_stats.reused_directory_summaries += 1
             if overview is None or abstract is None:
                 async with node.lock:
                     file_summaries = self._finalize_file_summaries(node)
@@ -571,6 +610,8 @@ class SemanticDagExecutor:
                     )
                 abstract = self._processor._extract_abstract_from_overview(overview)
                 overview, abstract = self._processor._enforce_size_limits(overview, abstract)
+                if self._incremental_update:
+                    self._incremental_reuse_stats.regenerated_directory_summaries += 1
 
             # Write directly — protected by the outer lifecycle SUBTREE lock
             try:
@@ -591,6 +632,10 @@ class SemanticDagExecutor:
                         overview=overview,
                     )
                     await self._add_vectorize_task(task)
+                    if self._incremental_update:
+                        self._incremental_reuse_stats.enqueued_directory_vectorizations += 1
+                elif self._incremental_update:
+                    self._incremental_reuse_stats.skipped_directory_vectorizations += 1
             except Exception as e:
                 logger.error(f"Failed to schedule vectorization for {dir_uri}: {e}", exc_info=True)
 
@@ -665,6 +710,27 @@ class SemanticDagExecutor:
             pending_nodes=self._stats.pending_nodes,
             in_progress_nodes=self._stats.in_progress_nodes,
             done_nodes=self._stats.done_nodes,
+        )
+
+    def get_incremental_reuse_stats(self) -> IncrementalReuseStats:
+        return IncrementalReuseStats(**vars(self._incremental_reuse_stats))
+
+    def _log_incremental_reuse_stats(self) -> None:
+        if not self._incremental_update:
+            return
+        stats = self._incremental_reuse_stats
+        logger.info(
+            f"[IncrementalReuse] root_uri={self._root_uri} target_uri={self._target_uri} "
+            f"reused_file_summaries={stats.reused_file_summaries} "
+            f"regenerated_file_summaries={stats.regenerated_file_summaries} "
+            f"missing_cached_file_summaries={stats.missing_cached_file_summaries} "
+            f"reused_directory_summaries={stats.reused_directory_summaries} "
+            f"regenerated_directory_summaries={stats.regenerated_directory_summaries} "
+            f"extracted_directory_abstracts={stats.extracted_directory_abstracts} "
+            f"skipped_file_vectorizations={stats.skipped_file_vectorizations} "
+            f"enqueued_file_vectorizations={stats.enqueued_file_vectorizations} "
+            f"skipped_directory_vectorizations={stats.skipped_directory_vectorizations} "
+            f"enqueued_directory_vectorizations={stats.enqueued_directory_vectorizations}"
         )
 
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -54,8 +54,19 @@ class DiffResult:
     added_files: List[str] = field(default_factory=list)
     deleted_files: List[str] = field(default_factory=list)
     updated_files: List[str] = field(default_factory=list)
+    unchanged_files: List[str] = field(default_factory=list)
     added_dirs: List[str] = field(default_factory=list)
     deleted_dirs: List[str] = field(default_factory=list)
+    unchanged_dirs: List[str] = field(default_factory=list)
+
+    def operation_counts(self) -> tuple[int, int, int, int, int]:
+        return (
+            len(self.added_files),
+            len(self.deleted_files),
+            len(self.updated_files),
+            len(self.added_dirs),
+            len(self.deleted_dirs),
+        )
 
 
 class RequestQueueStats:
@@ -651,6 +662,7 @@ class SemanticProcessor(DequeueHandlerBase):
             return files, dirs
 
         async def sync_dir(root_dir: str, target_dir: str) -> None:
+            before_counts = diff.operation_counts()
             root_files, root_dirs = await list_children(root_dir)
             target_files, target_dirs = await list_children(target_dir)
 
@@ -740,6 +752,8 @@ class SemanticProcessor(DequeueHandlerBase):
                             logger.error(
                                 f"[SyncDiff] Failed to move updated file: {root_file} -> {target_file}, error={e}"
                             )
+                    else:
+                        diff.unchanged_files.append(root_file)
                     continue
 
                 if root_file and not target_file:
@@ -811,6 +825,9 @@ class SemanticProcessor(DequeueHandlerBase):
 
                 if root_subdir and target_subdir:
                     await sync_dir(root_subdir, target_subdir)
+
+            if diff.operation_counts() == before_counts:
+                diff.unchanged_dirs.append(root_dir)
 
         target_exists = await viking_fs.exists(target_uri, ctx=ctx)
         if not target_exists:

--- a/tests/resource/test_watch_scheduler.py
+++ b/tests/resource/test_watch_scheduler.py
@@ -1,27 +1,76 @@
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 
 from openviking.resource.watch_scheduler import WatchScheduler
-from openviking.service.resource_service import ResourceService
+from openviking.server.identity import Role
+
+
+class _DummyResourceService:
+    pass
 
 
 class TestWatchSchedulerValidation:
     def test_check_interval_must_be_positive(self):
-        rs = ResourceService()
+        rs = _DummyResourceService()
         with pytest.raises(ValueError, match="check_interval must be > 0"):
             WatchScheduler(resource_service=rs, check_interval=0)
 
     def test_max_concurrency_must_be_positive(self):
-        rs = ResourceService()
+        rs = _DummyResourceService()
         with pytest.raises(ValueError, match="max_concurrency must be > 0"):
             WatchScheduler(resource_service=rs, max_concurrency=0)
 
 
 class TestWatchSchedulerResourceExistence:
     def test_url_like_sources_are_treated_as_existing(self):
-        rs = ResourceService()
+        rs = _DummyResourceService()
         scheduler = WatchScheduler(resource_service=rs, check_interval=1)
         assert scheduler._check_resource_exists("http://example.com") is True
         assert scheduler._check_resource_exists("https://example.com") is True
         assert scheduler._check_resource_exists("git@github.com:org/repo.git") is True
         assert scheduler._check_resource_exists("ssh://git@github.com/org/repo.git") is True
         assert scheduler._check_resource_exists("git://github.com/org/repo.git") is True
+
+
+class TestWatchSchedulerExecution:
+    @pytest.mark.asyncio
+    async def test_execute_task_reuses_resource_add_path(self):
+        rs = _DummyResourceService()
+        rs.add_resource = AsyncMock(return_value={"root_uri": "viking://resources/demo"})
+        scheduler = WatchScheduler(resource_service=rs, check_interval=1)
+        scheduler._watch_manager = MagicMock()
+        scheduler._watch_manager.update_execution_time = AsyncMock()
+        scheduler._watch_manager.update_task = AsyncMock()
+
+        task = MagicMock(
+            task_id="watch-1",
+            path="/tmp/demo",
+            to_uri="viking://resources/demo",
+            parent_uri="viking://resources",
+            reason="watch refresh",
+            instruction="keep updated",
+            watch_interval=15.0,
+            build_index=True,
+            summarize=False,
+            processor_kwargs={"custom_option": "x"},
+            account_id="acc",
+            user_id="user",
+            agent_id="agent",
+            original_role=Role.USER.value,
+        )
+
+        scheduler._check_resource_exists = lambda path: path == "/tmp/demo"
+
+        await scheduler._execute_task(task)
+
+        rs.add_resource.assert_awaited_once()
+        call = rs.add_resource.await_args
+        assert call.kwargs["path"] == "/tmp/demo"
+        assert call.kwargs["to"] == "viking://resources/demo"
+        assert call.kwargs["parent"] == "viking://resources"
+        assert call.kwargs["watch_interval"] == 15.0
+        assert call.kwargs["skip_watch_management"] is True
+        assert call.kwargs["build_index"] is True
+        assert call.kwargs["summarize"] is False
+        assert call.kwargs["custom_option"] == "x"
+        scheduler._watch_manager.update_execution_time.assert_awaited_once_with("watch-1")

--- a/tests/storage/test_semantic_dag_incremental_missing_summary.py
+++ b/tests/storage/test_semantic_dag_incremental_missing_summary.py
@@ -63,6 +63,8 @@ class _FakeProcessor:
     def __init__(self, viking_fs):
         self._fs = viking_fs
         self.summarized_files = []
+        self.generated_overviews = []
+        self.extracted_abstracts = []
 
     def _parse_overview_md(self, overview_content):
         results = {}
@@ -78,6 +80,7 @@ class _FakeProcessor:
         return {"name": file_path.split("/")[-1], "summary": "summary"}
 
     async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        self.generated_overviews.append(dir_uri)
         lines = ["FILES:"]
         for item in file_summaries:
             name = item.get("name", "")
@@ -86,6 +89,7 @@ class _FakeProcessor:
         return "\n".join(lines)
 
     def _extract_abstract_from_overview(self, overview):
+        self.extracted_abstracts.append(overview)
         return "abstract"
 
     def _enforce_size_limits(self, overview, abstract):
@@ -148,6 +152,12 @@ async def test_incremental_missing_summary_triggers_overview_regen(monkeypatch):
     assert "- a.txt:" in fake_fs._file_contents[f"{root_uri}/.overview.md"]
     assert "- a.txt:" in fake_fs._file_contents[f"{target_uri}/.overview.md"]
     first_run_calls = len(processor.summarized_files)
+    first_run_stats = executor1.get_incremental_reuse_stats()
+    assert first_run_stats.reused_file_summaries == 0
+    assert first_run_stats.regenerated_file_summaries == 1
+    assert first_run_stats.missing_cached_file_summaries == 1
+    assert first_run_stats.reused_directory_summaries == 0
+    assert first_run_stats.regenerated_directory_summaries == 1
 
     executor2 = SemanticDagExecutor(
         processor=processor,
@@ -161,8 +171,58 @@ async def test_incremental_missing_summary_triggers_overview_regen(monkeypatch):
     await executor2.run(root_uri)
 
     assert len(processor.summarized_files) == first_run_calls
+    second_run_stats = executor2.get_incremental_reuse_stats()
+    assert second_run_stats.reused_file_summaries == 1
+    assert second_run_stats.regenerated_file_summaries == 0
+    assert second_run_stats.missing_cached_file_summaries == 0
+    assert second_run_stats.reused_directory_summaries == 1
+    assert second_run_stats.regenerated_directory_summaries == 0
+
+
+@pytest.mark.asyncio
+async def test_incremental_missing_abstract_reuses_existing_overview(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+
+    root_uri = "viking://resources/root"
+    target_uri = "viking://resources/target"
+    tree = {
+        root_uri: [{"name": "a.txt", "isDir": False}],
+        target_uri: [{"name": "a.txt", "isDir": False}],
+    }
+
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "hello",
+            f"{target_uri}/a.txt": "hello",
+            f"{target_uri}/.overview.md": "FILES:\n- a.txt: cached summary",
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=target_uri,
+    )
+    monkeypatch.setattr(executor, "_add_vectorize_task", AsyncMock())
+    await executor.run(root_uri)
+
+    stats = executor.get_incremental_reuse_stats()
+    assert processor.generated_overviews == []
+    assert stats.reused_file_summaries == 1
+    assert stats.regenerated_file_summaries == 0
+    assert stats.reused_directory_summaries == 1
+    assert stats.regenerated_directory_summaries == 0
+    assert stats.extracted_directory_abstracts == 1
+    assert fake_fs._file_contents[f"{root_uri}/.abstract.md"] == "abstract"
 
 
 if __name__ == "__main__":
     pytest.main([__file__])
-

--- a/tests/storage/test_semantic_processor_incremental_diff.py
+++ b/tests/storage/test_semantic_processor_incremental_diff.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeVikingFS:
+    def __init__(self, *, dirs: Iterable[str], files: Dict[str, str]):
+        self._dirs: Set[str] = set(dirs)
+        self._files: Dict[str, str] = dict(files)
+        self.mv_vector_store_calls: List[Tuple[str, str]] = []
+
+    async def ls(self, uri, show_all_hidden: bool = False, ctx=None):
+        del show_all_hidden, ctx
+        entries = []
+        for child in sorted(self._dirs):
+            if child == uri or self._parent(child) != uri:
+                continue
+            entries.append({"name": child.rsplit("/", 1)[-1], "isDir": True})
+        for child in sorted(self._files):
+            if self._parent(child) != uri:
+                continue
+            entries.append({"name": child.rsplit("/", 1)[-1], "isDir": False})
+        return entries
+
+    async def exists(self, uri, ctx=None):
+        del ctx
+        return uri in self._dirs or uri in self._files
+
+    async def mkdir(self, uri, exist_ok: bool = True, ctx=None):
+        del exist_ok, ctx
+        self._ensure_dir(uri)
+
+    async def stat(self, uri, ctx=None):
+        del ctx
+        if uri in self._dirs:
+            return {"isDir": True}
+        if uri in self._files:
+            return {"isDir": False, "size": len(self._files[uri])}
+        raise FileNotFoundError(uri)
+
+    async def read_file(self, uri, ctx=None):
+        del ctx
+        if uri not in self._files:
+            raise FileNotFoundError(uri)
+        return self._files[uri]
+
+    async def rm(self, uri, recursive: bool = False, ctx=None, lock_handle=None):
+        del ctx, lock_handle
+        if uri in self._files:
+            self._files.pop(uri, None)
+            return
+        if recursive:
+            prefix = uri.rstrip("/") + "/"
+            for path in [path for path in self._files if path.startswith(prefix)]:
+                self._files.pop(path, None)
+            for path in [path for path in self._dirs if path == uri or path.startswith(prefix)]:
+                self._dirs.discard(path)
+            return
+        self._dirs.discard(uri)
+
+    async def mv(self, src, dst, ctx=None, lock_handle=None):
+        del ctx, lock_handle
+        if src in self._files:
+            self._ensure_dir(self._parent(dst))
+            self._files[dst] = self._files.pop(src)
+            return
+
+        src_prefix = src.rstrip("/") + "/"
+        dst_prefix = dst.rstrip("/") + "/"
+        affected_dirs = [path for path in self._dirs if path == src or path.startswith(src_prefix)]
+        affected_files = [
+            path for path in self._files if path == src or path.startswith(src_prefix)
+        ]
+
+        for path in sorted(affected_dirs, key=len):
+            self._dirs.discard(path)
+        for path in affected_dirs:
+            mapped = dst if path == src else dst_prefix + path[len(src_prefix) :]
+            self._ensure_dir(mapped)
+        for path in affected_files:
+            mapped = dst if path == src else dst_prefix + path[len(src_prefix) :]
+            self._ensure_dir(self._parent(mapped))
+            self._files[mapped] = self._files.pop(path)
+
+    async def delete_temp(self, uri, ctx=None):
+        await self.rm(uri, recursive=True, ctx=ctx)
+
+    async def _mv_vector_store_l0_l1(self, src, dst, ctx=None, lock_handle=None):
+        del ctx, lock_handle
+        self.mv_vector_store_calls.append((src, dst))
+
+    def _ensure_dir(self, uri: Optional[str]) -> None:
+        current = uri
+        while current and current not in self._dirs:
+            self._dirs.add(current)
+            current = self._parent(current)
+
+    @staticmethod
+    def _parent(uri: str) -> Optional[str]:
+        if "/" not in uri:
+            return None
+        parent = uri.rsplit("/", 1)[0]
+        return parent or None
+
+
+@pytest.mark.asyncio
+async def test_sync_topdown_recursive_reports_unchanged_paths(monkeypatch):
+    root_uri = "viking://resources/tmp-root"
+    target_uri = "viking://resources/final-root"
+    fake_fs = _FakeVikingFS(
+        dirs={
+            root_uri,
+            f"{root_uri}/child",
+            target_uri,
+            f"{target_uri}/child",
+        },
+        files={
+            f"{root_uri}/same.txt": "same",
+            f"{target_uri}/same.txt": "same",
+            f"{root_uri}/changed.txt": "new",
+            f"{target_uri}/changed.txt": "old",
+            f"{root_uri}/added.txt": "added",
+            f"{target_uri}/removed.txt": "removed",
+            f"{root_uri}/child/keep.txt": "keep",
+            f"{target_uri}/child/keep.txt": "keep",
+        },
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+
+    processor = SemanticProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc", "user", "agent"), role=Role.USER)
+    diff = await processor._sync_topdown_recursive(
+        root_uri,
+        target_uri,
+        ctx=ctx,
+        file_change_status={
+            f"{root_uri}/same.txt": False,
+            f"{root_uri}/changed.txt": True,
+            f"{root_uri}/child/keep.txt": False,
+        },
+    )
+
+    assert diff.added_files == [f"{root_uri}/added.txt"]
+    assert diff.updated_files == [f"{root_uri}/changed.txt"]
+    assert diff.deleted_files == [f"{target_uri}/removed.txt"]
+    assert set(diff.unchanged_files) == {
+        f"{root_uri}/same.txt",
+        f"{root_uri}/child/keep.txt",
+    }
+    assert diff.unchanged_dirs == [f"{root_uri}/child"]


### PR DESCRIPTION
## Summary
- reuse unchanged file summaries and cached directory summaries more aggressively during incremental semantic refresh
- expose unchanged file/dir counts in sync diff results and add incremental reuse logging/state for focused assertions
- add focused storage/watch regressions covering reuse fallbacks, diff observability, and scheduler reimport staying on add_resource path

## Validation
- python -m py_compile openviking/storage/queuefs/semantic_dag.py openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_dag_incremental_missing_summary.py tests/storage/test_semantic_processor_incremental_diff.py tests/resource/test_watch_scheduler.py
- direct focused unit invocation for the changed async/scheduler tests (pytest collection is blocked in this environment by missing optional dependency `volcenginesdkarkruntime` via `tests/conftest.py`, and `--noconftest` then trips a local `pytest_asyncio` package-collection issue)