### PR TITLE
feat(storage): 本地索引恢复增加时间节流进度日志

### DIFF
--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -946,6 +946,15 @@ class PersistCollection(LocalCollection):
         LocalCollection._register_scheduler_job(self)  # TTL expiration data cleanup
 
     def _recover(self):
+        index_count = 0
+        for f in os.listdir(self.index_dir):
+            try:
+                if safe_join(self.index_dir, f).is_dir():
+                    index_count += 1
+            except ValueError:
+                pass
+        if index_count > 0:
+            logger.info("Recovering %d index(es) from %s", index_count, self.index_dir)
         for folder in os.listdir(self.index_dir):
             try:
                 index_dir = safe_join(self.index_dir, folder)
@@ -983,23 +992,44 @@ class PersistCollection(LocalCollection):
             if not self.store_mgr:
                 raise RuntimeError("Store manager is not initialized")
             delta_list = self.store_mgr.get_delta_data_after_ts(newest_version)
+            logger.info(
+                "Index '%s': replaying %d delta records to recover from last persistent snapshot",
+                index_name,
+                len(delta_list),
+            )
             upsert_list: List[DeltaRecord] = []
             delete_list: List[DeltaRecord] = []
+            _processed = 0
+            _last_log = 0.0
             for data in delta_list:
                 if data.type == OpType.PUT.value:
                     if delete_list:
                         index.delete_data(delete_list)
+                        _processed += len(delete_list)
                         delete_list = []
                     upsert_list.append(data)
                 elif data.type == OpType.DEL.value:
                     if upsert_list:
                         index.upsert_data(upsert_list)
+                        _processed += len(upsert_list)
                         upsert_list = []
                     delete_list.append(data)
+                now = time.time()
+                if now - _last_log >= 5.0 and _processed > 0:
+                    logger.info(
+                        "Delta replay progress: %d/%d records for index '%s'",
+                        _processed,
+                        len(delta_list),
+                        index_name,
+                    )
+                    _last_log = now
             if upsert_list:
                 index.upsert_data(upsert_list)
+                _processed += len(upsert_list)
             if delete_list:
                 index.delete_data(delete_list)
+                _processed += len(delete_list)
+            logger.info("Index '%s': replay complete (%d records)", index_name, _processed)
             self.indexes.set(index_name, index)
 
     def _persist_all_indexes(self):


### PR DESCRIPTION
## Description

为 `PersistCollection._recover()` 增加时间节流的进度日志，帮助运维人员通过日志区分"服务正在恢复中"与"服务卡住了"。

当前的恢复过程完全是黑盒——`service.initialize()` 触发 collection recovery 时，可能回放数万条 delta 记录但没有任何进度输出。与 #1793 的健康检查超时问题叠加时，运维无法判断服务是真的在恢复还是已经卡死。

### 新增日志

| 位置 | 日志 | 节流方式 |
|------|------|---------|
| 恢复入口 | `"Recovering N index(es) from {path}"` | 无（仅一次） |
| 每个 index | `"Index '{name}': replaying N delta records"` | 无（每个 index 一次） |
| 回放中 | `"Delta replay progress: N/M records"` | 每 5 秒最多一条 |
| 完成 | `"Index '{name}': replay complete (N records)"` | 无（每个 index 一次） |

进度日志采用 ROS log throttled 风格——按时间节流（≥5s），而非按记录数节流，避免大量小 index 时日志刷屏。

## Related Issue

Refs #1793

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `openviking/storage/vectordb/collection/local_collection.py:948-1035`
  — `_recover()` 增加 4 处进度日志

## Testing

- [ ] I have added tests that prove my fix is effective
- [ ] I have tested this on the following platforms:
  - [ ] Linux / macOS / Windows

纯日志追加，无逻辑变更。需在实际 recovery 场景验证日志输出。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] ruff check: 0 errors

## Additional Notes

- 日志格式参考 ROS 的 `log_throttled` 设计——时间节流替代记录数节流
- 不影响 recovery 性能（`time.time()` 调用在每条记录上，开销可忽略）
- 恢复入口计数循环与主循环保持一致的 `try/except` 错误处理
