### PR TITLE
fix(docker): resolve image version explicitly

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Normalize image name
@@ -45,6 +46,27 @@ jobs:
           RAW_IMAGE_NAME: ${{ github.repository }}
         run: |
           echo "image=$(echo "$RAW_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve OpenViking version
+        id: openviking-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ github.event.inputs.version }}"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            version="${{ github.ref_name }}"
+          else
+            python -m pip install "setuptools-scm>=8.0"
+            version="$(
+              python -c "from build_support.versioning import resolve_openviking_version; print(resolve_openviking_version())"
+            )"
+          fi
+          if [ -z "${version}" ] || [ "${version}" = "0.0.0" ]; then
+            echo "Resolved invalid OpenViking version: ${version}" >&2
+            exit 2
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -85,8 +107,7 @@ jobs:
             type=image,name=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            # fallback to 0.0.0 if no version is provided
-            OPENVIKING_VERSION=${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.version) || (github.ref_type == 'tag' && github.ref_name) || '0.0.0' }}
+            OPENVIKING_VERSION=${{ steps.openviking-version.outputs.version }}
 
       - name: Build and push Docker image to Docker Hub
         id: push-dockerhub
@@ -98,8 +119,7 @@ jobs:
             type=image,name=docker.io/${{ secrets.DOCKERHUB_USERNAME }}/openviking,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            # fallback to 0.0.0 if no version is provided
-            OPENVIKING_VERSION=${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.version) || (github.ref_type == 'tag' && github.ref_name) || '0.0.0' }}
+            OPENVIKING_VERSION=${{ steps.openviking-version.outputs.version }}
 
       - name: Export GHCR image digest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,9 @@ COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH="/app/.venv/bin:/usr/local/cargo/bin:${PATH}"
-ARG OPENVIKING_VERSION=0.0.0
+ARG OPENVIKING_VERSION=
 ARG TARGETPLATFORM
 ARG UV_LOCK_STRATEGY=auto
-ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING=${OPENVIKING_VERSION}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -45,6 +44,14 @@ COPY third_party/ third_party/
 # stale, so Docker builds stay unblocked after dependency changes. Set
 # UV_LOCK_STRATEGY=locked to keep fail-fast reproducibility checks.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
+    if [ -n "${OPENVIKING_VERSION:-}" ]; then \
+        export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING="${OPENVIKING_VERSION}"; \
+    elif [ -f openviking/_version.py ]; then \
+        export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING="$(python -c "import runpy; print(runpy.run_path('openviking/_version.py')['version'])")"; \
+    else \
+        echo "OPENVIKING_VERSION build arg is required when building without openviking/_version.py" >&2; \
+        exit 2; \
+    fi; \
     case "${UV_LOCK_STRATEGY}" in \
         locked) \
             uv sync --locked --no-editable --extra bot --extra gemini \

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -247,7 +247,8 @@ After startup, you can access:
 - API service: `http://localhost:1933`
 - Console UI: `http://localhost:8020`
 
-To build the image yourself: `docker build -t openviking:latest .`
+To build the image yourself, pass an explicit OpenViking version:
+`docker build --build-arg OPENVIKING_VERSION=0.3.12 -t openviking:latest .`
 
 ### Kubernetes + Helm
 

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -245,7 +245,8 @@ docker compose up -d
 - API 服务：`http://localhost:1933`
 - Console 界面：`http://localhost:8020`
 
-如需自行构建镜像：`docker build -t openviking:latest .`
+如需自行构建镜像，请显式传入 OpenViking 版本：
+`docker build --build-arg OPENVIKING_VERSION=0.3.12 -t openviking:latest .`
 
 ### Kubernetes + Helm
 

--- a/tests/misc/test_docker_workflow_native_multiarch.py
+++ b/tests/misc/test_docker_workflow_native_multiarch.py
@@ -40,6 +40,22 @@ def test_build_docker_workflow_uses_manual_input_version_for_dispatch_tags():
     assert "type=ref,event=tag" in workflow
 
 
+def test_build_docker_workflow_does_not_force_zero_version_on_main_builds():
+    workflow = _read_text(".github/workflows/build-docker-image.yml")
+    zero_build_arg = (
+        "OPENVIKING_VERSION=${{ (github.event_name == 'workflow_dispatch' && "
+        "github.event.inputs.version) || (github.ref_type == 'tag' && "
+        "github.ref_name) || '0.0.0' }}"
+    )
+
+    assert "fetch-depth: 0" in workflow
+    assert "id: openviking-version" in workflow
+    assert "from build_support.versioning import resolve_openviking_version" in workflow
+    assert "OPENVIKING_VERSION=${{ steps.openviking-version.outputs.version }}" in workflow
+    assert zero_build_arg not in workflow
+    assert "fallback to 0.0.0" not in workflow
+
+
 def test_docker_workflows_normalize_image_names_to_lowercase():
     build_workflow = _read_text(".github/workflows/build-docker-image.yml")
     release_workflow = _read_text(".github/workflows/release.yml")

--- a/tests/misc/test_root_docker_image_packaging.py
+++ b/tests/misc/test_root_docker_image_packaging.py
@@ -36,6 +36,16 @@ def test_dockerfile_and_makefile_share_the_same_minimum_rust_version():
     assert docker_rust_version == make_rust_version
 
 
+def test_root_dockerfile_does_not_bake_zero_openviking_version_by_default():
+    dockerfile = _read_text("Dockerfile")
+
+    assert "ARG OPENVIKING_VERSION=0.0.0" not in dockerfile
+    assert "ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING" not in dockerfile
+    assert "COPY .git/ .git/" not in dockerfile
+    assert 'if [ -n "${OPENVIKING_VERSION:-}" ]; then' in dockerfile
+    assert "OPENVIKING_VERSION build arg is required" in dockerfile
+
+
 def test_openviking_package_includes_console_static_assets():
     pyproject = _read_text("pyproject.toml")
     setup_py = _read_text("setup.py")


### PR DESCRIPTION
## Description

Fix Docker image builds so OpenViking package metadata no longer falls back to `0.0.0`, which caused `/health` to report an incorrect `version` in Docker deployments.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Removed the Dockerfile default that forced `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING=0.0.0` when no build arg was provided.
- Added Docker image workflow version resolution so CI passes a real OpenViking version into image builds.
- Updated deployment docs and regression tests to require explicit image version handling and prevent `.git` copy/default-zero regressions.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Tested with:

```bash
.venv/bin/python -m pytest tests/misc/test_root_docker_image_packaging.py::test_root_dockerfile_does_not_bake_zero_openviking_version_by_default tests/misc/test_docker_workflow_native_multiarch.py::test_build_docker_workflow_does_not_force_zero_version_on_main_builds
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Running the broader misc test files also encountered an existing unrelated failure in `tests/misc/test_root_docker_image_packaging.py::test_root_build_system_includes_maturin_for_isolated_builds`, which expects `"--features"` in `setup.py`.
