### PR TITLE
docs(design): sync §4.6 role_id rules with #1643 passthrough behavior

### DIFF
--- a/docs/design/account-namespace-shared-session-design.md
+++ b/docs/design/account-namespace-shared-session-design.md
@@ -530,17 +530,16 @@ viking://session/{session_id}
     - `role = "assistant"` 时，默认填充 `ctx.user.agent_id`
 
 - `USER`
-  - 不接受显式传入的 `role_id`
-  - `role_id` 只能从 `ctx` 推导
-  - 具体规则为：
-    - `role = "user"` 时，写入 `ctx.user.user_id`
-    - `role = "assistant"` 时，写入 `ctx.user.agent_id`
+  - 可以显式传入 `role_id`，服务端以传入值为准
+  - 如果未显式传入：
+    - `role = "user"` 时，默认填充 `ctx.user.user_id`
+    - `role = "assistant"` 时，默认填充 `ctx.user.agent_id`
 
 额外约束：
 
-- `role = "user"` 时，最终写入的 `role_id` 必须是当前 account 下合法的 `user_id`
-- `role = "assistant"` 时，最终写入的 `role_id` 作为 `agent_id` 使用
-- 本阶段不引入独立的 agent registry；因此对 `assistant.role_id` 只做格式和上下文一致性校验
+- `role = "user"` 时，`role_id` 语义表示消息所属的 `user_id`，由调用方保证为当前 account 下合法的 `user_id`
+- `role = "assistant"` 时，`role_id` 作为 `agent_id` 使用
+- 本阶段不引入独立的 agent registry；服务端不对 `role_id` 做格式或上下文一致性校验，语义一致性由调用方承担
 
 ### 4.7 消息持久化结构
 


### PR DESCRIPTION
## Summary

Sync `docs/design/account-namespace-shared-session-design.md` §4.6 with the behavior merged in #1643 (`fix(session): allow explicit role_id passthrough`, qin-ctx, ~14h ago).

## What #1643 changed

`openviking/server/routers/sessions.py::_resolve_message_role_id` was simplified: the auth-mode/role-based `allow_explicit_role_id` gate and the `_ROLE_ID_PATTERN` alpha-numeric regex validation were both removed. After #1643:

- All auth modes (including `USER`) can pass `role_id` explicitly, and the server uses the caller-provided value verbatim.
- If `role_id` is not provided, the server falls back to `ctx.user.user_id` (for `role=user`) or `ctx.user.agent_id` (for `role=assistant`) — same default as before.
- The server no longer enforces the `^[a-zA-Z0-9_-]+$` format or account-scoped legitimacy; those become caller responsibilities.

The design doc §4.6 still documented the pre-#1643 rules (USER rejected explicit `role_id`, server regex-validated the result, assistant.role_id had format/context checks), so a user reading the doc and hitting the runtime would see a mismatch.

## Doc change (single file, +11/-12)

- USER bullet: rewrites "不接受显式传入" to "可以显式传入 `role_id`，服务端以传入值为准" + the same default-fill fallback as other modes.
- "额外约束" bullets: keep the semantic meaning of `role_id` for each role, but clarify validation is now caller-side and the server no longer performs regex / context-consistency checks.

No behavioral / API change; no English mirror exists for this file.

## Why worth the change

The design doc is the canonical spec that reviewers and integrators consult before wiring `role_id` into clients. Leaving it documenting removed server-side guards would mislead downstream implementers into relying on validation that no longer runs, and into thinking USER-scoped API keys still reject explicit `role_id`.

Fixes doc/code drift from #1643. Pure docs, no tests/code changes.
