### PR TITLE
fix: correct repo target uri

### DIFF
--- a/openviking/parse/accessors/git_accessor.py
+++ b/openviking/parse/accessors/git_accessor.py
@@ -182,6 +182,8 @@ class GitAccessor(DataAccessor):
                 raise ValueError(f"Unsupported source for GitAccessor: {source}")
 
             # Build metadata
+            # repo_name is in "org/repo" format (e.g. "volcengine/OpenViking")
+            # This is extracted via parse_code_hosting_url() from the original URL
             meta = {"repo_name": repo_name}
             if branch:
                 meta["repo_ref"] = branch
@@ -191,7 +193,7 @@ class GitAccessor(DataAccessor):
             return LocalResource(
                 path=local_dir,
                 source_type=SourceType.GIT,
-                original_source=source_str,
+                original_source=source_str,  # Full original URL (critical for TreeBuilder!)
                 meta=meta,
                 is_temporary=True,
             )
@@ -283,7 +285,15 @@ class GitAccessor(DataAccessor):
         return url
 
     def _get_repo_name(self, url: str) -> str:
-        """Get repository name with organization for GitHub/GitLab URLs."""
+        """Get repository name with organization for GitHub/GitLab URLs.
+
+        Returns repo name in "org/repo" format (e.g. "volcengine/OpenViking")
+        when possible. This is important for the final root_uri in VikingFS.
+
+        Example:
+          - Input: "https://github.com/volcengine/OpenViking"
+          - Returns: "volcengine/OpenViking"
+        """
         # First try to parse as code hosting URL
         parsed_org_repo = parse_code_hosting_url(url)
         if parsed_org_repo:

--- a/openviking/parse/accessors/git_accessor.py
+++ b/openviking/parse/accessors/git_accessor.py
@@ -414,6 +414,13 @@ class GitAccessor(DataAccessor):
                         raise RuntimeError(f"Failed to fetch commit {commit} from {url}")
             await self._run_git(["git", "-C", target_dir, "checkout", commit])
 
+        # Add .git_source_repo marker file with original URL (for consistency)
+        def _write_marker():
+            marker_file = Path(target_dir) / ".git_source_repo"
+            marker_file.write_text(url, encoding="utf-8")
+
+        await asyncio.to_thread(_write_marker)
+
         return name
 
     async def _github_zip_download(
@@ -502,6 +509,13 @@ class GitAccessor(DataAccessor):
 
         content_dir = await asyncio.to_thread(_find_content_dir)
 
+        # Add .git_source_repo marker file with original URL
+        def _write_marker():
+            marker_file = content_dir / ".git_source_repo"
+            marker_file.write_text(repo_url, encoding="utf-8")
+
+        await asyncio.to_thread(_write_marker)
+
         logger.info(f"[GitAccessor] GitHub ZIP extracted to {content_dir} ({repo_name})")
         return content_dir, repo_name
 
@@ -587,6 +601,13 @@ class GitAccessor(DataAccessor):
             return top_level[0] if len(top_level) == 1 else Path(extract_dir)
 
         content_dir = await asyncio.to_thread(_find_content_dir)
+
+        # Add .git_source_repo marker file with original URL
+        def _write_marker():
+            marker_file = content_dir / ".git_source_repo"
+            marker_file.write_text(repo_url, encoding="utf-8")
+
+        await asyncio.to_thread(_write_marker)
 
         logger.info(f"[GitAccessor] GitLab ZIP extracted to {content_dir} ({repo_name})")
         return content_dir, repo_name

--- a/openviking/parse/parsers/code/code.py
+++ b/openviking/parse/parsers/code/code.py
@@ -136,14 +136,20 @@ class CodeRepositoryParser(BaseParser):
 
         try:
             # Get metadata from DataAccessor
+            # _source_meta comes from GitAccessor and contains:
+            #   - repo_name: in "org/repo" format (e.g. "volcengine/OpenViking")
+            #   - repo_ref: branch name if specified
+            #   - repo_commit: commit hash if specified
             source_meta = kwargs.get("_source_meta", {})
             repo_name = source_meta.get("repo_name", "repository")
             branch = source_meta.get("repo_ref")
             commit = source_meta.get("repo_commit")
 
             # If repo_name is still default, try to extract from original source
+            # original_source is the full GitHub/GitLab URL that the user provided
+            # (e.g. "https://github.com/volcengine/OpenViking")
             if repo_name == "repository":
-                original_source = source_meta.get("original_source") or kwargs.get(
+                original_source = kwargs.get("original_source") or source_meta.get(
                     "original_source"
                 )
                 if original_source:
@@ -176,7 +182,17 @@ class CodeRepositoryParser(BaseParser):
             )
 
             # Use original URL as source_path instead of local temp dir for proper org/repo parsing in TreeBuilder
-            original_source = source_meta.get("original_source") or kwargs.get("original_source")
+            # source_path is CRITICAL:
+            #   1. TreeBuilder uses source_path to parse org/repo via parse_code_hosting_url()
+            #   2. If source_path is a local path (like /tmp/.../OpenViking), parsing fails
+            #   3. If source_path is the original GitHub URL (https://github.com/volcengine/OpenViking),
+            #      TreeBuilder can correctly extract "volcengine/OpenViking"
+            #
+            # Priority order:
+            #   1. First check kwargs["original_source"] - this is set by media_processor
+            #   2. Then check source_meta (rarely has it)
+            #   3. Fall back to local path only as last resort
+            original_source = kwargs.get("original_source") or source_meta.get("original_source")
             result = create_parse_result(
                 root=root,
                 source_path=original_source or str(source),
@@ -196,8 +212,9 @@ class CodeRepositoryParser(BaseParser):
 
         except Exception as e:
             logger.error(f"Failed to parse repository {source}: {e}", exc_info=True)
-            # Use original URL for error case as well
-            original_source = source_meta.get("original_source") or kwargs.get("original_source")
+            # Use original URL for error case as well - still important for TreeBuilder
+            # Even on failure, we want TreeBuilder to potentially get org/repo from the URL
+            original_source = kwargs.get("original_source") or source_meta.get("original_source")
             return create_parse_result(
                 root=ResourceNode(type=NodeType.ROOT, content_path=None),
                 source_path=original_source or str(source),

--- a/openviking/parse/parsers/directory.py
+++ b/openviking/parse/parsers/directory.py
@@ -481,30 +481,16 @@ class DirectoryParser(BaseParser):
 
     @staticmethod
     async def _add_git_metadata(source_path: Path, kwargs: dict) -> None:
-        """Add git metadata (branch, commit, repo_name) to kwargs dictionary."""
+        """Add git metadata (branch, commit) from .git directory if available."""
         try:
             from openviking.parse.accessors.git_accessor import GitAccessor
 
+            git_dir = source_path / ".git"
+            if not git_dir.exists():
+                return  # No .git directory, skip (we already have meta from accessor)
+
             git_accessor = GitAccessor()
 
-            # First try to read from .git_source_repo marker if available
-            marker_file = source_path / ".git_source_repo"
-            if marker_file.exists():
-                try:
-                    remote_url = marker_file.read_text(encoding="utf-8").strip()
-                    if remote_url:
-                        repo_name = git_accessor._get_repo_name(remote_url)
-                        if repo_name and repo_name != "repository":
-                            kwargs["repo_name"] = repo_name
-                        # If original_source not already in kwargs, set it from marker
-                        if "original_source" not in kwargs:
-                            kwargs["original_source"] = remote_url
-                        logger.debug(f"Got repo info from marker file: {repo_name}")
-                        return
-                except Exception as e:
-                    logger.debug(f"Failed to read marker file: {e}")
-
-            # Fallback to git commands if marker not available or failed
             # Get branch
             try:
                 branch = await git_accessor._run_git(
@@ -523,24 +509,10 @@ class DirectoryParser(BaseParser):
             except Exception as e:
                 logger.debug(f"Failed to get git commit: {e}")
 
-            # Get repo name from git remote
-            try:
-                remote_url = await git_accessor._run_git(
-                    ["git", "-C", str(source_path), "config", "--get", "remote.origin.url"]
-                )
-                if remote_url:
-                    repo_name = git_accessor._get_repo_name(remote_url)
-                    if repo_name and repo_name != "repository":
-                        kwargs["repo_name"] = repo_name
-                else:
-                    kwargs["repo_name"] = source_path.name
-            except Exception as e:
-                logger.debug(f"Failed to get git remote info: {e}")
-                kwargs["repo_name"] = source_path.name
+            # repo_name and original_source are already set from accessor, no need to get from git
 
         except Exception as e:
             logger.debug(f"Failed to get git metadata: {e}")
-            kwargs["repo_name"] = source_path.name
 
     @staticmethod
     async def _recursive_move(

--- a/openviking/parse/parsers/directory.py
+++ b/openviking/parse/parsers/directory.py
@@ -471,9 +471,11 @@ class DirectoryParser(BaseParser):
 
     @staticmethod
     async def _is_git_repository(source_path: Path) -> bool:
-        """Check if the directory contains a git repository."""
+        """Check if the directory contains a git repository (or has our .git_source_repo marker)."""
         try:
-            return (source_path / ".git").exists() and (source_path / ".git").is_dir()
+            git_dir = source_path / ".git"
+            marker_file = source_path / ".git_source_repo"
+            return (git_dir.exists() and git_dir.is_dir()) or marker_file.exists()
         except (OSError, PermissionError):
             return False
 
@@ -485,6 +487,24 @@ class DirectoryParser(BaseParser):
 
             git_accessor = GitAccessor()
 
+            # First try to read from .git_source_repo marker if available
+            marker_file = source_path / ".git_source_repo"
+            if marker_file.exists():
+                try:
+                    remote_url = marker_file.read_text(encoding="utf-8").strip()
+                    if remote_url:
+                        repo_name = git_accessor._get_repo_name(remote_url)
+                        if repo_name and repo_name != "repository":
+                            kwargs["repo_name"] = repo_name
+                        # If original_source not already in kwargs, set it from marker
+                        if "original_source" not in kwargs:
+                            kwargs["original_source"] = remote_url
+                        logger.debug(f"Got repo info from marker file: {repo_name}")
+                        return
+                except Exception as e:
+                    logger.debug(f"Failed to read marker file: {e}")
+
+            # Fallback to git commands if marker not available or failed
             # Get branch
             try:
                 branch = await git_accessor._run_git(
@@ -503,7 +523,7 @@ class DirectoryParser(BaseParser):
             except Exception as e:
                 logger.debug(f"Failed to get git commit: {e}")
 
-            # Get repo name
+            # Get repo name from git remote
             try:
                 remote_url = await git_accessor._run_git(
                     ["git", "-C", str(source_path), "config", "--get", "remote.origin.url"]

--- a/openviking/parse/parsers/directory.py
+++ b/openviking/parse/parsers/directory.py
@@ -94,7 +94,14 @@ class DirectoryParser(BaseParser):
             )
             from openviking.parse.parsers.code.code import CodeRepositoryParser
 
-            await self._add_git_metadata(source_path, kwargs)
+            # Don't add git metadata if we already have _source_meta from DataAccessor
+            # This is crucial:
+            #   1. _source_meta already contains repo_name in org/repo format from GitAccessor
+            #   2. kwargs also has original_source with the full GitHub/GitLab URL
+            #   3. Calling _add_git_metadata would overwrite repo_name with just directory name
+            #      and lose the org prefix!
+            if "_source_meta" not in kwargs:
+                await self._add_git_metadata(source_path, kwargs)
             return await CodeRepositoryParser().parse(str(source_path), instruction, **kwargs)
 
         dir_name = kwargs.get("source_name") or source_path.name

--- a/openviking/parse/tree_builder.py
+++ b/openviking/parse/tree_builder.py
@@ -147,6 +147,13 @@ class TreeBuilder:
             logger.debug(f"[TreeBuilder] Sanitized doc name: {original_name!r} -> {doc_name!r}")
 
         # Check if source_path is a GitHub/GitLab URL and extract org/repo
+        # This is critical for getting the full "org/repo" path instead of just repo name!
+        # For example:
+        #   - source_path = "https://github.com/volcengine/OpenViking"
+        #   - parsed_org_repo = "volcengine/OpenViking"
+        #   - final root_uri = "viking://resources/volcengine/OpenViking"
+        #
+        # Without this, we'd just get "viking://resources/OpenViking" without the org prefix
         final_doc_name = doc_name
         if source_path and source_format == "repository":
             parsed_org_repo = parse_code_hosting_url(source_path)

--- a/openviking/utils/media_processor.py
+++ b/openviking/utils/media_processor.py
@@ -148,6 +148,10 @@ class UnifiedResourceProcessor:
             parse_kwargs["vlm_processor"] = self._get_vlm_processor()
             parse_kwargs["storage"] = self.storage
             parse_kwargs["_source_meta"] = local_resource.meta
+            # CRITICAL: Pass along the original_source!
+            # This is the full URL the user provided (e.g. "https://github.com/volcengine/OpenViking")
+            # CodeRepositoryParser and TreeBuilder need this to extract the org/repo format
+            # Without it, we'd only get the repo name without the org prefix!
             parse_kwargs["original_source"] = local_resource.original_source
 
             # Set resource_name from source_name or path


### PR DESCRIPTION
# before:
ov add-resource https://github.com/markwhen/gogetxueqiu
Note: Resource is being processed in the background.
Use 'ov wait' to wait for completion, or 'ov observer queue' to check status.
status       success
errors       []
source_path  /tmp/ov_git_i6_t1w34/_extracted/gogetxueqiu-c30358d3305793bc770813fda10877016bf8ac76
meta         {"file_count":9,"dir_name":"gogetxueqiu-c30358d3305793bc770813fda10877016bf8ac76","total_processable":9,"processed_files":[{"path":"LICENSE","parser":"direct"},{"path":"README.md","parser":"MarkdownParser"},{"path":"agent.go","parser":"direct"},{"path":...
root_uri     viking://resources/gogetxueqiu-c30358d3305793bc770813fda10877016bf8ac
temp_uri     viking://temp/shengmaojia/04220649_1cb788/gogetxueqiu-c30358d3305793bc770813fda10877016bf8ac76

# after:
ov add-resource https://github.com/markwhen/gogetxueqiu
Note: Resource is being processed in the background.
Use 'ov wait' to wait for completion, or 'ov observer queue' to check status.
status       success
errors       []
source_path  https://github.com/markwhen/gogetxueqiu
meta         {"file_count":9,"repo_name":"markwhen/gogetxueqiu"}
root_uri     viking://resources/markwhen/gogetxueqiu
temp_uri     viking://temp/default/04221500_f17947/repository
