### PR TITLE
fix(server): map AGFS URI errors

### DIFF
--- a/openviking/server/error_mapping.py
+++ b/openviking/server/error_mapping.py
@@ -12,6 +12,7 @@ from openviking_cli.exceptions import (
     ConflictError,
     FailedPreconditionError,
     InvalidArgumentError,
+    InvalidURIError,
     NotFoundError,
     OpenVikingError,
     PermissionDeniedError,
@@ -25,7 +26,26 @@ def is_not_found_error(exc: Exception) -> bool:
     if isinstance(exc, AGFSHTTPError) and exc.status_code == 404:
         return True
     message = str(exc).lower()
-    return "not found" in message or "no such file or directory" in message
+    return any(
+        marker in message
+        for marker in (
+            "not found",
+            "no such file",
+            "does not exist",
+        )
+    )
+
+
+def is_invalid_uri_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "invalid uri",
+            "invalid viking uri",
+            "invalid viking://",
+        )
+    )
 
 
 def map_exception(
@@ -44,6 +64,8 @@ def map_exception(
         return NotFoundError(resource or str(exc), resource_type)
     if isinstance(exc, ValueError):
         message = str(exc)
+        if is_invalid_uri_error(exc):
+            return InvalidURIError(resource or message, message)
         if "not a directory" in message.lower():
             details = {"resource": resource} if resource else None
             return FailedPreconditionError(message, details=details)
@@ -67,6 +89,8 @@ def map_exception(
         message = str(exc)
         if is_not_found_error(exc):
             return NotFoundError(resource or message, resource_type)
+        if is_invalid_uri_error(exc):
+            return InvalidURIError(resource or message, message)
         lowered = message.lower()
         if "permission denied" in lowered:
             return PermissionDeniedError(message, resource=resource)
@@ -78,6 +102,8 @@ def map_exception(
     lowered = message.lower()
     if is_not_found_error(exc):
         return NotFoundError(resource or message, resource_type)
+    if is_invalid_uri_error(exc):
+        return InvalidURIError(resource or message, message)
     if "permission denied" in lowered or "access denied" in lowered:
         return PermissionDeniedError(message, resource=resource)
     if "timeout" in lowered or "connection refused" in lowered:

--- a/openviking_cli/exceptions.py
+++ b/openviking_cli/exceptions.py
@@ -37,6 +37,7 @@ class InvalidURIError(InvalidArgumentError):
         if reason:
             message += f" ({reason})"
         super().__init__(message, details={"uri": uri, "reason": reason})
+        self.code = "INVALID_URI"
 
 
 class UnsupportedDirectoryFilesError(InvalidArgumentError):

--- a/tests/server/test_error_mapping.py
+++ b/tests/server/test_error_mapping.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Focused tests for HTTP server exception-to-error mapping."""
+
+from openviking.pyagfs.exceptions import AGFSClientError
+from openviking.server.error_mapping import map_exception
+from openviking_cli.exceptions import InvalidURIError, NotFoundError
+
+
+def test_agfs_client_does_not_exist_maps_to_not_found():
+    mapped = map_exception(
+        AGFSClientError("path viking://missing does not exist"),
+        resource="viking://missing",
+        resource_type="file",
+    )
+
+    assert isinstance(mapped, NotFoundError)
+    assert mapped.code == "NOT_FOUND"
+    assert mapped.details == {"resource": "viking://missing", "type": "file"}
+
+
+def test_agfs_client_invalid_uri_maps_to_invalid_uri():
+    mapped = map_exception(
+        AGFSClientError("Invalid URI: viking://"),
+        resource="viking://",
+    )
+
+    assert isinstance(mapped, InvalidURIError)
+    assert mapped.code == "INVALID_URI"
+    assert mapped.details["uri"] == "viking://"
+
+
+def test_value_error_invalid_uri_maps_to_invalid_uri():
+    mapped = map_exception(ValueError("invalid viking URI: missing path"), resource="viking://")
+
+    assert isinstance(mapped, InvalidURIError)
+    assert mapped.code == "INVALID_URI"


### PR DESCRIPTION
## Summary
- map AGFS "does not exist" messages to structured `NOT_FOUND` errors
- map invalid Viking URI messages to `InvalidURIError` / `INVALID_URI`
- add focused server error-mapping regression tests

## Tests
- `PYTHONPATH=$PWD /Users/ming/code/volcengine/OpenViking/.venv/bin/python -m py_compile openviking/server/error_mapping.py openviking_cli/exceptions.py tests/server/test_error_mapping.py`
- `PYTHONPATH=$PWD /Users/ming/code/volcengine/OpenViking/.venv/bin/pytest tests/server/test_error_mapping.py -q`

Note: `tests/server/test_error_scenarios.py` cannot be run in this local checkout because the native `ragfs_python` binding is not installed.
