### PR TITLE
fix(bot\skill): Bot memory build, skill experience only extract existing skill_name, ov chat response field

### DIFF
--- a/bot/vikingbot/agent/memory.py
+++ b/bot/vikingbot/agent/memory.py
@@ -45,11 +45,13 @@ class MemoryStore:
 
         # Filter by min_score and sort by score descending
         def get_score(m):
-            return m.get('score', 0) if isinstance(m, dict) else getattr(m, 'score', 0.0)
+            return m.get("score", 0) if isinstance(m, dict) else getattr(m, "score", 0.0)
+
         def get_uri(m):
-            return m.get('uri', '') if isinstance(m, dict) else getattr(m, 'uri', '')
+            return m.get("uri", "") if isinstance(m, dict) else getattr(m, "uri", "")
+
         def get_abstract(m):
-            return m.get('abstract', '') if isinstance(m, dict) else getattr(m, 'abstract', '')
+            return m.get("abstract", "") if isinstance(m, dict) else getattr(m, "abstract", "")
 
         filtered_memories = [
             memory for memory in result if get_score(memory) >= min_score
@@ -140,7 +142,11 @@ class MemoryStore:
             return None
 
     async def get_viking_memory_context(
-        self, current_message: str, workspace_id: str, sender_id: str, user_ids: list[str] | None = None
+        self,
+        current_message: str,
+        workspace_id: str,
+        sender_id: str,
+        user_ids: list[str] | None = None,
     ) -> str:
         client = None
         try:
@@ -148,14 +154,13 @@ class MemoryStore:
             admin_user_id = config.admin_user_id
             # Use provided user_ids or fall back to sender_id
             search_user_ids = user_ids if user_ids else [sender_id]
-            logger.info(f'workspace_id={workspace_id}')
-            logger.info(f'user_ids={search_user_ids}')
-            logger.info(f'admin_user_id={admin_user_id}')
-            
+            logger.info(f"workspace_id={workspace_id}")
+            logger.info(f"user_ids={search_user_ids}")
+            logger.info(f"admin_user_id={admin_user_id}")
+
             client = await self._create_client(workspace_id)
             if not client:
                 return ""
-                
             result = await client.search_memory(
                 query=current_message, user_ids=search_user_ids, agent_user_id=admin_user_id, limit=30
             )
@@ -166,14 +171,14 @@ class MemoryStore:
             memory_list = []
             memory_list.append(f"user_memory[{len(result['user_memory'])}]:")
 
-            for i, mem in enumerate(result['user_memory']):
-                uri = mem.get('uri', '') if isinstance(mem, dict) else getattr(mem, 'uri', '')
-                score = mem.get('score', 0) if isinstance(mem, dict) else getattr(mem, 'score', 0)
+            for i, mem in enumerate(result["user_memory"]):
+                uri = mem.get("uri", "") if isinstance(mem, dict) else getattr(mem, "uri", "")
+                score = mem.get("score", 0) if isinstance(mem, dict) else getattr(mem, "score", 0)
                 memory_list.append(f"{i},{uri},{score}")
             memory_list.append(f"agent_memory[{len(result['agent_memory'])}]:")
-            for i, mem in enumerate(result['agent_memory']):
-                uri = mem.get('uri', '') if isinstance(mem, dict) else getattr(mem, 'uri', '')
-                score = mem.get('score', 0) if isinstance(mem, dict) else getattr(mem, 'score', 0)
+            for i, mem in enumerate(result["agent_memory"]):
+                uri = mem.get("uri", "") if isinstance(mem, dict) else getattr(mem, "uri", "")
+                score = mem.get("score", 0) if isinstance(mem, dict) else getattr(mem, "score", 0)
                 memory_list.append(f"{i},{uri},{score}")
             raw_memories_log = "\n".join(memory_list)
             logger.info(f"[RAW_MEMORIES]\n{raw_memories_log}")

--- a/bot/vikingbot/agent/memory.py
+++ b/bot/vikingbot/agent/memory.py
@@ -3,7 +3,7 @@
 import asyncio
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from loguru import logger
 
@@ -131,9 +131,18 @@ class MemoryStore:
         long_term = self.read_long_term()
         return f"## Long-term Memory\n{long_term}" if long_term else ""
 
+    async def _create_client(self, workspace_id: str) -> Optional[VikingClient]:
+        """Helper method to create a VikingClient with proper error handling."""
+        try:
+            return await VikingClient.create(agent_id=workspace_id)
+        except Exception as e:
+            logger.error(f"Failed to create VikingClient for workspace {workspace_id}: {e}")
+            return None
+
     async def get_viking_memory_context(
         self, current_message: str, workspace_id: str, sender_id: str, user_ids: list[str] | None = None
     ) -> str:
+        client = None
         try:
             config = load_config().ov_server
             admin_user_id = config.admin_user_id
@@ -142,7 +151,11 @@ class MemoryStore:
             logger.info(f'workspace_id={workspace_id}')
             logger.info(f'user_ids={search_user_ids}')
             logger.info(f'admin_user_id={admin_user_id}')
-            client = await VikingClient.create(agent_id=workspace_id)
+            
+            client = await self._create_client(workspace_id)
+            if not client:
+                return ""
+                
             result = await client.search_memory(
                 query=current_message, user_ids=search_user_ids, agent_user_id=admin_user_id, limit=30
             )
@@ -157,7 +170,7 @@ class MemoryStore:
                 uri = mem.get('uri', '') if isinstance(mem, dict) else getattr(mem, 'uri', '')
                 score = mem.get('score', 0) if isinstance(mem, dict) else getattr(mem, 'score', 0)
                 memory_list.append(f"{i},{uri},{score}")
-            memory_list.append(f'agent_memory[{len(result['agent_memory'])}]:')
+            memory_list.append(f"agent_memory[{len(result['agent_memory'])}]:")
             for i, mem in enumerate(result['agent_memory']):
                 uri = mem.get('uri', '') if isinstance(mem, dict) else getattr(mem, 'uri', '')
                 score = mem.get('score', 0) if isinstance(mem, dict) else getattr(mem, 'score', 0)
@@ -174,13 +187,30 @@ class MemoryStore:
         except Exception as e:
             logger.error(f"[READ_USER_MEMORY]: search error. {e}")
             return ""
+        finally:
+            if client:
+                try:
+                    await client.close()
+                except Exception as e:
+                    logger.warning(f"Error closing VikingClient: {e}")
 
     async def get_viking_user_profile(self, workspace_id: str, user_id: str) -> str:
-        client = await VikingClient.create(agent_id=workspace_id)
-        result = await client.read_user_profile(user_id)
-        if not result:
+        client = None
+        try:
+            client = await self._create_client(workspace_id)
+            if not client:
+                return ""
+            result = await client.read_user_profile(user_id)
+            return result or ""
+        except Exception as e:
+            logger.warning(f"[READ_USER_PROFILE]: user_id={user_id}, error. {e}")
             return ""
-        return result
+        finally:
+            if client:
+                try:
+                    await client.close()
+                except Exception as e:
+                    logger.warning(f"Error closing VikingClient: {e}")
 
     async def get_viking_user_profiles(self, workspace_id: str, user_ids: list[str]) -> str:
         """Get multiple user profiles concurrently.
@@ -195,34 +225,47 @@ class MemoryStore:
         if not user_ids:
             return ""
 
-        client = await VikingClient.create(agent_id=workspace_id)
+        client = None
+        try:
+            client = await self._create_client(workspace_id)
+            if not client:
+                return ""
 
-        async def fetch_profile(user_id: str) -> tuple[str, str]:
-            """Fetch a single user profile."""
-            try:
-                start_time = time.time()
-                profile = await client.read_user_profile(user_id)
-                cost = round(time.time() - start_time, 2)
-                logger.info(
-                    f"[READ_USER_PROFILE]: user_id={user_id}, cost {cost}s, "
-                    f"profile={profile[:50] if profile else 'None'}"
-                )
-                return (user_id, profile or "")
-            except Exception as e:
-                logger.error(f"[READ_USER_PROFILE]: user_id={user_id}, error. {e}")
-                return (user_id, "")
+            async def fetch_profile(user_id: str) -> tuple[str, str]:
+                """Fetch a single user profile."""
+                try:
+                    start_time = time.time()
+                    profile = await client.read_user_profile(user_id)
+                    cost = round(time.time() - start_time, 2)
+                    logger.info(
+                        f"[READ_USER_PROFILE]: user_id={user_id}, cost {cost}s, "
+                        f"profile={profile[:50] if profile else 'None'}"
+                    )
+                    return (user_id, profile or "")
+                except Exception as e:
+                    logger.error(f"[READ_USER_PROFILE]: user_id={user_id}, error. {e}")
+                    return (user_id, "")
 
-        # Fetch all profiles concurrently
-        tasks = [fetch_profile(user_id) for user_id in user_ids]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+            # Fetch all profiles concurrently
+            tasks = [fetch_profile(user_id) for user_id in user_ids]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Build the result string
-        parts = []
-        for result in results:
-            if isinstance(result, Exception):
-                continue
-            user_id, profile = result
-            if profile:
-                parts.append(f"## User profile for {user_id}: \n{profile}")
+            # Build the result string
+            parts = []
+            for result in results:
+                if isinstance(result, Exception):
+                    continue
+                user_id, profile = result
+                if profile:
+                    parts.append(f"## User profile for {user_id}: \n{profile}")
 
-        return "\n\n".join(parts) if parts else ""
+            return "\n\n".join(parts) if parts else ""
+        except Exception as e:
+            logger.error(f"[READ_USER_PROFILES]: error. {e}")
+            return ""
+        finally:
+            if client:
+                try:
+                    await client.close()
+                except Exception as e:
+                    logger.warning(f"Error closing VikingClient: {e}")

--- a/crates/ov_cli/src/commands/chat.rs
+++ b/crates/ov_cli/src/commands/chat.rs
@@ -47,7 +47,7 @@ pub struct ChatCommand {
     pub session: Option<String>,
 
     /// Sender ID
-    #[arg(short, long, default_value = "user")]
+    #[arg(long, default_value = "user")]
     pub sender: String,
 
     /// Non-interactive mode (single message)

--- a/crates/ov_cli/src/commands/chat.rs
+++ b/crates/ov_cli/src/commands/chat.rs
@@ -93,6 +93,8 @@ struct ChatResponse {
     session_id: String,
     message: String,
     #[serde(default)]
+    response_id: Option<String>,
+    #[serde(default)]
     events: Option<Vec<serde_json::Value>>,
 }
 
@@ -241,6 +243,7 @@ impl ChatCommand {
         let mut response = response;
         let mut buffer = String::new();
         let mut final_message = String::new();
+        let mut response_id: Option<String> = None;
 
         while let Some(chunk) = response
             .chunk()
@@ -267,10 +270,13 @@ impl ChatCommand {
                             if let Some(msg) = event.data.as_str() {
                                 final_message = msg.to_string();
                             } else if let Some(obj) = event.data.as_object() {
-                                if let Some(msg) = obj.get("message").and_then(|m| m.as_str()) {
+                                if let Some(msg) = obj.get("content").and_then(|m| m.as_str()) {
                                     final_message = msg.to_string();
-                                } else if let Some(err) = obj.get("error").and_then(|e| e.as_str())
-                                {
+                                }
+                                if let Some(rid) = obj.get("response_id").and_then(|r| r.as_str()) {
+                                    response_id = Some(rid.to_string());
+                                }
+                                if let Some(err) = obj.get("error").and_then(|e| e.as_str()) {
                                     eprintln!("\x1b[1;31mError: {}\x1b[0m", err);
                                 }
                             }
@@ -278,6 +284,10 @@ impl ChatCommand {
                     }
                 }
             }
+        }
+
+        if let Some(response_id) = response_id {
+            eprintln!("\x1b[2mResponse ID: {}\x1b[0m", response_id);
         }
 
         // Print final response with markdown if we have it
@@ -452,10 +462,11 @@ impl ChatCommand {
         auth: &ChatAuth,
     ) -> Result<()> {
         let url = format!("{}/chat/stream", self.endpoint);
+        let request_session_id = session_id.clone().or_else(|| self.session.clone());
 
         let request = ChatRequest {
             message: input.to_string(),
-            session_id: session_id.clone(),
+            session_id: request_session_id.clone(),
             user_id: Some(self.sender.clone()),
             stream: true,
             context: None,
@@ -474,11 +485,14 @@ impl ChatCommand {
             return Err(Error::Api(format!("Request failed ({}): {}", status, text)));
         }
 
-        // Process the SSE stream
         let mut response = response;
         let mut buffer = String::new();
         let mut final_message = String::new();
-        let mut got_session_id = false;
+        let mut response_id: Option<String> = None;
+
+        if session_id.is_none() {
+            *session_id = request_session_id;
+        }
 
         while let Some(chunk) = response
             .chunk()
@@ -500,25 +514,18 @@ impl ChatCommand {
                 // Parse SSE line: "data: {json}"
                 if let Some(data_str) = line.strip_prefix("data: ") {
                     if let Ok(event) = serde_json::from_str::<ChatStreamEvent>(data_str) {
-                        // Extract session_id from first response event if needed
-                        if !got_session_id && session_id.is_none() {
-                            if let Some(obj) = event.data.as_object() {
-                                if let Some(sid) = obj.get("session_id").and_then(|s| s.as_str()) {
-                                    *session_id = Some(sid.to_string());
-                                    got_session_id = true;
-                                }
-                            }
-                        }
-
                         self.print_stream_event(&event);
                         if event.event == "response" {
                             if let Some(msg) = event.data.as_str() {
                                 final_message = msg.to_string();
                             } else if let Some(obj) = event.data.as_object() {
-                                if let Some(msg) = obj.get("message").and_then(|m| m.as_str()) {
+                                if let Some(msg) = obj.get("content").and_then(|m| m.as_str()) {
                                     final_message = msg.to_string();
-                                } else if let Some(err) = obj.get("error").and_then(|e| e.as_str())
-                                {
+                                }
+                                if let Some(rid) = obj.get("response_id").and_then(|r| r.as_str()) {
+                                    response_id = Some(rid.to_string());
+                                }
+                                if let Some(err) = obj.get("error").and_then(|e| e.as_str()) {
                                     eprintln!("\x1b[1;31mError: {}\x1b[0m", err);
                                 }
                             }
@@ -526,6 +533,10 @@ impl ChatCommand {
                     }
                 }
             }
+        }
+
+        if let Some(response_id) = response_id {
+            eprintln!("\x1b[2mResponse ID: {}\x1b[0m", response_id);
         }
 
         // Print final response with markdown

--- a/openviking/prompts/templates/memory/skills.yaml
+++ b/openviking/prompts/templates/memory/skills.yaml
@@ -20,7 +20,8 @@ fields:
   - name: skill_name
     type: string
     description: |
-      Skill name, copied exactly from [ToolCall] if skill_name is present, otherwise inferred from conversation context.
+      Skill name, must be copied exactly from [ToolCall].
+      If no [ToolCall] contains a valid skill_name, do not generate a skills memory item.
       Used to uniquely identify this skill memory.
       Examples: "create_presentation", "analyze_code", "write_document"
     merge_op: immutable

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -11,6 +11,7 @@ import os
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from openviking.core.namespace import to_user_space, to_agent_space
+from openviking.message.part import ToolPart
 from openviking.server.identity import RequestContext, ToolContext
 from openviking.session.memory.dataclass import MemoryFileContent
 from openviking.session.memory.utils.uri import render_template
@@ -165,10 +166,25 @@ After exploring, analyze the conversation and output ALL memory write/edit/delet
         conversation_sections: List[str] = []
 
         def format_message_with_parts(msg: Message) -> str:
-            """Format message with text parts only, skipping tool call details."""
+            """Format message with text parts and ToolCall details."""
             parts = getattr(msg, "parts", [])
-            text_lines = [part.text for part in parts if hasattr(part, "text") and part.text]
-            return "\n".join(text_lines) if text_lines else msg.content
+            formatted_parts: List[str] = []
+            for part in parts:
+                if hasattr(part, "text") and part.text:
+                    formatted_parts.append(part.text)
+                elif isinstance(part, ToolPart):
+                    tool_info = {
+                        "type": "tool_call",
+                        "tool_name": part.tool_name,
+                        "tool_input": part.tool_input,
+                        "tool_output": part.tool_output[:500] if part.tool_output else "",
+                        "tool_status": part.tool_status,
+                        "duration_ms": part.duration_ms,
+                    }
+                    if part.skill_uri:
+                        tool_info["skill_name"] = part.skill_uri.rstrip("/").split("/")[-1]
+                    formatted_parts.append(f"[ToolCall] {json.dumps(tool_info, ensure_ascii=False)}")
+            return "\n".join(formatted_parts) if formatted_parts else msg.content
 
         def format_message_header(msg: Message, idx: int) -> str:
             """Format message header with role and role_id."""

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -83,10 +83,16 @@ class SessionExtractContextProvider(ExtractContextProvider):
 
     def _detect_language(self) -> str:
         """检测输出语言"""
-        from openviking.session.memory.utils import resolve_output_language_from_conversation
+        from openviking.message.part import TextPart
+        from openviking.session.memory.utils import resolve_output_language
 
-        conversation = self._assemble_conversation(self.messages)
-        return resolve_output_language_from_conversation(conversation)
+        text_parts = []
+        for message in self.messages or []:
+            for part in getattr(message, "parts", []):
+                if isinstance(part, TextPart) and part.text:
+                    text_parts.append(part.text)
+
+        return resolve_output_language("\n".join(text_parts))
 
     def instruction(self) -> str:
         output_language = self._output_language

--- a/tests/session/memory/test_memory_react_system_prompt.py
+++ b/tests/session/memory/test_memory_react_system_prompt.py
@@ -4,6 +4,7 @@
 Test that provider instruction correctly instructs LLM.
 """
 
+from openviking.message import Message, TextPart, ToolPart
 from openviking.session.memory.session_extract_context_provider import SessionExtractContextProvider
 
 
@@ -38,3 +39,59 @@ class TestProviderInstruction:
         # Check that output language instruction is present
         assert "Target Output Language" in instruction
         assert "All memory content MUST be written in" in instruction
+
+
+class TestSkillToolCallExposure:
+    def test_assemble_conversation_includes_skill_tool_call(self):
+        messages = [
+            Message(
+                id="m1",
+                role="assistant",
+                parts=[
+                    TextPart("Running a skill."),
+                    ToolPart(
+                        tool_id="tool_1",
+                        tool_name="read",
+                        tool_uri="viking://session/test/tools/tool_1",
+                        skill_uri="viking://agent/skills/create_presentation",
+                        tool_input={"file_path": "/skills/ppt/SKILL.md"},
+                        tool_output="ok",
+                        tool_status="completed",
+                        duration_ms=123,
+                    ),
+                ],
+            )
+        ]
+        provider = SessionExtractContextProvider(messages=messages)
+
+        conversation = provider._assemble_conversation(messages)
+
+        assert "[ToolCall]" in conversation
+        assert '"skill_name": "create_presentation"' in conversation
+
+    def test_assemble_conversation_without_skill_tool_call_has_no_skill_name(self):
+        messages = [
+            Message(
+                id="m1",
+                role="assistant",
+                parts=[
+                    TextPart("Running a tool."),
+                    ToolPart(
+                        tool_id="tool_1",
+                        tool_name="read",
+                        tool_uri="viking://session/test/tools/tool_1",
+                        tool_input={"file_path": "README.md"},
+                        tool_output="ok",
+                        tool_status="completed",
+                        duration_ms=123,
+                    ),
+                ],
+            )
+        ]
+        provider = SessionExtractContextProvider(messages=messages)
+
+        conversation = provider._assemble_conversation(messages)
+
+        assert "[ToolCall]" in conversation
+        assert '"tool_name": "read"' in conversation
+        assert '"skill_name":' not in conversation

--- a/tests/session/memory/test_memory_react_system_prompt.py
+++ b/tests/session/memory/test_memory_react_system_prompt.py
@@ -95,3 +95,30 @@ class TestSkillToolCallExposure:
         assert "[ToolCall]" in conversation
         assert '"tool_name": "read"' in conversation
         assert '"skill_name":' not in conversation
+
+    def test_detect_language_only_uses_text_parts(self):
+        messages = [
+            Message(
+                id="m1",
+                role="assistant",
+                parts=[TextPart("Please keep the memory in English.")],
+            ),
+            Message(
+                id="m2",
+                role="assistant",
+                parts=[
+                    ToolPart(
+                        tool_id="tool_1",
+                        tool_name="read",
+                        tool_uri="viking://session/test/tools/tool_1",
+                        tool_input={"file_path": "README.md"},
+                        tool_output="这是中文工具输出",
+                        tool_status="completed",
+                    )
+                ],
+            ),
+        ]
+
+        provider = SessionExtractContextProvider(messages=messages)
+
+        assert provider._detect_language() == "en"


### PR DESCRIPTION
## Description

1. 修改skill experience的提取，只提取ToolCall中存在的skill，不再从对话中总结；
2. 修复ov chat中流式对话，字段解析异常；--sender和-session 简写重复；
3. 修复bot memory引号问题；

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
