### PR TITLE
feat(storage): add explicit upsert write mode

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -174,7 +174,7 @@ openviking read viking://resources/docs/api.md
 
 ### write()
 
-Update an existing file, or create a new one when `mode="create"`, and automatically refresh related semantics and vectors.
+Update an existing file, create a new one with `mode="create"`, or use explicit `mode="upsert"` to create-or-replace, then automatically refresh related semantics and vectors.
 
 **Parameters**
 
@@ -182,14 +182,14 @@ Update an existing file, or create a new one when `mode="create"`, and automatic
 |-----------|------|----------|---------|-------------|
 | uri | str | Yes | - | File URI to write. For `mode="create"`, the file must not already exist |
 | content | str | Yes | - | New content to write |
-| mode | str | No | `replace` | `replace`, `append`, or `create` |
+| mode | str | No | `replace` | `replace`, `append`, `create`, or `upsert` |
 | wait | bool | No | `false` | Wait for background semantic/vector refresh |
 | timeout | float | No | `null` | Timeout in seconds when `wait=true` |
 
 **Notes**
 
-- `replace` and `append` require the file to exist; `create` targets a new file and returns `409 Conflict` when the path already exists. Directories are always rejected.
-- `create` only accepts text-writable extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`, `.py`, `.js`, `.ts`. Parent directories are created automatically.
+- `replace` and `append` require the file to exist; `create` targets a new file and returns `409 Conflict` when the path already exists; `upsert` creates missing files and replaces existing files explicitly. Directories are always rejected.
+- `create` and the create branch of `upsert` only accept text-writable extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`, `.py`, `.js`, `.ts`. Parent directories are created automatically.
 - Derived semantic files cannot be written directly: `.abstract.md`, `.overview.md`, `.relations.json`.
 - File content is updated before the API returns. `wait` only controls whether the call waits for semantic/vector refresh to finish.
 - The public API no longer accepts `regenerate_semantics` or `revectorize`; write always refreshes related semantics and vectors.

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -174,7 +174,7 @@ openviking read viking://resources/docs/api.md
 
 ### write()
 
-修改一个已存在的文件，或在 `mode="create"` 时创建新文件，并自动刷新相关语义与向量。
+修改一个已存在的文件，在 `mode="create"` 时创建新文件，或用显式 `mode="upsert"` 执行创建或替换，并自动刷新相关语义与向量。
 
 **参数**
 
@@ -182,14 +182,14 @@ openviking read viking://resources/docs/api.md
 |------|------|------|--------|------|
 | uri | str | 是 | - | 要写入的文件 URI。`mode="create"` 时目标文件必须不存在 |
 | content | str | 是 | - | 要写入的新内容 |
-| mode | str | 否 | `replace` | `replace`、`append` 或 `create` |
+| mode | str | 否 | `replace` | `replace`、`append`、`create` 或 `upsert` |
 | wait | bool | 否 | `false` | 是否等待后台语义/向量刷新完成 |
 | timeout | float | 否 | `null` | 当 `wait=true` 时的超时时间（秒） |
 
 **说明**
 
-- `replace` 和 `append` 要求文件已存在；`create` 仅用于创建新文件，目标路径已存在时返回 `409 Conflict`。目录始终会被拒绝。
-- `create` 只允许以下文本类扩展名：`.md`、`.txt`、`.json`、`.yaml`、`.yml`、`.toml`、`.py`、`.js`、`.ts`。父目录会自动创建。
+- `replace` 和 `append` 要求文件已存在；`create` 仅用于创建新文件，目标路径已存在时返回 `409 Conflict`；`upsert` 会显式创建缺失文件或替换已存在文件。目录始终会被拒绝。
+- `create` 和 `upsert` 的创建分支只允许以下文本类扩展名：`.md`、`.txt`、`.json`、`.yaml`、`.yml`、`.toml`、`.py`、`.js`、`.ts`。父目录会自动创建。
 - 不允许直接写入派生语义文件：`.abstract.md`、`.overview.md`、`.relations.json`。
 - 文件内容会在 API 返回前完成更新；`wait` 只控制是否等待语义/向量刷新完成。
 - 公共 API 已不再接受 `regenerate_semantics` 或 `revectorize`；写入后一定会自动刷新相关语义与向量。

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -428,7 +428,7 @@ class AsyncOpenViking:
         timeout: Optional[float] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
-        """Write text content to an existing file and refresh semantics/vectors."""
+        """Write text content to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
         await self._ensure_initialized()
         return await self._client.write(
             uri=uri,

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -267,7 +267,7 @@ class LocalClient(BaseClient):
         timeout: Optional[float] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
-        """Write text content to an existing file and refresh semantics/vectors."""
+        """Write text content to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
         execution = await run_with_telemetry(
             operation="content.write",
             telemetry=telemetry,

--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -28,7 +28,7 @@ logger = get_logger(__name__)
 
 
 class WriteContentRequest(BaseModel):
-    """Request to write, append, or create text content to a file."""
+    """Request to write, append, create, or upsert text content to a file."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -176,7 +176,7 @@ async def write(
     request: WriteContentRequest = Body(...),
     _ctx: RequestContext = Depends(get_request_context),
 ):
-    """Write text content to a file (replace, append, or create) and refresh semantics/vectors."""
+    """Write text content to a file (replace, append, create, or upsert) and refresh semantics/vectors."""
     service = get_service()
     uri = resolve_path_variables(request.uri)
     execution = await run_operation(

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -157,7 +157,9 @@ class FSService:
         directory_uri = VikingURI(abstract_uri).parent.uri
         return directory_uri, abstract_uri
 
-    async def rm(self, uri: str, ctx: RequestContext, recursive: bool = False) -> Optional[Dict[str, Any]]:
+    async def rm(
+        self, uri: str, ctx: RequestContext, recursive: bool = False
+    ) -> Optional[Dict[str, Any]]:
         """Remove resource."""
         uri = validate_viking_uri(uri)
         viking_fs = self._ensure_initialized()
@@ -283,7 +285,10 @@ class FSService:
         wait: bool = False,
         timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
-        """Write to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
+        """Write to a file and refresh semantics/vectors.
+
+        Modes: replace, append, create, or upsert.
+        """
         uri = validate_viking_uri(uri)
         viking_fs = self._ensure_initialized()
         coordinator = ContentWriteCoordinator(viking_fs=viking_fs)

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -283,7 +283,7 @@ class FSService:
         wait: bool = False,
         timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
-        """Write to an existing file and refresh semantics/vectors."""
+        """Write to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
         uri = validate_viking_uri(uri)
         viking_fs = self._ensure_initialized()
         coordinator = ContentWriteCoordinator(viking_fs=viking_fs)

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -64,9 +64,17 @@ class ContentWriteCoordinator:
                 timeout=timeout,
             )
 
-        stat = await self._safe_stat(normalized_uri, ctx=ctx)
+        stat = await self._safe_stat(normalized_uri, ctx=ctx, allow_not_found=mode == "replace")
         if stat.get("isDir"):
             raise InvalidArgumentError(f"write only supports existing files, got directory: {uri}")
+        if mode == "replace" and stat.get("not_found"):
+            return await self._create_and_write(
+                uri=normalized_uri,
+                content=content,
+                ctx=ctx,
+                wait=wait,
+                timeout=timeout,
+            )
 
         context_type = self._context_type_for_uri(normalized_uri)
         root_uri = await self._resolve_root_uri(normalized_uri, ctx=ctx)

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -67,9 +67,17 @@ class ContentWriteCoordinator:
                 timeout=timeout,
             )
 
-        stat = await self._safe_stat(normalized_uri, ctx=ctx)
+        stat = await self._safe_stat(normalized_uri, ctx=ctx, allow_not_found=mode == "replace")
         if stat.get("isDir"):
             raise InvalidArgumentError(f"write only supports existing files, got directory: {uri}")
+        if mode == "replace" and stat.get("not_found"):
+            return await self._create_and_write(
+                uri=normalized_uri,
+                content=content,
+                ctx=ctx,
+                wait=wait,
+                timeout=timeout,
+            )
 
         context_type = context_type_for_uri(normalized_uri)
         root_uri = await self._resolve_root_uri(normalized_uri, ctx=ctx)

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -67,17 +67,21 @@ class ContentWriteCoordinator:
                 timeout=timeout,
             )
 
-        stat = await self._safe_stat(normalized_uri, ctx=ctx, allow_not_found=mode == "replace")
+        stat = await self._safe_stat(normalized_uri, ctx=ctx, allow_not_found=mode == "upsert")
         if stat.get("isDir"):
             raise InvalidArgumentError(f"write only supports existing files, got directory: {uri}")
-        if mode == "replace" and stat.get("not_found"):
+        if mode == "upsert" and stat.get("not_found"):
             return await self._create_and_write(
                 uri=normalized_uri,
                 content=content,
                 ctx=ctx,
                 wait=wait,
                 timeout=timeout,
+                result_mode="upsert",
             )
+
+        write_mode = "replace" if mode == "upsert" else mode
+        result_mode = "upsert" if mode == "upsert" else mode
 
         context_type = context_type_for_uri(normalized_uri)
         root_uri = await self._resolve_root_uri(normalized_uri, ctx=ctx)
@@ -89,7 +93,8 @@ class ContentWriteCoordinator:
                 uri=normalized_uri,
                 root_uri=root_uri,
                 content=content,
-                mode=mode,
+                mode=write_mode,
+                result_mode=result_mode,
                 wait=wait,
                 timeout=timeout,
                 ctx=ctx,
@@ -101,7 +106,8 @@ class ContentWriteCoordinator:
             uri=normalized_uri,
             root_uri=root_uri,
             content=content,
-            mode=mode,
+            mode=write_mode,
+            result_mode=result_mode,
             context_type=context_type,
             wait=wait,
             timeout=timeout,
@@ -168,6 +174,7 @@ class ContentWriteCoordinator:
         root_uri: str,
         content: str,
         mode: str,
+        result_mode: str,
         context_type: str,
         wait: bool,
         timeout: Optional[float],
@@ -213,7 +220,7 @@ class ContentWriteCoordinator:
                 uri=uri,
                 root_uri=root_uri,
                 context_type=context_type,
-                mode=mode,
+                mode=result_mode,
                 written_bytes=written_bytes,
                 wait=wait,
                 queue_status=queue_status,
@@ -253,7 +260,7 @@ class ContentWriteCoordinator:
             logger.error("Failed to rollback direct content write for %s", uri, exc_info=True)
 
     def _validate_mode(self, mode: str) -> None:
-        if mode not in {"replace", "append", "create"}:
+        if mode not in {"replace", "append", "create", "upsert"}:
             raise InvalidArgumentError(f"unsupported write mode: {mode}")
 
     def _validate_target_uri(self, uri: str) -> None:
@@ -306,6 +313,7 @@ class ContentWriteCoordinator:
         ctx: RequestContext,
         wait: bool,
         timeout: Optional[float],
+        result_mode: str = "create",
     ) -> Dict[str, Any]:
         self._validate_create_extension(uri)
 
@@ -324,6 +332,7 @@ class ContentWriteCoordinator:
                 root_uri=root_uri,
                 content=content,
                 mode="create",
+                result_mode=result_mode,
                 wait=wait,
                 timeout=timeout,
                 ctx=ctx,
@@ -336,6 +345,7 @@ class ContentWriteCoordinator:
             root_uri=root_uri,
             content=content,
             mode="create",
+            result_mode=result_mode,
             context_type=context_type,
             wait=wait,
             timeout=timeout,
@@ -481,6 +491,7 @@ class ContentWriteCoordinator:
         root_uri: str,
         content: str,
         mode: str,
+        result_mode: str,
         wait: bool,
         timeout: Optional[float],
         ctx: RequestContext,
@@ -516,7 +527,7 @@ class ContentWriteCoordinator:
                 uri=uri,
                 root_uri=root_uri,
                 context_type="memory",
-                mode=mode,
+                mode=result_mode,
                 written_bytes=written_bytes,
                 wait=wait,
                 queue_status=queue_status,

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -268,7 +268,7 @@ class SyncOpenViking:
         timeout: Optional[float] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
-        """Write text content to an existing file and refresh semantics/vectors."""
+        """Write text content to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
         return run_async(
             self._async_client.write(
                 uri=uri,

--- a/openviking_cli/client/base.py
+++ b/openviking_cli/client/base.py
@@ -154,7 +154,7 @@ class BaseClient(ABC):
         timeout: Optional[float] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
-        """Write text content to an existing file and refresh semantics/vectors."""
+        """Write text content to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
         ...
 
     # ============= Search =============

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -654,7 +654,7 @@ class AsyncHTTPClient(BaseClient):
         timeout: Optional[float] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
-        """Write text content to an existing file and refresh semantics/vectors."""
+        """Write text content to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
         telemetry = self._validate_telemetry(telemetry)
         uri = VikingURI.normalize(uri)
         response = await self._http.post(

--- a/openviking_cli/client/sync_http.py
+++ b/openviking_cli/client/sync_http.py
@@ -406,7 +406,7 @@ class SyncHTTPClient:
         timeout: Optional[float] = None,
         telemetry: TelemetryRequest = False,
     ) -> Dict[str, Any]:
-        """Write text content to an existing file and refresh semantics/vectors."""
+        """Write text content to a file and refresh semantics/vectors. Modes: replace, append, create, or upsert."""
         return run_async(
             self._async_client.write(
                 uri=uri,

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -782,6 +782,45 @@ async def test_create_mode_regression_replace_unchanged(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_replace_mode_missing_file_falls_back_to_create(monkeypatch):
+    file_uri = "viking://user/default/memories/new-upsert.md"
+    root_uri = "viking://user/default/memories"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFSForCreate(file_uri=file_uri, root_uri=root_uri, file_exists=False)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+
+    captured = {}
+
+    async def _fake_create_and_write(*, uri, content, ctx, wait, timeout):
+        captured["uri"] = uri
+        captured["content"] = content
+        captured["ctx"] = ctx
+        captured["wait"] = wait
+        captured["timeout"] = timeout
+        return {"uri": uri, "mode": "create", "queue_status": None}
+
+    monkeypatch.setattr(coordinator, "_create_and_write", _fake_create_and_write)
+
+    result = await coordinator.write(
+        uri=file_uri,
+        content="created via replace",
+        ctx=ctx,
+        mode="replace",
+        wait=True,
+        timeout=12.5,
+    )
+
+    assert result["mode"] == "create"
+    assert captured == {
+        "uri": file_uri,
+        "content": "created via replace",
+        "ctx": ctx,
+        "wait": True,
+        "timeout": 12.5,
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_mode_regression_append_unchanged(monkeypatch):
     file_uri = "viking://user/default/memories/theme.md"
     root_uri = "viking://user/default/memories"

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -423,10 +423,13 @@ async def test_memory_write_timeout_after_enqueue_releases_write_lock(monkeypatc
 class _FakeVikingFSForCreate:
     """Variant of _FakeVikingFS that supports 'file doesn't exist' scenarios."""
 
-    def __init__(self, file_uri: str, root_uri: str, file_exists: bool = True):
+    def __init__(
+        self, file_uri: str, root_uri: str, file_exists: bool = True, file_is_dir: bool = False
+    ):
         self._file_uri = file_uri
         self._root_uri = root_uri
         self._file_exists = file_exists
+        self._file_is_dir = file_is_dir
         self.delete_temp_calls = []
         self.write_file_calls = []
         self.rm_calls = []
@@ -436,7 +439,7 @@ class _FakeVikingFSForCreate:
         del ctx
         if uri == self._file_uri:
             if self._file_exists:
-                return {"isDir": False}
+                return {"isDir": self._file_is_dir}
             raise NotFoundError(uri, "file")
         if uri == self._root_uri:
             return {"isDir": True}
@@ -797,7 +800,19 @@ async def test_create_mode_regression_replace_unchanged(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_replace_mode_missing_file_falls_back_to_create(monkeypatch):
+async def test_replace_mode_missing_file_stays_strict():
+    file_uri = "viking://user/default/memories/missing.md"
+    root_uri = "viking://user/default/memories"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFSForCreate(file_uri=file_uri, root_uri=root_uri, file_exists=False)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+
+    with pytest.raises(NotFoundError):
+        await coordinator.write(uri=file_uri, content="updated", ctx=ctx, mode="replace")
+
+
+@pytest.mark.asyncio
+async def test_upsert_mode_missing_file_uses_create_path(monkeypatch):
     file_uri = "viking://user/default/memories/new-upsert.md"
     root_uri = "viking://user/default/memories"
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
@@ -806,33 +821,88 @@ async def test_replace_mode_missing_file_falls_back_to_create(monkeypatch):
 
     captured = {}
 
-    async def _fake_create_and_write(*, uri, content, ctx, wait, timeout):
+    async def _fake_create_and_write(*, uri, content, ctx, wait, timeout, result_mode="create"):
         captured["uri"] = uri
         captured["content"] = content
         captured["ctx"] = ctx
         captured["wait"] = wait
         captured["timeout"] = timeout
-        return {"uri": uri, "mode": "create", "queue_status": None}
+        captured["result_mode"] = result_mode
+        return {"uri": uri, "mode": result_mode, "queue_status": None}
 
     monkeypatch.setattr(coordinator, "_create_and_write", _fake_create_and_write)
 
     result = await coordinator.write(
         uri=file_uri,
-        content="created via replace",
+        content="created via upsert",
         ctx=ctx,
-        mode="replace",
+        mode="upsert",
         wait=True,
         timeout=12.5,
     )
 
-    assert result["mode"] == "create"
+    assert result["mode"] == "upsert"
     assert captured == {
         "uri": file_uri,
-        "content": "created via replace",
+        "content": "created via upsert",
         "ctx": ctx,
         "wait": True,
         "timeout": 12.5,
+        "result_mode": "upsert",
     }
+
+
+@pytest.mark.asyncio
+async def test_upsert_mode_existing_directory_is_rejected():
+    file_uri = "viking://user/default/memories/existing-dir"
+    root_uri = "viking://user/default/memories"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFSForCreate(
+        file_uri=file_uri, root_uri=root_uri, file_exists=True, file_is_dir=True
+    )
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+
+    with pytest.raises(InvalidArgumentError):
+        await coordinator.write(uri=file_uri, content="updated", ctx=ctx, mode="upsert")
+
+
+@pytest.mark.asyncio
+async def test_upsert_mode_existing_file_uses_replace_path(monkeypatch):
+    file_uri = "viking://user/default/memories/theme.md"
+    root_uri = "viking://user/default/memories"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFSForCreate(file_uri=file_uri, root_uri=root_uri, file_exists=True)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    lock_manager = _FakeLockManager()
+
+    monkeypatch.setattr("openviking.storage.content_write.get_lock_manager", lambda: lock_manager)
+
+    write_calls = []
+
+    async def _fake_write_in_place(uri, content, *, mode, ctx):
+        del ctx
+        write_calls.append((uri, content, mode))
+
+    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
+        del uri, context_type, ctx
+
+    async def _fake_enqueue_memory_refresh(**kwargs):
+        del kwargs
+
+    async def _fake_wait_for_queues(*, timeout):
+        del timeout
+
+    monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
+    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
+    monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
+    monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
+
+    result = await coordinator.write(
+        uri=file_uri, content="updated", ctx=ctx, mode="upsert", wait=True
+    )
+
+    assert result["mode"] == "upsert"
+    assert write_calls == [(file_uri, "updated", "replace")]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -797,6 +797,45 @@ async def test_create_mode_regression_replace_unchanged(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_replace_mode_missing_file_falls_back_to_create(monkeypatch):
+    file_uri = "viking://user/default/memories/new-upsert.md"
+    root_uri = "viking://user/default/memories"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFSForCreate(file_uri=file_uri, root_uri=root_uri, file_exists=False)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+
+    captured = {}
+
+    async def _fake_create_and_write(*, uri, content, ctx, wait, timeout):
+        captured["uri"] = uri
+        captured["content"] = content
+        captured["ctx"] = ctx
+        captured["wait"] = wait
+        captured["timeout"] = timeout
+        return {"uri": uri, "mode": "create", "queue_status": None}
+
+    monkeypatch.setattr(coordinator, "_create_and_write", _fake_create_and_write)
+
+    result = await coordinator.write(
+        uri=file_uri,
+        content="created via replace",
+        ctx=ctx,
+        mode="replace",
+        wait=True,
+        timeout=12.5,
+    )
+
+    assert result["mode"] == "create"
+    assert captured == {
+        "uri": file_uri,
+        "content": "created via replace",
+        "ctx": ctx,
+        "wait": True,
+        "timeout": 12.5,
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_mode_regression_append_unchanged(monkeypatch):
     file_uri = "viking://user/default/memories/theme.md"
     root_uri = "viking://user/default/memories"


### PR DESCRIPTION
## Summary

This keeps `mode="replace"` strict and adds an explicit `mode="upsert"` for create-or-replace behavior.

Behavior after this change:
- `replace` and `append` still require an existing file.
- `create` creates a missing file and keeps returning a conflict when the target already exists.
- `upsert` creates a missing file through the create path.
- `upsert` replaces an existing file through the replace path.
- existing directories remain rejected.

The EN/ZH filesystem API docs and client docstrings now document the new mode.

## Verification

- `python3 -m py_compile openviking/storage/content_write.py openviking/client/local.py openviking/async_client.py openviking/sync_client.py openviking/service/fs_service.py openviking_cli/client/base.py openviking_cli/client/sync_http.py openviking_cli/client/http.py openviking/server/routers/content.py tests/server/test_content_write_service.py`
- `git diff --check`

## Related

- fixes #1709
