### PR TITLE
fix(memory): self-correct when LLM returns non-JSON during memory extraction (#1541)

### DIFF
--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -189,10 +189,17 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
             # If last iteration, add a message telling the model to return result directly
             if is_last_iteration:
+                schema_str = json.dumps(self._json_schema, ensure_ascii=False)
                 messages.append(
                     {
                         "role": "user",
-                        "content": "You have reached the maximum number of tool call iterations. Do not call any more tools - return your final result directly now.",
+                        "content": (
+                            "You have reached the maximum number of tool call iterations. "
+                            "Do not call any more tools. Output ONLY a JSON object matching "
+                            "the schema below — no prose, no markdown fences, no explanation. "
+                            "If you have nothing to commit, return the schema with empty arrays.\n"
+                            f"```json\n{schema_str}\n```"
+                        ),
                     }
                 )
 
@@ -431,10 +438,18 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 if error is not None:
                     print(f"content={content}")
                     logger.warning(f"Failed to parse memory operations: {error}")
+                    # Persist the failed assistant content + a corrective user message
+                    # so the next iteration sees the failure and can self-correct
+                    # instead of repeating the same plain-text drift (fixes #1541).
+                    self._append_invalid_response_correction(messages, content, error)
                     return (None, None)
 
                 # Validate that all URIs are allowed
-                self._validate_operations(operations)
+                try:
+                    self._validate_operations(operations)
+                except ValueError as ve:
+                    self._append_invalid_response_correction(messages, content, str(ve))
+                    return (None, None)
                 return (None, operations)
             except Exception as e:
                 logger.exception(f"Error parsing operations: {e}")
@@ -562,3 +577,36 @@ The final output of the model must strictly follow the JSON Schema format shown 
         # 支持 dict 消息和 object 消息
         last_msg = messages[-1]
         last_msg["cache_control"] = {"type": "ephemeral"}
+
+    _MAX_FAILED_CONTENT_CHARS = 1500
+
+    def _append_invalid_response_correction(
+        self,
+        messages: List[Dict[str, Any]],
+        content: str,
+        error: str,
+    ) -> None:
+        """Persist the unparseable assistant response + a corrective user message.
+
+        Without this, when the model returns plain prose (or any non-schema output)
+        the next iteration sees the exact same prompt and repeats the same drift,
+        exhausting `max_iterations` with zero memories extracted.
+        """
+        truncated = content or ""
+        if len(truncated) > self._MAX_FAILED_CONTENT_CHARS:
+            truncated = truncated[: self._MAX_FAILED_CONTENT_CHARS] + "...[truncated]"
+
+        schema_str = json.dumps(self._json_schema, ensure_ascii=False)
+        messages.append({"role": "assistant", "content": truncated})
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    "Your previous response could not be parsed as valid memory "
+                    f"operations: {error}. Output ONLY a JSON object matching the "
+                    "schema below — no prose, no markdown fences, no explanation. "
+                    "If you have nothing to commit, return the schema with empty arrays.\n"
+                    f"```json\n{schema_str}\n```"
+                ),
+            }
+        )

--- a/tests/session/memory/test_memory_react_invalid_response.py
+++ b/tests/session/memory/test_memory_react_invalid_response.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Tests for ExtractLoop's recovery from unparseable LLM responses.
+
+Reproduces issue #1541: when the model returns plain prose instead of the
+expected JSON, the loop must persist the failure context so the next
+iteration can self-correct rather than repeating the same drift.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openviking.session.memory.extract_loop import ExtractLoop
+
+
+@pytest.fixture
+def mock_vlm():
+    vlm = MagicMock()
+    vlm.model = "test-model"
+    vlm.max_retries = 2
+    vlm.get_completion_async = AsyncMock()
+    return vlm
+
+
+@pytest.fixture
+def mock_viking_fs():
+    return MagicMock()
+
+
+@pytest.fixture
+def extract_loop(mock_vlm, mock_viking_fs):
+    """Build an ExtractLoop with the JSON schema field already populated.
+
+    The helper under test reads ``self._json_schema`` directly, which is
+    normally set inside ``run()``. We patch a representative schema in here
+    so we can exercise the helper in isolation.
+    """
+    with (
+        patch("openviking.session.memory.extract_loop.SchemaModelGenerator"),
+        patch("openviking.session.memory.extract_loop.SchemaPromptGenerator"),
+    ):
+        loop = ExtractLoop(mock_vlm, mock_viking_fs)
+        loop._json_schema = {
+            "type": "object",
+            "properties": {
+                "delete_uris": {"type": "array", "items": {"type": "string"}},
+                "preferences": {"type": "array"},
+            },
+            "required": ["delete_uris", "preferences"],
+        }
+        return loop
+
+
+class TestAppendInvalidResponseCorrection:
+    """Direct tests on the helper that recovers from non-schema responses."""
+
+    def test_appends_assistant_and_user_messages(self, extract_loop):
+        messages = [{"role": "system", "content": "irrelevant"}]
+        extract_loop._append_invalid_response_correction(
+            messages,
+            content="I'd be happy to help! Sure, here are the memories...",
+            error="Expected dict after parsing, got <class 'str'>",
+        )
+
+        assert len(messages) == 3
+        assistant_msg, correction_msg = messages[1], messages[2]
+
+        assert assistant_msg["role"] == "assistant"
+        assert assistant_msg["content"] == ("I'd be happy to help! Sure, here are the memories...")
+
+        assert correction_msg["role"] == "user"
+        assert "could not be parsed" in correction_msg["content"]
+        assert "Expected dict" in correction_msg["content"]
+
+    def test_correction_includes_json_schema(self, extract_loop):
+        messages = []
+        extract_loop._append_invalid_response_correction(
+            messages, content="oops not JSON", error="parse error"
+        )
+        correction_body = messages[1]["content"]
+        # Schema must travel with the correction so the model has a fresh
+        # reminder of what shape to emit.
+        assert "delete_uris" in correction_body
+        assert "preferences" in correction_body
+        assert "```json" in correction_body
+
+    def test_correction_explicitly_forbids_prose_and_markdown_fences(self, extract_loop):
+        messages = []
+        extract_loop._append_invalid_response_correction(messages, content="x", error="e")
+        correction_body = messages[1]["content"]
+        assert "ONLY a JSON object" in correction_body
+        assert "no prose" in correction_body
+        assert "no markdown fences" in correction_body
+
+    def test_truncates_oversized_content(self, extract_loop):
+        # Models occasionally generate multi-KB ramblings; we don't want to
+        # blow up the next prompt with a copy of the whole thing.
+        big = "x" * (ExtractLoop._MAX_FAILED_CONTENT_CHARS + 5000)
+        messages = []
+        extract_loop._append_invalid_response_correction(messages, content=big, error="e")
+        assistant_content = messages[0]["content"]
+        assert len(assistant_content) < len(big)
+        assert assistant_content.endswith("...[truncated]")
+        assert len(assistant_content) == ExtractLoop._MAX_FAILED_CONTENT_CHARS + len(
+            "...[truncated]"
+        )
+
+    def test_short_content_not_truncated(self, extract_loop):
+        short = "short reply"
+        messages = []
+        extract_loop._append_invalid_response_correction(messages, content=short, error="e")
+        assert messages[0]["content"] == short
+
+    def test_handles_empty_content(self, extract_loop):
+        # In practice content may be ``None`` (no choices) or an empty string;
+        # both should produce a usable correction message instead of crashing.
+        messages = []
+        extract_loop._append_invalid_response_correction(messages, content="", error="e")
+        assert messages[0]["content"] == ""
+        assert messages[1]["role"] == "user"
+
+        messages2 = []
+        extract_loop._append_invalid_response_correction(messages2, content=None, error="e")
+        assert messages2[0]["content"] == ""
+
+    def test_schema_in_correction_is_valid_json(self, extract_loop):
+        # The schema is embedded inside a fenced code block — make sure the
+        # extracted JSON between the fences round-trips cleanly so the model
+        # sees a parseable schema reference.
+        messages = []
+        extract_loop._append_invalid_response_correction(messages, content="x", error="e")
+        body = messages[1]["content"]
+        start = body.index("```json\n") + len("```json\n")
+        end = body.index("\n```", start)
+        embedded = body[start:end]
+        round_tripped = json.loads(embedded)
+        assert round_tripped == extract_loop._json_schema
+
+
+class TestCallLLMPersistsFailureContext:
+    """Integration test on _call_llm: parse failure mutates ``messages``
+    so the next iteration sees the failure (without it, #1541 reproduces)."""
+
+    @pytest.mark.asyncio
+    async def test_unparseable_response_appends_failure_context(self, extract_loop):
+        # VLM returns plain prose; parse_json_with_stability returns the bare
+        # string and Layer 3 reports "Expected dict ... got <class 'str'>"
+        # — the exact symptom from the bug report.
+        response = MagicMock()
+        response.has_tool_calls = False
+        response.tool_calls = []
+        response.content = "I'm sorry, I cannot help with this request."
+        response.usage = {}
+        extract_loop.vlm.get_completion_async = AsyncMock(return_value=response)
+
+        # Pre-populate the precomputed expected_fields/operations_model that
+        # _call_llm uses, so the call doesn't depend on full run() setup.
+        extract_loop._operations_model = MagicMock()
+        extract_loop._expected_fields = ["delete_uris", "preferences"]
+        extract_loop._tool_schemas = []
+        extract_loop._disable_tools_for_iteration = True
+
+        messages = [{"role": "system", "content": "system prompt"}]
+        tool_calls, operations = await extract_loop._call_llm(messages)
+
+        assert tool_calls is None
+        assert operations is None
+        # Must persist failure context so iteration N+1 can self-correct
+        assert len(messages) == 3
+        assert messages[1]["role"] == "assistant"
+        assert "cannot help" in messages[1]["content"]
+        assert messages[2]["role"] == "user"
+        assert "could not be parsed" in messages[2]["content"]


### PR DESCRIPTION
## Summary

Fixes #1541 — `memcommit` extracting **0 memories** because the LLM returned plain conversational text instead of the schema-required JSON, then every retry exhausted `max_iterations` repeating the same drift.

The flow that breaks today:

1. `_call_llm` calls the model with `tool_choice="auto"`. Weak models (the reporter's `LongCat-Flash-Thinking`, but I've seen the same with smaller open models) sometimes ignore the system-prompt schema and respond with prose.
2. `parse_json_with_stability` returns `(None, "Expected dict after parsing, got <class 'str'>")` — the exact error from the bug report.
3. The current code logs a warning and returns `(None, None)` **without appending the failed content to `messages`**.
4. Iteration N+1 sees the exact same prompt and produces the same plain-text drift. After `max_iterations`, extraction completes with 0 memories.

## What this PR changes

- **Persist failure context.** When parse fails, append the failed assistant content + a corrective user message that re-states the JSON schema and forbids prose. The next iteration now has concrete feedback to recover from instead of silently re-running the same prompt. (`extract_loop.py:438-448`)
- **Same recovery on URI validation errors.** `_validate_operations(...)` raising `ValueError` (operations parsed cleanly but pointed at disallowed URIs) now goes through the same correction path so the model can fix the URIs in iteration N+1. (`extract_loop.py:444-448`)
- **Schema-anchored last-iteration prompt.** The "max iterations reached" message now embeds the JSON schema directly and explicitly forbids prose / markdown fences / explanation, so even when no prior failures were appended the final attempt has a strong, schema-grounded instruction. (`extract_loop.py:191-203`)
- **Truncation safety.** `_MAX_FAILED_CONTENT_CHARS = 1500` caps how much of the failed response we copy into the next prompt — models occasionally produce multi-KB ramblings.

This addresses solution #3 from the issue ("validation loop that asks LLM to retry if non-JSON response is detected") without invasive changes to the VLM backends. Solution #1 (`response_format`) and solution #2 (force tool calling) would each touch every backend; persistence of failure context is a smaller, surgical fix that works regardless of provider.

## Tests

New `tests/session/memory/test_memory_react_invalid_response.py` (8 tests, all green):

- 7 unit tests on `_append_invalid_response_correction`: 2-message append shape, schema embedded in correction, prose/markdown forbidden, oversized-content truncation, short-content untouched, empty/None content handled, embedded schema round-trips through `json.loads`.
- 1 integration test on `_call_llm`: a mock VLM returning plain prose triggers the failure-persistence path, leaving `messages` with the failed assistant content + corrective user message ready for iteration N+1.

```
$ PYTHONPATH=. pytest tests/session/memory/test_memory_react_invalid_response.py --noconftest --no-cov -q
8 passed, 4 warnings in 1.96s
```

`ruff check` and `ruff format --check` are clean on the changed files.

## Out of scope

- Adding `response_format` support to VLM backends (issue solution #1) — separate PR if maintainers want it.
- Adding a "submit_operations" tool to make `tool_choice="required"` viable (issue solution #2) — bigger refactor; happy to follow up if you'd prefer that direction.

## Backwards compatibility

- Behaviour unchanged when the LLM returns valid JSON on the first try (which is the common-path).
- The new `messages` entries appear only on the recovery path, so token usage is only affected for runs that were already failing.