### PR TITLE
feat(resources): add opt-in HTTP local path ingestion

### DIFF
--- a/openviking/server/local_input_guard.py
+++ b/openviking/server/local_input_guard.py
@@ -44,6 +44,29 @@ def require_remote_resource_source(source: str) -> str:
     return source
 
 
+def resolve_local_resource_path_for_http(source: str) -> str:
+    """Resolve and validate a local resource path accepted by HTTP add_resource."""
+    path = Path(source)
+    if not path.is_absolute():
+        raise PermissionDeniedError(
+            "HTTP local resource paths must be absolute paths and point to an existing file or directory."
+        )
+
+    try:
+        resolved = path.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise PermissionDeniedError(
+            "HTTP local resource paths must be absolute paths and point to an existing file or directory."
+        ) from exc
+
+    if not (resolved.is_file() or resolved.is_dir()):
+        raise PermissionDeniedError(
+            "HTTP local resource paths must point to a regular file or directory."
+        )
+
+    return str(resolved)
+
+
 def deny_direct_local_skill_input(value: str) -> None:
     """Reject obvious local filesystem paths for skill uploads over HTTP."""
     if looks_like_local_path(value):

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -14,7 +14,9 @@ from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.local_input_guard import (
+    is_remote_resource_source,
     require_remote_resource_source,
+    resolve_local_resource_path_for_http,
     resolve_uploaded_temp_file_id,
 )
 from openviking.server.models import Response
@@ -30,7 +32,8 @@ class AddResourceRequest(BaseModel):
     """Request model for add_resource.
 
     Attributes:
-        path: Remote resource source such as an HTTP(S) URL or repository URL.
+        path: Resource source path. Always supports remote HTTP(S)/repository URLs.
+            Supports absolute local file/directory paths only when allow_local_path=true.
             Either path or temp_file_id must be provided.
         temp_file_id: Temporary upload id returned by /api/v1/resources/temp_upload.
             Either path or temp_file_id must be provided.
@@ -196,7 +199,8 @@ async def add_resource(
     if request.to and request.parent:
         raise InvalidArgumentError("Cannot specify both 'to' and 'parent' at the same time.")
 
-    upload_temp_dir = get_openviking_config().storage.get_upload_temp_dir()
+    config = get_openviking_config()
+    upload_temp_dir = config.storage.get_upload_temp_dir()
     path = request.path
     allow_local_path_resolution = False
     original_filename = None
@@ -206,7 +210,11 @@ async def add_resource(
         )
         allow_local_path_resolution = True
     elif path is not None:
-        path = require_remote_resource_source(path)
+        if config.allow_local_path and not is_remote_resource_source(path):
+            path = resolve_local_resource_path_for_http(path)
+            allow_local_path_resolution = True
+        else:
+            path = require_remote_resource_source(path)
     if path is None:
         raise InvalidArgumentError("Either 'path' or 'temp_file_id' must be provided.")
 

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -147,6 +147,13 @@ class OpenVikingConfig(BaseModel):
             "When disabled (default), only public IP addresses and hostnames are allowed."
         ),
     )
+    allow_local_path: bool = Field(
+        default=False,
+        description=(
+            "Allow HTTP add_resource to accept direct local filesystem paths. "
+            "When disabled (default), HTTP only accepts remote URLs or temp-uploaded files."
+        ),
+    )
 
     log: LogConfig = Field(default_factory=lambda: LogConfig(), description="Logging configuration")
 

--- a/tests/server/test_api_local_input_security.py
+++ b/tests/server/test_api_local_input_security.py
@@ -7,6 +7,7 @@ import io
 import threading
 import zipfile
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -14,6 +15,17 @@ import pytest
 from openviking.parse.parsers.html import URLTypeDetector
 from openviking.utils.network_guard import ensure_public_remote_target
 from openviking_cli.exceptions import PermissionDeniedError
+
+
+def _patch_resources_config(monkeypatch, upload_temp_dir, *, allow_local_path: bool) -> None:
+    config = SimpleNamespace(
+        allow_local_path=allow_local_path,
+        storage=SimpleNamespace(get_upload_temp_dir=lambda: upload_temp_dir),
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.resources.get_openviking_config",
+        lambda: config,
+    )
 
 
 async def test_add_skill_accepts_temp_uploaded_file(
@@ -205,6 +217,81 @@ async def test_add_resource_rejects_loopback_remote_url(client: httpx.AsyncClien
     assert body["status"] == "error"
     assert body["error"]["code"] == "PERMISSION_DENIED"
     assert "public remote resource targets" in body["error"]["message"]
+
+
+async def test_add_resource_rejects_local_path_when_allow_local_path_disabled(
+    client: httpx.AsyncClient,
+    temp_dir,
+    upload_temp_dir,
+    monkeypatch,
+):
+    _patch_resources_config(monkeypatch, upload_temp_dir, allow_local_path=False)
+    source_file = temp_dir / "source.md"
+    source_file.write_text("# test\n")
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"path": str(source_file), "reason": "local path disabled"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "PERMISSION_DENIED"
+
+
+async def test_add_resource_accepts_local_path_when_allow_local_path_enabled(
+    client: httpx.AsyncClient,
+    temp_dir,
+    upload_temp_dir,
+    monkeypatch,
+):
+    _patch_resources_config(monkeypatch, upload_temp_dir, allow_local_path=True)
+    source_file = temp_dir / "source.md"
+    source_file.write_text("# test\n")
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"path": str(source_file), "reason": "local path enabled"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["root_uri"].startswith("viking://")
+
+
+async def test_add_resource_rejects_non_absolute_local_path_when_enabled(
+    client: httpx.AsyncClient,
+    upload_temp_dir,
+    monkeypatch,
+):
+    _patch_resources_config(monkeypatch, upload_temp_dir, allow_local_path=True)
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"path": "relative/path.md", "reason": "must be absolute"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "PERMISSION_DENIED"
+
+
+async def test_add_resource_rejects_nonexistent_local_path_when_enabled(
+    client: httpx.AsyncClient,
+    temp_dir,
+    upload_temp_dir,
+    monkeypatch,
+):
+    _patch_resources_config(monkeypatch, upload_temp_dir, allow_local_path=True)
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"path": str(temp_dir / "missing.md"), "reason": "missing path"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "PERMISSION_DENIED"
 
 
 async def test_add_resource_rejects_private_git_ssh_url(client: httpx.AsyncClient):

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -3,11 +3,33 @@
 
 """Tests for resource management endpoints."""
 
+from types import SimpleNamespace
 import zipfile
 
 import httpx
 
 from openviking.telemetry import get_current_telemetry
+
+
+def _patch_resources_config(monkeypatch, upload_temp_dir, *, allow_local_path: bool) -> None:
+    config = SimpleNamespace(
+        allow_local_path=allow_local_path,
+        storage=SimpleNamespace(get_upload_temp_dir=lambda: upload_temp_dir),
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.resources.get_openviking_config",
+        lambda: config,
+    )
+
+
+def _snapshot_directory(dir_path):
+    snapshot = {}
+    for file_path in sorted(dir_path.rglob("*")):
+        if file_path.is_file():
+            relative = str(file_path.relative_to(dir_path))
+            stat = file_path.stat()
+            snapshot[relative] = (stat.st_size, stat.st_mtime_ns, file_path.read_bytes())
+    return snapshot
 
 
 async def test_add_resource_success(
@@ -391,7 +413,12 @@ async def test_temp_upload_with_telemetry_returns_summary(
     assert body["telemetry"]["summary"]["operation"] == "resources.temp_upload"
 
 
-async def test_add_resource_rejects_direct_local_path(client: httpx.AsyncClient):
+async def test_add_resource_rejects_direct_local_path(
+    client: httpx.AsyncClient,
+    upload_temp_dir,
+    monkeypatch,
+):
+    _patch_resources_config(monkeypatch, upload_temp_dir, allow_local_path=False)
     resp = await client.post(
         "/api/v1/resources",
         json={"path": "/app/ov.conf", "reason": "security test"},
@@ -400,6 +427,58 @@ async def test_add_resource_rejects_direct_local_path(client: httpx.AsyncClient)
     body = resp.json()
     assert body["status"] == "error"
     assert body["error"]["code"] == "PERMISSION_DENIED"
+
+
+async def test_add_resource_accepts_local_file_path_when_enabled(
+    client: httpx.AsyncClient,
+    temp_dir,
+    upload_temp_dir,
+    monkeypatch,
+):
+    _patch_resources_config(monkeypatch, upload_temp_dir, allow_local_path=True)
+    source_file = temp_dir / "source.md"
+    source_file.write_text("# local file\n\nhello\n")
+    before_content = source_file.read_text()
+    before_mtime = source_file.stat().st_mtime_ns
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"path": str(source_file), "reason": "local file path"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["root_uri"].startswith("viking://")
+    assert source_file.read_text() == before_content
+    assert source_file.stat().st_mtime_ns == before_mtime
+
+
+async def test_add_resource_accepts_local_directory_path_when_enabled(
+    client: httpx.AsyncClient,
+    temp_dir,
+    upload_temp_dir,
+    monkeypatch,
+):
+    _patch_resources_config(monkeypatch, upload_temp_dir, allow_local_path=True)
+    source_dir = temp_dir / "source_dir"
+    source_dir.mkdir()
+    (source_dir / "a.md").write_text("# a\n")
+    nested_dir = source_dir / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "b.txt").write_text("hello\n")
+    before_snapshot = _snapshot_directory(source_dir)
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"path": str(source_dir), "reason": "local directory path"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["root_uri"].startswith("viking://")
+    assert _snapshot_directory(source_dir) == before_snapshot
 
 
 async def test_add_resource_accepts_temp_uploaded_file(


### PR DESCRIPTION

## Description

Enable opt-in local filesystem path ingestion for HTTP `add_resource` requests.  
When `allow_local_path` is enabled, absolute local file/directory paths are accepted and processed without pre-copying source content; default behavior remains unchanged and continues to reject direct local paths.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added `allow_local_path` config flag in `openviking_cli/utils/config/open_viking_config.py` (default: `false`).
- Added HTTP local path validation helper `resolve_local_resource_path_for_http()` in `openviking/server/local_input_guard.py`.
- Updated `openviking/server/routers/resources.py` path handling to:
  - keep remote URL validation flow,
  - allow local absolute path resolution only when `config.allow_local_path` is enabled,
  - keep default local-path rejection behavior unchanged.
- Added/updated tests for:
  - allow/deny behavior under `allow_local_path` on/off,
  - invalid local path rejection (relative/non-existent),
  - local file and directory ingestion success,
  - source no-mutation assertions for local file/directory inputs.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- Security default is preserved: HTTP direct local paths remain denied unless explicitly enabled with `allow_local_path=true`.
- Local-path processing remains copy-free for source inputs; parser staging still uses temp VikingFS output only.
- Targeted tests executed successfully for the new local-path scenarios.