### PR TITLE
fix(docker): collapse persistent state into /app/.openviking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,16 +118,24 @@ WORKDIR /app
 
 COPY --from=py-builder /app/.venv /app/.venv
 COPY docker/openviking-console-entrypoint.sh /usr/local/bin/openviking-console-entrypoint
-RUN chmod +x /usr/local/bin/openviking-console-entrypoint
-ENV PATH="/app/.venv/bin:$PATH"
-ENV OPENVIKING_CONFIG_FILE="/app/ov.conf"
-ENV OPENVIKING_CLI_CONFIG_FILE="/app/ovcli.conf"
+RUN mkdir -p /app/.openviking \
+ && chmod +x /usr/local/bin/openviking-console-entrypoint
+ENV HOME="/app" \
+    PATH="/app/.venv/bin:$PATH" \
+    OPENVIKING_CONFIG_FILE="/app/.openviking/ov.conf" \
+    OPENVIKING_CLI_CONFIG_FILE="/app/.openviking/ovcli.conf"
 
 EXPOSE 1933 8020
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD curl -fsS http://127.0.0.1:1933/health || exit 1
 
-# Default runs server + console; override command to run CLI, e.g.:
-# docker run --rm -v "$HOME/.openviking/ovcli.conf:/app/ovcli.conf" <image> openviking --help
+# All persistent state (ov.conf, ovcli.conf, workspace data) lives under
+# /app/.openviking, which mirrors the host's ~/.openviking layout. Mount one
+# volume there to persist everything across container restarts:
+#   docker run -v ~/.openviking:/app/.openviking <image>
+# If ov.conf is absent on first start, set OPENVIKING_CONF_CONTENT to the full
+# JSON, or `docker exec` in and run `openviking-server init`.
+# Override command to run CLI, e.g.:
+# docker run --rm -v ~/.openviking:/app/.openviking <image> openviking --help
 ENTRYPOINT ["openviking-console-entrypoint"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
       - "1933:1933"
       - "8020:8020"
     volumes:
-      # Mount the configuration and data directory to persist state
-      - ~/.openviking/ov.conf:/app/ov.conf
-      - ~/.openviking/data:/app/data
+      # All persistent state (ov.conf, ovcli.conf, workspace) lives here.
+      - ~/.openviking:/app/.openviking
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:1933/health || exit 1"]
       interval: 30s

--- a/docker/openviking-console-entrypoint.sh
+++ b/docker/openviking-console-entrypoint.sh
@@ -6,8 +6,35 @@ SERVER_HEALTH_URL="${SERVER_URL}/health"
 CONSOLE_PORT="${OPENVIKING_CONSOLE_PORT:-8020}"
 CONSOLE_HOST="${OPENVIKING_CONSOLE_HOST:-0.0.0.0}"
 WITH_BOT="${OPENVIKING_WITH_BOT:-1}"
+CONFIG_FILE="${OPENVIKING_CONFIG_FILE:-/app/.openviking/ov.conf}"
 SERVER_PID=""
 CONSOLE_PID=""
+
+ensure_config() {
+    if [ -f "${CONFIG_FILE}" ]; then
+        return
+    fi
+    mkdir -p "$(dirname "${CONFIG_FILE}")"
+    if [ -n "${OPENVIKING_CONF_CONTENT:-}" ]; then
+        printf '%s' "${OPENVIKING_CONF_CONTENT}" > "${CONFIG_FILE}"
+        echo "[openviking-console-entrypoint] wrote ${CONFIG_FILE} from OPENVIKING_CONF_CONTENT"
+        return
+    fi
+    cat >&2 <<EOF
+[openviking-console-entrypoint] ${CONFIG_FILE} not found.
+
+To start OpenViking, do one of:
+  - mount ~/.openviking on the host to /app/.openviking
+  - set OPENVIKING_CONF_CONTENT to the full ov.conf JSON
+  - docker exec into this container and run: openviking-server init
+
+The container will sleep until ${CONFIG_FILE} exists.
+EOF
+    while [ ! -f "${CONFIG_FILE}" ]; do
+        sleep 5
+    done
+    echo "[openviking-console-entrypoint] detected ${CONFIG_FILE}, starting OpenViking"
+}
 
 normalize_with_bot() {
     case "$1" in
@@ -41,6 +68,7 @@ if [ "$#" -gt 0 ]; then
 fi
 
 normalize_with_bot "${WITH_BOT}"
+ensure_config
 
 forward_signal() {
     if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then

--- a/docs/en/getting-started/02-quickstart.md
+++ b/docs/en/getting-started/02-quickstart.md
@@ -24,10 +24,10 @@ pip install openviking --upgrade --force-reinstall
 
 If you prefer to run OpenViking as a standalone service, Docker is recommended.
 
-1. **Prepare Configuration and Data Directories**
-   Create a data directory on your host machine and prepare the `ov.conf` configuration file (see the "Configuration" section below for details):
+1. **Prepare Configuration Directory**
+   Create the OpenViking directory on your host and prepare the `ov.conf` configuration file (see the "Configuration" section below for details). All persistent state — config and workspace data — lives under this single directory:
    ```bash
-   mkdir -p ~/.openviking/data
+   mkdir -p ~/.openviking
    touch ~/.openviking/ov.conf
    ```
 
@@ -42,8 +42,7 @@ If you prefer to run OpenViking as a standalone service, Docker is recommended.
          - "1933:1933"
          - "8020:8020"
        volumes:
-         - ~/.openviking/ov.conf:/app/ov.conf
-         - ~/.openviking/data:/app/data
+         - ~/.openviking:/app/.openviking
        restart: unless-stopped
    ```
    Then run the following command in the same directory:
@@ -52,6 +51,8 @@ If you prefer to run OpenViking as a standalone service, Docker is recommended.
    ```
 
    By default, the container starts the OpenViking API server on `1933`, the Console UI on `8020`, and the bundled `vikingbot` gateway. If you need to disable `vikingbot`, add either `command: ["--without-bot"]` or `environment: ["OPENVIKING_WITH_BOT=0"]`.
+
+   On platforms that don't allow bind mounts, set `OPENVIKING_CONF_CONTENT` to the full config JSON to bootstrap on first start, or `docker exec` in and run `openviking-server init` after the container is up. See [Deployment Guide](../guides/03-deployment.md#when-docker--v-is-not-available) for details.
 
 > **💡 Mac Local Network Access Tip (Connection reset error):**
 >
@@ -67,8 +68,7 @@ If you prefer to run OpenViking as a standalone service, Docker is recommended.
 >       - "8020:8020"
 >       - "1933:1934" # Map host 1933 to container 1934
 >     volumes:
->       - ~/.openviking/ov.conf:/app/ov.conf
->       - ~/.openviking/data:/app/data
+>       - ~/.openviking:/app/.openviking
 >     command: /bin/sh -c "apt-get update && apt-get install -y socat && socat TCP-LISTEN:1934,fork,reuseaddr TCP:127.0.0.1:1933 & openviking-server"
 > ```
 > This perfectly solves the access issue for Mac host machines.

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -184,16 +184,14 @@ curl http://localhost:1933/api/v1/fs/ls?uri=viking:// \
 
 ### Docker
 
-OpenViking provides pre-built Docker images published to GitHub Container Registry:
+OpenViking provides pre-built Docker images published to GitHub Container Registry. All persistent state — `ov.conf`, `ovcli.conf`, and the workspace data — lives under `/app/.openviking` inside the container, so a single mount is enough:
 
 ```bash
-# Note: ov.conf needs to set storage.workspace to /app/data for data persistence
 docker run -d \
   --name openviking \
   -p 1933:1933 \
   -p 8020:8020 \
-  -v ~/.openviking/ov.conf:/app/ov.conf \
-  -v ~/.openviking/data:/app/data \
+  -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
 ```
@@ -218,8 +216,7 @@ docker run -d \
   --name openviking \
   -p 1933:1933 \
   -p 8020:8020 \
-  -v ~/.openviking/ov.conf:/app/ov.conf \
-  -v ~/.openviking/data:/app/data \
+  -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest \
   --without-bot
@@ -231,11 +228,34 @@ docker run -d \
   -e OPENVIKING_WITH_BOT=0 \
   -p 1933:1933 \
   -p 8020:8020 \
-  -v ~/.openviking/ov.conf:/app/ov.conf \
-  -v ~/.openviking/data:/app/data \
+  -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
 ```
+
+#### When `docker -v` is not available
+
+Some managed platforms (Railway, Fly.io, Heroku-style PaaS) don't let you bind-mount a host path. If `ov.conf` doesn't exist when the container starts, the entrypoint will not crash — it prints a fix-it message and waits for the file to appear. You have two ways to provide it:
+
+**Option A: pass the full config through `OPENVIKING_CONF_CONTENT`.** The entrypoint writes the env value to `OPENVIKING_CONFIG_FILE` (defaults to `/app/.openviking/ov.conf`) before starting the server:
+
+```bash
+docker run -d \
+  --name openviking \
+  -p 1933:1933 \
+  -p 8020:8020 \
+  -e OPENVIKING_CONF_CONTENT="$(cat ~/.openviking/ov.conf)" \
+  --restart unless-stopped \
+  ghcr.io/volcengine/openviking:latest
+```
+
+**Option B: configure interactively after the container is up.** While the container is sleeping (waiting for `ov.conf`), `docker exec` in and run the setup wizard — it honors `OPENVIKING_CONFIG_FILE` and writes to the path the server is watching:
+
+```bash
+docker exec -it openviking openviking-server init
+```
+
+As soon as `ov.conf` appears, the entrypoint resumes and starts the server + console automatically.
 
 You can also use Docker Compose, which provides a `docker-compose.yml` in the project root:
 

--- a/docs/zh/getting-started/02-quickstart.md
+++ b/docs/zh/getting-started/02-quickstart.md
@@ -24,10 +24,10 @@ pip install openviking --upgrade --force-reinstall
 
 如果你希望将 OpenViking 作为独立的服务运行，推荐使用 Docker。
 
-1. **准备配置文件与数据目录**
-   在宿主机上创建数据目录，并准备好 `ov.conf` 配置文件（配置项参考下方“配置环境”章节）：
+1. **准备配置目录**
+   在宿主机上创建 OpenViking 目录，并准备好 `ov.conf` 配置文件（配置项参考下方“配置环境”章节）。所有持久化状态 —— 配置和工作区数据 —— 都放在这一个目录下：
    ```bash
-   mkdir -p ~/.openviking/data
+   mkdir -p ~/.openviking
    touch ~/.openviking/ov.conf
    ```
 
@@ -42,8 +42,7 @@ pip install openviking --upgrade --force-reinstall
          - "1933:1933"
          - "8020:8020"
        volumes:
-         - ~/.openviking/ov.conf:/app/ov.conf
-         - ~/.openviking/data:/app/data
+         - ~/.openviking:/app/.openviking
        restart: unless-stopped
    ```
    然后在同目录下执行启动命令：
@@ -52,6 +51,8 @@ pip install openviking --upgrade --force-reinstall
    ```
 
    默认情况下，容器会同时启动 OpenViking API 服务（`1933`）、Console 界面（`8020`）以及内置的 `vikingbot` gateway。如果你需要关闭 `vikingbot`，可以在 Compose 里增加 `command: ["--without-bot"]`，或者设置 `environment: ["OPENVIKING_WITH_BOT=0"]`。
+
+   如果运行平台不支持 bind mount，可以通过 `OPENVIKING_CONF_CONTENT` 环境变量传入完整的配置 JSON，或在容器启动后 `docker exec` 进去执行 `openviking-server init`。详见 [部署指南](../guides/03-deployment.md#无法使用-docker--v-时)。
 
 > **💡 Mac 本地网络访问提示 (Connection reset 报错)：**
 >
@@ -67,8 +68,7 @@ pip install openviking --upgrade --force-reinstall
 >       - "8020:8020"
 >       - "1933:1934" # 将宿主机 1933 映射到容器 1934
 >     volumes:
->       - ~/.openviking/ov.conf:/app/ov.conf
->       - ~/.openviking/data:/app/data
+>       - ~/.openviking:/app/.openviking
 >     command: /bin/sh -c "apt-get update && apt-get install -y socat && socat TCP-LISTEN:1934,fork,reuseaddr TCP:127.0.0.1:1933 & openviking-server"
 > ```
 > 这样即可完美解决 Mac 宿主机的访问问题。

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -182,16 +182,14 @@ curl http://localhost:1933/api/v1/fs/ls?uri=viking:// \
 
 ### Docker
 
-OpenViking 提供预构建的 Docker 镜像，发布在 GitHub Container Registry：
+OpenViking 提供预构建的 Docker 镜像，发布在 GitHub Container Registry。容器内所有持久化状态（`ov.conf`、`ovcli.conf` 以及工作区数据）都放在 `/app/.openviking` 下，挂载一个目录即可：
 
 ```bash
-# 注意 ov.conf 需要指定 storage.workspace 为 /app/data 以确保数据持久化
 docker run -d \
   --name openviking \
   -p 1933:1933 \
   -p 8020:8020 \
-  -v ~/.openviking/ov.conf:/app/ov.conf \
-  -v ~/.openviking/data:/app/data \
+  -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
 ```
@@ -216,8 +214,7 @@ docker run -d \
   --name openviking \
   -p 1933:1933 \
   -p 8020:8020 \
-  -v ~/.openviking/ov.conf:/app/ov.conf \
-  -v ~/.openviking/data:/app/data \
+  -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest \
   --without-bot
@@ -229,11 +226,34 @@ docker run -d \
   -e OPENVIKING_WITH_BOT=0 \
   -p 1933:1933 \
   -p 8020:8020 \
-  -v ~/.openviking/ov.conf:/app/ov.conf \
-  -v ~/.openviking/data:/app/data \
+  -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
 ```
+
+#### 无法使用 `docker -v` 时
+
+部分托管平台（如 Railway、Fly.io、Heroku 这类 PaaS）不支持把宿主机目录绑定挂载进容器。这种环境下，如果容器启动时找不到 `ov.conf`，entrypoint 不会崩溃 —— 它会打印一段修复指引并阻塞等待文件出现。你可以选用以下两种方式之一：
+
+**方案 A：通过 `OPENVIKING_CONF_CONTENT` 注入完整配置内容。** entrypoint 会在启动 server 前把这个环境变量的值写入到 `OPENVIKING_CONFIG_FILE`（默认 `/app/.openviking/ov.conf`）：
+
+```bash
+docker run -d \
+  --name openviking \
+  -p 1933:1933 \
+  -p 8020:8020 \
+  -e OPENVIKING_CONF_CONTENT="$(cat ~/.openviking/ov.conf)" \
+  --restart unless-stopped \
+  ghcr.io/volcengine/openviking:latest
+```
+
+**方案 B：容器起来之后再 `docker exec` 进去用向导配置。** 容器在等待 `ov.conf` 期间是存活的，`exec` 进去运行 setup wizard，它会按 `OPENVIKING_CONFIG_FILE` 写到 server 正在监听的位置：
+
+```bash
+docker exec -it openviking openviking-server init
+```
+
+`ov.conf` 出现后，entrypoint 会自动恢复并启动 server 与 console。
 
 也可以使用 Docker Compose，项目根目录提供了 `docker-compose.yml`：
 

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from openviking_cli.utils.config.consts import DEFAULT_CONFIG_DIR
+from openviking_cli.utils.config.consts import DEFAULT_CONFIG_DIR, OPENVIKING_CONFIG_ENV
 from openviking_cli.utils.ollama import (
     check_ollama_running,
     get_ollama_models,
@@ -553,9 +553,20 @@ def _build_cloud_config(
 # Config I/O
 # ---------------------------------------------------------------------------
 
-_DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "ov.conf"
-_DEFAULT_WORKSPACE = str(DEFAULT_CONFIG_DIR / "data")
 _PIP_LOCAL_EMBED = 'pip install "openviking[local-embed]"'
+
+
+def _config_path() -> Path:
+    """Where init writes ov.conf — honors OPENVIKING_CONFIG_FILE."""
+    override = os.environ.get(OPENVIKING_CONFIG_ENV)
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_CONFIG_DIR / "ov.conf"
+
+
+def _workspace_path() -> str:
+    """Workspace lives next to ov.conf so a single mount captures everything."""
+    return str(_config_path().parent / "data")
 
 
 def _write_config(config_dict: dict[str, Any], config_path: Path) -> bool:
@@ -656,7 +667,7 @@ def _wizard_ollama() -> dict[str, Any] | None:
             else:
                 print(f"  {_green('OK')} {vlm.ollama_model} pulled successfully")
 
-    return _build_ollama_config(embedding, vlm, _DEFAULT_WORKSPACE)
+    return _build_ollama_config(embedding, vlm, _workspace_path())
 
 
 def _wizard_llamacpp() -> dict[str, Any] | None:
@@ -833,7 +844,7 @@ def _wizard_llamacpp() -> dict[str, Any] | None:
     return _build_local_config(
         model_name=model_name,
         dimension=dimension,
-        workspace=_DEFAULT_WORKSPACE,
+        workspace=_workspace_path(),
         model_path=custom_model_path,
         vlm_config=vlm_config,
     )
@@ -849,10 +860,11 @@ def _wizard_cloud() -> dict[str, Any] | None:
     if choice > len(CLOUD_PROVIDERS):
         # Manual / Other
         print(f"\n  See example config: {_cyan('examples/ov.conf.example')}")
-        print(f"  Edit {_cyan(str(_DEFAULT_CONFIG_PATH))} manually.\n")
+        print(f"  Edit {_cyan(str(_config_path()))} manually.\n")
         return None
 
     provider = CLOUD_PROVIDERS[choice - 1]
+    workspace = _workspace_path()
 
     # Embedding config
     print(f"\n  {_bold('Embedding configuration')}")
@@ -879,7 +891,6 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_model = _prompt_required_input("Model", default=vlm_choice.default_vlm_model)
         vlm_api_base = vlm_choice.default_api_base
         vlm_provider = vlm_choice.provider
-        workspace = _DEFAULT_WORKSPACE
     elif vlm_mode == 2:
         vlm_choice = _get_cloud_provider("volcengine")
         print(f"\n  {_bold('VLM configuration')}")
@@ -890,7 +901,6 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_model = _prompt_required_input("Model", default=vlm_choice.default_vlm_model)
         vlm_api_base = vlm_choice.default_api_base
         vlm_provider = vlm_choice.provider
-        workspace = _DEFAULT_WORKSPACE
     elif vlm_mode == 3:
         _ensure_codex_auth()
         print(f"\n  {_bold('Codex VLM configuration')}")
@@ -898,7 +908,6 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_api_base = _DEFAULT_CODEX_BASE_URL
         vlm_api_key = None
         vlm_provider = "openai-codex"
-        workspace = _DEFAULT_WORKSPACE
     elif vlm_mode == 4:
         print(f"\n  {_bold('Kimi VLM configuration')}")
         vlm_api_key = _prompt_required_input("API Key")
@@ -908,7 +917,6 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_model = _prompt_required_input("Model", default=_DEFAULT_KIMI_MODEL)
         vlm_api_base = _DEFAULT_KIMI_BASE_URL
         vlm_provider = "kimi"
-        workspace = _DEFAULT_WORKSPACE
     else:
         print(f"\n  {_bold('GLM VLM configuration')}")
         vlm_api_key = _prompt_required_input("API Key")
@@ -918,7 +926,6 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_model = _prompt_required_input("Model", default=_DEFAULT_GLM_MODEL)
         vlm_api_base = _DEFAULT_GLM_BASE_URL
         vlm_provider = "glm"
-        workspace = _DEFAULT_WORKSPACE
 
     return _build_cloud_config(
         provider,
@@ -936,24 +943,25 @@ def _wizard_cloud() -> dict[str, Any] | None:
 
 def _wizard_custom() -> dict[str, Any] | None:
     """Custom configuration - point user to example config."""
+    config_path = _config_path()
     example = Path(__file__).parent.parent / "examples" / "ov.conf.example"
     if example.exists():
         print(f"\n  Example config: {_cyan(str(example))}")
-    print(f"  Config path:    {_cyan(str(_DEFAULT_CONFIG_PATH))}")
+    print(f"  Config path:    {_cyan(str(config_path))}")
 
     editor = os.environ.get("EDITOR", os.environ.get("VISUAL", ""))
     if editor:
-        if _prompt_confirm(f"Open {_DEFAULT_CONFIG_PATH} in {editor}?"):
-            _DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-            if not _DEFAULT_CONFIG_PATH.exists():
+        if _prompt_confirm(f"Open {config_path} in {editor}?"):
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            if not config_path.exists():
                 # Copy example as starting point
                 try:
-                    _DEFAULT_CONFIG_PATH.write_text(
+                    config_path.write_text(
                         example.read_text(encoding="utf-8"), encoding="utf-8"
                     )
                 except OSError:
                     pass
-            subprocess.run([editor, str(_DEFAULT_CONFIG_PATH)], check=False)
+            subprocess.run([editor, str(config_path)], check=False)
     else:
         print(f"\n  {_dim('Set $EDITOR to open the config file automatically.')}")
     return None
@@ -966,15 +974,18 @@ def _wizard_custom() -> dict[str, Any] | None:
 
 def run_init() -> int:
     """Run the interactive setup wizard."""
+    config_path = _config_path()
+    workspace = _workspace_path()
+
     print(f"\n  {_bold('OpenViking Setup')}")
     print(f"  {'=' * 16}\n")
     print(
-        f"  {_dim('Data will be stored under ~/.openviking/data unless you edit ov.conf later.')}\n"
+        f"  {_dim(f'Data will be stored under {workspace} unless you edit ov.conf later.')}\n"
     )
 
     # Check for existing config
-    if _DEFAULT_CONFIG_PATH.exists():
-        print(f"  {_yellow('Existing config found:')} {_DEFAULT_CONFIG_PATH}")
+    if config_path.exists():
+        print(f"  {_yellow('Existing config found:')} {config_path}")
         if not _prompt_confirm("Overwrite? (current config will be backed up as .bak)"):
             print("  Setup cancelled.\n")
             return 0
@@ -1025,7 +1036,7 @@ def run_init() -> int:
         return 0
 
     # Write
-    if not _write_config(config_dict, _DEFAULT_CONFIG_PATH):
+    if not _write_config(config_dict, config_path):
         return 1
 
     print(f"  {_green('OK')} Configuration written to the default config location\n")

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -956,9 +956,7 @@ def _wizard_custom() -> dict[str, Any] | None:
             if not config_path.exists():
                 # Copy example as starting point
                 try:
-                    config_path.write_text(
-                        example.read_text(encoding="utf-8"), encoding="utf-8"
-                    )
+                    config_path.write_text(example.read_text(encoding="utf-8"), encoding="utf-8")
                 except OSError:
                     pass
             subprocess.run([editor, str(config_path)], check=False)
@@ -979,9 +977,7 @@ def run_init() -> int:
 
     print(f"\n  {_bold('OpenViking Setup')}")
     print(f"  {'=' * 16}\n")
-    print(
-        f"  {_dim(f'Data will be stored under {workspace} unless you edit ov.conf later.')}\n"
-    )
+    print(f"  {_dim(f'Data will be stored under {workspace} unless you edit ov.conf later.')}\n")
 
     # Check for existing config
     if config_path.exists():

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 from openviking_cli.setup_wizard import (
     _DEFAULT_CODEX_MODEL,
     _DEFAULT_GLM_MODEL,
     _DEFAULT_KIMI_MODEL,
-    _DEFAULT_WORKSPACE,
     CLOUD_PROVIDERS,
     EMBEDDING_PRESETS,
     LOCAL_GGUF_PRESETS,
@@ -17,11 +17,13 @@ from openviking_cli.setup_wizard import (
     _build_cloud_config,
     _build_local_config,
     _build_ollama_config,
+    _config_path,
     _get_recommended_indices,
     _is_llamacpp_installed,
     _prompt_required_input,
     _prompt_required_int,
     _wizard_cloud,
+    _workspace_path,
     _write_config,
     run_init,
 )
@@ -192,7 +194,7 @@ class TestConfigBuilding:
                         config = _wizard_cloud()
 
         assert config is not None
-        assert config["storage"]["workspace"] == _DEFAULT_WORKSPACE
+        assert config["storage"]["workspace"] == _workspace_path()
         assert config["vlm"]["provider"] == "openai-codex"
         assert config["vlm"]["api_base"] == "https://chatgpt.com/backend-api/codex"
         assert "api_key" not in config["vlm"]
@@ -218,7 +220,7 @@ class TestConfigBuilding:
                     config = _wizard_cloud()
 
         assert config is not None
-        assert config["storage"]["workspace"] == _DEFAULT_WORKSPACE
+        assert config["storage"]["workspace"] == _workspace_path()
         assert config["vlm"]["provider"] == "openai"
         assert config["vlm"]["api_key"] == "openai-vlm-test"
         assert config["vlm"]["api_base"] == CLOUD_PROVIDERS[0].default_api_base
@@ -244,7 +246,7 @@ class TestConfigBuilding:
                     config = _wizard_cloud()
 
         assert config is not None
-        assert config["storage"]["workspace"] == _DEFAULT_WORKSPACE
+        assert config["storage"]["workspace"] == _workspace_path()
         assert config["vlm"]["provider"] == "volcengine"
         assert config["vlm"]["api_key"] == "ve-vlm-test"
         assert config["vlm"]["api_base"] == CLOUD_PROVIDERS[1].default_api_base
@@ -275,7 +277,7 @@ class TestConfigBuilding:
         assert config["vlm"]["api_key"] == "kimi-test"
         assert config["vlm"]["model"] == "kimi-code"
         assert config["vlm"]["api_base"] == "https://api.kimi.com/coding"
-        assert config["storage"]["workspace"] == _DEFAULT_WORKSPACE
+        assert config["storage"]["workspace"] == _workspace_path()
 
     def test_cloud_wizard_supports_glm_vlm(self):
         with patch(
@@ -302,7 +304,7 @@ class TestConfigBuilding:
         assert config["vlm"]["api_key"] == "glm-test"
         assert config["vlm"]["model"] == "glm-4.6v"
         assert config["vlm"]["api_base"] == "https://api.z.ai/api/coding/paas/v4"
-        assert config["storage"]["workspace"] == _DEFAULT_WORKSPACE
+        assert config["storage"]["workspace"] == _workspace_path()
 
     def test_prompt_required_input_uses_default_on_empty(self):
         with patch("builtins.input", return_value=""):
@@ -510,7 +512,7 @@ class TestConfigWriting:
         }
 
         with (
-            patch("openviking_cli.setup_wizard._DEFAULT_CONFIG_PATH", config_path),
+            patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(config_path)}, clear=False),
             patch("openviking_cli.setup_wizard._prompt_choice", return_value=2),
             patch("openviking_cli.setup_wizard._wizard_ollama", return_value=config),
             patch("openviking_cli.setup_wizard._prompt_confirm", return_value=True),
@@ -527,6 +529,30 @@ class TestConfigWriting:
         assert str(config_path) not in output
         assert "custom local model (hidden)" in output
         assert "default config location" in output
+
+    def test_env_overrides_config_path_and_derives_workspace(self, tmp_path):
+        config_path = tmp_path / "runtime" / "ov.conf"
+        with patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(config_path)}, clear=False):
+            assert _config_path() == config_path
+            assert _workspace_path() == str(config_path.parent / "data")
+
+    def test_run_init_writes_to_env_config_path(self, tmp_path):
+        config_path = tmp_path / "runtime" / "ov.conf"
+        config = {
+            "embedding": {"dense": {"provider": "ollama", "model": "qwen", "dimension": 1024}},
+            "storage": {"workspace": str(config_path.parent / "data")},
+        }
+        with (
+            patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(config_path)}, clear=False),
+            patch("openviking_cli.setup_wizard._prompt_choice", return_value=2),
+            patch("openviking_cli.setup_wizard._wizard_ollama", return_value=config),
+            patch("openviking_cli.setup_wizard._prompt_confirm", return_value=True),
+            patch("openviking_cli.setup_wizard._write_config", return_value=True) as mock_write,
+            patch("builtins.print"),
+        ):
+            assert run_init() == 0
+
+        mock_write.assert_called_once_with(config, config_path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces #1723 with a smaller, focused fix. The Docker image crashed on startup when \`ov.conf\` was missing, which made it impossible to \`docker exec\` in to fix the config — and the previous layout forced two separate volume mounts (\`/app/conf\` + \`/app/data\`), awkward on managed platforms that only expose a single persistent volume.

This PR collapses everything into one path that mirrors the host layout, and lets the container survive a missing config so users (or agents) can recover.

## Changes

- **Single mount, mirrored layout.** \`HOME=/app\` and all persistent state lives under \`/app/.openviking\` (\`ov.conf\`, \`ovcli.conf\`, workspace data). One mount: \`-v ~/.openviking:/app/.openviking\`.
- **Don't crash on missing config.** Entrypoint either materializes \`ov.conf\` from \`OPENVIKING_CONF_CONTENT\`, or prints a one-screen fix-it message and \`sleep\`s until the file appears — keeping the container alive for \`docker exec ... openviking-server init\`.
- **\`init\` honors \`OPENVIKING_CONFIG_FILE\`.** Workspace is derived from the config's parent directory, so a single env var places init output exactly where the server reads from. No new env vars introduced.

## Deliberately not in scope

- The pending state currently surfaces only via stdout (\`docker logs\`) and a failing healthcheck. A follow-up PR will add a tiny HTTP server that responds to **any** route with a structured 503 \`{status, error, fix}\` payload, so an agent watching \`http://host:1933/\` can self-discover the problem and report it to the user.
- CI workflow improvements from #1723 (conditional Docker Hub publishing, feature-branch builds) are unrelated to this fix and will be handled separately if still desired.

## Testing

- \`pytest tests/cli/test_setup_wizard.py -q\` — 41 passed
- \`sh -n docker/openviking-console-entrypoint.sh\` — syntax OK
- \`python -m compileall openviking_cli/setup_wizard.py\` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)