### PR TITLE
feat: add skill privacy config redaction MVP

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -27,6 +27,7 @@ from openviking.storage.queuefs.queue_manager import QueueManager, init_queue_ma
 from openviking.storage.transaction import LockManager, init_lock_manager
 from openviking.storage.viking_fs import VikingFS, init_viking_fs
 from openviking.utils.resource_processor import ResourceProcessor
+from openviking.utils.privacy_config_service import PrivacyConfigService
 from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.exceptions import NotInitializedError
 from openviking_cli.session.user_id import UserIdentifier
@@ -74,6 +75,7 @@ class OpenVikingService:
         self._embedder: Optional[Any] = None
         self._resource_processor: Optional[ResourceProcessor] = None
         self._skill_processor: Optional[SkillProcessor] = None
+        self._privacy_config_service: Optional[PrivacyConfigService] = None
         self._session_compressor: Optional[SessionCompressor] = None
         self._lock_manager: Optional[LockManager] = None
         self._directory_initializer: Optional[DirectoryInitializer] = None
@@ -300,7 +302,11 @@ class OpenVikingService:
         self._resource_processor = ResourceProcessor(
             vikingdb=self._vikingdb_manager,
         )
-        self._skill_processor = SkillProcessor(vikingdb=self._vikingdb_manager)
+        self._privacy_config_service = PrivacyConfigService(viking_fs=self._viking_fs)
+        self._skill_processor = SkillProcessor(
+            vikingdb=self._vikingdb_manager,
+            privacy_config_service=self._privacy_config_service,
+        )
         self._session_compressor = create_session_compressor(vikingdb=self._vikingdb_manager)
 
         # Start LockManager if initialized
@@ -317,6 +323,7 @@ class OpenVikingService:
 
         # Wire up sub-services
         self._fs_service.set_viking_fs(self._viking_fs)
+        self._fs_service.set_privacy_config_service(self._privacy_config_service)
         self._relation_service.set_viking_fs(self._viking_fs)
         self._pack_service.set_viking_fs(self._viking_fs)
         self._search_service.set_viking_fs(self._viking_fs)

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -13,6 +13,7 @@ from openviking.server.identity import RequestContext
 from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.storage.viking_fs import VikingFS
 from openviking.utils.embedding_utils import vectorize_directory_meta
+from openviking.utils.privacy_config_service import PrivacyConfigService
 from openviking_cli.exceptions import NotInitializedError
 from openviking_cli.utils import VikingURI, get_logger
 
@@ -22,12 +23,20 @@ logger = get_logger(__name__)
 class FSService:
     """File system operations service."""
 
-    def __init__(self, viking_fs: Optional[VikingFS] = None):
+    def __init__(
+        self,
+        viking_fs: Optional[VikingFS] = None,
+        privacy_config_service: Optional[PrivacyConfigService] = None,
+    ):
         self._viking_fs = viking_fs
+        self._privacy_config_service = privacy_config_service
 
     def set_viking_fs(self, viking_fs: VikingFS) -> None:
         """Set VikingFS instance (for deferred initialization)."""
         self._viking_fs = viking_fs
+
+    def set_privacy_config_service(self, privacy_config_service: PrivacyConfigService) -> None:
+        self._privacy_config_service = privacy_config_service
 
     def _ensure_initialized(self) -> VikingFS:
         """Ensure VikingFS is initialized."""
@@ -179,6 +188,15 @@ class FSService:
     async def read(self, uri: str, ctx: RequestContext, offset: int = 0, limit: int = -1) -> str:
         """Read file content."""
         viking_fs = self._ensure_initialized()
+        privacy_service = self._privacy_config_service
+        if privacy_service and privacy_service.is_skill_content_uri(uri):
+            content = await viking_fs.read_file(uri, offset=0, limit=-1, ctx=ctx)
+            restored = await privacy_service.restore_skill_content(uri, content, ctx)
+            if offset == 0 and limit == -1:
+                return restored
+            lines = restored.splitlines(keepends=True)
+            sliced = lines[offset:] if limit == -1 else lines[offset : offset + limit]
+            return "".join(sliced)
         return await viking_fs.read_file(uri, offset=offset, limit=limit, ctx=ctx)
 
     async def abstract(self, uri: str, ctx: RequestContext) -> str:

--- a/openviking/utils/privacy_config_service.py
+++ b/openviking/utils/privacy_config_service.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Privacy config storage and redaction helpers.
+
+Phase-1 scope only covers skill content redaction/restoration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from openviking.core.namespace import canonical_user_root
+from openviking.server.identity import RequestContext
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import NotFoundError
+from openviking_cli.utils import VikingURI, get_logger
+
+logger = get_logger(__name__)
+
+
+class PrivacyConfigService:
+    """Stores per-user privacy configs and restores redacted skill content on read."""
+
+    _ASSIGNMENT_PATTERN = re.compile(
+        r"^(?P<prefix>\s*(?:export\s+)?(?P<key>[A-Za-z][A-Za-z0-9_-]*)\s*[:=]\s*)"
+        r"(?P<value>.+?)(?P<suffix>\s*(?:[,;])?\s*(?:#.*)?)$"
+    )
+    _SENSITIVE_FIELDS = {
+        "api_key",
+        "token",
+        "ak",
+        "sk",
+        "access_key",
+        "secret_key",
+        "client_secret",
+        "base_url",
+    }
+    _SENSITIVE_SUFFIXES = (
+        "_api_key",
+        "_token",
+        "_access_key",
+        "_secret_key",
+        "_client_secret",
+        "_base_url",
+    )
+
+    def __init__(self, viking_fs: Optional[VikingFS] = None):
+        self._viking_fs = viking_fs
+
+    def set_viking_fs(self, viking_fs: VikingFS) -> None:
+        self._viking_fs = viking_fs
+
+    def _ensure_initialized(self) -> VikingFS:
+        if not self._viking_fs:
+            raise RuntimeError("PrivacyConfigService requires VikingFS")
+        return self._viking_fs
+
+    @classmethod
+    def is_skill_content_uri(cls, uri: str) -> bool:
+        normalized = VikingURI.normalize(uri)
+        return normalized.startswith("viking://agent/skills/") and normalized.endswith("/SKILL.md")
+
+    @classmethod
+    def _normalize_field_name(cls, raw_key: str) -> str:
+        normalized = re.sub(r"[^a-z0-9]+", "_", raw_key.lower()).strip("_")
+        return re.sub(r"_+", "_", normalized)
+
+    @classmethod
+    def _is_sensitive_field(cls, field_name: str) -> bool:
+        return field_name in cls._SENSITIVE_FIELDS or field_name.endswith(cls._SENSITIVE_SUFFIXES)
+
+    @staticmethod
+    def _placeholder(field_name: str) -> str:
+        return f"{{{{OV_PRIVACY:{field_name}}}}}"
+
+    @staticmethod
+    def _looks_like_literal_secret(value: str) -> bool:
+        stripped = value.strip()
+        if not stripped:
+            return False
+        if stripped.startswith("$"):
+            return False
+        if stripped.startswith("${") and stripped.endswith("}"):
+            return False
+        if stripped.startswith("{{OV_PRIVACY:"):
+            return False
+        return True
+
+    @staticmethod
+    def _strip_wrapping_quotes(value: str) -> str:
+        stripped = value.strip()
+        if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+            return stripped[1:-1]
+        return stripped
+
+    @classmethod
+    def _replace_value_with_placeholder(cls, original_value: str, field_name: str) -> str:
+        stripped = original_value.strip()
+        placeholder = cls._placeholder(field_name)
+        if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+            replacement = f"{stripped[0]}{placeholder}{stripped[0]}"
+        else:
+            replacement = placeholder
+        leading_ws = original_value[: len(original_value) - len(original_value.lstrip())]
+        trailing_ws = original_value[len(original_value.rstrip()) :]
+        return f"{leading_ws}{replacement}{trailing_ws}"
+
+    @classmethod
+    def _target_key(cls, target_uri: str) -> str:
+        normalized = VikingURI.normalize(target_uri)
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+    def describe_storage(self, category: str, target_uri: str, ctx: RequestContext) -> Dict[str, str]:
+        base_uri = (
+            f"{canonical_user_root(ctx)}/privacy_configs/{category}/{self._target_key(target_uri)}"
+        )
+        return {
+            "base_uri": base_uri,
+            "current_uri": f"{base_uri}/current.json",
+            "history_uri": f"{base_uri}/history",
+            "meta_uri": f"{base_uri}/.meta.json",
+        }
+
+    async def load_current_config(
+        self, category: str, target_uri: str, ctx: RequestContext
+    ) -> Optional[Dict]:
+        storage = self.describe_storage(category, target_uri, ctx)
+        return await self._read_json(storage["current_uri"], ctx)
+
+    async def sanitize_skill_content(self, skill_uri: str, content: str, ctx: RequestContext) -> str:
+        redacted_content, secrets = self._redact_skill_content(content)
+        if not secrets:
+            return content
+        await self._persist_config(
+            category="skill",
+            target_uri=skill_uri,
+            secrets=secrets,
+            ctx=ctx,
+        )
+        return redacted_content
+
+    async def restore_skill_content(self, skill_uri: str, content: str, ctx: RequestContext) -> str:
+        config = await self.load_current_config("skill", skill_uri, ctx)
+        if not config:
+            return content
+
+        restored = content
+        secrets = config.get("secrets", {})
+        if not isinstance(secrets, dict):
+            return content
+
+        for field_name, secret in secrets.items():
+            if not isinstance(field_name, str) or not isinstance(secret, str):
+                continue
+            restored = restored.replace(self._placeholder(field_name), secret)
+        return restored
+
+    def _redact_skill_content(self, content: str) -> tuple[str, Dict[str, str]]:
+        secrets: Dict[str, str] = {}
+        redacted_lines = []
+
+        for line in content.splitlines(keepends=True):
+            match = self._ASSIGNMENT_PATTERN.match(line.rstrip("\n"))
+            if not match:
+                redacted_lines.append(line)
+                continue
+
+            field_name = self._normalize_field_name(match.group("key"))
+            if not self._is_sensitive_field(field_name):
+                redacted_lines.append(line)
+                continue
+
+            original_value = match.group("value")
+            secret = self._strip_wrapping_quotes(original_value)
+            if not self._looks_like_literal_secret(secret):
+                redacted_lines.append(line)
+                continue
+
+            secrets[field_name] = secret
+            replacement = self._replace_value_with_placeholder(original_value, field_name)
+            new_line = (
+                f"{match.group('prefix')}{replacement}{match.group('suffix')}"
+                + ("\n" if line.endswith("\n") else "")
+            )
+            redacted_lines.append(new_line)
+
+        return "".join(redacted_lines), secrets
+
+    async def _persist_config(
+        self,
+        category: str,
+        target_uri: str,
+        secrets: Dict[str, str],
+        ctx: RequestContext,
+    ) -> None:
+        viking_fs = self._ensure_initialized()
+        storage = self.describe_storage(category, target_uri, ctx)
+        current_meta = await self._read_json(storage["meta_uri"], ctx)
+        current_version = int(current_meta.get("current_version", 0)) if current_meta else 0
+        next_version = current_version + 1
+        version_name = f"version_{next_version:03d}.json"
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        await viking_fs.mkdir(storage["base_uri"], exist_ok=True, ctx=ctx)
+        await viking_fs.mkdir(storage["history_uri"], exist_ok=True, ctx=ctx)
+
+        payload = {
+            "category": category,
+            "target_uri": VikingURI.normalize(target_uri),
+            "target_key": self._target_key(target_uri),
+            "version": next_version,
+            "created_at": timestamp,
+            "secrets": secrets,
+        }
+        meta_payload = {
+            "category": category,
+            "target_uri": VikingURI.normalize(target_uri),
+            "target_key": self._target_key(target_uri),
+            "current_version": next_version,
+            "updated_at": timestamp,
+            "secret_fields": sorted(secrets.keys()),
+        }
+
+        await viking_fs.write_file(
+            storage["current_uri"],
+            json.dumps(payload, ensure_ascii=True, indent=2),
+            ctx=ctx,
+        )
+        await viking_fs.write_file(
+            f"{storage['history_uri']}/{version_name}",
+            json.dumps(payload, ensure_ascii=True, indent=2),
+            ctx=ctx,
+        )
+        await viking_fs.write_file(
+            storage["meta_uri"],
+            json.dumps(meta_payload, ensure_ascii=True, indent=2),
+            ctx=ctx,
+        )
+
+    async def _read_json(self, uri: str, ctx: RequestContext) -> Optional[Dict]:
+        viking_fs = self._ensure_initialized()
+        try:
+            raw = await viking_fs.read_file(uri, ctx=ctx)
+        except NotFoundError:
+            return None
+        except Exception as exc:
+            logger.warning("Failed to read privacy config %s: %s", uri, exc)
+            return None
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse privacy config %s", uri)
+            return None
+        return data if isinstance(data, dict) else None

--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -23,6 +23,7 @@ from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConve
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
+from openviking.utils.privacy_config_service import PrivacyConfigService
 from openviking.utils.zip_safe import safe_extract_zip
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
@@ -42,9 +43,14 @@ class SkillProcessor:
     5. Index to vector store
     """
 
-    def __init__(self, vikingdb: VikingDBManager):
+    def __init__(
+        self,
+        vikingdb: VikingDBManager,
+        privacy_config_service: Optional[PrivacyConfigService] = None,
+    ):
         """Initialize skill processor."""
         self.vikingdb = vikingdb
+        self._privacy_config_service = privacy_config_service
 
     async def process_skill(
         self,
@@ -79,6 +85,15 @@ class SkillProcessor:
         telemetry.set(
             "skill.parse.duration_ms", round((time.perf_counter() - parse_start) * 1000, 3)
         )
+        skill_dir_uri = f"viking://agent/skills/{skill_dict['name']}"
+
+        if self._privacy_config_service:
+            skill_dict = dict(skill_dict)
+            skill_dict["content"] = await self._privacy_config_service.sanitize_skill_content(
+                skill_uri=f"{skill_dir_uri}/SKILL.md",
+                content=skill_dict.get("content", ""),
+                ctx=ctx,
+            )
 
         context = Context(
             uri=f"{canonical_agent_root(ctx)}/skills/{skill_dict['name']}",
@@ -105,8 +120,6 @@ class SkillProcessor:
             "skill.overview.duration_ms",
             round((time.perf_counter() - overview_start) * 1000, 3),
         )
-
-        skill_dir_uri = f"viking://agent/skills/{context.meta['name']}"
 
         write_start = time.perf_counter()
         await self._write_skill_content(

--- a/tests/service/test_privacy_config_service.py
+++ b/tests/service/test_privacy_config_service.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from openviking.server.identity import RequestContext, Role
+from openviking.service.fs_service import FSService
+from openviking.utils.privacy_config_service import PrivacyConfigService
+from openviking.utils.skill_processor import SkillProcessor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class FakeVikingFS:
+    def __init__(self):
+        self.files: dict[str, str] = {}
+        self.directories: set[str] = set()
+
+    async def mkdir(self, uri: str, exist_ok: bool = False, ctx=None, **kwargs):
+        del exist_ok, ctx, kwargs
+        self.directories.add(uri.rstrip("/"))
+
+    async def write_file(self, uri: str, content: str, ctx=None):
+        del ctx
+        self.files[uri] = content
+
+    async def write_file_bytes(self, uri: str, content: bytes, ctx=None):
+        del ctx
+        self.files[uri] = content.decode("utf-8")
+
+    async def write_context(
+        self,
+        uri: str,
+        content: str = "",
+        abstract: str = "",
+        overview: str = "",
+        content_filename: str = "content.md",
+        is_leaf: bool = False,
+        ctx=None,
+    ):
+        del is_leaf, ctx
+        self.directories.add(uri.rstrip("/"))
+        if content:
+            self.files[f"{uri}/{content_filename}"] = content
+        if abstract:
+            self.files[f"{uri}/.abstract.md"] = abstract
+        if overview:
+            self.files[f"{uri}/.overview.md"] = overview
+
+    async def read_file(self, uri: str, offset: int = 0, limit: int = -1, ctx=None) -> str:
+        del ctx
+        text = self.files[uri]
+        if offset == 0 and limit == -1:
+            return text
+        lines = text.splitlines(keepends=True)
+        sliced = lines[offset:] if limit == -1 else lines[offset : offset + limit]
+        return "".join(sliced)
+
+
+def _request_context() -> RequestContext:
+    return RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+
+
+def _skill_markdown(name: str, body: str) -> str:
+    return f"""---
+name: {name}
+description: test skill
+---
+
+{body}
+"""
+
+
+async def test_skill_privacy_config_versions_persist(monkeypatch):
+    fake_fs = FakeVikingFS()
+    privacy_service = PrivacyConfigService(viking_fs=fake_fs)
+    processor = SkillProcessor(vikingdb=SimpleNamespace(), privacy_config_service=privacy_service)
+    ctx = _request_context()
+
+    monkeypatch.setattr(
+        "openviking.utils.skill_processor.get_openviking_config",
+        lambda: SimpleNamespace(vlm=SimpleNamespace()),
+    )
+    processor._generate_overview = AsyncMock(return_value="redacted overview")
+    processor._index_skill = AsyncMock(return_value=None)
+
+    await processor.process_skill(
+        _skill_markdown("privacy-versioned-skill", 'api_key: "alpha-secret"\n'),
+        fake_fs,
+        ctx,
+    )
+    await processor.process_skill(
+        _skill_markdown("privacy-versioned-skill", 'api_key: "beta-secret"\ntoken: beta-token\n'),
+        fake_fs,
+        ctx,
+    )
+
+    skill_md_uri = "viking://agent/skills/privacy-versioned-skill/SKILL.md"
+    storage = privacy_service.describe_storage("skill", skill_md_uri, ctx)
+
+    current = json.loads(fake_fs.files[storage["current_uri"]])
+    version_001 = json.loads(fake_fs.files[f"{storage['history_uri']}/version_001.json"])
+    version_002 = json.loads(fake_fs.files[f"{storage['history_uri']}/version_002.json"])
+    meta = json.loads(fake_fs.files[storage["meta_uri"]])
+
+    assert current["version"] == 2
+    assert current["secrets"]["api_key"] == "beta-secret"
+    assert current["secrets"]["token"] == "beta-token"
+    assert version_001["secrets"]["api_key"] == "alpha-secret"
+    assert version_002["secrets"]["api_key"] == "beta-secret"
+    assert meta["current_version"] == 2
+    assert meta["secret_fields"] == ["api_key", "token"]
+
+
+async def test_skill_read_restores_user_secret_from_privacy_config(monkeypatch):
+    fake_fs = FakeVikingFS()
+    privacy_service = PrivacyConfigService(viking_fs=fake_fs)
+    processor = SkillProcessor(vikingdb=SimpleNamespace(), privacy_config_service=privacy_service)
+    fs_service = FSService(viking_fs=fake_fs, privacy_config_service=privacy_service)
+    ctx = _request_context()
+
+    monkeypatch.setattr(
+        "openviking.utils.skill_processor.get_openviking_config",
+        lambda: SimpleNamespace(vlm=SimpleNamespace()),
+    )
+    processor._generate_overview = AsyncMock(return_value="redacted overview")
+    processor._index_skill = AsyncMock(return_value=None)
+
+    result = await processor.process_skill(
+        _skill_markdown(
+            "privacy-restored-skill",
+            '# Skill\napi_key: "super-secret"\nbase_url: https://internal.example.com\n',
+        ),
+        fake_fs,
+        ctx,
+    )
+    skill_md_uri = f"{result['uri']}/SKILL.md"
+
+    raw_stored = await fake_fs.read_file(skill_md_uri, ctx=ctx)
+    restored = await fs_service.read(skill_md_uri, ctx=ctx)
+
+    assert "super-secret" not in raw_stored
+    assert "internal.example.com" not in raw_stored
+    assert "{{OV_PRIVACY:api_key}}" in raw_stored
+    assert "{{OV_PRIVACY:base_url}}" in raw_stored
+
+    assert 'api_key: "super-secret"' in restored
+    assert "base_url: https://internal.example.com" in restored
+    assert "{{OV_PRIVACY:" not in restored


### PR DESCRIPTION
## Summary
- add a minimal user-scoped privacy config service with versioned `current/history/meta` storage for skill secrets
- redact sensitive assignments before skill overview generation and SKILL.md persistence, then restore placeholders only on explicit SKILL.md reads
- add focused tests covering config versioning and skill read restoration using a fake VikingFS harness

## Testing
- `tmpdir=$(mktemp -d) && printf 'class Ark:\n    pass\n' > "$tmpdir/volcenginesdkarkruntime.py" && PYTHONPATH="$tmpdir:$PYTHONPATH" python -m pytest -q tests/service/test_privacy_config_service.py`
