### PR TITLE
fix(cli): tolerate BOM in ov config

### DIFF
--- a/openviking_cli/doctor.py
+++ b/openviking_cli/doctor.py
@@ -54,7 +54,7 @@ def _find_config() -> Optional[Path]:
 def _load_config_json(config_path: Path) -> Optional[dict]:
     """Parse ov.conf as JSON. Returns None if the file is unreadable or not valid JSON."""
     try:
-        raw = config_path.read_text(encoding="utf-8")
+        raw = config_path.read_text(encoding="utf-8-sig")
         raw = os.path.expandvars(raw)
         return json.loads(raw)
     except (OSError, json.JSONDecodeError):
@@ -72,7 +72,7 @@ def check_config() -> tuple[bool, str, Optional[str]]:
         )
 
     try:
-        raw = config_path.read_text(encoding="utf-8")
+        raw = config_path.read_text(encoding="utf-8-sig")
         raw = os.path.expandvars(raw)
         data = json.loads(raw)
     except json.JSONDecodeError as exc:

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -388,7 +388,7 @@ class OpenVikingConfigSingleton:
             if not config_path.exists():
                 raise FileNotFoundError(f"Config file does not exist: {config_file}")
 
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, "r", encoding="utf-8-sig") as f:
                 raw = f.read()
 
             # Expand $VAR and ${VAR} inside the JSON text (useful for container deployments).

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -32,6 +32,14 @@ class TestCheckConfig:
         assert ok
         assert str(config) in detail
 
+    def test_pass_with_utf8_bom_config(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text("\ufeff" + json.dumps({"embedding": {"dense": {}}}))
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            ok, detail, fix = check_config()
+        assert ok
+        assert str(config) in detail
+
     def test_fail_missing_config(self):
         with patch("openviking_cli.doctor._find_config", return_value=None):
             ok, detail, fix = check_config()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -233,6 +233,34 @@ def test_openviking_config_singleton_preserves_value_error_for_bad_config(tmp_pa
     OpenVikingConfigSingleton.reset_instance()
 
 
+def test_openviking_config_singleton_loads_utf8_bom_config(tmp_path, monkeypatch):
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, "/tmp/codex-no-config.json")
+
+    from openviking_cli.utils.config import open_viking_config as config_module
+
+    class _ConfigStub:
+        default_account = "default"
+
+    loaded = {}
+
+    def _from_dict(data):
+        loaded.update(data)
+        return _ConfigStub()
+
+    monkeypatch.setattr(config_module.OpenVikingConfig, "from_dict", _from_dict)
+
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text("\ufeff{}", encoding="utf-8")
+
+    config_module.OpenVikingConfigSingleton.reset_instance()
+    config = config_module.OpenVikingConfigSingleton.initialize(config_path=str(config_path))
+
+    assert config.default_account == "default"
+    assert loaded == {}
+
+    config_module.OpenVikingConfigSingleton.reset_instance()
+
+
 def test_require_config_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
     import openviking_cli.utils.config.config_loader as loader
 


### PR DESCRIPTION
## Summary
- read `ov.conf` with `utf-8-sig` in `openviking-server doctor`
- read `ov.conf` with `utf-8-sig` in `OpenVikingConfigSingleton._load_from_file`
- add focused coverage for BOM-prefixed config files

## Validation
- `uvx ruff check openviking_cli/doctor.py openviking_cli/utils/config/open_viking_config.py tests/cli/test_doctor.py tests/test_config_loader.py`
- `uvx ruff format --check openviking_cli/doctor.py openviking_cli/utils/config/open_viking_config.py tests/cli/test_doctor.py tests/test_config_loader.py`
- `python3 -m py_compile openviking_cli/doctor.py openviking_cli/utils/config/open_viking_config.py tests/cli/test_doctor.py tests/test_config_loader.py`
- ad-hoc BOM smoke for `check_config()` and `OpenVikingConfigSingleton.initialize(config_path=...)`
- `git diff --check`

Note: direct `pytest` collection in this local checkout is blocked by a missing optional test dependency (`pathspec`) imported from `tests/conftest.py`, so I used the focused import/behavior smoke above for the new paths.
