### PR TITLE
fix(storage): pass context_type in _enqueue_direct_vectorization and handle str from read_file

### DIFF
--- a/openviking/storage/local_fs.py
+++ b/openviking/storage/local_fs.py
@@ -6,6 +6,7 @@ import os
 import re
 import zipfile
 
+from openviking.core.directories import get_context_type_for_uri
 from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext
 from openviking.utils.embedding_utils import vectorize_directory_meta, vectorize_file
@@ -132,11 +133,17 @@ async def _enqueue_direct_vectorization(viking_fs, uri: str, ctx: RequestContext
                 overview = content.decode("utf-8") if isinstance(content, bytes) else content
         except Exception:
             return
-        await vectorize_directory_meta(dir_uri, abstract, overview, ctx=ctx)
+        await vectorize_directory_meta(
+            dir_uri, abstract, overview, context_type=get_context_type_for_uri(dir_uri), ctx=ctx
+        )
 
     async def index_file(file_uri: str, parent_uri: str, name: str) -> None:
         await vectorize_file(
-            file_path=file_uri, summary_dict={"name": name}, parent_uri=parent_uri, ctx=ctx
+            file_path=file_uri,
+            summary_dict={"name": name},
+            parent_uri=parent_uri,
+            context_type=get_context_type_for_uri(file_uri),
+            ctx=ctx,
         )
 
     await asyncio.gather(*(index_dir(dir_uri) for dir_uri in dir_uris))

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -454,13 +454,11 @@ async def index_resource(
 
     if await viking_fs.exists(abstract_uri, ctx=ctx):
         content = await viking_fs.read_file(abstract_uri, ctx=ctx)
-        if isinstance(content, bytes):
-            abstract = content.decode("utf-8")
+        abstract = content.decode("utf-8") if isinstance(content, bytes) else content
 
     if await viking_fs.exists(overview_uri, ctx=ctx):
         content = await viking_fs.read_file(overview_uri, ctx=ctx)
-        if isinstance(content, bytes):
-            overview = content.decode("utf-8")
+        overview = content.decode("utf-8") if isinstance(content, bytes) else content
 
     if abstract or overview:
         await vectorize_directory_meta(uri, abstract, overview, context_type=context_type, ctx=ctx)


### PR DESCRIPTION
## Description

Fix two bugs that cause memory directories (under `/memories/`) to be indexed with `context_type="resource"` instead of `"memory"` during ovpack import and reindex operations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

### Bug 1: `_enqueue_direct_vectorization` missing `context_type` ([local_fs.py](openviking/storage/local_fs.py))

`vectorize_directory_meta` and `vectorize_file` were called without passing `context_type`, so all directories and files imported via ovpack defaulted to `"resource"` — including those under `/memories/` which should be `"memory"`.

**Fix:** Pass `context_type=get_context_type_for_uri(uri)` to both functions.

### Bug 2: `index_resource` only handles `bytes` from `read_file` ([embedding_utils.py](openviking/utils/embedding_utils.py))

`read_file` may return `str` or `bytes`. The original code only decoded `bytes`, silently leaving `abstract`/`overview` empty when `read_file` returned `str`. Empty L0/L1 content meant `vectorize_directory_meta` was never called, so directory metadata vectors were missing or stale.

**Fix:** `abstract = content.decode("utf-8") if isinstance(content, bytes) else content`

## Testing

Verified on a live instance with 8,072 memory records:
- After fix: `stats/memories` increased to 8,707 (+635 records correctly classified as `"memory"`)
- All 316 memory directories now have correct `context_type="memory"` on L0/L1 vectors
- `ruff format` and `ruff check` pass

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/volcengine/OpenViking/blob/main/CONTRIBUTING.md) guide
- [x] My code follows the project's code style (ruff)
- [x] I have tested the changes

@chuanbao666 @baojun-zhang (storage layer maintainers)