### PR TITLE
Persist task tracker

### DIFF
--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -29,8 +29,8 @@ async def get_task(
     tracker = get_task_tracker()
     task = tracker.get(
         task_id,
-        owner_account_id=_ctx.account_id,
-        owner_user_id=_ctx.user.user_id,
+        account_id=_ctx.account_id,
+        user_id=_ctx.user.user_id,
     )
     if not task:
         raise OpenVikingError(
@@ -58,7 +58,7 @@ async def list_tasks(
         status=status,
         resource_id=resource_id,
         limit=limit,
-        owner_account_id=_ctx.account_id,
-        owner_user_id=_ctx.user.user_id,
+        account_id=_ctx.account_id,
+        user_id=_ctx.user.user_id,
     )
     return Response(status="ok", result=[t.to_dict() for t in tasks])

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -21,6 +21,7 @@ from openviking.service.relation_service import RelationService
 from openviking.service.resource_service import ResourceService
 from openviking.service.search_service import SearchService
 from openviking.service.session_service import SessionService
+from openviking.service.task_tracker import set_task_tracker
 from openviking.session import SessionCompressor, create_session_compressor
 from openviking.storage import VikingDBManager
 from openviking.storage.collection_schemas import init_context_collection
@@ -149,6 +150,7 @@ class OpenVikingService:
             lock_expire=tx_cfg.lock_expire,
             redo_recovery_enabled=tx_cfg.redo_recovery_enabled,
         )
+        set_task_tracker(config.build_task_tracker(self._agfs_client))
 
     @property
     def _agfs(self) -> Any:

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -89,8 +89,8 @@ class ReindexExecutor:
             if tracker.has_running(
                 REINDEX_TASK_TYPE,
                 uri,
-                owner_account_id=ctx.account_id,
-                owner_user_id=ctx.user.user_id,
+                account_id=ctx.account_id,
+                user_id=ctx.user.user_id,
             ):
                 raise OpenVikingError(
                     f"URI {uri} already has a reindex in progress",
@@ -107,8 +107,8 @@ class ReindexExecutor:
         task = tracker.create_if_no_running(
             REINDEX_TASK_TYPE,
             uri,
-            owner_account_id=ctx.account_id,
-            owner_user_id=ctx.user.user_id,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
         )
         if task is None:
             raise OpenVikingError(
@@ -376,7 +376,7 @@ class ReindexExecutor:
         ctx: RequestContext,
     ) -> None:
         tracker = get_task_tracker()
-        tracker.start(task_id, owner_account_id=ctx.account_id)
+        tracker.start(task_id, account_id=ctx.account_id, user_id=ctx.user.user_id)
         try:
             result = await self._run(
                 uri=uri,
@@ -384,9 +384,9 @@ class ReindexExecutor:
                 mode=mode,
                 ctx=ctx,
             )
-            tracker.complete(task_id, result, owner_account_id=ctx.account_id)
+            tracker.complete(task_id, result, account_id=ctx.account_id, user_id=ctx.user.user_id)
         except Exception as exc:
-            tracker.fail(task_id, str(exc), owner_account_id=ctx.account_id)
+            tracker.fail(task_id, str(exc), account_id=ctx.account_id, user_id=ctx.user.user_id)
 
     async def _reindex_resource(
         self,

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -376,7 +376,7 @@ class ReindexExecutor:
         ctx: RequestContext,
     ) -> None:
         tracker = get_task_tracker()
-        tracker.start(task_id)
+        tracker.start(task_id, owner_account_id=ctx.account_id)
         try:
             result = await self._run(
                 uri=uri,
@@ -384,9 +384,9 @@ class ReindexExecutor:
                 mode=mode,
                 ctx=ctx,
             )
-            tracker.complete(task_id, result)
+            tracker.complete(task_id, result, owner_account_id=ctx.account_id)
         except Exception as exc:
-            tracker.fail(task_id, str(exc))
+            tracker.fail(task_id, str(exc), owner_account_id=ctx.account_id)
 
     async def _reindex_resource(
         self,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -295,8 +295,8 @@ class ResourceService:
                 task = task_tracker.create(
                     "add_resource",
                     resource_id=root_uri,
-                    owner_account_id=ctx.account_id,
-                    owner_user_id=ctx.user.user_id,
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
                 )
                 result["task_id"] = task.task_id
                 if telemetry_id:
@@ -309,11 +309,14 @@ class ResourceService:
                         )
                     )
                 else:
-                    task_tracker.start(task.task_id, owner_account_id=ctx.account_id)
+                    task_tracker.start(
+                        task.task_id, account_id=ctx.account_id, user_id=ctx.user.user_id
+                    )
                     task_tracker.complete(
                         task.task_id,
                         {"root_uri": root_uri},
-                        owner_account_id=ctx.account_id,
+                        account_id=ctx.account_id,
+                        user_id=ctx.user.user_id,
                     )
             return result
         except Exception as exc:
@@ -333,13 +336,17 @@ class ResourceService:
                 unregister_wait_telemetry(telemetry_id)
 
     async def _monitor_queue_processing(
-        self, task_id: str, telemetry_id: str, owner_account_id: str
+        self,
+        task_id: str,
+        telemetry_id: str,
+        account_id: str,
+        user_id: str,
     ) -> None:
         from openviking.service.task_tracker import get_task_tracker
 
         task_tracker = get_task_tracker()
         request_wait_tracker = get_request_wait_tracker()
-        task_tracker.start(task_id, owner_account_id=owner_account_id)
+        task_tracker.start(task_id, account_id=account_id, user_id=user_id)
         try:
             await request_wait_tracker.wait_for_request(telemetry_id)
             status = request_wait_tracker.build_queue_status(telemetry_id)
@@ -348,16 +355,18 @@ class ResourceService:
                 task_tracker.fail(
                     task_id,
                     f"queue processing failed: {status}",
-                    owner_account_id=owner_account_id,
+                    account_id=account_id,
+                    user_id=user_id,
                 )
             else:
                 task_tracker.complete(
                     task_id,
                     {"queue_status": status},
-                    owner_account_id=owner_account_id,
+                    account_id=account_id,
+                    user_id=user_id,
                 )
         except Exception as exc:
-            task_tracker.fail(task_id, str(exc), owner_account_id=owner_account_id)
+            task_tracker.fail(task_id, str(exc), account_id=account_id, user_id=user_id)
         finally:
             request_wait_tracker.cleanup(telemetry_id)
             unregister_wait_telemetry(telemetry_id)
@@ -538,8 +547,8 @@ class ResourceService:
                 task_tracker = get_task_tracker()
                 task = task_tracker.create(
                     "add_skill",
-                    owner_account_id=ctx.account_id,
-                    owner_user_id=ctx.user.user_id,
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
                 )
                 result["task_id"] = task.task_id
                 if telemetry_id:
@@ -549,11 +558,19 @@ class ResourceService:
                             task.task_id,
                             telemetry_id,
                             ctx.account_id,
+                            ctx.user.user_id,
                         )
                     )
                 else:
-                    task_tracker.start(task.task_id, owner_account_id=ctx.account_id)
-                    task_tracker.complete(task.task_id, {}, owner_account_id=ctx.account_id)
+                    task_tracker.start(
+                        task.task_id, account_id=ctx.account_id, user_id=ctx.user.user_id
+                    )
+                    task_tracker.complete(
+                        task.task_id,
+                        {},
+                        account_id=ctx.account_id,
+                        user_id=ctx.user.user_id,
+                    )
 
             return result
         finally:

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -301,10 +301,20 @@ class ResourceService:
                 result["task_id"] = task.task_id
                 if telemetry_id:
                     monitor_started = True
-                    asyncio.create_task(self._monitor_queue_processing(task.task_id, telemetry_id))
+                    asyncio.create_task(
+                        self._monitor_queue_processing(
+                            task.task_id,
+                            telemetry_id,
+                            ctx.account_id,
+                        )
+                    )
                 else:
-                    task_tracker.start(task.task_id)
-                    task_tracker.complete(task.task_id, {"root_uri": root_uri})
+                    task_tracker.start(task.task_id, owner_account_id=ctx.account_id)
+                    task_tracker.complete(
+                        task.task_id,
+                        {"root_uri": root_uri},
+                        owner_account_id=ctx.account_id,
+                    )
             return result
         except Exception as exc:
             telemetry.set_error(
@@ -322,22 +332,32 @@ class ResourceService:
                 get_request_wait_tracker().cleanup(telemetry_id)
                 unregister_wait_telemetry(telemetry_id)
 
-    async def _monitor_queue_processing(self, task_id: str, telemetry_id: str) -> None:
+    async def _monitor_queue_processing(
+        self, task_id: str, telemetry_id: str, owner_account_id: str
+    ) -> None:
         from openviking.service.task_tracker import get_task_tracker
 
         task_tracker = get_task_tracker()
         request_wait_tracker = get_request_wait_tracker()
-        task_tracker.start(task_id)
+        task_tracker.start(task_id, owner_account_id=owner_account_id)
         try:
             await request_wait_tracker.wait_for_request(telemetry_id)
             status = request_wait_tracker.build_queue_status(telemetry_id)
             errors = sum(int(group.get("error_count", 0) or 0) for group in status.values())
             if errors:
-                task_tracker.fail(task_id, f"queue processing failed: {status}")
+                task_tracker.fail(
+                    task_id,
+                    f"queue processing failed: {status}",
+                    owner_account_id=owner_account_id,
+                )
             else:
-                task_tracker.complete(task_id, {"queue_status": status})
+                task_tracker.complete(
+                    task_id,
+                    {"queue_status": status},
+                    owner_account_id=owner_account_id,
+                )
         except Exception as exc:
-            task_tracker.fail(task_id, str(exc))
+            task_tracker.fail(task_id, str(exc), owner_account_id=owner_account_id)
         finally:
             request_wait_tracker.cleanup(telemetry_id)
             unregister_wait_telemetry(telemetry_id)
@@ -524,10 +544,16 @@ class ResourceService:
                 result["task_id"] = task.task_id
                 if telemetry_id:
                     monitor_started = True
-                    asyncio.create_task(self._monitor_queue_processing(task.task_id, telemetry_id))
+                    asyncio.create_task(
+                        self._monitor_queue_processing(
+                            task.task_id,
+                            telemetry_id,
+                            ctx.account_id,
+                        )
+                    )
                 else:
-                    task_tracker.start(task.task_id)
-                    task_tracker.complete(task.task_id, {})
+                    task_tracker.start(task.task_id, owner_account_id=ctx.account_id)
+                    task_tracker.complete(task.task_id, {}, owner_account_id=ctx.account_id)
 
             return result
         finally:

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -253,6 +253,7 @@ class SessionService:
         task = get_task_tracker().get(
             task_id,
             owner_account_id=ctx.account_id,
+            owner_user_id=ctx.user.user_id,
         )
         return task.to_dict() if task else None
 

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -252,8 +252,8 @@ class SessionService:
         """Query background commit task status by task_id for the calling owner."""
         task = get_task_tracker().get(
             task_id,
-            owner_account_id=ctx.account_id,
-            owner_user_id=ctx.user.user_id,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
         )
         return task.to_dict() if task else None
 

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Internal storage backends for TaskTracker."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Protocol
+
+from openviking.pyagfs.exceptions import AGFSAlreadyExistsError
+
+
+class TaskStore(Protocol):
+    def create(self, task: Any) -> None: ...
+
+    def update(self, task: Any) -> None: ...
+
+    def get(
+        self, task_id: str, *, owner_account_id: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]: ...
+
+    def list(self, owner_account_id: str) -> List[Dict[str, Any]]: ...
+
+    def delete(self, task_id: str, *, owner_account_id: str) -> None: ...
+
+
+class InMemoryTaskStore:
+    """Simple in-process task store."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[str, Dict[str, Any]] = {}
+
+    def create(self, task: Any) -> None:
+        self._tasks[task.task_id] = _task_to_payload(task)
+
+    def update(self, task: Any) -> None:
+        self._tasks[task.task_id] = _task_to_payload(task)
+
+    def get(
+        self, task_id: str, *, owner_account_id: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        payload = self._tasks.get(task_id)
+        if payload is None:
+            return None
+        if owner_account_id is not None and payload.get("owner_account_id") != owner_account_id:
+            return None
+        return deepcopy(payload)
+
+    def list(self, owner_account_id: str) -> List[Dict[str, Any]]:
+        return [
+            deepcopy(payload)
+            for payload in self._tasks.values()
+            if payload.get("owner_account_id") == owner_account_id
+        ]
+
+    def delete(self, task_id: str, *, owner_account_id: str) -> None:
+        payload = self._tasks.get(task_id)
+        if payload and payload.get("owner_account_id") == owner_account_id:
+            del self._tasks[task_id]
+
+
+class PersistentTaskStore:
+    """Persist task records into AGFS under account-scoped task directories."""
+
+    ROOT_PREFIX = "/local"
+    RESERVED_DIRNAME = "tasks"
+
+    def __init__(self, agfs: Any) -> None:
+        self._agfs = agfs
+
+    def create(self, task: Any) -> None:
+        self._write_task(task)
+
+    def update(self, task: Any) -> None:
+        self._write_task(task)
+
+    def get(
+        self, task_id: str, *, owner_account_id: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        if not owner_account_id:
+            return None
+        path = self._task_path(owner_account_id, task_id)
+        try:
+            raw = self._agfs.read(path)
+        except Exception:
+            return None
+        return json.loads(_decode_bytes(raw))
+
+    def list(self, owner_account_id: str) -> List[Dict[str, Any]]:
+        directory = self._task_dir(owner_account_id)
+        try:
+            items = self._agfs.ls(directory)
+        except Exception:
+            return []
+        tasks: List[Dict[str, Any]] = []
+        for item in items:
+            path = item.get("path") or f"{directory}/{item.get('name', '')}"
+            if not path.endswith(".json"):
+                continue
+            try:
+                raw = self._agfs.read(path)
+                tasks.append(json.loads(_decode_bytes(raw)))
+            except Exception:
+                continue
+        return tasks
+
+    def delete(self, task_id: str, *, owner_account_id: str) -> None:
+        self._agfs.rm(self._task_path(owner_account_id, task_id), force=True)
+
+    def _write_task(self, task: Any) -> None:
+        account_id = getattr(task, "owner_account_id", None)
+        if not account_id:
+            raise ValueError("PersistentTaskStore requires owner_account_id")
+        self._ensure_task_dir(account_id)
+        self._agfs.write(
+            self._task_path(account_id, task.task_id),
+            json.dumps(_task_to_payload(task), ensure_ascii=False).encode("utf-8"),
+        )
+
+    def _ensure_task_dir(self, account_id: str) -> None:
+        self._mkdir_if_missing(self._account_dir(account_id))
+        self._mkdir_if_missing(self._task_dir(account_id))
+
+    def _mkdir_if_missing(self, path: str) -> None:
+        try:
+            self._agfs.mkdir(path)
+        except AGFSAlreadyExistsError:
+            return
+        except Exception as exc:
+            if "already exists" in str(exc).lower():
+                return
+            raise
+
+    def _account_dir(self, account_id: str) -> str:
+        return f"{self.ROOT_PREFIX}/{account_id}"
+
+    def _task_dir(self, account_id: str) -> str:
+        return f"{self._account_dir(account_id)}/{self.RESERVED_DIRNAME}"
+
+    def _task_path(self, account_id: str, task_id: str) -> str:
+        return f"{self._task_dir(account_id)}/{task_id}.json"
+
+
+def _task_to_payload(task: Any) -> Dict[str, Any]:
+    status = getattr(task, "status", None)
+    return {
+        "task_id": task.task_id,
+        "task_type": task.task_type,
+        "status": status.value if hasattr(status, "value") else status,
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+        "resource_id": task.resource_id,
+        "owner_account_id": task.owner_account_id,
+        "owner_user_id": task.owner_user_id,
+        "result": deepcopy(task.result),
+        "error": task.error,
+    }
+
+
+def _decode_bytes(raw: Any) -> str:
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8")
+    return str(raw)

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -17,12 +17,16 @@ class TaskStore(Protocol):
     def update(self, task: Any) -> None: ...
 
     def get(
-        self, task_id: str, *, owner_account_id: Optional[str] = None
+        self,
+        task_id: str,
+        *,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]: ...
 
-    def list(self, owner_account_id: str) -> List[Dict[str, Any]]: ...
+    def list(self, account_id: str, *, user_id: Optional[str] = None) -> List[Dict[str, Any]]: ...
 
-    def delete(self, task_id: str, *, owner_account_id: str) -> None: ...
+    def delete(self, task_id: str, *, account_id: str, user_id: Optional[str] = None) -> None: ...
 
 
 class InMemoryTaskStore:
@@ -38,25 +42,36 @@ class InMemoryTaskStore:
         self._tasks[task.task_id] = _task_to_payload(task)
 
     def get(
-        self, task_id: str, *, owner_account_id: Optional[str] = None
+        self,
+        task_id: str,
+        *,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         payload = self._tasks.get(task_id)
         if payload is None:
             return None
-        if owner_account_id is not None and payload.get("owner_account_id") != owner_account_id:
+        if account_id is not None and payload.get("account_id") != account_id:
+            return None
+        if user_id is not None and payload.get("user_id") != user_id:
             return None
         return deepcopy(payload)
 
-    def list(self, owner_account_id: str) -> List[Dict[str, Any]]:
+    def list(self, account_id: str, *, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
         return [
             deepcopy(payload)
             for payload in self._tasks.values()
-            if payload.get("owner_account_id") == owner_account_id
+            if payload.get("account_id") == account_id
+            and (user_id is None or payload.get("user_id") == user_id)
         ]
 
-    def delete(self, task_id: str, *, owner_account_id: str) -> None:
+    def delete(self, task_id: str, *, account_id: str, user_id: Optional[str] = None) -> None:
         payload = self._tasks.get(task_id)
-        if payload and payload.get("owner_account_id") == owner_account_id:
+        if (
+            payload
+            and payload.get("account_id") == account_id
+            and (user_id is None or payload.get("user_id") == user_id)
+        ):
             del self._tasks[task_id]
 
 
@@ -76,19 +91,25 @@ class PersistentTaskStore:
         self._write_task(task)
 
     def get(
-        self, task_id: str, *, owner_account_id: Optional[str] = None
+        self,
+        task_id: str,
+        *,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        if not owner_account_id:
+        if not account_id or not user_id:
             return None
-        path = self._task_path(owner_account_id, task_id)
+        path = self._task_path(account_id, user_id, task_id)
         try:
             raw = self._agfs.read(path)
         except Exception:
             return None
         return json.loads(_decode_bytes(raw))
 
-    def list(self, owner_account_id: str) -> List[Dict[str, Any]]:
-        directory = self._task_dir(owner_account_id)
+    def list(self, account_id: str, *, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        if not user_id:
+            return []
+        directory = self._task_dir(account_id, user_id)
         try:
             items = self._agfs.ls(directory)
         except Exception:
@@ -105,22 +126,26 @@ class PersistentTaskStore:
                 continue
         return tasks
 
-    def delete(self, task_id: str, *, owner_account_id: str) -> None:
-        self._agfs.rm(self._task_path(owner_account_id, task_id), force=True)
+    def delete(self, task_id: str, *, account_id: str, user_id: Optional[str] = None) -> None:
+        if not user_id:
+            return
+        self._agfs.rm(self._task_path(account_id, user_id, task_id), force=True)
 
     def _write_task(self, task: Any) -> None:
-        account_id = getattr(task, "owner_account_id", None)
-        if not account_id:
-            raise ValueError("PersistentTaskStore requires owner_account_id")
-        self._ensure_task_dir(account_id)
+        account_id = getattr(task, "account_id", None)
+        user_id = getattr(task, "user_id", None)
+        if not account_id or not user_id:
+            raise ValueError("PersistentTaskStore requires account_id and user_id")
+        self._ensure_task_dir(account_id, user_id)
         self._agfs.write(
-            self._task_path(account_id, task.task_id),
+            self._task_path(account_id, user_id, task.task_id),
             json.dumps(_task_to_payload(task), ensure_ascii=False).encode("utf-8"),
         )
 
-    def _ensure_task_dir(self, account_id: str) -> None:
+    def _ensure_task_dir(self, account_id: str, user_id: str) -> None:
         self._mkdir_if_missing(self._account_dir(account_id))
-        self._mkdir_if_missing(self._task_dir(account_id))
+        self._mkdir_if_missing(self._task_root_dir(account_id))
+        self._mkdir_if_missing(self._task_dir(account_id, user_id))
 
     def _mkdir_if_missing(self, path: str) -> None:
         try:
@@ -135,11 +160,14 @@ class PersistentTaskStore:
     def _account_dir(self, account_id: str) -> str:
         return f"{self.ROOT_PREFIX}/{account_id}"
 
-    def _task_dir(self, account_id: str) -> str:
+    def _task_root_dir(self, account_id: str) -> str:
         return f"{self._account_dir(account_id)}/{self.RESERVED_DIRNAME}"
 
-    def _task_path(self, account_id: str, task_id: str) -> str:
-        return f"{self._task_dir(account_id)}/{task_id}.json"
+    def _task_dir(self, account_id: str, user_id: str) -> str:
+        return f"{self._task_root_dir(account_id)}/{user_id}"
+
+    def _task_path(self, account_id: str, user_id: str, task_id: str) -> str:
+        return f"{self._task_dir(account_id, user_id)}/{task_id}.json"
 
 
 def _task_to_payload(task: Any) -> Dict[str, Any]:
@@ -151,8 +179,8 @@ def _task_to_payload(task: Any) -> Dict[str, Any]:
         "created_at": task.created_at,
         "updated_at": task.updated_at,
         "resource_id": task.resource_id,
-        "owner_account_id": task.owner_account_id,
-        "owner_user_id": task.owner_user_id,
+        "account_id": task.account_id,
+        "user_id": task.user_id,
         "result": deepcopy(task.result),
         "error": task.error,
     }

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -49,8 +49,8 @@ class TaskRecord:
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
     resource_id: Optional[str] = None  # e.g. session_id
-    owner_account_id: Optional[str] = None
-    owner_user_id: Optional[str] = None
+    account_id: Optional[str] = None
+    user_id: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
 
@@ -60,8 +60,8 @@ class TaskRecord:
         d["status"] = self.status.value
         d["created_at_iso"] = datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat()
         d["updated_at_iso"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
-        d.pop("owner_account_id", None)
-        d.pop("owner_user_id", None)
+        d.pop("account_id", None)
+        d.pop("user_id", None)
         return d
 
 
@@ -178,8 +178,8 @@ class TaskTracker:
                     to_delete.append(tid)
             for tid in to_delete:
                 task = self._tasks[tid]
-                if isinstance(self._store, InMemoryTaskStore) and task.owner_account_id:
-                    self._store.delete(tid, owner_account_id=task.owner_account_id)
+                if isinstance(self._store, InMemoryTaskStore) and task.account_id:
+                    self._store.delete(tid, account_id=task.account_id, user_id=task.user_id)
                 del self._tasks[tid]
 
             # FIFO eviction if still over limit
@@ -188,8 +188,8 @@ class TaskTracker:
                 excess = len(self._tasks) - self.MAX_TASKS
                 for tid, _ in sorted_tasks[:excess]:
                     task = self._tasks[tid]
-                    if isinstance(self._store, InMemoryTaskStore) and task.owner_account_id:
-                        self._store.delete(tid, owner_account_id=task.owner_account_id)
+                    if isinstance(self._store, InMemoryTaskStore) and task.account_id:
+                        self._store.delete(tid, account_id=task.account_id, user_id=task.user_id)
                     del self._tasks[tid]
 
             if to_delete:
@@ -198,21 +198,21 @@ class TaskTracker:
     @staticmethod
     def _matches_owner(
         task: TaskRecord,
-        owner_account_id: Optional[str] = None,
-        owner_user_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> bool:
         """Return True when a task belongs to the requested owner filter."""
-        if owner_account_id is not None and task.owner_account_id != owner_account_id:
+        if account_id is not None and task.account_id != account_id:
             return False
-        if owner_user_id is not None and task.owner_user_id != owner_user_id:
+        if user_id is not None and task.user_id != user_id:
             return False
         return True
 
     @staticmethod
-    def _validate_owner(owner_account_id: str, owner_user_id: str) -> None:
+    def _validate_owner(account_id: str, user_id: str) -> None:
         """Reject ownerless task creation for user-originated background work."""
-        if not owner_account_id or not owner_user_id:
-            raise ValueError("Task ownership requires non-empty owner_account_id and owner_user_id")
+        if not account_id or not user_id:
+            raise ValueError("Task ownership requires non-empty account_id and user_id")
 
     # ── CRUD ──
 
@@ -221,17 +221,17 @@ class TaskTracker:
         task_type: str,
         resource_id: Optional[str] = None,
         *,
-        owner_account_id: str,
-        owner_user_id: str,
+        account_id: str,
+        user_id: str,
     ) -> TaskRecord:
         """Register a new pending task. Returns a snapshot copy."""
-        self._validate_owner(owner_account_id, owner_user_id)
+        self._validate_owner(account_id, user_id)
         task = TaskRecord(
             task_id=str(uuid4()),
             task_type=task_type,
             resource_id=resource_id,
-            owner_account_id=owner_account_id,
-            owner_user_id=owner_user_id,
+            account_id=account_id,
+            user_id=user_id,
         )
         with self._lock:
             self._tasks[task.task_id] = task
@@ -249,21 +249,21 @@ class TaskTracker:
         task_type: str,
         resource_id: str,
         *,
-        owner_account_id: str,
-        owner_user_id: str,
+        account_id: str,
+        user_id: str,
     ) -> Optional[TaskRecord]:
         """Atomically check for running tasks and create a new one if none exist.
 
         Returns TaskRecord on success, None if a running task already exists.
         This eliminates the race condition between has_running() and create().
         """
-        self._validate_owner(owner_account_id, owner_user_id)
+        self._validate_owner(account_id, user_id)
         with self._lock:
             # Check for existing running tasks
             has_active = any(
                 t.task_type == task_type
                 and t.resource_id == resource_id
-                and self._matches_owner(t, owner_account_id, owner_user_id)
+                and self._matches_owner(t, account_id, user_id)
                 and t.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
                 for t in self._tasks.values()
             )
@@ -274,8 +274,8 @@ class TaskTracker:
                 task_id=str(uuid4()),
                 task_type=task_type,
                 resource_id=resource_id,
-                owner_account_id=owner_account_id,
-                owner_user_id=owner_user_id,
+                account_id=account_id,
+                user_id=user_id,
             )
             self._tasks[task.task_id] = task
             self._store.create(task)
@@ -287,10 +287,15 @@ class TaskTracker:
         )
         return self._copy(task)
 
-    def start(self, task_id: str, owner_account_id: Optional[str] = None) -> None:
+    def start(
+        self,
+        task_id: str,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> None:
         """Transition task to RUNNING."""
         with self._lock:
-            task = self._load_for_update(task_id, owner_account_id)
+            task = self._load_for_update(task_id, account_id, user_id)
             if task:
                 task.status = TaskStatus.RUNNING
                 task.updated_at = time.time()
@@ -301,11 +306,12 @@ class TaskTracker:
         self,
         task_id: str,
         result: Optional[Dict[str, Any]] = None,
-        owner_account_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> None:
         """Transition task to COMPLETED with optional result."""
         with self._lock:
-            task = self._load_for_update(task_id, owner_account_id)
+            task = self._load_for_update(task_id, account_id, user_id)
             if task:
                 task.status = TaskStatus.COMPLETED
                 task.result = result
@@ -314,10 +320,16 @@ class TaskTracker:
                 self._store.update(task)
         logger.info("[TaskTracker] Task %s completed", task_id)
 
-    def fail(self, task_id: str, error: str, owner_account_id: Optional[str] = None) -> None:
+    def fail(
+        self,
+        task_id: str,
+        error: str,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> None:
         """Transition task to FAILED with sanitized error."""
         with self._lock:
-            task = self._load_for_update(task_id, owner_account_id)
+            task = self._load_for_update(task_id, account_id, user_id)
             if task:
                 task.status = TaskStatus.FAILED
                 task.error = _sanitize_error(error)
@@ -329,17 +341,17 @@ class TaskTracker:
     def get(
         self,
         task_id: str,
-        owner_account_id: Optional[str] = None,
-        owner_user_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> Optional[TaskRecord]:
         """Look up a single task. Returns a snapshot copy (None if not found)."""
         with self._lock:
             task = self._tasks.get(task_id)
-            if task is None and owner_account_id is not None:
-                task = self._load_from_store(task_id, owner_account_id)
+            if task is None and account_id is not None:
+                task = self._load_from_store(task_id, account_id, user_id)
                 if task is not None:
                     self._tasks[task.task_id] = task
-            if task is None or not self._matches_owner(task, owner_account_id, owner_user_id):
+            if task is None or not self._matches_owner(task, account_id, user_id):
                 return None
             return self._copy(task)
 
@@ -349,18 +361,18 @@ class TaskTracker:
         status: Optional[str] = None,
         resource_id: Optional[str] = None,
         limit: int = 50,
-        owner_account_id: Optional[str] = None,
-        owner_user_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> List[TaskRecord]:
         """List tasks with optional filters. Most-recent first. Returns snapshot copies."""
         with self._lock:
-            if owner_account_id is not None:
-                for task in self._load_all_from_store(owner_account_id):
+            if account_id is not None:
+                for task in self._load_all_from_store(account_id, user_id):
                     self._tasks[task.task_id] = task
             tasks = [
                 self._copy(t)
                 for t in self._tasks.values()
-                if self._matches_owner(t, owner_account_id, owner_user_id)
+                if self._matches_owner(t, account_id, user_id)
             ]
         if task_type:
             tasks = [t for t in tasks if t.task_type == task_type]
@@ -375,31 +387,34 @@ class TaskTracker:
         self,
         task_type: str,
         resource_id: str,
-        owner_account_id: Optional[str] = None,
-        owner_user_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> bool:
         """Check if there is already a running task for the given type+resource."""
         with self._lock:
-            if owner_account_id is not None:
-                for task in self._load_all_from_store(owner_account_id):
+            if account_id is not None:
+                for task in self._load_all_from_store(account_id, user_id):
                     self._tasks[task.task_id] = task
             return any(
                 t.task_type == task_type
                 and t.resource_id == resource_id
-                and self._matches_owner(t, owner_account_id, owner_user_id)
+                and self._matches_owner(t, account_id, user_id)
                 and t.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
                 for t in self._tasks.values()
             )
 
     def _load_for_update(
-        self, task_id: str, owner_account_id: Optional[str]
+        self,
+        task_id: str,
+        account_id: Optional[str],
+        user_id: Optional[str],
     ) -> Optional[TaskRecord]:
         task = self._tasks.get(task_id)
         if task is not None:
             return task
-        if owner_account_id is None:
+        if account_id is None or user_id is None:
             return None
-        return self._load_from_store(task_id, owner_account_id)
+        return self._load_from_store(task_id, account_id, user_id)
 
     @staticmethod
     def _record_from_payload(payload: Dict[str, Any]) -> TaskRecord:
@@ -407,15 +422,21 @@ class TaskTracker:
         data["status"] = TaskStatus(data["status"])
         return TaskRecord(**data)
 
-    def _load_from_store(self, task_id: str, owner_account_id: str) -> Optional[TaskRecord]:
-        payload = self._store.get(task_id, owner_account_id=owner_account_id)
+    def _load_from_store(
+        self,
+        task_id: str,
+        account_id: str,
+        user_id: Optional[str],
+    ) -> Optional[TaskRecord]:
+        payload = self._store.get(task_id, account_id=account_id, user_id=user_id)
         if payload is None:
             return None
         return self._record_from_payload(payload)
 
-    def _load_all_from_store(self, owner_account_id: str) -> List[TaskRecord]:
+    def _load_all_from_store(self, account_id: str, user_id: Optional[str]) -> List[TaskRecord]:
         return [
-            self._record_from_payload(payload) for payload in self._store.list(owner_account_id)
+            self._record_from_payload(payload)
+            for payload in self._store.list(account_id, user_id=user_id)
         ]
 
     @staticmethod

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -3,14 +3,13 @@
 """
 Async Task Tracker for OpenViking.
 
-Provides a lightweight, in-memory registry for tracking background operations
+Provides a lightweight registry for tracking background operations
 (e.g. session commit with wait=false). Callers receive a task_id that can be
 polled via the /tasks API to check completion status, results, or errors.
 
 Design decisions:
-  - v1 is pure in-memory (no persistence). Tasks are lost on restart.
   - Thread-safe (QueueManager workers run in separate threads).
-  - TTL-based cleanup prevents unbounded memory growth.
+  - TTL-based cleanup still applies to in-memory cache.
   - Error messages are sanitized to avoid leaking sensitive data.
 """
 
@@ -25,6 +24,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from openviking.service.task_store import InMemoryTaskStore, TaskStore
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -81,6 +81,13 @@ def get_task_tracker() -> "TaskTracker":
     return _instance
 
 
+def set_task_tracker(tracker: "TaskTracker") -> None:
+    """Replace the global TaskTracker singleton."""
+    global _instance
+    with _init_lock:
+        _instance = tracker
+
+
 def reset_task_tracker() -> None:
     """Reset singleton (for testing)."""
     global _instance
@@ -109,7 +116,7 @@ def _sanitize_error(error: str) -> str:
 
 
 class TaskTracker:
-    """In-memory async task tracker with TTL-based cleanup.
+    """Async task tracker with pluggable storage and in-memory compatibility cache.
 
     Thread-safe: all mutations go through ``_lock``.
     """
@@ -119,11 +126,16 @@ class TaskTracker:
     TTL_FAILED = 604_800  # 7 days
     CLEANUP_INTERVAL = 300  # 5 minutes
 
-    def __init__(self) -> None:
+    def __init__(self, store: Optional[TaskStore] = None) -> None:
+        self._store = store or InMemoryTaskStore()
         self._tasks: Dict[str, TaskRecord] = {}
         self._lock = threading.Lock()
         self._cleanup_task: Optional[asyncio.Task] = None
-        logger.info("[TaskTracker] Initialized (in-memory, max_tasks=%d)", self.MAX_TASKS)
+        logger.info(
+            "[TaskTracker] Initialized (store=%s, max_tasks=%d)",
+            self._store.__class__.__name__,
+            self.MAX_TASKS,
+        )
 
     # ── Lifecycle ──
 
@@ -165,6 +177,9 @@ class TaskTracker:
                 elif t.status == TaskStatus.FAILED and (now - t.updated_at) > self.TTL_FAILED:
                     to_delete.append(tid)
             for tid in to_delete:
+                task = self._tasks[tid]
+                if isinstance(self._store, InMemoryTaskStore) and task.owner_account_id:
+                    self._store.delete(tid, owner_account_id=task.owner_account_id)
                 del self._tasks[tid]
 
             # FIFO eviction if still over limit
@@ -172,6 +187,9 @@ class TaskTracker:
                 sorted_tasks = sorted(self._tasks.items(), key=lambda x: x[1].created_at)
                 excess = len(self._tasks) - self.MAX_TASKS
                 for tid, _ in sorted_tasks[:excess]:
+                    task = self._tasks[tid]
+                    if isinstance(self._store, InMemoryTaskStore) and task.owner_account_id:
+                        self._store.delete(tid, owner_account_id=task.owner_account_id)
                     del self._tasks[tid]
 
             if to_delete:
@@ -217,6 +235,7 @@ class TaskTracker:
         )
         with self._lock:
             self._tasks[task.task_id] = task
+            self._store.create(task)
         logger.debug(
             "[TaskTracker] Created task %s type=%s resource=%s",
             task.task_id,
@@ -259,6 +278,7 @@ class TaskTracker:
                 owner_user_id=owner_user_id,
             )
             self._tasks[task.task_id] = task
+            self._store.create(task)
         logger.debug(
             "[TaskTracker] Created task %s type=%s resource=%s",
             task.task_id,
@@ -267,32 +287,43 @@ class TaskTracker:
         )
         return self._copy(task)
 
-    def start(self, task_id: str) -> None:
+    def start(self, task_id: str, owner_account_id: Optional[str] = None) -> None:
         """Transition task to RUNNING."""
         with self._lock:
-            task = self._tasks.get(task_id)
+            task = self._load_for_update(task_id, owner_account_id)
             if task:
                 task.status = TaskStatus.RUNNING
                 task.updated_at = time.time()
+                self._tasks[task.task_id] = task
+                self._store.update(task)
 
-    def complete(self, task_id: str, result: Optional[Dict[str, Any]] = None) -> None:
+    def complete(
+        self,
+        task_id: str,
+        result: Optional[Dict[str, Any]] = None,
+        owner_account_id: Optional[str] = None,
+    ) -> None:
         """Transition task to COMPLETED with optional result."""
         with self._lock:
-            task = self._tasks.get(task_id)
+            task = self._load_for_update(task_id, owner_account_id)
             if task:
                 task.status = TaskStatus.COMPLETED
                 task.result = result
                 task.updated_at = time.time()
+                self._tasks[task.task_id] = task
+                self._store.update(task)
         logger.info("[TaskTracker] Task %s completed", task_id)
 
-    def fail(self, task_id: str, error: str) -> None:
+    def fail(self, task_id: str, error: str, owner_account_id: Optional[str] = None) -> None:
         """Transition task to FAILED with sanitized error."""
         with self._lock:
-            task = self._tasks.get(task_id)
+            task = self._load_for_update(task_id, owner_account_id)
             if task:
                 task.status = TaskStatus.FAILED
                 task.error = _sanitize_error(error)
                 task.updated_at = time.time()
+                self._tasks[task.task_id] = task
+                self._store.update(task)
         logger.warning("[TaskTracker] Task %s failed: %s", task_id, _sanitize_error(error))
 
     def get(
@@ -304,6 +335,10 @@ class TaskTracker:
         """Look up a single task. Returns a snapshot copy (None if not found)."""
         with self._lock:
             task = self._tasks.get(task_id)
+            if task is None and owner_account_id is not None:
+                task = self._load_from_store(task_id, owner_account_id)
+                if task is not None:
+                    self._tasks[task.task_id] = task
             if task is None or not self._matches_owner(task, owner_account_id, owner_user_id):
                 return None
             return self._copy(task)
@@ -319,6 +354,9 @@ class TaskTracker:
     ) -> List[TaskRecord]:
         """List tasks with optional filters. Most-recent first. Returns snapshot copies."""
         with self._lock:
+            if owner_account_id is not None:
+                for task in self._load_all_from_store(owner_account_id):
+                    self._tasks[task.task_id] = task
             tasks = [
                 self._copy(t)
                 for t in self._tasks.values()
@@ -342,6 +380,9 @@ class TaskTracker:
     ) -> bool:
         """Check if there is already a running task for the given type+resource."""
         with self._lock:
+            if owner_account_id is not None:
+                for task in self._load_all_from_store(owner_account_id):
+                    self._tasks[task.task_id] = task
             return any(
                 t.task_type == task_type
                 and t.resource_id == resource_id
@@ -349,6 +390,33 @@ class TaskTracker:
                 and t.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
                 for t in self._tasks.values()
             )
+
+    def _load_for_update(
+        self, task_id: str, owner_account_id: Optional[str]
+    ) -> Optional[TaskRecord]:
+        task = self._tasks.get(task_id)
+        if task is not None:
+            return task
+        if owner_account_id is None:
+            return None
+        return self._load_from_store(task_id, owner_account_id)
+
+    @staticmethod
+    def _record_from_payload(payload: Dict[str, Any]) -> TaskRecord:
+        data = dict(payload)
+        data["status"] = TaskStatus(data["status"])
+        return TaskRecord(**data)
+
+    def _load_from_store(self, task_id: str, owner_account_id: str) -> Optional[TaskRecord]:
+        payload = self._store.get(task_id, owner_account_id=owner_account_id)
+        if payload is None:
+            return None
+        return self._record_from_payload(payload)
+
+    def _load_all_from_store(self, owner_account_id: str) -> List[TaskRecord]:
+        return [
+            self._record_from_payload(payload) for payload in self._store.list(owner_account_id)
+        ]
 
     @staticmethod
     def _copy(task: TaskRecord) -> TaskRecord:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -705,8 +705,8 @@ class Session:
         task = tracker.create(
             "session_commit",
             resource_id=self.session_id,
-            owner_account_id=self.ctx.account_id,
-            owner_user_id=self.ctx.user.user_id,
+            account_id=self.ctx.account_id,
+            user_id=self.ctx.user.user_id,
         )
 
         asyncio.create_task(
@@ -773,11 +773,12 @@ class Session:
                     task_id,
                     f"Previous archive archive_{archive_index - 1:03d} failed; "
                     "cannot continue session commit",
-                    owner_account_id=self.ctx.account_id,
+                    account_id=self.ctx.account_id,
+                    user_id=self.ctx.user.user_id,
                 )
                 return
 
-            tracker.start(task_id, owner_account_id=self.ctx.account_id)
+            tracker.start(task_id, account_id=self.ctx.account_id, user_id=self.ctx.user.user_id)
             request_wait_tracker.register_request(telemetry.telemetry_id)
             register_telemetry(telemetry)
             try:
@@ -980,7 +981,8 @@ class Session:
                         },
                     },
                 },
-                owner_account_id=self.ctx.account_id,
+                account_id=self.ctx.account_id,
+                user_id=self.ctx.user.user_id,
             )
             logger.info(f"Session {self.session_id} memory extraction completed")
         except Exception as e:
@@ -991,7 +993,9 @@ class Session:
                 stage="memory_extraction",
                 error=str(e),
             )
-            tracker.fail(task_id, str(e), owner_account_id=self.ctx.account_id)
+            tracker.fail(
+                task_id, str(e), account_id=self.ctx.account_id, user_id=self.ctx.user.user_id
+            )
             logger.exception(f"Memory extraction failed for session {self.session_id}")
 
     async def _write_done_file(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -773,10 +773,11 @@ class Session:
                     task_id,
                     f"Previous archive archive_{archive_index - 1:03d} failed; "
                     "cannot continue session commit",
+                    owner_account_id=self.ctx.account_id,
                 )
                 return
 
-            tracker.start(task_id)
+            tracker.start(task_id, owner_account_id=self.ctx.account_id)
             request_wait_tracker.register_request(telemetry.telemetry_id)
             register_telemetry(telemetry)
             try:
@@ -979,6 +980,7 @@ class Session:
                         },
                     },
                 },
+                owner_account_id=self.ctx.account_id,
             )
             logger.info(f"Session {self.session_id} memory extraction completed")
         except Exception as e:
@@ -989,7 +991,7 @@ class Session:
                 stage="memory_extraction",
                 error=str(e),
             )
-            tracker.fail(task_id, str(e))
+            tracker.fail(task_id, str(e), owner_account_id=self.ctx.account_id)
             logger.exception(f"Memory extraction failed for session {self.session_id}")
 
     async def _write_done_file(

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1629,7 +1629,7 @@ class VikingFS:
         safe_parts = [self._shorten_component(p, self._MAX_FILENAME_BYTES) for p in parts]
         return f"/local/{account_id}/{'/'.join(safe_parts)}"
 
-    _INTERNAL_NAMES = {"_system", ".path.ovlock"}
+    _INTERNAL_NAMES = {"_system", "tasks", ".path.ovlock"}
     _ROOT_PATH = "/local"
 
     def _ls_entries(self, path: str) -> List[Dict[str, Any]]:

--- a/openviking_cli/utils/config/storage_config.py
+++ b/openviking_cli/utils/config/storage_config.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -12,6 +12,15 @@ from .transaction_config import TransactionConfig
 from .vectordb_config import VectorDBBackendConfig
 
 logger = get_logger(__name__)
+
+
+class TaskTrackerConfig(BaseModel):
+    """Configuration for async task tracking backend."""
+
+    backend: Literal["memory", "persistent"] = Field(
+        default="memory",
+        description="Task tracker backend. 'persistent' enables cross-instance task lookup.",
+    )
 
 
 class StorageConfig(BaseModel):
@@ -34,6 +43,11 @@ class StorageConfig(BaseModel):
     vectordb: VectorDBBackendConfig = Field(
         default_factory=VectorDBBackendConfig,
         description="VectorDB backend configuration",
+    )
+
+    task_tracker: TaskTrackerConfig = Field(
+        default_factory=TaskTrackerConfig,
+        description="Task tracker backend configuration",
     )
 
     params: Dict[str, Any] = Field(
@@ -75,3 +89,12 @@ class StorageConfig(BaseModel):
         upload_temp_dir = workspace_path / "temp" / "upload"
         upload_temp_dir.mkdir(parents=True, exist_ok=True)
         return upload_temp_dir
+
+    def build_task_tracker(self, agfs: Any):
+        """Build a TaskTracker from storage config."""
+        from openviking.service.task_store import PersistentTaskStore
+        from openviking.service.task_tracker import TaskTracker
+
+        if self.task_tracker.backend == "memory":
+            return TaskTracker()
+        return TaskTracker(store=PersistentTaskStore(agfs))

--- a/tests/misc/test_vikingfs_uri_guard.py
+++ b/tests/misc/test_vikingfs_uri_guard.py
@@ -194,3 +194,15 @@ class TestVikingFSURITraversalGuard:
         assert result["matches"][0]["uri"] == "viking://resources/test-root"
         assert result["matches"][0]["line"] == 1
         assert result["matches"][0]["content"] == "act"
+
+    def test_ls_entries_hides_reserved_tasks_dir_under_account_root(self) -> None:
+        fs = _make_viking_fs()
+        fs.agfs.ls.return_value = [
+            {"name": "resources", "isDir": True},
+            {"name": "tasks", "isDir": True},
+            {"name": "_system", "isDir": True},
+        ]
+
+        entries = fs._ls_entries("/local/default")
+
+        assert [entry["name"] for entry in entries] == ["resources"]

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -323,14 +323,14 @@ async def test_task_endpoints_are_user_scoped():
     alice_task = tracker.create(
         "session_commit",
         resource_id="alice-session",
-        owner_account_id=account_id,
-        owner_user_id="alice",
+        account_id=account_id,
+        user_id="alice",
     )
     bob_task = tracker.create(
         "session_commit",
         resource_id="bob-session",
-        owner_account_id=account_id,
-        owner_user_id="bob",
+        account_id=account_id,
+        user_id="bob",
     )
 
     alice_app = _build_task_http_test_app(

--- a/tests/test_session_task_tracking.py
+++ b/tests/test_session_task_tracking.py
@@ -69,13 +69,13 @@ def _make_tracked_commit(behavior="instant", result_overrides=None, gate=None, s
         task = tracker.create(
             "session_commit",
             resource_id=_sid,
-            owner_account_id=_ctx.account_id,
-            owner_user_id=_ctx.user.user_id,
+            account_id=_ctx.account_id,
+            user_id=_ctx.user.user_id,
         )
         archive_uri = f"viking://session/test/{_sid}/history/archive_001"
 
         async def _background():
-            tracker.start(task.task_id)
+            tracker.start(task.task_id, account_id=_ctx.account_id, user_id=_ctx.user.user_id)
             try:
                 if started:
                     started.set()
@@ -96,9 +96,19 @@ def _make_tracked_commit(behavior="instant", result_overrides=None, gate=None, s
                 }
                 if result_overrides:
                     final_result.update(result_overrides)
-                tracker.complete(task.task_id, final_result)
+                tracker.complete(
+                    task.task_id,
+                    final_result,
+                    account_id=_ctx.account_id,
+                    user_id=_ctx.user.user_id,
+                )
             except Exception as e:
-                tracker.fail(task.task_id, str(e))
+                tracker.fail(
+                    task.task_id,
+                    str(e),
+                    account_id=_ctx.account_id,
+                    user_id=_ctx.user.user_id,
+                )
 
         asyncio.create_task(_background())
 
@@ -336,11 +346,20 @@ async def test_add_resource_async_returns_task_id(api_client):
         task = tracker.create(
             "add_resource",
             resource_id=root_uri,
-            owner_account_id=kwargs["ctx"].account_id,
-            owner_user_id=kwargs["ctx"].user.user_id,
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
         )
-        tracker.start(task.task_id)
-        tracker.complete(task.task_id, {"root_uri": root_uri})
+        tracker.start(
+            task.task_id,
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
+        )
+        tracker.complete(
+            task.task_id,
+            {"root_uri": root_uri},
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
+        )
         return {"status": "success", "root_uri": root_uri, "task_id": task.task_id}
 
     service.resources.add_resource = fake_add_resource
@@ -389,14 +408,23 @@ async def test_add_resource_async_task_lifecycle(api_client):
         task = tracker.create(
             "add_resource",
             resource_id=root_uri,
-            owner_account_id=kwargs["ctx"].account_id,
-            owner_user_id=kwargs["ctx"].user.user_id,
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
         )
 
         async def _background():
-            tracker.start(task.task_id)
+            tracker.start(
+                task.task_id,
+                account_id=kwargs["ctx"].account_id,
+                user_id=kwargs["ctx"].user.user_id,
+            )
             await asyncio.sleep(0.05)
-            tracker.complete(task.task_id, {"root_uri": root_uri})
+            tracker.complete(
+                task.task_id,
+                {"root_uri": root_uri},
+                account_id=kwargs["ctx"].account_id,
+                user_id=kwargs["ctx"].user.user_id,
+            )
 
         asyncio.create_task(_background())
         return {"status": "success", "root_uri": root_uri, "task_id": task.task_id}
@@ -434,11 +462,20 @@ async def test_add_resource_task_list_filter(api_client):
         task = tracker.create(
             "add_resource",
             resource_id=root_uri,
-            owner_account_id=kwargs["ctx"].account_id,
-            owner_user_id=kwargs["ctx"].user.user_id,
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
         )
-        tracker.start(task.task_id)
-        tracker.complete(task.task_id, {"root_uri": root_uri})
+        tracker.start(
+            task.task_id,
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
+        )
+        tracker.complete(
+            task.task_id,
+            {"root_uri": root_uri},
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
+        )
         return {"status": "success", "root_uri": root_uri, "task_id": task.task_id}
 
     service.resources.add_resource = fake_add_resource
@@ -469,11 +506,20 @@ async def test_add_skill_async_returns_task_id(api_client):
         tracker = get_task_tracker()
         task = tracker.create(
             "add_skill",
-            owner_account_id=kwargs["ctx"].account_id,
-            owner_user_id=kwargs["ctx"].user.user_id,
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
         )
-        tracker.start(task.task_id)
-        tracker.complete(task.task_id, {})
+        tracker.start(
+            task.task_id,
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
+        )
+        tracker.complete(
+            task.task_id,
+            {},
+            account_id=kwargs["ctx"].account_id,
+            user_id=kwargs["ctx"].user.user_id,
+        )
         return {"status": "success", "task_id": task.task_id}
 
     service.resources.add_skill = fake_add_skill

--- a/tests/test_task_backend_config.py
+++ b/tests/test_task_backend_config.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from openviking.service.task_store import InMemoryTaskStore, PersistentTaskStore
+from openviking.service.task_tracker import TaskTracker
+from openviking_cli.utils.config.storage_config import StorageConfig
+
+
+class _FakeAgfs:
+    def mkdir(self, path: str, mode: str = "755"):
+        return {"message": "created", "mode": mode}
+
+    def write(self, path: str, data):
+        return "OK"
+
+    def read(self, path: str, offset: int = 0, size: int = -1, stream: bool = False):
+        raise FileNotFoundError(path)
+
+    def ls(self, path: str = "/"):
+        return []
+
+    def rm(self, path: str, recursive: bool = False, force: bool = True):
+        return {"message": "deleted"}
+
+
+def test_storage_config_defaults_task_backend_to_memory():
+    config = StorageConfig()
+    assert config.task_tracker.backend == "memory"
+
+
+def test_storage_config_accepts_memory_task_backend():
+    config = StorageConfig(task_tracker={"backend": "memory"})
+    assert config.task_tracker.backend == "memory"
+
+
+def test_storage_config_builds_memory_task_tracker():
+    tracker = StorageConfig(task_tracker={"backend": "memory"}).build_task_tracker(_FakeAgfs())
+    assert isinstance(tracker, TaskTracker)
+    assert isinstance(tracker._store, InMemoryTaskStore)
+
+
+def test_storage_config_builds_persistent_task_tracker():
+    tracker = StorageConfig(task_tracker={"backend": "persistent"}).build_task_tracker(_FakeAgfs())
+    assert isinstance(tracker, TaskTracker)
+    assert isinstance(tracker._store, PersistentTaskStore)

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -3,12 +3,15 @@
 
 """Unit tests for TaskTracker."""
 
+import json
 import time
 
 import pytest
 
+from openviking.pyagfs.exceptions import AGFSAlreadyExistsError
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
+from openviking.service.task_store import InMemoryTaskStore, PersistentTaskStore
 from openviking.service.task_tracker import (
     TaskStatus,
     TaskTracker,
@@ -44,6 +47,60 @@ def _make_ctx(account_id: str = "acme", user_id: str = "alice") -> RequestContex
         user=UserIdentifier(account_id, user_id, "agent-1"),
         role=Role.ADMIN,
     )
+
+
+class _FakeAgfs:
+    def __init__(self):
+        self.files = {}
+        self.dirs = {"/", "/local"}
+
+    def mkdir(self, path: str, mode: str = "755"):
+        self.dirs.add(path.rstrip("/") or "/")
+        return {"message": "created", "mode": mode}
+
+    def write(self, path: str, data):
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        self.files[path] = data
+        parent = path.rsplit("/", 1)[0] or "/"
+        self.dirs.add(parent)
+        return "OK"
+
+    def read(self, path: str, offset: int = 0, size: int = -1, stream: bool = False):
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        data = self.files[path]
+        if size >= 0:
+            return data[offset : offset + size]
+        return data[offset:]
+
+    def ls(self, path: str = "/"):
+        prefix = path.rstrip("/") or "/"
+        if prefix not in self.dirs:
+            return []
+        children = {}
+        for directory in self.dirs:
+            if directory in {prefix, "/"}:
+                continue
+            if directory.startswith(prefix + "/"):
+                name = directory[len(prefix) + 1 :].split("/", 1)[0]
+                if name:
+                    children[name] = {"name": name, "path": f"{prefix}/{name}", "is_dir": True}
+        for file_path in self.files:
+            if file_path.startswith(prefix + "/"):
+                name = file_path[len(prefix) + 1 :].split("/", 1)[0]
+                if name and "/" not in file_path[len(prefix) + 1 :]:
+                    children[name] = {"name": name, "path": f"{prefix}/{name}", "is_dir": False}
+        return list(children.values())
+
+
+class _FakeAgfsExistingDir(_FakeAgfs):
+    def mkdir(self, path: str, mode: str = "755"):
+        normalized = path.rstrip("/") or "/"
+        if normalized in self.dirs:
+            raise AGFSAlreadyExistsError(f"already exists: {path}")
+        self.dirs.add(normalized)
+        return {"message": "created", "mode": mode}
 
 
 # ── Basic CRUD ──
@@ -328,6 +385,71 @@ def test_singleton_reset():
     assert t1 is not t2
 
 
+def test_persistent_store_cross_tracker_visibility():
+    agfs = _FakeAgfs()
+    store = PersistentTaskStore(agfs)
+    tracker1 = TaskTracker(store=store)
+    tracker2 = TaskTracker(store=store)
+
+    task = tracker1.create("session_commit", resource_id="sess-123", **_owner_kwargs())
+    tracker1.start(task.task_id, owner_account_id="acme")
+    tracker1.complete(task.task_id, {"ok": True}, owner_account_id="acme")
+
+    loaded = tracker2.get(task.task_id, owner_account_id="acme", owner_user_id="alice")
+
+    assert loaded is not None
+    assert loaded.status == TaskStatus.COMPLETED
+    assert loaded.result == {"ok": True}
+
+
+def test_persistent_store_writes_task_record_json():
+    agfs = _FakeAgfs()
+    store = PersistentTaskStore(agfs)
+    tracker = TaskTracker(store=store)
+
+    task = tracker.create("add_resource", resource_id="viking://resources/demo", **_owner_kwargs())
+
+    raw = agfs.files[f"/local/acme/tasks/{task.task_id}.json"]
+    payload = json.loads(raw.decode("utf-8"))
+
+    assert payload["task_id"] == task.task_id
+    assert payload["task_type"] == "add_resource"
+    assert payload["owner_account_id"] == "acme"
+    assert payload["owner_user_id"] == "alice"
+    assert "schema_version" not in payload
+
+
+def test_inmemory_store_keeps_tasktracker_tasks_dict():
+    tracker = TaskTracker(store=InMemoryTaskStore())
+    task = tracker.create("session_commit", **_owner_kwargs())
+    assert task.task_id in tracker._tasks
+
+
+def test_persistent_store_survives_tracker_reset():
+    agfs = _FakeAgfs()
+    tracker1 = TaskTracker(store=PersistentTaskStore(agfs))
+    task = tracker1.create("session_commit", resource_id="sess-123", **_owner_kwargs())
+    tracker1.start(task.task_id, owner_account_id="acme")
+
+    tracker2 = TaskTracker(store=PersistentTaskStore(agfs))
+    loaded = tracker2.get(task.task_id, owner_account_id="acme", owner_user_id="alice")
+
+    assert loaded is not None
+    assert loaded.status == TaskStatus.RUNNING
+
+
+def test_persistent_store_ignores_existing_task_dirs():
+    agfs = _FakeAgfsExistingDir()
+    tracker = TaskTracker(store=PersistentTaskStore(agfs))
+
+    first = tracker.create("session_commit", resource_id="sess-1", **_owner_kwargs())
+    second = tracker.create("session_commit", resource_id="sess-2", **_owner_kwargs())
+
+    assert first.task_id != second.task_id
+    assert agfs.files[f"/local/acme/tasks/{first.task_id}.json"]
+    assert agfs.files[f"/local/acme/tasks/{second.task_id}.json"]
+
+
 def test_create_requires_owner(tracker: TaskTracker):
     with pytest.raises(TypeError):
         tracker.create("session_commit", resource_id="sess-123")
@@ -361,3 +483,17 @@ async def test_session_service_get_commit_task_is_owner_scoped():
     assert owner_result["task_id"] == task.task_id
     assert owner_result["resource_id"] == "sess-123"
     assert other_result is None
+
+
+@pytest.mark.asyncio
+async def test_session_service_get_commit_task_also_filters_account():
+    tracker = get_task_tracker()
+    task = tracker.create("session_commit", resource_id="sess-123", **_owner_kwargs())
+    service = SessionService()
+
+    other_account_result = await service.get_commit_task(
+        task.task_id,
+        _make_ctx(account_id="other-acme", user_id="alice"),
+    )
+
+    assert other_account_result is None

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -37,8 +37,8 @@ def tracker() -> TaskTracker:
 
 def _owner_kwargs(account_id: str = "acme", user_id: str = "alice"):
     return {
-        "owner_account_id": account_id,
-        "owner_user_id": user_id,
+        "account_id": account_id,
+        "user_id": user_id,
     }
 
 
@@ -188,15 +188,15 @@ def test_get_hides_task_from_other_owner(tracker: TaskTracker):
     task = tracker.create(
         "session_commit",
         resource_id="s1",
-        owner_account_id="acme",
-        owner_user_id="alice",
+        account_id="acme",
+        user_id="alice",
     )
 
     assert (
         tracker.get(
             task.task_id,
-            owner_account_id="acme",
-            owner_user_id="bob",
+            account_id="acme",
+            user_id="bob",
         )
         is None
     )
@@ -206,17 +206,17 @@ def test_list_tasks_filters_by_owner(tracker: TaskTracker):
     tracker.create(
         "session_commit",
         resource_id="alice-task",
-        owner_account_id="acme",
-        owner_user_id="alice",
+        account_id="acme",
+        user_id="alice",
     )
     tracker.create(
         "session_commit",
         resource_id="bob-task",
-        owner_account_id="acme",
-        owner_user_id="bob",
+        account_id="acme",
+        user_id="bob",
     )
 
-    tasks = tracker.list_tasks(owner_account_id="acme", owner_user_id="alice")
+    tasks = tracker.list_tasks(account_id="acme", user_id="alice")
 
     assert len(tasks) == 1
     assert tasks[0].resource_id == "alice-task"
@@ -269,14 +269,14 @@ def test_create_if_no_running_isolated_by_owner(tracker: TaskTracker):
     alice_task = tracker.create_if_no_running(
         "reindex",
         "viking://resources/demo",
-        owner_account_id="acme",
-        owner_user_id="alice",
+        account_id="acme",
+        user_id="alice",
     )
     bob_task = tracker.create_if_no_running(
         "reindex",
         "viking://resources/demo",
-        owner_account_id="acme",
-        owner_user_id="bob",
+        account_id="acme",
+        user_id="bob",
     )
 
     assert alice_task is not None
@@ -303,8 +303,8 @@ def test_to_dict(tracker: TaskTracker):
     assert isinstance(d["created_at_iso"], str)
     assert "T" in d["created_at_iso"]
     assert isinstance(d["updated_at_iso"], str)
-    assert "owner_account_id" not in d
-    assert "owner_user_id" not in d
+    assert "account_id" not in d
+    assert "user_id" not in d
 
 
 # ── Sanitization ──
@@ -392,10 +392,10 @@ def test_persistent_store_cross_tracker_visibility():
     tracker2 = TaskTracker(store=store)
 
     task = tracker1.create("session_commit", resource_id="sess-123", **_owner_kwargs())
-    tracker1.start(task.task_id, owner_account_id="acme")
-    tracker1.complete(task.task_id, {"ok": True}, owner_account_id="acme")
+    tracker1.start(task.task_id, account_id="acme", user_id="alice")
+    tracker1.complete(task.task_id, {"ok": True}, account_id="acme", user_id="alice")
 
-    loaded = tracker2.get(task.task_id, owner_account_id="acme", owner_user_id="alice")
+    loaded = tracker2.get(task.task_id, account_id="acme", user_id="alice")
 
     assert loaded is not None
     assert loaded.status == TaskStatus.COMPLETED
@@ -409,13 +409,13 @@ def test_persistent_store_writes_task_record_json():
 
     task = tracker.create("add_resource", resource_id="viking://resources/demo", **_owner_kwargs())
 
-    raw = agfs.files[f"/local/acme/tasks/{task.task_id}.json"]
+    raw = agfs.files[f"/local/acme/tasks/alice/{task.task_id}.json"]
     payload = json.loads(raw.decode("utf-8"))
 
     assert payload["task_id"] == task.task_id
     assert payload["task_type"] == "add_resource"
-    assert payload["owner_account_id"] == "acme"
-    assert payload["owner_user_id"] == "alice"
+    assert payload["account_id"] == "acme"
+    assert payload["user_id"] == "alice"
     assert "schema_version" not in payload
 
 
@@ -429,10 +429,10 @@ def test_persistent_store_survives_tracker_reset():
     agfs = _FakeAgfs()
     tracker1 = TaskTracker(store=PersistentTaskStore(agfs))
     task = tracker1.create("session_commit", resource_id="sess-123", **_owner_kwargs())
-    tracker1.start(task.task_id, owner_account_id="acme")
+    tracker1.start(task.task_id, account_id="acme", user_id="alice")
 
     tracker2 = TaskTracker(store=PersistentTaskStore(agfs))
-    loaded = tracker2.get(task.task_id, owner_account_id="acme", owner_user_id="alice")
+    loaded = tracker2.get(task.task_id, account_id="acme", user_id="alice")
 
     assert loaded is not None
     assert loaded.status == TaskStatus.RUNNING
@@ -446,8 +446,8 @@ def test_persistent_store_ignores_existing_task_dirs():
     second = tracker.create("session_commit", resource_id="sess-2", **_owner_kwargs())
 
     assert first.task_id != second.task_id
-    assert agfs.files[f"/local/acme/tasks/{first.task_id}.json"]
-    assert agfs.files[f"/local/acme/tasks/{second.task_id}.json"]
+    assert agfs.files[f"/local/acme/tasks/alice/{first.task_id}.json"]
+    assert agfs.files[f"/local/acme/tasks/alice/{second.task_id}.json"]
 
 
 def test_create_requires_owner(tracker: TaskTracker):
@@ -465,8 +465,8 @@ def test_create_rejects_blank_owner_values(tracker: TaskTracker):
         tracker.create(
             "session_commit",
             resource_id="sess-123",
-            owner_account_id="",
-            owner_user_id="alice",
+            account_id="",
+            user_id="alice",
         )
 
 


### PR DESCRIPTION
# OpenViking Task Tracker 持久化设计与当前实现说明

## 1. 背景

OpenViking 的异步任务跟踪由 `TaskTracker` 提供，典型任务包括：

- `session_commit`
- `add_resource`
- `add_skill`
- `admin_reindex`

这些接口会返回 `task_id`，调用方再通过下面两个接口查询状态：

- `GET /api/v1/tasks/{task_id}`
- `GET /api/v1/tasks`

原始实现只有进程内内存映射：

- `task_id -> TaskRecord`

这会带来两个问题：

1. 多实例部署时，一个实例返回的 `task_id`，请求打到另一个实例就查不到。
2. 服务重启后，历史任务状态随内存一起丢失。

当前实现已经把 `TaskTracker` 改造成“接口基本不变、存储后端可插拔”的结构，同时支持：

- `memory`
- `persistent`

其中 `persistent` 方案可以满足：

1. 集群内跨实例查询同一个 `task_id`
2. 服务重启后继续查询已落盘任务
3. 后续异步阶段继续更新同一个 `task_id`

## 2. 设计目标

当前实现的目标如下：

1. 不破坏 `TaskTracker` 的核心对外能力。
2. 允许通过配置在 `memory` 和 `persistent` 后端之间切换。
3. 在 `persistent` 模式下，任务状态对多实例可见。
4. 后续异步阶段可以基于 `task_id + account_id + user_id` 继续更新同一任务。
5. 保持实现简单，不引入额外的分布式协调复杂度。

## 3. 非目标

当前实现明确不处理下面这些复杂问题：

1. 不做持久化任务自动清理。
2. 不做实例宕机后自动把任务改成 `failed`。
3. 不做 lease / heartbeat / stale detection。
4. 不做任务接管或故障转移。
5. 不做 CAS 或分布式锁，允许简单的 last-write-wins。

## 4. 当前总体架构

### 4.1 组件

当前实现涉及三个核心部分：

1. `TaskTracker`
   - 文件：`openviking/service/task_tracker.py`
   - 负责任务生命周期、内存缓存、权限过滤、TTL 清理

2. `TaskStore`
   - 文件：`openviking/service/task_store.py`
   - 负责底层任务存储抽象

3. `StorageConfig.build_task_tracker()`
   - 文件：`openviking_cli/utils/config/storage_config.py`
   - 负责根据配置构建 `TaskTracker`

### 4.2 存储后端

`TaskStore` 当前有两种实现：

1. `InMemoryTaskStore`
2. `PersistentTaskStore`

`TaskTracker` 内部既保留：

- 当前进程内 `_tasks: Dict[str, TaskRecord]`

也持有：

- `self._store`

其中：

- `memory` 模式下，`self._store` 是 `InMemoryTaskStore`
- `persistent` 模式下，`self._store` 是 `PersistentTaskStore`

## 5. 配置方式

当前配置项如下：

```json
{
  "storage": {
    "task_tracker": {
      "backend": "memory"
    }
  }
}
```

支持值：

- `memory`
- `persistent`

### 5.1 默认值

当前默认值是：

```json
{
  "storage": {
    "task_tracker": {
      "backend": "memory"
    }
  }
}
```

也就是说：

- 默认行为仍然是单进程内存任务跟踪
- 如果需要跨实例 / 重启后可查，必须显式改成 `persistent`

### 5.2 构建逻辑

当前构建逻辑是：

- `backend == "memory"` -> `TaskTracker()`
- `backend == "persistent"` -> `TaskTracker(store=PersistentTaskStore(agfs))`

## 6. 数据模型

### 6.1 TaskRecord

当前 `TaskRecord` 字段如下：

```python
task_id: str
task_type: str
status: TaskStatus
created_at: float
updated_at: float
resource_id: Optional[str]
account_id: Optional[str]
user_id: Optional[str]
result: Optional[Dict[str, Any]]
error: Optional[str]
```

说明：

1. `account_id` / `user_id` 是任务归属信息。
2. `TaskRecord.to_dict()` 对外返回时会去掉 `account_id` / `user_id`。
3. 当前没有 `schema_version` 字段。

### 6.2 持久化 JSON 结构

持久化文件内部直接存 `TaskRecord` 的 JSON 表达，示例如下：

```json
{
  "task_id": "5f0ec6f0-9e69-4d32-8dc7-2e5f4c2efabc",
  "task_type": "add_resource",
  "status": "completed",
  "created_at": 1778300000.123,
  "updated_at": 1778300002.456,
  "resource_id": "viking://resources/demo",
  "account_id": "acme",
  "user_id": "alice",
  "result": {
    "root_uri": "viking://resources/demo"
  },
  "error": null
}
```

## 7. 持久化路径设计

### 7.1 当前物理路径

当前 `PersistentTaskStore` 的落盘路径是：

```text
/local/{account_id}/tasks/{user_id}/{task_id}.json
```

例如：

```text
/local/acme/tasks/alice/a59daadb-c164-446a-86a2-361ac65b2614.json
```

### 7.2 这样设计的原因

当前接口查询语义是按 `account_id + user_id` 过滤，因此路径上也带上 `user_id`，这样更一致：

1. `account_id` 负责租户级隔离
2. `user_id` 负责租户内用户级分桶
3. `task_id` 是该用户任务目录下的唯一键

相较于旧版的：

```text
/local/{account_id}/tasks/{task_id}.json
```

当前路径更符合现有接口行为。

### 7.3 目录层次

当前目录结构含义如下：

```text
/local/{account_id}/tasks/                  # 某个 account 的 task 根目录
/local/{account_id}/tasks/{user_id}/       # 某个 user 的 task 子目录
/local/{account_id}/tasks/{user_id}/{task_id}.json
```

### 7.4 保留目录约束

`tasks` 被视为内部保留目录，不应被当作普通业务资源使用。

当前实现里：

- `openviking/storage/viking_fs.py`

已经将 `tasks` 视为内部保留名称的一部分，用于避免被普通资源视图误用。

## 8. TaskStore 抽象

### 8.1 当前接口

当前 `TaskStore` 接口如下：

1. `create(task)`
2. `update(task)`
3. `get(task_id, account_id=None, user_id=None)`
4. `list(account_id, user_id=None)`
5. `delete(task_id, account_id, user_id=None)`

### 8.2 InMemoryTaskStore

`InMemoryTaskStore` 的特点：

1. 数据仅保存在当前进程内存
2. 支持按 `account_id` / `user_id` 过滤
3. 重启即丢失
4. 会配合 `TaskTracker` 的 TTL 清理删除内存记录

### 8.3 PersistentTaskStore

`PersistentTaskStore` 的特点：

1. 通过 AGFS 持久化到 `/local/...`
2. `create` / `update` 都是覆盖写目标 JSON 文件
3. `get` 必须提供：
   - `account_id`
   - `user_id`
4. `list` 当前只支持按单个 user 目录扫描
5. `delete` 当前也要求提供 `account_id + user_id`

### 8.4 目录创建行为

`PersistentTaskStore` 在写入前会确保目录存在：

1. `/local/{account_id}`
2. `/local/{account_id}/tasks`
3. `/local/{account_id}/tasks/{user_id}`

当前实现对 `mkdir already exists` 做了幂等处理，避免重复创建时报错。

## 9. TaskTracker 当前行为

### 9.1 创建任务

创建任务时：

1. 必须提供非空的 `account_id`
2. 必须提供非空的 `user_id`
3. 先写入内存 `_tasks`
4. 再调用 `self._store.create(task)`

适用接口：

- `create()`
- `create_if_no_running()`

### 9.2 更新任务

当前以下接口都支持显式传入：

- `start(task_id, account_id=None, user_id=None)`
- `complete(task_id, result=None, account_id=None, user_id=None)`
- `fail(task_id, error, account_id=None, user_id=None)`

行为分两种：

1. 如果当前实例内存里已经有这个 `task_id`
   - 直接命中内存对象
   - 更新内存
   - 同步写回 `self._store`

2. 如果当前实例内存里没有这个 `task_id`
   - 只有在同时提供 `account_id + user_id` 时
   - 才会去持久化层回捞
   - 回捞成功后更新并再次写回

这就是“跨实例 / 重启后继续更新同一个 task”的基础。

### 9.3 查询任务

`get(task_id, account_id=None, user_id=None)` 行为：

1. 先看本地 `_tasks`
2. 如果本地没有且传了 `account_id`
   - 尝试从 store 回捞
3. 最后通过 `_matches_owner()` 做 `account_id + user_id` 过滤

### 9.4 列表与查重

`list_tasks()` 和 `has_running()` 在带 `account_id` 的情况下，会先尝试从 store 加载该范围内任务，再做过滤。

当前在 `persistent` 模式下，真正的加载粒度已经是：

- `account_id + user_id`

因为 `PersistentTaskStore.list()` 当前只按单 user 目录列举。

## 10. HTTP 查询语义

### 10.1 当前 `/api/v1/tasks` 语义

`/api/v1/tasks` 当前不是只按 `account` 过滤，而是同时按：

- `account_id`
- `user_id`

过滤返回。

路由位于：

- `openviking/server/routers/tasks.py`

### 10.2 当前 `/api/v1/tasks/{task_id}` 语义

单任务查询同样按：

- `account_id`
- `user_id`

限制可见性。

也就是说：

1. 同一 account 下不同 user 默认互相不可见
2. task 的持久化路径分桶和查询权限语义保持一致

## 11. 后续异步阶段如何更新同一个 task_id

### 11.1 当前要求

如果任务后续更新有可能发生在：

- 另一个实例
- 当前实例重启之后
- 当前实例内存缓存丢失之后

那么后续更新代码必须显式携带：

- `task_id`
- `account_id`
- `user_id`

### 11.2 原因

因为当前持久化路径是：

```text
/local/{account_id}/tasks/{user_id}/{task_id}.json
```

如果没有 `user_id`，就无法从持久化层准确定位到文件。

### 11.3 当前已经补齐的调用链

当前实现里，下面这些异步更新链路都已经显式传递 `account_id + user_id`：

1. `session.commit_async()` 后续阶段
2. `ResourceService.add_resource()` 队列监控阶段
3. `ResourceService.add_skill()` 队列监控阶段
4. `ReindexExecutor._run_tracked()`

## 12. 清理语义

### 12.1 memory 模式

`memory` 模式保留原始的 TTL 清理行为：

1. `COMPLETED` 保留 24 小时
2. `FAILED` 保留 7 天
3. 每 5 分钟清理一次
4. 超过 `MAX_TASKS=10000` 时做 FIFO 淘汰

### 12.2 persistent 模式

当前一期实现里：

1. `TaskTracker` 仍然会清理当前进程内 `_tasks` 缓存
2. 但不会删除持久化 JSON 文件

也就是说：

- 内存缓存会过期
- 持久化记录不会自动清理

这是当前实现有意保留的简化策略。

## 13. 当前实现的优点

1. 对上层调用方改动小，`TaskTracker` 主接口仍然可用。
2. `memory` 和 `persistent` 可切换，便于渐进上线。
3. `persistent` 模式能满足最基本的跨实例查询诉求。
4. `account_id + user_id` 分桶与当前 HTTP 查询语义一致。
5. 后续异步阶段只要带齐三元组：
   - `task_id`
   - `account_id`
   - `user_id`
   就能继续更新同一任务。

## 14. 当前实现的限制

1. 持久化任务不会自动清理，长期运行会累积 JSON 文件。
2. 如果执行任务的实例中途挂掉，任务不会自动变成 `failed`。
3. `PersistentTaskStore.list()` 当前只支持 user 级列举，不支持 account 级聚合枚举。
4. `start/complete/fail` 在跨实例场景下必须显式传 `user_id`，否则无法命中持久化路径。
5. 当前没有分布式并发保护，多个实例同时更新同一任务时采用简单覆盖写语义。

## 15. 当前实现总结

当前代码已经落地了一个“一期可用”的持久化 task tracker：

1. 默认仍是 `memory`
2. 打开 `persistent` 后，可通过：
   - `/local/{account_id}/tasks/{user_id}/{task_id}.json`
   提供跨实例查询基础
3. `TaskTracker` 对外能力保留
4. `TaskStore` 负责存储抽象
5. 后续异步更新链路显式携带 `account_id + user_id`

这套实现已经满足最核心的集群诉求：

- 一个实例返回的 `task_id`
- 另一个实例可以查到
- 重启后仍可查
- 后续阶段还能继续更新到同一个 `task_id`

但它仍然是一个偏简单的一期实现，未来如果需要更完善的运维能力，还可以继续补：

- 持久化清理
- 宕机超时失败标记
- account 级任务枚举
- 更严格的并发更新保护
