### PR TITLE
ci(blog): deploy blog build to TOS

### DIFF
--- a/.github/workflows/blog-build.yml
+++ b/.github/workflows/blog-build.yml
@@ -1,41 +1,118 @@
-name: Blog Build & Deploy
+name: Blog TOS Deploy
 
 on:
   push:
-    branches: [blog]
-    paths: ['blog/**']
+    branches: [ blog ]
+    paths:
+      - 'blog/**'
+      - '.github/workflows/blog-build.yml'
   pull_request:
-    branches: [main]
-    paths: ['blog/**']
+    branches: [ blog ]
+    paths:
+      - 'blog/**'
+      - '.github/workflows/blog-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  TOS_BUCKET: openviking-blog
+  TOS_REGION: ap-southeast-1
+  TOS_ENDPOINT: tos-ap-southeast-1.volces.com
+  TOS_S3_ENDPOINT: tos-s3-ap-southeast-1.volces.com
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: blog
+  deploy:
+    name: Build and Upload Blog to TOS
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: blog/package-lock.json
-      - run: npm ci
-      - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
-        if: github.ref == 'refs/heads/blog'
-        with:
-          path: blog/dist
 
-  deploy:
-    if: github.ref == 'refs/heads/blog'
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/deploy-pages@v4
+      - name: Install blog dependencies
+        run: npm ci
+        working-directory: blog
+
+      - name: Build blog
+        run: npm run build
+        working-directory: blog
+
+      - name: Check TOS configuration
+        id: tos_config
+        env:
+          TOS_ACCESS_KEY: ${{ secrets.TOS_ACCESS_KEY }}
+          TOS_SECRET_KEY: ${{ secrets.TOS_SECRET_KEY }}
+        run: |
+          if [ -n "${TOS_ACCESS_KEY}" ] && [ -n "${TOS_SECRET_KEY}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: github.event_name != 'pull_request' && steps.tos_config.outputs.configured == 'true'
+        id: setup_python
+        continue-on-error: true
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install AWS CLI
+        if: github.event_name != 'pull_request' && steps.tos_config.outputs.configured == 'true'
+        id: install_aws_cli
+        continue-on-error: true
+        run: |
+          python -m pip install --upgrade awscli
+          aws configure set default.s3.addressing_style virtual
+
+      - name: Upload blog dist to TOS
+        id: upload_tos
+        if: github.event_name != 'pull_request' && steps.tos_config.outputs.configured == 'true'
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TOS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOS_SECRET_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.TOS_REGION }}
+          TOS_BUCKET: ${{ env.TOS_BUCKET }}
+          TOS_ENDPOINT: ${{ env.TOS_ENDPOINT }}
+          TOS_S3_ENDPOINT: ${{ env.TOS_S3_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          : "${AWS_ACCESS_KEY_ID:?Missing TOS_ACCESS_KEY secret}"
+          : "${AWS_SECRET_ACCESS_KEY:?Missing TOS_SECRET_KEY secret}"
+          : "${AWS_DEFAULT_REGION:?Missing TOS_REGION value}"
+          : "${TOS_BUCKET:?Missing TOS_BUCKET value}"
+          : "${TOS_ENDPOINT:?Missing TOS_ENDPOINT value}"
+          : "${TOS_S3_ENDPOINT:?Missing TOS_S3_ENDPOINT value}"
+
+          aws s3 cp blog/dist "s3://${TOS_BUCKET}/" \
+            --endpoint-url "https://${TOS_S3_ENDPOINT}" \
+            --recursive \
+            --only-show-errors
+
+      - name: Report TOS deployment failure
+        if: steps.setup_python.outcome == 'failure' || steps.install_aws_cli.outcome == 'failure' || steps.upload_tos.outcome == 'failure'
+        run: |
+          echo "::warning::Blog was built, but deploying to TOS failed. This deployment is non-blocking."
+          echo "## TOS deployment failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Blog build succeeded, but setting up TOS tooling or uploading blog/dist failed. This workflow keeps passing so TOS availability does not block other repository flows." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report skipped TOS upload
+        if: github.event_name == 'pull_request' || steps.tos_config.outputs.configured != 'true'
+        run: |
+          echo "## TOS upload skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Blog build succeeded. TOS upload is skipped for pull_request events." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Blog build succeeded, but TOS secrets are not fully configured for this repository. Upload was skipped without failing the workflow." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Description

Deploy the blog build output to the `openviking-blog` TOS bucket from the `blog` branch workflow.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Replace the blog GitHub Pages deploy flow with a TOS upload flow.
- Build the blog from `blog/` with `npm ci` and `npm run build`.
- Upload `blog/dist` to the fixed `openviking-blog` bucket using hardcoded TOS region and endpoints, with only AK/SK read from GitHub secrets.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Manual verification:

- `npm ci`
- `npm run build`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/blog-build.yml"); puts "yaml ok"'`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The PR targets the `blog` branch. The fixed TOS values are `openviking-blog`, `ap-southeast-1`, `tos-ap-southeast-1.volces.com`, and `tos-s3-ap-southeast-1.volces.com`.
