### PR TITLE
fix(cli): validate doctor config schema

### DIFF
--- a/openviking_cli/doctor.py
+++ b/openviking_cli/doctor.py
@@ -18,8 +18,9 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from openviking_cli.utils.config.config_loader import resolve_config_path
+from openviking_cli.utils.config.config_loader import load_json_config, resolve_config_path
 from openviking_cli.utils.config.consts import OPENVIKING_CONFIG_ENV
+from openviking_cli.utils.config.open_viking_config import OpenVikingConfig
 from openviking_cli.utils.config.vlm_config import VLMConfig
 
 # ANSI helpers (disabled when stdout is not a terminal)
@@ -62,7 +63,7 @@ def _load_config_json(config_path: Path) -> Optional[dict]:
 
 
 def check_config() -> tuple[bool, str, Optional[str]]:
-    """Validate ov.conf exists and is valid JSON with required sections."""
+    """Validate ov.conf exists, is valid JSON, and matches OpenVikingConfig."""
     config_path = _find_config()
     if config_path is None:
         return (
@@ -72,19 +73,14 @@ def check_config() -> tuple[bool, str, Optional[str]]:
         )
 
     try:
-        raw = config_path.read_text(encoding="utf-8")
-        raw = os.path.expandvars(raw)
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
+        data = load_json_config(config_path)
+    except ValueError as exc:
         return False, f"Invalid JSON in {config_path}", f"Fix syntax error: {exc}"
 
-    missing = [key for key in () if key not in data]
-    if missing:
-        return (
-            False,
-            f"{config_path} missing required sections: {', '.join(missing)}",
-            "Add the missing sections (see examples/ov.conf.example)",
-        )
+    try:
+        OpenVikingConfig.from_dict(data)
+    except ValueError as exc:
+        return False, f"Invalid configuration in {config_path}", f"Fix ov.conf: {exc}"
 
     return True, str(config_path), None
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -47,6 +47,24 @@ class TestCheckConfig:
         assert not ok
         assert "Invalid JSON" in detail
 
+    def test_fail_unknown_top_level_config_field(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text(json.dumps({"unknown_section": {}}))
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            ok, detail, fix = check_config()
+        assert not ok
+        assert "Invalid configuration" in detail
+        assert "unknown_section" in fix
+
+    def test_fail_unknown_nested_config_field(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text(json.dumps({"embedding": {"dense": {"enabld": True}}}))
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            ok, detail, fix = check_config()
+        assert not ok
+        assert "Invalid configuration" in detail
+        assert "embedding.dense.enabld" in fix
+
     def test_pass_without_embedding_section(self, tmp_path: Path):
         config = tmp_path / "ov.conf"
         config.write_text(json.dumps({"server": {}}))


### PR DESCRIPTION
## Summary
- validate `ov.conf` in `openviking-server doctor` through the canonical `OpenVikingConfig.from_dict` path instead of only checking JSON syntax
- preserve the existing missing-file and invalid-JSON diagnostics
- add focused doctor tests for unknown top-level and nested config fields

## Validation
- `uvx ruff check openviking_cli/doctor.py tests/cli/test_doctor.py`
- `uvx ruff format --check openviking_cli/doctor.py tests/cli/test_doctor.py`
- `python3 -m py_compile openviking_cli/doctor.py tests/cli/test_doctor.py`
- ad-hoc `check_config()` smoke for a valid OpenAI embedding config and an invalid `embedding.dense.enabld` typo
- `git diff --check`
