### PR TITLE
fix(storage): resolve skill write URI with agent scope prefix

### DIFF
--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -575,8 +575,12 @@ class ContentWriteCoordinator:
                 )
             root_uri = VikingURI.build(*parts[: memories_idx + 2])
         elif parts[0] == "agent":
-            if len(parts) >= 3 and parts[1] == "skills":
-                root_uri = VikingURI.build(*parts[:3])
+            try:
+                skills_idx = parts.index("skills")
+            except ValueError:
+                skills_idx = -1
+            if skills_idx >= 0 and len(parts) > skills_idx + 1:
+                root_uri = VikingURI.build(*parts[: skills_idx + 2])
             else:
                 try:
                     memories_idx = parts.index("memories")


### PR DESCRIPTION
## 背景

写入 `viking://agent/<agent_id>/skills/<skill_name>/SKILL.md` 这类 skill 文件时，会报错：

> write only supports memory or skill files under agent scope: viking://agent/default/skills/findable_skill_432cad9d/SKILL.md

## 根因

`ContentWriteCoordinator._resolve_root_uri` 在 agent 分支硬编码了 `parts[1] == "skills"` 的判断，即假定 URI 结构为 `viking://agent/skills/<name>/...`。

但实际使用中 URI 形如 `viking://agent/<agent_id>/skills/<skill_name>/...`，`skills` 位于 `parts[2]`，导致 skill 写入被错误地当作非法路径抛出 `InvalidArgumentError`。

对比 user 分支对 `memories` 的处理使用的是 `parts.index("memories")` 动态定位，这里行为不一致。

## 修复

改为用 `parts.index("skills")` 动态定位 skills 段，与 memories 分支的处理方式保持一致。

## 影响范围

- 修复：`viking://agent/<agent_id>/skills/<skill_name>/...` 路径下的 skill 文件写入。
- 兼容：原先可工作的 memories 路径不受影响（分支顺序和逻辑保持不变）。
