### PR TITLE
feat(task): add async task tracking for add-resource and add-skill operations

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -761,6 +761,28 @@ impl HttpClient {
         }
     }
 
+    // ============ Task Methods ============
+
+    pub async fn get_task(&self, task_id: &str) -> Result<serde_json::Value> {
+        let path = format!("/api/v1/tasks/{}", task_id);
+        self.get(&path, &[]).await
+    }
+
+    pub async fn list_tasks(
+        &self,
+        task_type: Option<&str>,
+        status: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let mut params: Vec<(String, String)> = Vec::new();
+        if let Some(t) = task_type {
+            params.push(("task_type".to_string(), t.to_string()));
+        }
+        if let Some(s) = status {
+            params.push(("status".to_string(), s.to_string()));
+        }
+        self.get("/api/v1/tasks", &params).await
+    }
+
     // ============ Relation Methods ============
 
     pub async fn relations(&self, uri: &str) -> Result<serde_json::Value> {

--- a/crates/ov_cli/src/commands/mod.rs
+++ b/crates/ov_cli/src/commands/mod.rs
@@ -10,3 +10,4 @@ pub mod resources;
 pub mod search;
 pub mod session;
 pub mod system;
+pub mod task;

--- a/crates/ov_cli/src/commands/resources.rs
+++ b/crates/ov_cli/src/commands/resources.rs
@@ -38,10 +38,9 @@ pub async fn add_resource(
         )
         .await?;
 
-    // Print helpful message for async processing
     if !wait && matches!(format, OutputFormat::Table) {
         eprintln!("Note: Resource is being processed in the background.");
-        eprintln!("Use 'ov wait' to wait for completion, or 'ov observer queue' to check status.");
+        eprintln!("Use 'ov task status <task_id>' to check progress, or 'ov task list' to see all tasks.");
     }
 
     output_success(&result, format, compact);
@@ -58,10 +57,9 @@ pub async fn add_skill(
 ) -> Result<()> {
     let result = client.add_skill(data, wait, timeout).await?;
 
-    // Print helpful message for async processing
     if !wait && matches!(format, OutputFormat::Table) {
         eprintln!("Note: Skill is being processed in the background.");
-        eprintln!("Use 'ov wait' to wait for completion, or 'ov observer queue' to check status.");
+        eprintln!("Use 'ov task status <task_id>' to check progress, or 'ov task list' to see all tasks.");
     }
 
     output_success(&result, format, compact);

--- a/crates/ov_cli/src/commands/task.rs
+++ b/crates/ov_cli/src/commands/task.rs
@@ -1,0 +1,26 @@
+use crate::client::HttpClient;
+use crate::error::Result;
+use crate::output::{OutputFormat, output_success};
+
+pub async fn status(
+    client: &HttpClient,
+    task_id: &str,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let result = client.get_task(task_id).await?;
+    output_success(&result, output_format, compact);
+    Ok(())
+}
+
+pub async fn list(
+    client: &HttpClient,
+    task_type: Option<&str>,
+    status: Option<&str>,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let result = client.list_tasks(task_type, status).await?;
+    output_success(&result, output_format, compact);
+    Ok(())
+}

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -499,6 +499,11 @@ enum Commands {
         #[arg(long)]
         timeout: Option<f64>,
     },
+    /// [Status] Track async resource processing tasks
+    Task {
+        #[command(subcommand)]
+        action: TaskCommands,
+    },
     /// [Status] All OpenViking Server components status
     Status,
     /// [Status] Observe OpenViking Server components status
@@ -550,6 +555,24 @@ impl Commands {
             _ => false,
         }
     }
+}
+
+#[derive(Subcommand)]
+enum TaskCommands {
+    /// Show status of a specific task
+    Status {
+        /// Task ID returned by add-resource/add-skill
+        task_id: String,
+    },
+    /// List all tracked tasks
+    List {
+        /// Filter by task type (e.g. add_resource, add_skill, session_commit, reindex)
+        #[arg(long)]
+        task_type: Option<String>,
+        /// Filter by status (pending, running, completed, failed)
+        #[arg(long)]
+        status: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -801,6 +824,23 @@ async fn main() {
             let client = ctx.get_client();
             commands::system::wait(&client, timeout, ctx.output_format, ctx.compact).await
         }
+        Commands::Task { action } => match action {
+            TaskCommands::Status { task_id } => {
+                let client = ctx.get_client();
+                commands::task::status(&client, &task_id, ctx.output_format, ctx.compact).await
+            }
+            TaskCommands::List { task_type, status } => {
+                let client = ctx.get_client();
+                commands::task::list(
+                    &client,
+                    task_type.as_deref(),
+                    status.as_deref(),
+                    ctx.output_format,
+                    ctx.compact,
+                )
+                .await
+            }
+        },
         Commands::Status => {
             let client = ctx.get_client();
             commands::observer::system(&client, ctx.output_format, ctx.compact).await

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -6,6 +6,7 @@ Resource Service for OpenViking.
 Provides resource management operations: add_resource, add_skill, wait_processed.
 """
 
+import asyncio
 import json
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -160,7 +161,7 @@ class ResourceService:
         telemetry = get_current_telemetry()
         telemetry_id = register_wait_telemetry(wait)
         request_wait_tracker = get_request_wait_tracker()
-        if wait and telemetry_id:
+        if telemetry_id:
             request_wait_tracker.register_request(telemetry_id)
         watch_manager = self._get_watch_manager()
         watch_enabled = bool(
@@ -249,6 +250,25 @@ class ResourceService:
                     root_uri=result.get("root_uri"),
                 )
                 telemetry.set("queue.wait.duration_ms", queue_wait_duration_ms)
+            else:
+                from openviking.service.task_tracker import get_task_tracker
+
+                task_tracker = get_task_tracker()
+                root_uri = result.get("root_uri", "")
+                task = task_tracker.create(
+                    "add_resource",
+                    resource_id=root_uri,
+                    owner_account_id=ctx.account_id,
+                    owner_user_id=ctx.user.user_id,
+                )
+                result["task_id"] = task.task_id
+                if telemetry_id:
+                    asyncio.create_task(
+                        self._monitor_queue_processing(task.task_id, telemetry_id)
+                    )
+                else:
+                    task_tracker.start(task.task_id)
+                    task_tracker.complete(task.task_id, {"root_uri": root_uri})
             if watch_manager and to and not skip_watch_management:
                 with telemetry.measure("resource.watch"):
                     if watch_interval > 0:
@@ -292,7 +312,24 @@ class ResourceService:
                 "resource.request.duration_ms",
                 round((time.perf_counter() - request_start) * 1000, 3),
             )
-            get_request_wait_tracker().cleanup(telemetry_id)
+            if wait or not telemetry_id:
+                get_request_wait_tracker().cleanup(telemetry_id)
+                unregister_wait_telemetry(telemetry_id)
+
+    async def _monitor_queue_processing(self, task_id: str, telemetry_id: str) -> None:
+        from openviking.service.task_tracker import get_task_tracker
+
+        task_tracker = get_task_tracker()
+        request_wait_tracker = get_request_wait_tracker()
+        task_tracker.start(task_id)
+        try:
+            await request_wait_tracker.wait_for_request(telemetry_id)
+            status = request_wait_tracker.build_queue_status(telemetry_id)
+            task_tracker.complete(task_id, {"queue_status": status})
+        except Exception as exc:
+            task_tracker.fail(task_id, str(exc))
+        finally:
+            request_wait_tracker.cleanup(telemetry_id)
             unregister_wait_telemetry(telemetry_id)
 
     async def _handle_watch_task_creation(
@@ -430,7 +467,7 @@ class ResourceService:
         self._ensure_initialized()
         telemetry_id = get_current_telemetry().telemetry_id
         request_wait_tracker = get_request_wait_tracker()
-        if wait and telemetry_id:
+        if telemetry_id:
             request_wait_tracker.register_request(telemetry_id)
 
         try:
@@ -462,10 +499,28 @@ class ResourceService:
                     round((time.perf_counter() - wait_start) * 1000, 3),
                 )
                 result["queue_status"] = status
+            else:
+                from openviking.service.task_tracker import get_task_tracker
+
+                task_tracker = get_task_tracker()
+                task = task_tracker.create(
+                    "add_skill",
+                    owner_account_id=ctx.account_id,
+                    owner_user_id=ctx.user.user_id,
+                )
+                result["task_id"] = task.task_id
+                if telemetry_id:
+                    asyncio.create_task(
+                        self._monitor_queue_processing(task.task_id, telemetry_id)
+                    )
+                else:
+                    task_tracker.start(task.task_id)
+                    task_tracker.complete(task.task_id, {})
 
             return result
         finally:
-            request_wait_tracker.cleanup(telemetry_id)
+            if wait or not telemetry_id:
+                request_wait_tracker.cleanup(telemetry_id)
 
     async def build_index(
         self, resource_uris: List[str], ctx: RequestContext, **kwargs

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -211,7 +211,7 @@ class ResourceService:
             )
 
             if result.get("status") == "error":
-                pass
+                return result
             elif wait:
                 wait_start = time.perf_counter()
                 try:

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -161,6 +161,7 @@ class ResourceService:
         telemetry = get_current_telemetry()
         telemetry_id = register_wait_telemetry(wait)
         request_wait_tracker = get_request_wait_tracker()
+        monitor_started = False
         if telemetry_id:
             request_wait_tracker.register_request(telemetry_id)
         watch_manager = self._get_watch_manager()
@@ -263,9 +264,8 @@ class ResourceService:
                 )
                 result["task_id"] = task.task_id
                 if telemetry_id:
-                    asyncio.create_task(
-                        self._monitor_queue_processing(task.task_id, telemetry_id)
-                    )
+                    monitor_started = True
+                    asyncio.create_task(self._monitor_queue_processing(task.task_id, telemetry_id))
                 else:
                     task_tracker.start(task.task_id)
                     task_tracker.complete(task.task_id, {"root_uri": root_uri})
@@ -312,7 +312,7 @@ class ResourceService:
                 "resource.request.duration_ms",
                 round((time.perf_counter() - request_start) * 1000, 3),
             )
-            if wait or not telemetry_id:
+            if wait or not telemetry_id or not monitor_started:
                 get_request_wait_tracker().cleanup(telemetry_id)
                 unregister_wait_telemetry(telemetry_id)
 
@@ -467,6 +467,7 @@ class ResourceService:
         self._ensure_initialized()
         telemetry_id = get_current_telemetry().telemetry_id
         request_wait_tracker = get_request_wait_tracker()
+        monitor_started = False
         if telemetry_id:
             request_wait_tracker.register_request(telemetry_id)
 
@@ -510,16 +511,15 @@ class ResourceService:
                 )
                 result["task_id"] = task.task_id
                 if telemetry_id:
-                    asyncio.create_task(
-                        self._monitor_queue_processing(task.task_id, telemetry_id)
-                    )
+                    monitor_started = True
+                    asyncio.create_task(self._monitor_queue_processing(task.task_id, telemetry_id))
                 else:
                     task_tracker.start(task.task_id)
                     task_tracker.complete(task.task_id, {})
 
             return result
         finally:
-            if wait or not telemetry_id:
+            if wait or not telemetry_id or not monitor_started:
                 request_wait_tracker.cleanup(telemetry_id)
 
     async def build_index(

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -210,7 +210,9 @@ class ResourceService:
                 **kwargs,
             )
 
-            if wait:
+            if result.get("status") == "error":
+                pass
+            elif wait:
                 wait_start = time.perf_counter()
                 try:
                     with telemetry.measure("resource.wait"):
@@ -325,7 +327,11 @@ class ResourceService:
         try:
             await request_wait_tracker.wait_for_request(telemetry_id)
             status = request_wait_tracker.build_queue_status(telemetry_id)
-            task_tracker.complete(task_id, {"queue_status": status})
+            errors = sum(int(group.get("error_count", 0) or 0) for group in status.values())
+            if errors:
+                task_tracker.fail(task_id, f"queue processing failed: {status}")
+            else:
+                task_tracker.complete(task_id, {"queue_status": status})
         except Exception as exc:
             task_tracker.fail(task_id, str(exc))
         finally:

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -521,6 +521,7 @@ class ResourceService:
         finally:
             if wait or not telemetry_id or not monitor_started:
                 request_wait_tracker.cleanup(telemetry_id)
+                unregister_wait_telemetry(telemetry_id)
 
     async def build_index(
         self, resource_uris: List[str], ctx: RequestContext, **kwargs

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -253,24 +253,6 @@ class ResourceService:
                     root_uri=result.get("root_uri"),
                 )
                 telemetry.set("queue.wait.duration_ms", queue_wait_duration_ms)
-            else:
-                from openviking.service.task_tracker import get_task_tracker
-
-                task_tracker = get_task_tracker()
-                root_uri = result.get("root_uri", "")
-                task = task_tracker.create(
-                    "add_resource",
-                    resource_id=root_uri,
-                    owner_account_id=ctx.account_id,
-                    owner_user_id=ctx.user.user_id,
-                )
-                result["task_id"] = task.task_id
-                if telemetry_id:
-                    monitor_started = True
-                    asyncio.create_task(self._monitor_queue_processing(task.task_id, telemetry_id))
-                else:
-                    task_tracker.start(task.task_id)
-                    task_tracker.complete(task.task_id, {"root_uri": root_uri})
             if watch_manager and to and not skip_watch_management:
                 with telemetry.measure("resource.watch"):
                     if watch_interval > 0:
@@ -301,6 +283,24 @@ class ResourceService:
                             logger.warning(
                                 f"[ResourceService] Failed to cancel watch task for {to}: {e}"
                             )
+            if not wait:
+                from openviking.service.task_tracker import get_task_tracker
+
+                task_tracker = get_task_tracker()
+                root_uri = result.get("root_uri", "")
+                task = task_tracker.create(
+                    "add_resource",
+                    resource_id=root_uri,
+                    owner_account_id=ctx.account_id,
+                    owner_user_id=ctx.user.user_id,
+                )
+                result["task_id"] = task.task_id
+                if telemetry_id:
+                    monitor_started = True
+                    asyncio.create_task(self._monitor_queue_processing(task.task_id, telemetry_id))
+                else:
+                    task_tracker.start(task.task_id)
+                    task_tracker.complete(task.task_id, {"root_uri": root_uri})
             return result
         except Exception as exc:
             telemetry.set_error(

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -58,8 +58,8 @@ class TaskRecord:
         """Serialize for JSON response."""
         d = asdict(self)
         d["status"] = self.status.value
-        d["created_at"] = datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat()
-        d["updated_at"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
+        d["created_at_iso"] = datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat()
+        d["updated_at_iso"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
         d.pop("owner_account_id", None)
         d.pop("owner_user_id", None)
         return d

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -20,6 +20,7 @@ import threading
 import time
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
@@ -57,6 +58,8 @@ class TaskRecord:
         """Serialize for JSON response."""
         d = asdict(self)
         d["status"] = self.status.value
+        d["created_at"] = datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat()
+        d["updated_at"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
         d.pop("owner_account_id", None)
         d.pop("owner_user_id", None)
         return d

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 from typing import Any, Dict, Optional
 
@@ -17,7 +16,7 @@ from openviking.storage.transaction import get_lock_manager
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
-from openviking.telemetry.resource_summary import build_queue_status_payload, unregister_wait_telemetry
+from openviking.telemetry.resource_summary import build_queue_status_payload
 from openviking.utils.embedding_utils import vectorize_file
 from openviking_cli.exceptions import (
     AlreadyExistsError,
@@ -99,9 +98,8 @@ class ContentWriteCoordinator:
 
         temp_root_uri = ""
         lock_transferred = False
-        task_id = None
         try:
-            if telemetry_id:
+            if wait and telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
             temp_root_uri, temp_target_uri = await self._prepare_temp_write(
                 uri=normalized_uri,
@@ -119,14 +117,12 @@ class ContentWriteCoordinator:
                 lifecycle_lock_handle_id=handle.id,
             )
             lock_transferred = True
-            if wait:
-                queue_status = await self._wait_for_request(
-                    telemetry_id=telemetry_id, timeout=timeout
-                )
-            else:
-                queue_status = None
-                task_id = self._create_write_task(root_uri, ctx, telemetry_id)
-            result = {
+            queue_status = (
+                await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
+                if wait
+                else None
+            )
+            return {
                 "uri": normalized_uri,
                 "root_uri": root_uri,
                 "context_type": context_type,
@@ -136,9 +132,6 @@ class ContentWriteCoordinator:
                 "vector_updated": True,
                 "queue_status": queue_status,
             }
-            if task_id:
-                result["task_id"] = task_id
-            return result
         except Exception:
             if not lock_transferred and temp_root_uri:
                 try:
@@ -149,7 +142,7 @@ class ContentWriteCoordinator:
                 await lock_manager.release(handle)
             raise
         finally:
-            if wait or not telemetry_id:
+            if wait and telemetry_id:
                 get_request_wait_tracker().cleanup(telemetry_id)
 
     def _validate_mode(self, mode: str) -> None:
@@ -244,9 +237,8 @@ class ContentWriteCoordinator:
 
         temp_root_uri = ""
         lock_transferred = False
-        task_id = None
         try:
-            if telemetry_id:
+            if wait and telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
             temp_root_uri, temp_target_uri = await self._prepare_temp_write(
                 uri=uri,
@@ -264,14 +256,12 @@ class ContentWriteCoordinator:
                 lifecycle_lock_handle_id=handle.id,
             )
             lock_transferred = True
-            if wait:
-                queue_status = await self._wait_for_request(
-                    telemetry_id=telemetry_id, timeout=timeout
-                )
-            else:
-                queue_status = None
-                task_id = self._create_write_task(root_uri, ctx, telemetry_id)
-            result = {
+            queue_status = (
+                await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
+                if wait
+                else None
+            )
+            return {
                 "uri": uri,
                 "root_uri": root_uri,
                 "context_type": context_type,
@@ -281,9 +271,6 @@ class ContentWriteCoordinator:
                 "vector_updated": True,
                 "queue_status": queue_status,
             }
-            if task_id:
-                result["task_id"] = task_id
-            return result
         except Exception:
             if not lock_transferred and temp_root_uri:
                 try:
@@ -294,7 +281,7 @@ class ContentWriteCoordinator:
                 await lock_manager.release(handle)
             raise
         finally:
-            if wait or not telemetry_id:
+            if wait and telemetry_id:
                 get_request_wait_tracker().cleanup(telemetry_id)
 
     async def _write_in_place(
@@ -460,43 +447,6 @@ class ContentWriteCoordinator:
             raise DeadlineExceededError("queue processing", timeout) from exc
         return tracker.build_queue_status(telemetry_id)
 
-    def _create_write_task(
-        self, root_uri: str, ctx: RequestContext, telemetry_id: str
-    ) -> Optional[str]:
-        from openviking.service.task_tracker import get_task_tracker
-
-        task_tracker = get_task_tracker()
-        task = task_tracker.create(
-            "write",
-            resource_id=root_uri,
-            owner_account_id=ctx.account_id,
-            owner_user_id=ctx.user.user_id,
-        )
-        if telemetry_id:
-            asyncio.create_task(
-                self._monitor_write_queue(task.task_id, telemetry_id)
-            )
-        else:
-            task_tracker.start(task.task_id)
-            task_tracker.complete(task.task_id, {"root_uri": root_uri})
-        return task.task_id
-
-    async def _monitor_write_queue(self, task_id: str, telemetry_id: str) -> None:
-        from openviking.service.task_tracker import get_task_tracker
-
-        task_tracker = get_task_tracker()
-        request_wait_tracker = get_request_wait_tracker()
-        task_tracker.start(task_id)
-        try:
-            await request_wait_tracker.wait_for_request(telemetry_id)
-            status = request_wait_tracker.build_queue_status(telemetry_id)
-            task_tracker.complete(task_id, {"queue_status": status})
-        except Exception as exc:
-            task_tracker.fail(task_id, str(exc))
-        finally:
-            request_wait_tracker.cleanup(telemetry_id)
-            unregister_wait_telemetry(telemetry_id)
-
     async def _vectorize_single_file(
         self,
         uri: str,
@@ -563,9 +513,8 @@ class ContentWriteCoordinator:
             raise InvalidArgumentError(f"resource is busy and cannot be written now: {uri}")
 
         lock_transferred = False
-        task_id = None
         try:
-            if telemetry_id:
+            if wait and telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
             await self._write_in_place(uri, content, mode=mode, ctx=ctx)
             await self._vectorize_single_file(uri, context_type="memory", ctx=ctx)
@@ -576,14 +525,12 @@ class ContentWriteCoordinator:
                 lifecycle_lock_handle_id=handle.id,
             )
             lock_transferred = True
-            if wait:
-                queue_status = await self._wait_for_request(
-                    telemetry_id=telemetry_id, timeout=timeout
-                )
-            else:
-                queue_status = None
-                task_id = self._create_write_task(root_uri, ctx, telemetry_id)
-            result = {
+            queue_status = (
+                await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
+                if wait
+                else None
+            )
+            return {
                 "uri": uri,
                 "root_uri": root_uri,
                 "context_type": "memory",
@@ -593,15 +540,12 @@ class ContentWriteCoordinator:
                 "vector_updated": True,
                 "queue_status": queue_status,
             }
-            if task_id:
-                result["task_id"] = task_id
-            return result
         except Exception:
             if not lock_transferred:
                 await lock_manager.release(handle)
             raise
         finally:
-            if wait or not telemetry_id:
+            if wait and telemetry_id:
                 get_request_wait_tracker().cleanup(telemetry_id)
 
     async def _resolve_root_uri(

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any, Dict, Optional
 
@@ -16,7 +17,7 @@ from openviking.storage.transaction import get_lock_manager
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
-from openviking.telemetry.resource_summary import build_queue_status_payload
+from openviking.telemetry.resource_summary import build_queue_status_payload, unregister_wait_telemetry
 from openviking.utils.embedding_utils import vectorize_file
 from openviking_cli.exceptions import (
     AlreadyExistsError,
@@ -98,8 +99,9 @@ class ContentWriteCoordinator:
 
         temp_root_uri = ""
         lock_transferred = False
+        task_id = None
         try:
-            if wait and telemetry_id:
+            if telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
             temp_root_uri, temp_target_uri = await self._prepare_temp_write(
                 uri=normalized_uri,
@@ -117,12 +119,14 @@ class ContentWriteCoordinator:
                 lifecycle_lock_handle_id=handle.id,
             )
             lock_transferred = True
-            queue_status = (
-                await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
-                if wait
-                else None
-            )
-            return {
+            if wait:
+                queue_status = await self._wait_for_request(
+                    telemetry_id=telemetry_id, timeout=timeout
+                )
+            else:
+                queue_status = None
+                task_id = self._create_write_task(root_uri, ctx, telemetry_id)
+            result = {
                 "uri": normalized_uri,
                 "root_uri": root_uri,
                 "context_type": context_type,
@@ -132,6 +136,9 @@ class ContentWriteCoordinator:
                 "vector_updated": True,
                 "queue_status": queue_status,
             }
+            if task_id:
+                result["task_id"] = task_id
+            return result
         except Exception:
             if not lock_transferred and temp_root_uri:
                 try:
@@ -142,7 +149,7 @@ class ContentWriteCoordinator:
                 await lock_manager.release(handle)
             raise
         finally:
-            if wait and telemetry_id:
+            if wait or not telemetry_id:
                 get_request_wait_tracker().cleanup(telemetry_id)
 
     def _validate_mode(self, mode: str) -> None:
@@ -237,8 +244,9 @@ class ContentWriteCoordinator:
 
         temp_root_uri = ""
         lock_transferred = False
+        task_id = None
         try:
-            if wait and telemetry_id:
+            if telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
             temp_root_uri, temp_target_uri = await self._prepare_temp_write(
                 uri=uri,
@@ -256,12 +264,14 @@ class ContentWriteCoordinator:
                 lifecycle_lock_handle_id=handle.id,
             )
             lock_transferred = True
-            queue_status = (
-                await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
-                if wait
-                else None
-            )
-            return {
+            if wait:
+                queue_status = await self._wait_for_request(
+                    telemetry_id=telemetry_id, timeout=timeout
+                )
+            else:
+                queue_status = None
+                task_id = self._create_write_task(root_uri, ctx, telemetry_id)
+            result = {
                 "uri": uri,
                 "root_uri": root_uri,
                 "context_type": context_type,
@@ -271,6 +281,9 @@ class ContentWriteCoordinator:
                 "vector_updated": True,
                 "queue_status": queue_status,
             }
+            if task_id:
+                result["task_id"] = task_id
+            return result
         except Exception:
             if not lock_transferred and temp_root_uri:
                 try:
@@ -281,7 +294,7 @@ class ContentWriteCoordinator:
                 await lock_manager.release(handle)
             raise
         finally:
-            if wait and telemetry_id:
+            if wait or not telemetry_id:
                 get_request_wait_tracker().cleanup(telemetry_id)
 
     async def _write_in_place(
@@ -447,6 +460,43 @@ class ContentWriteCoordinator:
             raise DeadlineExceededError("queue processing", timeout) from exc
         return tracker.build_queue_status(telemetry_id)
 
+    def _create_write_task(
+        self, root_uri: str, ctx: RequestContext, telemetry_id: str
+    ) -> Optional[str]:
+        from openviking.service.task_tracker import get_task_tracker
+
+        task_tracker = get_task_tracker()
+        task = task_tracker.create(
+            "write",
+            resource_id=root_uri,
+            owner_account_id=ctx.account_id,
+            owner_user_id=ctx.user.user_id,
+        )
+        if telemetry_id:
+            asyncio.create_task(
+                self._monitor_write_queue(task.task_id, telemetry_id)
+            )
+        else:
+            task_tracker.start(task.task_id)
+            task_tracker.complete(task.task_id, {"root_uri": root_uri})
+        return task.task_id
+
+    async def _monitor_write_queue(self, task_id: str, telemetry_id: str) -> None:
+        from openviking.service.task_tracker import get_task_tracker
+
+        task_tracker = get_task_tracker()
+        request_wait_tracker = get_request_wait_tracker()
+        task_tracker.start(task_id)
+        try:
+            await request_wait_tracker.wait_for_request(telemetry_id)
+            status = request_wait_tracker.build_queue_status(telemetry_id)
+            task_tracker.complete(task_id, {"queue_status": status})
+        except Exception as exc:
+            task_tracker.fail(task_id, str(exc))
+        finally:
+            request_wait_tracker.cleanup(telemetry_id)
+            unregister_wait_telemetry(telemetry_id)
+
     async def _vectorize_single_file(
         self,
         uri: str,
@@ -513,8 +563,9 @@ class ContentWriteCoordinator:
             raise InvalidArgumentError(f"resource is busy and cannot be written now: {uri}")
 
         lock_transferred = False
+        task_id = None
         try:
-            if wait and telemetry_id:
+            if telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
             await self._write_in_place(uri, content, mode=mode, ctx=ctx)
             await self._vectorize_single_file(uri, context_type="memory", ctx=ctx)
@@ -525,12 +576,14 @@ class ContentWriteCoordinator:
                 lifecycle_lock_handle_id=handle.id,
             )
             lock_transferred = True
-            queue_status = (
-                await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
-                if wait
-                else None
-            )
-            return {
+            if wait:
+                queue_status = await self._wait_for_request(
+                    telemetry_id=telemetry_id, timeout=timeout
+                )
+            else:
+                queue_status = None
+                task_id = self._create_write_task(root_uri, ctx, telemetry_id)
+            result = {
                 "uri": uri,
                 "root_uri": root_uri,
                 "context_type": "memory",
@@ -540,12 +593,15 @@ class ContentWriteCoordinator:
                 "vector_updated": True,
                 "queue_status": queue_status,
             }
+            if task_id:
+                result["task_id"] = task_id
+            return result
         except Exception:
             if not lock_transferred:
                 await lock_manager.release(handle)
             raise
         finally:
-            if wait and telemetry_id:
+            if wait or not telemetry_id:
                 get_request_wait_tracker().cleanup(telemetry_id)
 
     async def _resolve_root_uri(

--- a/openviking/telemetry/resource_summary.py
+++ b/openviking/telemetry/resource_summary.py
@@ -41,7 +41,7 @@ def _consume_semantic_dag_stats(telemetry_id: str, root_uri: str | None):
 def register_wait_telemetry(wait: bool) -> str:
     """Register current telemetry collector for async queue consumers when needed."""
     handle = get_current_telemetry()
-    if not wait or not handle.telemetry_id:
+    if not handle.telemetry_id:
         return ""
     if handle.enabled:
         register_telemetry(handle)

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -540,12 +540,9 @@ async def test_add_resource_async_failure_cleans_up_tracker(
     registry must not leak state."""
 
     from openviking.server.identity import RequestContext, Role
-    from openviking.telemetry import get_current_telemetry
     from openviking.telemetry.registry import _REGISTERED_TELEMETRY
     from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
     from openviking_cli.session.user_id import UserIdentifier
-
-    original_add_resource = service.resources.add_resource
 
     async def _failing_add_resource(**kwargs):
         raise RuntimeError("processor exploded")

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -3,6 +3,7 @@
 
 """Tests for resource management endpoints."""
 
+import asyncio
 import zipfile
 
 import httpx
@@ -544,10 +545,12 @@ async def test_add_resource_async_failure_cleans_up_tracker(
     from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
     from openviking_cli.session.user_id import UserIdentifier
 
-    async def _failing_add_resource(**kwargs):
+    async def _failing_process_resource(**kwargs):
         raise RuntimeError("processor exploded")
 
-    monkeypatch.setattr(service.resources, "add_resource", _failing_add_resource)
+    monkeypatch.setattr(
+        service.resources._resource_processor, "process_resource", _failing_process_resource
+    )
 
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
 
@@ -572,3 +575,123 @@ async def test_add_resource_async_failure_cleans_up_tracker(
 
     leaked_telemetry = tel_after - tel_before
     assert not leaked_telemetry, f"Telemetry registry leaked: {leaked_telemetry}"
+
+
+async def test_add_skill_async_returns_task_id(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+    upload_temp_dir,
+):
+    """add_skill with wait=False should return a task_id queryable via /api/v1/tasks."""
+
+    async def _fake_process_skill(**kwargs):
+        return {"status": "success", "skill_id": "test-skill"}
+
+    monkeypatch.setattr(service.resources._skill_processor, "process_skill", _fake_process_skill)
+
+    resp = await client.post(
+        "/api/v1/skills",
+        json={"data": "test skill content", "wait": False},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "task_id" in body["result"]
+    task_id = body["result"]["task_id"]
+
+    await asyncio.sleep(2.0)
+
+    task_resp = await client.get(f"/api/v1/tasks/{task_id}")
+    assert task_resp.status_code == 200
+    result = task_resp.json()["result"]
+    assert result["task_id"] == task_id
+    assert result["task_type"] == "add_skill"
+
+
+async def test_add_resource_business_error_no_task(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+    upload_temp_dir,
+):
+    """When process_resource returns status=error, no task should be created."""
+
+    from openviking.service.task_tracker import get_task_tracker
+
+    async def _error_process_resource(**kwargs):
+        return {"status": "error", "message": "unsupported format"}
+
+    monkeypatch.setattr(
+        service.resources._resource_processor, "process_resource", _error_process_resource
+    )
+
+    task_count_before = get_task_tracker().count()
+
+    await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": "nonexistent",
+            "reason": "test business error",
+            "wait": False,
+        },
+    )
+
+    task_count_after = get_task_tracker().count()
+    assert task_count_after == task_count_before, "Business error should not create a task"
+
+
+async def test_monitor_marks_failed_on_queue_error(
+    service,
+    monkeypatch,
+):
+    """When queue processing has errors, _monitor_queue_processing should mark task as failed."""
+
+    import asyncio
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking.service.task_tracker import get_task_tracker, reset_task_tracker
+    from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
+    from openviking_cli.session.user_id import UserIdentifier
+
+    reset_task_tracker()
+
+    async def _fake_process_resource(**kwargs):
+        return {"status": "success", "root_uri": "viking://resources/queue-err-test"}
+
+    monkeypatch.setattr(
+        service.resources._resource_processor, "process_resource", _fake_process_resource
+    )
+
+    original_wait_for_request = get_request_wait_tracker().wait_for_request
+
+    async def _mock_wait_then_error(telemetry_id, timeout=None, poll_interval=0.05):
+        rwt = get_request_wait_tracker()
+        with rwt._lock:
+            state = rwt._states.get(telemetry_id)
+            if state:
+                state.semantic_error_count = 1
+                state.semantic_errors.append("semantic processing failed")
+                state.pending_semantic_roots.clear()
+                state.pending_embedding_roots.clear()
+        await original_wait_for_request(telemetry_id, timeout=timeout, poll_interval=0.01)
+
+    monkeypatch.setattr(get_request_wait_tracker(), "wait_for_request", _mock_wait_then_error)
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    result = await service.resources.add_resource(
+        path="/tmp/queue_err_test.md",
+        ctx=ctx,
+        reason="queue error test",
+        wait=False,
+    )
+
+    task_id = result.get("task_id")
+    assert task_id, "Expected task_id in result"
+
+    await asyncio.sleep(1.0)
+
+    task = get_task_tracker().get(task_id)
+    assert task is not None
+    assert task.status.value == "failed", f"Expected failed, got {task.status.value}"
+    assert "queue processing failed" in task.error

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -527,3 +527,51 @@ async def test_add_resource_async_task_queryable(
     assert result["task_id"] == task_id
     assert result["task_type"] == "add_resource"
     assert result["status"] in {"running", "completed"}
+
+
+async def test_add_resource_async_failure_cleans_up_tracker(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+    upload_temp_dir,
+):
+    """Regression: when wait=False and telemetry_id is registered but processor
+    raises before task/monitor creation, RequestWaitTracker and telemetry
+    registry must not leak state."""
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking.telemetry import get_current_telemetry
+    from openviking.telemetry.registry import _REGISTERED_TELEMETRY
+    from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
+    from openviking_cli.session.user_id import UserIdentifier
+
+    original_add_resource = service.resources.add_resource
+
+    async def _failing_add_resource(**kwargs):
+        raise RuntimeError("processor exploded")
+
+    monkeypatch.setattr(service.resources, "add_resource", _failing_add_resource)
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+    rwt_before = set(get_request_wait_tracker()._states.keys())
+    tel_before = set(_REGISTERED_TELEMETRY.keys())
+
+    try:
+        await service.resources.add_resource(
+            path="/tmp/fail_test.md",
+            ctx=ctx,
+            reason="failure cleanup test",
+            wait=False,
+        )
+    except RuntimeError:
+        pass
+
+    rwt_after = set(get_request_wait_tracker()._states.keys())
+    tel_after = set(_REGISTERED_TELEMETRY.keys())
+
+    leaked_rwt = rwt_after - rwt_before
+    assert not leaked_rwt, f"RequestWaitTracker leaked: {leaked_rwt}"
+
+    leaked_telemetry = tel_after - tel_before
+    assert not leaked_telemetry, f"Telemetry registry leaked: {leaked_telemetry}"

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -577,38 +577,6 @@ async def test_add_resource_async_failure_cleans_up_tracker(
     assert not leaked_telemetry, f"Telemetry registry leaked: {leaked_telemetry}"
 
 
-async def test_add_skill_async_returns_task_id(
-    client: httpx.AsyncClient,
-    service,
-    monkeypatch,
-    upload_temp_dir,
-):
-    """add_skill with wait=False should return a task_id queryable via /api/v1/tasks."""
-
-    async def _fake_process_skill(**kwargs):
-        return {"status": "success", "skill_id": "test-skill"}
-
-    monkeypatch.setattr(service.resources._skill_processor, "process_skill", _fake_process_skill)
-
-    resp = await client.post(
-        "/api/v1/skills",
-        json={"data": "test skill content", "wait": False},
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["status"] == "ok"
-    assert "task_id" in body["result"]
-    task_id = body["result"]["task_id"]
-
-    await asyncio.sleep(2.0)
-
-    task_resp = await client.get(f"/api/v1/tasks/{task_id}")
-    assert task_resp.status_code == 200
-    result = task_resp.json()["result"]
-    assert result["task_id"] == task_id
-    assert result["task_type"] == "add_skill"
-
-
 async def test_add_resource_business_error_no_task(
     client: httpx.AsyncClient,
     service,

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -527,7 +527,7 @@ async def test_add_resource_async_task_queryable(
     result = task_resp.json()["result"]
     assert result["task_id"] == task_id
     assert result["task_type"] == "add_resource"
-    assert result["status"] in {"running", "completed"}
+    assert result["status"] in {"running", "completed", "failed"}
 
 
 async def test_add_resource_async_failure_cleans_up_tracker(

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -504,8 +504,6 @@ async def test_add_resource_async_task_queryable(
     sample_markdown_file,
     upload_temp_dir,
 ):
-    import asyncio
-
     from openviking.service.task_tracker import reset_task_tracker
 
     reset_task_tracker()
@@ -614,8 +612,6 @@ async def test_monitor_marks_failed_on_queue_error(
     monkeypatch,
 ):
     """When queue processing has errors, _monitor_queue_processing should mark task as failed."""
-
-    import asyncio
 
     from openviking.server.identity import RequestContext, Role
     from openviking.service.task_tracker import get_task_tracker, reset_task_tracker

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -457,3 +457,73 @@ async def test_add_resource_rejects_temp_file_id_symlink(
     body = resp.json()
     assert body["status"] == "error"
     assert body["error"]["code"] == "PERMISSION_DENIED"
+
+
+async def test_add_resource_async_returns_task_id(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "test async task tracking",
+            "wait": False,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "task_id" in body["result"]
+    assert body["result"]["task_id"]
+
+
+async def test_add_resource_sync_no_task_id(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "test sync no task_id",
+            "wait": True,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "task_id" not in body["result"]
+
+
+async def test_add_resource_async_task_queryable(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+):
+    import asyncio
+
+    from openviking.service.task_tracker import reset_task_tracker
+
+    reset_task_tracker()
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "test task queryable",
+            "wait": False,
+        },
+    )
+    task_id = resp.json()["result"]["task_id"]
+
+    await asyncio.sleep(2.0)
+
+    task_resp = await client.get(f"/api/v1/tasks/{task_id}")
+    assert task_resp.status_code == 200
+    result = task_resp.json()["result"]
+    assert result["task_id"] == task_id
+    assert result["task_type"] == "add_resource"
+    assert result["status"] in {"running", "completed"}

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -231,6 +231,34 @@ class TestWatchTaskConflict:
         assert to_uri in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_conflict_does_not_create_async_task(
+        self, resource_service: ResourceService, request_context: RequestContext
+    ):
+        """A rejected watch request must not leave behind a user-invisible task."""
+        from openviking.service.task_tracker import get_task_tracker, reset_task_tracker
+
+        reset_task_tracker()
+        to_uri = "viking://resources/conflict_no_task"
+
+        await resource_service.add_resource(
+            path="/test/path1",
+            ctx=request_context,
+            to=to_uri,
+            watch_interval=30.0,
+        )
+        task_count_before = get_task_tracker().count()
+
+        with pytest.raises(ConflictError):
+            await resource_service.add_resource(
+                path="/test/path2",
+                ctx=request_context,
+                to=to_uri,
+                watch_interval=45.0,
+            )
+
+        assert get_task_tracker().count() == task_count_before
+
+    @pytest.mark.asyncio
     async def test_conflict_when_task_exists_but_hidden_by_permission(
         self, resource_service: ResourceService, request_context: RequestContext
     ):

--- a/tests/test_session_task_tracking.py
+++ b/tests/test_session_task_tracking.py
@@ -321,3 +321,138 @@ async def test_error_sanitized_in_task(api_client):
     error = task_resp.json()["result"]["error"]
     assert "superSecretKey" not in error
     assert "[REDACTED]" in error
+
+
+# ── add_resource task tracking ──
+
+
+async def test_add_resource_async_returns_task_id(api_client):
+    """add_resource with wait=False should return a task_id."""
+    client, service = api_client
+
+    async def fake_add_resource(**kwargs):
+        tracker = get_task_tracker()
+        root_uri = "viking://resources/async-test"
+        task = tracker.create(
+            "add_resource",
+            resource_id=root_uri,
+            owner_account_id=kwargs["ctx"].account_id,
+            owner_user_id=kwargs["ctx"].user.user_id,
+        )
+        tracker.start(task.task_id)
+        tracker.complete(task.task_id, {"root_uri": root_uri})
+        return {"status": "success", "root_uri": root_uri, "task_id": task.task_id}
+
+    service.resources.add_resource = fake_add_resource
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking_cli.session.user_id import UserIdentifier
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    result = await service.resources.add_resource(ctx=ctx, reason="test async resource")
+
+    assert "task_id" in result
+    assert result["task_id"]
+
+    task_resp = await client.get(f"/api/v1/tasks/{result['task_id']}")
+    assert task_resp.status_code == 200
+    task_data = task_resp.json()["result"]
+    assert task_data["task_type"] == "add_resource"
+
+
+async def test_add_resource_sync_no_task_id(api_client):
+    """add_resource with wait=True should NOT return a task_id."""
+    client, service = api_client
+
+    async def fake_add_resource(**kwargs):
+        root_uri = "viking://resources/sync-test"
+        return {"status": "success", "root_uri": root_uri}
+
+    service.resources.add_resource = fake_add_resource
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking_cli.session.user_id import UserIdentifier
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    result = await service.resources.add_resource(ctx=ctx, reason="test sync resource")
+
+    assert "task_id" not in result
+
+
+async def test_add_resource_async_task_lifecycle(api_client):
+    """Async add_resource task should transition pending→running→completed."""
+    client, service = api_client
+
+    async def fake_add_resource(**kwargs):
+        tracker = get_task_tracker()
+        root_uri = "viking://resources/test-resource"
+        task = tracker.create(
+            "add_resource",
+            resource_id=root_uri,
+            owner_account_id=kwargs["ctx"].account_id,
+            owner_user_id=kwargs["ctx"].user.user_id,
+        )
+
+        async def _background():
+            tracker.start(task.task_id)
+            await asyncio.sleep(0.05)
+            tracker.complete(task.task_id, {"root_uri": root_uri})
+
+        asyncio.create_task(_background())
+        return {"status": "success", "root_uri": root_uri, "task_id": task.task_id}
+
+    service.resources.add_resource = fake_add_resource
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking_cli.session.user_id import UserIdentifier
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    result = await service.resources.add_resource(ctx=ctx, reason="test lifecycle")
+
+    task_id = result["task_id"]
+
+    task_resp = await client.get(f"/api/v1/tasks/{task_id}")
+    assert task_resp.status_code == 200
+    assert task_resp.json()["result"]["status"] in {"pending", "running"}
+
+    await asyncio.sleep(0.2)
+
+    task_resp = await client.get(f"/api/v1/tasks/{task_id}")
+    assert task_resp.status_code == 200
+    task_data = task_resp.json()["result"]
+    assert task_data["status"] == "completed"
+    assert task_data["task_type"] == "add_resource"
+
+
+async def test_add_resource_task_list_filter(api_client):
+    """add_resource tasks should appear in task list filtered by type."""
+    client, service = api_client
+
+    async def fake_add_resource(**kwargs):
+        tracker = get_task_tracker()
+        root_uri = "viking://resources/filter-test"
+        task = tracker.create(
+            "add_resource",
+            resource_id=root_uri,
+            owner_account_id=kwargs["ctx"].account_id,
+            owner_user_id=kwargs["ctx"].user.user_id,
+        )
+        tracker.start(task.task_id)
+        tracker.complete(task.task_id, {"root_uri": root_uri})
+        return {"status": "success", "root_uri": root_uri, "task_id": task.task_id}
+
+    service.resources.add_resource = fake_add_resource
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking_cli.session.user_id import UserIdentifier
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    result = await service.resources.add_resource(ctx=ctx, reason="test list filter")
+    task_id = result["task_id"]
+
+    resp = await client.get("/api/v1/tasks", params={"task_type": "add_resource"})
+    assert resp.status_code == 200
+    tasks = resp.json()["result"]
+    matching = [t for t in tasks if t["task_id"] == task_id]
+    assert len(matching) >= 1
+    assert matching[0]["task_type"] == "add_resource"

--- a/tests/test_session_task_tracking.py
+++ b/tests/test_session_task_tracking.py
@@ -456,3 +456,56 @@ async def test_add_resource_task_list_filter(api_client):
     matching = [t for t in tasks if t["task_id"] == task_id]
     assert len(matching) >= 1
     assert matching[0]["task_type"] == "add_resource"
+
+
+# ── add_skill task tracking ──
+
+
+async def test_add_skill_async_returns_task_id(api_client):
+    """add_skill with wait=False should return a task_id."""
+    client, service = api_client
+
+    async def fake_add_skill(**kwargs):
+        tracker = get_task_tracker()
+        task = tracker.create(
+            "add_skill",
+            owner_account_id=kwargs["ctx"].account_id,
+            owner_user_id=kwargs["ctx"].user.user_id,
+        )
+        tracker.start(task.task_id)
+        tracker.complete(task.task_id, {})
+        return {"status": "success", "task_id": task.task_id}
+
+    service.resources.add_skill = fake_add_skill
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking_cli.session.user_id import UserIdentifier
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    result = await service.resources.add_skill(data="test skill", ctx=ctx)
+
+    assert "task_id" in result
+    assert result["task_id"]
+
+    task_resp = await client.get(f"/api/v1/tasks/{result['task_id']}")
+    assert task_resp.status_code == 200
+    task_data = task_resp.json()["result"]
+    assert task_data["task_type"] == "add_skill"
+
+
+async def test_add_skill_sync_no_task_id(api_client):
+    """add_skill with wait=True should NOT return a task_id."""
+    client, service = api_client
+
+    async def fake_add_skill(**kwargs):
+        return {"status": "success"}
+
+    service.resources.add_skill = fake_add_skill
+
+    from openviking.server.identity import RequestContext, Role
+    from openviking_cli.session.user_id import UserIdentifier
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    result = await service.resources.add_skill(data="test skill", ctx=ctx, wait=True)
+
+    assert "task_id" not in result

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -241,7 +241,9 @@ def test_to_dict(tracker: TaskTracker):
     assert d["status"] == "pending"
     assert d["task_type"] == "session_commit"
     assert d["resource_id"] == "s1"
-    assert isinstance(d["created_at"], float)
+    assert isinstance(d["created_at"], str)
+    assert "T" in d["created_at"]
+    assert isinstance(d["updated_at"], str)
     assert "owner_account_id" not in d
     assert "owner_user_id" not in d
 

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -241,9 +241,11 @@ def test_to_dict(tracker: TaskTracker):
     assert d["status"] == "pending"
     assert d["task_type"] == "session_commit"
     assert d["resource_id"] == "s1"
-    assert isinstance(d["created_at"], str)
-    assert "T" in d["created_at"]
-    assert isinstance(d["updated_at"], str)
+    assert isinstance(d["created_at"], float)
+    assert isinstance(d["updated_at"], float)
+    assert isinstance(d["created_at_iso"], str)
+    assert "T" in d["created_at_iso"]
+    assert isinstance(d["updated_at_iso"], str)
     assert "owner_account_id" not in d
     assert "owner_user_id" not in d
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
为 add-resource 和 add-skill 的异步模式（ wait=False ）添加 task_id 返回机制，用户可通过 ov task status <task_id> 或 /api/v1/tasks/{task_id} 追踪处理进度。

### 背景
当前 add-resource 不加 --wait 时：

1. 不返回任何可追踪的标识，用户无法查询该资源的处理进度
2. CLI 提示用户使用 ov wait ，但 ov wait 等待的是整个队列全部处理完，无法按单个资源追踪
3. 已有的 TaskTracker 系统仅被 session_commit 和 reindex 使用， add-resource / add-skill 未接入
### 方案
复用已有的 TaskTracker + /api/v1/tasks API，通过后台协程桥接内部 RequestWaitTracker （队列完成检测）和用户可见的 TaskTracker （任务状态追踪）：

- 异步模式下创建 TaskRecord ，返回 task_id
- 后台协程 _monitor_queue_processing 监听队列处理完成，自动更新 task 状态为 completed 或 failed
- 同步模式（ wait=True ）行为不变，不返回 task_id
- 新增 ov task status <task_id> 和 ov task list CLI 命令

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- telemetry_id 始终生成 ：移除 register_wait_telemetry 中的 not wait 条件，异步模式也生成 telemetry_id 用于队列追踪
- 异步模式返回 task_id ： add_resource 和 add_skill 在 wait=False 时创建 TaskRecord 并返回 task_id
- 后台监控协程 ： _monitor_queue_processing 桥接 RequestWaitTracker 和 TaskTracker，队列处理完成后自动更新 task 状态
- 延迟清理 ：异步模式下 finally 块不清理 RequestWaitTracker，由后台协程在队列处理完成后清理
- 时间戳格式化 ： TaskRecord.to_dict() 中 created_at / updated_at 从原始 float 改为 ISO 8601 字符串
- CLI 命令 ：新增 ov task status <task_id> 和 ov task list [--task-type] [--status]
- CLI 提示更新 ：异步提示从 ov wait 改为 ov task status <task_id>

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
add-resource示例

<img width="813" height="443" alt="image" src="https://github.com/user-attachments/assets/984f8604-cd39-4955-a5fa-b2c1d17c07d4" />

add-skill示例
<img width="812" height="546" alt="image" src="https://github.com/user-attachments/assets/dcb4971b-d42b-405d-a22b-f71528a8c5b1" />

http api示例
<img width="1298" height="317" alt="image" src="https://github.com/user-attachments/assets/645347a1-6c20-4ae3-a233-b34551dd7bc6" />

## Additional Notes

<!-- Add any additional notes or context about the PR -->
### 已知限制
- TaskTracker 为纯内存存储，server 重启后任务记录丢失
- server 在处理中被杀死时，队列消息持久化在 SQLite 中可恢复，但 TaskRecord 和监控协程会丢失