### PR TITLE
fix(storage): treat append_file missing path as not_found

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1945,8 +1945,12 @@ class VikingFS:
             except AGFSHTTPError as e:
                 if e.status_code != 404:
                     raise
-            except AGFSClientError:
-                raise
+            except AGFSClientError as e:
+                if "not found" not in (str(e) or "").lower():
+                    raise
+            except RuntimeError as e:
+                if "not found" not in (str(e) or "").lower():
+                    raise
 
             await self._ensure_parent_dirs(path)
             final_content = (existing + content).encode("utf-8")

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1728,8 +1728,12 @@ class VikingFS:
             except AGFSHTTPError as e:
                 if e.status_code != 404:
                     raise
-            except AGFSClientError:
-                raise
+            except AGFSClientError as e:
+                if "not found" not in (str(e) or "").lower():
+                    raise
+            except RuntimeError as e:
+                if "not found" not in (str(e) or "").lower():
+                    raise
 
             await self._ensure_parent_dirs(path)
             final_content = (existing + content).encode("utf-8")

--- a/tests/misc/test_append_file_missing.py
+++ b/tests/misc/test_append_file_missing.py
@@ -63,3 +63,14 @@ async def test_append_file_other_runtime_error_bubbles():
 
     with pytest.raises(RuntimeError):
         await fs.append_file("viking://session/default/bad/messages.jsonl", "x\n")
+
+
+@pytest.mark.asyncio
+async def test_append_file_other_client_error_bubbles():
+    """AGFSClientError without 'not found' should still propagate."""
+    fs = _make_viking_fs()
+    fs._ensure_parent_dirs = AsyncMock()
+    fs.agfs.read.side_effect = AGFSClientError("permission denied")
+
+    with pytest.raises(AGFSClientError):
+        await fs.append_file("viking://session/default/bad/messages.jsonl", "x\n")

--- a/tests/misc/test_append_file_missing.py
+++ b/tests/misc/test_append_file_missing.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Ensures VikingFS.append_file treats missing files as empty content Before writing."""
+
+import contextvars
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.pyagfs.exceptions import AGFSClientError
+
+
+def _make_viking_fs():
+    """Create a VikingFS instance with all required hooks mocked."""
+    from openviking.storage.viking_fs import VikingFS
+
+    fs = VikingFS.__new__(VikingFS)
+    fs.agfs = MagicMock()
+    fs.query_embedder = None
+    fs.vector_store = None
+    fs._bound_ctx = contextvars.ContextVar("vikingfs_bound_ctx", default=None)
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_append_file_missing_runtime_error():
+    """Missing file should not crash when append_file reads a RuntimeError 'not found'."""
+    fs = _make_viking_fs()
+    fs._ensure_parent_dirs = AsyncMock()
+    fs.agfs.read.side_effect = RuntimeError("not found: /default/session/.../messages.jsonl")
+    fs.agfs.write = MagicMock()
+
+    await fs.append_file("viking://session/default/foo/messages.jsonl", "hello\n")
+
+    fs.agfs.write.assert_called_once()
+    path, payload = fs.agfs.write.call_args[0]
+    assert "messages.jsonl" in path
+    assert payload == b"hello\n"
+
+
+@pytest.mark.asyncio
+async def test_append_file_missing_client_error():
+    """AGFSClientError carrying 'not found' should also be treated as empty existing content."""
+    fs = _make_viking_fs()
+    fs._ensure_parent_dirs = AsyncMock()
+    fs.agfs.read.side_effect = AGFSClientError("not found: /default/session/default/messages.jsonl")
+    fs.agfs.write = MagicMock()
+
+    await fs.append_file("viking://session/default/bar/messages.jsonl", "line\n")
+
+    fs.agfs.write.assert_called_once()
+    _, payload = fs.agfs.write.call_args[0]
+    assert payload.endswith(b"line\n")
+
+
+@pytest.mark.asyncio
+async def test_append_file_other_runtime_error_bubbles():
+    """RuntimeErrors without 'not found' should still propagate."""
+    fs = _make_viking_fs()
+    fs._ensure_parent_dirs = AsyncMock()
+    fs.agfs.read.side_effect = RuntimeError("permission denied")
+
+    with pytest.raises(RuntimeError):
+        await fs.append_file("viking://session/default/bad/messages.jsonl", "x\n")


### PR DESCRIPTION
## Summary
- treat missing-file read failures as empty content in `VikingFS.append_file`
- handle `AGFSClientError` and `RuntimeError` variants that surface missing-path text instead of HTTP 404
- add focused regression coverage for append-on-missing behavior and non-missing runtime errors

## Testing
- `python3 -m pytest tests/misc/test_append_file_missing.py -q`
- `python -m compileall tests/misc/test_append_file_missing.py openviking/storage/viking_fs.py`
