### PR TITLE
fix(docs): simplify docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,20 +7,7 @@ on:
       - '.github/workflows/_docs.yml'
       - '.github/workflows/_docs-deploy.yml'
       - '.github/workflows/docs.yml'
-  push:
-    branches: [ main ]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/_docs.yml'
-      - '.github/workflows/_docs-deploy.yml'
-      - '.github/workflows/docs.yml'
   workflow_dispatch:
-    inputs:
-      deploy:
-        description: 'Deploy docs to GitHub Pages'
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -28,16 +15,6 @@ permissions:
 jobs:
   docs-check:
     name: Build Docs
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.deploy == false)
     uses: ./.github/workflows/_docs.yml
     permissions:
       contents: read
-
-  docs-deploy:
-    name: Build and Deploy Docs
-    if: github.repository == 'volcengine/OpenViking' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy == true))
-    uses: ./.github/workflows/_docs-deploy.yml
-    permissions:
-      contents: read
-      pages: write
-      id-token: write

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -238,6 +238,7 @@ export default defineConfig({
   },
   themeConfig: {
     logo: '/ov-logo.png',
+    logoLink: 'https://openviking.ai/',
     search: {
       provider: 'local'
     },

--- a/docs/en/about/02-changelog.md
+++ b/docs/en/about/02-changelog.md
@@ -579,7 +579,7 @@ This changelog is automatically generated from [GitHub Releases](https://github.
 ## What's Changed
 * docs: use openviking-server to launch server
 * fix: Session.add_message() support parts parameter
-* feat: support GitHub tree/<ref> URL for code repository import
+* feat: support GitHub tree/&lt;ref&gt; URL for code repository import
 * fix: improve ISO datetime parsing
 * feat(pdf): extract bookmarks as markdown headings for hierarchical parsing
 * feat: add index control to add_resource and refactor embedding logic

--- a/docs/en/concepts/13-privacy.md
+++ b/docs/en/concepts/13-privacy.md
@@ -70,7 +70,7 @@ add_skill
 
 1. **Extraction source**: model returns JSON; `values` is used as privacy key-value pairs.  
 2. **Content replacement**: matched plaintext is replaced by placeholders:
-   - `{{ov_privacy:skill:{skill_name}:{field_name}}}`
+   - <code v-pre>{{ov_privacy:skill:{skill_name}:{field_name}}}</code>
 3. **Block mapping captured**:
    - `original_content_blocks`
    - `replacement_content_blocks`

--- a/docs/zh/about/02-changelog.md
+++ b/docs/zh/about/02-changelog.md
@@ -568,7 +568,7 @@ v0.3.10 重点增强了 VLM provider、OpenClaw 插件生态、VikingDB 数据�
 ## What's Changed
 * docs: use openviking-server to launch server
 * fix: Session.add_message() support parts parameter
-* feat: support GitHub tree/<ref> URL for code repository import
+* feat: support GitHub tree/&lt;ref&gt; URL for code repository import
 * fix: improve ISO datetime parsing
 * feat(pdf): extract bookmarks as markdown headings for hierarchical parsing
 * feat: add index control to add_resource and refactor embedding logic

--- a/docs/zh/concepts/13-privacy.md
+++ b/docs/zh/concepts/13-privacy.md
@@ -70,7 +70,7 @@ add_skill
 
 1. **抽取结果来源**：模型返回 JSON，读取 `values` 字段作为隐私键值。  
 2. **内容替换**：原文中命中的敏感片段会替换为占位符：
-   - `{{ov_privacy:skill:{skill_name}:{field_name}}}`
+   - <code v-pre>{{ov_privacy:skill:{skill_name}:{field_name}}}</code>
 3. **保留块映射**：会同时记录：
    - `original_content_blocks`
    - `replacement_content_blocks`


### PR DESCRIPTION
## Description

Simplifies the docs workflow and keeps Pages deployment out of the PR check workflow. Also sets the VitePress logo link to https://openviking.ai/ and escapes Markdown placeholders that VitePress parsed as Vue syntax.

## Related Issue

<!-- Fixes #(issue number) -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Run the docs workflow as a reusable docs build check only.
- Point the docs logo link to https://openviking.ai/.
- Escape VitePress-sensitive placeholders in changelog and privacy docs.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Command run:

```sh
source ~/.nvm/nvm.sh && npm run docs:build
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
