### PR TITLE
fix: pass parent dir to _ensure_directory_exists in path lock

### DIFF
--- a/openviking/storage/transaction/path_lock.py
+++ b/openviking/storage/transaction/path_lock.py
@@ -233,9 +233,10 @@ class PathLock:
             # 有限超时
             deadline = asyncio.get_running_loop().time() + timeout
 
-        # 确保目录存在
-        if not self._ensure_directory_exists(path):
-            logger.warning(f"[POINT] Failed to ensure directory exists: {path}")
+        # 确保目录存在（传父目录而非文件本身）
+        parent = self._get_parent_path(path)
+        if parent and not self._ensure_directory_exists(parent):
+            logger.warning(f"[POINT] Failed to ensure directory exists: {parent}")
             return False
 
         while True:
@@ -324,9 +325,10 @@ class PathLock:
             # 有限超时
             deadline = asyncio.get_running_loop().time() + timeout
 
-        # 确保目录存在
-        if not self._ensure_directory_exists(path):
-            logger.warning(f"[SUBTREE] Failed to ensure directory exists: {path}")
+        # 确保目录存在（传父目录而非文件本身）
+        parent = self._get_parent_path(path)
+        if parent and not self._ensure_directory_exists(parent):
+            logger.warning(f"[SUBTREE] Failed to ensure directory exists: {parent}")
             return False
 
         while True:


### PR DESCRIPTION
## Bug Description

`acquire_point()` and `acquire_subtree()` in `openviking/storage/transaction/path_lock.py` call `_ensure_directory_exists(path)` where `path` is the lock target path.

When the target is a **file** (e.g., `viking://user/.../profile.md`), `_ensure_directory_exists()` tries to `stat()` the file path, then attempts `mkdir()` treating it as a directory, resulting in a "Not a directory" error. The lock acquisition silently fails, and the subsequent operation (reindex, write, etc.) is skipped.

## Reproduction

1. Create a memory file at a leaf path, e.g., `viking://user/default/memories/profile.md`
2. Call `POST /api/v1/maintenance/reindex` with the file URI
3. Observe: lock fails silently, reindex is skipped

## Root Cause

`_get_lock_path(path)` creates a lock file path like `{path}/.path.ovlock`. The lock file's parent directory must exist, but `_ensure_directory_exists(path)` receives the file path itself, not its parent directory.

For directory targets, `path` is already a directory, so `_ensure_directory_exists` works correctly. For file targets, it fails.

## Fix

Pass the parent directory to `_ensure_directory_exists` in both methods:

```python
parent = self._get_parent_path(path)
if parent and not self._ensure_directory_exists(parent):
    ...
```

## Testing

Verified with OpenViking v0.3.10 - file-level reindex now succeeds instead of silently failing.