### PR TITLE
fix(vlm): explicitly pass stream=False to prevent AsyncStream AttributeError

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -59,6 +59,7 @@ class OpenAIVLM(VLMBase):
             "model": self.model or "gpt-4o-mini",
             "messages": [{"role": "user", "content": prompt}],
             "temperature": self.temperature,
+            "stream": False,  # Explicitly disable streaming to prevent AsyncStream responses
         }
 
         if self.provider == "volcengine":
@@ -77,6 +78,7 @@ class OpenAIVLM(VLMBase):
             "model": self.model or "gpt-4o-mini",
             "messages": [{"role": "user", "content": prompt}],
             "temperature": self.temperature,
+            "stream": False,  # Explicitly disable streaming to prevent AsyncStream responses
         }
 
         if self.provider == "volcengine":
@@ -144,6 +146,7 @@ class OpenAIVLM(VLMBase):
             model=self.model or "gpt-4o-mini",
             messages=[{"role": "user", "content": content}],
             temperature=self.temperature,
+            stream=False,  # Explicitly disable streaming to prevent AsyncStream responses
         )
         self._update_token_usage_from_response(response)
         return response.choices[0].message.content or ""
@@ -165,6 +168,7 @@ class OpenAIVLM(VLMBase):
             model=self.model or "gpt-4o-mini",
             messages=[{"role": "user", "content": content}],
             temperature=self.temperature,
+            stream=False,  # Explicitly disable streaming to prevent AsyncStream responses
         )
         self._update_token_usage_from_response(response)
         return response.choices[0].message.content or ""


### PR DESCRIPTION
## Summary

- Add explicit `stream=False` to all `chat.completions.create()` kwargs in `OpenAIVLM` completion methods
- This prevents `AttributeError: 'AsyncStream' object has no attribute 'choices'` when the OpenAI client or a wrapper defaults to streaming mode
- Affects `get_completion`, `get_completion_async`, `get_vision_completion`, `get_vision_completion_async`

Fixes #1758

## Test plan
- [ ] Verify memory extraction no longer crashes with `AsyncStream` error when using llama.cpp or similar OpenAI-compatible servers
- [ ] `OpenAIVLM.get_completion_async` returns a string, not an `AsyncStream` object

🤖 Generated with [Claude Code](https://claude.com/claude-code)