### PR TITLE
feat(docker): support custom parameters via OPENVIKING_CONSOLE_PARAMETERS in console entrypoint

### DIFF
--- a/docker/openviking-console-entrypoint.sh
+++ b/docker/openviking-console-entrypoint.sh
@@ -6,6 +6,7 @@ SERVER_HEALTH_URL="${SERVER_URL}/health"
 SERVER_READY_URL="${SERVER_URL}/ready"
 CONSOLE_PORT="${OPENVIKING_CONSOLE_PORT:-8020}"
 CONSOLE_HOST="${OPENVIKING_CONSOLE_HOST:-0.0.0.0}"
+CONSOLE_PARAMETERS="${OPENVIKING_CONSOLE_PARAMETERS:-""}"
 WITH_BOT="${OPENVIKING_WITH_BOT:-1}"
 HEALTH_MAX_ATTEMPTS="${OPENVIKING_HEALTH_MAX_ATTEMPTS:-120}"
 READY_MAX_ATTEMPTS="${OPENVIKING_READY_MAX_ATTEMPTS:-300}"
@@ -154,10 +155,15 @@ until curl -fsS "${SERVER_READY_URL}" 2>/dev/null | grep -q '"status":"ready"'; 
 done
 echo "[openviking-console-entrypoint] openviking-server is ready"
 
+if [ -n "${CONSOLE_PARAMETERS}" ]; then
+    echo "[openviking-console-entrypoint] Starting console with extra parameter: ${CONSOLE_PARAMETERS}"
+fi
+
 python -m openviking.console.bootstrap \
     --host "${CONSOLE_HOST}" \
     --port "${CONSOLE_PORT}" \
-    --openviking-url "${SERVER_URL}" &
+    --openviking-url "${SERVER_URL}" \
+    ${CONSOLE_PARAMETERS} &
 CONSOLE_PID=$!
 
 while kill -0 "${SERVER_PID}" 2>/dev/null && kill -0 "${CONSOLE_PID}" 2>/dev/null; do


### PR DESCRIPTION
### Description

This PR introduces the `OPENVIKING_CONSOLE_PARAMETERS` environment variable to the console entrypoint script.

**The Problem:**
Currently, several guides (e.g., `05-observability.md`, `11-oauth.md`) and design docs (`mcp-oauth2-1.md`) explicitly state that users should start the console with the `--write-enabled` flag to perform administrative actions such as adding resources or managing tenants. However, there is currently no way to pass this flag when running OpenViking via Docker or Docker Compose, effectively locking containerized users into a "read-only" mode.

**The Solution:**
By adding support for `OPENVIKING_CONSOLE_PARAMETERS`, users can now inject `--write-enabled` (or any other future flags) into the bootstrap process via their `docker-compose.yml` or `docker run` environment settings.

## Related Issue

## Type of Change

* [x] New feature (non-breaking change that adds functionality)

## Changes Made

* Added `CONSOLE_PARAMETERS` variable to the entrypoint script, defaulting to an empty string.
* Implemented a conditional log output to only display "Starting console with extra parameter: ..." when the variable is non-empty, keeping logs clean.
* Appended `${CONSOLE_PARAMETERS}` to the `python -m openviking.console.bootstrap` execution command.

## Testing

* [x] Manual testing completed
  * **Case 1**: Set `OPENVIKING_CONSOLE_PARAMETERS="--write-enabled"`. Verified the console starts with write permissions and logs reflect the parameter.
  * **Case 2**: Unset the variable. Verified the console starts normally without trailing empty strings in the logs.
* [x] I have tested this on the following platforms:
  * [x] Linux (Docker environment)

## Checklist

* [x] My code follows the project's coding style
* [x] I have performed a self-review of my code
* [x] I have made corresponding changes to the documentation (Implementation now matches documentation)
* [x] My changes generate no new warnings

## Additional Notes

* This change ensures consistency between the manual Python execution described in the guides and the containerized deployment path.
* ✨ Assisted by Gemini