### PR TITLE
refactor(cli): share RAM environment detection

### DIFF
--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from openviking_cli.utils.environment import get_system_ram_gb as _get_system_ram_gb
 from openviking_cli.utils.config.consts import DEFAULT_CONFIG_DIR, OPENVIKING_CONFIG_ENV
 from openviking_cli.utils.ollama import (
     check_ollama_running,
@@ -222,41 +223,6 @@ def _configured_hint(enabled: bool) -> str:
 # ---------------------------------------------------------------------------
 # System info
 # ---------------------------------------------------------------------------
-
-
-def _get_system_ram_gb() -> int:
-    """Get total system RAM in GB."""
-    try:
-        pages = os.sysconf("SC_PHYS_PAGES")
-        page_size = os.sysconf("SC_PAGE_SIZE")
-        return (pages * page_size) // (1024**3)
-    except (ValueError, OSError, AttributeError):
-        pass
-    # Windows fallback
-    try:
-        import ctypes
-
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-
-        class MEMORYSTATUSEX(ctypes.Structure):
-            _fields_ = [
-                ("dwLength", ctypes.c_ulong),
-                ("dwMemoryLoad", ctypes.c_ulong),
-                ("ullTotalPhys", ctypes.c_ulonglong),
-                ("ullAvailPhys", ctypes.c_ulonglong),
-                ("ullTotalPageFile", ctypes.c_ulonglong),
-                ("ullAvailPageFile", ctypes.c_ulonglong),
-                ("ullTotalVirtual", ctypes.c_ulonglong),
-                ("ullAvailVirtual", ctypes.c_ulonglong),
-                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
-            ]
-
-        stat = MEMORYSTATUSEX()
-        stat.dwLength = ctypes.sizeof(stat)
-        kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
-        return stat.ullTotalPhys // (1024**3)
-    except Exception:
-        return 0
 
 
 # ---------------------------------------------------------------------------

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from openviking_cli.utils.config.consts import DEFAULT_CONFIG_DIR, OPENVIKING_CONFIG_ENV
+from openviking_cli.utils.environment import get_system_ram_gb as _get_system_ram_gb
 from openviking_cli.utils.ollama import (
     check_ollama_running,
     get_ollama_models,
@@ -444,41 +445,6 @@ def _print_banner() -> None:
 # ---------------------------------------------------------------------------
 # System info
 # ---------------------------------------------------------------------------
-
-
-def _get_system_ram_gb() -> int:
-    """Get total system RAM in GB."""
-    try:
-        pages = os.sysconf("SC_PHYS_PAGES")
-        page_size = os.sysconf("SC_PAGE_SIZE")
-        return (pages * page_size) // (1024**3)
-    except (ValueError, OSError, AttributeError):
-        pass
-    # Windows fallback
-    try:
-        import ctypes
-
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-
-        class MEMORYSTATUSEX(ctypes.Structure):
-            _fields_ = [
-                ("dwLength", ctypes.c_ulong),
-                ("dwMemoryLoad", ctypes.c_ulong),
-                ("ullTotalPhys", ctypes.c_ulonglong),
-                ("ullAvailPhys", ctypes.c_ulonglong),
-                ("ullTotalPageFile", ctypes.c_ulonglong),
-                ("ullAvailPageFile", ctypes.c_ulonglong),
-                ("ullTotalVirtual", ctypes.c_ulonglong),
-                ("ullAvailVirtual", ctypes.c_ulonglong),
-                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
-            ]
-
-        stat = MEMORYSTATUSEX()
-        stat.dwLength = ctypes.sizeof(stat)
-        kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
-        return stat.ullTotalPhys // (1024**3)
-    except Exception:
-        return 0
 
 
 def _parse_size_gb(size_hint: str) -> float:

--- a/openviking_cli/utils/environment.py
+++ b/openviking_cli/utils/environment.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Environment detection helpers shared by OpenViking CLI entry points."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+
+
+def get_system_ram_gb() -> int:
+    """Return total physical RAM in GiB, or 0 when it cannot be detected."""
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return int((pages * page_size) // (1024**3))
+    except (ValueError, OSError, AttributeError):
+        pass
+
+    try:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(stat)
+        if kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            return int(stat.ullTotalPhys // (1024**3))
+    except Exception:
+        pass
+    return 0

--- a/openviking_cli/utils/environment.py
+++ b/openviking_cli/utils/environment.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Environment detection helpers shared by OpenViking CLI entry points."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+
+
+def get_system_ram_gb() -> int:
+    """Return total physical RAM in GiB, or 0 when it cannot be detected."""
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return int((pages * page_size) // (1024**3))
+    except (ValueError, OSError, AttributeError):
+        pass
+
+    try:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(stat)
+        if kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            return int(stat.ullTotalPhys // (1024**3))
+    except (AttributeError, OSError, TypeError, ValueError, ctypes.ArgumentError):
+        pass
+    return 0

--- a/tests/cli/test_environment.py
+++ b/tests/cli/test_environment.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from openviking_cli.utils import environment
+
+
+def test_get_system_ram_gb_uses_sysconf_values():
+    def fake_sysconf(name: str) -> int:
+        values = {
+            "SC_PHYS_PAGES": 4 * 1024,
+            "SC_PAGE_SIZE": 1024 * 1024,
+        }
+        return values[name]
+
+    with patch.object(environment.os, "sysconf", side_effect=fake_sysconf):
+        assert environment.get_system_ram_gb() == 4
+
+
+def test_get_system_ram_gb_uses_windows_fallback_when_sysconf_unavailable():
+    class FakeKernel32:
+        def GlobalMemoryStatusEx(self, stat_ptr):
+            stat_ptr._obj.ullTotalPhys = 16 * 1024**3
+            return 1
+
+    with patch.object(environment.os, "sysconf", side_effect=AttributeError):
+        with patch.object(
+            environment.ctypes,
+            "windll",
+            SimpleNamespace(kernel32=FakeKernel32()),
+            create=True,
+        ):
+            assert environment.get_system_ram_gb() == 16
+
+
+def test_get_system_ram_gb_returns_zero_when_detection_fails():
+    with patch.object(environment.os, "sysconf", side_effect=OSError):
+        with patch.object(environment.ctypes, "windll", None, create=True):
+            assert environment.get_system_ram_gb() == 0


### PR DESCRIPTION
## Description

Move the setup wizard's RAM detection into a reusable CLI environment helper. This keeps the existing `openviking-server init` RAM-tier recommendations unchanged while making the detection logic available to future environment/doctor checks.

## Related Issue

Related to #1436

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added `openviking_cli.utils.environment.get_system_ram_gb()`.
- Updated `setup_wizard.py` to reuse the shared helper for RAM-tier model recommendations.
- Added focused tests for sysconf detection, Windows fallback detection, and failure fallback.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
python3 -m pytest -o addopts='' --confcutdir=tests/cli tests/cli/test_environment.py tests/cli/test_setup_wizard.py::TestRAMRecommendations -q
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Full pytest collection was not run because this local environment is missing optional dependencies required by the repository-level test conftest. The scoped CLI tests above avoid that global conftest and cover the changed helper directly.
