### PR TITLE
fix: recursive indexing in index_resource for nested directories

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -371,6 +371,7 @@ async def index_resource(
             if file_info.get("type") == "directory" or file_info.get("isDir"):
                 sub_uri = file_info.get("uri") or f"{uri}/{file_name}"
                 await index_resource(sub_uri, ctx)
+                continue
 
             file_uri = file_info.get("uri") or f"{uri}/{file_name}"
 

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -369,8 +369,8 @@ async def index_resource(
                 continue
 
             if file_info.get("type") == "directory" or file_info.get("isDir"):
-                # TODO: Recursive indexing? For now, skip subdirectories to match previous behavior
-                continue
+                sub_uri = file_info.get("uri") or f"{uri}/{file_name}"
+                await index_resource(sub_uri, ctx)
 
             file_uri = file_info.get("uri") or f"{uri}/{file_name}"
 


### PR DESCRIPTION
## Bug Description

`index_resource()` in `openviking/utils/embedding_utils.py` skips all subdirectories with a TODO comment:

```python
if file_info.get("type") == "directory" or file_info.get("isDir"):
    # TODO: Recursive indexing? For now, skip subdirectories to match previous behavior
    continue
```

This causes nested memory directories (e.g. `entities/people/`, `entities/music/`, `preferences/{user_id}/`) to **never be vectorized** during reindex operations.

## Impact

- `POST /api/v1/maintenance/reindex` only indexes top-level files in a directory
- All nested subdirectory content is silently skipped
- Users must manually call reindex on every leaf directory, which is impractical

## Fix

Replace the `continue` with a recursive call to `index_resource`:

```python
if file_info.get("type") == "directory" or file_info.get("isDir"):
    sub_uri = file_info.get("uri") or f"{uri}/{file_name}"
    await index_resource(sub_uri, ctx)
```

## Testing

Verified with OpenViking v0.3.10:
- Before: reindex on parent directory only indexed top-level files, nested `.md` files had zero vectors
- After: single reindex call on parent recursively indexes all nested subdirectories
- Search quality improved from empty results to accurate retrieval (scores 0.57-0.75)