### PR TITLE
docs(multi-tenant): finish agentId→agent_prefix rename in OpenClaw Plugin 2.0 section

### DIFF
--- a/docs/en/concepts/11-multi-tenant.md
+++ b/docs/en/concepts/11-multi-tenant.md
@@ -202,7 +202,7 @@ Characteristics of this model:
 
 - Simple integration, because the plugin does not manage account/user lifecycle
 - Best for "one OpenClaw instance maps to one OpenViking user identity"
-- `agentId` distinguishes different OpenClaw instances or agent roles
+- `agent_prefix` distinguishes different OpenClaw instances or agent roles
 - `resources` can be shared inside the same account, while `user` and `agent` memory stay identity-scoped
 
 ### Why the OpenClaw plugin usually does not set `account` / `user`
@@ -210,7 +210,7 @@ Characteristics of this model:
 In `api_key` mode, a user key is already enough to express identity:
 
 - `account` and `user` are resolved server-side from the key
-- The plugin only needs to provide `agentId`
+- The plugin only needs to provide `agent_prefix`
 - Internally, the plugin derives default `user` and `agent` memory scopes from the runtime identity
 
 If you give the plugin a root key directly, normal tenant-scoped data APIs will lack `X-OpenViking-Account` and `X-OpenViking-User`, so that is not a good default for day-to-day access.

--- a/docs/zh/concepts/11-multi-tenant.md
+++ b/docs/zh/concepts/11-multi-tenant.md
@@ -202,7 +202,7 @@ openclaw config set plugins.entries.openviking.config.agent_prefix "<agent-prefi
 
 - 接入简单，插件不需要管理 account/user 生命周期
 - 最适合“一个 OpenClaw 实例对应一个 OpenViking 用户”的场景
-- `agentId` 参与决定 agent 级空间，便于区分不同 OpenClaw 实例或不同 agent 角色
+- `agent_prefix` 参与决定 agent 级空间，便于区分不同 OpenClaw 实例或不同 agent 角色
 - 同一 account 内的 `resources` 可共享，`user` / `agent` memory 会按身份隔离
 
 ### OpenClaw 插件为何通常不配 `account` / `user`
@@ -210,7 +210,7 @@ openclaw config set plugins.entries.openviking.config.agent_prefix "<agent-prefi
 因为在 `api_key` 模式下，user key 已经足够表达身份：
 
 - `account`、`user` 由服务端从 key 反解
-- 插件只需要额外告诉服务端当前的 `agentId`
+- 插件只需要额外告诉服务端当前的 `agent_prefix`
 - 插件内部会根据运行时身份去解析默认的 `user` / `agent` 记忆空间
 
 如果给插件直接配置 root key，则普通租户数据 API 会缺少 `X-OpenViking-Account` / `X-OpenViking-User`，这不适合作为日常读写方式。


### PR DESCRIPTION
## Description

Follow-up to #1786 — finishes the `agentId` → `agent_prefix` rename in the **OpenClaw Plugin 2.0** subsection of `docs/{en,zh}/concepts/11-multi-tenant.md`. After #1783 / #1786 the subsection's surrounding text and bullet points still mentioned `agentId` for the OpenClaw plugin config field, while the actual config command and the parent paragraph (already updated to `agent_prefix`) are now inconsistent with two leftover bullets.

Two leftover references in each language file, both within the same "OpenClaw Plugin 2.0" subsection (i.e. about the user-facing config field):

1. EN L205 / ZH L205 — "Characteristics of this model" bullet
2. EN L213 / ZH L213 — "Why the OpenClaw plugin usually does not set `account` / `user`" bullet

Lines 271/273 (the `### 2. agentId does not define the tenant` section) describe the abstract server-side `agentId` concept, **not** the OpenClaw plugin config field, so they are intentionally untouched in this PR.

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/en/concepts/11-multi-tenant.md` L205, L213: ``` `agentId` ``` → ``` `agent_prefix` ```
- `docs/zh/concepts/11-multi-tenant.md` L205, L213: ``` `agentId` ``` → ``` `agent_prefix` ```

Total: 4 LOC, dual-doc EN+ZH mirror, no semantic change.
