### PR TITLE
fix(vlm): disable OpenAI SDK retries

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -66,6 +66,8 @@ def _build_openai_client_kwargs(
     else:
         kwargs = {"api_key": api_key, "base_url": api_base}
     kwargs["timeout"] = timeout
+    # OpenViking owns provider retry/backoff via retry_sync/retry_async.
+    kwargs["max_retries"] = 0
     if extra_headers:
         kwargs["default_headers"] = extra_headers
     return kwargs

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -200,6 +200,82 @@ class TestVLMExtraHeaders:
         assert "extra_body" not in call_kwargs
 
 
+class TestOpenAIVLMClientRetries:
+    """Test OpenAI SDK retries are disabled in favor of OpenViking retries."""
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
+    def test_openai_sync_client_disables_sdk_retries(self, mock_openai_class):
+        mock_openai_class.return_value = MagicMock()
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+                "max_retries": 5,
+            }
+        )
+
+        _ = vlm.get_client()
+
+        call_kwargs = mock_openai_class.call_args.kwargs
+        assert call_kwargs["max_retries"] == 0
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
+    def test_openai_async_client_disables_sdk_retries(self, mock_async_openai_class):
+        mock_async_openai_class.return_value = MagicMock()
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+                "max_retries": 5,
+            }
+        )
+
+        _ = vlm.get_async_client()
+
+        call_kwargs = mock_async_openai_class.call_args.kwargs
+        assert call_kwargs["max_retries"] == 0
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.AzureOpenAI")
+    def test_azure_sync_client_disables_sdk_retries(self, mock_azure_openai_class):
+        mock_azure_openai_class.return_value = MagicMock()
+
+        vlm = OpenAIVLM(
+            {
+                "provider": "azure",
+                "api_key": "sk-test",
+                "api_base": "https://example-resource.openai.azure.com",
+                "api_version": "2025-01-01-preview",
+                "max_retries": 5,
+            }
+        )
+
+        _ = vlm.get_client()
+
+        call_kwargs = mock_azure_openai_class.call_args.kwargs
+        assert call_kwargs["max_retries"] == 0
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncAzureOpenAI")
+    def test_azure_async_client_disables_sdk_retries(self, mock_async_azure_openai_class):
+        mock_async_azure_openai_class.return_value = MagicMock()
+
+        vlm = OpenAIVLM(
+            {
+                "provider": "azure",
+                "api_key": "sk-test",
+                "api_base": "https://example-resource.openai.azure.com",
+                "api_version": "2025-01-01-preview",
+                "max_retries": 5,
+            }
+        )
+
+        _ = vlm.get_async_client()
+
+        call_kwargs = mock_async_azure_openai_class.call_args.kwargs
+        assert call_kwargs["max_retries"] == 0
+
+
 class TestVLMBaseExtraHeaders:
     """Test VLMBase extracts extra_headers from config."""
 


### PR DESCRIPTION
## Description

Disable the OpenAI Python SDK's built-in retries for the OpenAI/Azure VLM backend so OpenViking's `retry_sync` / `retry_async` layer remains the single retry controller.

## Related Issue

Fixes #1856

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Set `max_retries=0` when constructing OpenAI and Azure OpenAI VLM clients.
- Keep OpenViking's configured `vlm.max_retries` as the only retry/backoff layer.
- Add regression coverage for sync/async OpenAI and Azure client construction.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Tested with:

```bash
.venv/bin/python -m pytest tests/unit/test_extra_headers_vlm.py
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The local test run still reports existing dependency/deprecation warnings unrelated to this change.
