### PR TITLE
fix(retrieve): skip empty docs before rerank

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -256,28 +256,40 @@ class HierarchicalRetriever:
     ) -> List[float]:
         """Return rerank scores or fall back to vector scores."""
         if not self._rerank_client or not documents:
-            return fallback_scores
+            return list(fallback_scores)
+
+        # Skip empty/whitespace-only docs. Empty content has no rerank signal,
+        # and some providers (e.g. Voyage) reject the whole batch with HTTP 400
+        # on any empty entry. Skipped slots keep their vector score.
+        kept_indices: List[int] = []
+        filtered_docs: List[str] = []
+        for i, d in enumerate(documents):
+            if isinstance(d, str) and d.strip():
+                kept_indices.append(i)
+                filtered_docs.append(d)
+
+        if not filtered_docs:
+            return list(fallback_scores)
 
         try:
-            scores = self._rerank_client.rerank_batch(query, documents)
+            scores = self._rerank_client.rerank_batch(query, filtered_docs)
         except Exception as e:
             logger.warning(
                 "[HierarchicalRetriever] Rerank failed, fallback to vector scores: %s", e
             )
-            return fallback_scores
+            return list(fallback_scores)
 
-        if not scores or len(scores) != len(documents):
+        if not scores or len(scores) != len(filtered_docs):
             logger.warning(
                 "[HierarchicalRetriever] Invalid rerank result, fallback to vector scores"
             )
-            return fallback_scores
+            return list(fallback_scores)
 
-        normalized_scores: List[float] = []
-        for score, fallback in zip(scores, fallback_scores, strict=True):
+        normalized_scores: List[float] = [float(fb) for fb in fallback_scores]
+        for j, idx in enumerate(kept_indices):
+            score = scores[j]
             if isinstance(score, (int, float)):
-                normalized_scores.append(float(score))
-            else:
-                normalized_scores.append(fallback)
+                normalized_scores[idx] = float(score)
         return normalized_scores
 
     def _merge_starting_points(

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -345,6 +345,49 @@ async def test_retrieve_falls_back_to_vector_scores_when_rerank_returns_none(mon
     assert fake_client.calls
 
 
+def test_rerank_scores_skips_empty_docs_and_keeps_vector_score(monkeypatch):
+    fake_client = FakeRerankClient([0.95, 0.05])
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.RerankClient.from_config",
+        lambda config: fake_client,
+    )
+
+    retriever = HierarchicalRetriever(
+        storage=DummyStorage(),
+        embedder=DummyEmbedder(),
+        rerank_config=_config(),
+    )
+
+    result = retriever._rerank_scores(
+        "hello",
+        ["alpha", "", "beta", "  "],
+        [0.1, 0.2, 0.3, 0.4],
+    )
+
+    # Empty slots (1, 3) keep vector scores; non-empty get rerank.
+    assert result == [0.95, 0.2, 0.05, 0.4]
+    assert fake_client.calls == [("hello", ["alpha", "beta"])]
+
+
+def test_rerank_scores_all_empty_returns_vector_scores_without_call(monkeypatch):
+    fake_client = FakeRerankClient([])
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.RerankClient.from_config",
+        lambda config: fake_client,
+    )
+
+    retriever = HierarchicalRetriever(
+        storage=DummyStorage(),
+        embedder=DummyEmbedder(),
+        rerank_config=_config(),
+    )
+
+    result = retriever._rerank_scores("hello", ["", "  ", "\n\t"], [0.1, 0.2, 0.3])
+
+    assert result == [0.1, 0.2, 0.3]
+    assert fake_client.calls == []
+
+
 @pytest.mark.asyncio
 async def test_quick_mode_skips_rerank(monkeypatch):
     fake_client = FakeRerankClient([0.95, 0.05, 0.05, 0.95])


### PR DESCRIPTION
## Description

Skip empty or whitespace-only documents before delegating to the rerank client. Some compatible providers (e.g. Voyage) reject the entire batch with HTTP 400 if any document is empty:

> "Error for argument 'documents': Value error, Input cannot contain empty strings or empty lists"

This causes recall to silently fall back to vector scores for every query whose retrieved candidates include a memory with an empty `abstract`, which `_merge_starting_points` produces by default via `str(r.get("abstract", ""))`.

The fix is at the retriever layer in `HierarchicalRetriever._rerank_scores` (shared with all rerank clients) rather than per-client, so it covers every backend (OpenAI/DashScope/Voyage, Cohere, LiteLLM, Volcengine) without touching each implementation. Empty slots keep their vector score from `fallback_scores` so they remain ranked — just without a rerank refinement, which is the honest behavior for content that has no rerank signal. An all-empty batch returns vector scores without a rerank call.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Filter empty/whitespace-only documents in `HierarchicalRetriever._rerank_scores` before calling `rerank_batch`; remap returned scores back to the original index space, with `fallback_scores[i]` (vector score) preserved for skipped slots.
- Short-circuit when every input document is empty: return the vector scores without making a rerank call.
- Add regression tests for a mixed (valid + empty) batch and an all-empty batch.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command:

```bash
.venv/bin/python -m pytest tests/retrieve/test_hierarchical_retriever_rerank.py -q
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

### Reproduction against Voyage rerank

```bash
$ curl -sS -X POST https://api.voyageai.com/v1/rerank \
    -H "Authorization: Bearer $VOYAGE_API_KEY" \
    -H "Content-Type: application/json" \
    -d '{"model":"rerank-2.5-lite","query":"x","documents":[""]}' \
    -w "\nHTTP %{http_code}\n"
{"detail":"The request body is not valid JSON, or some arguments were not specified properly. In particular, Error for argument 'documents': Value error, Input cannot contain empty strings or empty lists"}
HTTP 400
```

Server log before the fix:

```
ERROR  [OpenAIRerankClient] Rerank failed: 400 Client Error: Bad Request for url: https://api.voyageai.com/v1/rerank
WARNING [HierarchicalRetriever] Invalid rerank result, fallback to vector scores
```

After the fix: empty-abstract candidates are filtered out, only real content goes to the rerank API, and the empty slots keep their vector scores so the batch still ranks correctly without falling back.

## Additional Notes

The retriever callsite intentionally produces empty-string entries when a memory has no abstract (`str(r.get("abstract", ""))` in `_merge_starting_points`). Filtering at the retriever boundary is the smaller fix: no rerank-client subclass needs to change, and the same behavior applies regardless of provider. A wider refactor that handles empty-abstract memories upstream of retrieval is out of scope for this PR.