### PR TITLE
docs(feishu): document threadRequireMention + botName post #1534

### DIFF
--- a/bot/docs/CHANNEL.md
+++ b/bot/docs/CHANNEL.md
@@ -213,9 +213,11 @@ vikingbot gateway
       "enabled": true,
       "appId": "cli_xxx",
       "appSecret": "xxx",
+      "botName": "",
       "encryptKey": "",
       "verificationToken": "",
-      "allowFrom": []
+      "allowFrom": [],
+      "threadRequireMention": true
     }
   ]
 }
@@ -223,6 +225,8 @@ vikingbot gateway
 
 > 长连接模式下，`encryptKey` 和 `verificationToken` 是可选的。
 > `allowFrom`：留空以允许所有用户，或添加 `["ou_xxx"]` 以限制访问。
+> `botName`：用于在传给模型的群聊上下文中把 `@<open_id>` 提及替换为机器人名称，以及标注机器人自身发出的消息；留空则回退为 `"Bot"`。
+> `threadRequireMention`：群聊是否需要 `@` 机器人才响应。默认 `true` —— 普通群和话题群的所有消息都需要 `@`；设为 `false` 时，普通群无需 `@`，话题群仅首条消息无需 `@`，非 `DEBUG` 模式下后续回复仍需 `@`。
 
 **3. 运行**
 

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -124,7 +124,7 @@ class FeishuChannelConfig(BaseChannelConfig):
     allow_cmd_from: list[str] = Field(default_factory=list)  ## 允许执行命令的Feishu用户ID列表
     thread_require_mention: bool = Field(
         default=True,
-        description="话题群模式下是否需要@才响应：默认True=所有消息必须@才响应；False=新话题首条消息无需@，后续回复必须@",
+        description="群聊是否需要@才响应：默认True=普通群和话题群的所有消息都必须@才响应；False=普通群无需@，话题群仅首条消息无需@，非DEBUG模式下后续回复必须@",
     )
 
     def channel_id(self) -> str:


### PR DESCRIPTION
## 动机

`#1534 (feat(bot): enhance Feishu mentions and name display)` 2026-04-17 merge 后:

1. `thread_require_mention` 开关的语义**从"只作用于话题群"扩展为"同时作用于普通群和话题群"** — `bot/vikingbot/channels/feishu.py` `_check_should_process` 的控制流明确注释 "普通群和话题群都根据 thread_require_mention 判断"；但 `bot/docs/CHANNEL.md` 的飞书配置示例不含此字段，`bot/vikingbot/config/schema.py` 中该 Field 的 `description` 仍写 "话题群模式下…"，会误导用户以为普通群行为不变。
2. `bot_name` 配置项在 #1534 新增被 `_get_bot_name` 用作群聊上下文中机器人自身名称（空字符串回退为 `"Bot"`），`CHANNEL.md` 从未提及。

## 改动

两处纯文档/字段描述补齐，无行为改动:

- `bot/docs/CHANNEL.md` — 飞书 `<details>` 段的配置示例新增 `botName` / `threadRequireMention` 两项，并在示例下方补两行说明（`threadRequireMention` 的说明包含 DEBUG 模式例外分支以避免误导）。
- `bot/vikingbot/config/schema.py` — `thread_require_mention` Field 的 `description` 改为反映 post-#1534 的真实行为（"普通群和话题群 … 非 DEBUG 模式下后续回复必须@"）。

遵循 `loader.py` `camel_to_snake` 约定，JSON 侧用 camelCase。

## 测试

纯文档/描述字符串，无需新增测试。

## 相关

- 行为变更来源: #1534
- 之前相关 v0.3.9 docs-drift PR: #1567 (`tools.mcp_servers`), #1571 (`ov_tools_enable`)