### PR TITLE
docs(metrics): document otel.service_name and export_interval_ms keys

### DIFF
--- a/docs/en/concepts/12-metrics.md
+++ b/docs/en/concepts/12-metrics.md
@@ -377,6 +377,8 @@ Key fields:
 - `server.observability.metrics.exporters.otel.protocol`: `"grpc"` or `"http"`
 - `server.observability.metrics.exporters.otel.tls.insecure`: OTLP/gRPC only; `true` means plaintext (no TLS)
 - `server.observability.metrics.exporters.otel.endpoint`: OTLP endpoint (for gRPC, use `host:4317`; for HTTP, use a full URL)
+- `server.observability.metrics.exporters.otel.service_name`: OTLP `service.name` resource attribute (default `"openviking-server"`)
+- `server.observability.metrics.exporters.otel.export_interval_ms`: OTLP push interval in milliseconds (default `10000`)
 
 Example:
 

--- a/docs/zh/concepts/12-metrics.md
+++ b/docs/zh/concepts/12-metrics.md
@@ -380,6 +380,8 @@ scrape_configs:
 - `server.observability.metrics.exporters.otel.protocol`：`"grpc"` 或 `"http"`
 - `server.observability.metrics.exporters.otel.tls.insecure`：仅对 OTLP/gRPC 生效；`true` 表示明文连接（无 TLS）
 - `server.observability.metrics.exporters.otel.endpoint`：OTLP 端点（gRPC 用 `host:4317`；HTTP 必须是完整 URL）
+- `server.observability.metrics.exporters.otel.service_name`：OTLP `service.name` 资源属性（默认 `"openviking-server"`）
+- `server.observability.metrics.exporters.otel.export_interval_ms`：OTLP 推送间隔，单位毫秒（默认 `10000`）
 
 示例：
 


### PR DESCRIPTION
Source-of-truth for these two OTLP exporter knobs landed in #1666 (`openviking/server/config.py:46-65` defines `OTelExporterConfig.service_name` and `export_interval_ms`, and the JSON example below in this same section already uses both values), but the "Key fields" bullet list under **Exporters** only documents `enabled`, `protocol`, `tls.insecure`, and `endpoint`. Reader sees the example and has no key-field reference, so the two knobs feel undocumented.

This PR adds one bullet per knob to both EN and ZH `docs/{en,zh}/concepts/12-metrics.md`, byte-for-byte mirroring each language's existing convention (full-width punctuation in ZH, default values in backticks). Defaults match `OTelExporterConfig` in `openviking/server/config.py` (`service_name="openviking-server"`, `export_interval_ms=10000`).

No code change. Pure docs.