### PR TITLE
feat(fs): add opt-in deterministic ordering to ls

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -240,6 +240,7 @@ impl HttpClient {
         abs_limit: i32,
         show_all_hidden: bool,
         node_limit: i32,
+        enable_sort: bool,
     ) -> Result<serde_json::Value> {
         let params = vec![
             ("uri".to_string(), uri.to_string()),
@@ -249,6 +250,7 @@ impl HttpClient {
             ("abs_limit".to_string(), abs_limit.to_string()),
             ("show_all_hidden".to_string(), show_all_hidden.to_string()),
             ("node_limit".to_string(), node_limit.to_string()),
+            ("enable_sort".to_string(), enable_sort.to_string()),
         ];
         self.get("/api/v1/fs/ls", &params).await
     }

--- a/crates/ov_cli/src/commands/filesystem.rs
+++ b/crates/ov_cli/src/commands/filesystem.rs
@@ -11,6 +11,7 @@ pub async fn ls(
     abs_limit: i32,
     show_all_hidden: bool,
     node_limit: i32,
+    enable_sort: bool,
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
@@ -23,6 +24,7 @@ pub async fn ls(
             abs_limit,
             show_all_hidden,
             node_limit,
+            enable_sort,
         )
         .await?;
     output_success(&result, output_format, compact);

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -902,6 +902,7 @@ pub async fn handle_ls(
     abs_limit: i32,
     show_all_hidden: bool,
     node_limit: i32,
+    enable_sort: bool,
     ctx: CliContext,
 ) -> Result<()> {
     let mut params = vec![
@@ -918,6 +919,9 @@ pub async fn handle_ls(
     if show_all_hidden {
         params.push("-a".to_string());
     }
+    if enable_sort {
+        params.push("--enable-sort".to_string());
+    }
     print_command_echo("ov ls", &params.join(" "), ctx.config.echo_command);
 
     let client = ctx.get_client();
@@ -931,6 +935,7 @@ pub async fn handle_ls(
         abs_limit,
         show_all_hidden,
         node_limit,
+        enable_sort,
         ctx.output_format,
         ctx.compact,
     )

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -256,6 +256,11 @@ enum Commands {
             default_value = "256"
         )]
         node_limit: i32,
+        /// Return entries in deterministic order (files first, then case-folded
+        /// name asc) and apply a stable truncation window. Defaults to false:
+        /// entries follow the raw AGFS order. Only affects non-recursive ls.
+        #[arg(long = "enable-sort", default_value_t = false)]
+        enable_sort: bool,
     },
     /// [Data] Get directory tree
     Tree {
@@ -1102,7 +1107,8 @@ async fn main() {
             abs_limit,
             all,
             node_limit,
-        } => handlers::handle_ls(uri, simple, recursive, abs_limit, all, node_limit, ctx).await,
+            enable_sort,
+        } => handlers::handle_ls(uri, simple, recursive, abs_limit, all, node_limit, enable_sort, ctx).await,
         Commands::Tree {
             uri,
             abs_limit,

--- a/crates/ov_cli/src/tui/tree.rs
+++ b/crates/ov_cli/src/tui/tree.rs
@@ -139,7 +139,7 @@ impl TreeState {
 
     async fn fetch_children(client: &HttpClient, uri: &str) -> Result<Vec<TreeNode>, String> {
         let result = client
-            .ls(uri, false, false, "original", 256, false, 1000)
+            .ls(uri, false, false, "original", 256, false, 1000, false)
             .await
             .map_err(|e| e.to_string())?;
 

--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -29,6 +29,15 @@ async def ls(
     show_all_hidden: bool = Query(False, description="List all hidden files, like -a"),
     node_limit: int = Query(1000, description="Maximum number of nodes to list"),
     limit: Optional[int] = Query(None, description="Alias for node_limit"),
+    enable_sort: bool = Query(
+        False,
+        description=(
+            "Whether to return entries in a deterministic order "
+            "(files first, then case-folded name asc) and apply a "
+            "stable truncation window. Defaults to false: entries follow "
+            "the raw AGFS order. Only affects non-recursive ls."
+        ),
+    ),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """List directory contents."""
@@ -46,6 +55,7 @@ async def ls(
             abs_limit=abs_limit,
             show_all_hidden=show_all_hidden,
             node_limit=actual_node_limit,
+            enable_sort=enable_sort,
         )
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -62,6 +62,7 @@ class FSService:
         show_all_hidden: bool = False,
         node_limit: int = 1000,
         level_limit: int = 3,
+        enable_sort: bool = False,
     ) -> List[Any]:
         """List directory contents.
 
@@ -73,6 +74,12 @@ class FSService:
             abs_limit: int = 256 if output == "agent" else ignore
             show_all_hidden: bool = False (list all hidden files, like -a)
             node_limit: int = 1000 (maximum number of nodes to list)
+            enable_sort: bool = False (default). When True, entries are
+                returned in a deterministic order (files first, then
+                case-folded name asc) and the truncation window is stable.
+                When False (default), entries follow the raw AGFS order.
+                Note: only applied to non-recursive ls; recursive tree()
+                ignores this flag.
         """
         viking_fs = self._ensure_initialized()
         uri = validate_viking_uri(uri)
@@ -95,6 +102,7 @@ class FSService:
                     output="original",
                     show_all_hidden=show_all_hidden,
                     node_limit=node_limit,
+                    enable_sort=enable_sort,
                 )
             return [e.get("uri", "") for e in entries]
 
@@ -116,6 +124,7 @@ class FSService:
                 abs_limit=abs_limit,
                 show_all_hidden=show_all_hidden,
                 node_limit=node_limit,
+                enable_sort=enable_sort,
             )
         return entries
 

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1632,6 +1632,30 @@ class VikingFS:
     _INTERNAL_NAMES = {"_system", ".path.ovlock"}
     _ROOT_PATH = "/local"
 
+    # ls() deterministic ordering helpers.
+    # When deterministic ordering is enabled we must collect *all* eligible
+    # entries before sorting + truncating, otherwise the truncation window
+    # would not be stable. To avoid pathological cost on huge directories we
+    # cap the scan to max(node_limit * _LS_SCAN_FACTOR, _LS_SCAN_FLOOR) raw
+    # AGFS entries, which is enough to keep the top-N deterministic for any
+    # reasonable node_limit while bounding the per-entry work (uri build +
+    # access check + datetime parse).
+    _LS_SCAN_FACTOR = 4
+    _LS_SCAN_FLOOR = 4096
+
+    @staticmethod
+    def _ls_sort_key(entry: Dict[str, Any]) -> tuple:
+        """Deterministic sort key: files first, then case-folded name.
+
+        Falls back to the raw name to disambiguate entries that happen to
+        share a case-folded form (e.g. "Foo" vs "foo"), keeping the order
+        total and stable across calls.
+        """
+        name = entry.get("name", "") or ""
+        # bool(isDir) is True for directories; sorting ascending puts False
+        # (files) before True (directories) -> files come first.
+        return (bool(entry.get("isDir")), name.casefold(), name)
+
     def _ls_entries(self, path: str) -> List[Dict[str, Any]]:
         """List directory entries, filtering out internal directories.
 
@@ -2172,6 +2196,7 @@ class VikingFS:
         abs_limit: int = 256,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        enable_sort: bool = False,
         ctx: Optional[RequestContext] = None,
     ) -> List[Dict[str, Any]]:
         """
@@ -2183,6 +2208,13 @@ class VikingFS:
             abs_limit: int = 256
             show_all_hidden: bool = False (list all hidden files, like -a)
             node_limit: int = 1000 (maximum number of nodes to list)
+            enable_sort: bool = False (default). When True, entries are
+                returned in a deterministic order (files first, then
+                case-folded name asc) and the truncation window is stable
+                across calls. When False (default), entries follow the raw
+                AGFS order and are truncated by the original
+                "break on node_limit" rule (faster on huge dirs but not
+                idempotent under truncation).
 
         output="original"
         [{'name': '.abstract.md', 'size': 100, 'mode': 420, 'modTime': '2026-02-11T16:52:16.256334192+08:00', 'isDir': False, 'meta': {'Name': 'localfs', 'Type': 'local', 'Content': None}, 'uri': 'viking://resources/.abstract.md'}]
@@ -2192,9 +2224,18 @@ class VikingFS:
         """
         self._ensure_access(uri, ctx)
         if output == "original":
-            return await self._ls_original(uri, show_all_hidden, node_limit, ctx=ctx)
+            return await self._ls_original(
+                uri, show_all_hidden, node_limit, enable_sort=enable_sort, ctx=ctx
+            )
         elif output == "agent":
-            return await self._ls_agent(uri, abs_limit, show_all_hidden, node_limit, ctx=ctx)
+            return await self._ls_agent(
+                uri,
+                abs_limit,
+                show_all_hidden,
+                node_limit,
+                enable_sort=enable_sort,
+                ctx=ctx,
+            )
         else:
             raise ValueError(f"Invalid output format: {output}")
 
@@ -2204,6 +2245,7 @@ class VikingFS:
         abs_limit: int,
         show_all_hidden: bool,
         node_limit: int = 1000,
+        enable_sort: bool = False,
         ctx: Optional[RequestContext] = None,
     ) -> List[Dict[str, Any]]:
         """List directory contents (URI version)."""
@@ -2215,9 +2257,18 @@ class VikingFS:
             raise NotFoundError(uri, "directory")
         # basic info
         now = datetime.now(timezone.utc)
-        all_entries = []
-        for entry in entries:
-            if len(all_entries) >= node_limit:
+        # When sorting is enabled we need to collect all eligible entries
+        # before sort+truncate, so cap the scan to keep cost bounded on huge
+        # directories. When disabled, fall back to the legacy "break on
+        # node_limit" behaviour which is faster but not idempotent.
+        if enable_sort:
+            scan_cap = max(node_limit * self._LS_SCAN_FACTOR, self._LS_SCAN_FLOOR)
+            raw = entries[:scan_cap]
+        else:
+            raw = entries
+        filtered: List[Dict[str, Any]] = []
+        for entry in raw:
+            if not enable_sort and len(filtered) >= node_limit:
                 break
             name = entry.get("name", "")
             raw_time = entry.get("modTime", "")
@@ -2237,16 +2288,26 @@ class VikingFS:
                 "size": 0 if is_dir else entry.get("size", 0),
                 "isDir": is_dir,
                 "modTime": format_simplified(parsed_time, now),
+                # Carry the raw name so the deterministic sort key is stable
+                # regardless of any later URI rewriting.
+                "name": name,
             }
             if not self._is_accessible(new_entry["uri"], real_ctx):
                 continue
             if is_dir:
-                all_entries.append(new_entry)
+                filtered.append(new_entry)
             elif not name.startswith("."):
-                all_entries.append(new_entry)
+                filtered.append(new_entry)
             elif show_all_hidden:
-                all_entries.append(new_entry)
-        # call abstract in parallel 6 threads
+                filtered.append(new_entry)
+        if enable_sort:
+            # Deterministic order: files first, case-folded name asc.
+            filtered.sort(key=self._ls_sort_key)
+            all_entries = filtered[:node_limit]
+        else:
+            all_entries = filtered
+        # call abstract in parallel 6 threads (only on the kept window to
+        # avoid wasting IO on truncated entries).
         await self._batch_fetch_abstracts(all_entries, abs_limit, ctx=ctx)
         return all_entries
 
@@ -2255,6 +2316,7 @@ class VikingFS:
         uri: str,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        enable_sort: bool = False,
         ctx: Optional[RequestContext] = None,
     ) -> List[Dict[str, Any]]:
         """List directory contents (URI version)."""
@@ -2263,9 +2325,14 @@ class VikingFS:
         try:
             entries = self._ls_entries(path)
             # AGFS returns read-only structure, need to create new dict
-            all_entries = []
-            for entry in entries:
-                if len(all_entries) >= node_limit:
+            if enable_sort:
+                scan_cap = max(node_limit * self._LS_SCAN_FACTOR, self._LS_SCAN_FLOOR)
+                raw = entries[:scan_cap]
+            else:
+                raw = entries
+            filtered: List[Dict[str, Any]] = []
+            for entry in raw:
+                if not enable_sort and len(filtered) >= node_limit:
                     break
                 name = entry.get("name", "")
                 new_entry = dict(entry)  # Copy original data
@@ -2273,12 +2340,16 @@ class VikingFS:
                 if not self._is_accessible(new_entry["uri"], real_ctx):
                     continue
                 if entry.get("isDir"):
-                    all_entries.append(new_entry)
+                    filtered.append(new_entry)
                 elif not name.startswith("."):
-                    all_entries.append(new_entry)
+                    filtered.append(new_entry)
                 elif show_all_hidden:
-                    all_entries.append(new_entry)
-            return all_entries
+                    filtered.append(new_entry)
+            if enable_sort:
+                # Deterministic order: files first, case-folded name asc.
+                filtered.sort(key=self._ls_sort_key)
+                return filtered[:node_limit]
+            return filtered
         except Exception:
             raise NotFoundError(uri, "directory")
 


### PR DESCRIPTION
Introduce an `enable_sort` flag (default false) on the ls path so callers can request a stable, files-first / case-folded-name-asc order with a truncation window that no longer drifts under node_limit. The default behaviour is unchanged: entries follow the raw AGFS order, preserving backwards compatibility for all existing callers.

The flag is plumbed through VikingFS.ls / _ls_original / _ls_agent, the fs service, the HTTP /api/v1/fs/ls route, and the Rust ov CLI as `--enable-sort`.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
