### PR TITLE
feat: harden MCP add_resource + cc-memory-plugin claude wrapper

### DIFF
--- a/examples/claude-code-memory-plugin/README.md
+++ b/examples/claude-code-memory-plugin/README.md
@@ -51,11 +51,13 @@ If `ov.conf` is what you already maintain, the plugin reads it too — see [Conf
 The repo's `examples/.claude-plugin/marketplace.json` exposes the plugin as a local marketplace entry. From the OpenViking repo root:
 
 ```bash
-claude plugin marketplace add "$(pwd)/examples" --scope local
-claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope local
+claude plugin marketplace add "$(pwd)/examples" --scope user
+claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope user
 ```
 
-> Local install points Claude Code at the source directory. Edits to `scripts/`, `hooks/`, and config files take effect on the next hook invocation — no reinstall. But moving / renaming / deleting the source dir, or `git checkout`-ing to a branch without these files, breaks the plugin. A public marketplace listing for one-click install will follow.
+> `--scope user` makes the plugin active from any directory. Using `--scope local` ties enablement to the current dir and the plugin shows up disabled the moment you `cd` elsewhere.
+>
+> The marketplace entry points Claude Code at the source directory. Edits to `scripts/`, `hooks/`, and config files take effect on the next hook invocation — no reinstall. But moving / renaming / deleting the source dir, or `git checkout`-ing to a branch without these files, breaks the plugin. A public marketplace listing for one-click install will follow.
 
 #### 4. Start Claude Code
 

--- a/examples/claude-code-memory-plugin/README.md
+++ b/examples/claude-code-memory-plugin/README.md
@@ -84,10 +84,14 @@ Where is your OpenViking server?
 ```bash
 # ~/.zshrc or ~/.bashrc
 claude() {
-  if [ -f ~/.openviking/ovcli.conf ]; then
-    OPENVIKING_URL=$(jq -r '.url' ~/.openviking/ovcli.conf) \
-    OPENVIKING_API_KEY=$(jq -r '.api_key' ~/.openviking/ovcli.conf) \
-    command claude "$@"
+  local _ov_conf="${OPENVIKING_CLI_CONFIG_FILE:-$HOME/.openviking/ovcli.conf}"
+  if [ -f "$_ov_conf" ] && command -v jq >/dev/null 2>&1; then
+    local _ov_url _ov_key
+    _ov_url=$(jq -r '.url // empty'     "$_ov_conf" 2>/dev/null)
+    _ov_key=$(jq -r '.api_key // empty' "$_ov_conf" 2>/dev/null)
+    OPENVIKING_URL="${OPENVIKING_URL:-$_ov_url}" \
+    OPENVIKING_API_KEY="${OPENVIKING_API_KEY:-$_ov_key}" \
+      command claude "$@"
   else
     command claude "$@"
   fi

--- a/examples/claude-code-memory-plugin/README_CN.md
+++ b/examples/claude-code-memory-plugin/README_CN.md
@@ -51,11 +51,13 @@ curl http://localhost:1933/health   # 或者你的远程 URL
 仓库的 `examples/.claude-plugin/marketplace.json` 把本插件暴露为一个本地 marketplace 条目。在 OpenViking 仓库根目录：
 
 ```bash
-claude plugin marketplace add "$(pwd)/examples" --scope local
-claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope local
+claude plugin marketplace add "$(pwd)/examples" --scope user
+claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope user
 ```
 
-> 本地安装让 Claude Code 直接引用源码目录，对 `scripts/`、`hooks/`、配置文件的修改下次 hook 触发即生效，无需重装。但移动 / 重命名 / 删除源码目录，或 `git checkout` 到不含这些文件的分支，会立刻让插件失效。后续会发布公开 marketplace 以支持一键安装。
+> `--scope user` 让插件在任意目录下都启用。用 `--scope local` 会把启用状态绑死在当前目录,一旦 `cd` 到别处插件就显示 disabled,需要手动 enable。
+>
+> marketplace 条目让 Claude Code 直接引用源码目录,对 `scripts/`、`hooks/`、配置文件的修改下次 hook 触发即生效,无需重装。但移动 / 重命名 / 删除源码目录,或 `git checkout` 到不含这些文件的分支,会立刻让插件失效。后续会发布公开 marketplace 以支持一键安装。
 
 #### 4. 启动 Claude Code
 

--- a/examples/claude-code-memory-plugin/README_CN.md
+++ b/examples/claude-code-memory-plugin/README_CN.md
@@ -84,10 +84,14 @@ claude
 ```bash
 # ~/.zshrc 或 ~/.bashrc
 claude() {
-  if [ -f ~/.openviking/ovcli.conf ]; then
-    OPENVIKING_URL=$(jq -r '.url' ~/.openviking/ovcli.conf) \
-    OPENVIKING_API_KEY=$(jq -r '.api_key' ~/.openviking/ovcli.conf) \
-    command claude "$@"
+  local _ov_conf="${OPENVIKING_CLI_CONFIG_FILE:-$HOME/.openviking/ovcli.conf}"
+  if [ -f "$_ov_conf" ] && command -v jq >/dev/null 2>&1; then
+    local _ov_url _ov_key
+    _ov_url=$(jq -r '.url // empty'     "$_ov_conf" 2>/dev/null)
+    _ov_key=$(jq -r '.api_key // empty' "$_ov_conf" 2>/dev/null)
+    OPENVIKING_URL="${OPENVIKING_URL:-$_ov_url}" \
+    OPENVIKING_API_KEY="${OPENVIKING_API_KEY:-$_ov_key}" \
+      command claude "$@"
   else
     command claude "$@"
   fi

--- a/examples/claude-code-memory-plugin/setup-helper/install.sh
+++ b/examples/claude-code-memory-plugin/setup-helper/install.sh
@@ -209,16 +209,23 @@ fi
 heading '5. Plugin install'
 
 if [ "$CLAUDE_AVAILABLE" -eq 1 ]; then
+  # Use --scope user so the plugin is active from any directory, not just $REPO_DIR.
+  # `local` scope binds enablement to $REPO_DIR's .claude/settings.local.json, which
+  # surfaces as "disabled" the moment the user `cd`s elsewhere and forces a manual
+  # `claude plugin enable` post-install.
   info 'claude plugin marketplace add'
-  ( cd "$REPO_DIR" && claude plugin marketplace add "$REPO_DIR/examples" --scope local ) || \
+  ( cd "$REPO_DIR" && claude plugin marketplace add "$REPO_DIR/examples" --scope user ) || \
     warn 'marketplace add returned non-zero (likely already added) — continuing'
   info 'claude plugin install'
-  ( cd "$REPO_DIR" && claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope local )
+  ( cd "$REPO_DIR" && claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope user )
+  # Belt-and-suspenders: make sure it ends up enabled even if `install` left it
+  # in a disabled state (observed on some Claude Code versions).
+  claude plugin enable claude-code-memory-plugin@openviking-plugins-local --scope user >/dev/null 2>&1 || true
 else
   warn "Run these manually after installing Claude Code:"
   warn "  cd \"$REPO_DIR\""
-  warn '  claude plugin marketplace add "$(pwd)/examples" --scope local'
-  warn '  claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope local'
+  warn '  claude plugin marketplace add "$(pwd)/examples" --scope user'
+  warn '  claude plugin install claude-code-memory-plugin@openviking-plugins-local --scope user'
 fi
 
 # ----- Done -----

--- a/examples/claude-code-memory-plugin/setup-helper/install.sh
+++ b/examples/claude-code-memory-plugin/setup-helper/install.sh
@@ -26,7 +26,9 @@ OV_HOME="${OPENVIKING_HOME:-$HOME/.openviking}"
 REPO_DIR="${OPENVIKING_REPO_DIR:-$OV_HOME/openviking-repo}"
 REPO_URL="${OPENVIKING_REPO_URL:-https://github.com/volcengine/OpenViking.git}"
 REPO_BRANCH="${OPENVIKING_REPO_BRANCH:-main}"
-OVCLI_CONF="$OV_HOME/ovcli.conf"
+# Honor OPENVIKING_CLI_CONFIG_FILE (the env var the `ov` CLI itself reads —
+# crates/ov_cli/src/config.rs:6) so this installer matches CLI behavior.
+OVCLI_CONF="${OPENVIKING_CLI_CONFIG_FILE:-$OV_HOME/ovcli.conf}"
 
 MARKER_BEGIN='# >>> openviking claude-code memory plugin >>>'
 MARKER_END='# <<< openviking claude-code memory plugin <<<'
@@ -186,10 +188,14 @@ else
 
 $MARKER_BEGIN
 claude() {
-  if [ -f ~/.openviking/ovcli.conf ]; then
-    OPENVIKING_URL=\$(jq -r '.url' ~/.openviking/ovcli.conf) \\
-    OPENVIKING_API_KEY=\$(jq -r '.api_key' ~/.openviking/ovcli.conf) \\
-    command claude "\$@"
+  local _ov_conf="\${OPENVIKING_CLI_CONFIG_FILE:-\$HOME/.openviking/ovcli.conf}"
+  if [ -f "\$_ov_conf" ] && command -v jq >/dev/null 2>&1; then
+    local _ov_url _ov_key
+    _ov_url=\$(jq -r '.url // empty'     "\$_ov_conf" 2>/dev/null)
+    _ov_key=\$(jq -r '.api_key // empty' "\$_ov_conf" 2>/dev/null)
+    OPENVIKING_URL="\${OPENVIKING_URL:-\$_ov_url}" \\
+    OPENVIKING_API_KEY="\${OPENVIKING_API_KEY:-\$_ov_key}" \\
+      command claude "\$@"
   else
     command claude "\$@"
   fi

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -245,10 +245,13 @@ async def store(messages: list[StoreMessage]) -> str:
 _LOCAL_FILE_HINT = (
     "MCP add_resource only accepts remote URLs (http(s)://, git@, ssh://, git://). "
     "For local files or directories, use the `ov` CLI:\n"
-    "  1. Install: curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash\n"
-    "  2. (remote / multi-tenant only) configure ~/.openviking/ovcli.conf:\n"
-    '       {\"url\": \"http://localhost:1933\", \"api_key\": \"your-key\"}\n'
-    "  3. Run: ov add-resource <path>"
+    "  1. Try first: ov add-resource <path>\n"
+    "     (if `ov` is already on PATH, this is all you need)\n"
+    "  2. If `ov` is not installed, run:\n"
+    "     curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash\n"
+    "  3. Only if connecting to a remote / multi-tenant OpenViking server, "
+    "configure ~/.openviking/ovcli.conf:\n"
+    '       {\"url\": \"https://your-host\", \"api_key\": \"your-key\"}'
 )
 
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -251,7 +251,7 @@ _LOCAL_FILE_HINT = (
     "     curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash\n"
     "  3. Only if connecting to a remote / multi-tenant OpenViking server, "
     "configure ~/.openviking/ovcli.conf:\n"
-    '       {\"url\": \"https://your-host\", \"api_key\": \"your-key\"}'
+    '       {"url": "https://your-host", "api_key": "your-key"}'
 )
 
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -242,17 +242,34 @@ async def store(messages: list[StoreMessage]) -> str:
 # -- add_resource ----------------------------------------------------------
 
 
+_LOCAL_FILE_HINT = (
+    "MCP add_resource only accepts remote URLs (http(s)://, git@, ssh://, git://). "
+    "For local files or directories, use the `ov` CLI:\n"
+    "  1. Install: curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash\n"
+    "  2. (remote / multi-tenant only) configure ~/.openviking/ovcli.conf:\n"
+    '       {\"url\": \"http://localhost:1933\", \"api_key\": \"your-key\"}\n'
+    "  3. Run: ov add-resource <path>"
+)
+
+
 @mcp.tool()
 async def add_resource(path: str, description: str = "") -> str:
-    """Add a resource (local file path or URL) to OpenViking. This is an asynchronous operation — the resource will be processed in the background."""
+    """Add a remote resource (HTTP/HTTPS URL or git URL) to OpenViking. Asynchronous — processed in the background. Local file paths are not supported here; use the `ov add-resource` CLI for local files."""
+    from openviking.server.local_input_guard import require_remote_resource_source
+
     service = get_service()
     ctx = _get_ctx()
+    try:
+        path = require_remote_resource_source(path)
+    except PermissionDeniedError:
+        return f"Error: {_LOCAL_FILE_HINT}"
     try:
         result = await service.resources.add_resource(
             path=path,
             ctx=ctx,
             reason=description,
             wait=False,
+            enforce_public_remote_targets=True,
         )
         root_uri = result.get("root_uri", "")
         return (

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -175,11 +175,17 @@ async def test_store_batch_messages(service):
 # ---------------------------------------------------------------------------
 
 
-async def test_add_resource_nonexistent_path(service):
+async def test_add_resource_rejects_local_path_with_cli_hint(service):
     result = await add_resource(path="/tmp/definitely_does_not_exist_xyz.md")
-    assert (
-        "error" in result.lower() or "not found" in result.lower() or "resource" in result.lower()
-    )
+    assert "error" in result.lower()
+    assert "ov add-resource" in result
+    assert "ovcli.conf" in result
+
+
+async def test_add_resource_rejects_bare_filename_with_cli_hint(service):
+    result = await add_resource(path="some_local_file.md")
+    assert "error" in result.lower()
+    assert "ov add-resource" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Two related fixes around how OpenViking is reached from MCP / Claude Code:

1. **Server**: MCP `add_resource` now matches the REST router's contract — only remote URLs (`http(s)://`, `git@`, `ssh://`, `git://`) are accepted; local paths are rejected with a clear hint pointing at `ov add-resource`. The previous behavior either failed (path on the client filesystem doesn't exist on a remote server) or, worse, read server-local files.
2. **Plugin wrapper**: The `claude` shell function the cc-memory-plugin installer drops into the user's rc had four real problems — silent override of caller env vars, ignoring `OPENVIKING_CLI_CONFIG_FILE`, a `jq -r '.url'`-returns-literal-`"null"` bug, and no graceful fallback if `jq` is missing at runtime. Fixed inline; the install script itself now also honors `OPENVIKING_CLI_CONFIG_FILE`.

For local-file uploads via MCP: pure-MCP single-call upload isn't viable today (no binary attachment in MCP 1.x; base64-in-args burns LLM output tokens; a stdio shim breaks the "any client, zero config" promise), so we deliberately punt that to the `ov` CLI instead of half-solving it.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

**Server side**
- `openviking/server/mcp_endpoint.py`: `add_resource` runs `require_remote_resource_source(path)` before dispatching, and passes `enforce_public_remote_targets=True` to align with the REST `/api/v1/resources` route. On rejection, return a 3-step hint (install `ov`, optionally configure `~/.openviking/ovcli.conf` for remote / multi-tenant, then `ov add-resource <path>`). Tool docstring updated so the LLM knows local paths are out of scope.
- `tests/server/test_mcp_endpoint.py`: replace the loose nonexistent-path test with stricter assertions on the new hint, and add a bare-filename case.

**cc-memory-plugin**
- `examples/claude-code-memory-plugin/setup-helper/install.sh`:
  - `OVCLI_CONF` now resolves `OPENVIKING_CLI_CONFIG_FILE` first (the env var the `ov` CLI itself reads in `crates/ov_cli/src/config.rs:6`), then falls back to `$OV_HOME/ovcli.conf`.
  - The `claude` shell function injected into the user's rc now: respects `OPENVIKING_CLI_CONFIG_FILE`, treats existing `OPENVIKING_URL` / `OPENVIKING_API_KEY` as winning over conf values, uses `jq -r '.url // empty'` so missing keys produce empty strings (not the literal `"null"`), gates on `command -v jq` so a missing `jq` at runtime no longer corrupts caller env, and uses `local` for temporaries.
- `examples/claude-code-memory-plugin/README.md` / `README_CN.md`: documented snippet updated to match.

The plugin's hooks (`scripts/config.mjs`) already implemented all of this correctly via `env > ovcli.conf > ov.conf` resolution — this PR just brings the wrapper + installer up to the same standard.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (local venv missing `pathspec`; CI will validate the server-side change)
- [x] Verified the rendered wrapper from `install.sh`'s heredoc parses cleanly with `bash -n` and produces the intended function body
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (READMEs)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Behavior change: any caller that was passing local server-side paths to the MCP `add_resource` tool will now get a hint instead of an attempt-and-fail. The previous behavior was undefined for remote deployments, so this is a bug fix in spirit.

For users who already installed the plugin's `claude` wrapper, re-running the installer is safe — it detects the existing block via the begin/end markers and replaces it in place.