### PR TITLE
fix(vlm): ignore unusable default provider

### DIFF
--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -188,10 +188,9 @@ class VLMConfig(BaseModel):
             return self._get_provider_config_by_name(self.provider) or {}, self.provider
 
         if self.default_provider:
-            return (
-                self._get_provider_config_by_name(self.default_provider) or {},
-                self.default_provider,
-            )
+            config = self._get_provider_config_by_name(self.default_provider) or {}
+            if self._provider_has_usable_credentials(self.default_provider, config):
+                return config, self.default_provider
 
         if len(self.providers) == 1:
             provider_name = next(iter(self.providers))

--- a/tests/unit/test_vlm_config_provider_selection.py
+++ b/tests/unit/test_vlm_config_provider_selection.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+from openviking_cli.utils.config.vlm_config import VLMConfig
+
+
+def test_default_provider_selects_configured_provider_with_api_key():
+    config = VLMConfig(
+        model="gpt-4o-mini",
+        default_provider="openai",
+        providers={
+            "litellm": {"api_key": "sk-litellm"},
+            "openai": {"api_key": "sk-openai"},
+        },
+    )
+
+    provider_config, provider_name = config.get_provider_config()
+
+    assert provider_name == "openai"
+    assert provider_config["api_key"] == "sk-openai"
+
+
+def test_explicit_provider_takes_precedence_over_default_provider():
+    config = VLMConfig(
+        model="gpt-4o-mini",
+        provider="litellm",
+        default_provider="openai",
+        providers={
+            "litellm": {"api_key": "sk-litellm"},
+            "openai": {"api_key": "sk-openai"},
+        },
+    )
+
+    provider_config, provider_name = config.get_provider_config()
+
+    assert provider_name == "litellm"
+    assert provider_config["api_key"] == "sk-litellm"
+
+
+def test_default_provider_without_credentials_falls_back_to_usable_provider():
+    config = VLMConfig(
+        model="gpt-4o-mini",
+        default_provider="openai",
+        providers={
+            "openai": {},
+            "litellm": {"api_key": "sk-litellm"},
+        },
+    )
+
+    provider_config, provider_name = config.get_provider_config()
+    result = config._build_vlm_config_dict()
+
+    assert provider_name == "litellm"
+    assert provider_config["api_key"] == "sk-litellm"
+    assert result["provider"] == "litellm"
+    assert result["api_key"] == "sk-litellm"
+
+
+def test_unknown_default_provider_falls_back_to_usable_provider():
+    config = VLMConfig(
+        model="gpt-4o-mini",
+        default_provider="missing-provider",
+        providers={"openai": {"api_key": "sk-openai"}},
+    )
+
+    provider_config, provider_name = config.get_provider_config()
+
+    assert provider_name == "openai"
+    assert provider_config["api_key"] == "sk-openai"


### PR DESCRIPTION
## Summary
- let `default_provider` win only when that provider has usable credentials
- fall back to the existing provider selection path when the default provider is empty, missing, or otherwise unusable
- add focused VLMConfig provider-selection regressions for default-provider precedence and fallback behavior

## Validation
- `PYTHONPATH=. python3 - <<'PY' ... PY` (ad-hoc VLMConfig provider-selection assertions) - passed
- `python3 -m py_compile openviking_cli/utils/config/vlm_config.py tests/unit/test_vlm_config_provider_selection.py` - passed
- `git diff --check` - passed
- `uvx ruff check openviking_cli/utils/config/vlm_config.py tests/unit/test_vlm_config_provider_selection.py` - passed
- `uvx ruff format --check openviking_cli/utils/config/vlm_config.py tests/unit/test_vlm_config_provider_selection.py` - passed

Targeted pytest note: `uv run python -m pytest ...` could not complete in this local macOS environment because the editable build tries to build the Rust CLI and fails in local CommandLineTools with an `xcrun` architecture mismatch. Running pytest directly with system Python also loads the repository conftest and is missing project dependencies. No production/runtime surface is touched.
