### PR TITLE
fix(vlm): strip cache_control for Gemini + tools to avoid LiteLLM CachedContent 400

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -15,11 +15,8 @@ os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 import litellm
 from litellm import acompletion, completion
 
-
 from openviking.telemetry import tracer
-
 from openviking.utils.model_retry import retry_async, retry_sync
-
 
 from ..base import ToolCall, VLMBase, VLMResponse
 

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -234,6 +234,20 @@ class LiteLLMVLMProvider(VLMBase):
             extra["enable_thinking"] = thinking
             kwargs["extra_body"] = extra
 
+        # Workaround for LiteLLM bug where Gemini context-caching path emits
+        # both `cachedContent` and `toolConfig`, which Gemini rejects with a
+        # 400 "CachedContent can not be used with GenerateContent request
+        # setting system_instruction, tools or tool_config".
+        # See BerriAI/litellm#17304 and PR #25659. Remove when LiteLLM ships
+        # the fix.
+        if provider == "gemini" and tools:
+            kwargs["messages"] = [
+                {k: v for k, v in msg.items() if k != "cache_control"}
+                if isinstance(msg, dict)
+                else msg
+                for msg in messages
+            ]
+
         return kwargs
 
     def _parse_tool_calls(self, message) -> List[ToolCall]:

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -336,7 +336,7 @@ class LiteLLMVLMProvider(VLMBase):
             response = completion(**kwargs)
             elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))
@@ -367,7 +367,7 @@ class LiteLLMVLMProvider(VLMBase):
             response = await acompletion(**kwargs)
             elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))

--- a/tests/unit/test_litellm_vlm_gemini_cache.py
+++ b/tests/unit/test_litellm_vlm_gemini_cache.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for Gemini cache_control stripping workaround.
+
+LiteLLM has an open bug (BerriAI/litellm#17304, PR #25659) where the Gemini
+context-caching path leaves `tool_choice` in optional_params while also
+setting `cachedContent`. Gemini then rejects the combination with:
+
+    "CachedContent can not be used with GenerateContent request setting
+    system_instruction, tools or tool_config."
+
+OpenViking's memory-extraction ReAct loop adds `cache_control: ephemeral`
+markers and passes `tool_choice="auto"`, so every Gemini call with tools
+hits this 400. The LiteLLM VLM backend works around it by stripping
+`cache_control` markers from messages when the resolved provider is
+`gemini`.
+"""
+
+from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
+
+
+def _vlm(model: str) -> LiteLLMVLMProvider:
+    return LiteLLMVLMProvider({"api_key": "fake", "model": model, "max_tokens": 256})
+
+
+class TestGeminiCacheControlStripping:
+    def test_cache_control_stripped_for_gemini_with_tools(self):
+        vlm = _vlm("gemini-3.1-flash-lite-preview")
+        messages = [{"role": "user", "content": "hi", "cache_control": {"type": "ephemeral"}}]
+        tools = [{"type": "function", "function": {"name": "read", "parameters": {}}}]
+        kwargs = vlm._build_kwargs(
+            model="gemini/gemini-3.1-flash-lite-preview",
+            messages=messages,
+            tools=tools,
+        )
+        assert all("cache_control" not in m for m in kwargs["messages"])
+        assert kwargs["messages"][0]["content"] == "hi"
+        assert kwargs["tools"] == tools
+
+    def test_cache_control_preserved_for_gemini_without_tools(self):
+        vlm = _vlm("gemini-3.1-flash-lite-preview")
+        messages = [{"role": "user", "content": "hi", "cache_control": {"type": "ephemeral"}}]
+        kwargs = vlm._build_kwargs(
+            model="gemini/gemini-3.1-flash-lite-preview",
+            messages=messages,
+        )
+        assert kwargs["messages"][0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_cache_control_preserved_for_anthropic(self):
+        vlm = _vlm("claude-haiku-4-5")
+        messages = [{"role": "user", "content": "hi", "cache_control": {"type": "ephemeral"}}]
+        tools = [{"type": "function", "function": {"name": "read", "parameters": {}}}]
+        kwargs = vlm._build_kwargs(
+            model="anthropic/claude-haiku-4-5",
+            messages=messages,
+            tools=tools,
+        )
+        assert kwargs["messages"][0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_non_dict_messages_left_intact(self):
+        vlm = _vlm("gemini-3.1-flash-lite-preview")
+        sentinel = object()
+        messages = [sentinel]
+        tools = [{"type": "function", "function": {"name": "read", "parameters": {}}}]
+        kwargs = vlm._build_kwargs(
+            model="gemini/gemini-3.1-flash-lite-preview",
+            messages=messages,
+            tools=tools,
+        )
+        assert kwargs["messages"] == [sentinel]


### PR DESCRIPTION
## Description

When memory extraction runs against a Gemini model, every call with tools fails with:

```
litellm.BadRequestError: GeminiException BadRequestError - {
  "error": {
    "code": 400,
    "message": "CachedContent can not be used with GenerateContent request setting system_instruction, tools or tool_config.\n\nProposed fix: move those values to CachedContent from GenerateContent request.",
    "status": "INVALID_ARGUMENT"
  }
}
```

Root cause is upstream in LiteLLM: `vertex_ai/context_caching/vertex_ai_context_caching.py:check_and_create_cache` pops `tools` from `optional_params` but forgets `tool_choice`. `tool_choice` then gets emitted as `toolConfig` alongside `cachedContent`, and Gemini rejects the combination. See BerriAI/litellm#17304 and PR #25659 (open, unmerged).

OpenViking triggers it because `session/memory/extract_loop.py:_mark_cache_breakpoint` marks the last message with `cache_control: ephemeral` and `litellm_vlm.py:_build_kwargs` passes `tool_choice="auto"`. Both are correct on their own — together they hit the LiteLLM bug. Not Gemini-3 specific; any Gemini model crossing the 1024-token cache threshold with tools is affected.

## Related Issue

BerriAI/litellm#17304 (root cause), BerriAI/litellm#25659 (upstream fix, open).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `backends/litellm_vlm.py`: in `_build_kwargs`, when the resolved provider is `gemini` and tools are present, strip `cache_control` from message dicts before handing off to LiteLLM. Non-Gemini providers are unaffected; Gemini-without-tools is unaffected. Remove this guard when LiteLLM ships the fix.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```
PYTHONPATH=. pytest -o addopts='' -q --noconftest \
  tests/unit/test_litellm_vlm_gemini_cache.py
# 4 passed
```

Live smoke on `gemini-3.1-flash-lite-preview`: memory extraction succeeds end-to-end, returns well-formed structured JSON (verified against a real session). Before this patch, every extraction call returned 400.

## Checklist

- [x] My code follows the project's coding style (ruff clean).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation — not needed; transparent to non-Gemini users and to Gemini users once LiteLLM ships the upstream fix.
- [x] My changes generate no new warnings.

## Additional Notes

Trade-off: Gemini extraction calls do not benefit from LiteLLM prompt caching while this guard is active. Given extraction calls are stateless and ~5 per session, the lost caching is worth the working path.
