### PR TITLE
docs(storage): document task_tracker backend config from #1949

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1076,6 +1076,26 @@ Path locks are enabled by default and usually require no configuration. **The de
 
 For details on the lock mechanism, see [Path Locks and Crash Recovery](../concepts/09-transaction.md).
 
+## storage.task_tracker Section
+
+The task tracker records async task state for endpoints that return a `task_id` (task types include `session_commit`, `add_resource`, `add_skill`, and `admin_reindex`). The `persistent` backend stores task state on the workspace volume so that **a `task_id` returned by one instance can be looked up from another instance**, and task history survives a restart. The default `memory` backend keeps task state per process — sufficient for single-instance deployments.
+
+```json
+{
+  "storage": {
+    "task_tracker": {
+      "backend": "memory"
+    }
+  }
+}
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `backend` | str | Task tracker backend. `"memory"` keeps task state in process memory (single-instance). `"persistent"` enables cross-instance task lookup and survives restarts. | `"memory"` |
+
+Set `backend` to `"persistent"` for multi-instance deployments where callers may poll `GET /api/v1/tasks/{task_id}` from any instance, or when task history needs to outlive the process.
+
 ## encryption Section
 
 Enable at-rest data encryption to ensure data security and isolation in multi-tenant environments. Encryption is completely transparent to users with no API changes.

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1143,6 +1143,26 @@ openviking add-resource ./docs --exclude "*.tmp"
 
 路径锁机制的详细说明见 [路径锁与崩溃恢复](../concepts/09-transaction.md)。
 
+## storage.task_tracker 段
+
+任务跟踪器记录异步任务状态，适用于返回 `task_id` 的接口（任务类型包括 `session_commit`、`add_resource`、`add_skill`、`admin_reindex`）。`persistent` 后端把任务状态写到 workspace 卷上，因此**一个实例返回的 `task_id` 可以在另一个实例上查询**，并且任务历史在重启后仍可访问。默认 `memory` 后端把任务状态保留在进程内存中——适合单实例部署。
+
+```json
+{
+  "storage": {
+    "task_tracker": {
+      "backend": "memory"
+    }
+  }
+}
+```
+
+| 参数 | 类型 | 说明 | 默认值 |
+|------|------|------|--------|
+| `backend` | str | 任务跟踪器后端。`"memory"` 把任务状态保留在进程内存（单实例）；`"persistent"` 启用跨实例任务查询并在重启后仍可访问 | `"memory"` |
+
+多实例部署中如果调用方可能从任一实例 poll `GET /api/v1/tasks/{task_id}`，或者任务历史需要超过进程生命周期，请把 `backend` 设为 `"persistent"`。
+
 ## 完整 Schema
 
 ```json


### PR DESCRIPTION
## Summary

Document the new `storage.task_tracker.backend` configuration field added in #1949 (zhoujh01 / MaojiaSheng, 2026-05-11T03:06:31Z, `feat: Persist task tracker`). Both `docs/en/guides/01-configuration.md` and `docs/zh/guides/01-configuration.md` currently have zero mention of `task_tracker`, so operators reading the configuration guide cannot discover the field or know to enable `persistent` for multi-instance deployments.

## What's documented

- New `## storage.task_tracker Section` (EN) / `## storage.task_tracker 段` (ZH) inserted adjacent to `storage.transaction` in each file
- JSON example with default `backend: "memory"` (preserves existing single-process behavior)
- Parameter table mirroring `TaskTrackerConfig.backend` (`Literal["memory","persistent"]`, default `"memory"`) verbatim from `openviking_cli/utils/config/storage_config.py`
- Brief operator guidance: when to flip to `persistent` (cross-instance `task_id` lookup or restart survival)

Description copy uses `task_type` naming (`session_commit` / `add_resource` / `add_skill` / `admin_reindex`) matching #1949 PR body. Limitations called out in the PR's "非目标" list (no auto-cleanup, no lease/heartbeat, no takeover, no CAS — last-write-wins) are deliberately NOT advertised as features.

## Verification

```bash
# field & default verified against source
grep -nA3 'class TaskTrackerConfig' openviking_cli/utils/config/storage_config.py

# pre-flight sibling check (no competing PR)
gh search prs --repo volcengine/OpenViking --state open task_tracker
```

## Notes

- 20 LOC additive across two files, pure docs
- Both EN and ZH follow the existing `storage.transaction` section template (lead sentence → JSON example → parameter table → usage hint)
- Default value `"memory"` is highlighted so single-instance operators upgrading do not feel pressured to flip the backend
