### PR TITLE
feat(observability): support header param while OTLP export

### DIFF
--- a/docs/en/concepts/12-metrics.md
+++ b/docs/en/concepts/12-metrics.md
@@ -379,6 +379,7 @@ Key fields:
 - `server.observability.metrics.exporters.otel.endpoint`: OTLP endpoint (for gRPC, use `host:4317`; for HTTP, use a full URL)
 - `server.observability.metrics.exporters.otel.service_name`: OTLP `service.name` resource attribute (default `"openviking-server"`)
 - `server.observability.metrics.exporters.otel.export_interval_ms`: OTLP push interval in milliseconds (default `10000`)
+- `server.observability.metrics.exporters.otel.headers`: optional custom OTLP headers; sent as gRPC metadata for gRPC and HTTP headers for HTTP
 
 Example:
 
@@ -400,7 +401,8 @@ Example:
             },
             "endpoint": "otel-collector:4317",
             "service_name": "openviking-server",
-            "export_interval_ms": 10000
+            "export_interval_ms": 10000,
+            "headers": {}
           }
         }
       }

--- a/docs/en/guides/05-observability.md
+++ b/docs/en/guides/05-observability.md
@@ -298,7 +298,8 @@ Example:
             },
             "endpoint": "otel-collector:4317",
             "service_name": "openviking-server",
-            "export_interval_ms": 10000
+            "export_interval_ms": 10000,
+            "headers": {}
           }
         }
       },
@@ -309,7 +310,8 @@ Example:
           "insecure": true
         },
         "endpoint": "otel-collector:4317",
-        "service_name": "openviking-server"
+        "service_name": "openviking-server",
+        "headers": {}
       },
       "logs": {
         "enabled": true,
@@ -318,12 +320,19 @@ Example:
           "insecure": true
         },
         "endpoint": "otel-collector:4317",
-        "service_name": "openviking-server"
+        "service_name": "openviking-server",
+        "headers": {}
       }
     }
   }
 }
 ```
+
+Notes:
+
+- `headers` forwards custom OTLP request headers or gRPC metadata to the exporter.
+- This is useful when an OTLP backend requires extra auth headers for direct ingestion.
+- The `headers` shape is the same across `traces`, `logs`, and `metrics.exporters.otel`.
 
 For full fields, supported ranges, and more examples, see:
 

--- a/docs/zh/concepts/12-metrics.md
+++ b/docs/zh/concepts/12-metrics.md
@@ -382,6 +382,7 @@ scrape_configs:
 - `server.observability.metrics.exporters.otel.endpoint`：OTLP 端点（gRPC 用 `host:4317`；HTTP 必须是完整 URL）
 - `server.observability.metrics.exporters.otel.service_name`：OTLP `service.name` 资源属性（默认 `"openviking-server"`）
 - `server.observability.metrics.exporters.otel.export_interval_ms`：OTLP 推送间隔，单位毫秒（默认 `10000`）
+- `server.observability.metrics.exporters.otel.headers`：可选的自定义 OTLP 请求头；gRPC 会作为 metadata 发送，HTTP 会作为 headers 发送
 
 示例：
 
@@ -403,7 +404,8 @@ scrape_configs:
             },
             "endpoint": "otel-collector:4317",
             "service_name": "openviking-server",
-            "export_interval_ms": 10000
+            "export_interval_ms": 10000,
+            "headers": {}
           }
         }
       }

--- a/docs/zh/guides/05-observability.md
+++ b/docs/zh/guides/05-observability.md
@@ -297,7 +297,8 @@ OpenViking 将信号级别的可观测性配置统一放在 `server.observabilit
             },
             "endpoint": "otel-collector:4317",
             "service_name": "openviking-server",
-            "export_interval_ms": 10000
+            "export_interval_ms": 10000,
+            "headers": {}
           }
         }
       },
@@ -308,7 +309,8 @@ OpenViking 将信号级别的可观测性配置统一放在 `server.observabilit
           "insecure": true
         },
         "endpoint": "otel-collector:4317",
-        "service_name": "openviking-server"
+        "service_name": "openviking-server",
+        "headers": {}
       },
       "logs": {
         "enabled": true,
@@ -317,12 +319,19 @@ OpenViking 将信号级别的可观测性配置统一放在 `server.observabilit
           "insecure": true
         },
         "endpoint": "otel-collector:4317",
-        "service_name": "openviking-server"
+        "service_name": "openviking-server",
+        "headers": {}
       }
     }
   }
 }
 ```
+
+说明：
+
+- `headers` 用于给 OTLP exporter 透传自定义请求头或 gRPC metadata。
+- 常见场景包括直连需要额外鉴权头的 OTLP 后端；请只配置 header key/value，不要把敏感值写入日志或截图中。
+- 对 `traces`、`logs` 和 `metrics.exporters.otel` 三条链路，`headers` 的配置方式保持一致。
 
 完整字段、支持范围和更多示例见：
 
@@ -425,4 +434,3 @@ OpenViking 仓库里已经提供了可直接导入的 dashboard JSON：
 - [操作级 Telemetry 参考](07-operation-telemetry.md) - 请求级结构化追踪
 - [系统 API](../api/07-system.md) - 系统与 observer 接口参考
 - [指标](../concepts/12-metrics.md) - 时序指标与配置
-

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -26,7 +26,8 @@
                     },
                     "endpoint": "localhost:4317",
                     "service_name": "openviking-server",
-                    "export_interval_ms": 10000
+                    "export_interval_ms": 10000,
+                    "headers": {}
                 }
             }
         },
@@ -37,7 +38,8 @@
                 "insecure": false
             },
             "endpoint": "localhost:4317",
-            "service_name": "openviking-server"
+            "service_name": "openviking-server",
+            "headers": {}
         },
         "logs": {
             "enabled": false,
@@ -46,7 +48,8 @@
                 "insecure": false
             },
             "endpoint": "localhost:4317",
-            "service_name": "openviking-server"
+            "service_name": "openviking-server",
+            "headers": {}
         }
     }
   },

--- a/openviking/metrics/exporters/otel.py
+++ b/openviking/metrics/exporters/otel.py
@@ -121,6 +121,7 @@ class OTelMetricExporter(MetricExporter):
         service_name: str = "openviking-server",
         export_interval_ms: int = 10000,
         export_timeout_seconds: Optional[float] = None,
+        headers: Optional[dict[str, str]] = None,
         enabled: bool = True,
     ) -> None:
         """
@@ -136,6 +137,7 @@ class OTelMetricExporter(MetricExporter):
             service_name: Service name written into OTLP resource attributes.
             export_interval_ms: Periodic export interval in milliseconds.
             export_timeout_seconds: Transport timeout for one OTLP export request.
+            headers: Additional OTLP exporter headers for vendor-specific auth.
             enabled: Whether the exporter is enabled.
         """
         self._registry = registry
@@ -145,6 +147,7 @@ class OTelMetricExporter(MetricExporter):
         self._insecure = bool(insecure)
         self._endpoint = endpoint
         self._service_name = service_name
+        self._headers = {str(key): str(value) for key, value in (headers or {}).items()}
         self._export_interval_ms = max(1000, int(export_interval_ms))
         self._export_timeout_seconds = float(
             export_timeout_seconds
@@ -591,10 +594,13 @@ class OTelMetricExporter(MetricExporter):
         if self._http_session is None:
             return
         payload = request.SerializeToString()
+        request_headers = {"Content-Type": "application/x-protobuf"}
+        if self._headers:
+            request_headers.update(self._headers)
         self._http_session.post(
             self._endpoint,
             data=payload,
-            headers={"Content-Type": "application/x-protobuf"},
+            headers=request_headers,
             timeout=self._export_timeout_seconds,
         ).raise_for_status()
 
@@ -607,7 +613,15 @@ class OTelMetricExporter(MetricExporter):
         """
         if self._grpc_stub is None:
             return
-        self._grpc_stub.Export(request, timeout=self._export_timeout_seconds)
+        metadata = list(self._headers.items()) if self._headers else None
+        if metadata:
+            self._grpc_stub.Export(
+                request,
+                timeout=self._export_timeout_seconds,
+                metadata=metadata,
+            )
+        else:
+            self._grpc_stub.Export(request, timeout=self._export_timeout_seconds)
 
     def start(self) -> None:
         """

--- a/openviking/metrics/global_api.py
+++ b/openviking/metrics/global_api.py
@@ -174,6 +174,7 @@ def init_metrics_from_server_config(
                 endpoint=exporters_config.otel.endpoint,
                 service_name=exporters_config.otel.service_name,
                 export_interval_ms=exporters_config.otel.export_interval_ms,
+                headers=exporters_config.otel.headers,
                 enabled=True,
             )
             otel_exporter.start()

--- a/openviking/observability/context.py
+++ b/openviking/observability/context.py
@@ -259,6 +259,28 @@ def reset_observability_context(token: contextvars.Token) -> None:
     _OBSERVABILITY_CONTEXT.reset(token)
 
 
+def _clone_observability_context(ctx: Optional[ObservabilityContext]) -> ObservabilityContext:
+    """
+    Clone the current observability context.
+
+    Note:
+        ContextVars restore by object reference. If we mutate the existing context
+        in-place and then call `set()`, a later `reset(token)` would restore the
+        same mutated object, breaking the expected reset semantics.
+    """
+    if ctx is None:
+        return ObservabilityContext()
+
+    # Shallow copy: span attribute objects are treated as immutable snapshots.
+    return ObservabilityContext(
+        root=ctx.root,
+        operation=ctx.operation,
+        execution_trace_id=ctx.execution_trace_id,
+        execution_span_id=ctx.execution_span_id,
+        extra=dict(ctx.extra),
+    )
+
+
 def bind_root_context(root_attrs: RootSpanAttributes) -> contextvars.Token:
     """
     Bind root context for HTTP requests.
@@ -269,7 +291,8 @@ def bind_root_context(root_attrs: RootSpanAttributes) -> contextvars.Token:
     Returns:
         A token that can be used to reset the context.
     """
-    ctx = get_observability_context()
+    current = _OBSERVABILITY_CONTEXT.get()
+    ctx = _clone_observability_context(current)
     ctx.bind_root(root_attrs)
     return set_observability_context(ctx)
 
@@ -284,7 +307,8 @@ def bind_operation_context(operation_attrs: OperationSpanAttributes) -> contextv
     Returns:
         A token that can be used to reset the context.
     """
-    ctx = get_observability_context()
+    current = _OBSERVABILITY_CONTEXT.get()
+    ctx = _clone_observability_context(current)
     ctx.bind_operation(operation_attrs)
     return set_observability_context(ctx)
 

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -3,7 +3,7 @@
 """Server configuration for OpenViking HTTP Server."""
 
 import sys
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field, ValidationError
 
@@ -59,6 +59,7 @@ class OTelExporterConfig(BaseModel):
     endpoint: str = "localhost:4317"  # gRPC default: 4317; HTTP default: 4318
     service_name: str = "openviking-server"
     export_interval_ms: int = 10000
+    headers: Dict[str, str] = Field(default_factory=dict)
 
     model_config = {"extra": "forbid"}
 

--- a/openviking/telemetry/tracer.py
+++ b/openviking/telemetry/tracer.py
@@ -118,6 +118,7 @@ def init_tracer_from_server_config(server_config: Any) -> Any:
             service_name=trace_cfg.service_name,
             protocol=trace_cfg.protocol,
             insecure=trace_cfg.tls.insecure,
+            headers=trace_cfg.headers,
             enabled=trace_cfg.enabled,
         )
     except Exception as e:
@@ -143,6 +144,7 @@ def init_tracer(
     service_name: str,
     protocol: str = "grpc",
     insecure: bool = False,
+    headers: Optional[dict[str, str]] = None,
     enabled: bool = True,
 ) -> Any:
     """Initialize the OpenTelemetry tracer.
@@ -152,6 +154,7 @@ def init_tracer(
         service_name: Service name for tracing
         protocol: OTLP protocol ("grpc" or "http")
         insecure: For OTLP/gRPC only. When True, use plaintext instead of TLS.
+        headers: Additional OTLP exporter headers for vendor-specific auth.
         enabled: Whether to enable tracing
 
     Returns:
@@ -171,6 +174,7 @@ def init_tracer(
         return None
 
     try:
+        normalized_headers = {str(key): str(value) for key, value in (headers or {}).items()}
         resource_attributes = {
             "service.name": service_name,
         }
@@ -184,10 +188,12 @@ def init_tracer(
                 trace_exporter = OTLPGrpcSpanExporter(
                     endpoint=endpoint,
                     insecure=insecure,
+                    headers=normalized_headers,
                 )
             except TypeError:
                 trace_exporter = OTLPGrpcSpanExporter(
                     endpoint=endpoint,
+                    headers=normalized_headers,
                 )
         elif protocol == "http":
             if OTLPHttpSpanExporter is None:
@@ -198,6 +204,7 @@ def init_tracer(
                 )
             trace_exporter = OTLPHttpSpanExporter(
                 endpoint=endpoint,
+                headers=normalized_headers,
             )
         else:
             raise ValueError(f"Unsupported trace protocol: {protocol}")

--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -234,6 +234,7 @@ def init_otel_log_handler(
     endpoint: str = "localhost:4317",  # gRPC default: 4317; HTTP default: 4318
     service_name: str = "openviking-server",
     insecure: bool = False,
+    headers: Optional[dict[str, str]] = None,
     enabled: bool = True,
 ) -> Any:
     """Initialize OTel LoggingHandler.
@@ -243,6 +244,7 @@ def init_otel_log_handler(
         endpoint: OTLP logs endpoint.
         service_name: Service name.
         insecure: For OTLP/gRPC only. When True, use plaintext instead of TLS.
+        headers: Additional OTLP exporter headers for vendor-specific auth.
         enabled: Whether to enable the handler.
 
     Returns:
@@ -271,6 +273,7 @@ def init_otel_log_handler(
         return None
 
     try:
+        normalized_headers = {str(key): str(value) for key, value in (headers or {}).items()}
         # Create resource
         resource = Resource.create(
             {
@@ -287,9 +290,16 @@ def init_otel_log_handler(
             if OTLPGrpcLogExporter is None:
                 raise ImportError("gRPC OTLP log exporter not available")
             try:
-                otlp_exporter = OTLPGrpcLogExporter(endpoint=endpoint, insecure=insecure)
+                otlp_exporter = OTLPGrpcLogExporter(
+                    endpoint=endpoint,
+                    insecure=insecure,
+                    headers=normalized_headers,
+                )
             except TypeError:
-                otlp_exporter = OTLPGrpcLogExporter(endpoint=endpoint)
+                otlp_exporter = OTLPGrpcLogExporter(
+                    endpoint=endpoint,
+                    headers=normalized_headers,
+                )
         elif protocol == "http":
             if OTLPHttpLogExporter is None:
                 raise ImportError("HTTP OTLP log exporter not available")
@@ -298,7 +308,10 @@ def init_otel_log_handler(
                 raise ValueError(
                     "OTLP/HTTP endpoint must include scheme, e.g. 'http://localhost:4318/v1/logs'"
                 )
-            otlp_exporter = OTLPHttpLogExporter(endpoint=endpoint)
+            otlp_exporter = OTLPHttpLogExporter(
+                endpoint=endpoint,
+                headers=normalized_headers,
+            )
 
         if otlp_exporter is None:
             raise ValueError(f"Failed to create log exporter for protocol={protocol}")
@@ -356,6 +369,7 @@ def init_otel_log_handler_from_server_config(server_config: Any) -> Any:
         endpoint=logs_cfg.endpoint,
         service_name=logs_cfg.service_name,
         insecure=logs_cfg.tls.insecure,
+        headers=logs_cfg.headers,
         enabled=logs_cfg.enabled,
     )
     attach_otel_log_handler_to_existing_loggers()

--- a/tests/metrics/core/test_exporter.py
+++ b/tests/metrics/core/test_exporter.py
@@ -95,3 +95,73 @@ def test_otel_http_send_uses_export_timeout_not_refresh_deadline(registry):
     exporter._send_http_request(ExportMetricsServiceRequest())
 
     assert fake_session.timeout == 5.0
+
+
+def test_otel_http_send_forwards_custom_headers(registry):
+    """HTTP transport should merge vendor auth headers with protobuf content type."""
+    exporter = OTelMetricExporter(
+        registry=registry,
+        enabled=False,
+        protocol="http",
+        endpoint="https://apmplus-cn-beijing.ivolces.com/api/otlp/v1/metrics",
+        headers={"X-ByteAPM-AppKey": "metric-appkey"},
+    )
+
+    class _FakeSession:
+        def __init__(self):
+            self.headers = None
+
+        def post(self, _url, **kwargs):
+            self.headers = kwargs.get("headers")
+
+            class _Resp:
+                @staticmethod
+                def raise_for_status():
+                    return None
+
+            return _Resp()
+
+    exporter._http_session = _FakeSession()
+
+    from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+        ExportMetricsServiceRequest,
+    )
+
+    exporter._send_http_request(ExportMetricsServiceRequest())
+
+    assert exporter._http_session.headers == {
+        "Content-Type": "application/x-protobuf",
+        "X-ByteAPM-AppKey": "metric-appkey",
+    }
+
+
+def test_otel_grpc_send_forwards_custom_metadata(registry):
+    """gRPC transport should forward vendor auth headers as metadata pairs."""
+    exporter = OTelMetricExporter(
+        registry=registry,
+        enabled=False,
+        protocol="grpc",
+        endpoint="apmplus-cn-beijing.ivolces.com:4317",
+        headers={"X-ByteAPM-AppKey": "metric-appkey"},
+    )
+
+    class _FakeStub:
+        def __init__(self):
+            self.metadata = None
+            self.timeout = None
+
+        def Export(self, _request, **kwargs):
+            self.metadata = kwargs.get("metadata")
+            self.timeout = kwargs.get("timeout")
+            return None
+
+    exporter._grpc_stub = _FakeStub()
+
+    from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+        ExportMetricsServiceRequest,
+    )
+
+    exporter._send_grpc_request(ExportMetricsServiceRequest())
+
+    assert exporter._grpc_stub.metadata == [("X-ByteAPM-AppKey", "metric-appkey")]
+    assert exporter._grpc_stub.timeout == 5.0

--- a/tests/server/test_prometheus_metrics.py
+++ b/tests/server/test_prometheus_metrics.py
@@ -236,6 +236,48 @@ def test_reinitializing_metrics_shuts_down_existing_exporters(monkeypatch):
     shutdown_metrics(app=None)
 
 
+def test_metrics_otel_exporter_receives_headers_from_server_config(monkeypatch):
+    class FakeOTelExporter:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.__class__.instances.append(self)
+
+        def start(self):
+            return None
+
+        async def shutdown(self):
+            return None
+
+    from openviking.metrics import global_api as global_api_module
+
+    config = ServerConfig(
+        observability=ObservabilityConfig(
+            metrics=MetricsConfig(
+                enabled=True,
+                exporters=MetricsExportersConfig(
+                    prometheus=PrometheusExporterConfig(enabled=False),
+                    otel=OTelExporterConfig(
+                        enabled=True,
+                        headers={"X-ByteAPM-AppKey": "metric-appkey"},
+                    ),
+                ),
+            )
+        )
+    )
+
+    shutdown_metrics(app=None)
+    monkeypatch.setattr(global_api_module, "OTelMetricExporter", FakeOTelExporter)
+
+    init_metrics_from_server_config(config, app=None)
+
+    assert len(FakeOTelExporter.instances) == 1
+    assert FakeOTelExporter.instances[0].kwargs["headers"] == {"X-ByteAPM-AppKey": "metric-appkey"}
+
+    shutdown_metrics(app=None)
+
+
 @pytest.mark.asyncio
 async def test_async_shutdown_properly_awaits_exporter_cleanup(monkeypatch):
     """Async shutdown should properly await async exporter cleanup methods.

--- a/tests/test_server_config_loader.py
+++ b/tests/test_server_config_loader.py
@@ -117,3 +117,52 @@ def test_load_server_config_preserves_metrics_account_dimension_fields(tmp_path)
         "openviking_http_requests_total",
         "openviking_task_pending",
     ]
+
+
+def test_load_server_config_preserves_otlp_headers_fields(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "observability": {
+                        "traces": {
+                            "enabled": True,
+                            "headers": {
+                                "X-ByteAPM-AppKey": "trace-appkey",
+                            },
+                        },
+                        "logs": {
+                            "enabled": True,
+                            "headers": {
+                                "X-ByteAPM-AppKey": "log-appkey",
+                            },
+                        },
+                        "metrics": {
+                            "enabled": True,
+                            "exporters": {
+                                "otel": {
+                                    "enabled": True,
+                                    "headers": {
+                                        "X-ByteAPM-AppKey": "metric-appkey",
+                                    },
+                                }
+                            },
+                        },
+                    }
+                }
+            }
+        )
+    )
+
+    config = load_server_config(str(config_path))
+
+    assert config.observability.traces.headers == {
+        "X-ByteAPM-AppKey": "trace-appkey",
+    }
+    assert config.observability.logs.headers == {
+        "X-ByteAPM-AppKey": "log-appkey",
+    }
+    assert config.observability.metrics.exporters.otel.headers == {
+        "X-ByteAPM-AppKey": "metric-appkey",
+    }

--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -29,8 +29,10 @@ from openviking.telemetry import (
     get_current_telemetry,
     get_telemetry_runtime,
     register_telemetry,
+    tracer_module,
     unregister_telemetry,
 )
+from openviking_cli.utils import logger as logger_module
 from openviking.telemetry.backends.memory import MemoryOperationTelemetry
 from openviking.telemetry.context import bind_telemetry, bind_telemetry_stage
 from openviking.telemetry.snapshot import TelemetrySnapshot
@@ -234,6 +236,222 @@ def test_telemetry_summary_uses_simplified_internal_metric_keys():
         "pending": 1,
     }
     assert result["memory"] == {"extracted": 6}
+
+
+def test_init_tracer_forwards_headers_to_grpc_exporter(monkeypatch):
+    captured = {}
+
+    class FakeExporter:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(tracer_module, "OTLPGrpcSpanExporter", FakeExporter)
+    monkeypatch.setattr(tracer_module, "BatchSpanProcessor", lambda exporter, **kwargs: exporter)
+
+    class FakeTracerProvider:
+        def __init__(self, resource=None):
+            self.resource = resource
+
+        def add_span_processor(self, _processor):
+            return None
+
+    monkeypatch.setattr(tracer_module, "TracerProvider", FakeTracerProvider)
+    monkeypatch.setattr(
+        tracer_module,
+        "Resource",
+        SimpleNamespace(create=lambda attrs: attrs),
+    )
+    monkeypatch.setattr(
+        tracer_module,
+        "otel_trace",
+        SimpleNamespace(
+            set_tracer_provider=lambda _provider: None,
+            get_tracer=lambda service_name: f"tracer:{service_name}",
+        ),
+    )
+    monkeypatch.setattr(
+        tracer_module,
+        "TraceContextTextMapPropagator",
+        lambda: "propagator",
+    )
+    monkeypatch.setattr(tracer_module, "_setup_logging", lambda: None)
+    monkeypatch.setattr(tracer_module, "_init_asyncio_instrumentation", lambda: None)
+
+    tracer_module.init_tracer(
+        endpoint="apmplus-cn-beijing.ivolces.com:4317",
+        service_name="memorydb",
+        protocol="grpc",
+        insecure=True,
+        headers={"X-ByteAPM-AppKey": "trace-appkey"},
+        enabled=True,
+    )
+
+    assert captured["endpoint"] == "apmplus-cn-beijing.ivolces.com:4317"
+    assert captured["insecure"] is True
+    assert captured["headers"] == {"X-ByteAPM-AppKey": "trace-appkey"}
+
+
+def test_init_tracer_forwards_headers_to_http_exporter(monkeypatch):
+    captured = {}
+
+    class FakeExporter:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(tracer_module, "OTLPHttpSpanExporter", FakeExporter)
+    monkeypatch.setattr(tracer_module, "BatchSpanProcessor", lambda exporter, **kwargs: exporter)
+
+    class FakeTracerProvider:
+        def __init__(self, resource=None):
+            self.resource = resource
+
+        def add_span_processor(self, _processor):
+            return None
+
+    monkeypatch.setattr(tracer_module, "TracerProvider", FakeTracerProvider)
+    monkeypatch.setattr(
+        tracer_module,
+        "Resource",
+        SimpleNamespace(create=lambda attrs: attrs),
+    )
+    monkeypatch.setattr(
+        tracer_module,
+        "otel_trace",
+        SimpleNamespace(
+            set_tracer_provider=lambda _provider: None,
+            get_tracer=lambda service_name: f"tracer:{service_name}",
+        ),
+    )
+    monkeypatch.setattr(
+        tracer_module,
+        "TraceContextTextMapPropagator",
+        lambda: "propagator",
+    )
+    monkeypatch.setattr(tracer_module, "_setup_logging", lambda: None)
+    monkeypatch.setattr(tracer_module, "_init_asyncio_instrumentation", lambda: None)
+
+    tracer_module.init_tracer(
+        endpoint="https://apmplus-cn-beijing.ivolces.com/api/otlp/v1/traces",
+        service_name="memorydb",
+        protocol="http",
+        headers={"X-ByteAPM-AppKey": "trace-appkey"},
+        enabled=True,
+    )
+
+    assert captured["endpoint"] == "https://apmplus-cn-beijing.ivolces.com/api/otlp/v1/traces"
+    assert captured["headers"] == {"X-ByteAPM-AppKey": "trace-appkey"}
+
+
+def test_init_otel_log_handler_forwards_headers_to_grpc_exporter(monkeypatch):
+    captured = {}
+
+    class FakeExporter:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class FakeLoggerProvider:
+        def __init__(self, resource=None):
+            self.resource = resource
+
+        def add_log_record_processor(self, _processor):
+            return None
+
+    monkeypatch.setattr(logger_module, "_otel_log_handler_initialized", False)
+    monkeypatch.setattr(logger_module, "_otel_log_handler", None)
+    monkeypatch.setattr(logger_module, "OTLPGrpcLogExporter", FakeExporter)
+    monkeypatch.setattr(
+        logger_module,
+        "BatchLogRecordProcessor",
+        lambda exporter: exporter,
+    )
+    monkeypatch.setattr(logger_module, "LoggerProvider", FakeLoggerProvider)
+    monkeypatch.setattr(
+        logger_module,
+        "LoggingHandler",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(
+        logger_module,
+        "Resource",
+        SimpleNamespace(create=lambda attrs: attrs),
+    )
+    monkeypatch.setattr(logger_module, "set_logger_provider", lambda _provider: None)
+    monkeypatch.setattr(
+        logger_module,
+        "get_logger",
+        lambda _name: SimpleNamespace(
+            info=lambda *args, **kwargs: None, warning=lambda *args, **kwargs: None
+        ),
+    )
+
+    handler = logger_module.init_otel_log_handler(
+        protocol="grpc",
+        endpoint="apmplus-cn-beijing.ivolces.com:4317",
+        service_name="memorydb",
+        insecure=True,
+        headers={"X-ByteAPM-AppKey": "log-appkey"},
+        enabled=True,
+    )
+
+    assert handler is not None
+    assert captured["endpoint"] == "apmplus-cn-beijing.ivolces.com:4317"
+    assert captured["insecure"] is True
+    assert captured["headers"] == {"X-ByteAPM-AppKey": "log-appkey"}
+
+
+def test_init_otel_log_handler_forwards_headers_to_http_exporter(monkeypatch):
+    captured = {}
+
+    class FakeExporter:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class FakeLoggerProvider:
+        def __init__(self, resource=None):
+            self.resource = resource
+
+        def add_log_record_processor(self, _processor):
+            return None
+
+    monkeypatch.setattr(logger_module, "_otel_log_handler_initialized", False)
+    monkeypatch.setattr(logger_module, "_otel_log_handler", None)
+    monkeypatch.setattr(logger_module, "OTLPHttpLogExporter", FakeExporter)
+    monkeypatch.setattr(
+        logger_module,
+        "BatchLogRecordProcessor",
+        lambda exporter: exporter,
+    )
+    monkeypatch.setattr(logger_module, "LoggerProvider", FakeLoggerProvider)
+    monkeypatch.setattr(
+        logger_module,
+        "LoggingHandler",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(
+        logger_module,
+        "Resource",
+        SimpleNamespace(create=lambda attrs: attrs),
+    )
+    monkeypatch.setattr(logger_module, "set_logger_provider", lambda _provider: None)
+    monkeypatch.setattr(
+        logger_module,
+        "get_logger",
+        lambda _name: SimpleNamespace(
+            info=lambda *args, **kwargs: None, warning=lambda *args, **kwargs: None
+        ),
+    )
+
+    handler = logger_module.init_otel_log_handler(
+        protocol="http",
+        endpoint="https://apmplus-cn-beijing.ivolces.com/api/otlp/v1/logs",
+        service_name="memorydb",
+        headers={"X-ByteAPM-AppKey": "log-appkey"},
+        enabled=True,
+    )
+
+    assert handler is not None
+    assert captured["endpoint"] == "https://apmplus-cn-beijing.ivolces.com/api/otlp/v1/logs"
+    assert captured["headers"] == {"X-ByteAPM-AppKey": "log-appkey"}
 
 
 def test_telemetry_summary_detects_groups_by_prefix_without_static_key_lists():

--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -32,12 +32,12 @@ from openviking.telemetry import (
     tracer_module,
     unregister_telemetry,
 )
-from openviking_cli.utils import logger as logger_module
 from openviking.telemetry.backends.memory import MemoryOperationTelemetry
 from openviking.telemetry.context import bind_telemetry, bind_telemetry_stage
 from openviking.telemetry.snapshot import TelemetrySnapshot
 from openviking.telemetry.span_models import OperationSpanAttributes, RootSpanAttributes
 from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils import logger as logger_module
 
 
 def test_telemetry_module_exports_snapshot_and_runtime():


### PR DESCRIPTION
## Description
feat(observability): support header param while OTLP export

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- support header param while OTLP export


## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

https://github.com/volcengine/OpenViking/pull/1805

Supports adding header parameters during OTLP transmission, suitable for scenarios requiring additional information (such as authentication SK/SK).
Configuration as follows

```json
  "traces": {
            "enabled": false,
            "protocol": "grpc",
            "tls": {
                "insecure": false
            },
            "endpoint": "localhost:4317",
            "service_name": "openviking-server",
            "headers": {
              "xxx-header-1" :"xxx-value-1",
              "xxx-header-2" :"xxx-value-2"
            }
        },
```

Example -- Integrating into the Volcano Engine log service system requires adding information such as topic/ak/sk.

```
{
    "traces": {
        "enabled": true,
        "protocol": "grpc",
        "tls": {
            "insecure": false
        },
        "endpoint": "tls-cn-beijing.volces.com:4317",
        "service_name": "openviking-server-test0429",
        "headers": {
            "x-tls-otel-tracetopic": "your-topic",
            "x-tls-otel-ak": "your-ak",
            "x-tls-otel-sk": "your-sk",
            "x-tls-otel-region": "cn-beijing"
        }
    }
}
```