### PR TITLE
Fix OpenClaw plugin recall assembly

### DIFF
--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -213,7 +213,10 @@ export const memoryOpenVikingConfigSchema = {
         50,
         Math.min(10000, Math.floor(toNumber(cfg.recallMaxContentChars, DEFAULT_RECALL_MAX_CONTENT_CHARS))),
       ),
-      recallPreferAbstract: cfg.recallPreferAbstract === true,
+      recallPreferAbstract:
+        typeof cfg.recallPreferAbstract === "boolean"
+          ? cfg.recallPreferAbstract
+          : DEFAULT_RECALL_PREFER_ABSTRACT,
       recallTokenBudget: Math.max(
         100,
         Math.min(50000, Math.floor(toNumber(cfg.recallTokenBudget, DEFAULT_RECALL_TOKEN_BUDGET))),

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -6,12 +6,16 @@ import {
   compileSessionPatterns,
   getCaptureDecision,
   extractNewTurnMessages,
+  extractLatestUserText,
   extractSingleMessageText,
   shouldBypassSession,
 } from "./text-utils.js";
 import {
   trimForLog,
   toJsonLog,
+  postProcessMemories,
+  summarizeInjectionMemories,
+  pickMemoriesForInjection,
 } from "./memory-ranking.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
 
@@ -116,6 +120,16 @@ const ARCHIVE_BUDGET_CAP = 8_000;
 const RESERVED_MIN = 20_000;
 const RESERVED_RATIO = 0.15;
 const ARCHIVE_INDEX_TRIM_LIMIT = 10;
+const RECALL_QUERY_MAX_CHARS = 4_000;
+const ASSEMBLE_RECALL_MAX_ITEMS = 2;
+const ASSEMBLE_RECALL_MAX_CHARS_PER_ITEM = 140;
+
+type PreparedRecallQuery = {
+  query: string;
+  truncated: boolean;
+  originalChars: number;
+  finalChars: number;
+};
 
 function allocateContextBudget(totalBudget: number, instructionTokens = 0): ContextBudgets {
   const reserveFloor = totalBudget >= RESERVED_MIN * 2 ? RESERVED_MIN : 0;
@@ -132,6 +146,83 @@ function estimateTokens(messages: AgentMessage[]): number {
 
 function roughEstimate(messages: AgentMessage[]): number {
   return Math.ceil(JSON.stringify(messages).length / 4);
+}
+
+function normalizeRecallFact(line: string): string {
+  return line
+    .replace(/^- \[[^\]]*\]\s*/u, "")
+    .replace(/[`*_#>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncateRecallFact(line: string): string {
+  if (line.length <= ASSEMBLE_RECALL_MAX_CHARS_PER_ITEM) {
+    return line;
+  }
+  return `${line.slice(0, ASSEMBLE_RECALL_MAX_CHARS_PER_ITEM).trim()}...`;
+}
+
+function prepareRecallQuery(rawText: string): PreparedRecallQuery {
+  const sanitized = rawText.trim();
+  const originalChars = sanitized.length;
+  if (!sanitized) {
+    return { query: "", truncated: false, originalChars: 0, finalChars: 0 };
+  }
+
+  const query =
+    sanitized.length > RECALL_QUERY_MAX_CHARS
+      ? sanitized.slice(0, RECALL_QUERY_MAX_CHARS).trim()
+      : sanitized;
+
+  return {
+    query,
+    truncated: sanitized.length > RECALL_QUERY_MAX_CHARS,
+    originalChars,
+    finalChars: query.length,
+  };
+}
+
+async function buildRecallFactsWithBudget(
+  memories: Array<{ uri: string; abstract?: string; overview?: string }>,
+  readContent: (uri: string) => Promise<string>,
+  opts: {
+    recallPreferAbstract: boolean;
+    recallMaxContentChars: number;
+    recallTokenBudget: number;
+  },
+): Promise<{ facts: string[]; estimatedTokens: number }> {
+  const facts: string[] = [];
+  let usedTokens = 0;
+
+  for (const memory of memories) {
+    let candidate = "";
+    if (opts.recallPreferAbstract) {
+      candidate = (memory.abstract ?? memory.overview ?? "").trim();
+    }
+    if (!candidate) {
+      candidate = (await readContent(memory.uri)).trim();
+    }
+    if (!candidate) {
+      continue;
+    }
+
+    const fact = truncateRecallFact(normalizeRecallFact(candidate).slice(0, opts.recallMaxContentChars));
+    if (!fact) {
+      continue;
+    }
+    const factTokens = Math.ceil(fact.length / 4);
+    if (facts.length > 0 && usedTokens + factTokens > opts.recallTokenBudget) {
+      break;
+    }
+    facts.push(fact);
+    usedTokens += factTokens;
+    if (facts.length >= ASSEMBLE_RECALL_MAX_ITEMS) {
+      break;
+    }
+  }
+
+  return { facts, estimatedTokens: usedTokens };
 }
 
 function msgTokenEstimate(msg: AgentMessage): number {
@@ -402,7 +493,7 @@ export function formatMessageFaithful(msg: OVMessage): string {
 }
 
 function buildSystemPromptAddition(): string {
-  return [
+  const sections = [
     "## Session Context Guide",
     "",
     "Your conversation history may include:",
@@ -439,12 +530,40 @@ function buildSystemPromptAddition(): string {
     "  or state that the information comes from a compressed summary.",
     "- After expanding, cite the archive ID in your answer",
     '  (e.g. "Based on archive_003, ...").',
-  ].join("\n");
+  ];
+
+  return sections.join("\n");
 }
 
 function buildInstructionPrompt(): { text: string; tokens: number } {
   const text = buildSystemPromptAddition();
   return { text, tokens: Math.ceil(text.length / 4) };
+}
+
+function buildRecallMemory(
+  recallFacts: string[],
+  budget: number,
+): { messages: AgentMessage[]; tokens: number } {
+  if (recallFacts.length === 0) {
+    return { messages: [], tokens: 0 };
+  }
+
+  const message: AgentMessage = {
+    role: "user",
+    content: [
+      "[Relevant Long-Term Memory]",
+      "Use these facts silently when they directly help answer the current question.",
+      "Do not quote or dump them unless the user explicitly asks for stored memory details.",
+      ...recallFacts.map((fact, index) => `${index + 1}. ${fact}`),
+    ].join("\n"),
+  };
+
+  const messages = [message];
+  const tokens = roughEstimate(messages);
+  if (budget !== BUDGET_UNLIMITED && tokens > budget) {
+    return { messages: [], tokens: 0 };
+  }
+  return { messages, tokens };
 }
 
 function buildArchiveMemory(
@@ -650,6 +769,86 @@ export function createMemoryOpenVikingContextEngine(params: {
     }
   }
 
+  async function buildAssembleRecallFacts(
+    messages: AgentMessage[],
+    client: OpenVikingClient,
+    agentId: string,
+    sessionId: string,
+  ): Promise<{ facts: string[]; estimatedTokens: number }> {
+    if (!cfg.autoRecall) {
+      return { facts: [], estimatedTokens: 0 };
+    }
+
+    const rawRecallQuery = extractLatestUserText(messages as unknown[]);
+    const recallQuery = prepareRecallQuery(rawRecallQuery);
+    const queryText = recallQuery.query;
+    if (!queryText || queryText.length < 5) {
+      return { facts: [], estimatedTokens: 0 };
+    }
+    if (recallQuery.truncated) {
+      logger.info(
+        `openviking: assemble recall query truncated for session=${sessionId} ` +
+          `(chars=${recallQuery.originalChars}->${recallQuery.finalChars})`,
+      );
+    }
+
+    const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
+    const [userSettled, agentSettled] = await Promise.allSettled([
+      client.find(queryText, {
+        targetUri: "viking://user/memories",
+        limit: candidateLimit,
+        scoreThreshold: 0,
+      }, agentId),
+      client.find(queryText, {
+        targetUri: "viking://agent/memories",
+        limit: candidateLimit,
+        scoreThreshold: 0,
+      }, agentId),
+    ]);
+
+    const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
+    const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
+    if (userSettled.status === "rejected") {
+      logger.warn?.(`openviking: assemble user memories search failed: ${String(userSettled.reason)}`);
+    }
+    if (agentSettled.status === "rejected") {
+      logger.warn?.(`openviking: assemble agent memories search failed: ${String(agentSettled.reason)}`);
+    }
+
+    const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
+    const uniqueMemories = allMemories.filter((memory, index, self) =>
+      index === self.findIndex((m) => m.uri === memory.uri),
+    );
+    const leafOnly = uniqueMemories.filter((memory) => memory.level === 2);
+    const processed = postProcessMemories(leafOnly, {
+      limit: candidateLimit,
+      scoreThreshold: cfg.recallScoreThreshold,
+    });
+    const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
+    if (memories.length === 0) {
+      return { facts: [], estimatedTokens: 0 };
+    }
+
+    const { facts, estimatedTokens } = await buildRecallFactsWithBudget(
+      memories,
+      (uri) => client.read(uri, agentId),
+      {
+        recallPreferAbstract: cfg.recallPreferAbstract,
+        recallMaxContentChars: cfg.recallMaxContentChars,
+        recallTokenBudget: cfg.recallTokenBudget,
+      },
+    );
+    if (facts.length > 0) {
+      logger.info(
+        `openviking: assemble recall using ${facts.length} memories (~${estimatedTokens} tokens, budget=${cfg.recallTokenBudget})`,
+      );
+      logger.info(
+        `openviking: assemble recall detail ${toJsonLog({ count: memories.length, memories: summarizeInjectionMemories(memories) })}`,
+      );
+    }
+    return { facts, estimatedTokens };
+  }
+
   function extractSessionKey(runtimeContext: Record<string, unknown> | undefined): string | undefined {
     if (!runtimeContext) {
       return undefined;
@@ -728,6 +927,7 @@ export function createMemoryOpenVikingContextEngine(params: {
     ovMessages: OVMessage[],
     tokenBudget: number,
     ovSessionId: string,
+    recallFacts: string[] = [],
   ): {
     sanitized: AgentMessage[];
     archive: { messages: AgentMessage[]; tokens: number };
@@ -736,7 +936,9 @@ export function createMemoryOpenVikingContextEngine(params: {
     instruction: { text: string; tokens: number };
   } {
     const hasArchives = Boolean(overview) || preAbstracts.length > 0;
-    const instruction = hasArchives ? buildInstructionPrompt() : { text: "", tokens: 0 };
+    const instruction = hasArchives
+      ? buildInstructionPrompt()
+      : { text: "", tokens: 0 };
 
     // 4-layer context partitioning:
     //   Instruction — system prompt guide (Archive Index / Session History usage)
@@ -745,12 +947,17 @@ export function createMemoryOpenVikingContextEngine(params: {
     //   Reserved    — headroom for model output (not consumed here)
     const budgets = allocateContextBudget(tokenBudget, instruction.tokens);
     const archive = buildArchiveMemory(overview, preAbstracts, budgets.archiveMemory);
-    const sessionBudget = Math.max(
+    const recallMemoryBudget = Math.max(
       tokenBudget - budgets.reserved - instruction.tokens - archive.tokens,
       0,
     );
+    const recallMemory = buildRecallMemory(recallFacts, recallMemoryBudget);
+    const sessionBudget = Math.max(
+      tokenBudget - budgets.reserved - instruction.tokens - archive.tokens - recallMemory.tokens,
+      0,
+    );
     const session = buildSessionContext(ovMessages, sessionBudget);
-    const assembled = [...archive.messages, ...session.messages];
+    const assembled = [...archive.messages, ...recallMemory.messages, ...session.messages];
 
     logger.info(
       `openviking: assemble entering session content for ${ovSessionId}: ` +
@@ -763,7 +970,16 @@ export function createMemoryOpenVikingContextEngine(params: {
     normalizeAssistantContent(assembled);
     const sanitized = sanitizeToolUseResultPairing(assembled as never[]) as AgentMessage[];
 
-    return { sanitized, archive, session, budgets, instruction };
+    return {
+      sanitized,
+      archive: {
+        messages: [...archive.messages, ...recallMemory.messages],
+        tokens: archive.tokens + recallMemory.tokens,
+      },
+      session,
+      budgets,
+      instruction,
+    };
   }
 
   return {
@@ -819,6 +1035,7 @@ export function createMemoryOpenVikingContextEngine(params: {
         const client = await getClient();
         const routingRef = assembleParams.sessionId ?? sessionKey ?? OVSessionId;
         const agentId = resolveAgentId(routingRef, sessionKey, OVSessionId);
+        const recall = await buildAssembleRecallFacts(messages, client, agentId, OVSessionId);
         const ctx = await client.getSessionContext(OVSessionId, tokenBudget, agentId);
 
         const preAbstracts = ctx?.pre_archive_abstracts ?? [];
@@ -842,6 +1059,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           ctx.messages,
           tokenBudget,
           OVSessionId,
+          recall.facts,
         );
 
         if (sanitized.length === 0 && messages.length > 0) {
@@ -868,6 +1086,8 @@ export function createMemoryOpenVikingContextEngine(params: {
           sessionTokens: session.tokens,
           sessionBudget: budgets.sessionContext,
           reservedBudget: budgets.reserved,
+          recallFacts: recall.facts.length,
+          recallTokens: recall.estimatedTokens,
           messages: messageDigest(sanitized),
         });
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+﻿import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 
 import { Type } from "@sinclair/typebox";
@@ -165,6 +165,42 @@ const MAX_OPENVIKING_STDERR_LINES = 200;
 const MAX_OPENVIKING_STDERR_CHARS = 256_000;
 const AUTO_RECALL_TIMEOUT_MS = 5_000;
 const RECALL_QUERY_MAX_CHARS = 4_000;
+const SILENT_RECALL_MAX_ITEMS = 2;
+const SILENT_RECALL_MAX_CHARS_PER_ITEM = 160;
+
+function normalizeRecallLine(line: string): string {
+  return line
+    .replace(/^- \[[^\]]*\]\s*/u, "")
+    .replace(/[`*_#>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncateRecallLine(line: string): string {
+  if (line.length <= SILENT_RECALL_MAX_CHARS_PER_ITEM) {
+    return line;
+  }
+  return `${line.slice(0, SILENT_RECALL_MAX_CHARS_PER_ITEM).trim()}...`;
+}
+
+function buildSilentRecallContext(memoryLines: string[]): string {
+  const normalized = memoryLines
+    .map((line) => truncateRecallLine(normalizeRecallLine(line)))
+    .filter(Boolean)
+    .slice(0, SILENT_RECALL_MAX_ITEMS);
+
+  if (normalized.length === 0) {
+    return "";
+  }
+
+  return [
+    "Internal memory context for answer quality only.",
+    "Use it silently as background knowledge.",
+    "Do not quote, dump, or mention this memory context unless the user explicitly asks for stored memory details.",
+    "Only use the minimum facts needed to answer the current question.",
+    ...normalized.map((line, index) => `${index + 1}. ${line}`),
+  ].join("\n");
+}
 
 /**
  * OpenViking `UserIdentifier` allows only [a-zA-Z0-9_-] for agent_id
@@ -543,8 +579,8 @@ const contextEnginePlugin = {
         `(raw plugins.entries.openviking.config.agentId=${JSON.stringify(rawAgentId ?? "(missing)")}; ` +
         `${
           cfg.agentId !== "default"
-            ? "non-default → X-OpenViking-Agent is <configAgentId>_<ctx.agentId> (sanitized to [a-zA-Z0-9_-]) when hooks expose session agent; config-only if ctx.agentId unknown"
-            : 'default → X-OpenViking-Agent follows OpenClaw ctx.agentId per session (e.g. "main")'
+            ? "non-default -> X-OpenViking-Agent is <configAgentId>_<ctx.agentId> (sanitized to [a-zA-Z0-9_-]) when hooks expose session agent; config-only if ctx.agentId unknown"
+            : 'default -> X-OpenViking-Agent follows OpenClaw ctx.agentId per session (e.g. "main")'
         })`,
     );
     const routingDebugLog = cfg.logFindRequests
@@ -985,7 +1021,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
 
           let result;
           if (targetUri) {
-            // 如果指定了目标 URI，只检索该位置
+            // If target URI is specified, search that location only.
             result = await recallClient.find(
               query,
               {
@@ -996,7 +1032,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
               agentId,
             );
           } else {
-            // 默认同时检索 user 和 agent 两个位置的记忆
+            // By default, search both user and agent memories.
             const [userSettled, agentSettled] = await Promise.allSettled([
               recallClient.find(
                 query,
@@ -1019,7 +1055,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
             ]);
             const userResult = userSettled.status === "fulfilled" ? userSettled.value : { memories: [] };
             const agentResult = agentSettled.status === "fulfilled" ? agentSettled.value : { memories: [] };
-            // 合并两个位置的结果，去重
+            // 鍚堝苟涓や釜浣嶇疆鐨勭粨鏋滐紝鍘婚噸
             const allMemories = [...(userResult.memories ?? []), ...(agentResult.memories ?? [])];
             const uniqueMemories = allMemories.filter((memory, index, self) =>
               index === self.findIndex((m) => m.uri === memory.uri)
@@ -1369,6 +1405,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
     }));
 
     let contextEngineRef: ContextEngineWithCommit | null = null;
+    let contextEngineRegistered = false;
     const sessionAgentResolver = createSessionAgentResolver(cfg.agentId);
     const rememberSessionAgentId = (ctx: SessionAgentLookup) => {
       sessionAgentResolver.remember(ctx);
@@ -1409,6 +1446,15 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
     });
     api.on("before_prompt_build", async (event: unknown, ctx?: HookAgentContext) => {
       rememberSessionAgentId(ctx ?? {});
+
+      if (contextEngineRegistered || contextEngineRef) {
+        if (cfg.logFindRequests) {
+          api.logger.info(
+            "openviking: skipping before_prompt_build recall injection because assemble() owns recall",
+          );
+        }
+        return;
+      }
 
       if (cfg.logFindRequests) {
         api.logger.info(
@@ -1511,18 +1557,17 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
                       recallTokenBudget: cfg.recallTokenBudget,
                     },
                   );
-                  const memoryContext = memoryLines.join("\n");
+                  const memoryContext = buildSilentRecallContext(memoryLines);
+                  if (!memoryContext) {
+                    return;
+                  }
                   verboseRoutingInfo(
                     `openviking: injecting ${memoryLines.length} memories (~${estimatedTokens} tokens, budget=${cfg.recallTokenBudget})`,
                   );
                   verboseRoutingInfo(
                     `openviking: inject-detail ${toJsonLog({ count: memories.length, memories: summarizeInjectionMemories(memories) })}`,
                   );
-                  prependContextParts.push(
-                    "<relevant-memories>\nThe following OpenViking memories may be relevant:\n" +
-                      `${memoryContext}\n` +
-                    "</relevant-memories>",
-                  );
+                  prependContextParts.push(memoryContext);
                 }
               })(),
               AUTO_RECALL_TIMEOUT_MS,
@@ -1567,6 +1612,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
     });
 
     if (typeof api.registerContextEngine === "function") {
+      contextEngineRegistered = true;
       api.registerContextEngine(contextEnginePlugin.id, () => {
         contextEngineRef = createMemoryOpenVikingContextEngine({
           id: contextEnginePlugin.id,
@@ -1585,7 +1631,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
         return contextEngineRef;
       });
       api.logger.info(
-        "openviking: registered context-engine (before_prompt_build=auto-recall, afterTurn=auto-capture, assemble=archive+active, session→OV id=uuid-or-sha256 + diag/Phase2 options)",
+        "openviking: registered context-engine (assemble=auto-recall+archive+active, afterTurn=auto-capture, session->OV id=uuid-or-sha256 + diag/Phase2 options)",
       );
     } else {
       api.logger.warn(
@@ -1596,7 +1642,7 @@ const mergeFindResults = (results: FindResult[]): FindResult => {
     api.registerService({
       id: "openviking",
       start: async () => {
-        // Claim the pending entry — only the first start() call to claim it spawns the process.
+        // Claim the pending entry; only the first start() call to claim it spawns the process.
         // Subsequent start() calls (from other registrations sharing the same promise) fall through.
         const pendingEntry = localClientPendingPromises.get(localCacheKey);
         const isSpawner = cfg.mode === "local" && !!pendingEntry;
@@ -1871,8 +1917,8 @@ export type BuildMemoryLinesWithBudgetOptions = BuildMemoryLinesOptions & {
  *
  * The first memory is always included even if its token count exceeds the
  * remaining budget. This is intentional (spec Section 6.2): with
- * `recallMaxContentChars=500`, a single line is at most ~128 tokens — well
- * within the 2000-token default budget — so overshoot is bounded and
+ * `recallMaxContentChars=500`, a single line is at most ~128 tokens, well
+ * within the 2000-token default budget, so overshoot is bounded and
  * guarantees at least one memory is surfaced.
  */
 export async function buildMemoryLinesWithBudget(
@@ -1893,7 +1939,7 @@ export async function buildMemoryLinesWithBudget(
     const line = `- [${item.category ?? "memory"}] ${content}`;
     const lineTokens = estimateTokenCount(line);
 
-    // First line is always included even if it exceeds the budget (spec §6.2).
+    // First line is always included even if it exceeds the budget.
     if (lineTokens > budgetRemaining && lines.length > 0) {
       break;
     }

--- a/examples/openclaw-plugin/memory-ranking.ts
+++ b/examples/openclaw-plugin/memory-ranking.ts
@@ -136,6 +136,20 @@ function isPreferencesMemory(item: FindResultItem): boolean {
   );
 }
 
+const INSTRUCTIONAL_PREFERENCE_RE =
+  /must|always|never|only|exactly|strict|response|reply|output|format|single[-\s]?word|禁止|必须|只能|仅|严格|回复|响应|输出|格式|单个单词/i;
+
+function isInstructionLikePreference(item: FindResultItem): boolean {
+  if (!isPreferencesMemory(item)) {
+    return false;
+  }
+  const text = `${item.abstract ?? ""} ${item.overview ?? ""}`.trim();
+  if (!text) {
+    return false;
+  }
+  return INSTRUCTIONAL_PREFERENCE_RE.test(text);
+}
+
 function isEventMemory(item: FindResultItem): boolean {
   const category = (item.category ?? "").toLowerCase();
   return category === "events" || item.uri.includes("/events/");
@@ -229,7 +243,11 @@ export function pickMemoriesForInjection(
   }
 
   const query = buildRecallQueryProfile(queryText);
-  const sorted = [...items].sort((a, b) => rankForInjection(b, query) - rankForInjection(a, query));
+  const filteredItems = query.wantsPreference
+    ? items
+    : items.filter((item) => !isInstructionLikePreference(item));
+  const candidateItems = filteredItems.length > 0 ? filteredItems : items;
+  const sorted = [...candidateItems].sort((a, b) => rankForInjection(b, query) - rankForInjection(a, query));
   const deduped: FindResultItem[] = [];
   const seen = new Set<string>();
   for (const item of sorted) {

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+﻿import { describe, expect, it, vi } from "vitest";
 
 import type { OpenVikingClient } from "../../client.js";
 import { memoryOpenVikingConfigSchema } from "../../config.js";
@@ -43,11 +43,20 @@ function makeEngine(
   opts?: {
     cfgOverrides?: Record<string, unknown>;
     quickPrecheck?: () => Promise<{ ok: true } | { ok: false; reason: string }>;
+    findResult?: unknown;
+    readResult?: string;
   },
 ) {
   const logger = makeLogger();
   const client = {
     getSessionContext: vi.fn().mockResolvedValue(contextResult),
+    find: vi.fn().mockResolvedValue(
+      opts?.findResult ?? {
+        memories: [],
+        total: 0,
+      },
+    ),
+    read: vi.fn().mockResolvedValue(opts?.readResult ?? ""),
   } as unknown as OpenVikingClient;
   const getClient = vi.fn().mockResolvedValue(client);
   const resolveAgentId = vi.fn((sessionId: string) => `agent:${sessionId}`);
@@ -71,7 +80,11 @@ function makeEngine(
 
   return {
     engine,
-    client: client as unknown as { getSessionContext: ReturnType<typeof vi.fn> },
+    client: client as unknown as {
+      getSessionContext: ReturnType<typeof vi.fn>;
+      find: ReturnType<typeof vi.fn>;
+      read: ReturnType<typeof vi.fn>;
+    },
     getClient,
     logger,
     resolveAgentId,
@@ -398,6 +411,62 @@ describe("context-engine assemble()", () => {
     expect(result.messages).toBe(liveMessages);
     expect(result.estimatedTokens).toBe(roughEstimate(liveMessages));
     expect(result.systemPromptAddition).toBeUndefined();
+  });
+
+  it("moves recall into assemble messages instead of prompt prepend", async () => {
+    const { engine, client } = makeEngine(
+      {
+        latest_archive_overview: "",
+        pre_archive_abstracts: [],
+        messages: [
+          {
+            id: "msg_ov_1",
+            role: "assistant",
+            created_at: "2026-03-24T00:00:00Z",
+            parts: [{ type: "text", text: "Stored answer from OpenViking." }],
+          },
+        ],
+        estimatedTokens: 32,
+        stats: {
+          ...makeStats(),
+          activeTokens: 32,
+        },
+      },
+      {
+        cfgOverrides: {
+          autoRecall: true,
+          recallLimit: 2,
+          recallPreferAbstract: true,
+        },
+        findResult: {
+          memories: [
+            {
+              uri: "viking://user/default/memories/profile.md",
+              level: 2,
+              abstract: "User works at Turing Micro Sparrow Cloud and prefers concise answers.",
+              score: 0.93,
+            },
+          ],
+          total: 1,
+        },
+      },
+    );
+
+    const result = await engine.assemble({
+      sessionId: "session-recall",
+      messages: [{ role: "user", content: "which company do I work at?" }],
+      tokenBudget: 4096,
+    });
+
+    expect(client.find).toHaveBeenCalled();
+    expect(client.read).not.toHaveBeenCalled();
+    expect(result.systemPromptAddition).toBeUndefined();
+    expect(result.messages[0]).toEqual({
+      role: "user",
+      content: expect.stringContaining("Relevant Long-Term Memory"),
+    });
+    expect(result.messages[0].content).toContain("Turing Micro Sparrow Cloud");
+    expect(result.messages[0].content).not.toContain("<relevant-memories>");
   });
 
   it("still produces non-empty output when OV messages have empty parts (overview fills it)", async () => {

--- a/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
@@ -224,15 +224,13 @@ describe("plugin normal flow with healthy backend", () => {
       { agentId: "main", sessionId: "session-normal", sessionKey: "agent:main:normal" },
     );
 
-    expect(hookResult).toMatchObject({
-      prependContext: expect.stringContaining("User prefers Rust for backend tasks."),
-    });
+    expect(hookResult).toBeUndefined();
 
     const contextEngine = contextEngineFactory!() as {
       assemble: (params: {
         sessionId: string;
         messages: Array<{ role: string; content: string }>;
-      }) => Promise<{ messages: Array<{ role: string; content: unknown }> }>;
+      }) => Promise<{ messages: Array<{ role: string; content: unknown }>; systemPromptAddition?: string }>;
       afterTurn: (params: {
         sessionId: string;
         sessionFile: string;
@@ -243,7 +241,7 @@ describe("plugin normal flow with healthy backend", () => {
 
     const assembled = await contextEngine.assemble({
       sessionId: "session-normal",
-      messages: [{ role: "user", content: "fallback" }],
+      messages: [{ role: "user", content: "what backend language should we use?" }],
     });
 
     expect(assembled.messages[0]).toEqual({
@@ -251,6 +249,12 @@ describe("plugin normal flow with healthy backend", () => {
       content: "[Session History Summary]\nEarlier work focused on backend stack choices.",
     });
     expect(assembled.messages[1]).toEqual({
+      role: "user",
+      content: expect.stringContaining("Relevant Long-Term Memory"),
+    });
+    expect(assembled.messages[1].content).toContain("User prefers Rust for backend tasks.");
+    expect(assembled.messages[1].content).not.toContain("<relevant-memories>");
+    expect(assembled.messages[2]).toEqual({
       role: "assistant",
       content: [{ type: "text", text: "Stored answer from OpenViking." }],
     });


### PR DESCRIPTION
# Fix OpenClaw plugin recall assembly

## Summary

This patch changes the OpenViking OpenClaw plugin recall path so context-engine mode no longer injects recalled memories through `before_prompt_build` / `prependContext`.

Instead, auto-recall is owned by `assemble()` and added as a short internal context message alongside archive/session context. The recall payload is also shortened and filtered before injection.

## Problem

The previous plugin path could inject recalled memory as plain text during `before_prompt_build`. In string-content model pipelines this can surface raw recall context in the final prompt/answer, increase prompt pollution, and duplicate recall work even when the context engine owns assembly.

## Changes

- Skip `before_prompt_build` recall injection whenever a context engine is registered.
- - Move recall lookup into context-engine `assemble()`.
- - Inject only short, normalized recall facts into assembled context messages.
- - Prefer abstract recall by default when the option is not explicitly configured.
- - Filter instruction-like preference memories unless the query is asking for preferences.
- - Update focused unit tests for context-engine assembly and normal plugin flow.
## Validation

Focused plugin tests passed:

```bash
npm test -- --run tests/ut/context-engine-assemble.test.ts tests/ut/plugin-normal-flow-real-