### PR TITLE
fix: Enhance rerank client robustness for unexpected response payloads

### DIFF
--- a/openviking/models/rerank/volcengine_rerank.py
+++ b/openviking/models/rerank/volcengine_rerank.py
@@ -125,10 +125,41 @@ class RerankClient(RerankBase):
                 timeout=30,
             )
 
-            result = response.json()
-            # print(f"[RerankClient] Raw response: {result}")
-            if "result" not in result or "data" not in result["result"]:
-                logger.warning(f"[RerankClient] Unexpected response format: {result}")
+            try:
+                result = response.json()
+            except Exception:
+                logger.warning(
+                    "[RerankClient] Non-JSON response: status=%s body=%s",
+                    response.status_code,
+                    response.text[:1000],
+                )
+                return None
+
+            if not isinstance(result, dict):
+                logger.warning(
+                    "[RerankClient] Unexpected response type: status=%s type=%s body=%s",
+                    response.status_code,
+                    type(result).__name__,
+                    str(result)[:1000],
+                )
+                return None
+
+            result_payload = result.get("result")
+            if not isinstance(result_payload, dict):
+                logger.warning(
+                    "[RerankClient] Unexpected response payload: status=%s result_type=%s body=%s",
+                    response.status_code,
+                    type(result_payload).__name__,
+                    str(result)[:1000],
+                )
+                return None
+
+            if "data" not in result_payload:
+                logger.warning(
+                    "[RerankClient] Missing rerank data field: status=%s body=%s",
+                    response.status_code,
+                    str(result)[:1000],
+                )
                 return None
 
             # Update token usage tracking (estimate, VikingDB doesn't provide token info)
@@ -140,7 +171,7 @@ class RerankClient(RerankBase):
             )
 
             # Each document is a separate group, data array returns scores for each group sequentially
-            data = result["result"]["data"]
+            data = result_payload["data"]
             if len(data) != len(documents):
                 logger.warning(
                     "[RerankClient] Unexpected rerank result length: expected=%s actual=%s",


### PR DESCRIPTION
## Description

This PR improves the robustness of `RerankClient` response handling by adding defensive validation for unexpected rerank API responses.

Previously, the client assumed that the rerank service always returned a valid JSON object with the expected nested `result.data` structure. When the upstream service returned non-JSON content, an unexpected response type, or a malformed payload, the client could fail with unclear errors.


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add safe JSON parsing with warning logs for non-JSON responses.
- Validate that the parsed response is a dictionary before accessing nested fields.
- Validate that `result` exists and is a dictionary.
- Validate that `result.data` exists before continuing rerank result processing.
- Return `None` for invalid or malformed responses instead of raising unexpected runtime errors.
- Add diagnostic logs including response status code and truncated response body to help troubleshoot upstream issues.


## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
