### PR TITLE
fix(deploy): Helm readiness probe 改用 /ready 端点

### DIFF
--- a/bot/deploy/vke/k8s/deployment.yaml
+++ b/bot/deploy/vke/k8s/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /health
+            path: /ready
             port: 18791
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/deploy/helm/openviking/values.yaml
+++ b/deploy/helm/openviking/values.yaml
@@ -134,7 +134,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /ready
     port: http
   initialDelaySeconds: 15
   periodSeconds: 10

--- a/examples/k8s-helm/templates/deployment.yaml
+++ b/examples/k8s-helm/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 60
             periodSeconds: 10


### PR DESCRIPTION
## Description

修正 3 个 K8s 部署文件中 readiness probe 的路径：将 `readinessProbe` 从 `/health` 改为 `/ready`，以正确区分存活探针和就绪探针。

`/health` 是存活探针（liveness），只验证进程是否在运行。`/ready` 检查 AGFS、VectorDB、APIKeyManager 等子系统健康状况，适合作为 K8s readiness probe 判断 Pod 是否可服务流量。

`livenessProbe` 保持不变，继续使用 `/health`。

## Related Issue

Refs #1793

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `deploy/helm/openviking/values.yaml:137` — `readinessProbe` path: `/health` → `/ready`
- `examples/k8s-helm/templates/deployment.yaml:44` — 同上
- `bot/deploy/vke/k8s/deployment.yaml:77` — 同上

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

YAML 语法验证通过（helm lint 兼容），无运行时代码变更需测试。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- 依赖 #1878（`/ready` 端点需有 `_initialized` 检查，否则初始化期间 readiness probe 行为不正确）
- 仅修改 readiness probe 路径，liveness probe 保持 `/health` 不变
