### PR TITLE
fix(reindex): repair maintenance route and keep content compatibility

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Content endpoints for OpenViking HTTP Server."""
 
+import asyncio
 from urllib.parse import quote
 
 from fastapi import APIRouter, Body, Depends, Query
@@ -9,10 +10,16 @@ from fastapi.responses import Response as FastAPIResponse
 from pydantic import BaseModel, ConfigDict
 
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSNotFoundError
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_request_context, require_role
 from openviking.server.dependencies import get_service
-from openviking.server.identity import RequestContext
-from openviking.server.models import Response
+from openviking.server.identity import RequestContext, Role
+from openviking.server.models import ErrorInfo, Response
+from openviking.server.routers.maintenance import (
+    REINDEX_TASK_TYPE,
+    ReindexRequest,
+    _background_reindex_tracked,
+    _do_reindex,
+)
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
 from openviking_cli.exceptions import NotFoundError
@@ -171,3 +178,69 @@ async def write(
         result=execution.result,
         telemetry=execution.telemetry,
     ).model_dump(exclude_none=True)
+
+
+@router.post("/reindex", deprecated=True)
+async def reindex(
+    body: ReindexRequest = Body(...),
+    ctx: RequestContext = require_role(Role.ROOT, Role.ADMIN),
+):
+    """Compatibility alias for older clients that still call /api/v1/content/reindex."""
+    from openviking.service.task_tracker import get_task_tracker
+    from openviking.storage.viking_fs import get_viking_fs
+
+    uri = body.uri
+    viking_fs = get_viking_fs()
+
+    if not await viking_fs.exists(uri, ctx=ctx):
+        return Response(
+            status="error",
+            error=ErrorInfo(code="NOT_FOUND", message=f"URI not found: {uri}"),
+        )
+
+    service = get_service()
+    tracker = get_task_tracker()
+
+    if body.wait:
+        if tracker.has_running(
+            REINDEX_TASK_TYPE,
+            uri,
+            owner_account_id=ctx.account_id,
+            owner_user_id=ctx.user.user_id,
+        ):
+            return Response(
+                status="error",
+                error=ErrorInfo(
+                    code="CONFLICT",
+                    message=f"URI {uri} already has a reindex in progress",
+                ),
+            )
+        result = await _do_reindex(service, uri, body.regenerate, ctx)
+        return Response(status="ok", result=result)
+
+    task = tracker.create_if_no_running(
+        REINDEX_TASK_TYPE,
+        uri,
+        owner_account_id=ctx.account_id,
+        owner_user_id=ctx.user.user_id,
+    )
+    if task is None:
+        return Response(
+            status="error",
+            error=ErrorInfo(
+                code="CONFLICT",
+                message=f"URI {uri} already has a reindex in progress",
+            ),
+        )
+    asyncio.create_task(
+        _background_reindex_tracked(service, uri, body.regenerate, ctx, task.task_id)
+    )
+    return Response(
+        status="ok",
+        result={
+            "uri": uri,
+            "status": "accepted",
+            "task_id": task.task_id,
+            "message": "Reindex is processing in the background",
+        },
+    )

--- a/openviking/server/routers/maintenance.py
+++ b/openviking/server/routers/maintenance.py
@@ -4,10 +4,10 @@
 
 import asyncio
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body
 from pydantic import BaseModel
 
-from openviking.server.auth import get_request_context, require_role
+from openviking.server.auth import require_role
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext, Role
 from openviking.server.models import ErrorInfo, Response

--- a/openviking/server/routers/maintenance.py
+++ b/openviking/server/routers/maintenance.py
@@ -7,9 +7,9 @@ import asyncio
 from fastapi import APIRouter, Body, Depends
 from pydantic import BaseModel
 
-from openviking.server.auth import get_request_context, require_auth_root_or_admin
+from openviking.server.auth import get_request_context, require_role
 from openviking.server.dependencies import get_service
-from openviking.server.identity import RequestContext
+from openviking.server.identity import RequestContext, Role
 from openviking.server.models import ErrorInfo, Response
 from openviking_cli.utils import get_logger
 
@@ -30,10 +30,9 @@ router = APIRouter(prefix="/api/v1/maintenance", tags=["maintenance"])
 
 
 @router.post("/reindex")
-@require_auth_root_or_admin
 async def reindex(
-    request: ReindexRequest = Body(...),
-    _ctx: RequestContext = Depends(get_request_context),
+    body: ReindexRequest = Body(...),
+    ctx: RequestContext = require_role(Role.ROOT, Role.ADMIN),
 ):
     """Reindex content at a URI.
 
@@ -47,11 +46,11 @@ async def reindex(
     from openviking.service.task_tracker import get_task_tracker
     from openviking.storage.viking_fs import get_viking_fs
 
-    uri = request.uri
+    uri = body.uri
     viking_fs = get_viking_fs()
 
     # Validate URI exists
-    if not await viking_fs.exists(uri, ctx=_ctx):
+    if not await viking_fs.exists(uri, ctx=ctx):
         return Response(
             status="error",
             error=ErrorInfo(code="NOT_FOUND", message=f"URI not found: {uri}"),
@@ -60,13 +59,13 @@ async def reindex(
     service = get_service()
     tracker = get_task_tracker()
 
-    if request.wait:
+    if body.wait:
         # Synchronous path: block until reindex completes
         if tracker.has_running(
             REINDEX_TASK_TYPE,
             uri,
-            owner_account_id=_ctx.account_id,
-            owner_user_id=_ctx.user.user_id,
+            owner_account_id=ctx.account_id,
+            owner_user_id=ctx.user.user_id,
         ):
             return Response(
                 status="error",
@@ -75,15 +74,15 @@ async def reindex(
                     message=f"URI {uri} already has a reindex in progress",
                 ),
             )
-        result = await _do_reindex(service, uri, request.regenerate, _ctx)
+        result = await _do_reindex(service, uri, body.regenerate, ctx)
         return Response(status="ok", result=result)
     else:
         # Async path: run in background, return task_id for polling
         task = tracker.create_if_no_running(
             REINDEX_TASK_TYPE,
             uri,
-            owner_account_id=_ctx.account_id,
-            owner_user_id=_ctx.user.user_id,
+            owner_account_id=ctx.account_id,
+            owner_user_id=ctx.user.user_id,
         )
         if task is None:
             return Response(
@@ -94,7 +93,7 @@ async def reindex(
                 ),
             )
         asyncio.create_task(
-            _background_reindex_tracked(service, uri, request.regenerate, _ctx, task.task_id)
+            _background_reindex_tracked(service, uri, body.regenerate, ctx, task.task_id)
         )
         return Response(
             status="ok",

--- a/tests/server/test_api_content.py
+++ b/tests/server/test_api_content.py
@@ -149,8 +149,45 @@ async def test_reindex_uses_request_tenant_for_exists(monkeypatch):
     )
     monkeypatch.setattr("openviking.server.routers.content._do_reindex", fake_do_reindex)
 
-    response = await reindex(request=request, _ctx=ctx)
+    response = await reindex(body=request, ctx=ctx)
 
     assert response.status == "ok"
     assert seen["uri"] == "viking://resources/demo/demo-note.md"
     assert seen["ctx"] == ctx
+
+
+async def test_maintenance_reindex_sync_success_returns_ok_payload(client, monkeypatch):
+    async def fake_do_reindex(service, uri, regenerate, ctx):
+        return {"status": "success", "message": "Indexed 1 resources"}
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return True
+
+    class FakeTracker:
+        def has_running(self, task_type, uri, owner_account_id=None, owner_user_id=None):
+            return False
+
+    monkeypatch.setattr(
+        "openviking.storage.viking_fs.get_viking_fs",
+        lambda: FakeVikingFS(),
+    )
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.maintenance.get_service",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr("openviking.server.routers.maintenance._do_reindex", fake_do_reindex)
+
+    response = await client.post(
+        "/api/v1/maintenance/reindex",
+        json={"uri": "viking://resources/demo", "wait": True},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["result"]["status"] == "success"


### PR DESCRIPTION
## Description

This fixes the reindex HTTP surface so both the canonical maintenance endpoint
and existing `/api/v1/content/reindex` callers work again.

There were two problems:

1. `openviking/server/routers/maintenance.py` binds the request body to a
   parameter named `request`, so `@require_auth_root_or_admin` inspects the body
   model instead of the HTTP request and raises at runtime.
2. Existing docs, tests, and the current `ov` CLI still use
   `/api/v1/content/reindex`, but the live server only exposes
   `/api/v1/maintenance/reindex`.

This change repairs the maintenance route and adds a compatibility alias for the
older content route so existing clients stop failing while the maintenance route
remains the canonical home.

## Example

Before this change:

```bash
ov reindex --wait -o json viking://agent/does-not-exist/nope.md
# The current CLI posts to /api/v1/content/reindex, so against a server that
# only exposes /api/v1/maintenance/reindex the request can die before reindex
# logic runs:
# HTTP 404
# {
#   "detail": "Not Found"
# }
```

After this change, both routes return the normal structured application error:

```json
{
  "status": "error",
  "error": {
    "code": "NOT_FOUND",
    "message": "URI not found: viking://agent/does-not-exist/nope.md"
  }
}
```

## Related Issue

None found.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Repair the maintenance reindex handler so it no longer confuses the body model
  with the HTTP request during dependency/decorator resolution.
- Keep `/api/v1/maintenance/reindex` as the canonical route.
- Add a deprecated compatibility alias at `/api/v1/content/reindex` so current
  CLI and older clients continue to work.
- Add regression coverage for both the maintenance route and the compatibility
  route.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
uv run pytest -q tests/server/test_api_content.py -k reindex
uv run pytest -q tests/server/test_api_fs_content_endpoint_suite.py -k reindex
```

Live verification:

```bash
curl -sS -X POST http://127.0.0.1:1933/api/v1/maintenance/reindex \
  -H 'Content-Type: application/json' \
  --data '{"uri":"viking://agent/definitely-missing/nope.md","wait":true}'

curl -sS -X POST http://127.0.0.1:1933/api/v1/content/reindex \
  -H 'Content-Type: application/json' \
  --data '{"uri":"viking://agent/definitely-missing/nope.md","wait":true}'

ov reindex --wait -o json viking://agent/definitely-missing/nope.md
```

All three now return the expected structured `NOT_FOUND` response instead of a
route/decorator failure.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally does not try to solve unrelated reindex execution issues
such as lock contention on a real resource path. It only restores the HTTP/API
surface so the maintenance route works and the legacy content route remains
compatible for existing callers.

An earlier broader attempt existed in #1565, but that PR bundled this route
repair with an unrelated `/api/v1/content/write` fix. This retry keeps scope to
the reindex HTTP surface only.
