### PR TITLE
Fix docs npm registry for release builds

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,7 +13,7 @@
     },
     "node_modules/@algolia/abtesting": {
       "version": "1.17.0",
-      "resolved": "https://bnpm.byted.org/@algolia/abtesting/-/abtesting-1.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.17.0.tgz",
       "integrity": "sha512-nuhHZdTiCtRzJEe9VSNzyqE9cOQMt01UWBzymFnjbgwrxxZpbGHQde6Oa/y9zyspTCjbUtb7Q5HQek1CLiLyeg==",
       "dev": true,
       "license": "MIT",
@@ -29,7 +29,7 @@
     },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.17.7",
-      "resolved": "https://bnpm.byted.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
       "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
       "dev": true,
       "license": "MIT",
@@ -40,7 +40,7 @@
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
       "version": "1.17.7",
-      "resolved": "https://bnpm.byted.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
       "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
       "dev": true,
       "license": "MIT",
@@ -53,7 +53,7 @@
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
       "version": "1.17.7",
-      "resolved": "https://bnpm.byted.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
       "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
       "dev": true,
       "license": "MIT",
@@ -67,7 +67,7 @@
     },
     "node_modules/@algolia/autocomplete-shared": {
       "version": "1.17.7",
-      "resolved": "https://bnpm.byted.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
       "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
       "dev": true,
       "license": "MIT",
@@ -78,7 +78,7 @@
     },
     "node_modules/@algolia/client-abtesting": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/client-abtesting/-/client-abtesting-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.51.0.tgz",
       "integrity": "sha512-PKrKlIla1U2J7mFcIQn6N3pWP4oySmkxShnbbDsj/H7818gKbET5KsUwsVoNjWIxHKTJMCTcQ7ekAJ8Ea23NMg==",
       "dev": true,
       "license": "MIT",
@@ -94,7 +94,7 @@
     },
     "node_modules/@algolia/client-analytics": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/client-analytics/-/client-analytics-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.51.0.tgz",
       "integrity": "sha512-U+HCY1K16Km91pIRL1kN6bW6BbGFAF/WhkRSCx4wyl1aFpbrlhSFQs/dAwWbmyBiHWwVWhl7stWHQ1pum5EfMw==",
       "dev": true,
       "license": "MIT",
@@ -110,7 +110,7 @@
     },
     "node_modules/@algolia/client-common": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/client-common/-/client-common-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.51.0.tgz",
       "integrity": "sha512-YPJ3dEuZLCRp846Az94t6Z2gwSNRazP+SmBco7p6SCa4fYrtIE820PDXYZshbNrj2Z8Qfbmv7BQ1Lecl5L3G/w==",
       "dev": true,
       "license": "MIT",
@@ -120,7 +120,7 @@
     },
     "node_modules/@algolia/client-insights": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/client-insights/-/client-insights-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.51.0.tgz",
       "integrity": "sha512-/gEwLlR7fQ7YjOW+ADRZ0NxLDtpTC61FSzlZ01Gdl1kTJfU0Rq3Y/TYqwxGxlQGcUiXtGzrpjxXWh3Y0TZD6NA==",
       "dev": true,
       "license": "MIT",
@@ -136,7 +136,7 @@
     },
     "node_modules/@algolia/client-personalization": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/client-personalization/-/client-personalization-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.51.0.tgz",
       "integrity": "sha512-nRwUN1Y2cKyOAFZyIBagkEfZSIhP05nWhT4Rjwl84lcjECssYggftrAODrZ4leakXxSGjhxs/AdaAFEIBqwVFA==",
       "dev": true,
       "license": "MIT",
@@ -152,7 +152,7 @@
     },
     "node_modules/@algolia/client-query-suggestions": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.51.0.tgz",
       "integrity": "sha512-pybzYCG7VoQKppo+z5iZOKpW8XqtFxhsAIRgEaNboCnfypKukiBHJAwB+pmr7vMZXBsOHwklGYWwCG82e8qshA==",
       "dev": true,
       "license": "MIT",
@@ -168,7 +168,7 @@
     },
     "node_modules/@algolia/client-search": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/client-search/-/client-search-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.51.0.tgz",
       "integrity": "sha512-DWVIlj6RqcvdhwP0gBU9OpOQPnHdcAk9jlT+z8rsNb2+liWv4eUlfQZ7saGBraFsnygEHD3PtdppIHvqwBAb5w==",
       "dev": true,
       "license": "MIT",
@@ -184,7 +184,7 @@
     },
     "node_modules/@algolia/ingestion": {
       "version": "1.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/ingestion/-/ingestion-1.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.51.0.tgz",
       "integrity": "sha512-bA25s12iUDJi/X8M7tWlPRT8GeOhls/yDbdoUqinz27lNqsOlcM1UrAxIKdIZ6lm3sXit+ewPIz1pS2x6rXu8g==",
       "dev": true,
       "license": "MIT",
@@ -200,7 +200,7 @@
     },
     "node_modules/@algolia/monitoring": {
       "version": "1.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/monitoring/-/monitoring-1.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.51.0.tgz",
       "integrity": "sha512-zj+RcE5e0NE0/ew6oEOTgOplPHry+w2oi7h0Y87lhdq4E0d7xLS31KVB8kKfCGkrG7AYtZvrcyvLOKS5d0no4Q==",
       "dev": true,
       "license": "MIT",
@@ -216,7 +216,7 @@
     },
     "node_modules/@algolia/recommend": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/recommend/-/recommend-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.51.0.tgz",
       "integrity": "sha512-/HDgccfye1Rq3bPxaSCsvSEBHzSMmtpM9ZRGRtAuC62Cv+ql/76IWnxjGTDXtqIJ+/j7ZlFYAzq9fkp95wF2SQ==",
       "dev": true,
       "license": "MIT",
@@ -232,7 +232,7 @@
     },
     "node_modules/@algolia/requester-browser-xhr": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.51.0.tgz",
       "integrity": "sha512-nJdW+WBwGlXWMJbxxB7/AJPvNq0lLJSudXmIQCJbmH8jsOXQhRpAtoCD4ceLyJKv3ze9JbQu4Gqu5JDLckuFcw==",
       "dev": true,
       "license": "MIT",
@@ -245,7 +245,7 @@
     },
     "node_modules/@algolia/requester-fetch": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/requester-fetch/-/requester-fetch-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.51.0.tgz",
       "integrity": "sha512-bsBgRI/1h1mjS3eCyfGau78yGZVmiDLmT1aU6dMnk75/T0SgKqnSKNpQ53xKoDYVChGDcNnpHXWpoUSo8MH1+w==",
       "dev": true,
       "license": "MIT",
@@ -258,7 +258,7 @@
     },
     "node_modules/@algolia/requester-node-http": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/@algolia/requester-node-http/-/requester-node-http-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.51.0.tgz",
       "integrity": "sha512-zPrIDVPpmKWgrjmWOqpqrhqAhNjvVkjoj+mqw2NBPxEOuKNzP0H+Qz5NJLLTOepBVj1UFedFaF3AUgxLsB9ukQ==",
       "dev": true,
       "license": "MIT",
@@ -271,7 +271,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://bnpm.byted.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
@@ -281,7 +281,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://bnpm.byted.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
@@ -291,7 +291,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
-      "resolved": "https://bnpm.byted.org/@babel/parser/-/parser-7.29.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
@@ -307,7 +307,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://bnpm.byted.org/@babel/types/-/types-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
@@ -321,14 +321,14 @@
     },
     "node_modules/@docsearch/css": {
       "version": "3.8.2",
-      "resolved": "https://bnpm.byted.org/@docsearch/css/-/css-3.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
       "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docsearch/js": {
       "version": "3.8.2",
-      "resolved": "https://bnpm.byted.org/@docsearch/js/-/js-3.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
       "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
       "dev": true,
       "license": "MIT",
@@ -339,7 +339,7 @@
     },
     "node_modules/@docsearch/react": {
       "version": "3.8.2",
-      "resolved": "https://bnpm.byted.org/@docsearch/react/-/react-3.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
       "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
       "dev": true,
       "license": "MIT",
@@ -372,7 +372,7 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
       "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
@@ -389,7 +389,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
       "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
@@ -406,7 +406,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
       "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
@@ -423,7 +423,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
       "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
@@ -440,7 +440,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
       "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
@@ -457,7 +457,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
       "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
@@ -474,7 +474,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
       "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
@@ -491,7 +491,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
       "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
@@ -508,7 +508,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
       "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
@@ -525,7 +525,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
       "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
@@ -542,7 +542,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
       "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
@@ -559,7 +559,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
       "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
@@ -576,7 +576,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
       "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
@@ -593,7 +593,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
       "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
@@ -610,7 +610,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
       "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
@@ -627,7 +627,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
       "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
@@ -644,7 +644,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
       "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
@@ -661,7 +661,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
       "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
@@ -678,7 +678,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
       "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
@@ -695,7 +695,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
       "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
@@ -712,7 +712,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
       "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
@@ -729,7 +729,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
       "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
@@ -746,7 +746,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
       "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
@@ -763,7 +763,7 @@
     },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.79",
-      "resolved": "https://bnpm.byted.org/@iconify-json/simple-icons/-/simple-icons-1.2.79.tgz",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.79.tgz",
       "integrity": "sha512-aNyO7Fd1qej9oQfIyohYFRv0lhQLaZ+6UkK1c1qwax0MDPUOZOdq65MlU500kow97pD/W+b2u1And3e25eE24Q==",
       "dev": true,
       "license": "CC0-1.0",
@@ -773,21 +773,21 @@
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/@iconify/types/-/types-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://bnpm.byted.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
       "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
@@ -801,7 +801,7 @@
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
       "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
@@ -815,7 +815,7 @@
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
       "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
@@ -829,7 +829,7 @@
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
       "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
@@ -843,7 +843,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
       "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
@@ -857,7 +857,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
       "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
@@ -871,7 +871,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
       "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
@@ -888,7 +888,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
@@ -905,7 +905,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
       "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
@@ -922,7 +922,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
@@ -939,7 +939,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
       "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
@@ -956,7 +956,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
@@ -973,7 +973,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
       "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
@@ -990,7 +990,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
@@ -1007,7 +1007,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
       "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
@@ -1024,7 +1024,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
@@ -1041,7 +1041,7 @@
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
       "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
@@ -1058,7 +1058,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
       "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
@@ -1075,7 +1075,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
@@ -1092,7 +1092,7 @@
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
       "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
@@ -1106,7 +1106,7 @@
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
       "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
@@ -1120,7 +1120,7 @@
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
       "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
@@ -1134,7 +1134,7 @@
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
       "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
@@ -1148,7 +1148,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
       "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
@@ -1162,7 +1162,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
       "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
@@ -1176,7 +1176,7 @@
     },
     "node_modules/@shikijs/core": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/@shikijs/core/-/core-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
       "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
       "dev": true,
       "license": "MIT",
@@ -1191,7 +1191,7 @@
     },
     "node_modules/@shikijs/engine-javascript": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
       "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
       "dev": true,
       "license": "MIT",
@@ -1203,7 +1203,7 @@
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
       "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
       "dev": true,
       "license": "MIT",
@@ -1214,7 +1214,7 @@
     },
     "node_modules/@shikijs/langs": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
       "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
       "dev": true,
       "license": "MIT",
@@ -1224,7 +1224,7 @@
     },
     "node_modules/@shikijs/themes": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
       "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
       "dev": true,
       "license": "MIT",
@@ -1234,7 +1234,7 @@
     },
     "node_modules/@shikijs/transformers": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
       "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
       "dev": true,
       "license": "MIT",
@@ -1245,7 +1245,7 @@
     },
     "node_modules/@shikijs/types": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/@shikijs/types/-/types-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
       "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
       "dev": true,
       "license": "MIT",
@@ -1256,21 +1256,21 @@
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "resolved": "https://bnpm.byted.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://bnpm.byted.org/@types/estree/-/estree-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
-      "resolved": "https://bnpm.byted.org/@types/hast/-/hast-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "dev": true,
       "license": "MIT",
@@ -1280,14 +1280,14 @@
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
-      "resolved": "https://bnpm.byted.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
-      "resolved": "https://bnpm.byted.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
@@ -1298,7 +1298,7 @@
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
-      "resolved": "https://bnpm.byted.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "dev": true,
       "license": "MIT",
@@ -1308,35 +1308,35 @@
     },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
-      "resolved": "https://bnpm.byted.org/@types/unist/-/unist-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
-      "resolved": "https://bnpm.byted.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "resolved": "https://bnpm.byted.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
-      "resolved": "https://bnpm.byted.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
       "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
       "dev": true,
       "license": "MIT",
@@ -1350,7 +1350,7 @@
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
       "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
       "dev": true,
       "license": "MIT",
@@ -1364,7 +1364,7 @@
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "dev": true,
       "license": "MIT",
@@ -1375,7 +1375,7 @@
     },
     "node_modules/@vue/compiler-sfc": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
       "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
       "dev": true,
       "license": "MIT",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
       "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
       "dev": true,
       "license": "MIT",
@@ -1404,7 +1404,7 @@
     },
     "node_modules/@vue/devtools-api": {
       "version": "7.7.9",
-      "resolved": "https://bnpm.byted.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
       "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
       "dev": true,
       "license": "MIT",
@@ -1414,7 +1414,7 @@
     },
     "node_modules/@vue/devtools-kit": {
       "version": "7.7.9",
-      "resolved": "https://bnpm.byted.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
       "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
       "dev": true,
       "license": "MIT",
@@ -1430,7 +1430,7 @@
     },
     "node_modules/@vue/devtools-shared": {
       "version": "7.7.9",
-      "resolved": "https://bnpm.byted.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
       "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
       "dev": true,
       "license": "MIT",
@@ -1440,7 +1440,7 @@
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
       "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
       "dev": true,
       "license": "MIT",
@@ -1450,7 +1450,7 @@
     },
     "node_modules/@vue/runtime-core": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
       "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
       "dev": true,
       "license": "MIT",
@@ -1461,7 +1461,7 @@
     },
     "node_modules/@vue/runtime-dom": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
       "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
       "dev": true,
       "license": "MIT",
@@ -1474,7 +1474,7 @@
     },
     "node_modules/@vue/server-renderer": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "dev": true,
       "license": "MIT",
@@ -1488,14 +1488,14 @@
     },
     "node_modules/@vue/shared": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/@vue/shared/-/shared-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
       "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
       "version": "12.8.2",
-      "resolved": "https://bnpm.byted.org/@vueuse/core/-/core-12.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
       "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
       "dev": true,
       "license": "MIT",
@@ -1511,7 +1511,7 @@
     },
     "node_modules/@vueuse/integrations": {
       "version": "12.8.2",
-      "resolved": "https://bnpm.byted.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
       "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
       "dev": true,
       "license": "MIT",
@@ -1578,7 +1578,7 @@
     },
     "node_modules/@vueuse/metadata": {
       "version": "12.8.2",
-      "resolved": "https://bnpm.byted.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
       "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
       "dev": true,
       "license": "MIT",
@@ -1588,7 +1588,7 @@
     },
     "node_modules/@vueuse/shared": {
       "version": "12.8.2",
-      "resolved": "https://bnpm.byted.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
       "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
       "dev": true,
       "license": "MIT",
@@ -1601,7 +1601,7 @@
     },
     "node_modules/algoliasearch": {
       "version": "5.51.0",
-      "resolved": "https://bnpm.byted.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
       "integrity": "sha512-u3XS8HaTzt5YN90KPsOXMRjYJUMVD1dtr6yi4NXQluMbZ5IjQNBu1MEabdAxFhYtEuexqomPMSmRIhQJUd3QSg==",
       "dev": true,
       "license": "MIT",
@@ -1627,7 +1627,7 @@
     },
     "node_modules/birpc": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/birpc/-/birpc-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
       "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
       "dev": true,
       "license": "MIT",
@@ -1637,7 +1637,7 @@
     },
     "node_modules/ccount": {
       "version": "2.0.1",
-      "resolved": "https://bnpm.byted.org/ccount/-/ccount-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
       "dev": true,
       "license": "MIT",
@@ -1648,7 +1648,7 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "resolved": "https://bnpm.byted.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "dev": true,
       "license": "MIT",
@@ -1659,7 +1659,7 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
-      "resolved": "https://bnpm.byted.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "dev": true,
       "license": "MIT",
@@ -1670,7 +1670,7 @@
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
-      "resolved": "https://bnpm.byted.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
       "dev": true,
       "license": "MIT",
@@ -1681,7 +1681,7 @@
     },
     "node_modules/copy-anything": {
       "version": "4.0.5",
-      "resolved": "https://bnpm.byted.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
       "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
       "dev": true,
       "license": "MIT",
@@ -1697,14 +1697,14 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://bnpm.byted.org/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://bnpm.byted.org/dequal/-/dequal-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
@@ -1714,7 +1714,7 @@
     },
     "node_modules/devlop": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/devlop/-/devlop-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "dev": true,
       "license": "MIT",
@@ -1728,14 +1728,14 @@
     },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
       "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://bnpm.byted.org/entities/-/entities-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1748,7 +1748,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
-      "resolved": "https://bnpm.byted.org/esbuild/-/esbuild-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1787,14 +1787,14 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://bnpm.byted.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/focus-trap": {
       "version": "7.8.0",
-      "resolved": "https://bnpm.byted.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
@@ -1804,7 +1804,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://bnpm.byted.org/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1819,7 +1819,7 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
-      "resolved": "https://bnpm.byted.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
       "dev": true,
       "license": "MIT",
@@ -1843,7 +1843,7 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://bnpm.byted.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "dev": true,
       "license": "MIT",
@@ -1857,14 +1857,14 @@
     },
     "node_modules/hookable": {
       "version": "5.5.3",
-      "resolved": "https://bnpm.byted.org/hookable/-/hookable-5.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
-      "resolved": "https://bnpm.byted.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
       "dev": true,
       "license": "MIT",
@@ -1875,7 +1875,7 @@
     },
     "node_modules/is-what": {
       "version": "5.5.0",
-      "resolved": "https://bnpm.byted.org/is-what/-/is-what-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
       "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
       "dev": true,
       "license": "MIT",
@@ -1888,7 +1888,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://bnpm.byted.org/magic-string/-/magic-string-0.30.21.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
@@ -1898,14 +1898,14 @@
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
-      "resolved": "https://bnpm.byted.org/mark.js/-/mark.js-8.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
-      "resolved": "https://bnpm.byted.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "dev": true,
       "license": "MIT",
@@ -1927,7 +1927,7 @@
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
-      "resolved": "https://bnpm.byted.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
       "dev": true,
       "funding": [
@@ -1948,7 +1948,7 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
-      "resolved": "https://bnpm.byted.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
       "dev": true,
       "funding": [
@@ -1965,7 +1965,7 @@
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
-      "resolved": "https://bnpm.byted.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
       "dev": true,
       "funding": [
@@ -1987,7 +1987,7 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
-      "resolved": "https://bnpm.byted.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
       "dev": true,
       "funding": [
@@ -2004,7 +2004,7 @@
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
-      "resolved": "https://bnpm.byted.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
       "dev": true,
       "funding": [
@@ -2021,21 +2021,21 @@
     },
     "node_modules/minisearch": {
       "version": "7.2.0",
-      "resolved": "https://bnpm.byted.org/minisearch/-/minisearch-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
       "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mitt": {
       "version": "3.0.1",
-      "resolved": "https://bnpm.byted.org/mitt/-/mitt-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://bnpm.byted.org/nanoid/-/nanoid-3.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
@@ -2054,7 +2054,7 @@
     },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
-      "resolved": "https://bnpm.byted.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
       "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
       "dev": true,
       "license": "MIT",
@@ -2066,21 +2066,21 @@
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/postcss": {
       "version": "8.5.10",
-      "resolved": "https://bnpm.byted.org/postcss/-/postcss-8.5.10.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
@@ -2109,7 +2109,7 @@
     },
     "node_modules/preact": {
       "version": "10.29.1",
-      "resolved": "https://bnpm.byted.org/preact/-/preact-10.29.1.tgz",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "dev": true,
       "license": "MIT",
@@ -2120,7 +2120,7 @@
     },
     "node_modules/property-information": {
       "version": "7.1.0",
-      "resolved": "https://bnpm.byted.org/property-information/-/property-information-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "dev": true,
       "license": "MIT",
@@ -2131,7 +2131,7 @@
     },
     "node_modules/regex": {
       "version": "6.1.0",
-      "resolved": "https://bnpm.byted.org/regex/-/regex-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
       "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
       "dev": true,
       "license": "MIT",
@@ -2141,7 +2141,7 @@
     },
     "node_modules/regex-recursion": {
       "version": "6.0.2",
-      "resolved": "https://bnpm.byted.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
       "dev": true,
       "license": "MIT",
@@ -2151,21 +2151,21 @@
     },
     "node_modules/regex-utilities": {
       "version": "2.3.0",
-      "resolved": "https://bnpm.byted.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "resolved": "https://bnpm.byted.org/rfdc/-/rfdc-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.2",
-      "resolved": "https://bnpm.byted.org/rollup/-/rollup-4.60.2.tgz",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
@@ -2210,7 +2210,7 @@
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
-      "resolved": "https://bnpm.byted.org/search-insights/-/search-insights-2.17.3.tgz",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
       "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
       "dev": true,
       "license": "MIT",
@@ -2218,7 +2218,7 @@
     },
     "node_modules/shiki": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/shiki/-/shiki-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
       "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
       "dev": true,
       "license": "MIT",
@@ -2235,7 +2235,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://bnpm.byted.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2245,7 +2245,7 @@
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
-      "resolved": "https://bnpm.byted.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
       "dev": true,
       "license": "MIT",
@@ -2256,7 +2256,7 @@
     },
     "node_modules/speakingurl": {
       "version": "14.0.1",
-      "resolved": "https://bnpm.byted.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2266,7 +2266,7 @@
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
-      "resolved": "https://bnpm.byted.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
       "dev": true,
       "license": "MIT",
@@ -2281,7 +2281,7 @@
     },
     "node_modules/superjson": {
       "version": "2.2.6",
-      "resolved": "https://bnpm.byted.org/superjson/-/superjson-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
       "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
       "dev": true,
       "license": "MIT",
@@ -2294,14 +2294,14 @@
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
-      "resolved": "https://bnpm.byted.org/tabbable/-/tabbable-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
-      "resolved": "https://bnpm.byted.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
       "dev": true,
       "license": "MIT",
@@ -2312,7 +2312,7 @@
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
-      "resolved": "https://bnpm.byted.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "dev": true,
       "license": "MIT",
@@ -2326,7 +2326,7 @@
     },
     "node_modules/unist-util-position": {
       "version": "5.0.0",
-      "resolved": "https://bnpm.byted.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "dev": true,
       "license": "MIT",
@@ -2340,7 +2340,7 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
-      "resolved": "https://bnpm.byted.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
       "dev": true,
       "license": "MIT",
@@ -2354,7 +2354,7 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.1.0",
-      "resolved": "https://bnpm.byted.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "dev": true,
       "license": "MIT",
@@ -2370,7 +2370,7 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.2",
-      "resolved": "https://bnpm.byted.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "dev": true,
       "license": "MIT",
@@ -2385,7 +2385,7 @@
     },
     "node_modules/vfile": {
       "version": "6.0.3",
-      "resolved": "https://bnpm.byted.org/vfile/-/vfile-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
       "dev": true,
       "license": "MIT",
@@ -2400,7 +2400,7 @@
     },
     "node_modules/vfile-message": {
       "version": "4.0.3",
-      "resolved": "https://bnpm.byted.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "dev": true,
       "license": "MIT",
@@ -2415,7 +2415,7 @@
     },
     "node_modules/vite": {
       "version": "5.4.21",
-      "resolved": "https://bnpm.byted.org/vite/-/vite-5.4.21.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
@@ -2475,7 +2475,7 @@
     },
     "node_modules/vitepress": {
       "version": "1.6.4",
-      "resolved": "https://bnpm.byted.org/vitepress/-/vitepress-1.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
       "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
       "dev": true,
       "license": "MIT",
@@ -2517,7 +2517,7 @@
     },
     "node_modules/vue": {
       "version": "3.5.33",
-      "resolved": "https://bnpm.byted.org/vue/-/vue-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "dev": true,
       "license": "MIT",
@@ -2539,7 +2539,7 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
-      "resolved": "https://bnpm.byted.org/zwitch/-/zwitch-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Description

Fix the docs release build on GitHub runners by removing internal registry URLs from the docs lockfile. The existing `docs/package-lock.json` was generated with `bnpm.byted.org` tarball URLs, so `npm ci` can fail outside the ByteDance network when the release workflow builds and deploys the VitePress site.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Added `docs/.npmrc` to pin docs installs to the public npm registry.
- Updated `docs/package-lock.json` resolved tarball URLs from `bnpm.byted.org` to `registry.npmjs.org`.
- Kept the locked package versions and integrity hashes unchanged.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `npm ci`
- `npm run docs:build`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This only changes the package tarball source URLs used by npm. It does not change the resolved dependency versions.
