### PR TITLE
fix(server): validate skill metadata

### DIFF
--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -31,6 +31,7 @@ from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.zip_safe import safe_extract_zip
+from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
 
@@ -88,6 +89,7 @@ class SkillProcessor:
             data,
             allow_local_path_resolution=allow_local_path_resolution,
         )
+        self._validate_skill_dict(skill_dict)
         telemetry.set(
             "skill.parse.duration_ms", round((time.perf_counter() - parse_start) * 1000, 3)
         )
@@ -213,6 +215,13 @@ class SkillProcessor:
             raise ValueError(f"Unsupported data type: {type(data)}")
 
         return skill_dict, auxiliary_files, base_path
+
+    @staticmethod
+    def _validate_skill_dict(skill_dict: Dict[str, Any]) -> None:
+        """Validate normalized skill metadata before storage/indexing."""
+        name = skill_dict.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise InvalidArgumentError("Skill data must include a non-empty 'name' field")
 
     @staticmethod
     def _build_skill_abstract(skill_dict: Dict[str, Any]) -> str:

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -190,6 +190,19 @@ async def test_add_skill_business_error_uses_error_envelope(
     assert body["error"]["message"] == "Skill parse error: boom"
 
 
+async def test_add_skill_empty_dict_returns_invalid_argument(client: httpx.AsyncClient):
+    resp = await client.post(
+        "/api/v1/skills",
+        json={"data": {}, "wait": True},
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert "name" in body["error"]["message"]
+
+
 async def test_add_resource_with_summary_only_telemetry(
     client: httpx.AsyncClient,
     sample_markdown_file,

--- a/tests/unit/test_skill_processor_none.py
+++ b/tests/unit/test_skill_processor_none.py
@@ -10,6 +10,7 @@ skill data is None, instead of falling through to the generic
 import pytest
 
 from openviking.utils.skill_processor import SkillProcessor
+from openviking_cli.exceptions import InvalidArgumentError
 
 
 class TestParseSkillNoneData:
@@ -37,6 +38,13 @@ class TestParseSkillNoneData:
         assert skill_dict["name"] == "test-skill"
         assert aux_files == []
         assert base_path is None
+
+    @pytest.mark.parametrize("skill_dict", [{}, {"description": "missing name"}, {"name": ""}])
+    def test_validate_skill_dict_requires_name(self, skill_dict):
+        """Dict skill data should fail fast when required metadata is missing."""
+        processor = SkillProcessor(vikingdb=None)
+        with pytest.raises(InvalidArgumentError, match="non-empty 'name' field"):
+            processor._validate_skill_dict(skill_dict)
 
     def test_parse_skill_unsupported_type_still_raises(self):
         """Non-None unsupported types should still raise with type info."""


### PR DESCRIPTION
## Description

Validate structured skill metadata before skill storage and indexing so malformed skill input returns a structured 400 error instead of raising an internal `KeyError`.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Added explicit validation for normalized skill dict metadata before later code indexes `skill_dict["name"]`.
- Return `INVALID_ARGUMENT` for missing or empty skill `name` values instead of allowing a `KeyError` to become a 500.
- Added unit and HTTP API regression coverage for invalid empty skill payloads.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Tested with:

- `.venv/bin/python -m pytest tests/unit/test_skill_processor_none.py -q`
- `.venv/bin/python -m pytest tests/server/test_api_resources.py::test_add_skill_empty_dict_returns_invalid_argument -q`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No documentation changes are required. Targeted tests passed; the test output included existing dependency/deprecation warnings unrelated to this change.
