### PR TITLE
docs(bot): sync gateway config example with #1640 security defaults

### DIFF
--- a/bot/docs/rfc-openviking-cli-ov-chat.md
+++ b/bot/docs/rfc-openviking-cli-ov-chat.md
@@ -302,8 +302,9 @@ Vikingbot 的配置项统一放在 `ov.conf` 的 `bot` 字段下：
       "memory_window": 50
     },
     "gateway": {
-      "host": "0.0.0.0",
-      "port": 18791
+      "host": "127.0.0.1",
+      "port": 18791,
+      "token": ""
     },
     "channels": [
       {"type": "feishu", "enabled": false, "app_id": "", "app_secret": ""}
@@ -319,7 +320,7 @@ Vikingbot 的配置项统一放在 `ov.conf` 的 `bot` 字段下：
 **配置说明 / Configuration Notes:**
 - `server.with_bot`: 启用时自动在同一机器上启动 Vikingbot gateway
 - `bot.agents`: Agent 配置，包括 LLM 模型、最大工具迭代次数、记忆窗口
-- `bot.gateway`: HTTP Gateway 监听地址
+- `bot.gateway`: HTTP Gateway 监听地址；`host` 默认 `127.0.0.1`，当绑定到非 localhost 时必须配置 `token`（用于 `X-Gateway-Token` 鉴权），否则启动失败
 - `bot.channels`: 渠道配置列表，支持 openapi、feishu 等
 - `bot.sandbox`: 沙箱执行配置
 


### PR DESCRIPTION
## Description

Sync the `bot.gateway` config example and notes in `bot/docs/rfc-openviking-cli-ov-chat.md` with the security defaults introduced by #1640 (`fix(bot):Fix bot api-channel auth check`, merged 2026-04-22):

1. Example `host` default changed from `"0.0.0.0"` to `"127.0.0.1"` — matches the new `GatewayConfig.host` default in `bot/vikingbot/config/schema.py` and the hardened server startup path in `openviking/server/bootstrap.py`.
2. Added the new `token: ""` field to the example — `GatewayConfig.token` is the canonical replacement for the deprecated `api_key`, and is used for the `X-Gateway-Token` proxy auth header.
3. Extended the `bot.gateway` bullet to describe the fail-fast contract (`requires_gateway_token`): when the gateway binds to a non-localhost host, a non-empty `token` is mandatory or startup fails.

Without this doc sync, users copy-pasting the sample JSON from the RFC will (a) accidentally bind the gateway to `0.0.0.0` contrary to the new safe default, and (b) hit the fail-fast token check at startup with no docs context.

## Related Issue

Docs drift from #1640 (merged 2026-04-22 by @chenjw). No open issue.

## Type of Change

- [x] Documentation update

## Check of the Task

- [x] No functional change — docs-only
- [x] Reviewed the PR #1640 diff (schema.py `GatewayConfig`, server/config.py `load_bot_gateway_token`, server/bootstrap.py fail-fast) to confirm the new contract
- [x] Local `grep` confirms `bot/docs/rfc-openviking-cli-ov-chat.md` is the only doc carrying the now-outdated `bot.gateway` example (`bot/docs/CHANNEL.md` does not reference `bot.gateway`)

