### PR TITLE
fix(bot): 端口冲突预检 + /health 上报真实版本

### DIFF
--- a/bot/vikingbot/__init__.py
+++ b/bot/vikingbot/__init__.py
@@ -3,8 +3,13 @@ vikingbot - A lightweight AI agent framework
 """
 
 import warnings
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
-__version__ = "0.1.3"
+try:
+    __version__ = _pkg_version("openviking")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
+
 __logo__ = "🐈"
 
 # Suppress RequestsDependencyWarning from requests module

--- a/bot/vikingbot/cli/commands.py
+++ b/bot/vikingbot/cli/commands.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import select
+import socket
 import sys
 import time
 import warnings
@@ -81,6 +82,32 @@ def get_or_create_machine_id() -> str:
 def _init_bot_data(config):
     """Initialize bot data directory and set global paths."""
     set_bot_data_path(config.bot_data_path)
+
+
+def _abort_if_port_in_use(port: int, label: str) -> None:
+    """Exit with a clear message if anything is already listening on ``port``.
+
+    Without this check, a stale process holding the port keeps serving
+    traffic while a freshly-started gateway silently fails to bind — the
+    operator believes they upgraded but the old (potentially unpatched)
+    binary is still answering requests.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        try:
+            s.connect(("127.0.0.1", port))
+            in_use = True
+        except (ConnectionRefusedError, socket.timeout, OSError):
+            in_use = False
+    if in_use:
+        print(
+            f"Error: {label} port {port} is already in use.\n"
+            f"  A previous process is still bound — refusing to start a duplicate.\n"
+            f"  Identify it:  lsof -nP -iTCP:{port} -sTCP:LISTEN\n"
+            f"  Kill it, then retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +275,8 @@ def gateway(
     config_path: str = typer.Option(None, "--config", "-c", help="ov.conf path"),
 ):
     """Start the vikingbot gateway with OpenAPI chat enabled by default."""
+
+    _abort_if_port_in_use(port, "vikingbot gateway")
 
     if verbose:
         import logging

--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -32,6 +33,34 @@ def _get_version() -> str:
         return __version__
     except ImportError:
         return "unknown"
+
+
+VIKINGBOT_DEFAULT_PORT = 18790
+
+
+def _abort_if_port_in_use(port: int, label: str) -> None:
+    """Exit with a clear message if anything is already listening on ``port``.
+
+    Without this, ``--with-bot`` would spawn a vikingbot subprocess that
+    silently fails to bind while a stale process keeps serving traffic —
+    the operator believes they upgraded but the old binary still answers.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        try:
+            s.connect(("127.0.0.1", port))
+            in_use = True
+        except (ConnectionRefusedError, socket.timeout, OSError):
+            in_use = False
+    if in_use:
+        print(
+            f"Error: {label} port {port} is already in use.\n"
+            f"  A previous process is still bound — refusing to start a duplicate.\n"
+            f"  Identify it:  lsof -nP -iTCP:{port} -sTCP:LISTEN\n"
+            f"  Kill it, then retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def _normalize_host_arg(host: Optional[str]) -> Optional[str]:
@@ -170,6 +199,7 @@ def main():
 
     bot_process: Optional[BotProcess] = None
     if config.with_bot:
+        _abort_if_port_in_use(VIKINGBOT_DEFAULT_PORT, "vikingbot gateway")
         print(f"Bot API proxy enabled, forwarding to {config.bot_api_url}")
         # Determine if bot logging should be enabled
         enable_bot_logging = args.enable_bot_logging


### PR DESCRIPTION
## 修两个排障时被坑的点

**1. `--with-bot` 端口被占时不报错**

`bootstrap.py` 启动 vikingbot 子进程后只 `sleep(2)` 看进程死没死。但 vikingbot 要 ~5s 才走到 uvicorn bind，2s 时还在 import，进程当然是活的 → openviking-server 以为成功了，HTTP 代理转发到 18790，那里旧的 vikingbot 还在响应。从外面看一切正常，实际升级根本没生效。

修复：fork 前用 `socket.connect` 试一下 18790，被占就直接 exit 1 + 打 `lsof` 提示。两层都加（`bootstrap.py` 和 `vikingbot gateway`）。

**2. `/health` 永远返回 `version: "0.1.3"`**

`vikingbot/__init__.py` 里写死的。改成从 `importlib.metadata.version("openviking")` 动态读。

## 测试
- 端口空闲 → 静默通过
- 端口被占 → 毫秒级 exit 1，错误信息带 `lsof` 提示
- `/health` 正确反映已安装版本

🤖 Generated with [Claude Code](https://claude.com/claude-code)