### PR TITLE
fix: return None for all-empty rerank batches (PR #1345 follow-up)

### DIFF
--- a/openviking/models/rerank/openai_rerank.py
+++ b/openviking/models/rerank/openai_rerank.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+OpenAI-compatible Rerank API Client.
+
+Supports third-party rerank services like Alibaba Cloud DashScope (qwen3-rerank)
+via api_key + api_base configuration.
+"""
+
+# For logging, use Python's built-in logging
+import logging
+from typing import Dict, List, Optional
+
+import requests
+
+from openviking.models.rerank.base import RerankBase
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIRerankClient(RerankBase):
+    """
+    OpenAI-compatible rerank API client using Bearer token auth.
+
+    Compatible with services like Alibaba Cloud DashScope.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        api_base: str,
+        model_name: str,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Initialize OpenAI-compatible rerank client.
+
+        Args:
+            api_key: Bearer token for authentication
+            api_base: Full endpoint URL for the rerank API
+            model_name: Model name to use for reranking
+            extra_headers: Optional extra headers for API requests
+        """
+        super().__init__()
+        self.api_key = api_key
+        self.api_base = api_base
+        self.model_name = model_name
+        self.extra_headers = extra_headers or {}
+        self.provider = "openai"
+
+    def rerank_batch(self, query: str, documents: List[str]) -> Optional[List[float]]:
+        """
+        Batch rerank documents against a query.
+
+        Args:
+            query: Query text
+            documents: List of document texts to rank
+
+        Returns:
+            List of rerank scores for each document (same order as input),
+            or None when rerank fails and the caller should fall back
+        """
+        if not documents:
+            return []
+
+        # Filter out empty documents — rerank providers (e.g. DashScope) reject
+        # empty strings with HTTP 400.
+        valid_indices = [i for i, d in enumerate(documents) if d and d.strip()]
+        if not valid_indices:
+            # All documents are empty — signal caller to fall back to vector scores.
+            return None
+
+        if len(valid_indices) < len(documents):
+            filtered_docs = [documents[i] for i in valid_indices]
+            logger.debug(
+                "[OpenAIRerankClient] Filtered %d empty documents from %d total",
+                len(documents) - len(valid_indices),
+                len(documents),
+            )
+        else:
+            filtered_docs = documents
+
+        req_body = {
+            "model": self.model_name,
+            "query": query,
+            "documents": filtered_docs,
+        }
+
+        try:
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            }
+            if self.extra_headers:
+                headers.update(self.extra_headers)
+
+            response = requests.post(
+                url=self.api_base,
+                headers=headers,
+                json=req_body,
+                timeout=30,
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            # Update token usage tracking (estimate, OpenAI rerank doesn't provide token info)
+            self._extract_and_update_token_usage(result, query, filtered_docs)
+
+            # Standard OpenAI/Cohere rerank format: results[].{index, relevance_score}
+            results = result.get("results")
+            if not results:
+                logger.warning(f"[OpenAIRerankClient] Unexpected response format: {result}")
+                return None
+
+            if len(results) != len(filtered_docs):
+                logger.warning(
+                    "[OpenAIRerankClient] Unexpected rerank result length: expected=%s actual=%s",
+                    len(filtered_docs),
+                    len(results),
+                )
+                return None
+
+            # Map scores back to original document indices.
+            # Empty documents get a score of 0.0.
+            filtered_scores = [0.0] * len(filtered_docs)
+            for item in results:
+                idx = item.get("index")
+                if idx is None or not (0 <= idx < len(filtered_docs)):
+                    logger.warning(
+                        "[OpenAIRerankClient] Out-of-bounds or missing index in result: %s", item
+                    )
+                    return None
+                filtered_scores[idx] = item.get("relevance_score", 0.0)
+
+            scores = [0.0] * len(documents)
+            for fi, oi in enumerate(valid_indices):
+                scores[oi] = filtered_scores[fi]
+
+            logger.debug(
+                "[OpenAIRerankClient] Reranked %d documents (%d non-empty)",
+                len(documents),
+                len(valid_indices),
+            )
+            return scores
+
+        except Exception as e:
+            logger.error(f"[OpenAIRerankClient] Rerank failed: {e}")
+            return None
+
+    @classmethod
+    def from_config(cls, config) -> Optional["OpenAIRerankClient"]:
+        """
+        Create OpenAIRerankClient from RerankConfig.
+
+        Args:
+            config: RerankConfig instance with provider='openai'
+
+        Returns:
+            OpenAIRerankClient instance or None if config is not available
+        """
+        if not config or not config.is_available():
+            return None
+        return cls(
+            api_key=config.api_key,
+            api_base=config.api_base,
+            model_name=config.model or "qwen3-rerank",
+            extra_headers=config.extra_headers,
+        )

--- a/tests/unit/test_openai_rerank.py
+++ b/tests/unit/test_openai_rerank.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for OpenAI-compatible rerank client (DashScope, etc.)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from openviking.models.rerank import OpenAIRerankClient
+
+
+class TestOpenAIRerankClient:
+    """Test cases for OpenAIRerankClient."""
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_basic(self, mock_post):
+        """Basic rerank returns scores in original order."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.3},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        scores = client.rerank_batch("What is UCW?", ["doc A", "doc B"])
+
+        assert scores == [0.9, 0.3]
+        payload = mock_post.call_args[1]["json"]
+        assert payload["model"] == "qwen3-rerank"
+        assert payload["query"] == "What is UCW?"
+        assert payload["documents"] == ["doc A", "doc B"]
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_empty_input_returns_empty_list(self, mock_post):
+        """Empty document list returns empty list (not None)."""
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        assert client.rerank_batch("query", []) == []
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_all_empty_returns_none(self, mock_post):
+        """All-empty documents signal caller to fall back (return None).
+
+        This is the key correctness fix: when every document is empty/whitespace,
+        we must return None (not [0.0, 0.0, ...]) so the retriever's fallback
+        to vector scores is triggered.
+        """
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        result = client.rerank_batch("query", ["", "", ""])
+        assert result is None
+        mock_post.assert_not_called()  # No HTTP call should be made
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_all_whitespace_returns_none(self, mock_post):
+        """All-whitespace documents also signal fallback (return None)."""
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        result = client.rerank_batch("query", ["  ", "\t", "\n"])
+        assert result is None
+        mock_post.assert_not_called()
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_mixed_empty_and_non_empty(self, mock_post):
+        """Mixed empty/non-empty documents: filter empty, rerank non-empty.
+
+        Empty documents get score 0.0 in the returned list; non-empty
+        documents get actual rerank scores.
+        """
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"index": 0, "relevance_score": 0.75},  # "real doc" at original index 1
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        scores = client.rerank_batch("query", ["", "real doc", "  "])
+
+        assert scores == [0.0, 0.75, 0.0]
+        # Only the non-empty doc should be sent to the API
+        payload = mock_post.call_args[1]["json"]
+        assert payload["documents"] == ["real doc"]
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_filters_empty_debug_log(self, mock_post, caplog):
+        """Filtering empty documents should log the count."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"results": [{"index": 0, "relevance_score": 0.5}]}
+        mock_post.return_value = mock_response
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        with caplog.at_level("DEBUG"):
+            client.rerank_batch("q", ["", "doc", "  "])
+
+        assert "Filtered 2 empty documents from 3 total" in caplog.text
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_api_error_returns_none(self, mock_post):
+        """API error returns None so caller can fall back."""
+        mock_post.side_effect = requests.exceptions.Timeout("connection timeout")
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        result = client.rerank_batch("query", ["doc"])
+        assert result is None
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_http_400_returns_none(self, mock_post):
+        """HTTP 400 (e.g., DashScope rejecting empty docs without filter) returns None."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Bad Request")
+        mock_post.return_value = mock_response
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        result = client.rerank_batch("query", ["doc"])
+        assert result is None
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_batch_unexpected_result_length_returns_none(self, mock_post):
+        """Mismatched result length signals failure (return None)."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "results": [{"index": 0, "relevance_score": 0.5}]  # only 1 result for 2 docs
+        }
+        mock_post.return_value = mock_response
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        result = client.rerank_batch("query", ["doc1", "doc2"])
+        assert result is None
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_rerank_preserves_original_order(self, mock_post):
+        """Rerank results are mapped back to original document order."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        # API returns out of order
+        mock_response.json.return_value = {
+            "results": [
+                {"index": 2, "relevance_score": 0.99},
+                {"index": 0, "relevance_score": 0.50},
+                {"index": 1, "relevance_score": 0.01},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+        )
+        scores = client.rerank_batch("q", ["first", "second", "third"])
+
+        assert scores[0] == 0.50  # "first" was index 0
+        assert scores[1] == 0.01  # "second" was index 1
+        assert scores[2] == 0.99  # "third" was index 2
+
+    @patch("openviking.models.rerank.openai_rerank.requests.post")
+    def test_extra_headers_passed_to_request(self, mock_post):
+        """Extra headers from config are included in the request."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"results": [{"index": 0, "relevance_score": 0.5}]}
+        mock_post.return_value = mock_response
+
+        client = OpenAIRerankClient(
+            api_key="test-key",
+            api_base="https://dashscope.aliyuncs.com/api/v1/rerank",
+            model_name="qwen3-rerank",
+            extra_headers={"X-Custom-Header": "custom-value"},
+        )
+        client.rerank_batch("q", ["doc"])
+
+        headers = mock_post.call_args[1]["headers"]
+        assert headers["X-Custom-Header"] == "custom-value"
+        assert headers["Authorization"] == "Bearer test-key"


### PR DESCRIPTION
## Summary

Fix the blocking correctness issue raised by qin-ctx in PR #1345.

### Problem
When all documents in a batch are empty/whitespace,  returned . This caused the retriever to skip its fallback to vector scores because it interpreted the all-zero list as a successful rerank result.

### Fix
Return  when  is empty, signaling the caller to fall back to vector scores.

### Changes
- : Return  instead of  for all-empty batches
- : Regression tests covering:
  - All-empty documents return 
  - All-whitespace documents return 
  - Mixed empty/non-empty documents are filtered correctly
  - API error / HTTP 400 / unexpected result length all return 
  - Basic rerank functionality preserved

### Related
- Original PR: #1345
- Review comment: qin-ctx (CHANGES_REQUESTED)
