### PR TITLE
fix(storage): make content writes immediately readable

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -185,6 +185,7 @@ Update an existing file, or create a new one when `mode="create"`, and automatic
 - `replace` and `append` require the file to exist; `create` targets a new file and returns `409 Conflict` when the path already exists. Directories are always rejected.
 - `create` only accepts text-writable extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`, `.py`, `.js`, `.ts`. Parent directories are created automatically.
 - Derived semantic files cannot be written directly: `.abstract.md`, `.overview.md`, `.relations.json`.
+- File content is updated before the API returns. `wait` only controls whether the call waits for semantic/vector refresh to finish.
 - The public API no longer accepts `regenerate_semantics` or `revectorize`; write always refreshes related semantics and vectors.
 
 **Python SDK (Embedded / HTTP)**
@@ -236,8 +237,9 @@ openviking write viking://resources/docs/api.md \
     "context_type": "resource",
     "mode": "replace",
     "written_bytes": 29,
-    "semantic_updated": true,
-    "vector_updated": true,
+    "content_updated": true,
+    "semantic_status": "complete",
+    "vector_status": "complete",
     "queue_status": {
       "Semantic": {
         "processed": 1,

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -185,6 +185,7 @@ openviking read viking://resources/docs/api.md
 - `replace` 和 `append` 要求文件已存在；`create` 仅用于创建新文件，目标路径已存在时返回 `409 Conflict`。目录始终会被拒绝。
 - `create` 只允许以下文本类扩展名：`.md`、`.txt`、`.json`、`.yaml`、`.yml`、`.toml`、`.py`、`.js`、`.ts`。父目录会自动创建。
 - 不允许直接写入派生语义文件：`.abstract.md`、`.overview.md`、`.relations.json`。
+- 文件内容会在 API 返回前完成更新；`wait` 只控制是否等待语义/向量刷新完成。
 - 公共 API 已不再接受 `regenerate_semantics` 或 `revectorize`；写入后一定会自动刷新相关语义与向量。
 
 **Python SDK (Embedded / HTTP)**
@@ -236,8 +237,9 @@ openviking write viking://resources/docs/api.md \
     "context_type": "resource",
     "mode": "replace",
     "written_bytes": 29,
-    "semantic_updated": true,
-    "vector_updated": true,
+    "content_updated": true,
+    "semantic_status": "complete",
+    "vector_status": "complete",
     "queue_status": {
       "Semantic": {
         "processed": 1,

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -86,35 +86,113 @@ class ContentWriteCoordinator:
                 telemetry_id=telemetry_id,
             )
 
+        return await self._write_direct_with_refresh(
+            uri=normalized_uri,
+            root_uri=root_uri,
+            content=content,
+            mode=mode,
+            context_type=context_type,
+            wait=wait,
+            timeout=timeout,
+            ctx=ctx,
+            written_bytes=written_bytes,
+            telemetry_id=telemetry_id,
+        )
+
+    def _build_write_result(
+        self,
+        *,
+        uri: str,
+        root_uri: str,
+        context_type: str,
+        mode: str,
+        written_bytes: int,
+        wait: bool,
+        queue_status: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        semantic_status, vector_status = self._refresh_statuses(
+            wait=wait,
+            queue_status=queue_status,
+        )
+        return {
+            "uri": uri,
+            "root_uri": root_uri,
+            "context_type": context_type,
+            "mode": mode,
+            "written_bytes": written_bytes,
+            "content_updated": True,
+            "semantic_status": semantic_status,
+            "vector_status": vector_status,
+            # Legacy fields: kept for existing clients. They now mean the refresh
+            # was accepted (queued or completed), not necessarily completed.
+            "semantic_updated": semantic_status != "failed",
+            "vector_updated": vector_status != "failed",
+            "queue_status": queue_status,
+        }
+
+    def _refresh_statuses(
+        self,
+        *,
+        wait: bool,
+        queue_status: Optional[Dict[str, Any]],
+    ) -> tuple[str, str]:
+        if not wait:
+            return "queued", "queued"
+        if not queue_status:
+            return "complete", "complete"
+
+        def _has_errors(name: str) -> bool:
+            status = queue_status.get(name, {})
+            if not isinstance(status, dict):
+                return False
+            try:
+                return int(status.get("error_count", 0) or 0) > 0
+            except (TypeError, ValueError):
+                return bool(status.get("errors"))
+
+        semantic_status = "failed" if _has_errors("Semantic") else "complete"
+        vector_status = "failed" if _has_errors("Embedding") else "complete"
+        return semantic_status, vector_status
+
+    async def _write_direct_with_refresh(
+        self,
+        *,
+        uri: str,
+        root_uri: str,
+        content: str,
+        mode: str,
+        context_type: str,
+        wait: bool,
+        timeout: Optional[float],
+        ctx: RequestContext,
+        written_bytes: int,
+        telemetry_id: str,
+    ) -> Dict[str, Any]:
         lock_manager = get_lock_manager()
         handle = lock_manager.create_handle()
         lock_path = self._viking_fs._uri_to_path(root_uri, ctx=ctx)
         acquired = await lock_manager.acquire_subtree(handle, lock_path)
         if not acquired:
             await lock_manager.release(handle)
-            raise InvalidArgumentError(
-                f"resource is busy and cannot be written now: {normalized_uri}"
-            )
+            raise InvalidArgumentError(f"resource is busy and cannot be written now: {uri}")
 
-        temp_root_uri = ""
+        previous_content: Optional[str] = None
+        content_written = False
         lock_transferred = False
         try:
+            if mode != "create":
+                previous_content = await self._viking_fs.read_file(uri, ctx=ctx)
             if wait and telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
-            temp_root_uri, temp_target_uri = await self._prepare_temp_write(
-                uri=normalized_uri,
-                root_uri=root_uri,
-                content=content,
-                mode=mode,
-                ctx=ctx,
-            )
+            await self._write_in_place(uri, content, mode=mode, ctx=ctx)
+            content_written = True
             await self._enqueue_semantic_refresh(
-                temp_root_uri=temp_root_uri,
-                target_root_uri=root_uri,
-                temp_target_uri=temp_target_uri,
+                root_uri=root_uri,
+                changed_uri=uri,
                 context_type=context_type,
                 ctx=ctx,
                 lifecycle_lock_handle_id=handle.id,
+                change_type="added" if mode == "create" else "modified",
             )
             lock_transferred = True
             queue_status = (
@@ -122,28 +200,48 @@ class ContentWriteCoordinator:
                 if wait
                 else None
             )
-            return {
-                "uri": normalized_uri,
-                "root_uri": root_uri,
-                "context_type": context_type,
-                "mode": mode,
-                "written_bytes": written_bytes,
-                "semantic_updated": True,
-                "vector_updated": True,
-                "queue_status": queue_status,
-            }
+            return self._build_write_result(
+                uri=uri,
+                root_uri=root_uri,
+                context_type=context_type,
+                mode=mode,
+                written_bytes=written_bytes,
+                wait=wait,
+                queue_status=queue_status,
+            )
         except Exception:
-            if not lock_transferred and temp_root_uri:
-                try:
-                    await self._viking_fs.delete_temp(temp_root_uri, ctx=ctx)
-                except Exception:
-                    logger.debug("Failed to clean temp tree after write failure", exc_info=True)
+            if not lock_transferred and content_written:
+                await self._rollback_direct_write(
+                    uri=uri,
+                    previous_content=previous_content,
+                    mode=mode,
+                    ctx=ctx,
+                    lock_handle=handle,
+                )
             if not lock_transferred:
                 await lock_manager.release(handle)
             raise
         finally:
             if wait and telemetry_id:
                 get_request_wait_tracker().cleanup(telemetry_id)
+
+    async def _rollback_direct_write(
+        self,
+        *,
+        uri: str,
+        previous_content: Optional[str],
+        mode: str,
+        ctx: RequestContext,
+        lock_handle: Any,
+    ) -> None:
+        try:
+            if mode == "create":
+                await self._viking_fs.rm(uri, ctx=ctx, lock_handle=lock_handle)
+                return
+            if previous_content is not None:
+                await self._viking_fs.write_file(uri, previous_content, ctx=ctx)
+        except Exception:
+            logger.error("Failed to rollback direct content write for %s", uri, exc_info=True)
 
     def _validate_mode(self, mode: str) -> None:
         if mode not in {"replace", "append", "create"}:
@@ -206,9 +304,6 @@ class ContentWriteCoordinator:
         if not stat.get("not_found"):
             raise AlreadyExistsError(uri, "file")
 
-        # VikingFS.write_file auto-creates parent directories
-        await self._viking_fs.write_file(uri, content, ctx=ctx)
-
         context_type = self._context_type_for_uri(uri)
         root_uri = await self._resolve_root_uri(uri, ctx=ctx, _allow_not_found=True)
         written_bytes = len(content.encode("utf-8"))
@@ -227,62 +322,18 @@ class ContentWriteCoordinator:
                 telemetry_id=telemetry_id,
             )
 
-        lock_manager = get_lock_manager()
-        handle = lock_manager.create_handle()
-        lock_path = self._viking_fs._uri_to_path(root_uri, ctx=ctx)
-        acquired = await lock_manager.acquire_subtree(handle, lock_path)
-        if not acquired:
-            await lock_manager.release(handle)
-            raise InvalidArgumentError(f"resource is busy and cannot be written now: {uri}")
-
-        temp_root_uri = ""
-        lock_transferred = False
-        try:
-            if wait and telemetry_id:
-                get_request_wait_tracker().register_request(telemetry_id)
-            temp_root_uri, temp_target_uri = await self._prepare_temp_write(
-                uri=uri,
-                root_uri=root_uri,
-                content=content,
-                mode="create",
-                ctx=ctx,
-            )
-            await self._enqueue_semantic_refresh(
-                temp_root_uri=temp_root_uri,
-                target_root_uri=root_uri,
-                temp_target_uri=temp_target_uri,
-                context_type=context_type,
-                ctx=ctx,
-                lifecycle_lock_handle_id=handle.id,
-            )
-            lock_transferred = True
-            queue_status = (
-                await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
-                if wait
-                else None
-            )
-            return {
-                "uri": uri,
-                "root_uri": root_uri,
-                "context_type": context_type,
-                "mode": "create",
-                "written_bytes": written_bytes,
-                "semantic_updated": True,
-                "vector_updated": True,
-                "queue_status": queue_status,
-            }
-        except Exception:
-            if not lock_transferred and temp_root_uri:
-                try:
-                    await self._viking_fs.delete_temp(temp_root_uri, ctx=ctx)
-                except Exception:
-                    logger.debug("Failed to clean temp tree after write failure", exc_info=True)
-            if not lock_transferred:
-                await lock_manager.release(handle)
-            raise
-        finally:
-            if wait and telemetry_id:
-                get_request_wait_tracker().cleanup(telemetry_id)
+        return await self._write_direct_with_refresh(
+            uri=uri,
+            root_uri=root_uri,
+            content=content,
+            mode="create",
+            context_type=context_type,
+            wait=wait,
+            timeout=timeout,
+            ctx=ctx,
+            written_bytes=written_bytes,
+            telemetry_id=telemetry_id,
+        )
 
     async def _write_in_place(
         self,
@@ -316,73 +367,23 @@ class ContentWriteCoordinator:
             return
         await self._viking_fs.write_file(uri, content, ctx=ctx)
 
-    async def _prepare_temp_write(
-        self,
-        *,
-        uri: str,
-        root_uri: str,
-        content: str,
-        mode: str,
-        ctx: RequestContext,
-    ) -> tuple[str, str]:
-        temp_base = self._viking_fs.create_temp_uri(ctx=ctx)
-        await self._viking_fs.mkdir(temp_base, exist_ok=True, ctx=ctx)
-        root_name = root_uri.rstrip("/").split("/")[-1]
-        temp_root_uri = f"{temp_base.rstrip('/')}/{root_name}"
-        await self._copy_tree(root_uri, temp_root_uri, ctx=ctx)
-
-        temp_target_uri = self._translate_to_temp_uri(
-            uri=uri, root_uri=root_uri, temp_root_uri=temp_root_uri
-        )
-        await self._write_in_place(temp_target_uri, content, mode=mode, ctx=ctx)
-        return temp_root_uri, temp_target_uri
-
-    async def _copy_tree(self, src_uri: str, dst_uri: str, *, ctx: RequestContext) -> None:
-        stat = await self._safe_stat(src_uri, ctx=ctx)
-        if not stat.get("isDir"):
-            raise InvalidArgumentError(f"incremental write root must be a directory: {src_uri}")
-
-        await self._viking_fs.mkdir(dst_uri, exist_ok=True, ctx=ctx)
-        entries = await self._viking_fs.ls(
-            src_uri, output="original", show_all_hidden=True, ctx=ctx
-        )
-        for entry in entries:
-            name = entry.get("name", "")
-            if not name or name in {".", ".."}:
-                continue
-            src_child = VikingURI(src_uri).join(name).uri
-            dst_child = VikingURI(dst_uri).join(name).uri
-            if entry.get("isDir", False):
-                await self._copy_tree(src_child, dst_child, ctx=ctx)
-                continue
-            content = await self._viking_fs.read_file_bytes(src_child, ctx=ctx)
-            await self._viking_fs.write_file_bytes(dst_child, content, ctx=ctx)
-
-    def _translate_to_temp_uri(self, *, uri: str, root_uri: str, temp_root_uri: str) -> str:
-        if uri == root_uri:
-            return temp_root_uri
-        prefix = root_uri.rstrip("/") + "/"
-        if not uri.startswith(prefix):
-            raise InvalidArgumentError(f"uri {uri} is not inside write root {root_uri}")
-        relative = uri[len(prefix) :]
-        return f"{temp_root_uri.rstrip('/')}/{relative}"
-
     async def _enqueue_semantic_refresh(
         self,
         *,
-        temp_root_uri: str,
-        target_root_uri: str,
-        temp_target_uri: str,
+        root_uri: str,
+        changed_uri: str,
         context_type: str,
         ctx: RequestContext,
         lifecycle_lock_handle_id: str,
+        change_type: str = "modified",
+        target_uri: str = "",
     ) -> None:
         queue_manager = get_queue_manager()
         semantic_queue = queue_manager.get_queue(queue_manager.SEMANTIC, allow_create=True)
         telemetry = get_current_telemetry()
         msg = SemanticMsg(
-            uri=temp_root_uri,
-            target_uri=target_root_uri,
+            uri=root_uri,
+            target_uri=target_uri,
             context_type=context_type,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
@@ -391,7 +392,7 @@ class ContentWriteCoordinator:
             skip_vectorization=False,
             telemetry_id=telemetry.telemetry_id,
             lifecycle_lock_handle_id=lifecycle_lock_handle_id,
-            changes={"modified": [temp_target_uri]},
+            changes={change_type: [changed_uri]},
         )
         await semantic_queue.enqueue(msg)
         if msg.telemetry_id:
@@ -530,16 +531,15 @@ class ContentWriteCoordinator:
                 if wait
                 else None
             )
-            return {
-                "uri": uri,
-                "root_uri": root_uri,
-                "context_type": "memory",
-                "mode": mode,
-                "written_bytes": written_bytes,
-                "semantic_updated": True,
-                "vector_updated": True,
-                "queue_status": queue_status,
-            }
+            return self._build_write_result(
+                uri=uri,
+                root_uri=root_uri,
+                context_type="memory",
+                mode=mode,
+                written_bytes=written_bytes,
+                wait=wait,
+                queue_status=queue_status,
+            )
         except Exception:
             if not lock_transferred:
                 await lock_manager.release(handle)

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -123,10 +123,6 @@ class ContentWriteCoordinator:
             "content_updated": True,
             "semantic_status": semantic_status,
             "vector_status": vector_status,
-            # Legacy fields: kept for existing clients. They now mean the refresh
-            # was accepted (queued or completed), not necessarily completed.
-            "semantic_updated": semantic_status != "failed",
-            "vector_updated": vector_status != "failed",
             "queue_status": queue_status,
         }
 

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -80,6 +80,7 @@ class SemanticDagExecutor:
         recursive: bool = True,
         lifecycle_lock_handle_id: str = "",
         is_code_repo: bool = False,
+        changes: Optional[Dict[str, List[str]]] = None,
     ):
         self._processor = processor
         self._context_type = context_type
@@ -92,6 +93,10 @@ class SemanticDagExecutor:
         self._recursive = recursive
         self._lifecycle_lock_handle_id = lifecycle_lock_handle_id
         self._is_code_repo = is_code_repo
+        self._changes = changes or {}
+        self._changed_paths = {
+            path for key in ("added", "modified", "deleted") for path in self._changes.get(key, [])
+        }
         self._llm_sem = asyncio.Semaphore(max_concurrent_llm)
         self._viking_fs = get_viking_fs()
         self._nodes: Dict[str, DirNode] = {}
@@ -115,6 +120,9 @@ class SemanticDagExecutor:
             return
 
         if not self._target_uri or not self._root_uri:
+            return noop_callback
+
+        if self._target_uri == self._root_uri:
             return noop_callback
 
         # If full update, move temp uri to target uri has been handled in the processor
@@ -316,7 +324,22 @@ class SemanticDagExecutor:
         except Exception:
             return None
 
+    def _is_direct_incremental_update(self) -> bool:
+        return (
+            self._incremental_update
+            and bool(self._changed_paths)
+            and self._target_uri == self._root_uri
+        )
+
+    def _path_has_direct_change(self, uri: str) -> bool:
+        if uri in self._changed_paths:
+            return True
+        prefix = uri.rstrip("/") + "/"
+        return any(path.startswith(prefix) for path in self._changed_paths)
+
     async def _check_file_content_changed(self, file_path: str) -> bool:
+        if self._is_direct_incremental_update():
+            return file_path in self._changed_paths
         target_path = self._get_target_file_path(file_path)
         if not target_path:
             return True
@@ -392,6 +415,17 @@ class SemanticDagExecutor:
     async def _check_dir_children_changed(
         self, dir_uri: str, current_files: List[str], current_dirs: List[str]
     ) -> bool:
+        if self._is_direct_incremental_update():
+            if self._path_has_direct_change(dir_uri):
+                return True
+            for current_file in current_files:
+                if self._file_change_status.get(current_file, True):
+                    return True
+            for current_dir in current_dirs:
+                if self._dir_change_status.get(current_dir, True):
+                    return True
+            return False
+
         target_path = self._get_target_file_path(dir_uri)
         if not target_path:
             return True

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -298,6 +298,7 @@ class SemanticProcessor(DequeueHandlerBase):
                         await self._process_memory_directory(msg)
                     else:
                         is_incremental = False
+                        target_uri = msg.target_uri
                         viking_fs = get_viking_fs()
                         if msg.target_uri:
                             target_exists = await viking_fs.exists(
@@ -309,10 +310,19 @@ class SemanticProcessor(DequeueHandlerBase):
                                 logger.info(
                                     f"Target URI exists, using incremental update: {msg.target_uri}"
                                 )
+                            elif target_exists and msg.changes and msg.uri == msg.target_uri:
+                                is_incremental = True
+                                logger.info(
+                                    f"Using direct incremental semantic update for: {msg.uri}"
+                                )
+                        elif msg.changes:
+                            is_incremental = True
+                            target_uri = msg.uri
+                            logger.info(f"Using direct incremental semantic update for: {msg.uri}")
 
                         # Re-acquire lifecycle lock if handle was lost (e.g. server restart)
                         if msg.lifecycle_lock_handle_id:
-                            lock_uri = msg.target_uri or msg.uri
+                            lock_uri = target_uri or msg.uri
                             msg.lifecycle_lock_handle_id = await self._ensure_lifecycle_lock(
                                 msg.lifecycle_lock_handle_id,
                                 viking_fs._uri_to_path(lock_uri, ctx=self._current_ctx),
@@ -324,12 +334,13 @@ class SemanticProcessor(DequeueHandlerBase):
                             max_concurrent_llm=self.max_concurrent_llm,
                             ctx=self._current_ctx,
                             incremental_update=is_incremental,
-                            target_uri=msg.target_uri,
+                            target_uri=target_uri,
                             semantic_msg_id=msg.id,
                             telemetry_id=msg.telemetry_id,
                             recursive=msg.recursive,
                             lifecycle_lock_handle_id=msg.lifecycle_lock_handle_id,
                             is_code_repo=msg.is_code_repo,
+                            changes=msg.changes,
                         )
                         self._dag_executor = executor
                         if msg.lifecycle_lock_handle_id:

--- a/tests/server/test_api_content_write.py
+++ b/tests/server/test_api_content_write.py
@@ -91,6 +91,31 @@ async def test_write_appends_existing_resource_file(client_with_resource):
     assert read_resp.json()["result"] == original + "\n\nAppended section."
 
 
+async def test_write_without_wait_is_immediately_readable(client_with_resource):
+    client, uri = client_with_resource
+    file_uri = await _first_file_uri(client, uri)
+    original = (await client.get("/api/v1/content/read", params={"uri": file_uri})).json()["result"]
+
+    write_resp = await client.post(
+        "/api/v1/content/write",
+        json={
+            "uri": file_uri,
+            "content": "\nImmediate append.",
+            "mode": "append",
+            "wait": False,
+        },
+    )
+    assert write_resp.status_code == 200
+    body = write_resp.json()
+    assert body["result"]["content_updated"] is True
+    assert body["result"]["semantic_status"] == "queued"
+    assert body["result"]["vector_status"] == "queued"
+
+    read_resp = await client.get("/api/v1/content/read", params={"uri": file_uri})
+    assert read_resp.status_code == 200
+    assert read_resp.json()["result"] == original + "\nImmediate append."
+
+
 @pytest.mark.asyncio
 async def test_write_missing_uri_validation(client):
     resp = await client.post("/api/v1/content/write", json={"content": "missing uri"})

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -140,8 +140,9 @@ async def test_memory_write_vector_refresh_includes_generated_summary(monkeypatc
         ctx,
         semantic_msg_id=None,
         use_summary=False,
+        preserve_existing_created_at=False,
     ):
-        del ctx, semantic_msg_id, use_summary
+        del ctx, semantic_msg_id, use_summary, preserve_existing_created_at
         captured["file_path"] = file_path
         captured["summary_dict"] = summary_dict
         captured["parent_uri"] = parent_uri
@@ -193,6 +194,9 @@ class _FakeVikingFS:
         self._file_uri = file_uri
         self._root_uri = root_uri
         self.delete_temp_calls = []
+        self.write_file_calls = []
+        self.rm_calls = []
+        self.content = {file_uri: "original"}
 
     async def stat(self, uri: str, ctx=None):
         del ctx
@@ -210,6 +214,20 @@ class _FakeVikingFS:
         del ctx
         self.delete_temp_calls.append(temp_uri)
 
+    async def read_file(self, uri: str, ctx=None):
+        del ctx
+        return self.content[uri]
+
+    async def write_file(self, uri: str, content: str, ctx=None):
+        del ctx
+        self.write_file_calls.append((uri, content))
+        self.content[uri] = content
+
+    async def rm(self, uri: str, ctx=None, lock_handle=None):
+        del ctx, lock_handle
+        self.rm_calls.append(uri)
+        self.content.pop(uri, None)
+
 
 @pytest.mark.asyncio
 async def test_write_timeout_after_enqueue_does_not_release_resource_lock(monkeypatch):
@@ -225,20 +243,16 @@ async def test_write_timeout_after_enqueue_does_not_release_resource_lock(monkey
         lambda: lock_manager,
     )
 
-    async def _fake_prepare_temp_write(**kwargs):
-        del kwargs
-        return "viking://temp/demo", "viking://temp/demo/doc.md"
-
     async def _fake_enqueue_semantic_refresh(**kwargs):
         del kwargs
         return None
 
-    async def _fake_wait_for_queues(*, timeout):
+    async def _fake_wait_for_request(*, telemetry_id, timeout):
+        del telemetry_id
         raise DeadlineExceededError("queue processing", timeout)
 
-    monkeypatch.setattr(coordinator, "_prepare_temp_write", _fake_prepare_temp_write)
     monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
-    monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
+    monkeypatch.setattr(coordinator, "_wait_for_request", _fake_wait_for_request)
 
     with pytest.raises(DeadlineExceededError):
         await coordinator.write(
@@ -250,6 +264,111 @@ async def test_write_timeout_after_enqueue_does_not_release_resource_lock(monkey
 
     assert lock_manager.release_calls == []
     assert viking_fs.delete_temp_calls == []
+    assert viking_fs.content[file_uri] == "updated"
+
+
+@pytest.mark.asyncio
+async def test_resource_write_updates_target_and_queues_refresh_before_return(monkeypatch):
+    file_uri = "viking://resources/demo/doc.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    lock_manager = _FakeLockManager()
+    captured_enqueue = {}
+
+    monkeypatch.setattr(
+        "openviking.storage.content_write.get_lock_manager",
+        lambda: lock_manager,
+    )
+
+    async def _fake_enqueue_semantic_refresh(**kwargs):
+        captured_enqueue.update(kwargs)
+
+    monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
+
+    result = await coordinator.write(
+        uri=file_uri,
+        content="updated",
+        ctx=ctx,
+        mode="replace",
+        wait=False,
+    )
+
+    assert viking_fs.content[file_uri] == "updated"
+    assert result["content_updated"] is True
+    assert result["semantic_status"] == "queued"
+    assert result["vector_status"] == "queued"
+    assert captured_enqueue["root_uri"] == root_uri
+    assert captured_enqueue["changed_uri"] == file_uri
+    assert captured_enqueue["change_type"] == "modified"
+    assert viking_fs.delete_temp_calls == []
+    assert lock_manager.release_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resource_write_rolls_back_replace_when_enqueue_fails(monkeypatch):
+    file_uri = "viking://resources/demo/doc.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    lock_manager = _FakeLockManager()
+
+    monkeypatch.setattr(
+        "openviking.storage.content_write.get_lock_manager",
+        lambda: lock_manager,
+    )
+
+    async def _fail_enqueue(**kwargs):
+        del kwargs
+        raise RuntimeError("queue unavailable")
+
+    monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fail_enqueue)
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        await coordinator.write(
+            uri=file_uri,
+            content="updated",
+            ctx=ctx,
+            mode="replace",
+        )
+
+    assert viking_fs.content[file_uri] == "original"
+    assert lock_manager.release_calls == ["lock-1"]
+
+
+@pytest.mark.asyncio
+async def test_resource_write_rolls_back_create_when_enqueue_fails(monkeypatch):
+    file_uri = "viking://resources/demo/new.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFSForCreate(file_uri=file_uri, root_uri=root_uri, file_exists=False)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    lock_manager = _FakeLockManager()
+
+    monkeypatch.setattr(
+        "openviking.storage.content_write.get_lock_manager",
+        lambda: lock_manager,
+    )
+
+    async def _fail_enqueue(**kwargs):
+        del kwargs
+        raise RuntimeError("queue unavailable")
+
+    monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fail_enqueue)
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        await coordinator.write(
+            uri=file_uri,
+            content="new content",
+            ctx=ctx,
+            mode="create",
+        )
+
+    assert file_uri not in viking_fs.content
+    assert viking_fs.rm_calls == [file_uri]
+    assert lock_manager.release_calls == ["lock-1"]
 
 
 @pytest.mark.asyncio
@@ -278,13 +397,14 @@ async def test_memory_write_timeout_after_enqueue_does_not_release_lock(monkeypa
         del kwargs
         return None
 
-    async def _fake_wait_for_queues(*, timeout):
+    async def _fake_wait_for_request(*, telemetry_id, timeout):
+        del telemetry_id
         raise DeadlineExceededError("queue processing", timeout)
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
     monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
-    monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
+    monkeypatch.setattr(coordinator, "_wait_for_request", _fake_wait_for_request)
 
     with pytest.raises(DeadlineExceededError):
         await coordinator.write(
@@ -309,6 +429,8 @@ class _FakeVikingFSForCreate:
         self._file_exists = file_exists
         self.delete_temp_calls = []
         self.write_file_calls = []
+        self.rm_calls = []
+        self.content = {}
 
     async def stat(self, uri: str, ctx=None):
         del ctx
@@ -334,6 +456,12 @@ class _FakeVikingFSForCreate:
     async def write_file(self, uri: str, content: str, *, ctx=None):
         del ctx
         self.write_file_calls.append((uri, content))
+        self.content[uri] = content
+
+    async def rm(self, uri: str, *, ctx=None, lock_handle=None):
+        del ctx, lock_handle
+        self.rm_calls.append(uri)
+        self.content.pop(uri, None)
 
 
 # Create-mode tests
@@ -350,8 +478,11 @@ async def test_create_mode_new_file_success(monkeypatch):
 
     monkeypatch.setattr("openviking.storage.content_write.get_lock_manager", lambda: lock_manager)
 
+    write_calls = []
+
     async def _fake_write_in_place(uri, content, *, mode, ctx):
-        del uri, mode, ctx
+        del mode, ctx
+        write_calls.append((uri, content))
         return content
 
     async def _fake_vectorize_single_file(uri, *, context_type, ctx):
@@ -376,6 +507,7 @@ async def test_create_mode_new_file_success(monkeypatch):
     )
 
     assert result["mode"] == "create"
+    assert write_calls == [(file_uri, "new content")]
 
 
 @pytest.mark.asyncio
@@ -455,8 +587,11 @@ async def test_create_mode_parent_dirs_auto_created(monkeypatch):
 
     monkeypatch.setattr("openviking.storage.content_write.get_lock_manager", lambda: lock_manager)
 
+    write_calls = []
+
     async def _fake_write_in_place(uri, content, *, mode, ctx):
-        del uri, mode, ctx
+        del mode, ctx
+        write_calls.append((uri, content))
         return content
 
     async def _fake_vectorize_single_file(uri, *, context_type, ctx):
@@ -476,11 +611,12 @@ async def test_create_mode_parent_dirs_auto_created(monkeypatch):
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
-    await coordinator.write(
+    result = await coordinator.write(
         uri=file_uri, content="nested content", mode="create", ctx=ctx, wait=True
     )
 
-    assert len(viking_fs.write_file_calls) > 0
+    assert result["mode"] == "create"
+    assert write_calls == [(file_uri, "nested content")]
 
 
 @pytest.mark.asyncio
@@ -581,13 +717,12 @@ async def test_create_mode_resource_scope(monkeypatch):
 
     monkeypatch.setattr("openviking.storage.content_write.get_lock_manager", lambda: lock_manager)
 
-    async def _fake_prepare_temp_write(**kwargs):
-        del kwargs
-        return "viking://temp/demo", "viking://temp/demo/test.md"
-
     async def _fake_enqueue_semantic_refresh(**kwargs):
         # Verify resource-scope URIs take the resource write path
+        assert kwargs["root_uri"] == root_uri
+        assert kwargs["changed_uri"] == file_uri
         assert kwargs["context_type"] == "resource"
+        assert kwargs["change_type"] == "added"
         del kwargs
         return None
 
@@ -595,7 +730,6 @@ async def test_create_mode_resource_scope(monkeypatch):
         del timeout
         return None
 
-    monkeypatch.setattr(coordinator, "_prepare_temp_write", _fake_prepare_temp_write)
     monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -603,6 +737,7 @@ async def test_create_mode_resource_scope(monkeypatch):
         uri=file_uri, content="content", mode="create", ctx=ctx, wait=True
     )
     assert result["context_type"] == "resource"
+    assert viking_fs.content[file_uri] == "content"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_request_wait_tracking.py
+++ b/tests/server/test_request_wait_tracking.py
@@ -45,6 +45,7 @@ class _FakeVikingFS:
     def __init__(self, file_uri: str, root_uri: str):
         self._file_uri = file_uri
         self._root_uri = root_uri
+        self.content = {file_uri: "original"}
 
     async def stat(self, uri: str, ctx=None):
         del ctx
@@ -61,6 +62,18 @@ class _FakeVikingFS:
     async def delete_temp(self, temp_uri: str, ctx=None):
         del temp_uri, ctx
         return None
+
+    async def read_file(self, uri: str, ctx=None):
+        del ctx
+        return self.content[uri]
+
+    async def write_file(self, uri: str, content: str, ctx=None):
+        del ctx
+        self.content[uri] = content
+
+    async def rm(self, uri: str, ctx=None, lock_handle=None):
+        del ctx, lock_handle
+        self.content.pop(uri, None)
 
 
 @pytest.mark.asyncio
@@ -264,10 +277,6 @@ async def test_content_write_wait_uses_request_tracker(monkeypatch):
         raising=False,
     )
 
-    async def _fake_prepare_temp_write(**kwargs):
-        del kwargs
-        return "viking://temp/demo", "viking://temp/demo/doc.md"
-
     async def _fake_enqueue_semantic_refresh(**kwargs):
         del kwargs
         return None
@@ -276,7 +285,6 @@ async def test_content_write_wait_uses_request_tracker(monkeypatch):
         del timeout
         raise AssertionError("global queue wait should not be used")
 
-    monkeypatch.setattr(coordinator, "_prepare_temp_write", _fake_prepare_temp_write)
     monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _explode_wait_for_queues)
 
@@ -294,6 +302,8 @@ async def test_content_write_wait_uses_request_tracker(monkeypatch):
     assert tracker.wait_calls == [(telemetry.telemetry_id, 5.0)]
     assert tracker.build_calls == [telemetry.telemetry_id]
     assert tracker.cleaned == [telemetry.telemetry_id]
+    assert result["semantic_status"] == "complete"
+    assert result["vector_status"] == "complete"
 
 
 @pytest.mark.asyncio
@@ -327,10 +337,6 @@ async def test_content_write_wait_uses_request_tracker_when_telemetry_disabled(m
         raising=False,
     )
 
-    async def _fake_prepare_temp_write(**kwargs):
-        del kwargs
-        return "viking://temp/demo", "viking://temp/demo/doc.md"
-
     async def _fake_enqueue_semantic_refresh(**kwargs):
         del kwargs
         return None
@@ -339,7 +345,6 @@ async def test_content_write_wait_uses_request_tracker_when_telemetry_disabled(m
         del timeout
         raise AssertionError("global queue wait should not be used")
 
-    monkeypatch.setattr(coordinator, "_prepare_temp_write", _fake_prepare_temp_write)
     monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _explode_wait_for_queues)
 
@@ -357,6 +362,8 @@ async def test_content_write_wait_uses_request_tracker_when_telemetry_disabled(m
     assert tracker.wait_calls == [(telemetry.telemetry_id, 5.0)]
     assert tracker.build_calls == [telemetry.telemetry_id]
     assert tracker.cleaned == [telemetry.telemetry_id]
+    assert result["semantic_status"] == "complete"
+    assert result["vector_status"] == "complete"
 
 
 async def _return_true(handle, path):

--- a/tests/storage/test_semantic_dag_incremental_missing_summary.py
+++ b/tests/storage/test_semantic_dag_incremental_missing_summary.py
@@ -63,6 +63,7 @@ class _FakeProcessor:
     def __init__(self, viking_fs):
         self._fs = viking_fs
         self.summarized_files = []
+        self.sync_calls = []
 
     def _parse_overview_md(self, overview_content):
         results = {}
@@ -94,6 +95,7 @@ class _FakeProcessor:
     async def _sync_topdown_recursive(
         self, root_uri, target_uri, ctx=None, file_change_status=None, lifecycle_lock_handle_id=""
     ):
+        self.sync_calls.append((root_uri, target_uri))
         root_uri = self._fs._norm(root_uri)
         target_uri = self._fs._norm(target_uri)
         for path, content in list(self._fs._file_contents.items()):
@@ -163,6 +165,50 @@ async def test_incremental_missing_summary_triggers_overview_regen(monkeypatch):
     assert len(processor.summarized_files) == first_run_calls
 
 
+@pytest.mark.asyncio
+async def test_direct_incremental_update_uses_changes_without_temp_sync(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+
+    root_uri = "viking://resources/root"
+    tree = {
+        root_uri: [
+            {"name": "a.txt", "isDir": False},
+            {"name": "b.txt", "isDir": False},
+        ],
+    }
+
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "new content",
+            f"{root_uri}/b.txt": "unchanged",
+            f"{root_uri}/.overview.md": "FILES:\n- a.txt: old-a\n- b.txt: old-b",
+            f"{root_uri}/.abstract.md": "old-abstract",
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=root_uri,
+        changes={"modified": [f"{root_uri}/a.txt"]},
+    )
+    monkeypatch.setattr(executor, "_add_vectorize_task", AsyncMock())
+
+    await executor.run(root_uri)
+
+    assert processor.summarized_files == [f"{root_uri}/a.txt"]
+    assert processor.sync_calls == []
+    overview = fake_fs._file_contents[f"{root_uri}/.overview.md"]
+    assert "- a.txt: summary" in overview
+    assert "- b.txt: old-b" in overview
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
-


### PR DESCRIPTION
## Description

Make content writes for resource and skill files update the target file before returning, while semantic and vector refresh continue asynchronously unless `wait=true` is requested.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Write resource and skill content directly to the target URI before semantic refresh is queued, with rollback if refresh enqueue fails.
- Treat `wait=true` as waiting for semantic/vector processing only, and expose explicit `content_updated`, `semantic_status`, and `vector_status` response fields.
- Support direct incremental semantic DAG updates from `changes` without temp-to-target sync, and add regression coverage for immediate readability and rollback behavior.
- Update filesystem API docs with the new response fields and immediate-read behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
.venv/bin/python -m py_compile openviking/storage/content_write.py openviking/storage/queuefs/semantic_processor.py openviking/storage/queuefs/semantic_dag.py
.venv/bin/python -m pytest tests/server/test_content_write_service.py tests/storage/test_semantic_dag_incremental_missing_summary.py
.venv/bin/python -m pytest tests/server/test_request_wait_tracking.py tests/server/test_api_content_write.py
git diff --check
```

Note: `python -m pytest ...` with the system Python failed because the installed `pydantic-core` version is incompatible with the installed `pydantic` version, so validation was run with the project `.venv`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

After this change, a non-waiting write can be read back immediately from the same URI. Semantic and vector refresh status is reported separately from content persistence.

Response format:

```json
{
  "uri": "viking://resources/demo/doc.md",
  "root_uri": "viking://resources/demo",
  "context_type": "resource",
  "mode": "append",
  "written_bytes": 6,
  "content_updated": true,
  "semantic_status": "queued",
  "vector_status": "queued",
  "queue_status": null
}
```

Status values:

- `content_updated`: `true` means the target file has already been updated before the API returns.
- `semantic_status`: `queued` when `wait=false`; `complete` or `failed` when `wait=true`.
- `vector_status`: `queued` when `wait=false`; `complete` or `failed` when `wait=true`.
- `queue_status`: `null` when `wait=false`; request wait details when `wait=true`.
