### PR TITLE
docs(api): add *.larkoffice.com to supported Feishu URL hosts

### DIFF
--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -16,7 +16,7 @@ Resources are external knowledge that agents can reference. This guide covers ho
 | Video | `.mp4`, `.mov`, `.avi` | Frame extraction + VLM |
 | Audio | `.mp3`, `.wav`, `.m4a` | Transcription |
 | Documents | `.docx` | Text extraction |
-| Feishu/Lark | URL (`*.feishu.cn`, `*.larksuite.com`) | Cloud document parsing via `lark-oapi` |
+| Feishu/Lark | URL (`*.feishu.cn`, `*.larksuite.com`, `*.larkoffice.com`) | Cloud document parsing via `lark-oapi` |
 
 ## Processing Pipeline
 

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -16,7 +16,7 @@
 | 视频 | `.mp4`, `.mov`, `.avi` | 帧提取 + VLM |
 | 音频 | `.mp3`, `.wav`, `.m4a` | 语音转录 |
 | 文档 | `.docx` | 文本提取 |
-| 飞书/Lark | URL（`*.feishu.cn`、`*.larksuite.com`） | 云端文档解析（`lark-oapi`） |
+| 飞书/Lark | URL（`*.feishu.cn`、`*.larksuite.com`、`*.larkoffice.com`） | 云端文档解析（`lark-oapi`） |
 
 ## 处理流程
 


### PR DESCRIPTION
## Summary

Add `*.larkoffice.com` to the supported Feishu URL host list in the API resources overview table (EN + ZH mirror), closing the docs drift against #1684 (merged 2026-04-24T10:42Z).

## Why

#1684 extended `_ALLOWED_FEISHU_HOSTS` in `openviking/parse/parsers/feishu.py` and host-matching in `openviking/parse/accessors/feishu_accessor.py` to include `*.larkoffice.com`, so ByteDance-internal Feishu documents under `*.larkoffice.com/{docx,wiki,sheets,base}/…` now route through `FeishuParser` correctly. However the "Sources" table in `docs/en/api/02-resources.md` (line 19) and its `docs/zh/api/02-resources.md` mirror still listed only `*.feishu.cn` and `*.larksuite.com`, which misinforms users about the supported host set.

No behavior change — docs-only, single-line table edit on both locales.

## Type of Change

- [x] Documentation (docs)

## Testing

Docs-only, no runtime impact. Line 19 of both files now includes `*.larkoffice.com` in the same host-list position; Chinese full-width punctuation (`、`) convention preserved on the ZH row. Detailed path-shape examples (`{docx,wiki,sheets,base}`, lines 218-221) are already documented on the canonical `*.feishu.cn` host and apply identically to `*.larkoffice.com` as a natural consequence of the allowlist extension (no path-shape change in #1684).

## Checklist

- [x] Code follows project style guidelines
- [x] EN + ZH docs synchronized
