### PR TITLE
fix(vlm): support OpenAI reasoning-model families (gpt-5, o1, o3, o4)

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -79,7 +79,7 @@ class OpenAIVLM(VLMBase):
         self._sync_client = None
         self._async_client = None
         self.api_version = config.get("api_version")
-        self.reasoning_effort = config.get("reasoning_effort", "minimal")
+        self.reasoning_effort = config.get("reasoning_effort", "low")
 
     def get_client(self):
         """Get sync client"""

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-
 from openviking.telemetry import tracer
 
 try:
@@ -30,6 +29,20 @@ _DASHSCOPE_HOSTS = {
     "dashscope.aliyuncs.com",
     "dashscope-intl.aliyuncs.com",
 }
+
+
+_REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def _is_reasoning_model(model: Optional[str]) -> bool:
+    """OpenAI reasoning-model families reject `max_tokens` and non-default `temperature`.
+
+    They require `max_completion_tokens` and only accept `temperature=1` (server default).
+    """
+    if not model:
+        return False
+    name = model.lower()
+    return any(name.startswith(p) for p in _REASONING_MODEL_PREFIXES)
 
 
 def _build_openai_client_kwargs(
@@ -259,15 +272,18 @@ class OpenAIVLM(VLMBase):
         thinking: bool = False,
     ) -> Dict[str, Any]:
         kwargs_messages = messages or [{"role": "user", "content": prompt}]
-        kwargs = {
-            "model": self.model or "gpt-4o-mini",
+        model = self.model or "gpt-4o-mini"
+        kwargs: Dict[str, Any] = {
+            "model": model,
             "messages": kwargs_messages,
-            "temperature": self.temperature,
             "stream": self.stream,
         }
+        if not _is_reasoning_model(model):
+            kwargs["temperature"] = self.temperature
         self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
-            kwargs["max_tokens"] = self.max_tokens
+            token_key = "max_completion_tokens" if _is_reasoning_model(model) else "max_tokens"
+            kwargs[token_key] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
@@ -292,15 +308,18 @@ class OpenAIVLM(VLMBase):
                 content.append({"type": "text", "text": prompt})
             kwargs_messages = [{"role": "user", "content": content}]
 
-        kwargs = {
-            "model": self.model or "gpt-4o-mini",
+        model = self.model or "gpt-4o-mini"
+        kwargs: Dict[str, Any] = {
+            "model": model,
             "messages": kwargs_messages,
-            "temperature": self.temperature,
             "stream": self.stream,
         }
+        if not _is_reasoning_model(model):
+            kwargs["temperature"] = self.temperature
         self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
-            kwargs["max_tokens"] = self.max_tokens
+            token_key = "max_completion_tokens" if _is_reasoning_model(model) else "max_tokens"
+            kwargs[token_key] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -79,6 +79,7 @@ class OpenAIVLM(VLMBase):
         self._sync_client = None
         self._async_client = None
         self.api_version = config.get("api_version")
+        self.reasoning_effort = config.get("reasoning_effort", "minimal")
 
     def get_client(self):
         """Get sync client"""
@@ -273,17 +274,19 @@ class OpenAIVLM(VLMBase):
     ) -> Dict[str, Any]:
         kwargs_messages = messages or [{"role": "user", "content": prompt}]
         model = self.model or "gpt-4o-mini"
+        is_reasoning = _is_reasoning_model(model)
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": kwargs_messages,
             "stream": self.stream,
         }
-        if not _is_reasoning_model(model):
+        if is_reasoning:
+            kwargs["reasoning_effort"] = self.reasoning_effort
+        else:
             kwargs["temperature"] = self.temperature
         self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
-            token_key = "max_completion_tokens" if _is_reasoning_model(model) else "max_tokens"
-            kwargs[token_key] = self.max_tokens
+            kwargs["max_completion_tokens" if is_reasoning else "max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
@@ -309,17 +312,19 @@ class OpenAIVLM(VLMBase):
             kwargs_messages = [{"role": "user", "content": content}]
 
         model = self.model or "gpt-4o-mini"
+        is_reasoning = _is_reasoning_model(model)
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": kwargs_messages,
             "stream": self.stream,
         }
-        if not _is_reasoning_model(model):
+        if is_reasoning:
+            kwargs["reasoning_effort"] = self.reasoning_effort
+        else:
             kwargs["temperature"] = self.temperature
         self._apply_provider_specific_extra_body(kwargs, thinking)
         if self.max_tokens is not None:
-            token_key = "max_completion_tokens" if _is_reasoning_model(model) else "max_tokens"
-            kwargs[token_key] = self.max_tokens
+            kwargs["max_completion_tokens" if is_reasoning else "max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"

--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -48,23 +48,17 @@ __all__ = [
 ]
 
 
-
-
 class PydanticEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, BaseModel) :
+        if isinstance(obj, BaseModel):
             # 保存类名和属性值
-            return {
-                **obj.model_dump(mode='python')
-            }
+            return {**obj.model_dump(mode="python")}
         elif is_dataclass(obj):
             return asdict(obj)
         return super().default(obj)
 
 
-
 class JsonUtils:
-
     @staticmethod
     def dumps(obj, indent=4, ensure_ascii=False):
         if obj is None:
@@ -477,5 +471,3 @@ def parse_json_with_stability(
             return model_class.model_validate(tolerant_data), None
         except Exception as e2:
             return None, f"Model validation failed even after tolerance: {e} (fallback: {e2})"
-
-

--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -344,7 +344,9 @@ def parse_value_with_tolerance(value, annotation):
         else:
             parsed_value = value
     elif origin_type is list:
-        if isinstance(value, str):
+        if value is None:
+            parsed_value = []
+        elif isinstance(value, str):
             parsed_value = [value]
         elif isinstance(value, dict):
             parsed_value = [value]

--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -11,7 +11,7 @@ Layer 5: Validation Tolerance - TypeAdapter(strict=False) + list item filtering
 """
 
 import json
-from dataclasses import is_dataclass, asdict
+from dataclasses import asdict, is_dataclass
 from types import UnionType
 from typing import (
     Any,
@@ -26,8 +26,7 @@ from typing import (
 )
 
 import json_repair
-from pydantic import TypeAdapter, BaseModel, parse_obj_as
-
+from pydantic import BaseModel, TypeAdapter
 
 from openviking_cli.utils import get_logger
 
@@ -169,7 +168,7 @@ def _get_origin_type(annotation) -> Type:
     if origin is Union or origin is UnionType:
         args = get_args(annotation)
         # Handle Optional[T] which is Union[T, None]
-        if len(args) == 2 and args[1] == type(None):
+        if len(args) == 2 and args[1] is type(None):
             return _get_origin_type(args[0])
     elif origin is list:
         return list
@@ -191,7 +190,7 @@ def _get_arg_type(annotation) -> Optional[Type]:
     origin = get_origin(annotation)
     if origin is Union or origin is UnionType:
         args = get_args(annotation)
-        if len(args) == 2 and args[1] == type(None):
+        if len(args) == 2 and args[1] is type(None):
             return _get_arg_type(args[0])
     elif origin is list:
         args = get_args(annotation)

--- a/tests/unit/test_vlm_reasoning_models.py
+++ b/tests/unit/test_vlm_reasoning_models.py
@@ -69,7 +69,7 @@ class TestReasoningModelTextKwargs:
         assert kwargs["max_completion_tokens"] == 512
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
-        assert kwargs["reasoning_effort"] == "minimal"
+        assert kwargs["reasoning_effort"] == "low"
 
     def test_o3_mini_uses_max_completion_tokens(self):
         vlm = OpenAIVLM(
@@ -84,7 +84,7 @@ class TestReasoningModelTextKwargs:
         assert kwargs["max_completion_tokens"] == 256
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
-        assert kwargs["reasoning_effort"] == "minimal"
+        assert kwargs["reasoning_effort"] == "low"
 
     def test_reasoning_effort_overridable_via_config(self):
         vlm = OpenAIVLM(
@@ -145,7 +145,7 @@ class TestReasoningModelVisionKwargs:
         assert kwargs["max_completion_tokens"] == 1024
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
-        assert kwargs["reasoning_effort"] == "minimal"
+        assert kwargs["reasoning_effort"] == "low"
 
     def test_gpt4o_vision_keeps_max_tokens_and_temperature(self):
         vlm = OpenAIVLM(

--- a/tests/unit/test_vlm_reasoning_models.py
+++ b/tests/unit/test_vlm_reasoning_models.py
@@ -69,6 +69,7 @@ class TestReasoningModelTextKwargs:
         assert kwargs["max_completion_tokens"] == 512
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
+        assert kwargs["reasoning_effort"] == "minimal"
 
     def test_o3_mini_uses_max_completion_tokens(self):
         vlm = OpenAIVLM(
@@ -83,6 +84,20 @@ class TestReasoningModelTextKwargs:
         assert kwargs["max_completion_tokens"] == 256
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
+        assert kwargs["reasoning_effort"] == "minimal"
+
+    def test_reasoning_effort_overridable_via_config(self):
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "gpt-5-mini",
+                "api_base": "https://api.openai.com/v1",
+                "max_tokens": 512,
+                "reasoning_effort": "high",
+            }
+        )
+        kwargs = vlm._build_text_kwargs(prompt="hi")
+        assert kwargs["reasoning_effort"] == "high"
 
     def test_gpt4o_mini_keeps_max_tokens_and_temperature(self):
         vlm = OpenAIVLM(
@@ -98,6 +113,7 @@ class TestReasoningModelTextKwargs:
         assert kwargs["max_tokens"] == 512
         assert "max_completion_tokens" not in kwargs
         assert kwargs["temperature"] == 0.5
+        assert "reasoning_effort" not in kwargs
 
     def test_reasoning_model_without_max_tokens_omits_both(self):
         vlm = OpenAIVLM(
@@ -129,6 +145,7 @@ class TestReasoningModelVisionKwargs:
         assert kwargs["max_completion_tokens"] == 1024
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
+        assert kwargs["reasoning_effort"] == "minimal"
 
     def test_gpt4o_vision_keeps_max_tokens_and_temperature(self):
         vlm = OpenAIVLM(

--- a/tests/unit/test_vlm_reasoning_models.py
+++ b/tests/unit/test_vlm_reasoning_models.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for reasoning-model parameter translation in the OpenAI VLM backend.
+
+OpenAI reasoning-model families (gpt-5, o1, o3, o4) reject the `max_tokens` and
+non-default `temperature` parameters. They require `max_completion_tokens` and
+only accept `temperature=1` (the server default). This module verifies that the
+OpenAI VLM backend translates parameters for reasoning models while leaving
+non-reasoning models (e.g. gpt-4o-mini) unchanged.
+"""
+
+import pytest
+
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM, _is_reasoning_model
+
+
+class TestIsReasoningModel:
+    """Pure function: reasoning-model prefix detection."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-nano-2025-08-07",
+            "GPT-5-Mini",
+            "o1",
+            "o1-preview",
+            "o1-mini",
+            "o3",
+            "o3-mini",
+            "o4-mini",
+            "o4-mini-2025-04-16",
+        ],
+    )
+    def test_reasoning_model_detected(self, model):
+        assert _is_reasoning_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "doubao-seed-2-0-pro-260215",
+            "gpt-3.5-turbo",
+            "",
+            None,
+        ],
+    )
+    def test_non_reasoning_model_not_detected(self, model):
+        assert _is_reasoning_model(model) is False
+
+
+class TestReasoningModelTextKwargs:
+    """`_build_text_kwargs` should translate params for reasoning models."""
+
+    def test_gpt5_mini_uses_max_completion_tokens(self):
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "gpt-5-mini",
+                "api_base": "https://api.openai.com/v1",
+                "max_tokens": 512,
+            }
+        )
+        kwargs = vlm._build_text_kwargs(prompt="hi")
+        assert kwargs["max_completion_tokens"] == 512
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+
+    def test_o3_mini_uses_max_completion_tokens(self):
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "o3-mini",
+                "api_base": "https://api.openai.com/v1",
+                "max_tokens": 256,
+            }
+        )
+        kwargs = vlm._build_text_kwargs(prompt="hi")
+        assert kwargs["max_completion_tokens"] == 256
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+
+    def test_gpt4o_mini_keeps_max_tokens_and_temperature(self):
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "gpt-4o-mini",
+                "api_base": "https://api.openai.com/v1",
+                "max_tokens": 512,
+                "temperature": 0.5,
+            }
+        )
+        kwargs = vlm._build_text_kwargs(prompt="hi")
+        assert kwargs["max_tokens"] == 512
+        assert "max_completion_tokens" not in kwargs
+        assert kwargs["temperature"] == 0.5
+
+    def test_reasoning_model_without_max_tokens_omits_both(self):
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "gpt-5",
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+        kwargs = vlm._build_text_kwargs(prompt="hi")
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+        assert "temperature" not in kwargs
+
+
+class TestReasoningModelVisionKwargs:
+    """`_build_vision_kwargs` should apply the same translation."""
+
+    def test_gpt5_mini_vision_uses_max_completion_tokens(self):
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "gpt-5-mini",
+                "api_base": "https://api.openai.com/v1",
+                "max_tokens": 1024,
+            }
+        )
+        kwargs = vlm._build_vision_kwargs(prompt="describe this")
+        assert kwargs["max_completion_tokens"] == 1024
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+
+    def test_gpt4o_vision_keeps_max_tokens_and_temperature(self):
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "model": "gpt-4o",
+                "api_base": "https://api.openai.com/v1",
+                "max_tokens": 1024,
+                "temperature": 0.2,
+            }
+        )
+        kwargs = vlm._build_vision_kwargs(prompt="describe this")
+        assert kwargs["max_tokens"] == 1024
+        assert "max_completion_tokens" not in kwargs
+        assert kwargs["temperature"] == 0.2


### PR DESCRIPTION
## Description

OpenAI reasoning models (`gpt-5`, `gpt-5.4`, `o1`, `o3`, `o4`) reject `max_tokens` and non-default `temperature`, and consume `max_completion_tokens` as reasoning tokens when `reasoning_effort` is unset. The raw `OpenAIVLM` backend sends both unconditionally, so `provider: "openai"` + any reasoning model fails with:

```
Error code: 400 - {"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","type":"invalid_request_error","code":"unsupported_parameter"}}
```

The sibling `LiteLLMVLMProvider` already works around this via `litellm.drop_params=True` (`backends/litellm_vlm.py:115`). This PR brings the raw backend to parity.

## Related Issue

Complements #983 and #1514 (Qwen/GLM `enable_thinking`). No overlap — different vendors, different params.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `backends/openai_vlm.py`: prefix-match `gpt-5|o1|o3|o4`; for matches, send `max_completion_tokens` + `reasoning_effort` (default `low`, overridable via `vlm.reasoning_effort`) and omit `temperature`. Non-reasoning models unchanged.
- `session/memory/utils/json_parser.py`: coerce `None → []` for list-typed fields in `parse_value_with_tolerance` (reasoning models sometimes emit `null` for empty arrays).

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```
PYTHONPATH=. pytest -o addopts='' -q --noconftest \
  tests/unit/test_vlm_reasoning_models.py tests/unit/test_extra_headers_vlm.py
# 41 passed
```

Live smoke on `gpt-5-mini`: extraction produces well-formed JSON memory operations (`reasoning_tokens=0`, `finish_reason=stop`).

## Checklist

- [x] My code follows the project's coding style (ruff clean).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation — not needed; transparent to non-reasoning-model users.
- [x] My changes generate no new warnings.

## Additional Notes

`gpt-5.4-nano` + tools is out of scope — OpenAI routes that combination to `/v1/responses` instead of `/v1/chat/completions`.
