### PR TITLE
docs(s3fs): document endpoint scheme auto-prefix from #1701

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -772,9 +772,9 @@ RAGFS uses Rust binding mode by default, directly accessing the file system thro
 | `region` | str | AWS region where the bucket is located (e.g., us-east-1, cn-beijing) | null |
 | `access_key` | str | S3 access key ID | null |
 | `secret_key` | str | S3 secret access key corresponding to the access key ID | null |
-| `endpoint` | str | Custom S3 endpoint URL, required for S3-compatible services like MinIO or LocalStack | null |
+| `endpoint` | str | Custom S3 endpoint, required for S3-compatible services like MinIO or LocalStack. Accepts a full URL (`https://...` or `http://...`) or a bare hostname; bare hostnames are auto-prefixed with `https://` or `http://` based on `use_ssl` | null |
 | `prefix` | str | Optional key prefix for namespace isolation | "" |
-| `use_ssl` | bool | Enable/disable SSL (HTTPS) for S3 connections | true |
+| `use_ssl` | bool | Enable/disable SSL (HTTPS) for S3 connections. Also controls the scheme auto-prefixed onto bare-hostname `endpoint` values | true |
 | `use_path_style` | bool | true for PathStyle used by MinIO and some S3-compatible services; false for VirtualHostStyle used by TOS and some S3-compatible services | true |
 | `directory_marker_mode` | str | How to persist directory markers: `none`, `empty`, or `nonempty` | `"empty"` |
 | `normalize_encoding` | bool | Escape only URL-reserved or URL-unsafe characters in S3 object keys as `!HH` hexadecimal bytes while preserving safe characters | `true` |

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -745,9 +745,9 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 | `region` | str | 存储桶所在的 AWS 区域（例如 us-east-1, cn-beijing） | null |
 | `access_key` | str | S3 访问密钥 ID | null |
 | `secret_key` | str | 与访问密钥 ID 对应的 S3 秘密访问密钥 | null |
-| `endpoint` | str | 自定义 S3 端点 URL，对于 MinIO 或 LocalStack 等 S3 兼容服务是必需的 | null |
+| `endpoint` | str | 自定义 S3 端点，对于 MinIO 或 LocalStack 等 S3 兼容服务是必需的。可以填完整 URL（`https://...` 或 `http://...`），也可以只填主机名；只填主机名时会根据 `use_ssl` 自动补 `https://` 或 `http://` | null |
 | `prefix` | str | 用于命名空间隔离的可选键前缀 | "" |
-| `use_ssl` | bool | 为 S3 连接启用/禁用 SSL（HTTPS） | true |
+| `use_ssl` | bool | 为 S3 连接启用/禁用 SSL（HTTPS）。也用于决定 `endpoint` 仅填主机名时自动补的协议前缀 | true |
 | `use_path_style` | bool | true 表示对 MinIO 和某些 S3 兼容服务使用 PathStyle；false 表示对 TOS 和某些 S3 兼容服务使用 VirtualHostStyle | true |
 | `directory_marker_mode` | str | 目录 marker 的持久化方式，可选 `none`、`empty`、`nonempty` | `"empty"` |
 | `normalize_encoding` | bool | 仅把 S3 object key 中 URL 保留字符或不安全字符转义为 `!HH` 十六进制字节，同时保留安全字符 | `true` |


### PR DESCRIPTION
The `s3fs` plugin gained scheme auto-prefix in [#1701](https://github.com/volcengine/OpenViking/pull/1701) (zexuyann, merged 2026-04-25): bare-hostname `endpoint` values are now wrapped with `https://` (or `http://` when `use_ssl=false`). The configuration table still described `endpoint` as a "URL" only, and `use_ssl` made no mention of governing the auto-prefixed scheme — but the existing examples in this same doc (`"endpoint": "s3.amazonaws.com"`, lines 813 / 837 en, 786 / 810 zh) already pass bare hostnames, so users had to read the Rust client source to know the behavior is intentional.

This PR mirrors the change into both language docs:

- `endpoint`: clarify both `https://...` / `http://...` URLs and bare hostnames are accepted; bare hostnames get auto-prefixed based on `use_ssl`
- `use_ssl`: note that it also drives the scheme used when an endpoint is given as a bare hostname

Pure docs, identical edits in `docs/en/guides/01-configuration.md` and `docs/zh/guides/01-configuration.md`. No behavior change.

Source for the auto-prefix logic: `crates/ragfs/src/plugins/s3fs/client.rs:194-216` (post-#1701).