### PR TITLE
fix(openclaw-plugin): sync release metadata to 2026.4.34

### DIFF
--- a/examples/openclaw-plugin/install-manifest.json
+++ b/examples/openclaw-plugin/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": "1.0",
-  "pluginVersion": "2026.4.9",
+  "pluginVersion": "2026.4.34",
   "plugin": {
     "id": "openviking",
     "kind": "context-engine",

--- a/examples/openclaw-plugin/package-lock.json
+++ b/examples/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/openviking",
-  "version": "2026.3.25",
+  "version": "2026.4.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/openviking",
-      "version": "2026.3.25",
+      "version": "2026.4.34",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "fflate": "^0.8.2"

--- a/examples/openclaw-plugin/package.json
+++ b/examples/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openviking",
-  "version": "2026.4.33",
+  "version": "2026.4.34",
   "displayName": "OpenViking",
   "description": "OpenClaw context-engine plugin for memory management — powered by OpenViking",
   "type": "module",


### PR DESCRIPTION
## Description

Sync the OpenClaw plugin release metadata to `2026.4.34` so the package manifest, lockfile, and install manifest all report the same version.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Bump `examples/openclaw-plugin/package.json` to `2026.4.34`
- Update the root package version entries in `examples/openclaw-plugin/package-lock.json`
- Sync `examples/openclaw-plugin/install-manifest.json` `pluginVersion` to the same release version

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This is a metadata-only change. No runtime behavior was modified, and no automated tests were run for this version sync.
