### PR TITLE
fix(server): skip identity resolution on health check without credentials

### DIFF
--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -43,23 +43,22 @@ async def health_check(request: Request):
             effective_auth_mode = config.get_effective_auth_mode()
         result["auth_mode"] = effective_auth_mode.value
 
-        # Always try to resolve identity - resolve_identity handles all auth modes
-        try:
-            identity = await resolve_identity(
-                request,
-                x_api_key=x_api_key,
-                authorization=authorization,
-                x_openviking_account=x_openviking_account,
-                x_openviking_user=x_openviking_user,
-                x_openviking_agent=x_openviking_agent,
-            )
-            # Always set identity fields if available
-            result["account_id"] = str(identity.account_id)
-            result["user_id"] = str(identity.user_id)
-            result["agent_id"] = str(identity.agent_id)
-            result["role"] = identity.role.value
-        except Exception as e:
-            logger.warning(f"Failed to resolve identity: {e}")
+        if x_api_key or authorization:
+            try:
+                identity = await resolve_identity(
+                    request,
+                    x_api_key=x_api_key,
+                    authorization=authorization,
+                    x_openviking_account=x_openviking_account,
+                    x_openviking_user=x_openviking_user,
+                    x_openviking_agent=x_openviking_agent,
+                )
+                result["account_id"] = str(identity.account_id)
+                result["user_id"] = str(identity.user_id)
+                result["agent_id"] = str(identity.agent_id)
+                result["role"] = identity.role.value
+            except Exception as e:
+                logger.warning(f"Failed to resolve identity: {e}")
     except Exception as e:
         logger.error(f"Failed to get health check: {e}")
 


### PR DESCRIPTION
## Description

When multi-tenant auth (`AuthMode.API_KEY`) is enabled, the `/health` endpoint logs noisy WARNING every 30 seconds because it unconditionally calls `resolve_identity()` — which raises `UnauthenticatedError` when no API key is present.

This was a regression introduced in #1545 (auth refactor), which removed the original credential guard (`if x_api_key or authorization:`) in favor of "always try to resolve".

**Symptom:**

```
2026-04-27 10:23:02,518 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
2026-04-27 10:23:02,518 - uvicorn.access - INFO - 127.0.0.1:56896 - "GET /health HTTP/1.1" 200
2026-04-27 10:23:32,573 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
2026-04-27 10:23:32,573 - uvicorn.access - INFO - 127.0.0.1:38968 - "GET /health HTTP/1.1" 200
2026-04-27 10:24:02,621 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
2026-04-27 10:24:02,622 - uvicorn.access - INFO - 127.0.0.1:60866 - "GET /health HTTP/1.1" 200
2026-04-27 10:24:32,678 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
2026-04-27 10:24:32,678 - uvicorn.access - INFO - 127.0.0.1:47598 - "GET /health HTTP/1.1" 200
2026-04-27 10:25:02,738 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
2026-04-27 10:25:02,738 - uvicorn.access - INFO - 127.0.0.1:40384 - "GET /health HTTP/1.1" 200
2026-04-27 10:25:32,785 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
2026-04-27 10:25:32,786 - uvicorn.access - INFO - 127.0.0.1:54476 - "GET /health HTTP/1.1" 200
2026-04-27 10:26:02,837 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
2026-04-27 10:26:02,837 - uvicorn.access - INFO - 127.0.0.1:54438 - "GET /health HTTP/1.1" 200
2026-04-27 10:26:32,897 - openviking.server.routers.system - WARNING - Failed to resolve identity: Missing API Key when resolving identity.
```

## Related Issue

Regression from #1545

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Restore credential guard in `/health` endpoint: only call `resolve_identity()` when `X-API-Key` or `Authorization` header is present
- Health checks without credentials now silently return `{"status": "ok"}` without triggering WARNING logs
- Health checks with credentials still resolve and return identity info as before

## Testing

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The original code before #1545 already had this guard (`elif x_api_key or authorization:`). The refactor removed it under the assumption that `resolve_identity()` handles all auth modes internally, but it doesn't handle the "no credentials at all" case gracefully in API_KEY mode.