### PR TITLE
fix(resources): clean up temp dir after incremental sync

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -146,6 +146,18 @@ class SemanticDagExecutor:
                     f"added_dirs={len(diff.added_dirs)}, "
                     f"deleted_dirs={len(diff.deleted_dirs)}"
                 )
+
+                # Clean up the temp tree after a successful sync.
+                try:
+                    temp_parent_uri = "/".join(self._root_uri.rstrip("/").rsplit("/", 1)[:-1])
+                    if temp_parent_uri and temp_parent_uri.startswith("viking://temp/"):
+                        viking_fs = get_viking_fs()
+                        await viking_fs.delete_temp(temp_parent_uri, ctx=self._ctx)
+                        logger.debug(f"[SyncDiff] Cleaned up temp dir: {temp_parent_uri}")
+                except Exception as cleanup_err:
+                    logger.warning(
+                        f"[SyncDiff] Failed to clean up temp dir after sync: {cleanup_err}"
+                    )
             except Exception as e:
                 logger.error(
                     f"[SyncDiff] Error in sync_diff_callback: "


### PR DESCRIPTION
## Summary

When `sync_diff_callback` successfully completes an incremental update (watch-triggered or explicit re-add), the temp directory tree used as the diff source was never removed from `viking://temp/`. Over time this left behind one empty temp directory shell per watch tick, accumulating indefinitely.

This PR adds a cleanup step inside `sync_diff_callback` (in `SemanticDagExecutor`) that removes the temp parent directory immediately after a successful sync, mirroring the cleanup that already happens on the new-resource path in `ResourceProcessor`.

**Root cause**: `delete_temp` was only called on error paths or in `ResourceProcessor` for the first-add case. The incremental-update success path in `SemanticDagExecutor` had no corresponding cleanup.

**Fix**: After the `logger.info(f"[SyncDiff] Diff computed: ...")` line in `sync_diff_callback`, compute the parent URI from `self._root_uri` and call `delete_temp` if it lives under `viking://temp/`. Failures are caught and logged as warnings (non-fatal).

## Type of Change

- [x] Bug fix (fix)

## Testing

- Manually verified with a watch task set to 5-minute intervals: new files added to the watched source directory sync to the resource URI, and no residual empty dirs accumulate under `data/viking/<account>/temp/` after the sync completes.
- Existing test suite passes (the one failing test — `test_resource_processor_first_add_persist_does_not_await_agfs_mv` — fails on `origin/main` as well due to an uninitialized `LockManager` in the test fixture; unrelated to this change).

## Related Issues

N/A

## Checklist

- [x] Code follows project style guidelines (ruff format + ruff check pass)
- [x] Manual testing completed
- [x] All tests pass (pre-existing failure unrelated to this change)

/cc @chuanbao666 @baojun-zhang @myysy