### PR TITLE
[security] fix(ragfs): require explicit mount auth and confine localfs paths

### DIFF
--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -70,6 +70,26 @@ impl LocalFileSystem {
             }
         }
 
+        let boundary = if resolved.exists() {
+            resolved
+                .canonicalize()
+                .map_err(|e| Error::plugin(format!("failed to canonicalize path: {}", e)))?
+        } else {
+            let parent = resolved.parent().ok_or_else(|| Error::invalid_path(path.to_string()))?;
+            let canonical_parent = parent
+                .canonicalize()
+                .map_err(|e| Error::plugin(format!("failed to canonicalize parent path: {}", e)))?;
+            canonical_parent.join(
+                resolved
+                    .file_name()
+                    .ok_or_else(|| Error::invalid_path(path.to_string()))?,
+            )
+        };
+
+        if !boundary.starts_with(&self.base_path) {
+            return Err(Error::permission_denied(path.to_string()));
+        }
+
         Ok(resolved)
     }
 }
@@ -487,6 +507,23 @@ mod tests {
 
         let fs = LocalFileSystem::new(base.to_str().unwrap()).unwrap();
         let err = fs.read("../outside.txt", 0, 0).await.unwrap_err();
+        assert!(matches!(err, Error::PermissionDenied(_)));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_localfs_rejects_symlink_escape() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("safe");
+        let escaped_dir = tmp.path().join("escaped");
+        let outside = escaped_dir.join("outside.txt");
+        std::fs::create_dir(&base).unwrap();
+        std::fs::create_dir(&escaped_dir).unwrap();
+        std::fs::write(&outside, b"secret").unwrap();
+        std::os::unix::fs::symlink(&escaped_dir, base.join("link_out")).unwrap();
+
+        let fs = LocalFileSystem::new(base.to_str().unwrap()).unwrap();
+        let err = fs.read("link_out/outside.txt", 0, 0).await.unwrap_err();
         assert!(matches!(err, Error::PermissionDenied(_)));
     }
 }

--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::core::errors::{Error, Result};
 use crate::core::filesystem::FileSystem;
@@ -45,27 +45,39 @@ impl LocalFileSystem {
             )));
         }
 
-        Ok(Self { base_path: path })
+        Ok(Self {
+            base_path: path
+                .canonicalize()
+                .map_err(|e| Error::plugin(format!("failed to canonicalize base path: {}", e)))?,
+        })
     }
 
     /// Resolve a virtual path to actual local path
-    fn resolve_path(&self, path: &str) -> PathBuf {
-        // Remove leading slash to make it relative
+    fn resolve_path(&self, path: &str) -> Result<PathBuf> {
         let relative = path.strip_prefix('/').unwrap_or(path);
+        let mut resolved = self.base_path.clone();
 
-        // Join with base path
-        if relative.is_empty() {
-            self.base_path.clone()
-        } else {
-            self.base_path.join(relative)
+        for component in Path::new(relative).components() {
+            match component {
+                Component::CurDir => {}
+                Component::Normal(segment) => resolved.push(segment),
+                Component::ParentDir => {
+                    return Err(Error::permission_denied(path.to_string()));
+                }
+                Component::RootDir | Component::Prefix(_) => {
+                    return Err(Error::invalid_path(path.to_string()));
+                }
+            }
         }
+
+        Ok(resolved)
     }
 }
 
 #[async_trait]
 impl FileSystem for LocalFileSystem {
     async fn create(&self, path: &str) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if file already exists
         if local_path.exists() {
@@ -87,7 +99,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn mkdir(&self, path: &str, _mode: u32) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if directory already exists
         if local_path.exists() {
@@ -109,7 +121,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn remove(&self, path: &str) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists
         if !local_path.exists() {
@@ -135,7 +147,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn remove_all(&self, path: &str) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists
         if !local_path.exists() {
@@ -150,7 +162,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn read(&self, path: &str, offset: u64, size: u64) -> Result<Vec<u8>> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists and is not a directory
         let metadata = fs::metadata(&local_path)
@@ -181,7 +193,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn write(&self, path: &str, data: &[u8], offset: u64, flags: WriteFlag) -> Result<u64> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if it's a directory
         if local_path.exists() && local_path.is_dir() {
@@ -222,7 +234,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn read_dir(&self, path: &str) -> Result<Vec<FileInfo>> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if directory exists
         if !local_path.exists() {
@@ -263,7 +275,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn stat(&self, path: &str) -> Result<FileInfo> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Get file metadata
         let metadata = fs::metadata(&local_path)
@@ -289,8 +301,8 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn rename(&self, old_path: &str, new_path: &str) -> Result<()> {
-        let old_local = self.resolve_path(old_path);
-        let new_local = self.resolve_path(new_path);
+        let old_local = self.resolve_path(old_path)?;
+        let new_local = self.resolve_path(new_path)?;
 
         // Check if old path exists
         if !old_local.exists() {
@@ -312,7 +324,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn chmod(&self, path: &str, _mode: u32) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists
         if !local_path.exists() {
@@ -457,5 +469,24 @@ VERSION: 1.0.0
 
     fn config_params(&self) -> &[ConfigParameter] {
         &self.config_params
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_localfs_rejects_parent_dir_traversal() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("safe");
+        let outside = tmp.path().join("outside.txt");
+        std::fs::create_dir(&base).unwrap();
+        std::fs::write(&outside, b"secret").unwrap();
+
+        let fs = LocalFileSystem::new(base.to_str().unwrap()).unwrap();
+        let err = fs.read("../outside.txt", 0, 0).await.unwrap_err();
+        assert!(matches!(err, Error::PermissionDenied(_)));
     }
 }

--- a/crates/ragfs/src/server/config.rs
+++ b/crates/ragfs/src/server/config.rs
@@ -18,6 +18,9 @@ pub struct ServerConfig {
 
     /// Enable CORS
     pub enable_cors: bool,
+
+    /// API key required for mount-management endpoints
+    pub api_key: String,
 }
 
 impl Default for ServerConfig {
@@ -26,6 +29,7 @@ impl Default for ServerConfig {
             address: "0.0.0.0:8080".to_string(),
             log_level: "info".to_string(),
             enable_cors: true,
+            api_key: String::new(),
         }
     }
 }
@@ -62,6 +66,10 @@ pub struct Args {
     /// Enable CORS
     #[arg(long, default_value = "true", env = "RAGFS_ENABLE_CORS")]
     pub enable_cors: bool,
+
+    /// API key required for mount-management endpoints
+    #[arg(long, default_value = "", env = "RAGFS_API_KEY")]
+    pub api_key: String,
 }
 
 impl Args {
@@ -71,6 +79,7 @@ impl Args {
             address: self.address.clone(),
             log_level: self.log_level.clone(),
             enable_cors: self.enable_cors,
+            api_key: self.api_key.clone(),
         }
     }
 
@@ -106,6 +115,7 @@ mod tests {
             address: "127.0.0.1:3000".to_string(),
             log_level: "debug".to_string(),
             enable_cors: false,
+            api_key: String::new(),
         };
 
         let addr = config.socket_addr().unwrap();
@@ -118,6 +128,7 @@ mod tests {
             address: "invalid".to_string(),
             log_level: "info".to_string(),
             enable_cors: true,
+            api_key: String::new(),
         };
 
         assert!(config.socket_addr().is_err());

--- a/crates/ragfs/src/server/handlers.rs
+++ b/crates/ragfs/src/server/handlers.rs
@@ -112,6 +112,20 @@ pub struct MountInfo {
     pub plugin: String,
 }
 
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    if a_bytes.len() != b_bytes.len() {
+        return false;
+    }
+
+    let mut diff = 0u8;
+    for (x, y) in a_bytes.iter().zip(b_bytes.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 fn authorize_mount_management(headers: &HeaderMap, state: &AppState) -> Option<Response> {
     if state.mount_api_key.is_empty() {
         return Some(
@@ -138,7 +152,7 @@ fn authorize_mount_management(headers: &HeaderMap, state: &AppState) -> Option<R
         }
     };
 
-    if supplied != state.mount_api_key {
+    if !constant_time_eq(supplied, &state.mount_api_key) {
         return Some(
             (
                 StatusCode::FORBIDDEN,

--- a/crates/ragfs/src/server/handlers.rs
+++ b/crates/ragfs/src/server/handlers.rs
@@ -4,7 +4,7 @@
 
 use axum::{
     extract::{Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -18,6 +18,8 @@ use crate::core::{FileSystem, MountableFS, PluginConfig, WriteFlag};
 pub struct AppState {
     /// The mounted filesystem
     pub fs: Arc<MountableFS>,
+    /// API key required for mount-management endpoints
+    pub mount_api_key: String,
 }
 
 /// Standard API response
@@ -108,6 +110,45 @@ pub struct MountInfo {
     pub path: String,
     /// Plugin name
     pub plugin: String,
+}
+
+fn authorize_mount_management(headers: &HeaderMap, state: &AppState) -> Option<Response> {
+    if state.mount_api_key.is_empty() {
+        return Some(
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ApiResponse::<()>::error(
+                    "RAGFS mount-management API key is not configured",
+                )),
+            )
+                .into_response(),
+        );
+    }
+
+    let supplied = match headers.get("X-API-Key").and_then(|v| v.to_str().ok()) {
+        Some(value) if !value.is_empty() => value,
+        _ => {
+            return Some(
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(ApiResponse::<()>::error("X-API-Key header required")),
+                )
+                    .into_response(),
+            )
+        }
+    };
+
+    if supplied != state.mount_api_key {
+        return Some(
+            (
+                StatusCode::FORBIDDEN,
+                Json(ApiResponse::<()>::error("Invalid API key")),
+            )
+                .into_response(),
+        );
+    }
+
+    None
 }
 
 // ============================================================================
@@ -257,7 +298,11 @@ pub async fn create_directory(
 // ============================================================================
 
 /// GET /api/v1/mounts - List all mounts
-pub async fn list_mounts(State(state): State<AppState>) -> Response {
+pub async fn list_mounts(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Some(response) = authorize_mount_management(&headers, &state) {
+        return response;
+    }
+
     let mounts = state.fs.list_mounts().await;
     let mount_infos: Vec<MountInfo> = mounts
         .into_iter()
@@ -270,8 +315,13 @@ pub async fn list_mounts(State(state): State<AppState>) -> Response {
 /// POST /api/v1/mount - Mount a filesystem
 pub async fn mount_filesystem(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<MountRequest>,
 ) -> Response {
+    if let Some(response) = authorize_mount_management(&headers, &state) {
+        return response;
+    }
+
     // Convert JSON params to ConfigValue
     let params = req
         .params
@@ -326,8 +376,13 @@ pub async fn mount_filesystem(
 /// POST /api/v1/unmount - Unmount a filesystem
 pub async fn unmount_filesystem(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<UnmountRequest>,
 ) -> Response {
+    if let Some(response) = authorize_mount_management(&headers, &state) {
+        return response;
+    }
+
     match state.fs.unmount(&req.path).await {
         Ok(_) => (
             StatusCode::OK,

--- a/crates/ragfs/src/server/main.rs
+++ b/crates/ragfs/src/server/main.rs
@@ -51,7 +51,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Create application state
-    let state = AppState { fs: fs.clone() };
+    let state = AppState {
+        fs: fs.clone(),
+        mount_api_key: config.api_key.clone(),
+    };
 
     // Create router
     let app = create_router(state, config.enable_cors);
@@ -73,10 +76,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("  POST   /api/v1/mount");
     tracing::info!("  POST   /api/v1/unmount");
     tracing::info!("");
-    tracing::info!("Example: Mount MemFS");
-    tracing::info!("  curl -X POST http://{}/api/v1/mount \\", addr);
-    tracing::info!("    -H 'Content-Type: application/json' \\");
-    tracing::info!("    -d '{{\"plugin\": \"memfs\", \"path\": \"/memfs\"}}'");
+    if config.api_key.is_empty() {
+        tracing::warn!("Mount-management endpoints are disabled until RAGFS_API_KEY (or api_key in config) is set");
+    } else {
+        tracing::info!("Mount-management endpoints require X-API-Key authentication");
+        tracing::info!("Example: Mount MemFS");
+        tracing::info!("  curl -X POST http://{}/api/v1/mount \\", addr);
+        tracing::info!("    -H 'X-API-Key: <RAGFS_API_KEY>' \\");
+        tracing::info!("    -H 'Content-Type: application/json' \\");
+        tracing::info!("    -d '{{\"plugin\": \"memfs\", \"path\": \"/memfs\"}}'");
+    }
 
     // Create TCP listener
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/ragfs/src/server/router.rs
+++ b/crates/ragfs/src/server/router.rs
@@ -59,15 +59,94 @@ pub fn create_router(state: AppState, enable_cors: bool) -> Router {
 mod tests {
     use super::*;
     use crate::core::MountableFS;
+    use crate::plugins::MemFSPlugin;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use serde_json::json;
     use std::sync::Arc;
+    use tower::util::ServiceExt;
 
     #[test]
     fn test_router_creation() {
         let state = AppState {
             fs: Arc::new(MountableFS::new()),
+            mount_api_key: String::new(),
         };
 
         let _router = create_router(state, true);
         // If this compiles and runs, the router is correctly configured
+    }
+
+    #[tokio::test]
+    async fn test_mount_routes_require_api_key_when_unconfigured() {
+        let fs = Arc::new(MountableFS::new());
+        fs.register_plugin(MemFSPlugin).await;
+        let state = AppState {
+            fs,
+            mount_api_key: String::new(),
+        };
+        let app = create_router(state, false);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/mount")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({"plugin":"memfs","path":"/mem"}).to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_mount_routes_accept_valid_api_key() {
+        let fs = Arc::new(MountableFS::new());
+        fs.register_plugin(MemFSPlugin).await;
+        let state = AppState {
+            fs,
+            mount_api_key: "secret-key".to_string(),
+        };
+        let app = create_router(state, false);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/mount")
+            .header("content-type", "application/json")
+            .header("X-API-Key", "secret-key")
+            .body(Body::from(
+                json!({"plugin":"memfs","path":"/mem"}).to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_mount_routes_reject_invalid_api_key() {
+        let fs = Arc::new(MountableFS::new());
+        fs.register_plugin(MemFSPlugin).await;
+        let state = AppState {
+            fs,
+            mount_api_key: "secret-key".to_string(),
+        };
+        let app = create_router(state, false);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/mount")
+            .header("content-type", "application/json")
+            .header("X-API-Key", "wrong-key")
+            .body(Body::from(
+                json!({"plugin":"memfs","path":"/mem"}).to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }


### PR DESCRIPTION
## Summary
This PR hardens the RAGFS HTTP control plane by requiring explicit authentication for mount-management endpoints and by preventing `localfs` from resolving paths outside the mounted base directory.
- mount-management routes now fail closed until an operator explicitly sets `RAGFS_API_KEY` (or `api_key` in the RAGFS config)
- `GET /api/v1/mounts`, `POST /api/v1/mount`, and `POST /api/v1/unmount` now require `X-API-Key`, and the key comparison now uses constant-time matching
- `localfs` now rejects both `..` traversal and symlink-based escapes so mounted paths cannot escape the configured `local_dir`
- regression tests lock in the fail-closed mount behavior, valid/invalid key handling, parent-directory traversal denial, and symlink escape denial

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Unauthenticated RAGFS mount-management API | remote caller can mount `localfs` and then use the generic file API to read/write/delete host files | Critical |
| `localfs` mount-root escape via traversal or symlink | caller can reach host paths outside the configured mount root and access files the operator did not intend to expose | High |

## Before this PR
- the standalone RAGFS HTTP server exposed `GET /api/v1/mounts`, `POST /api/v1/mount`, and `POST /api/v1/unmount` without any authentication
- the same server defaulted to binding `0.0.0.0:8080`, so any network-reachable deployment exposed mount management as a remote control-plane surface
- `localfs` accepted any existing `local_dir`, then resolved request paths with a raw `base_path.join(relative)` pattern
- no regression tests enforced a fail-closed mount boundary or blocked traversal/symlink escapes out of the mounted base path

## After this PR
- mount-management endpoints return `503` until an operator explicitly configures a mount-management API key
- once configured, mount-management endpoints require `X-API-Key` and reject missing or incorrect credentials using constant-time comparison
- `localfs` canonicalizes the configured base path and rejects both parent-directory traversal and symlink escapes before any filesystem operation executes
- targeted regression tests now cover the fail-closed mount behavior, successful authenticated mount, invalid-key rejection, parent-directory traversal denial, and symlink escape denial

## Explicit operator choice
Use this when the RAGFS HTTP server should expose mount management to a trusted caller.

Secure default (mount management disabled):
```yaml
address: "0.0.0.0:8080"
log_level: "info"
enable_cors: true
api_key: ""
```

Explicitly enabled mount management:
```yaml
address: "0.0.0.0:8080"
log_level: "info"
enable_cors: true
api_key: "replace-with-strong-random-value"
```

Equivalent environment-based enablement:
```bash
export RAGFS_API_KEY='replace-with-strong-random-value'
```

Behavior summary:
- when `api_key` is empty, mount-management endpoints are disabled and return `503`
- when `api_key` is set, the operator regains trusted control of mount management through `X-API-Key`
- ordinary file and directory routes stay unchanged in this PR; this patch narrows the exposed control-plane boundary around mounting and unmounting filesystems

## Why this matters
The RAGFS mount API is not a harmless metadata surface. It changes which host-backed filesystems the server exposes under the generic file API. On vulnerable code, any remote caller who could reach the server could mount `localfs` on `/`, then use ordinary `GET/PUT/POST/DELETE /api/v1/files` and directory routes against host paths. Separately, even a trusted `localfs` mount could be widened unintentionally because traversal components and symlink escapes were not blocked.

## Attack flow
```text
unauthenticated HTTP request
    -> RAGFS mount-management endpoint
        -> attacker mounts localfs over an arbitrary host directory
            -> generic file API reads / writes / deletes host files
```

```text
mounted localfs request path
    -> localfs path resolution follows traversal or outward symlink
        -> path escapes configured local_dir
            -> caller reaches host files outside the intended mount root
```

## Affected code
| Issue | Files |
|-------|-------|
| Unauthenticated mount-management API | `crates/ragfs/src/server/config.rs`, `crates/ragfs/src/server/handlers.rs`, `crates/ragfs/src/server/main.rs`, `crates/ragfs/src/server/router.rs` |
| `localfs` mount-root escape | `crates/ragfs/src/plugins/localfs/mod.rs` |

## Root cause
Issue 1: unauthenticated mount-management API
- the RAGFS HTTP server exposed mount-management handlers without any authentication or secure default gate
- this broke the control-plane boundary between ordinary file access and privileged filesystem mounting

Issue 2: `localfs` mount-root escape
- `localfs` resolved virtual paths with a direct join against the configured base path
- this failed to enforce that request paths remain inside the configured mount root and did not block symlink-based escapes

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Unauthenticated RAGFS mount-management API | 9.8 Critical | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` |
| `localfs` mount-root escape | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L` |

Rationale:
- the mount-management issue is remotely reachable without prior authentication and directly enables host file exposure and tampering through the existing file API
- the `localfs` escape issue is strongest once `localfs` is mounted, but it still violates the operator’s expected trust boundary for a constrained mount

## Safe reproduction steps
### 1. Unauthenticated mount-management API
1. Start `ragfs-server` with default settings and no `RAGFS_API_KEY`.
2. Send:
   ```bash
   curl -X POST http://127.0.0.1:8080/api/v1/mount \
     -H 'Content-Type: application/json' \
     -d '{"plugin":"localfs","path":"/host","params":{"local_dir":"/"}}'
   ```
3. On vulnerable code, the mount succeeds.
4. Then read a host file through the generic API:
   ```bash
   curl 'http://127.0.0.1:8080/api/v1/files?path=/host/etc/hosts'
   ```
5. Observe that pre-patch code exposes host-backed content without any mount-management authentication.

### 2. `localfs` mount-root escape
1. Mount `localfs` to a constrained directory such as `/tmp/safe`.
2. Request a path containing `..`, for example:
   ```bash
   curl 'http://127.0.0.1:8080/api/v1/files?path=/host/../outside.txt'
   ```
3. On vulnerable code, the request resolves outside the configured `local_dir` instead of being rejected.
4. Create a symlink inside the mounted root that points outside the root, then request a file through that symlink path.
5. On vulnerable code, the symlink target is reachable even though it sits outside the configured mount root.

Prefer bounded local repros against disposable test paths rather than sensitive real files.

## Expected vulnerable behavior
- remote callers can create or inspect mounts without authenticating
- once `localfs` is mounted, the generic file API can be turned into host file read/write/delete access
- a mounted `localfs` path containing `..` or an outward symlink can escape the intended mount root

## Changes in this PR
- add an `api_key` server config / `RAGFS_API_KEY` environment control for mount-management endpoints
- fail closed for mount-management when no API key is configured
- require `X-API-Key` for `GET /api/v1/mounts`, `POST /api/v1/mount`, and `POST /api/v1/unmount` using constant-time key comparison
- update startup logging so operators can see whether mount management is disabled or explicitly enabled
- canonicalize `localfs` base paths and reject both parent-directory traversal and symlink-based escapes before filesystem operations run
- add regression tests for unconfigured mount rejection, valid-key acceptance, invalid-key rejection, parent-directory traversal denial, and symlink escape denial

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| mount-management auth | `crates/ragfs/src/server/config.rs`, `crates/ragfs/src/server/handlers.rs`, `crates/ragfs/src/server/main.rs`, `crates/ragfs/src/server/router.rs` | add secure-by-default API-key gate and route-level authentication for mount management |
| localfs path confinement | `crates/ragfs/src/plugins/localfs/mod.rs` | canonicalize base path, reject `..` traversal and symlink escapes, and add confinement regression coverage |

## Maintainer impact
- patch scope stays inside the `crates/ragfs` subsystem
- ordinary file and directory route behavior is unchanged except for the trusted mount-management boundary
- the new pattern is easier to maintain because the mount-management trust boundary is explicit in config, handlers, and regression tests

## Fix rationale
- mounting and unmounting filesystems is a privileged control-plane action, not ordinary data-plane traffic
- failing closed until an operator sets an explicit API key keeps the standalone server safe by default without removing mount functionality
- using constant-time comparison avoids leaking the mount-management API key through timing side channels
- rejecting traversal components and symlink-based escapes inside `localfs` is a narrow, durable way to preserve the operator’s intended mount root across all file operations
- the added tests are sufficient to lock in the mount-management auth boundary and the `localfs` confinement boundary

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `cargo test -p ragfs test_mount_routes_require_api_key_when_unconfigured -- --nocapture`
- [x] `cargo test -p ragfs test_mount_routes_accept_valid_api_key -- --nocapture`
- [x] `cargo test -p ragfs test_mount_routes_reject_invalid_api_key -- --nocapture`
- [x] `cargo test -p ragfs test_localfs_rejects_parent_dir_traversal -- --nocapture`
- [x] `cargo test -p ragfs test_localfs_rejects_symlink_escape -- --nocapture`
- [x] `cargo check -p ragfs`
- [ ] `cargo test -p ragfs --lib --tests` (currently still has unrelated pre-existing QueueFS test failures outside this patch scope)

Executed with:
- `cargo test -p ragfs test_mount_routes_require_api_key_when_unconfigured -- --nocapture`
- `cargo test -p ragfs test_mount_routes_accept_valid_api_key -- --nocapture`
- `cargo test -p ragfs test_mount_routes_reject_invalid_api_key -- --nocapture`
- `cargo test -p ragfs test_localfs_rejects_parent_dir_traversal -- --nocapture`
- `cargo test -p ragfs test_localfs_rejects_symlink_escape -- --nocapture`
- `cargo check -p ragfs`
- `cargo test -p ragfs --lib --tests`

Broader-suite note:
- `cargo test -p ragfs --lib --tests` still reports unrelated pre-existing QueueFS failures:
  - `plugins::queuefs::tests::test_multi_queue`
  - `plugins::queuefs::tests::test_nested_queues`
  - `plugins::queuefs::tests::test_queuefs_plugin`
  - `plugins::queuefs::tests::test_queuefs_read_dir`

## Disclosure notes
- claims are bounded to the reviewed `crates/ragfs` code paths and targeted local reproduction
- the repository does not currently provide a meaningful `SECURITY.md` disclosure guide in the root of this checkout
- no unrelated application-layer files were changed outside the RAGFS security boundary
