### PR TITLE
fix(session): allow explicit role_id passthrough

### DIFF
--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -3,7 +3,6 @@
 """Sessions endpoints for OpenViking HTTP Server."""
 
 import logging
-import re
 from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, Path, Query, Request
@@ -12,13 +11,11 @@ from pydantic import BaseModel, model_validator
 from openviking.message.part import TextPart, part_from_dict
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
-from openviking.server.identity import AuthMode, RequestContext, Role
+from openviking.server.identity import AuthMode, RequestContext
 from openviking.server.models import ErrorInfo, Response
-from openviking_cli.exceptions import InvalidArgumentError
 
 router = APIRouter(prefix="/api/v1/sessions", tags=["sessions"])
 logger = logging.getLogger(__name__)
-_ROLE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class TextPartRequest(BaseModel):
@@ -116,22 +113,9 @@ def _resolve_message_role_id(
     if request.role not in {"user", "assistant"}:
         return request.role_id
 
-    role_id_provided = "role_id" in request.model_fields_set
-    allow_explicit_role_id = _request_auth_mode(http_request) == AuthMode.TRUSTED or ctx.role in {
-        Role.ROOT,
-        Role.ADMIN,
-    }
-    if not allow_explicit_role_id and role_id_provided:
-        raise InvalidArgumentError(
-            "USER requests cannot explicitly set role_id; it is derived from the request context."
-        )
-
-    role_id = request.role_id if allow_explicit_role_id else None
+    role_id = request.role_id
     if not role_id:
         role_id = ctx.user.user_id if request.role == "user" else ctx.user.agent_id
-
-    if not _ROLE_ID_PATTERN.match(role_id):
-        raise InvalidArgumentError("role_id must be alpha-numeric string.")
 
     return role_id
 

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -17,7 +17,6 @@ from openviking.server.api_keys import APIKeyManager
 from openviking.server.config import ServerConfig
 from openviking.server.identity import RequestContext, Role
 from openviking.server.routers import sessions as sessions_router
-from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
 from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
@@ -308,20 +307,25 @@ async def test_add_message_admin_request_allows_registered_user_role_id(service,
     assert session.messages[-1].role_id == "alice"
 
 
-async def test_add_message_user_request_rejects_explicit_role_id(service, monkeypatch):
+async def test_add_message_user_request_allows_explicit_role_id(service, monkeypatch):
+    session_id = "user-explicit-role-id"
     ctx = RequestContext(
         user=UserIdentifier("acct_session_user", "alice", "assistant-user"),
         role=Role.USER,
     )
 
-    with pytest.raises(InvalidArgumentError, match="cannot explicitly set role_id"):
-        await _call_add_message_route(
-            service,
-            monkeypatch,
-            ctx=ctx,
-            payload=_message_request("user", content="hello user", role_id="alice"),
-            session_id="user-explicit-role-id",
-        )
+    response = await _call_add_message_route(
+        service,
+        monkeypatch,
+        ctx=ctx,
+        payload=_message_request("user", content="hello user", role_id="wx/user-01@abc"),
+        session_id=session_id,
+    )
+
+    assert response.result["message_count"] == 1
+    session = await service.sessions.get(session_id, ctx, auto_create=False)
+    await session.load()
+    assert session.messages[-1].role_id == "wx/user-01@abc"
 
 
 async def test_add_message_user_request_autofills_role_id(service, monkeypatch):


### PR DESCRIPTION
## Description

Allow session add-message requests to persist explicit `role_id` values without server-side caller-role or format enforcement.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Remove the `USER`-specific rejection path for explicit session message `role_id` values.
- Stop normalizing or validating `role_id` format on the sessions add-message route and only auto-fill when the field is missing or empty.
- Update the server session API tests to cover explicit `role_id` passthrough for `USER` requests, including raw sender-style identifiers.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Local verification:
- `python -m pytest -o addopts='' tests/server/test_api_sessions.py`
- `python -m compileall openviking/server/routers/sessions.py tests/server/test_api_sessions.py`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

Existing test output includes pre-existing Pydantic deprecation warnings unrelated to this change.
