### PR TITLE
fix(resource): avoid directory rename on FUSE backends during temp

### DIFF
--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -28,6 +28,36 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _move_temp_to_resource(agfs: Any, src_path: str, dst_path: str) -> None:
+    """Move a temp entry to its resource location.
+
+    For files we use ``agfs.mv`` (a simple rename). For directories we fall
+    back to recursive copy + remove because some FUSE-mounted object stores
+    (e.g. TOS / hpvs_fs) do not implement directory rename and return ENOSYS.
+    """
+    from openviking.pyagfs.helpers import cp as agfs_cp
+
+    try:
+        info = agfs.stat(src_path)
+    except Exception:
+        # Let the caller handle NotFound etc., matching the original mv behavior.
+        agfs.mv(src_path, dst_path)
+        return
+
+    is_dir = info.get("isDir", False) if isinstance(info, dict) else False
+    if not is_dir:
+        agfs.mv(src_path, dst_path)
+        return
+
+    agfs_cp(agfs, src_path, dst_path, recursive=True)
+    try:
+        agfs.rm(src_path, recursive=True)
+    except Exception as e:
+        logger.warning(
+            f"[ResourceProcessor] Failed to remove temp dir {src_path} after copy: {e}"
+        )
+
+
 class ResourceProcessor:
     """
     Handles coordinated write operations.
@@ -280,7 +310,13 @@ class ResourceProcessor:
                                 dst_path = viking_fs._uri_to_path(root_uri, ctx=ctx)
 
                             src_path = viking_fs._uri_to_path(temp_uri, ctx=ctx)
-                            await asyncio.to_thread(viking_fs.agfs.mv, src_path, dst_path)
+                            # Some underlying FS (e.g. TOS/hpvs_fs FUSE mounts)
+                            # do not support directory rename (ENOSYS), so for
+                            # directories we fall back to recursive cp + rm.
+                            # Files still use mv.
+                            await asyncio.to_thread(
+                                _move_temp_to_resource, viking_fs.agfs, src_path, dst_path
+                            )
 
                             lifecycle_lock_handle_id = await self._try_acquire_lifecycle_lock(
                                 lock_manager, dst_path

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -41,7 +41,13 @@ class _CtxMgr:
 
 class _FakeVikingFS:
     def __init__(self, *, exists_result=False):
-        self.agfs = SimpleNamespace(mv=MagicMock(return_value={"status": "ok"}))
+        self.agfs = SimpleNamespace(
+            mv=MagicMock(return_value={"status": "ok"}),
+            # _move_temp_to_resource stats the src first; returning
+            # isDir=False keeps the original test path (agfs.mv for files).
+            stat=MagicMock(return_value={"isDir": False}),
+            rm=MagicMock(return_value={"status": "ok"}),
+        )
         self._exists_result = exists_result
 
     def bind_request_context(self, ctx):


### PR DESCRIPTION
## fix(resource): 避免在 FUSE 后端上对目录做 rename
### 问题
K8s 部署下 add_resource 报错：

```
failed to rename: Function not implemented 
(os error 38)
```
TOS 通过 hpvs_fs FUSE 挂载， 支持文件 rename，但不支持目录 rename （返回 ENOSYS）。

### 根因
resource_processor.py Phase 3.5 绕过了 viking_fs.mv （已是 cp + rm），直接调用底层 agfs.mv(temp_dir, resource_dir) ，落到 Rust 的 fs::rename ，对目录就会失败。

### 修复
新增 _move_temp_to_resource ：

- 文件 → 仍用 agfs.mv （rename，TOS 支持）
- 目录 → 递归 cp + rm （绕过目录 rename）
### 变更
- openviking/utils/resource_processor.py ：新增 helper 并替换调用点
- tests/misc/test_resource_processor_mv.py ：给 agfs mock 补上 stat / rm
### 影响
- 普通 FS 下文件仍走 rename，性能无回退
- FUSE/对象存储后端从失败变为成功
- 无 Rust 改动，无 mount 结构改动