### PR TITLE
feat(git): added azure devops support (#1625)

### DIFF
--- a/examples/skills/ov-server-operate/SKILL.md
+++ b/examples/skills/ov-server-operate/SKILL.md
@@ -55,7 +55,8 @@ Note 2: Replace the root_api_key with your own root-api-key. Ask the user to set
   },
   "parsers": {
     "code": {
-      "gitlab_domains": ["code.byted.org"]
+      "gitlab_domains": ["code.byted.org"],
+      "azure_devops_domains": ["ssh.dev.azure.com", "vs-ssh.visualstudio.com"]
     }
   },
   "embedding": {

--- a/openviking/parse/accessors/git_accessor.py
+++ b/openviking/parse/accessors/git_accessor.py
@@ -21,6 +21,7 @@ from urllib.parse import unquote, urlparse
 from openviking.utils import is_github_url, is_gitlab_url, parse_code_hosting_url
 from openviking.utils.code_hosting_utils import (
     _domain_matches,
+    _extract_azure_devops_repo_parts,
     is_code_hosting_url,
     is_git_repo_url,
     validate_git_ssh_uri,
@@ -276,6 +277,11 @@ class GitAccessor(DataAccessor):
                 base_parts = path_parts[: git_index + 1]
 
             config = get_openviking_config()
+            if _domain_matches(parsed, getattr(config.code, "azure_devops_domains", [])):
+                azure_repo_parts = _extract_azure_devops_repo_parts(path_parts)
+                if azure_repo_parts:
+                    base_parts = path_parts[: len(azure_repo_parts) + 1]
+
             if _domain_matches(parsed, config.code.github_domains + config.code.gitlab_domains):
                 base_parts = path_parts[:2]
             base_path = "/" + "/".join(base_parts)

--- a/openviking/utils/code_hosting_utils.py
+++ b/openviking/utils/code_hosting_utils.py
@@ -156,6 +156,7 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
             azure_repo_parts = _extract_azure_devops_ssh_repo_parts(path_parts)
         if azure_repo_parts:
             return "/".join(_sanitize_segment(part.removesuffix(".git")) for part in azure_repo_parts)
+        return None
 
     # For code hosting URLs with org/repo structure
     if _domain_matches(parsed, all_domains) and len(path_parts) >= 2:

--- a/openviking/utils/code_hosting_utils.py
+++ b/openviking/utils/code_hosting_utils.py
@@ -8,7 +8,7 @@ platforms like GitHub and GitLab.
 """
 
 from typing import Optional
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
 from openviking_cli.utils.config import get_openviking_config
 
@@ -51,6 +51,60 @@ def _extract_host(url: str) -> str:
     return (parsed.hostname or parsed.netloc or "").strip().lower()
 
 
+def _get_all_domains() -> list[str]:
+    config = get_openviking_config()
+    return list(
+        set(
+            config.code.github_domains
+            + config.code.gitlab_domains
+            + getattr(config.code, "azure_devops_domains", [])
+            + config.code.code_hosting_domains
+        )
+    )
+
+
+def _get_azure_devops_domains() -> set[str]:
+    config = get_openviking_config()
+    return set(getattr(config.code, "azure_devops_domains", []))
+
+
+def _sanitize_segment(segment: str) -> str:
+    decoded_segment = unquote(segment)
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in decoded_segment)
+
+
+def _extract_azure_devops_repo_parts(path_parts: list[str]) -> Optional[list[str]]:
+    """Return Azure DevOps repository path parts ending in repo name."""
+    try:
+        git_index = path_parts.index("_git")
+    except ValueError:
+        return None
+
+    if git_index < 2 or git_index + 1 >= len(path_parts) or len(path_parts) != git_index + 2:
+        return None
+
+    repo_parts = path_parts[:git_index] + [path_parts[git_index + 1]]
+    if not all(repo_parts):
+        return None
+    return repo_parts
+
+
+def _extract_azure_devops_ssh_repo_parts(path_parts: list[str]) -> Optional[list[str]]:
+    """Return Azure DevOps SSH repository path parts ending in repo name."""
+    if len(path_parts) != 4 or path_parts[0] != "v3":
+        return None
+
+    repo_parts = path_parts[1:]
+    if not all(repo_parts):
+        return None
+    return repo_parts
+
+
+def _is_azure_devops_browse_url(query: str) -> bool:
+    """Return True for Azure DevOps repo browsing URLs like ?path=/README.md."""
+    return "path" in parse_qs(query, keep_blank_values=True)
+
+
 def parse_code_hosting_url(url: str) -> Optional[str]:
     """Parse code hosting platform URL to get org/repo path.
 
@@ -62,14 +116,8 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
         org/repo path like "volcengine/OpenViking" or None if not a valid
         code hosting URL
     """
-    config = get_openviking_config()
-    all_domains = list(
-        set(
-            config.code.github_domains
-            + config.code.gitlab_domains
-            + config.code.code_hosting_domains
-        )
-    )
+    all_domains = _get_all_domains()
+    host = _extract_host(url)
 
     # Handle git@ SSH URLs: git@host:org/repo.git
     if url.startswith("git@"):
@@ -79,6 +127,12 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
         if host_part not in all_domains:
             return None
         path_parts = [p for p in path_part.split("/") if p]
+        if host_part in _get_azure_devops_domains():
+            azure_repo_parts = _extract_azure_devops_ssh_repo_parts(path_parts)
+            if azure_repo_parts:
+                return "/".join(
+                    _sanitize_segment(part.removesuffix(".git")) for part in azure_repo_parts
+                )
         if len(path_parts) < 2:
             return None
         # Take only first 2 segments (consistent with HTTP branch)
@@ -86,8 +140,8 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
         repo = path_parts[1]
         if repo.endswith(".git"):
             repo = repo[:-4]
-        org = "".join(c if c.isalnum() or c in "-_" else "_" for c in org)
-        repo = "".join(c if c.isalnum() or c in "-_" else "_" for c in repo)
+        org = _sanitize_segment(org)
+        repo = _sanitize_segment(repo)
         return f"{org}/{repo}"
 
     if not url.startswith(("http://", "https://", "git://", "ssh://")):
@@ -96,19 +150,23 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
     parsed = urlparse(url)
     path_parts = [p for p in parsed.path.split("/") if p]
 
-    # For GitHub/GitLab URLs with org/repo structure
-    if (
-        _domain_matches(parsed, config.code.github_domains + config.code.gitlab_domains)
-        and len(path_parts) >= 2
-    ):
+    if _domain_matches(parsed, list(_get_azure_devops_domains())):
+        azure_repo_parts = _extract_azure_devops_repo_parts(path_parts)
+        if azure_repo_parts is None:
+            azure_repo_parts = _extract_azure_devops_ssh_repo_parts(path_parts)
+        if azure_repo_parts:
+            return "/".join(_sanitize_segment(part.removesuffix(".git")) for part in azure_repo_parts)
+
+    # For code hosting URLs with org/repo structure
+    if _domain_matches(parsed, all_domains) and len(path_parts) >= 2:
         # Take first two parts: org/repo
         org = path_parts[0]
         repo = path_parts[1]
         if repo.endswith(".git"):
             repo = repo[:-4]
         # Sanitize both parts
-        org = "".join(c if c.isalnum() or c in "-_" else "_" for c in org)
-        repo = "".join(c if c.isalnum() or c in "-_" else "_" for c in repo)
+        org = _sanitize_segment(org)
+        repo = _sanitize_segment(repo)
         return f"{org}/{repo}"
 
     return None
@@ -149,14 +207,7 @@ def is_code_hosting_url(url: str) -> bool:
     Returns:
         True if the URL is a code hosting platform URL
     """
-    config = get_openviking_config()
-    all_domains = list(
-        set(
-            config.code.github_domains
-            + config.code.gitlab_domains
-            + config.code.code_hosting_domains
-        )
-    )
+    all_domains = _get_all_domains()
 
     # Handle git@ SSH URLs
     if url.startswith("git@"):
@@ -203,13 +254,7 @@ def is_git_repo_url(url: str) -> bool:
     # http/https: check domain AND require exactly 2 path parts (owner/repo)
     if url.startswith(("http://", "https://")):
         config = get_openviking_config()
-        all_domains = list(
-            set(
-                config.code.github_domains
-                + config.code.gitlab_domains
-                + config.code.code_hosting_domains
-            )
-        )
+        all_domains = _get_all_domains()
         parsed = urlparse(url)
         if not _domain_matches(parsed, all_domains):
             return False
@@ -217,6 +262,33 @@ def is_git_repo_url(url: str) -> bool:
         # Strip .git suffix from last part for counting
         if path_parts and path_parts[-1].endswith(".git"):
             path_parts[-1] = path_parts[-1][:-4]
+
+        if _extract_host(url) in _get_azure_devops_domains():
+            azure_repo_parts = _extract_azure_devops_repo_parts(path_parts)
+            if azure_repo_parts:
+                if _is_azure_devops_browse_url(parsed.query):
+                    return False
+                return True
+
+        non_repo_paths = {
+            "blob",
+            "commit",
+            "commits",
+            "issues",
+            "merge_requests",
+            "pull",
+            "pulls",
+            "raw",
+            "releases",
+            "wiki",
+        }
+        if (
+            _extract_host(url) in config.code.github_domains + config.code.gitlab_domains
+            and len(path_parts) >= 3
+            and path_parts[2] in non_repo_paths
+        ):
+            return False
+
         # owner/repo
         if len(path_parts) == 2:
             return True

--- a/openviking/utils/network_guard.py
+++ b/openviking/utils/network_guard.py
@@ -41,7 +41,9 @@ def _get_allowed_code_hosting_domains() -> set[str]:
         allowed.update(
             {
                 "github.com",
+                "www.github.com",
                 "gitlab.com",
+                "www.gitlab.com",
                 "dev.azure.com",
                 "ssh.dev.azure.com",
                 "vs-ssh.visualstudio.com",

--- a/openviking/utils/network_guard.py
+++ b/openviking/utils/network_guard.py
@@ -26,17 +26,27 @@ def _get_allowed_code_hosting_domains() -> set[str]:
     allowed = set()
     try:
         config = get_openviking_config()
-        # Add configured GitHub and GitLab domains
+        # Add configured code hosting domains
         if hasattr(config, "code"):
             if hasattr(config.code, "github_domains"):
                 allowed.update(config.code.github_domains)
             if hasattr(config.code, "gitlab_domains"):
                 allowed.update(config.code.gitlab_domains)
+            if hasattr(config.code, "azure_devops_domains"):
+                allowed.update(config.code.azure_devops_domains)
             if hasattr(config.code, "code_hosting_domains"):
                 allowed.update(config.code.code_hosting_domains)
     except Exception:
         # If config can't be loaded, use defaults
-        allowed.update({"github.com", "gitlab.com", "www.github.com", "www.gitlab.com"})
+        allowed.update(
+            {
+                "github.com",
+                "gitlab.com",
+                "dev.azure.com",
+                "ssh.dev.azure.com",
+                "vs-ssh.visualstudio.com",
+            }
+        )
     return allowed
 
 
@@ -103,7 +113,7 @@ def ensure_public_remote_target(source: str) -> None:
 
     Skips validation if:
     - allow_private_networks is True in config
-    - Host is in configured github_domains/gitlab_domains/code_hosting_domains
+    - Host is in configured github_domains/gitlab_domains/azure_devops_domains/code_hosting_domains
     """
     host = extract_remote_host(source)
     if not host:
@@ -137,7 +147,8 @@ def ensure_public_remote_target(source: str) -> None:
         raise PermissionDeniedError(
             "HTTP server only accepts public remote resource targets; "
             f"host '{host}' resolves to non-public address '{non_public[0]}'. "
-            "To allow this, add the domain to code.gitlab_domains/code.github_domains/code.code_hosting_domains "
+            "To allow this, add the domain to code.gitlab_domains/code.github_domains/"
+            "code.azure_devops_domains/code.code_hosting_domains "
             "or set allow_private_networks=true in your ov.conf."
         )
 

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -201,12 +201,14 @@ class CodeHostingConfig(ParserConfig):
         code_hosting_domains: List of code hosting platform domains (github.com, gitlab.com, etc.)
         github_domains: List of GitHub domains (github.com, www.github.com)
         gitlab_domains: List of GitLab domains (gitlab.com, www.gitlab.com)
+        azure_devops_domains: List of Azure DevOps domains (dev.azure.com, ssh.dev.azure.com)
     """
 
     # Code hosting platform configuration
     code_hosting_domains: list = None
     github_domains: list = None
     gitlab_domains: list = None
+    azure_devops_domains: list = None
 
     def __post_init__(self):
         """Initialize default values for mutable fields."""
@@ -216,6 +218,12 @@ class CodeHostingConfig(ParserConfig):
             self.github_domains = ["github.com", "www.github.com"]
         if self.gitlab_domains is None:
             self.gitlab_domains = ["gitlab.com", "www.gitlab.com"]
+        if self.azure_devops_domains is None:
+            self.azure_devops_domains = [
+                "dev.azure.com",
+                "ssh.dev.azure.com",
+                "vs-ssh.visualstudio.com",
+            ]
 
 
 @dataclass

--- a/tests/misc/test_network_guard.py
+++ b/tests/misc/test_network_guard.py
@@ -246,6 +246,11 @@ class TestEnsurePublicRemoteTarget:
         ensure_public_remote_target("git@github.com:user/repo.git")  # should not raise
 
     @patch("openviking.utils.network_guard._resolve_host_addresses")
+    def test_allows_azure_devops_domain_from_platform_specific_config(self, mock_resolve) -> None:
+        mock_resolve.return_value = {"127.0.0.1"}
+        ensure_public_remote_target("git@ssh.dev.azure.com:v3/org/project/repo")  # should not raise
+
+    @patch("openviking.utils.network_guard._resolve_host_addresses")
     def test_allows_when_dns_returns_empty(self, mock_resolve) -> None:
         """Unresolvable host is allowed through (fail-open for DNS)."""
         mock_resolve.return_value = set()

--- a/tests/test_code_hosting_utils.py
+++ b/tests/test_code_hosting_utils.py
@@ -143,6 +143,14 @@ def test_parse_code_hosting_url_azure_rule_not_applied_to_github():
     assert parse_code_hosting_url("https://github.com/org/repo/tree/main/_git/config") == "org/repo"
 
 
+def test_parse_code_hosting_url_azure_devops_non_repo_page():
+    assert parse_code_hosting_url("https://dev.azure.com/org/project/_build") is None
+
+
+def test_parse_code_hosting_url_azure_devops_pull_request_page():
+    assert parse_code_hosting_url("https://dev.azure.com/org/project/_git/repo/pullrequest/123") is None
+
+
 # --- validate_git_ssh_uri ---
 
 

--- a/tests/test_code_hosting_utils.py
+++ b/tests/test_code_hosting_utils.py
@@ -17,6 +17,11 @@ def _mock_config():
         code=SimpleNamespace(
             github_domains=["github.com", "www.github.com"],
             gitlab_domains=["gitlab.com", "www.gitlab.com"],
+            azure_devops_domains=[
+                "dev.azure.com",
+                "ssh.dev.azure.com",
+                "vs-ssh.visualstudio.com",
+            ],
             code_hosting_domains=["github.com", "gitlab.com"],
         )
     )
@@ -95,6 +100,49 @@ def test_parse_code_hosting_url_https_with_port():
     assert parse_code_hosting_url("https://github.com:443/org/repo") == "org/repo"
 
 
+def test_parse_code_hosting_url_azure_devops_repo():
+    assert (
+        parse_code_hosting_url("https://dev.azure.com/org/project/_git/repo")
+        == "org/project/repo"
+    )
+
+
+def test_parse_code_hosting_url_azure_devops_repo_dotgit():
+    assert (
+        parse_code_hosting_url("https://dev.azure.com/org/project/_git/repo.git")
+        == "org/project/repo"
+    )
+
+
+def test_parse_code_hosting_url_azure_devops_repo_with_encoded_spaces():
+    assert (
+        parse_code_hosting_url("https://dev.azure.com/org/my%20project/_git/repo")
+        == "org/my_project/repo"
+    )
+
+
+def test_parse_code_hosting_url_azure_devops_ssh_repo():
+    assert parse_code_hosting_url("git@ssh.dev.azure.com:v3/org/project/repo") == "org/project/repo"
+
+
+def test_parse_code_hosting_url_azure_devops_ssh_scheme_repo():
+    assert (
+        parse_code_hosting_url("ssh://git@ssh.dev.azure.com/v3/org/project/repo.git")
+        == "org/project/repo"
+    )
+
+
+def test_parse_code_hosting_url_azure_devops_legacy_ssh_repo():
+    assert (
+        parse_code_hosting_url("git@vs-ssh.visualstudio.com:v3/org/project/repo")
+        == "org/project/repo"
+    )
+
+
+def test_parse_code_hosting_url_azure_rule_not_applied_to_github():
+    assert parse_code_hosting_url("https://github.com/org/repo/tree/main/_git/config") == "org/repo"
+
+
 # --- validate_git_ssh_uri ---
 
 
@@ -136,7 +184,11 @@ def test_is_code_hosting_url_ssh_url_with_userinfo():
     assert is_code_hosting_url("ssh://git@github.com/org/repo.git") is True
 
 
-def test_is_code_hosting_url_https_with_port():
+def test_is_code_hosting_url_azure_devops_ssh():
+    assert is_code_hosting_url("git@ssh.dev.azure.com:v3/org/project/repo") is True
+
+
+def test_is_code_hosting_url_https_with_explicit_port():
     assert is_code_hosting_url("https://github.com:443/org/repo") is True
 
 
@@ -170,6 +222,45 @@ def test_is_git_repo_url_https_with_port():
     assert is_git_repo_url("https://github.com:443/org/repo") is True
 
 
+def test_is_git_repo_url_azure_devops_repo():
+    assert is_git_repo_url("https://dev.azure.com/org/project/_git/repo") is True
+
+
+def test_is_git_repo_url_azure_devops_repo_dotgit():
+    assert is_git_repo_url("https://dev.azure.com/org/project/_git/repo.git") is True
+
+
+def test_is_git_repo_url_azure_devops_ssh_repo():
+    assert is_git_repo_url("git@ssh.dev.azure.com:v3/org/project/repo") is True
+
+
+def test_is_git_repo_url_azure_devops_ssh_scheme_repo():
+    assert is_git_repo_url("ssh://git@ssh.dev.azure.com/v3/org/project/repo.git") is True
+
+
+def test_is_git_repo_url_azure_devops_legacy_ssh_repo():
+    assert is_git_repo_url("git@vs-ssh.visualstudio.com:v3/org/project/repo") is True
+
+
+def test_is_git_repo_url_azure_devops_non_repo_page():
+    assert is_git_repo_url("https://dev.azure.com/org/project/_build") is False
+
+
+def test_is_git_repo_url_azure_devops_browse_url_with_path_query():
+    assert (
+        is_git_repo_url("https://dev.azure.com/org/project/_git/repo?path=/README.md")
+        is False
+    )
+
+
+def test_is_git_repo_url_azure_devops_pull_request_page():
+    assert is_git_repo_url("https://dev.azure.com/org/project/_git/repo/pullrequest/123") is False
+
+
+def test_is_git_repo_url_azure_devops_commit_page():
+    assert is_git_repo_url("https://dev.azure.com/org/project/_git/repo/commit/abc1234") is False
+
+
 def test_is_git_repo_url_https_issues():
     assert is_git_repo_url("https://github.com/org/repo/issues/123") is False
 
@@ -180,6 +271,10 @@ def test_is_git_repo_url_https_pull():
 
 def test_is_git_repo_url_https_blob():
     assert is_git_repo_url("https://github.com/org/repo/blob/main/file.py") is False
+
+
+def test_is_git_repo_url_github_tree_path_with__git_segment():
+    assert is_git_repo_url("https://github.com/org/repo/tree/main/_git/config") is False
 
 
 def test_is_git_repo_url_unknown_domain():

--- a/tests/unit/test_accessors_git.py
+++ b/tests/unit/test_accessors_git.py
@@ -28,8 +28,31 @@ def _patch_config():
         yield
 
 
+def _mock_config():
+    return SimpleNamespace(
+        code=SimpleNamespace(
+            github_domains=["github.com", "www.github.com"],
+            gitlab_domains=["gitlab.com", "www.gitlab.com"],
+            azure_devops_domains=[
+                "dev.azure.com",
+                "ssh.dev.azure.com",
+                "vs-ssh.visualstudio.com",
+            ],
+            code_hosting_domains=["github.com", "gitlab.com"],
+        )
+    )
+
+
 class TestGitAccessor:
     """Tests for GitAccessor."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_config(self):
+        with patch(
+            "openviking_cli.utils.config.open_viking_config.OpenVikingConfigSingleton.get_instance",
+            side_effect=_mock_config,
+        ):
+            yield
 
     @pytest.fixture
     def accessor(self) -> GitAccessor:
@@ -45,6 +68,9 @@ class TestGitAccessor:
         [
             "git@github.com:volcengine/OpenViking.git",
             "git@gitlab.com:org/repo.git",
+            "git@ssh.dev.azure.com:v3/org/project/repo",
+            "ssh://git@ssh.dev.azure.com/v3/org/project/repo.git",
+            "git@vs-ssh.visualstudio.com:v3/org/project/repo",
         ],
     )
     def test_can_handle_git_ssh_url(self, accessor: GitAccessor, source: str) -> None:
@@ -75,6 +101,17 @@ class TestGitAccessor:
         """GitAccessor should handle GitHub URLs with branch/commit."""
         assert accessor.can_handle(source) is True
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "https://dev.azure.com/org/project/_git/repo",
+            "https://dev.azure.com/org/project/_git/repo.git",
+        ],
+    )
+    def test_can_handle_azure_devops_http_url(self, accessor: GitAccessor, source: str) -> None:
+        """GitAccessor should handle Azure DevOps repository URLs."""
+        assert accessor.can_handle(source) is True
+
     def test_can_handle_git_protocol_url(self, accessor: GitAccessor) -> None:
         """GitAccessor should handle git:// URLs."""
         assert accessor.can_handle("git://github.com/volcengine/OpenViking.git") is True
@@ -90,18 +127,25 @@ class TestGitAccessor:
         "source",
         [
             "/path/to/repo.git",
-            "/path/to/archive.zip",
         ],
     )
     def test_can_handle_local_files(self, accessor: GitAccessor, source: str) -> None:
-        """GitAccessor should handle local .git and .zip files."""
+        """GitAccessor should handle local .git files."""
         assert accessor.can_handle(Path(source)) is True
+
+    def test_cannot_handle_local_zip_file(self, accessor: GitAccessor) -> None:
+        """GitAccessor should leave local zip files to LocalAccessor/ZipParser."""
+        assert accessor.can_handle(Path("/path/to/archive.zip")) is False
 
     @pytest.mark.parametrize(
         "source",
         [
             "https://example.com/page.html",
             "https://github.com/volcengine/OpenViking/issues/123",
+            "https://dev.azure.com/org/project/_build",
+            "https://dev.azure.com/org/project/_git/repo?path=/README.md",
+            "https://dev.azure.com/org/project/_git/repo/pullrequest/123",
+            "https://dev.azure.com/org/project/_git/repo/commit/abc1234",
             "git@example.com:repo",
         ],
     )

--- a/tests/unit/test_accessors_http.py
+++ b/tests/unit/test_accessors_http.py
@@ -2,9 +2,27 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Unit tests for HTTPAccessor."""
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 
 from openviking.parse.accessors import AccessorRegistry, GitAccessor, HTTPAccessor
+
+
+def _mock_config():
+    return SimpleNamespace(
+        code=SimpleNamespace(
+            github_domains=["github.com", "www.github.com"],
+            gitlab_domains=["gitlab.com", "www.gitlab.com"],
+            azure_devops_domains=[
+                "dev.azure.com",
+                "ssh.dev.azure.com",
+                "vs-ssh.visualstudio.com",
+            ],
+            code_hosting_domains=["github.com", "gitlab.com"],
+        )
+    )
 
 
 class TestHTTPAccessor:
@@ -60,6 +78,14 @@ class TestHTTPAccessor:
 class TestHTTPAccessorPriorityRouting:
     """Tests that verify HTTPAccessor works correctly with priority-based routing."""
 
+    @pytest.fixture(autouse=True)
+    def _patch_config(self):
+        with patch(
+            "openviking_cli.utils.config.open_viking_config.OpenVikingConfigSingleton.get_instance",
+            side_effect=_mock_config,
+        ):
+            yield
+
     def test_git_url_routed_to_git_accessor(self) -> None:
         """Git URLs should be routed to GitAccessor, not HTTPAccessor."""
         registry = AccessorRegistry(register_default=False)
@@ -79,6 +105,23 @@ class TestHTTPAccessorPriorityRouting:
         assert accessor is not None
         assert accessor.__class__.__name__ == "GitAccessor"
 
+    def test_azure_devops_git_url_routed_to_git_accessor(self) -> None:
+        """Azure DevOps repo URLs should be routed to GitAccessor."""
+        registry = AccessorRegistry(register_default=False)
+        http = HTTPAccessor()
+        git = GitAccessor()
+        registry.register(http)
+        registry.register(git)
+
+        test_url = "https://dev.azure.com/org/project/_git/repo"
+
+        assert git.can_handle(test_url) is True
+        assert http.can_handle(test_url) is True
+
+        accessor = registry.get_accessor(test_url)
+        assert accessor is not None
+        assert accessor.__class__.__name__ == "GitAccessor"
+
     def test_regular_http_url_routed_to_http_accessor(self) -> None:
         """Regular HTTP URLs should be routed to HTTPAccessor."""
         registry = AccessorRegistry(register_default=False)
@@ -94,6 +137,23 @@ class TestHTTPAccessorPriorityRouting:
         assert http.can_handle(test_url) is True
 
         # Registry picks HTTPAccessor
+        accessor = registry.get_accessor(test_url)
+        assert accessor is not None
+        assert accessor.__class__.__name__ == "HTTPAccessor"
+
+    def test_azure_devops_browse_url_routed_to_http_accessor(self) -> None:
+        """Azure DevOps browse URLs should stay with HTTPAccessor."""
+        registry = AccessorRegistry(register_default=False)
+        http = HTTPAccessor()
+        git = GitAccessor()
+        registry.register(http)
+        registry.register(git)
+
+        test_url = "https://dev.azure.com/org/project/_git/repo?path=/README.md"
+
+        assert git.can_handle(test_url) is False
+        assert http.can_handle(test_url) is True
+
         accessor = registry.get_accessor(test_url)
         assert accessor is not None
         assert accessor.__class__.__name__ == "HTTPAccessor"


### PR DESCRIPTION
## Description

Add first-class Azure DevOps support for code-hosting URL handling in OpenViking. This teaches the parser and accessor routing to recognize Azure DevOps repository URLs, keeps Azure domains configurable through a dedicated setting, and avoids treating Azure web UI pages as cloneable git repositories.

## Related Issue

Fixes #1625 

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made
- add Azure DevOps URL support for `dev.azure.com`, `ssh.dev.azure.com`, and Azure's legacy `vs-ssh.visualstudio.com`
- introduce dedicated `code.azure_devops_domains` config and include Azure domains in network guard allowlisting
- add coverage for Azure DevOps repo, browse, pull request, and commit URLs across code-hosting and accessor tests

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
 
## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published