### PR TITLE
fix(api-test): adapt tests for error envelope HTTP status codes

### DIFF
--- a/tests/api_test/filesystem/test_fs_mv.py
+++ b/tests/api_test/filesystem/test_fs_mv.py
@@ -5,8 +5,8 @@ import uuid
 class TestFsMv:
     def test_fs_mv(self, api_client):
         random_id = str(uuid.uuid4())[:8]
-        src_dir = f"/tmp/test-mv-src-{random_id}"
-        dst_dir = f"/tmp/test-mv-dst-{random_id}"
+        src_dir = f"viking://resources/test-mv-src-{random_id}"
+        dst_dir = f"viking://resources/test-mv-dst-{random_id}"
 
         try:
             response = api_client.fs_mkdir(src_dir)
@@ -31,3 +31,9 @@ class TestFsMv:
         except Exception as e:
             print(f"Error: {e}")
             raise
+        finally:
+            try:
+                api_client.fs_rm(dst_dir, recursive=True)
+                api_client.fs_rm(src_dir, recursive=True)
+            except Exception:
+                pass

--- a/tests/api_test/filesystem/test_fs_rm.py
+++ b/tests/api_test/filesystem/test_fs_rm.py
@@ -5,7 +5,7 @@ import uuid
 class TestFsRm:
     def test_fs_rm(self, api_client):
         random_id = str(uuid.uuid4())[:8]
-        test_dir = f"/tmp/test-rm-{random_id}"
+        test_dir = f"viking://resources/test-rm-{random_id}"
 
         try:
             response = api_client.fs_mkdir(test_dir)

--- a/tests/api_test/scenarios/resources_retrieval/test_build_error_handling.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_build_error_handling.py
@@ -140,18 +140,14 @@ class TestBuildErrorHandling:
 
         try:
             response = api_client.add_resource(path=zip_path, wait=True)
-            assert response.status_code == 200
-
-            data = response.json()
-            assert data.get("status") in ("ok", "error"), (
-                f"损坏ZIP应返回 ok 或 error, 实际: {data.get('status')}"
+            assert response.status_code == 500, (
+                f"损坏ZIP应返回 500, 实际: {response.status_code}"
             )
 
-            if data.get("status") == "ok":
-                result = data.get("result", {})
-                root_uri = result.get("root_uri")
-                if root_uri:
-                    assert_root_uri_valid(root_uri)
+            data = response.json()
+            assert data.get("status") == "error", (
+                f"损坏ZIP应返回 error, 实际: {data.get('status')}"
+            )
 
             print("✓ TC-E16 损坏的ZIP文件处理通过")
         finally:


### PR DESCRIPTION
After #1744 (fix(api): return processing errors as error envelopes), the server returns proper HTTP error status codes instead of always 200:

- Corrupted ZIP: returns HTTP 500 with PROCESSING_ERROR envelope (was HTTP 200 with inner status='error')
- Invalid URI (local paths like /tmp/...): returns HTTP 400 with INVALID_ARGUMENT envelope (was HTTP 200 with inner status='error')

Changes:
- test_build_error_handling.py: assert status_code == 500 and response status == 'error' for corrupted ZIP
- test_fs_mv.py: use viking://resources/ URIs instead of /tmp/ paths, add cleanup in finally block
- test_fs_rm.py: use viking://resources/ URIs instead of /tmp/ paths

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
