### PR TITLE
fix(resources): accept legacy target field for uploads

### DIFF
--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -36,6 +36,8 @@ class AddResourceRequest(BaseModel):
             Either path or temp_file_id must be provided.
         to: Target URI for the resource (e.g., "viking://resources/my_resource").
             If not specified, an auto-generated URI will be used.
+        target: Deprecated legacy alias for 'to'. Older console bundles used this
+            field name when creating resources after temp_upload.
         parent: Parent URI under which the resource will be stored.
             Cannot be used together with 'to'.
         reason: Reason for adding the resource. Used for documentation and monitoring.
@@ -68,6 +70,7 @@ class AddResourceRequest(BaseModel):
     path: Optional[str] = None
     temp_file_id: Optional[str] = None
     to: Optional[str] = None
+    target: Optional[str] = None
     parent: Optional[str] = None
     reason: str = ""
     instruction: str = ""
@@ -82,6 +85,17 @@ class AddResourceRequest(BaseModel):
     preserve_structure: Optional[bool] = None
     telemetry: TelemetryRequest = False
     watch_interval: float = 0
+
+    @model_validator(mode="before")
+    @classmethod
+    def apply_legacy_target_alias(cls, data):
+        if not isinstance(data, dict):
+            return data
+
+        if not data.get("to") and data.get("target"):
+            data = dict(data)
+            data["to"] = data["target"]
+        return data
 
     @model_validator(mode="after")
     def check_path_or_temp_file_id(self):

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -422,6 +422,30 @@ async def test_add_resource_accepts_temp_uploaded_file(
     assert body["result"]["root_uri"].startswith("viking://")
 
 
+async def test_add_resource_accepts_legacy_target_field(
+    client: httpx.AsyncClient,
+    upload_temp_dir,
+):
+    upload_resp = await client.post(
+        "/api/v1/resources/temp_upload",
+        files={"file": ("sample.md", b"# upload\n", "text/markdown")},
+    )
+    temp_file_id = upload_resp.json()["result"]["temp_file_id"]
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": temp_file_id,
+            "target": "viking://resources/legacy-target.md",
+            "reason": "legacy console payload",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["root_uri"] == "viking://resources/legacy-target.md"
+
+
 async def test_add_resource_rejects_temp_file_id_directory(
     client: httpx.AsyncClient,
     upload_temp_dir,


### PR DESCRIPTION
## Description

Add backward compatibility for legacy console upload payloads by accepting the deprecated `target` field in `AddResourceRequest` and mapping it to `to`.

This prevents older deployed console bundles from failing during the second step of the upload flow.

## Related Issue

- No linked issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- accept legacy `target` as a deprecated alias for `to` in `AddResourceRequest`
- preserve existing behavior by letting explicit `to` continue to take precedence
- add a regression test covering the legacy upload payload path

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Runtime validation performed in this environment:

- reproduced the issue against a running `0.3.9` deployment where `temp_upload` succeeded and `POST /api/v1/resources` failed with `422`
- applied the compatibility fix locally and verified the same upload flow completed successfully

Note: the focused `pytest` run was not executed here because `pytest` was not installed in the available virtualenv.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

The root cause was a drift between older published console bundles and the current server request schema:

- legacy console payload: `target`
- server request schema: `to` / `parent`

Because the request model forbids unknown fields, the upload flow failed before request handling logic could normalize the input.
