### PR TITLE
docs(openclaw-plugin): sync recall placeholder defaults to 5000/8000

### DIFF
--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -117,7 +117,7 @@
     },
     "recallMaxContentChars": {
       "label": "Recall Max Content Chars",
-      "placeholder": "500",
+      "placeholder": "5000",
       "advanced": true,
       "help": "Maximum characters per memory content in auto-recall injection"
     },
@@ -128,7 +128,7 @@
     },
     "recallTokenBudget": {
       "label": "Recall Token Budget",
-      "placeholder": "2000",
+      "placeholder": "8000",
       "advanced": true,
       "help": "Maximum estimated tokens for auto-recall memory injection"
     },


### PR DESCRIPTION
## Summary

`openclaw.plugin.json` UI hint placeholders still displayed the old `recallMaxContentChars` / `recallTokenBudget` defaults (`500` / `2000`) after #1617 merged. That PR raised the effective runtime defaults to `5000` / `8000` in `config.ts` (`DEFAULT_RECALL_MAX_CONTENT_CHARS` / `DEFAULT_RECALL_TOKEN_BUDGET`), validated on locomo-small (65.7% → 88.6% accuracy), but the shipped plugin manifest was not touched.

Users opening the plugin config panel currently see `500` / `2000` as the suggested defaults — which is misleading because leaving the fields blank produces `5000` / `8000` at runtime. Updating the two `placeholder` strings restores parity between UI guidance and actual behavior.

## Files

- `examples/openclaw-plugin/openclaw.plugin.json`:
  - `uiHints.recallMaxContentChars.placeholder`: `"500"` → `"5000"`
  - `uiHints.recallTokenBudget.placeholder`: `"2000"` → `"8000"`

`commitTokenThreshold.placeholder` (also `"2000"`) is unrelated and intentionally left unchanged.

Refs: #1617

## Notes

Pure JSON manifest update, no code/runtime change. Single-author commit (r266-tech via r2668940489@gmail.com).
