### PR TITLE
fix(docker): bind server to 0.0.0.0 so Docker port-mapping works

### DIFF
--- a/docker/openviking-console-entrypoint.sh
+++ b/docker/openviking-console-entrypoint.sh
@@ -106,10 +106,12 @@ forward_signal() {
 
 trap 'forward_signal' INT TERM
 
+SERVER_HOST="${OPENVIKING_SERVER_HOST:-0.0.0.0}"
+
 if [ "${WITH_BOT}" = "1" ]; then
-    openviking-server --with-bot &
+    openviking-server --host "${SERVER_HOST}" --with-bot &
 else
-    openviking-server &
+    openviking-server --host "${SERVER_HOST}" &
 fi
 SERVER_PID=$!
 

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -197,9 +197,21 @@ docker run -d \
 ```
 
 By default, the Docker image starts:
-- OpenViking HTTP service on port `1933`
+- OpenViking HTTP service on port `1933` (bound to `0.0.0.0`)
 - OpenViking Console on port `8020`
 - `vikingbot` gateway
+
+Since the server binds to `0.0.0.0` inside the container (required for Docker port-mapping to work), you **must** set `root_api_key` in your `ov.conf`:
+
+```json
+{
+  "server": {
+    "root_api_key": "your-secret-root-key"
+  }
+}
+```
+
+The server will refuse to start without it. You can override the bind address via the `OPENVIKING_SERVER_HOST` environment variable if needed.
 
 Upgrade the container:
 ```bash

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -195,9 +195,21 @@ docker run -d \
 ```
 
 Docker 镜像默认会同时启动：
-- OpenViking HTTP 服务，端口 `1933`
+- OpenViking HTTP 服务，端口 `1933`（绑定 `0.0.0.0`）
 - OpenViking Console，端口 `8020`
 - `vikingbot` gateway
+
+由于容器内服务绑定 `0.0.0.0`（Docker 端口映射所必需），你**必须**在 `ov.conf` 中设置 `root_api_key`：
+
+```json
+{
+  "server": {
+    "root_api_key": "your-secret-root-key"
+  }
+}
+```
+
+未设置时服务将拒绝启动。如需自定义绑定地址，可通过环境变量 `OPENVIKING_SERVER_HOST` 覆盖。
 
 升级容器的方式
 ```bash


### PR DESCRIPTION
## Summary
- Docker entrypoint now passes `--host 0.0.0.0` to `openviking-server`, fixing the issue where the default `127.0.0.1` binding made the server unreachable from outside the container via `docker -p` port-mapping
- Added `OPENVIKING_SERVER_HOST` env var to allow overriding the bind address
- Updated en/zh deployment docs to document the `root_api_key` requirement for Docker (enforced by existing `validate_server_config`)

## Test plan
- [ ] `docker run` with `root_api_key` set in `ov.conf` → server starts and is reachable via mapped port
- [ ] `docker run` without `root_api_key` → server refuses to start with clear error message
- [ ] `OPENVIKING_SERVER_HOST=127.0.0.1` overrides the default `0.0.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)