### PR TITLE
fix(metrics): scope vikingdb vector count to configured default account

### DIFF
--- a/docs/en/concepts/12-metrics.md
+++ b/docs/en/concepts/12-metrics.md
@@ -318,8 +318,8 @@ Typical `component` values include:
 
 | Metric Family | Type | Common Labels | Meaning |
 |---------------|------|---------------|---------|
-| `openviking_vikingdb_collection_health` | Gauge | `collection, valid` | collection health |
-| `openviking_vikingdb_collection_vectors` | Gauge | `collection, valid` | current vector count per collection |
+| `openviking_vikingdb_collection_health` | Gauge | `account_id, collection, valid` | collection health |
+| `openviking_vikingdb_collection_vectors` | Gauge | `account_id, collection, valid` | current vector count per collection |
 | `openviking_model_usage_available` | Gauge | `model_type, valid` | whether model usage statistics are currently available |
 
 Possible `model_type` values include:

--- a/docs/zh/concepts/12-metrics.md
+++ b/docs/zh/concepts/12-metrics.md
@@ -321,8 +321,8 @@ scrape_configs:
 
 | 指标族 | 类型 | 常见标签 | 含义 |
 |--------|------|----------|------|
-| `openviking_vikingdb_collection_health` | Gauge | `collection, valid` | collection 健康状态 |
-| `openviking_vikingdb_collection_vectors` | Gauge | `collection, valid` | collection 当前向量数 |
+| `openviking_vikingdb_collection_health` | Gauge | `account_id, collection, valid` | collection 健康状态 |
+| `openviking_vikingdb_collection_vectors` | Gauge | `account_id, collection, valid` | collection 当前向量数 |
 | `openviking_model_usage_available` | Gauge | `model_type, valid` | 模型使用统计是否可用 |
 
 其中 `model_type` 可能包括：

--- a/openviking/metrics/account_dimension.py
+++ b/openviking/metrics/account_dimension.py
@@ -39,6 +39,8 @@ ACCOUNT_DIMENSION_SUPPORTED_METRICS = frozenset(
         "openviking_retrieval_latency_seconds",
         "openviking_retrieval_rerank_used_total",
         "openviking_retrieval_rerank_fallback_total",
+        "openviking_vikingdb_collection_health",
+        "openviking_vikingdb_collection_vectors",
         "openviking_session_lifecycle_total",
         "openviking_session_contexts_used_total",
         "openviking_session_archive_total",

--- a/openviking/metrics/collectors/base.py
+++ b/openviking/metrics/collectors/base.py
@@ -339,18 +339,38 @@ class StateMetricCollector(MetricCollector, Refreshable, ABC):
         match_labels: dict,
         labels: dict | None = None,
         label_names: tuple[str, ...] = (),
+        account_id: str | None = None,
     ) -> None:
         """Replace the full gauge series selected by `match_labels` with one fresh value."""
-        registry.gauge_delete_matching(str(metric_name), match_labels=match_labels)
+        if account_id is None:
+            registry.gauge_delete_matching(str(metric_name), match_labels=match_labels)
+        else:
+            registry.gauge_delete_matching(
+                str(metric_name),
+                match_labels=match_labels,
+                account_id=account_id,
+            )
         if labels is None:
-            registry.set_gauge(str(metric_name), float(value))
+            if account_id is None:
+                registry.set_gauge(str(metric_name), float(value))
+            else:
+                registry.set_gauge(str(metric_name), float(value), account_id=account_id)
             return
-        registry.set_gauge(
-            str(metric_name),
-            float(value),
-            labels=labels,
-            label_names=label_names,
-        )
+        if account_id is None:
+            registry.set_gauge(
+                str(metric_name),
+                float(value),
+                labels=labels,
+                label_names=label_names,
+            )
+        else:
+            registry.set_gauge(
+                str(metric_name),
+                float(value),
+                labels=labels,
+                label_names=label_names,
+                account_id=account_id,
+            )
 
 
 class DomainStatsMetricCollector(MetricCollector, Refreshable, ABC):

--- a/openviking/metrics/collectors/vikingdb.py
+++ b/openviking/metrics/collectors/vikingdb.py
@@ -36,6 +36,7 @@ class VikingDBCollector(StateMetricCollector):
     config: CollectorConfig = CollectorConfig(ttl_seconds=10.0, timeout_seconds=0.8)
     _last_collection: str = field(default="unknown", init=False, repr=False)
     _last_account: str = field(default="default", init=False, repr=False)
+    _last_vectors: float = field(default=0.0, init=False, repr=False)
 
     def read_metric_input(self):
         """Read the latest VikingDB collection state from the datasource."""
@@ -52,15 +53,17 @@ class VikingDBCollector(StateMetricCollector):
         account_id, collection, ok, vectors = metric_input
         self._last_collection = str(collection)
         self._last_account = str(account_id)
-        base = {"account_id": str(account_id), "collection": str(collection)}
-        labels = {"account_id": str(account_id), "collection": str(collection), "valid": "1"}
+        self._last_vectors = float(vectors)
+        base = {"collection": str(collection)}
+        labels = {"collection": str(collection), "valid": "1"}
         self.replace_gauge_series(
             registry,
             self.COLLECTION_HEALTH,
             1.0 if ok else 0.0,
             match_labels=base,
             labels=labels,
-            label_names=("account_id", "collection", "valid"),
+            label_names=("collection", "valid"),
+            account_id=self._last_account,
         )
         self.replace_gauge_series(
             registry,
@@ -68,7 +71,8 @@ class VikingDBCollector(StateMetricCollector):
             float(vectors),
             match_labels=base,
             labels=labels,
-            label_names=("account_id", "collection", "valid"),
+            label_names=("collection", "valid"),
+            account_id=self._last_account,
         )
 
     def collect_error_hook(self, registry, error: Exception) -> None:
@@ -79,27 +83,23 @@ class VikingDBCollector(StateMetricCollector):
         """Export stale VikingDB gauges under `valid=0` when datasource refresh fails."""
         account_id = self._last_account
         collection = self._last_collection
-        base = {"account_id": account_id, "collection": collection}
-        last_vectors = registry.gauge_get(
-            self.COLLECTION_VECTORS,
-            labels={"account_id": account_id, "collection": collection, "valid": "1"},
-        )
-        if last_vectors is None:
-            last_vectors = 0.0
-        labels = {"account_id": account_id, "collection": collection, "valid": "0"}
+        base = {"collection": collection}
+        labels = {"collection": collection, "valid": "0"}
         self.replace_gauge_series(
             registry,
             self.COLLECTION_HEALTH,
             0.0,
             match_labels=base,
             labels=labels,
-            label_names=("account_id", "collection", "valid"),
+            label_names=("collection", "valid"),
+            account_id=account_id,
         )
         self.replace_gauge_series(
             registry,
             self.COLLECTION_VECTORS,
-            float(last_vectors),
+            float(self._last_vectors),
             match_labels=base,
             labels=labels,
-            label_names=("account_id", "collection", "valid"),
+            label_names=("collection", "valid"),
+            account_id=account_id,
         )

--- a/openviking/metrics/collectors/vikingdb.py
+++ b/openviking/metrics/collectors/vikingdb.py
@@ -35,6 +35,7 @@ class VikingDBCollector(StateMetricCollector):
     data_source: VikingDBStateDataSource
     config: CollectorConfig = CollectorConfig(ttl_seconds=10.0, timeout_seconds=0.8)
     _last_collection: str = field(default="unknown", init=False, repr=False)
+    _last_account: str = field(default="default", init=False, repr=False)
 
     def read_metric_input(self):
         """Read the latest VikingDB collection state from the datasource."""
@@ -48,17 +49,18 @@ class VikingDBCollector(StateMetricCollector):
         to the last observed collection name and preserves last vectors count when present,
         emitting `valid="0"` to mark the data as stale.
         """
-        collection, ok, vectors = metric_input
+        account_id, collection, ok, vectors = metric_input
         self._last_collection = str(collection)
-        base = {"collection": str(collection)}
-        labels = {"collection": str(collection), "valid": "1"}
+        self._last_account = str(account_id)
+        base = {"account_id": str(account_id), "collection": str(collection)}
+        labels = {"account_id": str(account_id), "collection": str(collection), "valid": "1"}
         self.replace_gauge_series(
             registry,
             self.COLLECTION_HEALTH,
             1.0 if ok else 0.0,
             match_labels=base,
             labels=labels,
-            label_names=("collection", "valid"),
+            label_names=("account_id", "collection", "valid"),
         )
         self.replace_gauge_series(
             registry,
@@ -66,7 +68,7 @@ class VikingDBCollector(StateMetricCollector):
             float(vectors),
             match_labels=base,
             labels=labels,
-            label_names=("collection", "valid"),
+            label_names=("account_id", "collection", "valid"),
         )
 
     def collect_error_hook(self, registry, error: Exception) -> None:
@@ -75,22 +77,23 @@ class VikingDBCollector(StateMetricCollector):
 
     def collect_stale_hook(self, registry, error: Exception) -> None:
         """Export stale VikingDB gauges under `valid=0` when datasource refresh fails."""
+        account_id = self._last_account
         collection = self._last_collection
-        base = {"collection": collection}
+        base = {"account_id": account_id, "collection": collection}
         last_vectors = registry.gauge_get(
             self.COLLECTION_VECTORS,
-            labels={"collection": collection, "valid": "1"},
+            labels={"account_id": account_id, "collection": collection, "valid": "1"},
         )
         if last_vectors is None:
             last_vectors = 0.0
-        labels = {"collection": collection, "valid": "0"}
+        labels = {"account_id": account_id, "collection": collection, "valid": "0"}
         self.replace_gauge_series(
             registry,
             self.COLLECTION_HEALTH,
             0.0,
             match_labels=base,
             labels=labels,
-            label_names=("collection", "valid"),
+            label_names=("account_id", "collection", "valid"),
         )
         self.replace_gauge_series(
             registry,
@@ -98,5 +101,5 @@ class VikingDBCollector(StateMetricCollector):
             float(last_vectors),
             match_labels=base,
             labels=labels,
-            label_names=("collection", "valid"),
+            label_names=("account_id", "collection", "valid"),
         )

--- a/openviking/metrics/datasources/observer_state.py
+++ b/openviking/metrics/datasources/observer_state.py
@@ -7,7 +7,9 @@ import time
 from typing import Any
 
 from openviking.metrics.core.base import ReadEnvelope
+from openviking.server.identity import AccountNamespacePolicy, RequestContext, Role
 from openviking.storage.transaction import get_lock_manager
+from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import run_async
 
 from .base import DomainStatsMetricDataSource, StateMetricDataSource
@@ -108,13 +110,28 @@ class VikingDBStateDataSource(StateMetricDataSource):
         """Store the optional service object used to resolve the active VikingDB manager."""
         self._service = service
 
-    def read_vikingdb_state(self) -> ReadEnvelope[tuple[str, bool, int]]:
+    def _make_default_ctx(self) -> tuple[str, RequestContext]:
+        """Build a RequestContext scoped to the configured default account, returning (account_id, ctx)."""
+        try:
+            from openviking_cli.utils.config import get_openviking_config
+
+            config = get_openviking_config()
+            account_id = config.default_account or "default"
+            user_id = config.default_user or "default"
+        except Exception:
+            account_id = "default"
+            user_id = "default"
+        user = UserIdentifier(account_id=account_id, user_id=user_id, agent_id="metrics")
+        ctx = RequestContext(user=user, role=Role.USER, namespace_policy=AccountNamespacePolicy())
+        return account_id, ctx
+
+    def read_vikingdb_state(self) -> ReadEnvelope[tuple[str, str, bool, int]]:
         """
         Read the collection name, health status, and approximate row count for VikingDB.
 
         Returns:
-            A tuple of `(collection_name, healthy, count)`. Missing services or failures fall
-            back to safe default values so metrics collection remains best-effort.
+            A tuple of `(account_id, collection_name, healthy, count)`. Missing services or
+            failures fall back to safe default values so metrics collection remains best-effort.
         """
         vikingdb = None
         if self._service is not None:
@@ -124,11 +141,12 @@ class VikingDBStateDataSource(StateMetricDataSource):
         if vikingdb is None:
             return ReadEnvelope(
                 ok=False,
-                value=("default", False, 0),
+                value=("default", "default", False, 0),
                 error_type="NotAvailable",
                 error_message="vikingdb manager missing",
             )
 
+        account_id, ctx = self._make_default_ctx()
         collection = self.normalize_str(
             getattr(vikingdb, "collection_name", "default"), default="default"
         )
@@ -138,7 +156,7 @@ class VikingDBStateDataSource(StateMetricDataSource):
             runner=run_async,
         )
         count_env = self.safe_read_async(
-            lambda: vikingdb.count(filter=None, ctx=None),
+            lambda: vikingdb.count(filter=None, ctx=ctx),
             default=0,
             runner=run_async,
         )
@@ -147,7 +165,7 @@ class VikingDBStateDataSource(StateMetricDataSource):
         envelope_ok = bool(ok_env.ok and count_env.ok)
         return ReadEnvelope(
             ok=envelope_ok,
-            value=(collection, ok, count),
+            value=(account_id, collection, ok, count),
             error_type=ok_env.error_type or count_env.error_type,
             error_message=ok_env.error_message or count_env.error_message,
         )

--- a/tests/metrics/collectors/test_state_collectors.py
+++ b/tests/metrics/collectors/test_state_collectors.py
@@ -274,7 +274,11 @@ def test_vikingdb_collector_exports_health_and_count(monkeypatch):
     registry = MetricRegistry()
     VikingDBCollector(data_source=VikingDBStateDataSource(service=Service())).collect(registry)
     text = PrometheusExporter(registry=registry).render()
-    assert 'openviking_vikingdb_collection_health{collection="my_collection",valid="1"} 1.0' in text
     assert (
-        'openviking_vikingdb_collection_vectors{collection="my_collection",valid="1"} 123.0' in text
+        'openviking_vikingdb_collection_health{account_id="__unknown__",collection="my_collection",valid="1"} 1.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="__unknown__",collection="my_collection",valid="1"} 123.0'
+        in text
     )

--- a/tests/metrics/datasources/test_state_datasources.py
+++ b/tests/metrics/datasources/test_state_datasources.py
@@ -14,6 +14,7 @@ from openviking.metrics.collectors.base import (
 )
 from openviking.metrics.core.base import ReadEnvelope
 from openviking.metrics.core.registry import MetricRegistry
+from openviking.metrics.datasources.observer_state import VikingDBStateDataSource
 
 
 class _EnvelopeStateCollector(StateMetricCollector):
@@ -233,3 +234,31 @@ def test_async_system_probe_datasource_returns_default_on_exception(monkeypatch)
     assert env.ok is False
     assert env.value == {"queue": False}
     assert env.error_type == "RuntimeError"
+
+
+def test_vikingdb_state_datasource_uses_default_account_ctx_for_count(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class DummyVikingDB:
+        collection_name = "my_collection"
+
+        async def health_check(self):
+            return True
+
+        async def count(self, filter=None, ctx=None):
+            captured["ctx"] = ctx
+            return 123
+
+    class Service:
+        _vikingdb_manager = DummyVikingDB()
+
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: SimpleNamespace(default_account="acct_demo", default_user="user_demo"),
+    )
+
+    env = VikingDBStateDataSource(service=Service()).read_vikingdb_state()
+    assert env.ok is True
+    assert env.value == ("acct_demo", "my_collection", True, 123)
+    ctx = captured["ctx"]
+    assert getattr(ctx, "account_id", None) == "acct_demo"


### PR DESCRIPTION
## Summary

`VikingDBStateDataSource` was calling `vikingdb.count(ctx=None)`, which bypassed tenant scoping and returned vector counts for the internal default account instead of the account configured in `ov.conf`. This caused `collection_health` and `collection_vectors` gauges to always show zero (or data from the wrong tenant) on the metrics dashboard.

Changes:
- Added `_make_default_ctx()` that reads `default_account`/`default_user` from config and builds a proper `RequestContext`
- Pass the scoped ctx into `vikingdb.count()` so results reflect the active account
- Added `account_id` as a label to `collection_health` and `collection_vectors` gauges so dashboard `account_id` variables can filter correctly
- Updated collector tuple unpacking to handle the new `(account_id, collection, ok, count)` shape from the datasource

## Type of Change

- [x] Bug fix (fix)

## Testing

- Manually verified that `collection_vectors` gauges now reflect the correct account's vector counts after the fix
- `ruff format` and `ruff check` pass on all changed files

## Checklist

- [x] Code follows project style guidelines (ruff format + ruff check pass)
- [x] Manual testing completed

/cc @qin-ctx @MaojiaSheng