### PR TITLE
feat(vlm): expose timeout as a config field and thread it through

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -209,6 +209,7 @@ class LiteLLMVLMProvider(VLMBase):
             "model": model,
             "messages": messages,
             "temperature": self.temperature,
+            "timeout": self.timeout,
         }
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -15,11 +15,8 @@ os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 import litellm
 from litellm import acompletion, completion
 
-
 from openviking.telemetry import tracer
-
 from openviking.utils.model_retry import retry_async, retry_sync
-
 
 from ..base import ToolCall, VLMBase, VLMResponse
 
@@ -323,7 +320,7 @@ class LiteLLMVLMProvider(VLMBase):
             response = completion(**kwargs)
             elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))
@@ -354,7 +351,7 @@ class LiteLLMVLMProvider(VLMBase):
             response = await acompletion(**kwargs)
             elapsed = time.perf_counter() - t0
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
-            tracer.info(f'response={response}')
+            tracer.info(f"response={response}")
             if tools:
                 return self._build_vlm_response(response, has_tools=True)
             return self._clean_response(self._extract_content_from_response(response))

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-
 from openviking.telemetry import tracer
 
 try:

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -78,6 +78,7 @@ class OpenAIVLM(VLMBase):
                 self.api_base,
                 self.api_version,
                 self.extra_headers,
+                self.timeout,
             )
             if self.provider == "azure":
                 self._sync_client = openai.AzureOpenAI(**kwargs)
@@ -96,6 +97,7 @@ class OpenAIVLM(VLMBase):
                 self.api_base,
                 self.api_version,
                 self.extra_headers,
+                self.timeout,
             )
             if self.provider == "azure":
                 self._async_client = openai.AsyncAzureOpenAI(**kwargs)

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -61,6 +61,7 @@ class VLMBase(ABC):
         self.api_base = config.get("api_base")
         self.temperature = config.get("temperature", 0.0)
         self.max_retries = config.get("max_retries", 3)
+        self.timeout = config.get("timeout", 60.0)
         self.max_tokens = config.get("max_tokens")
         self.extra_headers = config.get("extra_headers")
         self.stream = config.get("stream", False)

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -13,6 +13,15 @@ class VLMConfig(BaseModel):
     api_base: Optional[str] = Field(default=None, description="API base URL")
     temperature: float = Field(default=0.0, description="Generation temperature")
     max_retries: int = Field(default=3, description="Maximum retry attempts")
+    timeout: float = Field(
+        default=60.0,
+        gt=0.0,
+        description=(
+            "Per-request HTTP timeout in seconds for VLM API calls. Applied to "
+            "the underlying OpenAI/Azure/LiteLLM clients. Increase for slow or "
+            "high-latency endpoints (e.g., DashScope, local inference servers)."
+        ),
+    )
 
     provider: Optional[str] = Field(default=None, description="Provider type")
     backend: Optional[str] = Field(

--- a/tests/models/vlm/test_timeout_config.py
+++ b/tests/models/vlm/test_timeout_config.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for ``vlm.timeout`` configuration propagation.
+
+Before this was wired through, ``_build_openai_client_kwargs`` exposed a
+``timeout`` parameter (#1208) but callers never passed it, so the default
+60.0s was always used and end users could not override it via ``ov.conf``.
+These tests lock in that the config value flows through to the underlying
+OpenAI and LiteLLM clients.
+"""
+from unittest import mock
+
+import pytest
+
+from openviking.models.vlm.backends.openai_vlm import (
+    OpenAIVLM,
+    _build_openai_client_kwargs,
+)
+from openviking_cli.utils.config.vlm_config import VLMConfig
+
+
+def test_vlm_config_accepts_timeout():
+    cfg = VLMConfig(model="gpt-4o-mini", api_key="sk-x", timeout=120.0)
+    assert cfg.timeout == 120.0
+
+
+def test_vlm_config_timeout_defaults_to_60():
+    cfg = VLMConfig(model="gpt-4o-mini", api_key="sk-x")
+    assert cfg.timeout == 60.0
+
+
+def test_vlm_config_rejects_non_positive_timeout():
+    with pytest.raises(Exception):
+        VLMConfig(model="gpt-4o-mini", api_key="sk-x", timeout=0)
+
+
+def test_build_openai_client_kwargs_default_timeout():
+    kwargs = _build_openai_client_kwargs(
+        "openai", "sk-x", "https://example.invalid", None, None
+    )
+    assert kwargs["timeout"] == 60.0
+
+
+def test_build_openai_client_kwargs_custom_timeout():
+    kwargs = _build_openai_client_kwargs(
+        "openai",
+        "sk-x",
+        "https://example.invalid",
+        None,
+        None,
+        timeout=120.0,
+    )
+    assert kwargs["timeout"] == 120.0
+
+
+def test_openai_vlm_propagates_config_timeout():
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+            "timeout": 120.0,
+        }
+    )
+    assert vlm.timeout == 120.0
+
+    with mock.patch(
+        "openviking.models.vlm.backends.openai_vlm.openai.OpenAI"
+    ) as fake:
+        vlm.get_client()
+    assert fake.call_args.kwargs.get("timeout") == 120.0
+
+
+def test_openai_vlm_defaults_to_60_timeout_when_config_omits_it():
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+        }
+    )
+    assert vlm.timeout == 60.0
+
+    with mock.patch(
+        "openviking.models.vlm.backends.openai_vlm.openai.OpenAI"
+    ) as fake:
+        vlm.get_client()
+    assert fake.call_args.kwargs.get("timeout") == 60.0
+
+
+def test_litellm_build_kwargs_includes_timeout():
+    from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
+
+    vlm = LiteLLMVLMProvider(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+            "timeout": 90.0,
+        }
+    )
+    kwargs = vlm._build_text_kwargs(prompt="hi")
+    assert kwargs["timeout"] == 90.0

--- a/tests/models/vlm/test_timeout_config.py
+++ b/tests/models/vlm/test_timeout_config.py
@@ -8,9 +8,11 @@ Before this was wired through, ``_build_openai_client_kwargs`` exposed a
 These tests lock in that the config value flows through to the underlying
 OpenAI and LiteLLM clients.
 """
+
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 
 from openviking.models.vlm.backends.openai_vlm import (
     OpenAIVLM,
@@ -30,14 +32,12 @@ def test_vlm_config_timeout_defaults_to_60():
 
 
 def test_vlm_config_rejects_non_positive_timeout():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         VLMConfig(model="gpt-4o-mini", api_key="sk-x", timeout=0)
 
 
 def test_build_openai_client_kwargs_default_timeout():
-    kwargs = _build_openai_client_kwargs(
-        "openai", "sk-x", "https://example.invalid", None, None
-    )
+    kwargs = _build_openai_client_kwargs("openai", "sk-x", "https://example.invalid", None, None)
     assert kwargs["timeout"] == 60.0
 
 
@@ -65,9 +65,7 @@ def test_openai_vlm_propagates_config_timeout():
     )
     assert vlm.timeout == 120.0
 
-    with mock.patch(
-        "openviking.models.vlm.backends.openai_vlm.openai.OpenAI"
-    ) as fake:
+    with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
         vlm.get_client()
     assert fake.call_args.kwargs.get("timeout") == 120.0
 
@@ -83,9 +81,7 @@ def test_openai_vlm_defaults_to_60_timeout_when_config_omits_it():
     )
     assert vlm.timeout == 60.0
 
-    with mock.patch(
-        "openviking.models.vlm.backends.openai_vlm.openai.OpenAI"
-    ) as fake:
+    with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
         vlm.get_client()
     assert fake.call_args.kwargs.get("timeout") == 60.0
 


### PR DESCRIPTION
## Description

Setting `vlm.timeout` in `ov.conf` fails today. PR #1208 added a `timeout` parameter to the OpenAI client builder, but there's no config field for it and no caller passes a value, so the 60s default is the only option. On slow endpoints (DashScope, local inference, oversized overview prompts) this triggers retry loops that can't be tuned without patching source.

This PR adds the missing `timeout` field and wires it through both the OpenAI and LiteLLM backends.

## Related Issue

Follows up on #1208 by actually wiring the parameter through to config. Related to #529 (oversized overview prompts triggering VLM timeouts).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Example

Trying to raise the timeout via `ov.conf` on current `main`:

```python
VLMConfig(model="gpt-4o-mini", api_key="sk-x", timeout=120)
```

Before:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for VLMConfig
timeout
  Extra inputs are not permitted [type=extra_forbidden, input_value=120, ...]
```

After: `timeout=120` is accepted. `OpenAIVLM.get_client()` passes `timeout=120.0` to `openai.OpenAI(...)`, and `LiteLLMVLMProvider` includes `"timeout": 120.0` in its `acompletion` kwargs.

## Changes Made

- `openviking_cli/utils/config/vlm_config.py`: add `timeout: float = Field(default=60.0, gt=0.0, ...)`.
- `openviking/models/vlm/base.py`: read `config.get("timeout", 60.0)` into `self.timeout` in `VLMBase.__init__`.
- `openviking/models/vlm/backends/openai_vlm.py`: pass `self.timeout` into `_build_openai_client_kwargs` from both `get_client` and `get_async_client`.
- `openviking/models/vlm/backends/litellm_vlm.py`: include `"timeout": self.timeout` in the kwargs dict that flows into `completion` / `acompletion`.
- `tests/models/vlm/test_timeout_config.py`: 8 tests covering config acceptance, default preservation, `gt=0` validation, and propagation through both backends.

## Testing

- [x] Added regression tests: `tests/models/vlm/test_timeout_config.py`
- [x] New and existing unit tests pass locally
- [x] Tested on:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Pre-existing failures in `tests/models/vlm/test_volcengine_cache.py` reproduce identically on unmodified `main` and are unrelated to this change.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Commented where behavior is non-obvious
- [x] Updated the config field description
- [x] No new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Backward compatible — users who don't set `vlm.timeout` continue to get the 60.0s default. The `gt=0.0` validator prevents `timeout=0`, which would silently disable the timeout in httpx and is rarely what the caller intends.
