### PR TITLE
fix(parser): validate feishu config limits

### DIFF
--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -503,6 +503,27 @@ class FeishuConfig(ParserConfig):
         30.0  # TODO: not yet passed to lark-oapi client, reserved for future use
     )
 
+    def validate(self) -> None:
+        """
+        Validate configuration.
+
+        Raises:
+            ValueError: If configuration is invalid
+        """
+        super().validate()
+
+        if not self.domain:
+            raise ValueError("domain cannot be empty")
+
+        if self.max_rows_per_sheet <= 0:
+            raise ValueError("max_rows_per_sheet must be positive")
+
+        if self.max_records_per_table <= 0:
+            raise ValueError("max_records_per_table must be positive")
+
+        if self.request_timeout <= 0:
+            raise ValueError("request_timeout must be positive")
+
 
 @dataclass
 class DirectoryConfig(ParserConfig):

--- a/tests/parse/test_markdown_char_limit.py
+++ b/tests/parse/test_markdown_char_limit.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from openviking.parse.parsers.markdown import MarkdownParser
-from openviking_cli.utils.config.parser_config import ParserConfig, load_parser_configs_from_dict
+from openviking_cli.utils.config.parser_config import (
+    FeishuConfig,
+    ParserConfig,
+    load_parser_configs_from_dict,
+)
 
 # ---------------------------------------------------------------------------
 # ParserConfig
@@ -52,6 +56,29 @@ class TestParserConfigMaxSectionChars:
     def test_validate_accepts_positive(self):
         config = ParserConfig(max_section_chars=1)
         config.validate()  # must not raise
+
+
+class TestFeishuConfigValidation:
+    def test_validate_accepts_defaults(self):
+        config = FeishuConfig()
+        config.validate()
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            ("domain", "", "domain"),
+            ("max_rows_per_sheet", 0, "max_rows_per_sheet"),
+            ("max_rows_per_sheet", -1, "max_rows_per_sheet"),
+            ("max_records_per_table", 0, "max_records_per_table"),
+            ("max_records_per_table", -1, "max_records_per_table"),
+            ("request_timeout", 0, "request_timeout"),
+            ("request_timeout", -0.1, "request_timeout"),
+        ],
+    )
+    def test_validate_rejects_invalid_values(self, field, value, message):
+        config = FeishuConfig(**{field: value})
+        with pytest.raises(ValueError, match=message):
+            config.validate()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `FeishuConfig.validate()` to reject empty domain and non-positive Feishu import limits/timeouts
- add focused config validation tests for default acceptance and invalid Feishu values

## Validation
- `python3 - <<'PY' ... FeishuConfig().validate() ... invalid cases raise ValueError ... PY`
- `python3 -m py_compile openviking_cli/utils/config/parser_config.py tests/parse/test_markdown_char_limit.py`