### PR TITLE
fix(server): 延迟初始化失败时退出进程

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -183,6 +184,14 @@ def create_app(
 
         logger.info("OpenVikingService initialization complete")
 
+    def _on_deferred_init_done(task):
+        if task.exception():
+            logger.error(
+                "Deferred initialization failed, exiting",
+                exc_info=task.exception(),
+            )
+            os._exit(1)
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         """Application lifespan handler."""
@@ -221,13 +230,7 @@ def create_app(
             # Start heavy initialization as background task after yield
             if service is not None:
                 deferred_task = asyncio.create_task(_deferred_init(service, app, config))
-                deferred_task.add_done_callback(
-                    lambda t: (
-                        logger.error("Deferred initialization failed", exc_info=t.exception())
-                        if t.exception()
-                        else None
-                    )
-                )
+                deferred_task.add_done_callback(_on_deferred_init_done)
             yield
 
         # Wait for deferred initialization to complete before shutdown
@@ -458,9 +461,7 @@ def create_app(
         return _handler
 
     for _route, (_fname, _mime) in _favicon_files.items():
-        app.add_api_route(
-            _route, _make_favicon_handler(_fname, _mime), include_in_schema=False
-        )
+        app.add_api_route(_route, _make_favicon_handler(_fname, _mime), include_in_schema=False)
 
     # MCP endpoint — serves 5 tools (search, read, store, forget, health)
     # via streamable HTTP for Claude Code and other MCP clients.

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -56,6 +56,22 @@ from openviking_cli.utils.logger import init_otel_log_handler_from_server_config
 logger = get_logger(__name__)
 
 
+def _on_deferred_init_done(task):
+    if task.cancelled():
+        logger.warning("Deferred initialization cancelled")
+        return
+
+    exc = task.exception()
+    if exc is None:
+        return
+
+    logger.error(
+        "Deferred initialization failed, exiting",
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
+    os._exit(1)
+
+
 def _format_error_location(loc: object) -> str:
     if not isinstance(loc, (list, tuple)):
         return "request"
@@ -183,14 +199,6 @@ def create_app(
             app.state.api_key_manager = None
 
         logger.info("OpenVikingService initialization complete")
-
-    def _on_deferred_init_done(task):
-        if task.exception():
-            logger.error(
-                "Deferred initialization failed, exiting",
-                exc_info=task.exception(),
-            )
-            os._exit(1)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):

--- a/tests/server/test_server_health.py
+++ b/tests/server/test_server_health.py
@@ -7,9 +7,61 @@ import asyncio
 import time
 
 import httpx
+import pytest
 
-from openviking.server.app import create_app
+from openviking.server.app import _on_deferred_init_done, create_app
 from openviking.server.config import ServerConfig
+
+
+class _ExitCalled(Exception):
+    def __init__(self, code: int):
+        self.code = code
+        super().__init__(f"os._exit({code})")
+
+
+async def test_deferred_init_failure_exits_process(monkeypatch):
+    async def fail_init():
+        raise RuntimeError("init failed")
+
+    def fake_exit(code: int):
+        raise _ExitCalled(code)
+
+    monkeypatch.setattr("openviking.server.app.os._exit", fake_exit)
+    task = asyncio.create_task(fail_init())
+    with pytest.raises(RuntimeError):
+        await task
+
+    with pytest.raises(_ExitCalled) as exc_info:
+        _on_deferred_init_done(task)
+
+    assert exc_info.value.code == 1
+
+
+async def test_deferred_init_success_does_not_exit(monkeypatch):
+    async def complete_init():
+        return None
+
+    monkeypatch.setattr(
+        "openviking.server.app.os._exit",
+        lambda code: pytest.fail(f"os._exit({code}) should not be called"),
+    )
+    task = asyncio.create_task(complete_init())
+    await task
+
+    _on_deferred_init_done(task)
+
+
+async def test_deferred_init_cancellation_does_not_exit(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.server.app.os._exit",
+        lambda code: pytest.fail(f"os._exit({code}) should not be called"),
+    )
+    task = asyncio.create_task(asyncio.sleep(60))
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    _on_deferred_init_done(task)
 
 
 async def test_health_endpoint(client: httpx.AsyncClient):
@@ -50,6 +102,9 @@ async def test_404_for_unknown_route(client: httpx.AsyncClient):
 
 async def test_lifespan_shutdown_ignores_cancelled_service_close():
     class _Service:
+        async def initialize(self):
+            pass
+
         async def close(self):
             raise asyncio.CancelledError("shutdown")
 


### PR DESCRIPTION
## Description

当 `_deferred_init` 因 `service.initialize()` 异常而失败时，进程应退出而非以静默故障状态继续运行。

#1892 报告：`_deferred_init` 失败后 `app.state.api_key_manager` 永不设置，`/health` 返回 200 但所有认证请求返回 500。改用 `os._exit(1)` 恢复原有故障信号。

### 改动

将 inline lambda 提取为 `_on_deferred_init_done` 函数，失败时 `os._exit(1)` 替代仅记录日志。

## Related Issue

Refs #1892 (Bug 2)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `openviking/server/app.py`
  - 新增 `_on_deferred_init_done(task)`：检查 task 异常，失败时 `os._exit(1)`
  - 新增 `import os`
  - `add_done_callback` 从 inline lambda 改为命名函数

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

进程退出行为需集成测试验证，单元测试难以覆盖 `os._exit(1)`。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- 命名函数优于 inline lambda：逻辑集中，便于测试和审查

