### PR TITLE
docs(api): add memory_diff.json to archive directory tree

### DIFF
--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -864,6 +864,7 @@ viking://session/{session_id}/
     |   +-- messages.jsonl    # Written in Phase 1
     |   +-- .abstract.md      # Written in Phase 2 (background)
     |   +-- .overview.md      # Written in Phase 2 (background)
+    |   +-- memory_diff.json  # Written in Phase 2 (background, on memory changes)
     |   +-- .done             # Phase 2 completion marker
     +-- archive_002/
 ```

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -864,6 +864,7 @@ viking://session/{session_id}/
     |   +-- messages.jsonl    # Phase 1 写入
     |   +-- .abstract.md      # Phase 2 写入（后台）
     |   +-- .overview.md      # Phase 2 写入（后台）
+    |   +-- memory_diff.json  # Phase 2 写入（后台，记忆变更时）
     |   +-- .done             # Phase 2 完成标记
     +-- archive_002/
 ```


### PR DESCRIPTION
PR #1710 (Feat/memory diff) added a `memory_diff.json` artifact to `history/archive_N/` (written by Phase 2 memory extraction in `openviking/session/compressor_v2.py` when `archive_uri and result.has_changes()`). The directory tree under `### get_session_archive()` in `docs/{en,zh}/api/05-sessions.md` lists `messages.jsonl` / `.abstract.md` / `.overview.md` / `.done` but not `memory_diff.json`, so SDK / integration consumers reading this tree won't know to expect the new artifact.

This PR mirrors the new file into both EN and ZH trees in the same position (after `.overview.md`, before `.done`) with the conditional documented inline (`on memory changes` / `记忆变更时`).

- `docs/en/api/05-sessions.md`: +1 LOC
- `docs/zh/api/05-sessions.md`: +1 LOC

Pure docs, no behavior change. Aligned with existing `Phase 2 写入（后台）` / `Written in Phase 2 (background)` convention.
