### PR TITLE
docs(api): document isLocked field in stat() response (#1940)

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -465,11 +465,14 @@ openviking stat viking://resources/my-project/docs/api.md
     "mode": 33188,
     "modTime": "2024-01-01T00:00:00Z",
     "isDir": false,
+    "isLocked": false,
     "uri": "viking://resources/docs/api.md"
   },
   "time": 0.1
 }
 ```
+
+The `isLocked` field reports whether the path is currently held by a path lock — either the path itself has a valid `.path.ovlock`, or any ancestor directory holds a SUBTREE lock. Returns `false` when the LockManager is unavailable or the lookup fails, so callers can avoid attempting a write only to observe `ResourceBusyError`.
 
 ---
 

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -465,11 +465,14 @@ openviking stat viking://resources/my-project/docs/api.md
     "mode": 33188,
     "modTime": "2024-01-01T00:00:00Z",
     "isDir": false,
+    "isLocked": false,
     "uri": "viking://resources/docs/api.md"
   },
   "time": 0.1
 }
 ```
+
+`isLocked` 字段反映路径当前是否被 path lock 持有：路径自身存在有效的 `.path.ovlock`，或者任一祖先目录持有 SUBTREE 锁。当 LockManager 不可用或查询失败时返回 `false`，调用方可据此避免先写入再观察到 `ResourceBusyError`。
 
 ---
 


### PR DESCRIPTION
## Summary

#1940 (feat(fs): expose isLocked in stat() to surface path-lock state, fengluodb / qin-ctx merge 2026-05-09) added an `isLocked` boolean to the dict returned by `VikingFS.stat()` and surfaced it through `/api/v1/fs/stat`. The Python docstring and example dict were updated, but the user-facing API reference (`docs/en/api/03-filesystem.md` + `docs/zh/api/03-filesystem.md`) was not, so users reading the `stat()` Response example don't know the new field exists.

## Changes

`docs/en/api/03-filesystem.md` and `docs/zh/api/03-filesystem.md` `stat()` Response section:
1. Add `"isLocked": false` to the JSON example, mirroring the docstring example in `viking_fs.py` (`{... 'isDir': True, 'isLocked': False, 'meta': {...}}`).
2. Add one descriptive sentence paraphrasing the `PathLock.is_locked` detection rules + the best-effort fallback behavior — both verbatim from the source PR's docstring/body.

Description sources (verbatim from #1940):
- Detection rules: "Aligned with conflict-detection in the acquire flow: the path itself has a valid `.path.ovlock`; or any ancestor directory holds a SUBTREE lock."
- Best-effort fallback: "Both are best-effort and degrade to `False` when the LockManager is unavailable, keeping `stat()` resilient."
- User benefit: "Without having to attempt a write and observe `ResourceBusyError`."

## Why

Pure documentation drift catch — the source PR added a public field whose visibility is "transparently passes the dict through" the HTTP endpoint, but the Response JSON example in the API reference still shows the old shape. Multi-tenant / concurrent callers reading the docs would not know `isLocked` is available without inspecting the returned dict at runtime.

EN + ZH parity preserved.