### PR TITLE
feat(parse): support larkoffice.com Feishu document URLs

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -256,7 +256,11 @@ class FeishuAccessor(DataAccessor):
         parsed = urlparse(url)
         host = parsed.hostname or ""
         path = parsed.path
-        is_feishu_domain = host.endswith(".feishu.cn") or host.endswith(".larksuite.com")
+        is_feishu_domain = (
+            host.endswith(".feishu.cn")
+            or host.endswith(".larksuite.com")
+            or host.endswith(".larkoffice.com")
+        )
         has_doc_path = any(
             path == f"/{t}" or path.startswith(f"/{t}/") for t in ("docx", "wiki", "sheets", "base")
         )

--- a/openviking/parse/parsers/feishu.py
+++ b/openviking/parse/parsers/feishu.py
@@ -33,7 +33,7 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-_ALLOWED_FEISHU_HOSTS = ("feishu.cn", "larksuite.com")
+_ALLOWED_FEISHU_HOSTS = ("feishu.cn", "larksuite.com", "larkoffice.com")
 
 
 def _getattr_safe(obj, key: str, default=None):

--- a/tests/parse/test_feishu_parser.py
+++ b/tests/parse/test_feishu_parser.py
@@ -125,6 +125,13 @@ class TestIsFeishuUrl:
             "https://example.larksuite.com/sheets/abc123"
         )
 
+    def test_larkoffice(self):
+        from openviking.utils.media_processor import UnifiedResourceProcessor
+
+        assert UnifiedResourceProcessor._is_feishu_url(
+            "https://example.larkoffice.com/wiki/wikicn123"
+        )
+
     def test_non_feishu_url(self):
         from openviking.utils.media_processor import UnifiedResourceProcessor
 
@@ -624,6 +631,30 @@ class TestParseAsyncIntegration:
         assert result.source_format == "feishu_docx"
         assert result.meta["feishu_doc_type"] == "docx"
         assert result.meta["feishu_token"] == "real_token"
+
+    def test_parse_content_routes_larkoffice_url(self):
+        """Test that parse_content routes larkoffice.com URLs to FeishuParser.parse() correctly."""
+        parser = FeishuParser()
+
+        # Mock the underlying parse() method to avoid network/SDK calls
+        mock_result = MagicMock()
+        mock_result.source_format = "feishu_docx"
+        mock_result.meta = {"feishu_token": "larkoffice123"}
+        
+        async def _mock_parse(*a, **kw):
+            return mock_result
+            
+        parser.parse = _mock_parse
+
+        result = asyncio.get_event_loop().run_until_complete(
+            parser.parse_content(
+                content="", 
+                source_path="https://bytedance.larkoffice.com/wiki/larkoffice123"
+            )
+        )
+
+        assert result.source_format == "feishu_docx"
+        assert result.meta["feishu_token"] == "larkoffice123"
 
     def test_parse_unsupported_type(self):
         """Test that unsupported document types return error ParseResult."""


### PR DESCRIPTION
## Summary
Support `*.larkoffice.com` Feishu document URLs (docx/wiki/sheets/base), allowing `bytedance.larkoffice.com/wiki/...` to be routed through the `FeishuParser` instead of generic HTML fetch.

## Type of Change
- [x] New feature (feat)
- [ ] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Changes Made
- Problem: `*.larkoffice.com/wiki/...` was currently treated as generic HTML fetch, resulting in a login page or 404 content instead of correct Feishu document parsing.
- Fix: Extended Feishu URL detection (`_is_feishu_url` and `_ALLOWED_FEISHU_HOSTS`) to include `*.larkoffice.com` and correctly route `FeishuParser.parse_content()` for such URLs.
- Tests: Added regression tests for URL detection and `parse_content` routing.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist
- [x] Code follows project style guidelines
- [x] Tests added for new functionality