### PR TITLE
docs(observability): note ov tui image preview capability

### DIFF
--- a/docs/en/guides/05-observability.md
+++ b/docs/en/guides/05-observability.md
@@ -15,7 +15,7 @@ If you just want to know where to look first, start with the table below.
 | Entry point | Best for | Typical use case |
 | --- | --- | --- |
 | `/health`, `observer/*` | service health, queue backlog, VikingDB and VLM status | deployment validation, on-call checks |
-| `ov tui` | `viking://` trees, directory summaries, file content, vector records | development debugging, verifying that data actually landed |
+| `ov tui` | `viking://` trees, directory summaries, file content, vector records, image preview for supported image files | development debugging, verifying that data actually landed |
 | `OpenViking Console` | web UI for browsing, search, resource import, tenants, and system state | interactive investigation without typing every command |
 | `telemetry` | per-request duration, token usage, vector retrieval, ingestion stages | debugging one specific slow or unexpected call |
 | `/metrics` | request trends, error rates, latency distribution, queue and probe state | Prometheus scraping, Grafana dashboards, alert rules |
@@ -152,7 +152,7 @@ Common keys:
 A typical debugging flow is:
 
 1. Run `ov tui viking://resources` and locate the target document or directory.
-2. Confirm the right-side panel shows `abstract`, `overview`, or file content.
+2. Confirm the right-side panel shows `abstract`, `overview`, or file content (supported image files — `png`, `jpg`, `jpeg`, `gif`, `bmp`, `webp`, `tiff`, `tif` — are rendered inline as a preview).
 3. Press `v` to inspect vector records for that URI.
 4. Press `c` to get the total count, and `n` to keep paging if needed.
 

--- a/docs/zh/guides/05-observability.md
+++ b/docs/zh/guides/05-observability.md
@@ -15,7 +15,7 @@
 | 入口 | 适合看什么 | 典型场景 |
 | --- | --- | --- |
 | `/health`、`observer/*` | 服务是否健康、队列是否堆积、VikingDB/VLM 状态 | 部署验收、值班巡检 |
-| `ov tui` | `viking://` 文件树、目录摘要、文件正文、向量记录 | 开发调试、核对资源是否真正落库 |
+| `ov tui` | `viking://` 文件树、目录摘要、文件正文、向量记录、受支持图片文件的预览 | 开发调试、核对资源是否真正落库 |
 | `OpenViking Console` | Web UI 里的文件浏览、检索、资源导入、租户与系统状态 | 不想手敲命令时做交互式排查 |
 | `telemetry` | 单次请求耗时、token、向量检索、资源处理阶段 | 排查一次具体调用为什么慢、为什么结果异常 |
 | `/metrics` | 请求量趋势、错误率、时延分布、队列与探针状态 | Prometheus 抓取、Grafana 看板、告警规则 |
@@ -152,7 +152,7 @@ ov tui viking://resources
 一个常见排查流程是：
 
 1. 用 `ov tui viking://resources` 找到目标文档或目录。
-2. 确认右侧能看到 `abstract` / `overview` / 正文内容。
+2. 确认右侧能看到 `abstract` / `overview` / 正文内容（受支持的图片文件 —— `png` / `jpg` / `jpeg` / `gif` / `bmp` / `webp` / `tiff` / `tif` —— 会直接渲染预览）。
 3. 按 `v` 进入向量记录视图，确认该 URI 下是否已经有向量数据。
 4. 按 `c` 查看总量，必要时按 `n` 翻页继续核对。
 


### PR DESCRIPTION
## Why

#1916 (feat: ov CLI support, merged 2026-05-08) added `crates/ov_cli/src/tui/image_preview.rs` so that `ov tui` now renders supported image files inline (`png` / `jpg` / `jpeg` / `gif` / `bmp` / `webp` / `tiff` / `tif`, per `is_image_file()`).

`docs/{en,zh}/guides/05-observability.md` is the canonical entry point doc for `ov tui`, but the capabilities table and the data-plane debugging flow only mentioned trees, directory summaries, file content, and vector records — image preview was undocumented (likewise absent from `docs/{en,zh}/about/02-changelog.md` post-#1916).

This is a docs-only mirror update so the observability guide reflects the new behavior of `ov tui`.

## What

* Capabilities table row for `ov tui`: add "image preview for supported image files" (EN) / "受支持图片文件的预览" (ZH).
* Debugging-flow step 2: note that supported image files (with the exact `png/jpg/jpeg/gif/bmp/webp/tiff/tif` whitelist) are rendered inline as a preview, alongside `abstract` / `overview` / file content.

Pure docs, dual-language mirror, +2 / -2 lines per file.

## Refs

* Source PR: #1916
* New file: `crates/ov_cli/src/tui/image_preview.rs` (added in #1916)