### PR TITLE
feat(auth): add account permission profiles for data API phase 1

### DIFF
--- a/openviking/models/embedder/__init__.py
+++ b/openviking/models/embedder/__init__.py
@@ -47,11 +47,16 @@ from openviking.models.embedder.vikingdb_embedders import (
     VikingDBHybridEmbedder,
     VikingDBSparseEmbedder,
 )
-from openviking.models.embedder.volcengine_embedders import (
-    VolcengineDenseEmbedder,
-    VolcengineHybridEmbedder,
-    VolcengineSparseEmbedder,
-)
+try:
+    from openviking.models.embedder.volcengine_embedders import (
+        VolcengineDenseEmbedder,
+        VolcengineHybridEmbedder,
+        VolcengineSparseEmbedder,
+    )
+except ImportError:
+    VolcengineDenseEmbedder = None  # volcenginesdkarkruntime not installed
+    VolcengineHybridEmbedder = None
+    VolcengineSparseEmbedder = None
 from openviking.models.embedder.voyage_embedders import VoyageDenseEmbedder
 
 __all__ = [

--- a/openviking/server/api_keys.py
+++ b/openviking/server/api_keys.py
@@ -4,6 +4,7 @@
 
 import hmac
 import json
+import re
 import secrets
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -12,10 +13,21 @@ from typing import Dict, Optional
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
 
-from openviking.server.identity import AccountNamespacePolicy, ResolvedIdentity, Role
+from openviking.server.identity import (
+    DEFAULT_PERMISSION_PROFILE_ID,
+    AccountNamespacePolicy,
+    EffectivePermissions,
+    NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+    PermissionProfile,
+    ResolvedIdentity,
+    Role,
+    get_builtin_permission_profiles,
+)
 from openviking.storage.viking_fs import VikingFS
 from openviking_cli.exceptions import (
     AlreadyExistsError,
+    FailedPreconditionError,
+    InvalidArgumentError,
     NotFoundError,
     UnauthenticatedError,
 )
@@ -53,6 +65,7 @@ class AccountInfo:
     created_at: str
     users: Dict[str, dict] = field(default_factory=dict)
     namespace_policy: AccountNamespacePolicy = field(default_factory=AccountNamespacePolicy)
+    permission_profiles: Dict[str, PermissionProfile] = field(default_factory=dict)
 
 
 class APIKeyManager:
@@ -108,11 +121,13 @@ class APIKeyManager:
                     allow_legacy_inference=not fresh_workspace,
                 )
             )
+            permission_profiles = self._resolve_permission_profiles(settings_data)
 
             self._accounts[account_id] = AccountInfo(
                 created_at=info.get("created_at", ""),
                 users=users,
                 namespace_policy=namespace_policy,
+                permission_profiles=permission_profiles,
             )
             if should_persist_settings:
                 await self._save_settings_json(account_id, settings_data=settings_data)
@@ -195,13 +210,37 @@ class APIKeyManager:
             isolate_agent_scope_by_user=False,
         )
 
+    def _resolve_permission_profiles(self, settings_data: Optional[dict]) -> Dict[str, PermissionProfile]:
+        """Load custom account-level permission profiles from persisted settings."""
+        acl_data = settings_data.get("acl") if isinstance(settings_data, dict) else None
+        raw_profiles = acl_data.get("permission_profiles") if isinstance(acl_data, dict) else None
+        if not isinstance(raw_profiles, dict):
+            return {}
+
+        profiles: Dict[str, PermissionProfile] = {}
+        builtin_ids = set(get_builtin_permission_profiles())
+        for profile_id, profile_data in raw_profiles.items():
+            if not isinstance(profile_id, str) or not profile_id:
+                continue
+            if profile_id in builtin_ids:
+                logger.warning(
+                    "Ignoring custom permission profile %s because it collides with a built-in id",
+                    profile_id,
+                )
+                continue
+            profiles[profile_id] = PermissionProfile.from_dict(profile_id, profile_data)
+        return profiles
+
     def resolve(self, api_key: str) -> ResolvedIdentity:
         """Resolve an API key to identity. Sequential matching: root key first, then user key index."""
         if not api_key:
             raise UnauthenticatedError("Missing API Key")
 
         if hmac.compare_digest(api_key, self._root_key):
-            return ResolvedIdentity(role=Role.ROOT)
+            return ResolvedIdentity(
+                role=Role.ROOT,
+                effective_permissions=EffectivePermissions.full_access(),
+            )
 
         # Use prefix index to quickly locate candidate keys
         key_prefix = self._get_key_prefix(api_key)
@@ -211,20 +250,34 @@ class APIKeyManager:
             if entry.is_hashed:
                 # Verify hashed key
                 if self._verify_api_key(api_key, entry.key_or_hash):
+                    permission_profile, permissions = self._resolve_effective_permissions(
+                        entry.role,
+                        entry.account_id,
+                        entry.user_id,
+                    )
                     return ResolvedIdentity(
                         role=entry.role,
                         account_id=entry.account_id,
                         user_id=entry.user_id,
                         namespace_policy=self.get_account_policy(entry.account_id),
+                        permission_profile=permission_profile,
+                        effective_permissions=permissions,
                     )
             else:
                 # Verify plaintext key
                 if hmac.compare_digest(api_key, entry.key_or_hash):
+                    permission_profile, permissions = self._resolve_effective_permissions(
+                        entry.role,
+                        entry.account_id,
+                        entry.user_id,
+                    )
                     return ResolvedIdentity(
                         role=entry.role,
                         account_id=entry.account_id,
                         user_id=entry.user_id,
                         namespace_policy=self.get_account_policy(entry.account_id),
+                        permission_profile=permission_profile,
+                        effective_permissions=permissions,
                     )
 
         raise UnauthenticatedError("Invalid API Key")
@@ -259,6 +312,7 @@ class APIKeyManager:
         user_info = {
             "role": "admin",
             "key": stored_key,
+            "permission_profile": DEFAULT_PERMISSION_PROFILE_ID,
         }
         if self._encryption_enabled:
             user_info["key_prefix"] = key_prefix
@@ -267,6 +321,7 @@ class APIKeyManager:
             created_at=now,
             users={admin_user_id: user_info},
             namespace_policy=policy,
+            permission_profiles={},
         )
 
         entry = UserKeyEntry(
@@ -318,13 +373,20 @@ class APIKeyManager:
 
         await self._save_accounts_json()
 
-    async def register_user(self, account_id: str, user_id: str, role: str = "user") -> str:
+    async def register_user(
+        self,
+        account_id: str,
+        user_id: str,
+        role: str = "user",
+        permission_profile: str = DEFAULT_PERMISSION_PROFILE_ID,
+    ) -> str:
         """Register a new user in an account. Returns the user's API key."""
         account = self._accounts.get(account_id)
         if account is None:
             raise NotFoundError(account_id, "account")
         if user_id in account.users:
             raise AlreadyExistsError(user_id, "user")
+        self.get_permission_profile(account_id, permission_profile)
 
         key = self._generate_api_key()
 
@@ -340,6 +402,7 @@ class APIKeyManager:
         user_info = {
             "role": role,
             "key": stored_key,
+            "permission_profile": permission_profile,
         }
         if self._encryption_enabled:
             user_info["key_prefix"] = key_prefix
@@ -493,6 +556,7 @@ class APIKeyManager:
                     "account_id": account_id,
                     "created_at": info.created_at,
                     "user_count": len(info.users),
+                    "custom_permission_profile_count": len(info.permission_profiles),
                     **info.namespace_policy.to_dict(),
                 }
             )
@@ -518,9 +582,106 @@ class APIKeyManager:
                 {
                     "user_id": user_id,
                     "role": user_info.get("role", "user"),
+                    "permission_profile": user_info.get(
+                        "permission_profile",
+                        DEFAULT_PERMISSION_PROFILE_ID,
+                    ),
                 }
             )
         return result
+
+    def get_permission_profiles(self, account_id: str) -> list[dict]:
+        """List built-in and account custom permission profiles."""
+        account = self._accounts.get(account_id)
+        if account is None:
+            raise NotFoundError(account_id, "account")
+
+        profiles = list(get_builtin_permission_profiles().values()) + list(
+            account.permission_profiles.values()
+        )
+        profiles.sort(key=lambda profile: (not profile.builtin, profile.profile_id))
+        return [profile.to_dict() for profile in profiles]
+
+    def get_permission_profile(self, account_id: str, profile_id: str) -> PermissionProfile:
+        """Resolve a built-in or account custom permission profile."""
+        if profile_id in get_builtin_permission_profiles():
+            return get_builtin_permission_profiles()[profile_id]
+
+        account = self._accounts.get(account_id)
+        if account is None:
+            raise NotFoundError(account_id, "account")
+
+        profile = account.permission_profiles.get(profile_id)
+        if profile is None:
+            raise NotFoundError(profile_id, "permission profile")
+        return profile
+
+    async def upsert_permission_profile(
+        self,
+        account_id: str,
+        profile_id: str,
+        *,
+        permissions: EffectivePermissions,
+    ) -> PermissionProfile:
+        """Create or update a custom account permission profile."""
+        account = self._accounts.get(account_id)
+        if account is None:
+            raise NotFoundError(account_id, "account")
+
+        normalized_profile_id = self._normalize_custom_permission_profile_id(profile_id)
+        profile = PermissionProfile(
+            profile_id=normalized_profile_id,
+            permissions=permissions,
+            builtin=False,
+        )
+        account.permission_profiles[normalized_profile_id] = profile
+        await self._save_settings_json(account_id)
+        return profile
+
+    async def delete_permission_profile(self, account_id: str, profile_id: str) -> None:
+        """Delete a custom permission profile after verifying no user still references it."""
+        account = self._accounts.get(account_id)
+        if account is None:
+            raise NotFoundError(account_id, "account")
+
+        normalized_profile_id = self._normalize_custom_permission_profile_id(profile_id)
+        if normalized_profile_id not in account.permission_profiles:
+            raise NotFoundError(normalized_profile_id, "permission profile")
+
+        in_use_by = [
+            user_id
+            for user_id, user_info in account.users.items()
+            if user_info.get("permission_profile", DEFAULT_PERMISSION_PROFILE_ID)
+            == normalized_profile_id
+        ]
+        if in_use_by:
+            raise FailedPreconditionError(
+                f"Permission profile is still assigned to users: {', '.join(sorted(in_use_by))}",
+                details={
+                    "profile_id": normalized_profile_id,
+                    "user_ids": sorted(in_use_by),
+                },
+            )
+
+        del account.permission_profiles[normalized_profile_id]
+        await self._save_settings_json(account_id)
+
+    async def set_user_permission_profile(
+        self,
+        account_id: str,
+        user_id: str,
+        profile_id: str,
+    ) -> None:
+        """Assign a permission profile to a user."""
+        account = self._accounts.get(account_id)
+        if account is None:
+            raise NotFoundError(account_id, "account")
+        if user_id not in account.users:
+            raise NotFoundError(user_id, "user")
+
+        self.get_permission_profile(account_id, profile_id)
+        account.users[user_id]["permission_profile"] = profile_id
+        await self._save_users_json(account_id)
 
     def has_user(self, account_id: str, user_id: str) -> bool:
         """Return True when the account registry contains the given user."""
@@ -528,6 +689,60 @@ class APIKeyManager:
         if account is None:
             return False
         return user_id in account.users
+
+    def _resolve_effective_permissions(
+        self,
+        role: Role,
+        account_id: str,
+        user_id: str,
+    ) -> tuple[Optional[str], EffectivePermissions]:
+        """Resolve effective permissions for the authenticated identity."""
+        if role in {Role.ROOT, Role.ADMIN}:
+            account = self._accounts.get(account_id)
+            user_info = account.users.get(user_id, {}) if account is not None else {}
+            return user_info.get("permission_profile"), EffectivePermissions.full_access()
+        return self._resolve_user_permissions(account_id, user_id)
+
+    def _resolve_user_permissions(
+        self,
+        account_id: str,
+        user_id: str,
+    ) -> tuple[Optional[str], EffectivePermissions]:
+        """Resolve the stored profile assignment into effective permissions."""
+        account = self._accounts.get(account_id)
+        if account is None:
+            return None, EffectivePermissions.no_access()
+
+        user_info = account.users.get(user_id, {})
+        profile_id = user_info.get("permission_profile") or DEFAULT_PERMISSION_PROFILE_ID
+        try:
+            profile = self.get_permission_profile(account_id, profile_id)
+        except NotFoundError:
+            logger.warning(
+                "User %s in account %s references missing permission profile %s; "
+                "falling back to no_data_access",
+                user_id,
+                account_id,
+                profile_id,
+            )
+            fallback = self.get_permission_profile(account_id, NO_DATA_ACCESS_PERMISSION_PROFILE_ID)
+            return profile_id, fallback.permissions
+        return profile_id, profile.permissions
+
+    def _normalize_custom_permission_profile_id(self, profile_id: str) -> str:
+        """Validate custom profile ids and block collisions with built-ins."""
+        normalized = profile_id.strip() if isinstance(profile_id, str) else ""
+        if not normalized:
+            raise InvalidArgumentError("permission profile id must be a non-empty string.")
+        if normalized in get_builtin_permission_profiles():
+            raise InvalidArgumentError(
+                f"permission profile id '{normalized}' is reserved by a built-in profile."
+            )
+        if not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", normalized):
+            raise InvalidArgumentError(
+                "permission profile id must match [a-z][a-z0-9_-]{0,63}."
+            )
+        return normalized
 
     # ---- internal helpers ----
 
@@ -645,4 +860,11 @@ class APIKeyManager:
         path = SETTINGS_PATH_TEMPLATE.format(account_id=account_id)
         merged_settings = dict(settings_data) if isinstance(settings_data, dict) else {}
         merged_settings["namespace"] = account.namespace_policy.to_dict()
+        existing_acl = merged_settings.get("acl")
+        acl_settings = dict(existing_acl) if isinstance(existing_acl, dict) else {}
+        acl_settings["permission_profiles"] = {
+            profile_id: profile.permissions.to_dict()
+            for profile_id, profile in sorted(account.permission_profiles.items())
+        }
+        merged_settings["acl"] = acl_settings
         await self._write_json(path, merged_settings)

--- a/openviking/server/auth.py
+++ b/openviking/server/auth.py
@@ -8,7 +8,14 @@ from typing import Optional
 from fastapi import Depends, Header, Request
 
 from openviking.metrics.account_context import set_metric_account_context
-from openviking.server.identity import AuthMode, RequestContext, ResolvedIdentity, Role
+from openviking.server.identity import (
+    DEFAULT_PERMISSION_PROFILE_ID,
+    AuthMode,
+    EffectivePermissions,
+    RequestContext,
+    ResolvedIdentity,
+    Role,
+)
 from openviking_cli.exceptions import (
     InvalidArgumentError,
     PermissionDeniedError,
@@ -92,6 +99,7 @@ async def resolve_identity(
             account_id=x_openviking_account or "default",
             user_id=x_openviking_user or "default",
             agent_id=x_openviking_agent or "default",
+            effective_permissions=EffectivePermissions.full_access(),
         )
 
     if auth_mode == AuthMode.TRUSTED:
@@ -114,6 +122,8 @@ async def resolve_identity(
             account_id=x_openviking_account,
             user_id=x_openviking_user,
             agent_id=x_openviking_agent or "default",
+            permission_profile=DEFAULT_PERMISSION_PROFILE_ID,
+            effective_permissions=EffectivePermissions.full_access(),
         )
 
     # AuthMode.API_KEY
@@ -160,6 +170,7 @@ async def get_request_context(
     path = request.url.path
     auth_mode = _auth_mode(request)
     api_key_manager = getattr(request.app.state, "api_key_manager", None)
+    account_policy_resolver = getattr(api_key_manager, "get_account_policy", None)
     if (
         auth_mode == AuthMode.API_KEY
         and api_key_manager is not None
@@ -187,10 +198,12 @@ async def get_request_context(
         ),
         role=identity.role,
         namespace_policy=(
-            api_key_manager.get_account_policy(identity.account_id)
-            if api_key_manager is not None
+            account_policy_resolver(identity.account_id)
+            if callable(account_policy_resolver)
             else identity.namespace_policy
         ),
+        permission_profile=identity.permission_profile,
+        effective_permissions=identity.effective_permissions,
     )
     request.state.metric_account_id = ctx.account_id
     set_metric_account_context(account_id=ctx.account_id)

--- a/openviking/server/identity.py
+++ b/openviking/server/identity.py
@@ -23,6 +23,106 @@ class AuthMode(str, Enum):
     DEV = "dev"
 
 
+DATA_READ_PERMISSION = "data.read"
+DATA_WRITE_PERMISSION = "data.write"
+DEFAULT_PERMISSION_PROFILE_ID = "data_rw"
+READ_ONLY_PERMISSION_PROFILE_ID = "data_readonly"
+NO_DATA_ACCESS_PERMISSION_PROFILE_ID = "no_data_access"
+
+
+@dataclass(frozen=True)
+class EffectivePermissions:
+    """Effective data API permissions carried through the request context."""
+
+    data_read: bool = True
+    data_write: bool = True
+
+    @classmethod
+    def full_access(cls) -> "EffectivePermissions":
+        return cls(data_read=True, data_write=True)
+
+    @classmethod
+    def read_only(cls) -> "EffectivePermissions":
+        return cls(data_read=True, data_write=False)
+
+    @classmethod
+    def no_access(cls) -> "EffectivePermissions":
+        return cls(data_read=False, data_write=False)
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict]) -> "EffectivePermissions":
+        if not isinstance(data, dict):
+            return cls.full_access()
+        return cls(
+            data_read=bool(data.get("data_read", True)),
+            data_write=bool(data.get("data_write", True)),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "data_read": self.data_read,
+            "data_write": self.data_write,
+        }
+
+    def allows(self, permission: str) -> bool:
+        if permission == DATA_READ_PERMISSION:
+            return self.data_read
+        if permission == DATA_WRITE_PERMISSION:
+            return self.data_write
+        return False
+
+
+@dataclass(frozen=True)
+class PermissionProfile:
+    """Named account-level permission profile."""
+
+    profile_id: str
+    permissions: EffectivePermissions
+    builtin: bool = False
+
+    @classmethod
+    def from_dict(
+        cls,
+        profile_id: str,
+        data: Optional[dict],
+        *,
+        builtin: bool = False,
+    ) -> "PermissionProfile":
+        return cls(
+            profile_id=profile_id,
+            permissions=EffectivePermissions.from_dict(data),
+            builtin=builtin,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "profile_id": self.profile_id,
+            "builtin": self.builtin,
+            **self.permissions.to_dict(),
+        }
+
+
+def get_builtin_permission_profiles() -> dict[str, PermissionProfile]:
+    """Return assignable built-in permission profiles."""
+    return {
+        DEFAULT_PERMISSION_PROFILE_ID: PermissionProfile(
+            profile_id=DEFAULT_PERMISSION_PROFILE_ID,
+            permissions=EffectivePermissions.full_access(),
+            builtin=True,
+        ),
+        READ_ONLY_PERMISSION_PROFILE_ID: PermissionProfile(
+            profile_id=READ_ONLY_PERMISSION_PROFILE_ID,
+            permissions=EffectivePermissions.read_only(),
+            builtin=True,
+        ),
+        NO_DATA_ACCESS_PERMISSION_PROFILE_ID: PermissionProfile(
+            profile_id=NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+            permissions=EffectivePermissions.no_access(),
+            builtin=True,
+        ),
+    }
+
+
 @dataclass(frozen=True)
 class AccountNamespacePolicy:
     """Account-level namespace isolation policy."""
@@ -55,6 +155,10 @@ class ResolvedIdentity:
     user_id: Optional[str] = None
     agent_id: Optional[str] = None
     namespace_policy: AccountNamespacePolicy = field(default_factory=AccountNamespacePolicy)
+    permission_profile: Optional[str] = None
+    effective_permissions: EffectivePermissions = field(
+        default_factory=EffectivePermissions.full_access
+    )
 
 
 @dataclass
@@ -64,10 +168,19 @@ class RequestContext:
     user: UserIdentifier
     role: Role
     namespace_policy: AccountNamespacePolicy = field(default_factory=AccountNamespacePolicy)
+    permission_profile: Optional[str] = None
+    effective_permissions: EffectivePermissions = field(
+        default_factory=EffectivePermissions.full_access
+    )
 
     @property
     def account_id(self) -> str:
         return self.user.account_id
+
+    def has_permission(self, permission: str) -> bool:
+        if self.role in {Role.ROOT, Role.ADMIN}:
+            return True
+        return self.effective_permissions.allows(permission)
 
 
 @dataclass
@@ -89,3 +202,14 @@ class ToolContext:
     @property
     def account_id(self) -> str:
         return self.request_ctx.user.account_id
+
+    @property
+    def permission_profile(self):
+        return self.request_ctx.permission_profile
+
+    @property
+    def effective_permissions(self):
+        return self.request_ctx.effective_permissions
+
+    def has_permission(self, permission: str) -> bool:
+        return self.request_ctx.has_permission(permission)

--- a/openviking/server/permissions.py
+++ b/openviking/server/permissions.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Phase-1 data API permission checks."""
+
+from openviking.server.identity import (
+    DATA_READ_PERMISSION,
+    DATA_WRITE_PERMISSION,
+    DEFAULT_PERMISSION_PROFILE_ID,
+    RequestContext,
+)
+from openviking_cli.exceptions import PermissionDeniedError
+
+
+def require_permission(
+    ctx: RequestContext,
+    permission: str,
+    *,
+    operation: str,
+    resource: str | None = None,
+) -> None:
+    """Raise a structured permission error when the context lacks the capability."""
+    if ctx.has_permission(permission):
+        return
+
+    raise PermissionDeniedError(
+        f"Permission denied for {operation}: requires {permission}.",
+        resource=resource,
+        details={
+            "operation": operation,
+            "required_permission": permission,
+            "permission_profile": ctx.permission_profile or DEFAULT_PERMISSION_PROFILE_ID,
+            "role": ctx.role.value,
+            "effective_permissions": ctx.effective_permissions.to_dict(),
+        },
+    )
+
+
+def require_data_read(
+    ctx: RequestContext,
+    *,
+    operation: str,
+    resource: str | None = None,
+) -> None:
+    """Require phase-1 read permission."""
+    require_permission(ctx, DATA_READ_PERMISSION, operation=operation, resource=resource)
+
+
+def require_data_write(
+    ctx: RequestContext,
+    *,
+    operation: str,
+    resource: str | None = None,
+) -> None:
+    """Require phase-1 write permission."""
+    require_permission(ctx, DATA_WRITE_PERMISSION, operation=operation, resource=resource)

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -12,7 +12,13 @@ from openviking.server.auth import (
     require_auth_root_or_admin,
 )
 from openviking.server.dependencies import get_service
-from openviking.server.identity import AccountNamespacePolicy, RequestContext, Role
+from openviking.server.identity import (
+    DEFAULT_PERMISSION_PROFILE_ID,
+    AccountNamespacePolicy,
+    EffectivePermissions,
+    RequestContext,
+    Role,
+)
 from openviking.server.models import Response
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.exceptions import PermissionDeniedError
@@ -34,10 +40,20 @@ class CreateAccountRequest(BaseModel):
 class RegisterUserRequest(BaseModel):
     user_id: str
     role: str = "user"
+    permission_profile: str = DEFAULT_PERMISSION_PROFILE_ID
 
 
 class SetRoleRequest(BaseModel):
     role: str
+
+
+class UpsertPermissionProfileRequest(BaseModel):
+    data_read: bool = True
+    data_write: bool = False
+
+
+class SetUserPermissionProfileRequest(BaseModel):
+    permission_profile: str
 
 
 def _get_api_key_manager(request: Request):
@@ -161,7 +177,12 @@ async def register_user(
     """Register a new user in an account."""
     _check_account_access(ctx, account_id)
     manager = _get_api_key_manager(request)
-    user_key = await manager.register_user(account_id, body.user_id, body.role)
+    user_key = await manager.register_user(
+        account_id,
+        body.user_id,
+        body.role,
+        permission_profile=body.permission_profile,
+    )
     service = get_service()
     user_ctx = RequestContext(
         user=UserIdentifier(account_id, body.user_id, "default"),
@@ -175,6 +196,7 @@ async def register_user(
             "account_id": account_id,
             "user_id": body.user_id,
             "user_key": user_key,
+            "permission_profile": body.permission_profile,
         },
     )
 
@@ -226,6 +248,81 @@ async def set_user_role(
             "account_id": account_id,
             "user_id": user_id,
             "role": body.role,
+        },
+    )
+
+
+@router.get("/accounts/{account_id}/permission-profiles")
+@require_auth_root_or_admin
+async def list_permission_profiles(
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """List assignable built-in and custom permission profiles for an account."""
+    _check_account_access(ctx, account_id)
+    manager = _get_api_key_manager(request)
+    profiles = manager.get_permission_profiles(account_id)
+    return Response(status="ok", result=profiles)
+
+
+@router.put("/accounts/{account_id}/permission-profiles/{profile_id}")
+@require_auth_root_or_admin
+async def upsert_permission_profile(
+    body: UpsertPermissionProfileRequest,
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    profile_id: str = Path(..., description="Permission profile ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Create or update a custom permission profile for an account."""
+    _check_account_access(ctx, account_id)
+    manager = _get_api_key_manager(request)
+    profile = await manager.upsert_permission_profile(
+        account_id,
+        profile_id,
+        permissions=EffectivePermissions(
+            data_read=body.data_read,
+            data_write=body.data_write,
+        ),
+    )
+    return Response(status="ok", result=profile.to_dict())
+
+
+@router.delete("/accounts/{account_id}/permission-profiles/{profile_id}")
+@require_auth_root_or_admin
+async def delete_permission_profile(
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    profile_id: str = Path(..., description="Permission profile ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Delete a custom permission profile from an account."""
+    _check_account_access(ctx, account_id)
+    manager = _get_api_key_manager(request)
+    await manager.delete_permission_profile(account_id, profile_id)
+    return Response(status="ok", result={"deleted": True, "profile_id": profile_id})
+
+
+@router.put("/accounts/{account_id}/users/{user_id}/permission-profile")
+@require_auth_root_or_admin
+async def set_user_permission_profile(
+    body: SetUserPermissionProfileRequest,
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    user_id: str = Path(..., description="User ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Assign a permission profile to a user."""
+    _check_account_access(ctx, account_id)
+    manager = _get_api_key_manager(request)
+    await manager.set_user_permission_profile(account_id, user_id, body.permission_profile)
+    return Response(
+        status="ok",
+        result={
+            "account_id": account_id,
+            "user_id": user_id,
+            "permission_profile": body.permission_profile,
         },
     )
 

--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -13,6 +13,7 @@ from openviking.server.dependencies import get_service
 from openviking.server.error_mapping import map_exception
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
+from openviking.server.permissions import require_data_read, require_data_write
 from openviking_cli.exceptions import NotFoundError
 
 router = APIRouter(prefix="/api/v1/fs", tags=["filesystem"])
@@ -31,6 +32,7 @@ async def ls(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """List directory contents."""
+    require_data_read(_ctx, operation="filesystem.ls", resource=uri)
     service = get_service()
     actual_node_limit = limit if limit is not None else node_limit
     try:
@@ -67,6 +69,7 @@ async def tree(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Get directory tree."""
+    require_data_read(_ctx, operation="filesystem.tree", resource=uri)
     service = get_service()
     actual_node_limit = limit if limit is not None else node_limit
     try:
@@ -96,6 +99,7 @@ async def stat(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Get resource status."""
+    require_data_read(_ctx, operation="filesystem.stat", resource=uri)
     service = get_service()
     try:
         result = await service.fs.stat(uri, ctx=_ctx)
@@ -128,6 +132,7 @@ async def mkdir(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Create directory."""
+    require_data_write(_ctx, operation="filesystem.mkdir", resource=request.uri)
     service = get_service()
     try:
         await service.fs.mkdir(request.uri, ctx=_ctx, description=request.description)
@@ -147,6 +152,7 @@ async def rm(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Remove resource."""
+    require_data_write(_ctx, operation="filesystem.rm", resource=uri)
     service = get_service()
     try:
         await service.fs.rm(uri, ctx=_ctx, recursive=recursive)
@@ -178,6 +184,7 @@ async def mv(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Move resource."""
+    require_data_write(_ctx, operation="filesystem.mv", resource=request.from_uri)
     service = get_service()
     try:
         await service.fs.mv(request.from_uri, request.to_uri, ctx=_ctx)

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -18,6 +18,7 @@ from openviking.server.local_input_guard import (
     resolve_uploaded_temp_file_id,
 )
 from openviking.server.models import Response
+from openviking.server.permissions import require_data_write
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
 from openviking_cli.exceptions import InvalidArgumentError
@@ -144,6 +145,7 @@ async def temp_upload(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Upload a temporary file for add_resource or import_ovpack."""
+    require_data_write(_ctx, operation="resources.temp_upload")
 
     async def _upload() -> dict[str, str]:
         import json
@@ -192,6 +194,11 @@ async def add_resource(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Add resource to OpenViking."""
+    require_data_write(
+        _ctx,
+        operation="resources.add_resource",
+        resource=request.to or request.parent,
+    )
     service = get_service()
     if request.to and request.parent:
         raise InvalidArgumentError("Cannot specify both 'to' and 'parent' at the same time.")
@@ -257,6 +264,7 @@ async def add_skill(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Add skill to OpenViking."""
+    require_data_write(_ctx, operation="resources.add_skill")
     service = get_service()
     upload_temp_dir = get_openviking_config().storage.get_upload_temp_dir()
     data = request.data

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -13,6 +13,7 @@ from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
+from openviking.server.permissions import require_data_read
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
 from openviking.utils.search_filters import merge_time_filter
@@ -117,6 +118,11 @@ async def find(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Semantic search without session context."""
+    require_data_read(
+        _ctx,
+        operation="search.find",
+        resource=request.target_uri or "viking://",
+    )
     service = get_service()
     actual_limit = _resolve_search_limit(request.limit, request.node_limit)
     effective_filter = _resolve_search_filter(
@@ -154,6 +160,11 @@ async def search(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Semantic search with optional session context."""
+    require_data_read(
+        _ctx,
+        operation="search.search",
+        resource=request.target_uri or "viking://",
+    )
     service = get_service()
     actual_limit = _resolve_search_limit(request.limit, request.node_limit)
     effective_filter = _resolve_search_filter(
@@ -200,6 +211,7 @@ async def grep(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Content search with pattern."""
+    require_data_read(_ctx, operation="search.grep", resource=request.uri)
     service = get_service()
     try:
         result = await service.fs.grep(
@@ -228,6 +240,7 @@ async def glob(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """File pattern matching."""
+    require_data_read(_ctx, operation="search.glob", resource=request.uri)
     service = get_service()
     try:
         result = await service.fs.glob(

--- a/openviking_cli/exceptions.py
+++ b/openviking_cli/exceptions.py
@@ -98,9 +98,16 @@ class UnauthenticatedError(OpenVikingError):
 class PermissionDeniedError(OpenVikingError):
     """Permission denied for the requested operation."""
 
-    def __init__(self, message: str = "Permission denied", resource: Optional[str] = None):
-        details = {"resource": resource} if resource else {}
-        super().__init__(message, code="PERMISSION_DENIED", details=details)
+    def __init__(
+        self,
+        message: str = "Permission denied",
+        resource: Optional[str] = None,
+        details: Optional[dict] = None,
+    ):
+        merged_details = dict(details or {})
+        if resource is not None:
+            merged_details.setdefault("resource", resource)
+        super().__init__(message, code="PERMISSION_DENIED", details=merged_details)
 
 
 # ============= Service Errors =============

--- a/tests/server/test_acl_phase1_routes.py
+++ b/tests/server/test_acl_phase1_routes.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Router-level ACL tests for the phase-1 data API permission checks."""
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from openviking.server.auth import get_request_context
+from openviking.server.error_mapping import map_exception
+from openviking.server.identity import (
+    NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+    READ_ONLY_PERMISSION_PROFILE_ID,
+    EffectivePermissions,
+    RequestContext,
+    Role,
+)
+from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS, ErrorInfo, Response
+from openviking.server.routers.filesystem import router as filesystem_router
+from openviking.server.routers.resources import router as resources_router
+from openviking.server.routers.search import router as search_router
+from openviking_cli.exceptions import OpenVikingError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(filesystem_router)
+    app.include_router(search_router)
+    app.include_router(resources_router)
+
+    @app.exception_handler(OpenVikingError)
+    async def openviking_error_handler(_: Request, exc: OpenVikingError):
+        http_status = ERROR_CODE_TO_HTTP_STATUS.get(exc.code, 500)
+        return JSONResponse(
+            status_code=http_status,
+            content=Response(
+                status="error",
+                error=ErrorInfo(
+                    code=exc.code,
+                    message=exc.message,
+                    details=exc.details,
+                ),
+            ).model_dump(),
+        )
+
+    @app.exception_handler(Exception)
+    async def general_error_handler(_: Request, exc: Exception):
+        mapped = map_exception(exc)
+        if mapped is None:
+            raise exc
+        http_status = ERROR_CODE_TO_HTTP_STATUS.get(mapped.code, 500)
+        return JSONResponse(
+            status_code=http_status,
+            content=Response(
+                status="error",
+                error=ErrorInfo(
+                    code=mapped.code,
+                    message=mapped.message,
+                    details=mapped.details,
+                ),
+            ).model_dump(),
+        )
+
+    return app
+
+
+@pytest.fixture
+async def acl_client():
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, app
+
+
+def _ctx(
+    *,
+    profile_id: str,
+    permissions: EffectivePermissions,
+) -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier("acme", "alice", "default"),
+        role=Role.USER,
+        permission_profile=profile_id,
+        effective_permissions=permissions,
+    )
+
+
+@pytest.mark.asyncio
+async def test_filesystem_ls_denies_without_data_read(acl_client):
+    client, app = acl_client
+    app.dependency_overrides[get_request_context] = lambda: _ctx(
+        profile_id=NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+        permissions=EffectivePermissions.no_access(),
+    )
+    try:
+        resp = await client.get("/api/v1/fs/ls", params={"uri": "viking://"})
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["details"] == {
+        "resource": "viking://",
+        "operation": "filesystem.ls",
+        "required_permission": "data.read",
+        "permission_profile": NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+        "role": "user",
+        "effective_permissions": {"data_read": False, "data_write": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_filesystem_mkdir_denies_without_data_write(acl_client):
+    client, app = acl_client
+    app.dependency_overrides[get_request_context] = lambda: _ctx(
+        profile_id=READ_ONLY_PERMISSION_PROFILE_ID,
+        permissions=EffectivePermissions.read_only(),
+    )
+    try:
+        resp = await client.post(
+            "/api/v1/fs/mkdir",
+            json={"uri": "viking://resources/restricted"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["details"] == {
+        "resource": "viking://resources/restricted",
+        "operation": "filesystem.mkdir",
+        "required_permission": "data.write",
+        "permission_profile": READ_ONLY_PERMISSION_PROFILE_ID,
+        "role": "user",
+        "effective_permissions": {"data_read": True, "data_write": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_find_denies_without_data_read(acl_client):
+    client, app = acl_client
+    app.dependency_overrides[get_request_context] = lambda: _ctx(
+        profile_id=NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+        permissions=EffectivePermissions.no_access(),
+    )
+    try:
+        resp = await client.post(
+            "/api/v1/search/find",
+            json={"query": "sample", "target_uri": "viking://resources", "limit": 5},
+        )
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["details"] == {
+        "resource": "viking://resources",
+        "operation": "search.find",
+        "required_permission": "data.read",
+        "permission_profile": NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+        "role": "user",
+        "effective_permissions": {"data_read": False, "data_write": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_resources_add_resource_denies_without_data_write(acl_client):
+    client, app = acl_client
+    app.dependency_overrides[get_request_context] = lambda: _ctx(
+        profile_id=READ_ONLY_PERMISSION_PROFILE_ID,
+        permissions=EffectivePermissions.read_only(),
+    )
+    try:
+        resp = await client.post(
+            "/api/v1/resources",
+            json={"path": "https://example.com/demo.md", "reason": "fixture"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["details"] == {
+        "operation": "resources.add_resource",
+        "required_permission": "data.write",
+        "permission_profile": READ_ONLY_PERMISSION_PROFILE_ID,
+        "role": "user",
+        "effective_permissions": {"data_read": True, "data_write": False},
+    }

--- a/tests/server/test_acl_phase1_unit.py
+++ b/tests/server/test_acl_phase1_unit.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Lightweight unit tests for phase-1 ACL permission profiles."""
+
+import pytest
+
+from openviking.server.api_keys import APIKeyManager
+from openviking.server.identity import (
+    READ_ONLY_PERMISSION_PROFILE_ID,
+    EffectivePermissions,
+    RequestContext,
+    Role,
+)
+from openviking.server.permissions import require_data_read, require_data_write
+from openviking_cli.exceptions import PermissionDeniedError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeAGFS:
+    def __init__(self):
+        self.storage: dict[str, bytes] = {}
+
+    def read(self, path: str) -> bytes:
+        if path not in self.storage:
+            raise FileNotFoundError(path)
+        return self.storage[path]
+
+    def write(self, path: str, content: bytes) -> None:
+        self.storage[path] = content
+
+    def mkdir(self, path: str) -> None:
+        return None
+
+
+class _FakeVikingFS:
+    def __init__(self):
+        self.agfs = _FakeAGFS()
+
+    async def encrypt_bytes(self, account_id: str, content: bytes) -> bytes:
+        return content
+
+    async def decrypt_bytes(self, account_id: str, raw: bytes) -> bytes:
+        return raw
+
+
+ROOT_KEY = "phase1-root-key"
+
+
+@pytest.mark.asyncio
+async def test_permission_profile_persistence_and_resolution():
+    viking_fs = _FakeVikingFS()
+    manager = APIKeyManager(root_key=ROOT_KEY, viking_fs=viking_fs)
+    await manager.load()
+
+    await manager.create_account("acme", "alice")
+    await manager.upsert_permission_profile(
+        "acme",
+        "readonly_docs",
+        permissions=EffectivePermissions(data_read=True, data_write=False),
+    )
+    user_key = await manager.register_user(
+        "acme",
+        "bob",
+        permission_profile="readonly_docs",
+    )
+
+    resolved = manager.resolve(user_key)
+    assert resolved.permission_profile == "readonly_docs"
+    assert resolved.effective_permissions == EffectivePermissions(
+        data_read=True,
+        data_write=False,
+    )
+
+    reloaded = APIKeyManager(root_key=ROOT_KEY, viking_fs=viking_fs)
+    await reloaded.load()
+    assert {item["profile_id"] for item in reloaded.get_permission_profiles("acme")} >= {
+        "data_rw",
+        "data_readonly",
+        "no_data_access",
+        "readonly_docs",
+    }
+
+
+@pytest.mark.asyncio
+async def test_admin_profile_assignment_keeps_admin_semantics():
+    viking_fs = _FakeVikingFS()
+    manager = APIKeyManager(root_key=ROOT_KEY, viking_fs=viking_fs)
+    await manager.load()
+
+    admin_key = await manager.create_account("acme", "alice")
+    await manager.set_user_permission_profile("acme", "alice", READ_ONLY_PERMISSION_PROFILE_ID)
+
+    resolved = manager.resolve(admin_key)
+    assert resolved.role == Role.ADMIN
+    assert resolved.permission_profile == READ_ONLY_PERMISSION_PROFILE_ID
+    assert resolved.effective_permissions == EffectivePermissions.full_access()
+
+
+def test_permission_denied_error_is_structured_for_read_and_write():
+    ctx = RequestContext(
+        user=UserIdentifier("acme", "alice", "default"),
+        role=Role.USER,
+        permission_profile="readonly_docs",
+        effective_permissions=EffectivePermissions(data_read=True, data_write=False),
+    )
+
+    require_data_read(ctx, operation="search.find", resource="viking://resources")
+
+    with pytest.raises(PermissionDeniedError) as exc_info:
+        require_data_write(ctx, operation="filesystem.mkdir", resource="viking://resources/demo")
+
+    assert exc_info.value.details == {
+        "resource": "viking://resources/demo",
+        "operation": "filesystem.mkdir",
+        "required_permission": "data.write",
+        "permission_profile": "readonly_docs",
+        "role": "user",
+        "effective_permissions": {"data_read": True, "data_write": False},
+    }

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -313,6 +313,61 @@ async def test_regenerate_key(admin_client: httpx.AsyncClient):
     assert resp.status_code == 200
 
 
+async def test_manage_permission_profiles_and_assign_user(admin_client: httpx.AsyncClient):
+    """ROOT can manage custom permission profiles and assign them to users."""
+    acct = _uid()
+    create_resp = await admin_client.post(
+        "/api/v1/admin/accounts",
+        json={"account_id": acct, "admin_user_id": "alice"},
+        headers=root_headers(),
+    )
+    assert create_resp.status_code == 200
+
+    upsert_resp = await admin_client.put(
+        f"/api/v1/admin/accounts/{acct}/permission-profiles/readonly_docs",
+        json={"data_read": True, "data_write": False},
+        headers=root_headers(),
+    )
+    assert upsert_resp.status_code == 200
+    assert upsert_resp.json()["result"] == {
+        "profile_id": "readonly_docs",
+        "builtin": False,
+        "data_read": True,
+        "data_write": False,
+    }
+
+    list_resp = await admin_client.get(
+        f"/api/v1/admin/accounts/{acct}/permission-profiles",
+        headers=root_headers(),
+    )
+    assert list_resp.status_code == 200
+    profile_ids = {item["profile_id"] for item in list_resp.json()["result"]}
+    assert {"data_rw", "data_readonly", "no_data_access", "readonly_docs"} <= profile_ids
+
+    register_resp = await admin_client.post(
+        f"/api/v1/admin/accounts/{acct}/users",
+        json={"user_id": "bob", "role": "user", "permission_profile": "readonly_docs"},
+        headers=root_headers(),
+    )
+    assert register_resp.status_code == 200
+    assert register_resp.json()["result"]["permission_profile"] == "readonly_docs"
+
+    assign_resp = await admin_client.put(
+        f"/api/v1/admin/accounts/{acct}/users/bob/permission-profile",
+        json={"permission_profile": "data_readonly"},
+        headers=root_headers(),
+    )
+    assert assign_resp.status_code == 200
+    assert assign_resp.json()["result"]["permission_profile"] == "data_readonly"
+
+    users_resp = await admin_client.get(
+        f"/api/v1/admin/accounts/{acct}/users",
+        headers=root_headers(),
+    )
+    users = {item["user_id"]: item for item in users_resp.json()["result"]}
+    assert users["bob"]["permission_profile"] == "data_readonly"
+
+
 # ---- Permission guard ----
 
 

--- a/tests/server/test_api_filesystem.py
+++ b/tests/server/test_api_filesystem.py
@@ -5,8 +5,17 @@
 
 import httpx
 
+from openviking.server.auth import get_request_context
+from openviking.server.identity import (
+    NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+    READ_ONLY_PERMISSION_PROFILE_ID,
+    EffectivePermissions,
+    RequestContext,
+    Role,
+)
 from openviking.pyagfs.exceptions import AGFSHTTPError
 from openviking.storage.errors import ResourceBusyError
+from openviking_cli.session.user_id import UserIdentifier
 
 
 async def test_ls_root(client: httpx.AsyncClient):
@@ -206,3 +215,50 @@ async def test_rm_agfs_internal_error_does_not_look_successful(client, service, 
     body = resp.json()
     assert body["status"] == "error"
     assert body["error"]["code"] == "UNAVAILABLE"
+
+
+async def test_ls_requires_data_read_permission(client, app):
+    app.dependency_overrides[get_request_context] = lambda: RequestContext(
+        user=UserIdentifier.the_default_user(),
+        role=Role.USER,
+        permission_profile=NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+        effective_permissions=EffectivePermissions(data_read=False, data_write=False),
+    )
+    try:
+        resp = await client.get("/api/v1/fs/ls", params={"uri": "viking://"})
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["error"]["code"] == "PERMISSION_DENIED"
+    assert body["error"]["details"] == {
+        "resource": "viking://",
+        "operation": "filesystem.ls",
+        "required_permission": "data.read",
+        "permission_profile": NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+        "role": "user",
+        "effective_permissions": {"data_read": False, "data_write": False},
+    }
+
+
+async def test_mkdir_requires_data_write_permission(client, app):
+    app.dependency_overrides[get_request_context] = lambda: RequestContext(
+        user=UserIdentifier.the_default_user(),
+        role=Role.USER,
+        permission_profile=READ_ONLY_PERMISSION_PROFILE_ID,
+        effective_permissions=EffectivePermissions(data_read=True, data_write=False),
+    )
+    try:
+        resp = await client.post(
+            "/api/v1/fs/mkdir",
+            json={"uri": "viking://resources/restricted_dir"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["error"]["code"] == "PERMISSION_DENIED"
+    assert body["error"]["details"]["operation"] == "filesystem.mkdir"
+    assert body["error"]["details"]["required_permission"] == "data.write"

--- a/tests/server/test_api_key_manager.py
+++ b/tests/server/test_api_key_manager.py
@@ -9,7 +9,12 @@ import pytest
 import pytest_asyncio
 
 from openviking.server.api_keys import APIKeyManager
-from openviking.server.identity import AccountNamespacePolicy, Role
+from openviking.server.identity import (
+    READ_ONLY_PERMISSION_PROFILE_ID,
+    AccountNamespacePolicy,
+    EffectivePermissions,
+    Role,
+)
 from openviking.service.core import OpenVikingService
 from openviking_cli.exceptions import AlreadyExistsError, NotFoundError, UnauthenticatedError
 from openviking_cli.session.user_id import UserIdentifier
@@ -201,6 +206,63 @@ async def test_get_users(manager: APIKeyManager):
     roles = {u["user_id"]: u["role"] for u in users}
     assert roles["alice"] == "admin"
     assert roles["bob"] == "user"
+
+
+async def test_custom_permission_profile_is_persisted_and_applied(manager_service):
+    """Custom permission profiles should persist and drive effective user permissions."""
+    acct = _uid()
+    mgr1 = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await mgr1.load()
+
+    await mgr1.create_account(acct, "alice")
+    profile = await mgr1.upsert_permission_profile(
+        acct,
+        "readonly_docs",
+        permissions=EffectivePermissions(data_read=True, data_write=False),
+    )
+    user_key = await mgr1.register_user(
+        acct,
+        "bob",
+        "user",
+        permission_profile=profile.profile_id,
+    )
+
+    identity = mgr1.resolve(user_key)
+    assert identity.permission_profile == "readonly_docs"
+    assert identity.effective_permissions == EffectivePermissions(
+        data_read=True,
+        data_write=False,
+    )
+
+    mgr2 = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await mgr2.load()
+
+    profiles = {item["profile_id"]: item for item in mgr2.get_permission_profiles(acct)}
+    assert profiles["readonly_docs"] == {
+        "profile_id": "readonly_docs",
+        "builtin": False,
+        "data_read": True,
+        "data_write": False,
+    }
+
+    reloaded_identity = mgr2.resolve(user_key)
+    assert reloaded_identity.permission_profile == "readonly_docs"
+    assert reloaded_identity.effective_permissions == EffectivePermissions(
+        data_read=True,
+        data_write=False,
+    )
+
+
+async def test_admin_profile_assignment_does_not_reduce_admin_access(manager: APIKeyManager):
+    """ADMIN semantics must remain full-access even when a restrictive profile is assigned."""
+    acct = _uid()
+    admin_key = await manager.create_account(acct, "alice")
+    await manager.set_user_permission_profile(acct, "alice", READ_ONLY_PERMISSION_PROFILE_ID)
+
+    identity = manager.resolve(admin_key)
+    assert identity.role == Role.ADMIN
+    assert identity.permission_profile == READ_ONLY_PERMISSION_PROFILE_ID
+    assert identity.effective_permissions == EffectivePermissions.full_access()
 
 
 # ---- Persistence tests ----

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -7,7 +7,15 @@ import zipfile
 
 import httpx
 
+from openviking.server.auth import get_request_context
+from openviking.server.identity import (
+    READ_ONLY_PERMISSION_PROFILE_ID,
+    EffectivePermissions,
+    RequestContext,
+    Role,
+)
 from openviking.telemetry import get_current_telemetry
+from openviking_cli.session.user_id import UserIdentifier
 
 
 async def test_add_resource_success(
@@ -188,6 +196,37 @@ async def test_add_resource_file_not_found(client: httpx.AsyncClient):
     body = resp.json()
     assert body["status"] == "error"
     assert body["error"]["code"] == "PERMISSION_DENIED"
+
+
+async def test_add_resource_requires_data_write_permission(
+    client: httpx.AsyncClient,
+    app,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    app.dependency_overrides[get_request_context] = lambda: RequestContext(
+        user=UserIdentifier.the_default_user(),
+        role=Role.USER,
+        permission_profile=READ_ONLY_PERMISSION_PROFILE_ID,
+        effective_permissions=EffectivePermissions(data_read=True, data_write=False),
+    )
+    try:
+        resp = await client.post(
+            "/api/v1/resources",
+            json={
+                "temp_file_id": sample_markdown_file.name,
+                "reason": "test resource",
+                "wait": False,
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["error"]["code"] == "PERMISSION_DENIED"
+    assert body["error"]["details"]["operation"] == "resources.add_resource"
+    assert body["error"]["details"]["required_permission"] == "data.write"
 
 
 async def test_add_resource_with_to(

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -10,7 +10,12 @@ import pytest
 
 from openviking.models.embedder.base import EmbedResult
 from openviking.server.auth import get_request_context
-from openviking.server.identity import RequestContext, Role
+from openviking.server.identity import (
+    NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+    EffectivePermissions,
+    RequestContext,
+    Role,
+)
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -68,6 +73,29 @@ async def test_find_with_inaccessible_target_uri_returns_permission_denied(
     assert body["status"] == "error"
     assert body["error"]["code"] == "PERMISSION_DENIED"
     assert "Access denied" in body["error"]["message"]
+
+
+async def test_find_requires_data_read_permission(client: httpx.AsyncClient, app):
+    app.dependency_overrides[get_request_context] = lambda: RequestContext(
+        user=UserIdentifier.the_default_user(),
+        role=Role.USER,
+        permission_profile=NO_DATA_ACCESS_PERMISSION_PROFILE_ID,
+        effective_permissions=EffectivePermissions(data_read=False, data_write=False),
+    )
+    try:
+        resp = await client.post(
+            "/api/v1/search/find",
+            json={"query": "sample", "target_uri": "viking://resources", "limit": 5},
+        )
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["error"]["code"] == "PERMISSION_DENIED"
+    assert body["error"]["details"]["operation"] == "search.find"
+    assert body["error"]["details"]["required_permission"] == "data.read"
+    assert body["error"]["details"]["permission_profile"] == NO_DATA_ACCESS_PERMISSION_PROFILE_ID
 
 
 async def test_find_with_score_threshold(client_with_resource):

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -20,7 +20,7 @@ from openviking.server.app import create_app
 from openviking.server.auth import get_request_context, resolve_identity
 from openviking.server.config import ServerConfig, _is_localhost, validate_server_config
 from openviking.server.dependencies import set_service
-from openviking.server.identity import ResolvedIdentity, Role
+from openviking.server.identity import EffectivePermissions, ResolvedIdentity, Role
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS, ErrorInfo, Response
 from openviking.service.core import OpenVikingService
 from openviking.service.task_tracker import get_task_tracker, reset_task_tracker
@@ -546,6 +546,26 @@ async def test_root_tenant_scoped_requests_allow_explicit_identity():
     assert ctx.role == Role.ROOT
     assert ctx.user.account_id == "acme"
     assert ctx.user.user_id == "alice"
+
+
+async def test_request_context_propagates_permission_profile_and_effective_permissions():
+    """Resolved identity permission state should flow into the request context."""
+    request = _make_request("/api/v1/search/find", auth_enabled=True)
+    identity = ResolvedIdentity(
+        role=Role.USER,
+        account_id="acme",
+        user_id="alice",
+        permission_profile="readonly_docs",
+        effective_permissions=EffectivePermissions(data_read=True, data_write=False),
+    )
+
+    ctx = await get_request_context(request, identity)
+
+    assert ctx.permission_profile == "readonly_docs"
+    assert ctx.effective_permissions == EffectivePermissions(
+        data_read=True,
+        data_write=False,
+    )
 
 
 async def test_root_monitoring_requests_allow_implicit_default_identity():


### PR DESCRIPTION
## Summary
- add account-level permission profiles with built-in coarse data read/write capabilities and custom profile persistence
- propagate effective permissions through auth/request context while preserving ROOT and ADMIN full-access semantics
- enforce phase-1 data permissions on filesystem, search, and resource mutation APIs with structured permission-denied errors

## Testing
- OPENVIKING_CONFIG_FILE=/Users/bytedance/contextgo/OpenViking-acl-profiles/test_data/test-ov.conf pytest --no-cov tests/server/test_acl_phase1_unit.py tests/server/test_acl_phase1_routes.py -q
- COVERAGE_FILE=/tmp/openviking-auth-acl.coverage OPENVIKING_CONFIG_FILE=/Users/bytedance/contextgo/OpenViking-acl-profiles/test_data/test-ov.conf pytest --no-cov tests/server/test_auth.py -k "request_context_propagates_permission_profile_and_effective_permissions or root_system_status_allows_implicit_default_identity or root_tenant_scoped_requests_allow_explicit_identity or root_monitoring_requests_allow_implicit_default_identity or root_system_wait_allows_implicit_default_identity or root_monitoring_requests_keep_200_via_http or root_system_wait_keeps_200_via_http or task_endpoints_are_user_scoped" -q

## Notes
- broader server/auth integration tests that instantiate OpenVikingService are currently blocked in this environment by the missing ragfs_python native binding