### PR TITLE
docs(guides/configuration): document storage.transaction.redo_recovery_enabled (#1934)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1061,7 +1061,8 @@ Path locks are enabled by default and usually require no configuration. **The de
   "storage": {
     "transaction": {
       "lock_timeout": 5.0,
-      "lock_expire": 300.0
+      "lock_expire": 300.0,
+      "redo_recovery_enabled": true
     }
   }
 }
@@ -1071,6 +1072,7 @@ Path locks are enabled by default and usually require no configuration. **The de
 |-----------|------|-------------|---------|
 | `lock_timeout` | float | Path lock acquisition timeout (seconds). `0` = fail immediately if locked (default). `> 0` = wait/retry up to this many seconds, then raise `LockAcquisitionError`. | `0.0` |
 | `lock_expire` | float | Lock inactivity threshold (seconds). Locks not refreshed within this window are treated as stale and reclaimed. | `300.0` |
+| `redo_recovery_enabled` | bool | Enable session-commit phase-2 crash-recovery redo. When `false`, pending redo markers are not written and startup redo recovery is skipped. | `true` |
 
 For details on the lock mechanism, see [Path Locks and Crash Recovery](../concepts/09-transaction.md).
 
@@ -1234,7 +1236,8 @@ For detailed encryption explanations, see [Data Encryption](../concepts/10-encry
     },
     "transaction": {
       "lock_timeout": 0.0,
-      "lock_expire": 300.0
+      "lock_expire": 300.0,
+      "redo_recovery_enabled": true
     },
     "vectordb": {
       "backend": "local|remote",

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1128,7 +1128,8 @@ openviking add-resource ./docs --exclude "*.tmp"
   "storage": {
     "transaction": {
       "lock_timeout": 5.0,
-      "lock_expire": 300.0
+      "lock_expire": 300.0,
+      "redo_recovery_enabled": true
     }
   }
 }
@@ -1138,6 +1139,7 @@ openviking add-resource ./docs --exclude "*.tmp"
 |------|------|------|--------|
 | `lock_timeout` | float | 获取路径锁的等待超时（秒）。`0` = 立即失败（默认）；`> 0` = 最多等待此时间后抛出 `LockAcquisitionError` | `0.0` |
 | `lock_expire` | float | 锁失活阈值（秒）。超过此时间未被 refresh 的锁会被视为陈旧锁并回收 | `300.0` |
+| `redo_recovery_enabled` | bool | 是否启用 session commit 阶段 2 的崩溃恢复 redo。设为 `false` 时不写入待执行 redo marker，启动时也不执行 redo 恢复。 | `true` |
 
 路径锁机制的详细说明见 [路径锁与崩溃恢复](../concepts/09-transaction.md)。
 
@@ -1208,7 +1210,8 @@ openviking add-resource ./docs --exclude "*.tmp"
     },
     "transaction": {
       "lock_timeout": 0.0,
-      "lock_expire": 300.0
+      "lock_expire": 300.0,
+      "redo_recovery_enabled": true
     },
     "vectordb": {
       "backend": "local|remote",


### PR DESCRIPTION
## Description

Documents the new `storage.transaction.redo_recovery_enabled` config field added in #1934 (zhoujh01, merged today by qin-ctx). The field is wired through `TransactionConfig` → `LockManager` → `Session._run_memory_extraction` and is fully functional, but `docs/{en,zh}/guides/01-configuration.md` only listed `lock_timeout` / `lock_expire` under `storage.transaction`.

EN/ZH dual-doc, byte-mirror with the existing `lock_timeout`/`lock_expire` rows. Three additions per file (1 in dedicated section JSON example, 1 in field table, 1 in complete-schema appendix). Description copy is paraphrased from the pydantic `Field(description=...)` of `redo_recovery_enabled` in `openviking_cli/utils/config/transaction_config.py`.

## Related Issue

Follow-up docs catch of #1934.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Documentation has been updated where necessary