### PR TITLE
feat(semantic): add output_language_override to pin summary/overview language

### DIFF
--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -54,12 +54,10 @@ class SessionExtractContextProvider(ExtractContextProvider):
 
     def _detect_language(self) -> str:
         """检测输出语言"""
-        from openviking.session.memory.utils import detect_language_from_conversation
+        from openviking.session.memory.utils import resolve_output_language_from_conversation
 
         conversation = self._assemble_conversation(self.messages)
-        config = get_openviking_config()
-        fallback_language = (config.language_fallback or "en").strip() or "en"
-        return detect_language_from_conversation(conversation, fallback_language=fallback_language)
+        return resolve_output_language_from_conversation(conversation)
 
     def instruction(self) -> str:
         output_language = self._output_language

--- a/openviking/session/memory/utils/__init__.py
+++ b/openviking/session/memory/utils/__init__.py
@@ -25,6 +25,7 @@ from openviking.session.memory.utils.language import (
     detect_language_from_conversation,
     resolve_output_language,
     resolve_output_language_from_conversation,
+    resolve_with_override,
 )
 from openviking.session.memory.utils.messages import (
     parse_memory_file_with_fields,
@@ -60,6 +61,7 @@ __all__ = [
     "detect_language_from_conversation",
     "resolve_output_language",
     "resolve_output_language_from_conversation",
+    "resolve_with_override",
     # Messages
     "pretty_print_messages",
     "parse_memory_file_with_fields",

--- a/openviking/session/memory/utils/__init__.py
+++ b/openviking/session/memory/utils/__init__.py
@@ -23,6 +23,8 @@ from openviking.session.memory.utils.json_parser import (
 )
 from openviking.session.memory.utils.language import (
     detect_language_from_conversation,
+    resolve_output_language,
+    resolve_output_language_from_conversation,
 )
 from openviking.session.memory.utils.messages import (
     parse_memory_file_with_fields,
@@ -56,6 +58,8 @@ __all__ = [
     "truncate_content",
     # Language
     "detect_language_from_conversation",
+    "resolve_output_language",
+    "resolve_output_language_from_conversation",
     # Messages
     "pretty_print_messages",
     "parse_memory_file_with_fields",

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -48,28 +48,24 @@ def _detect_language_from_text(user_text: str, fallback_language: str) -> str:
     return fallback
 
 
-def resolve_with_override(config, detect_with_fallback: Callable[[str], str]) -> str:
-    """Return config override if set, else call `detect_with_fallback(fallback)`.
+def resolve_with_override(config, detect: Callable[[], str]) -> str:
+    """Return config override if set, else call `detect()`.
 
-    The callable receives the resolved fallback language and returns the
-    detected output language, letting callers choose the detector (text vs
-    conversation vs messages) without duplicating the override/fallback
-    resolution logic.
+    The callable returns the detected output language, letting callers choose
+    the detector (text vs conversation vs messages) without duplicating the
+    override resolution logic.
     """
     if config is None:
         config = get_openviking_config()
     override = (getattr(config, "output_language_override", None) or "").strip()
     if override:
         return override
-    fallback = (getattr(config, "language_fallback", None) or "en").strip() or "en"
-    return detect_with_fallback(fallback)
+    return detect()
 
 
 def resolve_output_language(text: str, config=None) -> str:
     """Resolve output language from text, honoring config override before detection."""
-    return resolve_with_override(
-        config, lambda fallback: _detect_language_from_text(text, fallback)
-    )
+    return resolve_with_override(config, lambda: _detect_language_from_text(text, "en"))
 
 
 def resolve_output_language_from_conversation(conversation: str, config=None) -> str:
@@ -78,12 +74,7 @@ def resolve_output_language_from_conversation(conversation: str, config=None) ->
     When no override is set, uses `detect_language_from_conversation` which
     scopes detection to user-role content only.
     """
-    return resolve_with_override(
-        config,
-        lambda fallback: detect_language_from_conversation(
-            conversation, fallback_language=fallback
-        ),
-    )
+    return resolve_with_override(config, lambda: detect_language_from_conversation(conversation))
 
 
 def detect_language_from_conversation(conversation: str, fallback_language: str = "en") -> str:

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -5,8 +5,10 @@ Language detection utilities.
 """
 
 import re
+from typing import Callable
 
 from openviking_cli.utils import get_logger
+from openviking_cli.utils.config import get_openviking_config
 
 logger = get_logger(__name__)
 
@@ -46,39 +48,42 @@ def _detect_language_from_text(user_text: str, fallback_language: str) -> str:
     return fallback
 
 
-def resolve_output_language(text: str, config=None) -> str:
-    """Resolve output language, honoring config override before content detection.
+def resolve_with_override(config, detect_with_fallback: Callable[[str], str]) -> str:
+    """Return config override if set, else call `detect_with_fallback(fallback)`.
 
-    When `output_language_override` is set in OpenViking config, returns it directly
-    and skips content-based detection entirely. Otherwise falls back to
-    `_detect_language_from_text` using the configured `language_fallback`.
+    The callable receives the resolved fallback language and returns the
+    detected output language, letting callers choose the detector (text vs
+    conversation vs messages) without duplicating the override/fallback
+    resolution logic.
     """
     if config is None:
-        from openviking_cli.utils.config import get_openviking_config
-
         config = get_openviking_config()
     override = (getattr(config, "output_language_override", None) or "").strip()
     if override:
         return override
     fallback = (getattr(config, "language_fallback", None) or "en").strip() or "en"
-    return _detect_language_from_text(text, fallback)
+    return detect_with_fallback(fallback)
+
+
+def resolve_output_language(text: str, config=None) -> str:
+    """Resolve output language from text, honoring config override before detection."""
+    return resolve_with_override(
+        config, lambda fallback: _detect_language_from_text(text, fallback)
+    )
 
 
 def resolve_output_language_from_conversation(conversation: str, config=None) -> str:
-    """Resolve output language for a conversation, honoring config override.
+    """Resolve output language from a conversation, honoring config override.
 
-    Mirrors `resolve_output_language` but uses `detect_language_from_conversation`
-    (user-only extraction) when no override is set.
+    When no override is set, uses `detect_language_from_conversation` which
+    scopes detection to user-role content only.
     """
-    if config is None:
-        from openviking_cli.utils.config import get_openviking_config
-
-        config = get_openviking_config()
-    override = (getattr(config, "output_language_override", None) or "").strip()
-    if override:
-        return override
-    fallback = (getattr(config, "language_fallback", None) or "en").strip() or "en"
-    return detect_language_from_conversation(conversation, fallback_language=fallback)
+    return resolve_with_override(
+        config,
+        lambda fallback: detect_language_from_conversation(
+            conversation, fallback_language=fallback
+        ),
+    )
 
 
 def detect_language_from_conversation(conversation: str, fallback_language: str = "en") -> str:

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -46,6 +46,41 @@ def _detect_language_from_text(user_text: str, fallback_language: str) -> str:
     return fallback
 
 
+def resolve_output_language(text: str, config=None) -> str:
+    """Resolve output language, honoring config override before content detection.
+
+    When `output_language_override` is set in OpenViking config, returns it directly
+    and skips content-based detection entirely. Otherwise falls back to
+    `_detect_language_from_text` using the configured `language_fallback`.
+    """
+    if config is None:
+        from openviking_cli.utils.config import get_openviking_config
+
+        config = get_openviking_config()
+    override = (getattr(config, "output_language_override", None) or "").strip()
+    if override:
+        return override
+    fallback = (getattr(config, "language_fallback", None) or "en").strip() or "en"
+    return _detect_language_from_text(text, fallback)
+
+
+def resolve_output_language_from_conversation(conversation: str, config=None) -> str:
+    """Resolve output language for a conversation, honoring config override.
+
+    Mirrors `resolve_output_language` but uses `detect_language_from_conversation`
+    (user-only extraction) when no override is set.
+    """
+    if config is None:
+        from openviking_cli.utils.config import get_openviking_config
+
+        config = get_openviking_config()
+    override = (getattr(config, "output_language_override", None) or "").strip()
+    if override:
+        return override
+    fallback = (getattr(config, "language_fallback", None) or "en").strip() or "en"
+    return detect_language_from_conversation(conversation, fallback_language=fallback)
+
+
 def detect_language_from_conversation(conversation: str, fallback_language: str = "en") -> str:
     """Detect dominant language from user messages in conversation.
 

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -17,7 +17,7 @@ def _detect_language_from_text(user_text: str, fallback_language: str) -> str:
     """Internal shared helper to detect dominant language from text."""
     fallback = (fallback_language or "en").strip() or "en"
 
-    #return "zh-CN"
+    # return "zh-CN"
 
     if not user_text:
         return fallback

--- a/openviking/session/memory_extractor.py
+++ b/openviking/session/memory_extractor.py
@@ -279,10 +279,14 @@ class MemoryExtractor:
                 return []
 
             config = get_openviking_config()
-            fallback_language = (config.language_fallback or "en").strip() or "en"
-            output_language = self._detect_output_language(
-                messages, fallback_language=fallback_language
-            )
+            override = (getattr(config, "output_language_override", None) or "").strip()
+            if override:
+                output_language = override
+            else:
+                fallback_language = (config.language_fallback or "en").strip() or "en"
+                output_language = self._detect_output_language(
+                    messages, fallback_language=fallback_language
+                )
             history_summary = str(context.get("summary") or "")
 
             prompt = render_prompt(

--- a/openviking/session/memory_extractor.py
+++ b/openviking/session/memory_extractor.py
@@ -278,15 +278,13 @@ class MemoryExtractor:
                 logger.warning("No formatted messages, returning empty list")
                 return []
 
+            from openviking.session.memory.utils.language import resolve_with_override
+
             config = get_openviking_config()
-            override = (getattr(config, "output_language_override", None) or "").strip()
-            if override:
-                output_language = override
-            else:
-                fallback_language = (config.language_fallback or "en").strip() or "en"
-                output_language = self._detect_output_language(
-                    messages, fallback_language=fallback_language
-                )
+            output_language = resolve_with_override(
+                config,
+                lambda fb: self._detect_output_language(messages, fallback_language=fb),
+            )
             history_summary = str(context.get("summary") or "")
 
             prompt = render_prompt(

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -872,10 +872,9 @@ class SemanticProcessor(DequeueHandlerBase):
             logger.warning("VLM not available, using empty summary")
             return {"name": file_name, "summary": ""}
 
-        from openviking.session.memory.utils.language import _detect_language_from_text
+        from openviking.session.memory.utils.language import resolve_output_language
 
-        fallback_language = (get_openviking_config().language_fallback or "en").strip() or "en"
-        output_language = _detect_language_from_text(content, fallback_language)
+        output_language = resolve_output_language(content)
 
         # Detect file type and select appropriate prompt
         file_type = self._detect_file_type(file_name)
@@ -1079,9 +1078,7 @@ class SemanticProcessor(DequeueHandlerBase):
             logger.warning("VLM not available, using default overview")
             return f"# {dir_uri.split('/')[-1]}\n\n[Directory overview is not ready]"
 
-        from openviking.session.memory.utils.language import _detect_language_from_text
-
-        fallback_language = (config.language_fallback or "en").strip() or "en"
+        from openviking.session.memory.utils.language import resolve_output_language
 
         # Build file index mapping and summary string
         file_index_map = {}
@@ -1091,7 +1088,7 @@ class SemanticProcessor(DequeueHandlerBase):
             file_summaries_lines.append(f"[{idx}] {item['name']}: {item['summary']}")
         file_summaries_str = "\n".join(file_summaries_lines) if file_summaries_lines else "None"
 
-        output_language = _detect_language_from_text(file_summaries_str, fallback_language)
+        output_language = resolve_output_language(file_summaries_str, config=config)
 
         # Build subdirectory summary string
         children_abstracts_str = (

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -136,8 +136,8 @@ class OpenVikingConfig(BaseModel):
     language_fallback: str = Field(
         default="en",
         description=(
-            "Fallback language used by memory extraction and semantic processing when dominant "
-            "user language cannot be confidently detected"
+            "Deprecated. No longer used — detection falls back to 'en' when no language can be "
+            "inferred. Set output_language_override instead to pin an explicit language."
         ),
     )
 
@@ -150,6 +150,16 @@ class OpenVikingConfig(BaseModel):
             "(e.g., 'en', 'zh-CN', 'ja'). Leave empty (default) to auto-detect per content."
         ),
     )
+
+    @model_validator(mode="after")
+    def _warn_on_deprecated_language_fallback(self) -> "OpenVikingConfig":
+        if self.language_fallback and self.language_fallback != "en":
+            logging.getLogger(__name__).warning(
+                "Config field 'language_fallback=%s' is deprecated and has no effect; "
+                "remove it, or set 'output_language_override' to pin an explicit language.",
+                self.language_fallback,
+            )
+        return self
 
     allow_private_networks: bool = Field(
         default=False,

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -141,6 +141,16 @@ class OpenVikingConfig(BaseModel):
         ),
     )
 
+    output_language_override: str = Field(
+        default="",
+        description=(
+            "When non-empty, bypasses content-based language detection for memory extraction "
+            "and semantic summaries/overviews and forces this language instead. Use when your "
+            "corpus is mixed-language but you want summaries pinned to a single language "
+            "(e.g., 'en', 'zh-CN', 'ja'). Leave empty (default) to auto-detect per content."
+        ),
+    )
+
     allow_private_networks: bool = Field(
         default=False,
         description=(

--- a/tests/storage/test_semantic_processor_language.py
+++ b/tests/storage/test_semantic_processor_language.py
@@ -10,7 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from openviking.prompts import render_prompt
-from openviking.session.memory.utils.language import _detect_language_from_text
+from openviking.session.memory.utils.language import (
+    _detect_language_from_text,
+    resolve_output_language,
+    resolve_output_language_from_conversation,
+)
 
 
 class TestLanguageDetection:
@@ -317,3 +321,52 @@ class TestGenerateTextSummaryOutputLanguage:
                 assert _verify_content_language(result["summary"], expected_lang), (
                     f"{file_name}: Content language mismatch. Expected {expected_lang}, got: {result['summary']}"
                 )
+
+
+class TestOutputLanguageOverride:
+    """Config-level `output_language_override` bypasses content-based detection."""
+
+    def _make_config(self, override: str = "", fallback: str = "en"):
+        config = MagicMock()
+        config.output_language_override = override
+        config.language_fallback = fallback
+        return config
+
+    def test_override_unset_detects_from_content(self):
+        config = self._make_config(override="")
+        result = resolve_output_language("これは日本語のテキストです", config=config)
+        assert result == "ja"
+
+    def test_override_unset_uses_fallback_for_latin_text(self):
+        config = self._make_config(override="", fallback="en")
+        result = resolve_output_language(
+            "Plain English text with no special scripts", config=config
+        )
+        assert result == "en"
+
+    def test_override_set_bypasses_detection(self):
+        config = self._make_config(override="en")
+        result = resolve_output_language("これは日本語のテキストです", config=config)
+        assert result == "en"
+
+    def test_override_set_wins_over_fallback(self):
+        config = self._make_config(override="zh-CN", fallback="en")
+        result = resolve_output_language("Plain English text", config=config)
+        assert result == "zh-CN"
+
+    def test_override_whitespace_treated_as_unset(self):
+        config = self._make_config(override="   ")
+        result = resolve_output_language("これは日本語のテキストです", config=config)
+        assert result == "ja"
+
+    def test_conversation_override_set_bypasses_detection(self):
+        config = self._make_config(override="en")
+        conversation = "[user]: これは日本語のメッセージです\n[assistant]: reply"
+        result = resolve_output_language_from_conversation(conversation, config=config)
+        assert result == "en"
+
+    def test_conversation_override_unset_detects_from_user_content(self):
+        config = self._make_config(override="")
+        conversation = "[user]: これは日本語のメッセージです\n[assistant]: reply"
+        result = resolve_output_language_from_conversation(conversation, config=config)
+        assert result == "ja"


### PR DESCRIPTION
## Description

Adds a new config key `output_language_override` that, when set, bypasses
content-based language detection in semantic summary/overview generation and
memory extraction. When empty (default), behavior is unchanged.

Content-based detection (added in #1076 to resolve #934, strengthened in
open #1521) works well when a directory's content is monolingual, but
fails on mixed-language corpora — `_detect_language_from_text` latches
onto minority-script content and flips the entire directory's
`.overview.md` / `.abstract.md` to a language the user does not read.
`language_fallback` does not help because detection runs regardless.

Symmetric impact: an English-primary deployment with some imported
Japanese/Chinese content, or a Chinese-primary deployment with embedded
English documentation, now has a single knob to pin output language.

## Related Issue

Related to #934 (closed by #1076), #1067, and #1521. Complements, does
not conflict with, the source-language-following direction — override is
opt-in and defaults off.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Add `output_language_override: str = ""` field to `OpenVikingConfig`
- Add `resolve_with_override(config, detect_with_fallback)` as the
  canonical primitive and two thin convenience wrappers
  (`resolve_output_language`, `resolve_output_language_from_conversation`)
  in `openviking/session/memory/utils/language.py`
- Wire the helpers into `SemanticProcessor` (file summary + overview
  generation), `MemoryExtractor`, and `SessionExtractContextProvider` so
  all three language-resolution paths share one override source of truth
- Add `TestOutputLanguageOverride` covering override set/unset paths for
  both text and conversation resolvers (7 new tests)

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```
$ pytest tests/storage/test_semantic_processor_language.py::TestOutputLanguageOverride \
        tests/storage/test_semantic_processor_language.py::TestLanguageDetection \
        tests/storage/test_semantic_processor_language.py::TestLanguageFlow \
        tests/storage/test_semantic_processor_language.py::TestOverviewGenerationFlow -v
======================= 25 passed, 11 warnings in 0.02s =======================
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Example

Before (English-primary corpus with minority non-English content):

```
$ ov overview viking://user/<me>/memories/events
# events

このディレクトリは、システム管理、ソフトウェア開発、プロジェクト管理、および個人的な業務記録を網羅した...

## Quick Navigation

*   **システムメンテナンスとクリーンアップについて知りたい**
    *   OpenClawの削除と監査 → [mem_928970ea-...], [mem_fcd7d860-...]
```

Reproducible deterministically via `ov reindex --regenerate --wait`.

After, with `output_language_override: en`:

```yaml
# ov.conf
semantic:
  language_fallback: en
  output_language_override: en
```

The detector is skipped, prompts receive `Output Language: en`, and the
overview is generated in English regardless of in-corpus non-English
fragments. Same mechanism works for any target language — e.g.,
`output_language_override: zh-CN` pins summaries to Chinese on an
English-heavy subdirectory.

Pseudocode of the change in `semantic_processor.py`:

```python
# Before
fallback_language = (config.language_fallback or "en").strip() or "en"
output_language = _detect_language_from_text(content, fallback_language)

# After
output_language = resolve_output_language(content, config=config)
# where resolve_output_language honors config.output_language_override first,
# then falls back to _detect_language_from_text when override is empty.
```

## Additional Notes

The override is strictly additive: when unset (the default), behavior is
identical to current `main`, so this does not interact with the open PR
#1521. They can be merged in either order.

No docs update included — happy to add a note under the semantic
summaries section of `docs/en/` and `docs/zh/` if maintainers prefer
that in-PR vs a follow-up.