### PR TITLE
feat(reindex): add recursive subdirectory indexing support

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -413,11 +413,13 @@ impl HttpClient {
         &self,
         uri: &str,
         regenerate: bool,
+        recursive: bool,
         wait: bool,
     ) -> Result<serde_json::Value> {
         let body = serde_json::json!({
             "uri": uri,
             "regenerate": regenerate,
+            "recursive": recursive,
             "wait": wait,
         });
         self.post("/api/v1/content/reindex", &body).await

--- a/crates/ov_cli/src/commands/content.rs
+++ b/crates/ov_cli/src/commands/content.rs
@@ -65,11 +65,12 @@ pub async fn reindex(
     client: &HttpClient,
     uri: &str,
     regenerate: bool,
+    recursive: bool,
     wait: bool,
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
-    let result = client.reindex(uri, regenerate, wait).await?;
+    let result = client.reindex(uri, regenerate, recursive, wait).await?;
     crate::output::output_success(result, output_format, compact);
     Ok(())
 }

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -540,12 +540,13 @@ pub async fn handle_write(
     .await
 }
 
-pub async fn handle_reindex(uri: String, regenerate: bool, wait: bool, ctx: CliContext) -> Result<()> {
+pub async fn handle_reindex(uri: String, regenerate: bool, recursive: bool, wait: bool, ctx: CliContext) -> Result<()> {
     let client = ctx.get_client();
     commands::content::reindex(
         &client,
         &uri,
         regenerate,
+        recursive,
         wait,
         ctx.output_format,
         ctx.compact,

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -540,6 +540,9 @@ enum Commands {
         /// Force regenerate summaries even if they exist
         #[arg(short, long)]
         regenerate: bool,
+        /// Recursively index subdirectories (only applies when --regenerate is not set)
+        #[arg(short, long)]
+        recursive: bool,
         /// Wait for reindex to complete
         #[arg(long, default_value = "true")]
         wait: bool,
@@ -1094,8 +1097,9 @@ async fn main() {
         Commands::Reindex {
             uri,
             regenerate,
+            recursive,
             wait,
-        } => handlers::handle_reindex(uri, regenerate, wait, ctx).await,
+        } => handlers::handle_reindex(uri, regenerate, recursive, wait, ctx).await,
         Commands::Get { uri, local_path } => handlers::handle_get(uri, local_path, ctx).await,
         Commands::Find {
             query,

--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -208,7 +208,7 @@ async def reindex(
             owner_user_id=ctx.user.user_id,
         ):
             return error_response("CONFLICT", f"URI {uri} already has a reindex in progress")
-        result = await _do_reindex(service, uri, body.regenerate, ctx)
+        result = await _do_reindex(service, uri, body.regenerate, body.recursive, ctx)
         return response_from_result(result)
 
     task = tracker.create_if_no_running(
@@ -220,7 +220,9 @@ async def reindex(
     if task is None:
         return error_response("CONFLICT", f"URI {uri} already has a reindex in progress")
     asyncio.create_task(
-        _background_reindex_tracked(service, uri, body.regenerate, ctx, task.task_id)
+        _background_reindex_tracked(
+            service, uri, body.regenerate, body.recursive, ctx, task.task_id
+        )
     )
     return Response(
         status="ok",

--- a/openviking/server/routers/maintenance.py
+++ b/openviking/server/routers/maintenance.py
@@ -25,6 +25,7 @@ class ReindexRequest(BaseModel):
 
     uri: str
     regenerate: bool = False
+    recursive: bool = False
     wait: bool = True
 
 
@@ -40,7 +41,7 @@ async def reindex(
 
     Re-embeds existing .abstract.md/.overview.md content into the vector
     database. If regenerate=True, also regenerates L0/L1 summaries via LLM
-    before re-embedding.
+    before re-embedding. If recursive=True, also indexes all subdirectories.
 
     Uses path locking to prevent concurrent reindexes on the same URI.
     Set wait=False to run in the background and track progress via task API.
@@ -67,7 +68,7 @@ async def reindex(
             owner_user_id=ctx.user.user_id,
         ):
             return error_response("CONFLICT", f"URI {uri} already has a reindex in progress")
-        result = await _do_reindex(service, uri, body.regenerate, ctx)
+        result = await _do_reindex(service, uri, body.regenerate, body.recursive, ctx)
         return response_from_result(result)
     else:
         # Async path: run in background, return task_id for polling
@@ -80,7 +81,9 @@ async def reindex(
         if task is None:
             return error_response("CONFLICT", f"URI {uri} already has a reindex in progress")
         asyncio.create_task(
-            _background_reindex_tracked(service, uri, body.regenerate, ctx, task.task_id)
+            _background_reindex_tracked(
+                service, uri, body.regenerate, body.recursive, ctx, task.task_id
+            )
         )
         return Response(
             status="ok",
@@ -97,6 +100,7 @@ async def _do_reindex(
     service,
     uri: str,
     regenerate: bool,
+    recursive: bool,
     ctx: RequestContext,
 ) -> dict:
     """Execute reindex within a lock scope."""
@@ -107,15 +111,18 @@ async def _do_reindex(
 
     async with LockContext(get_lock_manager(), [path], lock_mode="point"):
         if regenerate:
+            if recursive:
+                logger.warning("recursive=True is ignored when regenerate=True for uri=%s", uri)
             return await service.resources.summarize([uri], ctx=ctx)
         else:
-            return await service.resources.build_index([uri], ctx=ctx)
+            return await service.resources.build_index([uri], ctx=ctx, recursive=recursive)
 
 
 async def _background_reindex_tracked(
     service,
     uri: str,
     regenerate: bool,
+    recursive: bool,
     ctx: RequestContext,
     task_id: str,
 ) -> None:
@@ -125,7 +132,7 @@ async def _background_reindex_tracked(
     tracker = get_task_tracker()
     tracker.start(task_id)
     try:
-        result = await _do_reindex(service, uri, regenerate, ctx)
+        result = await _do_reindex(service, uri, regenerate, recursive, ctx)
         tracker.complete(task_id, {"uri": uri, **result})
         logger.info("Background reindex completed: uri=%s task=%s", uri, task_id)
     except Exception as exc:

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -431,6 +431,7 @@ async def vectorize_file(
 async def index_resource(
     uri: str,
     ctx: RequestContext,
+    recursive: bool = False,
 ) -> None:
     """
     Build vector index for a resource directory.
@@ -441,6 +442,8 @@ async def index_resource(
     The context_type is derived from the URI so that memory directories
     (``/memories/``) are indexed as ``"memory"`` rather than the default
     ``"resource"``.
+
+    If recursive=True, subdirectories are recursively indexed as well.
     """
     viking_fs = get_viking_fs()
     context_type = get_context_type_for_uri(uri)
@@ -454,13 +457,11 @@ async def index_resource(
 
     if await viking_fs.exists(abstract_uri, ctx=ctx):
         content = await viking_fs.read_file(abstract_uri, ctx=ctx)
-        if isinstance(content, bytes):
-            abstract = content.decode("utf-8")
+        abstract = content.decode("utf-8") if isinstance(content, bytes) else content
 
     if await viking_fs.exists(overview_uri, ctx=ctx):
         content = await viking_fs.read_file(overview_uri, ctx=ctx)
-        if isinstance(content, bytes):
-            overview = content.decode("utf-8")
+        overview = content.decode("utf-8") if isinstance(content, bytes) else content
 
     if abstract or overview:
         await vectorize_directory_meta(uri, abstract, overview, context_type=context_type, ctx=ctx)
@@ -476,7 +477,9 @@ async def index_resource(
                 continue
 
             if file_info.get("type") == "directory" or file_info.get("isDir"):
-                # TODO: Recursive indexing? For now, skip subdirectories to match previous behavior
+                if recursive:
+                    sub_uri = file_info.get("uri") or f"{uri}/{file_name}"
+                    await index_resource(sub_uri, ctx, recursive=True)
                 continue
 
             file_uri = file_info.get("uri") or f"{uri}/{file_name}"

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -86,8 +86,9 @@ class ResourceProcessor:
         self, resource_uris: List[str], ctx: RequestContext, **kwargs
     ) -> Dict[str, Any]:
         """Expose index building as a standalone method."""
+        recursive = kwargs.get("recursive", False)
         for uri in resource_uris:
-            await index_resource(uri, ctx)
+            await index_resource(uri, ctx, recursive=recursive)
         return {"status": "success", "message": f"Indexed {len(resource_uris)} resources"}
 
     async def summarize(

--- a/tests/server/test_api_content.py
+++ b/tests/server/test_api_content.py
@@ -153,7 +153,7 @@ async def test_reindex_uses_request_tenant_for_exists(monkeypatch):
         def has_running(self, task_type, uri, owner_account_id=None, owner_user_id=None):
             return False
 
-    async def fake_do_reindex(service, uri, regenerate, ctx):
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
         return {"status": "success", "message": "Indexed 1 resources"}
 
     ctx = RequestContext(
@@ -181,7 +181,7 @@ async def test_reindex_uses_request_tenant_for_exists(monkeypatch):
 
 
 async def test_maintenance_reindex_sync_success_returns_ok_payload(client, monkeypatch):
-    async def fake_do_reindex(service, uri, regenerate, ctx):
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
         return {"status": "success", "message": "Indexed 1 resources"}
 
     class FakeVikingFS:
@@ -215,3 +215,91 @@ async def test_maintenance_reindex_sync_success_returns_ok_payload(client, monke
     body = response.json()
     assert body["status"] == "ok"
     assert body["result"]["status"] == "success"
+
+
+async def test_reindex_recursive_parameter_schema(client):
+    """Test reindex accepts recursive parameter in request schema."""
+    resp = await client.post(
+        "/api/v1/maintenance/reindex",
+        json={"uri": "viking://resources/test", "recursive": True, "wait": True},
+    )
+    assert resp.status_code != 404
+    assert resp.status_code != 405
+
+
+async def test_reindex_recursive_defaults_to_false(client, monkeypatch):
+    """Test that recursive defaults to False when not provided."""
+    captured = {}
+
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
+        captured["recursive"] = recursive
+        return {"status": "success", "message": "Indexed 1 resources"}
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return True
+
+    class FakeTracker:
+        def has_running(self, task_type, uri, owner_account_id=None, owner_user_id=None):
+            return False
+
+    monkeypatch.setattr(
+        "openviking.storage.viking_fs.get_viking_fs",
+        lambda: FakeVikingFS(),
+    )
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.maintenance.get_service",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr("openviking.server.routers.maintenance._do_reindex", fake_do_reindex)
+
+    response = await client.post(
+        "/api/v1/maintenance/reindex",
+        json={"uri": "viking://resources/demo", "wait": True},
+    )
+
+    assert response.status_code == 200
+    assert captured["recursive"] is False
+
+
+async def test_reindex_recursive_true_is_forwarded(client, monkeypatch):
+    """Test that recursive=True is forwarded to _do_reindex."""
+    captured = {}
+
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
+        captured["recursive"] = recursive
+        return {"status": "success", "message": "Indexed 1 resources"}
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return True
+
+    class FakeTracker:
+        def has_running(self, task_type, uri, owner_account_id=None, owner_user_id=None):
+            return False
+
+    monkeypatch.setattr(
+        "openviking.storage.viking_fs.get_viking_fs",
+        lambda: FakeVikingFS(),
+    )
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.maintenance.get_service",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr("openviking.server.routers.maintenance._do_reindex", fake_do_reindex)
+
+    response = await client.post(
+        "/api/v1/maintenance/reindex",
+        json={"uri": "viking://resources/demo", "recursive": True, "wait": True},
+    )
+
+    assert response.status_code == 200
+    assert captured["recursive"] is True

--- a/tests/server/test_api_fs_content_endpoint_suite.py
+++ b/tests/server/test_api_fs_content_endpoint_suite.py
@@ -229,7 +229,7 @@ async def test_reindex_sync_conflict_returns_error_payload(client, monkeypatch):
 
 
 async def test_reindex_sync_business_error_returns_error_envelope(client, monkeypatch):
-    async def fake_do_reindex(service, uri, regenerate, ctx):
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
         return {"status": "error", "message": "bad summarize"}
 
     monkeypatch.setattr(
@@ -258,7 +258,7 @@ async def test_reindex_sync_business_error_returns_error_envelope(client, monkey
 
 
 async def test_maintenance_reindex_sync_business_error_returns_error_envelope(client, monkeypatch):
-    async def fake_do_reindex(service, uri, regenerate, ctx):
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
         return {"status": "error", "message": "bad maintenance summarize"}
 
     monkeypatch.setattr(
@@ -287,7 +287,7 @@ async def test_maintenance_reindex_sync_business_error_returns_error_envelope(cl
 
 
 async def test_reindex_sync_success_returns_ok_payload(client, monkeypatch):
-    async def fake_do_reindex(service, uri, regenerate, ctx):
+    async def fake_do_reindex(service, uri, regenerate, recursive, ctx):
         return {"status": "success", "message": "Indexed 1 resources"}
 
     monkeypatch.setattr(

--- a/tests/unit/test_index_resource_recursive.py
+++ b/tests/unit/test_index_resource_recursive.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Unit tests for index_resource recursive behavior."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _make_ctx() -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice", agent_id="default"),
+        role=Role.ADMIN,
+    )
+
+
+@pytest.fixture
+def ctx():
+    return _make_ctx()
+
+
+@pytest.fixture
+def fake_fs():
+    fs = AsyncMock()
+    fs.exists = AsyncMock(return_value=False)
+    fs.ls = AsyncMock(return_value=[])
+    return fs
+
+
+async def test_index_resource_skips_subdirectories_when_recursive_false(ctx, fake_fs):
+    """When recursive=False (default), subdirectories are skipped."""
+    fake_fs.ls.return_value = [
+        {"name": "subdir", "type": "directory", "uri": "viking://resources/root/subdir"},
+        {"name": "file.md", "type": "file", "uri": "viking://resources/root/file.md"},
+    ]
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=fake_fs),
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+        patch(
+            "openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock
+        ) as mock_vec_file,
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://resources/root", ctx, recursive=False)
+
+        mock_vec_file.assert_called_once()
+        call_args = mock_vec_file.call_args
+        assert call_args.kwargs["file_path"] == "viking://resources/root/file.md"
+
+
+async def test_index_resource_recurses_into_subdirectories_when_recursive_true(ctx, fake_fs):
+    """When recursive=True, subdirectories are recursively indexed."""
+
+    async def fake_ls(uri, ctx=None):
+        if uri == "viking://resources/root":
+            return [
+                {"name": "subdir", "type": "directory", "uri": "viking://resources/root/subdir"},
+                {"name": "file1.md", "type": "file", "uri": "viking://resources/root/file1.md"},
+            ]
+        if uri == "viking://resources/root/subdir":
+            return [
+                {
+                    "name": "file2.md",
+                    "type": "file",
+                    "uri": "viking://resources/root/subdir/file2.md",
+                },
+            ]
+        return []
+
+    fake_fs.ls = fake_ls
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=fake_fs),
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+        patch(
+            "openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock
+        ) as mock_vec_file,
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://resources/root", ctx, recursive=True)
+
+        assert mock_vec_file.call_count == 2
+        indexed_uris = [c.kwargs["file_path"] for c in mock_vec_file.call_args_list]
+        assert "viking://resources/root/file1.md" in indexed_uris
+        assert "viking://resources/root/subdir/file2.md" in indexed_uris
+
+
+async def test_index_resource_default_recursive_is_false(ctx, fake_fs):
+    """Default value of recursive parameter is False."""
+    fake_fs.ls.return_value = [
+        {"name": "subdir", "type": "directory", "uri": "viking://resources/root/subdir"},
+        {"name": "file.md", "type": "file", "uri": "viking://resources/root/file.md"},
+    ]
+
+    subdir_ls_called = {"value": False}
+
+    original_ls = fake_fs.ls
+
+    async def tracking_ls(uri, ctx=None):
+        if uri == "viking://resources/root/subdir":
+            subdir_ls_called["value"] = True
+        return await original_ls(uri, ctx) if isinstance(original_ls, AsyncMock) else []
+
+    fake_fs.ls = tracking_ls
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=fake_fs),
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+        patch("openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock),
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://resources/root", ctx)
+
+        assert not subdir_ls_called["value"]
+
+
+async def test_index_resource_recursive_with_isDir_flag(ctx, fake_fs):
+    """Subdirectories identified by isDir=True are also recursed into."""
+
+    async def fake_ls(uri, ctx=None):
+        if uri == "viking://resources/root":
+            return [
+                {"name": "nested", "isDir": True, "uri": "viking://resources/root/nested"},
+                {"name": "top.md", "type": "file", "uri": "viking://resources/root/top.md"},
+            ]
+        if uri == "viking://resources/root/nested":
+            return [
+                {
+                    "name": "deep.md",
+                    "type": "file",
+                    "uri": "viking://resources/root/nested/deep.md",
+                },
+            ]
+        return []
+
+    fake_fs.ls = fake_ls
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=fake_fs),
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+        patch(
+            "openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock
+        ) as mock_vec_file,
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://resources/root", ctx, recursive=True)
+
+        assert mock_vec_file.call_count == 2
+        indexed_uris = [c.kwargs["file_path"] for c in mock_vec_file.call_args_list]
+        assert "viking://resources/root/top.md" in indexed_uris
+        assert "viking://resources/root/nested/deep.md" in indexed_uris
+
+
+async def test_index_resource_recursive_deep_nesting(ctx, fake_fs):
+    """Recursive indexing works with 3+ levels of nesting."""
+
+    async def fake_ls(uri, ctx=None):
+        if uri == "viking://resources/l0":
+            return [
+                {"name": "l1", "type": "directory", "uri": "viking://resources/l0/l1"},
+                {"name": "f0.md", "type": "file", "uri": "viking://resources/l0/f0.md"},
+            ]
+        if uri == "viking://resources/l0/l1":
+            return [
+                {"name": "l2", "type": "directory", "uri": "viking://resources/l0/l1/l2"},
+                {"name": "f1.md", "type": "file", "uri": "viking://resources/l0/l1/f1.md"},
+            ]
+        if uri == "viking://resources/l0/l1/l2":
+            return [
+                {"name": "f2.md", "type": "file", "uri": "viking://resources/l0/l1/l2/f2.md"},
+            ]
+        return []
+
+    fake_fs.ls = fake_ls
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=fake_fs),
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+        patch(
+            "openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock
+        ) as mock_vec_file,
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://resources/l0", ctx, recursive=True)
+
+        assert mock_vec_file.call_count == 3
+        indexed_uris = [c.kwargs["file_path"] for c in mock_vec_file.call_args_list]
+        assert "viking://resources/l0/f0.md" in indexed_uris
+        assert "viking://resources/l0/l1/f1.md" in indexed_uris
+        assert "viking://resources/l0/l1/l2/f2.md" in indexed_uris
+
+
+async def test_index_resource_recursive_empty_subdirectory(ctx, fake_fs):
+    """Recursive indexing handles empty subdirectories without error."""
+
+    async def fake_ls(uri, ctx=None):
+        if uri == "viking://resources/root":
+            return [
+                {"name": "empty", "type": "directory", "uri": "viking://resources/root/empty"},
+                {"name": "file.md", "type": "file", "uri": "viking://resources/root/file.md"},
+            ]
+        if uri == "viking://resources/root/empty":
+            return []
+        return []
+
+    fake_fs.ls = fake_ls
+
+    with (
+        patch("openviking.utils.embedding_utils.get_viking_fs", return_value=fake_fs),
+        patch("openviking.utils.embedding_utils.vectorize_directory_meta", new_callable=AsyncMock),
+        patch(
+            "openviking.utils.embedding_utils.vectorize_file", new_callable=AsyncMock
+        ) as mock_vec_file,
+    ):
+        from openviking.utils.embedding_utils import index_resource
+
+        await index_resource("viking://resources/root", ctx, recursive=True)
+
+        assert mock_vec_file.call_count == 1
+        assert mock_vec_file.call_args.kwargs["file_path"] == "viking://resources/root/file.md"


### PR DESCRIPTION
## Summary

Add `recursive` parameter to the reindex operation, allowing vector indexing to traverse subdirectories instead of only processing the current directory level.

Previously, `index_resource()` would skip subdirectories with a `# TODO: recursive` comment. This PR implements that TODO, enabling users to recursively index an entire directory tree in a single operation.

### Changes

- **Python backend**: Add `recursive` parameter to `index_resource()`, `build_index()`, `_do_reindex()`, and related API routes
- **Rust CLI**: Add `--recursive` / `-r` flag to `ov reindex` command
- **API model**: Add `recursive` field to `ReindexRequest` (defaults to `false`, backward compatible)
- **Safety**: Log warning when `recursive=True` is combined with `regenerate=True` (regenerate ignores recursive, as it operates through SemanticQueue which has its own traversal logic)

## Type of Change

- [x] New feature (feat)

## Testing

- [x] Unit tests pass (6 tests for recursive behavior: skip subdirs when false, recurse when true, default is false, isDir flag, deep nesting, empty subdirectory)
- [x] API tests pass (3 tests: recursive parameter schema, defaults to false, true is forwarded)
- [x] Existing test signatures updated for new parameter
- [x] ruff format + ruff check clean

## Related Issues

Related to the `# TODO: recursive` comment in `embedding_utils.py`

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (if needed) — no doc changes needed, CLI --help is auto-generated
- [x] All tests pass
