### PR TITLE
feat(setup-wizard): openviking-server init 的一揽子优化

### DIFF
--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -1122,9 +1122,9 @@ def run_init() -> int:
     mode = _prompt_choice(
         "Choose setup mode:",
         [
+            ("Cloud API", "(VolcEngine, BytePlus, OpenAI, etc.)"),
             ("Local embedding via llama.cpp", "(CPU embedding, no GPU required)"),
             ("Local models via Ollama", "(recommended for macOS / Apple Silicon)"),
-            ("Cloud API", "(VolcEngine, BytePlus, OpenAI, etc.)"),
             ("Custom", "(manual editing)"),
         ],
         default=1,
@@ -1133,11 +1133,11 @@ def run_init() -> int:
     config_dict: dict[str, Any] | None = None
 
     if mode == 1:
-        config_dict = _wizard_llamacpp()
-    elif mode == 2:
-        config_dict = _wizard_ollama()
-    elif mode == 3:
         config_dict = _wizard_cloud()
+    elif mode == 2:
+        config_dict = _wizard_llamacpp()
+    elif mode == 3:
+        config_dict = _wizard_ollama()
     else:
         _wizard_custom()
         return 0

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -356,6 +356,22 @@ class CloudProvider:
 
 CLOUD_PROVIDERS: list[CloudProvider] = [
     CloudProvider(
+        "VolcEngine (火山引擎)",
+        "volcengine",
+        "https://ark.cn-beijing.volces.com/api/v3",
+        "doubao-embedding-vision-251215",
+        1024,
+        "doubao-seed-2-0-code-preview-260215",
+    ),
+    CloudProvider(
+        "BytePlus",
+        "openai",
+        "https://ark.ap-southeast.bytepluses.com/api/v3",
+        "doubao-embedding-vision-251215",
+        1024,
+        "doubao-seed-2-0-code-preview-260215",
+    ),
+    CloudProvider(
         "OpenAI",
         "openai",
         "https://api.openai.com/v1",
@@ -363,27 +379,20 @@ CLOUD_PROVIDERS: list[CloudProvider] = [
         1536,
         "gpt-5.4",
     ),
-    CloudProvider(
-        "Volcengine (Doubao)",
-        "volcengine",
-        "https://ark.cn-beijing.volces.com/api/v3",
-        "doubao-embedding-vision-251215",
-        1024,
-        "doubao-seed-2-0-code-preview-260215",
-    ),
 ]
 
 
-def _get_cloud_provider(provider_name: str) -> CloudProvider:
+def _get_cloud_provider_by_label(label: str) -> CloudProvider:
     for provider in CLOUD_PROVIDERS:
-        if provider.provider == provider_name:
+        if provider.label == label:
             return provider
-    raise ValueError(f"Unknown cloud provider: {provider_name}")
+    raise ValueError(f"Unknown cloud provider: {label}")
 
 
 _WIZARD_VLM_OPTIONS: list[tuple[str, str]] = [
+    ("VolcEngine (火山引擎)", "(API)"),
+    ("BytePlus", "(API)"),
     ("OpenAI", "(API)"),
-    ("Volcengine", "(API)"),
     ("OpenAI Codex", "(Subscription)"),
     ("Kimi", "(Subscription API Key)"),
     ("GLM", "(Subscription API Key)"),
@@ -770,7 +779,7 @@ def _wizard_llamacpp() -> dict[str, Any] | None:
         "VLM (language model) setup:",
         [
             ("Use Ollama for VLM", _dim("(requires Ollama installed)")),
-            ("Use Cloud API for VLM", _dim("(OpenAI, Volcengine, etc.)")),
+            ("Use Cloud API for VLM", _dim("(VolcEngine, BytePlus, OpenAI, etc.)")),
             ("Skip VLM", _dim("(embedding only, add VLM later)")),
         ],
         default=1,
@@ -882,8 +891,8 @@ def _wizard_cloud() -> dict[str, Any] | None:
     vlm_mode = _prompt_choice("VLM provider:", _WIZARD_VLM_OPTIONS, default=1)
 
     if vlm_mode == 1:
-        vlm_choice = _get_cloud_provider("openai")
-        print(f"\n  {_bold('VLM configuration')}")
+        vlm_choice = _get_cloud_provider_by_label("VolcEngine (火山引擎)")
+        print(f"\n  {_bold('VolcEngine VLM configuration')}")
         vlm_api_key = _prompt_required_input("API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
@@ -892,8 +901,8 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_api_base = vlm_choice.default_api_base
         vlm_provider = vlm_choice.provider
     elif vlm_mode == 2:
-        vlm_choice = _get_cloud_provider("volcengine")
-        print(f"\n  {_bold('VLM configuration')}")
+        vlm_choice = _get_cloud_provider_by_label("BytePlus")
+        print(f"\n  {_bold('BytePlus VLM configuration')}")
         vlm_api_key = _prompt_required_input("API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
@@ -902,13 +911,23 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_api_base = vlm_choice.default_api_base
         vlm_provider = vlm_choice.provider
     elif vlm_mode == 3:
+        vlm_choice = _get_cloud_provider_by_label("OpenAI")
+        print(f"\n  {_bold('OpenAI VLM configuration')}")
+        vlm_api_key = _prompt_required_input("API Key")
+        if not vlm_api_key:
+            print(f"  {_red('API key is required')}")
+            return None
+        vlm_model = _prompt_required_input("Model", default=vlm_choice.default_vlm_model)
+        vlm_api_base = vlm_choice.default_api_base
+        vlm_provider = vlm_choice.provider
+    elif vlm_mode == 4:
         _ensure_codex_auth()
         print(f"\n  {_bold('Codex VLM configuration')}")
         vlm_model = _prompt_required_input("Model", default=_DEFAULT_CODEX_MODEL)
         vlm_api_base = _DEFAULT_CODEX_BASE_URL
         vlm_api_key = None
         vlm_provider = "openai-codex"
-    elif vlm_mode == 4:
+    elif vlm_mode == 5:
         print(f"\n  {_bold('Kimi VLM configuration')}")
         vlm_api_key = _prompt_required_input("API Key")
         if not vlm_api_key:
@@ -939,6 +958,33 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_api_key=vlm_api_key,
         vlm_api_base=vlm_api_base,
     )
+
+
+def _wizard_server() -> dict[str, Any] | None:
+    """Prompt for server host binding and root_api_key (when remote)."""
+    print(f"\n  {_bold('Server binding')}")
+    print(f"  {_dim('Local: only this machine can reach the server.')}")
+    print(f"  {_dim('Remote: bind to 0.0.0.0 — required for Docker / LAN access.')}")
+
+    mode = _prompt_choice(
+        "Bind server host to:",
+        [
+            ("Local (127.0.0.1)", _dim("(default, safer)")),
+            ("Remote (0.0.0.0)", _dim("(required for Docker / remote access)")),
+        ],
+        default=1,
+    )
+
+    if mode == 1:
+        return {"host": "127.0.0.1"}
+
+    print(f"\n  {_bold('Remote binding requires a root API key.')}")
+    print(f"  {_dim('Clients must send this key as a Bearer token to authenticate.')}")
+    root_api_key = _prompt_required_input("Root API Key")
+    if not root_api_key:
+        print(f"  {_red('Root API key is required for remote binding')}")
+        return None
+    return {"host": "0.0.0.0", "root_api_key": root_api_key}
 
 
 def _wizard_custom() -> dict[str, Any] | None:
@@ -992,7 +1038,7 @@ def run_init() -> int:
         [
             ("Local embedding via llama.cpp", "(CPU embedding, no GPU required)"),
             ("Local models via Ollama", "(recommended for macOS / Apple Silicon)"),
-            ("Cloud API", "(OpenAI, Volcengine, etc.)"),
+            ("Cloud API", "(VolcEngine, BytePlus, OpenAI, etc.)"),
             ("Custom", "(manual editing)"),
         ],
         default=1,
@@ -1014,6 +1060,12 @@ def run_init() -> int:
         print("\n  Setup cancelled.\n")
         return 0
 
+    server_dict = _wizard_server()
+    if server_dict is None:
+        print("\n  Setup cancelled.\n")
+        return 0
+    config_dict["server"] = server_dict
+
     # Summary
     emb = config_dict.get("embedding", {}).get("dense", {})
     vlm = config_dict.get("vlm", {})
@@ -1024,6 +1076,9 @@ def run_init() -> int:
         print("    Model path: custom local model (hidden)")
     vlm_summary = _configured_hint(bool(vlm))
     print(f"    VLM:        {vlm_summary}")
+    print(f"    Server:     bound to {server_dict['host']}")
+    if server_dict.get("root_api_key"):
+        print("    Root API key: configured (hidden)")
     print("    Workspace:  configured (hidden)")
     print("    Config:     default config location")
 

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -95,12 +95,80 @@ def _prompt_choice(prompt: str, options: list[tuple[str, str]], default: int = 1
         print(f"  {_red('Please enter a number between 1 and ' + str(len(options)))}")
 
 
-def _prompt_required_input(prompt: str, default: str | None = None) -> str:
-    """Prompt for a required free-text value."""
+def _mask_secret(value: str, prefix: int = 7, suffix: int = 4) -> str:
+    """Mask a secret string, showing only the first ``prefix`` and last ``suffix`` chars."""
+    if not value:
+        return ""
+    if len(value) <= prefix + suffix:
+        return "*" * len(value)
+    return f"{value[:prefix]}{'*' * (len(value) - prefix - suffix)}{value[-suffix:]}"
+
+
+def _masked_input(prompt: str) -> str:
+    """Read a line of input, echoing ``*`` per character; on submit, rewrite
+    the line to show ``prompt + _mask_secret(value)`` (prefix 7 + suffix 4).
+
+    Falls back to plain ``input()`` when stdin/stdout aren't TTYs (tests,
+    pipes) and to ``getpass.getpass`` (no echo at all) on platforms
+    without ``termios`` (Windows).
+    """
+    import sys
+
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return input(prompt)
+
+    try:
+        import termios
+        import tty
+    except ImportError:
+        import getpass
+
+        return getpass.getpass(prompt)
+
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    fd = sys.stdin.fileno()
+    old_attrs = termios.tcgetattr(fd)
+    chars: list[str] = []
+    try:
+        tty.setraw(fd)
+        while True:
+            ch = sys.stdin.read(1)
+            if ch in ("\r", "\n"):
+                break
+            if ch == "\x03":  # Ctrl-C
+                raise KeyboardInterrupt
+            if ch == "\x04":  # Ctrl-D / EOF
+                if not chars:
+                    raise EOFError
+                break
+            if ch in ("\x7f", "\b"):  # Backspace / DEL
+                if chars:
+                    chars.pop()
+                    sys.stdout.write("\b \b")
+                    sys.stdout.flush()
+                continue
+            if ch < " ":  # Other control chars — ignore
+                continue
+            chars.append(ch)
+            sys.stdout.write("*")
+            sys.stdout.flush()
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+        value = "".join(chars)
+        # Rewrite the line: \r → clear → prompt + masked preview + \n.
+        sys.stdout.write("\r\033[2K" + prompt + _mask_secret(value) + "\n")
+        sys.stdout.flush()
+    return value
+
+
+def _prompt_required_input(prompt: str, default: str | None = None, *, mask: bool = False) -> str:
+    """Prompt for a required free-text value. When ``mask`` is True, echo ``*`` per char."""
+    reader = _masked_input if mask else input
     while True:
         try:
             prompt_text = f"  {prompt} [{default}]: " if default is not None else f"  {prompt}: "
-            raw = input(prompt_text).strip()
+            raw = reader(prompt_text).strip()
         except EOFError:
             return default or ""
         if not raw and default is not None:
@@ -108,6 +176,11 @@ def _prompt_required_input(prompt: str, default: str | None = None) -> str:
         if raw:
             return raw
         print(f"  {_red(prompt + ' is required')}")
+
+
+def _prompt_api_key(prompt: str = "API Key") -> str:
+    """Prompt for an API key with inline masked echo (no extra confirmation line)."""
+    return _prompt_required_input(prompt, mask=True)
 
 
 def _prompt_required_int(prompt: str, default: int | None = None) -> int | None:
@@ -578,12 +651,25 @@ def _workspace_path() -> str:
     return str(_config_path().parent / "data")
 
 
+def _next_backup_path(config_path: Path) -> Path:
+    """Return a non-conflicting backup path: .bak, then .bak.1, .bak.2, ..."""
+    base = config_path.with_suffix(".conf.bak")
+    if not base.exists():
+        return base
+    i = 1
+    while True:
+        candidate = base.with_suffix(f".bak.{i}")
+        if not candidate.exists():
+            return candidate
+        i += 1
+
+
 def _write_config(config_dict: dict[str, Any], config_path: Path) -> bool:
-    """Write config dict as JSON. Backs up existing file as .bak."""
+    """Write config dict as JSON. Backs up existing file as .bak (rotates on conflict)."""
     try:
         config_path.parent.mkdir(parents=True, exist_ok=True)
         if config_path.exists():
-            backup = config_path.with_suffix(".conf.bak")
+            backup = _next_backup_path(config_path)
             config_path.rename(backup)
             print(f"  {_dim('Existing config backed up to ' + str(backup))}")
         config_path.write_text(
@@ -834,7 +920,7 @@ def _wizard_llamacpp() -> dict[str, Any] | None:
         choice = _prompt_choice("Cloud provider for VLM:", provider_options, default=1)
         provider = CLOUD_PROVIDERS[choice - 1]
 
-        vlm_api_key = _prompt_required_input("VLM API Key")
+        vlm_api_key = _prompt_api_key("VLM API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
             return None
@@ -877,7 +963,7 @@ def _wizard_cloud() -> dict[str, Any] | None:
 
     # Embedding config
     print(f"\n  {_bold('Embedding configuration')}")
-    embedding_api_key = _prompt_required_input("API Key")
+    embedding_api_key = _prompt_api_key("API Key")
     if not embedding_api_key:
         print(f"  {_red('API key is required')}")
         return None
@@ -893,7 +979,7 @@ def _wizard_cloud() -> dict[str, Any] | None:
     if vlm_mode == 1:
         vlm_choice = _get_cloud_provider_by_label("VolcEngine (火山引擎)")
         print(f"\n  {_bold('VolcEngine VLM configuration')}")
-        vlm_api_key = _prompt_required_input("API Key")
+        vlm_api_key = _prompt_api_key("API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
             return None
@@ -903,7 +989,7 @@ def _wizard_cloud() -> dict[str, Any] | None:
     elif vlm_mode == 2:
         vlm_choice = _get_cloud_provider_by_label("BytePlus")
         print(f"\n  {_bold('BytePlus VLM configuration')}")
-        vlm_api_key = _prompt_required_input("API Key")
+        vlm_api_key = _prompt_api_key("API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
             return None
@@ -913,7 +999,7 @@ def _wizard_cloud() -> dict[str, Any] | None:
     elif vlm_mode == 3:
         vlm_choice = _get_cloud_provider_by_label("OpenAI")
         print(f"\n  {_bold('OpenAI VLM configuration')}")
-        vlm_api_key = _prompt_required_input("API Key")
+        vlm_api_key = _prompt_api_key("API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
             return None
@@ -929,7 +1015,7 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_provider = "openai-codex"
     elif vlm_mode == 5:
         print(f"\n  {_bold('Kimi VLM configuration')}")
-        vlm_api_key = _prompt_required_input("API Key")
+        vlm_api_key = _prompt_api_key("API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
             return None
@@ -938,7 +1024,7 @@ def _wizard_cloud() -> dict[str, Any] | None:
         vlm_provider = "kimi"
     else:
         print(f"\n  {_bold('GLM VLM configuration')}")
-        vlm_api_key = _prompt_required_input("API Key")
+        vlm_api_key = _prompt_api_key("API Key")
         if not vlm_api_key:
             print(f"  {_red('API key is required')}")
             return None
@@ -980,7 +1066,7 @@ def _wizard_server() -> dict[str, Any] | None:
 
     print(f"\n  {_bold('Remote binding requires a root API key.')}")
     print(f"  {_dim('Clients must send this key as a Bearer token to authenticate.')}")
-    root_api_key = _prompt_required_input("Root API Key")
+    root_api_key = _prompt_api_key("Root API Key")
     if not root_api_key:
         print(f"  {_red('Root API key is required for remote binding')}")
         return None

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -23,6 +23,7 @@ from openviking_cli.setup_wizard import (
     _prompt_required_input,
     _prompt_required_int,
     _wizard_cloud,
+    _wizard_server,
     _workspace_path,
     _write_config,
     run_init,
@@ -136,7 +137,7 @@ class TestConfigBuilding:
         assert vlm_cfg["api_base"] == "http://localhost:11434"
 
     def test_cloud_config_structure(self):
-        provider = CLOUD_PROVIDERS[0]  # OpenAI
+        provider = CLOUD_PROVIDERS[2]  # OpenAI
 
         config = _build_cloud_config(
             provider,
@@ -153,7 +154,7 @@ class TestConfigBuilding:
         assert config["vlm"]["provider"] == "openai"
 
     def test_cloud_config_supports_codex_vlm(self):
-        provider = CLOUD_PROVIDERS[1]  # Volcengine
+        provider = CLOUD_PROVIDERS[0]  # VolcEngine
 
         config = _build_cloud_config(
             provider,
@@ -176,7 +177,7 @@ class TestConfigBuilding:
     def test_cloud_wizard_codex_uses_default_base_and_workspace(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[2, 3],
+            side_effect=[1, 4],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
@@ -202,7 +203,7 @@ class TestConfigBuilding:
     def test_cloud_wizard_supports_openai_vlm_option(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[1, 1],
+            side_effect=[3, 3],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
@@ -223,12 +224,12 @@ class TestConfigBuilding:
         assert config["storage"]["workspace"] == _workspace_path()
         assert config["vlm"]["provider"] == "openai"
         assert config["vlm"]["api_key"] == "openai-vlm-test"
-        assert config["vlm"]["api_base"] == CLOUD_PROVIDERS[0].default_api_base
+        assert config["vlm"]["api_base"] == CLOUD_PROVIDERS[2].default_api_base
 
     def test_cloud_wizard_supports_volcengine_vlm_option(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[1, 2],
+            side_effect=[3, 1],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
@@ -249,13 +250,40 @@ class TestConfigBuilding:
         assert config["storage"]["workspace"] == _workspace_path()
         assert config["vlm"]["provider"] == "volcengine"
         assert config["vlm"]["api_key"] == "ve-vlm-test"
-        assert config["vlm"]["api_base"] == CLOUD_PROVIDERS[1].default_api_base
+        assert config["vlm"]["api_base"] == CLOUD_PROVIDERS[0].default_api_base
         assert config["vlm"]["model"] == "doubao-seed-2-0-code-preview-260215"
+
+    def test_cloud_wizard_supports_byteplus_vlm_option(self):
+        with patch(
+            "openviking_cli.setup_wizard._prompt_choice",
+            side_effect=[3, 2],
+        ):
+            with patch(
+                "openviking_cli.setup_wizard._prompt_required_input",
+                side_effect=[
+                    "embed-test",
+                    "text-embedding-3-small",
+                    "bp-vlm-test",
+                    "doubao-seed-2-0-code-preview-260215",
+                ],
+            ):
+                with patch(
+                    "openviking_cli.setup_wizard._prompt_required_int",
+                    return_value=1536,
+                ):
+                    config = _wizard_cloud()
+
+        assert config is not None
+        assert config["storage"]["workspace"] == _workspace_path()
+        assert config["vlm"]["provider"] == "openai"
+        assert config["vlm"]["api_key"] == "bp-vlm-test"
+        assert config["vlm"]["api_base"] == CLOUD_PROVIDERS[1].default_api_base
+        assert config["vlm"]["api_base"] == "https://ark.ap-southeast.bytepluses.com/api/v3"
 
     def test_cloud_wizard_supports_kimi_vlm(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[2, 4],
+            side_effect=[1, 5],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
@@ -282,7 +310,7 @@ class TestConfigBuilding:
     def test_cloud_wizard_supports_glm_vlm(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[2, 5],
+            side_effect=[1, 6],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
@@ -321,50 +349,50 @@ class TestConfigBuilding:
     def test_cloud_wizard_uses_requested_defaults_when_inputs_are_empty(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[2, 3],
+            side_effect=[1, 4],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
                 side_effect=[
                     "ve-test",
-                    CLOUD_PROVIDERS[1].default_embedding_model,
+                    CLOUD_PROVIDERS[0].default_embedding_model,
                     _DEFAULT_CODEX_MODEL,
                 ],
             ) as prompt_input:
                 with patch(
                     "openviking_cli.setup_wizard._prompt_required_int",
-                    return_value=CLOUD_PROVIDERS[1].default_embedding_dim,
+                    return_value=CLOUD_PROVIDERS[0].default_embedding_dim,
                 ) as prompt_int:
                     with patch("openviking_cli.setup_wizard._ensure_codex_auth", return_value=True):
                         config = _wizard_cloud()
 
         assert config is not None
-        assert config["embedding"]["dense"]["model"] == CLOUD_PROVIDERS[1].default_embedding_model
-        assert config["embedding"]["dense"]["dimension"] == CLOUD_PROVIDERS[1].default_embedding_dim
+        assert config["embedding"]["dense"]["model"] == CLOUD_PROVIDERS[0].default_embedding_model
+        assert config["embedding"]["dense"]["dimension"] == CLOUD_PROVIDERS[0].default_embedding_dim
         assert config["vlm"]["model"] == _DEFAULT_CODEX_MODEL
-        prompt_input.assert_any_call("Model", default=CLOUD_PROVIDERS[1].default_embedding_model)
+        prompt_input.assert_any_call("Model", default=CLOUD_PROVIDERS[0].default_embedding_model)
         prompt_input.assert_any_call("Model", default=_DEFAULT_CODEX_MODEL)
         prompt_int.assert_called_once_with(
-            "Dimension", default=CLOUD_PROVIDERS[1].default_embedding_dim
+            "Dimension", default=CLOUD_PROVIDERS[0].default_embedding_dim
         )
 
     def test_cloud_wizard_kimi_uses_requested_default_model(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[2, 4],
+            side_effect=[1, 5],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
                 side_effect=[
                     "ve-test",
-                    CLOUD_PROVIDERS[1].default_embedding_model,
+                    CLOUD_PROVIDERS[0].default_embedding_model,
                     "kimi-test",
                     _DEFAULT_KIMI_MODEL,
                 ],
             ) as prompt_input:
                 with patch(
                     "openviking_cli.setup_wizard._prompt_required_int",
-                    return_value=CLOUD_PROVIDERS[1].default_embedding_dim,
+                    return_value=CLOUD_PROVIDERS[0].default_embedding_dim,
                 ):
                     config = _wizard_cloud()
 
@@ -375,20 +403,20 @@ class TestConfigBuilding:
     def test_cloud_wizard_glm_uses_requested_default_model(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[2, 5],
+            side_effect=[1, 6],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
                 side_effect=[
                     "ve-test",
-                    CLOUD_PROVIDERS[1].default_embedding_model,
+                    CLOUD_PROVIDERS[0].default_embedding_model,
                     "glm-test",
                     _DEFAULT_GLM_MODEL,
                 ],
             ) as prompt_input:
                 with patch(
                     "openviking_cli.setup_wizard._prompt_required_int",
-                    return_value=CLOUD_PROVIDERS[1].default_embedding_dim,
+                    return_value=CLOUD_PROVIDERS[0].default_embedding_dim,
                 ):
                     config = _wizard_cloud()
 
@@ -399,28 +427,28 @@ class TestConfigBuilding:
     def test_cloud_wizard_volcengine_uses_requested_default_model(self):
         with patch(
             "openviking_cli.setup_wizard._prompt_choice",
-            side_effect=[1, 2],
+            side_effect=[3, 1],
         ):
             with patch(
                 "openviking_cli.setup_wizard._prompt_required_input",
                 side_effect=[
                     "embed-test",
-                    CLOUD_PROVIDERS[0].default_embedding_model,
+                    CLOUD_PROVIDERS[2].default_embedding_model,
                     "ve-vlm-test",
-                    CLOUD_PROVIDERS[1].default_vlm_model,
+                    CLOUD_PROVIDERS[0].default_vlm_model,
                 ],
             ) as prompt_input:
                 with patch(
                     "openviking_cli.setup_wizard._prompt_required_int",
-                    return_value=CLOUD_PROVIDERS[0].default_embedding_dim,
+                    return_value=CLOUD_PROVIDERS[2].default_embedding_dim,
                 ):
                     config = _wizard_cloud()
 
         assert config is not None
         assert config["vlm"]["provider"] == "volcengine"
         assert config["vlm"]["api_key"] == "ve-vlm-test"
-        assert config["vlm"]["model"] == CLOUD_PROVIDERS[1].default_vlm_model
-        prompt_input.assert_any_call("Model", default=CLOUD_PROVIDERS[1].default_vlm_model)
+        assert config["vlm"]["model"] == CLOUD_PROVIDERS[0].default_vlm_model
+        prompt_input.assert_any_call("Model", default=CLOUD_PROVIDERS[0].default_vlm_model)
 
     def test_all_presets_valid(self):
         """Every preset should produce a config with required fields."""
@@ -515,6 +543,10 @@ class TestConfigWriting:
             patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(config_path)}, clear=False),
             patch("openviking_cli.setup_wizard._prompt_choice", return_value=2),
             patch("openviking_cli.setup_wizard._wizard_ollama", return_value=config),
+            patch(
+                "openviking_cli.setup_wizard._wizard_server",
+                return_value={"host": "127.0.0.1"},
+            ),
             patch("openviking_cli.setup_wizard._prompt_confirm", return_value=True),
             patch("openviking_cli.setup_wizard._write_config", return_value=True),
             patch("builtins.print") as mock_print,
@@ -546,13 +578,19 @@ class TestConfigWriting:
             patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(config_path)}, clear=False),
             patch("openviking_cli.setup_wizard._prompt_choice", return_value=2),
             patch("openviking_cli.setup_wizard._wizard_ollama", return_value=config),
+            patch(
+                "openviking_cli.setup_wizard._wizard_server",
+                return_value={"host": "127.0.0.1"},
+            ),
             patch("openviking_cli.setup_wizard._prompt_confirm", return_value=True),
             patch("openviking_cli.setup_wizard._write_config", return_value=True) as mock_write,
             patch("builtins.print"),
         ):
             assert run_init() == 0
 
-        mock_write.assert_called_once_with(config, config_path)
+        expected = dict(config)
+        expected["server"] = {"host": "127.0.0.1"}
+        mock_write.assert_called_once_with(expected, config_path)
 
 
 # ---------------------------------------------------------------------------
@@ -650,3 +688,38 @@ class TestLocalGGUFPresets:
             assert preset.dimension > 0
             assert preset.model_name
             assert preset.label
+
+
+class TestCloudProviderOrdering:
+    def test_volcengine_is_first_and_default(self):
+        assert CLOUD_PROVIDERS[0].label == "VolcEngine (火山引擎)"
+        assert CLOUD_PROVIDERS[0].provider == "volcengine"
+
+    def test_byteplus_is_second(self):
+        assert CLOUD_PROVIDERS[1].label == "BytePlus"
+        assert CLOUD_PROVIDERS[1].default_api_base == (
+            "https://ark.ap-southeast.bytepluses.com/api/v3"
+        )
+
+    def test_openai_is_third(self):
+        assert CLOUD_PROVIDERS[2].label == "OpenAI"
+        assert CLOUD_PROVIDERS[2].provider == "openai"
+
+
+class TestServerWizard:
+    def test_local_mode_returns_loopback_host(self):
+        with patch("openviking_cli.setup_wizard._prompt_choice", return_value=1):
+            assert _wizard_server() == {"host": "127.0.0.1"}
+
+    def test_remote_mode_requires_root_api_key(self):
+        with (
+            patch("openviking_cli.setup_wizard._prompt_choice", return_value=2),
+            patch(
+                "openviking_cli.setup_wizard._prompt_required_input",
+                return_value="my-secret-key",
+            ),
+        ):
+            assert _wizard_server() == {
+                "host": "0.0.0.0",
+                "root_api_key": "my-secret-key",
+            }

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -545,7 +545,7 @@ class TestConfigWriting:
 
         with (
             patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(config_path)}, clear=False),
-            patch("openviking_cli.setup_wizard._prompt_choice", return_value=2),
+            patch("openviking_cli.setup_wizard._prompt_choice", return_value=3),
             patch("openviking_cli.setup_wizard._wizard_ollama", return_value=config),
             patch(
                 "openviking_cli.setup_wizard._wizard_server",
@@ -580,7 +580,7 @@ class TestConfigWriting:
         }
         with (
             patch.dict(os.environ, {"OPENVIKING_CONFIG_FILE": str(config_path)}, clear=False),
-            patch("openviking_cli.setup_wizard._prompt_choice", return_value=2),
+            patch("openviking_cli.setup_wizard._prompt_choice", return_value=3),
             patch("openviking_cli.setup_wizard._wizard_ollama", return_value=config),
             patch(
                 "openviking_cli.setup_wizard._wizard_server",

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -20,6 +20,10 @@ from openviking_cli.setup_wizard import (
     _config_path,
     _get_recommended_indices,
     _is_llamacpp_installed,
+    _mask_secret,
+    _masked_input,
+    _next_backup_path,
+    _prompt_api_key,
     _prompt_required_input,
     _prompt_required_int,
     _wizard_cloud,
@@ -704,6 +708,86 @@ class TestCloudProviderOrdering:
     def test_openai_is_third(self):
         assert CLOUD_PROVIDERS[2].label == "OpenAI"
         assert CLOUD_PROVIDERS[2].provider == "openai"
+
+
+class TestBackupRotation:
+    def test_first_backup_uses_bak_suffix(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        assert _next_backup_path(config_path) == tmp_path / "ov.conf.bak"
+
+    def test_rotates_when_bak_exists(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        (tmp_path / "ov.conf.bak").write_text("old", encoding="utf-8")
+        assert _next_backup_path(config_path) == tmp_path / "ov.conf.bak.1"
+
+    def test_skips_existing_numbered_backups(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        (tmp_path / "ov.conf.bak").write_text("0", encoding="utf-8")
+        (tmp_path / "ov.conf.bak.1").write_text("1", encoding="utf-8")
+        (tmp_path / "ov.conf.bak.2").write_text("2", encoding="utf-8")
+        assert _next_backup_path(config_path) == tmp_path / "ov.conf.bak.3"
+
+    def test_write_config_rotates_existing_backup(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        config_path.write_text('{"v":1}', encoding="utf-8")
+        (tmp_path / "ov.conf.bak").write_text('{"old":true}', encoding="utf-8")
+
+        config = _build_ollama_config(EMBEDDING_PRESETS[0], VLM_PRESETS[0], str(tmp_path / "data"))
+        assert _write_config(config, config_path) is True
+
+        # Original backup preserved, new one rotated to .bak.1
+        assert (tmp_path / "ov.conf.bak").read_text() == '{"old":true}'
+        assert (tmp_path / "ov.conf.bak.1").read_text() == '{"v":1}'
+
+
+class TestApiKeyMasking:
+    def test_mask_short_secret_is_fully_starred(self):
+        assert _mask_secret("abc") == "***"
+        assert _mask_secret("a" * 11) == "*" * 11
+
+    def test_mask_long_secret_keeps_prefix_and_suffix(self):
+        value = "sk-proj-1234567890ABCDEF"
+        masked = _mask_secret(value)
+        assert masked.startswith("sk-proj")
+        assert masked.endswith("CDEF")
+        assert "1234567890AB" not in masked
+        assert len(masked) == len(value)
+
+    def test_mask_empty(self):
+        assert _mask_secret("") == ""
+
+    def test_prompt_api_key_uses_masked_input(self):
+        with patch(
+            "openviking_cli.setup_wizard._masked_input",
+            return_value="sk-proj-1234567890ABCDEF",
+        ) as masked:
+            value = _prompt_api_key("API Key")
+        assert value == "sk-proj-1234567890ABCDEF"
+        masked.assert_called_once()
+
+    def test_prompt_api_key_does_not_print_extra_preview_line(self, capsys):
+        with patch(
+            "openviking_cli.setup_wizard._masked_input",
+            return_value="sk-proj-1234567890ABCDEF",
+        ):
+            _prompt_api_key("API Key")
+        # No extra "Using ..." confirmation line — the inline rewrite in
+        # _masked_input is the only place the masked preview should appear.
+        assert "Using API Key" not in capsys.readouterr().out
+
+    def test_masked_input_falls_back_to_input_for_non_tty(self):
+        with patch("builtins.input", return_value="paste-me") as plain:
+            assert _masked_input("API Key: ") == "paste-me"
+        plain.assert_called_once_with("API Key: ")
+
+    def test_prompt_required_input_with_mask_routes_through_masked_input(self):
+        with patch(
+            "openviking_cli.setup_wizard._masked_input",
+            return_value="hunter2",
+        ) as masked:
+            value = _prompt_required_input("API Key", mask=True)
+        assert value == "hunter2"
+        masked.assert_called_once()
 
 
 class TestServerWizard:


### PR DESCRIPTION
## 背景

`openviking-server init` 在 Docker 场景与多次重跑场景下易用性不足，且对 API Key 输入缺乏掩码，存在被人肉读到 / 录屏泄露的风险。本 PR 对 setup wizard 做四项优化。

## 优化内容

### 1. 新增 Server 绑定步骤
- 在向导最后一步加入 `Local (127.0.0.1)` / `Remote (0.0.0.0)` 选项；
- 选择 Remote 时**强制**输入 `root_api_key`，否则向导终止；
- Remote 模式专为 Docker / 局域网部署而设，让 wizard 在容器里也真正可用。

### 2. Cloud Provider 重排 + 新增 BytePlus
- `VolcEngine (火山引擎)` 改为第一项并设为默认（保留中文与大小写）；
- 新增 `BytePlus`（OpenAI 兼容协议，endpoint `https://ark.ap-southeast.bytepluses.com/api/v3`）放在第二项；
- `OpenAI` 落到第三项；
- VLM provider 选项同步重排：VolcEngine → BytePlus → OpenAI → Codex → Kimi → GLM。

### 3. `.bak` 备份滚动
- 之前重跑 wizard 会用 `.bak` 直接覆盖上一次备份；
- 现在检测到 `.bak` 已存在时，自动回退到 `.bak.1` / `.bak.2` / ... 直到找到不冲突的文件名，避免静默丢历史。

### 4. API Key 输入掩码
- API Key / VLM API Key / Root API Key 输入时，每个键入或粘贴的字符都即时回显成 `*`；
- 用户回车提交后，**原地**重写当前行为 `API Key: sk-proj-***********CDEF`（前 7 后 4 显示，中间星号），不会另起一行；
- TTY 检测：在管道 / 测试环境自动回退到普通 `input()`；Windows 无 termios 时回退到 `getpass.getpass`（完全静默）。

## 测试

- `tests/cli/test_setup_wizard.py`：58 / 58 通过；
- 覆盖：provider 顺序、server wizard（local + remote/root_api_key）、`.bak` 滚动（首次 / 已存在 / 多个已存在）、`_mask_secret` 边界、`_masked_input` TTY fallback、`_prompt_api_key` 不打印额外行；
- `ruff check` 通过。

## Test plan
- [x] 在 Docker 容器内 `openviking-server init`，选 Remote，确认提示输入 root_api_key 且空值会拒绝；
- [x] 重跑 init，确认旧 `.bak` 被保留、新备份落到 `.bak.1`；
- [x] 在交互终端粘贴一个长 API Key，确认输入时全是 `*`，回车后该行变成 `prefix7****suffix4`；
- [x] 选择 VolcEngine、BytePlus、OpenAI 三种 provider 各跑一次，确认 endpoint 与 provider 字段正确写入 ov.conf。

<img width="1506" height="2674" alt="image" src="https://github.com/user-attachments/assets/3b8f267a-112f-4f04-9278-2ea5fed33d59" />