### PR TITLE
fix(docs): deploy docs on PR merge to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: 17. Docs
 
 on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/_docs.yml'
+      - '.github/workflows/_docs-deploy.yml'
+      - '.github/workflows/docs.yml'
   push:
     branches: [ main ]
     paths:
@@ -14,9 +20,16 @@ permissions:
   contents: read
 
 jobs:
+  docs-check:
+    name: Build Docs
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/_docs.yml
+    permissions:
+      contents: read
+
   docs-deploy:
     name: Build and Deploy Docs
-    if: github.repository == 'volcengine/OpenViking'
+    if: github.repository == 'volcengine/OpenViking' && github.event_name != 'pull_request'
     uses: ./.github/workflows/_docs-deploy.yml
     permissions:
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,8 @@
 name: 17. Docs
 
 on:
-  pull_request:
+  push:
+    branches: [ main ]
     paths:
       - 'docs/**'
       - '.github/workflows/_docs.yml'
@@ -13,8 +14,11 @@ permissions:
   contents: read
 
 jobs:
-  docs-check:
-    name: Build Docs
-    uses: ./.github/workflows/_docs.yml
+  docs-deploy:
+    name: Build and Deploy Docs
+    if: github.repository == 'volcengine/OpenViking'
+    uses: ./.github/workflows/_docs-deploy.yml
     permissions:
       contents: read
+      pages: write
+      id-token: write


### PR DESCRIPTION
## Summary
- Restore `push` trigger on `main` branch so docs auto-deploy when PRs touching `docs/` are merged
- Replace build-only `docs-check` job with `docs-deploy` (build + deploy to GitHub Pages)
- The push trigger and deploy job were accidentally removed in #1778

## Test plan
- [ ] Merge this PR and verify the workflow triggers on the push event
- [ ] Confirm docs are deployed to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)