### PR TITLE
fix(security): address targeted code scanning alerts

### DIFF
--- a/bot/demo/werewolf/werewolf_server.py
+++ b/bot/demo/werewolf/werewolf_server.py
@@ -116,6 +116,16 @@ def get_viking_path(config: Dict[str, Any]) -> Path:
     return storage_path / "viking"
 
 
+def _internal_error_response(message: str = "Internal server error") -> JSONResponse:
+    """Return a generic server error without leaking exception details."""
+    return JSONResponse(content={"error": message}, status_code=500)
+
+
+def _failed_operation_response(message: str) -> JSONResponse:
+    """Return a generic operation failure without surfacing raw exception text."""
+    return JSONResponse(content={"success": False, "error": message})
+
+
 # ============================================================================
 # API Client
 # ============================================================================
@@ -1554,8 +1564,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
 
         try:
             await start_current_game(state)
-        except ValueError as e:
-            return JSONResponse(content={"success": False, "error": str(e)})
+        except ValueError:
+            logger.warning("Failed to start game")
+            return _failed_operation_response("Failed to start game")
 
         return JSONResponse(content={"success": True, "session_id": state.session_id, "game_mode": state.game_mode})
 
@@ -1570,8 +1581,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
 
         try:
             session_id = await restart_game_session(state)
-        except ValueError as e:
-            return JSONResponse(content={"success": False, "error": str(e)})
+        except ValueError:
+            logger.warning("Failed to restart game")
+            return _failed_operation_response("Failed to restart game")
 
         return JSONResponse(content={"success": True, "session_id": session_id, "game_mode": state.game_mode})
 
@@ -1586,8 +1598,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
 
         try:
             await continue_current_game(state)
-        except ValueError as e:
-            return JSONResponse(content={"success": False, "error": str(e)})
+        except ValueError:
+            logger.warning("Failed to continue game")
+            return _failed_operation_response("Failed to continue game")
 
         return JSONResponse(content={"success": True, "session_id": state.session_id})
 
@@ -1706,8 +1719,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
                 "content": content,
                 "name": file_path.name
             })
-        except Exception as e:
-            return JSONResponse(content={"error": str(e)}, status_code=500)
+        except Exception:
+            logger.exception("Failed to read OpenViking file")
+            return _internal_error_response("Failed to read file")
 
     @fastapi_app.get("/api/conversations")
     async def get_conversations():
@@ -1751,8 +1765,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
                 "content": content,
                 "filename": file_path.name
             })
-        except Exception as e:
-            return JSONResponse(content={"error": str(e)}, status_code=500)
+        except Exception:
+            logger.exception("Failed to read conversation file")
+            return _internal_error_response("Failed to read conversation")
 
     @fastapi_app.get("/api/replay-state/{session_id}")
     async def get_replay_state(session_id: str):
@@ -1764,8 +1779,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
         try:
             payload = json.loads(replay_state_path.read_text(encoding="utf-8"))
             return JSONResponse(content=payload)
-        except Exception as e:
-            return JSONResponse(content={"error": str(e)}, status_code=500)
+        except Exception:
+            logger.exception("Failed to load replay state")
+            return _internal_error_response("Failed to load replay state")
 
     @fastapi_app.get("/api/bot-sessions")
     async def get_bot_sessions():
@@ -1856,8 +1872,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
                 "content": content,
                 "raw_content": file_path.read_text(encoding="utf-8")
             })
-        except Exception as e:
-            return JSONResponse(content={"error": str(e)}, status_code=500)
+        except Exception:
+            logger.exception("Failed to read bot session file")
+            return _internal_error_response("Failed to read session file")
 
     @fastapi_app.get("/api/game-file/{channel_id}/{filename}")
     async def get_game_file(channel_id: str, filename: str):
@@ -1879,8 +1896,9 @@ def create_fastapi_app(state: GameState) -> FastAPI:
                 "filename": filename,
                 "content": content
             })
-        except Exception as e:
-            return JSONResponse(content={"error": str(e)}, status_code=500)
+        except Exception:
+            logger.exception("Failed to read game file")
+            return _internal_error_response("Failed to read game file")
 
     @fastapi_app.get("/api/leaderboard")
     async def get_leaderboard():

--- a/bot/tests/test_werewolf_server_security.py
+++ b/bot/tests/test_werewolf_server_security.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from bot.demo.werewolf.werewolf_server import GameState, create_fastapi_app
+
+
+def _make_client(tmp_path) -> TestClient:
+    state = GameState(
+        game_id="test-game",
+        vikingbot_url="http://127.0.0.1:18790",
+        config_path=tmp_path / "ov.conf",
+        config={},
+        storage_path=tmp_path,
+    )
+    return TestClient(create_fastapi_app(state))
+
+
+def test_start_endpoint_hides_value_error_details(tmp_path):
+    client = _make_client(tmp_path)
+
+    async def _raise_value_error(_state):
+        raise ValueError("secret filesystem detail")
+
+    with patch("bot.demo.werewolf.werewolf_server.start_current_game", new=_raise_value_error):
+        response = client.post("/api/start", json={"game_mode": "all_agents"})
+
+    assert response.status_code == 200
+    assert response.json() == {"success": False, "error": "Failed to start game"}
+    assert "secret filesystem detail" not in response.text
+
+
+def test_conversation_endpoint_hides_internal_exception_details(tmp_path):
+    conversation_dir = tmp_path / "bot" / "workspace" / "werewolf"
+    conversation_dir.mkdir(parents=True, exist_ok=True)
+    (conversation_dir / "CONVERSATION_demo.md").write_text("demo", encoding="utf-8")
+
+    client = _make_client(tmp_path)
+
+    with patch.object(Path, "read_text", side_effect=RuntimeError("secret stack detail")):
+        response = client.get("/api/conversation/demo")
+
+    assert response.status_code == 500
+    assert response.json() == {"error": "Failed to read conversation"}
+    assert "secret stack detail" not in response.text

--- a/openviking/storage/vectordb/index/local_index.py
+++ b/openviking/storage/vectordb/index/local_index.py
@@ -13,6 +13,11 @@ from openviking.storage.vectordb.index.index import IIndex
 from openviking.storage.vectordb.store.data import CandidateData, DeltaRecord
 from openviking.storage.vectordb.utils.constants import IndexFileMarkers
 from openviking.storage.vectordb.utils.data_processor import DataProcessor
+from openviking.storage.vectordb.utils.path_safety import (
+    safe_join,
+    safe_join_name,
+)
+from openviking.storage.vectordb.utils.validation import validate_name_str
 from openviking_cli.utils.logger import default_logger as logger
 
 
@@ -524,9 +529,10 @@ class PersistentIndex(LocalIndex):
         if cands_list is None:
             cands_list = []
 
-        self.index_dir = os.path.join(path, name)
+        validate_name_str(name)
+        self.index_dir = str(safe_join_name(path, name))
         os.makedirs(self.index_dir, exist_ok=True)
-        self.version_dir = os.path.join(self.index_dir, "versions")
+        self.version_dir = str(safe_join(self.index_dir, "versions"))
         os.makedirs(self.version_dir, exist_ok=True)
 
         newest_version = self.get_newest_version()
@@ -537,7 +543,7 @@ class PersistentIndex(LocalIndex):
         else:
             self.now_version = str(newest_version)
 
-        index_path = os.path.join(self.version_dir, self.now_version)
+        index_path = str(safe_join(self.version_dir, self.now_version))
         super().__init__(index_path, meta)
         # Remove scheduling logic, unified scheduling by collection layer
 
@@ -562,13 +568,13 @@ class PersistentIndex(LocalIndex):
         index_config_json = json.dumps(index_config_dict)
 
         builder = IndexEngineProxy(index_config_json, normalize_vector_flag)
-        build_index_path = os.path.join(self.version_dir, version_str)
+        build_index_path = str(safe_join(self.version_dir, version_str))
         builder.add_data(self._convert_candidate_list_for_index(cands_list))
 
         dump_version_int = builder.dump(build_index_path)
         if dump_version_int > 0:
             dump_version_str = str(dump_version_int)
-            new_index_path = os.path.join(self.version_dir, dump_version_str)
+            new_index_path = str(safe_join(self.version_dir, dump_version_str))
             shutil.move(build_index_path, new_index_path)
             Path(new_index_path + IndexFileMarkers.WRITE_DONE.value).touch()
             self.now_version = dump_version_str
@@ -637,13 +643,13 @@ class PersistentIndex(LocalIndex):
             if update_ts <= newest_version:
                 return 0
             now_ns_ts = str(int(time.time_ns()))
-            index_path = os.path.join(self.version_dir, now_ns_ts)
+            index_path = str(safe_join(self.version_dir, now_ns_ts))
             os.makedirs(index_path, exist_ok=True)
             dump_version = self.engine_proxy.dump(index_path)
             if dump_version < 0:
                 return 0
             # todo get dump timestamp
-            dump_index_path = os.path.join(self.version_dir, str(dump_version))
+            dump_index_path = str(safe_join(self.version_dir, str(dump_version)))
             shutil.move(index_path, dump_index_path)
             Path(dump_index_path + ".write_done").touch()
             self._clean_index([self.now_version, str(dump_version)])
@@ -671,8 +677,8 @@ class PersistentIndex(LocalIndex):
             not_clean_set.add(file_name + ".write_done")
         for file_name in os.listdir(self.version_dir):
             if file_name not in not_clean_set:
-                path = os.path.join(self.version_dir, file_name)
-                if os.path.isdir(path):
+                path = safe_join(self.version_dir, file_name)
+                if path.is_dir():
                     shutil.rmtree(path)
                 else:
                     os.remove(path)
@@ -698,9 +704,9 @@ class PersistentIndex(LocalIndex):
 
         valid_versions = []
         for name in os.listdir(self.version_dir):
-            version_path = os.path.join(self.version_dir, name)
+            version_path = safe_join(self.version_dir, name)
             # Must be a directory
-            if not os.path.isdir(version_path):
+            if not version_path.is_dir():
                 continue
 
             # Must be an integer (timestamp)
@@ -708,8 +714,8 @@ class PersistentIndex(LocalIndex):
                 continue
 
             # Must have corresponding .write_done file
-            marker_path = version_path + IndexFileMarkers.WRITE_DONE.value
-            if not os.path.exists(marker_path):
+            marker_path = Path(str(version_path) + IndexFileMarkers.WRITE_DONE.value)
+            if not marker_path.exists():
                 continue
 
             valid_versions.append(int(name))

--- a/openviking/storage/vectordb/utils/path_safety.py
+++ b/openviking/storage/vectordb/utils/path_safety.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Helpers for safe vectordb path handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+from openviking.storage.vectordb.utils.validation import validate_name_str
+
+PathLike = Union[str, Path]
+
+
+def resolve_storage_path(path: PathLike) -> Path:
+    """Return a normalized absolute path for storage operations."""
+    return Path(path).expanduser().resolve()
+
+
+def safe_join(base: PathLike, *parts: str) -> Path:
+    """Join child parts under base and ensure the result stays within base."""
+    base_path = resolve_storage_path(base)
+    candidate = base_path.joinpath(*parts).resolve()
+    try:
+        candidate.relative_to(base_path)
+    except ValueError as exc:
+        escaped = "/".join(parts) if parts else str(candidate)
+        raise ValueError(f"path escapes base directory: {escaped!r}") from exc
+    return candidate
+
+
+def safe_join_name(base: PathLike, name: str) -> Path:
+    """Join a validated vectordb name under base."""
+    validate_name_str(name)
+    return safe_join(base, name)

--- a/openviking/storage/vectordb/utils/stale_lock.py
+++ b/openviking/storage/vectordb/utils/stale_lock.py
@@ -27,8 +27,16 @@ import os
 import sys
 
 from openviking_cli.utils import get_logger
+from openviking.storage.vectordb.utils.path_safety import resolve_storage_path
 
 logger = get_logger(__name__)
+_LOG_ESCAPE_TABLE = str.maketrans(
+    {
+        "\n": r"\n",
+        "\r": r"\r",
+        "\t": r"\t",
+    }
+)
 
 # RocksDB creates a LOCK file inside the store directory.
 # The standard layout is: <data_dir>/vectordb/<collection>/store/LOCK
@@ -38,6 +46,13 @@ _LOCK_GLOB_PATTERNS = [
     os.path.join("**", "LOCK"),
 ]
 _CONTAINER_MARKERS = ("/.dockerenv", "/run/.containerenv")
+
+
+def _safe_log_text(value: object, max_length: int = 160) -> str:
+    text = str(value).translate(_LOG_ESCAPE_TABLE)
+    if len(text) > max_length:
+        return text[: max_length - 3] + "..."
+    return text
 
 
 def _is_containerized() -> bool:
@@ -59,7 +74,10 @@ def _can_reclaim_posix_lock(lock_path: str) -> bool:
     try:
         import fcntl
     except ImportError:
-        logger.debug("fcntl unavailable, skipping RocksDB LOCK probe: %s", lock_path)
+        logger.debug(
+            "fcntl unavailable, skipping RocksDB LOCK probe: %s",
+            _safe_log_text(lock_path),
+        )
         return False
 
     try:
@@ -67,10 +85,17 @@ def _can_reclaim_posix_lock(lock_path: str) -> bool:
             try:
                 fcntl.lockf(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
-                logger.debug("RocksDB LOCK is held by a live process, skipping: %s", lock_path)
+                logger.debug(
+                    "RocksDB LOCK is held by a live process, skipping: %s",
+                    _safe_log_text(lock_path),
+                )
                 return False
             except OSError as exc:
-                logger.debug("Could not probe RocksDB LOCK %s: %s", lock_path, exc)
+                logger.debug(
+                    "Could not probe RocksDB LOCK %s: %s",
+                    _safe_log_text(lock_path),
+                    _safe_log_text(exc),
+                )
                 return False
 
             try:
@@ -79,7 +104,11 @@ def _can_reclaim_posix_lock(lock_path: str) -> bool:
                 pass
             return True
     except OSError as exc:
-        logger.debug("Could not open RocksDB LOCK %s for probe: %s", lock_path, exc)
+        logger.debug(
+            "Could not open RocksDB LOCK %s for probe: %s",
+            _safe_log_text(lock_path),
+            _safe_log_text(exc),
+        )
         return False
 
 
@@ -100,11 +129,12 @@ def clean_stale_rocksdb_locks(data_dir: str) -> int:
     if not _should_clean_stale_rocksdb_locks():
         return 0
 
+    data_root = resolve_storage_path(data_dir)
     removed = 0
     seen: set[str] = set()
 
     for pattern in _LOCK_GLOB_PATTERNS:
-        full_pattern = os.path.join(data_dir, pattern)
+        full_pattern = os.path.join(str(data_root), pattern)
         for lock_path in glob.glob(full_pattern, recursive=True):
             # Normalize to avoid processing the same file twice from
             # overlapping glob patterns.
@@ -118,7 +148,7 @@ def clean_stale_rocksdb_locks(data_dir: str) -> int:
                     continue
                 os.remove(lock_path)
                 removed += 1
-                logger.info("Removed stale RocksDB LOCK: %s", lock_path)
+                logger.info("Removed stale RocksDB LOCK: %s", _safe_log_text(lock_path))
             except FileNotFoundError:
                 # Another startup path may have removed it already.
                 continue
@@ -126,12 +156,20 @@ def clean_stale_rocksdb_locks(data_dir: str) -> int:
                 # File is held by a live process — leave it alone.
                 logger.debug(
                     "RocksDB LOCK is held by a live process, skipping: %s",
-                    lock_path,
+                    _safe_log_text(lock_path),
                 )
             except OSError as exc:
-                logger.warning("Could not remove RocksDB LOCK %s: %s", lock_path, exc)
+                logger.warning(
+                    "Could not remove RocksDB LOCK %s: %s",
+                    _safe_log_text(lock_path),
+                    _safe_log_text(exc),
+                )
 
     if removed:
-        logger.info("Cleaned %d stale RocksDB LOCK file(s) under %s", removed, data_dir)
+        logger.info(
+            "Cleaned %d stale RocksDB LOCK file(s) under %s",
+            removed,
+            _safe_log_text(data_root),
+        )
 
     return removed

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -110,6 +110,11 @@ def _prompt_confirm(prompt: str, default: bool = True) -> bool:
     return raw in ("y", "yes")
 
 
+def _configured_hint(enabled: bool) -> str:
+    """Return a non-sensitive summary label for setup output."""
+    return "configured" if enabled else _dim("(not configured)")
+
+
 # ---------------------------------------------------------------------------
 # System info
 # ---------------------------------------------------------------------------
@@ -868,20 +873,15 @@ def run_init() -> int:
     # Summary
     emb = config_dict.get("embedding", {}).get("dense", {})
     vlm = config_dict.get("vlm", {})
-    ws = config_dict.get("storage", {}).get("workspace", _DEFAULT_WORKSPACE)
 
     print(f"\n  {_bold('Summary:')}")
-    print(
-        f"    Embedding:  {emb.get('provider', '')} / {emb.get('model', '')} ({emb.get('dimension', '')}d)"
-    )
+    print(f"    Embedding:  {_configured_hint(bool(emb))}")
     if emb.get("model_path"):
-        print(f"    Model path: {emb['model_path']}")
-    vlm_summary = (
-        f"{vlm.get('provider', '')} / {vlm.get('model', '')}" if vlm else _dim("(not configured)")
-    )
+        print("    Model path: custom local model (hidden)")
+    vlm_summary = _configured_hint(bool(vlm))
     print(f"    VLM:        {vlm_summary}")
-    print(f"    Workspace:  {ws}")
-    print(f"    Config:     {_DEFAULT_CONFIG_PATH}")
+    print("    Workspace:  configured (hidden)")
+    print("    Config:     default config location")
 
     if not _prompt_confirm("\n  Save configuration?"):
         print("\n  Setup cancelled.\n")
@@ -891,7 +891,7 @@ def run_init() -> int:
     if not _write_config(config_dict, _DEFAULT_CONFIG_PATH):
         return 1
 
-    print(f"  {_green('OK')} Configuration written to {_DEFAULT_CONFIG_PATH}\n")
+    print(f"  {_green('OK')} Configuration written to the default config location\n")
 
     # Post-init tips
     print(f"  {_bold('Next steps:')}")

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -16,6 +16,7 @@ from openviking_cli.setup_wizard import (
     _get_recommended_indices,
     _is_llamacpp_installed,
     _write_config,
+    run_init,
 )
 from openviking_cli.utils.ollama import (
     check_ollama_running,
@@ -210,6 +211,44 @@ class TestConfigWriting:
 
         assert _write_config(config, config_path) is True
         assert config_path.exists()
+
+    def test_run_init_redacts_summary_output(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        config = {
+            "embedding": {
+                "dense": {
+                    "provider": "local",
+                    "model": "secret-model",
+                    "dimension": 1024,
+                    "model_path": "/very/secret/model.gguf",
+                }
+            },
+            "vlm": {
+                "provider": "openai",
+                "model": "secret-vlm",
+            },
+            "storage": {
+                "workspace": "/very/secret/workspace",
+            },
+        }
+
+        with patch("openviking_cli.setup_wizard._DEFAULT_CONFIG_PATH", config_path), patch(
+            "openviking_cli.setup_wizard._prompt_choice", return_value=2
+        ), patch("openviking_cli.setup_wizard._wizard_ollama", return_value=config), patch(
+            "openviking_cli.setup_wizard._prompt_confirm", return_value=True
+        ), patch("openviking_cli.setup_wizard._write_config", return_value=True), patch(
+            "builtins.print"
+        ) as mock_print:
+            assert run_init() == 0
+
+        output = "\n".join(
+            " ".join(str(arg) for arg in call.args) for call in mock_print.call_args_list
+        )
+        assert "/very/secret/model.gguf" not in output
+        assert "/very/secret/workspace" not in output
+        assert str(config_path) not in output
+        assert "custom local model (hidden)" in output
+        assert "default config location" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Address a targeted set of GitHub code scanning findings by tightening local index path handling, sanitizing user-influenced lock cleanup logs, and preventing sensitive setup or demo server errors from being exposed to users.

## Related Issue

N/A - addresses targeted GitHub code scanning alerts

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Tightened persistent index path creation and version file traversal so index paths stay under the expected base directory.
- Sanitized stale RocksDB lock cleanup logs and redacted setup wizard summary output so sensitive values are not echoed back to users.
- Replaced raw exception text in werewolf demo API responses with generic error messages and added regression tests for the setup wizard and demo server endpoints.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command:

`python -m pytest --override-ini addopts='' tests/cli/test_setup_wizard.py bot/tests/test_werewolf_server_security.py -q`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally leaves unrelated local changes such as `uv.lock` out of the commit.
