### PR TITLE
Fix docs build and split docs workflows

### DIFF
--- a/.github/workflows/_docs-deploy.yml
+++ b/.github/workflows/_docs-deploy.yml
@@ -1,14 +1,19 @@
-name: 17. _Docs Build
+name: 18. _Docs Deploy
 
 on:
   workflow_call:
 
 jobs:
-  build:
-    name: Build Docs
+  deploy:
+    name: Build and Deploy Docs
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -29,3 +34,15 @@ jobs:
         working-directory: docs
         env:
           DOCS_BASE: /${{ github.event.repository.name }}/
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/.vitepress/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -1,0 +1,62 @@
+name: 17. _Docs
+
+on:
+  workflow_call:
+    inputs:
+      deploy:
+        description: 'Whether to deploy the built docs to GitHub Pages'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install docs dependencies
+        run: npm ci
+        working-directory: docs
+
+      - name: Build docs
+        run: npm run docs:build
+        working-directory: docs
+        env:
+          DOCS_BASE: /${{ github.event.repository.name }}/
+
+      - name: Upload Pages artifact
+        if: inputs.deploy
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy Docs
+    if: inputs.deploy
+    needs: [build]
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/_docs.yml'
+      - '.github/workflows/_docs-deploy.yml'
       - '.github/workflows/docs.yml'
   push:
     branches: [ main ]
     paths:
       - 'docs/**'
       - '.github/workflows/_docs.yml'
+      - '.github/workflows/_docs-deploy.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
     inputs:
@@ -30,16 +32,12 @@ jobs:
     uses: ./.github/workflows/_docs.yml
     permissions:
       contents: read
-    with:
-      deploy: false
 
   docs-deploy:
     name: Build and Deploy Docs
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy == true)
-    uses: ./.github/workflows/_docs.yml
+    uses: ./.github/workflows/_docs-deploy.yml
     permissions:
       contents: read
       pages: write
       id-token: write
-    with:
-      deploy: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: 17. Docs
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/_docs.yml'
+      - '.github/workflows/docs.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/_docs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Deploy docs to GitHub Pages'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs-check:
+    name: Build Docs
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.deploy == false)
+    uses: ./.github/workflows/_docs.yml
+    permissions:
+      contents: read
+    with:
+      deploy: false
+
+  docs-deploy:
+    name: Build and Deploy Docs
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy == true)
+    uses: ./.github/workflows/_docs.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    with:
+      deploy: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,6 +383,4 @@ jobs:
       contents: read
       pages: write
       id-token: write
-    uses: ./.github/workflows/_docs.yml
-    with:
-      deploy: true
+    uses: ./.github/workflows/_docs-deploy.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,43 +379,10 @@ jobs:
   deploy-docs:
     name: Build and Deploy Docs
     if: github.event_name == 'release'
-    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: docs/package-lock.json
-
-      - name: Install docs dependencies
-        run: npm ci
-        working-directory: docs
-
-      - name: Build docs
-        run: npm run docs:build
-        working-directory: docs
-        env:
-          DOCS_BASE: /${{ github.event.repository.name }}/
-
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: docs/.vitepress/dist
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+    uses: ./.github/workflows/_docs.yml
+    with:
+      deploy: true

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -799,7 +799,6 @@ Typical choices:
 - Characters such as `?`, `&`, `#`, spaces, `%`, `@`, and `+` are escaped in place without rewriting the whole segment.
 - Set `false` to keep original path segments in object keys.
 
-</details>
 <details>
 <summary><b>PathStyle S3</b></summary>
 Supports S3 storage in PathStyle mode, such as MinIO, SeaweedFS.

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -772,7 +772,6 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 - `?`、`&`、`#`、空格、`%`、`@`、`+` 等字符会在原位被转义，不会导致整个路径段一起重写。
 - 设为 `false` 时，会在 object key 中保留原始路径段。
 
-</details>
 <details>
 <summary><b>PathStyle S3</b></summary>
 支持 PathStyle 模式的 S3 存储， 如 MinIO、SeaweedFS.


### PR DESCRIPTION
## Description

Fix the docs build failure that blocked the release docs deployment, and split docs build/deploy into standalone reusable workflows so docs issues can be caught before release.

The release docs job failed at `npm run docs:build` because the configuration guide markdown contained unmatched `</details>` tags. This PR removes those invalid tags and separates docs CI from docs deployment permissions.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Removed unmatched `</details>` tags from the English and Chinese configuration guides.
- Added a docs build reusable workflow for PR checks and build-only validation.
- Added a separate docs deploy reusable workflow that owns GitHub Pages permissions.
- Added a standalone docs workflow for PR checks, main-branch docs deploys, and manual docs runs.
- Updated the release workflow to call the docs deploy workflow instead of embedding docs build/deploy steps inline.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

Commands and checks run:

- `npm ci`
- `npm run docs:build`
- GitHub Actions fork validation: https://github.com/yufeng201/OpenViking/actions/runs/24891712063

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The docs workflow is intentionally split so build-only PR checks do not request GitHub Pages permissions. The deploy workflow is used only for main-branch/manual/release docs deployment.
