### PR TITLE
fix(docker): entrypoint 等待 /ready 后再启动 console

### DIFF
--- a/docker/openviking-console-entrypoint.sh
+++ b/docker/openviking-console-entrypoint.sh
@@ -7,6 +7,8 @@ SERVER_READY_URL="${SERVER_URL}/ready"
 CONSOLE_PORT="${OPENVIKING_CONSOLE_PORT:-8020}"
 CONSOLE_HOST="${OPENVIKING_CONSOLE_HOST:-0.0.0.0}"
 WITH_BOT="${OPENVIKING_WITH_BOT:-1}"
+HEALTH_MAX_ATTEMPTS="${OPENVIKING_HEALTH_MAX_ATTEMPTS:-120}"
+READY_MAX_ATTEMPTS="${OPENVIKING_READY_MAX_ATTEMPTS:-300}"
 CONFIG_FILE="${OPENVIKING_CONFIG_FILE:-/app/.openviking/ov.conf}"
 PENDING_HEALTH_SCRIPT="/usr/local/bin/openviking-pending-health"
 SERVER_PID=""
@@ -124,7 +126,7 @@ until curl -fsS "${SERVER_HEALTH_URL}" >/dev/null 2>&1; do
         wait "${SERVER_PID}" || true
         exit 1
     fi
-    if [ "${attempt}" -ge 120 ]; then
+    if [ "${attempt}" -ge "${HEALTH_MAX_ATTEMPTS}" ]; then
         echo "[openviking-console-entrypoint] timed out waiting for ${SERVER_HEALTH_URL}" >&2
         forward_signal
         wait "${SERVER_PID}" || true
@@ -142,7 +144,7 @@ until curl -fsS "${SERVER_READY_URL}" 2>/dev/null | grep -q '"status":"ready"'; 
         wait "${SERVER_PID}" || true
         exit 1
     fi
-    if [ "${ready_attempt}" -ge 300 ]; then
+    if [ "${ready_attempt}" -ge "${READY_MAX_ATTEMPTS}" ]; then
         echo "[openviking-console-entrypoint] timed out waiting for ${SERVER_READY_URL}" >&2
         forward_signal
         wait "${SERVER_PID}" || true

--- a/docker/openviking-console-entrypoint.sh
+++ b/docker/openviking-console-entrypoint.sh
@@ -3,6 +3,7 @@ set -eu
 
 SERVER_URL="http://127.0.0.1:1933"
 SERVER_HEALTH_URL="${SERVER_URL}/health"
+SERVER_READY_URL="${SERVER_URL}/ready"
 CONSOLE_PORT="${OPENVIKING_CONSOLE_PORT:-8020}"
 CONSOLE_HOST="${OPENVIKING_CONSOLE_HOST:-0.0.0.0}"
 WITH_BOT="${OPENVIKING_WITH_BOT:-1}"
@@ -131,6 +132,25 @@ until curl -fsS "${SERVER_HEALTH_URL}" >/dev/null 2>&1; do
     fi
     sleep 1
 done
+
+# Wait for server to become fully ready before starting console
+ready_attempt=0
+until curl -fsS "${SERVER_READY_URL}" 2>/dev/null | grep -q '"status":"ready"'; do
+    ready_attempt=$((ready_attempt + 1))
+    if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+        echo "[openviking-console-entrypoint] openviking-server exited before becoming ready" >&2
+        wait "${SERVER_PID}" || true
+        exit 1
+    fi
+    if [ "${ready_attempt}" -ge 300 ]; then
+        echo "[openviking-console-entrypoint] timed out waiting for ${SERVER_READY_URL}" >&2
+        forward_signal
+        wait "${SERVER_PID}" || true
+        exit 1
+    fi
+    sleep 2
+done
+echo "[openviking-console-entrypoint] openviking-server is ready"
 
 python -m openviking.console.bootstrap \
     --host "${CONSOLE_HOST}" \


### PR DESCRIPTION
## Description

Docker entrypoint 在两阶段 lifespan 架构下调整启动时序：在原有的 `/health` 存活检查之后，新增第二阶段轮询 `/ready` 端点，确保服务完全初始化后再启动 OpenViking Console。

### 原有行为

```
until curl /health → 200     # 原阻塞到 init 完成
start console
```

### 修改后

```
Phase 1: until curl /health → 200   # 验证进程存活
Phase 2: until curl /ready → "ready"  # 等待 init 完成，最多 10 分钟（可配置）
echo "openviking-server is ready"
start console                        # 此时服务 fully ready
```

## Related Issue

Refs #1793

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `docker/openviking-console-entrypoint.sh`
  - 新增 `SERVER_READY_URL` 变量
  - 新增 `/ready` 轮询循环（Phase 2）
  - `OPENVIKING_HEALTH_MAX_ATTEMPTS` 环境变量控制 `/health` 超时（默认 120）
  - `OPENVIKING_READY_MAX_ATTEMPTS` 环境变量控制 `/ready` 超时（默认 300）

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- 依赖 #1878（`/ready` 端点需有 `_initialized` 检查 + 分阶段 lifespan）
- Dockerfile 的 `HEALTHCHECK` 和 `docker-compose.yml` 的 `healthcheck` 保持不变，继续使用 `/health`（liveness probe）
- 慢速集合恢复场景下（分钟级），Phase 2 循环提供充足的等待窗口

Fix #1793