### PR TITLE
fix(ci): remove duplicate docs deploy from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,11 +376,3 @@ jobs:
             fi
           done <<< "$SOURCE_TAGS"
 
-  deploy-docs:
-    name: Build and Deploy Docs
-    if: github.event_name == 'release'
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    uses: ./.github/workflows/_docs-deploy.yml


### PR DESCRIPTION
## Summary
- Remove the `deploy-docs` job from `release.yml` that was failing with _"Tag 'v0.3.13' is not allowed to deploy to github-pages due to environment protection rules"_
- The job ran on `release` events where `GITHUB_REF` is a tag, but `github-pages` environment only allows deployments from the `main` branch
- This was redundant — `docs.yml` already deploys docs on push to `main`

## Test plan
- [x] Verify `docs.yml` still triggers on push to `main` with docs path changes
- [ ] Next release should no longer produce a failed docs deploy job

🤖 Generated with [Claude Code](https://claude.com/claude-code)