### PR TITLE
docs(en): list dashscope in embedding provider table (#1535)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -119,7 +119,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 |-----------|------|-------------|
 | `max_concurrent` | int | Maximum concurrent embedding requests (`embedding.max_concurrent`, default: `10`) |
 | `max_retries` | int | Maximum retry attempts for transient embedding provider errors (`embedding.max_retries`, default: `3`; `0` disables retry) |
-| `provider` | str | `"volcengine"`, `"openai"`, `"vikingdb"`, `"jina"`, `"voyage"`, or `"gemini"` |
+| `provider` | str | `"volcengine"`, `"openai"`, `"vikingdb"`, `"jina"`, `"voyage"`, `"dashscope"`, or `"gemini"` |
 | `api_key` | str | API key |
 | `model` | str | Model name |
 | `dimension` | int | Vector dimension. For Voyage, this maps to `output_dimension` |


### PR DESCRIPTION
#1535 added DashScope (Alibaba Tongyi) as a first-class embedding provider (`openviking/models/embedder/dashscope_embedders.py`, factory registration in `openviking_cli/utils/config/embedding_config.py`, validator accepting `provider="dashscope"` at line 209). The PR also added a full DashScope example section further down in `docs/en/guides/01-configuration.md` (lines 303–347).

The **Dense Embedding parameters quick-reference table** at line 122 still enumerates only the six legacy providers and does not mention `dashscope`, so a reader scanning the parameter table has no hint that DashScope is a valid `provider` value until they scroll another ~180 lines down.

`docs/zh/guides/01-configuration.md` (line 124) already lists `dashscope` in the equivalent zh table, so this is a pure EN/ZH parity + config-source-of-truth fix (`embedding_config.py:40` lists `dashscope` among the 12 valid providers).

### Change

`docs/en/guides/01-configuration.md` line 122: +1 token (`"dashscope"`) inserted into the provider enum, ordering mirrors zh.

Docs-only, no code logic change.
