### PR TITLE
docs(retrieval): document Union[str, list[str]] target_uri from #1753

### DIFF
--- a/docs/en/api/06-retrieval.md
+++ b/docs/en/api/06-retrieval.md
@@ -23,7 +23,7 @@ Basic vector similarity search.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | query | str | Yes | - | Search query string |
-| target_uri | str | No | "" | Limit search to specific URI prefix |
+| target_uri | str or list[str] | No | "" | Limit search to one or more URI prefixes |
 | limit | int | No | 10 | Maximum number of results |
 | node_limit | int | No | None | Optional HTTP alias that overrides `limit` when provided |
 | score_threshold | float | No | None | Minimum relevance score threshold |
@@ -194,7 +194,7 @@ Search with session context and intent analysis.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | query | str | Yes | - | Search query string |
-| target_uri | str | No | "" | Limit search to specific URI prefix |
+| target_uri | str or list[str] | No | "" | Limit search to one or more URI prefixes |
 | session | Session | No | None | Session for context-aware search (SDK) |
 | session_id | str | No | None | Session ID for context-aware search (HTTP) |
 | limit | int | No | 10 | Maximum number of results |

--- a/docs/zh/api/06-retrieval.md
+++ b/docs/zh/api/06-retrieval.md
@@ -23,7 +23,7 @@ OpenViking 提供两种搜索方法：`find` 用于简单的语义搜索，`sear
 | 参数 | 类型 | 必填 | 默认值 | 说明 |
 |------|------|------|--------|------|
 | query | str | 是 | - | 搜索查询字符串 |
-| target_uri | str | 否 | "" | 限制搜索范围到指定的 URI 前缀 |
+| target_uri | str 或 list[str] | 否 | "" | 限制搜索范围到一个或多个 URI 前缀 |
 | limit | int | 否 | 10 | 最大返回结果数 |
 | node_limit | int | 否 | None | 可选 HTTP 别名；如果提供，会覆盖 `limit` |
 | score_threshold | float | 否 | None | 最低相关性分数阈值 |
@@ -194,7 +194,7 @@ curl -X POST http://localhost:1933/api/v1/search/find \
 | 参数 | 类型 | 必填 | 默认值 | 说明 |
 |------|------|------|--------|------|
 | query | str | 是 | - | 搜索查询字符串 |
-| target_uri | str | 否 | "" | 限制搜索范围到指定的 URI 前缀 |
+| target_uri | str 或 list[str] | 否 | "" | 限制搜索范围到一个或多个 URI 前缀 |
 | session | Session | 否 | None | 用于上下文感知搜索的会话（SDK） |
 | session_id | str | 否 | None | 用于上下文感知搜索的会话 ID（HTTP） |
 | limit | int | 否 | 10 | 最大返回结果数 |


### PR DESCRIPTION
## Background

#1753 (myysy author / zhoujh01 merger 2026-04-28T03:09:34Z) extended `target_uri` from `str` to `Union[str, List[str]]` across the full `find` / `search` stack so callers can scope a single query to multiple URI prefixes in one request:

- `openviking/server/routers/search.py:65` `FindRequest.target_uri: Union[str, List[str]] = ""`
- `openviking/server/routers/search.py:82` `SearchRequest.target_uri: Union[str, List[str]] = ""`
- `openviking/storage/viking_fs.py` `VikingFS.find` normalizes a list and forwards as `target_directories`

The merge updated SDK clients but did not touch the user-facing API reference.

## Drift

`docs/{en,zh}/api/06-retrieval.md` `find()` and `search()` parameter tables (4 cells total) still document `target_uri` as `str` only. Readers consulting the API reference will not know the new list form is supported and may fan out to N sequential calls instead of using a single batched request.

## Fix

Update the Type column from `str` to `str or list[str]` (matching the existing `bool or object` / `"updated_at" or "created_at"` convention in the same file) and broaden the description to "one or more URI prefixes". Pure docs, byte-for-byte aligned with the merged source signature; no behavior change.

- EN find() L26 + search() L197
- ZH find() L26 + search() L197 (full-width punctuation `或` per ZH convention)
