### PR TITLE
fix(server): map AGFS 'not a directory' to FailedPrecondition in glob

### DIFF
--- a/openviking/server/error_mapping.py
+++ b/openviking/server/error_mapping.py
@@ -440,6 +440,9 @@ def map_exception(
         if is_invalid_uri_error(exc):
             return InvalidURIError(resource or message, message)
         lowered = message.lower()
+        if "not a directory" in lowered:
+            details = {"resource": resource} if resource else None
+            return FailedPreconditionError(message, details=details)
         if "permission denied" in lowered:
             return PermissionDeniedError(message, resource=resource)
         if "already exists" in lowered:

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -247,4 +247,9 @@ async def glob(
         if "not found" in err_msg or "no such file or directory" in err_msg:
             raise NotFoundError(request.uri or request.pattern, "file")
         raise
+    except Exception as exc:
+        mapped = map_exception(exc, resource=request.uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from exc
+        raise
     return Response(status="ok", result=result)


### PR DESCRIPTION
## 背景

调用 `/api/v1/search/glob` 或 `ov glob` 时，如果 `--uri` 指向一个文件（而不是目录），会返回：

> Error: API error: [INTERNAL] Internal server error

服务端日志堆栈：

> openviking.pyagfs.exceptions.AGFSPluginError: plugin error: not a directory: /normal/resources/SKILL/SKILL.md

## 根因

1. `openviking/server/routers/search.py` 的 glob handler 只捕获 `AGFSNotFoundError` 和 `AGFSClientError` 特定消息（"not found" / "no such file or directory"），缺少 grep handler 那样的 `except Exception + map_exception` 兜底。
2. `openviking/server/error_mapping.py:map_exception` 在 `AGFSClientError` 分支里没有识别 `"not a directory"` 的消息（该关键字只出现在 `ValueError` 分支中），导致 `map_exception` 返回 `None`。

两层因素叠加，使异常冒泡为 500 Internal Server Error。

## 修复

1. search router 的 glob handler 追加 `except Exception + map_exception` 兜底，与 grep handler 保持一致。
2. `map_exception` 的 `AGFSClientError` 分支新增对 `"not a directory"` 的识别，映射为 `FailedPreconditionError`，与 `ValueError` 分支行为一致。

修复后，客户端会收到明确的 `FAILED_PRECONDITION` 错误信息，便于定位问题；未知异常仍按原逻辑冒泡，行为不变。

## 影响范围

- 受影响接口：`/api/v1/search/glob`
- 对所有使用 `map_exception` 的调用方同样受益（任何 `AGFSClientError: not a directory` 消息都会被正确映射）。
