### PR TITLE
docs(ovcli.conf): note interactive setup-cli + multi-server switch from #1916

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -966,6 +966,8 @@ For memory-related settings, add a `memory` section in `ov.conf`:
 
 ### ovcli.conf
 
+You can edit this file by hand, or generate it interactively with `ov config setup-cli`. If you maintain configurations for multiple servers, switch between them with `ov config switch`.
+
 Config file for the HTTP client (`SyncHTTPClient` / `AsyncHTTPClient`) and CLI to connect to a remote server:
 
 ```json

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -940,6 +940,8 @@ openviking-server --config /path/to/ov.conf
 
 ### ovcli.conf
 
+你可以手动编辑此文件，也可以用 `ov config setup-cli` 交互式生成。如果你维护着多个服务端的配置，可以用 `ov config switch` 在它们之间切换。
+
 HTTP 客户端（`SyncHTTPClient` / `AsyncHTTPClient`）和 CLI 工具连接远程服务端的配置文件：
 
 ```json


### PR DESCRIPTION
### Problem

#1916 (`feat: ov CLI support`, MaojiaSheng → ZaynJarvis 2026-05-08) added `ov config setup-cli` (interactive `ovcli.conf` generation) and `ov config switch` (multi-server profile switching). The PR updated `README.md` (line 507) and `README_CN.md` (line 435) under "CLI/Client Configuration Examples", but the dedicated `ovcli.conf` reference section in the configuration guide (`docs/{en,zh}/guides/01-configuration.md`) still only describes the manual JSON edit path. Users who reach the reference doc — typically the audience reading config field tables — never learn that the file can also be generated and swapped via the CLI.

### Fix

Adds one sentence at the top of each `### ovcli.conf` subsection (EN + ZH), naming both subcommands and framing them as the manual-vs-interactive complement of editing by hand. Wording is grounded in #1916's own README diff — `ov config setup-cli` for interactive initialization, `ov config switch` for switching between configurations. No new fields, no behavior change, no JSON example changes.

### Diff

`docs/en/guides/01-configuration.md` (+2):

```
### ovcli.conf

+You can edit this file by hand, or generate it interactively with `ov config setup-cli`. If you maintain configurations for multiple servers, switch between them with `ov config switch`.
+
 Config file for the HTTP client (`SyncHTTPClient` / `AsyncHTTPClient`) and CLI to connect to a remote server:
```

`docs/zh/guides/01-configuration.md` (+2): byte-for-byte semantic mirror in CN.

### Why this isn't redundant with the README catch in #1916

The README block lives under the onboarding "CLI/Client Configuration Examples" subsection — quickstart audience. `docs/{en,zh}/guides/01-configuration.md` is the dedicated reference doc covering the full ovcli.conf field table, CLI flag overrides, and gitignore behavior. Reference-doc readers do not necessarily read README first; surfacing the same two commands at the top of the dedicated section closes the discoverability gap without duplicating implementation detail.

### Source PR & precedent

- Source: #1916 by @MaojiaSheng, merged by @ZaynJarvis 2026-05-08
- Form-factor precedent: my own #1925 (qin-ctx, 7.2h) covered `temp_upload` server config + `ovcli.conf upload.mode` drift from #1899 in the same file.