### PR TITLE
feat(codex-memory-plugin): add client config file support

### DIFF
--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -21,7 +21,9 @@ Codex gets four tools:
 - `.codex-plugin/plugin.json`: plugin metadata
 - `.mcp.json`: MCP server wiring for Codex
 - `src/memory-server.ts`: MCP server source
-- `package.json`: build and start scripts
+- `src/config.ts`: config loader and precedence resolver
+- `tests/config.test.mjs`: config-loading tests (`node --test`)
+- `package.json`: build, start, and test scripts
 - `tsconfig.json`: TypeScript build config
 
 ## Prerequisites
@@ -59,13 +61,44 @@ Or copy `.mcp.json` into a Codex workspace and adjust the `cwd` path if needed.
 
 The server reads OpenViking connection settings from `~/.openviking/ov.conf`.
 
+Per-plugin overrides may live in `~/.openviking/codex-memory-plugin/config.json`.
+This is optional; when the file is absent the server falls back to `ov.conf`
+defaults and the literal defaults below.
+
+Resolution precedence (highest wins):
+
+1. environment variable
+2. client config (`~/.openviking/codex-memory-plugin/config.json`)
+3. `ov.conf` default
+4. built-in literal default
+
+Supported client config keys (all optional):
+
+- `apiKey`
+- `accountId`
+- `userId`
+- `agentId` (default: `codex`)
+- `timeoutMs` (default: `15000`)
+- `recallLimit` (default: `6`)
+- `scoreThreshold` (default: `0.01`)
+
+Example `~/.openviking/codex-memory-plugin/config.json`:
+
+```json
+{
+  "agentId": "codex-prod",
+  "recallLimit": 8
+}
+```
+
 Supported environment overrides:
 
 - `OPENVIKING_CONFIG_FILE`: alternate `ov.conf` path
+- `OPENVIKING_CODEX_CONFIG_FILE`: alternate client config path
 - `OPENVIKING_API_KEY`: API key override
-- `OPENVIKING_ACCOUNT`: account identity, default from `ov.conf`
-- `OPENVIKING_USER`: user identity, default from `ov.conf`
-- `OPENVIKING_AGENT_ID`: agent identity, default `codex`
+- `OPENVIKING_ACCOUNT`: account identity, default from client config or `ov.conf`
+- `OPENVIKING_USER`: user identity, default from client config or `ov.conf`
+- `OPENVIKING_AGENT_ID`: agent identity, default from client config or `ov.conf`
 - `OPENVIKING_TIMEOUT_MS`: HTTP timeout, default `15000`
 - `OPENVIKING_RECALL_LIMIT`: recall result limit, default `6`
 - `OPENVIKING_SCORE_THRESHOLD`: recall threshold, default `0.01`

--- a/examples/codex-memory-plugin/package.json
+++ b/examples/codex-memory-plugin/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "start": "node ./servers/memory-server.js"
+    "start": "node ./servers/memory-server.js",
+    "test": "npm run build && node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/examples/codex-memory-plugin/src/config.ts
+++ b/examples/codex-memory-plugin/src/config.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join, resolve as resolvePath } from "node:path"
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>
+}
+
+export function loadOvConf(env: NodeJS.ProcessEnv = process.env): Record<string, unknown> {
+  const defaultPath = join(homedir(), ".openviking", "ov.conf")
+  const configPath = resolvePath(
+    (env.OPENVIKING_CONFIG_FILE || defaultPath).replace(/^~/, homedir()),
+  )
+  try {
+    return readJson(configPath)
+  } catch (err) {
+    const code = (err as { code?: string })?.code
+    const detail = code === "ENOENT" ? `Config file not found: ${configPath}` : `Invalid config file: ${configPath}`
+    process.stderr.write(`[openviking-memory] ${detail}\n`)
+    process.exit(1)
+  }
+}
+
+export function loadClientConfig(env: NodeJS.ProcessEnv = process.env): Record<string, unknown> {
+  const defaultPath = join(homedir(), ".openviking", "codex-memory-plugin", "config.json")
+  const configPath = resolvePath(
+    (env.OPENVIKING_CODEX_CONFIG_FILE || defaultPath).replace(/^~/, homedir()),
+  )
+  try {
+    return readJson(configPath)
+  } catch (err) {
+    const code = (err as { code?: string })?.code
+    if (code === "ENOENT") return {}
+    process.stderr.write(`[openviking-memory] Invalid client config: ${configPath}\n`)
+    process.exit(1)
+  }
+}
+
+export type ResolvedConfig = {
+  baseUrl: string
+  apiKey: string
+  accountId: string
+  userId: string
+  agentId: string
+  timeoutMs: number
+  recallLimit: number
+  scoreThreshold: number
+}
+
+function str(value: unknown, fallback: string): string {
+  if (typeof value === "string" && value.trim()) return value.trim()
+  return fallback
+}
+
+function num(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return fallback
+}
+
+export function resolveConfig(
+  ovConf: Record<string, unknown>,
+  clientConfig: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+): ResolvedConfig {
+  const serverConfig = (ovConf.server ?? {}) as Record<string, unknown>
+  const host = str(serverConfig.host, "127.0.0.1").replace("0.0.0.0", "127.0.0.1")
+  const port = Math.floor(num(serverConfig.port, 1933))
+
+  return {
+    baseUrl: `http://${host}:${port}`,
+    apiKey: str(env.OPENVIKING_API_KEY, str(clientConfig.apiKey, str(serverConfig.root_api_key, ""))),
+    accountId: str(env.OPENVIKING_ACCOUNT, str(clientConfig.accountId, str(ovConf.default_account, "default"))),
+    userId: str(env.OPENVIKING_USER, str(clientConfig.userId, str(ovConf.default_user, "default"))),
+    agentId: str(env.OPENVIKING_AGENT_ID, str(clientConfig.agentId, str(ovConf.default_agent, "codex"))),
+    timeoutMs: Math.max(1000, Math.floor(num(env.OPENVIKING_TIMEOUT_MS, num(clientConfig.timeoutMs, 15000)))),
+    recallLimit: Math.max(1, Math.floor(num(env.OPENVIKING_RECALL_LIMIT, num(clientConfig.recallLimit, 6)))),
+    scoreThreshold: Math.min(1, Math.max(0, num(env.OPENVIKING_SCORE_THRESHOLD, num(clientConfig.scoreThreshold, 0.01)))),
+  }
+}

--- a/examples/codex-memory-plugin/src/memory-server.ts
+++ b/examples/codex-memory-plugin/src/memory-server.ts
@@ -1,10 +1,8 @@
 import { createHash } from "node:crypto"
-import { readFileSync } from "node:fs"
-import { homedir } from "node:os"
-import { join, resolve as resolvePath } from "node:path"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod"
+import { loadClientConfig, loadOvConf, resolveConfig } from "./config.js"
 
 type FindResultItem = {
   uri: string
@@ -38,39 +36,6 @@ type SystemStatus = {
   user?: unknown
 }
 
-function readJson(path: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>
-}
-
-function loadOvConf(): Record<string, unknown> {
-  const defaultPath = join(homedir(), ".openviking", "ov.conf")
-  const configPath = resolvePath(
-    (process.env.OPENVIKING_CONFIG_FILE || defaultPath).replace(/^~/, homedir()),
-  )
-  try {
-    return readJson(configPath)
-  } catch (err) {
-    const code = (err as { code?: string })?.code
-    const detail = code === "ENOENT" ? `Config file not found: ${configPath}` : `Invalid config file: ${configPath}`
-    process.stderr.write(`[openviking-memory] ${detail}\n`)
-    process.exit(1)
-  }
-}
-
-function str(value: unknown, fallback: string): string {
-  if (typeof value === "string" && value.trim()) return value.trim()
-  return fallback
-}
-
-function num(value: unknown, fallback: number): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value
-  if (typeof value === "string" && value.trim()) {
-    const parsed = Number(value)
-    if (Number.isFinite(parsed)) return parsed
-  }
-  return fallback
-}
-
 function md5Short(value: string): string {
   return createHash("md5").update(value).digest("hex").slice(0, 12)
 }
@@ -92,21 +57,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-const ovConf = loadOvConf()
-const serverConfig = (ovConf.server ?? {}) as Record<string, unknown>
-const host = str(serverConfig.host, "127.0.0.1").replace("0.0.0.0", "127.0.0.1")
-const port = Math.floor(num(serverConfig.port, 1933))
-
-const config = {
-  baseUrl: `http://${host}:${port}`,
-  apiKey: str(process.env.OPENVIKING_API_KEY, str(serverConfig.root_api_key, "")),
-  accountId: str(process.env.OPENVIKING_ACCOUNT, str(ovConf.default_account, "default")),
-  userId: str(process.env.OPENVIKING_USER, str(ovConf.default_user, "default")),
-  agentId: str(process.env.OPENVIKING_AGENT_ID, str(ovConf.default_agent, "codex")),
-  timeoutMs: Math.max(1000, Math.floor(num(process.env.OPENVIKING_TIMEOUT_MS, 15000))),
-  recallLimit: Math.max(1, Math.floor(num(process.env.OPENVIKING_RECALL_LIMIT, 6))),
-  scoreThreshold: Math.min(1, Math.max(0, num(process.env.OPENVIKING_SCORE_THRESHOLD, 0.01))),
-}
+const config = resolveConfig(loadOvConf(), loadClientConfig(), process.env)
 
 class OpenVikingClient {
   private runtimeIdentity: { userId: string; agentId: string } | null = null

--- a/examples/codex-memory-plugin/tests/config.test.mjs
+++ b/examples/codex-memory-plugin/tests/config.test.mjs
@@ -1,0 +1,111 @@
+import { strict as assert } from "node:assert"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, it } from "node:test"
+
+import { loadClientConfig, resolveConfig } from "../servers/config.js"
+
+const OV_CONF = {
+  server: { host: "127.0.0.1", port: 1933, root_api_key: "ov-key" },
+  default_account: "ov-account",
+  default_user: "ov-user",
+  default_agent: "ov-agent",
+}
+
+let tmpDir
+let originalEnv
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "codex-memory-plugin-test-"))
+  originalEnv = { ...process.env }
+  delete process.env.OPENVIKING_CODEX_CONFIG_FILE
+  delete process.env.OPENVIKING_AGENT_ID
+  delete process.env.OPENVIKING_API_KEY
+  delete process.env.OPENVIKING_ACCOUNT
+  delete process.env.OPENVIKING_USER
+  delete process.env.OPENVIKING_TIMEOUT_MS
+  delete process.env.OPENVIKING_RECALL_LIMIT
+  delete process.env.OPENVIKING_SCORE_THRESHOLD
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+  process.env = originalEnv
+})
+
+describe("loadClientConfig", () => {
+  it("returns empty object when no client config exists", () => {
+    process.env.OPENVIKING_CODEX_CONFIG_FILE = join(tmpDir, "missing.json")
+    const result = loadClientConfig(process.env)
+    assert.deepEqual(result, {})
+  })
+
+  it("reads agentId from client config when present", () => {
+    const configPath = join(tmpDir, "config.json")
+    writeFileSync(configPath, JSON.stringify({ agentId: "foo" }))
+    process.env.OPENVIKING_CODEX_CONFIG_FILE = configPath
+
+    const result = loadClientConfig(process.env)
+    assert.equal(result.agentId, "foo")
+  })
+})
+
+describe("resolveConfig precedence", () => {
+  it("uses ov.conf default when no client config or env override is set", () => {
+    const config = resolveConfig(OV_CONF, {}, {})
+    assert.equal(config.agentId, "ov-agent")
+    assert.equal(config.apiKey, "ov-key")
+    assert.equal(config.accountId, "ov-account")
+    assert.equal(config.userId, "ov-user")
+  })
+
+  it("falls back to literal defaults when ov.conf has no tenant fields set", () => {
+    const config = resolveConfig({}, {}, {})
+    assert.equal(config.agentId, "codex")
+    assert.equal(config.accountId, "default")
+    assert.equal(config.userId, "default")
+  })
+
+  it("client config overrides ov.conf default_agent", () => {
+    const config = resolveConfig(OV_CONF, { agentId: "foo" }, {})
+    assert.equal(config.agentId, "foo")
+  })
+
+  it("env var OPENVIKING_AGENT_ID overrides client config agentId", () => {
+    const config = resolveConfig(OV_CONF, { agentId: "foo" }, { OPENVIKING_AGENT_ID: "bar" })
+    assert.equal(config.agentId, "bar")
+  })
+
+  it("client config also overrides apiKey, accountId, userId, and numeric fields", () => {
+    const config = resolveConfig(OV_CONF, {
+      apiKey: "client-key",
+      accountId: "client-account",
+      userId: "client-user",
+      timeoutMs: 5000,
+      recallLimit: 12,
+      scoreThreshold: 0.5,
+    }, {})
+    assert.equal(config.apiKey, "client-key")
+    assert.equal(config.accountId, "client-account")
+    assert.equal(config.userId, "client-user")
+    assert.equal(config.timeoutMs, 5000)
+    assert.equal(config.recallLimit, 12)
+    assert.equal(config.scoreThreshold, 0.5)
+  })
+
+  it("env vars take precedence over client config for all fields", () => {
+    const config = resolveConfig(OV_CONF, {
+      apiKey: "client-key",
+      agentId: "client-agent",
+      timeoutMs: 5000,
+    }, {
+      OPENVIKING_API_KEY: "env-key",
+      OPENVIKING_AGENT_ID: "env-agent",
+      OPENVIKING_TIMEOUT_MS: "9000",
+    })
+    assert.equal(config.apiKey, "env-key")
+    assert.equal(config.agentId, "env-agent")
+    assert.equal(config.timeoutMs, 9000)
+  })
+})


### PR DESCRIPTION
## Description

Adds a per-plugin client config file to `codex-memory-plugin`, mirroring the pattern that already exists in `claude-code-memory-plugin`. The Codex plugin previously had no client-side `config.json`; the only ways to point it at a non-default `agentId` were a process env var (`OPENVIKING_AGENT_ID`) or `ov.conf default_agent`. The latter is shared with the bare `ov` CLI, and the former forces users to wire env into their MCP server config.

This PR closes the gap so the two plugins now share the same config story.

## Why

The Claude plugin already supports this layout — `examples/claude-code-memory-plugin/servers/memory-server.js` reads `OPENVIKING_CC_CONFIG_FILE || ~/.openviking/claude-code-memory-plugin/config.json` and exposes `agentId`, `apiKey`, and the rest as configurable fields. The Codex plugin diverged: it accepted env vars but not a client-side JSON, which forced agent-id wiring into Codex's `mcp_servers` env block. Bringing Codex up to parity removes that asymmetry.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `examples/codex-memory-plugin/src/config.ts` exposing `loadOvConf`, `loadClientConfig`, and `resolveConfig`. Client config defaults to `~/.openviking/codex-memory-plugin/config.json` and is overridable via `OPENVIKING_CODEX_CONFIG_FILE`.
- Refactor `examples/codex-memory-plugin/src/memory-server.ts` to consume `resolveConfig`. Inline config loading is removed; behavior is preserved (same fallbacks, same identity headers).
- Add `examples/codex-memory-plugin/tests/config.test.mjs` (`node --test`) covering: missing client config, present client config, env-var overrides, and multi-source precedence.
- Wire a `test` script into `package.json` so `npm test` builds and runs the new suite.
- Document the new config file, env override, and full precedence ladder in `examples/codex-memory-plugin/README.md`.

Precedence (highest to lowest), preserved from the original server: env var (e.g. `OPENVIKING_AGENT_ID`) -> client config (`~/.openviking/codex-memory-plugin/config.json`) -> `ov.conf` default (`default_account`/`default_user`/`default_agent`) -> literal fallback (`default` for tenant ids, `codex` for agentId, etc.).

## Example

Create the config:

```json
// ~/.openviking/codex-memory-plugin/config.json
{
  "agentId": "codex"
}
```

Run the plugin without setting `OPENVIKING_AGENT_ID`:

```sh
node examples/codex-memory-plugin/servers/memory-server.js
```

The plugin now sends `X-OpenViking-Agent: codex` on every request, with no env var required.

Override via env still works for ephemeral overrides:

```sh
OPENVIKING_AGENT_ID=experimental node examples/codex-memory-plugin/servers/memory-server.js
```

## Testing

- [x] `npm install` (no new deps)
- [x] `npm run build` (clean)
- [x] `npm test` -> 8/8 pass
- [x] Tested on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test cases (all in `tests/config.test.mjs`):

```
loadClientConfig
  ok returns empty object when no client config exists
  ok reads agentId from client config when present
resolveConfig precedence
  ok uses ov.conf default when no client config or env override is set
  ok falls back to literal defaults when ov.conf has no tenant fields set
  ok client config overrides ov.conf default_agent
  ok env var OPENVIKING_AGENT_ID overrides client config agentId
  ok client config also overrides apiKey, accountId, userId, and numeric fields
  ok env vars take precedence over client config for all fields
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

No breaking changes. Existing setups that use `OPENVIKING_AGENT_ID` env or `ov.conf default_agent` keep working unchanged; the new client config is purely additive and optional. All existing fallbacks (account/user defaults to `"default"`, agent defaults to `"codex"`) are preserved exactly as they were.
