### PR TITLE
fix(session): drop user registry check for message role_id

### DIFF
--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -133,14 +133,6 @@ def _resolve_message_role_id(
     if not _ROLE_ID_PATTERN.match(role_id):
         raise InvalidArgumentError("role_id must be alpha-numeric string.")
 
-    if request.role == "user":
-        api_key_manager = getattr(http_request.app.state, "api_key_manager", None)
-        has_user = getattr(api_key_manager, "has_user", None)
-        if callable(has_user) and not has_user(ctx.account_id, role_id):
-            raise InvalidArgumentError(
-                f"role_id '{role_id}' is not a registered user in account '{ctx.account_id}'."
-            )
-
     return role_id
 
 

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -345,7 +345,7 @@ async def test_add_message_user_request_autofills_role_id(service, monkeypatch):
     assert session.messages[-1].role_id == "assistant-user"
 
 
-async def test_add_message_rejects_unregistered_user_role_id(service, monkeypatch):
+async def test_add_message_admin_request_allows_unregistered_user_role_id(service, monkeypatch):
     manager = APIKeyManager(root_key=TEST_ROOT_KEY, viking_fs=service.viking_fs)
     await manager.load()
     account_id = "acct_session_invalid"
@@ -356,15 +356,19 @@ async def test_add_message_rejects_unregistered_user_role_id(service, monkeypatc
         role=Role.ADMIN,
     )
 
-    with pytest.raises(InvalidArgumentError, match="not a registered user"):
-        await _call_add_message_route(
-            service,
-            monkeypatch,
-            ctx=ctx,
-            payload=_message_request("user", content="hello invalid", role_id="ghost"),
-            api_key_manager=manager,
-            session_id="invalid-user-role-id",
-        )
+    response = await _call_add_message_route(
+        service,
+        monkeypatch,
+        ctx=ctx,
+        payload=_message_request("user", content="hello invalid", role_id="ghost"),
+        api_key_manager=manager,
+        session_id="invalid-user-role-id",
+    )
+
+    assert response.result["message_count"] == 1
+    session = await service.sessions.get("invalid-user-role-id", ctx, auto_create=False)
+    await session.load()
+    assert session.messages[-1].role_id == "ghost"
 
 
 async def test_add_multiple_messages(client: httpx.AsyncClient):


### PR DESCRIPTION
## Description

Remove the session `add_message` user-registry validation for `role_id` so message actor IDs remain backward-compatible and are not forced to map to registered account users.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- removed `api_key_manager.has_user(...)` validation from session `role_id` resolution for `add_message`
- restored compatibility for unregistered/default user contexts when writing user messages
- updated the existing session API test to assert unregistered `role_id` values are accepted

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

`session.role_id` is now treated purely as the message actor identifier on this HTTP path instead of being constrained by account user registration.
