### PR TITLE
docs(admin): list `list_agents` endpoint in API overview tables

### DIFF
--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -476,6 +476,7 @@ Below are all HTTP API endpoints provided by OpenViking, grouped by functional m
 | DELETE | `/api/v1/admin/accounts/{account_id}` | Delete workspace (cascade data cleanup) | ROOT |
 | POST | `/api/v1/admin/accounts/{account_id}/users` | Register user | ROOT/ADMIN |
 | GET | `/api/v1/admin/accounts/{account_id}/users` | List users | ROOT/ADMIN |
+| GET | `/api/v1/admin/accounts/{account_id}/agents` | List agent namespaces | ROOT/ADMIN |
 | DELETE | `/api/v1/admin/accounts/{account_id}/users/{user_id}` | Remove user | ROOT/ADMIN |
 | PUT | `/api/v1/admin/accounts/{account_id}/users/{user_id}/role` | Change user role | ROOT |
 | POST | `/api/v1/admin/accounts/{account_id}/users/{user_id}/key` | Regenerate user key | ROOT/ADMIN |

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -476,6 +476,7 @@ JSON 输出 - 错误：
 | DELETE | `/api/v1/admin/accounts/{account_id}` | 删除工作区（级联清理数据） | ROOT |
 | POST | `/api/v1/admin/accounts/{account_id}/users` | 注册用户 | ROOT/ADMIN |
 | GET | `/api/v1/admin/accounts/{account_id}/users` | 列出用户 | ROOT/ADMIN |
+| GET | `/api/v1/admin/accounts/{account_id}/agents` | 列出 agent namespace | ROOT/ADMIN |
 | DELETE | `/api/v1/admin/accounts/{account_id}/users/{user_id}` | 移除用户 | ROOT/ADMIN |
 | PUT | `/api/v1/admin/accounts/{account_id}/users/{user_id}/role` | 修改用户角色 | ROOT |
 | POST | `/api/v1/admin/accounts/{account_id}/users/{user_id}/key` | 重新生成 User Key | ROOT/ADMIN |


### PR DESCRIPTION
## Description

Mirrors the new admin discovery endpoint added by #1821 (qin-ctx, 2026-04-30) into the API endpoint summary tables in `docs/{en,zh}/api/01-overview.md`.

#1821 added the `GET /api/v1/admin/accounts/{account_id}/agents` endpoint (with full implementation, ROOT/ADMIN access, dual-language details in `docs/{en,zh}/api/08-admin.md`) but did not update the parallel "Admin (Multi-tenant)" endpoint summary tables in `01-overview.md`. Readers scanning the overview for available admin endpoints would not see the new `list_agents` API.

This PR adds one row to each table, between the existing `List users` and `Remove user` rows, mirroring the convention from the surrounding rows and the wording already used in `08-admin.md` (which says "List agent namespaces" / "列出 agent namespace").

## Related Issue

Follow-up to #1821 (no separate issue).

## Type of Change

- [x] Documentation update

## Test Plan

Doc-only change — no behavior change. Tables now match `08-admin.md` permission matrix and the implementation in `openviking/server/routers/admin.py:list_agents`.