### PR TITLE
Fix JsonUtils typed loads validation

### DIFF
--- a/openviking/session/memory/utils/__init__.py
+++ b/openviking/session/memory/utils/__init__.py
@@ -12,6 +12,7 @@ from openviking.session.memory.utils.content import (
     truncate_content,
 )
 from openviking.session.memory.utils.json_parser import (
+    JsonUtils,
     _any_to_str,
     _get_arg_type,
     _get_origin_type,
@@ -84,6 +85,7 @@ __all__ = [
     "parse_json_with_stability",
     "value_fault_tolerance",
     "parse_value_with_tolerance",
+    "JsonUtils",
     "_get_origin_type",
     "_get_arg_type",
     "_any_to_str",

--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -69,7 +69,7 @@ class JsonUtils:
         if not json_str:
             return None
         if clazz:
-            return TypeAdapter.validate_python(clazz, json_repair.loads(json_str))
+            return TypeAdapter(clazz).validate_python(json_repair.loads(json_str), strict=False)
         return json_repair.loads(json_str)
 
 

--- a/tests/session/memory/test_json_stability.py
+++ b/tests/session/memory/test_json_stability.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 from openviking.session.memory.utils import (
+    JsonUtils,
     _get_arg_type,
     _get_origin_type,
     extract_json_content,
@@ -140,17 +141,17 @@ class TestTypeHelpers:
 
     def test_get_origin_type_from_optional(self):
         """Test extracts type from Optional[T]."""
-        assert _get_origin_type(Optional[str]) == str
-        assert _get_origin_type(Optional[int]) == int
+        assert _get_origin_type(Optional[str]) is str
+        assert _get_origin_type(Optional[int]) is int
 
     def test_get_origin_type_from_list(self):
         """Test returns list for List[T]."""
-        assert _get_origin_type(List[str]) == list
+        assert _get_origin_type(List[str]) is list
 
     def test_get_arg_type_from_list(self):
         """Test extracts item type from List[T]."""
-        assert _get_arg_type(List[str]) == str
-        assert _get_arg_type(List[int]) == int
+        assert _get_arg_type(List[str]) is str
+        assert _get_arg_type(List[int]) is int
 
 
 class TestParseJsonWithStability:
@@ -222,6 +223,26 @@ Please be careful with the output."""
         data, error = parse_json_with_stability(content)
         assert data is None
         assert error is not None
+
+
+class TestJsonUtilsLoads:
+    """Tests for JsonUtils.loads convenience parsing."""
+
+    class TestModel(BaseModel):
+        reasonning: str
+        count: Optional[int] = None
+
+    def test_loads_returns_raw_dict_without_model(self):
+        """Test raw JSON loading still returns a dict without a model class."""
+        data = JsonUtils.loads('{"reasonning": "test", "count": 42}')
+        assert data == {"reasonning": "test", "count": 42}
+
+    def test_loads_validates_pydantic_model(self):
+        """Test model class loading uses a TypeAdapter instance."""
+        data = JsonUtils.loads('{"reasonning": "test", "count": "42"}', self.TestModel)
+        assert isinstance(data, self.TestModel)
+        assert data.reasonning == "test"
+        assert data.count == 42
 
 
 class TestMemoryOperationsIntegration:


### PR DESCRIPTION
## Summary
- instantiate `TypeAdapter` with the requested model type before validating repaired JSON
- export `JsonUtils` from the memory utils package
- cover raw dict loading and pydantic model loading for `JsonUtils.loads`

Supersedes #1497, which had to be replaced because a follow-up commit used an invalid local author identity that cannot satisfy CLA.

## Validation
- `uvx ruff check openviking/session/memory/utils/json_parser.py tests/session/memory/test_json_stability.py openviking/session/memory/utils/__init__.py`
- `uvx ruff format --check openviking/session/memory/utils/json_parser.py tests/session/memory/test_json_stability.py openviking/session/memory/utils/__init__.py`

Local pytest was attempted, but this machine cannot build the editable package because the local CommandLineTools `libxcrun.dylib` architecture is incompatible with the active arm64 toolchain.
