### PR TITLE
docs(vlm): document timeout config field (#1580)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -445,6 +445,7 @@ Vision Language Model for semantic extraction (L0/L1 generation).
 | `thinking` | bool | Enable thinking mode for VolcEngine models (default: `false`) |
 | `max_concurrent` | int | Maximum concurrent semantic LLM calls (default: `100`) |
 | `max_retries` | int | Maximum retry attempts for transient VLM provider errors (default: `3`; `0` disables retry) |
+| `timeout` | float | Per-request HTTP timeout in seconds passed to the underlying OpenAI/LiteLLM client. Increase for slow endpoints (e.g., DashScope, local inference). Must be `> 0` (default: `60.0`) |
 | `extra_headers` | object | Custom HTTP headers (for OpenAI-compatible providers, optional) |
 | `stream` | bool | Enable streaming mode (for OpenAI-compatible providers, default: `false`) |
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -417,6 +417,7 @@ OpenViking 使用 JSON 配置文件（`ov.conf`）进行设置。配置文件支
 | `thinking` | bool | 启用思考模式（仅对部分火山模型生效，默认：`false`） |
 | `max_concurrent` | int | 语义处理阶段 LLM 最大并发调用数（默认：`100`） |
 | `max_retries` | int | VLM provider 瞬时错误的最大重试次数（默认：`3`；`0` 表示禁用重试） |
+| `timeout` | float | 单次 VLM API 请求的 HTTP 超时时间（秒），传递给底层 OpenAI/LiteLLM 客户端。慢端点（如 DashScope、本地推理）可调大。必须 `> 0`（默认：`60.0`） |
 | `extra_headers` | object | 自定义 HTTP 请求头（OpenAI 兼容 provider 可用，可选） |
 | `stream` | bool | 启用流式模式（OpenAI 兼容 provider 可用，默认：`false`） |
 


### PR DESCRIPTION
## Summary

PR #1580 (0xble, merged 2026-04-20) added a new `timeout` field to `VLMConfig` (default `60.0`, `gt=0.0` validation) and wired it through both OpenAI and LiteLLM backends. Users can now set `vlm.timeout` in `ov.conf` to increase per-request HTTP timeout for slow endpoints (DashScope, local inference, large overview prompts).

`docs/en/guides/01-configuration.md` and `docs/zh/guides/01-configuration.md` list the other VLM fields (`api_key`, `model`, `max_retries`, `extra_headers`, `stream`, …) in the parameter tables but are missing `timeout`. Users who want to raise the timeout have no signal from the docs that the field exists — they have to read `vlm_config.py` source or the #1580 PR description.

## Changes

- `docs/en/guides/01-configuration.md`: +1 row in the `vlm` Parameters table describing `timeout` (type `float`, default `60.0`, must be `> 0`, slow-endpoint use case mirrored from the Field description in `vlm_config.py`)
- `docs/zh/guides/01-configuration.md`: +1 row in the 参数 table (中文描述, 与 EN 镜像)

Docs-only change; no code touched.

## Related

- Follows up on #1580 (documents the field it added)
- Related to #529 (oversized overview prompts triggering VLM timeouts — one of the user scenarios mentioned in #1580 motivation)
