### PR TITLE
fix(claude-code-plugin): correct memory scope resolution

### DIFF
--- a/examples/claude-code-memory-plugin/MIGRATION.md
+++ b/examples/claude-code-memory-plugin/MIGRATION.md
@@ -101,6 +101,8 @@ Add the `claude_code` section to `~/.openviking/ov.conf` for plugin-specific set
 {
   "claude_code": {
     "agentId": "claude-code",
+    "account": "default",
+    "user": "default",
     "recallLimit": 6,
     "captureMode": "semantic",
     "captureTimeoutMs": 30000,
@@ -108,6 +110,12 @@ Add the `claude_code` section to `~/.openviking/ov.conf` for plugin-specific set
   }
 }
 ```
+
+Set `account` and `user` when the plugin authenticates with a root key or when the
+server runs in trusted auth mode. With a user key, OpenViking derives account/user
+identity from the key. The new plugin sends shorthand scopes such as
+`viking://user/memories` unchanged and lets the server resolve them from the
+effective request identity.
 
 ## Behavior Changes
 

--- a/examples/claude-code-memory-plugin/README.md
+++ b/examples/claude-code-memory-plugin/README.md
@@ -165,6 +165,8 @@ Optionally add a `claude_code` section for plugin-specific overrides:
 {
   "claude_code": {
     "agentId": "claude-code",
+    "account": "default",
+    "user": "default",
     "recallLimit": 6,
     "captureMode": "semantic",
     "captureTimeoutMs": 30000,
@@ -218,6 +220,8 @@ export OPENVIKING_CONFIG_FILE="~/custom/path/ov.conf"
 | Field | Default | Description |
 |-------|---------|-------------|
 | `agentId` | `claude-code` | Agent identity for memory isolation |
+| `account` | `default_account` | Tenant account sent as `X-OpenViking-Account`. Needed when using a root key or trusted auth mode; with a user key, OpenViking derives this from the key. |
+| `user` | `default_user` | Tenant user sent as `X-OpenViking-User`. Needed when using a root key or trusted auth mode; with a user key, OpenViking derives this from the key. |
 | `timeoutMs` | `15000` | HTTP request timeout for recall/general requests (ms) |
 | `autoRecall` | `true` | Enable auto-recall on every user prompt |
 | `recallLimit` | `6` | Max memories to inject per turn |
@@ -229,6 +233,11 @@ export OPENVIKING_CONFIG_FILE="~/custom/path/ov.conf"
 | `captureMaxLength` | `24000` | Max text length for capture |
 | `captureTimeoutMs` | `30000` | HTTP request timeout for auto-capture requests (ms) |
 | `captureAssistantTurns` | `false` | Include assistant turns in auto-capture input; default is user-only capture |
+
+**Scope resolution** is handled by the OpenViking server. The plugin sends shorthand
+target URIs such as `viking://user/memories`, `viking://agent/memories`, and
+`viking://agent/skills` unchanged. OpenViking resolves those scopes using the
+effective account/user/agent identity from the API key and `X-OpenViking-*` headers.
 
 ## Hook Timeouts
 

--- a/examples/claude-code-memory-plugin/README_CN.md
+++ b/examples/claude-code-memory-plugin/README_CN.md
@@ -162,6 +162,8 @@ vim ~/.openviking/ov.conf
 {
   "claude_code": {
     "agentId": "claude-code",
+    "account": "default",
+    "user": "default",
     "recallLimit": 6,
     "captureMode": "semantic",
     "captureTimeoutMs": 30000,
@@ -213,6 +215,8 @@ export OPENVIKING_CONFIG_FILE="~/custom/path/ov.conf"
 | 字段 | 默认值 | 描述 |
 |------|-------|------|
 | `agentId` | `claude-code` | 用于记忆隔离的代理标识 |
+| `account` | `default_account` | 作为 `X-OpenViking-Account` 发送的租户账号。使用 root key 或 trusted 认证模式时需要；使用 user key 时 OpenViking 会从 key 推导。 |
+| `user` | `default_user` | 作为 `X-OpenViking-User` 发送的租户用户。使用 root key 或 trusted 认证模式时需要；使用 user key 时 OpenViking 会从 key 推导。 |
 | `timeoutMs` | `15000` | 召回/通用请求的 HTTP 请求超时（毫秒）|
 | `autoRecall` | `true` | 每次用户提示时启用自动召回 |
 | `recallLimit` | `6` | 每轮注入的最大记忆数 |
@@ -224,6 +228,11 @@ export OPENVIKING_CONFIG_FILE="~/custom/path/ov.conf"
 | `captureMaxLength` | `24000` | 捕获的最大文本长度 |
 | `captureTimeoutMs` | `30000` | 自动捕获请求的 HTTP 请求超时（毫秒）|
 | `captureAssistantTurns` | `false` | 在自动捕获输入中包含助手轮次；默认只捕获用户 |
+
+**作用域解析**由 OpenViking 服务端处理。插件会原样发送
+`viking://user/memories`、`viking://agent/memories` 和
+`viking://agent/skills` 等简写 target URI。OpenViking 会根据 API key 和
+`X-OpenViking-*` headers 得到的有效 account/user/agent 身份来解析这些作用域。
 
 ## Hook 超时
 

--- a/examples/claude-code-memory-plugin/scripts/auto-capture.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-capture.mjs
@@ -47,6 +47,8 @@ async function fetchJSON(path, init = {}) {
     const headers = { "Content-Type": "application/json" };
     if (cfg.apiKey) headers["X-API-Key"] = cfg.apiKey;
     if (cfg.agentId) headers["X-OpenViking-Agent"] = cfg.agentId;
+    if (cfg.account) headers["X-OpenViking-Account"] = cfg.account;
+    if (cfg.user) headers["X-OpenViking-User"] = cfg.user;
     const res = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
     const body = await res.json();
     if (!res.ok || body.status === "error") return null;

--- a/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
@@ -37,6 +37,8 @@ async function fetchJSON(path, init = {}) {
     const headers = { "Content-Type": "application/json" };
     if (cfg.apiKey) headers["X-API-Key"] = cfg.apiKey;
     if (cfg.agentId) headers["X-OpenViking-Agent"] = cfg.agentId;
+    if (cfg.account) headers["X-OpenViking-Account"] = cfg.account;
+    if (cfg.user) headers["X-OpenViking-User"] = cfg.user;
     const res = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
     const body = await res.json();
     if (!res.ok || body.status === "error") return null;
@@ -155,68 +157,13 @@ function postProcess(items, limit, threshold) {
 }
 
 // ---------------------------------------------------------------------------
-// URI space resolution (mirrors MCP server's normalizeTargetUri logic)
-// ---------------------------------------------------------------------------
-
-const USER_RESERVED_DIRS = new Set(["memories"]);
-const AGENT_RESERVED_DIRS = new Set(["memories", "skills", "instructions", "workspaces"]);
-const _spaceCache = {};
-
-async function resolveScopeSpace(scope) {
-  if (_spaceCache[scope]) return _spaceCache[scope];
-
-  let fallbackSpace = "default";
-  try {
-    const status = await fetchJSON("/api/v1/system/status");
-    if (status && typeof status.user === "string" && status.user.trim()) {
-      fallbackSpace = status.user.trim();
-    }
-  } catch { /* use fallback */ }
-
-  const reservedDirs = scope === "user" ? USER_RESERVED_DIRS : AGENT_RESERVED_DIRS;
-  try {
-    const entries = await fetchJSON(`/api/v1/fs/ls?uri=${encodeURIComponent(`viking://${scope}`)}&output=original`);
-    if (Array.isArray(entries)) {
-      const spaces = entries
-        .filter(e => e?.isDir)
-        .map(e => (typeof e.name === "string" ? e.name.trim() : ""))
-        .filter(n => n && !n.startsWith(".") && !reservedDirs.has(n));
-      if (spaces.length > 0) {
-        if (spaces.includes(fallbackSpace)) { _spaceCache[scope] = fallbackSpace; return fallbackSpace; }
-        if (scope === "user" && spaces.includes("default")) { _spaceCache[scope] = "default"; return "default"; }
-        if (spaces.length === 1) { _spaceCache[scope] = spaces[0]; return spaces[0]; }
-      }
-    }
-  } catch { /* use fallback */ }
-
-  _spaceCache[scope] = fallbackSpace;
-  return fallbackSpace;
-}
-
-async function resolveTargetUri(targetUri) {
-  const trimmed = targetUri.trim().replace(/\/+$/, "");
-  const m = trimmed.match(/^viking:\/\/(user|agent)(?:\/(.*))?$/);
-  if (!m) return trimmed;
-  const scope = m[1];
-  const rawRest = (m[2] ?? "").trim();
-  if (!rawRest) return trimmed;
-  const parts = rawRest.split("/").filter(Boolean);
-  if (parts.length === 0) return trimmed;
-  const reservedDirs = scope === "user" ? USER_RESERVED_DIRS : AGENT_RESERVED_DIRS;
-  if (!reservedDirs.has(parts[0])) return trimmed;
-  const space = await resolveScopeSpace(scope);
-  return `viking://${scope}/${space}/${parts.join("/")}`;
-}
-
-// ---------------------------------------------------------------------------
 // Search OpenViking
 // ---------------------------------------------------------------------------
 
 async function searchScope(query, targetUri, limit) {
-  const resolvedUri = await resolveTargetUri(targetUri);
   const result = await fetchJSON("/api/v1/search/find", {
     method: "POST",
-    body: JSON.stringify({ query, target_uri: resolvedUri, limit, score_threshold: 0 }),
+    body: JSON.stringify({ query, target_uri: targetUri, limit, score_threshold: 0 }),
   });
   return result?.memories || [];
 }

--- a/examples/claude-code-memory-plugin/scripts/config.mjs
+++ b/examples/claude-code-memory-plugin/scripts/config.mjs
@@ -79,6 +79,8 @@ export function loadConfig() {
     baseUrl,
     apiKey,
     agentId: str(cc.agentId, "claude-code"),
+    account: str(cc.account, str(file.default_account, "")),
+    user: str(cc.user, str(file.default_user, "")),
     timeoutMs,
 
     // Recall

--- a/examples/claude-code-memory-plugin/scripts/debug-capture.mjs
+++ b/examples/claude-code-memory-plugin/scripts/debug-capture.mjs
@@ -196,6 +196,8 @@ async function fetchJSON(path, init = {}) {
     const headers = { "Content-Type": "application/json" };
     if (cfg.apiKey) headers["X-API-Key"] = cfg.apiKey;
     if (cfg.agentId) headers["X-OpenViking-Agent"] = cfg.agentId;
+    if (cfg.account) headers["X-OpenViking-Account"] = cfg.account;
+    if (cfg.user) headers["X-OpenViking-User"] = cfg.user;
     const res = await fetch(url, { ...init, headers, signal: controller.signal });
     const body = await res.json();
     dim(`  ${init.method || "GET"} ${path} -> ${res.status}`);

--- a/examples/claude-code-memory-plugin/scripts/debug-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/debug-recall.mjs
@@ -70,6 +70,8 @@ async function fetchJSON(path, init = {}) {
     const headers = { "Content-Type": "application/json" };
     if (cfg.apiKey) headers["X-API-Key"] = cfg.apiKey;
     if (cfg.agentId) headers["X-OpenViking-Agent"] = cfg.agentId;
+    if (cfg.account) headers["X-OpenViking-Account"] = cfg.account;
+    if (cfg.user) headers["X-OpenViking-User"] = cfg.user;
     const res = await fetch(url, { ...init, headers, signal: controller.signal });
     const body = await res.json();
     if (!res.ok || body.status === "error") {
@@ -186,69 +188,14 @@ function postProcess(items, limit, threshold) {
 }
 
 // ---------------------------------------------------------------------------
-// URI space resolution — copied from auto-recall.mjs
-// ---------------------------------------------------------------------------
-
-const USER_RESERVED_DIRS = new Set(["memories"]);
-const AGENT_RESERVED_DIRS = new Set(["memories", "skills", "instructions", "workspaces"]);
-const _spaceCache = {};
-
-async function resolveScopeSpace(scope) {
-  if (_spaceCache[scope]) return _spaceCache[scope];
-
-  let fallbackSpace = "default";
-  try {
-    const status = await fetchJSON("/api/v1/system/status");
-    if (status && typeof status.user === "string" && status.user.trim()) {
-      fallbackSpace = status.user.trim();
-    }
-  } catch { /* use fallback */ }
-
-  const reservedDirs = scope === "user" ? USER_RESERVED_DIRS : AGENT_RESERVED_DIRS;
-  try {
-    const entries = await fetchJSON(`/api/v1/fs/ls?uri=${encodeURIComponent(`viking://${scope}`)}&output=original`);
-    if (Array.isArray(entries)) {
-      const spaces = entries
-        .filter(e => e?.isDir)
-        .map(e => (typeof e.name === "string" ? e.name.trim() : ""))
-        .filter(n => n && !n.startsWith(".") && !reservedDirs.has(n));
-      if (spaces.length > 0) {
-        if (spaces.includes(fallbackSpace)) { _spaceCache[scope] = fallbackSpace; return fallbackSpace; }
-        if (scope === "user" && spaces.includes("default")) { _spaceCache[scope] = "default"; return "default"; }
-        if (spaces.length === 1) { _spaceCache[scope] = spaces[0]; return spaces[0]; }
-      }
-    }
-  } catch { /* use fallback */ }
-
-  _spaceCache[scope] = fallbackSpace;
-  return fallbackSpace;
-}
-
-async function resolveTargetUri(targetUri) {
-  const trimmed = targetUri.trim().replace(/\/+$/, "");
-  const m = trimmed.match(/^viking:\/\/(user|agent)(?:\/(.*))?$/);
-  if (!m) return trimmed;
-  const scope = m[1];
-  const rawRest = (m[2] ?? "").trim();
-  if (!rawRest) return trimmed;
-  const parts = rawRest.split("/").filter(Boolean);
-  if (parts.length === 0) return trimmed;
-  const reservedDirs = scope === "user" ? USER_RESERVED_DIRS : AGENT_RESERVED_DIRS;
-  if (!reservedDirs.has(parts[0])) return trimmed;
-  const space = await resolveScopeSpace(scope);
-  return `viking://${scope}/${space}/${parts.join("/")}`;
-}
-
-// ---------------------------------------------------------------------------
 // Search — adapted from auto-recall.mjs (verbose on error)
 // ---------------------------------------------------------------------------
 
 async function searchScope(queryText, targetUri, limit) {
-  const resolvedUri = await resolveTargetUri(targetUri);
-  dim(`  target: ${targetUri} -> ${resolvedUri}`);
+  dim(`  target: ${targetUri}`);
   const result = await fetchJSON("/api/v1/search/find", {
     method: "POST",
-    body: JSON.stringify({ query: queryText, target_uri: resolvedUri, limit, score_threshold: 0 }),
+    body: JSON.stringify({ query: queryText, target_uri: targetUri, limit, score_threshold: 0 }),
   });
   return result?.memories || [];
 }

--- a/examples/claude-code-memory-plugin/servers/memory-server.js
+++ b/examples/claude-code-memory-plugin/servers/memory-server.js
@@ -12,7 +12,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { createHash } from "node:crypto";
 // ---------------------------------------------------------------------------
 // Configuration — loaded from ov.conf (shared with OpenClaw plugin).
 // Env var: OPENVIKING_CONFIG_FILE (default: ~/.openviking/ov.conf)
@@ -60,6 +59,8 @@ const config = {
     baseUrl: `http://${host}:${port}`,
     apiKey: str(serverCfg.root_api_key, ""),
     agentId: str(cc.agentId, "claude-code"),
+    account: str(cc.account, str(file.default_account, "")),
+    user: str(cc.user, str(file.default_user, "")),
     timeoutMs: Math.max(1000, Math.floor(num(cc.timeoutMs, 15000))),
     recallLimit: Math.max(1, Math.floor(num(cc.recallLimit, 6))),
     scoreThreshold: Math.min(1, Math.max(0, num(cc.scoreThreshold, 0.01))),
@@ -68,14 +69,9 @@ const config = {
 // OpenViking HTTP Client (ported from openclaw-plugin/client.ts)
 // ---------------------------------------------------------------------------
 const MEMORY_URI_PATTERNS = [
-    /^viking:\/\/user\/(?:[^/]+\/)?memories(?:\/|$)/,
-    /^viking:\/\/agent\/(?:[^/]+\/)?memories(?:\/|$)/,
+    /^viking:\/\/user\/(?:.*\/)?memories(?:\/|$)/,
+    /^viking:\/\/agent\/(?:.*\/)?memories(?:\/|$)/,
 ];
-const USER_STRUCTURE_DIRS = new Set(["memories"]);
-const AGENT_STRUCTURE_DIRS = new Set(["memories", "skills", "instructions", "workspaces"]);
-function md5Short(input) {
-    return createHash("md5").update(input).digest("hex").slice(0, 12);
-}
 function isMemoryUri(uri) {
     return MEMORY_URI_PATTERNS.some((p) => p.test(uri));
 }
@@ -83,13 +79,15 @@ class OpenVikingClient {
     baseUrl;
     apiKey;
     agentId;
+    account;
+    user;
     timeoutMs;
-    resolvedSpaceByScope = {};
-    runtimeIdentity = null;
-    constructor(baseUrl, apiKey, agentId, timeoutMs) {
+    constructor(baseUrl, apiKey, agentId, account, user, timeoutMs) {
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;
         this.agentId = agentId;
+        this.account = account;
+        this.user = user;
         this.timeoutMs = timeoutMs;
     }
     async request(path, init = {}) {
@@ -101,6 +99,10 @@ class OpenVikingClient {
                 headers.set("X-API-Key", this.apiKey);
             if (this.agentId)
                 headers.set("X-OpenViking-Agent", this.agentId);
+            if (this.account)
+                headers.set("X-OpenViking-Account", this.account);
+            if (this.user)
+                headers.set("X-OpenViking-User", this.user);
             if (init.body && !headers.has("Content-Type"))
                 headers.set("Content-Type", "application/json");
             const response = await fetch(`${this.baseUrl}${path}`, {
@@ -129,81 +131,12 @@ class OpenVikingClient {
             return false;
         }
     }
-    async ls(uri) {
-        return this.request(`/api/v1/fs/ls?uri=${encodeURIComponent(uri)}&output=original`);
-    }
-    async getRuntimeIdentity() {
-        if (this.runtimeIdentity)
-            return this.runtimeIdentity;
-        const fallback = { userId: "default", agentId: this.agentId || "default" };
-        try {
-            const status = await this.request("/api/v1/system/status");
-            const userId = typeof status.user === "string" && status.user.trim() ? status.user.trim() : "default";
-            this.runtimeIdentity = { userId, agentId: this.agentId || "default" };
-            return this.runtimeIdentity;
-        }
-        catch {
-            this.runtimeIdentity = fallback;
-            return fallback;
-        }
-    }
-    async resolveScopeSpace(scope) {
-        const cached = this.resolvedSpaceByScope[scope];
-        if (cached)
-            return cached;
-        const identity = await this.getRuntimeIdentity();
-        const fallbackSpace = scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
-        const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
-        try {
-            const entries = await this.ls(`viking://${scope}`);
-            const spaces = entries
-                .filter((e) => e?.isDir === true)
-                .map((e) => (typeof e.name === "string" ? e.name.trim() : ""))
-                .filter((n) => n && !n.startsWith(".") && !reservedDirs.has(n));
-            if (spaces.length > 0) {
-                if (spaces.includes(fallbackSpace)) {
-                    this.resolvedSpaceByScope[scope] = fallbackSpace;
-                    return fallbackSpace;
-                }
-                if (scope === "user" && spaces.includes("default")) {
-                    this.resolvedSpaceByScope[scope] = "default";
-                    return "default";
-                }
-                if (spaces.length === 1) {
-                    this.resolvedSpaceByScope[scope] = spaces[0];
-                    return spaces[0];
-                }
-            }
-        }
-        catch { /* fall through */ }
-        this.resolvedSpaceByScope[scope] = fallbackSpace;
-        return fallbackSpace;
-    }
-    async normalizeTargetUri(targetUri) {
-        const trimmed = targetUri.trim().replace(/\/+$/, "");
-        const match = trimmed.match(/^viking:\/\/(user|agent)(?:\/(.*))?$/);
-        if (!match)
-            return trimmed;
-        const scope = match[1];
-        const rawRest = (match[2] ?? "").trim();
-        if (!rawRest)
-            return trimmed;
-        const parts = rawRest.split("/").filter(Boolean);
-        if (parts.length === 0)
-            return trimmed;
-        const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
-        if (!reservedDirs.has(parts[0]))
-            return trimmed;
-        const space = await this.resolveScopeSpace(scope);
-        return `viking://${scope}/${space}/${parts.join("/")}`;
-    }
     async find(query, options) {
-        const normalizedTargetUri = await this.normalizeTargetUri(options.targetUri);
         return this.request("/api/v1/search/find", {
             method: "POST",
             body: JSON.stringify({
                 query,
-                target_uri: normalizedTargetUri,
+                target_uri: options.targetUri,
                 limit: options.limit,
                 score_threshold: options.scoreThreshold,
             }),
@@ -369,7 +302,7 @@ async function searchBothScopes(client, query, limit) {
 // ---------------------------------------------------------------------------
 // MCP Server
 // ---------------------------------------------------------------------------
-const client = new OpenVikingClient(config.baseUrl, config.apiKey, config.agentId, config.timeoutMs);
+const client = new OpenVikingClient(config.baseUrl, config.apiKey, config.agentId, config.account, config.user, config.timeoutMs);
 const server = new McpServer({
     name: "openviking-memory",
     version: "0.1.0",

--- a/examples/claude-code-memory-plugin/src/memory-server.ts
+++ b/examples/claude-code-memory-plugin/src/memory-server.ts
@@ -13,7 +13,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { createHash } from "node:crypto";
 
 // ---------------------------------------------------------------------------
 // Types (ported from openclaw-plugin/client.ts)
@@ -35,8 +34,6 @@ type FindResult = {
   skills?: FindResultItem[];
   total?: number;
 };
-
-type ScopeName = "user" | "agent";
 
 // ---------------------------------------------------------------------------
 // Configuration — loaded from ov.conf (shared with OpenClaw plugin).
@@ -90,6 +87,8 @@ const config = {
   baseUrl: `http://${host}:${port}`,
   apiKey: str(serverCfg.root_api_key, ""),
   agentId: str(cc.agentId, "claude-code"),
+  account: str(cc.account, str(file.default_account, "")),
+  user: str(cc.user, str(file.default_user, "")),
   timeoutMs: Math.max(1000, Math.floor(num(cc.timeoutMs, 15000))),
   recallLimit: Math.max(1, Math.floor(num(cc.recallLimit, 6))),
   scoreThreshold: Math.min(1, Math.max(0, num(cc.scoreThreshold, 0.01))),
@@ -100,28 +99,21 @@ const config = {
 // ---------------------------------------------------------------------------
 
 const MEMORY_URI_PATTERNS = [
-  /^viking:\/\/user\/(?:[^/]+\/)?memories(?:\/|$)/,
-  /^viking:\/\/agent\/(?:[^/]+\/)?memories(?:\/|$)/,
+  /^viking:\/\/user\/(?:.*\/)?memories(?:\/|$)/,
+  /^viking:\/\/agent\/(?:.*\/)?memories(?:\/|$)/,
 ];
-const USER_STRUCTURE_DIRS = new Set(["memories"]);
-const AGENT_STRUCTURE_DIRS = new Set(["memories", "skills", "instructions", "workspaces"]);
-
-function md5Short(input: string): string {
-  return createHash("md5").update(input).digest("hex").slice(0, 12);
-}
 
 function isMemoryUri(uri: string): boolean {
   return MEMORY_URI_PATTERNS.some((p) => p.test(uri));
 }
 
 class OpenVikingClient {
-  private resolvedSpaceByScope: Partial<Record<ScopeName, string>> = {};
-  private runtimeIdentity: { userId: string; agentId: string } | null = null;
-
   constructor(
     private readonly baseUrl: string,
     private readonly apiKey: string,
     private readonly agentId: string,
+    private readonly account: string,
+    private readonly user: string,
     private readonly timeoutMs: number,
   ) {}
 
@@ -132,6 +124,8 @@ class OpenVikingClient {
       const headers = new Headers(init.headers ?? {});
       if (this.apiKey) headers.set("X-API-Key", this.apiKey);
       if (this.agentId) headers.set("X-OpenViking-Agent", this.agentId);
+      if (this.account) headers.set("X-OpenViking-Account", this.account);
+      if (this.user) headers.set("X-OpenViking-User", this.user);
       if (init.body && !headers.has("Content-Type")) headers.set("Content-Type", "application/json");
 
       const response = await fetch(`${this.baseUrl}${path}`, {
@@ -166,92 +160,15 @@ class OpenVikingClient {
     }
   }
 
-  private async ls(uri: string): Promise<Array<Record<string, unknown>>> {
-    return this.request<Array<Record<string, unknown>>>(
-      `/api/v1/fs/ls?uri=${encodeURIComponent(uri)}&output=original`,
-    );
-  }
-
-  private async getRuntimeIdentity(): Promise<{ userId: string; agentId: string }> {
-    if (this.runtimeIdentity) return this.runtimeIdentity;
-    const fallback = { userId: "default", agentId: this.agentId || "default" };
-    try {
-      const status = await this.request<{ user?: unknown }>("/api/v1/system/status");
-      const userId =
-        typeof status.user === "string" && status.user.trim() ? status.user.trim() : "default";
-      this.runtimeIdentity = { userId, agentId: this.agentId || "default" };
-      return this.runtimeIdentity;
-    } catch {
-      this.runtimeIdentity = fallback;
-      return fallback;
-    }
-  }
-
-  private async resolveScopeSpace(scope: ScopeName): Promise<string> {
-    const cached = this.resolvedSpaceByScope[scope];
-    if (cached) return cached;
-
-    const identity = await this.getRuntimeIdentity();
-    const fallbackSpace =
-      scope === "user" ? identity.userId : md5Short(`${identity.userId}:${identity.agentId}`);
-    const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
-
-    try {
-      const entries = await this.ls(`viking://${scope}`);
-      const spaces = entries
-        .filter((e) => e?.isDir === true)
-        .map((e) => (typeof e.name === "string" ? e.name.trim() : ""))
-        .filter((n) => n && !n.startsWith(".") && !reservedDirs.has(n));
-
-      if (spaces.length > 0) {
-        if (spaces.includes(fallbackSpace)) {
-          this.resolvedSpaceByScope[scope] = fallbackSpace;
-          return fallbackSpace;
-        }
-        if (scope === "user" && spaces.includes("default")) {
-          this.resolvedSpaceByScope[scope] = "default";
-          return "default";
-        }
-        if (spaces.length === 1) {
-          this.resolvedSpaceByScope[scope] = spaces[0]!;
-          return spaces[0]!;
-        }
-      }
-    } catch { /* fall through */ }
-
-    this.resolvedSpaceByScope[scope] = fallbackSpace;
-    return fallbackSpace;
-  }
-
-  private async normalizeTargetUri(targetUri: string): Promise<string> {
-    const trimmed = targetUri.trim().replace(/\/+$/, "");
-    const match = trimmed.match(/^viking:\/\/(user|agent)(?:\/(.*))?$/);
-    if (!match) return trimmed;
-
-    const scope = match[1] as ScopeName;
-    const rawRest = (match[2] ?? "").trim();
-    if (!rawRest) return trimmed;
-
-    const parts = rawRest.split("/").filter(Boolean);
-    if (parts.length === 0) return trimmed;
-
-    const reservedDirs = scope === "user" ? USER_STRUCTURE_DIRS : AGENT_STRUCTURE_DIRS;
-    if (!reservedDirs.has(parts[0]!)) return trimmed;
-
-    const space = await this.resolveScopeSpace(scope);
-    return `viking://${scope}/${space}/${parts.join("/")}`;
-  }
-
   async find(
     query: string,
     options: { targetUri: string; limit: number; scoreThreshold?: number },
   ): Promise<FindResult> {
-    const normalizedTargetUri = await this.normalizeTargetUri(options.targetUri);
     return this.request<FindResult>("/api/v1/search/find", {
       method: "POST",
       body: JSON.stringify({
         query,
-        target_uri: normalizedTargetUri,
+        target_uri: options.targetUri,
         limit: options.limit,
         score_threshold: options.scoreThreshold,
       }),
@@ -441,7 +358,14 @@ async function searchBothScopes(
 // MCP Server
 // ---------------------------------------------------------------------------
 
-const client = new OpenVikingClient(config.baseUrl, config.apiKey, config.agentId, config.timeoutMs);
+const client = new OpenVikingClient(
+  config.baseUrl,
+  config.apiKey,
+  config.agentId,
+  config.account,
+  config.user,
+  config.timeoutMs,
+);
 
 const server = new McpServer({
   name: "openviking-memory",


### PR DESCRIPTION
## Summary

- Stop the Claude Code memory plugin from canonicalizing shorthand `viking://user/...` and `viking://agent/...` target URIs before search.
- Let the OpenViking server resolve those shorthand scopes from request context.
- Pass configured account and user identity headers from hook scripts and the MCP server.

## Why

The plugin was trying to infer concrete user and agent storage paths on the client side. In multi-account or multi-agent setups, that can produce paths that do not exist or do not match the server-side tenant context.

The server already owns URI scope resolution and has the correct request context. Keeping shorthand target URIs intact avoids duplicating that logic in the plugin.

Tenant-scoped OpenViking APIs also require account and user identity headers. Without those headers, requests can fail even when the plugin has the correct API key and agent id.

## Validation

- `npm run build`
- `node --check scripts/auto-recall.mjs`
- `node --check scripts/debug-recall.mjs`
- `node --check scripts/auto-capture.mjs`
- `node --check scripts/debug-capture.mjs`
- `node --check servers/memory-server.js`
