### PR TITLE
build: declare pytest-html in [test] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ test = [
     "pytest-asyncio>=0.21.0",
     "boto3>=1.42.44",
     "pytest-cov>=4.0.0",
+    "pytest-html>=4.0.0",
     "ragas>=0.1.0",
     "datasets>=2.0.0",
     "pandas>=2.0.0",


### PR DESCRIPTION
## Summary

Adds `pytest-html>=4.0.0` to the `[test]` optional-dependencies group so that a fresh `uv pip install -e .[test]` (or `pip install -e .[test]`) leaves the working tree in a state where `pytest tests/oc2ov_test/` can collect.

## Bug

`tests/oc2ov_test/conftest.py` registers four pytest-html hooks:

- `pytest_html_report_title` (line 77)
- `pytest_html_results_summary` (line 82)
- `pytest_html_results_table_header` (line 125)
- `pytest_html_results_table_row` (line 130)

These hooks require the `pytest-html` plugin to be installed for pluggy to recognise them. The `[test]` extra in `pyproject.toml` does not declare `pytest-html`, so a fresh install of `[test]` extras leaves the suite unable to even collect:

```
INTERNALERROR> pluggy._manager.PluginValidationError: unknown hook 'pytest_html_report_title' in plugin <module 'conftest' from '.../tests/oc2ov_test/conftest.py'>
==================== no tests collected, 9 errors in 0.34s =====================
```

## Reproduction (against current `main`)

```
git clone https://github.com/volcengine/OpenViking
cd OpenViking
uv venv && source .venv/bin/activate
uv pip install -e .[test]
pytest tests/oc2ov_test/ --collect-only
# → 9 errors, all "unknown hook 'pytest_html_report_title'"
```

Verified on Python 3.13; the bug is environment-independent — it triggers on every fresh `[test]` install.

## Fix

One-line addition to `pyproject.toml`:

```diff
     "pytest-cov>=4.0.0",
+    "pytest-html>=4.0.0",
     "ragas>=0.1.0",
```

Pinned at `>=4.0.0` to match the open-version style used elsewhere in `[test]`.

## Test plan

After the change, `pytest tests/oc2ov_test/ --collect-only` proceeds past plugin loading:

```
plugins: html-4.2.0, cov-7.1.0, metadata-3.1.1, ...
collecting ...
```

The `unknown hook` PluginValidationError no longer triggers. Downstream collection issues that may surface afterwards (e.g., `ModuleNotFoundError` from the `tests/oc2ov_test/` framework setup) are unrelated to this PR and exist on `main` independently.