### PR TITLE
fix(api_keys): proxy get_user_role in NewAPIKeyManager (trusted-mode 500 regression)

### DIFF
--- a/openviking/server/api_keys/new.py
+++ b/openviking/server/api_keys/new.py
@@ -387,6 +387,13 @@ class NewAPIKeyManager:
         """Return True when the account registry contains the given user."""
         return self._legacy.has_user(account_id, user_id)
 
+    def get_user_role(self, account_id: str, user_id: str) -> Role:
+        """Return the role of the given user in the given account.
+
+        Returns Role.USER if the account or user doesn't exist.
+        """
+        return self._legacy.get_user_role(account_id, user_id)
+
     # ---- Property proxies for backward compatibility with tests ----
 
     @property

--- a/tests/server/test_api_key_manager.py
+++ b/tests/server/test_api_key_manager.py
@@ -652,3 +652,62 @@ async def test_is_new_format_key_validation():
     assert not is_new_format_key("onepart")
     assert not is_new_format_key("two.parts")
     assert not is_new_format_key("too.many.parts.here")
+
+
+# ---- get_user_role / legacy public API parity ----
+
+
+async def test_get_user_role_returns_admin_for_account_admin(manager: APIKeyManager):
+    """get_user_role must return ADMIN for the account's first admin user.
+
+    Trusted mode (openviking/server/auth.py) calls this method to resolve the
+    effective role when X-OpenViking-Account / X-OpenViking-User headers are
+    present. Must not raise AttributeError on the default APIKeyManager.
+    """
+    acct = _uid()
+    await manager.create_account(acct, "admin_user")
+    assert manager.get_user_role(acct, "admin_user") == Role.ADMIN
+
+
+async def test_get_user_role_returns_user_for_registered_user(manager: APIKeyManager):
+    acct = _uid()
+    await manager.create_account(acct, "admin_user")
+    await manager.register_user(acct, "regular_user", "user")
+    assert manager.get_user_role(acct, "regular_user") == Role.USER
+
+
+async def test_get_user_role_defaults_to_user_when_user_missing(manager: APIKeyManager):
+    """Missing user should default to Role.USER, matching legacy behavior."""
+    acct = _uid()
+    await manager.create_account(acct, "admin_user")
+    assert manager.get_user_role(acct, "nobody") == Role.USER
+
+
+async def test_get_user_role_defaults_to_user_when_account_missing(manager: APIKeyManager):
+    """Missing account should default to Role.USER, matching legacy behavior."""
+    assert manager.get_user_role("no_such_account", "no_such_user") == Role.USER
+
+
+def test_new_api_key_manager_public_api_parity_with_legacy():
+    """NewAPIKeyManager must expose every public method LegacyAPIKeyManager does.
+
+    PR #1686 wrapped LegacyAPIKeyManager in a NewAPIKeyManager that forwards
+    methods by hand rather than inheriting. A missing proxy (e.g. get_user_role)
+    becomes a latent AttributeError at runtime. This test enforces parity on the
+    public surface so future wrappers can't silently regress the contract.
+    """
+    from openviking.server.api_keys.legacy import LegacyAPIKeyManager
+    from openviking.server.api_keys.new import NewAPIKeyManager
+
+    def _public_methods(cls) -> set:
+        return {
+            name for name in dir(cls) if not name.startswith("_") and callable(getattr(cls, name))
+        }
+
+    legacy_public = _public_methods(LegacyAPIKeyManager)
+    new_public = _public_methods(NewAPIKeyManager)
+    missing = legacy_public - new_public
+    assert not missing, (
+        f"NewAPIKeyManager is missing public methods present on "
+        f"LegacyAPIKeyManager: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

Hotfix for a runtime regression introduced by #1686 (API Key security refactor, merged as 85986a91).

`NewAPIKeyManager` wraps `LegacyAPIKeyManager` via composition and proxies a subset of methods by hand, but missed `get_user_role`. The default `APIKeyManager` alias now points at `NewAPIKeyManager`, so in `AuthMode.TRUSTED` with `root_api_key` configured, any request bearing `X-OpenViking-Account` + `X-OpenViking-User` headers hits `openviking/server/auth.py:187`:

```python
trusted_role = api_key_manager.get_user_role(effective_account_id, effective_user_id)
```

This raises `AttributeError` (no such method on `NewAPIKeyManager`) and FastAPI returns **500**.

Trigger conditions (all must hold):
1. Server in `AuthMode.TRUSTED` — the production-recommended trusted deployment.
2. `config.root_api_key` configured — `app.py:85` creates the `APIKeyManager` on this condition regardless of auth mode (the `elif` at line 97 that sets `api_key_manager = None` is only reached when `root_api_key` is empty).
3. Request provides both `X-OpenViking-Account` and `X-OpenViking-User` (or the equivalent explicit identity in the URL path).

## Fix

Add an explicit proxy `NewAPIKeyManager.get_user_role -> self._legacy.get_user_role`.

## Tests

- **Direct `get_user_role` coverage** on the default `APIKeyManager` for the four trusted-mode branches (`admin_user`, `regular_user`, missing user, missing account). Mirrors the existing assertions in `tests/server/test_auth.py::test_trusted_mode_*`.
- **Public API parity assertion** comparing `LegacyAPIKeyManager` and `NewAPIKeyManager` — every non-underscore method on the legacy class must exist on the new class. This turns future wrapper-proxy drift into a CI-visible failure instead of a latent runtime `AttributeError`.

## Test plan

- [ ] `uv run pytest tests/server/test_api_key_manager.py -k "get_user_role or parity" -v` passes
- [ ] `uv run pytest tests/server/test_auth.py -k "trusted_mode_looks_up_role or trusted_mode_defaults_to_user_when" -v` passes (these existing tests exercise the same `auth.py:187` path end-to-end)

## Scope

This PR is intentionally minimal. Out-of-scope follow-ups from the review:
- **Timing oracle in `NewAPIKeyManager.resolve`** (account/user enumeration via Argon2 timing) — separate security PR; needs dummy-verify gated on `is_new_format_key` + IP rate limiting so the fix itself doesn't become a DoS amplifier.
- **Silent default switch to new key format** (`__init__.py:14` aliases `NewAPIKeyManager as APIKeyManager` with no opt-in) — separate migration PR adding an `api_key_format: legacy|new` config flag.
- **Identity-bearing key format** (base64-decoded key yields account_id + user_id, and `validate_user_id` now permits `@`) — product/compliance decision; needs explicit documentation that this is not an opaque secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)