### PR TITLE
docs(opencode-plugin): document account/user tenant config from #1820

### DIFF
--- a/examples/opencode-memory-plugin/README.md
+++ b/examples/opencode-memory-plugin/README.md
@@ -71,10 +71,12 @@ OpenCode auto-discovers first-level `*.ts` and `*.js` files under `~/.config/ope
 
 This plugin also works if you intentionally place it in a workspace-local plugin directory, because it stores config and runtime files next to the plugin file itself.
 
-Recommended: provide the API key via environment variable instead of writing it into the config file:
+Recommended: provide the API key and tenant identity via environment variables instead of writing them into the config file:
 
 ```bash
 export OPENVIKING_API_KEY="your-api-key-here"
+export OPENVIKING_ACCOUNT="default"
+export OPENVIKING_USER="opencode"
 ```
 
 ## Configuration
@@ -85,6 +87,8 @@ Example config:
 {
   "endpoint": "http://localhost:1933",
   "apiKey": "",
+  "account": "default",
+  "user": "opencode",
   "enabled": true,
   "timeoutMs": 30000,
   "autoCommit": {
@@ -94,7 +98,9 @@ Example config:
 }
 ```
 
-The environment variable `OPENVIKING_API_KEY` takes precedence over the config file.
+`account` and `user` are sent as `X-OpenViking-Account` and `X-OpenViking-User` tenant headers on every plugin API request; leave them empty to omit the headers.
+
+The environment variables `OPENVIKING_API_KEY`, `OPENVIKING_ACCOUNT`, and `OPENVIKING_USER` take precedence over the config file.
 
 ## Runtime Files
 
@@ -216,6 +222,8 @@ Add an `autoRecall` block to your `openviking-config.json` to customize recall b
 {
   "endpoint": "http://localhost:1933",
   "apiKey": "",
+  "account": "default",
+  "user": "opencode",
   "enabled": true,
   "timeoutMs": 30000,
   "autoCommit": {

--- a/examples/opencode-memory-plugin/README_CN.md
+++ b/examples/opencode-memory-plugin/README_CN.md
@@ -71,10 +71,12 @@ OpenCode 会自动发现 `~/.config/opencode/plugins` 下一级目录中的 `*.t
 
 如果您有意将插件放置在工作区本地插件目录中，此插件也可以使用，因为它会将配置和运行时文件存储在插件文件旁边。
 
-推荐：通过环境变量提供 API 密钥，而不是将其写入配置文件：
+推荐：通过环境变量提供 API 密钥和租户身份，而不是将其写入配置文件：
 
 ```bash
 export OPENVIKING_API_KEY="your-api-key-here"
+export OPENVIKING_ACCOUNT="default"
+export OPENVIKING_USER="opencode"
 ```
 
 ## 配置
@@ -85,6 +87,8 @@ export OPENVIKING_API_KEY="your-api-key-here"
 {
   "endpoint": "http://localhost:1933",
   "apiKey": "",
+  "account": "default",
+  "user": "opencode",
   "enabled": true,
   "timeoutMs": 30000,
   "autoCommit": {
@@ -94,7 +98,9 @@ export OPENVIKING_API_KEY="your-api-key-here"
 }
 ```
 
-环境变量 `OPENVIKING_API_KEY` 优先于配置文件。
+`account` 和 `user` 会作为 `X-OpenViking-Account` 与 `X-OpenViking-User` 租户头随每次插件 API 请求发送；留空则不会附加这些头。
+
+环境变量 `OPENVIKING_API_KEY`、`OPENVIKING_ACCOUNT` 和 `OPENVIKING_USER` 优先于配置文件。
 
 ## 运行时文件
 


### PR DESCRIPTION
## Summary

Document the `account` and `user` tenant config fields added to the OpenCode memory plugin in #1820.

#1820 added:
- `account` and `user` config keys (and `OPENVIKING_ACCOUNT` / `OPENVIKING_USER` env var loaders) to `examples/opencode-memory-plugin/openviking-memory.ts`
- Concrete defaults `"account": "default", "user": "opencode"` to `openviking-config.example.json`
- New `buildOpenVikingHeaders()` helper that emits `X-OpenViking-Account` and `X-OpenViking-User` headers when the values are non-empty

The plugin README (EN + ZH) was missing all three of these signals: the env-var bash block, the JSON config example, and the precedence statement only mentioned `OPENVIKING_API_KEY`. New users `cp openviking-config.example.json` and see `account` / `user` keys, but reading the README they would not know what those fields do or that env vars exist for them.

## Changes

- `examples/opencode-memory-plugin/README.md`: env-var bash block adds the two new exports; both JSON config examples (Configuration + Example Config with Recall) gain `account` / `user`; one-line description of the tenant headers + updated precedence statement
- `examples/opencode-memory-plugin/README_CN.md`: same set of changes in Chinese (this file does not yet have the autoRecall section, so only one JSON example to update)

Field defaults `"default"` / `"opencode"` mirror `openviking-config.example.json` exactly. The "leave empty to omit the headers" wording mirrors `if (config.account)` / `if (config.user)` truthy checks in `buildOpenVikingHeaders` from #1820.

Pure docs, no behavioral change.