### PR TITLE
fix(server): 分阶段 lifespan 使 /health 在初始化期间可响应

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -219,15 +219,13 @@ def create_app(
         async with mcp_lifespan():
             # Start heavy initialization as background task after yield
             if service is not None:
-                deferred_task = asyncio.create_task(
-                    _deferred_init(service, app, config)
-                )
+                deferred_task = asyncio.create_task(_deferred_init(service, app, config))
                 deferred_task.add_done_callback(
-                    lambda t: logger.error(
-                        "Deferred initialization failed", exc_info=t.exception()
+                    lambda t: (
+                        logger.error("Deferred initialization failed", exc_info=t.exception())
+                        if t.exception()
+                        else None
                     )
-                    if t.exception()
-                    else None
                 )
             yield
 

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -219,7 +219,16 @@ def create_app(
         async with mcp_lifespan():
             # Start heavy initialization as background task after yield
             if service is not None:
-                deferred_task = asyncio.create_task(_deferred_init(service, app, config))
+                deferred_task = asyncio.create_task(
+                    _deferred_init(service, app, config)
+                )
+                deferred_task.add_done_callback(
+                    lambda t: logger.error(
+                        "Deferred initialization failed", exc_info=t.exception()
+                    )
+                    if t.exception()
+                    else None
+                )
             yield
 
         # Wait for deferred initialization to complete before shutdown

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -142,17 +142,9 @@ def create_app(
 
     validate_server_config(config)
 
-    @asynccontextmanager
-    async def lifespan(app: FastAPI):
-        """Application lifespan handler."""
-        nonlocal service
-        owns_service = service is None
-        if owns_service:
-            service = OpenVikingService()
-            await service.initialize()
-
-        assert service is not None
-        set_service(service)
+    async def _deferred_init(service, app, config):
+        """Run heavy initialization in background after server starts accepting requests."""
+        await service.initialize()
 
         # Initialize APIKeyManager after service (needs VikingFS)
         effective_auth_mode = config.get_effective_auth_mode()
@@ -188,6 +180,19 @@ def create_app(
             # AuthMode.DEV - logging already handled in validate_server_config
             app.state.api_key_manager = None
 
+        logger.info("OpenVikingService initialization complete")
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        """Application lifespan handler."""
+        nonlocal service
+        owns_service = service is None
+        if owns_service:
+            service = OpenVikingService()
+
+        assert service is not None
+        set_service(service)
+
         from openviking.metrics.global_api import (
             init_metrics_from_server_config,
         )
@@ -209,8 +214,20 @@ def create_app(
         # Start MCP session manager (must be active before /mcp requests)
         from openviking.server.mcp_endpoint import mcp_lifespan
 
+        deferred_task = None
+
         async with mcp_lifespan():
+            # Start heavy initialization as background task after yield
+            if owns_service:
+                deferred_task = asyncio.create_task(_deferred_init(service, app, config))
             yield
+
+        # Wait for deferred initialization to complete before shutdown
+        if deferred_task and not deferred_task.done():
+            try:
+                await deferred_task
+            except Exception:
+                logger.exception("Deferred initialization failed")
 
         # Cleanup
         from openviking.metrics.global_api import shutdown_metrics_async

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -218,7 +218,7 @@ def create_app(
 
         async with mcp_lifespan():
             # Start heavy initialization as background task after yield
-            if owns_service:
+            if service is not None:
                 deferred_task = asyncio.create_task(_deferred_init(service, app, config))
             yield
 

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -72,6 +72,21 @@ async def readiness_check(request: Request):
     Returns 200 when all subsystems are operational, 503 otherwise.
     No authentication required (designed for K8s probes).
     """
+    # If service is still initializing, return 503 immediately
+    try:
+        service = get_service()
+        if not service._initialized:
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "reason": "initializing"},
+            )
+    except Exception:
+        # If get_service() fails (service not yet set), also return 503
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not_ready", "reason": "initializing"},
+        )
+
     checks = {}
 
     # 1. AGFS: try to list root

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -80,8 +80,8 @@ async def readiness_check(request: Request):
                 status_code=503,
                 content={"status": "not_ready", "reason": "initializing"},
             )
-    except Exception:
-        # If get_service() fails (service not yet set), also return 503
+    except RuntimeError:
+        # get_service() raises RuntimeError when service not yet set
         return JSONResponse(
             status_code=503,
             content={"status": "not_ready", "reason": "initializing"},

--- a/tests/server/test_server_health.py
+++ b/tests/server/test_server_health.py
@@ -4,6 +4,7 @@
 """Tests for server infrastructure: health, system status, middleware, error handling."""
 
 import asyncio
+import time
 
 import httpx
 
@@ -56,3 +57,97 @@ async def test_lifespan_shutdown_ignores_cancelled_service_close():
 
     async with app.router.lifespan_context(app):
         pass
+
+
+async def test_health_responds_during_initialization(monkeypatch):
+    """Health endpoint responds 200 even during phased service initialization."""
+
+    # Service is "initializing" — _initialized is False
+    class MockService:
+        _initialized = False
+
+    service = MockService()
+    monkeypatch.setattr("openviking.server.dependencies._service", service)
+
+    app = create_app(config=ServerConfig(), service=service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+
+
+async def test_ready_returns_503_before_initialized(monkeypatch):
+    """Ready returns 503 when service._initialized is False."""
+
+    class MockService:
+        _initialized = False
+
+    service = MockService()
+    monkeypatch.setattr("openviking.server.dependencies._service", service)
+
+    app = create_app(config=ServerConfig(), service=service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/ready")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "not_ready"
+        assert body["reason"] == "initializing"
+
+
+async def test_ready_returns_200_after_initialized(monkeypatch):
+    """Ready returns 200 when service is fully initialized and subsystems are healthy."""
+
+    class MockVikingFS:
+        async def ls(self, path, ctx=None):
+            return []
+
+        def _get_vector_store(self):
+            class MockVectorStore:
+                async def health_check(self):
+                    return True
+
+            return MockVectorStore()
+
+    class MockService:
+        _initialized = True
+
+    service = MockService()
+    monkeypatch.setattr("openviking.server.dependencies._service", service)
+    monkeypatch.setattr("openviking.server.routers.system.get_viking_fs", lambda: MockVikingFS())
+    monkeypatch.setattr(
+        "openviking_cli.utils.ollama.detect_ollama_in_config",
+        lambda config: (False, None, None),
+    )
+
+    app = create_app(config=ServerConfig(), service=service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/ready")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ready"
+
+
+async def test_slow_init_does_not_block_health(monkeypatch):
+    """Health endpoint responds quickly even when initialization is slow."""
+
+    # Health is stateless — it doesn't call get_service() or depend on _initialized
+    class MockService:
+        _initialized = False
+
+    service = MockService()
+    monkeypatch.setattr("openviking.server.dependencies._service", service)
+
+    app = create_app(config=ServerConfig(), service=service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        start = time.perf_counter()
+        resp = await client.get("/health")
+        elapsed = time.perf_counter() - start
+
+        assert resp.status_code == 200
+        # Health responds instantly since it's stateless (no service dependency)
+        assert elapsed < 0.5


### PR DESCRIPTION
## Description

修复 `/health` 存活探针在 `service.initialize()` 期间被阻塞的问题。

Issue #1793 报告：服务器在 ASGI lifespan 中的 `await service.initialize()` 之后才 `yield`，导致初始化期间所有 HTTP 请求（包括 `/health`）被阻塞。当现有 workspace 数据触发 `PersistCollection._recover()` 等昂贵恢复操作时，Docker health-check 超时杀死仍在初始化的服务，形成无限重启循环。

### 技术方案

将 ASGI lifespan 重构为两阶段，利用 `/health` 端点本身不依赖 `get_service()` 的特性（只读取 `request.app.state.config`）：

- **yield 前（快速路径，< 1s）**: `set_service(service)`、metrics、tracing、task tracker、MCP lifespan
- **yield 后（后台任务）**: `service.initialize()` 和 `APIKeyManager` 初始化作为 `asyncio.create_task()` 运行

同时为 `/ready` 端点增加 `_initialized` 检查，确保就绪探针在初始化完成前返回 503。

## Related Issue

Fixes #1793

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `openviking/server/app.py`
  - 新增 `_deferred_init(service, app, config)` 函数，封装 `service.initialize()` + `APIKeyManager` 初始化
  - 重构 `lifespan()`：yield 前仅执行 essentials，后台初始化通过 `asyncio.create_task()` 启动
- `openviking/server/routers/system.py`
  - `/ready` 端点新增 `service._initialized` 检查，初始化未完成时返回 503 `{"status": "not_ready", "reason": "initializing"}`
- `tests/server/test_server_health.py`
  - 新增 4 个测试用例

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Windows

新增测试：
- `test_health_responds_during_initialization` — 初始化期间 /health 返回 200
- `test_ready_returns_503_before_initialized` — 初始化未完成时 /ready 返回 503
- `test_ready_returns_200_after_initialized` — 初始化完成后 /ready 返回 200
- `test_slow_init_does_not_block_health` — 慢初始化不阻塞 /health

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- 这是针对 Issue #1793 的 4 个分支中的第 1 个，后续分支包含 SIGTERM handler 修复（#1883）、Helm readiness probe 修正、Docker entrypoint 调整
- APIKeyManager 的初始化延后到 `_deferred_init()` 中，因为其依赖 `service.viking_fs`（在 `service.initialize()` 内创建）
- 后台初始化任务在 shutdown 前通过 `await deferred_task` 等待完成，避免资源泄漏
- ruff check: 0 errors, ruff format: 2 files reformatted
