### PR TITLE
fix(memory): require parseable final extract output

### DIFF
--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -524,7 +524,8 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
     def _build_final_operations_skeleton(self) -> Dict[str, List[Any]]:
         """Build an empty operations object matching the expected flat schema fields."""
-        return {field: [] for field in self._expected_fields or ["delete_uris"]}
+        fields = ["delete_uris", *(self._expected_fields or [])]
+        return {field: [] for field in dict.fromkeys(fields)}
 
     def _build_final_operations_instruction(self) -> str:
         """Build schema-aware final-iteration instructions for the LLM."""

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -8,11 +8,16 @@ Reference: bot/vikingbot/agent/loop.py AgentLoop structure
 
 import asyncio
 import json
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from openviking.models.vlm.base import VLMBase, ToolCall
+from openviking.models.vlm.base import ToolCall, VLMBase
 from openviking.server.identity import RequestContext
-from openviking.session.memory.memory_isolation_handler import RoleScope, MemoryIsolationHandler
+from openviking.session.memory.dataclass import (
+    MemoryFileContent,
+    ResolvedOperation,
+    ResolvedOperations,
+)
+from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.schema_model_generator import (
     SchemaModelGenerator,
     SchemaPromptGenerator,
@@ -20,17 +25,11 @@ from openviking.session.memory.schema_model_generator import (
 from openviking.session.memory.tools import (
     MEMORY_TOOLS_REGISTRY,
     add_tool_call_pair_to_messages,
-    get_tool,
 )
 from openviking.session.memory.utils import (
     parse_json_with_stability,
     parse_memory_file_with_fields,
     pretty_print_messages,
-)
-from openviking.session.memory.dataclass import (
-    MemoryFileContent,
-    ResolvedOperation,
-    ResolvedOperations,
 )
 from openviking.session.memory.utils.json_parser import JsonUtils
 from openviking.session.memory.utils.uri import supplement_operation_uris
@@ -93,7 +92,6 @@ class ExtractLoop:
         self._expected_fields: Optional[List[str]] = None
         self._operations_model: Optional[Any] = None
 
-
         # Transaction handle for file locking
         self._transaction_handle = None
         # Flag to disable tools in next iteration after unknown tool error
@@ -123,7 +121,6 @@ class ExtractLoop:
         self.schema_prompt_generator = SchemaPromptGenerator(schemas)
         self.schema_model_generator.generate_all_models()
 
-
         # 预计算工具 schemas
         allowed_tools = self.context_provider.get_tools()
         self._tool_schemas = [
@@ -145,11 +142,11 @@ class ExtractLoop:
         # 预计算 operations_model
         role_scope = self._isolation_handler.get_read_scope() if self._isolation_handler else None
 
-        self._operations_model = self.schema_model_generator.create_structured_operations_model(role_scope)
+        self._operations_model = self.schema_model_generator.create_structured_operations_model(
+            role_scope
+        )
 
         json_schema = self._operations_model.model_json_schema()
-
-
 
         # Build initial messages from provider
         import json
@@ -189,7 +186,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 messages.append(
                     {
                         "role": "user",
-                        "content": "You have reached the maximum number of tool call iterations. Do not call any more tools - return your final result directly now.",
+                        "content": self._build_final_operations_instruction(),
                     }
                 )
 
@@ -238,10 +235,12 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 tracer.info(f"Extended max_iterations to {max_iterations} for format retry")
                 self._add_format_error_message(messages)
 
-            # If it's the last iteration, use empty operations
+            # If it's the last iteration, fail instead of silently treating an
+            # unparseable final response as "no memory operations".
             if iteration >= max_iterations:
-                final_operations = ResolvedOperations()
-                break
+                raise RuntimeError(
+                    "Memory extraction final response could not be parsed as JSON operations"
+                )
 
             self._disable_tools_for_iteration = True
             continue
@@ -256,9 +255,8 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
         return final_operations, tools_used
 
-
     async def resolve_operations(self, operations) -> ResolvedOperations:
-        tracer.info(f'operations={JsonUtils.dumps(operations)}')
+        tracer.info(f"operations={JsonUtils.dumps(operations)}")
         upsert_operations: List[ResolvedOperation] = []
         delete_file_contents: List[MemoryFileContent] = []
         errors: List[str] = []
@@ -280,7 +278,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
             for item in items:
                 # 转换为 dict
                 item_dict = dict(item)
-                item_dict['memory_type'] = memory_type
+                item_dict["memory_type"] = memory_type
                 # 填充 user_id 和 agent_id
                 self._isolation_handler.fill_role_ids(item_dict, role_scope=role_scope)
 
@@ -329,10 +327,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     op.old_memory_file_content = old_content
                     break
 
-
-
         return resolved
-
 
     @tracer("extract_loop.execute_tool_calls")
     async def _execute_tool_calls(self, messages, tool_calls, tools_used) -> bool:
@@ -375,11 +370,6 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 }
             )
 
-            # Track read tool calls for refetch detection
-            if tool_call.name == "read" and tool_call.arguments.get("uri"):
-                uri = tool_call.arguments["uri"]
-                # 内容由 ToolContext.read_file_contents 记录
-
             add_tool_call_pair_to_messages(
                 messages,
                 call_id=tool_call.id,
@@ -389,7 +379,6 @@ The final output of the model must strictly follow the JSON Schema format shown 
             )
 
         return has_unknown_tool
-
 
     async def _call_llm(
         self, messages: List[Dict[str, Any]]
@@ -492,8 +481,6 @@ The final output of the model must strictly follow the JSON Schema format shown 
         print("No tool calls or operations parsed")
         return (None, None)
 
-
-
     async def _execute_in_parallel(
         self,
         tasks: List[Any],
@@ -501,10 +488,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
         """Execute tasks in parallel, similar to AgentLoop."""
         return await asyncio.gather(*tasks)
 
-    async def _check_unread_existing_files(
-        self,
-        operations: ResolvedOperations
-    ) -> Dict:
+    async def _check_unread_existing_files(self, operations: ResolvedOperations) -> Dict:
 
         refetch_uris = {}
         for operation in operations.upsert_operations:
@@ -513,13 +497,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     continue
                 try:
                     content = await self.context_provider.execute_tool(
-                        ToolCall(
-                            id="",
-                            name="read",
-                            arguments={
-                                "uri": uri
-                            }
-                        )
+                        ToolCall(id="", name="read", arguments={"uri": uri})
                     )
                     # 读取出错表示文件不存在
                     if isinstance(content, Dict):
@@ -542,6 +520,25 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     "Do not include any explanation, markdown formatting, or text outside the JSON."
                 ),
             }
+        )
+
+    def _build_final_operations_skeleton(self) -> Dict[str, List[Any]]:
+        """Build an empty operations object matching the expected flat schema fields."""
+        return {field: [] for field in self._expected_fields or ["delete_uris"]}
+
+    def _build_final_operations_instruction(self) -> str:
+        """Build schema-aware final-iteration instructions for the LLM."""
+        skeleton = json.dumps(
+            self._build_final_operations_skeleton(),
+            ensure_ascii=False,
+            indent=2,
+        )
+        return (
+            "You have reached the maximum number of tool call iterations. "
+            "Do not call any more tools. Return your final result now as ONLY a valid JSON object "
+            "matching the required schema. Do not include explanations or markdown. "
+            "If there are no memory changes, return this exact empty-shape JSON with all fields present:\n"
+            f"{skeleton}"
         )
 
     async def _add_refetch_results_to_messages(

--- a/tests/session/memory/test_memory_react.py
+++ b/tests/session/memory/test_memory_react.py
@@ -199,4 +199,77 @@ class TestAllowedDirectoriesList:
 
                 # Verify the result contains the expected directories with variables replaced
                 assert "viking://user/default/memories/preferences" in result
-                assert "viking://agent/default/memories/tools" in result
+        assert "viking://agent/default/memories/tools" in result
+
+
+class TestExtractLoopFinalJsonRetry:
+    def test_final_instruction_includes_schema_aware_empty_json(self):
+        extract_loop = object.__new__(ExtractLoop)
+        extract_loop._expected_fields = ["delete_uris", "preferences", "tools"]
+
+        instruction = extract_loop._build_final_operations_instruction()
+
+        assert "ONLY a valid JSON object" in instruction
+        assert '"delete_uris": []' in instruction
+        assert '"preferences": []' in instruction
+        assert '"tools": []' in instruction
+
+    @pytest.mark.asyncio
+    async def test_final_unparseable_response_raises_instead_of_empty_success(self):
+        class FakeVLM:
+            model = "test-model"
+
+            def __init__(self):
+                self.seen_messages = []
+
+            async def get_completion_async(self, **kwargs):
+                self.seen_messages.append(list(kwargs["messages"]))
+                return "this is not json"
+
+        class FakeContextProvider:
+            read_file_contents = {}
+
+            def get_memory_schemas(self, ctx):
+                return [
+                    MemoryTypeSchema(
+                        memory_type="preferences",
+                        description="Preferences",
+                        directory="viking://user/{user_space}/memories/preferences",
+                        filename_template="{topic}.md",
+                        fields=[],
+                    )
+                ]
+
+            def get_tools(self):
+                return []
+
+            def get_extract_context(self):
+                return MagicMock()
+
+            def instruction(self):
+                return "Extract memory operations."
+
+            async def prefetch(self):
+                return []
+
+        vlm = FakeVLM()
+        extract_loop = ExtractLoop(
+            vlm=vlm,
+            viking_fs=MagicMock(),
+            context_provider=FakeContextProvider(),
+            max_iterations=1,
+        )
+
+        with pytest.raises(RuntimeError, match="final response could not be parsed"):
+            await extract_loop.run()
+
+        final_prompts = [
+            message["content"]
+            for messages in vlm.seen_messages
+            for message in messages
+            if message.get("role") == "user"
+            and "maximum number of tool call iterations" in message.get("content", "")
+        ]
+        assert final_prompts
+        assert '"delete_uris": []' in final_prompts[-1]
+        assert '"preferences": []' in final_prompts[-1]

--- a/tests/session/memory/test_memory_react.py
+++ b/tests/session/memory/test_memory_react.py
@@ -199,7 +199,7 @@ class TestAllowedDirectoriesList:
 
                 # Verify the result contains the expected directories with variables replaced
                 assert "viking://user/default/memories/preferences" in result
-        assert "viking://agent/default/memories/tools" in result
+                assert "viking://agent/default/memories/tools" in result
 
 
 class TestExtractLoopFinalJsonRetry:
@@ -213,6 +213,15 @@ class TestExtractLoopFinalJsonRetry:
         assert '"delete_uris": []' in instruction
         assert '"preferences": []' in instruction
         assert '"tools": []' in instruction
+
+    def test_final_skeleton_always_includes_delete_uris(self):
+        extract_loop = object.__new__(ExtractLoop)
+        extract_loop._expected_fields = ["preferences"]
+
+        assert extract_loop._build_final_operations_skeleton() == {
+            "delete_uris": [],
+            "preferences": [],
+        }
 
     @pytest.mark.asyncio
     async def test_final_unparseable_response_raises_instead_of_empty_success(self):


### PR DESCRIPTION
## Summary
- make the final ExtractLoop iteration prompt JSON-only and schema-aware with an explicit empty operations skeleton
- fail the final unparseable response path instead of silently returning empty `ResolvedOperations`
- add focused regression coverage for the final prompt shape and final unparseable response behavior

## Validation
- `python3 -m py_compile openviking/session/memory/extract_loop.py tests/session/memory/test_memory_react.py`
- `git diff --check`
- `uvx ruff check openviking/session/memory/extract_loop.py tests/session/memory/test_memory_react.py`
- `uvx ruff format openviking/session/memory/extract_loop.py tests/session/memory/test_memory_react.py`

Targeted pytest note: this local checkout cannot import the target memory test module with system Python because optional project dependency `litellm` is not installed; `uv run python -m pytest ...` also cannot complete here because the editable build tries to build the Rust CLI and the local macOS CommandLineTools `xcrun` is an incompatible architecture. The new tests are still included for CI.
