### PR TITLE
docs(openclaw): surface openclaw openviking status / --json in Verify section (#1904)

### DIFF
--- a/docs/en/agent-integrations/03-openclaw.md
+++ b/docs/en/agent-integrations/03-openclaw.md
@@ -108,7 +108,15 @@ openclaw config set plugins.entries.openviking.config.agent_prefix your-prefix
 
 ## Verify
 
-Check that the plugin owns the `contextEngine` slot:
+For a one-shot health check covering plugin registration, server connectivity, and version compatibility, run:
+
+```bash
+openclaw openviking status
+```
+
+For automation, append `--json` to `openclaw openviking status` to get a machine-readable result. `openclaw openviking setup` also supports `--json` when used with `--base-url`.
+
+Or check the underlying signals manually. The plugin owns the `contextEngine` slot:
 
 ```bash
 openclaw config get plugins.slots.contextEngine

--- a/docs/zh/agent-integrations/03-openclaw.md
+++ b/docs/zh/agent-integrations/03-openclaw.md
@@ -108,7 +108,15 @@ openclaw config set plugins.entries.openviking.config.agent_prefix your-prefix
 
 ## 验证
 
-确认插件占用了 `contextEngine` 槽位：
+要一键检查插件注册、服务端连通性和版本兼容性，运行：
+
+```bash
+openclaw openviking status
+```
+
+自动化场景下，可为 `openclaw openviking status` 追加 `--json` 获取机器可读结果。`openclaw openviking setup` 也支持 `--json`，但自动化使用时需同时提供 `--base-url`。
+
+或手动核对各个信号。确认插件占用了 `contextEngine` 槽位：
 
 ```bash
 openclaw config get plugins.slots.contextEngine


### PR DESCRIPTION
## Summary

Surface `openclaw openviking status` (and its `--json` automation flag) in the OpenClaw plugin integration's `Verify` section in both `docs/en/agent-integrations/03-openclaw.md` and the `docs/zh/...` mirror.

#1904 (LinQiang391, merged 2026-05-08 by qin-ctx) made `openclaw openviking setup` / `openclaw openviking status` the canonical CLI surface for the plugin and reworked `INSTALL.md` / `INSTALL-AGENT.md` / `INSTALL-ZH.md` accordingly. The integration doc was not touched in that PR — its `Verify` section still only lists indirect manual checks (slot lookup, log follow, log cat, `ov-install --current-version`), none of which probe server compatibility or summarise plugin health in one command.

## What's added

A small additive intro to `Verify` (~6 lines per language, before the existing manual checks):

1. `openclaw openviking status` as the one-shot health check covering plugin registration, server connectivity, and version compatibility.
2. `--json` automation note, with the explicit caveat that `setup --json` requires `--base-url` (the existing CLI rejects bare `setup --json` with `"--json requires --base-url for non-interactive mode"`, so the docs need to call this out — see `examples/openclaw-plugin/commands/setup.ts` L498).
3. Existing manual signals (`openclaw config get plugins.slots.contextEngine`, `openclaw logs --follow`, `cat openviking.log`, `ov-install --current-version`) are kept intact — they still help when debugging individual layers.

## Source-of-truth references

- `examples/openclaw-plugin/commands/setup.ts` L590-612 — `.command("status").description("Show current OpenViking plugin status and connectivity")` with `.option("--zh", ...)`, `.option("--json", ...)`. Calls `getStatus(configPath)`, then either JSON.stringify or `printStatus`.
- `examples/openclaw-plugin/commands/setup.ts` L444-461 — `setup` registers `--reconfigure`, `--zh`, `--base-url`, `--api-key`, `--agent-prefix`, `--account-id`, `--user-id`, `--allow-offline`, `--force-slot`, `--json`.
- `examples/openclaw-plugin/commands/setup.ts` L498 — `"--json requires --base-url for non-interactive mode"` error.
- `getStatus` / `checkServiceHealth` / `formatCompatRange` together cover registration + connectivity + version-compat — supports the "one-shot health check covering …" wording.

## What's not changed

- The "See also" section already links to `INSTALL-AGENT.md` ("Agent operator guide — for agents driving installation on behalf of a user") which is the authoritative agent-flow reference; this PR doesn't duplicate that content, only adds discoverability for the most direct verify path.
- `## Install via ClawHub (recommended)` keeps the interactive `openclaw openviking setup` example unchanged — the bulk of the doc is human-facing, and the new note is scoped to `Verify`.

## Test plan

- [x] Verified `status` command behaviour against `commands/setup.ts` (line numbers above).
- [x] Verified `--json requires --base-url` constraint exists (setup.ts L498).
- [x] No competing PRs touching `docs/en/agent-integrations/03-openclaw.md` or `docs/zh/...` (`gh pr list --state open --search openclaw` returned 10 unrelated plugin-internal PRs).
- [x] Codex `gpt-5.5 xhigh` two-round adversarial review (round 1 needs-attention 0.86 on missing `--base-url` caveat for `setup --json` → reworked → round 2 approve).

## Codex adversarial review

- **Round 1**: needs-attention, conf 0.86 — original parenthetical "(also supported on `openclaw openviking setup`)" implied agents could append `--json` to bare `setup` for automation; in fact `setup --json` requires `--base-url`. Could read as a docs-bug nit.
- **Round 2 (after rework)**: approve — wording now explicitly splits "`status --json` for automation" vs "`setup` also supports `--json` when used with `--base-url`".

If something feels off about the framing or the doc placement, please feel free to close and mark accordingly.
