### PR TITLE
fix: reject mismatched ragfs cpython extensions

### DIFF
--- a/openviking/pyagfs/__init__.py
+++ b/openviking/pyagfs/__init__.py
@@ -43,6 +43,25 @@ _logger = logging.getLogger(__name__)
 _LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
 
 
+def _is_compatible_ragfs_extension(path: str, ext_suffix: str) -> bool:
+    """Return whether a vendored ragfs_python extension can be loaded here."""
+    name = Path(path).name
+    if not name.startswith("ragfs_python"):
+        return False
+
+    # CPython-specific extensions are only safe for the exact running
+    # interpreter ABI tag. A cp310 binary must not be loaded on cp312/cp313.
+    if ".cpython-" in name:
+        return name == f"ragfs_python{ext_suffix}"
+
+    # Stable ABI artifacts are intentionally interpreter-independent.
+    if name.startswith("ragfs_python.abi3."):
+        return True
+
+    # Keep accepting generic platform extensions when projects ship them.
+    return name.endswith((".so", ".dylib", ".pyd"))
+
+
 def _find_ragfs_so():
     """Locate the ragfs_python native extension inside openviking/lib/.
 
@@ -61,11 +80,12 @@ def _find_ragfs_so():
         abi3_exact = _LIB_DIR / f"ragfs_python{abi3_suffix}"
         if abi3_exact.exists():
             return str(abi3_exact)
-        # Glob fallback: ragfs_python.cpython-*, ragfs_python.abi3.*, ragfs_python.*.pyd
+        # Glob fallback: keep stable/generic artifacts, but never load a
+        # CPython-version-specific binary whose tag differs from EXT_SUFFIX.
         for pattern in ("ragfs_python.cpython-*", "ragfs_python.abi3.*", "ragfs_python.*"):
-            matches = glob.glob(str(_LIB_DIR / pattern))
-            if matches:
-                return matches[0]
+            for match in sorted(glob.glob(str(_LIB_DIR / pattern))):
+                if _is_compatible_ragfs_extension(match, ext_suffix):
+                    return match
     except Exception:
         pass
     return None

--- a/tests/misc/test_pyagfs_loader.py
+++ b/tests/misc/test_pyagfs_loader.py
@@ -5,7 +5,9 @@ import openviking.pyagfs as pyagfs
 
 def test_find_ragfs_so_rejects_mismatched_cpython_binary(tmp_path, monkeypatch):
     monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
-    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so")
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so"
+    )
 
     (tmp_path / "ragfs_python.cpython-310-x86_64-linux-gnu.so").touch()
 
@@ -14,7 +16,9 @@ def test_find_ragfs_so_rejects_mismatched_cpython_binary(tmp_path, monkeypatch):
 
 def test_find_ragfs_so_prefers_exact_cpython_suffix(tmp_path, monkeypatch):
     monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
-    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so")
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so"
+    )
     exact = tmp_path / "ragfs_python.cpython-312-x86_64-linux-gnu.so"
     exact.touch()
     (tmp_path / "ragfs_python.cpython-310-x86_64-linux-gnu.so").touch()
@@ -24,7 +28,9 @@ def test_find_ragfs_so_prefers_exact_cpython_suffix(tmp_path, monkeypatch):
 
 def test_find_ragfs_so_allows_stable_abi_artifact(tmp_path, monkeypatch):
     monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
-    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so")
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so"
+    )
     abi3 = tmp_path / "ragfs_python.abi3.so"
     abi3.touch()
 

--- a/tests/misc/test_pyagfs_loader.py
+++ b/tests/misc/test_pyagfs_loader.py
@@ -1,0 +1,31 @@
+import sysconfig
+
+import openviking.pyagfs as pyagfs
+
+
+def test_find_ragfs_so_rejects_mismatched_cpython_binary(tmp_path, monkeypatch):
+    monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so")
+
+    (tmp_path / "ragfs_python.cpython-310-x86_64-linux-gnu.so").touch()
+
+    assert pyagfs._find_ragfs_so() is None
+
+
+def test_find_ragfs_so_prefers_exact_cpython_suffix(tmp_path, monkeypatch):
+    monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so")
+    exact = tmp_path / "ragfs_python.cpython-312-x86_64-linux-gnu.so"
+    exact.touch()
+    (tmp_path / "ragfs_python.cpython-310-x86_64-linux-gnu.so").touch()
+
+    assert pyagfs._find_ragfs_so() == str(exact)
+
+
+def test_find_ragfs_so_allows_stable_abi_artifact(tmp_path, monkeypatch):
+    monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so")
+    abi3 = tmp_path / "ragfs_python.abi3.so"
+    abi3.touch()
+
+    assert pyagfs._find_ragfs_so() == str(abi3)


### PR DESCRIPTION
## Summary
- keep exact `EXT_SUFFIX` and stable `abi3` ragfs_python loading paths
- reject vendored `ragfs_python.cpython-*` binaries whose ABI tag does not match the running interpreter
- add loader regressions for mismatched CPython tags, exact matches, and abi3 artifacts

## Tests
- direct pyagfs loader smoke script covering mismatched and exact CPython suffixes
- `git diff --check`

Note: `pytest tests/misc/test_pyagfs_loader.py -q` is blocked in this local checkout before the target test by `tests/conftest.py` importing optional dependency `litellm`, which is not installed in this environment.