### PR TITLE
fix(embedding): surface upstream errors instead of silent timeout

### DIFF
--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """System endpoints for OpenViking HTTP Server."""
 
+import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Request
@@ -18,6 +19,19 @@ from openviking_cli.utils import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter()
+
+
+async def _embedding_probe(embedder) -> str:
+    """Quick embedding probe: embed a single token and check for errors."""
+    from openviking.models.embedder.base import embed_compat
+
+    try:
+        await embed_compat(embedder, "ok", is_query=True)
+        return "ok"
+    except Exception as e:
+        provider = getattr(embedder, "provider", "unknown")
+        model = getattr(embedder, "model_name", "unknown")
+        return f"error: provider={provider} model={model}: {e}"
 
 
 @router.get("/health", tags=["system"])
@@ -119,7 +133,25 @@ async def readiness_check(request: Request):
     except Exception as e:
         checks["api_key_manager"] = f"error: {e}"
 
-    # 4. Ollama: connectivity check if configured
+    # 4. Embedding: quick probe to verify the provider is reachable
+    try:
+        from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+        ov_config = OpenVikingConfigSingleton.get_instance()
+        embedder = ov_config.embedding.get_embedder()
+        if embedder is not None:
+            probe_result = await asyncio.wait_for(
+                _embedding_probe(embedder), timeout=10.0
+            )
+            checks["embedding"] = probe_result
+        else:
+            checks["embedding"] = "not_configured"
+    except asyncio.TimeoutError:
+        checks["embedding"] = "error: probe timed out (provider unreachable)"
+    except Exception as e:
+        checks["embedding"] = f"error: {e}"
+
+    # 5. Ollama: connectivity check if configured
     try:
         from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
         from openviking_cli.utils.ollama import check_ollama_running, detect_ollama_in_config


### PR DESCRIPTION
## Summary
- **Problem**: When an embedding provider returns 500 or hangs (e.g., BytePlus endpoint down), `ov find` shows misleading `Network error: HTTP request failed` because the Rust CLI times out (60s) before the Python server finishes retrying the embedding call (3+ minutes with SDK retries compounding on top of OV retries). Neither `ov health` nor `ov ready` checks embedding connectivity, so users have no way to detect a broken provider.
- Set explicit **30s timeout** and **disable SDK-level retries** (`max_retries=0`) on the OpenAI embedding client — the server now fails fast enough for the CLI to receive the actual error
- Add **try-except in `HierarchicalRetriever.retrieve()`** around `embed_compat()` with provider/model context in the error message, so users see exactly which backend is broken
- Add **embedding connectivity probe to `/ready` endpoint** (10s timeout) — `ov ready` now catches a broken embedding provider before any search is attempted

## Test plan
- [x] All existing embedding unit tests pass (164 passed, pre-existing failures unchanged)
- [x] No new test regressions introduced
- [ ] Manual test: start server with a broken embedding config → `ov ready` should report `embedding: error: ...`
- [ ] Manual test: `ov find` with broken provider → should return specific error instead of "Network error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)