### PR TITLE
feat(search): support multiple target_uri in find and search

### DIFF
--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -314,7 +314,7 @@ class AsyncOpenViking:
     async def search(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         session: Optional[Union["Session", Any]] = None,
         session_id: Optional[str] = None,
         limit: int = 10,
@@ -357,7 +357,7 @@ class AsyncOpenViking:
     async def find(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -275,7 +275,7 @@ class LocalClient(BaseClient):
     async def find(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict[str, Any]] = None,
@@ -306,7 +306,7 @@ class LocalClient(BaseClient):
     async def search(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         session_id: Optional[str] = None,
         limit: int = 10,
         score_threshold: Optional[float] = None,

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -3,7 +3,7 @@
 """Search endpoints for OpenViking HTTP Server."""
 
 import math
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -62,7 +62,7 @@ class FindRequest(BaseModel):
     """Request model for find."""
 
     query: str
-    target_uri: str = ""
+    target_uri: Union[str, List[str]] = ""
     limit: int = 10
     node_limit: Optional[int] = None
     score_threshold: Optional[float] = None
@@ -79,7 +79,7 @@ class SearchRequest(BaseModel):
     """Request model for search with session."""
 
     query: str
-    target_uri: str = ""
+    target_uri: Union[str, List[str]] = ""
     session_id: Optional[str] = None
     limit: int = 10
     node_limit: Optional[int] = None

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -6,7 +6,7 @@ Search Service for OpenViking.
 Provides semantic search operations: search, find.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import VikingFS
@@ -44,7 +44,7 @@ class SearchService:
         self,
         query: str,
         ctx: RequestContext,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         session: Optional["Session"] = None,
         limit: int = 10,
         score_threshold: Optional[float] = None,
@@ -54,7 +54,7 @@ class SearchService:
 
         Args:
             query: Query string
-            target_uri: Target directory URI
+            target_uri: Target directory URI(s), supports str or List[str]
             session: Session object for context
             limit: Max results
             score_threshold: Score threshold
@@ -85,7 +85,7 @@ class SearchService:
         self,
         query: str,
         ctx: RequestContext,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,
@@ -94,7 +94,7 @@ class SearchService:
 
         Args:
             query: Query string
-            target_uri: Target directory URI
+            target_uri: Target directory URI(s), supports str or List[str]
             limit: Max results
             score_threshold: Score threshold
             filter: Metadata filters

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1001,7 +1001,7 @@ class VikingFS:
     async def find(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,
@@ -1011,7 +1011,7 @@ class VikingFS:
 
         Args:
             query: Search query
-            target_uri: Target directory URI
+            target_uri: Target directory URI(s), supports str or List[str]
             limit: Return count
             score_threshold: Score threshold
             filter: Metadata filter
@@ -1028,12 +1028,23 @@ class VikingFS:
             TypedQuery,
         )
 
-        if target_uri and target_uri not in {"/", "viking://"}:
+        # Normalize target_uri to list
+        target_uri_list = [target_uri] if isinstance(target_uri, str) else (target_uri or [])
+        real_ctx = self._ctx_or_default(ctx)
+        canonical_target_uri_list: List[str] = []
+        for item in target_uri_list:
+            if not item or item in {"/", "viking://"}:
+                continue
             try:
-                target_uri = canonicalize_uri(target_uri, self._ctx_or_default(ctx))
+                canonical_target_uri_list.append(canonicalize_uri(item, real_ctx))
             except NamespaceShapeError as exc:
                 raise InvalidArgumentError(str(exc)) from exc
-            self._ensure_access(target_uri, ctx)
+        target_uri_list = canonical_target_uri_list
+        # Use first URI for context inference and access check
+        primary_target_uri = target_uri_list[0] if target_uri_list else ""
+
+        if primary_target_uri and primary_target_uri not in {"/", "viking://"}:
+            self._ensure_access(primary_target_uri, ctx)
 
         storage = self._get_vector_store()
         if not storage:
@@ -1050,16 +1061,15 @@ class VikingFS:
         )
 
         # Infer context_type (None = search all types)
-        context_type = self._infer_context_type(target_uri) if target_uri else None
+        context_type = self._infer_context_type(primary_target_uri) if primary_target_uri else None
 
         typed_query = TypedQuery(
             query=query,
             context_type=context_type,
             intent="",
-            target_directories=[target_uri] if target_uri else None,
+            target_directories=target_uri_list if target_uri_list else None,
         )
 
-        real_ctx = self._ctx_or_default(ctx)
         logger.debug(
             f"[VikingFS.find] Calling retriever.retrieve with ctx.account_id={real_ctx.account_id}, ctx.user={real_ctx.user}"
         )

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -6,7 +6,7 @@ Synchronous OpenViking client implementation.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from openviking.session import Session
@@ -160,7 +160,7 @@ class SyncOpenViking:
     def search(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         session: Optional["Session"] = None,
         session_id: Optional[str] = None,
         limit: int = 10,
@@ -191,7 +191,7 @@ class SyncOpenViking:
     def find(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,

--- a/openviking_cli/client/base.py
+++ b/openviking_cli/client/base.py
@@ -153,7 +153,7 @@ class BaseClient(ABC):
     async def find(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,
@@ -166,7 +166,7 @@ class BaseClient(ABC):
     async def search(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         session_id: Optional[str] = None,
         limit: int = 10,
         score_threshold: Optional[float] = None,

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -259,6 +259,21 @@ class AsyncHTTPClient(BaseClient):
         return telemetry
 
     @staticmethod
+    def _normalize_target_uri(
+        target_uri: Union[str, List[str]],
+    ) -> Union[str, List[str]]:
+        """Normalize target_uri for the search endpoints.
+
+        Accepts either a single string or a list of strings and applies
+        ``VikingURI.normalize`` to each non-empty entry.
+        """
+        if isinstance(target_uri, list):
+            return [VikingURI.normalize(u) if u else u for u in target_uri]
+        if target_uri:
+            return VikingURI.normalize(target_uri)
+        return target_uri
+
+    @staticmethod
     def _attach_telemetry(result: Any, response_data: Dict[str, Any]) -> Any:
         telemetry = response_data.get("telemetry")
         if telemetry is None:
@@ -614,7 +629,7 @@ class AsyncHTTPClient(BaseClient):
     async def find(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         node_limit: Optional[int] = None,
         score_threshold: Optional[float] = None,
@@ -623,14 +638,13 @@ class AsyncHTTPClient(BaseClient):
     ) -> FindResult:
         """Semantic search without session context."""
         telemetry = self._validate_telemetry(telemetry)
-        if target_uri:
-            target_uri = VikingURI.normalize(target_uri)
+        normalized_target = self._normalize_target_uri(target_uri)
         actual_limit = node_limit if node_limit is not None else limit
         response = await self._http.post(
             "/api/v1/search/find",
             json={
                 "query": query,
-                "target_uri": target_uri,
+                "target_uri": normalized_target,
                 "limit": actual_limit,
                 "score_threshold": score_threshold,
                 "filter": filter,
@@ -643,7 +657,7 @@ class AsyncHTTPClient(BaseClient):
     async def search(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         session: Optional[Any] = None,
         session_id: Optional[str] = None,
         limit: int = 10,
@@ -654,15 +668,14 @@ class AsyncHTTPClient(BaseClient):
     ) -> FindResult:
         """Semantic search with optional session context."""
         telemetry = self._validate_telemetry(telemetry)
-        if target_uri:
-            target_uri = VikingURI.normalize(target_uri)
+        normalized_target = self._normalize_target_uri(target_uri)
         actual_limit = node_limit if node_limit is not None else limit
         sid = session_id or (session.session_id if session else None)
         response = await self._http.post(
             "/api/v1/search/search",
             json={
                 "query": query,
-                "target_uri": target_uri,
+                "target_uri": normalized_target,
                 "session_id": sid,
                 "limit": actual_limit,
                 "score_threshold": score_threshold,

--- a/openviking_cli/client/sync_http.py
+++ b/openviking_cli/client/sync_http.py
@@ -206,7 +206,7 @@ class SyncHTTPClient:
     def search(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         session: Optional[Any] = None,
         session_id: Optional[str] = None,
         limit: int = 10,
@@ -233,7 +233,7 @@ class SyncHTTPClient:
     def find(
         self,
         query: str,
-        target_uri: str = "",
+        target_uri: Union[str, List[str]] = "",
         limit: int = 10,
         node_limit: Optional[int] = None,
         score_threshold: Optional[float] = None,


### PR DESCRIPTION
Extend the ``target_uri`` parameter from ``str`` to ``Union[str, List[str]]`` across the full find/search stack so callers can scope a single query to multiple directories in one request:

- server: FindRequest / SearchRequest accept list[str] target_uri
- service: SearchService.find / .search forward list[str]
- storage: VikingFS.find normalizes list[str], canonicalizes each entry, and forwards the full list as target_directories to the retriever (matching the existing behaviour of VikingFS.search)
- clients: BaseClient, LocalClient, AsyncHTTPClient, SyncHTTPClient, AsyncOpenViking and SyncOpenViking signatures updated; the HTTP client gains a ``_normalize_target_uri`` helper that applies ``VikingURI.normalize`` to each non-empty entry

Single-string behaviour is fully preserved: a plain ``str`` is normalized internally to a one-element list, and empty ``""`` keeps today's no-target semantics.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
