### PR TITLE
fix: repair /maintenance/reindex auth and /content/write memory-mode calls

### DIFF
--- a/openviking/server/routers/maintenance.py
+++ b/openviking/server/routers/maintenance.py
@@ -4,7 +4,7 @@
 
 import asyncio
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, Request
 from pydantic import BaseModel
 
 from openviking.server.auth import get_request_context, require_auth_root_or_admin
@@ -32,8 +32,9 @@ router = APIRouter(prefix="/api/v1/maintenance", tags=["maintenance"])
 @router.post("/reindex")
 @require_auth_root_or_admin
 async def reindex(
-    request: ReindexRequest = Body(...),
-    _ctx: RequestContext = Depends(get_request_context),
+    request: Request,
+    body: ReindexRequest = Body(...),
+    ctx: RequestContext = Depends(get_request_context),
 ):
     """Reindex content at a URI.
 
@@ -47,11 +48,11 @@ async def reindex(
     from openviking.service.task_tracker import get_task_tracker
     from openviking.storage.viking_fs import get_viking_fs
 
-    uri = request.uri
+    uri = body.uri
     viking_fs = get_viking_fs()
 
     # Validate URI exists
-    if not await viking_fs.exists(uri, ctx=_ctx):
+    if not await viking_fs.exists(uri, ctx=ctx):
         return Response(
             status="error",
             error=ErrorInfo(code="NOT_FOUND", message=f"URI not found: {uri}"),
@@ -60,13 +61,13 @@ async def reindex(
     service = get_service()
     tracker = get_task_tracker()
 
-    if request.wait:
+    if body.wait:
         # Synchronous path: block until reindex completes
         if tracker.has_running(
             REINDEX_TASK_TYPE,
             uri,
-            owner_account_id=_ctx.account_id,
-            owner_user_id=_ctx.user.user_id,
+            owner_account_id=ctx.account_id,
+            owner_user_id=ctx.user.user_id,
         ):
             return Response(
                 status="error",
@@ -75,15 +76,15 @@ async def reindex(
                     message=f"URI {uri} already has a reindex in progress",
                 ),
             )
-        result = await _do_reindex(service, uri, request.regenerate, _ctx)
+        result = await _do_reindex(service, uri, body.regenerate, ctx)
         return Response(status="ok", result=result)
     else:
         # Async path: run in background, return task_id for polling
         task = tracker.create_if_no_running(
             REINDEX_TASK_TYPE,
             uri,
-            owner_account_id=_ctx.account_id,
-            owner_user_id=_ctx.user.user_id,
+            owner_account_id=ctx.account_id,
+            owner_user_id=ctx.user.user_id,
         )
         if task is None:
             return Response(
@@ -94,7 +95,7 @@ async def reindex(
                 ),
             )
         asyncio.create_task(
-            _background_reindex_tracked(service, uri, request.regenerate, _ctx, task.task_id)
+            _background_reindex_tracked(service, uri, body.regenerate, ctx, task.task_id)
         )
         return Response(
             status="ok",

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -163,7 +163,8 @@ class ContentWriteCoordinator:
             existing_raw = await self._viking_fs.read_file(uri, ctx=ctx)
             _, metadata = deserialize_full(existing_raw)
             if metadata:
-                content = serialize_with_metadata(content, metadata)
+                metadata["content"] = content
+                content = serialize_with_metadata(metadata)
             await self._viking_fs.write_file(uri, content, ctx=ctx)
             return
 
@@ -172,7 +173,8 @@ class ContentWriteCoordinator:
             existing_content, metadata = deserialize_full(existing_raw)
             updated_content = existing_content + content
             if metadata:
-                updated_raw = serialize_with_metadata(updated_content, metadata)
+                metadata["content"] = updated_content
+                updated_raw = serialize_with_metadata(metadata)
             else:
                 updated_raw = updated_content
             await self._viking_fs.write_file(uri, updated_raw, ctx=ctx)

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -65,7 +65,7 @@ async def test_memory_replace_preserves_metadata(service):
         "updated_at": "2026-04-01T10:05:00",
         "fields": {"topic": "theme"},
     }
-    full_content = serialize_with_metadata("Original preference", metadata)
+    full_content = serialize_with_metadata({**metadata, "content": "Original preference"})
     _, expected_metadata = deserialize_full(full_content)
     await service.viking_fs.write_file(memory_uri, full_content, ctx=ctx)
 


### PR DESCRIPTION
## Summary

Two independent server issues prevent HTTP callers from ever using the admin reindex endpoint or rewriting memory files through `/content/write`. Both are signature/call-site mismatches in current `main` (31628cd0).

## Issue 1 — `/api/v1/maintenance/reindex` always raises RuntimeError

`server/routers/maintenance.py::reindex` is decorated with `@require_auth_root_or_admin`, but its signature does not match what the decorator introspects (via `inspect.signature(...).bind(...).apply_defaults()`):

```python
async def reindex(
    request: ReindexRequest = Body(...),           # shadows the FastAPI Request object
    _ctx: RequestContext = Depends(get_request_context),  # not discoverable as "ctx"
):
```

The decorator at `server/auth.py:252-268` looks up `request` (expecting a real `fastapi.Request`) and `ctx`. Because `_ctx` is not `ctx`, every call hits:

```
RuntimeError: require_auth_role decorator requires 'ctx' parameter
```

Even if the name were fixed, the `request: ReindexRequest` shadow would make `request.app.state` raise `AttributeError` once auth checking proceeds to `server/auth.py:270`.

### Fix
Align the handler with the existing convention used in `server/routers/pack.py:48-53`:

```python
async def reindex(
    request: Request,                                # real FastAPI Request
    body: ReindexRequest = Body(...),
    ctx: RequestContext = Depends(get_request_context),
):
    ...
    uri = body.uri
    ...
```

`_ctx` → `ctx` at all 7 references; `request.uri/wait/regenerate` → `body.uri/wait/regenerate`.

## Issue 2 — `/api/v1/content/write` always 500s for memory paths

`session/memory/utils/content.py::serialize_with_metadata` is defined and used by three other call sites (`memory_updater.py:423`, `memory_type_registry.py:266`, and tests) as:

```python
def serialize_with_metadata(metadata: Dict[str, Any], content_template: str = None, ...):
    content = metadata.pop("content", "") or ""
```

i.e. `content` is pulled out of the first-argument dict by key.

`storage/content_write.py:166, :175` are the only offenders: they pass `(content_str, metadata_dict)`:

```python
content = serialize_with_metadata(content, metadata)
```

This triggers `AttributeError: 'str' object has no attribute 'pop'` for every `mode=replace` write against a memory URI and every `mode=append` write with existing metadata. The code path has never worked; `/content/write` against `viking://(user|agent)/.../memories/...` always 500s.

### Fix
Match the existing call shape by injecting `content` into the metadata dict:

```python
metadata["content"] = content
content = serialize_with_metadata(metadata)
```

Also updates `tests/server/test_content_write_service.py::test_memory_replace_preserves_metadata` which had the same `(str, dict)` misuse in its setup.

## Verification

Local checks against a fresh server restart after applying the patch:

- `POST /api/v1/maintenance/reindex` with `X-OpenViking-Account: default` + `X-OpenViking-User: default` + `Authorization: Bearer <root_api_key>` and body `{"uri": "viking://agent/<name>/memories", "regenerate": true, "wait": true}` returns `{"status":"ok","result":{"status":"success","enqueued_count":1}}` for five different agent memories directories (previously returned HTTP 500).
- `POST /api/v1/content/write` replacing `viking://agent/<name>/memories/soul.md` returns `{"status":"ok","result":{"semantic_updated":true,"vector_updated":true,...}}` (previously returned HTTP 500).
- `pytest tests/server/test_content_write_service.py::test_memory_replace_preserves_metadata` passes.
- Six other failures exist in the touched test files on unmodified `origin/main` as well (three `DeadlineExceededError` timing tests and a `SearchReplacePatch` suite); they are not introduced by this change.

## Test plan

- [ ] CI test matrix passes
- [ ] `tests/server/test_content_write_service.py::test_memory_replace_preserves_metadata` passes against CI runners
- [ ] Manual smoke: `POST /api/v1/maintenance/reindex` with a valid root key + tenant headers returns 200
- [ ] Manual smoke: `POST /api/v1/content/write` with `mode=replace` against a `viking://user/<u>/memories/...md` returns 200 with `semantic_updated=true`