### PR TITLE
fix(openclaw): surface tenant headers in remote setup

### DIFF
--- a/examples/openclaw-plugin/INSTALL-ZH.md
+++ b/examples/openclaw-plugin/INSTALL-ZH.md
@@ -135,6 +135,8 @@ openclaw config set plugins.entries.openviking.config.port 1933
 | `mode` | `remote` | 使用已有远端 OpenViking 服务 |
 | `baseUrl` | `http://127.0.0.1:1933` | 远端 OpenViking 服务地址 |
 | `apiKey` | 空 | 远端 OpenViking API Key；服务端未开启认证时可不填 |
+| `accountId` | 空 | 租户/账号请求头。使用 `root_api_key` / root key 访问租户级 API 时必填。 |
+| `userId` | 空 | 用户请求头。使用 root key 访问租户级 API 时需要与 `accountId` 一起配置。 |
 | `agentId` | `default` | 当前 OpenClaw 实例在远端 OpenViking 上的标识 |
 
 常见设置：
@@ -145,6 +147,15 @@ openclaw config set plugins.entries.openviking.config.baseUrl http://your-server
 openclaw config set plugins.entries.openviking.config.apiKey your-api-key
 openclaw config set plugins.entries.openviking.config.agentId your-agent-id
 ```
+
+如果 `apiKey` 使用的是 `root_api_key` / root key，还需要配置租户身份请求头，供租户级 API 使用：
+
+```bash
+openclaw config set plugins.entries.openviking.config.accountId default
+openclaw config set plugins.entries.openviking.config.userId default
+```
+
+如果使用普通用户 API Key，通常可以不填 `accountId` 和 `userId`，由服务端从 key 中解析租户身份。
 
 ## 启动
 

--- a/examples/openclaw-plugin/INSTALL.md
+++ b/examples/openclaw-plugin/INSTALL.md
@@ -142,6 +142,8 @@ Use this mode when you already have a running OpenViking server and want OpenCla
 | `mode` | `remote` | Connect to an existing OpenViking server |
 | `baseUrl` | `http://127.0.0.1:1933` | Remote OpenViking HTTP endpoint |
 | `apiKey` | empty | Optional OpenViking API key |
+| `accountId` | empty | Tenant/account header. Required when `apiKey` is a root API key and the plugin calls tenant-scoped APIs. |
+| `userId` | empty | User header. Required together with `accountId` when using a root API key for tenant-scoped APIs. |
 | `agentId` | `default` | Logical identifier used by this OpenClaw instance on the remote server |
 
 Common remote-mode settings:
@@ -152,6 +154,15 @@ openclaw config set plugins.entries.openviking.config.baseUrl http://your-server
 openclaw config set plugins.entries.openviking.config.apiKey your-api-key
 openclaw config set plugins.entries.openviking.config.agentId your-agent-id
 ```
+
+If the API key is `root_api_key` / a root key, also set the tenant identity headers used by tenant-scoped APIs:
+
+```bash
+openclaw config set plugins.entries.openviking.config.accountId default
+openclaw config set plugins.entries.openviking.config.userId default
+```
+
+For regular user API keys, `accountId` and `userId` can usually be left empty because the server derives the tenant identity from the key.
 
 ## Start
 

--- a/examples/openclaw-plugin/commands/setup.ts
+++ b/examples/openclaw-plugin/commands/setup.ts
@@ -615,9 +615,21 @@ async function setupRemote(
   const defaultUrl = existing?.baseUrl ? String(existing.baseUrl) : DEFAULT_REMOTE_URL;
   const defaultApiKey = existing?.apiKey ? String(existing.apiKey) : "";
   const defaultAgentId = existing?.agentId ? String(existing.agentId) : "";
+  const defaultAccountId = existing?.accountId ? String(existing.accountId) : "";
+  const defaultUserId = existing?.userId ? String(existing.userId) : "";
 
   const baseUrl = await q(tr(zh, "OpenViking server URL", "OpenViking 服务器地址"), defaultUrl);
   const apiKey = await q(tr(zh, "API Key (optional)", "API Key（可选）"), defaultApiKey);
+  const accountId = await q(tr(
+    zh,
+    "Account ID (optional; required with root API keys for tenant-scoped APIs)",
+    "Account ID（可选；root API Key 访问租户级 API 时必填）",
+  ), defaultAccountId);
+  const userId = await q(tr(
+    zh,
+    "User ID (optional; required with root API keys for tenant-scoped APIs)",
+    "User ID（可选；root API Key 访问租户级 API 时必填）",
+  ), defaultUserId);
   const agentId = await q(tr(zh, "Agent ID (optional)", "Agent ID（可选）"), defaultAgentId);
 
   console.log("");
@@ -646,6 +658,10 @@ async function setupRemote(
   };
   if (apiKey) pluginCfg.apiKey = apiKey;
   else delete pluginCfg.apiKey;
+  if (accountId) pluginCfg.accountId = accountId;
+  else delete pluginCfg.accountId;
+  if (userId) pluginCfg.userId = userId;
+  else delete pluginCfg.userId;
   if (agentId) pluginCfg.agentId = agentId;
   else delete pluginCfg.agentId;
   delete pluginCfg.configPath;
@@ -657,6 +673,8 @@ async function setupRemote(
   console.log(`  ${tr(zh, "mode:", "模式:")}    remote`);
   console.log(`  baseUrl: ${baseUrl}`);
   if (apiKey) console.log(`  apiKey:  ${maskKey(apiKey)}`);
+  if (accountId) console.log(`  accountId: ${accountId}`);
+  if (userId) console.log(`  userId:    ${userId}`);
   if (agentId) console.log(`  agentId: ${agentId}`);
   console.log("");
   console.log(tr(zh,
@@ -671,4 +689,5 @@ export const __test__ = {
   parsePosixEnvPythonPath,
   validateLocalConfigPath,
   setupLocal,
+  setupRemote,
 };

--- a/examples/openclaw-plugin/setup-helper/install.js
+++ b/examples/openclaw-plugin/setup-helper/install.js
@@ -121,6 +121,8 @@ let selectedMode = "remote";
 let selectedServerPort = DEFAULT_SERVER_PORT;
 let remoteBaseUrl = "http://127.0.0.1:1933";
 let remoteApiKey = "";
+let remoteAccountId = "";
+let remoteUserId = "";
 let remoteAgentId = "";
 let openvikingPythonPath = "";
 let upgradeRuntimeConfig = null;
@@ -601,6 +603,20 @@ async function collectRemoteConfig() {
   if (installYes) return;
   remoteBaseUrl = await question(tr("OpenViking server URL", "OpenViking 服务器地址"), remoteBaseUrl);
   remoteApiKey = await question(tr("API Key (optional)", "API Key（可选）"), remoteApiKey);
+  remoteAccountId = await question(
+    tr(
+      "Account ID (optional; required with root API keys for tenant-scoped APIs)",
+      "Account ID（可选；root API Key 访问租户级 API 时必填）",
+    ),
+    remoteAccountId,
+  );
+  remoteUserId = await question(
+    tr(
+      "User ID (optional; required with root API keys for tenant-scoped APIs)",
+      "User ID（可选；root API Key 访问租户级 API 时必填）",
+    ),
+    remoteUserId,
+  );
   remoteAgentId = await question(tr("Agent ID (optional)", "Agent ID（可选）"), remoteAgentId);
 }
 
@@ -1445,6 +1461,12 @@ function extractRuntimeConfigFromPluginEntry(entryConfig) {
     if (typeof entryConfig.apiKey === "string" && entryConfig.apiKey.trim()) {
       runtime.apiKey = entryConfig.apiKey;
     }
+    if (typeof entryConfig.accountId === "string" && entryConfig.accountId.trim()) {
+      runtime.accountId = entryConfig.accountId.trim();
+    }
+    if (typeof entryConfig.userId === "string" && entryConfig.userId.trim()) {
+      runtime.userId = entryConfig.userId.trim();
+    }
     if (typeof entryConfig.agentId === "string" && entryConfig.agentId.trim()) {
       runtime.agentId = entryConfig.agentId.trim();
     }
@@ -1772,6 +1794,8 @@ async function prepareStrongPluginUpgrade() {
   if (upgradeRuntimeConfig.mode === "remote") {
     remoteBaseUrl = upgradeRuntimeConfig.baseUrl || remoteBaseUrl;
     remoteApiKey = upgradeRuntimeConfig.apiKey || "";
+    remoteAccountId = upgradeRuntimeConfig.accountId || "";
+    remoteUserId = upgradeRuntimeConfig.userId || "";
     remoteAgentId = upgradeRuntimeConfig.agentId || "";
   } else {
     selectedServerPort = upgradeRuntimeConfig.port || DEFAULT_SERVER_PORT;
@@ -2090,7 +2114,14 @@ async function configureOpenClawPlugin({
 
   const effectiveRuntimeConfig = runtimeConfig || (
     selectedMode === "remote"
-      ? { mode: "remote", baseUrl: remoteBaseUrl, apiKey: remoteApiKey, agentId: remoteAgentId }
+      ? {
+          mode: "remote",
+          baseUrl: remoteBaseUrl,
+          apiKey: remoteApiKey,
+          accountId: remoteAccountId,
+          userId: remoteUserId,
+          agentId: remoteAgentId,
+        }
       : { mode: "local", configPath: join(OPENVIKING_DIR, "ov.conf"), port: selectedServerPort }
   );
 
@@ -2105,6 +2136,12 @@ async function configureOpenClawPlugin({
     await oc(["config", "set", `plugins.entries.${pluginId}.config.baseUrl`, effectiveRuntimeConfig.baseUrl || remoteBaseUrl]);
     if (effectiveRuntimeConfig.apiKey) {
       await oc(["config", "set", `plugins.entries.${pluginId}.config.apiKey`, effectiveRuntimeConfig.apiKey]);
+    }
+    if (effectiveRuntimeConfig.accountId) {
+      await oc(["config", "set", `plugins.entries.${pluginId}.config.accountId`, effectiveRuntimeConfig.accountId]);
+    }
+    if (effectiveRuntimeConfig.userId) {
+      await oc(["config", "set", `plugins.entries.${pluginId}.config.userId`, effectiveRuntimeConfig.userId]);
     }
     if (effectiveRuntimeConfig.agentId) {
       await oc(["config", "set", `plugins.entries.${pluginId}.config.agentId`, effectiveRuntimeConfig.agentId]);

--- a/examples/openclaw-plugin/tests/ut/setup-command.test.ts
+++ b/examples/openclaw-plugin/tests/ut/setup-command.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { __test__ } from "../../commands/setup.js";
+
+const originalFetch = globalThis.fetch;
+
+describe("openviking setup remote tenant config", () => {
+  let tempDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "openviking-setup-"));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ version: "test" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    logSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes accountId and userId when remote setup uses a root API key", async () => {
+    const prompts: string[] = [];
+    const answers = new Map([
+      ["OpenViking server URL", "http://openviking.example"],
+      ["API Key (optional)", "root-api-key"],
+      ["Account ID (optional; required with root API keys for tenant-scoped APIs)", "default"],
+      ["User ID (optional; required with root API keys for tenant-scoped APIs)", "default"],
+      ["Agent ID (optional)", "coding-agent"],
+    ]);
+
+    await __test__.setupRemote(false, join(tempDir, "openclaw.json"), null, async (prompt, def = "") => {
+      prompts.push(`${prompt}=${def}`);
+      return answers.get(prompt) ?? def;
+    });
+
+    const saved = JSON.parse(await readFile(join(tempDir, "openclaw.json"), "utf8"));
+    expect(saved.plugins.entries.openviking.config).toMatchObject({
+      mode: "remote",
+      baseUrl: "http://openviking.example",
+      apiKey: "root-api-key",
+      accountId: "default",
+      userId: "default",
+      agentId: "coding-agent",
+    });
+    expect(prompts).toContain(
+      "Account ID (optional; required with root API keys for tenant-scoped APIs)=",
+    );
+    expect(prompts).toContain(
+      "User ID (optional; required with root API keys for tenant-scoped APIs)=",
+    );
+  });
+
+  it("preserves existing accountId and userId as remote setup defaults", async () => {
+    const existing = {
+      mode: "remote",
+      baseUrl: "http://old.example",
+      apiKey: "root-api-key",
+      accountId: "tenant-a",
+      userId: "alice",
+      agentId: "agent-a",
+    };
+    const seenDefaults = new Map<string, string>();
+
+    await __test__.setupRemote(false, join(tempDir, "openclaw.json"), existing, async (prompt, def = "") => {
+      seenDefaults.set(prompt, def);
+      return def;
+    });
+
+    expect(seenDefaults.get("Account ID (optional; required with root API keys for tenant-scoped APIs)")).toBe(
+      "tenant-a",
+    );
+    expect(seenDefaults.get("User ID (optional; required with root API keys for tenant-scoped APIs)")).toBe(
+      "alice",
+    );
+
+    const saved = JSON.parse(await readFile(join(tempDir, "openclaw.json"), "utf8"));
+    expect(saved.plugins.entries.openviking.config.accountId).toBe("tenant-a");
+    expect(saved.plugins.entries.openviking.config.userId).toBe("alice");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `accountId` and `userId` prompts to OpenClaw remote-mode setup so root-key users can configure the tenant headers required by tenant-scoped OpenViking APIs.
- Preserve/write those fields in the setup-helper install and upgrade flows.
- Document the root-key `accountId` / `userId` configuration in both English and Chinese install guides.
- Add regression coverage for the remote setup wizard saving and defaulting tenant header config.

Fixes #1700.

## Why
OpenViking now requires ROOT/root-key requests to tenant-scoped APIs to include `X-OpenViking-Account` and `X-OpenViking-User`. The OpenClaw plugin client already supports these headers through `accountId` and `userId`, but the supported setup/docs path only exposed `baseUrl`, `apiKey`, and `agentId`. A user following the documented remote-mode setup with `root_api_key` can therefore hit the reported `INVALID_ARGUMENT` error after upgrade.

## Affected files
- `examples/openclaw-plugin/commands/setup.ts`
- `examples/openclaw-plugin/setup-helper/install.js`
- `examples/openclaw-plugin/INSTALL.md`
- `examples/openclaw-plugin/INSTALL-ZH.md`
- `examples/openclaw-plugin/tests/ut/setup-command.test.ts`

## Test plan
- `node --check examples/openclaw-plugin/setup-helper/install.js`
- `npm test -- --run tests/ut/setup-command.test.ts tests/ut/client.test.ts` from `examples/openclaw-plugin`
- `npm test -- --run tests/ut/setup-command.test.ts` from `examples/openclaw-plugin`
- `git diff --check`

Note: I also tried `tests/ut/config.test.ts`, but current `main` appears to have stale assertions expecting the default mode to be `local` while `config.ts` now defaults invalid/missing mode to `remote`; that failure is unrelated to this patch.
