### PR TITLE
ci(docs): set TOS cache headers for static assets

### DIFF
--- a/.github/workflows/docs-tos.yml
+++ b/.github/workflows/docs-tos.yml
@@ -94,9 +94,22 @@ jobs:
             *) TOS_S3_ENDPOINT="${TOS_ENDPOINT}" ;;
           esac
 
-          aws s3 cp docs/.vitepress/dist "s3://${TOS_BUCKET}/" \
+          DIST_DIR="docs/.vitepress/dist"
+          HTML_CACHE_CONTROL="public, max-age=0, must-revalidate"
+          STATIC_CACHE_CONTROL="public, max-age=31536000, immutable"
+
+          aws s3 cp "${DIST_DIR}" "s3://${TOS_BUCKET}/" \
             --endpoint-url "https://${TOS_S3_ENDPOINT}" \
             --recursive \
+            --exclude ".git/*" \
+            --exclude "assets/*" \
+            --cache-control "${HTML_CACHE_CONTROL}" \
+            --only-show-errors
+
+          aws s3 cp "${DIST_DIR}/assets" "s3://${TOS_BUCKET}/assets/" \
+            --endpoint-url "https://${TOS_S3_ENDPOINT}" \
+            --recursive \
+            --cache-control "${STATIC_CACHE_CONTROL}" \
             --only-show-errors
 
       - name: Report TOS deployment failure


### PR DESCRIPTION
## Description

Set explicit Cache-Control metadata when the docs site is uploaded to TOS. Non-asset entry files keep a revalidation policy, while VitePress hashed assets under `assets/` get long-lived immutable caching.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- Split the TOS docs upload into non-asset and `assets/` upload groups.
- Set `public, max-age=0, must-revalidate` for HTML and other non-asset docs entries.
- Set `public, max-age=31536000, immutable` for VitePress hashed static assets.
- Exclude generated `.git` metadata from TOS uploads.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation commands:

- `npm run docs:build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-tos.yml"); puts "yaml ok"'`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The generated docs dist currently includes a `.git` directory, so the TOS upload now explicitly excludes `.git/*` from the non-asset upload pass.
