### PR TITLE
docs(config): document encryption.api_key_hashing.enabled in 01-configuration.md (#1736)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1057,6 +1057,7 @@ Enable at-rest data encryption to ensure data security and isolation in multi-te
 |-----------|------|-------------|---------|
 | `enabled` | bool | Whether encryption is enabled | `false` |
 | `provider` | str | Key provider: `"local"`, `"vault"`, or `"volcengine_kms"` | - |
+| `api_key_hashing.enabled` | bool | Whether to apply Argon2id one-way hashing to API key values (independent of file-level `enabled`); see [Encryption Guide](./08-encryption.md) | `false` |
 
 ### Local (File)
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1009,6 +1009,7 @@ openviking add-resource ./docs --exclude "*.tmp"
 |------|------|------|--------|
 | `enabled` | bool | 是否启用加密 | `false` |
 | `provider` | str | 密钥提供程序：`"local"`、`"vault"` 或 `"volcengine_kms"` | - |
+| `api_key_hashing.enabled` | bool | 是否对 API key 字段启用 Argon2id 单向哈希（与文件级 `enabled` 独立控制），详见 [加密指南](./08-encryption.md) | `false` |
 
 ### Local（本地文件）
 


### PR DESCRIPTION
Summary
-------

`docs/{en,zh}/guides/01-configuration.md` `encryption` section's parameter table is missing the new `api_key_hashing.enabled` sibling key introduced by #1736 (feat(encryption): make apikey hash encryption as single switch). The deeper `08-encryption.md` guide and `examples/ov.conf.example` were updated in that PR; this top-level config schema reference was not.

Changes
-------

- `docs/en/guides/01-configuration.md`: append one row to the `encryption` Section parameters table — `api_key_hashing.enabled` (bool, default `false`).
- `docs/zh/guides/01-configuration.md`: mirror in Chinese.

Both rows cross-link to `./08-encryption.md` (the existing Encryption Guide already linked from this section) so users get the field at the schema-reference layer and follow through for full semantics.

Why
---

`encryption.api_key_hashing.enabled` is the second top-level switch under `encryption`, controlling Argon2id one-way hashing of API key values independently of file-level encryption (`encryption.enabled`). It was previously implicit (file encryption implied hashing); #1736 split it into a dedicated config knob with default `false`. The schema-reference table is the canonical place readers look for the full set of `encryption.*` keys; missing the new sibling forces them to read 08-encryption.md or the source to discover it.

Source-of-truth: `openviking/server/config.py` `api_key_hashing_enabled: bool = False`; mirrored in `examples/ov.conf.example` (`"api_key_hashing": { "enabled": false }`) and `docs/{en,zh}/guides/08-encryption.md` (Argon2id table).

Type of Change
--------------

- [x] Documentation update

Diff
----

`+1 EN, +1 ZH` table row.
