### PR TITLE
feat(server): add shared temp upload mode

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -1,6 +1,7 @@
 use reqwest::{Client as ReqwestClient, StatusCode};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use std::env;
 use std::fs::File;
 use std::path::Path;
 use std::str::FromStr;
@@ -48,6 +49,20 @@ pub struct HttpClient {
 }
 
 impl HttpClient {
+    fn upload_mode(&self) -> Option<String> {
+        match env::var("OPENVIKING_UPLOAD_MODE") {
+            Ok(value) => {
+                let normalized = value.trim().to_ascii_lowercase();
+                if normalized == "shared" || normalized == "local" {
+                    Some(normalized)
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        }
+    }
+
     /// Create a new HTTP client
     pub fn new(
         base_url: impl Into<String>,
@@ -137,7 +152,10 @@ impl HttpClient {
             .mime_str("application/octet-stream")
             .map_err(|e| Error::Network(format!("Failed to set mime type: {}", e)))?;
 
-        let form = reqwest::multipart::Form::new().part("file", part);
+        let mut form = reqwest::multipart::Form::new().part("file", part);
+        if let Some(upload_mode) = self.upload_mode() {
+            form = form.text("upload_mode", upload_mode);
+        }
 
         let mut headers = self.build_headers();
         // Remove Content-Type: application/json, let reqwest set multipart/form-data automatically
@@ -884,7 +902,10 @@ impl HttpClient {
             .mime_str("application/octet-stream")
             .map_err(|e| Error::Network(format!("Failed to set mime type: {}", e)))?;
 
-        let form = reqwest::multipart::Form::new().part("file", part);
+        let mut form = reqwest::multipart::Form::new().part("file", part);
+        if let Some(upload_mode) = self.upload_mode() {
+            form = form.text("upload_mode", upload_mode);
+        }
 
         let mut headers = self.build_headers();
         headers.remove(reqwest::header::CONTENT_TYPE);

--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -132,7 +132,9 @@ client.initialize()
 #### HTTP Call Examples
 
 - CLI, `SyncHTTPClient`, and `AsyncHTTPClient` automatically upload local files or directories before calling the server API.
+- Python HTTP client and CLI can also opt into shared temporary uploads via client config (`ovcli.conf` -> `upload.mode = "shared"`).
 - Raw HTTP calls don't get this convenience layer. When using `curl` or other HTTP clients, you need to first call `POST /api/v1/resources/temp_upload`, then pass the returned `temp_file_id` to the target API.
+- `temp_upload` defaults to `upload_mode=local`. Use `upload_mode=shared` only when you explicitly want distributed shared temporary uploads.
 - For raw HTTP imports of local directories, you need to first zip them into a `.zip` file and upload using the above method; the server does not accept direct host directory paths.
 - `POST /api/v1/resources` can directly accept remote URLs, but does not accept host local paths like `./doc.md` or `/tmp/doc.md`.
 

--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -485,12 +485,12 @@ Upload a temporary file for subsequent importing of local files via [add_resourc
 
 #### 1. API Implementation Overview
 
-This endpoint is used to upload local files to server temporary storage, returning a `temp_file_id` for use with subsequent API calls. This is a helper endpoint typically not called directly but used automatically via the SDK or CLI.
+This endpoint uploads a local file into temporary server-managed storage and returns a `temp_file_id` for subsequent API calls. This is a helper endpoint typically not called directly but used automatically via the SDK or CLI.
 
 **Processing Flow**:
 1. Receive uploaded file
-2. Clean up expired temporary files
-3. Save to temporary directory and record original filename
+2. Choose temporary upload backend based on `upload_mode`
+3. Save the file and record original filename
 4. Return temporary file ID
 
 **Code Entry Points**:
@@ -505,6 +505,14 @@ This endpoint is used to upload local files to server temporary storage, returni
 |-----------|------|----------|---------|-------------|
 | file | UploadFile | Yes | - | Uploaded file (multipart/form-data) |
 | telemetry | bool | No | False | Whether to return telemetry data |
+| upload_mode | string | No | `"local"` | Temporary upload mode. `local` keeps the existing single-node behavior. `shared` uploads to shared temporary storage for distributed deployments. |
+
+Notes:
+
+- The default is `local`, so existing clients keep the original behavior unless they explicitly opt into `shared`.
+- Use `upload_mode=shared` only when you explicitly want distributed shared temporary uploads.
+- `shared` mode returns a one-time `temp_file_id` in the `shared_<upload_id>` form.
+- Shared upload objects live under the internal `viking://upload/...` namespace and are not part of the normal filesystem browsing surface.
 
 #### 3. Usage Examples
 
@@ -521,9 +529,18 @@ curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
   -F "file=@./documents/guide.md"
 ```
 
+Distributed / shared upload:
+
+```bash
+curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
+  -H "X-API-Key: your-key" \
+  -F "file=@./documents/guide.md" \
+  -F "upload_mode=shared"
+```
+
 **Python SDK**
 
-The `add_resource`, `add_skill` and other endpoints in the Python SDK automatically handle local file uploads, no need to call this endpoint manually.
+The `add_resource`, `add_skill` and other endpoints in the Python SDK automatically handle local file uploads, no need to call this endpoint manually. To opt into distributed shared temporary uploads in HTTP client mode, set `upload.mode` to `"shared"` in `ovcli.conf`.
 
 **CLI**
 
@@ -539,6 +556,17 @@ CLI commands also automatically handle local file uploads, no need to call this 
   },
   "telemetry": {
     "operation_id": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+Possible shared response:
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "temp_file_id": "shared_7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123"
   }
 }
 ```

--- a/docs/en/api/04-skills.md
+++ b/docs/en/api/04-skills.md
@@ -181,6 +181,7 @@ Skills are a special type of resource that define actions or tools agents can pe
     - Send structured skill data directly in `data`
     - Send raw `SKILL.md` content in `data`
     - First call `POST /api/v1/resources/temp_upload` to upload a local `SKILL.md` file/zip directory, then call `POST /api/v1/skills` with `temp_file_id`
+    - `temp_upload` defaults to local temporary storage; pass `upload_mode=shared` only when you explicitly need distributed shared temporary uploads. In Python HTTP client / CLI flows, this can also be driven by `ovcli.conf` via `upload.mode = "shared"`
   - `POST /api/v1/skills` does not accept direct host filesystem paths in `data`.
 
 - **Supported data formats**:

--- a/docs/en/getting-started/03-quickstart-server.md
+++ b/docs/en/getting-started/03-quickstart-server.md
@@ -159,7 +159,7 @@ export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf
 
 ## Connect with curl
 
-Use direct `path` for remote URLs. For local files, upload first with `POST /api/v1/resources/temp_upload`, then call the target API with the returned `temp_file_id`. For local directories in raw HTTP mode, zip the directory first and upload the `.zip` file.
+Use direct `path` for remote URLs. For local files, upload first with `POST /api/v1/resources/temp_upload`, then call the target API with the returned `temp_file_id`. `temp_upload` defaults to local temporary storage; pass `upload_mode=shared` only when you explicitly want distributed shared temporary uploads. In Python HTTP client / CLI flows, the same mode can be selected through `ovcli.conf` with `upload.mode = "shared"`. For local directories in raw HTTP mode, zip the directory first and upload the `.zip` file.
 
 ```bash
 # Add a resource

--- a/docs/en/guides/07-operation-telemetry.md
+++ b/docs/en/guides/07-operation-telemetry.md
@@ -116,6 +116,7 @@ curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
 ```
 
 This endpoint currently accepts the boolean form only.
+`upload_mode` is also a form field for this endpoint; it defaults to `local` and should only be set to `shared` when you explicitly need distributed shared temporary uploads. Python HTTP client / CLI users can alternatively drive the same behavior with `ovcli.conf` -> `upload.mode = "shared"`.
 
 ## Common summary groups
 

--- a/docs/en/guides/09-ovpack.md
+++ b/docs/en/guides/09-ovpack.md
@@ -69,6 +69,9 @@ async def import_example():
 **HTTP API**
 ```bash
 # Step 1: Upload the local ovpack file
+# This uses local temporary storage by default.
+# Add: -F "upload_mode=shared" only when you explicitly need distributed shared temporary uploads.
+# Python HTTP client / CLI users can instead set ovcli.conf: upload.mode = "shared".
 TEMP_FILE_ID=$(
   curl -sS -X POST http://localhost:1933/api/v1/resources/temp_upload \
     -H "X-API-Key: your-key" \

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -132,7 +132,9 @@ client.initialize()
 #### HTTP 调用示例
 
 - CLI、`SyncHTTPClient`、`AsyncHTTPClient` 遇到本地文件或目录时，会先自动上传，再调用服务端 API。
+- Python HTTP client 和 CLI 也可以通过客户端配置启用 shared 临时上传（`ovcli.conf` 中设置 `upload.mode = "shared"`）。
 - 裸 HTTP 调用没有这层封装。使用 `curl` 或其他 HTTP 客户端时，需要先调用 `POST /api/v1/resources/temp_upload`，再把返回的 `temp_file_id` 传给目标 API。
+- `temp_upload` 默认使用 `upload_mode=local`。只有在你显式需要分布式共享临时上传时，才应传 `upload_mode=shared`。
 - 裸 HTTP 如果导入本地目录，需要先自行打成 `.zip` 再通过上述方法上传；服务端不接受直接传宿主机目录路径。
 - `POST /api/v1/resources` 可以直接接收远端 URL，但不接受 `./doc.md`、`/tmp/doc.md` 这类宿主机本地路径。
 

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -478,12 +478,12 @@ auxiliary_files 2
 
 #### 1. API 实现介绍
 
-此接口用于上传本地文件到服务器临时存储，返回 `temp_file_id` 供后续 API 使用。这是一个辅助接口，通常不直接调用，而是通过 SDK 或 CLI 自动使用。
+此接口用于把本地文件上传到服务端托管的临时存储中，返回 `temp_file_id` 供后续 API 使用。这是一个辅助接口，通常不直接调用，而是通过 SDK 或 CLI 自动使用。
 
 **处理流程**：
 1. 接收上传的文件
-2. 清理过期的临时文件
-3. 保存到临时目录并记录原始文件名
+2. 根据 `upload_mode` 选择临时上传后端
+3. 保存文件并记录原始文件名
 4. 返回临时文件 ID
 
 **代码入口**：
@@ -498,6 +498,14 @@ auxiliary_files 2
 |------|------|------|--------|------|
 | file | UploadFile | 是 | - | 上传的文件（multipart/form-data） |
 | telemetry | bool | 否 | False | 是否返回遥测数据 |
+| upload_mode | string | 否 | `"local"` | 临时上传模式。`local` 保持现有单机行为；`shared` 将文件上传到共享临时存储，适用于分布式部署。 |
+
+说明：
+
+- 默认值是 `local`，所以现有客户端在不改动的情况下仍保持原有行为。
+- 只有在你明确需要分布式共享临时上传时，才应显式使用 `upload_mode=shared`。
+- `shared` 模式下返回的一次性 `temp_file_id` 形如 `shared_<upload_id>`。
+- shared 上传对象存放在内部 `viking://upload/...` 命名空间下，不属于普通文件系统浏览空间。
 
 #### 3. 使用示例
 
@@ -514,9 +522,18 @@ curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
   -F "file=@./documents/guide.md"
 ```
 
+分布式 / shared 上传：
+
+```bash
+curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
+  -H "X-API-Key: your-key" \
+  -F "file=@./documents/guide.md" \
+  -F "upload_mode=shared"
+```
+
 **Python SDK**
 
-Python SDK 中的 `add_resource`、`add_skill` 等接口会自动处理本地文件上传，无需手动调用此接口。
+Python SDK 中的 `add_resource`、`add_skill` 等接口会自动处理本地文件上传，无需手动调用此接口。在 Python HTTP client 模式下，如果要启用分布式 shared 临时上传，可以在 `ovcli.conf` 中设置 `upload.mode = "shared"`。
 
 **CLI**
 
@@ -532,6 +549,17 @@ CLI 命令也会自动处理本地文件上传，无需手动调用此接口。
   },
   "telemetry": {
     "operation_id": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+shared 模式的响应示例：
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "temp_file_id": "shared_7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123"
   }
 }
 ```

--- a/docs/zh/api/04-skills.md
+++ b/docs/zh/api/04-skills.md
@@ -182,6 +182,7 @@ This tool wraps the MCP tool `search-web`. Call this when the user needs functio
     1. 在 `data` 中直接传结构化 skill 数据
     2. 在 `data` 中直接传原始 `SKILL.md` 内容
     3. 先调用 `POST /api/v1/resources/temp_upload` 上传本地 `SKILL.md` 文件/zip 目录，再调用 `POST /api/v1/skills` 并传入 `temp_file_id`
+    4. `temp_upload` 默认使用本地临时存储；只有在明确需要分布式共享临时上传时，才传 `upload_mode=shared`。在 Python HTTP client / CLI 流程里，也可以通过 `ovcli.conf` 的 `upload.mode = "shared"` 驱动这一行为
   - `POST /api/v1/skills` 不接受在 `data` 中直接传宿主机本地路径。
 
 - **支持的数据格式**：

--- a/docs/zh/getting-started/03-quickstart-server.md
+++ b/docs/zh/getting-started/03-quickstart-server.md
@@ -158,7 +158,7 @@ export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf
 
 ## 使用 curl 连接
 
-远端 URL 可以直接放在 `path` 里。本地文件需要先调用 `POST /api/v1/resources/temp_upload` 上传，再用返回的 `temp_file_id` 调目标 API。裸 HTTP 如果导入本地目录，需要先把目录打成 `.zip` 再上传。
+远端 URL 可以直接放在 `path` 里。本地文件需要先调用 `POST /api/v1/resources/temp_upload` 上传，再用返回的 `temp_file_id` 调目标 API。`temp_upload` 默认使用本地临时存储；只有在你显式需要分布式共享临时上传时，才传 `upload_mode=shared`。在 Python HTTP client / CLI 流程里，也可以通过 `ovcli.conf` 中的 `upload.mode = "shared"` 选择这一模式。裸 HTTP 如果导入本地目录，需要先把目录打成 `.zip` 再上传。
 
 ```bash
 # Add a resource

--- a/docs/zh/guides/07-operation-telemetry.md
+++ b/docs/zh/guides/07-operation-telemetry.md
@@ -116,6 +116,7 @@ curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
 ```
 
 这个接口当前只支持布尔形态的表单参数。
+这个接口的 `upload_mode` 也是表单字段；默认值为 `local`，只有在明确需要分布式共享临时上传时，才应设置为 `shared`。Python HTTP client / CLI 用户也可以通过 `ovcli.conf` 的 `upload.mode = "shared"` 达到同样效果。
 
 ## 常见 summary 分组
 

--- a/docs/zh/guides/09-ovpack.md
+++ b/docs/zh/guides/09-ovpack.md
@@ -80,6 +80,9 @@ async def import_example():
 **HTTP API**
 ```bash
 # 第一步：上传本地 ovpack 文件
+# 默认使用本地临时存储。
+# 只有在明确需要分布式共享临时上传时，才额外传：-F "upload_mode=shared"
+# Python HTTP client / CLI 也可以改为在 ovcli.conf 中设置：upload.mode = "shared"
 TEMP_FILE_ID=$(
   curl -sS -X POST http://localhost:1933/api/v1/resources/temp_upload \
     -H "X-API-Key: your-key" \

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -105,7 +105,7 @@ def resolve_uri(
         return _resolve_agent_uri(parts, ctx=ctx, require_canonical=require_canonical)
     if scope == "session":
         return _resolve_session_uri(parts)
-    if scope in {"resources", "temp", "queue"}:
+    if scope in {"resources", "temp", "queue", "upload"}:
         return ResolvedNamespace(uri=VikingURI.normalize(uri).rstrip("/"), scope=scope)
     return ResolvedNamespace(uri=VikingURI.normalize(uri).rstrip("/"), scope=scope)
 
@@ -125,6 +125,8 @@ def is_accessible(uri: str, ctx: RequestContext) -> bool:
 
     if target.scope in {"", "resources", "temp", "queue", "session"}:
         return True
+    if target.scope == "upload":
+        return False
     if target.scope == "user":
         if target.owner_user_id and target.owner_user_id != ctx.user.user_id:
             return False

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -95,6 +95,16 @@ class ObservabilityConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class TempUploadConfig(BaseModel):
+    """Temporary upload configuration."""
+
+    default_mode: str = "local"
+    shared_max_size_bytes: int = 512 * 1024 * 1024
+    shared_prefix: str = "viking://upload"
+
+    model_config = {"extra": "forbid"}
+
+
 class ServerConfig(BaseModel):
     host: str = "127.0.0.1"
     port: int = 1933
@@ -107,6 +117,7 @@ class ServerConfig(BaseModel):
     encryption_enabled: bool = False  # Whether file-level AES encryption is enabled
     api_key_hashing_enabled: bool = False  # Whether API key Argon2id hashing is enabled (default: false, rely on file encryption)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
+    temp_upload: TempUploadConfig = Field(default_factory=TempUploadConfig)
 
     model_config = {"extra": "forbid"}
 

--- a/openviking/server/local_input_guard.py
+++ b/openviking/server/local_input_guard.py
@@ -4,10 +4,9 @@
 
 from __future__ import annotations
 
-import json
 import re
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 from openviking.utils.network_guard import ensure_public_remote_target
 from openviking_cli.exceptions import PermissionDeniedError
@@ -55,6 +54,8 @@ def deny_direct_local_skill_input(value: str) -> None:
 
 def _read_upload_meta(meta_path: Path) -> Optional[dict]:
     """Read upload metadata file if it exists."""
+    import json
+
     try:
         if meta_path.exists():
             with open(meta_path, "r") as f:
@@ -62,57 +63,3 @@ def _read_upload_meta(meta_path: Path) -> Optional[dict]:
     except Exception:
         pass
     return None
-
-
-def resolve_uploaded_temp_file_id(
-    temp_file_id: str, upload_temp_dir: Path
-) -> Tuple[str, Optional[str]]:
-    """Resolve a temp upload id to a regular file under the server upload temp dir.
-
-    Returns:
-        Tuple of (resolved_file_path, original_filename)
-        original_filename is None if no meta file exists.
-    """
-    if not temp_file_id or temp_file_id in {".", ".."}:
-        raise PermissionDeniedError(
-            "HTTP server only accepts regular files from the upload temp directory."
-        )
-
-    raw_name = Path(temp_file_id)
-    if raw_name.name != temp_file_id or "/" in temp_file_id or "\\" in temp_file_id:
-        raise PermissionDeniedError(
-            "HTTP server only accepts temp_file_id values issued from the upload temp directory."
-        )
-
-    raw_path = upload_temp_dir / temp_file_id
-    if raw_path.is_symlink():
-        raise PermissionDeniedError(
-            "HTTP server only accepts regular files from the upload temp directory."
-        )
-
-    try:
-        resolved_path = raw_path.resolve(strict=True)
-    except (FileNotFoundError, OSError) as exc:
-        raise PermissionDeniedError(
-            "HTTP server only accepts regular files from the upload temp directory."
-        ) from exc
-
-    upload_root = upload_temp_dir.resolve()
-    try:
-        resolved_path.relative_to(upload_root)
-    except ValueError as exc:
-        raise PermissionDeniedError(
-            "HTTP server only accepts temp_file_id values issued from the upload temp directory."
-        ) from exc
-
-    if not resolved_path.is_file():
-        raise PermissionDeniedError(
-            "HTTP server only accepts regular files from the upload temp directory."
-        )
-
-    # Try to read original filename from meta file
-    meta_path = upload_temp_dir / f"{temp_file_id}.ov_upload.meta"
-    meta = _read_upload_meta(meta_path)
-    original_filename = meta.get("original_filename") if meta else None
-
-    return (str(resolved_path), original_filename)

--- a/openviking/server/routers/pack.py
+++ b/openviking/server/routers/pack.py
@@ -13,9 +13,8 @@ from starlette.background import BackgroundTask
 from openviking.server.auth import get_request_context, require_auth_root_or_admin
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
-from openviking.server.local_input_guard import resolve_uploaded_temp_file_id
 from openviking.server.models import Response
-from openviking_cli.utils.config.open_viking_config import get_openviking_config
+from openviking.server.temp_upload_store import TempUploadStore
 
 router = APIRouter(prefix="/api/v1/pack", tags=["pack"])
 
@@ -96,15 +95,21 @@ async def import_ovpack(
 ):
     """Import .ovpack file."""
     service = get_service()
-
-    upload_temp_dir = get_openviking_config().storage.get_upload_temp_dir()
-    file_path, _ = resolve_uploaded_temp_file_id(body.temp_file_id, upload_temp_dir)
-
-    result = await service.pack.import_ovpack(
-        file_path,
-        body.parent,
-        ctx=ctx,
-        force=body.force,
-        vectorize=body.vectorize,
-    )
+    store = TempUploadStore.build(request.app.state.config)
+    resolved = await store.resolve_for_consume(body.temp_file_id, ctx)
+    try:
+        result = await service.pack.import_ovpack(
+            resolved.local_path,
+            body.parent,
+            ctx=ctx,
+            force=body.force,
+            vectorize=body.vectorize,
+        )
+    except Exception:
+        await store.mark_failed(resolved, ctx)
+        raise
+    else:
+        await store.mark_consumed(resolved, ctx)
+    finally:
+        await resolved.cleanup()
     return Response(status="ok", result={"uri": result})

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Resource endpoints for OpenViking HTTP Server."""
 
-import time
-import uuid
-from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, File, Form, UploadFile
+from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from openviking.server.auth import get_request_context
@@ -15,13 +12,12 @@ from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.local_input_guard import (
     require_remote_resource_source,
-    resolve_uploaded_temp_file_id,
 )
 from openviking.server.responses import response_from_result
 from openviking.server.telemetry import run_operation
+from openviking.server.temp_upload_store import TempUploadStore
 from openviking.telemetry import TelemetryRequest
 from openviking_cli.exceptions import InvalidArgumentError
-from openviking_cli.utils.config.open_viking_config import get_openviking_config
 
 router = APIRouter(prefix="/api/v1", tags=["resources"])
 
@@ -116,63 +112,20 @@ class AddSkillRequest(BaseModel):
         return self
 
 
-def _cleanup_temp_files(temp_dir: Path, max_age_hours: int = 1):
-    """Clean up temporary files older than max_age_hours."""
-    if not temp_dir.exists():
-        return
-
-    now = time.time()
-    max_age_seconds = max_age_hours * 3600
-
-    for file_path in temp_dir.iterdir():
-        if file_path.is_file():
-            file_age = now - file_path.stat().st_mtime
-            if file_age > max_age_seconds:
-                file_path.unlink(missing_ok=True)
-
-                # Also clean up corresponding .ov_upload.meta file
-                if not file_path.name.endswith(".ov_upload.meta"):
-                    meta_path = temp_dir / f"{file_path.name}.ov_upload.meta"
-                    if meta_path.exists():
-                        meta_path.unlink(missing_ok=True)
-
-
 @router.post("/resources/temp_upload")
 async def temp_upload(
+    request: Request,
     file: UploadFile = File(...),
     telemetry: bool = Form(False),
+    upload_mode: str = Form("local"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Upload a temporary file for add_resource or import_ovpack."""
 
     async def _upload() -> dict[str, str]:
-        import json
-
-        config = get_openviking_config()
-        temp_dir = config.storage.get_upload_temp_dir()
-
-        # Clean up old temporary files
-        _cleanup_temp_files(temp_dir)
-
-        # Save the uploaded file
-        file_ext = Path(file.filename).suffix if file.filename else ".tmp"
-        temp_filename = f"upload_{uuid.uuid4().hex}{file_ext}"
-        temp_file_path = temp_dir / temp_filename
-
-        with open(temp_file_path, "wb") as f:
-            f.write(await file.read())
-
-        # Save metadata with original filename
-        if file.filename:
-            meta_path = temp_dir / f"{temp_filename}.ov_upload.meta"
-            meta = {
-                "original_filename": file.filename,
-                "upload_time": time.time(),
-            }
-            with open(meta_path, "w") as f:
-                json.dump(meta, f)
-
-        return {"temp_file_id": temp_filename}
+        store = TempUploadStore.build(request.app.state.config)
+        temp_file_id = await store.save_upload(file, upload_mode, _ctx)
+        return {"temp_file_id": temp_file_id}
 
     execution = await run_operation(
         operation="resources.temp_upload",
@@ -184,6 +137,7 @@ async def temp_upload(
 
 @router.post("/resources")
 async def add_resource(
+    http_request: Request,
     request: AddResourceRequest,
     _ctx: RequestContext = Depends(get_request_context),
 ):
@@ -192,14 +146,15 @@ async def add_resource(
     if request.to and request.parent:
         raise InvalidArgumentError("Cannot specify both 'to' and 'parent' at the same time.")
 
-    upload_temp_dir = get_openviking_config().storage.get_upload_temp_dir()
     path = request.path
     allow_local_path_resolution = False
     original_filename = None
+    resolved = None
     if request.temp_file_id:
-        path, original_filename = resolve_uploaded_temp_file_id(
-            request.temp_file_id, upload_temp_dir
-        )
+        store = TempUploadStore.build(http_request.app.state.config)
+        resolved = await store.resolve_for_consume(request.temp_file_id, _ctx)
+        path = resolved.local_path
+        original_filename = resolved.original_filename
         allow_local_path_resolution = True
     elif path is not None:
         path = require_remote_resource_source(path)
@@ -223,49 +178,86 @@ async def add_resource(
     if request.preserve_structure is not None:
         kwargs["preserve_structure"] = request.preserve_structure
 
+    store = TempUploadStore.build(http_request.app.state.config) if resolved else None
+
+    async def _add() -> dict[str, Any]:
+        try:
+            result = await service.resources.add_resource(
+                path=path,
+                ctx=_ctx,
+                to=request.to,
+                parent=request.parent,
+                reason=request.reason,
+                instruction=request.instruction,
+                wait=request.wait,
+                timeout=request.timeout,
+                allow_local_path_resolution=allow_local_path_resolution,
+                enforce_public_remote_targets=True,
+                **kwargs,
+            )
+        except Exception:
+            if resolved and store:
+                await store.mark_failed(resolved, _ctx)
+            raise
+        else:
+            if resolved and store:
+                await store.mark_consumed(resolved, _ctx)
+            return result
+        finally:
+            if resolved:
+                await resolved.cleanup()
+
     execution = await run_operation(
         operation="resources.add_resource",
         telemetry=request.telemetry,
-        fn=lambda: service.resources.add_resource(
-            path=path,
-            ctx=_ctx,
-            to=request.to,
-            parent=request.parent,
-            reason=request.reason,
-            instruction=request.instruction,
-            wait=request.wait,
-            timeout=request.timeout,
-            allow_local_path_resolution=allow_local_path_resolution,
-            enforce_public_remote_targets=True,
-            **kwargs,
-        ),
+        fn=_add,
     )
     return response_from_result(execution.result, telemetry=execution.telemetry)
 
 
 @router.post("/skills")
 async def add_skill(
+    http_request: Request,
     request: AddSkillRequest,
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Add skill to OpenViking."""
     service = get_service()
-    upload_temp_dir = get_openviking_config().storage.get_upload_temp_dir()
     data = request.data
     allow_local_path_resolution = False
+    resolved = None
     if request.temp_file_id:
-        data, _ = resolve_uploaded_temp_file_id(request.temp_file_id, upload_temp_dir)
+        store = TempUploadStore.build(http_request.app.state.config)
+        resolved = await store.resolve_for_consume(request.temp_file_id, _ctx)
+        data = resolved.local_path
         allow_local_path_resolution = True
+
+    store = TempUploadStore.build(http_request.app.state.config) if resolved else None
+
+    async def _add() -> dict[str, Any]:
+        try:
+            result = await service.resources.add_skill(
+                data=data,
+                ctx=_ctx,
+                wait=request.wait,
+                timeout=request.timeout,
+                allow_local_path_resolution=allow_local_path_resolution,
+            )
+        except Exception:
+            if resolved and store:
+                await store.mark_failed(resolved, _ctx)
+            raise
+        else:
+            if resolved and store:
+                await store.mark_consumed(resolved, _ctx)
+            return result
+        finally:
+            if resolved:
+                await resolved.cleanup()
 
     execution = await run_operation(
         operation="resources.add_skill",
         telemetry=request.telemetry,
-        fn=lambda: service.resources.add_skill(
-            data=data,
-            ctx=_ctx,
-            wait=request.wait,
-            timeout=request.timeout,
-            allow_local_path_resolution=allow_local_path_resolution,
-        ),
+        fn=_add,
     )
     return response_from_result(execution.result, telemetry=execution.telemetry)

--- a/openviking/server/temp_upload_store.py
+++ b/openviking/server/temp_upload_store.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Temporary upload storage backends for HTTP server uploads."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from openviking.server.config import ServerConfig, TempUploadConfig
+from openviking.server.identity import RequestContext, Role
+from openviking.server.local_input_guard import _read_upload_meta
+from openviking.storage.transaction import get_lock_manager
+from openviking.storage.viking_fs import get_viking_fs
+from openviking_cli.exceptions import InvalidArgumentError, PermissionDeniedError
+from openviking_cli.utils.config.open_viking_config import get_openviking_config
+
+_CHUNK_SIZE = 1024 * 1024
+
+
+@dataclass
+class ResolvedTempUpload:
+    mode: str
+    temp_file_id: str
+    original_filename: Optional[str]
+    local_path: str
+    lock_handle: Any = None
+
+    async def cleanup(self) -> None:
+        if self.lock_handle is not None:
+            with suppress(Exception):
+                await get_lock_manager().release(self.lock_handle)
+            self.lock_handle = None
+
+        if self.mode == "shared" and self.local_path:
+            with suppress(FileNotFoundError):
+                os.unlink(self.local_path)
+
+
+def get_temp_upload_config(server_config: ServerConfig) -> TempUploadConfig:
+    return server_config.temp_upload
+
+
+def _shared_prefix(cfg: TempUploadConfig) -> str:
+    return cfg.shared_prefix.rstrip("/")
+
+
+def _shared_upload_uri(cfg: TempUploadConfig, ctx: RequestContext, upload_id: str) -> str:
+    return f"{_shared_prefix(cfg)}/{upload_id}"
+
+
+def _shared_content_uri(cfg: TempUploadConfig, ctx: RequestContext, upload_id: str) -> str:
+    return f"{_shared_upload_uri(cfg, ctx, upload_id)}/content"
+
+
+def _shared_meta_uri(cfg: TempUploadConfig, ctx: RequestContext, upload_id: str) -> str:
+    return f"{_shared_upload_uri(cfg, ctx, upload_id)}/meta.json"
+
+
+def _parse_shared_temp_file_id(temp_file_id: str) -> Optional[str]:
+    if not temp_file_id.startswith("shared_"):
+        return None
+    upload_id = temp_file_id[len("shared_") :].strip()
+    if not upload_id or "/" in upload_id or "\\" in upload_id:
+        return None
+    return upload_id
+
+
+async def _stream_upload_to_local_temp(upload_file: Any, max_size_bytes: int) -> tuple[str, int]:
+    suffix = Path(upload_file.filename or "upload.tmp").suffix or ".tmp"
+    fd, temp_path = tempfile.mkstemp(prefix="ov_http_upload_", suffix=suffix)
+    os.close(fd)
+    total = 0
+    try:
+        with open(temp_path, "wb") as f:
+            while True:
+                chunk = await upload_file.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_size_bytes:
+                    raise InvalidArgumentError(
+                        f"Upload exceeds size limit ({max_size_bytes} bytes)."
+                    )
+                f.write(chunk)
+        return temp_path, total
+    except Exception:
+        with suppress(FileNotFoundError):
+            os.unlink(temp_path)
+        raise
+
+
+class TempUploadStore:
+    def __init__(self, server_config: ServerConfig):
+        self.server_config = server_config
+        self.temp_cfg = get_temp_upload_config(server_config)
+
+    @staticmethod
+    def build(server_config: ServerConfig) -> "TempUploadStore":
+        return TempUploadStore(server_config)
+
+    @staticmethod
+    def _internal_ctx(ctx: RequestContext) -> RequestContext:
+        return RequestContext(
+            user=ctx.user,
+            role=Role.ROOT,
+            namespace_policy=ctx.namespace_policy,
+        )
+
+    async def save_upload(
+        self,
+        upload_file: Any,
+        upload_mode: str,
+        ctx: RequestContext,
+    ) -> str:
+        if upload_mode == "local":
+            return await self._save_local(upload_file)
+        if upload_mode == "shared":
+            return await self._save_shared(upload_file, ctx)
+        raise InvalidArgumentError("upload_mode must be 'local' or 'shared'.")
+
+    async def resolve_for_consume(
+        self,
+        temp_file_id: str,
+        ctx: RequestContext,
+    ) -> ResolvedTempUpload:
+        shared_id = _parse_shared_temp_file_id(temp_file_id)
+        if shared_id is None:
+            return self._resolve_local(temp_file_id)
+        return await self._resolve_shared(temp_file_id, shared_id, ctx)
+
+    async def mark_failed(self, resolved: ResolvedTempUpload, ctx: RequestContext) -> None:
+        shared_id = _parse_shared_temp_file_id(resolved.temp_file_id)
+        if shared_id is None or resolved.lock_handle is None:
+            return
+        meta = await self._read_shared_meta(shared_id, ctx)
+        meta["state"] = "uploaded"
+        meta["updated_at"] = int(time.time())
+        await self._write_shared_meta(shared_id, ctx, meta)
+
+    async def mark_consumed(self, resolved: ResolvedTempUpload, ctx: RequestContext) -> None:
+        shared_id = _parse_shared_temp_file_id(resolved.temp_file_id)
+        if shared_id is None:
+            return
+        uri = _shared_upload_uri(self.temp_cfg, ctx, shared_id)
+        await get_viking_fs().rm(
+            uri,
+            recursive=True,
+            ctx=self._internal_ctx(ctx),
+            lock_handle=resolved.lock_handle,
+        )
+
+    async def try_cleanup_invalid_or_expired(
+        self,
+        temp_file_id: str,
+        ctx: RequestContext,
+    ) -> None:
+        shared_id = _parse_shared_temp_file_id(temp_file_id)
+        if shared_id is None:
+            return
+        uri = _shared_upload_uri(self.temp_cfg, ctx, shared_id)
+        with suppress(Exception):
+            await get_viking_fs().rm(uri, recursive=True, ctx=self._internal_ctx(ctx))
+
+    async def _save_local(self, upload_file: Any) -> str:
+        config = get_openviking_config()
+        temp_dir = config.storage.get_upload_temp_dir()
+        self._cleanup_local_temp_files(temp_dir)
+
+        file_ext = Path(upload_file.filename).suffix if upload_file.filename else ".tmp"
+        temp_filename = f"upload_{uuid.uuid4().hex}{file_ext}"
+        temp_file_path = temp_dir / temp_filename
+
+        total = 0
+        with open(temp_file_path, "wb") as f:
+            while True:
+                chunk = await upload_file.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > self.temp_cfg.shared_max_size_bytes:
+                    f.close()
+                    with suppress(FileNotFoundError):
+                        temp_file_path.unlink()
+                    raise InvalidArgumentError(
+                        f"Upload exceeds size limit ({self.temp_cfg.shared_max_size_bytes} bytes)."
+                    )
+                f.write(chunk)
+
+        if upload_file.filename:
+            meta_path = temp_dir / f"{temp_filename}.ov_upload.meta"
+            meta = {
+                "original_filename": upload_file.filename,
+                "upload_time": time.time(),
+            }
+            with open(meta_path, "w", encoding="utf-8") as f:
+                json.dump(meta, f)
+
+        return temp_filename
+
+    async def _save_shared(self, upload_file: Any, ctx: RequestContext) -> str:
+        temp_path, total_size = await _stream_upload_to_local_temp(
+            upload_file, self.temp_cfg.shared_max_size_bytes
+        )
+        upload_id = uuid.uuid4().hex
+        temp_file_id = f"shared_{upload_id}"
+        vfs = get_viking_fs()
+        internal_ctx = self._internal_ctx(ctx)
+        content_uri = _shared_content_uri(self.temp_cfg, ctx, upload_id)
+        meta_uri = _shared_meta_uri(self.temp_cfg, ctx, upload_id)
+        now = int(time.time())
+        meta = {
+            "version": 1,
+            "upload_mode": "shared",
+            "upload_id": upload_id,
+            "temp_file_id": temp_file_id,
+            "account": ctx.account_id,
+            "user": ctx.user.user_id,
+            "agent": ctx.user.agent_id,
+            "original_filename": upload_file.filename or "",
+            "content_type": getattr(upload_file, "content_type", None),
+            "file_ext": Path(upload_file.filename or "").suffix,
+            "size": total_size,
+            "sha256": None,
+            "storage_uri": content_uri,
+            "state": "uploaded",
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        try:
+            with open(temp_path, "rb") as f:
+                content = f.read()
+            await vfs.write_file_bytes(content_uri, content, ctx=internal_ctx)
+            await vfs.write_file(meta_uri, json.dumps(meta, ensure_ascii=False), ctx=internal_ctx)
+            return temp_file_id
+        except Exception:
+            with suppress(Exception):
+                await self.try_cleanup_invalid_or_expired(temp_file_id, ctx)
+            raise
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temp_path)
+
+    def _resolve_local(self, temp_file_id: str) -> ResolvedTempUpload:
+        upload_temp_dir = get_openviking_config().storage.get_upload_temp_dir()
+        if not temp_file_id or temp_file_id in {".", ".."}:
+            raise PermissionDeniedError(
+                "HTTP server only accepts regular files from the upload temp directory."
+            )
+        raw_name = Path(temp_file_id)
+        if raw_name.name != temp_file_id or "/" in temp_file_id or "\\" in temp_file_id:
+            raise PermissionDeniedError(
+                "HTTP server only accepts temp_file_id values issued from the upload temp directory."
+            )
+
+        raw_path = upload_temp_dir / temp_file_id
+        if raw_path.is_symlink():
+            raise PermissionDeniedError(
+                "HTTP server only accepts regular files from the upload temp directory."
+            )
+
+        try:
+            resolved_path = raw_path.resolve(strict=True)
+        except (FileNotFoundError, OSError) as exc:
+            raise PermissionDeniedError(
+                "HTTP server only accepts regular files from the upload temp directory."
+            ) from exc
+
+        upload_root = upload_temp_dir.resolve()
+        try:
+            resolved_path.relative_to(upload_root)
+        except ValueError as exc:
+            raise PermissionDeniedError(
+                "HTTP server only accepts temp_file_id values issued from the upload temp directory."
+            ) from exc
+
+        if not resolved_path.is_file():
+            raise PermissionDeniedError(
+                "HTTP server only accepts regular files from the upload temp directory."
+            )
+
+        meta_path = upload_temp_dir / f"{temp_file_id}.ov_upload.meta"
+        meta = _read_upload_meta(meta_path)
+        original_filename = meta.get("original_filename") if meta else None
+        return ResolvedTempUpload(
+            mode="local",
+            temp_file_id=temp_file_id,
+            original_filename=original_filename,
+            local_path=str(resolved_path),
+        )
+
+    async def _resolve_shared(
+        self,
+        temp_file_id: str,
+        upload_id: str,
+        ctx: RequestContext,
+    ) -> ResolvedTempUpload:
+        meta = await self._read_shared_meta(upload_id, ctx)
+        self._validate_shared_meta(meta, temp_file_id, ctx)
+
+        content_uri = meta["storage_uri"]
+        vfs = get_viking_fs()
+        internal_ctx = self._internal_ctx(ctx)
+        if not await vfs.exists(content_uri, ctx=internal_ctx):
+            await self.try_cleanup_invalid_or_expired(temp_file_id, ctx)
+            raise PermissionDeniedError("Temporary upload is invalid: content missing.")
+
+        lock_path = vfs._uri_to_path(
+            _shared_upload_uri(self.temp_cfg, ctx, upload_id),
+            ctx=internal_ctx,
+        )
+        handle = get_lock_manager().create_handle()
+        acquired = await get_lock_manager().acquire_subtree(handle, lock_path, timeout=0.0)
+        if not acquired:
+            raise PermissionDeniedError("Temporary upload is being consumed.")
+
+        try:
+            meta = await self._read_shared_meta(upload_id, ctx)
+            now = int(time.time())
+            if meta.get("state") != "uploaded":
+                raise PermissionDeniedError("Temporary upload is being consumed.")
+
+            meta["state"] = "consuming"
+            meta["updated_at"] = now
+            await self._write_shared_meta(upload_id, ctx, meta)
+
+            file_ext = meta.get("file_ext") or ".tmp"
+            fd, temp_path = tempfile.mkstemp(prefix="ov_shared_upload_", suffix=file_ext)
+            os.close(fd)
+            try:
+                content = await vfs.read_file_bytes(content_uri, ctx=internal_ctx)
+                with open(temp_path, "wb") as f:
+                    f.write(content)
+            except Exception:
+                with suppress(FileNotFoundError):
+                    os.unlink(temp_path)
+                raise
+
+            return ResolvedTempUpload(
+                mode="shared",
+                temp_file_id=temp_file_id,
+                original_filename=meta.get("original_filename") or None,
+                local_path=temp_path,
+                lock_handle=handle,
+            )
+        except Exception:
+            with suppress(Exception):
+                await get_lock_manager().release(handle)
+            raise
+
+    async def _read_shared_meta(self, upload_id: str, ctx: RequestContext) -> dict[str, Any]:
+        meta_uri = _shared_meta_uri(self.temp_cfg, ctx, upload_id)
+        try:
+            raw = await get_viking_fs().read_file(meta_uri, ctx=self._internal_ctx(ctx))
+            data = json.loads(raw)
+        except Exception as exc:
+            raise PermissionDeniedError("Temporary upload metadata is invalid or missing.") from exc
+        if not isinstance(data, dict):
+            raise PermissionDeniedError("Temporary upload metadata is invalid or missing.")
+        return data
+
+    async def _write_shared_meta(
+        self,
+        upload_id: str,
+        ctx: RequestContext,
+        meta: dict[str, Any],
+    ) -> None:
+        meta_uri = _shared_meta_uri(self.temp_cfg, ctx, upload_id)
+        await get_viking_fs().write_file(
+            meta_uri,
+            json.dumps(meta, ensure_ascii=False),
+            ctx=self._internal_ctx(ctx),
+        )
+
+    def _validate_shared_meta(
+        self,
+        meta: dict[str, Any],
+        temp_file_id: str,
+        ctx: RequestContext,
+    ) -> None:
+        if meta.get("temp_file_id") != temp_file_id:
+            raise PermissionDeniedError("Invalid temp_file_id.")
+        if meta.get("account") != ctx.account_id:
+            raise PermissionDeniedError("Temporary upload does not belong to current account.")
+
+    @staticmethod
+    def _cleanup_local_temp_files(temp_dir: Path, max_age_hours: int = 1) -> None:
+        if not temp_dir.exists():
+            return
+        now = time.time()
+        max_age_seconds = max_age_hours * 3600
+        for file_path in temp_dir.iterdir():
+            if not file_path.is_file():
+                continue
+            file_age = now - file_path.stat().st_mtime
+            if file_age > max_age_seconds:
+                file_path.unlink(missing_ok=True)
+                if not file_path.name.endswith(".ov_upload.meta"):
+                    meta_path = temp_dir / f"{file_path.name}.ov_upload.meta"
+                    if meta_path.exists():
+                        meta_path.unlink(missing_ok=True)

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1673,6 +1673,8 @@ class VikingFS:
             return None
         if self._is_legacy_temp_uri_parts(parts):
             return None
+        if scope == "upload":
+            return None
         if scope == "user" and second not in self._USER_STRUCTURE_DIRS:
             return second
         if scope == "agent" and second not in self._AGENT_STRUCTURE_DIRS:
@@ -1700,6 +1702,8 @@ class VikingFS:
             if parts[1] == ctx.user.user_space_name():
                 return True
             return self._is_legacy_temp_uri_parts(parts)
+        if scope == "upload":
+            return ctx.role == Role.ROOT
         if scope == "_system":
             return False
         return namespace_is_accessible(normalized_uri, ctx)

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -193,6 +193,9 @@ class AsyncHTTPClient(BaseClient):
         self._user = UserIdentifier.the_default_user()
         self._timeout = timeout
         self._extra_headers = extra_headers
+        self._upload_mode = None
+        if should_load_cli_config and cli_config is not None and cli_config.upload is not None:
+            self._upload_mode = cli_config.upload.mode
         self._http: Optional[httpx.AsyncClient] = None
         self._observer: Optional[_HTTPObserver] = None
 
@@ -346,9 +349,13 @@ class AsyncHTTPClient(BaseClient):
         """Upload a file to /api/v1/resources/temp_upload and return the temp_file_id."""
         with open(file_path, "rb") as f:
             files = {"file": (Path(file_path).name, f, "application/octet-stream")}
+            data = None
+            if self._upload_mode:
+                data = {"upload_mode": self._upload_mode}
             response = await self._http.post(
                 "/api/v1/resources/temp_upload",
                 files=files,
+                data=data,
             )
         result = self._handle_response(response)
         return result.get("temp_file_id", "")

--- a/openviking_cli/utils/config/ovcli_config.py
+++ b/openviking_cli/utils/config/ovcli_config.py
@@ -15,6 +15,7 @@ from .consts import DEFAULT_OVCLI_CONF, OPENVIKING_CLI_CONFIG_ENV
 class OVCLIUploadConfig(BaseModel):
     """Upload-related defaults in ovcli.conf."""
 
+    mode: Optional[str] = None
     ignore_dirs: Optional[str] = None
     include: Optional[str] = None
     exclude: Optional[str] = None

--- a/openviking_cli/utils/uri.py
+++ b/openviking_cli/utils/uri.py
@@ -40,7 +40,7 @@ class VikingURI:
         "session",
     }
     PUBLIC_SCOPES = frozenset(LISTABLE_SCOPES)
-    INTERNAL_SCOPES = frozenset({"temp", "queue"})
+    INTERNAL_SCOPES = frozenset({"temp", "queue", "upload"})
     # All valid scopes that can be addressed by the URI parser/storage internals.
     # Public API handlers must not use this as their external whitelist.
     VISITABLE_SCOPES = PUBLIC_SCOPES | INTERNAL_SCOPES

--- a/tests/client/test_http_client_config.py
+++ b/tests/client/test_http_client_config.py
@@ -88,6 +88,7 @@ def test_async_http_client_accepts_ovcli_upload_section(tmp_path, monkeypatch):
                 "url": "http://config-host:1933",
                 "api_key": "config-key",
                 "upload": {
+                    "mode": "shared",
                     "ignore_dirs": "node_modules,.cache",
                     "include": "*.md,*.pdf",
                     "exclude": "*.tmp,*.log",
@@ -101,6 +102,7 @@ def test_async_http_client_accepts_ovcli_upload_section(tmp_path, monkeypatch):
 
     assert client._url == "http://config-host:1933"
     assert client._api_key == "config-key"
+    assert client._upload_mode == "shared"
 
 
 def test_async_http_client_rejects_unknown_ovcli_upload_field(tmp_path, monkeypatch):

--- a/tests/client/test_http_client_local_upload.py
+++ b/tests/client/test_http_client_local_upload.py
@@ -15,8 +15,8 @@ class _FakeHTTPClient:
     def __init__(self):
         self.calls = []
 
-    async def post(self, path, json=None, files=None):
-        self.calls.append({"path": path, "json": json, "files": files})
+    async def post(self, path, json=None, files=None, data=None):
+        self.calls.append({"path": path, "json": json, "files": files, "data": data})
         return object()
 
 
@@ -148,3 +148,34 @@ async def test_import_ovpack_fails_fast_when_path_is_directory(tmp_path):
         await client.import_ovpack(str(pack_dir), parent="viking://resources/")
 
     assert fake_http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_upload_temp_file_forwards_shared_upload_mode_from_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "url": "http://localhost:1933",
+                "upload": {
+                    "mode": "shared",
+                },
+            }
+        )
+    )
+    monkeypatch.setenv(OPENVIKING_CLI_CONFIG_ENV, str(config_path))
+
+    upload_file = tmp_path / "demo.md"
+    upload_file.write_text("# Demo\n")
+
+    client = AsyncHTTPClient()
+    fake_http = _FakeHTTPClient()
+    client._http = fake_http
+    client._handle_response = lambda _response: {"temp_file_id": "shared_abc"}
+
+    temp_file_id = await client._upload_temp_file(str(upload_file))
+
+    assert temp_file_id == "shared_abc"
+    call = fake_http.calls[-1]
+    assert call["path"] == "/api/v1/resources/temp_upload"
+    assert call["data"] == {"upload_mode": "shared"}

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -7,6 +7,7 @@ import zipfile
 
 import httpx
 
+from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
 
 
@@ -509,6 +510,86 @@ async def test_add_resource_accepts_temp_uploaded_file(
     body = resp.json()
     assert body["status"] == "ok"
     assert body["result"]["root_uri"].startswith("viking://")
+
+
+async def test_shared_temp_upload_and_add_resource_deletes_upload_dir(
+    client: httpx.AsyncClient,
+    service,
+):
+    upload_resp = await client.post(
+        "/api/v1/resources/temp_upload",
+        files={"file": ("shared.md", b"# shared upload\n", "text/markdown")},
+        data={"upload_mode": "shared"},
+    )
+    assert upload_resp.status_code == 200
+    temp_file_id = upload_resp.json()["result"]["temp_file_id"]
+    assert temp_file_id.startswith("shared_")
+
+    upload_id = temp_file_id[len("shared_") :]
+    upload_root = f"viking://upload/{upload_id}"
+    vfs = get_viking_fs()
+    assert await vfs.exists(f"{upload_root}/meta.json")
+    assert await vfs.exists(f"{upload_root}/content")
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"temp_file_id": temp_file_id, "reason": "shared upload"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["root_uri"].startswith("viking://")
+    assert not await vfs.exists(upload_root)
+
+
+async def test_shared_temp_upload_failed_consume_is_retryable(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    upload_resp = await client.post(
+        "/api/v1/resources/temp_upload",
+        files={"file": ("shared.md", b"# shared upload\n", "text/markdown")},
+        data={"upload_mode": "shared"},
+    )
+    temp_file_id = upload_resp.json()["result"]["temp_file_id"]
+
+    async def fake_add_resource(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(service.resources, "add_resource", fake_add_resource)
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"temp_file_id": temp_file_id, "reason": "shared upload"},
+    )
+    assert resp.status_code == 500
+
+    upload_id = temp_file_id[len("shared_") :]
+    meta_uri = f"viking://upload/{upload_id}/meta.json"
+    meta_raw = await get_viking_fs().read_file(meta_uri)
+    assert '"state": "uploaded"' in meta_raw
+
+
+async def test_shared_upload_fs_read_is_denied_for_non_root(
+    client: httpx.AsyncClient,
+):
+    upload_resp = await client.post(
+        "/api/v1/resources/temp_upload",
+        files={"file": ("shared.md", b"# shared upload\n", "text/markdown")},
+        data={"upload_mode": "shared"},
+    )
+    assert upload_resp.status_code == 200
+    temp_file_id = upload_resp.json()["result"]["temp_file_id"]
+    upload_id = temp_file_id[len("shared_") :]
+
+    resp = await client.get(
+        "/api/v1/fs/read",
+        params={"uri": f"viking://upload/{upload_id}/meta.json"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "PERMISSION_DENIED"
 
 
 async def test_add_resource_rejects_temp_file_id_directory(


### PR DESCRIPTION
# Temp Upload 单接口分布式方案设计

## 背景

当前 `POST /api/v1/resources/temp_upload` 的实现会将上传内容直接写入当前实例本机的 `upload_temp_dir`，并返回一个本地文件名形式的 `temp_file_id`。随后：

- `POST /api/v1/resources`
- `POST /api/v1/skills`
- `POST /api/v1/pack/import`

会根据该 `temp_file_id` 回到本机目录读取文件并继续处理。

这套机制在单机场景可用，但在远程分布式部署下存在根本问题：

1. 上传请求可能落到实例 A。
2. 后续消费请求可能落到实例 B。
3. 实例 B 本地没有该上传文件，导致 `temp_file_id` 无法解析。

本方案的目标是在**不新增上传接口**、**不破坏当前默认行为**的前提下，为 `temp_upload` 增加一个可选的共享上传模式，使其在分布式集群下可稳定使用。

---

## 目标

本方案需要满足以下目标：

1. 保留现有 `POST /api/v1/resources/temp_upload` 作为唯一上传入口。
2. 保留当前默认行为，不影响现有 CLI、console、SDK、curl 调用。
3. 支持通过一个新增参数显式启用分布式共享上传。
4. 保持现有消费接口不变，仍然只接受 `temp_file_id`。
5. `shared` 模式下的 `temp_file_id` 是一次性消费 token。
6. 成功消费后立即删除共享上传对象。
7. 失败时允许重试。
8. 不依赖“每个实例周期性扫描全量临时目录”的 cleaner。
9. 第一阶段尽量复用现有 `add_resource` / `add_skill` / `pack.import` 路径。

---

## 非目标

本方案明确不覆盖以下内容：

1. 不新增 init / complete / presign 两段式上传接口。
2. 不实现断点续传或 multipart object upload。
3. 不引入 Redis / DB 作为必须依赖。
4. 不在第一阶段把全部 parser 改为直接流式读取对象存储。
5. 不允许客户端直接使用 shared 存储 URI 参与导入。

---

## 总体方案

保留原有接口：

`POST /api/v1/resources/temp_upload`

新增 multipart 表单字段：

- `upload_mode=local|shared`

默认值：

- `local`

语义如下：

- `local`：保持当前行为，上传内容写本机临时目录。
- `shared`：上传内容写共享临时空间，支持任意实例消费。

后续消费接口全部保持不变：

- `POST /api/v1/resources`
- `POST /api/v1/skills`
- `POST /api/v1/pack/import`

调用方继续只传：

- `temp_file_id`

服务端内部根据 `temp_file_id` 的格式和元数据，决定走 local 解析还是 shared 解析。

---

## API 设计

### 上传接口

接口：

`POST /api/v1/resources/temp_upload`

请求字段：

- `file`：multipart 文件，必填
- `telemetry`：保留现有字段
- `upload_mode`：新增字段，可选
  - `local`
  - `shared`
  - 默认 `local`

返回结构保持不变：

```json
{
  "temp_file_id": "..."
}
```

### 消费接口

以下接口均不做对外结构变更：

- `POST /api/v1/resources`
- `POST /api/v1/skills`
- `POST /api/v1/pack/import`

它们仍然只接收 `temp_file_id`，不增加额外模式字段。

---

## `temp_file_id` 设计

### local 模式

沿用当前格式：

```text
upload_<uuid>.<ext>
```

示例：

```text
upload_3113340a08084a9998b6351146fbbd42.zip
```

### shared 模式

shared token 格式定义为：

```text
shared_<upload_id>
```

示例：

```text
shared_7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123
```

### `upload_id` 生成方式

由服务端生成：

```python
uuid.uuid4().hex
```

这样做的原因：

1. 实现简单。
2. 熵高，碰撞概率极低。
3. 不暴露账号、用户、时间等业务信息。
4. 便于直接拼接成 `shared_<upload_id>`。

### 解析规则

- 以 `upload_` 开头且符合旧格式：按 local 解析。
- 以 `shared_` 开头：按 shared 解析。
- 其他格式：拒绝。

---

## shared 存储布局

shared 上传对象统一放到受控内部前缀：

```text
viking://upload/{upload_id}/
```

目录中包含两个对象：

- `content`
- `meta.json`

示例：

```text
viking://upload/7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123/content
viking://upload/7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123/meta.json
```

这样设计的原因：

1. 它是临时上传空间，不应进入最终 `viking://resources`。
2. 它与普通 `viking://temp/...` 工作临时目录隔离，避免混淆权限语义。
3. 可以复用 VikingFS/AGFS/S3 能力。
4. 便于对象存储 lifecycle 兜底清理。

### 安全边界

`viking://upload/...` 是**内部受控临时上传空间**，不是普通 temp 工作目录，也不是普通业务资源空间。

必须满足：

1. 客户端不能直接传该 URI 给业务导入接口。
2. 服务端只接受 `temp_file_id`，不接受客户端指定 shared `storage_uri`。
3. shared 内容路径只对服务端内部可见。
4. shared 上传内容不通过普通资源读取能力直接暴露给普通用户。

---

## `meta.json` 设计

### 目的

`meta.json` 用于承载 shared 上传的最小控制信息，包括：

- 所属账号
- 上传发起用户（仅记录）
- 原始文件名
- 内容对象位置
- 文件大小 / 摘要
- 当前状态
- 正在消费的抢占信息

### 结构

建议第一版使用以下 schema：

```json
{
  "version": 1,
  "upload_mode": "shared",
  "upload_id": "7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123",
  "temp_file_id": "shared_7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123",

  "account": "acme",
  "user": "alice",
  "agent": "default",

  "original_filename": "repo.zip",
  "content_type": "application/zip",
  "file_ext": ".zip",
  "size": 1048576,
  "sha256": null,

  "storage_uri": "viking://upload/7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123/content",

  "state": "uploaded",
  "created_at": 1778131200,
  "updated_at": 1778131200
}
```

### 字段说明

- `version`：元数据 schema 版本
- `upload_mode`：固定 `shared`
- `upload_id`：shared 上传主键
- `temp_file_id`：对外 token
- `account` / `user` / `agent`：归属信息
- `original_filename`：上传时原始文件名
- `content_type`：MIME 类型
- `file_ext`：扩展名，materialize 本地临时文件时保留
- `size`：文件大小
- `sha256`：可选完整性校验
- `storage_uri`：shared 内容对象位置
- `state`：状态机
- `created_at` / `updated_at`：时间戳

---

## 状态机设计

shared 模式只使用两个状态：

- `uploaded`
- `consuming`

### 状态含义

- `uploaded`：可被消费
- `consuming`：已被某个实例抢占，正在消费中

### 为什么不使用 `consumed`

本方案里，shared token 是一次性消费 token。

消费成功后将立即删除整个 upload 目录，因此不需要持久化一个长期存在的 `consumed` 状态。

### 状态流转

正常流转如下：

```text
uploaded -> consuming -> delete
```

失败流转如下：

```text
uploaded -> consuming -> uploaded
```

---

## 上传完成语义

shared 上传视为完成的条件是：

1. `content` 已写完
2. `meta.json` 已写入
3. `meta.state == "uploaded"`

### 写入顺序

必须严格按以下顺序：

1. 生成 `upload_id`
2. 创建 upload 目录
3. 流式写 `content`
4. 边写边统计 `size`，可选计算 `sha256`
5. 最后写 `meta.json`

### 结论

- `meta.json` 是唯一完成标志
- 只有 `content` 没有 `meta.json` 的对象是 orphan，不可消费
- orphan 由对象存储 lifecycle 兜底清理

---

## 上传流程

### local 模式

1. 接收请求
2. `upload_mode=local`
3. 将文件流式写入本地 `upload_temp_dir`
4. 写对应 `.ov_upload.meta`
5. 返回 `upload_...`

### shared 模式

1. 接收请求
2. `upload_mode=shared`
3. 校验服务端已启用 shared 上传
4. 生成 `upload_id`
5. 边读边校验大小上限
6. 流式写入 shared `content`
7. 生成并写入 `meta.json`
8. 返回 `shared_<upload_id>`

---

## 大小限制

建议配置：

- `shared_max_size_bytes`
- `local_max_size_bytes`，可选

### 执行方式

上传时边读边计数：

1. 每读一个 chunk，累计字节数
2. 如果超过上限：
   - 立即停止上传
   - 删除已写半成品
   - 返回错误

不能等上传完成后再做大小校验。

---

## 消费接口

以下接口保持不变：

- `POST /api/v1/resources`
- `POST /api/v1/skills`
- `POST /api/v1/pack/import`

调用方继续只传：

```json
{
  "temp_file_id": "..."
}
```

消费模式完全由服务端内部判断。

---

## shared 消费语义

`shared_<upload_id>` 是**一次性消费 token**。

规则如下：

1. 同一个 token 只能成功消费一次。
2. 开始消费前，必须先从 `uploaded` 抢占到 `consuming`。
3. 只有一个实例可以抢占成功。
4. 消费成功后，立即删除整个 upload 目录。
5. 消费失败后，状态恢复回 `uploaded`，允许重试。

---

## 为什么需要 `consuming`

如果不引入 `consuming` 状态，在并发场景下会出现问题：

1. 实例 A 和 B 同时读到 `uploaded`
2. A 和 B 都开始消费
3. 可能两个实例都成功

这样 shared token 就不是一次性了。

因此必须引入抢占状态：

- `uploaded -> consuming`

只有抢占成功的实例可以继续消费。

---

## 抢占规则

shared 消费开始前，必须执行原子抢占：

```text
uploaded -> consuming
```

抢占要求：

1. 只有当当前状态是 `uploaded` 时，才能成功进入 `consuming`
2. 如果当前状态已经是 `consuming`，则说明已有实例正在消费
3. 后来的实例必须直接返回错误

### 实现要求

这一状态变更必须具备原子语义，不能只是：

1. 先读状态
2. 再普通写状态

否则仍有竞态。

实现上可以复用现有事务/路径锁能力，或在 shared upload store 内实现一个最小互斥机制。无论具体机制如何，最终都必须保证：

- 同一 token 同时只有一个实例能进入 `consuming`

---

## 消费流程

### local token

保持现状：

1. 校验 `temp_file_id`
2. 校验路径位于本地 `upload_temp_dir`
3. 返回本地路径给下游逻辑

### shared token

统一流程如下：

1. 解析 `temp_file_id`
2. 判断它是 `shared_...`
3. 读取 `meta.json`
4. 校验：
   - token 格式合法
   - `account` 匹配当前请求
   - `state == "uploaded"`
   - `content` 存在
5. 抢占状态：`uploaded -> consuming`
6. 将 shared `content` 下载到当前实例本地临时文件
7. 将本地临时文件路径交给现有消费逻辑
8. 如果业务成功：
   - 立即删除整个 shared upload 目录
9. 如果业务失败：
   - 将状态从 `consuming` 恢复为 `uploaded`
10. 请求结束时清理 materialize 出来的本地临时文件

---

## 为什么消费时要先下载到本地

第一阶段建议统一采用：

- `shared` 内容先下载到当前实例本地临时文件
- 再走现有 `add_resource` / `add_skill` / `pack.import`

原因：

1. 当前下游链路大量逻辑默认输入是本地路径。
2. 这样可以最小改动复用现有 parser / import 逻辑。
3. 不需要在第一阶段把所有解析链改成直接读对象存储流。

这意味着，例如 `add_resource` 在 shared 模式下的实际流程是：

1. 解析 token
2. 抢占
3. 下载到本地临时文件
4. 调现有 `add_resource(path=local_path, ...)`

---

## materialize 本地临时文件

### 规则

shared 内容被消费时，需要 materialize 成当前实例本地临时文件。

要求：

1. 文件名尽量保留原扩展名
2. 采用流式下载，不整文件读入内存
3. materialize 失败时删除半成品

建议生成路径示例：

```text
/tmp/ov_shared_upload_<uuid>.zip
```

### 生命周期

本地 materialize 文件是**请求级资源**。

必须由统一解析器返回：

- `local_path`
- `cleanup()`

调用方必须在最外层 `finally` 中执行 cleanup。

对 local 模式：

- `cleanup()` 为 no-op

对 shared 模式：

- `cleanup()` 删除本地临时文件

---

## 成功与失败语义

### 成功

“消费成功”的定义是：

- 目标业务接口已完成核心导入逻辑，并准备返回成功

例如：

- `resources.add_resource` 成功
- `skills.add_skill` 成功
- `pack.import` 成功

此时执行：

1. 删除整个 shared upload 目录
2. 返回成功响应

### 失败

如果业务处理失败：

1. 不删除 shared upload 目录
2. 将 `state` 从 `consuming` 恢复回 `uploaded`
3. 允许调用方后续重试
4. 清理 materialize 本地临时文件

---

## 懒删除

### 为什么不使用集群周期 cleaner

不采用“每个实例定时扫描全量 upload 前缀”的 cleaner，原因：

1. 集群下会重复扫目录
2. 不优雅
3. 成本高

### 懒删除定义

懒删除只针对“当前请求访问到的无效 token”。

也就是说：

- 访问到了一个 token
- 判断它已经无效
- 顺手删掉这个 token 对应的 upload 目录

它不是全量扫描，不是后台全局清理。

### 懒删除触发条件

1. `meta.json` 存在但 `content` 丢失
2. `meta.json` 损坏或关键字段非法
3. `state == "consuming"` 且对象已不完整

### 删除范围

删除整个目录：

```text
viking://upload/{upload_id}/
```

包括：

- `content`
- `meta.json`

### 幂等要求

懒删除必须是幂等的：

1. 目录不存在也算成功
2. 只剩部分对象也算成功
3. 删除失败不影响主错误返回

---

## 对象存储 lifecycle

对象存储 lifecycle 仍然需要保留，但只作为兜底：

1. 清理无人再访问的 orphan `content`
2. 清理因异常遗留的旧对象

lifecycle 不是业务状态判断主机制。

业务上“是否可消费”仍然由应用层在读时校验：

- `state`
- 归属
- 内容完整性

---

## 异常状态处理

### `meta.json` 存在，`content` 丢失

处理：

1. 返回错误
2. 尝试懒删除整个目录

### `content` 存在，`meta.json` 缺失

处理：

1. 不可消费
2. 视为 orphan
3. 由 lifecycle 清理

### token 正在被消费

处理：

- 返回 `Temporary upload is being consumed`

### token 归属不匹配

处理：

- 返回 `Temporary upload does not belong to current account`

---

## 安全要求

必须满足：

1. 客户端不能直接传 shared `storage_uri`
2. 客户端只能传 `temp_file_id`
3. shared 路径只服务端内部可见
4. 必须校验：
   - `account`
   - `state`
   - 内容完整性

local 模式继续保留当前安全规则：

1. 只允许本地 `upload_temp_dir` 下的普通文件
2. 防路径穿越
3. 防 symlink escape

---

## 配置设计

建议在 `server` 下新增：

```json
{
  "server": {
    "temp_upload": {
      "default_mode": "local",
      "shared_max_size_bytes": 536870912,
      "shared_prefix": "viking://upload"
    }
  }
}
```

### 字段说明

- `default_mode`
  - 第一阶段固定为 `local`
- `shared_max_size_bytes`
  - shared 上传大小上限
- `shared_prefix`
  - shared 上传根前缀

---

## 客户端策略

为了让分布式场景真正可用，客户端需要支持显式上传模式配置。

建议客户端配置：

- `upload.mode = local | shared | auto`

第一阶段最低要求：

1. CLI 支持显式 `shared`
2. console 支持显式 `shared`
3. SDK / HTTP client 支持显式 `shared`

当前第一阶段实现中：

1. 默认行为仍然是 `local`
2. Rust CLI 可通过环境变量 `OPENVIKING_UPLOAD_MODE=shared` 显式启用 shared 上传
3. console / SDK / HTTP client 只有在显式传 `upload_mode=shared` 时才走 shared
4. 若不做任何配置，所有客户端都保持原有 local 上传行为

如果后续做 `auto`，建议规则为：

1. 非 localhost
2. 服务端声明支持 shared
3. 则自动使用 `shared`

第一阶段不依赖自动探测。

---

## 示例

### 默认 local

```bash
curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
  -F "file=@./README.md"
```

返回：

```json
{
  "status": "ok",
  "result": {
    "temp_file_id": "upload_3113340a08084a9998b6351146fbbd42.md"
  }
}
```

### shared 上传

```bash
curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
  -F "file=@./repo.zip" \
  -F "upload_mode=shared"
```

返回：

```json
{
  "status": "ok",
  "result": {
    "temp_file_id": "shared_7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123"
  }
}
```

### shared 导入资源

```bash
curl -X POST http://localhost:1933/api/v1/resources \
  -H "Content-Type: application/json" \
  -d '{
    "temp_file_id": "shared_7f3c1b8d4f2e4b1bb0f6e8b2d9a4c123",
    "to": "viking://resources/code"
  }'
```

处理过程等价于：

1. 解析 token
2. 抢占 `uploaded -> consuming`
3. 下载 `content` 到本地临时文件
4. 调现有 `add_resource(path=local_path, ...)`
5. 成功后删除 shared upload 目录
6. 清理本地临时文件

---

## 代码改动建议

核心改动点如下：

1. `openviking/server/routers/resources.py`
   - `temp_upload` 增加 `upload_mode`
   - 改为分块流式写入
2. 新增 `openviking/server/temp_upload_store.py`
   - `TempUploadStore`
   - `LocalTempUploadStore`
   - `SharedTempUploadStore`
   - `ResolvedTempUpload`
3. `openviking/server/local_input_guard.py`
   - 从本地 temp 目录解析器升级为统一 `temp_file_id` 解析器
4. `openviking/server/routers/pack.py`
   - 接入统一 shared/local 解析
5. `openviking/server/config.py`
   - 增加 `server.temp_upload` 配置
6. CLI / console / SDK
   - 支持传 `upload_mode=shared`

---

## 测试重点

### 兼容性

1. 不传 `upload_mode` 时行为完全不变
2. local token 现有流程不回归

### shared 正常链路

1. shared 上传成功
2. 跨实例消费成功
3. `resources` / `skills` / `pack.import` 都可用

### 单次消费

1. 同一个 shared token 并发消费时只有一个成功
2. 成功后整个目录立即删除
3. 再次消费失败

### 失败重试

1. 消费失败后状态恢复为 `uploaded`
2. 后续可重新消费

### 崩溃语义

1. 如果实例在 `consuming` 后崩溃，不会自动恢复
2. 这类残留对象由人工处理或底层 lifecycle 兜底

### 过期与异常

1. `meta.json` 有、`content` 缺失时触发懒删除
2. orphan 内容由 lifecycle 兜底

### 资源清理

1. materialize 文件在请求结束后删除
2. 大文件不整文件进内存

---

## 最终结论

最终方案如下：

1. 保留单接口：`POST /api/v1/resources/temp_upload`
2. 新增参数：`upload_mode=local|shared`
3. 默认：`local`
4. shared token 格式：`shared_<upload_id>`
5. `upload_id`：`uuid.uuid4().hex`
6. shared 存储：`viking://upload/{upload_id}/`
7. 元数据：`meta.json`
8. 状态机：`uploaded -> consuming -> delete`
9. shared token 是一次性消费 token
10. 成功后立即删除
11. 失败恢复为 `uploaded`
12. 不做集群周期 cleaner
13. 懒删除只处理当前访问到的无效对象
14. 第一阶段统一下载到本地后复用现有消费链路