### PR TITLE
fix(storage): use UTC date comparison for modTime display in ls & fix same day detection

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -19,7 +19,7 @@ import json
 import re
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -1105,7 +1105,7 @@ class VikingFS:
         """Recursively list all contents (agent format with abstracts)."""
         path = self._uri_to_path(uri, ctx=ctx)
         all_entries = []
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         real_ctx = self._ctx_or_default(ctx)
 
         async def _walk(current_path: str, current_rel: str, current_depth: int):
@@ -2189,7 +2189,7 @@ class VikingFS:
         except Exception:
             raise NotFoundError(uri, "directory")
         # basic info
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         all_entries = []
         for entry in entries:
             if len(all_entries) >= node_limit:
@@ -2198,14 +2198,14 @@ class VikingFS:
             raw_time = entry.get("modTime", "")
             parsed_time = now
             if isinstance(raw_time, (int, float)):
-                parsed_time = datetime.fromtimestamp(raw_time)
+                parsed_time = datetime.fromtimestamp(raw_time, tz=timezone.utc)
             elif raw_time:
                 if len(raw_time) > 26 and "+" in raw_time:
                     parts = raw_time.split("+")
                     raw_time = parts[0][:26] + "+" + parts[1]
                 parsed_time = parse_iso_datetime(raw_time)
             elif isinstance(entry.get("mtime"), (int, float)):
-                parsed_time = datetime.fromtimestamp(entry["mtime"])
+                parsed_time = datetime.fromtimestamp(entry["mtime"], tz=timezone.utc)
             new_entry = {
                 "uri": self._path_to_uri(f"{path}/{name}", ctx=ctx),
                 "size": entry.get("size", 0),

--- a/openviking/utils/time_utils.py
+++ b/openviking/utils/time_utils.py
@@ -35,16 +35,15 @@ def format_iso8601(dt: datetime) -> str:
 
 def format_simplified(dt: datetime, now: datetime) -> str:
     """
-    Format datetime object to simplified format: yyyy-MM-dd (if not in a day) or HH:mm:ss (if in a day).
-
-    This format is more readable for humans and is used in VikingDB.
+    Format datetime in UTC: HH:MM:SS if same UTC date as *now*, else YYYY-MM-DD.
     """
-    dt = dt.replace(tzinfo=None)
-    # if in a day
-    if (now - dt).days < 1:
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc)
+    if now.tzinfo is not None:
+        now = now.astimezone(timezone.utc)
+    if dt.date() == now.date():
         return dt.strftime("%H:%M:%S")
-    else:
-        return dt.strftime("%Y-%m-%d")
+    return dt.strftime("%Y-%m-%d")
 
 
 def get_current_timestamp() -> str:


### PR DESCRIPTION
## Summary
- `format_simplified` used `(now - dt).days < 1` (24-hour window) to decide date vs time display — a file from yesterday 20:00 UTC shown at today 18:00 UTC (22h gap) would incorrectly display as time `20:00:15` instead of date `2026-05-06`
- Fixed to compare `.date()` in UTC so the boundary aligns with calendar days
- All timestamps in `_ls_agent` / `_ls_recursive_agent` now use `datetime.now(timezone.utc)` and `fromtimestamp(..., tz=timezone.utc)` consistently

## Test plan
- [x] Verified with 3 cases: 22h cross-day, same-day, 2min cross-midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)