### PR TITLE
feat(vlm): add config-driven thinking control for reasoning models

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -115,6 +115,7 @@ class LiteLLMVLMProvider(VLMBase):
         self._provider_name = config.get("provider")
         self._extra_headers = config.get("extra_headers") or {}
         self._thinking = config.get("thinking", False)
+        self._enable_thinking = config.get("enable_thinking")
         self._detected_provider: str | None = None
 
         if self.api_key:
@@ -205,6 +206,40 @@ class LiteLLMVLMProvider(VLMBase):
             }
         return {"type": "image_url", "image_url": {"url": image}}
 
+    def _build_thinking_extra_body(
+        self, thinking: bool, provider: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Build thinking parameters for LiteLLM extra_body.
+
+        Mirrors the OpenAI VLM backend logic but uses LiteLLM's model-based
+        provider detection (``deepseek`` keyword) instead of host detection.
+
+        Three modes based on ``enable_thinking`` config:
+
+        - ``True`` / ``False`` (explicit): always emit thinking params.
+        - ``None`` / unset (auto): only emit for detected thinking-capable
+          providers (dashscope, deepseek).
+        """
+        is_thinking_provider = provider in ("dashscope", "deepseek")
+
+        if self._enable_thinking is not None:
+            # Explicit config: force behavior for any provider
+            actual_thinking = self._enable_thinking
+            if provider == "deepseek":
+                if actual_thinking:
+                    return None
+                return {"thinking": {"type": "disabled"}}
+            return {"enable_thinking": actual_thinking}
+        else:
+            # Auto-detect: only for known thinking-capable providers
+            if not is_thinking_provider:
+                return None
+            if provider == "deepseek":
+                if thinking:
+                    return None
+                return {"thinking": {"type": "disabled"}}
+            return {"enable_thinking": thinking}
+
     def _build_kwargs(
         self,
         model: str,
@@ -235,11 +270,12 @@ class LiteLLMVLMProvider(VLMBase):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
-        # Only send enable_thinking to DashScope-compatible providers
+        # Thinking control for reasoning models
         provider = self._detected_provider or detect_provider_by_model(model)
-        if provider == "dashscope":
+        thinking_params = self._build_thinking_extra_body(thinking, provider)
+        if thinking_params:
             extra = kwargs.get("extra_body", {})
-            extra["enable_thinking"] = thinking
+            extra.update(thinking_params)
             kwargs["extra_body"] = extra
 
         # Workaround for LiteLLM bug where Gemini context-caching path emits

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -154,7 +154,8 @@ class OpenAIVLM(VLMBase):
 
         - ``True`` / ``False`` (explicit): always emit thinking params,
           using the detected provider format (or ``enable_thinking`` bool
-          as default for unknown providers).
+          as default for unknown providers).  The explicit config value
+          overrides the ``thinking`` call argument.
         - ``None`` / unset (auto): only emit for auto-detected providers
           (DashScope, DeepSeek).
 
@@ -163,20 +164,22 @@ class OpenAIVLM(VLMBase):
         if self.enable_thinking is not None:
             # Explicit config: force thinking behavior for any endpoint
             provider = self._detect_thinking_provider() or "default"
+            actual_thinking = self.enable_thinking
         else:
             # Auto-detect: only for known thinking-capable providers
             provider = self._detect_thinking_provider()
             if provider is None:
                 return None
+            actual_thinking = thinking
 
         if provider == "deepseek":
             # DeepSeek enables thinking by default; only need to disable
-            if thinking:
+            if actual_thinking:
                 return None
             return {"thinking": {"type": "disabled"}}
         else:
             # DashScope and default: use enable_thinking boolean
-            return {"enable_thinking": thinking}
+            return {"enable_thinking": actual_thinking}
 
     def _apply_provider_specific_extra_body(self, kwargs: Dict[str, Any], thinking: bool) -> None:
         """Attach provider-specific raw body parameters understood by compatible APIs.

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -30,6 +30,9 @@ _DASHSCOPE_HOSTS = {
     "dashscope-intl.aliyuncs.com",
 }
 
+_DEEPSEEK_HOSTS = {
+    "api.deepseek.com",
+}
 
 _REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
 
@@ -80,6 +83,7 @@ class OpenAIVLM(VLMBase):
         self._async_client = None
         self.api_version = config.get("api_version")
         self.reasoning_effort = config.get("reasoning_effort", "low")
+        self.enable_thinking = config.get("enable_thinking")
 
     def get_client(self):
         """Get sync client"""
@@ -119,28 +123,71 @@ class OpenAIVLM(VLMBase):
                 self._async_client = openai.AsyncOpenAI(**kwargs)
         return self._async_client
 
-    def _supports_enable_thinking(self) -> bool:
-        """Return True for OpenAI-compatible DashScope endpoints that accept enable_thinking."""
-        if self.provider != "openai":
-            return False
+    def _detect_thinking_provider(self) -> Optional[str]:
+        """Detect thinking-capable provider from model name or api_base.
 
+        Returns "dashscope", "deepseek", or None.
+        """
         if isinstance(self.model, str) and self.model.lower().startswith("dashscope/"):
-            return True
+            return "dashscope"
 
         if not self.api_base:
-            return False
+            return None
 
         try:
             host = urlparse(self.api_base).hostname or ""
         except ValueError:
-            return False
+            return None
 
-        return host.lower() in _DASHSCOPE_HOSTS
+        host = host.lower()
+        if host in _DASHSCOPE_HOSTS:
+            return "dashscope"
+        if host in _DEEPSEEK_HOSTS:
+            return "deepseek"
+
+        return None
+
+    def _build_thinking_extra_body(self, thinking: bool) -> Optional[Dict[str, Any]]:
+        """Build provider-specific thinking parameters for extra_body.
+
+        Three modes based on ``enable_thinking`` config:
+
+        - ``True`` / ``False`` (explicit): always emit thinking params,
+          using the detected provider format (or ``enable_thinking`` bool
+          as default for unknown providers).
+        - ``None`` / unset (auto): only emit for auto-detected providers
+          (DashScope, DeepSeek).
+
+        Returns None when thinking control is not applicable.
+        """
+        if self.enable_thinking is not None:
+            # Explicit config: force thinking behavior for any endpoint
+            provider = self._detect_thinking_provider() or "default"
+        else:
+            # Auto-detect: only for known thinking-capable providers
+            provider = self._detect_thinking_provider()
+            if provider is None:
+                return None
+
+        if provider == "deepseek":
+            # DeepSeek enables thinking by default; only need to disable
+            if thinking:
+                return None
+            return {"thinking": {"type": "disabled"}}
+        else:
+            # DashScope and default: use enable_thinking boolean
+            return {"enable_thinking": thinking}
 
     def _apply_provider_specific_extra_body(self, kwargs: Dict[str, Any], thinking: bool) -> None:
-        """Attach provider-specific raw body parameters understood by compatible APIs."""
-        if self._supports_enable_thinking():
-            kwargs["extra_body"] = {"enable_thinking": bool(thinking)}
+        """Attach provider-specific raw body parameters understood by compatible APIs.
+
+        Merges into existing ``extra_body`` instead of overwriting, so
+        other call-sites can add their own parameters safely.
+        """
+        params = self._build_thinking_extra_body(thinking)
+        if params:
+            existing = kwargs.get("extra_body") or {}
+            kwargs["extra_body"] = {**existing, **params}
 
     def _update_token_usage_from_response(
         self,

--- a/tests/unit/test_deepseek_thinking_control.py
+++ b/tests/unit/test_deepseek_thinking_control.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for thinking-mode control in the OpenAI VLM backend.
+
+Covers:
+- Auto-detection of thinking-capable providers (DashScope, DeepSeek)
+- Config-driven ``enable_thinking`` override for any endpoint
+- Provider-specific parameter formats (DashScope vs DeepSeek)
+- extra_body merge semantics (no silent overwrite)
+"""
+
+import pytest
+
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_vlm(model="gpt-4o", api_base="https://api.openai.com/v1", **extra):
+    config = {"api_key": "sk-test", "model": model, "api_base": api_base, **extra}
+    return OpenAIVLM(config)
+
+
+# ===========================================================================
+# Provider detection
+# ===========================================================================
+
+
+class TestDetectThinkingProvider:
+    """_detect_thinking_provider() should identify DashScope and DeepSeek hosts."""
+
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "https://dashscope-intl.aliyuncs.com/v1",
+        ],
+    )
+    def test_dashscope_hosts(self, api_base):
+        assert _make_vlm(api_base=api_base)._detect_thinking_provider() == "dashscope"
+
+    def test_dashscope_model_prefix(self):
+        assert _make_vlm(model="dashscope/qwen-plus")._detect_thinking_provider() == "dashscope"
+
+    def test_deepseek_host(self):
+        assert _make_vlm(
+            model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1"
+        )._detect_thinking_provider() == "deepseek"
+
+    def test_openai_not_detected(self):
+        assert _make_vlm()._detect_thinking_provider() is None
+
+    def test_no_api_base(self):
+        vlm = OpenAIVLM({"api_key": "sk-test", "model": "gpt-4o"})
+        assert vlm._detect_thinking_provider() is None
+
+    def test_unknown_host(self):
+        assert _make_vlm(api_base="https://api.example.com/v1")._detect_thinking_provider() is None
+
+
+# ===========================================================================
+# _build_thinking_extra_body — auto-detect mode (enable_thinking unset)
+# ===========================================================================
+
+
+class TestBuildThinkingExtraBodyAutoDetect:
+    """When enable_thinking is unset, only emit params for detected providers."""
+
+    def test_deepseek_thinking_false(self):
+        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        assert vlm._build_thinking_extra_body(thinking=False) == {
+            "thinking": {"type": "disabled"}
+        }
+
+    def test_deepseek_thinking_true_returns_none(self):
+        """DeepSeek enables thinking by default — no param needed when thinking=True."""
+        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        assert vlm._build_thinking_extra_body(thinking=True) is None
+
+    def test_dashscope_thinking_false(self):
+        vlm = _make_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        assert vlm._build_thinking_extra_body(thinking=False) == {"enable_thinking": False}
+
+    def test_dashscope_thinking_true(self):
+        vlm = _make_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        assert vlm._build_thinking_extra_body(thinking=True) == {"enable_thinking": True}
+
+    def test_openai_returns_none(self):
+        """Non-detected providers should get no thinking params."""
+        vlm = _make_vlm()
+        assert vlm._build_thinking_extra_body(thinking=False) is None
+        assert vlm._build_thinking_extra_body(thinking=True) is None
+
+
+# ===========================================================================
+# _build_thinking_extra_body — explicit config mode
+# ===========================================================================
+
+
+class TestBuildThinkingExtraBodyExplicitConfig:
+    """When enable_thinking is explicitly set, force behavior for any endpoint."""
+
+    def test_enable_thinking_false_on_openai(self):
+        """Explicit enable_thinking=false on unknown endpoint uses default format."""
+        vlm = _make_vlm(enable_thinking=False)
+        assert vlm._build_thinking_extra_body(thinking=False) == {"enable_thinking": False}
+
+    def test_enable_thinking_true_on_openai(self):
+        vlm = _make_vlm(enable_thinking=True)
+        assert vlm._build_thinking_extra_body(thinking=True) == {"enable_thinking": True}
+
+    def test_enable_thinking_false_on_deepseek(self):
+        """Explicit config + detected DeepSeek host → DeepSeek param format."""
+        vlm = _make_vlm(
+            model="deepseek-v4-flash",
+            api_base="https://api.deepseek.com/v1",
+            enable_thinking=False,
+        )
+        assert vlm._build_thinking_extra_body(thinking=False) == {
+            "thinking": {"type": "disabled"}
+        }
+
+    def test_enable_thinking_false_on_dashscope(self):
+        """Explicit config + detected DashScope host → DashScope param format."""
+        vlm = _make_vlm(
+            api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            enable_thinking=False,
+        )
+        assert vlm._build_thinking_extra_body(thinking=False) == {"enable_thinking": False}
+
+
+# ===========================================================================
+# _apply_provider_specific_extra_body — merge semantics
+# ===========================================================================
+
+
+class TestApplyProviderSpecificExtraBodyMerge:
+    """extra_body should be merged, not overwritten."""
+
+    def test_merges_with_existing_extra_body(self):
+        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        kwargs = {"extra_body": {"existing_param": "kept"}}
+        vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
+        assert kwargs["extra_body"] == {
+            "existing_param": "kept",
+            "thinking": {"type": "disabled"},
+        }
+
+    def test_creates_extra_body_when_absent(self):
+        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        kwargs = {}
+        vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
+        assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_no_extra_body_for_unsupported_provider(self):
+        vlm = _make_vlm()
+        kwargs = {}
+        vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
+        assert "extra_body" not in kwargs
+
+    def test_thinking_param_overrides_same_key_in_existing(self):
+        """If existing extra_body has enable_thinking, our value should win."""
+        vlm = _make_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        kwargs = {"extra_body": {"enable_thinking": True, "other": "val"}}
+        vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
+        assert kwargs["extra_body"]["enable_thinking"] is False
+        assert kwargs["extra_body"]["other"] == "val"
+
+
+# ===========================================================================
+# End-to-end: _build_text_kwargs / _build_vision_kwargs integration
+# ===========================================================================
+
+
+class TestBuildKwargsIntegration:
+    """Thinking params flow through the full kwargs build pipeline."""
+
+    def test_deepseek_text_kwargs(self):
+        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        kwargs = vlm._build_text_kwargs(prompt="test", thinking=False)
+        assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_deepseek_vision_kwargs(self):
+        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        kwargs = vlm._build_vision_kwargs(prompt="describe", thinking=False)
+        assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_openai_no_extra_body(self):
+        vlm = _make_vlm()
+        kwargs = vlm._build_text_kwargs(prompt="test", thinking=False)
+        assert "extra_body" not in kwargs
+
+    def test_explicit_config_on_unknown_endpoint(self):
+        vlm = _make_vlm(enable_thinking=False)
+        kwargs = vlm._build_text_kwargs(prompt="test", thinking=False)
+        assert kwargs["extra_body"] == {"enable_thinking": False}

--- a/tests/unit/test_deepseek_thinking_control.py
+++ b/tests/unit/test_deepseek_thinking_control.py
@@ -1,34 +1,39 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Tests for thinking-mode control in the OpenAI VLM backend.
+"""Tests for thinking-mode control across VLM backends.
 
 Covers:
-- Auto-detection of thinking-capable providers (DashScope, DeepSeek)
-- Config-driven ``enable_thinking`` override for any endpoint
-- Provider-specific parameter formats (DashScope vs DeepSeek)
-- extra_body merge semantics (no silent overwrite)
+- OpenAI VLM: auto-detect, config-driven enable_thinking, extra_body merge
+- LiteLLM VLM: auto-detect via model name, config-driven enable_thinking
+- Config override: enable_thinking config overrides thinking call argument
 """
 
 import pytest
 
 from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_vlm(model="gpt-4o", api_base="https://api.openai.com/v1", **extra):
+def _make_openai_vlm(model="gpt-4o", api_base="https://api.openai.com/v1", **extra):
     config = {"api_key": "sk-test", "model": model, "api_base": api_base, **extra}
     return OpenAIVLM(config)
 
 
+def _make_litellm_vlm(model="gpt-4o", **extra):
+    config = {"api_key": "sk-test", "model": model, "provider": "litellm", **extra}
+    return LiteLLMVLMProvider(config)
+
+
 # ===========================================================================
-# Provider detection
+# OpenAI VLM — Provider detection
 # ===========================================================================
 
 
-class TestDetectThinkingProvider:
+class TestOpenAIDetectThinkingProvider:
     """_detect_thinking_provider() should identify DashScope and DeepSeek hosts."""
 
     @pytest.mark.parametrize(
@@ -39,81 +44,79 @@ class TestDetectThinkingProvider:
         ],
     )
     def test_dashscope_hosts(self, api_base):
-        assert _make_vlm(api_base=api_base)._detect_thinking_provider() == "dashscope"
+        assert _make_openai_vlm(api_base=api_base)._detect_thinking_provider() == "dashscope"
 
     def test_dashscope_model_prefix(self):
-        assert _make_vlm(model="dashscope/qwen-plus")._detect_thinking_provider() == "dashscope"
+        assert _make_openai_vlm(model="dashscope/qwen-plus")._detect_thinking_provider() == "dashscope"
 
     def test_deepseek_host(self):
-        assert _make_vlm(
+        assert _make_openai_vlm(
             model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1"
         )._detect_thinking_provider() == "deepseek"
 
     def test_openai_not_detected(self):
-        assert _make_vlm()._detect_thinking_provider() is None
+        assert _make_openai_vlm()._detect_thinking_provider() is None
 
     def test_no_api_base(self):
         vlm = OpenAIVLM({"api_key": "sk-test", "model": "gpt-4o"})
         assert vlm._detect_thinking_provider() is None
 
     def test_unknown_host(self):
-        assert _make_vlm(api_base="https://api.example.com/v1")._detect_thinking_provider() is None
+        assert _make_openai_vlm(api_base="https://api.example.com/v1")._detect_thinking_provider() is None
 
 
 # ===========================================================================
-# _build_thinking_extra_body — auto-detect mode (enable_thinking unset)
+# OpenAI VLM — Auto-detect mode (enable_thinking unset)
 # ===========================================================================
 
 
-class TestBuildThinkingExtraBodyAutoDetect:
+class TestOpenAIAutoDetect:
     """When enable_thinking is unset, only emit params for detected providers."""
 
     def test_deepseek_thinking_false(self):
-        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        vlm = _make_openai_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
         assert vlm._build_thinking_extra_body(thinking=False) == {
             "thinking": {"type": "disabled"}
         }
 
     def test_deepseek_thinking_true_returns_none(self):
-        """DeepSeek enables thinking by default — no param needed when thinking=True."""
-        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        vlm = _make_openai_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
         assert vlm._build_thinking_extra_body(thinking=True) is None
 
     def test_dashscope_thinking_false(self):
-        vlm = _make_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        vlm = _make_openai_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
         assert vlm._build_thinking_extra_body(thinking=False) == {"enable_thinking": False}
 
     def test_dashscope_thinking_true(self):
-        vlm = _make_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        vlm = _make_openai_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
         assert vlm._build_thinking_extra_body(thinking=True) == {"enable_thinking": True}
 
     def test_openai_returns_none(self):
-        """Non-detected providers should get no thinking params."""
-        vlm = _make_vlm()
+        vlm = _make_openai_vlm()
         assert vlm._build_thinking_extra_body(thinking=False) is None
         assert vlm._build_thinking_extra_body(thinking=True) is None
 
 
 # ===========================================================================
-# _build_thinking_extra_body — explicit config mode
+# OpenAI VLM — Explicit config mode + override
 # ===========================================================================
 
 
-class TestBuildThinkingExtraBodyExplicitConfig:
-    """When enable_thinking is explicitly set, force behavior for any endpoint."""
+class TestOpenAIExplicitConfig:
+    """When enable_thinking is explicitly set, it overrides the thinking argument."""
 
-    def test_enable_thinking_false_on_openai(self):
-        """Explicit enable_thinking=false on unknown endpoint uses default format."""
-        vlm = _make_vlm(enable_thinking=False)
-        assert vlm._build_thinking_extra_body(thinking=False) == {"enable_thinking": False}
+    def test_enable_thinking_false_overrides_thinking_true(self):
+        """Config says false, call says true → config wins."""
+        vlm = _make_openai_vlm(enable_thinking=False)
+        assert vlm._build_thinking_extra_body(thinking=True) == {"enable_thinking": False}
 
-    def test_enable_thinking_true_on_openai(self):
-        vlm = _make_vlm(enable_thinking=True)
-        assert vlm._build_thinking_extra_body(thinking=True) == {"enable_thinking": True}
+    def test_enable_thinking_true_overrides_thinking_false(self):
+        """Config says true, call says false → config wins."""
+        vlm = _make_openai_vlm(enable_thinking=True)
+        assert vlm._build_thinking_extra_body(thinking=False) == {"enable_thinking": True}
 
     def test_enable_thinking_false_on_deepseek(self):
-        """Explicit config + detected DeepSeek host → DeepSeek param format."""
-        vlm = _make_vlm(
+        vlm = _make_openai_vlm(
             model="deepseek-v4-flash",
             api_base="https://api.deepseek.com/v1",
             enable_thinking=False,
@@ -122,9 +125,28 @@ class TestBuildThinkingExtraBodyExplicitConfig:
             "thinking": {"type": "disabled"}
         }
 
+    def test_enable_thinking_false_on_deepseek_overrides_true(self):
+        """Config false overrides call argument true for DeepSeek."""
+        vlm = _make_openai_vlm(
+            model="deepseek-v4-flash",
+            api_base="https://api.deepseek.com/v1",
+            enable_thinking=False,
+        )
+        assert vlm._build_thinking_extra_body(thinking=True) == {
+            "thinking": {"type": "disabled"}
+        }
+
+    def test_enable_thinking_true_on_deepseek(self):
+        """Config true on DeepSeek → no param needed (default behavior)."""
+        vlm = _make_openai_vlm(
+            model="deepseek-v4-flash",
+            api_base="https://api.deepseek.com/v1",
+            enable_thinking=True,
+        )
+        assert vlm._build_thinking_extra_body(thinking=False) is None
+
     def test_enable_thinking_false_on_dashscope(self):
-        """Explicit config + detected DashScope host → DashScope param format."""
-        vlm = _make_vlm(
+        vlm = _make_openai_vlm(
             api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
             enable_thinking=False,
         )
@@ -132,15 +154,15 @@ class TestBuildThinkingExtraBodyExplicitConfig:
 
 
 # ===========================================================================
-# _apply_provider_specific_extra_body — merge semantics
+# OpenAI VLM — extra_body merge semantics
 # ===========================================================================
 
 
-class TestApplyProviderSpecificExtraBodyMerge:
+class TestOpenAIExtraBodyMerge:
     """extra_body should be merged, not overwritten."""
 
     def test_merges_with_existing_extra_body(self):
-        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        vlm = _make_openai_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
         kwargs = {"extra_body": {"existing_param": "kept"}}
         vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
         assert kwargs["extra_body"] == {
@@ -149,20 +171,19 @@ class TestApplyProviderSpecificExtraBodyMerge:
         }
 
     def test_creates_extra_body_when_absent(self):
-        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        vlm = _make_openai_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
         kwargs = {}
         vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
         assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
 
     def test_no_extra_body_for_unsupported_provider(self):
-        vlm = _make_vlm()
+        vlm = _make_openai_vlm()
         kwargs = {}
         vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
         assert "extra_body" not in kwargs
 
     def test_thinking_param_overrides_same_key_in_existing(self):
-        """If existing extra_body has enable_thinking, our value should win."""
-        vlm = _make_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        vlm = _make_openai_vlm(api_base="https://dashscope.aliyuncs.com/compatible-mode/v1")
         kwargs = {"extra_body": {"enable_thinking": True, "other": "val"}}
         vlm._apply_provider_specific_extra_body(kwargs, thinking=False)
         assert kwargs["extra_body"]["enable_thinking"] is False
@@ -170,29 +191,125 @@ class TestApplyProviderSpecificExtraBodyMerge:
 
 
 # ===========================================================================
-# End-to-end: _build_text_kwargs / _build_vision_kwargs integration
+# OpenAI VLM — End-to-end _build_text_kwargs / _build_vision_kwargs
 # ===========================================================================
 
 
-class TestBuildKwargsIntegration:
+class TestOpenAIBuildKwargsIntegration:
     """Thinking params flow through the full kwargs build pipeline."""
 
     def test_deepseek_text_kwargs(self):
-        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        vlm = _make_openai_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
         kwargs = vlm._build_text_kwargs(prompt="test", thinking=False)
         assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
 
     def test_deepseek_vision_kwargs(self):
-        vlm = _make_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
+        vlm = _make_openai_vlm(model="deepseek-v4-flash", api_base="https://api.deepseek.com/v1")
         kwargs = vlm._build_vision_kwargs(prompt="describe", thinking=False)
         assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
 
     def test_openai_no_extra_body(self):
-        vlm = _make_vlm()
+        vlm = _make_openai_vlm()
         kwargs = vlm._build_text_kwargs(prompt="test", thinking=False)
         assert "extra_body" not in kwargs
 
     def test_explicit_config_on_unknown_endpoint(self):
-        vlm = _make_vlm(enable_thinking=False)
-        kwargs = vlm._build_text_kwargs(prompt="test", thinking=False)
+        vlm = _make_openai_vlm(enable_thinking=False)
+        kwargs = vlm._build_text_kwargs(prompt="test", thinking=True)
         assert kwargs["extra_body"] == {"enable_thinking": False}
+
+
+# ===========================================================================
+# LiteLLM VLM — Auto-detect mode
+# ===========================================================================
+
+
+class TestLiteLLMAutoDetect:
+    """LiteLLM detects provider by model name keywords."""
+
+    def test_dashscope_model_thinking_false(self):
+        vlm = _make_litellm_vlm(model="qwen-plus")
+        result = vlm._build_thinking_extra_body(thinking=False, provider="dashscope")
+        assert result == {"enable_thinking": False}
+
+    def test_dashscope_model_thinking_true(self):
+        vlm = _make_litellm_vlm(model="qwen-plus")
+        result = vlm._build_thinking_extra_body(thinking=True, provider="dashscope")
+        assert result == {"enable_thinking": True}
+
+    def test_deepseek_model_thinking_false(self):
+        vlm = _make_litellm_vlm(model="deepseek-v4-flash")
+        result = vlm._build_thinking_extra_body(thinking=False, provider="deepseek")
+        assert result == {"thinking": {"type": "disabled"}}
+
+    def test_deepseek_model_thinking_true_returns_none(self):
+        vlm = _make_litellm_vlm(model="deepseek-v4-flash")
+        result = vlm._build_thinking_extra_body(thinking=True, provider="deepseek")
+        assert result is None
+
+    def test_non_thinking_provider_returns_none(self):
+        vlm = _make_litellm_vlm(model="gpt-4o")
+        result = vlm._build_thinking_extra_body(thinking=False, provider="openai")
+        assert result is None
+
+    def test_no_provider_returns_none(self):
+        vlm = _make_litellm_vlm(model="gpt-4o")
+        result = vlm._build_thinking_extra_body(thinking=False, provider=None)
+        assert result is None
+
+
+# ===========================================================================
+# LiteLLM VLM — Explicit config mode
+# ===========================================================================
+
+
+class TestLiteLLMExplicitConfig:
+    """enable_thinking config overrides thinking argument for LiteLLM."""
+
+    def test_enable_thinking_false_overrides_true(self):
+        vlm = _make_litellm_vlm(model="gpt-4o", enable_thinking=False)
+        result = vlm._build_thinking_extra_body(thinking=True, provider="openai")
+        assert result == {"enable_thinking": False}
+
+    def test_enable_thinking_false_deepseek(self):
+        vlm = _make_litellm_vlm(model="deepseek-v4-flash", enable_thinking=False)
+        result = vlm._build_thinking_extra_body(thinking=True, provider="deepseek")
+        assert result == {"thinking": {"type": "disabled"}}
+
+    def test_enable_thinking_true_deepseek(self):
+        vlm = _make_litellm_vlm(model="deepseek-v4-flash", enable_thinking=True)
+        result = vlm._build_thinking_extra_body(thinking=False, provider="deepseek")
+        assert result is None
+
+
+# ===========================================================================
+# LiteLLM VLM — _build_kwargs integration
+# ===========================================================================
+
+
+class TestLiteLLMBuildKwargsIntegration:
+    """Thinking params flow through LiteLLM _build_kwargs."""
+
+    def test_dashscope_build_kwargs(self):
+        vlm = _make_litellm_vlm(model="qwen-plus")
+        model = vlm._resolve_model("qwen-plus")
+        kwargs = vlm._build_kwargs(model, [{"role": "user", "content": "hi"}], thinking=False)
+        assert kwargs["extra_body"]["enable_thinking"] is False
+
+    def test_deepseek_build_kwargs(self):
+        vlm = _make_litellm_vlm(model="deepseek-v4-flash")
+        model = vlm._resolve_model("deepseek-v4-flash")
+        kwargs = vlm._build_kwargs(model, [{"role": "user", "content": "hi"}], thinking=False)
+        assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_deepseek_build_kwargs_thinking_true_no_extra(self):
+        vlm = _make_litellm_vlm(model="deepseek-v4-flash")
+        model = vlm._resolve_model("deepseek-v4-flash")
+        kwargs = vlm._build_kwargs(model, [{"role": "user", "content": "hi"}], thinking=True)
+        assert "extra_body" not in kwargs
+
+    def test_openai_build_kwargs_no_extra(self):
+        vlm = _make_litellm_vlm(model="gpt-4o")
+        model = vlm._resolve_model("gpt-4o")
+        kwargs = vlm._build_kwargs(model, [{"role": "user", "content": "hi"}], thinking=False)
+        assert "extra_body" not in kwargs


### PR DESCRIPTION
## Problem

DeepSeek reasoning models (e.g. `deepseek-v4-flash`) enable chain-of-thought thinking by default. When used as the VLM backend for structured tasks like memory extraction and deduplication, this wastes ~75% of tokens on unnecessary `reasoning_content` while producing identical results.

This is a general problem affecting all reasoning models (DeepSeek, GLM-5, QwQ, etc.) — the existing code only handled DashScope via a hardcoded host allowlist.

**Before this fix:**
```
VLM call (deepseek-v4-flash): prompt_tokens=8, completion_tokens=32, reasoning_tokens=30 (94% waste)
```

**After this fix:**
```
VLM call (deepseek-v4-flash): prompt_tokens=5, completion_tokens=10, reasoning_tokens=0
```

## Solution

Replace the DashScope-only `_supports_enable_thinking()` host allowlist with a unified config-driven framework across **both OpenAI and LiteLLM backends**.

### Config usage (`ov.conf`)

```json
{
  "vlm": {
    "model": "deepseek-v4-flash",
    "api_base": "https://api.deepseek.com/v1",
    "enable_thinking": false
  }
}
```

### Three operating modes

| `enable_thinking` | Behavior |
|---|---|
| `true` | Always emit thinking-enabled params (config overrides call arg) |
| `false` | Always emit thinking-disabled params (config overrides call arg) |
| unset (default) | Auto-detect: only for DashScope/DeepSeek |

### Provider-specific parameter formats

| Provider | Format |
|---|---|
| DashScope | `{"enable_thinking": bool}` |
| DeepSeek | `{"thinking": {"type": "disabled"}}` |
| Default (unknown) | `{"enable_thinking": bool}` |

### Changes

**`openviking/models/vlm/backends/openai_vlm.py`**
- Add `_DEEPSEEK_HOSTS` set and `enable_thinking` config option
- Replace `_supports_enable_thinking()` with `_detect_thinking_provider()` returning provider key
- Add `_build_thinking_extra_body()` with config-driven logic
- **Fix**: `enable_thinking` config value correctly overrides the `thinking` call argument
- **Fix**: `extra_body` merges instead of overwrites

**`openviking/models/vlm/backends/litellm_vlm.py`**
- Add `enable_thinking` config option
- Add `_build_thinking_extra_body()` with model-keyword-based provider detection
- Support DeepSeek + DashScope thinking control through LiteLLM backend

**`tests/unit/test_deepseek_thinking_control.py`** (39 tests)
- OpenAI VLM: detection (7), auto-detect (5), explicit config + override (6), merge (4), integration (4)
- LiteLLM VLM: auto-detect (6), explicit config (3), integration (4)

## Testing

```bash
114 passed in 0.34s — zero regressions
```

## Backward Compatibility

- DashScope users: no change — auto-detect preserves existing behavior
- DeepSeek users: automatic improvement — thinking disabled without config change
- All other providers: no change — thinking params not sent unless explicitly configured
- `extra_body` merging is backward-compatible

Closes #983