### PR TITLE
feat(config): adding support for local `ovcli.conf` file

### DIFF
--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -110,11 +110,18 @@ impl Config {
     }
 
     pub fn load_default() -> Result<Self> {
-        // Resolution order: env var > default path
+        // Resolution order: env var > local dir > default path
         if let Ok(env_path) = std::env::var(OPENVIKING_CLI_CONFIG_ENV) {
             let p = PathBuf::from(env_path);
             if p.exists() {
                 return Self::from_file(&p.to_string_lossy());
+            }
+        }
+
+        if let Ok(cwd) = std::env::current_dir() {
+            let local_config = cwd.join("ovcli.conf");
+            if local_config.exists() {
+                return Self::from_file(&local_config.to_string_lossy());
             }
         }
 
@@ -301,9 +308,17 @@ mod tests {
         )
         .expect("config should deserialize with extra_headers");
 
-        let headers = config.extra_headers.expect("extra_headers should be present");
-        assert_eq!(headers.get("X-Custom-Header"), Some(&"custom-value".to_string()));
-        assert_eq!(headers.get("Authorization"), Some(&"Bearer token".to_string()));
+        let headers = config
+            .extra_headers
+            .expect("extra_headers should be present");
+        assert_eq!(
+            headers.get("X-Custom-Header"),
+            Some(&"custom-value".to_string())
+        );
+        assert_eq!(
+            headers.get("Authorization"),
+            Some(&"Bearer token".to_string())
+        );
     }
 
     #[test]
@@ -331,8 +346,40 @@ mod tests {
         )
         .expect("config should deserialize with alias");
 
-        let headers = config.extra_headers.expect("extra_headers should be present");
-        assert_eq!(headers.get("X-Custom-Header"), Some(&"custom-value".to_string()));
-        assert_eq!(headers.get("Authorization"), Some(&"Bearer token".to_string()));
+        let headers = config
+            .extra_headers
+            .expect("extra_headers should be present");
+        assert_eq!(
+            headers.get("X-Custom-Header"),
+            Some(&"custom-value".to_string())
+        );
+        assert_eq!(
+            headers.get("Authorization"),
+            Some(&"Bearer token".to_string())
+        );
+    }
+
+    #[test]
+    fn load_default_picks_up_local_ovcli_conf() {
+        use std::env;
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let local_conf = tmp.path().join("ovcli.conf");
+        std::fs::write(
+            &local_conf,
+            r#"{ "url": "http://local-override:9999", "api_key": "local-key" }"#,
+        )
+        .expect("write local config");
+
+        let prev_dir = env::current_dir().expect("get cwd");
+        env::set_current_dir(tmp.path()).expect("cd into temp dir");
+
+        let config = Config::load_default().expect("should load local config");
+
+        // Restore working directory
+        env::set_current_dir(&prev_dir).expect("restore cwd");
+
+        assert_eq!(config.url, "http://local-override:9999");
+        assert_eq!(config.api_key.as_deref(), Some("local-key"));
     }
 }

--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -75,7 +75,7 @@ client = ov.SyncHTTPClient(
 client.initialize()
 ```
 
-When `url` is not explicitly provided, the HTTP client automatically reads connection information from `ovcli.conf`. `ovcli.conf` is a configuration file shared between the HTTP client and CLI. Default path: `~/.openviking/ovcli.conf`. You can also specify the path via environment variable:
+When `url` is not explicitly provided, the HTTP client automatically reads connection information from `ovcli.conf`. `ovcli.conf` is a configuration file shared between the HTTP client and CLI. The CLI looks for `ovcli.conf` in the current working directory first, then falls back to `~/.openviking/ovcli.conf` (see [resolution order](../guides/01-configuration.md#ovcliconf-resolution-order)). You can also specify the path via environment variable:
 
 ```bash
 export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -933,6 +933,17 @@ OpenViking uses two config files:
 
 When config files are at the default path, OpenViking loads them automatically — no additional setup needed.
 
+#### `ovcli.conf` resolution order
+
+The CLI resolves `ovcli.conf` in the following order, using the first one found:
+
+1. **Environment variable** — `OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf`
+2. **Current directory** — `./ovcli.conf` in the working directory where the CLI is invoked
+3. **Default path** — `~/.openviking/ovcli.conf`
+4. **Built-in defaults** — if none of the above exist
+
+#### Overriding config file paths
+
 If config files are at a different location, there are two ways to specify:
 
 ```bash

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -75,7 +75,7 @@ client = ov.SyncHTTPClient(
 client.initialize()
 ```
 
-未显式传入 `url` 时，HTTP 客户端会自动从 `ovcli.conf` 读取连接信息。`ovcli.conf` 是 HTTP 客户端和 CLI 共享的配置文件，默认路径 `~/.openviking/ovcli.conf`，也可通过环境变量指定：
+未显式传入 `url` 时，HTTP 客户端会自动从 `ovcli.conf` 读取连接信息。`ovcli.conf` 是 HTTP 客户端和 CLI 共享的配置文件。CLI 会优先查找当前工作目录下的 `ovcli.conf`，然后回退到 `~/.openviking/ovcli.conf`（详见[解析顺序](../guides/01-configuration.md#ovcliconf-解析顺序)）。也可通过环境变量指定：
 
 ```bash
 export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -907,6 +907,17 @@ OpenViking 使用两个配置文件：
 
 配置文件放在默认路径时，OpenViking 自动加载，无需额外设置。
 
+#### `ovcli.conf` 解析顺序
+
+CLI 按以下顺序查找 `ovcli.conf`，使用第一个找到的文件：
+
+1. **环境变量** — `OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf`
+2. **当前目录** — CLI 启动时所在工作目录下的 `./ovcli.conf`
+3. **默认路径** — `~/.openviking/ovcli.conf`
+4. **内置默认值** — 以上均不存在时使用
+
+#### 指定配置文件路径
+
 如果配置文件在其他位置，有两种指定方式：
 
 ```bash


### PR DESCRIPTION
## Description

Adding support for reading local `ovcli.conf` in the current working directory over the global default `~/.openviking/ovcli.conf`.

This is especially useful for creating project specific CLI configurations.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- `+` reading local `ovcli.conf` before default location

## Testing

Added a new test for local file and executed the suite.

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
