### PR TITLE
fix(parse): ignore sqlite database extensions

### DIFF
--- a/openviking/parse/parsers/constants.py
+++ b/openviking/parse/parsers/constants.py
@@ -43,7 +43,8 @@ IGNORE_EXTENSIONS = {
     ".iso",
     ".img",
     ".db",
-    ".sqlitive",
+    ".sqlite",
+    ".sqlite3",
     # Archive formats
     ".zip",
     ".tar",

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -189,6 +189,14 @@ class TestShouldSkipFile:
         assert skip is True
         assert ".jpg" in reason
 
+    def test_sqlite_extensions_are_ignored(self, tmp_path: Path) -> None:
+        for name in ["cache.sqlite", "cache.sqlite3"]:
+            f = tmp_path / name
+            f.write_bytes(b"SQLite format 3\x00")
+            skip, reason = should_skip_file(f)
+            assert skip is True
+            assert f.suffix in reason
+
     def test_large_file(self, tmp_path: Path) -> None:
         f = tmp_path / "big.txt"
         f.write_bytes(b"x" * 100)


### PR DESCRIPTION
## Summary
- replace the misspelled ignored extension `.sqlitive` with real SQLite suffixes
- ignore both `.sqlite` and `.sqlite3` files during upload scanning
- add a focused regression test for SQLite database files

## Testing
- python -m pytest tests/test_upload_utils.py -q
