### PR TITLE
fix(volcengine): set fields for collection using apikey

### DIFF
--- a/openviking/storage/vectordb/collection/volcengine_api_key_collection.py
+++ b/openviking/storage/vectordb/collection/volcengine_api_key_collection.py
@@ -243,11 +243,13 @@ class VolcengineApiKeyCollection(ICollection):
         )
 
     def get_meta_data(self):
+        from openviking.storage.collection_schemas import CollectionSchemas
         return {
             "ProjectName": self.project_name,
             "CollectionName": self.collection_name,
             "IndexName": self.index_name,
             "Description": "data-plane only backend",
+            "Fields": CollectionSchemas.context_collection.get("Fields", []),
         }
 
     def close(self):


### PR DESCRIPTION
## Description

This PR fixes an issue where the collection metadata returned by get_meta_data() was missing the Fields definition when using Volcengine VikingDB with API Key authentication, resulting in   
  incomplete schema information for downstream collection creation/description.  

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add Fields to the metadata returned by VolcengineApiKeyCollection.get_meta_data()    
- Read Fields from CollectionSchemas.context_collection, defaulting to [] when absent

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
