### PR TITLE
fix(cli): ov chat auth from config with required headers

### DIFF
--- a/crates/ov_cli/src/commands/chat.rs
+++ b/crates/ov_cli/src/commands/chat.rs
@@ -15,6 +15,7 @@ use rustyline::error::ReadlineError;
 use serde::{Deserialize, Serialize};
 use termimad::MadSkin;
 
+use crate::config::Config;
 use crate::utils;
 
 use crate::error::{Error, Result};
@@ -32,6 +33,14 @@ pub struct ChatCommand {
     /// API key for authentication
     #[arg(short, long, env = "VIKINGBOT_API_KEY")]
     pub api_key: Option<String>,
+
+    /// Account identifier to send as X-OpenViking-Account
+    #[arg(long)]
+    pub account: Option<String>,
+
+    /// User identifier to send as X-OpenViking-User
+    #[arg(long)]
+    pub user: Option<String>,
 
     /// Session ID to use (creates new if not provided)
     #[arg(short, long)]
@@ -95,9 +104,16 @@ struct ChatStreamEvent {
     timestamp: Option<String>,
 }
 
+struct ChatAuth {
+    api_key: Option<String>,
+    account: Option<String>,
+    user: Option<String>,
+}
+
 impl ChatCommand {
     /// Execute the chat command
     pub async fn execute(&self) -> Result<()> {
+        let auth = self.resolve_auth()?;
         let client = Client::builder()
             .timeout(Duration::from_secs(300))
             .build()
@@ -105,24 +121,55 @@ impl ChatCommand {
 
         if let Some(message) = &self.message {
             // Single message mode
-            self.send_message(&client, message).await
+            self.send_message(&client, message, &auth).await
         } else {
             // Interactive mode
-            self.run_interactive(&client).await
+            self.run_interactive(&client, &auth).await
         }
     }
 
+    fn resolve_auth(&self) -> Result<ChatAuth> {
+        let config = Config::load()?;
+        Ok(ChatAuth {
+            api_key: self.api_key.clone().or(config.api_key),
+            account: self.account.clone().or(config.account),
+            user: self.user.clone().or(config.user),
+        })
+    }
+
+    fn apply_auth_headers(
+        &self,
+        mut req_builder: reqwest::RequestBuilder,
+        auth: &ChatAuth,
+    ) -> reqwest::RequestBuilder {
+        if let Some(api_key) = &auth.api_key {
+            req_builder = req_builder.header("X-API-Key", api_key);
+        }
+        if let Some(account) = &auth.account {
+            req_builder = req_builder.header("X-OpenViking-Account", account);
+        }
+        if let Some(user) = &auth.user {
+            req_builder = req_builder.header("X-OpenViking-User", user);
+        }
+        req_builder
+    }
+
     /// Send a single message and get response
-    async fn send_message(&self, client: &Client, message: &str) -> Result<()> {
+    async fn send_message(&self, client: &Client, message: &str, auth: &ChatAuth) -> Result<()> {
         if self.stream {
-            self.send_message_stream(client, message).await
+            self.send_message_stream(client, message, auth).await
         } else {
-            self.send_message_non_stream(client, message).await
+            self.send_message_non_stream(client, message, auth).await
         }
     }
 
     /// Send a single message with non-streaming response
-    async fn send_message_non_stream(&self, client: &Client, message: &str) -> Result<()> {
+    async fn send_message_non_stream(
+        &self,
+        client: &Client,
+        message: &str,
+        auth: &ChatAuth,
+    ) -> Result<()> {
         let url = format!("{}/chat", self.endpoint);
 
         let request = ChatRequest {
@@ -133,11 +180,7 @@ impl ChatCommand {
             context: None,
         };
 
-        let mut req_builder = client.post(&url).json(&request);
-
-        if let Some(api_key) = &self.api_key {
-            req_builder = req_builder.header("X-API-Key", api_key);
-        }
+        let req_builder = self.apply_auth_headers(client.post(&url).json(&request), auth);
 
         let response = req_builder
             .send()
@@ -165,7 +208,12 @@ impl ChatCommand {
     }
 
     /// Send a single message with streaming response
-    async fn send_message_stream(&self, client: &Client, message: &str) -> Result<()> {
+    async fn send_message_stream(
+        &self,
+        client: &Client,
+        message: &str,
+        auth: &ChatAuth,
+    ) -> Result<()> {
         let url = format!("{}/chat/stream", self.endpoint);
 
         let request = ChatRequest {
@@ -176,11 +224,7 @@ impl ChatCommand {
             context: None,
         };
 
-        let mut req_builder = client.post(&url).json(&request);
-
-        if let Some(api_key) = &self.api_key {
-            req_builder = req_builder.header("X-API-Key", api_key);
-        }
+        let req_builder = self.apply_auth_headers(client.post(&url).json(&request), auth);
 
         let response = req_builder
             .send()
@@ -246,7 +290,7 @@ impl ChatCommand {
     }
 
     /// Run interactive chat mode with rustyline
-    async fn run_interactive(&self, client: &Client) -> Result<()> {
+    async fn run_interactive(&self, client: &Client, auth: &ChatAuth) -> Result<()> {
         println!("Vikingbot Chat - Interactive Mode");
         println!("Endpoint: {}", self.endpoint);
         if let Some(session) = &self.session {
@@ -296,7 +340,7 @@ impl ChatCommand {
 
                     // Send message
                     match self
-                        .send_interactive_message(client, input, &mut session_id)
+                        .send_interactive_message(client, input, &mut session_id, auth)
                         .await
                     {
                         Ok(_) => {}
@@ -336,12 +380,13 @@ impl ChatCommand {
         client: &Client,
         input: &str,
         session_id: &mut Option<String>,
+        auth: &ChatAuth,
     ) -> Result<()> {
         if self.stream {
-            self.send_interactive_message_stream(client, input, session_id)
+            self.send_interactive_message_stream(client, input, session_id, auth)
                 .await
         } else {
-            self.send_interactive_message_non_stream(client, input, session_id)
+            self.send_interactive_message_non_stream(client, input, session_id, auth)
                 .await
         }
     }
@@ -352,6 +397,7 @@ impl ChatCommand {
         client: &Client,
         input: &str,
         session_id: &mut Option<String>,
+        auth: &ChatAuth,
     ) -> Result<()> {
         let url = format!("{}/chat", self.endpoint);
 
@@ -363,11 +409,7 @@ impl ChatCommand {
             context: None,
         };
 
-        let mut req_builder = client.post(&url).json(&request);
-
-        if let Some(api_key) = &self.api_key {
-            req_builder = req_builder.header("X-API-Key", api_key);
-        }
+        let req_builder = self.apply_auth_headers(client.post(&url).json(&request), auth);
 
         let response = req_builder
             .send()
@@ -407,6 +449,7 @@ impl ChatCommand {
         client: &Client,
         input: &str,
         session_id: &mut Option<String>,
+        auth: &ChatAuth,
     ) -> Result<()> {
         let url = format!("{}/chat/stream", self.endpoint);
 
@@ -418,11 +461,7 @@ impl ChatCommand {
             context: None,
         };
 
-        let mut req_builder = client.post(&url).json(&request);
-
-        if let Some(api_key) = &self.api_key {
-            req_builder = req_builder.header("X-API-Key", api_key);
-        }
+        let req_builder = self.apply_auth_headers(client.post(&url).json(&request), auth);
 
         let response = req_builder
             .send()
@@ -641,6 +680,8 @@ impl ChatCommand {
         Self {
             endpoint,
             api_key,
+            account: None,
+            user: None,
             session,
             sender,
             message,

--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -27,7 +27,9 @@ pub struct Config {
     #[serde(default = "default_url")]
     pub url: String,
     pub api_key: Option<String>,
+    #[serde(alias = "account_id")]
     pub account: Option<String>,
+    #[serde(alias = "user_id")]
     pub user: Option<String>,
     pub agent_id: Option<String>,
     #[serde(default = "default_timeout")]
@@ -180,6 +182,21 @@ mod tests {
         assert!(config.upload.ignore_dirs.is_none());
         assert!(config.upload.include.is_none());
         assert!(config.upload.exclude.is_none());
+    }
+
+    #[test]
+    fn config_deserializes_account_id_and_user_id_aliases() {
+        let config: Config = serde_json::from_str(
+            r#"{
+                "url": "http://localhost:1933",
+                "account_id": "acme",
+                "user_id": "alice"
+            }"#,
+        )
+        .expect("config should deserialize aliases");
+
+        assert_eq!(config.account.as_deref(), Some("acme"));
+        assert_eq!(config.user.as_deref(), Some("alice"));
     }
 
     #[test]

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -801,6 +801,8 @@ async fn main() {
             let cmd = commands::chat::ChatCommand {
                 endpoint,
                 api_key,
+                account: ctx.config.account.clone(),
+                user: ctx.config.user.clone(),
                 session: session_id,
                 sender,
                 message,


### PR DESCRIPTION
## Summary

Fixes #1574

This PR fixes `ov chat` command failing with 401 Unauthorized even when valid credentials are configured in `ovcli.conf`.

## Problem

`ov chat` was not reading `api_key`, `account`, and `user` from the configuration file, and was not sending the required `X-OpenViking-Account` and `X-OpenViking-User` headers for API_KEY auth mode.

## Changes

### 1. `crates/ov_cli/src/commands/chat.rs`

- Added `account` and `user` CLI arguments to `ChatCommand`
- Added `ChatAuth` struct to hold resolved authentication info
- Added `resolve_auth()` method to load auth from Config when not provided via CLI
- Added `apply_auth_headers()` helper to send all required headers
- Updated all `send_message*` methods to use the new auth flow

### 2. `crates/ov_cli/src/config.rs`

- Added `#[serde(alias = "account_id")]` on `account` field
- Added `#[serde(alias = "user_id")]` on `user` field
- Added test for deserializing `account_id`/`user_id` aliases

### 3. `crates/ov_cli/src/main.rs`

- Pass `account` and `user` from `ctx.config` to `ChatCommand` construction

## Testing

Before:
```bash
$ ov chat -m "hello"
Error: API error: Request failed (401 Unauthorized): Missing API Key...
```

After:
```bash
$ ov chat -m "hello"
Bot:
Hello! I'm VikingBot, an AI assistant built on the OpenViking...
```

## Checklist

- [x] Code compiles (`cargo build --release -p ov_cli`)
- [x] Fix verified by testing `ov chat` command
- [x] Backward compatible (CLI args override config values)
- [x] Supports both `account`/`user` and `account_id`/`user_id` field names

---

**AI Assistant Note:** This fix was identified through code analysis by Hermes Agent with Codex tooling. See #1574 for full investigation details.
