### PR TITLE
docs(mcp): add OAuth 2.1 roadmap and MCP-Key2OAuth disclaimer

### DIFF
--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -80,15 +80,29 @@ Add `--scope user` to make the config global (shared across all projects).
 
 ### Claude.ai / Claude Desktop (OAuth Proxy)
 
-Claude.ai and Claude Desktop Connector require MCP servers to use OAuth authentication — API Keys cannot be passed directly. Use [MCP-Key2OAuth](https://mcp.767911.xyz/) to proxy API Key auth as an OAuth flow:
+Claude.ai and Claude Desktop Connector require MCP servers to use OAuth 2.1 authentication — API Keys cannot be passed directly.
 
-1. Visit https://mcp.767911.xyz/
+#### Official OAuth Support (Planned)
+
+We are evaluating built-in OAuth 2.1 authorization endpoints for `openviking-server`. The initial design includes:
+
+- **OTP Authorization**: Obtain a one-time passcode via CLI (`ov otp`) or REST API, then enter it on the OAuth authorization page — no external dependencies required
+- **Console Quick-Auth**: Leverage the Web Console (port 8020) same-origin session for one-click authorization
+- **Third-party Login**: Optional delegated login via GitHub / Google or other IdPs
+
+These approaches are currently in design review; implementation timeline is TBD.
+
+#### Current Workaround: MCP-Key2OAuth (Community Project)
+
+Until official OAuth support is available, the community project [MCP-Key2OAuth](https://github.com/t0saki/MCP-Key2OAuth) can proxy API Key auth as an OAuth flow:
+
+1. Follow the project README to self-host the proxy (Cloudflare Workers)
 2. Enter your OpenViking MCP server URL (e.g., `https://your-server.com/mcp`)
 3. Generate the proxied URL
 4. In Claude.ai / Claude Desktop, enter the generated URL — it will redirect to the proxy for auth
 5. After authorization, MCP tools are available
 
-> ⚠️ MCP-Key2OAuth is a community project. OpenViking does not guarantee its security.
+> ⚠️ **Disclaimer:** MCP-Key2OAuth is a third-party community-maintained project. The OpenViking team makes no guarantees regarding its security, availability, or data handling. Please assess the risks before use. If you have concerns, consider waiting for the official OAuth implementation or deploying your own proxy.
 
 
 ## Available MCP Tools

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -80,15 +80,29 @@ claude mcp add --transport http openviking \
 
 ### Claude.ai / Claude Desktop（OAuth 代理鉴权）
 
-Claude.ai 和 Claude Desktop Connector 强制要求 MCP 服务器使用 OAuth 鉴权，无法直接传入 API Key。可借助 [MCP-Key2OAuth](https://mcp.767911.xyz/) 将 API Key 认证代理为 OAuth 流程：
+Claude.ai 和 Claude Desktop Connector 强制要求 MCP 服务器使用 OAuth 2.1 鉴权，无法直接传入 API Key。
 
-1. 访问 https://mcp.767911.xyz/
+#### 官方 OAuth 支持（规划中）
+
+我们正在考虑在 `openviking-server` 中内置 OAuth 2.1 授权端点，初步方案包括：
+
+- **OTP 授权**：通过 CLI (`ov otp`) 或 REST API 获取一次性口令，在 OAuth 授权页面输入完成认证，无需外部依赖
+- **Console 快捷授权**：利用 Web Console (8020) 同源 session 实现一键授权
+- **第三方登录**：可选的 GitHub / Google 等 IdP 委托登录
+
+上述方案尚在设计评审阶段，实现时间待定。
+
+#### 当前可用方案：MCP-Key2OAuth（社区项目）
+
+在官方 OAuth 实现就绪之前，可以借助社区项目 [MCP-Key2OAuth](https://github.com/t0saki/MCP-Key2OAuth) 将 API Key 认证代理为 OAuth 流程：
+
+1. 参照项目 README 自行部署代理服务（Cloudflare Workers）
 2. 填入你的 OpenViking MCP 服务器 URL（如 `https://your-server.com/mcp`）
 3. 生成代理后的新 URL
 4. 在 Claude.ai / Claude Desktop 中填入生成的新 URL，连接时会跳转至代理站进行鉴权
 5. 授权完成后即可正常使用
 
-> ⚠️ MCP-Key2OAuth 为社区项目，OpenViking 不保证其安全性。
+> ⚠️ **免责声明：** MCP-Key2OAuth 为社区维护的第三方项目，OpenViking 团队不对其安全性、可用性或数据处理方式做任何保证。使用前请自行评估风险。如有顾虑，建议等待官方 OAuth 实现或自行搭建代理。
 
 
 ## 可用的 MCP 工具


### PR DESCRIPTION
## Description

Update MCP integration docs (zh + en) to document the OAuth 2.1 authentication roadmap for platforms that require it (Claude.ai, Claude Desktop), and clarify the status of the community MCP-Key2OAuth proxy.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add "Official OAuth Support (Planned)" subsection with three approaches under evaluation:
  - **OTP Authorization**: CLI / REST API one-time passcode, zero external dependencies
  - **Console Quick-Auth**: Web Console same-origin session for one-click auth
  - **Third-party Login**: Optional GitHub / Google IdP delegation
- Reframe MCP-Key2OAuth as "Current Workaround (Community Project)" with strengthened disclaimer (no security/availability/data-handling guarantee from OpenViking)
- Replace hosted demo URL (`mcp.767911.xyz`) with self-deployment instruction per project README
- Both `docs/zh/guides/06-mcp-integration.md` and `docs/en/guides/06-mcp-integration.md` updated symmetrically

## Testing

- [ ] N/A (documentation only)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published