### PR TITLE
chore(cli): bump ov_cli version to 0.3.14

### DIFF
--- a/crates/ov_cli/Cargo.toml
+++ b/crates/ov_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ov_cli"
-version = "0.2.6"
+version = "0.3.14"
 edition = "2024"
 rust-version = "1.91.1"
 authors = ["OpenViking Contributors"]


### PR DESCRIPTION
## Summary
- Bump `ov_cli` Cargo.toml version from `0.2.6` → `0.3.14` to align with project release

## Follow-up
After merge, tag `cli@0.3.14` and push to trigger CI multi-arch build + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)