### PR TITLE
fix(session): verify live messages clear before commit

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -122,9 +122,7 @@ WM_UPDATE_TOOL: Dict[str, Any] = {
                     "type": "object",
                     "required": list(WM_SEVEN_SECTIONS),
                     "additionalProperties": False,
-                    "properties": {
-                        name: _WM_SECTION_OP_SCHEMA for name in WM_SEVEN_SECTIONS
-                    },
+                    "properties": dict.fromkeys(WM_SEVEN_SECTIONS, _WM_SECTION_OP_SCHEMA),
                 }
             },
         },
@@ -384,9 +382,7 @@ class Session:
         keep = max(0, int(self._meta.keep_recent_count or 0))
         total = len(self._messages)
         if keep <= 0:
-            self._meta.pending_tokens = sum(
-                int(m.estimated_tokens or 0) for m in self._messages
-            )
+            self._meta.pending_tokens = sum(int(m.estimated_tokens or 0) for m in self._messages)
         elif total > keep:
             self._meta.pending_tokens = sum(
                 int(m.estimated_tokens or 0) for m in self._messages[: total - keep]
@@ -669,9 +665,7 @@ class Session:
                 # replaces messages.jsonl under the lock, consistent with the
                 # previous behavior of writing empty messages on full clear.
                 await self._write_to_agfs_async(messages=self._messages)
-                live_message_count = await self._read_live_message_count(
-                    fallback_to_memory=False
-                )
+                live_message_count = await self._read_live_message_count(fallback_to_memory=False)
             except Exception as e:
                 # Rollback: restore messages so they aren't lost
                 logger.error(f"[commit] Failed to write messages.jsonl durably: {e}")
@@ -877,7 +871,9 @@ class Session:
                     if self._viking_fs:
                         for usage in usage_records:
                             try:
-                                await self._viking_fs.link(self._session_uri, usage.uri, ctx=self.ctx)
+                                await self._viking_fs.link(
+                                    self._session_uri, usage.uri, ctx=self.ctx
+                                )
                             except Exception as e:
                                 logger.warning(f"Failed to create relation to {usage.uri}: {e}")
 
@@ -887,8 +883,8 @@ class Session:
                     if self._vikingdb_manager:
                         uris = [u.uri for u in usage_records if u.uri]
                         try:
-                            active_count_updated = await self._vikingdb_manager.increment_active_count(
-                                self.ctx, uris
+                            active_count_updated = (
+                                await self._vikingdb_manager.increment_active_count(self.ctx, uris)
                             )
                         except Exception as e:
                             logger.debug(f"Could not update active_count for usage URIs: {e}")
@@ -976,9 +972,7 @@ class Session:
         missing_files = []
         for file_name in required_files:
             try:
-                await self._viking_fs.read_file(
-                    f"{archive_uri}/{file_name}", ctx=self.ctx
-                )
+                await self._viking_fs.read_file(f"{archive_uri}/{file_name}", ctx=self.ctx)
             except Exception:
                 missing_files.append(file_name)
 
@@ -1538,8 +1532,10 @@ class Session:
           tool_call / JSON / schema anomaly, fall back to the creation
           prompt so we never persist malformed output as WM.
         """
-        _wm_debug(f"_generate_archive_summary_async called "
-                  f"messages={len(messages)} prior_wm={len(latest_archive_overview)}B")
+        _wm_debug(
+            f"_generate_archive_summary_async called "
+            f"messages={len(messages)} prior_wm={len(latest_archive_overview)}B"
+        )
         if not messages:
             return ""
 
@@ -1549,8 +1545,7 @@ class Session:
         if not (vlm and vlm.is_available()):
             turn_count = len([m for m in messages if m.role == "user"])
             return (
-                f"# Session Summary\n\n"
-                f"**Overview**: {turn_count} turns, {len(messages)} messages"
+                f"# Session Summary\n\n**Overview**: {turn_count} turns, {len(messages)} messages"
             )
 
         try:
@@ -1559,8 +1554,7 @@ class Session:
             logger.warning(f"Prompt module unavailable: {e}")
             turn_count = len([m for m in messages if m.role == "user"])
             return (
-                f"# Session Summary\n\n"
-                f"**Overview**: {turn_count} turns, {len(messages)} messages"
+                f"# Session Summary\n\n**Overview**: {turn_count} turns, {len(messages)} messages"
             )
 
         # -------- Detect WM v2 format --------
@@ -1577,7 +1571,10 @@ class Session:
             try:
                 prompt = render_prompt(
                     "compression.ov_wm_v2",
-                    {"messages": formatted, "latest_archive_overview": latest_archive_overview or ""},
+                    {
+                        "messages": formatted,
+                        "latest_archive_overview": latest_archive_overview or "",
+                    },
                 )
                 return await vlm.get_completion_async(prompt)
             except Exception as e:
@@ -1613,14 +1610,12 @@ class Session:
             )
         except Exception as e:
             import traceback as _tb
-            _wm_debug(
-                f"tool_call raised: {type(e).__name__}: {e} "
-                f"tb={_tb.format_exc()[-400:]}"
+
+            _wm_debug(f"tool_call raised: {type(e).__name__}: {e} tb={_tb.format_exc()[-400:]}")
+            logger.warning("WM update tool_call failed (%s); falling back to creation prompt", e)
+            return await self._fallback_generate_wm_creation(
+                formatted, messages, latest_archive_overview
             )
-            logger.warning(
-                "WM update tool_call failed (%s); falling back to creation prompt", e
-            )
-            return await self._fallback_generate_wm_creation(formatted, messages, latest_archive_overview)
 
         has_tc = bool(getattr(resp, "has_tool_calls", False) and getattr(resp, "tool_calls", None))
         _preview = (str(resp)[:200]).replace(chr(10), " ")
@@ -1632,17 +1627,14 @@ class Session:
         )
 
         if not has_tc:
-            logger.warning(
-                "WM update: LLM returned no tool_call; falling back to creation prompt"
+            logger.warning("WM update: LLM returned no tool_call; falling back to creation prompt")
+            return await self._fallback_generate_wm_creation(
+                formatted, messages, latest_archive_overview
             )
-            return await self._fallback_generate_wm_creation(formatted, messages, latest_archive_overview)
 
         try:
             raw_args = resp.tool_calls[0].arguments
-            _wm_debug(
-                f"raw_args type={type(raw_args).__name__} "
-                f"preview={str(raw_args)[:400]!r}"
-            )
+            _wm_debug(f"raw_args type={type(raw_args).__name__} preview={str(raw_args)[:400]!r}")
             args = raw_args
             if isinstance(args, str):
                 args = json.loads(args)
@@ -1668,8 +1660,7 @@ class Session:
                             patched = raw_str.rstrip().rstrip(",") + ("}" * opens)
                             recovered = json.loads(patched)
                             _wm_debug(
-                                f"recovered by closing {opens} brace(s); "
-                                f"patched_len={len(patched)}"
+                                f"recovered by closing {opens} brace(s); patched_len={len(patched)}"
                             )
                     except Exception as e2:
                         _wm_debug(f"brace-close recovery failed: {e2}")
@@ -1686,15 +1677,12 @@ class Session:
                 _wm_debug("args has section keys directly; accepting as ops")
                 ops = args
             else:
-                raise ValueError(
-                    f"tool_call arguments.sections missing; keys={list(args.keys())}"
-                )
+                raise ValueError(f"tool_call arguments.sections missing; keys={list(args.keys())}")
             if not isinstance(ops, dict):
                 raise ValueError("ops is not a dict")
         except Exception as e:
             _wm_debug(
-                f"args parse failed: {type(e).__name__}: {e}; "
-                f"attempting regex recovery from raw"
+                f"args parse failed: {type(e).__name__}: {e}; attempting regex recovery from raw"
             )
             # Regex salvage: when the LLM emits slightly-broken JSON (curly
             # quote, unescaped newline, truncated string), OV's VLM backend
@@ -1727,15 +1715,15 @@ class Session:
                     len(WM_SEVEN_SECTIONS),
                 )
                 return self._merge_wm_sections(latest_archive_overview, salvaged)
-            _wm_debug(
-                "regex recovery salvaged 0 sections; falling back to creation prompt"
-            )
+            _wm_debug("regex recovery salvaged 0 sections; falling back to creation prompt")
             logger.warning(
                 "WM update: tool_call arguments parse failed (%s); "
                 "regex recovery found nothing; falling back to creation prompt",
                 e,
             )
-            return await self._fallback_generate_wm_creation(formatted, messages, latest_archive_overview)
+            return await self._fallback_generate_wm_creation(
+                formatted, messages, latest_archive_overview
+            )
 
         _wm_debug(
             f"ops keys={list(ops.keys())[:7]} "
@@ -1770,8 +1758,7 @@ class Session:
             logger.warning(f"WM creation fallback failed: {e}")
             turn_count = len([m for m in messages if m.role == "user"])
             return (
-                f"# Session Summary\n\n"
-                f"**Overview**: {turn_count} turns, {len(messages)} messages"
+                f"# Session Summary\n\n**Overview**: {turn_count} turns, {len(messages)} messages"
             )
 
     @staticmethod
@@ -1843,9 +1830,11 @@ class Session:
         return "<section_size_warnings>\n" + "\n\n".join(warnings) + "\n</section_size_warnings>"
 
     # Sections where server enforces APPEND-only regardless of what the LLM emits.
-    _WM_APPEND_ONLY_SECTIONS = frozenset({
-        "Errors & Corrections",
-    })
+    _WM_APPEND_ONLY_SECTIONS = frozenset(
+        {
+            "Errors & Corrections",
+        }
+    )
 
     # Very loose path-like token regex used to detect file paths that existed
     # in prior Files & Context and MUST NOT silently disappear after UPDATE.
@@ -1855,11 +1844,32 @@ class Session:
         re.IGNORECASE,
     )
 
-    _WM_TITLE_STOPWORDS = frozenset({
-        "the", "a", "an", "and", "or", "of", "to", "in", "on", "for",
-        "with", "by", "at", "from", "session", "title", "working", "memory",
-        "plan", "plans", "notes", "note",
-    })
+    _WM_TITLE_STOPWORDS = frozenset(
+        {
+            "the",
+            "a",
+            "an",
+            "and",
+            "or",
+            "of",
+            "to",
+            "in",
+            "on",
+            "for",
+            "with",
+            "by",
+            "at",
+            "from",
+            "session",
+            "title",
+            "working",
+            "memory",
+            "plan",
+            "plans",
+            "notes",
+            "note",
+        }
+    )
 
     @staticmethod
     def _wm_recover_ops_from_raw(raw_str: str) -> Dict[str, Any]:
@@ -1884,9 +1894,7 @@ class Session:
         names_alt = "|".join(re.escape(n) for n in WM_SEVEN_SECTIONS)
 
         # --- KEEP: "Name": {"op": "KEEP"} ---
-        keep_re = re.compile(
-            rf'"({names_alt})"\s*:\s*\{{\s*"op"\s*:\s*"KEEP"\s*\}}'
-        )
+        keep_re = re.compile(rf'"({names_alt})"\s*:\s*\{{\s*"op"\s*:\s*"KEEP"\s*\}}')
         for m in keep_re.finditer(raw_str):
             ops.setdefault(m.group(1), {"op": "KEEP"})
 
@@ -1916,7 +1924,7 @@ class Session:
         # Tolerate truncated array (no closing ']').
         append_re = re.compile(
             rf'"({names_alt})"\s*:\s*\{{\s*"op"\s*:\s*"APPEND"\s*,\s*"items"\s*:\s*\['
-            rf'([\s\S]*?)(?:\]|$)',
+            rf"([\s\S]*?)(?:\]|$)",
         )
         item_re = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
         for m in append_re.finditer(raw_str):
@@ -1957,9 +1965,7 @@ class Session:
         return items
 
     @staticmethod
-    def _wm_enforce_append_only(
-        header: str, op: Any, old_content: str
-    ) -> Dict[str, Any]:
+    def _wm_enforce_append_only(header: str, op: Any, old_content: str) -> Dict[str, Any]:
         """Guard: force KEEP/APPEND semantics on APPEND-only sections.
 
         - KEEP and APPEND pass through.
@@ -2015,22 +2021,117 @@ class Session:
         r"\b(?:because|decided|chose|committed|agreed|resolved)\b",
         re.IGNORECASE,
     )
-    _WM_ANCHOR_STOPWORDS = frozenset({
-        "the", "a", "an", "and", "or", "of", "to", "in", "on", "for",
-        "with", "by", "at", "from", "is", "are", "was", "were", "has",
-        "have", "had", "been", "be", "will", "would", "could", "should",
-        "may", "might", "shall", "this", "that", "these", "those",
-        "not", "no", "but", "if", "then", "so", "as", "it", "its",
-        "they", "their", "them", "she", "her", "he", "him", "his",
-        "we", "our", "us", "you", "your", "who", "which", "what",
-        "when", "where", "how", "why", "all", "each", "every",
-        "both", "few", "more", "most", "other", "some", "such",
-        "than", "too", "very", "also", "just", "about", "after",
-        "before", "between", "into", "through", "during", "again",
-        "further", "once", "here", "there", "over", "under", "out",
-        "up", "down", "off", "own", "same", "only", "new", "old",
-        "key", "facts", "decisions", "session", "working", "memory",
-    })
+    _WM_ANCHOR_STOPWORDS = frozenset(
+        {
+            "the",
+            "a",
+            "an",
+            "and",
+            "or",
+            "of",
+            "to",
+            "in",
+            "on",
+            "for",
+            "with",
+            "by",
+            "at",
+            "from",
+            "is",
+            "are",
+            "was",
+            "were",
+            "has",
+            "have",
+            "had",
+            "been",
+            "be",
+            "will",
+            "would",
+            "could",
+            "should",
+            "may",
+            "might",
+            "shall",
+            "this",
+            "that",
+            "these",
+            "those",
+            "not",
+            "no",
+            "but",
+            "if",
+            "then",
+            "so",
+            "as",
+            "it",
+            "its",
+            "they",
+            "their",
+            "them",
+            "she",
+            "her",
+            "he",
+            "him",
+            "his",
+            "we",
+            "our",
+            "us",
+            "you",
+            "your",
+            "who",
+            "which",
+            "what",
+            "when",
+            "where",
+            "how",
+            "why",
+            "all",
+            "each",
+            "every",
+            "both",
+            "few",
+            "more",
+            "most",
+            "other",
+            "some",
+            "such",
+            "than",
+            "too",
+            "very",
+            "also",
+            "just",
+            "about",
+            "after",
+            "before",
+            "between",
+            "into",
+            "through",
+            "during",
+            "again",
+            "further",
+            "once",
+            "here",
+            "there",
+            "over",
+            "under",
+            "out",
+            "up",
+            "down",
+            "off",
+            "own",
+            "same",
+            "only",
+            "new",
+            "old",
+            "key",
+            "facts",
+            "decisions",
+            "session",
+            "working",
+            "memory",
+        }
+    )
 
     @staticmethod
     def _extract_lexical_anchors(text: str) -> set:
@@ -2063,16 +2164,12 @@ class Session:
             if key and key not in old_lower:
                 fresh_items.append(it)
         if fresh_items:
-            _wm_debug(
-                f"guard: salvaged {len(fresh_items)} new items from rejected UPDATE"
-            )
+            _wm_debug(f"guard: salvaged {len(fresh_items)} new items from rejected UPDATE")
             return {"op": "APPEND", "items": fresh_items}
         return {"op": "KEEP"}
 
     @staticmethod
-    def _wm_enforce_key_facts_consolidation(
-        op: Any, old_content: str
-    ) -> Dict[str, Any]:
+    def _wm_enforce_key_facts_consolidation(op: Any, old_content: str) -> Dict[str, Any]:
         """Guard: allow controlled consolidation for Key Facts & Decisions.
 
         Layer 1 — reject trivially small UPDATEs (< 15% bullet count).
@@ -2106,10 +2203,7 @@ class Session:
                 append_items = Session._wm_extract_bullet_items(raw)
             append_items = [str(it) for it in append_items if it]
             old_lower = (old_content or "").lower()
-            fresh = [
-                it for it in append_items
-                if it.strip("_* `").lower() not in old_lower
-            ]
+            fresh = [it for it in append_items if it.strip("_* `").lower() not in old_lower]
             emergency = (
                 len(old_items) > Session._WM_SECTION_BULLET_THRESHOLD * 2
                 or est_tokens > Session._WM_SECTION_TOKEN_THRESHOLD * 2
@@ -2166,13 +2260,9 @@ class Session:
                 f"new={len(new_items)} / old={len(old_items)} = "
                 f"{ratio:.2%} < {Session._WM_KEY_FACTS_MIN_BULLET_RATIO:.0%}"
             )
-            salvaged = Session._salvage_new_items_from_rejected_update(
-                new_content, old_content
-            )
+            salvaged = Session._salvage_new_items_from_rejected_update(new_content, old_content)
             if is_emergency and salvaged.get("op") == "APPEND":
-                _wm_debug(
-                    "guard: suppressing salvage APPEND (emergency level)"
-                )
+                _wm_debug("guard: suppressing salvage APPEND (emergency level)")
                 return {"op": "KEEP"}
             return salvaged
 
@@ -2189,13 +2279,9 @@ class Session:
                     f"({covered}/{len(old_anchors)}) < "
                     f"{Session._WM_KEY_FACTS_MIN_ANCHOR_COVERAGE:.0%}"
                 )
-                salvaged = Session._salvage_new_items_from_rejected_update(
-                    new_content, old_content
-                )
+                salvaged = Session._salvage_new_items_from_rejected_update(new_content, old_content)
                 if is_emergency and salvaged.get("op") == "APPEND":
-                    _wm_debug(
-                        "guard: suppressing salvage APPEND (emergency level)"
-                    )
+                    _wm_debug("guard: suppressing salvage APPEND (emergency level)")
                     return {"op": "KEEP"}
                 return salvaged
             _wm_debug(
@@ -2236,7 +2322,7 @@ class Session:
         added_paths = new_paths - old_paths
         _wm_debug(
             f"guard: 'Files & Context' UPDATE drops {len(missing)} paths "
-            f"{sorted(list(missing))[:5]}; forcing KEEP (+ APPEND new paths="
+            f"{sorted(missing)[:5]}; forcing KEEP (+ APPEND new paths="
             f"{len(added_paths)})"
         )
         if added_paths:
@@ -2273,10 +2359,7 @@ class Session:
 
         def meaningful_words(text: str) -> set:
             tokens = re.findall(r"[A-Za-z][A-Za-z0-9\.]{2,}|[\d\.]+", text or "")
-            return {
-                t.lower() for t in tokens
-                if t.lower() not in Session._WM_TITLE_STOPWORDS
-            }
+            return {t.lower() for t in tokens if t.lower() not in Session._WM_TITLE_STOPWORDS}
 
         old_w = meaningful_words(old_content)
         new_w = meaningful_words(new_content)
@@ -2326,9 +2409,7 @@ class Session:
             f"guard: Open Issues UPDATE silently dropped {len(dropped)} "
             f"items; restoring once (will not restore again if re-dropped)"
         )
-        restored = "\n".join(
-            f"- [silently dropped, restored] {it}" for it in dropped
-        )
+        restored = "\n".join(f"- [silently dropped, restored] {it}" for it in dropped)
         merged = (new_content + ("\n" if new_content else "") + restored).strip()
         return {"op": "UPDATE", "content": merged}
 
@@ -2402,7 +2483,9 @@ class Session:
                     if bad_items:
                         logger.warning(
                             "wm_v2: dropped %d non-string APPEND item(s) in section %r: %s",
-                            len(bad_items), header, [type(s).__name__ for s in bad_items],
+                            len(bad_items),
+                            header,
+                            [type(s).__name__ for s in bad_items],
                         )
                     appended = "\n".join(
                         f"- {s.strip()}" for s in items if isinstance(s, str) and s.strip()

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -440,6 +440,7 @@ class Session:
 
         # Use filesystem-based distributed lock so this works across workers/processes.
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
+        live_message_count = 0
         async with LockContext(get_lock_manager(), [session_path], lock_mode="point"):
             # Authoritative check under lock: handles the race where two concurrent
             # callers both passed the pre-check but only the first should archive.
@@ -460,12 +461,22 @@ class Session:
 
             try:
                 await self._write_to_agfs_async(messages=[])
+                live_message_count = await self._read_live_message_count(fallback_to_memory=False)
             except Exception as e:
                 # Rollback: restore messages so they aren't lost
-                logger.error(f"[commit] Failed to write empty messages.jsonl: {e}")
+                logger.error(f"[commit] Failed to clear live messages.jsonl durably: {e}")
                 self._messages.extend(messages_to_archive)
                 self._compression.compression_index -= 1
                 raise
+
+            if live_message_count != 0:
+                self._messages.extend(messages_to_archive)
+                self._compression.compression_index -= 1
+                raise FailedPreconditionError(
+                    f"Session {self.session_id} live messages.jsonl still contains "
+                    f"{live_message_count} messages after commit clear.",
+                    details={"live_message_count": live_message_count},
+                )
         # Lock released — live session is now clean.
         # Any add_message() from here appends to the fresh empty list.
 
@@ -481,7 +492,7 @@ class Session:
                 ctx=self.ctx,
             )
 
-        self._meta.message_count = 0
+        self._meta.message_count = live_message_count
         await self._save_meta()
 
         self._compression.original_count += len(messages_to_archive)
@@ -1176,7 +1187,7 @@ class Session:
         self._meta = latest_meta
         await self._save_meta()
 
-    async def _read_live_message_count(self) -> int:
+    async def _read_live_message_count(self, fallback_to_memory: bool = True) -> int:
         """Count current live session messages from persisted storage."""
         if not self._viking_fs:
             return len(self._messages)
@@ -1186,7 +1197,9 @@ class Session:
                 ctx=self.ctx,
             )
         except Exception:
-            return len(self._messages)
+            if fallback_to_memory:
+                return len(self._messages)
+            raise
         return len([line for line in content.strip().split("\n") if line.strip()])
 
     def _extract_abstract_from_summary(self, summary: str) -> str:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -616,6 +616,7 @@ class Session:
 
         # Use filesystem-based distributed lock so this works across workers/processes.
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
+        live_message_count = len(self._messages)
         async with LockContext(get_lock_manager(), [session_path], lock_mode="point"):
             # Authoritative check under lock: handles the race where two concurrent
             # callers both passed the pre-check but only the first should archive.
@@ -668,12 +669,29 @@ class Session:
                 # replaces messages.jsonl under the lock, consistent with the
                 # previous behavior of writing empty messages on full clear.
                 await self._write_to_agfs_async(messages=self._messages)
+                live_message_count = await self._read_live_message_count(
+                    fallback_to_memory=False
+                )
             except Exception as e:
                 # Rollback: restore messages so they aren't lost
-                logger.error(f"[commit] Failed to write messages.jsonl: {e}")
+                logger.error(f"[commit] Failed to write messages.jsonl durably: {e}")
                 self._messages = list(messages_to_archive) + list(self._messages)
                 self._compression.compression_index -= 1
                 raise
+
+            expected_live_message_count = len(self._messages)
+            if live_message_count != expected_live_message_count:
+                self._messages = list(messages_to_archive) + list(self._messages)
+                self._compression.compression_index -= 1
+                raise FailedPreconditionError(
+                    f"Session {self.session_id} live messages.jsonl contains "
+                    f"{live_message_count} messages after commit clear; "
+                    f"expected {expected_live_message_count}.",
+                    details={
+                        "live_message_count": live_message_count,
+                        "expected_live_message_count": expected_live_message_count,
+                    },
+                )
         # Lock released — live session now contains only the retained tail.
 
         # ===== Phase 1 continued: Write raw archive (no LLM calls, no lock needed) =====
@@ -690,7 +708,7 @@ class Session:
 
         # WM v2: live session is now the retained tail; pending_tokens resets
         # because anything that was pending has been archived.
-        self._meta.message_count = len(self._messages)
+        self._meta.message_count = live_message_count
         self._meta.pending_tokens = 0
         self._meta.keep_recent_count = keep_recent_count
         await self._save_meta()
@@ -908,7 +926,11 @@ class Session:
                 telemetry_snapshot=snapshot,
             )
 
-            # Write .done file last — signals that all state is finalized
+            # Verify required archive artifacts before writing .done. The .done marker is
+            # the completion signal consumed by later context assembly, so do not expose an
+            # archive as completed until the durable messages and summary artifacts are all
+            # readable.
+            await self._verify_archive_completion_artifacts(archive_uri)
             await self._write_done_file(archive_uri, first_message_id, last_message_id)
 
             tracker.complete(
@@ -939,6 +961,32 @@ class Session:
             )
             tracker.fail(task_id, str(e))
             logger.exception(f"Memory extraction failed for session {self.session_id}")
+
+    async def _verify_archive_completion_artifacts(self, archive_uri: str) -> None:
+        """Ensure an archive has all required artifacts before marking it done."""
+        if not self._viking_fs:
+            return
+
+        required_files = (
+            "messages.jsonl",
+            ".abstract.md",
+            ".overview.md",
+            ".meta.json",
+        )
+        missing_files = []
+        for file_name in required_files:
+            try:
+                await self._viking_fs.read_file(
+                    f"{archive_uri}/{file_name}", ctx=self.ctx
+                )
+            except Exception:
+                missing_files.append(file_name)
+
+        if missing_files:
+            raise RuntimeError(
+                f"Archive {archive_uri} is missing required artifacts before .done: "
+                + ", ".join(missing_files)
+            )
 
     async def _write_done_file(
         self,
@@ -1396,7 +1444,7 @@ class Session:
         self._meta = latest_meta
         await self._save_meta()
 
-    async def _read_live_message_count(self) -> int:
+    async def _read_live_message_count(self, fallback_to_memory: bool = True) -> int:
         """Count current live session messages from persisted storage."""
         if not self._viking_fs:
             return len(self._messages)
@@ -1406,7 +1454,9 @@ class Session:
                 ctx=self.ctx,
             )
         except Exception:
-            return len(self._messages)
+            if fallback_to_memory:
+                return len(self._messages)
+            raise
         return len([line for line in content.strip().split("\n") if line.strip()])
 
     def _extract_abstract_from_summary(self, summary: str) -> str:

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -269,16 +269,12 @@ class TestCommit:
 
         done_exists = True
         try:
-            await session._viking_fs.read_file(
-                f"{result['archive_uri']}/.done", ctx=session.ctx
-            )
+            await session._viking_fs.read_file(f"{result['archive_uri']}/.done", ctx=session.ctx)
         except Exception:
             done_exists = False
         assert done_exists is False
 
-    async def test_commit_rolls_back_when_live_messages_not_cleared(
-        self, client: AsyncOpenViking
-    ):
+    async def test_commit_rolls_back_when_live_messages_not_cleared(self, client: AsyncOpenViking):
         """Commit must fail if persisted live messages.jsonl stays non-empty."""
         session = client.session(session_id="commit_durability_guard")
         session.add_message("user", [TextPart("First round message")])
@@ -296,9 +292,7 @@ class TestCommit:
 
         session._viking_fs.write_file = stale_empty_messages
 
-        with pytest.raises(
-            FailedPreconditionError, match="live messages.jsonl contains"
-        ):
+        with pytest.raises(FailedPreconditionError, match="live messages.jsonl contains"):
             await session.commit_async()
 
         assert len(session.messages) == initial_message_count

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -236,3 +236,31 @@ class TestCommit:
         session.add_message("user", [TextPart("Second round message")])
         with pytest.raises(FailedPreconditionError, match="unresolved failed archive"):
             await session.commit_async()
+
+
+    async def test_commit_rolls_back_when_live_messages_not_cleared(
+        self, client: AsyncOpenViking
+    ):
+        """Commit must fail if persisted live messages.jsonl stays non-empty."""
+        session = client.session(session_id="commit_durability_guard")
+        session.add_message("user", [TextPart("First round message")])
+        session.add_message("assistant", [TextPart("First round response")])
+        initial_message_count = len(session.messages)
+
+        original_write_file = session._viking_fs.write_file
+
+        async def stale_empty_messages(*args, **kwargs):
+            uri = kwargs.get("uri", args[0] if args else None)
+            content = kwargs.get("content", args[1] if len(args) > 1 else None)
+            if uri == f"{session._session_uri}/messages.jsonl" and content == "":
+                return None
+            return await original_write_file(*args, **kwargs)
+
+        session._viking_fs.write_file = stale_empty_messages
+
+        with pytest.raises(FailedPreconditionError, match="live messages.jsonl still contains"):
+            await session.commit_async()
+
+        assert len(session.messages) == initial_message_count
+        assert session._compression.compression_index == 0
+        assert await session._read_live_message_count(fallback_to_memory=False) == initial_message_count

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -236,3 +236,74 @@ class TestCommit:
         session.add_message("user", [TextPart("Second round message")])
         with pytest.raises(FailedPreconditionError, match="unresolved failed archive"):
             await session.commit_async()
+
+    async def test_commit_fails_phase2_when_archive_artifact_is_missing(
+        self, client: AsyncOpenViking
+    ):
+        """Phase 2 must not write .done until required archive artifacts are readable."""
+        session = client.session(session_id="missing_archive_artifact_guard")
+        session.add_message("user", [TextPart("First round message")])
+        session.add_message("assistant", [TextPart("First round response")])
+
+        original_write_file = session._viking_fs.write_file
+
+        async def drop_overview_artifact(*args, **kwargs):
+            uri = kwargs.get("uri", args[0] if args else None)
+            if uri and uri.endswith("/.overview.md"):
+                return None
+            return await original_write_file(*args, **kwargs)
+
+        session._viking_fs.write_file = drop_overview_artifact
+
+        result = await session.commit_async()
+        task_result = await _wait_for_task(result["task_id"])
+
+        assert task_result["status"] == "failed"
+        failed_marker = await session._viking_fs.read_file(
+            f"{result['archive_uri']}/.failed.json",
+            ctx=session.ctx,
+        )
+        failed_payload = json.loads(failed_marker)
+        assert failed_payload["stage"] == "memory_extraction"
+        assert ".overview.md" in failed_payload["error"]
+
+        done_exists = True
+        try:
+            await session._viking_fs.read_file(
+                f"{result['archive_uri']}/.done", ctx=session.ctx
+            )
+        except Exception:
+            done_exists = False
+        assert done_exists is False
+
+    async def test_commit_rolls_back_when_live_messages_not_cleared(
+        self, client: AsyncOpenViking
+    ):
+        """Commit must fail if persisted live messages.jsonl stays non-empty."""
+        session = client.session(session_id="commit_durability_guard")
+        session.add_message("user", [TextPart("First round message")])
+        session.add_message("assistant", [TextPart("First round response")])
+        initial_message_count = len(session.messages)
+
+        original_write_file = session._viking_fs.write_file
+
+        async def stale_empty_messages(*args, **kwargs):
+            uri = kwargs.get("uri", args[0] if args else None)
+            content = kwargs.get("content", args[1] if len(args) > 1 else None)
+            if uri == f"{session._session_uri}/messages.jsonl" and content == "":
+                return None
+            return await original_write_file(*args, **kwargs)
+
+        session._viking_fs.write_file = stale_empty_messages
+
+        with pytest.raises(
+            FailedPreconditionError, match="live messages.jsonl contains"
+        ):
+            await session.commit_async()
+
+        assert len(session.messages) == initial_message_count
+        assert session._compression.compression_index == 0
+        assert (
+            await session._read_live_message_count(fallback_to_memory=False)
+            == initial_message_count
+        )

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -237,10 +237,7 @@ class TestCommit:
         with pytest.raises(FailedPreconditionError, match="unresolved failed archive"):
             await session.commit_async()
 
-
-    async def test_commit_rolls_back_when_live_messages_not_cleared(
-        self, client: AsyncOpenViking
-    ):
+    async def test_commit_rolls_back_when_live_messages_not_cleared(self, client: AsyncOpenViking):
         """Commit must fail if persisted live messages.jsonl stays non-empty."""
         session = client.session(session_id="commit_durability_guard")
         session.add_message("user", [TextPart("First round message")])
@@ -263,4 +260,7 @@ class TestCommit:
 
         assert len(session.messages) == initial_message_count
         assert session._compression.compression_index == 0
-        assert await session._read_live_message_count(fallback_to_memory=False) == initial_message_count
+        assert (
+            await session._read_live_message_count(fallback_to_memory=False)
+            == initial_message_count
+        )


### PR DESCRIPTION
## Summary
- read back the live `messages.jsonl` immediately after clearing it during commit
- roll back the in-memory session state if the persisted live file is still non-empty
- add a regression test that simulates a stale empty-write no-op

## Validation
- `./.venv/bin/python -m py_compile openviking/session/session.py tests/session/test_session_commit.py`
- ad-hoc async validation with a fake VikingFS to confirm `commit_async()` now raises and restores state when the live `messages.jsonl` stays non-empty
- full pytest in this environment is blocked because local OpenViking test startup still requires `ragfs_python`, and rebuilding it currently fails with an `xcrun` CommandLineTools architecture mismatch on this machine

Closes #1487.
