### PR TITLE
feat(metrics): fan out vikingdb collection metrics across accounts

### DIFF
--- a/examples/grafana/openviking_demo_dashboard.json
+++ b/examples/grafana/openviking_demo_dashboard.json
@@ -250,7 +250,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(openviking_http_requests_total[$__rate_interval]))",
+          "expr": "sum(rate(openviking_http_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "HTTP RPS",
           "range": true,
           "refId": "A"
@@ -324,7 +324,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(openviking_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(openviking_http_request_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "HTTP P95",
           "range": true,
           "refId": "A"
@@ -402,7 +402,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(openviking_retrieval_requests_total[$__rate_interval]))",
+          "expr": "sum(rate(openviking_retrieval_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "Retrieval RPS",
           "range": true,
           "refId": "A"
@@ -480,7 +480,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(openviking_resource_stage_total[$__rate_interval]))",
+          "expr": "sum(rate(openviking_resource_stage_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "Resource RPS",
           "range": true,
           "refId": "A"
@@ -558,7 +558,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(openviking_vlm_calls_total[$__rate_interval]))",
+          "expr": "sum(rate(openviking_vlm_calls_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "VLM RPS",
           "range": true,
           "refId": "A"
@@ -636,7 +636,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(openviking_embedding_requests_total[$__rate_interval]))",
+          "expr": "sum(rate(openviking_embedding_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "Embedding RPS",
           "range": true,
           "refId": "A"
@@ -1190,8 +1190,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by (collection) (openviking_vikingdb_collection_health{valid=\"1\"}) or on(collection) max by (collection) (openviking_vikingdb_collection_health{valid=\"0\"})",
-          "legendFormat": "{{collection}} health",
+          "expr": "max by (collection, account_id) (openviking_vikingdb_collection_health{account_id=~\"$account_id\", valid=\"1\"}) or on(collection, account_id) max by (collection, account_id) (openviking_vikingdb_collection_health{account_id=~\"$account_id\", valid=\"0\"})",
+          "legendFormat": "{{account_id}} {{collection}} health",
           "range": true,
           "refId": "A"
         }
@@ -1268,7 +1268,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by (collection) (openviking_vikingdb_collection_vectors{valid=\"1\"}) or on(collection) max by (collection) (openviking_vikingdb_collection_vectors{valid=\"0\"})",
+          "expr": "sum by (collection) (openviking_vikingdb_collection_vectors{account_id=~\"$account_id\", valid=\"1\"} or on(collection, account_id) openviking_vikingdb_collection_vectors{account_id=~\"$account_id\", valid=\"0\"})",
           "legendFormat": "{{collection}} vectors",
           "range": true,
           "refId": "A"
@@ -1384,7 +1384,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (route, status) (rate(openviking_http_requests_total[$__rate_interval]))",
+          "expr": "sum by (route, status) (rate(openviking_http_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{route}} / {{status}}",
           "range": true,
           "refId": "A"
@@ -1485,7 +1485,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_http_requests_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_http_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -1586,7 +1586,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(openviking_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(openviking_http_request_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{route}}",
           "range": true,
           "refId": "A"
@@ -1687,7 +1687,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_http_request_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -1788,7 +1788,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by (route) (openviking_http_inflight_requests)",
+          "expr": "max by (route) (openviking_http_inflight_requests{account_id=~\"$account_id\"})",
           "legendFormat": "{{route}}",
           "range": true,
           "refId": "A"
@@ -1889,7 +1889,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (openviking_http_inflight_requests)",
+          "expr": "sum by (account_id) (openviking_http_inflight_requests{account_id=~\"$account_id\"})",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -2003,14 +2003,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (context_type) (rate(openviking_retrieval_requests_total[$__rate_interval]))",
+          "expr": "sum by (context_type) (rate(openviking_retrieval_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "requests {{context_type}}",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (context_type) (rate(openviking_retrieval_results_total[$__rate_interval]))",
+          "expr": "sum by (context_type) (rate(openviking_retrieval_results_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "results {{context_type}}",
           "range": true,
           "refId": "B"
@@ -2111,14 +2111,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_retrieval_requests_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_retrieval_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "requests {{account_id}}",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_retrieval_results_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_retrieval_results_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "results {{account_id}}",
           "range": true,
           "refId": "B"
@@ -2219,7 +2219,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, context_type) (rate(openviking_retrieval_latency_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, context_type) (rate(openviking_retrieval_latency_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{context_type}}",
           "range": true,
           "refId": "A"
@@ -2320,7 +2320,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_retrieval_latency_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_retrieval_latency_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -2421,7 +2421,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (operation, status) (rate(openviking_operation_requests_total[$__rate_interval]))",
+          "expr": "sum by (operation, status) (rate(openviking_operation_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{status}}",
           "range": true,
           "refId": "A"
@@ -2522,7 +2522,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_operation_requests_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_operation_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -2623,7 +2623,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(openviking_operation_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(openviking_operation_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{operation}}",
           "range": true,
           "refId": "A"
@@ -2724,7 +2724,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_operation_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_operation_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -2838,7 +2838,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (stage, status) (rate(openviking_resource_stage_total[$__rate_interval]))",
+          "expr": "sum by (stage, status) (rate(openviking_resource_stage_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{stage}} / {{status}}",
           "range": true,
           "refId": "A"
@@ -2939,7 +2939,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_resource_stage_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_resource_stage_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -3041,7 +3041,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(openviking_resource_stage_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(openviking_resource_stage_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{stage}}",
           "range": true,
           "refId": "A"
@@ -3142,7 +3142,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_resource_stage_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_resource_stage_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -3440,7 +3440,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (provider, model_name) (rate(openviking_vlm_calls_total[$__rate_interval]))",
+          "expr": "sum by (provider, model_name) (rate(openviking_vlm_calls_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{provider}} / {{model_name}}",
           "range": true,
           "refId": "A"
@@ -3541,7 +3541,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_vlm_calls_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_vlm_calls_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -3642,21 +3642,21 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (provider, model_name) (rate(openviking_vlm_tokens_input_total[$__rate_interval]))",
+          "expr": "sum by (provider, model_name) (rate(openviking_vlm_tokens_input_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "input {{provider}} / {{model_name}}",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (provider, model_name) (rate(openviking_vlm_tokens_output_total[$__rate_interval]))",
+          "expr": "sum by (provider, model_name) (rate(openviking_vlm_tokens_output_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "output {{provider}} / {{model_name}}",
           "range": true,
           "refId": "B"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (provider, model_name) (rate(openviking_vlm_tokens_total[$__rate_interval]))",
+          "expr": "sum by (provider, model_name) (rate(openviking_vlm_tokens_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "total {{provider}} / {{model_name}}",
           "range": true,
           "refId": "C"
@@ -3757,7 +3757,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_vlm_tokens_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_vlm_tokens_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "total {{account_id}}",
           "range": true,
           "refId": "A"
@@ -3858,7 +3858,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, provider, model_name) (rate(openviking_vlm_call_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, provider, model_name) (rate(openviking_vlm_call_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{provider}} / {{model_name}}",
           "range": true,
           "refId": "A"
@@ -3959,7 +3959,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_vlm_call_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_vlm_call_duration_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -4060,7 +4060,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (status) (rate(openviking_embedding_requests_total[$__rate_interval]))",
+          "expr": "sum by (status) (rate(openviking_embedding_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -4161,7 +4161,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (account_id) (rate(openviking_embedding_requests_total[$__rate_interval]))",
+          "expr": "sum by (account_id) (rate(openviking_embedding_requests_total{account_id=~\"$account_id\"}[$__rate_interval]))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -4262,7 +4262,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, status) (rate(openviking_embedding_latency_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, status) (rate(openviking_embedding_latency_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -4363,7 +4363,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_embedding_latency_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_embedding_latency_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "{{account_id}}",
           "range": true,
           "refId": "A"
@@ -4841,21 +4841,21 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (rate(openviking_http_requests_total[$__rate_interval])))",
+          "expr": "topk(10, sum by (account_id) (rate(openviking_http_requests_total{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "http {{account_id}}",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (rate(openviking_retrieval_requests_total[$__rate_interval])))",
+          "expr": "topk(10, sum by (account_id) (rate(openviking_retrieval_requests_total{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "retrieval {{account_id}}",
           "range": true,
           "refId": "B"
         },
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (rate(openviking_operation_requests_total[$__rate_interval])))",
+          "expr": "topk(10, sum by (account_id) (rate(openviking_operation_requests_total{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "operation {{account_id}}",
           "range": true,
           "refId": "C"
@@ -4932,28 +4932,28 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (rate(openviking_vlm_calls_total[$__rate_interval])))",
+          "expr": "topk(10, sum by (account_id) (rate(openviking_vlm_calls_total{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "vlm calls {{account_id}}",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (rate(openviking_vlm_tokens_total[$__rate_interval])))",
+          "expr": "topk(10, sum by (account_id) (rate(openviking_vlm_tokens_total{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "vlm tokens {{account_id}}",
           "range": true,
           "refId": "B"
         },
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (rate(openviking_embedding_requests_total[$__rate_interval])))",
+          "expr": "topk(10, sum by (account_id) (rate(openviking_embedding_requests_total{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "embedding req {{account_id}}",
           "range": true,
           "refId": "C"
         },
         {
           "editorMode": "code",
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_embedding_latency_seconds_bucket[$__rate_interval]))))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, account_id) (rate(openviking_embedding_latency_seconds_bucket{account_id=~\"$account_id\"}[$__rate_interval]))))",
           "legendFormat": "embedding p95 {{account_id}}",
           "range": true,
           "refId": "D"
@@ -5030,14 +5030,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (rate(openviking_resource_stage_total[$__rate_interval])))",
+          "expr": "topk(10, sum by (account_id) (rate(openviking_resource_stage_total{account_id=~\"$account_id\"}[$__rate_interval])))",
           "legendFormat": "resource {{account_id}}",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "topk(10, sum by (account_id) (openviking_http_inflight_requests))",
+          "expr": "topk(10, sum by (account_id) (openviking_http_inflight_requests{account_id=~\"$account_id\"}))",
           "legendFormat": "inflight {{account_id}}",
           "range": true,
           "refId": "B"
@@ -5086,14 +5086,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(openviking_http_requests_total, account_id)",
+        "definition": "label_values(openviking_vikingdb_collection_vectors, account_id)",
         "includeAll": true,
         "label": "account_id",
         "multi": true,
         "name": "account_id",
         "options": [],
         "query": {
-          "query": "label_values(openviking_http_requests_total, account_id)",
+          "query": "label_values(openviking_vikingdb_collection_vectors, account_id)",
           "refId": "account_id-var"
         },
         "refresh": 2,

--- a/openviking/metrics/account_dimension.py
+++ b/openviking/metrics/account_dimension.py
@@ -39,6 +39,8 @@ ACCOUNT_DIMENSION_SUPPORTED_METRICS = frozenset(
         "openviking_retrieval_latency_seconds",
         "openviking_retrieval_rerank_used_total",
         "openviking_retrieval_rerank_fallback_total",
+        "openviking_vikingdb_collection_health",
+        "openviking_vikingdb_collection_vectors",
         "openviking_session_lifecycle_total",
         "openviking_session_contexts_used_total",
         "openviking_session_archive_total",

--- a/openviking/metrics/bootstrap.py
+++ b/openviking/metrics/bootstrap.py
@@ -83,7 +83,7 @@ def create_default_collector_manager(*, app=None, service=None) -> CollectorMana
     manager.register(ObserverHealthCollector(data_source=ObserverStateDataSource(service=service)))
     manager.register(ObserverStateCollector(data_source=ObserverStateDataSource(service=service)))
     manager.register(LockCollector(data_source=LockStateDataSource()))
-    manager.register(VikingDBCollector(data_source=VikingDBStateDataSource(service=service)))
+    manager.register(VikingDBCollector(data_source=VikingDBStateDataSource(service=service, app=app)))
     manager.register(
         ModelUsageCollector(
             data_source=ModelUsageDataSource(config_provider=get_openviking_config, service=service)

--- a/openviking/metrics/collectors/base.py
+++ b/openviking/metrics/collectors/base.py
@@ -339,18 +339,38 @@ class StateMetricCollector(MetricCollector, Refreshable, ABC):
         match_labels: dict,
         labels: dict | None = None,
         label_names: tuple[str, ...] = (),
+        account_id: str | None = None,
     ) -> None:
         """Replace the full gauge series selected by `match_labels` with one fresh value."""
-        registry.gauge_delete_matching(str(metric_name), match_labels=match_labels)
+        if account_id is None:
+            registry.gauge_delete_matching(str(metric_name), match_labels=match_labels)
+        else:
+            registry.gauge_delete_matching(
+                str(metric_name),
+                match_labels=match_labels,
+                account_id=account_id,
+            )
         if labels is None:
-            registry.set_gauge(str(metric_name), float(value))
+            if account_id is None:
+                registry.set_gauge(str(metric_name), float(value))
+            else:
+                registry.set_gauge(str(metric_name), float(value), account_id=account_id)
             return
-        registry.set_gauge(
-            str(metric_name),
-            float(value),
-            labels=labels,
-            label_names=label_names,
-        )
+        if account_id is None:
+            registry.set_gauge(
+                str(metric_name),
+                float(value),
+                labels=labels,
+                label_names=label_names,
+            )
+        else:
+            registry.set_gauge(
+                str(metric_name),
+                float(value),
+                labels=labels,
+                label_names=label_names,
+                account_id=account_id,
+            )
 
 
 class DomainStatsMetricCollector(MetricCollector, Refreshable, ABC):

--- a/openviking/metrics/collectors/vikingdb.py
+++ b/openviking/metrics/collectors/vikingdb.py
@@ -12,6 +12,13 @@ from openviking.metrics.datasources.observer_state import VikingDBStateDataSourc
 from .base import CollectorConfig, StateMetricCollector
 
 
+@dataclass(frozen=True)
+class VikingDBSample:
+    collection: str
+    vectors: float
+    synthetic: bool = False
+
+
 @dataclass
 class VikingDBCollector(StateMetricCollector):
     """
@@ -34,7 +41,7 @@ class VikingDBCollector(StateMetricCollector):
 
     data_source: VikingDBStateDataSource
     config: CollectorConfig = CollectorConfig(ttl_seconds=10.0, timeout_seconds=0.8)
-    _last_samples: dict[str, tuple[str, float]] = field(default_factory=dict, init=False, repr=False)
+    _last_samples: dict[str, VikingDBSample] = field(default_factory=dict, init=False, repr=False)
 
     def read_metric_input(self):
         """Read the latest VikingDB collection state from the datasource."""
@@ -49,7 +56,7 @@ class VikingDBCollector(StateMetricCollector):
         for that account when available and emits `valid="0"` so dashboards can distinguish stale
         per-account data from a real zero-count collection.
         """
-        current_samples: dict[str, tuple[str, float]] = {}
+        current_samples: dict[str, VikingDBSample] = {}
         for account_id, collection, ok, vectors in metric_input:
             account = str(account_id)
             coll = str(collection)
@@ -57,17 +64,37 @@ class VikingDBCollector(StateMetricCollector):
             previous = self._last_samples.get(account)
 
             if ok:
-                current_samples[account] = (coll, vec)
+                current_samples[account] = VikingDBSample(collection=coll, vectors=vec)
                 self._emit_account_gauges(registry, account, coll, 1.0, vec, "1")
                 continue
 
-            stale_vectors = previous[1] if previous is not None else vec
-            current_samples[account] = (coll, stale_vectors)
+            stale_vectors = vec
+            if previous is not None and not previous.synthetic:
+                stale_vectors = previous.vectors
+            current_samples[account] = VikingDBSample(collection=coll, vectors=stale_vectors)
             self._emit_account_gauges(registry, account, coll, 0.0, stale_vectors, "0")
+
+        # Remove series for accounts whose collection label changed since the last export.
+        for account_id, sample in current_samples.items():
+            previous = self._last_samples.get(account_id)
+            if previous is None or previous.collection == sample.collection:
+                continue
+            old_collection = previous.collection
+            base = {"collection": old_collection}
+            registry.gauge_delete_matching(
+                self.COLLECTION_HEALTH,
+                match_labels=base,
+                account_id=account_id,
+            )
+            registry.gauge_delete_matching(
+                self.COLLECTION_VECTORS,
+                match_labels=base,
+                account_id=account_id,
+            )
 
         # Remove series for accounts that disappeared from the latest datasource snapshot.
         for removed_account in set(self._last_samples) - set(current_samples):
-            old_collection, _ = self._last_samples[removed_account]
+            old_collection = self._last_samples[removed_account].collection
             base = {"collection": old_collection}
             registry.gauge_delete_matching(
                 self.COLLECTION_HEALTH,
@@ -83,8 +110,14 @@ class VikingDBCollector(StateMetricCollector):
 
     def collect_stale_hook(self, registry, error: Exception) -> None:
         """Export stale VikingDB gauges under `valid=0` when datasource refresh fails."""
-        for account_id, (collection, vectors) in self._last_samples.items():
-            self._emit_account_gauges(registry, account_id, collection, 0.0, vectors, "0")
+        if not self._last_samples:
+            self._last_samples = {
+                "default": VikingDBSample(collection="default", vectors=0.0, synthetic=True)
+            }
+            self._emit_account_gauges(registry, "default", "default", 0.0, 0.0, "0")
+            return
+        for account_id, sample in self._last_samples.items():
+            self._emit_account_gauges(registry, account_id, sample.collection, 0.0, sample.vectors, "0")
 
     def _emit_account_gauges(
         self,

--- a/openviking/metrics/collectors/vikingdb.py
+++ b/openviking/metrics/collectors/vikingdb.py
@@ -34,7 +34,7 @@ class VikingDBCollector(StateMetricCollector):
 
     data_source: VikingDBStateDataSource
     config: CollectorConfig = CollectorConfig(ttl_seconds=10.0, timeout_seconds=0.8)
-    _last_collection: str = field(default="unknown", init=False, repr=False)
+    _last_samples: dict[str, tuple[str, float]] = field(default_factory=dict, init=False, repr=False)
 
     def read_metric_input(self):
         """Read the latest VikingDB collection state from the datasource."""
@@ -44,59 +44,74 @@ class VikingDBCollector(StateMetricCollector):
         """
         Refresh VikingDB gauges from the datasource.
 
-        On success, gauges are exported with `valid="1"`. On failure, the collector falls back
-        to the last observed collection name and preserves last vectors count when present,
-        emitting `valid="0"` to mark the data as stale.
+        Healthy account samples are exported with `valid="1"`. If one account read fails inside
+        an otherwise successful fan-out cycle, the collector reuses the last observed vector count
+        for that account when available and emits `valid="0"` so dashboards can distinguish stale
+        per-account data from a real zero-count collection.
         """
-        collection, ok, vectors = metric_input
-        self._last_collection = str(collection)
-        base = {"collection": str(collection)}
-        labels = {"collection": str(collection), "valid": "1"}
-        self.replace_gauge_series(
-            registry,
-            self.COLLECTION_HEALTH,
-            1.0 if ok else 0.0,
-            match_labels=base,
-            labels=labels,
-            label_names=("collection", "valid"),
-        )
-        self.replace_gauge_series(
-            registry,
-            self.COLLECTION_VECTORS,
-            float(vectors),
-            match_labels=base,
-            labels=labels,
-            label_names=("collection", "valid"),
-        )
+        current_samples: dict[str, tuple[str, float]] = {}
+        for account_id, collection, ok, vectors in metric_input:
+            account = str(account_id)
+            coll = str(collection)
+            vec = float(vectors)
+            previous = self._last_samples.get(account)
 
-    def collect_error_hook(self, registry, error: Exception) -> None:
-        """Delegate failure handling to the stale hook by re-raising the datasource error."""
-        raise error
+            if ok:
+                current_samples[account] = (coll, vec)
+                self._emit_account_gauges(registry, account, coll, 1.0, vec, "1")
+                continue
+
+            stale_vectors = previous[1] if previous is not None else vec
+            current_samples[account] = (coll, stale_vectors)
+            self._emit_account_gauges(registry, account, coll, 0.0, stale_vectors, "0")
+
+        # Remove series for accounts that disappeared from the latest datasource snapshot.
+        for removed_account in set(self._last_samples) - set(current_samples):
+            old_collection, _ = self._last_samples[removed_account]
+            base = {"collection": old_collection}
+            registry.gauge_delete_matching(
+                self.COLLECTION_HEALTH,
+                match_labels=base,
+                account_id=removed_account,
+            )
+            registry.gauge_delete_matching(
+                self.COLLECTION_VECTORS,
+                match_labels=base,
+                account_id=removed_account,
+            )
+        self._last_samples = current_samples
 
     def collect_stale_hook(self, registry, error: Exception) -> None:
         """Export stale VikingDB gauges under `valid=0` when datasource refresh fails."""
-        collection = self._last_collection
+        for account_id, (collection, vectors) in self._last_samples.items():
+            self._emit_account_gauges(registry, account_id, collection, 0.0, vectors, "0")
+
+    def _emit_account_gauges(
+        self,
+        registry,
+        account_id: str,
+        collection: str,
+        health: float,
+        vectors: float,
+        valid: str,
+    ) -> None:
         base = {"collection": collection}
-        last_vectors = registry.gauge_get(
-            self.COLLECTION_VECTORS,
-            labels={"collection": collection, "valid": "1"},
-        )
-        if last_vectors is None:
-            last_vectors = 0.0
-        labels = {"collection": collection, "valid": "0"}
+        labels = {"collection": collection, "valid": valid}
         self.replace_gauge_series(
             registry,
             self.COLLECTION_HEALTH,
-            0.0,
+            health,
             match_labels=base,
             labels=labels,
             label_names=("collection", "valid"),
+            account_id=account_id,
         )
         self.replace_gauge_series(
             registry,
             self.COLLECTION_VECTORS,
-            float(last_vectors),
+            vectors,
             match_labels=base,
             labels=labels,
             label_names=("collection", "valid"),
+            account_id=account_id,
         )

--- a/openviking/metrics/datasources/observer_state.py
+++ b/openviking/metrics/datasources/observer_state.py
@@ -7,7 +7,9 @@ import time
 from typing import Any
 
 from openviking.metrics.core.base import ReadEnvelope
+from openviking.server.identity import AccountNamespacePolicy, RequestContext, Role
 from openviking.storage.transaction import get_lock_manager
+from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import run_async
 
 from .base import DomainStatsMetricDataSource, StateMetricDataSource
@@ -104,17 +106,78 @@ class VikingDBStateDataSource(StateMetricDataSource):
     VikingDB health and vector-count gauges from one normalized snapshot.
     """
 
-    def __init__(self, *, service: Any = None) -> None:
-        """Store the optional service object used to resolve the active VikingDB manager."""
+    def __init__(self, *, service: Any = None, app: Any = None) -> None:
+        """Store optional handles used to resolve VikingDB manager and account inventory."""
         self._service = service
+        self._app = app
 
-    def read_vikingdb_state(self) -> ReadEnvelope[tuple[str, bool, int]]:
+    def _read_default_identity(self) -> tuple[str, str]:
+        """Read configured default (account_id, user_id), falling back to `default` values."""
+        try:
+            from openviking_cli.utils.config import get_openviking_config
+
+            config = get_openviking_config()
+            account_id = config.default_account or "default"
+            user_id = config.default_user or "default"
+        except Exception:
+            account_id = "default"
+            user_id = "default"
+        return account_id, user_id
+
+    def _make_ctx(self, *, account_id: str, user_id: str) -> RequestContext:
+        """Build a RequestContext scoped to one account/user pair."""
+        user = UserIdentifier(account_id=account_id, user_id=user_id, agent_id="metrics")
+        ctx = RequestContext(user=user, role=Role.USER, namespace_policy=AccountNamespacePolicy())
+        return ctx
+
+    def _iter_metric_identities(self) -> list[tuple[str, str]]:
+        """
+        Return account/user pairs for fan-out collection.
+
+        The configured default identity is always included first. When API key manager is
+        available (server api_key mode), each known account contributes one user identity
+        (the first listed user) so metrics can emit one per-account series per scrape.
+        """
+        default_account, default_user = self._read_default_identity()
+        identities: dict[str, str] = {str(default_account): str(default_user)}
+
+        manager = getattr(getattr(self._app, "state", None), "api_key_manager", None)
+        if manager is None:
+            return list(identities.items())
+        if not hasattr(manager, "get_accounts") or not hasattr(manager, "get_users"):
+            return list(identities.items())
+
+        try:
+            accounts = manager.get_accounts() or []
+        except Exception:
+            return list(identities.items())
+
+        for item in accounts:
+            account_id = self.normalize_str(getattr(item, "get", lambda *_: None)("account_id"))
+            if not account_id:
+                continue
+            user_id = default_user
+            try:
+                users = manager.get_users(account_id, limit=1, expose_key=False)
+            except TypeError:
+                users = manager.get_users(account_id, limit=1)
+            except Exception:
+                users = []
+            if users:
+                first_user = users[0]
+                user_id = self.normalize_str(
+                    getattr(first_user, "get", lambda *_: None)("user_id"), default=default_user
+                )
+            identities[account_id] = user_id
+        return list(identities.items())
+
+    def read_vikingdb_state(self) -> ReadEnvelope[list[tuple[str, str, bool, int]]]:
         """
         Read the collection name, health status, and approximate row count for VikingDB.
 
         Returns:
-            A tuple of `(collection_name, healthy, count)`. Missing services or failures fall
-            back to safe default values so metrics collection remains best-effort.
+            A list of tuples `(account_id, collection_name, healthy, count)`. Missing services or
+            failures fall back to safe default values so metrics collection remains best-effort.
         """
         vikingdb = None
         if self._service is not None:
@@ -124,30 +187,48 @@ class VikingDBStateDataSource(StateMetricDataSource):
         if vikingdb is None:
             return ReadEnvelope(
                 ok=False,
-                value=("default", False, 0),
+                value=[("default", "default", False, 0)],
                 error_type="NotAvailable",
                 error_message="vikingdb manager missing",
             )
 
+        identities = self._iter_metric_identities()
         collection = self.normalize_str(
             getattr(vikingdb, "collection_name", "default"), default="default"
         )
-        ok_env = self.safe_read_async(
+        results: list[tuple[str, str, bool, int]] = []
+        any_success = False
+        first_error_type: str | None = None
+        first_error_message: str | None = None
+
+        health_env = self.safe_read_async(
             lambda: vikingdb.health_check(),
             default=False,
             runner=run_async,
         )
-        count_env = self.safe_read_async(
-            lambda: vikingdb.count(filter=None, ctx=None),
-            default=0,
-            runner=run_async,
-        )
-        ok = bool(ok_env.value)
-        count = self.as_int(count_env.value, default=0)
-        envelope_ok = bool(ok_env.ok and count_env.ok)
+        base_health_ok = bool(health_env.value)
+
+        for account_id, user_id in identities:
+            ctx = self._make_ctx(account_id=account_id, user_id=user_id)
+            count_env = self.safe_read_async(
+                lambda _ctx=ctx: vikingdb.count(filter=None, ctx=_ctx),
+                default=0,
+                runner=run_async,
+            )
+            sample_ok = base_health_ok and count_env.ok
+            count = self.as_int(count_env.value, default=0)
+            results.append((account_id, collection, sample_ok, count))
+            if health_env.ok and count_env.ok:
+                any_success = True
+            else:
+                if first_error_type is None:
+                    first_error_type = health_env.error_type or count_env.error_type
+                if first_error_message is None:
+                    first_error_message = health_env.error_message or count_env.error_message
+
         return ReadEnvelope(
-            ok=envelope_ok,
-            value=(collection, ok, count),
-            error_type=ok_env.error_type or count_env.error_type,
-            error_message=ok_env.error_message or count_env.error_message,
+            ok=any_success,
+            value=results,
+            error_type=first_error_type,
+            error_message=first_error_message,
         )

--- a/tests/metrics/collectors/test_state_collectors.py
+++ b/tests/metrics/collectors/test_state_collectors.py
@@ -354,6 +354,58 @@ def test_vikingdb_collector_stale_valid_zero_fallback_keeps_multi_account_vector
     )
 
 
+def test_vikingdb_collector_cold_start_failure_emits_default_stale_series(
+    registry, render_prometheus
+):
+    class DS:
+        def read_vikingdb_state(self):
+            raise RuntimeError("boom")
+
+    collector = VikingDBCollector(data_source=DS())
+    collector.collect(registry)
+    text = render_prometheus(registry)
+    assert (
+        'openviking_vikingdb_collection_health{account_id="__unknown__",collection="default",valid="0"} 0.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="__unknown__",collection="default",valid="0"} 0.0'
+        in text
+    )
+
+
+def test_vikingdb_collector_cold_start_fallback_is_removed_after_recovery(
+    registry, render_prometheus
+):
+    class DS:
+        def __init__(self):
+            self.fail = True
+
+        def read_vikingdb_state(self):
+            if self.fail:
+                raise RuntimeError("boom")
+            return [("default", "context", True, 10)]
+
+    ds = DS()
+    collector = VikingDBCollector(data_source=ds)
+    collector.collect(registry)
+    ds.fail = False
+    collector.collect(registry)
+    text = render_prometheus(registry)
+    assert (
+        'openviking_vikingdb_collection_health{account_id="__unknown__",collection="default",valid="0"}'
+        not in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="__unknown__",collection="default",valid="0"}'
+        not in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="__unknown__",collection="context",valid="1"} 10.0'
+        in text
+    )
+
+
 def test_vikingdb_collector_partial_fanout_failure_emits_stale_series_for_failed_account(
     registry, render_prometheus, configure_account_dimension
 ):

--- a/tests/metrics/collectors/test_state_collectors.py
+++ b/tests/metrics/collectors/test_state_collectors.py
@@ -10,6 +10,7 @@ from openviking.metrics.collectors.observer_health import ObserverHealthCollecto
 from openviking.metrics.collectors.queue import QueueCollector
 from openviking.metrics.collectors.task_tracker import TaskTrackerCollector
 from openviking.metrics.collectors.vikingdb import VikingDBCollector
+from openviking.metrics.core.base import ReadEnvelope
 from openviking.metrics.core.registry import MetricRegistry
 from openviking.metrics.datasources.observer_state import (
     LockStateDataSource,
@@ -274,7 +275,142 @@ def test_vikingdb_collector_exports_health_and_count(monkeypatch):
     registry = MetricRegistry()
     VikingDBCollector(data_source=VikingDBStateDataSource(service=Service())).collect(registry)
     text = PrometheusExporter(registry=registry).render()
-    assert 'openviking_vikingdb_collection_health{collection="my_collection",valid="1"} 1.0' in text
     assert (
-        'openviking_vikingdb_collection_vectors{collection="my_collection",valid="1"} 123.0' in text
+        'openviking_vikingdb_collection_health{account_id="__unknown__",collection="my_collection",valid="1"} 1.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="__unknown__",collection="my_collection",valid="1"} 123.0'
+        in text
+    )
+
+
+def test_vikingdb_collector_emits_multi_account_series(registry, render_prometheus, configure_account_dimension):
+    class DS:
+        def read_vikingdb_state(self):
+            return [
+                ("acct_a", "context", True, 10),
+                ("acct_b", "context", True, 20),
+            ]
+
+    configure_account_dimension(
+        enabled=True,
+        metric_allowlist={
+            VikingDBCollector.COLLECTION_HEALTH,
+            VikingDBCollector.COLLECTION_VECTORS,
+        },
+        max_active_accounts=100,
+    )
+    collector = VikingDBCollector(data_source=DS())
+    collector.collect(registry)
+    text = render_prometheus(registry)
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="acct_a",collection="context",valid="1"} 10.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="acct_b",collection="context",valid="1"} 20.0'
+        in text
+    )
+
+
+def test_vikingdb_collector_stale_valid_zero_fallback_keeps_multi_account_vectors(
+    registry, render_prometheus, configure_account_dimension
+):
+    class DS:
+        def __init__(self):
+            self.fail = False
+
+        def read_vikingdb_state(self):
+            if self.fail:
+                raise RuntimeError("boom")
+            return [
+                ("acct_a", "context", True, 10),
+                ("acct_b", "context", True, 20),
+            ]
+
+    configure_account_dimension(
+        enabled=True,
+        metric_allowlist={
+            VikingDBCollector.COLLECTION_HEALTH,
+            VikingDBCollector.COLLECTION_VECTORS,
+        },
+        max_active_accounts=100,
+    )
+    ds = DS()
+    collector = VikingDBCollector(data_source=ds)
+    collector.collect(registry)
+    ds.fail = True
+    collector.collect(registry)
+    text = render_prometheus(registry)
+    # Dashboard query compatibility: each account keeps a `valid=0` fallback series.
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="acct_a",collection="context",valid="0"} 10.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="acct_b",collection="context",valid="0"} 20.0'
+        in text
+    )
+
+
+def test_vikingdb_collector_partial_fanout_failure_emits_stale_series_for_failed_account(
+    registry, render_prometheus, configure_account_dimension
+):
+    class DS:
+        def __init__(self):
+            self.round = 0
+
+        def read_vikingdb_state(self):
+            self.round += 1
+            if self.round == 1:
+                return ReadEnvelope(
+                    ok=True,
+                    value=[
+                        ("acct_a", "context", True, 10),
+                        ("acct_b", "context", True, 20),
+                    ],
+                )
+            return ReadEnvelope(
+                ok=True,
+                value=[
+                    ("acct_a", "context", True, 11),
+                    ("acct_b", "context", False, 0),
+                ],
+                error_type="RuntimeError",
+                error_message="acct_b down",
+            )
+
+    configure_account_dimension(
+        enabled=True,
+        metric_allowlist={
+            VikingDBCollector.COLLECTION_HEALTH,
+            VikingDBCollector.COLLECTION_VECTORS,
+        },
+        max_active_accounts=100,
+    )
+    ds = DS()
+    collector = VikingDBCollector(data_source=ds)
+    collector.collect(registry)
+    collector.collect(registry)
+    text = render_prometheus(registry)
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="acct_a",collection="context",valid="1"} 11.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_health{account_id="acct_a",collection="context",valid="0"}'
+        not in text
+    )
+    assert (
+        'openviking_vikingdb_collection_health{account_id="acct_b",collection="context",valid="0"} 0.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="acct_b",collection="context",valid="0"} 20.0'
+        in text
+    )
+    assert (
+        'openviking_vikingdb_collection_vectors{account_id="acct_b",collection="context",valid="1"}'
+        not in text
     )

--- a/tests/metrics/datasources/test_state_datasources.py
+++ b/tests/metrics/datasources/test_state_datasources.py
@@ -14,6 +14,7 @@ from openviking.metrics.collectors.base import (
 )
 from openviking.metrics.core.base import ReadEnvelope
 from openviking.metrics.core.registry import MetricRegistry
+from openviking.metrics.datasources.observer_state import VikingDBStateDataSource
 
 
 class _EnvelopeStateCollector(StateMetricCollector):
@@ -232,4 +233,153 @@ def test_async_system_probe_datasource_returns_default_on_exception(monkeypatch)
     env = ds.read_probe_state()
     assert env.ok is False
     assert env.value == {"queue": False}
+    assert env.error_type == "RuntimeError"
+
+
+def test_vikingdb_state_datasource_uses_default_account_ctx_for_count(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class DummyVikingDB:
+        collection_name = "my_collection"
+
+        async def health_check(self):
+            return True
+
+        async def count(self, filter=None, ctx=None):
+            captured["ctx"] = ctx
+            return 123
+
+    class Service:
+        _vikingdb_manager = DummyVikingDB()
+
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: SimpleNamespace(default_account="acct_demo", default_user="user_demo"),
+    )
+
+    env = VikingDBStateDataSource(service=Service()).read_vikingdb_state()
+    assert env.ok is True
+    assert env.value == [("acct_demo", "my_collection", True, 123)]
+    ctx = captured["ctx"]
+    assert getattr(ctx, "account_id", None) == "acct_demo"
+
+
+def test_vikingdb_state_datasource_fanout_reads_multiple_accounts(monkeypatch):
+    seen: list[tuple[str, str]] = []
+
+    class DummyVikingDB:
+        collection_name = "context"
+
+        async def health_check(self):
+            return True
+
+        async def count(self, filter=None, ctx=None):
+            seen.append(
+                (
+                    getattr(ctx, "account_id", ""),
+                    getattr(getattr(ctx, "user", None), "user_id", ""),
+                )
+            )
+            return {"acct_default": 11, "acct_a": 21, "acct_b": 31}.get(
+                getattr(ctx, "account_id", ""), 0
+            )
+
+    class APIKeyManager:
+        def get_accounts(self):
+            return [{"account_id": "acct_a"}, {"account_id": "acct_b"}]
+
+        def get_users(self, account_id, limit=1, expose_key=False):
+            return [{"user_id": f"user_{account_id[-1]}"}]
+
+    class App:
+        state = SimpleNamespace(api_key_manager=APIKeyManager())
+
+    class Service:
+        _vikingdb_manager = DummyVikingDB()
+
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: SimpleNamespace(default_account="acct_default", default_user="user_default"),
+    )
+
+    env = VikingDBStateDataSource(service=Service(), app=App()).read_vikingdb_state()
+    assert env.ok is True
+    assert env.value == [
+        ("acct_default", "context", True, 11),
+        ("acct_a", "context", True, 21),
+        ("acct_b", "context", True, 31),
+    ]
+    assert seen == [
+        ("acct_default", "user_default"),
+        ("acct_a", "user_a"),
+        ("acct_b", "user_b"),
+    ]
+
+
+def test_vikingdb_state_datasource_fanout_partial_failure_marks_failed_account_not_ok(monkeypatch):
+    health_calls = {"count": 0}
+
+    class DummyVikingDB:
+        collection_name = "context"
+
+        async def health_check(self):
+            health_calls["count"] += 1
+            return True
+
+        async def count(self, filter=None, ctx=None):
+            if getattr(ctx, "account_id", "") == "acct_b":
+                raise RuntimeError("acct_b down")
+            return {"acct_default": 11, "acct_a": 21}.get(getattr(ctx, "account_id", ""), 0)
+
+    class APIKeyManager:
+        def get_accounts(self):
+            return [{"account_id": "acct_a"}, {"account_id": "acct_b"}]
+
+        def get_users(self, account_id, limit=1, expose_key=False):
+            return [{"user_id": f"user_{account_id[-1]}"}]
+
+    class App:
+        state = SimpleNamespace(api_key_manager=APIKeyManager())
+
+    class Service:
+        _vikingdb_manager = DummyVikingDB()
+
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: SimpleNamespace(default_account="acct_default", default_user="user_default"),
+    )
+
+    env = VikingDBStateDataSource(service=Service(), app=App()).read_vikingdb_state()
+    assert env.ok is True
+    assert env.value == [
+        ("acct_default", "context", True, 11),
+        ("acct_a", "context", True, 21),
+        ("acct_b", "context", False, 0),
+    ]
+    assert env.error_type == "RuntimeError"
+    assert "acct_b down" in (env.error_message or "")
+    assert health_calls["count"] == 1
+
+
+def test_vikingdb_state_datasource_fanout_all_fail_sets_envelope_not_ok(monkeypatch):
+    class DummyVikingDB:
+        collection_name = "context"
+
+        async def health_check(self):
+            raise RuntimeError("health down")
+
+        async def count(self, filter=None, ctx=None):
+            raise RuntimeError("count down")
+
+    class Service:
+        _vikingdb_manager = DummyVikingDB()
+
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: SimpleNamespace(default_account="acct_default", default_user="user_default"),
+    )
+
+    env = VikingDBStateDataSource(service=Service()).read_vikingdb_state()
+    assert env.ok is False
+    assert env.value == [("acct_default", "context", False, 0)]
     assert env.error_type == "RuntimeError"


### PR DESCRIPTION
## Summary

- Fan out VikingDB collection metrics across configured/default and api-key-managed accounts
- Expose `account_id` on the VikingDB collection metric families and preserve stale semantics on per-account partial failures
- Update the demo dashboard `account_id` selector to source from VikingDB metrics directly

## Motivation

This replaces the earlier default-account-only approach behind #1760 with actual per-account fan-out so the `account_id` label is semantically accurate.

## Changes

- Add `openviking_vikingdb_collection_health` and `openviking_vikingdb_collection_vectors` to the account-dimension allowlist
- Wire the VikingDB metrics datasource to app state so it can enumerate API-key-managed accounts
- Read VikingDB count metrics once per account using account-scoped request contexts
- Mark partial per-account failures as stale (`valid="0"`) instead of exporting fresh zero-count samples
- Reuse the last known vector count for failed-account fallback series
- Clean up stale placeholder / old collection series correctly after recovery or label changes
- Extend datasource and collector tests for multi-account and partial-failure behavior
- Source the Grafana demo dashboard `account_id` variable from `openviking_vikingdb_collection_vectors`

## Test Plan

- [x] Targeted unit tests pass (`tests/metrics/collectors/test_state_collectors.py tests/metrics/datasources/test_state_datasources.py`)
- [x] JSON validation for `examples/grafana/openviking_demo_dashboard.json`
- [x] Manual code review of datasource/collector stale semantics, recovery cleanup, and dashboard queries

## Screenshots / Examples

N/A

## Notes for Reviewers

- The branch is rebased onto current `main` and is not stacked on the closed #1760.
- Per-account reads that fail export stale vector counts (`valid="0"`) from the last successful scrape, not zero. On the next successful scrape the stale series is replaced with fresh data and placeholder fallback entries are removed.

/cc @qin-ctx 
