### PR TITLE
docs(skill): sync ov add-memory output example after #1613

### DIFF
--- a/examples/skills/ov-add-data/SKILL.md
+++ b/examples/skills/ov-add-data/SKILL.md
@@ -131,10 +131,10 @@ ov add-memory '[
 
 ## Output
 
-Returns count of memory extracted:
+Returns `OK` once the request is accepted. Memory extraction runs asynchronously on the server after the commit is queued, so the CLI does not wait for extraction to finish:
 
 ```
-memories_extracted   1
+OK
 ```
 
 ## Agent Best Practices


### PR DESCRIPTION
## Description

`ov add-memory` CLI output documented in `examples/skills/ov-add-data/SKILL.md` no longer matches actual behavior after #1613 (merged 2026-04-21 by @qin-ctx).

`crates/ov_cli/src/commands/session.rs` was changed to emit a simple `"OK"` because the commit endpoint runs asynchronously and `memories_extracted` isn't meaningful at response time:

```rust
// before
let memories_extracted = commit_response["memories_extracted"].as_i64().unwrap_or(0);
let result = json!({ "memories_extracted": memories_extracted });
output_success(&result, output_format, compact);

// after (#1613)
output_success(&json!("OK"), output_format, compact);
```

But `SKILL.md` still shows the old expected output:

```
memories_extracted   1
```

An agent reading this skill to decide whether `add-memory` succeeded will be confused when the CLI just prints `OK`.

## Fix

Update the "Output" section in `examples/skills/ov-add-data/SKILL.md` to reflect the new `OK` output and note that extraction runs async after commit is queued.

## Type of Change

- [x] Documentation update

## Test plan

- [x] Visually diffed against `#1613`'s `session.rs` change (`output_success(&json!("OK"), ...)`)
- [x] Confirmed no other `add-memory` output example in the repo needs updating (`memories_extracted` still appears in `docs/{en,zh}/api/05-sessions.md` and `docs/{en,zh}/concepts/08-session.md` but those document the `/commit` HTTP API response body, which still carries `memories_extracted` — not the CLI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
