### PR TITLE
fix: reject mismatched ragfs cpython extensions

### DIFF
--- a/openviking/pyagfs/__init__.py
+++ b/openviking/pyagfs/__init__.py
@@ -7,6 +7,7 @@ import importlib.util
 import logging
 import os
 import sys
+import sysconfig
 from pathlib import Path
 
 from .client import AGFSClient, FileHandle
@@ -42,28 +43,49 @@ _logger = logging.getLogger(__name__)
 _LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
 
 
+def _is_compatible_ragfs_extension(path: str, ext_suffix: str) -> bool:
+    """Return whether a vendored ragfs_python extension can be loaded here."""
+    name = Path(path).name
+    if not name.startswith("ragfs_python"):
+        return False
+
+    # CPython-specific extensions are only safe for the exact running
+    # interpreter ABI tag. A cp310 binary must not be loaded on cp312/cp313.
+    if ".cpython-" in name:
+        return name == f"ragfs_python{ext_suffix}"
+
+    # Stable ABI artifacts are intentionally interpreter-independent.
+    if name.startswith("ragfs_python.abi3."):
+        return True
+
+    # Keep accepting generic platform extensions when projects ship them.
+    return name.endswith((".so", ".dylib", ".pyd"))
+
+
 def _find_ragfs_so():
     """Locate the ragfs_python native extension inside openviking/lib/.
 
     Returns the path to the ``.so`` / ``.dylib`` / ``.pyd`` file, or *None*.
     """
     try:
-        # The ragfs-python crate is built with PyO3's stable ABI. Do not load
-        # cpython-specific artifacts from older source-checkout builds.
+        ext_suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
+        # Exact match first: ragfs_python.cpython-312-darwin.so or ragfs_python.abi3.so
+        exact = _LIB_DIR / f"ragfs_python{ext_suffix}"
+        if exact.exists():
+            return str(exact)
+        # Try abi3 suffix explicitly first (stable ABI)
+        abi3_suffix = ".abi3.so"
         if sys.platform == "win32":
-            for filename in ("ragfs_python.pyd", "ragfs_python.abi3.pyd"):
-                exact_path = _LIB_DIR / filename
-                if exact_path.exists():
-                    return str(exact_path)
-        else:
-            abi3_exact = _LIB_DIR / "ragfs_python.abi3.so"
-            if abi3_exact.exists():
-                return str(abi3_exact)
-        # Glob fallback handles platform-tagged abi3 artifacts if any.
-        for pattern in ("ragfs_python.abi3.*",):
-            matches = glob.glob(str(_LIB_DIR / pattern))
-            if matches:
-                return matches[0]
+            abi3_suffix = ".abi3.pyd"
+        abi3_exact = _LIB_DIR / f"ragfs_python{abi3_suffix}"
+        if abi3_exact.exists():
+            return str(abi3_exact)
+        # Glob fallback: keep stable/generic artifacts, but never load a
+        # CPython-version-specific binary whose tag differs from EXT_SUFFIX.
+        for pattern in ("ragfs_python.cpython-*", "ragfs_python.abi3.*", "ragfs_python.*"):
+            for match in sorted(glob.glob(str(_LIB_DIR / pattern))):
+                if _is_compatible_ragfs_extension(match, ext_suffix):
+                    return match
     except Exception:
         pass
     return None

--- a/openviking/pyagfs/__init__.py
+++ b/openviking/pyagfs/__init__.py
@@ -50,8 +50,10 @@ def _is_compatible_ragfs_extension(path: str, ext_suffix: str) -> bool:
         return False
 
     # CPython-specific extensions are only safe for the exact running
-    # interpreter ABI tag. A cp310 binary must not be loaded on cp312/cp313.
-    if ".cpython-" in name:
+    # interpreter ABI tag. Reject both Unix-style `.cpython-312-...` and
+    # Windows-style `.cp312-...` artifacts unless they exactly match
+    # the active EXT_SUFFIX.
+    if name.startswith("ragfs_python.cp") and not name.startswith("ragfs_python.abi3."):
         return name == f"ragfs_python{ext_suffix}"
 
     # Stable ABI artifacts are intentionally interpreter-independent.

--- a/tests/misc/test_pyagfs_loader.py
+++ b/tests/misc/test_pyagfs_loader.py
@@ -1,38 +1,37 @@
-from pathlib import Path
+import sysconfig
+
+import openviking.pyagfs as pyagfs
 
 
-def test_pyagfs_loader_prefers_abi3_artifact(monkeypatch, tmp_path: Path):
-    import openviking.pyagfs as pyagfs
-
-    cpython_artifact = tmp_path / "ragfs_python.cpython-312-darwin.so"
-    abi3_artifact = tmp_path / "ragfs_python.abi3.so"
-    cpython_artifact.write_bytes(b"old")
-    abi3_artifact.write_bytes(b"new")
-
+def test_find_ragfs_so_rejects_mismatched_cpython_binary(tmp_path, monkeypatch):
     monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
-    assert pyagfs._find_ragfs_so() == str(abi3_artifact)
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so"
+    )
 
-
-def test_pyagfs_loader_ignores_cpython_specific_artifact(monkeypatch, tmp_path: Path):
-    import openviking.pyagfs as pyagfs
-
-    cpython_artifact = tmp_path / "ragfs_python.cpython-312-darwin.so"
-    cpython_artifact.write_bytes(b"old")
-
-    monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
+    (tmp_path / "ragfs_python.cpython-310-x86_64-linux-gnu.so").touch()
 
     assert pyagfs._find_ragfs_so() is None
 
 
-def test_pyagfs_loader_finds_windows_maturin_abi3_pyd(monkeypatch, tmp_path: Path):
-    import openviking.pyagfs as pyagfs
-
-    cpython_artifact = tmp_path / "ragfs_python.cp310-win_amd64.pyd"
-    abi3_artifact = tmp_path / "ragfs_python.pyd"
-    cpython_artifact.write_bytes(b"old")
-    abi3_artifact.write_bytes(b"new")
-
+def test_find_ragfs_so_prefers_exact_cpython_suffix(tmp_path, monkeypatch):
     monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
-    monkeypatch.setattr(pyagfs.sys, "platform", "win32")
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so"
+    )
+    exact = tmp_path / "ragfs_python.cpython-312-x86_64-linux-gnu.so"
+    exact.touch()
+    (tmp_path / "ragfs_python.cpython-310-x86_64-linux-gnu.so").touch()
 
-    assert pyagfs._find_ragfs_so() == str(abi3_artifact)
+    assert pyagfs._find_ragfs_so() == str(exact)
+
+
+def test_find_ragfs_so_allows_stable_abi_artifact(tmp_path, monkeypatch):
+    monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda name: ".cpython-312-x86_64-linux-gnu.so"
+    )
+    abi3 = tmp_path / "ragfs_python.abi3.so"
+    abi3.touch()
+
+    assert pyagfs._find_ragfs_so() == str(abi3)

--- a/tests/misc/test_pyagfs_loader.py
+++ b/tests/misc/test_pyagfs_loader.py
@@ -26,6 +26,25 @@ def test_find_ragfs_so_prefers_exact_cpython_suffix(tmp_path, monkeypatch):
     assert pyagfs._find_ragfs_so() == str(exact)
 
 
+def test_find_ragfs_so_rejects_mismatched_windows_cpython_binary(tmp_path, monkeypatch):
+    monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cp312-win_amd64.pyd")
+
+    (tmp_path / "ragfs_python.cp310-win_amd64.pyd").touch()
+
+    assert pyagfs._find_ragfs_so() is None
+
+
+def test_find_ragfs_so_prefers_exact_windows_cpython_suffix(tmp_path, monkeypatch):
+    monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda name: ".cp312-win_amd64.pyd")
+    exact = tmp_path / "ragfs_python.cp312-win_amd64.pyd"
+    exact.touch()
+    (tmp_path / "ragfs_python.cp310-win_amd64.pyd").touch()
+
+    assert pyagfs._find_ragfs_so() == str(exact)
+
+
 def test_find_ragfs_so_allows_stable_abi_artifact(tmp_path, monkeypatch):
     monkeypatch.setattr(pyagfs, "_LIB_DIR", tmp_path)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- keep exact `EXT_SUFFIX` and stable `abi3` ragfs_python loading paths
- reject vendored `ragfs_python.cpython-*` binaries whose ABI tag does not match the running interpreter
- add loader regressions for mismatched CPython tags, exact matches, and abi3 artifacts

This reopens #1727 from a clean branch because the earlier PR had a follow-up commit authored with a local machine identity (`ming <ming@MacBook-Pro-8.local>`), which prevented the CLA check from matching the intended GitHub account. This branch uses the correct `euyua9` commit identity: `euyu <chris.eth@foxmail.com>`.

## Tests
- direct pyagfs loader smoke script covering mismatched and exact CPython suffixes plus abi3 artifacts
- `git diff --check origin/main...HEAD`

Note: `python -m pytest tests/misc/test_pyagfs_loader.py -q` is blocked in this local checkout before the target test by `tests/conftest.py` importing optional dependency `pathspec`, which is not installed in this environment.
