### PR TITLE
feat(cli): add live embedding validation and reindex dry-run planner

### DIFF
--- a/crates/ov_cli/src/commands/content.rs
+++ b/crates/ov_cli/src/commands/content.rs
@@ -1,6 +1,10 @@
 use crate::client::HttpClient;
 use crate::error::Result;
 use crate::output::OutputFormat;
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -74,6 +78,30 @@ pub async fn reindex(
     Ok(())
 }
 
+pub async fn reindex_all_dry_run(
+    client: &HttpClient,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let listing = client
+        .ls("viking://resources", true, true, "original", 0, false, 100_000)
+        .await?;
+    let resource_uris = collect_resource_uris(&listing);
+    let embedding_summary = load_embedding_config_summary();
+
+    let result = json!({
+        "mode": "dry-run",
+        "scope": "all",
+        "root_uri": "viking://resources",
+        "resource_count": resource_uris.len(),
+        "resource_uris": resource_uris,
+        "embedding": embedding_summary.to_value(),
+    });
+
+    crate::output::output_success(&result, output_format, compact);
+    Ok(())
+}
+
 pub async fn get(client: &HttpClient, uri: &str, local_path: &str) -> Result<()> {
     // Check if target path already exists
     let path = Path::new(local_path);
@@ -99,4 +127,236 @@ pub async fn get(client: &HttpClient, uri: &str, local_path: &str) -> Result<()>
 
     println!("Downloaded {} bytes to {}", bytes.len(), local_path);
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EmbeddingConfigSummary {
+    provider: Option<String>,
+    model: Option<String>,
+    dimension: Option<i64>,
+    config_path: Option<String>,
+    note: Option<String>,
+}
+
+impl EmbeddingConfigSummary {
+    fn to_value(&self) -> Value {
+        json!({
+            "provider": self.provider,
+            "model": self.model,
+            "dimension": self.dimension,
+            "config_path": self.config_path,
+            "note": self.note,
+        })
+    }
+}
+
+fn load_embedding_config_summary() -> EmbeddingConfigSummary {
+    match resolve_server_config_path() {
+        Some(path) => load_embedding_config_summary_from_path(&path),
+        None => EmbeddingConfigSummary {
+            provider: None,
+            model: None,
+            dimension: None,
+            config_path: None,
+            note: Some("ov.conf not found".to_string()),
+        },
+    }
+}
+
+fn load_embedding_config_summary_from_path(path: &Path) -> EmbeddingConfigSummary {
+    let config_path = path.display().to_string();
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) => {
+            return EmbeddingConfigSummary {
+                provider: None,
+                model: None,
+                dimension: None,
+                config_path: Some(config_path),
+                note: Some(format!("Failed to read ov.conf: {}", err)),
+            };
+        }
+    };
+
+    let parsed: Value = match serde_json::from_str(&content) {
+        Ok(value) => value,
+        Err(err) => {
+            return EmbeddingConfigSummary {
+                provider: None,
+                model: None,
+                dimension: None,
+                config_path: Some(config_path),
+                note: Some(format!("Failed to parse ov.conf: {}", err)),
+            };
+        }
+    };
+
+    let mut summary = parse_embedding_config_summary(&parsed);
+    summary.config_path = Some(config_path);
+    if summary.note.is_none() && (summary.provider.is_none() || summary.model.is_none()) {
+        summary.note = Some("embedding.dense is not configured".to_string());
+    }
+    summary
+}
+
+fn parse_embedding_config_summary(value: &Value) -> EmbeddingConfigSummary {
+    let dense = value
+        .get("embedding")
+        .and_then(|embedding| embedding.get("dense"))
+        .and_then(Value::as_object);
+
+    let provider = dense
+        .and_then(|dense| dense.get("provider"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let model = dense
+        .and_then(|dense| dense.get("model"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let dimension = dense
+        .and_then(|dense| dense.get("dimension"))
+        .and_then(value_as_i64);
+
+    EmbeddingConfigSummary {
+        provider,
+        model,
+        dimension,
+        config_path: None,
+        note: None,
+    }
+}
+
+fn resolve_server_config_path() -> Option<std::path::PathBuf> {
+    if let Ok(path) = env::var("OPENVIKING_CONFIG_FILE") {
+        let path = std::path::PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        let path = home.join(".openviking").join("ov.conf");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let system_path = std::path::PathBuf::from("/etc/openviking/ov.conf");
+    if system_path.exists() {
+        return Some(system_path);
+    }
+
+    None
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    match value {
+        Value::Number(number) => number.as_i64(),
+        Value::String(text) => text.parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+fn is_reindexable_resource_uri(uri: &str) -> bool {
+    uri.starts_with("viking://resources") && uri != "viking://resources" && uri != "viking://resources/"
+}
+
+fn collect_resource_uris(value: &Value) -> Vec<String> {
+    let mut uris = BTreeSet::new();
+    collect_resource_uris_into(value, &mut uris);
+    uris.into_iter().collect()
+}
+
+fn collect_resource_uris_into(value: &Value, uris: &mut BTreeSet<String>) {
+    match value {
+        Value::String(uri) => {
+            if is_reindexable_resource_uri(uri) {
+                uris.insert(uri.to_string());
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_resource_uris_into(item, uris);
+            }
+        }
+        Value::Object(map) => {
+            if let Some(uri) = map.get("uri").and_then(Value::as_str) {
+                if is_reindexable_resource_uri(uri) {
+                    uris.insert(uri.to_string());
+                }
+            }
+            for key in ["children", "tree", "result"] {
+                if let Some(nested) = map.get(key) {
+                    collect_resource_uris_into(nested, uris);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_resource_uris, load_embedding_config_summary_from_path, parse_embedding_config_summary};
+    use serde_json::json;
+    use std::fs;
+
+    #[test]
+    fn collect_resource_uris_deduplicates_nested_entries() {
+        let listing = json!([
+            "viking://resources",
+            "viking://resources/doc-a.md",
+            {"uri": "viking://resources/doc-b.md"},
+            {
+                "uri": "viking://resources/folder",
+                "children": [
+                    {"uri": "viking://resources/doc-a.md"},
+                    {"uri": "viking://resources/folder/doc-c.md"}
+                ]
+            }
+        ]);
+
+        let uris = collect_resource_uris(&listing);
+
+        assert_eq!(
+            uris,
+            vec![
+                "viking://resources/doc-a.md".to_string(),
+                "viking://resources/doc-b.md".to_string(),
+                "viking://resources/folder".to_string(),
+                "viking://resources/folder/doc-c.md".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_embedding_config_summary_reads_provider_model_and_dimension() {
+        let config = json!({
+            "embedding": {
+                "dense": {
+                    "provider": "openai",
+                    "model": "text-embedding-3-small",
+                    "dimension": "1536"
+                }
+            }
+        });
+
+        let summary = parse_embedding_config_summary(&config);
+
+        assert_eq!(summary.provider.as_deref(), Some("openai"));
+        assert_eq!(summary.model.as_deref(), Some("text-embedding-3-small"));
+        assert_eq!(summary.dimension, Some(1536));
+    }
+
+    #[test]
+    fn load_embedding_config_summary_from_path_reports_parse_errors() {
+        let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+        let config_path = temp_dir.path().join("ov.conf");
+        fs::write(&config_path, "{not-json").expect("config should be written");
+
+        let summary = load_embedding_config_summary_from_path(&config_path);
+
+        assert_eq!(summary.config_path.as_deref(), Some(config_path.to_string_lossy().as_ref()));
+        assert!(summary.note.as_deref().unwrap_or_default().contains("Failed to parse ov.conf"));
+    }
 }

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -451,8 +451,52 @@ pub async fn handle_write(
     .await
 }
 
-pub async fn handle_reindex(uri: String, regenerate: bool, wait: bool, ctx: CliContext) -> Result<()> {
+pub async fn handle_reindex(
+    uri: Option<String>,
+    all: bool,
+    dry_run: bool,
+    regenerate: bool,
+    wait: bool,
+    ctx: CliContext,
+) -> Result<()> {
+    let mut params = Vec::new();
+    if let Some(uri) = &uri {
+        params.push(uri.clone());
+    }
+    if all {
+        params.push("--all".to_string());
+    }
+    if dry_run {
+        params.push("--dry-run".to_string());
+    }
+    if regenerate {
+        params.push("--regenerate".to_string());
+    }
+    if wait {
+        params.push("--wait".to_string());
+    }
+    print_command_echo("ov reindex", &params.join(" "), ctx.config.echo_command);
+
     let client = ctx.get_client();
+    if all {
+        if !dry_run {
+            return Err(Error::Client(
+                "Batch reindex execution is not implemented in this MVP. Use 'ov reindex --all --dry-run' to inspect the plan.".into(),
+            ));
+        }
+        return commands::content::reindex_all_dry_run(&client, ctx.output_format, ctx.compact)
+            .await;
+    }
+
+    if dry_run {
+        return Err(Error::Client(
+            "Dry-run is currently only supported with '--all' in this MVP.".into(),
+        ));
+    }
+
+    let uri = uri.ok_or_else(|| {
+        Error::Client("Specify a target URI or use '--all --dry-run'.".to_string())
+    })?;
     commands::content::reindex(
         &client,
         &uri,

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -509,10 +509,22 @@ enum Commands {
         #[arg(long)]
         no_vectorize: bool,
     },
-    /// [Admin] Reindex content at URI (regenerates .abstract.md and .overview.md)
+    /// [Admin] Reindex content at URI or inspect an all-resources dry-run plan
+    #[command(group(
+        clap::ArgGroup::new("reindex_target")
+            .required(true)
+            .multiple(false)
+            .args(["uri", "all"])
+    ))]
     Reindex {
         /// Viking URI
-        uri: String,
+        uri: Option<String>,
+        /// Plan a batch reindex for all resources (MVP dry-run only)
+        #[arg(long, conflicts_with = "uri")]
+        all: bool,
+        /// Show the batch reindex plan without executing it
+        #[arg(long, requires = "all")]
+        dry_run: bool,
         /// Force regenerate summaries even if they exist
         #[arg(short, long)]
         regenerate: bool,
@@ -841,9 +853,11 @@ async fn main() {
         } => handlers::handle_write(uri, content, from_file, append, wait, timeout, ctx).await,
         Commands::Reindex {
             uri,
+            all,
+            dry_run,
             regenerate,
             wait,
-        } => handlers::handle_reindex(uri, regenerate, wait, ctx).await,
+        } => handlers::handle_reindex(uri, all, dry_run, regenerate, wait, ctx).await,
         Commands::Get { uri, local_path } => handlers::handle_get(uri, local_path, ctx).await,
         Commands::Find {
             query,
@@ -902,7 +916,7 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, CliContext};
+    use super::{Cli, CliContext, Commands};
     use crate::config::Config;
     use crate::handlers;
     use crate::output::OutputFormat;
@@ -979,5 +993,40 @@ mod tests {
         handlers::append_time_filter_params(&mut params, after.as_deref(), before.as_deref());
 
         assert_eq!(params, vec!["--after 7d", "--before 2026-03-12"]);
+    }
+
+    #[test]
+    fn cli_reindex_parses_all_dry_run_mode() {
+        let cli = Cli::try_parse_from(["ov", "reindex", "--all", "--dry-run"])
+            .expect("reindex all dry-run should parse");
+
+        match cli.command {
+            Commands::Reindex {
+                uri,
+                all,
+                dry_run,
+                regenerate,
+                wait,
+            } => {
+                assert!(uri.is_none());
+                assert!(all);
+                assert!(dry_run);
+                assert!(!regenerate);
+                assert!(wait);
+            }
+            other => panic!("unexpected command parsed: {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn cli_reindex_rejects_dry_run_without_all() {
+        let result = Cli::try_parse_from(["ov", "reindex", "--dry-run"]);
+        assert!(result.is_err(), "dry-run without --all should not parse");
+    }
+
+    #[test]
+    fn cli_reindex_rejects_uri_and_all_together() {
+        let result = Cli::try_parse_from(["ov", "reindex", "viking://resources/demo.md", "--all"]);
+        assert!(result.is_err(), "uri and --all should be mutually exclusive");
     }
 }

--- a/openviking_cli/doctor.py
+++ b/openviking_cli/doctor.py
@@ -9,6 +9,7 @@ native vector engine, AGFS, embedding provider, VLM provider, and disk space.
 
 from __future__ import annotations
 
+import argparse
 import importlib
 import json
 import os
@@ -16,7 +17,7 @@ import platform
 import shutil
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from openviking_cli.utils.config.config_loader import resolve_config_path
 from openviking_cli.utils.config.consts import OPENVIKING_CONFIG_ENV
@@ -58,6 +59,99 @@ def _load_config_json(config_path: Path) -> Optional[dict]:
         return json.loads(raw)
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def _is_placeholder_secret(value: Any) -> bool:
+    return not value or (isinstance(value, str) and value.startswith("{"))
+
+
+def _configured_dimension(dense: dict[str, Any]) -> Optional[int]:
+    value = dense.get("dimension")
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_dense_embedder_for_live_validation(dense: dict[str, Any]):
+    from openviking_cli.utils.config.embedding_config import EmbeddingConfig, EmbeddingModelConfig
+
+    dense_config = EmbeddingModelConfig.model_validate(dense)
+    embedding_config = EmbeddingConfig.model_validate({"dense": dense_config.model_dump()})
+    return embedding_config.get_embedder()
+
+
+def _get_local_embedding_helpers():
+    from openviking.models.embedder.local_embedders import (
+        get_local_model_cache_path,
+        get_local_model_spec,
+    )
+
+    return get_local_model_cache_path, get_local_model_spec
+
+
+def _format_live_embedding_fix(provider: str, dense: dict[str, Any], exc: Exception) -> str:
+    provider_label = provider or "embedding"
+    api_base = dense.get("api_base")
+    model = dense.get("model")
+    lines = [f"Check embedding.dense.model for {provider_label} in ov.conf"]
+    if api_base:
+        lines.append(f"Verify embedding.dense.api_base is reachable: {api_base}")
+    if model:
+        lines.append(f"Confirm model '{model}' exists and supports embeddings")
+    lines.append(f"Provider error: {type(exc).__name__}: {exc}")
+    return "\n".join(lines)
+
+
+def _run_live_embedding_validation(
+    provider: str,
+    model: str,
+    dense: dict[str, Any],
+) -> tuple[bool, str, Optional[str]]:
+    embedder = None
+    try:
+        embedder = _build_dense_embedder_for_live_validation(dense)
+        result = embedder.embed("OpenViking doctor validation probe", is_query=False)
+        vector = getattr(result, "dense_vector", None)
+        if not vector:
+            return (
+                False,
+                f"{provider}/{model} (live validation returned no dense vector)",
+                "Check embedding provider credentials, endpoint, and model configuration in ov.conf",
+            )
+
+        actual_dimension = len(vector)
+        configured_dimension = _configured_dimension(dense)
+        if configured_dimension is not None and configured_dimension != actual_dimension:
+            return (
+                False,
+                (
+                    f"{provider}/{model} "
+                    f"(live dimension mismatch: config={configured_dimension}, actual={actual_dimension})"
+                ),
+                (
+                    "Update embedding.dense.dimension to match the provider output "
+                    f"({actual_dimension}) or switch to a model that returns {configured_dimension} dimensions"
+                ),
+            )
+
+        detail = f"{provider}/{model} (live OK, dim={actual_dimension})"
+        if configured_dimension is not None:
+            detail = f"{provider}/{model} (live OK, dim={actual_dimension} matches config)"
+        return True, detail, None
+    except Exception as exc:
+        return (
+            False,
+            f"{provider}/{model} (live validation failed: {type(exc).__name__})",
+            _format_live_embedding_fix(provider, dense, exc),
+        )
+    finally:
+        if embedder is not None:
+            close = getattr(embedder, "close", None)
+            if callable(close):
+                close()
 
 
 def check_config() -> tuple[bool, str, Optional[str]]:
@@ -142,7 +236,7 @@ def check_agfs() -> tuple[bool, str, Optional[str]]:
         )
 
 
-def check_embedding() -> tuple[bool, str, Optional[str]]:
+def check_embedding(live: bool = False) -> tuple[bool, str, Optional[str]]:
     """Load embedding config and verify provider connectivity."""
     config_path = _find_config()
     if config_path is None:
@@ -158,10 +252,7 @@ def check_embedding() -> tuple[bool, str, Optional[str]]:
     model = dense.get("model", "bge-small-zh-v1.5-f16")
 
     if provider == "local":
-        from openviking.models.embedder.local_embedders import (
-            get_local_model_cache_path,
-            get_local_model_spec,
-        )
+        get_local_model_cache_path, get_local_model_spec = _get_local_embedding_helpers()
 
         try:
             get_local_model_spec(model)
@@ -197,21 +288,29 @@ def check_embedding() -> tuple[bool, str, Optional[str]]:
             return True, f"{provider}/{model} ({cached_file})", None
         return (
             True,
-            f"{provider}/{model} (will auto-download during startup initialization)",
+            (
+                f"{provider}/{model} "
+                "(will auto-download during startup initialization)"
+            ),
             None,
         )
 
     # Ollama doesn't need an API key
     if provider == "ollama":
-        return True, f"{provider}/{model}", None
+        if not live:
+            return True, f"{provider}/{model}", None
+        return _run_live_embedding_validation(provider, model, dense)
 
     api_key = dense.get("api_key", "")
-    if not api_key or api_key.startswith("{"):
+    if _is_placeholder_secret(api_key):
         return (
             False,
             f"{provider}/{model} (no API key)",
             "Set embedding.dense.api_key in ov.conf",
         )
+
+    if live:
+        return _run_live_embedding_validation(provider, model, dense)
 
     return True, f"{provider}/{model}", None
 
@@ -321,24 +420,34 @@ _CHECKS = [
     ("Python", check_python),
     ("Native Engine", check_native_engine),
     ("AGFS", check_agfs),
-    ("Embedding", check_embedding),
     ("VLM", check_vlm),
     ("Ollama", check_ollama),
     ("Disk", check_disk),
 ]
 
 
-def run_doctor() -> int:
+def run_doctor(*, live_embedding: bool = False) -> int:
     """Run all diagnostic checks and print a formatted report.
 
     Returns 0 if all checks pass, 1 otherwise.
     """
     print("\nOpenViking Doctor\n")
 
-    failed = 0
-    max_label = max(len(label) for label, _ in _CHECKS)
+    checks = [
+        ("Config", check_config),
+        ("Python", check_python),
+        ("Native Engine", check_native_engine),
+        ("AGFS", check_agfs),
+        ("Embedding", lambda: check_embedding(live=live_embedding)),
+        ("VLM", check_vlm),
+        ("Ollama", check_ollama),
+        ("Disk", check_disk),
+    ]
 
-    for label, check_fn in _CHECKS:
+    failed = 0
+    max_label = max(len(label) for label, _ in checks)
+
+    for label, check_fn in checks:
         try:
             ok, detail, fix = check_fn()
         except Exception as exc:
@@ -365,6 +474,29 @@ def run_doctor() -> int:
     return 0
 
 
-def main() -> int:
+def _normalize_argv(argv: Optional[list[str]]) -> list[str]:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args and args[0] == "doctor":
+        return args[1:]
+    return args
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="openviking-server doctor")
+    parser.add_argument("--config", help="Path to ov.conf")
+    parser.add_argument(
+        "--live",
+        "--live-embedding",
+        dest="live_embedding",
+        action="store_true",
+        help="Perform a small live embedding validation for endpoint/model checks",
+    )
+    return parser.parse_args(_normalize_argv(argv))
+
+
+def main(argv: Optional[list[str]] = None) -> int:
     """Entry point for ``openviking-server doctor``."""
-    return run_doctor()
+    args = _parse_args(argv)
+    if args.config:
+        os.environ[OPENVIKING_CONFIG_ENV] = args.config
+    return run_doctor(live_embedding=args.live_embedding)

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -19,6 +19,7 @@ from openviking_cli.doctor import (
     check_ollama,
     check_python,
     check_vlm,
+    main as doctor_main,
     run_doctor,
 )
 
@@ -139,16 +140,51 @@ class TestCheckAgfs:
 
 
 class TestCheckEmbedding:
+    class _FakeEmbedResult:
+        def __init__(self, vector: list[float]):
+            self.dense_vector = vector
+
+    class _FakeDenseEmbedder:
+        def __init__(self, vector: list[float]):
+            self.vector = vector
+            self.closed = False
+
+        def embed(self, text: str, is_query: bool = False):
+            return TestCheckEmbedding._FakeEmbedResult(self.vector)
+
+        def close(self):
+            self.closed = True
+
+    @staticmethod
+    def _local_helpers(model_path: Path):
+        def get_local_model_cache_path(_model: str, _cache_dir: str) -> Path:
+            return model_path
+
+        def get_local_model_spec(model: str):
+            return {"model": model}
+
+        return get_local_model_cache_path, get_local_model_spec
+
     def test_fail_local_default_when_optional_dependency_missing(self, tmp_path: Path):
         config = tmp_path / "ov.conf"
         config.write_text(json.dumps({}))
+        real_import = __import__
+
+        def import_side_effect(name):
+            if name == "llama_cpp":
+                raise ImportError("No module named 'llama_cpp'")
+            return real_import(name)
 
         with patch("openviking_cli.doctor._find_config", return_value=config):
             with patch(
-                "openviking_cli.doctor.importlib.import_module",
-                side_effect=ImportError("No module named 'llama_cpp'"),
+                "openviking_cli.doctor._get_local_embedding_helpers",
+                return_value=self._local_helpers(tmp_path / "unused.gguf"),
             ):
-                ok, detail, fix = check_embedding()
+                with patch(
+                    "openviking_cli.doctor.importlib.import_module",
+                    side_effect=import_side_effect,
+                ):
+                    ok, detail, fix = check_embedding()
 
         assert not ok
         assert "missing llama-cpp-python" in detail
@@ -164,8 +200,8 @@ class TestCheckEmbedding:
 
         with patch("openviking_cli.doctor._find_config", return_value=config):
             with patch(
-                "openviking.models.embedder.local_embedders.get_local_model_cache_path",
-                return_value=cached_model,
+                "openviking_cli.doctor._get_local_embedding_helpers",
+                return_value=self._local_helpers(cached_model),
             ):
                 with patch.object(Path, "exists", autospec=True, return_value=True):
                     with patch(
@@ -186,12 +222,18 @@ class TestCheckEmbedding:
         real_import = __import__
 
         with patch("openviking_cli.doctor._find_config", return_value=config):
-            with patch.object(Path, "exists", autospec=True, return_value=False):
-                with patch(
-                    "openviking_cli.doctor.importlib.import_module",
-                    side_effect=lambda name: object() if name == "llama_cpp" else real_import(name),
-                ):
-                    ok, detail, fix = check_embedding()
+            with patch(
+                "openviking_cli.doctor._get_local_embedding_helpers",
+                return_value=self._local_helpers(tmp_path / "missing.gguf"),
+            ):
+                with patch.object(Path, "exists", autospec=True, return_value=False):
+                    with patch(
+                        "openviking_cli.doctor.importlib.import_module",
+                        side_effect=lambda name: object()
+                        if name == "llama_cpp"
+                        else real_import(name),
+                    ):
+                        ok, detail, fix = check_embedding()
 
         assert ok
         assert "startup initialization" in detail
@@ -213,11 +255,138 @@ class TestCheckEmbedding:
         )
 
         with patch("openviking_cli.doctor._find_config", return_value=config):
-            ok, detail, fix = check_embedding()
+            with patch(
+                "openviking_cli.doctor._get_local_embedding_helpers",
+                return_value=(
+                    lambda _model, _cache_dir: tmp_path / "unused.gguf",
+                    lambda _model: (_ for _ in ()).throw(
+                        ValueError("Unknown local embedding model: unknown-local-model")
+                    ),
+                ),
+            ):
+                ok, detail, fix = check_embedding()
 
         assert not ok
         assert "unsupported local model" in detail
         assert "Unknown local embedding model" in fix
+
+    def test_live_remote_validation_passes_and_matches_dimension(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text(
+            json.dumps(
+                {
+                    "embedding": {
+                        "dense": {
+                            "provider": "openai",
+                            "model": "text-embedding-3-small",
+                            "api_key": "sk-test123",
+                            "dimension": 3,
+                        }
+                    }
+                }
+            )
+        )
+        fake_embedder = self._FakeDenseEmbedder([0.1, 0.2, 0.3])
+
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            with patch(
+                "openviking_cli.doctor._build_dense_embedder_for_live_validation",
+                return_value=fake_embedder,
+            ):
+                ok, detail, fix = check_embedding(live=True)
+
+        assert ok
+        assert "live OK" in detail
+        assert "matches config" in detail
+        assert fix is None
+        assert fake_embedder.closed
+
+    def test_live_remote_validation_fails_on_dimension_mismatch(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text(
+            json.dumps(
+                {
+                    "embedding": {
+                        "dense": {
+                            "provider": "openai",
+                            "model": "text-embedding-3-small",
+                            "api_key": "sk-test123",
+                            "dimension": 5,
+                        }
+                    }
+                }
+            )
+        )
+
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            with patch(
+                "openviking_cli.doctor._build_dense_embedder_for_live_validation",
+                return_value=self._FakeDenseEmbedder([0.1, 0.2, 0.3]),
+            ):
+                ok, detail, fix = check_embedding(live=True)
+
+        assert not ok
+        assert "live dimension mismatch" in detail
+        assert "Update embedding.dense.dimension" in fix
+
+    def test_live_remote_validation_surfaces_actionable_provider_error(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text(
+            json.dumps(
+                {
+                    "embedding": {
+                        "dense": {
+                            "provider": "openai",
+                            "model": "text-embedding-3-small",
+                            "api_key": "sk-test123",
+                            "api_base": "https://example.invalid/v1",
+                        }
+                    }
+                }
+            )
+        )
+
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            with patch(
+                "openviking_cli.doctor._build_dense_embedder_for_live_validation",
+                side_effect=RuntimeError("401 unauthorized"),
+            ):
+                ok, detail, fix = check_embedding(live=True)
+
+        assert not ok
+        assert "live validation failed" in detail
+        assert "embedding.dense.api_base" in fix
+        assert "401 unauthorized" in fix
+
+    def test_live_local_validation_keeps_static_local_checks(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text(json.dumps({}))
+        cached_model = (
+            Path.home() / ".cache" / "openviking" / "models" / "bge-small-zh-v1.5-f16.gguf"
+        )
+        real_import = __import__
+
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            with patch(
+                "openviking_cli.doctor._get_local_embedding_helpers",
+                return_value=self._local_helpers(cached_model),
+            ):
+                with patch.object(Path, "exists", autospec=True, return_value=True):
+                    with patch(
+                        "openviking_cli.doctor.importlib.import_module",
+                        side_effect=lambda name: object()
+                        if name == "llama_cpp"
+                        else real_import(name),
+                    ):
+                        with patch(
+                            "openviking_cli.doctor._build_dense_embedder_for_live_validation"
+                        ) as live_builder:
+                            ok, detail, fix = check_embedding(live=True)
+
+        assert ok
+        assert "local/bge-small-zh-v1.5-f16" in detail
+        assert fix is None
+        live_builder.assert_not_called()
 
     def test_pass_with_api_key(self, tmp_path: Path):
         config = tmp_path / "ov.conf"
@@ -447,6 +616,20 @@ class TestRunDoctor:
         assert code == 1
         captured = capsys.readouterr()
         assert "FAIL" in captured.out
+
+
+class TestDoctorMain:
+    def test_main_parses_live_and_config_flags(self, tmp_path: Path):
+        config = tmp_path / "doctor.conf"
+        config.write_text(json.dumps({"embedding": {"dense": {}}}))
+
+        with patch("openviking_cli.doctor.run_doctor", return_value=0) as run:
+            with patch.dict(os.environ, {}, clear=False):
+                exit_code = doctor_main(["doctor", "--config", str(config), "--live"])
+                assert os.environ["OPENVIKING_CONFIG_FILE"] == str(config)
+
+        assert exit_code == 0
+        run.assert_called_once_with(live_embedding=True)
 
 
 def _import_fail(blocked_name: str):


### PR DESCRIPTION
## Summary
- add optional live embedding validation to `openviking-server doctor` for real endpoint/model checks
- add `ov reindex --all --dry-run` planner support in the Rust CLI
- cover the new doctor flow and CLI parsing with focused tests

## Testing
- tmpdir=/var/folders/sg/8wz47vrs179fbyw479ssxhh00000gn/T/tmp.Fv8vNEN2XU && printf 'class Ark:\n    pass\n' > "/volcenginesdkarkruntime.py" && PYTHONPATH=":" python -m pytest -q tests/cli/test_doctor.py
- cargo test -p ov_cli cli_reindex -- --nocapture