### PR TITLE
[security] fix(bot): prevent image tool from reading host files outside sandbox

### DIFF
--- a/bot/tests/test_image_tool_sandbox.py
+++ b/bot/tests/test_image_tool_sandbox.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for image tool sandbox file handling."""
+
+import base64
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeSandbox:
+    def __init__(self, files=None, error=None):
+        self.files = files or {}
+        self.error = error
+        self.read_paths = []
+
+    async def read_file_bytes(self, path: str) -> bytes:
+        self.read_paths.append(path)
+        if self.error:
+            raise self.error
+        return self.files[path]
+
+
+class _SandboxManager:
+    def __init__(self, sandbox):
+        self._sandbox = sandbox
+
+    async def get_sandbox(self, session_key):
+        return self._sandbox
+
+
+def _load_image_tool(monkeypatch):
+    """Load the image tool directly so this regression stays isolated."""
+    repo_root = Path(__file__).resolve().parents[2]
+    image_path = repo_root / "bot" / "vikingbot" / "agent" / "tools" / "image.py"
+
+    base_mod = types.ModuleType("vikingbot.agent.tools.base")
+
+    class Tool:
+        pass
+
+    class ToolContext:
+        pass
+
+    base_mod.Tool = Tool
+    base_mod.ToolContext = ToolContext
+
+    events_mod = types.ModuleType("vikingbot.bus.events")
+
+    class OutboundMessage:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    events_mod.OutboundMessage = OutboundMessage
+
+    utils_mod = types.ModuleType("vikingbot.utils")
+    utils_mod.get_data_path = lambda: repo_root
+
+    monkeypatch.setitem(sys.modules, "vikingbot", types.ModuleType("vikingbot"))
+    monkeypatch.setitem(sys.modules, "vikingbot.agent", types.ModuleType("vikingbot.agent"))
+    monkeypatch.setitem(
+        sys.modules, "vikingbot.agent.tools", types.ModuleType("vikingbot.agent.tools")
+    )
+    monkeypatch.setitem(sys.modules, "vikingbot.agent.tools.base", base_mod)
+    monkeypatch.setitem(sys.modules, "vikingbot.bus", types.ModuleType("vikingbot.bus"))
+    monkeypatch.setitem(sys.modules, "vikingbot.bus.events", events_mod)
+    monkeypatch.setitem(sys.modules, "vikingbot.utils", utils_mod)
+
+    spec = importlib.util.spec_from_file_location("image_tool_under_test", image_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.ImageGenerationTool
+
+
+@pytest.mark.asyncio
+async def test_image_tool_uses_sandbox_for_local_paths(monkeypatch, tmp_path):
+    secret = tmp_path / "host-secret.png"
+    secret.write_bytes(b"OPENVIKING_HOST_SECRET_MARKER")
+    sandbox = _FakeSandbox(error=PermissionError("outside sandbox"))
+    context = SimpleNamespace(session_key="session", sandbox_manager=_SandboxManager(sandbox))
+
+    ImageGenerationTool = _load_image_tool(monkeypatch)
+    tool = ImageGenerationTool()
+
+    with pytest.raises(PermissionError):
+        await tool._parse_image_data(str(secret), context)
+
+    assert sandbox.read_paths == [str(secret)]
+
+
+@pytest.mark.asyncio
+async def test_image_tool_reads_sandbox_local_file_paths(monkeypatch):
+    sandbox = _FakeSandbox(files={"image.png": b"SANDBOX_IMAGE_BYTES"})
+    context = SimpleNamespace(session_key="session", sandbox_manager=_SandboxManager(sandbox))
+
+    ImageGenerationTool = _load_image_tool(monkeypatch)
+    tool = ImageGenerationTool()
+    data_uri, format_type = await tool._parse_image_data("image.png", context)
+
+    assert sandbox.read_paths == ["image.png"]
+    assert format_type == "data"
+    assert data_uri.startswith("data:image/png;base64,")
+    assert base64.b64decode(data_uri.split(",", 1)[1]) == b"SANDBOX_IMAGE_BYTES"
+
+
+@pytest.mark.asyncio
+async def test_image_tool_keeps_data_uri_support_without_sandbox_context(monkeypatch):
+    ImageGenerationTool = _load_image_tool(monkeypatch)
+    tool = ImageGenerationTool()
+    data_uri = "data:image/png;base64,UE5H"
+
+    parsed, format_type = await tool._parse_image_data(data_uri)
+
+    assert parsed == data_uri
+    assert format_type == "data"

--- a/bot/tests/test_image_tool_sandbox.py
+++ b/bot/tests/test_image_tool_sandbox.py
@@ -33,8 +33,8 @@ class _SandboxManager:
         return self._sandbox
 
 
-def _load_image_tool(monkeypatch):
-    """Load the image tool directly so this regression stays isolated."""
+def _load_image_module(monkeypatch):
+    """Load the image tool module directly so this regression stays isolated."""
     repo_root = Path(__file__).resolve().parents[2]
     image_path = repo_root / "bot" / "vikingbot" / "agent" / "tools" / "image.py"
 
@@ -74,7 +74,11 @@ def _load_image_tool(monkeypatch):
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
-    return module.ImageGenerationTool
+    return module
+
+
+def _load_image_tool(monkeypatch):
+    return _load_image_module(monkeypatch).ImageGenerationTool
 
 
 @pytest.mark.asyncio
@@ -118,3 +122,74 @@ async def test_image_tool_keeps_data_uri_support_without_sandbox_context(monkeyp
 
     assert parsed == data_uri
     assert format_type == "data"
+
+
+def test_image_tool_documents_mask_sandbox_local_paths(monkeypatch):
+    ImageGenerationTool = _load_image_tool(monkeypatch)
+    tool = ImageGenerationTool()
+
+    mask_description = tool.parameters["properties"]["mask"]["description"]
+
+    assert "sandbox-local" in mask_description
+
+
+@pytest.mark.asyncio
+async def test_image_tool_keeps_url_support_without_sandbox_context(monkeypatch):
+    ImageGenerationTool = _load_image_tool(monkeypatch)
+    tool = ImageGenerationTool()
+    image_url = "https://example.com/image.png"
+
+    parsed, format_type = await tool._parse_image_data(image_url)
+
+    assert parsed == image_url
+    assert format_type == "url"
+
+
+@pytest.mark.asyncio
+async def test_image_tool_rejects_local_paths_without_sandbox_context(monkeypatch):
+    ImageGenerationTool = _load_image_tool(monkeypatch)
+    tool = ImageGenerationTool()
+
+    with pytest.raises(ValueError, match="sandbox context"):
+        await tool._parse_image_data("image.png")
+
+
+@pytest.mark.asyncio
+async def test_edit_mode_reads_base_image_and_mask_from_sandbox(monkeypatch, tmp_path):
+    sandbox = _FakeSandbox(
+        files={
+            "base.png": b"SANDBOX_BASE_IMAGE_BYTES",
+            "mask.png": b"SANDBOX_MASK_IMAGE_BYTES",
+        }
+    )
+    context = SimpleNamespace(session_key="session", sandbox_manager=_SandboxManager(sandbox))
+    module = _load_image_module(monkeypatch)
+    monkeypatch.setattr(module, "get_data_path", lambda: tmp_path)
+    captured_kwargs = {}
+
+    async def fake_image_edit(**kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(
+            data=[SimpleNamespace(b64_json=base64.b64encode(b"OUTPUT").decode())]
+        )
+
+    monkeypatch.setattr(module.litellm, "aimage_edit", fake_image_edit)
+    tool = module.ImageGenerationTool(gen_image_model="openai/dall-e-2")
+
+    result = await tool.execute(
+        context,
+        mode="edit",
+        prompt="edit safely",
+        base_image="base.png",
+        mask="mask.png",
+        send_to_user=False,
+    )
+
+    assert sandbox.read_paths == ["base.png", "mask.png"]
+    assert captured_kwargs["image"].startswith("data:image/png;base64,")
+    assert captured_kwargs["mask"].startswith("data:image/png;base64,")
+    assert (
+        base64.b64decode(captured_kwargs["image"].split(",", 1)[1]) == b"SANDBOX_BASE_IMAGE_BYTES"
+    )
+    assert base64.b64decode(captured_kwargs["mask"].split(",", 1)[1]) == b"SANDBOX_MASK_IMAGE_BYTES"
+    assert result.startswith("生成图片：")

--- a/bot/vikingbot/agent/tools/image.py
+++ b/bot/vikingbot/agent/tools/image.py
@@ -5,7 +5,6 @@ import logging
 import mimetypes
 import uuid
 from io import BytesIO
-from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 import httpx
@@ -44,7 +43,7 @@ class ImageGenerationTool(Tool):
                 },
                 "base_image": {
                     "type": "string",
-                    "description": "Base image for edit/variation mode: base64 data URI or image file path (required for edit and variation modes)",
+                    "description": "Base image for edit/variation mode: base64 data URI, image URL, or sandbox-local image file path (required for edit and variation modes)",
                 },
                 "mask": {
                     "type": "string",
@@ -105,9 +104,11 @@ class ImageGenerationTool(Tool):
         """Check if the current model is a Seedream model."""
         return "seedream" in self.gen_image_model.lower()
 
-    async def _parse_image_data(self, image_str: str) -> tuple[str, str]:
+    async def _parse_image_data(
+        self, image_str: str, tool_context: "ToolContext | None" = None
+    ) -> tuple[str, str]:
         """
-        Parse image from base64 data URI, URL, or file path.
+        Parse image from base64 data URI, URL, or sandbox-local file path.
         Returns: (image_data, format_type) where format_type is "data" or "url"
         """
         if image_str.startswith("data:"):
@@ -115,10 +116,14 @@ class ImageGenerationTool(Tool):
         elif image_str.startswith("http://") or image_str.startswith("https://"):
             return image_str, "url"
         else:
+            if tool_context is None:
+                raise ValueError("Local image paths require a sandbox context")
             mime_type, _ = mimetypes.guess_type(image_str)
             if not mime_type:
                 mime_type = "application/octet-stream"
-            base64_str = base64.b64encode(Path(image_str).read_bytes()).decode("utf-8")
+            sandbox = await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+            image_bytes = await sandbox.read_file_bytes(image_str)
+            base64_str = base64.b64encode(image_bytes).decode("utf-8")
             data_uri = f"data:{mime_type};base64,{base64_str}"
             return data_uri, "data"
 
@@ -157,6 +162,7 @@ class ImageGenerationTool(Tool):
 
     async def _seedream_image_to_image(
         self,
+        tool_context: "ToolContext",
         base_image: str,
         prompt: str,
         strength: float,
@@ -164,7 +170,7 @@ class ImageGenerationTool(Tool):
         n: int,
     ) -> Any:
         """Shared method for Seedream image-to-image generation (used by edit and variation modes)."""
-        base_image_data, base_format = await self._parse_image_data(base_image)
+        base_image_data, base_format = await self._parse_image_data(base_image, tool_context)
         kwargs = self._build_common_kwargs(
             size=size,
             n=n,
@@ -217,6 +223,7 @@ class ImageGenerationTool(Tool):
             elif mode == "edit":
                 if self._is_seedream_model:
                     response = await self._seedream_image_to_image(
+                        tool_context=tool_context,
                         base_image=base_image,  # type: ignore[arg-type]
                         prompt=prompt,  # type: ignore[arg-type]
                         strength=0.7,
@@ -224,12 +231,14 @@ class ImageGenerationTool(Tool):
                         n=n,
                     )
                 else:
-                    base_image_data, base_format = await self._parse_image_data(base_image)  # type: ignore[arg-type]
+                    base_image_data, base_format = await self._parse_image_data(
+                        base_image, tool_context
+                    )  # type: ignore[arg-type]
                     edit_kwargs = self._build_common_kwargs(size=size, n=n, include_style=False)
                     edit_kwargs["prompt"] = prompt
                     edit_kwargs["image"] = base_image_data
                     if mask:
-                        mask_data, mask_format = await self._parse_image_data(mask)
+                        mask_data, mask_format = await self._parse_image_data(mask, tool_context)
                         if mask_format == "bytes":
                             edit_kwargs["mask"] = BytesIO(mask_data)  # type: ignore
                         else:
@@ -239,6 +248,7 @@ class ImageGenerationTool(Tool):
             elif mode == "variation":
                 if self._is_seedream_model:
                     response = await self._seedream_image_to_image(
+                        tool_context=tool_context,
                         base_image=base_image,  # type: ignore[arg-type]
                         prompt="Create a variation of this image",
                         strength=0.3,
@@ -246,7 +256,9 @@ class ImageGenerationTool(Tool):
                         n=n,
                     )
                 else:
-                    base_image_data, base_format = await self._parse_image_data(base_image)  # type: ignore[arg-type]
+                    base_image_data, base_format = await self._parse_image_data(
+                        base_image, tool_context
+                    )  # type: ignore[arg-type]
                     var_kwargs = self._build_common_kwargs(size=size, n=n, include_style=False)
                     var_kwargs["image"] = base_image_data
                     response = await litellm.aimage_variation(**var_kwargs)

--- a/bot/vikingbot/agent/tools/image.py
+++ b/bot/vikingbot/agent/tools/image.py
@@ -47,7 +47,7 @@ class ImageGenerationTool(Tool):
                 },
                 "mask": {
                     "type": "string",
-                    "description": "Mask image for edit mode: base64 data URI or image URL (optional, transparent areas indicate where to edit)",
+                    "description": "Mask image for edit mode: base64 data URI, image URL, or sandbox-local image file path (optional, transparent areas indicate where to edit)",
                 },
                 "size": {
                     "type": "string",

--- a/bot/vikingbot/sandbox/backends/direct.py
+++ b/bot/vikingbot/sandbox/backends/direct.py
@@ -112,7 +112,7 @@ class DirectBackend(SandboxBackend):
             raise FileNotFoundError(f"File not found: {path}")
         if not sandbox_path.is_file():
             raise IOError(f"Not a file: {path}")
-        return sandbox_path.read_bytes()
+        return await asyncio.to_thread(sandbox_path.read_bytes)
 
     async def read_file(self, path: str) -> str:
         return (await self.read_file_bytes(path)).decode("utf-8")

--- a/bot/vikingbot/sandbox/backends/direct.py
+++ b/bot/vikingbot/sandbox/backends/direct.py
@@ -1,17 +1,14 @@
 """Direct backend implementation - executes commands directly on host without sandboxing."""
 
 import asyncio
-import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from loguru import logger
 
-from vikingbot.sandbox.base import SandboxBackend
-from vikingbot.sandbox.backends import register_backend
-
-
 from vikingbot.config.schema import SandboxConfig, SessionKey
+from vikingbot.sandbox.backends import register_backend
+from vikingbot.sandbox.base import SandboxBackend
 
 
 @register_backend("direct")
@@ -105,7 +102,7 @@ class DirectBackend(SandboxBackend):
         """Get the current working directory (uses actual host cwd)."""
         return str(self._workspace)
 
-    async def read_file(self, path: str) -> str:
+    async def read_file_bytes(self, path: str) -> bytes:
         sandbox_path = Path(path)
         if not sandbox_path.is_absolute():
             sandbox_path = self._workspace / path
@@ -115,7 +112,10 @@ class DirectBackend(SandboxBackend):
             raise FileNotFoundError(f"File not found: {path}")
         if not sandbox_path.is_file():
             raise IOError(f"Not a file: {path}")
-        return sandbox_path.read_text(encoding="utf-8")
+        return sandbox_path.read_bytes()
+
+    async def read_file(self, path: str) -> str:
+        return (await self.read_file_bytes(path)).decode("utf-8")
 
     async def write_file(self, path: str, content: str) -> None:
         sandbox_path = Path(path)

--- a/bot/vikingbot/sandbox/base.py
+++ b/bot/vikingbot/sandbox/base.py
@@ -1,5 +1,6 @@
 """Abstract interface for sandbox backends."""
 
+import asyncio
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
@@ -93,7 +94,7 @@ class SandboxBackend(ABC):
             raise FileNotFoundError(f"File not found: {path}")
         if not sandbox_path.is_file():
             raise IOError(f"Not a file: {path}")
-        return sandbox_path.read_bytes()
+        return await asyncio.to_thread(sandbox_path.read_bytes)
 
     async def read_file(self, path: str) -> str:
         """Read file from sandbox (default implementation: host filesystem).

--- a/bot/vikingbot/sandbox/base.py
+++ b/bot/vikingbot/sandbox/base.py
@@ -73,6 +73,28 @@ class SandboxBackend(ABC):
             return self.workspace / path.lstrip("/")
         return self.workspace / path
 
+    async def read_file_bytes(self, path: str) -> bytes:
+        """Read file bytes from sandbox (default implementation: host filesystem).
+
+        Args:
+            path: Path to file (absolute or relative to sandbox_cwd)
+
+        Returns:
+            File content as bytes
+
+        Raises:
+            FileNotFoundError: If file doesn't exist
+            IOError: If read fails
+            PermissionError: If path outside workspace and restriction is enabled
+        """
+        sandbox_path = self._resolve_path(path)
+        self._check_path_restriction(sandbox_path)
+        if not sandbox_path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+        if not sandbox_path.is_file():
+            raise IOError(f"Not a file: {path}")
+        return sandbox_path.read_bytes()
+
     async def read_file(self, path: str) -> str:
         """Read file from sandbox (default implementation: host filesystem).
 
@@ -87,13 +109,7 @@ class SandboxBackend(ABC):
             IOError: If read fails
             PermissionError: If path outside workspace and restriction is enabled
         """
-        sandbox_path = self._resolve_path(path)
-        self._check_path_restriction(sandbox_path)
-        if not sandbox_path.exists():
-            raise FileNotFoundError(f"File not found: {path}")
-        if not sandbox_path.is_file():
-            raise IOError(f"Not a file: {path}")
-        return sandbox_path.read_text(encoding="utf-8")
+        return (await self.read_file_bytes(path)).decode("utf-8")
 
     async def write_file(self, path: str, content: str) -> None:
         """Write file to sandbox (default implementation: host filesystem).


### PR DESCRIPTION
## Summary

This PR fixes a bot image-tool sandbox bypass where model/tool-controlled local image paths were read directly from the host filesystem before being sent to the configured image-generation provider.

The patch keeps existing `data:` URI and HTTP(S) image inputs working, but changes local image path handling so paths are resolved through the session sandbox rather than through `Path(...).read_bytes()` on the host.

## Security issues covered

| Issue | Boundary | Impact | Fix |
|---|---|---|---|
| Image tool local path sandbox bypass | Bot tool call -> host filesystem -> image provider | A tool call using `base_image` or `mask` could read files accessible to the bot process outside the intended sandbox and encode them as image input | Read local image paths through the session sandbox via a new binary-safe sandbox read method |

## Before this PR

- `ImageGenerationTool._parse_image_data()` accepted any non-`data:` and non-HTTP(S) value as a local path.
- Local paths were read directly with `Path(image_str).read_bytes()`.
- `base_image` and `mask` values therefore bypassed the sandbox abstraction used by the normal filesystem tools.
- An absolute host path or traversal-style path could be attempted by the image tool before provider submission.

## After this PR

- Local image paths require a `ToolContext`.
- The image tool obtains the current session sandbox through `tool_context.sandbox_manager.get_sandbox(tool_context.session_key)`.
- The sandbox API exposes `read_file_bytes()` for binary-safe image reads.
- The direct sandbox backend applies its existing path restriction before reading bytes.
- `data:` URI and HTTP(S) URL support remains unchanged.

## Why this matters

The bot already has a sandbox/file-tool boundary for workspace file access. The image generation tool is reachable as a normal tool, and its schema advertised local file paths for image edit/variation inputs. Reading those paths directly on the host creates a separate file-read sink outside the sandbox controls.

If an agent or user-controlled prompt can influence an image tool call, a path such as `/etc/hostname`, an application config path, or another file readable by the bot process could be converted into a base64 `data:` URI and passed into the image-generation request.

## How this differs from #1600

This is related to the same general trust-boundary family as #1600, but it is not the same issue.

- #1600 hardens RAGFS/localfs mount authorization and path confinement.
- This PR hardens the bot image-generation tool path parser.
- The vulnerable code here is `bot/vikingbot/agent/tools/image.py`, specifically the local image parsing path for `base_image` and `mask`.
- The failure mode here is direct host file reading before provider submission, not RAGFS mount creation or localfs resource mounting.

Both boundaries can matter independently because a deployment may restrict normal file tools or RAGFS paths while still exposing the image tool.

## Attack flow

1. The bot exposes the image generation tool.
2. A tool call enters edit or variation mode with a local-looking `base_image` or `mask` value.
3. The previous parser treats the value as a host path when it is not `data:` or HTTP(S).
4. The host process reads that path directly with `Path(image_str).read_bytes()`.
5. The bytes are base64-encoded into a `data:` URI and sent to the configured image-generation provider.

Example vulnerable input shape:

```json
{
  "mode": "edit",
  "prompt": "edit this image",
  "base_image": "/etc/hostname"
}
```

## Affected code

- `bot/vikingbot/agent/tools/image.py`
- `bot/vikingbot/sandbox/base.py`
- `bot/vikingbot/sandbox/backends/direct.py`

## Root cause

- The image tool implemented its own local-path handling instead of using the established sandbox abstraction.
- The parser made a trust decision based only on string prefixes: `data:`, `http://`, or `https://`.
- Anything else became a host filesystem read.
- The sandbox interface did not have a binary-safe read method for image bytes, so the image tool bypassed the sandbox instead of reusing it.

## CVSS assessment

Issue: bot image tool reads host files outside sandbox

Suggested CVSS v3.1: **6.5 Medium**

Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`

Rationale:

- Network-adjacent/application-reachable tool call surface in typical bot deployments.
- Low complexity once the image tool is available.
- Requires ability to cause or influence a tool call, so privileges are modeled as low rather than none.
- Main impact is confidentiality: files readable by the bot process can be copied into outbound provider requests.
- No direct integrity or availability impact is claimed by this PR.

## Safe reproduction steps

On vulnerable code, call the image parser with a local file path outside the intended sandbox:

```python
import asyncio
import base64
from pathlib import Path
from vikingbot.agent.tools.image import ImageGenerationTool

async def main():
    marker = Path("/tmp/openviking-host-secret.txt")
    marker.write_text("OPENVIKING_HOST_SECRET_MARKER")

    tool = ImageGenerationTool()
    data_uri, format_type = await tool._parse_image_data(str(marker))
    decoded = base64.b64decode(data_uri.split(",", 1)[1]).decode()

    print(format_type)
    print(decoded)

asyncio.run(main())
```

## Expected vulnerable behavior

The vulnerable parser returns `format_type == "data"` and the decoded data URI contains `OPENVIKING_HOST_SECRET_MARKER`, proving the image tool read the host file directly.

After this PR, local image paths require sandbox context and are read through the sandbox. A sandbox-denied absolute host path raises instead of being read directly.

## Changes in this PR

- Pass `ToolContext` into image parsing paths for edit and variation modes.
- Replace direct host `Path(...).read_bytes()` with `sandbox.read_file_bytes(...)`.
- Add `read_file_bytes()` to the sandbox interface.
- Implement binary-safe reads in the direct sandbox backend after path restriction checks.
- Update the tool schema text to clarify that local image paths are sandbox-local paths.
- Add focused regression tests for sandbox use, denied host paths, sandbox-local reads, `data:`/HTTP(S) compatibility, mask schema documentation, and edit-mode mask handling.

## Files changed

| Category | Files | Notes |
|---|---|---|
| Image tool hardening | `bot/vikingbot/agent/tools/image.py` | Routes local image reads through the sandbox context |
| Sandbox API | `bot/vikingbot/sandbox/base.py` | Adds binary-safe file read API |
| Direct backend | `bot/vikingbot/sandbox/backends/direct.py` | Enforces existing path restrictions before byte reads |
| Regression tests | `bot/tests/test_image_tool_sandbox.py` | Covers the host-read bypass and safe supported inputs |

## Maintainer impact

- Existing `data:` URI image inputs continue to work.
- Existing HTTP(S) image URL inputs continue to work.
- Local image path inputs now need to be valid within the active sandbox/session context.
- The change avoids sending arbitrary host-readable files to image providers through the image tool.

## Fix rationale

The security boundary should be enforced at the point where a tool-controlled string becomes a file read. Reusing the existing sandbox manager keeps image file access aligned with the rest of the bot filesystem model instead of maintaining a separate host-path interpretation path in the image tool.

A binary-safe sandbox method is added so image bytes can be read without forcing image data through text-oriented APIs.

## Type of change

- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [x] Security hardening
- [ ] Other

## Test plan

Validated locally with:

```bash
PYTHONPATH=.:bot /Users/lennon/.hermes/hermes-agent/venv/bin/python -m py_compile \
  bot/vikingbot/agent/tools/image.py \
  bot/vikingbot/sandbox/base.py \
  bot/vikingbot/sandbox/backends/direct.py \
  bot/tests/test_image_tool_sandbox.py
```

```bash
PYTHONPATH=.:bot /Users/lennon/.hermes/hermes-agent/venv/bin/python -m pytest \
  -o addopts="" bot/tests/test_image_tool_sandbox.py -q
```

Result:

```text
7 passed, 4 warnings
```

```bash
ruff check \
  bot/vikingbot/agent/tools/image.py \
  bot/vikingbot/sandbox/base.py \
  bot/vikingbot/sandbox/backends/direct.py \
  bot/tests/test_image_tool_sandbox.py
```

```bash
ruff format --check \
  bot/vikingbot/agent/tools/image.py \
  bot/vikingbot/sandbox/base.py \
  bot/vikingbot/sandbox/backends/direct.py \
  bot/tests/test_image_tool_sandbox.py
```

```bash
git diff --check
```

## Disclosure notes

This PR is intentionally bounded to the bot image-generation tool's local file path handling. It does not claim to audit all provider request paths or all sandbox integrations. The specific issue fixed here is that image edit/variation inputs could trigger direct host file reads outside the sandbox abstraction.

