### PR TITLE
perf(docker): cache cargo+ccache and drop redundant maturin step (-51% rebuild on .py change)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,19 @@ ARG UV_LOCK_STRATEGY=auto
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    ccache \
     cmake \
     git \
  && rm -rf /var/lib/apt/lists/*
+
+# Route gcc/g++/cc through ccache so cmake (which asks shutil.which("gcc")) picks
+# up /usr/lib/ccache/gcc and benefits from the BuildKit cache mount on /root/.ccache.
+ENV PATH="/usr/lib/ccache:${PATH}"
+ENV CCACHE_DIR=/root/.ccache
+# Pin Cargo's target dir to a stable path so a BuildKit cache mount can persist
+# build artifacts across layer reruns even when uv builds the wheel in an
+# ephemeral isolated tempdir.
+ENV CARGO_TARGET_DIR=/cargo-target
 
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
@@ -44,6 +54,10 @@ COPY third_party/ third_party/
 # stale, so Docker builds stay unblocked after dependency changes. Set
 # UV_LOCK_STRATEGY=locked to keep fail-fast reproducibility checks.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
+    --mount=type=cache,target=/cargo-target,id=cargo-target-${TARGETPLATFORM} \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
+    --mount=type=cache,target=/root/.ccache,id=ccache-${TARGETPLATFORM} \
     if [ -n "${OPENVIKING_VERSION:-}" ]; then \
         export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING="${OPENVIKING_VERSION}"; \
     elif [ -f openviking/_version.py ]; then \
@@ -71,6 +85,10 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
 # Build ragfs-python (Rust RAGFS binding) and extract the native extension
 # into the installed openviking package.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
+    --mount=type=cache,target=/cargo-target,id=cargo-target-${TARGETPLATFORM} \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
+    --mount=type=cache,target=/root/.ccache,id=ccache-${TARGETPLATFORM} \
     uv pip install maturin && \
     export _TMPDIR=$(mktemp -d) && \
     trap 'rm -rf "$_TMPDIR"' EXIT && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,47 +82,6 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
             ;; \
     esac
 
-# Build ragfs-python (Rust RAGFS binding) and extract the native extension
-# into the installed openviking package.
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
-    --mount=type=cache,target=/cargo-target,id=cargo-target-${TARGETPLATFORM} \
-    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
-    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
-    --mount=type=cache,target=/root/.ccache,id=ccache-${TARGETPLATFORM} \
-    uv pip install maturin && \
-    export _TMPDIR=$(mktemp -d) && \
-    trap 'rm -rf "$_TMPDIR"' EXIT && \
-    cd crates/ragfs-python && \
-    python -m maturin build --release --out "$_TMPDIR" && \
-    cd ../.. && \
-    export _OV_LIB=$(python -c "import openviking; from pathlib import Path; print(Path(openviking.__file__).resolve().parent / 'lib')") && \
-    mkdir -p "$_OV_LIB" && \
-    python - <<'PY'
-import glob
-import os
-import sys
-import zipfile
-
-tmpdir = os.environ["_TMPDIR"]
-ov_lib = os.environ["_OV_LIB"]
-whls = glob.glob(os.path.join(tmpdir, "ragfs_python-*.whl"))
-assert whls, "maturin produced no wheel"
-
-with zipfile.ZipFile(whls[0]) as zf:
-    for name in zf.namelist():
-        bn = os.path.basename(name)
-        if bn.startswith("ragfs_python") and (bn.endswith(".so") or bn.endswith(".pyd")):
-            dst = os.path.join(ov_lib, bn)
-            with zf.open(name) as src, open(dst, "wb") as f:
-                f.write(src.read())
-            os.chmod(dst, 0o755)
-            print(f"ragfs-python: extracted {bn} -> {dst}")
-            sys.exit(0)
-
-print("WARNING: No ragfs_python .so/.pyd in wheel")
-sys.exit(1)
-PY
-
 # Stage 3: runtime
 FROM python:3.13-slim-trixie
 


### PR DESCRIPTION
## Description

Speed up Docker rebuilds when only Python source changes by adding BuildKit cache mounts to the heavy `py-builder` stage and removing a redundant second `maturin build` step.

In the current Dockerfile, any change inside `openviking/` invalidates step 11 (`COPY openviking/ openviking/`), which cascades through the two heavy `RUN` steps:
- step 15 (`uv sync --no-editable`) — triggers `setup.py` to rebuild the `ov` Rust CLI, `ragfs-python` (via maturin), and the C++ vector engine via cmake.
- step 16 — reinstalls maturin and rebuilds `ragfs-python` a second time, overwriting the `.so` already installed in the venv.

Neither rerun benefits from any persistent cache, so a one-line `.py` edit costs ~10 minutes of native compilation that produces output identical to the previous build.

## Related Issue

N/A

## Type of Change

- [x] Performance improvement

## Changes Made

- Add BuildKit cache mounts to step 15 for `/cargo-target`, `/usr/local/cargo/registry`, `/usr/local/cargo/git`, and `/root/.ccache` so cargo and gcc/g++ reuse work across rebuilds.
- Pin `CARGO_TARGET_DIR=/cargo-target` so the path stays stable when uv builds wheels in ephemeral isolated tempdirs.
- Install `ccache` and prepend `/usr/lib/ccache` to `PATH` so cmake's `shutil.which("gcc")` resolves to the ccache wrapper.
- Drop step 16 entirely. `setup.py`'s `build_ragfs_python_artifact` already runs maturin during step 15 (uv invokes setuptools `build_meta` with `bdist_wheel` in argv, so `_should_require_ragfs_artifact()` returns True and the build fails closed if the `.so` can't be produced). The `.so` is bundled into the wheel via `package_data` and installed into `/app/.venv` on wheel install.

## Why step 16 was introduced — and why it became redundant

Step 16 was introduced in #1221 (the agfs → ragfs(Rust) rewrite) and was correct at that time. Two follow-up PRs since then made it obsolete:

| Date | PR | Author | Effect on step 16 |
|---|---|---|---|
| 2026-04-05 | #1221 | @MaojiaSheng | **Introduces step 16.** At this commit, `pyproject.toml`'s `build-system.requires` does not list `maturin`, and `setup.py`'s `build_ragfs_python_artifact` silently skips when `shutil.which(\"maturin\")` returns `None`. So step 15's isolated wheel build env has no maturin → ragfs is skipped → the wheel contains no `.so` → runtime import would fail. Step 16 is the necessary fallback: explicitly install maturin, build ragfs, extract the `.so` into the installed venv. |
| 2026-04-09 | #1307 | @Jiahui Zhou | Adds `\"maturin>=1.0,<2.0\"` to `pyproject.toml`'s `build-system.requires` (commit message: \"build: move ragfs-python packaging into setup.py\"). From this point on, step 15's isolated build env already has maturin, so `build_ragfs_python_artifact` runs successfully inside the wheel build. **Step 16 becomes a no-op overwrite** of the `.so` that step 15 already installed. |
| 2026-04-15 | #1466 | @Qin Haojie | Adds `_should_require_ragfs_artifact()` so wheel builds **fail closed** if `ragfs_python.abi3.so` can't be produced. This upgrades \"step 15 produces the .so\" from an empirical observation to a code-enforced contract. |

So step 16's original safety role has been migrated into `setup.py` + `pyproject.toml` since #1307, in a strictly more robust way (the wheel itself fails closed; no separate post-install patching needed). This PR removes the now-redundant fallback.

## Testing

End-to-end verified on the deployment build server (ARM Neoverse-N1, 4 vCPU @ 2.0 GHz, QEMU virt, Debian 13 aarch64 host, LXC container with 12 GiB RAM):

| build | step 15 | step 16 | total | vs baseline |
|---|---:|---:|---:|---|
| baseline (no perf changes) | 510s | 113s | **12m22s** | — |
| this PR, cold (cache empty) | 354s | (deleted) | 9m32s | -23% |
| this PR, hot (.py edit, cache hit) | 240.8s | (deleted) | **6m02s** | **-51%** |

Local sanity check on a developer laptop (Apple M4 Pro, 14-core / 48 GiB host, Linux VM via colima with 14 vCPU / 16 GiB):

| build | step 15 | total |
|---|---:|---:|
| this PR, cold (after `docker builder prune -a`) | 305.6s | 6m21s |
| this PR, hot (.py edit) | **87.3s** | **2m12s** |

Runtime correctness (built image actually starts and serves):
- `ls /app/.venv/lib/python3.13/site-packages/openviking/lib/` → `ragfs_python.abi3.so` (11.8 MB) is present, written by step 15's wheel install (no longer overwritten by the deleted step 16).
- `python -c \"from openviking.lib import ragfs_python; print(ragfs_python.__file__)\"` resolves to the venv path with no errors.
- `docker compose up -d` + `curl /health` → `{\"status\":\"ok\",\"healthy\":true,\"version\":\"0.3.15.devN\",\"auth_mode\":\"api_key\"}`.

- [ ] I have added tests that prove my fix is effective or that my feature works
  - N/A — build-only change with no functional behavior added or removed. Validated via the timing tables and the runtime import / health check above.
- [x] New and existing unit tests pass locally with my changes
  - Pytest is unaffected; the change touches only `Dockerfile`.
- [x] I have tested this on the following platforms:
  - [x] Linux (ARM aarch64 build server — full build + runtime verification)
  - [x] macOS (Apple Silicon / colima Linux VM, build only)
  - [ ] Windows (not tested; Dockerfile path)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (no doc impact)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Cache mounts were chosen over restructuring `COPY` order because:
- A `COPY` split + `uv sync --reinstall-package openviking` does not avoid recompilation: `setup.py`'s `build_extension` (cmake-driven C++ engine build) does not honor any skip env var, so a Python-only reinstall would still rerun cmake. Adding such a flag would expand the diff into `setup.py` and increase review surface.
- Cache mounts are reproducibility-neutral (they affect speed only, not the wheel/image bits), and a fresh BuildKit cache produces a build identical to the previous behavior.

The largest remaining cost inside step 15 is uv wheel packaging + cmake configure (~3–4 min on the build server, ~80 s locally) that cache mounts cannot address. Reaching ~1 minute hot rebuilds would require switching to an editable install or splitting native vs Python source into separate `COPY` layers, which is out of scope for this PR.