### PR TITLE
fix(mcp): support recursive directory deletion in forget tool

### DIFF
--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -114,7 +114,7 @@ Once connected, OpenViking exposes 9 tools:
 | `add_resource` | Add a local file or URL as a resource | `path`, `description` (optional) |
 | `grep` | Regex content search across `viking://` files | `uri`, `pattern` (string or array), `case_insensitive` |
 | `glob` | Find files matching a glob pattern | `pattern`, `uri` (optional scope) |
-| `forget` | Delete any `viking://` URI (use `search` to find it first) | `uri` |
+| `forget` | Delete any `viking://` URI (use `search` to find it first; pass `recursive=true` to delete a directory) | `uri`, `recursive` (optional) |
 | `health` | Check OpenViking service health | none |
 
 ## Troubleshooting

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -106,7 +106,7 @@ claude mcp add --transport http openviking \
 | `add_resource` | 添加本地文件或 URL 作为资源 | `path`, `description`(可选) |
 | `grep` | 在 `viking://` 文件中进行正则内容搜索 | `uri`, `pattern`（字符串或数组）, `case_insensitive` |
 | `glob` | 按 glob 模式匹配文件 | `pattern`, `uri`(可选范围) |
-| `forget` | 删除任意 `viking://` URI（先用 `search` 查找） | `uri` |
+| `forget` | 删除任意 `viking://` URI（先用 `search` 查找；删除目录需 `recursive=true`） | `uri`, `recursive`(可选) |
 | `health` | 检查 OpenViking 服务健康状态 | 无 |
 
 ## 故障排除

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -456,11 +456,11 @@ async def glob(pattern: str, uri: str = "viking://", node_limit: int = 100) -> s
 
 
 @mcp.tool()
-async def forget(uri: str) -> str:
-    """Permanently delete a viking:// URI from OpenViking. This is irreversible. Only use when the user explicitly asks to forget or delete something. Always confirm with the user before calling this tool. Use the search tool first to find the exact URI, then pass it here."""
+async def forget(uri: str, recursive: bool = False) -> str:
+    """Permanently delete a viking:// URI from OpenViking. This is irreversible. Only use when the user explicitly asks to forget or delete something. Always confirm with the user before calling this tool. Use the search tool first to find the exact URI, then pass it here. Set recursive=true only when the user explicitly asks to delete a directory tree."""
     service = get_service()
     ctx = _get_ctx()
-    await service.fs.rm(uri, ctx=ctx)
+    await service.fs.rm(uri, ctx=ctx, recursive=recursive)
     return f"Deleted: {uri}"
 
 

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -29,7 +29,7 @@ from openviking.server.mcp_endpoint import (
     search,
 )
 from openviking.server.mcp_endpoint import ls as list_tool
-from openviking_cli.exceptions import UnauthenticatedError
+from openviking_cli.exceptions import FailedPreconditionError, UnauthenticatedError
 from openviking_cli.session.user_id import UserIdentifier
 
 DEFAULT_CTX = RequestContext(
@@ -347,6 +347,28 @@ async def test_forget_by_uri_deletes_resource(service):
     await service.viking_fs.write(uri, "resource data", ctx=ctx)
 
     result = await forget(uri=uri)
+    assert "deleted" in result.lower()
+
+
+async def test_forget_directory_without_recursive_fails(service):
+    ctx = DEFAULT_CTX
+    dir_uri = "viking://resources/test_forget_dir"
+    child_uri = f"{dir_uri}/child.md"
+    await service.viking_fs.mkdir(dir_uri, ctx=ctx, exist_ok=True)
+    await service.viking_fs.write(child_uri, "child data", ctx=ctx)
+
+    with pytest.raises(FailedPreconditionError):
+        await forget(uri=dir_uri)
+
+
+async def test_forget_directory_with_recursive_succeeds(service):
+    ctx = DEFAULT_CTX
+    dir_uri = "viking://resources/test_forget_dir_recursive"
+    child_uri = f"{dir_uri}/child.md"
+    await service.viking_fs.mkdir(dir_uri, ctx=ctx, exist_ok=True)
+    await service.viking_fs.write(child_uri, "child data", ctx=ctx)
+
+    result = await forget(uri=dir_uri, recursive=True)
     assert "deleted" in result.lower()
 
 


### PR DESCRIPTION
## Description

The MCP `forget` tool only forwarded `uri` to `service.fs.rm`, never exposing or forwarding a `recursive` flag. The underlying `VikingFS.rm` raises `FailedPreconditionError("Cannot remove directory without --recursive: ...")` whenever the target is a directory, so any directory URI passed to `forget` failed — contradicting the documented behavior ("Delete any `viking://` URI") and diverging from the REST `DELETE /api/v1/fs?recursive=...` endpoint and the `ov rm` CLI.

## Related Issue

Fixes #1928

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Test update

## Changes Made

- `openviking/server/mcp_endpoint.py`: add an optional `recursive: bool = False` parameter to `forget` and forward it to `service.fs.rm`. The docstring only gains one short sentence about the new flag to keep the MCP tool description token cost minimal.
- `tests/server/test_mcp_endpoint.py`: add `test_forget_directory_without_recursive_fails` (expects `FailedPreconditionError`) and `test_forget_directory_with_recursive_succeeds`.
- `docs/zh/guides/06-mcp-integration.md` and `docs/en/guides/06-mcp-integration.md`: list the optional `recursive` parameter for `forget` in the MCP tool table and note that directory deletion requires `recursive=true`.

The default stays `False`, matching the REST API and the `ov rm` CLI, so an agent cannot accidentally wipe a directory tree without an explicit user request.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`pytest tests/server/test_mcp_endpoint.py -x -q` -> 32 passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published