### PR TITLE
fix(retrieval): restore score_propagation_alpha default to 0.5

### DIFF
--- a/openviking_cli/utils/config/retrieval_config.py
+++ b/openviking_cli/utils/config/retrieval_config.py
@@ -17,13 +17,14 @@ class RetrievalConfig(BaseModel):
         ),
     )
     score_propagation_alpha: float = Field(
-        default=0.0,
+        default=0.5,
         ge=0.0,
         le=1.0,
         description=(
             "Weight for each child result's own score when blending with its parent score "
-            "during hierarchical retrieval. 0 uses only the parent score; "
-            "1 uses only the child score."
+            "during hierarchical retrieval. 0.5 keeps the historic equal blend "
+            "(matches the pre-refactor SCORE_PROPAGATION_ALPHA constant); "
+            "0 uses only the parent score; 1 uses only the child score."
         ),
     )
 


### PR DESCRIPTION
## Summary

#1770 refactored the hardcoded `SCORE_PROPAGATION_ALPHA = 0.5` constant in `openviking/retrieve/hierarchical_retriever.py` into a new `RetrievalConfig` field, but set the field default to `0.0` instead of `0.5`. With the existing formula

```python
final_score = alpha * embedding_score + (1 - alpha) * parent_score
```

a default of `0.0` silently drops every child's own embedding score and keeps only the propagated parent score, changing default ranking behavior for any caller that does not configure a `retrieval` block.

The same PR's docs and example config all state the default is `0.5`:

- `README.md` — `"score_propagation_alpha": 0.5`
- `docs/en/guides/01-configuration.md` — `score_propagation_alpha ... | Default | 0.5 | "0.5 keeps the existing equal blend"`
- `docs/zh/guides/01-configuration.md` — `score_propagation_alpha ... | 默认值 | 0.5 | 0.5 保持当前 50/50 行为`
- `docs/en/concepts/07-retrieval.md` — table: `retrieval.score_propagation_alpha | 0.5 | 50% embedding + 50% parent`
- `docs/zh/concepts/07-retrieval.md` — same
- `examples/ov.conf.example` — `"score_propagation_alpha": 0.5`

Restoring the field default to `0.5` aligns the shipped code with the documented and pre-refactor behavior. The field description is also updated to reference the historical constant so future readers see the link.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## How verified

- Read `RetrievalConfig` field default vs. the documentation tables added in #1770; confirmed mismatch.
- Confirmed `_recursive_search` uses `alpha = self.score_propagation_alpha` and `final_score = alpha * embedding_score + (1 - alpha) * parent_score`, so `alpha = 0.0` reduces every node's final score to its parent's score.
- Confirmed pre-refactor `HierarchicalRetriever` carried `SCORE_PROPAGATION_ALPHA = 0.5`, so `0.5` is the historical default we want to restore.

## Notes

`hotness_alpha` default = `0.0` is intentional (matches docs and the explicit "disable boost by default" wording), so this PR only touches `score_propagation_alpha`.