### PR TITLE
feat(resources): add durable resource metadata

### DIFF
--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -49,6 +49,7 @@ Add a resource to the knowledge base.
 | wait | bool | No | False | Wait for semantic processing to complete |
 | timeout | float | No | None | Timeout in seconds (only used when wait=True) |
 | watch_interval | float | No | 0 | Watch interval (minutes). >0 enables/updates watch; <=0 disables watch. Only takes effect when `to` is provided |
+| metadata | object | No | None | Durable JSON metadata stored with the resource directory and returned by `GET /api/v1/fs/stat` |
 
 `POST /api/v1/resources` uses `to` in JSON. CLI uses `--to`.
 
@@ -60,6 +61,53 @@ Add a resource to the knowledge base.
   - Local file: call `POST /api/v1/resources/temp_upload` first, then pass the returned `temp_file_id`
   - Local directory: zip it first, upload the `.zip` file, then pass the returned `temp_file_id`
 - `POST /api/v1/resources` does not accept direct host filesystem paths such as `./guide.md`, `/tmp/guide.md`, or `/tmp/my-dir/`.
+
+**Resource metadata**
+
+Callers can attach a JSON object when adding a resource. The metadata is stored with the
+resource directory and does not participate in semantic processing or vectorization.
+
+```bash
+curl -X POST http://localhost:1933/api/v1/resources \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "path": "https://example.com/guide.md",
+    "to": "viking://resources/guides/example",
+    "metadata": {
+      "source": {"kind": "web", "id": "guide"},
+      "sync": {"etag": "abc123"}
+    }
+  }'
+```
+
+Read it back through filesystem stat:
+
+```bash
+curl "http://localhost:1933/api/v1/fs/stat?uri=viking://resources/guides/example" \
+  -H "X-API-Key: your-key"
+```
+
+Patch metadata without re-importing or reprocessing content:
+
+```
+PATCH /api/v1/resources/metadata
+```
+
+```bash
+curl -X PATCH http://localhost:1933/api/v1/resources/metadata \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "uri": "viking://resources/guides/example",
+    "patch": {
+      "sync": {"etag": "def456"},
+      "stale": null
+    }
+  }'
+```
+
+The patch is a JSON object merge: nested objects are merged, and `null` removes a field.
 
 **Incremental Updates**
 

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -49,6 +49,7 @@ Input -> Parser -> TreeBuilder -> AGFS -> SemanticQueue -> Vector Index
 | wait | bool | 否 | False | 等待语义处理完成 |
 | timeout | float | 否 | None | 超时时间（秒），仅在 wait=True 时生效 |
 | watch_interval | float | 否 | 0 | 定时更新间隔（分钟）。>0 开启/更新定时任务；<=0 关闭（停用）定时任务。仅在指定 `to` 时生效 |
+| metadata | object | 否 | None | 随资源目录持久保存的 JSON 元数据，可通过 `GET /api/v1/fs/stat` 返回 |
 
 `POST /api/v1/resources` 的 JSON 字段名是 `to`；CLI 对应参数是 `--to`。
 
@@ -60,6 +61,53 @@ Input -> Parser -> TreeBuilder -> AGFS -> SemanticQueue -> Vector Index
   - 本地文件：先调用 `POST /api/v1/resources/temp_upload`，再把返回的 `temp_file_id` 传给目标 API
   - 本地目录：先自行打成 `.zip`，上传该压缩包，再把返回的 `temp_file_id` 传给目标 API
 - `POST /api/v1/resources` 不接受 `./guide.md`、`/tmp/guide.md`、`/tmp/my-dir/` 这类宿主机本地路径。
+
+**资源元数据**
+
+添加资源时可以附带一个 JSON object。该元数据会随资源目录持久保存，
+不会参与语义处理或向量化。
+
+```bash
+curl -X POST http://localhost:1933/api/v1/resources \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "path": "https://example.com/guide.md",
+    "to": "viking://resources/guides/example",
+    "metadata": {
+      "source": {"kind": "web", "id": "guide"},
+      "sync": {"etag": "abc123"}
+    }
+  }'
+```
+
+通过 filesystem stat 读取：
+
+```bash
+curl "http://localhost:1933/api/v1/fs/stat?uri=viking://resources/guides/example" \
+  -H "X-API-Key: your-key"
+```
+
+无需重新导入或重新处理内容即可更新元数据：
+
+```
+PATCH /api/v1/resources/metadata
+```
+
+```bash
+curl -X PATCH http://localhost:1933/api/v1/resources/metadata \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "uri": "viking://resources/guides/example",
+    "patch": {
+      "sync": {"etag": "def456"},
+      "stale": null
+    }
+  }'
+```
+
+patch 是 JSON object merge：嵌套 object 会合并，`null` 表示删除字段。
 
 **增量更新（Incremental Update）**
 

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -222,6 +222,7 @@ class AsyncOpenViking:
         build_index: bool = True,
         summarize: bool = False,
         watch_interval: float = 0,
+        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -256,7 +257,22 @@ class AsyncOpenViking:
             summarize=summarize,
             telemetry=telemetry,
             watch_interval=watch_interval,
+            metadata=metadata,
             **kwargs,
+        )
+
+    async def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Patch durable metadata for a resource without reprocessing content."""
+        await self._ensure_initialized()
+        return await self._client.patch_resource_metadata(
+            uri=uri,
+            patch=patch,
+            telemetry=telemetry,
         )
 
     @property

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -222,8 +222,8 @@ class AsyncOpenViking:
         build_index: bool = True,
         summarize: bool = False,
         watch_interval: float = 0,
-        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -99,6 +99,7 @@ class LocalClient(BaseClient):
         summarize: bool = False,
         telemetry: TelemetryRequest = False,
         watch_interval: float = 0,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking."""
@@ -120,7 +121,29 @@ class LocalClient(BaseClient):
                 build_index=build_index,
                 summarize=summarize,
                 watch_interval=watch_interval,
+                metadata=metadata,
                 **kwargs,
+            ),
+        )
+        return attach_telemetry_payload(
+            execution.result,
+            execution.telemetry,
+        )
+
+    async def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Patch durable metadata for a resource."""
+        execution = await run_with_telemetry(
+            operation="resources.patch_metadata",
+            telemetry=telemetry,
+            fn=lambda: self._service.resources.patch_resource_metadata(
+                uri=uri,
+                patch=patch,
+                ctx=self._ctx,
             ),
         )
         return attach_telemetry_payload(

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -61,6 +61,7 @@ class AddResourceRequest(BaseModel):
             Note: If the target URI already has an active watch task, a ConflictError will be
             raised. You must first cancel the existing watch (set watch_interval <= 0) before
             creating a new one.
+        metadata: Durable resource metadata stored with the imported resource directory.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -82,12 +83,23 @@ class AddResourceRequest(BaseModel):
     preserve_structure: Optional[bool] = None
     telemetry: TelemetryRequest = False
     watch_interval: float = 0
+    metadata: Optional[dict[str, Any]] = None
 
     @model_validator(mode="after")
     def check_path_or_temp_file_id(self):
         if not self.path and not self.temp_file_id:
             raise ValueError("Either 'path' or 'temp_file_id' must be provided")
         return self
+
+
+class PatchResourceMetadataRequest(BaseModel):
+    """Request model for patching durable resource metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    uri: str
+    patch: dict[str, Any]
+    telemetry: TelemetryRequest = False
 
 
 class AddSkillRequest(BaseModel):
@@ -215,7 +227,7 @@ async def add_resource(
     if source_name is None and original_filename is not None:
         source_name = original_filename
 
-    kwargs = {
+    kwargs: dict[str, Any] = {
         "strict": request.strict,
         "source_name": source_name,
         "ignore_dirs": request.ignore_dirs,
@@ -239,9 +251,33 @@ async def add_resource(
             instruction=request.instruction,
             wait=request.wait,
             timeout=request.timeout,
+            metadata=request.metadata,
             allow_local_path_resolution=allow_local_path_resolution,
             enforce_public_remote_targets=True,
             **kwargs,
+        ),
+    )
+    return Response(
+        status="ok",
+        result=execution.result,
+        telemetry=execution.telemetry,
+    ).model_dump(exclude_none=True)
+
+
+@router.patch("/resources/metadata")
+async def patch_resource_metadata(
+    request: PatchResourceMetadataRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Patch durable metadata for a resource."""
+    service = get_service()
+    execution = await run_operation(
+        operation="resources.patch_metadata",
+        telemetry=request.telemetry,
+        fn=lambda: service.resources.patch_resource_metadata(
+            uri=request.uri,
+            patch=request.patch,
+            ctx=_ctx,
         ),
     )
     return Response(

--- a/openviking/server/routers/webdav.py
+++ b/openviking/server/routers/webdav.py
@@ -30,6 +30,7 @@ _RESERVED_FILENAMES = frozenset(
         ".abstract.md",
         ".overview.md",
         ".relations.json",
+        ".resource.metadata.json",
         ".path.ovlock",
     }
 )

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -174,7 +174,7 @@ class FSService:
     async def stat(self, uri: str, ctx: RequestContext) -> Dict[str, Any]:
         """Get resource status."""
         viking_fs = self._ensure_initialized()
-        return await viking_fs.stat(uri, ctx=ctx)
+        return await viking_fs.stat(uri, ctx=ctx, include_metadata=True)
 
     async def read(self, uri: str, ctx: RequestContext, offset: int = 0, limit: int = -1) -> str:
         """Read file content."""

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -114,6 +114,7 @@ class ResourceService:
         build_index: bool = True,
         summarize: bool = False,
         watch_interval: float = 0,
+        metadata: Optional[Dict[str, Any]] = None,
         skip_watch_management: bool = False,
         allow_local_path_resolution: bool = True,
         enforce_public_remote_targets: bool = False,
@@ -156,6 +157,12 @@ class ResourceService:
             InvalidArgumentError: If the URI scope is not 'resources'
         """
         self._ensure_initialized()
+        viking_fs = self._viking_fs
+        resource_processor = self._resource_processor
+        assert viking_fs is not None
+        assert resource_processor is not None
+        if metadata is not None:
+            metadata = viking_fs.normalize_resource_metadata(metadata)
         request_start = time.perf_counter()
         telemetry = get_current_telemetry()
         telemetry_id = register_wait_telemetry(wait)
@@ -194,7 +201,7 @@ class ResourceService:
                 path = require_remote_resource_source(path)
                 kwargs.setdefault("request_validator", ensure_public_remote_target)
 
-            result = await self._resource_processor.process_resource(
+            result = await resource_processor.process_resource(
                 path=path,
                 ctx=ctx,
                 reason=reason,
@@ -207,6 +214,10 @@ class ResourceService:
                 allow_local_path_resolution=allow_local_path_resolution,
                 **kwargs,
             )
+
+            root_uri = result.get("root_uri")
+            if metadata is not None and root_uri:
+                await viking_fs.write_resource_metadata(root_uri, metadata, ctx=ctx)
 
             if wait:
                 wait_start = time.perf_counter()
@@ -294,6 +305,25 @@ class ResourceService:
             )
             get_request_wait_tracker().cleanup(telemetry_id)
             unregister_wait_telemetry(telemetry_id)
+
+    async def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        ctx: RequestContext,
+    ) -> Dict[str, Any]:
+        """Patch durable resource metadata without reprocessing content."""
+        self._ensure_initialized()
+        viking_fs = self._viking_fs
+        assert viking_fs is not None
+        parsed = VikingURI(uri)
+        if parsed.scope != "resources":
+            raise InvalidArgumentError(
+                f"resource metadata only supports resources scope, got {parsed.scope}"
+            )
+
+        metadata = await viking_fs.patch_resource_metadata(uri, patch, ctx=ctx)
+        return {"uri": uri, "metadata": metadata}
 
     async def _handle_watch_task_creation(
         self,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -114,10 +114,10 @@ class ResourceService:
         build_index: bool = True,
         summarize: bool = False,
         watch_interval: float = 0,
-        metadata: Optional[Dict[str, Any]] = None,
         skip_watch_management: bool = False,
         allow_local_path_resolution: bool = True,
         enforce_public_remote_targets: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking (only supports resources scope).

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -29,7 +29,9 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-_DERIVED_FILENAMES = frozenset({".abstract.md", ".overview.md", ".relations.json"})
+_DERIVED_FILENAMES = frozenset(
+    {".abstract.md", ".overview.md", ".relations.json", ".resource.metadata.json"}
+)
 _CREATE_ALLOWED_EXTENSIONS = frozenset(
     {".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".py", ".js", ".ts"}
 )

--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -15,7 +15,7 @@ from openviking_cli.utils.uri import VikingURI
 
 logger = get_logger(__name__)
 
-_DERIVED_FILENAMES = frozenset({".relations.json"})
+_DERIVED_FILENAMES = frozenset({".relations.json", ".resource.metadata.json"})
 
 _UNSAFE_PATH_RE = re.compile(r"(^|[\\/])\.\.($|[\\/])")
 _DRIVE_RE = re.compile(r"^[A-Za-z]:")

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+RESOURCE_METADATA_FILENAME = ".resource.metadata.json"
+
 
 def _ensure_non_empty_search_query(query: str) -> None:
     if not query.strip():
@@ -211,6 +213,7 @@ class VikingFS:
         self.rerank_config = rerank_config
         self.vector_store = vector_store
         self._encryptor = encryptor
+        self._resource_metadata_locks: dict[str, asyncio.Lock] = {}
         self._bound_ctx: contextvars.ContextVar[Optional[RequestContext]] = contextvars.ContextVar(
             "vikingfs_bound_ctx", default=None
         )
@@ -701,7 +704,12 @@ class VikingFS:
             "files_scanned": files_scanned,
         }
 
-    async def stat(self, uri: str, ctx: Optional[RequestContext] = None) -> Dict[str, Any]:
+    async def stat(
+        self,
+        uri: str,
+        ctx: Optional[RequestContext] = None,
+        include_metadata: bool = False,
+    ) -> Dict[str, Any]:
         """
         File/directory information.
 
@@ -709,7 +717,12 @@ class VikingFS:
         """
         self._ensure_access(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
-        return self.agfs.stat(path)
+        info = dict(self.agfs.stat(path))
+        if include_metadata and info.get("isDir"):
+            metadata = await self._read_resource_metadata(uri, ctx=ctx)
+            if metadata is not None:
+                info["metadata"] = metadata
+        return info
 
     async def exists(self, uri: str, ctx: Optional[RequestContext] = None) -> bool:
         """Check if a URI exists.
@@ -1392,6 +1405,99 @@ class VikingFS:
             return f"viking:/{path}"
         else:
             return f"viking://{path}"
+
+    @staticmethod
+    def _resource_metadata_uri(uri: str) -> str:
+        return f"{uri.rstrip('/')}/{RESOURCE_METADATA_FILENAME}"
+
+    @staticmethod
+    def normalize_resource_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(metadata, dict):
+            raise InvalidArgumentError("resource metadata must be a JSON object")
+        try:
+            return json.loads(json.dumps(metadata, ensure_ascii=False))
+        except TypeError as exc:
+            raise InvalidArgumentError("resource metadata must be JSON serializable") from exc
+
+    @classmethod
+    def _apply_resource_metadata_patch(
+        cls,
+        current: Dict[str, Any],
+        patch: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        result = dict(current)
+        for key, value in patch.items():
+            if value is None:
+                result.pop(key, None)
+                continue
+            existing = result.get(key)
+            if isinstance(existing, dict) and isinstance(value, dict):
+                result[key] = cls._apply_resource_metadata_patch(existing, value)
+            else:
+                result[key] = value
+        return result
+
+    async def _read_resource_metadata(
+        self,
+        uri: str,
+        ctx: Optional[RequestContext] = None,
+    ) -> Optional[Dict[str, Any]]:
+        metadata_uri = self._resource_metadata_uri(uri)
+        try:
+            raw_metadata = await self.read_file(metadata_uri, ctx=ctx)
+        except NotFoundError:
+            return None
+
+        try:
+            metadata = json.loads(raw_metadata)
+        except json.JSONDecodeError:
+            logger.warning(f"[VikingFS] Ignoring invalid resource metadata at {metadata_uri}")
+            return None
+        if not isinstance(metadata, dict):
+            logger.warning(f"[VikingFS] Ignoring non-object resource metadata at {metadata_uri}")
+            return None
+        return metadata
+
+    async def write_resource_metadata(
+        self,
+        uri: str,
+        metadata: Dict[str, Any],
+        ctx: Optional[RequestContext] = None,
+    ) -> Dict[str, Any]:
+        """Persist durable metadata for a resource directory."""
+        self._ensure_mutable_access(uri, ctx)
+        path = self._uri_to_path(uri, ctx=ctx)
+        stat = self.agfs.stat(path)
+        if not stat.get("isDir"):
+            raise InvalidArgumentError(f"resource metadata can only be set on directories: {uri}")
+
+        normalized_metadata = self.normalize_resource_metadata(metadata)
+        metadata_uri = self._resource_metadata_uri(uri)
+        metadata_json = json.dumps(
+            normalized_metadata,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        await self.write_file(metadata_uri, metadata_json + "\n", ctx=ctx)
+        return normalized_metadata
+
+    async def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        ctx: Optional[RequestContext] = None,
+    ) -> Dict[str, Any]:
+        """Merge durable metadata into a resource directory without reprocessing content."""
+        real_ctx = self._ctx_or_default(ctx)
+        canonical_uri = canonicalize_uri(uri, real_ctx)
+        metadata_lock = self._resource_metadata_locks.setdefault(canonical_uri, asyncio.Lock())
+
+        async with metadata_lock:
+            normalized_patch = self.normalize_resource_metadata(patch)
+            current = await self._read_resource_metadata(canonical_uri, ctx=real_ctx) or {}
+            updated = self._apply_resource_metadata_patch(current, normalized_patch)
+            return await self.write_resource_metadata(canonical_uri, updated, ctx=real_ctx)
 
     def _looks_like_legacy_temp_leaf(self, value: str) -> bool:
         return bool(re.match(r"^\d{8}_[0-9a-f]{6}$", value or ""))

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -116,8 +116,8 @@ class SyncOpenViking:
         timeout: float = None,
         build_index: bool = True,
         summarize: bool = False,
-        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking (resources scope only)

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -116,6 +116,7 @@ class SyncOpenViking:
         timeout: float = None,
         build_index: bool = True,
         summarize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -140,8 +141,24 @@ class SyncOpenViking:
                 timeout=timeout,
                 build_index=build_index,
                 summarize=summarize,
+                metadata=metadata,
                 telemetry=telemetry,
                 **kwargs,
+            )
+        )
+
+    def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Patch durable metadata for a resource."""
+        return run_async(
+            self._async_client.patch_resource_metadata(
+                uri=uri,
+                patch=patch,
+                telemetry=telemetry,
             )
         )
 

--- a/openviking_cli/client/base.py
+++ b/openviking_cli/client/base.py
@@ -42,8 +42,8 @@ class BaseClient(ABC):
         wait: bool = False,
         timeout: Optional[float] = None,
         watch_interval: float = 0,
-        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking."""
         ...

--- a/openviking_cli/client/base.py
+++ b/openviking_cli/client/base.py
@@ -42,9 +42,20 @@ class BaseClient(ABC):
         wait: bool = False,
         timeout: Optional[float] = None,
         watch_interval: float = 0,
+        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking."""
+        ...
+
+    @abstractmethod
+    async def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Patch durable metadata for a resource."""
         ...
 
     @abstractmethod

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -338,6 +338,7 @@ class AsyncHTTPClient(BaseClient):
         exclude: Optional[str] = None,
         directly_upload_media: bool = True,
         preserve_structure: Optional[bool] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking."""
@@ -357,6 +358,7 @@ class AsyncHTTPClient(BaseClient):
             "include": include,
             "exclude": exclude,
             "directly_upload_media": directly_upload_media,
+            "metadata": metadata,
             "telemetry": telemetry,
         }
         if preserve_structure is not None:
@@ -385,6 +387,26 @@ class AsyncHTTPClient(BaseClient):
         response = await self._http.post(
             "/api/v1/resources",
             json=request_data,
+        )
+        response_data = self._handle_response_data(response)
+        return self._attach_telemetry(response_data.get("result"), response_data)
+
+    async def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Patch durable metadata for a resource."""
+        telemetry = self._validate_telemetry(telemetry)
+        uri = VikingURI.normalize(uri)
+        response = await self._http.patch(
+            "/api/v1/resources/metadata",
+            json={
+                "uri": uri,
+                "patch": patch,
+                "telemetry": telemetry,
+            },
         )
         response_data = self._handle_response_data(response)
         return self._attach_telemetry(response_data.get("result"), response_data)

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -338,8 +338,8 @@ class AsyncHTTPClient(BaseClient):
         exclude: Optional[str] = None,
         directly_upload_media: bool = True,
         preserve_structure: Optional[bool] = None,
-        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking."""
         telemetry = self._validate_telemetry(telemetry)

--- a/openviking_cli/client/sync_http.py
+++ b/openviking_cli/client/sync_http.py
@@ -162,6 +162,7 @@ class SyncHTTPClient:
         include: Optional[str] = None,
         exclude: Optional[str] = None,
         directly_upload_media: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking."""
@@ -169,18 +170,34 @@ class SyncHTTPClient:
             raise ValueError("Cannot specify both 'to' and 'parent' at the same time.")
         return run_async(
             self._async_client.add_resource(
-                path,
-                to,
-                parent,
-                reason,
-                instruction,
-                wait,
-                timeout,
-                strict,
-                ignore_dirs,
-                include,
-                exclude,
-                directly_upload_media,
+                path=path,
+                to=to,
+                parent=parent,
+                reason=reason,
+                instruction=instruction,
+                wait=wait,
+                timeout=timeout,
+                strict=strict,
+                ignore_dirs=ignore_dirs,
+                include=include,
+                exclude=exclude,
+                directly_upload_media=directly_upload_media,
+                metadata=metadata,
+                telemetry=telemetry,
+            )
+        )
+
+    def patch_resource_metadata(
+        self,
+        uri: str,
+        patch: Dict[str, Any],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Patch durable metadata for a resource."""
+        return run_async(
+            self._async_client.patch_resource_metadata(
+                uri=uri,
+                patch=patch,
                 telemetry=telemetry,
             )
         )

--- a/openviking_cli/client/sync_http.py
+++ b/openviking_cli/client/sync_http.py
@@ -162,8 +162,8 @@ class SyncHTTPClient:
         include: Optional[str] = None,
         exclude: Optional[str] = None,
         directly_upload_media: bool = True,
-        metadata: Optional[Dict[str, Any]] = None,
         telemetry: TelemetryRequest = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Add resource to OpenViking."""
         if to and parent:

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -33,6 +33,136 @@ async def test_add_resource_success(
     assert body["result"]["root_uri"].startswith("viking://")
 
 
+async def test_add_resource_with_metadata_persists_to_stat(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    metadata = {
+        "source": {"kind": "docs", "id": "guide"},
+        "sync": {"etag": "abc123"},
+    }
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "metadata resource",
+            "metadata": metadata,
+        },
+    )
+    assert resp.status_code == 200
+    root_uri = resp.json()["result"]["root_uri"]
+
+    stat_resp = await client.get("/api/v1/fs/stat", params={"uri": root_uri})
+    assert stat_resp.status_code == 200
+    assert stat_resp.json()["result"]["metadata"] == metadata
+
+
+async def test_add_resource_rejects_non_object_metadata(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "metadata resource",
+            "metadata": ["not", "an", "object"],
+        },
+    )
+    assert resp.status_code == 422
+
+
+async def test_patch_resource_metadata_merges_and_deletes_fields(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "metadata patch resource",
+            "metadata": {
+                "source": {"kind": "docs", "etag": "v1"},
+                "remove_me": True,
+            },
+        },
+    )
+    assert resp.status_code == 200
+    root_uri = resp.json()["result"]["root_uri"]
+
+    patch_resp = await client.patch(
+        "/api/v1/resources/metadata",
+        json={
+            "uri": root_uri,
+            "patch": {
+                "source": {"etag": "v2"},
+                "status": "active",
+                "remove_me": None,
+            },
+        },
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["result"]["metadata"] == {
+        "source": {"kind": "docs", "etag": "v2"},
+        "status": "active",
+    }
+
+    stat_resp = await client.get("/api/v1/fs/stat", params={"uri": root_uri})
+    assert stat_resp.status_code == 200
+    assert stat_resp.json()["result"]["metadata"] == {
+        "source": {"kind": "docs", "etag": "v2"},
+        "status": "active",
+    }
+
+
+async def test_patch_resource_metadata_creates_metadata_when_missing(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "metadata patch resource",
+        },
+    )
+    assert resp.status_code == 200
+    root_uri = resp.json()["result"]["root_uri"]
+
+    patch_resp = await client.patch(
+        "/api/v1/resources/metadata",
+        json={"uri": root_uri, "patch": {"source": {"id": "new"}}},
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["result"]["metadata"] == {"source": {"id": "new"}}
+
+
+async def test_patch_resource_metadata_rejects_non_object_patch(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "metadata patch resource",
+        },
+    )
+    assert resp.status_code == 200
+    root_uri = resp.json()["result"]["root_uri"]
+
+    patch_resp = await client.patch(
+        "/api/v1/resources/metadata",
+        json={"uri": root_uri, "patch": ["not", "an", "object"]},
+    )
+    assert patch_resp.status_code == 422
+
+
 async def test_add_resource_with_wait(
     client: httpx.AsyncClient,
     sample_markdown_file,

--- a/tests/server/test_http_client_sdk.py
+++ b/tests/server/test_http_client_sdk.py
@@ -48,11 +48,29 @@ async def test_sdk_add_resource(http_client):
     f.parent.mkdir(parents=True, exist_ok=True)
     f.write_text(SAMPLE_MD_CONTENT)
 
-    result = await client.add_resource(path=str(f), reason="sdk test", wait=True)
+    metadata = {"source": {"kind": "sdk", "etag": "v1"}}
+    result = await client.add_resource(
+        path=str(f),
+        reason="sdk test",
+        wait=True,
+        metadata=metadata,
+    )
     assert "usage" not in result
     assert "telemetry" not in result
     assert "root_uri" in result
     assert result["root_uri"].startswith("viking://")
+
+    stat = await client.stat(result["root_uri"])
+    assert stat["metadata"] == metadata
+
+    patched = await client.patch_resource_metadata(
+        result["root_uri"],
+        {"source": {"etag": "v2"}, "status": "active"},
+    )
+    assert patched["metadata"] == {
+        "source": {"kind": "sdk", "etag": "v2"},
+        "status": "active",
+    }
 
 
 async def test_sdk_add_skill_from_local_file(http_client):


### PR DESCRIPTION
## Description

This adds a small durable metadata surface for resource directories.

Integrations that import external systems often need to remember stable,
machine-readable state next to the imported resource: source IDs, source
kind, ETags, sync cursors, provenance, or lifecycle flags. Today the resource
API has `reason` and `instruction`, but those fields are ingestion context,
not a durable metadata API. If a caller only wants to update an upstream ETag
after a sync, the available options are awkward:

- Re-import the resource so the new state is attached indirectly, which can
  re-run parsing, summaries, embeddings, and queue work even though the user
  content did not change.
- Write an app-specific file inside the resource tree, which makes integration
  bookkeeping look like user content and risks surfacing through file views or
  content processing.
- Keep a side database outside OpenViking, which splits the source of truth
  for a resource between OpenViking and the integration.

This PR adds:

- Optional `metadata` on `POST /api/v1/resources`.
- `metadata` in `GET /api/v1/fs/stat` responses when a resource directory has
  metadata.
- `PATCH /api/v1/resources/metadata` for merge-style metadata updates without
  reprocessing resource content.
- SDK support for `add_resource(..., metadata=...)` and
  `patch_resource_metadata(...)`.

Metadata is stored as a hidden sidecar file and is excluded from WebDAV
listings, direct content-write/import surfaces, and semantic processing.

## Example

Current integration behavior is missing a clean place for source state:

```json
{
  "temp_file_id": "uploaded-calendar-event.md",
  "reason": "calendar sync",
  "instruction": "keep this available for retrieval"
}
```

After the import, a sync worker may need to remember:

```json
{
  "source": {
    "kind": "calendar",
    "id": "evt_123"
  },
  "sync": {
    "etag": "v1"
  }
}
```

Before this PR, updating only `sync.etag` to `v2` means either re-importing
the resource or storing that state somewhere outside OpenViking.

With this PR, the state can live with the resource without becoming resource
content:

```http
POST /api/v1/resources
{
  "temp_file_id": "uploaded-calendar-event.md",
  "reason": "calendar sync",
  "metadata": {
    "source": {
      "kind": "calendar",
      "id": "evt_123"
    },
    "sync": {
      "etag": "v1"
    }
  }
}
```

```http
GET /api/v1/fs/stat?uri=viking://resources/calendar/evt_123
```

```json
{
  "metadata": {
    "source": {
      "kind": "calendar",
      "id": "evt_123"
    },
    "sync": {
      "etag": "v1"
    }
  }
}
```

Later, updating the change detector does not need a re-import:

```http
PATCH /api/v1/resources/metadata
{
  "uri": "viking://resources/calendar/evt_123",
  "patch": {
    "sync": {
      "etag": "v2"
    },
    "stale": null
  }
}
```

## Related Issue

None.

## Changes Made

- Added durable JSON-object metadata storage for resource directories.
- Added merge-patch semantics where nested objects merge and `null` removes a
  field.
- Added server, service, local client, async HTTP client, sync HTTP client,
  and high-level SDK methods.
- Hid the metadata sidecar from WebDAV and user content/import paths.
- Added API documentation in English and Chinese.
- Added API and SDK tests for create, stat, patch, validation, and delete-by-
  null behavior.

## Testing

- `uv run ruff check openviking/async_client.py openviking/client/local.py openviking/server/routers/resources.py openviking/server/routers/webdav.py openviking/service/fs_service.py openviking/service/resource_service.py openviking/storage/content_write.py openviking/storage/local_fs.py openviking/storage/viking_fs.py openviking/sync_client.py openviking_cli/client/base.py openviking_cli/client/http.py openviking_cli/client/sync_http.py tests/server/test_api_resources.py tests/server/test_http_client_sdk.py`
- `git diff --check upstream/main..HEAD`
- `uv run --all-extras pytest tests/server/test_api_resources.py -q`
- `uv run --all-extras pytest tests/server/test_http_client_sdk.py::test_sdk_add_resource -q`
