### PR TITLE
fix(search): reject empty queries

### DIFF
--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -10,13 +10,18 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import VikingFS
-from openviking_cli.exceptions import NotInitializedError
+from openviking_cli.exceptions import InvalidArgumentError, NotInitializedError
 from openviking_cli.utils import get_logger
 
 if TYPE_CHECKING:
     from openviking.session import Session
 
 logger = get_logger(__name__)
+
+
+def _ensure_non_empty_query(query: str) -> None:
+    if not query.strip():
+        raise InvalidArgumentError("Search query must not be empty.")
 
 
 class SearchService:
@@ -58,6 +63,7 @@ class SearchService:
         Returns:
             FindResult
         """
+        _ensure_non_empty_query(query)
         viking_fs = self._ensure_initialized()
 
         session_info = None
@@ -96,6 +102,7 @@ class SearchService:
         Returns:
             FindResult
         """
+        _ensure_non_empty_query(query)
         viking_fs = self._ensure_initialized()
         result = await viking_fs.find(
             query=query,

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -54,6 +54,11 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _ensure_non_empty_search_query(query: str) -> None:
+    if not query.strip():
+        raise InvalidArgumentError("Search query must not be empty.")
+
+
 def _is_directory_not_empty_error(message: str) -> bool:
     """Check if an error message indicates a directory not empty error.
 
@@ -1013,6 +1018,7 @@ class VikingFS:
         Returns:
             FindResult
         """
+        _ensure_non_empty_search_query(query)
         telemetry = get_current_telemetry()
         from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever
         from openviking_cli.retrieve import (
@@ -1105,6 +1111,7 @@ class VikingFS:
         Returns:
             FindResult
         """
+        _ensure_non_empty_search_query(query)
         telemetry = get_current_telemetry()
         from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever
         from openviking.retrieve.intent_analyzer import IntentAnalyzer

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -11,7 +11,9 @@ import pytest
 from openviking.models.embedder.base import EmbedResult
 from openviking.server.auth import get_request_context
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.viking_fs import VikingFS
 from openviking.utils.time_utils import parse_iso_datetime
+from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -91,6 +93,61 @@ async def test_find_no_results(client: httpx.AsyncClient):
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
+
+
+@pytest.mark.parametrize("query", ["", "   \t\n"])
+async def test_find_rejects_empty_query(client: httpx.AsyncClient, service, query: str):
+    class RaisingEmbedder:
+        def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+            raise AssertionError("empty query should not be embedded")
+
+        async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
+            raise AssertionError("empty query should not be embedded")
+
+    service.viking_fs.query_embedder = RaisingEmbedder()
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": query},
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert "must not be empty" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("query", ["", "   \t\n"])
+async def test_search_rejects_empty_query(client: httpx.AsyncClient, service, query: str):
+    class RaisingEmbedder:
+        def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+            raise AssertionError("empty query should not be embedded")
+
+        async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
+            raise AssertionError("empty query should not be embedded")
+
+    service.viking_fs.query_embedder = RaisingEmbedder()
+
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": query},
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert "must not be empty" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("method_name", ["find", "search"])
+async def test_vikingfs_rejects_empty_query_before_initialization(method_name: str):
+    viking_fs = VikingFS.__new__(VikingFS)
+    method = getattr(viking_fs, method_name)
+
+    with pytest.raises(InvalidArgumentError, match="must not be empty"):
+        await method(query=" ")
 
 
 async def test_find_with_since_compiles_time_range(client: httpx.AsyncClient, service, monkeypatch):


### PR DESCRIPTION
## Description

Reject empty or whitespace-only search queries before they reach embedding providers, preventing provider-side 400 errors from surfacing as internal server errors.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added `INVALID_ARGUMENT` validation for empty search queries in `SearchService.find` and `SearchService.search`.
- Added defensive empty-query validation in `VikingFS.find` and `VikingFS.search` for direct callers that bypass the service layer.
- Added regression tests for empty `find` and `search` requests, including coverage that embedding is not called.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command:

```bash
.venv/bin/python -m pytest tests/server/test_api_search.py -q
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The focused test run passes with existing dependency/deprecation warnings from the test environment.
