### PR TITLE
ci: deploy VitePress docs to TOS

### DIFF
--- a/.github/workflows/docs-tos.yml
+++ b/.github/workflows/docs-tos.yml
@@ -1,0 +1,113 @@
+name: 19. Docs TOS Deploy
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-tos.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOCS_BASE: /
+
+jobs:
+  deploy:
+    name: Build and Upload Docs to TOS
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install docs dependencies
+        run: npm ci
+        working-directory: docs
+
+      - name: Build docs
+        run: npm run docs:build
+        working-directory: docs
+
+      - name: Check TOS configuration
+        id: tos_config
+        env:
+          TOS_ACCESS_KEY: ${{ secrets.TOS_ACCESS_KEY }}
+          TOS_SECRET_KEY: ${{ secrets.TOS_SECRET_KEY }}
+          TOS_REGION: ${{ secrets.TOS_REGION }}
+          TOS_BUCKET: ${{ secrets.TOS_BUCKET }}
+          TOS_ENDPOINT: ${{ secrets.TOS_ENDPOINT }}
+        run: |
+          if [ -n "${TOS_ACCESS_KEY}" ] && [ -n "${TOS_SECRET_KEY}" ] && [ -n "${TOS_REGION}" ] && [ -n "${TOS_BUCKET}" ] && [ -n "${TOS_ENDPOINT}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.tos_config.outputs.configured == 'true'
+        id: setup_python
+        continue-on-error: true
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install AWS CLI
+        if: steps.tos_config.outputs.configured == 'true'
+        id: install_aws_cli
+        continue-on-error: true
+        run: python -m pip install --upgrade awscli
+
+      - name: Upload docs dist to TOS
+        id: upload_tos
+        if: steps.tos_config.outputs.configured == 'true'
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TOS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOS_SECRET_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.TOS_REGION }}
+          TOS_BUCKET: ${{ secrets.TOS_BUCKET }}
+          TOS_ENDPOINT: ${{ secrets.TOS_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          : "${AWS_ACCESS_KEY_ID:?Missing TOS_ACCESS_KEY secret}"
+          : "${AWS_SECRET_ACCESS_KEY:?Missing TOS_SECRET_KEY secret}"
+          : "${AWS_DEFAULT_REGION:?Missing TOS_REGION secret}"
+          : "${TOS_BUCKET:?Missing TOS_BUCKET secret}"
+          : "${TOS_ENDPOINT:?Missing TOS_ENDPOINT secret}"
+
+          TOS_ENDPOINT="${TOS_ENDPOINT#https://}"
+          TOS_ENDPOINT="${TOS_ENDPOINT#http://}"
+          case "${TOS_ENDPOINT}" in
+            tos-s3-*) TOS_S3_ENDPOINT="${TOS_ENDPOINT}" ;;
+            tos-*) TOS_S3_ENDPOINT="tos-s3-${TOS_ENDPOINT#tos-}" ;;
+            *) TOS_S3_ENDPOINT="${TOS_ENDPOINT}" ;;
+          esac
+
+          aws s3 sync docs/.vitepress/dist "s3://${TOS_BUCKET}/" \
+            --endpoint-url "https://${TOS_S3_ENDPOINT}" \
+            --delete \
+            --only-show-errors
+
+      - name: Report TOS deployment failure
+        if: steps.setup_python.outcome == 'failure' || steps.install_aws_cli.outcome == 'failure' || steps.upload_tos.outcome == 'failure'
+        run: |
+          echo "::warning::Docs were built, but deploying to TOS failed. This deployment is non-blocking."
+          echo "## TOS deployment failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Docs build succeeded, but setting up TOS tooling or uploading docs/.vitepress/dist failed. This workflow keeps passing so TOS availability does not block other repository flows." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report skipped TOS upload
+        if: steps.tos_config.outputs.configured != 'true'
+        run: |
+          echo "## TOS upload skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Docs build succeeded, but TOS secrets are not fully configured for this repository. Upload was skipped without failing the workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-tos.yml
+++ b/.github/workflows/docs-tos.yml
@@ -64,7 +64,9 @@ jobs:
         if: steps.tos_config.outputs.configured == 'true'
         id: install_aws_cli
         continue-on-error: true
-        run: python -m pip install --upgrade awscli
+        run: |
+          python -m pip install --upgrade awscli
+          aws configure set default.s3.addressing_style virtual
 
       - name: Upload docs dist to TOS
         id: upload_tos

--- a/.github/workflows/docs-tos.yml
+++ b/.github/workflows/docs-tos.yml
@@ -92,9 +92,9 @@ jobs:
             *) TOS_S3_ENDPOINT="${TOS_ENDPOINT}" ;;
           esac
 
-          aws s3 sync docs/.vitepress/dist "s3://${TOS_BUCKET}/" \
+          aws s3 cp docs/.vitepress/dist "s3://${TOS_BUCKET}/" \
             --endpoint-url "https://${TOS_S3_ENDPOINT}" \
-            --delete \
+            --recursive \
             --only-show-errors
 
       - name: Report TOS deployment failure

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -133,7 +133,7 @@ function collectAllMdFiles(srcDir: string): { relativePath: string; absPath: str
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function buildLlmsTxt(siteConfig: any) {
-  const siteUrl = process.env.DOCS_SITE_URL || 'https://volcengine.github.io/OpenViking'
+  const siteUrl = (process.env.DOCS_SITE_URL || '').replace(/\/$/, '')
   const base = (siteConfig.site.base || '/').replace(/\/$/, '')
   const srcDir = siteConfig.srcDir
   const outDir = siteConfig.outDir


### PR DESCRIPTION
## Description

Build the VitePress documentation site and upload `docs/.vitepress/dist` to Volcengine TOS when TOS secrets are configured. The TOS deployment path is intentionally non-blocking so upload or tooling failures do not block other repository flows.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add a GitHub Actions workflow that builds the docs site and uploads the dist output to TOS.
- Use TOS S3-compatible endpoint handling while accepting the standard TOS endpoint secret shape.
- Force AWS CLI S3 uploads to use virtual-hosted-style addressing, which is required for this TOS endpoint/bucket combination.
- Keep TOS configuration, tooling setup, and upload failures non-blocking.
- Stop hardcoding a docs host for generated `llms.txt` links unless `DOCS_SITE_URL` is explicitly provided.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

Commands and checks run:

- `env -u DOCS_SITE_URL npm run docs:build`
- YAML parsing for `.github/workflows/docs-tos.yml`
- `git diff --check`
- Local SigV4 PutObject smoke test against TOS S3 endpoint
- GitHub Actions validation run on fork: https://github.com/yufeng201/OpenViking/actions/runs/25494731925

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

TOS upload uses the S3-compatible endpoint. If a normal TOS endpoint such as `tos-cn-beijing.volces.com` is provided, the workflow converts it to `tos-s3-cn-beijing.volces.com`. The upload uses `aws s3 cp --recursive`, so it uploads and overwrites matching files without requiring bucket listing or deleting stale remote objects. AWS CLI is configured with `default.s3.addressing_style virtual` so requests use `bucket.endpoint/object` addressing.