### PR TITLE
fix(vlm): apply max_concurrent cap to all async VLM calls

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -15,11 +15,8 @@ os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 import litellm
 from litellm import acompletion, completion
 
-
 from openviking.telemetry import tracer
-
 from openviking.utils.model_retry import retry_async, retry_sync
-
 
 from ..base import ToolCall, VLMBase, VLMResponse
 
@@ -322,7 +319,7 @@ class LiteLLMVLMProvider(VLMBase):
             response = completion(**kwargs)
             elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))
@@ -354,7 +351,7 @@ class LiteLLMVLMProvider(VLMBase):
                 response = await acompletion(**kwargs)
                 elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -349,9 +349,10 @@ class LiteLLMVLMProvider(VLMBase):
         tracer.info(f"request: {json.dumps(kwargs, ensure_ascii=False, indent=2)}")
 
         async def _call() -> Union[str, VLMResponse]:
-            t0 = time.perf_counter()
-            response = await acompletion(**kwargs)
-            elapsed = time.perf_counter() - t0
+            async with self._acquire_call_slot():
+                t0 = time.perf_counter()
+                response = await acompletion(**kwargs)
+                elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
             tracer.info(f'response={response}')
             if tools:
@@ -404,9 +405,10 @@ class LiteLLMVLMProvider(VLMBase):
         kwargs = self._build_vision_kwargs(prompt, images, thinking, tools, None, messages)
 
         async def _call() -> Union[str, VLMResponse]:
-            t0 = time.perf_counter()
-            response = await acompletion(**kwargs)
-            elapsed = time.perf_counter() - t0
+            async with self._acquire_call_slot():
+                t0 = time.perf_counter()
+                response = await acompletion(**kwargs)
+                elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
             if tools:
                 return self._build_vlm_response(response, has_tools=True)

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-
 from openviking.telemetry import tracer
 
 try:

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -364,9 +364,10 @@ class OpenAIVLM(VLMBase):
         kwargs = self._build_text_kwargs(prompt, tools, tool_choice, messages, thinking)
 
         async def _call() -> Union[str, VLMResponse]:
-            t0 = time.perf_counter()
-            response = await client.chat.completions.create(**kwargs)
-            elapsed = time.perf_counter() - t0
+            async with self._acquire_call_slot():
+                t0 = time.perf_counter()
+                response = await client.chat.completions.create(**kwargs)
+                elapsed = time.perf_counter() - t0
             if tools:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
@@ -474,9 +475,10 @@ class OpenAIVLM(VLMBase):
         kwargs = self._build_vision_kwargs(prompt, images, tools, None, messages, thinking)
 
         async def _call() -> Union[str, VLMResponse]:
-            t0 = time.perf_counter()
-            response = await client.chat.completions.create(**kwargs)
-            elapsed = time.perf_counter() - t0
+            async with self._acquire_call_slot():
+                t0 = time.perf_counter()
+                response = await client.chat.completions.create(**kwargs)
+                elapsed = time.perf_counter() - t0
             if tools:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.telemetry import tracer
+
 from ..base import ToolCall, VLMResponse
 from .openai_vlm import OpenAIVLM
 

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -161,9 +161,10 @@ class VolcEngineVLM(OpenAIVLM):
         last_error = None
         for attempt in range(self.max_retries + 1):
             try:
-                t0 = time.perf_counter()
-                response = await client.chat.completions.create(**kwargs)
-                elapsed = time.perf_counter() - t0
+                async with self._acquire_call_slot():
+                    t0 = time.perf_counter()
+                    response = await client.chat.completions.create(**kwargs)
+                    elapsed = time.perf_counter() - t0
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 result = self._build_vlm_response(response, has_tools=bool(tools))
                 if tools:
@@ -366,9 +367,10 @@ class VolcEngineVLM(OpenAIVLM):
             kwargs["tool_choice"] = "auto"
 
         client = self.get_async_client()
-        t0 = time.perf_counter()
-        response = await client.chat.completions.create(**kwargs)
-        elapsed = time.perf_counter() - t0
+        async with self._acquire_call_slot():
+            t0 = time.perf_counter()
+            response = await client.chat.completions.create(**kwargs)
+            elapsed = time.perf_counter() - t0
         self._update_token_usage_from_response(response, duration_seconds=elapsed)
         result = self._build_vlm_response(response, has_tools=bool(tools))
         if tools:

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: AGPL-3.0
 """VLM base interface and abstract classes"""
 
+import asyncio
 import logging
 import re
 from abc import ABC, abstractmethod
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from openviking.utils.time_utils import format_iso8601
 
@@ -64,9 +66,29 @@ class VLMBase(ABC):
         self.max_tokens = config.get("max_tokens")
         self.extra_headers = config.get("extra_headers")
         self.stream = config.get("stream", False)
+        self.max_concurrent = config.get("max_concurrent", 100)
 
         # Token usage tracking
         self._token_tracker = TokenUsageTracker()
+
+        # Lazy-created per-instance semaphore that caps concurrent async calls.
+        # Created on first use so the semaphore binds to the running event loop.
+        self._call_semaphore: Optional[asyncio.Semaphore] = None
+
+    @asynccontextmanager
+    async def _acquire_call_slot(self) -> AsyncIterator[None]:
+        """Cap concurrent async LLM calls at ``max_concurrent``.
+
+        The semaphore is created lazily on first use so it attaches to the
+        running event loop. Values <= 0 disable capping.
+        """
+        if self.max_concurrent is None or self.max_concurrent <= 0:
+            yield
+            return
+        if self._call_semaphore is None:
+            self._call_semaphore = asyncio.Semaphore(self.max_concurrent)
+        async with self._call_semaphore:
+            yield
 
     @abstractmethod
     def get_completion(

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -34,7 +34,13 @@ class VLMConfig(BaseModel):
     thinking: bool = Field(default=False, description="Enable thinking mode for VolcEngine models")
 
     max_concurrent: int = Field(
-        default=100, description="Maximum number of concurrent LLM calls for semantic processing"
+        default=100,
+        description=(
+            "Maximum number of concurrent async LLM calls per VLM instance. "
+            "Caps all get_completion_async / get_vision_completion_async calls, "
+            "including semantic queue processing and session archive summary "
+            "generation. Set <= 0 to disable."
+        ),
     )
 
     api_version: Optional[str] = Field(

--- a/tests/models/vlm/test_max_concurrent_cap.py
+++ b/tests/models/vlm/test_max_concurrent_cap.py
@@ -7,6 +7,7 @@ that invoked ``get_completion_async`` directly (for example the session
 archive summary generator at ``openviking/session/session.py``) bypassed the
 cap. These tests lock in that the cap now applies to every async VLM call.
 """
+
 import asyncio
 
 import pytest

--- a/tests/models/vlm/test_max_concurrent_cap.py
+++ b/tests/models/vlm/test_max_concurrent_cap.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the shared ``vlm.max_concurrent`` semaphore.
+
+``max_concurrent`` used to cap only the semantic queue worker path. Callers
+that invoked ``get_completion_async`` directly (for example the session
+archive summary generator at ``openviking/session/session.py``) bypassed the
+cap. These tests lock in that the cap now applies to every async VLM call.
+"""
+import asyncio
+
+import pytest
+
+from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
+
+
+@pytest.mark.asyncio
+async def test_get_completion_async_respects_max_concurrent(monkeypatch):
+    vlm = LiteLLMVLMProvider(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-fake",
+            "api_base": "https://example.invalid",
+            "max_concurrent": 2,
+            "max_retries": 0,
+        }
+    )
+
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def fake_acompletion(**kwargs):
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        await asyncio.sleep(0.05)
+        async with lock:
+            in_flight -= 1
+
+        class _Resp:
+            choices = [
+                type(
+                    "c",
+                    (),
+                    {"message": type("m", (), {"content": "ok"})()},
+                )()
+            ]
+            usage = type(
+                "u",
+                (),
+                {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            )()
+
+        return _Resp()
+
+    monkeypatch.setattr(
+        "openviking.models.vlm.backends.litellm_vlm.acompletion",
+        fake_acompletion,
+    )
+
+    await asyncio.gather(*(vlm.get_completion_async(prompt=f"q{i}") for i in range(10)))
+
+    assert peak <= 2, f"expected peak <= max_concurrent (2), got {peak}"
+
+
+@pytest.mark.asyncio
+async def test_max_concurrent_disabled_when_nonpositive(monkeypatch):
+    vlm = LiteLLMVLMProvider(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-fake",
+            "api_base": "https://example.invalid",
+            "max_concurrent": 0,
+            "max_retries": 0,
+        }
+    )
+
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def fake_acompletion(**kwargs):
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        await asyncio.sleep(0.02)
+        async with lock:
+            in_flight -= 1
+
+        class _Resp:
+            choices = [
+                type(
+                    "c",
+                    (),
+                    {"message": type("m", (), {"content": "ok"})()},
+                )()
+            ]
+            usage = type(
+                "u",
+                (),
+                {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            )()
+
+        return _Resp()
+
+    monkeypatch.setattr(
+        "openviking.models.vlm.backends.litellm_vlm.acompletion",
+        fake_acompletion,
+    )
+
+    await asyncio.gather(*(vlm.get_completion_async(prompt=f"q{i}") for i in range(5)))
+
+    assert peak == 5, f"expected uncapped concurrency (5), got {peak}"


### PR DESCRIPTION
## Description

Setting `vlm.max_concurrent` doesn't actually cap all VLM calls today. It's enforced on the semantic queue worker and the page-batch parser, but the session archive summary path calls the VLM backend directly with no limit. When many sessions commit around the same time, the server can fire far more parallel LLM requests than `max_concurrent` allows — with real cost and provider rate-limit consequences.

This PR moves the concurrency cap into the VLM base class so every async call path honors the same ceiling.

## Related Issue

None filed separately. Related to #1245 (batching `_process_memory_directory`), which addressed a different code path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Example

Configure `max_concurrent=2`, fire 10 concurrent `get_completion_async` calls against a mocked backend that tracks peak in-flight count:

```python
vlm = LiteLLMVLMProvider({"max_concurrent": 2, "max_retries": 0, ...})
await asyncio.gather(*(vlm.get_completion_async(f"q{i}") for i in range(10)))
```

```
Before: peak_in_flight = 10  (cap ignored)
After:  peak_in_flight = 2   (cap honored)
```

## Changes Made

- Add a lazy per-instance `asyncio.Semaphore` to `VLMBase`, sized by `max_concurrent`.
- Wrap the active call in each backend's async methods (`litellm_vlm`, `openai_vlm`, `volcengine_vlm` — text and vision).
- Treat `max_concurrent <= 0` as "disabled" for callers who explicitly want no cap.
- Update the `max_concurrent` config description to reflect that it now caps all async LLM calls.
- Add regression tests covering the cap being enforced and being opt-out.

## Testing

- [x] Added regression tests: `tests/models/vlm/test_max_concurrent_cap.py`
- [x] New and existing unit tests pass locally
- [x] Tested on:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Pre-existing failures in `tests/models/vlm/test_volcengine_cache.py` reproduce identically on unmodified `main` and are unrelated to this change.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Commented where behavior is non-obvious (semaphore lazy init)
- [x] Updated the config field description
- [x] No new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

The semaphore is created lazily on first use so it attaches to the running event loop. A class-level semaphore would break any setup that runs multiple event loops in the same process.
