### PR TITLE
Revert "fix: fall back to prefix filters for volcengine path scope"

### DIFF
--- a/openviking/storage/vectordb_adapters/volcengine_adapter.py
+++ b/openviking/storage/vectordb_adapters/volcengine_adapter.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from openviking.storage.expr import PathScope
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb.collection.volcengine_collection import (
     VolcengineCollection,
@@ -132,16 +131,6 @@ class VolcengineCollectionAdapter(CollectionAdapter):
             index_meta["VectorIndex"]["EnableSparse"] = True
             index_meta["VectorIndex"]["SearchWithSparseLogitAlpha"] = sparse_weight
         return index_meta
-
-    def _compile_filter(self, expr):
-        if isinstance(expr, PathScope):
-            path = (
-                self._encode_uri_field_value(expr.path)
-                if expr.field in self._URI_FIELD_NAMES
-                else expr.path
-            )
-            return {"op": "prefix", "field": expr.field, "prefix": path}
-        return super()._compile_filter(expr)
 
     def _normalize_record_for_read(self, record: Dict[str, Any]) -> Dict[str, Any]:
         return super()._normalize_record_for_read(record)

--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -1,6 +1,5 @@
 from volcengine.base.Request import Request
 
-from openviking.storage.expr import PathScope
 from openviking.storage.vectordb.collection.volcengine_clients import (
     ClientForConsoleApi,
     ClientForDataApi,
@@ -179,21 +178,3 @@ def test_volcengine_collection_get_meta_data_returns_empty_on_collection_not_fou
     monkeypatch.setattr(collection.console_client, "do_req", lambda *args, **kwargs: _Response())
 
     assert collection.get_meta_data() == {}
-
-
-def test_volcengine_adapter_compiles_pathscope_to_prefix_filter():
-    config = VectorDBBackendConfig(
-        backend="volcengine",
-        name="context",
-        volcengine=VolcengineConfig(
-            ak="test-ak",
-            sk="test-sk",
-            region="cn-beijing",
-        ),
-    )
-
-    adapter = VolcengineCollectionAdapter.from_config(config)
-
-    compiled = adapter.compile_filter(PathScope("uri", "viking://resources/demo", depth=-1))
-
-    assert compiled == {"op": "prefix", "field": "uri", "prefix": "viking://resources/demo"}


### PR DESCRIPTION
Reverts volcengine/OpenViking#1342