### PR TITLE
fix(auth): honor trusted root api key role

### DIFF
--- a/openviking/server/auth.py
+++ b/openviking/server/auth.py
@@ -135,6 +135,7 @@ async def resolve_identity(
 
     if auth_mode == AuthMode.TRUSTED:
         configured_root_api_key = _configured_root_api_key(request)
+        root_api_key_authenticated = False
         if configured_root_api_key:
             if not api_key:
                 raise UnauthenticatedError(
@@ -144,6 +145,7 @@ async def resolve_identity(
                 raise UnauthenticatedError(
                     "Invalid API Key in trusted mode with Root API Key enabled."
                 )
+            root_api_key_authenticated = True
         explicit_account_id, explicit_user_id = _explicit_identity_from_request(request)
         if (
             x_openviking_account
@@ -181,6 +183,14 @@ async def resolve_identity(
                 raise InvalidArgumentError(
                     "Trusted mode requests must include " + " and ".join(missing_fields) + "."
                 )
+
+        if root_api_key_authenticated:
+            return ResolvedIdentity(
+                role=Role.ROOT,
+                account_id=effective_account_id or "trusted",
+                user_id=effective_user_id or "trusted",
+                agent_id=x_openviking_agent or "default",
+            )
 
         trusted_role = Role.USER
         if api_key_manager and effective_account_id and effective_user_id:

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -17,7 +17,7 @@ from starlette.requests import Request
 
 from openviking.server import app as server_app_module
 from openviking.server.app import create_app
-from openviking.server.auth import get_request_context, resolve_identity
+from openviking.server.auth import get_request_context, require_role, resolve_identity
 from openviking.server.config import ServerConfig, _is_localhost, validate_server_config
 from openviking.server.dependencies import set_service
 from openviking.server.identity import ResolvedIdentity, Role
@@ -121,6 +121,13 @@ def _build_auth_http_test_app(
     @app.post("/api/v1/system/wait")
     async def system_wait(ctx=Depends(get_request_context)):
         """Expose a non-tenant system route for auth regression tests."""
+        return {"status": "ok", "result": {"role": ctx.role.value}}
+
+    @app.post("/api/v1/maintenance/reindex-auth-check")
+    async def maintenance_reindex_auth_check(
+        ctx=require_role(Role.ROOT, Role.ADMIN),
+    ):
+        """Expose a maintenance route that requires elevated permissions."""
         return {"status": "ok", "result": {"role": ctx.role.value}}
 
     @app.get("/api/v1/debug/vector/scroll")
@@ -880,7 +887,7 @@ async def test_trusted_mode_with_root_api_key_accepts_matching_api_key():
         x_openviking_agent="assistant-1",
     )
 
-    assert identity.role == Role.USER
+    assert identity.role == Role.ROOT
     assert identity.account_id == "acme"
     assert identity.user_id == "alice"
     assert identity.agent_id == "assistant-1"
@@ -1011,6 +1018,30 @@ async def test_trusted_mode_http_routes_accept_api_key_when_root_key_configured(
 
     assert response.status_code == 200
     assert response.json()["result"] == {"account_id": "acme", "user_id": "alice"}
+
+
+async def test_trusted_mode_root_api_key_grants_root_role_for_maintenance_routes():
+    """Trusted mode root_api_key should satisfy elevated maintenance route role checks."""
+    app = _build_auth_http_test_app(
+        identity=None,
+        auth_enabled=False,
+        auth_mode="trusted",
+        root_api_key=ROOT_KEY,
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/api/v1/maintenance/reindex-auth-check",
+            headers={
+                "X-API-Key": ROOT_KEY,
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "alice",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["result"] == {"role": "root"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #1722.

In trusted mode, requests authenticated with the configured `root_api_key` were accepted as valid trusted requests but still resolved to `Role.USER` unless the supplied account/user existed in the API key manager with a higher role. That meant `ov reindex --sudo` could send the right root key and tenant headers, but privileged non-admin routes such as `/api/v1/maintenance/reindex` still failed with `PERMISSION_DENIED`.

This PR makes the trusted-mode root key behave as the deployment-level root credential after it has been validated.

## What changed

- Track when trusted-mode authentication succeeded via the configured `root_api_key`.
- Resolve matching trusted root-key requests as `Role.ROOT` while preserving the explicit tenant headers on the resulting identity.
- Update existing trusted-mode root-key coverage to assert the resolved root role.
- Add an HTTP regression test for a maintenance-style route requiring `ROOT`/`ADMIN`, matching the `ov reindex --sudo` failure mode.

## Relationship to prior work

This complements #1589, which wired `--sudo` to use `root_api_key` on the CLI side. That PR made the client send the correct credential; this PR fixes the remaining server-side trusted-mode role resolution so the credential satisfies privileged route checks.

Related but different prior work:

- #1616 enabled trusted-mode admin behavior, but did not cover privileged non-admin maintenance routes.
- #1691 fixed a `NewAPIKeyManager.get_user_role` proxy regression that caused 500s, but not the `root_api_key` resolving as `USER` behavior.

## Files changed

- `openviking/server/auth.py`
  - Matching trusted-mode `root_api_key` requests now resolve as `Role.ROOT`.
- `tests/server/test_auth.py`
  - Adds/updates trusted-mode root-key regression coverage.

## Test plan

- [x] `PYTHONPATH=. /Users/$USER/.hermes/hermes-agent/venv/bin/python -m py_compile openviking/server/auth.py tests/server/test_auth.py`
- [x] `PYTHONPATH=. /Users/$USER/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/server/test_auth.py::test_trusted_mode_with_root_api_key_requires_matching_api_key tests/server/test_auth.py::test_trusted_mode_with_root_api_key_accepts_matching_api_key tests/server/test_auth.py::test_trusted_mode_http_routes_require_api_key_when_root_key_configured tests/server/test_auth.py::test_trusted_mode_http_routes_accept_api_key_when_root_key_configured tests/server/test_auth.py::test_trusted_mode_root_api_key_grants_root_role_for_maintenance_routes -q`
- [x] `ruff check openviking/server/auth.py tests/server/test_auth.py`
- [x] `ruff format --check openviking/server/auth.py tests/server/test_auth.py`
- [x] `git diff --check`

Note: I also tried the full `tests/server/test_auth.py` file locally, but unrelated existing fixture setup in this environment reads the operator's `~/.openviking/ov.conf` and fails before many tests run because local Volcengine embedding/VLM API keys are not configured. The focused auth tests above avoid that unrelated environment dependency and cover this regression directly.
