### PR TITLE
fix(console): use correct add_resource target field

### DIFF
--- a/openviking/console/static/app.js
+++ b/openviking/console/static/app.js
@@ -1662,7 +1662,7 @@ function bindFind() {
 
 function buildAddResourcePayload() {
   const payload = {
-    target: elements.addResourceTarget.value.trim(),
+    to: elements.addResourceTarget.value.trim(),
     reason: elements.addResourceReason.value.trim(),
     instruction: elements.addResourceInstruction.value.trim(),
     wait: elements.addResourceWait.checked,

--- a/tests/misc/test_console_static_assets.py
+++ b/tests/misc/test_console_static_assets.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_console_add_resource_payload_uses_to_field():
+    app_js = _read_text("openviking/console/static/app.js")
+
+    assert "function buildAddResourcePayload()" in app_js
+    assert "to: elements.addResourceTarget.value.trim()," in app_js
+    assert "target: elements.addResourceTarget.value.trim()," not in app_js


### PR DESCRIPTION
## Description

Fix the console add-resource payload so uploaded files use the server's expected `to` field instead of the rejected legacy `target` field.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Update the console add-resource payload builder to send `to` instead of `target`
- Keep the existing upload flow unchanged so temp upload still resolves to `temp_file_id`
- Add a static asset regression test to prevent the payload field from drifting again

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Targeted local validation:
- `python -m pytest -o addopts='' tests/misc/test_console_static_assets.py -q`
- `python -m pytest -o addopts='' tests/server/test_api_resources.py -q`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This fixes the console-side 422 failure when uploading resources through the web UI.
