### PR TITLE
fix(s3fs): auto-prepend scheme to bare endpoint hostnames

### DIFF
--- a/crates/ragfs/src/plugins/s3fs/client.rs
+++ b/crates/ragfs/src/plugins/s3fs/client.rs
@@ -194,7 +194,23 @@ impl S3Client {
             .unwrap_or("us-east-1")
             .to_string();
 
-        let endpoint = config.get("endpoint").and_then(|v| v.as_string());
+        let raw_endpoint = config.get("endpoint").and_then(|v| v.as_string());
+        let use_ssl = if let Some(v) = config.get("use_ssl").and_then(|v| v.as_bool()) {
+            v
+        } else if let Some(v) = config.get("disable_ssl").and_then(|v| v.as_bool()) {
+            !v
+        } else {
+            true
+        };
+        let endpoint = raw_endpoint.map(|ep| {
+            if ep.starts_with("https://") || ep.starts_with("http://") {
+                ep.to_string()
+            } else if use_ssl {
+                format!("https://{}", ep)
+            } else {
+                format!("http://{}", ep)
+            }
+        });
 
         let access_key = config
             .get("access_key_id")


### PR DESCRIPTION
## Description

The SDK's `endpoint_url()` requires a full URI with scheme. Bare hostnames like
`my-bucket.oss.aliyuncs.com` are treated as relative URLs, causing
`ResolveEndpointError`.

Now reads `use_ssl` (priority) and `disable_ssl` (fallback) config keys to
prepend `https://` or `http://`. Endpoints already containing a scheme are
passed through unchanged.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Read `endpoint` as a raw hostname or URI from S3FS config
- Use `use_ssl` first and fall back to `disable_ssl` for compatibility
- Auto-prepend `https://` or `http://` only when the endpoint does not already include a scheme

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
- [ ] Linux
- [x] macOS
- [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally keeps the diff minimal and only updates the endpoint
normalization logic in `crates/ragfs/src/plugins/s3fs/client.rs`.
