### PR TITLE
fix(build): sanitize Rust native build env

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,39 @@ ENGINE_SOURCE_DIR = "src/"
 ENGINE_BUILD_CONFIG = get_host_engine_build_config(platform.machine())
 
 
+def _sanitize_native_build_env(env):
+    """Keep Rust native builds from accidentally linking against Linuxbrew libs.
+
+    On older glibc systems, Homebrew-provided native libraries can require a newer
+    libc than the host linker/runtime supports. When pkg-config resolves xz/bzip2
+    from Linuxbrew, Cargo inherits those library search paths and link fails.
+    """
+
+    sanitized_env = env.copy()
+
+    pkg_config = sanitized_env.get("PKG_CONFIG") or shutil.which("pkg-config")
+    if pkg_config and "linuxbrew" in os.path.realpath(pkg_config).lower():
+        system_pkg_config = "/usr/bin/pkg-config"
+        if Path(system_pkg_config).exists():
+            sanitized_env["PKG_CONFIG"] = system_pkg_config
+
+    for key in ("PKG_CONFIG_PATH", "LIBRARY_PATH", "LD_LIBRARY_PATH"):
+        value = sanitized_env.get(key)
+        if not value:
+            continue
+        kept_paths = [
+            path
+            for path in value.split(os.pathsep)
+            if path and "linuxbrew" not in os.path.realpath(path).lower()
+        ]
+        if kept_paths:
+            sanitized_env[key] = os.pathsep.join(kept_paths)
+        else:
+            sanitized_env.pop(key, None)
+
+    return sanitized_env
+
+
 def _get_windows_python_sabi_library() -> Path:
     """Return the stable-ABI Python library path for Windows abi3 extensions."""
     candidate_roots = []
@@ -171,7 +204,7 @@ class OpenVikingBuildExt(build_ext):
         if ov_cli_dir.exists() and shutil.which("cargo"):
             print("Building ov CLI from source...")
             try:
-                env = os.environ.copy()
+                env = _sanitize_native_build_env(os.environ.copy())
                 env["OPENVIKING_VERSION"] = resolve_openviking_version(
                     env=env, project_root=SETUP_DIR
                 )
@@ -262,7 +295,7 @@ class OpenVikingBuildExt(build_ext):
         with tempfile.TemporaryDirectory() as tmpdir:
             try:
                 print("Building ragfs-python (Rust RAGFS binding) via maturin...")
-                env = os.environ.copy()
+                env = _sanitize_native_build_env(os.environ.copy())
                 build_args = [
                     sys.executable,
                     "-m",


### PR DESCRIPTION
## Description
Sanitize the native Rust build environment in `setup.py` to prevent local builds from accidentally linking against Linuxbrew-provided libraries on Linux.
## Related Issue
<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
## Changes Made
<!-- List the main changes made in this PR -->
- Added `_sanitize_native_build_env(env)` in `setup.py` to remove Linuxbrew-specific library resolution from Rust native builds.
- Prefer `/usr/bin/pkg-config` when the active `pkg-config` resolves to a Linuxbrew-managed binary.
- Filter Linuxbrew paths from `PKG_CONFIG_PATH`, `LIBRARY_PATH`, and `LD_LIBRARY_PATH` before building the Rust-based `ov` CLI and `ragfs-python` extension.
## Testing
<!-- Describe how you tested your changes -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
## Screenshots (if applicable)
N/A
## Additional Notes
This change is intentionally limited to build-time environment sanitization. It is meant to avoid linker failures on older Linux systems where Linuxbrew-provided native libraries depend on a newer `glibc` than the host system supports.