### PR TITLE
fix docs custom domain asset paths

### DIFF
--- a/.github/workflows/_docs-deploy.yml
+++ b/.github/workflows/_docs-deploy.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run docs:build
         working-directory: docs
         env:
-          DOCS_BASE: /${{ github.event.repository.name }}/
+          DOCS_BASE: /
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -28,4 +28,4 @@ jobs:
         run: npm run docs:build
         working-directory: docs
         env:
-          DOCS_BASE: /${{ github.event.repository.name }}/
+          DOCS_BASE: /

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
 
   docs-deploy:
     name: Build and Deploy Docs
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy == true)
+    if: github.repository == 'volcengine/OpenViking' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy == true))
     uses: ./.github/workflows/_docs-deploy.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Description

Fix the docs build base path for the custom GitHub Pages domain. The deployed site is served from `https://docs.openviking.ai/`, so VitePress assets must be emitted from `/assets/...` instead of `/OpenViking/assets/...`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Build docs with `DOCS_BASE: /` so generated CSS, JS, font, and image paths work on the custom domain root.
- Apply the same base path to the deploy workflow.
- Restrict the Pages deploy job to `volcengine/OpenViking` so forks still run PR docs checks without publishing Pages.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated locally with:

```bash
DOCS_BASE=/ vitepress build .
```

Also checked the generated `index.html` uses root asset paths such as `/assets/...` rather than `/OpenViking/assets/...`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The root cause was that the GitHub Pages workflows set `DOCS_BASE` to `/${{ github.event.repository.name }}/`, which is correct for a project page URL but incorrect once the site is served from the custom domain root.