### PR TITLE
Fix/add resource incremental target

### DIFF
--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -311,8 +311,11 @@ class ResourceProcessor:
                     except Exception:
                         pass
 
-                    # 数据已移动到 root_uri，后续处理使用 root_uri
-                    temp_uri = root_uri
+                    # Only switch to root_uri after a first-time persist. For repeated
+                    # writes to an existing target we must keep the fresh temp tree so
+                    # semantic processing can diff temp source against target_uri.
+                    if not target_exists:
+                        temp_uri = root_uri
 
             # ============ Phase 4: Optional Steps ============
             build_index = kwargs.get("build_index", True)

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -20,6 +20,16 @@ class _DummyTelemetry:
     def set_error(self, *args, **kwargs):
         return None
 
+    class _Measure:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def measure(self, *args, **kwargs):
+        return self._Measure()
+
 
 class _CtxMgr:
     def __enter__(self):
@@ -30,14 +40,15 @@ class _CtxMgr:
 
 
 class _FakeVikingFS:
-    def __init__(self):
+    def __init__(self, *, exists_result=False):
         self.agfs = SimpleNamespace(mv=MagicMock(return_value={"status": "ok"}))
+        self._exists_result = exists_result
 
     def bind_request_context(self, ctx):
         return _CtxMgr()
 
     async def exists(self, uri, ctx=None):
-        return False
+        return self._exists_result
 
     async def mkdir(self, uri, exist_ok=False, ctx=None):
         return None
@@ -83,3 +94,47 @@ async def test_resource_processor_first_add_persist_does_not_await_agfs_mv(monke
     assert result["status"] == "success"
     assert result["root_uri"] == "viking://resources/root"
     fake_fs.agfs.mv.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_resource_processor_second_add_preserves_temp_uri_for_incremental(monkeypatch):
+    from openviking.utils.resource_processor import ResourceProcessor
+
+    fake_fs = _FakeVikingFS(exists_result=True)
+    summarize_calls = []
+
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_current_telemetry",
+        lambda: _DummyTelemetry(),
+    )
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+
+    rp = ResourceProcessor(vikingdb=_DummyVikingDB(), media_storage=None)
+    rp._get_media_processor = MagicMock()
+    rp._get_media_processor.return_value.process = AsyncMock(
+        return_value=SimpleNamespace(
+            temp_dir_path="viking://temp/tmpdir",
+            source_path="x",
+            source_format="text",
+            meta={},
+            warnings=[],
+        )
+    )
+
+    context_tree = SimpleNamespace(
+        root=SimpleNamespace(uri="viking://resources/root", temp_uri="viking://temp/root_tmp")
+    )
+    rp.tree_builder.finalize_from_temp = AsyncMock(return_value=context_tree)
+    rp._summarizer = SimpleNamespace(
+        summarize=AsyncMock(
+            side_effect=lambda *args, **kwargs: summarize_calls.append(kwargs)
+            or {"status": "success"}
+        )
+    )
+
+    result = await rp.process_resource(path="x", ctx=object(), build_index=True)
+
+    assert result["status"] == "success"
+    assert result["root_uri"] == "viking://resources/root"
+    assert summarize_calls[0]["temp_uris"] == ["viking://temp/root_tmp"]
+    fake_fs.agfs.mv.assert_not_called()


### PR DESCRIPTION
## Description
Fix incremental update detection for repeated `add-resource --to <existing-uri>` calls.
Previously, when a resource was added a second time to the same target URI, the ingestion flow overwrote the fresh `temp_uri` with `root_uri` before semantic processing. That caused the semantic queue to lose the source-vs-target distinction required for diffing, so the incremental update path was not triggered.
This change preserves the fresh temp tree for repeated writes to an existing target while keeping the first-time persist flow unchanged. A regression test was also added to cover this scenario.
## Related Issue
<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
N/A
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update
## Changes Made
- preserve `temp_uri` for repeated writes when the target resource already exists
- keep the existing first-time persist behavior that switches to `root_uri` for new targets
- add a regression test in `tests/misc/test_resource_processor_mv.py` for repeated `add-resource --to same-uri`
## Testing
<!-- Describe how you tested your changes -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
Notes:
- manually reproduced the issue with a second `add-resource --to viking://resources/java`
- traced the ingestion and semantic enqueue flow to confirm incremental target handling was lost
- local pytest execution is currently blocked by environment issues unrelated to this change:
  - missing `_sqlite3` for `pytest-cov`
  - missing `litellm` during test initialization
## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
## Screenshots (if applicable)
N/A
## Additional Notes
This fix is intentionally minimal. It only changes when `temp_uri` is rewritten after persistence so downstream semantic processing can correctly diff the fresh import tree against the existing target URI.