### PR TITLE
feat: replace controversial examples with neutral alternatives

### DIFF
--- a/benchmark/RAG/README.md
+++ b/benchmark/RAG/README.md
@@ -428,11 +428,11 @@ Example (single result):
 
 ```json
 {
-  "_global_index": 2,
-  "question": "When did Caroline go to the LGBTQ support group?",
-  "gold_answers": ["7 May 2023"],
+  "_global_index": 18,
+  "question": "When did Melanie sign up for a pottery class?",
+  "gold_answers": ["2 July 2023"],
   "llm": {
-    "final_answer": "7 May 2023 (the day before the chat at 1:56 pm on 8 May, 2023)"
+    "final_answer": "2 July 2023 (mentioned in the conversation on 3 July 2023)"
   },
   "metrics": {
     "Recall": 1.0,
@@ -441,7 +441,7 @@ Example (single result):
   },
   "llm_evaluation": {
     "prompt_used": "Locomo_0or4",
-    "reasoning": "The generated answer explicitly includes the exact date 7 May 2023 that matches the gold answer...",
+    "reasoning": "The generated answer explicitly includes the exact date 2 July 2023 that matches the gold answer...",
     "normalized_score": 4
   }
 }

--- a/benchmark/RAG/README_zh.md
+++ b/benchmark/RAG/README_zh.md
@@ -428,11 +428,11 @@ datasets/{dataset_name}/viking_store_index_dir
 
 ```json
 {
-  "_global_index": 2,
-  "question": "When did Caroline go to the LGBTQ support group?",
-  "gold_answers": ["7 May 2023"],
+  "_global_index": 18,
+  "question": "When did Melanie sign up for a pottery class?",
+  "gold_answers": ["2 July 2023"],
   "llm": {
-    "final_answer": "7 May 2023 (the day before the chat at 1:56 pm on 8 May, 2023)"
+    "final_answer": "2 July 2023 (mentioned in the conversation on 3 July 2023)"
   },
   "metrics": {
     "Recall": 1.0,
@@ -441,7 +441,7 @@ datasets/{dataset_name}/viking_store_index_dir
   },
   "llm_evaluation": {
     "prompt_used": "Locomo_0or4",
-    "reasoning": "The generated answer explicitly includes the exact date 7 May 2023 that matches the gold answer...",
+    "reasoning": "The generated answer explicitly includes the exact date 2 July 2023 that matches the gold answer...",
     "normalized_score": 4
   }
 }

--- a/openviking/prompts/templates/compression/ov_wm_v2_update.yaml
+++ b/openviking/prompts/templates/compression/ov_wm_v2_update.yaml
@@ -44,7 +44,7 @@ template: |
   The goal is a document that lets a future assistant seamlessly continue the
   conversation. Concrete facts (names, dates, decisions, relationships, exact
   values) MUST survive. But repetitive events of the same type should be
-  consolidated into patterns — "Caroline attended 5 pride parades" is better
+  consolidated into patterns — "Tim competed in 5 swimming contests" is better
   than 5 separate entries. The test: can a new assistant answer the user's
   likely follow-up questions from this WM alone?
 
@@ -115,9 +115,9 @@ template: |
     2. Preserve: names, dates, exact numbers, decisions with rationale,
        relationships, preferences. These are non-negotiable anchors.
     3. Drop: intermediate chronological steps that don't change the
-       current state (e.g., 5 separate "attended pride parade" entries
-       become "Caroline regularly attends pride parades; most recently
-       on [date], felt [emotion]").
+       current state (e.g., 5 separate "competed in swimming contest" entries
+       become "Tim regularly competes in swimming contests; won 2 gold
+       medals, most recently on [date]").
     4. The consolidation target is a "continuation-grade" fact list:
        enough to answer follow-up questions without re-reading history,
        but not a verbatim transcript of every event.

--- a/tests/unit/session/test_working_memory_growth.py
+++ b/tests/unit/session/test_working_memory_growth.py
@@ -148,8 +148,8 @@ def test_key_facts_consolidation_rejected_when_trivially_small():
 _RICH_KEY_FACTS = "\n".join([
     "- Caroline adopted a rescue dog named Biscuit on 15 March 2024.",
     "- Melanie's family took 3 camping trips to Yellowstone because the kids love hiking.",
-    "- Caroline attended pride parade on 10 June 2023, felt empowered.",
-    "- Caroline attended pride parade on 9 June 2024, brought friends.",
+    "- Caroline competed in swimming contest on 10 June 2023, won gold medal.",
+    "- Caroline competed in swimming contest on 9 June 2024, brought friends to cheer.",
     "- Sweden trip planned for August 2025 with budget of 5000 dollars.",
     "- Decided to use Python because the team has 4 years experience.",
     "- Marcus is Caroline's brother, lives in Portland.",
@@ -191,7 +191,7 @@ _RICH_KEY_FACTS = "\n".join([
 
 _GOOD_CONSOLIDATION = "\n".join([
     "- Caroline adopted rescue dog Biscuit (golden retriever mix, 3 years old) on 15 March 2024; vet at Pawsome Clinic every 6 months. Neighbor Jake (retired teacher, next door since 2020) offered to pet-sit during Sweden trip.",
-    "- Caroline regularly attends pride parades; most recently on 9 June 2024, brought friends.",
+    "- Caroline regularly competes in swimming contests; most recently on 9 June 2024, won 2 gold medals total.",
     "- Caroline's art: switched from acrylic to watercolor (March 2024) because of studio ventilation; exhibition on 22 November 2024 at Gallery One (12 paintings, 500 dollars space); studio in garage, converted 2023. Budget 200 dollars/month.",
     "- Caroline took ceramics class starting January 2025; resolved to run half-marathon Spring 2025 (target under 2 hours, runs 5 miles mornings along river trail, group meets Wednesdays 6 AM).",
     "- Caroline volunteers at shelter every Saturday morning.",
@@ -264,7 +264,7 @@ def test_key_facts_consolidation_accepted_at_low_volume_with_anchors():
 
     consolidated = "\n".join([
         "- Caroline adopted Biscuit (golden retriever, 3 years old) on 15 March 2024; vet every 6 months at Pawsome Clinic.",
-        "- Caroline attends pride parades regularly; latest 9 June 2024.",
+        "- Caroline competes in swimming contests regularly; latest 9 June 2024, 2 gold medals total.",
         "- Caroline's art: watercolor (switched March 2024 because ventilation); exhibition 22 November 2024 at Gallery One, 12 paintings, 500 dollars. Studio in garage since 2023. Budget 200 dollars/month. Also took ceramics January 2025.",
         "- Caroline runs half-marathon Spring 2025, target under 2 hours; runs 5 miles mornings, group Wednesdays 6 AM. Volunteers shelter Saturdays.",
         "- Marcus: Caroline's brother, Portland. Joint savings, Sunday calls. Committed to Sweden trip help.",


### PR DESCRIPTION
## Summary
- Replace pride parade / LGBTQ references in prompt template, tests, and benchmark READMEs with neutral examples (swimming contests, pottery class)
- All unit tests pass with the new examples

## Test plan
- [x] `pytest tests/unit/session/test_working_memory_growth.py` — all 22 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)