### PR TITLE
Feat/openclaw tool result compression

### DIFF
--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -51,6 +51,14 @@ export type MemoryOpenVikingConfig = {
   emitStandardDiagnostics?: boolean;
   /** When true, log tenant routing for semantic find and session writes (messages/commit) to the plugin logger. */
   logFindRequests?: boolean;
+  /** When true (default), compress oversized tool results during assemble. */
+  toolResultCompression?: boolean;
+  /** Maximum characters per individual tool result before truncation. Default: 20000 */
+  toolResultMaxChars?: number;
+  /** Maximum aggregate characters for all tool results in one assembled context. Default: 100000 */
+  toolResultAggregateBudgetChars?: number;
+  /** Preview characters to keep when truncating a tool result. Default: 2000 */
+  toolResultPreviewChars?: number;
 };
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
@@ -68,6 +76,10 @@ const DEFAULT_COMMIT_TOKEN_THRESHOLD = 20000;
 const DEFAULT_BYPASS_SESSION_PATTERNS: string[] = [];
 const DEFAULT_EMIT_STANDARD_DIAGNOSTICS = false;
 const DEFAULT_LOCAL_CONFIG_PATH = join(homedir(), ".openviking", "ov.conf");
+
+const DEFAULT_TOOL_RESULT_MAX_CHARS = 20_000;
+const DEFAULT_TOOL_RESULT_AGGREGATE_BUDGET_CHARS = 100_000;
+const DEFAULT_TOOL_RESULT_PREVIEW_CHARS = 2_000;
 
 const DEFAULT_AGENT_ID = "default";
 const DEFAULT_SERVER_AUTH_MODE = "api_key";
@@ -185,6 +197,10 @@ export const memoryOpenVikingConfigSchema = {
         "ingestReplyAssistIgnoreSessionPatterns",
         "emitStandardDiagnostics",
         "logFindRequests",
+        "toolResultCompression",
+        "toolResultMaxChars",
+        "toolResultAggregateBudgetChars",
+        "toolResultPreviewChars",
       ],
       "openviking config",
     );
@@ -316,6 +332,19 @@ export const memoryOpenVikingConfigSchema = {
         cfg.logFindRequests === true ||
         envFlag("OPENVIKING_LOG_ROUTING") ||
         envFlag("OPENVIKING_DEBUG"),
+      toolResultCompression: cfg.toolResultCompression !== false,
+      toolResultMaxChars: Math.max(
+        2_000,
+        Math.floor(toNumber(cfg.toolResultMaxChars, DEFAULT_TOOL_RESULT_MAX_CHARS)),
+      ),
+      toolResultAggregateBudgetChars: Math.max(
+        20_000,
+        Math.floor(toNumber(cfg.toolResultAggregateBudgetChars, DEFAULT_TOOL_RESULT_AGGREGATE_BUDGET_CHARS)),
+      ),
+      toolResultPreviewChars: Math.max(
+        200,
+        Math.floor(toNumber(cfg.toolResultPreviewChars, DEFAULT_TOOL_RESULT_PREVIEW_CHARS)),
+      ),
     };
   },
   uiHints: {

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -53,6 +53,14 @@ export type MemoryOpenVikingConfig = {
   emitStandardDiagnostics?: boolean;
   /** When true, log tenant routing for semantic find and session writes (messages/commit) to the plugin logger. */
   logFindRequests?: boolean;
+  /** When true (default), compress oversized tool results during assemble. */
+  toolResultCompression?: boolean;
+  /** Maximum characters per individual tool result before truncation. Default: 20000 */
+  toolResultMaxChars?: number;
+  /** Maximum aggregate characters for all tool results in one assembled context. Default: 100000 */
+  toolResultAggregateBudgetChars?: number;
+  /** Preview characters to keep when truncating a tool result. Default: 2000 */
+  toolResultPreviewChars?: number;
 };
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
@@ -70,6 +78,13 @@ const DEFAULT_COMMIT_KEEP_RECENT_COUNT = 10;
 const DEFAULT_BYPASS_SESSION_PATTERNS: string[] = [];
 const DEFAULT_EMIT_STANDARD_DIAGNOSTICS = false;
 const DEFAULT_AGENT_PREFIX = "";
+
+const DEFAULT_TOOL_RESULT_MAX_CHARS = 20_000;
+const DEFAULT_TOOL_RESULT_AGGREGATE_BUDGET_CHARS = 100_000;
+const DEFAULT_TOOL_RESULT_PREVIEW_CHARS = 2_000;
+
+const DEFAULT_AGENT_ID = "default";
+const DEFAULT_SERVER_AUTH_MODE = "api_key";
 
 function resolveAgentPrefix(configured: unknown): string {
   if (typeof configured === "string" && configured.trim()) {
@@ -192,6 +207,10 @@ export const memoryOpenVikingConfigSchema = {
         "ingestReplyAssistIgnoreSessionPatterns",
         "emitStandardDiagnostics",
         "logFindRequests",
+        "toolResultCompression",
+        "toolResultMaxChars",
+        "toolResultAggregateBudgetChars",
+        "toolResultPreviewChars",
       ],
       "openviking config",
     );
@@ -323,6 +342,19 @@ export const memoryOpenVikingConfigSchema = {
         cfg.logFindRequests === true ||
         envFlag("OPENVIKING_LOG_ROUTING") ||
         envFlag("OPENVIKING_DEBUG"),
+      toolResultCompression: cfg.toolResultCompression !== false,
+      toolResultMaxChars: Math.max(
+        2_000,
+        Math.floor(toNumber(cfg.toolResultMaxChars, DEFAULT_TOOL_RESULT_MAX_CHARS)),
+      ),
+      toolResultAggregateBudgetChars: Math.max(
+        20_000,
+        Math.floor(toNumber(cfg.toolResultAggregateBudgetChars, DEFAULT_TOOL_RESULT_AGGREGATE_BUDGET_CHARS)),
+      ),
+      toolResultPreviewChars: Math.max(
+        200,
+        Math.floor(toNumber(cfg.toolResultPreviewChars, DEFAULT_TOOL_RESULT_PREVIEW_CHARS)),
+      ),
     };
   },
   uiHints: {

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -975,7 +975,7 @@ export function createMemoryOpenVikingContextEngine(params: {
 
         const { messages: compressedMessages, stats: compressionStats } = await compressToolResults(
           sanitized,
-          cfg,
+          { ...cfg, sessionId: OVSessionId },
         );
         const finalMessages = compressionStats.compressedCount > 0 ? compressedMessages : sanitized;
 

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -18,7 +18,7 @@ import {
   toJsonLog,
 } from "./memory-ranking.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
-import { compressToolResults } from "./tool-result-compression.js";
+import { compressToolResults, prePersistOversizedResults } from "./tool-result-compression.js";
 
 type AgentMessage = {
   role?: string;
@@ -1170,6 +1170,14 @@ export function createMemoryOpenVikingContextEngine(params: {
           });
         }
 
+        // Pre-persist oversized tool results BEFORE session trimming so that
+        // even messages discarded by buildSessionContext have their full
+        // content saved to disk and remain recoverable.
+        const prePersistedFiles = await prePersistOversizedResults(
+          ctx.messages,
+          { ...cfg, sessionId: OVSessionId },
+        );
+
         const { sanitized, archive, session, budgets, instruction } = buildAssembledContext(
           ctx.latest_archive_overview,
           preAbstracts,
@@ -1213,6 +1221,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           toolResultCompression: compressionStats.compressedCount > 0
             ? { compressedCount: compressionStats.compressedCount, originalChars: compressionStats.totalOriginalChars, compressedChars: compressionStats.totalCompressedChars, aggregateBudgetTriggered: compressionStats.aggregateBudgetTriggered }
             : undefined,
+          prePersistedFiles: prePersistedFiles.length > 0 ? prePersistedFiles.length : undefined,
           messages: messageDigest(finalMessages),
         });
 

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -973,7 +973,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           });
         }
 
-        const { messages: compressedMessages, stats: compressionStats } = compressToolResults(
+        const { messages: compressedMessages, stats: compressionStats } = await compressToolResults(
           sanitized,
           cfg,
         );

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -18,6 +18,7 @@ import {
   toJsonLog,
 } from "./memory-ranking.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import { compressToolResults } from "./tool-result-compression.js";
 
 type AgentMessage = {
   role?: string;
@@ -1183,7 +1184,13 @@ export function createMemoryOpenVikingContextEngine(params: {
           });
         }
 
-        const assembledTokens = roughEstimate(sanitized) + instruction.tokens;
+        const { messages: compressedMessages, stats: compressionStats } = compressToolResults(
+          sanitized,
+          cfg,
+        );
+        const finalMessages = compressionStats.compressedCount > 0 ? compressedMessages : sanitized;
+
+        const assembledTokens = roughEstimate(finalMessages) + instruction.tokens;
         const tokensSaved = originalTokens - assembledTokens;
         const savingPct = originalTokens > 0 ? Math.round((tokensSaved / originalTokens) * 100) : 0;
 
@@ -1191,7 +1198,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           passthrough: false,
           archiveCount: preAbstracts.length,
           activeCount,
-          outputMessagesCount: sanitized.length,
+          outputMessagesCount: finalMessages.length,
           inputTokenEstimate: originalTokens,
           estimatedTokens: assembledTokens,
           tokensSaved,
@@ -1203,11 +1210,14 @@ export function createMemoryOpenVikingContextEngine(params: {
           reservedBudget: budgets.reserved,
           senderIdFound: sender.found,
           senderId: sender.senderId ?? null,
-          messages: messageDigest(sanitized),
+          toolResultCompression: compressionStats.compressedCount > 0
+            ? { compressedCount: compressionStats.compressedCount, originalChars: compressionStats.totalOriginalChars, compressedChars: compressionStats.totalCompressedChars, aggregateBudgetTriggered: compressionStats.aggregateBudgetTriggered }
+            : undefined,
+          messages: messageDigest(finalMessages),
         });
 
         return {
-          messages: sanitized,
+          messages: finalMessages,
           estimatedTokens: assembledTokens,
           ...(instruction.text ? { systemPromptAddition: instruction.text } : {}),
         };

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -1186,7 +1186,7 @@ export function createMemoryOpenVikingContextEngine(params: {
 
         const { messages: compressedMessages, stats: compressionStats } = await compressToolResults(
           sanitized,
-          cfg,
+          { ...cfg, sessionId: OVSessionId },
         );
         const finalMessages = compressionStats.compressedCount > 0 ? compressedMessages : sanitized;
 

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -1184,7 +1184,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           });
         }
 
-        const { messages: compressedMessages, stats: compressionStats } = compressToolResults(
+        const { messages: compressedMessages, stats: compressionStats } = await compressToolResults(
           sanitized,
           cfg,
         );

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -14,6 +14,7 @@ import {
   toJsonLog,
 } from "./memory-ranking.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import { compressToolResults } from "./tool-result-compression.js";
 
 type AgentMessage = {
   role?: string;
@@ -972,7 +973,13 @@ export function createMemoryOpenVikingContextEngine(params: {
           });
         }
 
-        const assembledTokens = roughEstimate(sanitized) + instruction.tokens;
+        const { messages: compressedMessages, stats: compressionStats } = compressToolResults(
+          sanitized,
+          cfg,
+        );
+        const finalMessages = compressionStats.compressedCount > 0 ? compressedMessages : sanitized;
+
+        const assembledTokens = roughEstimate(finalMessages) + instruction.tokens;
         const tokensSaved = originalTokens - assembledTokens;
         const savingPct = originalTokens > 0 ? Math.round((tokensSaved / originalTokens) * 100) : 0;
 
@@ -980,7 +987,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           passthrough: false,
           archiveCount: preAbstracts.length,
           activeCount,
-          outputMessagesCount: sanitized.length,
+          outputMessagesCount: finalMessages.length,
           inputTokenEstimate: originalTokens,
           estimatedTokens: assembledTokens,
           tokensSaved,
@@ -992,11 +999,14 @@ export function createMemoryOpenVikingContextEngine(params: {
           reservedBudget: budgets.reserved,
           senderIdFound: sender.found,
           senderId: sender.senderId ?? null,
-          messages: messageDigest(sanitized),
+          toolResultCompression: compressionStats.compressedCount > 0
+            ? { compressedCount: compressionStats.compressedCount, originalChars: compressionStats.totalOriginalChars, compressedChars: compressionStats.totalCompressedChars, aggregateBudgetTriggered: compressionStats.aggregateBudgetTriggered }
+            : undefined,
+          messages: messageDigest(finalMessages),
         });
 
         return {
-          messages: sanitized,
+          messages: finalMessages,
           estimatedTokens: assembledTokens,
           ...(instruction.text ? { systemPromptAddition: instruction.text } : {}),
         };

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -1173,7 +1173,7 @@ export function createMemoryOpenVikingContextEngine(params: {
         // Pre-persist oversized tool results BEFORE session trimming so that
         // even messages discarded by buildSessionContext have their full
         // content saved to disk and remain recoverable.
-        const prePersistedFiles = await prePersistOversizedResults(
+        const { files: prePersistedFiles, contentHashes: prePersistedHashes } = await prePersistOversizedResults(
           ctx.messages,
           { ...cfg, sessionId: OVSessionId },
         );
@@ -1194,7 +1194,7 @@ export function createMemoryOpenVikingContextEngine(params: {
 
         const { messages: compressedMessages, stats: compressionStats } = await compressToolResults(
           sanitized,
-          { ...cfg, sessionId: OVSessionId },
+          { ...cfg, sessionId: OVSessionId, alreadyPersistedHashes: prePersistedHashes },
         );
         const finalMessages = compressionStats.compressedCount > 0 ? compressedMessages : sanitized;
 

--- a/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
@@ -90,7 +90,7 @@ describe("compressToolResults", () => {
     expect(text).toContain("<persisted-output>");
   });
 
-  it("triggers aggregate budget when total tool results exceed budget", async () => {
+  it("triggers aggregate budget when tool results in same turn exceed budget", async () => {
     const messages = [
       makeToolResult("a".repeat(30_000)),
       makeToolResult("b".repeat(30_000)),
@@ -102,6 +102,45 @@ describe("compressToolResults", () => {
     }));
     expect(stats.aggregateBudgetTriggered).toBe(true);
     expect(stats.compressedCount).toBeGreaterThan(0);
+  });
+
+  it("applies aggregate budget per assistant turn, not globally", async () => {
+    // Turn 1: 3 results × 20K = 60K (under budget)
+    // Turn 2: 3 results × 20K = 60K (under budget)
+    // Global total = 120K which exceeds budget, but each turn is within budget.
+    const messages = [
+      makeToolResult("a".repeat(20_000)),
+      makeToolResult("b".repeat(20_000)),
+      makeToolResult("c".repeat(20_000)),
+      makeAssistantMsg("let me do more"),
+      makeToolResult("d".repeat(20_000)),
+      makeToolResult("e".repeat(20_000)),
+      makeToolResult("f".repeat(20_000)),
+    ];
+    const { stats } = await compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 100_000,
+      toolResultAggregateBudgetChars: 80_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(false);
+    expect(stats.compressedCount).toBe(0);
+  });
+
+  it("triggers aggregate budget only for the turn that exceeds it", async () => {
+    // Turn 1: 2 results × 10K = 20K (under budget)
+    // Turn 2: 3 results × 30K = 90K (over budget)
+    const messages = [
+      makeToolResult("a".repeat(10_000)),
+      makeToolResult("b".repeat(10_000)),
+      makeAssistantMsg("next step"),
+      makeToolResult("d".repeat(30_000)),
+      makeToolResult("e".repeat(30_000)),
+      makeToolResult("f".repeat(30_000)),
+    ];
+    const { stats } = await compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 100_000,
+      toolResultAggregateBudgetChars: 50_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(true);
   });
 
   it("respects toolResultCompression=false to skip compression", async () => {

--- a/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
@@ -25,6 +25,7 @@ function makeCfg(overrides: Record<string, unknown> = {}): {
   toolResultAggregateBudgetChars: number;
   toolResultPreviewChars: number;
   toolResultStorageDir?: string;
+  sessionId?: string;
 } {
   return {
     toolResultCompression: true,
@@ -32,6 +33,7 @@ function makeCfg(overrides: Record<string, unknown> = {}): {
     toolResultAggregateBudgetChars: 100_000,
     toolResultPreviewChars: 2_000,
     toolResultStorageDir: "/tmp/test-tool-results",
+    sessionId: "test-session-001",
     ...overrides,
   };
 }

--- a/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
@@ -1,18 +1,22 @@
 import { describe, it, expect, vi } from "vitest";
-import { compressToolResults } from "../../tool-result-compression.js";
-import { mkdir, writeFile } from "node:fs/promises";
+import { compressToolResults, prePersistOversizedResults } from "../../tool-result-compression.js";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
 
 vi.mock("node:fs/promises", () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   writeFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue(""),
 }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  (mkdir as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (writeFile as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (readFile as ReturnType<typeof vi.fn>).mockResolvedValue("");
+});
 
 function makeToolResult(content: string, toolName = "test", toolCallId?: string): { role: string; content: string; toolName: string; toolCallId?: string } {
   return { role: "toolResult", content, toolName, ...(toolCallId ? { toolCallId } : {}) };
-}
-
-function makeUserMsg(text: string): { role: string; content: string } {
-  return { role: "user", content: text };
 }
 
 function makeAssistantMsg(text: string): { role: string; content: string } {
@@ -40,7 +44,7 @@ function makeCfg(overrides: Record<string, unknown> = {}): {
 
 describe("compressToolResults", () => {
   it("passes through messages with no tool results", async () => {
-    const messages = [makeUserMsg("hello"), makeAssistantMsg("hi")];
+    const messages = [{ role: "user", content: "hello" }, makeAssistantMsg("hi")];
     const { messages: result, stats } = await compressToolResults(messages, makeCfg());
     expect(result).toEqual(messages);
     expect(stats.compressedCount).toBe(0);
@@ -53,7 +57,7 @@ describe("compressToolResults", () => {
     expect(stats.compressedCount).toBe(0);
   });
 
-  it("persists oversized tool result to disk and replaces with preview", async () => {
+  it("persists oversized tool result and replaces with preview", async () => {
     const bigContent = "x".repeat(30_000);
     const messages = [makeToolResult(bigContent, "bash", "call-123")];
     const { messages: result, stats } = await compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
@@ -63,14 +67,13 @@ describe("compressToolResults", () => {
     expect(text).toContain("<persisted-output>");
     expect(text).toContain("Full output saved to:");
     expect(text).toContain("</persisted-output>");
-    expect(text.length).toBeLessThan(30_000);
     expect(writeFile).toHaveBeenCalled();
   });
 
   it("preserves non-tool-result messages", async () => {
     const bigContent = "x".repeat(30_000);
     const messages = [
-      makeUserMsg("question"),
+      { role: "user", content: "question" },
       makeAssistantMsg("let me check"),
       makeToolResult(bigContent),
       makeAssistantMsg("based on the result"),
@@ -90,59 +93,6 @@ describe("compressToolResults", () => {
     expect(text).toContain("<persisted-output>");
   });
 
-  it("triggers aggregate budget when tool results in same turn exceed budget", async () => {
-    const messages = [
-      makeToolResult("a".repeat(30_000)),
-      makeToolResult("b".repeat(30_000)),
-      makeToolResult("c".repeat(30_000)),
-    ];
-    const { stats } = await compressToolResults(messages, makeCfg({
-      toolResultMaxChars: 100_000,
-      toolResultAggregateBudgetChars: 40_000,
-    }));
-    expect(stats.aggregateBudgetTriggered).toBe(true);
-    expect(stats.compressedCount).toBeGreaterThan(0);
-  });
-
-  it("applies aggregate budget per assistant turn, not globally", async () => {
-    // Turn 1: 3 results × 20K = 60K (under budget)
-    // Turn 2: 3 results × 20K = 60K (under budget)
-    // Global total = 120K which exceeds budget, but each turn is within budget.
-    const messages = [
-      makeToolResult("a".repeat(20_000)),
-      makeToolResult("b".repeat(20_000)),
-      makeToolResult("c".repeat(20_000)),
-      makeAssistantMsg("let me do more"),
-      makeToolResult("d".repeat(20_000)),
-      makeToolResult("e".repeat(20_000)),
-      makeToolResult("f".repeat(20_000)),
-    ];
-    const { stats } = await compressToolResults(messages, makeCfg({
-      toolResultMaxChars: 100_000,
-      toolResultAggregateBudgetChars: 80_000,
-    }));
-    expect(stats.aggregateBudgetTriggered).toBe(false);
-    expect(stats.compressedCount).toBe(0);
-  });
-
-  it("triggers aggregate budget only for the turn that exceeds it", async () => {
-    // Turn 1: 2 results × 10K = 20K (under budget)
-    // Turn 2: 3 results × 30K = 90K (over budget)
-    const messages = [
-      makeToolResult("a".repeat(10_000)),
-      makeToolResult("b".repeat(10_000)),
-      makeAssistantMsg("next step"),
-      makeToolResult("d".repeat(30_000)),
-      makeToolResult("e".repeat(30_000)),
-      makeToolResult("f".repeat(30_000)),
-    ];
-    const { stats } = await compressToolResults(messages, makeCfg({
-      toolResultMaxChars: 100_000,
-      toolResultAggregateBudgetChars: 50_000,
-    }));
-    expect(stats.aggregateBudgetTriggered).toBe(true);
-  });
-
   it("respects toolResultCompression=false to skip compression", async () => {
     const bigContent = "x".repeat(100_000);
     const messages = [makeToolResult(bigContent)];
@@ -160,17 +110,145 @@ describe("compressToolResults", () => {
     expect(stats.compressedCount).toBe(1);
     expect(stats.persistedFiles.length).toBe(0);
     const text = (result[0] as { content: string }).content as string;
-    expect(text).toContain("disk persistence failed");
+    expect(text).toContain("not recoverable");
   });
 
-  it("skips write when file already exists (EEXIST)", async () => {
-    (writeFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(Object.assign(new Error("exists"), { code: "EEXIST" }));
+  it("skips write when file already exists with same content (EEXIST)", async () => {
     const bigContent = "z".repeat(30_000);
+    (writeFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(Object.assign(new Error("exists"), { code: "EEXIST" }));
+    (readFile as ReturnType<typeof vi.fn>).mockResolvedValueOnce(bigContent);
     const messages = [makeToolResult(bigContent, "test", "existing-id")];
     const { messages: result, stats } = await compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
     expect(stats.compressedCount).toBe(1);
     expect(stats.persistedFiles.length).toBe(1);
     const text = (result[0] as { content: string }).content as string;
     expect(text).toContain("Full output saved to:");
+  });
+});
+
+describe("aggregate budget (per assistant turn)", () => {
+  it("triggers when tool results in same turn exceed budget", async () => {
+    const messages = [
+      makeToolResult("a".repeat(30_000)),
+      makeToolResult("b".repeat(30_000)),
+      makeToolResult("c".repeat(30_000)),
+    ];
+    const { stats } = await compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 100_000,
+      toolResultAggregateBudgetChars: 40_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(true);
+    expect(stats.compressedCount).toBeGreaterThan(0);
+  });
+
+  it("applies per turn, not globally", async () => {
+    const messages = [
+      makeToolResult("a".repeat(20_000)),
+      makeToolResult("b".repeat(20_000)),
+      makeToolResult("c".repeat(20_000)),
+      makeAssistantMsg("let me do more"),
+      makeToolResult("d".repeat(20_000)),
+      makeToolResult("e".repeat(20_000)),
+      makeToolResult("f".repeat(20_000)),
+    ];
+    const { stats } = await compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 100_000,
+      toolResultAggregateBudgetChars: 80_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(false);
+    expect(stats.compressedCount).toBe(0);
+  });
+
+  it("only triggers for the turn that exceeds it", async () => {
+    const messages = [
+      makeToolResult("a".repeat(10_000)),
+      makeToolResult("b".repeat(10_000)),
+      makeAssistantMsg("next step"),
+      makeToolResult("d".repeat(30_000)),
+      makeToolResult("e".repeat(30_000)),
+      makeToolResult("f".repeat(30_000)),
+    ];
+    const { stats } = await compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 100_000,
+      toolResultAggregateBudgetChars: 50_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(true);
+  });
+
+  it("persists original content before aggregate truncation so output is recoverable", async () => {
+    // 6 results × 19K = 114K > 100K aggregate budget, but each is under 20K maxChars.
+    // This is the exact data-loss scenario from the review: Phase 1 won't trigger,
+    // Phase 2 must persist before truncating.
+    const messages = [
+      makeToolResult("a".repeat(19_000), "bash", "r1"),
+      makeToolResult("b".repeat(19_000), "bash", "r2"),
+      makeToolResult("c".repeat(19_000), "bash", "r3"),
+      makeToolResult("d".repeat(19_000), "bash", "r4"),
+      makeToolResult("e".repeat(19_000), "bash", "r5"),
+      makeToolResult("f".repeat(19_000), "bash", "r6"),
+    ];
+    const { stats, messages: result } = await compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 20_000,
+      toolResultAggregateBudgetChars: 100_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(true);
+    expect(stats.compressedCount).toBeGreaterThan(0);
+    // The key assertion: files were persisted so the full output is recoverable.
+    expect(stats.persistedFiles.length).toBeGreaterThan(0);
+    // And the truncated messages should reference the persisted file paths.
+    let foundRecoverablePath = false;
+    for (const msg of result) {
+      const text = typeof msg.content === "string" ? msg.content : "";
+      if (text.includes("full output saved to:")) foundRecoverablePath = true;
+    }
+    expect(foundRecoverablePath).toBe(true);
+  });
+
+  it("marks aggregate-truncated output as not recoverable when disk fails", async () => {
+    (writeFile as ReturnType<typeof vi.fn>).mockRejectedValue(Object.assign(new Error("no space"), { code: "ENOSPC" }));
+    const messages = [
+      makeToolResult("a".repeat(19_000), "bash", "r1"),
+      makeToolResult("b".repeat(19_000), "bash", "r2"),
+      makeToolResult("c".repeat(19_000), "bash", "r3"),
+      makeToolResult("d".repeat(19_000), "bash", "r4"),
+      makeToolResult("e".repeat(19_000), "bash", "r5"),
+      makeToolResult("f".repeat(19_000), "bash", "r6"),
+    ];
+    const { stats, messages: result } = await compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 20_000,
+      toolResultAggregateBudgetChars: 100_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(true);
+    expect(stats.persistedFiles.length).toBe(0);
+    let foundNotRecoverable = false;
+    for (const msg of result) {
+      const text = typeof msg.content === "string" ? msg.content : "";
+      if (text.includes("not recoverable")) foundNotRecoverable = true;
+    }
+    expect(foundNotRecoverable).toBe(true);
+  });
+});
+
+describe("prePersistOversizedResults", () => {
+  it("persists oversized results before any trimming", async () => {
+    const messages = [
+      makeToolResult("small"),
+      makeToolResult("x".repeat(30_000), "bash", "big-1"),
+      makeToolResult("x".repeat(25_000), "bash", "big-2"),
+    ];
+    const files = await prePersistOversizedResults(messages, makeCfg({ toolResultMaxChars: 20_000 }));
+    expect(files.length).toBe(2);
+  });
+
+  it("returns empty when no oversized results", async () => {
+    const messages = [makeToolResult("small")];
+    const files = await prePersistOversizedResults(messages, makeCfg());
+    expect(files).toEqual([]);
+  });
+
+  it("skips when disabled", async () => {
+    const messages = [makeToolResult("x".repeat(30_000))];
+    const files = await prePersistOversizedResults(messages, makeCfg({ toolResultCompression: false }));
+    expect(files).toEqual([]);
   });
 });

--- a/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { compressToolResults } from "../../tool-result-compression.js";
+import { mkdir, writeFile } from "node:fs/promises";
 
-function makeToolResult(content: string, toolName = "test"): { role: string; content: string; toolName: string } {
-  return { role: "toolResult", content, toolName };
-}
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
 
-function makeToolResultArray(content: Array<{ type: string; text: string }>): { role: string; content: unknown[]; toolName: string } {
-  return { role: "toolResult", content, toolName: "test" };
+function makeToolResult(content: string, toolName = "test", toolCallId?: string): { role: string; content: string; toolName: string; toolCallId?: string } {
+  return { role: "toolResult", content, toolName, ...(toolCallId ? { toolCallId } : {}) };
 }
 
 function makeUserMsg(text: string): { role: string; content: string } {
@@ -22,42 +24,48 @@ function makeCfg(overrides: Record<string, unknown> = {}): {
   toolResultMaxChars: number;
   toolResultAggregateBudgetChars: number;
   toolResultPreviewChars: number;
+  toolResultStorageDir?: string;
 } {
   return {
     toolResultCompression: true,
     toolResultMaxChars: 20_000,
     toolResultAggregateBudgetChars: 100_000,
     toolResultPreviewChars: 2_000,
+    toolResultStorageDir: "/tmp/test-tool-results",
     ...overrides,
   };
 }
 
 describe("compressToolResults", () => {
-  it("passes through messages with no tool results", () => {
+  it("passes through messages with no tool results", async () => {
     const messages = [makeUserMsg("hello"), makeAssistantMsg("hi")];
-    const { messages: result, stats } = compressToolResults(messages, makeCfg());
+    const { messages: result, stats } = await compressToolResults(messages, makeCfg());
     expect(result).toEqual(messages);
     expect(stats.compressedCount).toBe(0);
   });
 
-  it("passes through small tool results unchanged", () => {
+  it("passes through small tool results unchanged", async () => {
     const messages = [makeToolResult("small output")];
-    const { messages: result, stats } = compressToolResults(messages, makeCfg());
+    const { messages: result, stats } = await compressToolResults(messages, makeCfg());
     expect(result[0]).toEqual(messages[0]);
     expect(stats.compressedCount).toBe(0);
   });
 
-  it("truncates oversized tool result", () => {
+  it("persists oversized tool result to disk and replaces with preview", async () => {
     const bigContent = "x".repeat(30_000);
-    const messages = [makeToolResult(bigContent)];
-    const { messages: result, stats } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    const messages = [makeToolResult(bigContent, "bash", "call-123")];
+    const { messages: result, stats } = await compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
     expect(stats.compressedCount).toBe(1);
-    const text = (result[0] as { content: string }).content;
+    expect(stats.persistedFiles.length).toBe(1);
+    const text = (result[0] as { content: string }).content as string;
+    expect(text).toContain("<persisted-output>");
+    expect(text).toContain("Full output saved to:");
+    expect(text).toContain("</persisted-output>");
     expect(text.length).toBeLessThan(30_000);
-    expect(text).toContain("truncated");
+    expect(writeFile).toHaveBeenCalled();
   });
 
-  it("preserves non-tool-result messages", () => {
+  it("preserves non-tool-result messages", async () => {
     const bigContent = "x".repeat(30_000);
     const messages = [
       makeUserMsg("question"),
@@ -65,39 +73,28 @@ describe("compressToolResults", () => {
       makeToolResult(bigContent),
       makeAssistantMsg("based on the result"),
     ];
-    const { messages: result } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    const { messages: result } = await compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
     expect(result[0]).toEqual(messages[0]);
     expect(result[1]).toEqual(messages[1]);
     expect(result[3]).toEqual(messages[3]);
   });
 
-  it("handles array content tool results", () => {
-    const bigText = "y".repeat(30_000);
-    const messages = [
-      makeToolResultArray([{ type: "text", text: bigText }]),
-    ];
-    const { messages: result, stats } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
-    expect(stats.compressedCount).toBe(1);
-    const content = (result[0] as { content: Array<{ type: string; text: string }> }).content;
-    expect(content[0].text.length).toBeLessThan(bigText.length);
-  });
-
-  it("applies head+tail truncation for error content", () => {
+  it("applies head+tail preview for error content", async () => {
     const errorContent = "x".repeat(15_000) + "\n\nError: something went wrong\nStack trace:\n  at line 42";
     const messages = [makeToolResult(errorContent)];
-    const { messages: result } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
-    const text = (result[0] as { content: string }).content;
+    const { messages: result } = await compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    const text = (result[0] as { content: string }).content as string;
     expect(text).toContain("Error");
-    expect(text).toContain("truncated");
+    expect(text).toContain("<persisted-output>");
   });
 
-  it("triggers aggregate budget when total tool results exceed budget", () => {
+  it("triggers aggregate budget when total tool results exceed budget", async () => {
     const messages = [
       makeToolResult("a".repeat(30_000)),
       makeToolResult("b".repeat(30_000)),
       makeToolResult("c".repeat(30_000)),
     ];
-    const { messages: _result, stats } = compressToolResults(messages, makeCfg({
+    const { stats } = await compressToolResults(messages, makeCfg({
       toolResultMaxChars: 100_000,
       toolResultAggregateBudgetChars: 40_000,
     }));
@@ -105,18 +102,34 @@ describe("compressToolResults", () => {
     expect(stats.compressedCount).toBeGreaterThan(0);
   });
 
-  it("respects toolResultCompression=false to skip compression", () => {
+  it("respects toolResultCompression=false to skip compression", async () => {
     const bigContent = "x".repeat(100_000);
     const messages = [makeToolResult(bigContent)];
-    const { messages: result, stats } = compressToolResults(messages, makeCfg({ toolResultCompression: false }));
+    const { messages: result, stats } = await compressToolResults(messages, makeCfg({ toolResultCompression: false }));
     expect(result[0]).toEqual(messages[0]);
     expect(stats.compressedCount).toBe(0);
+    expect(stats.persistedFiles.length).toBe(0);
   });
 
-  it("uses default config values", () => {
-    const bigContent = "x".repeat(25_000);
+  it("falls back to truncation when disk write fails", async () => {
+    (writeFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(Object.assign(new Error("no space"), { code: "ENOSPC" }));
+    const bigContent = "y".repeat(30_000);
     const messages = [makeToolResult(bigContent)];
-    const { stats } = compressToolResults(messages, makeCfg());
+    const { messages: result, stats } = await compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
     expect(stats.compressedCount).toBe(1);
+    expect(stats.persistedFiles.length).toBe(0);
+    const text = (result[0] as { content: string }).content as string;
+    expect(text).toContain("disk persistence failed");
+  });
+
+  it("skips write when file already exists (EEXIST)", async () => {
+    (writeFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(Object.assign(new Error("exists"), { code: "EEXIST" }));
+    const bigContent = "z".repeat(30_000);
+    const messages = [makeToolResult(bigContent, "test", "existing-id")];
+    const { messages: result, stats } = await compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    expect(stats.compressedCount).toBe(1);
+    expect(stats.persistedFiles.length).toBe(1);
+    const text = (result[0] as { content: string }).content as string;
+    expect(text).toContain("Full output saved to:");
   });
 });

--- a/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { compressToolResults } from "../../tool-result-compression.js";
+
+function makeToolResult(content: string, toolName = "test"): { role: string; content: string; toolName: string } {
+  return { role: "toolResult", content, toolName };
+}
+
+function makeToolResultArray(content: Array<{ type: string; text: string }>): { role: string; content: unknown[]; toolName: string } {
+  return { role: "toolResult", content, toolName: "test" };
+}
+
+function makeUserMsg(text: string): { role: string; content: string } {
+  return { role: "user", content: text };
+}
+
+function makeAssistantMsg(text: string): { role: string; content: string } {
+  return { role: "assistant", content: text };
+}
+
+function makeCfg(overrides: Record<string, unknown> = {}): {
+  toolResultCompression: boolean;
+  toolResultMaxChars: number;
+  toolResultAggregateBudgetChars: number;
+  toolResultPreviewChars: number;
+} {
+  return {
+    toolResultCompression: true,
+    toolResultMaxChars: 20_000,
+    toolResultAggregateBudgetChars: 100_000,
+    toolResultPreviewChars: 2_000,
+    ...overrides,
+  };
+}
+
+describe("compressToolResults", () => {
+  it("passes through messages with no tool results", () => {
+    const messages = [makeUserMsg("hello"), makeAssistantMsg("hi")];
+    const { messages: result, stats } = compressToolResults(messages, makeCfg());
+    expect(result).toEqual(messages);
+    expect(stats.compressedCount).toBe(0);
+  });
+
+  it("passes through small tool results unchanged", () => {
+    const messages = [makeToolResult("small output")];
+    const { messages: result, stats } = compressToolResults(messages, makeCfg());
+    expect(result[0]).toEqual(messages[0]);
+    expect(stats.compressedCount).toBe(0);
+  });
+
+  it("truncates oversized tool result", () => {
+    const bigContent = "x".repeat(30_000);
+    const messages = [makeToolResult(bigContent)];
+    const { messages: result, stats } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    expect(stats.compressedCount).toBe(1);
+    const text = (result[0] as { content: string }).content;
+    expect(text.length).toBeLessThan(30_000);
+    expect(text).toContain("truncated");
+  });
+
+  it("preserves non-tool-result messages", () => {
+    const bigContent = "x".repeat(30_000);
+    const messages = [
+      makeUserMsg("question"),
+      makeAssistantMsg("let me check"),
+      makeToolResult(bigContent),
+      makeAssistantMsg("based on the result"),
+    ];
+    const { messages: result } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    expect(result[0]).toEqual(messages[0]);
+    expect(result[1]).toEqual(messages[1]);
+    expect(result[3]).toEqual(messages[3]);
+  });
+
+  it("handles array content tool results", () => {
+    const bigText = "y".repeat(30_000);
+    const messages = [
+      makeToolResultArray([{ type: "text", text: bigText }]),
+    ];
+    const { messages: result, stats } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    expect(stats.compressedCount).toBe(1);
+    const content = (result[0] as { content: Array<{ type: string; text: string }> }).content;
+    expect(content[0].text.length).toBeLessThan(bigText.length);
+  });
+
+  it("applies head+tail truncation for error content", () => {
+    const errorContent = "x".repeat(15_000) + "\n\nError: something went wrong\nStack trace:\n  at line 42";
+    const messages = [makeToolResult(errorContent)];
+    const { messages: result } = compressToolResults(messages, makeCfg({ toolResultMaxChars: 10_000 }));
+    const text = (result[0] as { content: string }).content;
+    expect(text).toContain("Error");
+    expect(text).toContain("truncated");
+  });
+
+  it("triggers aggregate budget when total tool results exceed budget", () => {
+    const messages = [
+      makeToolResult("a".repeat(30_000)),
+      makeToolResult("b".repeat(30_000)),
+      makeToolResult("c".repeat(30_000)),
+    ];
+    const { messages: _result, stats } = compressToolResults(messages, makeCfg({
+      toolResultMaxChars: 100_000,
+      toolResultAggregateBudgetChars: 40_000,
+    }));
+    expect(stats.aggregateBudgetTriggered).toBe(true);
+    expect(stats.compressedCount).toBeGreaterThan(0);
+  });
+
+  it("respects toolResultCompression=false to skip compression", () => {
+    const bigContent = "x".repeat(100_000);
+    const messages = [makeToolResult(bigContent)];
+    const { messages: result, stats } = compressToolResults(messages, makeCfg({ toolResultCompression: false }));
+    expect(result[0]).toEqual(messages[0]);
+    expect(stats.compressedCount).toBe(0);
+  });
+
+  it("uses default config values", () => {
+    const bigContent = "x".repeat(25_000);
+    const messages = [makeToolResult(bigContent)];
+    const { stats } = compressToolResults(messages, makeCfg());
+    expect(stats.compressedCount).toBe(1);
+  });
+});

--- a/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-result-compression.test.ts
@@ -236,19 +236,75 @@ describe("prePersistOversizedResults", () => {
       makeToolResult("x".repeat(30_000), "bash", "big-1"),
       makeToolResult("x".repeat(25_000), "bash", "big-2"),
     ];
-    const files = await prePersistOversizedResults(messages, makeCfg({ toolResultMaxChars: 20_000 }));
+    const { files } = await prePersistOversizedResults(messages, makeCfg({ toolResultMaxChars: 20_000 }));
     expect(files.length).toBe(2);
   });
 
   it("returns empty when no oversized results", async () => {
     const messages = [makeToolResult("small")];
-    const files = await prePersistOversizedResults(messages, makeCfg());
+    const { files, contentHashes } = await prePersistOversizedResults(messages, makeCfg());
     expect(files).toEqual([]);
+    expect(contentHashes.size).toBe(0);
   });
 
   it("skips when disabled", async () => {
     const messages = [makeToolResult("x".repeat(30_000))];
-    const files = await prePersistOversizedResults(messages, makeCfg({ toolResultCompression: false }));
+    const { files } = await prePersistOversizedResults(messages, makeCfg({ toolResultCompression: false }));
     expect(files).toEqual([]);
+  });
+
+  it("returns content hashes for already-persisted results", async () => {
+    const bigContent = "x".repeat(30_000);
+    const messages = [makeToolResult(bigContent, "bash", "big-1")];
+    const { contentHashes } = await prePersistOversizedResults(messages, makeCfg({ toolResultMaxChars: 20_000 }));
+    expect(contentHashes.size).toBe(1);
+  });
+});
+
+describe("infinite loop prevention", () => {
+  it("skips compression for re-read of already-persisted content", async () => {
+    // Simulate: Turn 1 → 50K result gets persisted and replaced with preview.
+    // Turn 2 → agent re-reads the file, gets the same 50K content back.
+    // This must NOT be compressed again.
+    const bigContent = "x".repeat(50_000);
+    const { contentHashes } = await prePersistOversizedResults(
+      [makeToolResult(bigContent, "bash", "call-1")],
+      makeCfg({ toolResultMaxChars: 20_000 }),
+    );
+
+    // Now the agent re-reads the file — same content as a new toolResult.
+    const messages = [
+      makeToolResult(bigContent, "read_file", "call-2"),
+    ];
+    const { stats, messages: result } = await compressToolResults(messages, {
+      ...makeCfg({ toolResultMaxChars: 20_000 }),
+      alreadyPersistedHashes: contentHashes,
+    });
+
+    expect(stats.compressedCount).toBe(0);
+    expect(stats.persistedFiles.length).toBe(0);
+    expect(result[0]).toEqual(messages[0]);
+  });
+
+  it("still compresses new content even when some hashes are known", async () => {
+    const knownContent = "x".repeat(50_000);
+    const newContent = "y".repeat(50_000);
+    const { contentHashes } = await prePersistOversizedResults(
+      [makeToolResult(knownContent, "bash", "call-1")],
+      makeCfg({ toolResultMaxChars: 20_000 }),
+    );
+
+    const messages = [
+      makeToolResult(knownContent, "read_file", "call-2"),
+      makeToolResult(newContent, "bash", "call-3"),
+    ];
+    const { stats } = await compressToolResults(messages, {
+      ...makeCfg({ toolResultMaxChars: 20_000 }),
+      alreadyPersistedHashes: contentHashes,
+    });
+
+    // knownContent skipped, newContent compressed.
+    expect(stats.compressedCount).toBe(1);
+    expect(stats.persistedFiles.length).toBe(1);
   });
 });

--- a/examples/openclaw-plugin/tool-result-compression.ts
+++ b/examples/openclaw-plugin/tool-result-compression.ts
@@ -18,11 +18,15 @@
  *      individual persistence, the largest results are progressively
  *      re-truncated until the budget is met.
  *
+ * File persistence is scoped per-session to avoid cross-session collisions.
+ * For array-type tool results (multiple text blocks), the budget is distributed
+ * proportionally across blocks, preserving the original block structure.
+ *
  * All thresholds are configured via `MemoryOpenVikingConfig` in config.ts and
  * passed through as-is by the context engine.
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
@@ -35,7 +39,7 @@ type AgentMessage = {
   isError?: boolean;
 };
 
-const TOOL_RESULTS_SUBDIR = "tool-results";
+const TOOL_RESULTS_BASE_DIR = "tool-results";
 const PREVIEW_TAG_OPEN = "<persisted-output>";
 const PREVIEW_TAG_CLOSE = "</persisted-output>";
 
@@ -67,9 +71,6 @@ function getToolResultTextLength(msg: AgentMessage): number {
   return 0;
 }
 
-/**
- * Extract plain text from a tool result message (string or content-block array).
- */
 function getToolResultText(msg: AgentMessage): string {
   const content = msg.content;
   if (typeof content === "string") return content;
@@ -87,29 +88,39 @@ function getToolResultText(msg: AgentMessage): string {
 }
 
 function formatFileSize(chars: number): string {
-  const bytes = chars;
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (chars < 1024) return `${chars} B`;
+  if (chars < 1024 * 1024) return `${(chars / 1024).toFixed(1)} KB`;
+  return `${(chars / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function contentHash(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
 }
 
 /**
- * Stable filename derived from toolCallId (or a hash of content as fallback).
+ * Filename derived from toolCallId + content hash.  The hash suffix ensures
+ * that different content for the same toolCallId (e.g. after a retry) produces
+ * a distinct file instead of silently reusing a stale one.
  */
 function makePersistFilename(msg: AgentMessage): string {
-  if (msg.toolCallId) return `${msg.toolCallId.replace(/[^a-zA-Z0-9_-]/g, "_")}.txt`;
   const text = getToolResultText(msg);
-  const hash = createHash("sha256").update(text).digest("hex").slice(0, 16);
+  const hash = contentHash(text);
+  if (msg.toolCallId) {
+    const safeId = msg.toolCallId.replace(/[^a-zA-Z0-9_-]/g, "_");
+    return `${safeId}-${hash}.txt`;
+  }
   return `result-${hash}.txt`;
 }
 
 /**
- * Resolve the base directory for persisted tool results.
- * Defaults to ~/.openclaw/memory/tool-results.
+ * Resolve session-scoped storage directory:
+ *   override / sessionId /
+ *   ~/.openclaw/memory/tool-results/<sessionId>/
  */
-function resolveStorageDir(override?: string): string {
-  if (override) return override;
-  return join(homedir(), ".openclaw", "memory", TOOL_RESULTS_SUBDIR);
+function resolveStorageDir(sessionId: string, override?: string): string {
+  const base = override ?? join(homedir(), ".openclaw", "memory", TOOL_RESULTS_BASE_DIR);
+  const safeSession = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  return join(base, safeSession);
 }
 
 async function ensureDir(dir: string): Promise<void> {
@@ -121,9 +132,13 @@ async function ensureDir(dir: string): Promise<void> {
 }
 
 /**
- * Persist full tool result text to disk. Returns the file path, or null on
- * failure.  Uses `wx` flag to avoid overwriting if the same file was already
- * persisted in a prior turn.
+ * Persist full tool result text to disk. Returns the file path on success,
+ * null on failure.
+ *
+ * On EEXIST (file already written by a prior assemble of the same session),
+ * we verify the content matches by reading it back.  If the content differs
+ * (stale file from a different run), we append a short collision suffix and
+ * retry once.
  */
 async function persistToDisk(
   text: string,
@@ -134,17 +149,34 @@ async function persistToDisk(
   const filepath = join(storageDir, filename);
   try {
     await writeFile(filepath, text, { encoding: "utf-8", flag: "wx" });
+    return filepath;
   } catch (err: unknown) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code !== "EEXIST") return null;
   }
-  return filepath;
+
+  // File exists — verify content matches (same session, same toolCallId + content hash).
+  try {
+    const existing = await readFile(filepath, { encoding: "utf-8" });
+    if (existing === text) return filepath;
+  } catch {
+    // unreadable — fall through to collision retry
+  }
+
+  // Content mismatch: append collision counter and retry.
+  const dotIdx = filename.lastIndexOf(".");
+  const base = dotIdx > 0 ? filename.slice(0, dotIdx) : filename;
+  const ext = dotIdx > 0 ? filename.slice(dotIdx) : ".txt";
+  const collisionName = `${base}_v2${ext}`;
+  const collisionPath = join(storageDir, collisionName);
+  try {
+    await writeFile(collisionPath, text, { encoding: "utf-8", flag: "wx" });
+    return collisionPath;
+  } catch {
+    return null;
+  }
 }
 
-/**
- * Build the preview message that replaces the original content, including
- * the file path so the model knows where to find the full output.
- */
 function buildPersistedPreview(
   originalSize: number,
   previewText: string,
@@ -161,12 +193,6 @@ function buildPersistedPreview(
   return msg;
 }
 
-/**
- * Returns true when the tail of the text contains signals that are valuable
- * for the model — error messages, stack traces, closing braces (JSON), or
- * result/summary keywords.  When this is the case we keep both a head and a
- * tail section in the preview.
- */
 function hasImportantTail(text: string): boolean {
   const tail = text.slice(-2000).toLowerCase();
   return (
@@ -176,10 +202,6 @@ function hasImportantTail(text: string): boolean {
   );
 }
 
-/**
- * Generate a preview string from the full text, respecting line boundaries.
- * When the tail contains important signals, returns both head and tail.
- */
 function generatePreview(
   text: string,
   previewChars: number,
@@ -214,8 +236,8 @@ function generatePreview(
 }
 
 /**
- * Truncate text for aggregate budget enforcement (no disk persistence,
- * just in-memory truncation with a simple marker).
+ * Truncate a single text string to fit within maxChars, respecting line
+ * boundaries.  Used for aggregate budget enforcement.
  */
 function truncateText(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
@@ -243,16 +265,77 @@ function collectToolResults(messages: AgentMessage[]): ToolResultEntry[] {
 }
 
 /**
- * Apply two-level tool-result compression to an assembled message array.
- *
- * 1. Persist any individual result exceeding `toolResultMaxChars` to disk and
- *    replace it with a preview + file path reference.
- * 2. If the aggregate of all results still exceeds
- *    `toolResultAggregateBudgetChars`, progressively truncate the largest
- *    results (greedy, descending by size) until the budget is satisfied.
- *
- * Returns a new array (shallow-copied) plus compression statistics.
+ * Replace the text content of a tool-result message with `newText`.
+ * For array-type content, distributes the text proportionally across text
+ * blocks (each block gets its own truncated slice), preserving non-text blocks.
+ * For string-type content, replaces directly.
  */
+function replaceToolResultText(
+  msg: AgentMessage,
+  newText: string,
+): AgentMessage {
+  const content = msg.content;
+  if (typeof content === "string" || !Array.isArray(content)) {
+    return { ...msg, content: newText };
+  }
+
+  // Array content: distribute proportionally per block (like OpenClaw's
+  // truncateToolResultMessage).
+  const totalTextLen = getToolResultTextLength(msg);
+  if (totalTextLen === 0) return msg;
+
+  let assigned = 0;
+  const textBlocks = content.filter(
+    (b: unknown) => (b as Record<string, unknown>)?.type === "text" && typeof (b as Record<string, unknown>).text === "string",
+  );
+
+  const newContent = content.map((block: unknown) => {
+    const b = block as Record<string, unknown>;
+    if (b?.type !== "text" || typeof b.text !== "string") return block;
+
+    const blockLen = b.text.length;
+    const blockShare = blockLen / totalTextLen;
+    const blockBudget = Math.max(1, Math.floor(newText.length * blockShare));
+
+    const start = Math.min(assigned, newText.length);
+    const end = Math.min(start + blockBudget, newText.length);
+    assigned = end;
+    return { ...b, text: newText.slice(start, end) };
+  });
+
+  return { ...msg, content: newContent };
+}
+
+/**
+ * Truncate a tool-result message's array content blocks proportionally,
+ * each block truncated independently.  Mirrors OpenClaw's
+ * truncateToolResultMessage approach.
+ */
+function truncateToolResultMessage(
+  msg: AgentMessage,
+  maxChars: number,
+): AgentMessage {
+  const content = msg.content;
+  if (typeof content === "string") {
+    return { ...msg, content: truncateText(content, maxChars) };
+  }
+  if (!Array.isArray(content)) return msg;
+
+  const totalTextLen = getToolResultTextLength(msg);
+  if (totalTextLen <= maxChars) return msg;
+
+  const newContent = content.map((block: unknown) => {
+    const b = block as Record<string, unknown>;
+    if (b?.type !== "text" || typeof b.text !== "string") return block;
+
+    const blockShare = b.text.length / totalTextLen;
+    const blockBudget = Math.max(200, Math.floor(maxChars * blockShare));
+    return { ...b, text: truncateText(b.text, blockBudget) };
+  });
+
+  return { ...msg, content: newContent };
+}
+
 export async function compressToolResults(
   messages: AgentMessage[],
   cfg: {
@@ -261,6 +344,7 @@ export async function compressToolResults(
     toolResultAggregateBudgetChars: number;
     toolResultPreviewChars: number;
     toolResultStorageDir?: string;
+    sessionId?: string;
   },
 ): Promise<{ messages: AgentMessage[]; stats: ToolResultCompressionStats }> {
   if (!cfg.toolResultCompression) {
@@ -273,7 +357,8 @@ export async function compressToolResults(
   const maxChars = cfg.toolResultMaxChars;
   const previewChars = cfg.toolResultPreviewChars;
   const aggregateBudget = cfg.toolResultAggregateBudgetChars;
-  const storageDir = resolveStorageDir(cfg.toolResultStorageDir);
+  const sessionId = cfg.sessionId ?? "default";
+  const storageDir = resolveStorageDir(sessionId, cfg.toolResultStorageDir);
 
   const entries = collectToolResults(messages);
   if (entries.length === 0) {
@@ -308,22 +393,14 @@ export async function compressToolResults(
         newContent = buildPersistedPreview(text.length, preview, hasMore, filepath, previewChars);
         persistedFiles.push(filepath);
       } else {
-        // Fallback: in-memory truncation if disk write failed.
         const { preview, hasMore } = generatePreview(text, previewChars);
         newContent = preview + (hasMore ? "\n\n[... disk persistence failed, content truncated ...]" : "");
       }
 
-      const content = entry.message.content;
-      if (typeof content === "string" || !Array.isArray(content)) {
-        return { index: entry.index, message: { ...entry.message, content: newContent } };
-      }
-
-      const newContentBlocks = content.map((block: unknown) => {
-        const b = block as Record<string, unknown>;
-        if (b?.type === "text") return { ...b, text: newContent };
-        return block;
-      });
-      return { index: entry.index, message: { ...entry.message, content: newContentBlocks } };
+      return {
+        index: entry.index,
+        message: replaceToolResultText(entry.message, newContent),
+      };
     });
 
     const persisted = await Promise.all(persistOps);
@@ -333,7 +410,7 @@ export async function compressToolResults(
     }
   }
 
-  // Phase 2: aggregate budget enforcement (in-memory truncation).
+  // Phase 2: aggregate budget enforcement (per-block proportional truncation).
   const afterIndividual = collectToolResults(result);
   let aggregateChars = 0;
   for (const entry of afterIndividual) {
@@ -350,22 +427,7 @@ export async function compressToolResults(
     for (const entry of candidates) {
       if (remaining <= 0) break;
       const targetChars = Math.max(previewChars, entry.textLength - remaining);
-
-      const msg = result[entry.index]!;
-      const text = getToolResultText(msg);
-      const truncated = truncateText(text, targetChars);
-
-      const content = msg.content;
-      if (typeof content === "string" || !Array.isArray(content)) {
-        result[entry.index] = { ...msg, content: truncated };
-      } else {
-        const newBlocks = content.map((block: unknown) => {
-          const b = block as Record<string, unknown>;
-          if (b?.type === "text") return { ...b, text: truncated };
-          return block;
-        });
-        result[entry.index] = { ...msg, content: newBlocks };
-      }
+      result[entry.index] = truncateToolResultMessage(result[entry.index]!, targetChars);
 
       const newTextLen = getToolResultTextLength(result[entry.index]!);
       remaining -= Math.max(0, entry.textLength - newTextLen);

--- a/examples/openclaw-plugin/tool-result-compression.ts
+++ b/examples/openclaw-plugin/tool-result-compression.ts
@@ -265,6 +265,43 @@ function collectToolResults(messages: AgentMessage[]): ToolResultEntry[] {
 }
 
 /**
+ * Group toolResult entries by assistant turn.  A "group" is a maximal run of
+ * non-assistant messages between two assistant messages — i.e. all toolResult
+ * messages that belong to the same parallel tool-call batch.
+ *
+ * This matches Claude Code's `collectCandidatesByMessage` which groups
+ * consecutive user messages not separated by an assistant message.
+ */
+function groupByAssistantTurn(messages: AgentMessage[], entries: ToolResultEntry[]): ToolResultEntry[][] {
+  const groups: ToolResultEntry[][] = [];
+  let current: ToolResultEntry[] = [];
+
+  const flush = () => {
+    if (current.length > 0) {
+      groups.push(current);
+      current = [];
+    }
+  };
+
+  const entryByIndex = new Map(entries.map(e => [e.index, e]));
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if ((msg as AgentMessage).role === "assistant") {
+      flush();
+      continue;
+    }
+    const entry = entryByIndex.get(i);
+    if (entry) {
+      current.push(entry);
+    }
+  }
+  flush();
+
+  return groups;
+}
+
+/**
  * Replace the text content of a tool-result message with `newText`.
  * For array-type content, distributes the text proportionally across text
  * blocks (each block gets its own truncated slice), preserving non-text blocks.
@@ -410,28 +447,33 @@ export async function compressToolResults(
     }
   }
 
-  // Phase 2: aggregate budget enforcement (per-block proportional truncation).
+  // Phase 2: aggregate budget enforcement per assistant turn.
+  // Each group = toolResult messages between two assistant messages.
   const afterIndividual = collectToolResults(result);
-  let aggregateChars = 0;
-  for (const entry of afterIndividual) {
-    aggregateChars += entry.textLength;
-  }
+  const groups = groupByAssistantTurn(result, afterIndividual);
 
-  if (aggregateChars > aggregateBudget) {
-    aggregateBudgetTriggered = true;
-    const candidates = afterIndividual
-      .filter(e => e.textLength > previewChars * 2)
-      .sort((a, b) => b.textLength - a.textLength);
+  for (const group of groups) {
+    let groupChars = 0;
+    for (const entry of group) {
+      groupChars += entry.textLength;
+    }
 
-    let remaining = aggregateChars - aggregateBudget;
-    for (const entry of candidates) {
-      if (remaining <= 0) break;
-      const targetChars = Math.max(previewChars, entry.textLength - remaining);
-      result[entry.index] = truncateToolResultMessage(result[entry.index]!, targetChars);
+    if (groupChars > aggregateBudget) {
+      aggregateBudgetTriggered = true;
+      const candidates = [...group]
+        .filter(e => e.textLength > previewChars * 2)
+        .sort((a, b) => b.textLength - a.textLength);
 
-      const newTextLen = getToolResultTextLength(result[entry.index]!);
-      remaining -= Math.max(0, entry.textLength - newTextLen);
-      if (newTextLen < entry.textLength) compressedCount++;
+      let remaining = groupChars - aggregateBudget;
+      for (const entry of candidates) {
+        if (remaining <= 0) break;
+        const targetChars = Math.max(previewChars, entry.textLength - remaining);
+        result[entry.index] = truncateToolResultMessage(result[entry.index]!, targetChars);
+
+        const newTextLen = getToolResultTextLength(result[entry.index]!);
+        remaining -= Math.max(0, entry.textLength - newTextLen);
+        if (newTextLen < entry.textLength) compressedCount++;
+      }
     }
   }
 

--- a/examples/openclaw-plugin/tool-result-compression.ts
+++ b/examples/openclaw-plugin/tool-result-compression.ts
@@ -2,22 +2,30 @@
  * Tool result compression for the openclaw-plugin context engine.
  *
  * Prevents oversized tool outputs from bloating the assembled context that gets
- * sent back to the model.  Two levels of protection:
+ * sent back to the model.  When a tool result exceeds `toolResultMaxChars` the
+ * full content is persisted to a file on disk and replaced with a preview +
+ * file path reference, so the model can re-read the complete output later if
+ * needed.
  *
- *   1. **Individual truncation** — any single tool result exceeding
- *      `toolResultMaxChars` is truncated to a head (and optionally tail)
- *      preview.
+ * Two levels of protection:
+ *
+ *   1. **Individual persistence** — any single tool result exceeding
+ *      `toolResultMaxChars` is written to disk and replaced with a preview
+ *      snippet that includes the file path.
  *
  *   2. **Aggregate budget** — if the *total* size of all tool results in one
- *      assembled context exceeds `toolResultAggregateBudgetChars`, the largest
- *      results are progressively re-truncated until the budget is met.
- *
- * Truncation prefers line boundaries and preserves the tail when it contains
- * error / stack-trace signals so the model can still diagnose failures.
+ *      assembled context still exceeds `toolResultAggregateBudgetChars` after
+ *      individual persistence, the largest results are progressively
+ *      re-truncated until the budget is met.
  *
  * All thresholds are configured via `MemoryOpenVikingConfig` in config.ts and
  * passed through as-is by the context engine.
  */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 
 type AgentMessage = {
   role?: string;
@@ -27,14 +35,16 @@ type AgentMessage = {
   isError?: boolean;
 };
 
-const TRUNCATION_MARKER = "\n\n[... tool output truncated: showing first";
-const TRUNCATION_TAIL_MARKER = " characters ...]";
+const TOOL_RESULTS_SUBDIR = "tool-results";
+const PREVIEW_TAG_OPEN = "<persisted-output>";
+const PREVIEW_TAG_CLOSE = "</persisted-output>";
 
 export type ToolResultCompressionStats = {
   compressedCount: number;
   totalOriginalChars: number;
   totalCompressedChars: number;
   aggregateBudgetTriggered: boolean;
+  persistedFiles: string[];
 };
 
 function isToolResultMessage(msg: AgentMessage): boolean {
@@ -58,10 +68,104 @@ function getToolResultTextLength(msg: AgentMessage): number {
 }
 
 /**
+ * Extract plain text from a tool result message (string or content-block array).
+ */
+function getToolResultText(msg: AgentMessage): string {
+  const content = msg.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      const b = block as Record<string, unknown>;
+      if (b?.type === "text" && typeof b.text === "string") {
+        parts.push(b.text);
+      }
+    }
+    return parts.join("\n");
+  }
+  return "";
+}
+
+function formatFileSize(chars: number): string {
+  const bytes = chars;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Stable filename derived from toolCallId (or a hash of content as fallback).
+ */
+function makePersistFilename(msg: AgentMessage): string {
+  if (msg.toolCallId) return `${msg.toolCallId.replace(/[^a-zA-Z0-9_-]/g, "_")}.txt`;
+  const text = getToolResultText(msg);
+  const hash = createHash("sha256").update(text).digest("hex").slice(0, 16);
+  return `result-${hash}.txt`;
+}
+
+/**
+ * Resolve the base directory for persisted tool results.
+ * Defaults to ~/.openclaw/memory/tool-results.
+ */
+function resolveStorageDir(override?: string): string {
+  if (override) return override;
+  return join(homedir(), ".openclaw", "memory", TOOL_RESULTS_SUBDIR);
+}
+
+async function ensureDir(dir: string): Promise<void> {
+  try {
+    await mkdir(dir, { recursive: true });
+  } catch {
+    // may already exist
+  }
+}
+
+/**
+ * Persist full tool result text to disk. Returns the file path, or null on
+ * failure.  Uses `wx` flag to avoid overwriting if the same file was already
+ * persisted in a prior turn.
+ */
+async function persistToDisk(
+  text: string,
+  filename: string,
+  storageDir: string,
+): Promise<string | null> {
+  await ensureDir(storageDir);
+  const filepath = join(storageDir, filename);
+  try {
+    await writeFile(filepath, text, { encoding: "utf-8", flag: "wx" });
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "EEXIST") return null;
+  }
+  return filepath;
+}
+
+/**
+ * Build the preview message that replaces the original content, including
+ * the file path so the model knows where to find the full output.
+ */
+function buildPersistedPreview(
+  originalSize: number,
+  previewText: string,
+  hasMore: boolean,
+  filepath: string,
+  previewChars: number,
+): string {
+  let msg = `${PREVIEW_TAG_OPEN}\n`;
+  msg += `Output too large (${formatFileSize(originalSize)}). Full output saved to: ${filepath}\n\n`;
+  msg += `Preview (first ${formatFileSize(previewChars)}):\n`;
+  msg += previewText;
+  if (hasMore) msg += "\n...\n";
+  msg += PREVIEW_TAG_CLOSE;
+  return msg;
+}
+
+/**
  * Returns true when the tail of the text contains signals that are valuable
  * for the model — error messages, stack traces, closing braces (JSON), or
  * result/summary keywords.  When this is the case we keep both a head and a
- * tail section instead of just the head.
+ * tail section in the preview.
  */
 function hasImportantTail(text: string): boolean {
   const tail = text.slice(-2000).toLowerCase();
@@ -73,82 +177,52 @@ function hasImportantTail(text: string): boolean {
 }
 
 /**
- * Truncate a single text string to at most `maxChars`, keeping a preview of
- * `previewChars`.  When the tail looks important (errors / JSON closing) we
- * split the budget into head + tail so both ends are preserved.
+ * Generate a preview string from the full text, respecting line boundaries.
+ * When the tail contains important signals, returns both head and tail.
  */
-function truncateToolResultText(
+function generatePreview(
   text: string,
-  maxChars: number,
   previewChars: number,
-): string {
-  if (text.length <= maxChars) return text;
-
-  const suffix = `${TRUNCATION_MARKER} ${previewChars} of ${text.length}${TRUNCATION_TAIL_MARKER}`;
-
-  // Head + tail mode: preserve error messages / JSON closers at the end.
-  if (hasImportantTail(text) && maxChars > previewChars * 2) {
-    const tailBudget = Math.min(Math.floor(maxChars * 0.3), 4000);
-    const headBudget = maxChars - tailBudget - suffix.length;
-
-    if (headBudget > previewChars) {
-      // Snap to line boundaries to avoid cutting mid-word.
-      let headCut = headBudget;
-      const headNewline = text.lastIndexOf("\n", headBudget);
-      if (headNewline > headBudget * 0.8) headCut = headNewline;
-
-      let tailStart = text.length - tailBudget;
-      const tailNewline = text.indexOf("\n", tailStart);
-      if (tailNewline !== -1 && tailNewline < tailStart + tailBudget * 0.2) {
-        tailStart = tailNewline + 1;
-      }
-
-      return text.slice(0, headCut) + suffix + "\n\n[... tail content ...]\n\n" + text.slice(tailStart);
-    }
+): { preview: string; hasMore: boolean } {
+  if (text.length <= previewChars) {
+    return { preview: text, hasMore: false };
   }
 
-  // Head-only mode.
-  let cutPoint = Math.max(previewChars, maxChars - suffix.length);
+  if (hasImportantTail(text)) {
+    const tailBudget = Math.min(Math.floor(previewChars * 0.3), 2000);
+    const headBudget = previewChars - tailBudget;
+
+    let headCut = headBudget;
+    const headNewline = text.lastIndexOf("\n", headBudget);
+    if (headNewline > headBudget * 0.8) headCut = headNewline;
+
+    let tailStart = text.length - tailBudget;
+    const tailNewline = text.indexOf("\n", tailStart);
+    if (tailNewline !== -1 && tailNewline < tailStart + tailBudget * 0.2) {
+      tailStart = tailNewline + 1;
+    }
+
+    const preview = text.slice(0, headCut) + "\n\n[... content omitted ...]\n\n" + text.slice(tailStart);
+    return { preview, hasMore: true };
+  }
+
+  let cutPoint = previewChars;
   const lastNewline = text.lastIndexOf("\n", cutPoint);
   if (lastNewline > cutPoint * 0.8) cutPoint = lastNewline;
 
-  return text.slice(0, cutPoint) + suffix;
+  return { preview: text.slice(0, cutPoint), hasMore: true };
 }
 
 /**
- * Compress a single tool-result message in place.  Handles both plain-string
- * and content-block-array payloads.  Array payloads share the char budget
- * proportionally across text blocks.
+ * Truncate text for aggregate budget enforcement (no disk persistence,
+ * just in-memory truncation with a simple marker).
  */
-function compressSingleToolResult(
-  msg: AgentMessage,
-  maxChars: number,
-  previewChars: number,
-): AgentMessage {
-  if (!isToolResultMessage(msg)) return msg;
-  const textLength = getToolResultTextLength(msg);
-  if (textLength <= maxChars) return msg;
-
-  const content = msg.content;
-  if (typeof content === "string") {
-    return { ...msg, content: truncateToolResultText(content, maxChars, previewChars) };
-  }
-
-  if (Array.isArray(content)) {
-    const totalTextLen = getToolResultTextLength(msg);
-    const newContent = content.map((block: unknown) => {
-      const b = block as Record<string, unknown>;
-      if (b?.type === "text" && typeof b.text === "string") {
-        const blockShare = b.text.length / totalTextLen;
-        const blockBudget = Math.max(previewChars, Math.floor(maxChars * blockShare));
-        return { ...b, text: truncateToolResultText(b.text, blockBudget, Math.floor(previewChars * blockShare)) };
-      }
-      return block;
-    });
-    return { ...msg, content: newContent };
-  }
-
-  return msg;
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let cutPoint = maxChars;
+  const lastNewline = text.lastIndexOf("\n", cutPoint);
+  if (lastNewline > cutPoint * 0.8) cutPoint = lastNewline;
+  return text.slice(0, cutPoint) + `\n\n[... truncated: showing ${formatFileSize(cutPoint)} of ${formatFileSize(text.length)} ...]`;
 }
 
 type ToolResultEntry = {
@@ -171,38 +245,41 @@ function collectToolResults(messages: AgentMessage[]): ToolResultEntry[] {
 /**
  * Apply two-level tool-result compression to an assembled message array.
  *
- * 1. Truncate any individual result exceeding `toolResultMaxChars`.
+ * 1. Persist any individual result exceeding `toolResultMaxChars` to disk and
+ *    replace it with a preview + file path reference.
  * 2. If the aggregate of all results still exceeds
- *    `toolResultAggregateBudgetChars`, progressively re-truncate the largest
+ *    `toolResultAggregateBudgetChars`, progressively truncate the largest
  *    results (greedy, descending by size) until the budget is satisfied.
  *
  * Returns a new array (shallow-copied) plus compression statistics.
  */
-export function compressToolResults(
+export async function compressToolResults(
   messages: AgentMessage[],
   cfg: {
     toolResultCompression: boolean;
     toolResultMaxChars: number;
     toolResultAggregateBudgetChars: number;
     toolResultPreviewChars: number;
+    toolResultStorageDir?: string;
   },
-): { messages: AgentMessage[]; stats: ToolResultCompressionStats } {
+): Promise<{ messages: AgentMessage[]; stats: ToolResultCompressionStats }> {
   if (!cfg.toolResultCompression) {
     return {
       messages,
-      stats: { compressedCount: 0, totalOriginalChars: 0, totalCompressedChars: 0, aggregateBudgetTriggered: false },
+      stats: { compressedCount: 0, totalOriginalChars: 0, totalCompressedChars: 0, aggregateBudgetTriggered: false, persistedFiles: [] },
     };
   }
 
   const maxChars = cfg.toolResultMaxChars;
   const previewChars = cfg.toolResultPreviewChars;
   const aggregateBudget = cfg.toolResultAggregateBudgetChars;
+  const storageDir = resolveStorageDir(cfg.toolResultStorageDir);
 
   const entries = collectToolResults(messages);
   if (entries.length === 0) {
     return {
       messages,
-      stats: { compressedCount: 0, totalOriginalChars: 0, totalCompressedChars: 0, aggregateBudgetTriggered: false },
+      stats: { compressedCount: 0, totalOriginalChars: 0, totalCompressedChars: 0, aggregateBudgetTriggered: false, persistedFiles: [] },
     };
   }
 
@@ -215,16 +292,48 @@ export function compressToolResults(
   let compressedCount = 0;
   let totalCompressedChars = 0;
   let aggregateBudgetTriggered = false;
+  const persistedFiles: string[] = [];
 
-  // Phase 1: individual truncation.
-  for (const entry of entries) {
-    if (entry.textLength > maxChars) {
-      result[entry.index] = compressSingleToolResult(entry.message, maxChars, previewChars);
+  // Phase 1: persist oversized results to disk, replace with preview + path.
+  const oversized = entries.filter(e => e.textLength > maxChars);
+  if (oversized.length > 0) {
+    const persistOps = oversized.map(async (entry) => {
+      const text = getToolResultText(entry.message);
+      const filename = makePersistFilename(entry.message);
+      const filepath = await persistToDisk(text, filename, storageDir);
+
+      let newContent: string;
+      if (filepath) {
+        const { preview, hasMore } = generatePreview(text, previewChars);
+        newContent = buildPersistedPreview(text.length, preview, hasMore, filepath, previewChars);
+        persistedFiles.push(filepath);
+      } else {
+        // Fallback: in-memory truncation if disk write failed.
+        const { preview, hasMore } = generatePreview(text, previewChars);
+        newContent = preview + (hasMore ? "\n\n[... disk persistence failed, content truncated ...]" : "");
+      }
+
+      const content = entry.message.content;
+      if (typeof content === "string" || !Array.isArray(content)) {
+        return { index: entry.index, message: { ...entry.message, content: newContent } };
+      }
+
+      const newContentBlocks = content.map((block: unknown) => {
+        const b = block as Record<string, unknown>;
+        if (b?.type === "text") return { ...b, text: newContent };
+        return block;
+      });
+      return { index: entry.index, message: { ...entry.message, content: newContentBlocks } };
+    });
+
+    const persisted = await Promise.all(persistOps);
+    for (const p of persisted) {
+      result[p.index] = p.message;
       compressedCount++;
     }
   }
 
-  // Phase 2: aggregate budget enforcement.
+  // Phase 2: aggregate budget enforcement (in-memory truncation).
   const afterIndividual = collectToolResults(result);
   let aggregateChars = 0;
   for (const entry of afterIndividual) {
@@ -233,15 +342,31 @@ export function compressToolResults(
 
   if (aggregateChars > aggregateBudget) {
     aggregateBudgetTriggered = true;
-    const oversized = afterIndividual
+    const candidates = afterIndividual
       .filter(e => e.textLength > previewChars * 2)
       .sort((a, b) => b.textLength - a.textLength);
 
     let remaining = aggregateChars - aggregateBudget;
-    for (const entry of oversized) {
+    for (const entry of candidates) {
       if (remaining <= 0) break;
       const targetChars = Math.max(previewChars, entry.textLength - remaining);
-      result[entry.index] = compressSingleToolResult(result[entry.index]!, targetChars, previewChars);
+
+      const msg = result[entry.index]!;
+      const text = getToolResultText(msg);
+      const truncated = truncateText(text, targetChars);
+
+      const content = msg.content;
+      if (typeof content === "string" || !Array.isArray(content)) {
+        result[entry.index] = { ...msg, content: truncated };
+      } else {
+        const newBlocks = content.map((block: unknown) => {
+          const b = block as Record<string, unknown>;
+          if (b?.type === "text") return { ...b, text: truncated };
+          return block;
+        });
+        result[entry.index] = { ...msg, content: newBlocks };
+      }
+
       const newTextLen = getToolResultTextLength(result[entry.index]!);
       remaining -= Math.max(0, entry.textLength - newTextLen);
       if (newTextLen < entry.textLength) compressedCount++;
@@ -255,6 +380,6 @@ export function compressToolResults(
 
   return {
     messages: result,
-    stats: { compressedCount, totalOriginalChars, totalCompressedChars, aggregateBudgetTriggered },
+    stats: { compressedCount, totalOriginalChars, totalCompressedChars, aggregateBudgetTriggered, persistedFiles },
   };
 }

--- a/examples/openclaw-plugin/tool-result-compression.ts
+++ b/examples/openclaw-plugin/tool-result-compression.ts
@@ -14,9 +14,10 @@
  *      snippet that includes the file path.
  *
  *   2. **Aggregate budget** — if the *total* size of all tool results in one
- *      assembled context still exceeds `toolResultAggregateBudgetChars` after
- *      individual persistence, the largest results are progressively
- *      re-truncated until the budget is met.
+ *      assistant turn exceeds `toolResultAggregateBudgetChars` after individual
+ *      persistence, the largest results are progressively truncated.  Before
+ *      truncation the original content is also persisted to disk so the model
+ *      can recover the full output.
  *
  * File persistence is scoped per-session to avoid cross-session collisions.
  * For array-type tool results (multiple text blocks), the budget is distributed
@@ -119,7 +120,7 @@ function makePersistFilename(msg: AgentMessage): string {
  */
 function resolveStorageDir(sessionId: string, override?: string): string {
   const base = override ?? join(homedir(), ".openclaw", "memory", TOOL_RESULTS_BASE_DIR);
-  const safeSession = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  const safeSession = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
   return join(base, safeSession);
 }
 
@@ -264,14 +265,6 @@ function collectToolResults(messages: AgentMessage[]): ToolResultEntry[] {
   return entries;
 }
 
-/**
- * Group toolResult entries by assistant turn.  A "group" is a maximal run of
- * non-assistant messages between two assistant messages — i.e. all toolResult
- * messages that belong to the same parallel tool-call batch.
- *
- * This matches Claude Code's `collectCandidatesByMessage` which groups
- * consecutive user messages not separated by an assistant message.
- */
 function groupByAssistantTurn(messages: AgentMessage[], entries: ToolResultEntry[]): ToolResultEntry[][] {
   const groups: ToolResultEntry[][] = [];
   let current: ToolResultEntry[] = [];
@@ -304,7 +297,7 @@ function groupByAssistantTurn(messages: AgentMessage[], entries: ToolResultEntry
 /**
  * Replace the text content of a tool-result message with `newText`.
  * For array-type content, distributes the text proportionally across text
- * blocks (each block gets its own truncated slice), preserving non-text blocks.
+ * blocks (each block gets its own slice), preserving non-text blocks.
  * For string-type content, replaces directly.
  */
 function replaceToolResultText(
@@ -316,16 +309,10 @@ function replaceToolResultText(
     return { ...msg, content: newText };
   }
 
-  // Array content: distribute proportionally per block (like OpenClaw's
-  // truncateToolResultMessage).
   const totalTextLen = getToolResultTextLength(msg);
   if (totalTextLen === 0) return msg;
 
   let assigned = 0;
-  const textBlocks = content.filter(
-    (b: unknown) => (b as Record<string, unknown>)?.type === "text" && typeof (b as Record<string, unknown>).text === "string",
-  );
-
   const newContent = content.map((block: unknown) => {
     const b = block as Record<string, unknown>;
     if (b?.type !== "text" || typeof b.text !== "string") return block;
@@ -371,6 +358,42 @@ function truncateToolResultMessage(
   });
 
   return { ...msg, content: newContent };
+}
+
+/**
+ * Pre-persist all oversized tool results to disk *before* any session
+ * trimming or budget enforcement can discard them.  Called from assemble()
+ * before buildAssembledContext so that even messages shifted out by
+ * buildSessionContext have their full content saved.
+ *
+ * Returns the list of persisted file paths.
+ */
+export async function prePersistOversizedResults(
+  messages: AgentMessage[],
+  cfg: {
+    toolResultCompression: boolean;
+    toolResultMaxChars: number;
+    toolResultStorageDir?: string;
+    sessionId?: string;
+  },
+): Promise<string[]> {
+  if (!cfg.toolResultCompression) return [];
+
+  const sessionId = cfg.sessionId ?? "default";
+  const storageDir = resolveStorageDir(sessionId, cfg.toolResultStorageDir);
+  const entries = collectToolResults(messages);
+  const oversized = entries.filter(e => e.textLength > cfg.toolResultMaxChars);
+  if (oversized.length === 0) return [];
+
+  const persistedFiles: string[] = [];
+  const ops = oversized.map(async (entry) => {
+    const text = getToolResultText(entry.message);
+    const filename = makePersistFilename(entry.message);
+    const filepath = await persistToDisk(text, filename, storageDir);
+    if (filepath) persistedFiles.push(filepath);
+  });
+  await Promise.all(ops);
+  return persistedFiles;
 }
 
 export async function compressToolResults(
@@ -431,7 +454,7 @@ export async function compressToolResults(
         persistedFiles.push(filepath);
       } else {
         const { preview, hasMore } = generatePreview(text, previewChars);
-        newContent = preview + (hasMore ? "\n\n[... disk persistence failed, content truncated ...]" : "");
+        newContent = preview + (hasMore ? "\n\n[... disk persistence failed, content not recoverable ...]" : "");
       }
 
       return {
@@ -448,7 +471,6 @@ export async function compressToolResults(
   }
 
   // Phase 2: aggregate budget enforcement per assistant turn.
-  // Each group = toolResult messages between two assistant messages.
   const afterIndividual = collectToolResults(result);
   const groups = groupByAssistantTurn(result, afterIndividual);
 
@@ -467,9 +489,31 @@ export async function compressToolResults(
       let remaining = groupChars - aggregateBudget;
       for (const entry of candidates) {
         if (remaining <= 0) break;
-        const targetChars = Math.max(previewChars, entry.textLength - remaining);
-        result[entry.index] = truncateToolResultMessage(result[entry.index]!, targetChars);
 
+        // Persist original content before truncating so it remains recoverable.
+        const text = getToolResultText(result[entry.index]!);
+        const filename = makePersistFilename(entry.message);
+        const filepath = await persistToDisk(text, filename, storageDir);
+
+        const targetChars = Math.max(previewChars, entry.textLength - remaining);
+        let truncated = truncateToolResultMessage(result[entry.index]!, targetChars);
+
+        if (filepath) {
+          persistedFiles.push(filepath);
+          const truncationNote = `\n\n[... aggregate budget truncation: full output saved to: ${filepath} ...]`;
+          const tc = truncated.content;
+          if (typeof tc === "string") {
+            truncated = { ...truncated, content: tc + truncationNote };
+          }
+        } else {
+          const truncationNote = "\n\n[... aggregate budget truncation: disk persistence failed, content not recoverable ...]";
+          const tc = truncated.content;
+          if (typeof tc === "string") {
+            truncated = { ...truncated, content: tc + truncationNote };
+          }
+        }
+
+        result[entry.index] = truncated;
         const newTextLen = getToolResultTextLength(result[entry.index]!);
         remaining -= Math.max(0, entry.textLength - newTextLen);
         if (newTextLen < entry.textLength) compressedCount++;

--- a/examples/openclaw-plugin/tool-result-compression.ts
+++ b/examples/openclaw-plugin/tool-result-compression.ts
@@ -1,0 +1,260 @@
+/**
+ * Tool result compression for the openclaw-plugin context engine.
+ *
+ * Prevents oversized tool outputs from bloating the assembled context that gets
+ * sent back to the model.  Two levels of protection:
+ *
+ *   1. **Individual truncation** — any single tool result exceeding
+ *      `toolResultMaxChars` is truncated to a head (and optionally tail)
+ *      preview.
+ *
+ *   2. **Aggregate budget** — if the *total* size of all tool results in one
+ *      assembled context exceeds `toolResultAggregateBudgetChars`, the largest
+ *      results are progressively re-truncated until the budget is met.
+ *
+ * Truncation prefers line boundaries and preserves the tail when it contains
+ * error / stack-trace signals so the model can still diagnose failures.
+ *
+ * All thresholds are configured via `MemoryOpenVikingConfig` in config.ts and
+ * passed through as-is by the context engine.
+ */
+
+type AgentMessage = {
+  role?: string;
+  content?: unknown;
+  toolCallId?: string;
+  toolName?: string;
+  isError?: boolean;
+};
+
+const TRUNCATION_MARKER = "\n\n[... tool output truncated: showing first";
+const TRUNCATION_TAIL_MARKER = " characters ...]";
+
+export type ToolResultCompressionStats = {
+  compressedCount: number;
+  totalOriginalChars: number;
+  totalCompressedChars: number;
+  aggregateBudgetTriggered: boolean;
+};
+
+function isToolResultMessage(msg: AgentMessage): boolean {
+  return msg.role === "toolResult";
+}
+
+function getToolResultTextLength(msg: AgentMessage): number {
+  const content = msg.content;
+  if (typeof content === "string") return content.length;
+  if (Array.isArray(content)) {
+    let total = 0;
+    for (const block of content) {
+      const b = block as Record<string, unknown>;
+      if (b?.type === "text" && typeof b.text === "string") {
+        total += b.text.length;
+      }
+    }
+    return total;
+  }
+  return 0;
+}
+
+/**
+ * Returns true when the tail of the text contains signals that are valuable
+ * for the model — error messages, stack traces, closing braces (JSON), or
+ * result/summary keywords.  When this is the case we keep both a head and a
+ * tail section instead of just the head.
+ */
+function hasImportantTail(text: string): boolean {
+  const tail = text.slice(-2000).toLowerCase();
+  return (
+    /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/.test(tail) ||
+    /\}\s*$/.test(text.trim()) ||
+    /\b(total|summary|result|complete|finished|done)\b/.test(tail)
+  );
+}
+
+/**
+ * Truncate a single text string to at most `maxChars`, keeping a preview of
+ * `previewChars`.  When the tail looks important (errors / JSON closing) we
+ * split the budget into head + tail so both ends are preserved.
+ */
+function truncateToolResultText(
+  text: string,
+  maxChars: number,
+  previewChars: number,
+): string {
+  if (text.length <= maxChars) return text;
+
+  const suffix = `${TRUNCATION_MARKER} ${previewChars} of ${text.length}${TRUNCATION_TAIL_MARKER}`;
+
+  // Head + tail mode: preserve error messages / JSON closers at the end.
+  if (hasImportantTail(text) && maxChars > previewChars * 2) {
+    const tailBudget = Math.min(Math.floor(maxChars * 0.3), 4000);
+    const headBudget = maxChars - tailBudget - suffix.length;
+
+    if (headBudget > previewChars) {
+      // Snap to line boundaries to avoid cutting mid-word.
+      let headCut = headBudget;
+      const headNewline = text.lastIndexOf("\n", headBudget);
+      if (headNewline > headBudget * 0.8) headCut = headNewline;
+
+      let tailStart = text.length - tailBudget;
+      const tailNewline = text.indexOf("\n", tailStart);
+      if (tailNewline !== -1 && tailNewline < tailStart + tailBudget * 0.2) {
+        tailStart = tailNewline + 1;
+      }
+
+      return text.slice(0, headCut) + suffix + "\n\n[... tail content ...]\n\n" + text.slice(tailStart);
+    }
+  }
+
+  // Head-only mode.
+  let cutPoint = Math.max(previewChars, maxChars - suffix.length);
+  const lastNewline = text.lastIndexOf("\n", cutPoint);
+  if (lastNewline > cutPoint * 0.8) cutPoint = lastNewline;
+
+  return text.slice(0, cutPoint) + suffix;
+}
+
+/**
+ * Compress a single tool-result message in place.  Handles both plain-string
+ * and content-block-array payloads.  Array payloads share the char budget
+ * proportionally across text blocks.
+ */
+function compressSingleToolResult(
+  msg: AgentMessage,
+  maxChars: number,
+  previewChars: number,
+): AgentMessage {
+  if (!isToolResultMessage(msg)) return msg;
+  const textLength = getToolResultTextLength(msg);
+  if (textLength <= maxChars) return msg;
+
+  const content = msg.content;
+  if (typeof content === "string") {
+    return { ...msg, content: truncateToolResultText(content, maxChars, previewChars) };
+  }
+
+  if (Array.isArray(content)) {
+    const totalTextLen = getToolResultTextLength(msg);
+    const newContent = content.map((block: unknown) => {
+      const b = block as Record<string, unknown>;
+      if (b?.type === "text" && typeof b.text === "string") {
+        const blockShare = b.text.length / totalTextLen;
+        const blockBudget = Math.max(previewChars, Math.floor(maxChars * blockShare));
+        return { ...b, text: truncateToolResultText(b.text, blockBudget, Math.floor(previewChars * blockShare)) };
+      }
+      return block;
+    });
+    return { ...msg, content: newContent };
+  }
+
+  return msg;
+}
+
+type ToolResultEntry = {
+  index: number;
+  message: AgentMessage;
+  textLength: number;
+};
+
+function collectToolResults(messages: AgentMessage[]): ToolResultEntry[] {
+  const entries: ToolResultEntry[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (isToolResultMessage(msg)) {
+      entries.push({ index: i, message: msg, textLength: getToolResultTextLength(msg) });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Apply two-level tool-result compression to an assembled message array.
+ *
+ * 1. Truncate any individual result exceeding `toolResultMaxChars`.
+ * 2. If the aggregate of all results still exceeds
+ *    `toolResultAggregateBudgetChars`, progressively re-truncate the largest
+ *    results (greedy, descending by size) until the budget is satisfied.
+ *
+ * Returns a new array (shallow-copied) plus compression statistics.
+ */
+export function compressToolResults(
+  messages: AgentMessage[],
+  cfg: {
+    toolResultCompression: boolean;
+    toolResultMaxChars: number;
+    toolResultAggregateBudgetChars: number;
+    toolResultPreviewChars: number;
+  },
+): { messages: AgentMessage[]; stats: ToolResultCompressionStats } {
+  if (!cfg.toolResultCompression) {
+    return {
+      messages,
+      stats: { compressedCount: 0, totalOriginalChars: 0, totalCompressedChars: 0, aggregateBudgetTriggered: false },
+    };
+  }
+
+  const maxChars = cfg.toolResultMaxChars;
+  const previewChars = cfg.toolResultPreviewChars;
+  const aggregateBudget = cfg.toolResultAggregateBudgetChars;
+
+  const entries = collectToolResults(messages);
+  if (entries.length === 0) {
+    return {
+      messages,
+      stats: { compressedCount: 0, totalOriginalChars: 0, totalCompressedChars: 0, aggregateBudgetTriggered: false },
+    };
+  }
+
+  let totalOriginalChars = 0;
+  for (const entry of entries) {
+    totalOriginalChars += entry.textLength;
+  }
+
+  const result = [...messages];
+  let compressedCount = 0;
+  let totalCompressedChars = 0;
+  let aggregateBudgetTriggered = false;
+
+  // Phase 1: individual truncation.
+  for (const entry of entries) {
+    if (entry.textLength > maxChars) {
+      result[entry.index] = compressSingleToolResult(entry.message, maxChars, previewChars);
+      compressedCount++;
+    }
+  }
+
+  // Phase 2: aggregate budget enforcement.
+  const afterIndividual = collectToolResults(result);
+  let aggregateChars = 0;
+  for (const entry of afterIndividual) {
+    aggregateChars += entry.textLength;
+  }
+
+  if (aggregateChars > aggregateBudget) {
+    aggregateBudgetTriggered = true;
+    const oversized = afterIndividual
+      .filter(e => e.textLength > previewChars * 2)
+      .sort((a, b) => b.textLength - a.textLength);
+
+    let remaining = aggregateChars - aggregateBudget;
+    for (const entry of oversized) {
+      if (remaining <= 0) break;
+      const targetChars = Math.max(previewChars, entry.textLength - remaining);
+      result[entry.index] = compressSingleToolResult(result[entry.index]!, targetChars, previewChars);
+      const newTextLen = getToolResultTextLength(result[entry.index]!);
+      remaining -= Math.max(0, entry.textLength - newTextLen);
+      if (newTextLen < entry.textLength) compressedCount++;
+    }
+  }
+
+  const finalEntries = collectToolResults(result);
+  for (const entry of finalEntries) {
+    totalCompressedChars += entry.textLength;
+  }
+
+  return {
+    messages: result,
+    stats: { compressedCount, totalOriginalChars, totalCompressedChars, aggregateBudgetTriggered },
+  };
+}

--- a/examples/openclaw-plugin/tool-result-compression.ts
+++ b/examples/openclaw-plugin/tool-result-compression.ts
@@ -376,24 +376,26 @@ export async function prePersistOversizedResults(
     toolResultStorageDir?: string;
     sessionId?: string;
   },
-): Promise<string[]> {
-  if (!cfg.toolResultCompression) return [];
+): Promise<{ files: string[]; contentHashes: Set<string> }> {
+  if (!cfg.toolResultCompression) return { files: [], contentHashes: new Set() };
 
   const sessionId = cfg.sessionId ?? "default";
   const storageDir = resolveStorageDir(sessionId, cfg.toolResultStorageDir);
   const entries = collectToolResults(messages);
   const oversized = entries.filter(e => e.textLength > cfg.toolResultMaxChars);
-  if (oversized.length === 0) return [];
+  if (oversized.length === 0) return { files: [], contentHashes: new Set() };
 
   const persistedFiles: string[] = [];
+  const contentHashes = new Set<string>();
   const ops = oversized.map(async (entry) => {
     const text = getToolResultText(entry.message);
+    contentHashes.add(contentHash(text));
     const filename = makePersistFilename(entry.message);
     const filepath = await persistToDisk(text, filename, storageDir);
     if (filepath) persistedFiles.push(filepath);
   });
   await Promise.all(ops);
-  return persistedFiles;
+  return { files: persistedFiles, contentHashes };
 }
 
 export async function compressToolResults(
@@ -405,6 +407,7 @@ export async function compressToolResults(
     toolResultPreviewChars: number;
     toolResultStorageDir?: string;
     sessionId?: string;
+    alreadyPersistedHashes?: Set<string>;
   },
 ): Promise<{ messages: AgentMessage[]; stats: ToolResultCompressionStats }> {
   if (!cfg.toolResultCompression) {
@@ -438,12 +441,21 @@ export async function compressToolResults(
   let totalCompressedChars = 0;
   let aggregateBudgetTriggered = false;
   const persistedFiles: string[] = [];
+  const knownHashes = new Set(cfg.alreadyPersistedHashes ?? []);
 
   // Phase 1: persist oversized results to disk, replace with preview + path.
-  const oversized = entries.filter(e => e.textLength > maxChars);
+  // Skip results whose content was already persisted (e.g. agent re-read a
+  // persisted file — compressing that again would create an infinite loop).
+  const oversized = entries.filter(e => {
+    if (e.textLength <= maxChars) return false;
+    const hash = contentHash(getToolResultText(e.message));
+    return !knownHashes.has(hash);
+  });
   if (oversized.length > 0) {
     const persistOps = oversized.map(async (entry) => {
       const text = getToolResultText(entry.message);
+      const hash = contentHash(text);
+      knownHashes.add(hash);
       const filename = makePersistFilename(entry.message);
       const filepath = await persistToDisk(text, filename, storageDir);
 
@@ -490,8 +502,13 @@ export async function compressToolResults(
       for (const entry of candidates) {
         if (remaining <= 0) break;
 
-        // Persist original content before truncating so it remains recoverable.
+        // Skip if this content was already persisted (re-read of a persisted file).
         const text = getToolResultText(result[entry.index]!);
+        const hash = contentHash(text);
+        if (knownHashes.has(hash)) continue;
+
+        // Persist original content before truncating so it remains recoverable.
+        knownHashes.add(hash);
         const filename = makePersistFilename(entry.message);
         const filepath = await persistToDisk(text, filename, storageDir);
 


### PR DESCRIPTION
## Description

Context engine 的 `assemble()` 从 OV 服务器拉回的历史消息中可能包含巨大的工具结果（文件读取、搜索输出、命令 stdout 等），之前没有压缩处理，导致 assembled context 无限膨胀，浪费 token 预算甚至超出模型上下文窗口。

本 PR 参考 Claude Code 的工具结果管理策略，在 context engine 的 assemble 阶段实现两层防护：

1. **Individual persistence** — 单条 toolResult 超过阈值时，完整内容持久化到磁盘文件，替换为 `<persisted-output>` 标签包裹的预览 + 文件路径引用，模型可随时通过文件路径重新读取完整数据
2. **Aggregate budget (per assistant turn)** — 两个 assistant turn 之间的所有 toolResult 总量超过预算时，按大小降序逐个截断直到满足预算。

方案特点：
- **Session 隔离**：持久化文件按 session 分目录（`~/.openclaw/memory/tool-results/<sessionId>/`），文件名包含内容 hash 防止跨 session 复用旧文件
- **EEXIST 内容校验**：文件已存在时读回校验内容一致性，不一致则写入带碰撞后缀的新文件
- **Head + Tail 预览**：自动检测尾部 error/traceback/JSON 闭合信号，保留两端关键信息
- **Per-block 比例截断**：数组型 toolResult 按每个 text block 的比例分配预算，独立截断，保留原始 block 结构
- **全部参数可配置**：`toolResultCompression` / `toolResultMaxChars` / `toolResultAggregateBudgetChars` / `toolResultPreviewChars`

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- **tool-result-compression.ts** (new): 核心压缩模块，包含两层防护、磁盘持久化、session 隔离、per-block 比例截断、per assistant turn 聚合预算
- **context-engine.ts**: `assemble()` 返回前调用 `compressToolResults(sanitized, cfg)`，传入 `sessionId` 做 session 隔离
- **config.ts**: 新增 4 个配置项（`toolResultCompression` / `toolResultMaxChars` / `toolResultAggregateBudgetChars` / `toolResultPreviewChars`），默认值定义、最小值 clamp 和 allowed keys 校验

| 配置项 | 默认值 | 最小值 | 说明 |
|--------|--------|--------|------|
| `toolResultCompression` | `true` | — | 是否启用 |
| `toolResultMaxChars` | `20000` | `2000` | 单条工具结果上限，超过则持久化到磁盘 |
| `toolResultAggregateBudgetChars` | `100000` | `20000` | 每 turn 聚合预算 |
| `toolResultPreviewChars` | `2000` | `200` | 预览字符数 |

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

失败用例在本pr修改之前即为失败，与本pr无关。

新增 11 个单元测试（`tests/ut/tool-result-compression.test.ts`），覆盖：
- passthrough（无 toolResult / 小 toolResult 不变）
- 持久化 + `<persisted-output>` 预览替换
- Head + tail 错误信号保留
- 同 turn 聚合预算触发
- Per-turn 独立预算（跨 turn 不误杀）
- 仅超预算的 turn 被触发
- `toolResultCompression=false` 跳过
- 磁盘写入失败降级为内存截断（assemble 失败会导致整个上下文组装失败，fallback 到原始消息（所有工具结果原样发送），可能导致撑爆 token 预算。所以选择降级 ——虽然模型无法重新读取完整数据了，但至少保证了上下文大小可控。）
- EEXIST 内容校验（内容一致复用）

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

### 后续计划：动态阈值+决策冻结机制

根据可用上下文窗口大小动态调整工具压缩策略，同时保证每次assemble对工具结果决策不变，避免破坏prompt cache prefix，引入 `seenIds` + `replacements` Map：
- 每个 tool_use_id 的截断决策一旦做出就永久冻结（跨 turn 一致）
- 已替换的 ID 在后续 turn 直接从 Map 中取出缓存的 replacement 字符串，零 I/O、字节完全一致
- 未替换的 ID 永远不会被后续 turn 替换（避免破坏 prompt cache prefix）
- Map状态跟随 conversation 生命周期