### PR TITLE
docs(openclaw-plugin): drop agent_end from README hook list per #1866

### DIFF
--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -19,7 +19,7 @@ This document is not an installation guide. It is an implementation-focused desi
 In the current implementation, the plugin plays four roles at once:
 
 - `context-engine`: implements `assemble`, `afterTurn`, and `compact`
-- hook layer: handles `session_start`, `session_end`, `agent_end`, and `before_reset`
+- hook layer: handles `session_start`, `session_end`, and `before_reset`
 - tool provider: registers memory/archive tools plus OpenViking resource and skill import tools
 - runtime manager: connects to and monitors a remote OpenViking service
 

--- a/examples/openclaw-plugin/README_CN.md
+++ b/examples/openclaw-plugin/README_CN.md
@@ -19,7 +19,7 @@
 按当前代码职责看，插件同时扮演四个角色：
 
 - `context-engine`：实现 `assemble`、`afterTurn`、`compact`
-- Hook 层：接管 `session_start`、`session_end`、`agent_end`、`before_reset`
+- Hook 层：接管 `session_start`、`session_end`、`before_reset`
 - Tool 提供者：注册 memory/archive 工具，以及 OpenViking resource 和 skill 导入工具
 - 运行时管理器：连接并监控远程 OpenViking 服务
 


### PR DESCRIPTION
## Summary

`#1866` (Mijamind719→ qin-ctx, merged 2026-05-06T08:50Z) explicitly **removed the `agent_end` hook** from `examples/openclaw-plugin/index.ts` because OpenClaw 5.2 blocks that typed hook for non-bundled plugins without conversation access (per the PR description: _"the `agent_end` hook is removed because 5.2 blocks that typed hook for non-bundled plugins without conversation access; session routing is already recorded through `session_start`/`session_end`."_).

After the merge, `examples/openclaw-plugin/index.ts` only registers `session_start`, `session_end`, and `before_reset` (verified with `grep -n "api.on(" examples/openclaw-plugin/index.ts`):

```ts
api.on("session_start", async (_event, ctx) => { ... });
api.on("session_end",   async (_event, ctx) => { ... });
api.on("before_reset",  async (_event, ctx) => { ... });
```

But the hook-layer bullet in `README.md` (line 22) and `README_CN.md` (line 22) still list `agent_end`. Drop it so the README matches the runtime registration.

## Scope

- `examples/openclaw-plugin/README.md` — removed `, ` + ``` `agent_end` ``` from the hook-layer bullet
- `examples/openclaw-plugin/README_CN.md` — removed ``` `agent_end`、 ``` from the same bullet (Chinese)

Pure docs, no code or behavior change. Refs `#1866`.