### PR TITLE
Fix MemorySearchTool context forwarding

### DIFF
--- a/openviking/session/memory/tools.py
+++ b/openviking/session/memory/tools.py
@@ -243,12 +243,13 @@ class MemorySearchTool(MemoryTool):
             if ctx and hasattr(ctx, "default_search_uris") and ctx.default_search_uris:
                 target_uri = ctx.default_search_uris
             limit = kwargs.get("limit", 10)
+            request_ctx = ctx.request_ctx if ctx else None
             # 多搜索 10 个，过滤抽象文件后再截断
             search_result = await viking_fs.search(
                 query,
                 target_uri=target_uri,
                 limit=limit + 10,
-                ctx=ctx,
+                ctx=request_ctx,
             )
             return optimize_search_result(search_result.to_dict(), limit=limit)
         except Exception as e:

--- a/tests/session/memory/test_memory_tools.py
+++ b/tests/session/memory/test_memory_tools.py
@@ -4,6 +4,9 @@
 Tests for memory tools.
 """
 
+import pytest
+
+from openviking.server.identity import RequestContext, Role, ToolContext
 from openviking.session.memory.tools import (
     MemoryLsTool,
     MemoryReadTool,
@@ -12,6 +15,7 @@ from openviking.session.memory.tools import (
     get_tool_schemas,
     list_tools,
 )
+from openviking_cli.session.user_id import UserIdentifier
 
 
 class TestMemoryTools:
@@ -33,7 +37,65 @@ class TestMemoryTools:
         assert tool.name == "search"
         assert "Semantic search" in tool.description
         assert "query" in tool.parameters["properties"]
-        assert "session_info" in tool.parameters["properties"]
+        assert "limit" in tool.parameters["properties"]
+
+    @pytest.mark.asyncio
+    async def test_search_tool_uses_request_context(self):
+        """Test MemorySearchTool passes RequestContext into VikingFS search."""
+
+        class MockSearchResult:
+            def to_dict(self):
+                return {
+                    "memories": [
+                        {
+                            "uri": "viking://user/test-account/test-user/memories/profile.md",
+                            "score": 0.9,
+                        }
+                    ],
+                    "resources": [],
+                    "skills": [],
+                }
+
+        class MockVikingFS:
+            def __init__(self):
+                self.received_ctx = None
+                self.received_target_uri = None
+                self.received_limit = None
+
+            async def search(self, query, target_uri="", limit=10, ctx=None, **kwargs):
+                self.received_ctx = ctx
+                self.received_target_uri = target_uri
+                self.received_limit = limit
+                _ = ctx.namespace_policy
+                return MockSearchResult()
+
+        request_ctx = RequestContext(
+            user=UserIdentifier(
+                account_id="test-account",
+                user_id="test-user",
+                agent_id="test-agent",
+            ),
+            role=Role.USER,
+        )
+        tool_ctx = ToolContext(
+            request_ctx=request_ctx,
+            default_search_uris=["viking://user/test-account/test-user/memories"],
+        )
+        viking_fs = MockVikingFS()
+
+        result = await MemorySearchTool().execute(
+            viking_fs,
+            tool_ctx,
+            query="profile",
+            limit=2,
+        )
+
+        assert result == [
+            {"uri": "viking://user/test-account/test-user/memories/profile.md", "score": 0.9}
+        ]
+        assert viking_fs.received_ctx is request_ctx
+        assert viking_fs.received_target_uri == tool_ctx.default_search_uris
+        assert viking_fs.received_limit == 12
 
     def test_ls_tool_properties(self):
         """Test MemoryLsTool properties."""


### PR DESCRIPTION
## Summary
- pass RequestContext to viking_fs.search from MemorySearchTool
- add regression test to ensure request context is forwarded

## Testing
- not run (unit test only)

## Issue
- closes #1771