### PR TITLE
fix(search): return 404 for missing grep URI

### DIFF
--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSNotFoundError
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
+from openviking.server.error_mapping import map_exception
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
 from openviking.server.telemetry import run_operation
@@ -218,6 +219,11 @@ async def grep(
         err_msg = str(e).lower()
         if "not found" in err_msg or "no such file or directory" in err_msg:
             raise NotFoundError(request.uri, "file")
+        raise
+    except Exception as exc:
+        mapped = map_exception(exc, resource=request.uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from exc
         raise
     return Response(status="ok", result=result)
 

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -619,6 +619,7 @@ class VikingFS:
             ctx: Request context
         """
         self._ensure_access(uri, ctx)
+        await self.stat(uri, ctx=ctx)
 
         flags = re.IGNORECASE if case_insensitive else 0
         compiled_pattern = re.compile(pattern, flags)

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -341,6 +341,19 @@ async def test_grep_case_insensitive(client_with_resource):
     assert resp.json()["status"] == "ok"
 
 
+async def test_grep_missing_uri_returns_not_found(client: httpx.AsyncClient):
+    resp = await client.post(
+        "/api/v1/search/grep",
+        json={
+            "uri": "viking://resources/nonexistent_grep_test_xyz",
+            "pattern": "test",
+        },
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["status"] == "error"
+
+
 async def test_grep_exclude_uri_excludes_specific_uri_range(
     client: httpx.AsyncClient,
     upload_temp_dir,


### PR DESCRIPTION
## Description

Fixes `POST /api/v1/search/grep` so a missing root URI returns `404 NOT_FOUND` instead of `200 OK` with an empty `matches` array.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Validate the grep root URI before recursively scanning.
- Map generic storage `not found` errors in the grep route to the standard `404 NOT_FOUND` API error.
- Add a regression test for missing grep URI behavior.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command:

```bash
.venv/bin/python -m pytest tests/server/test_api_search.py -k grep
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

System `python -m pytest` fails in this local environment because the global `pydantic` and `pydantic-core` versions are incompatible, so validation used the project virtualenv.
