### PR TITLE
refactor(opencode-plugin): migrate auto recall from chat.messages.transform to chat.message hook

### DIFF
--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -1429,18 +1429,6 @@ interface RecallSearchItem {
   overview?: string
 }
 
-/** Minimal message part type for hook injection. */
-interface RecallMessagePart {
-  type: "text" | "tool" | "reasoning"
-  text?: string
-}
-
-/** Minimal message shape for chat.messages.transform hook. */
-interface RecallWithParts {
-  info: { role: string }
-  parts: RecallMessagePart[]
-}
-
 const AUTO_RECALL_TIMEOUT_MS = 5_000
 
 // ─── Scoring helpers ───
@@ -1623,25 +1611,18 @@ function formatMemoryBlock(
 
 // ─── Hook helpers ───
 
-/** Extract text from the last user message. Returns null if empty or already injected. */
-function extractLatestUserText(messages: RecallWithParts[]): string | null {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-    if (msg.info.role !== "user") continue
-    const parts = msg.parts ?? []
-    const texts: string[] = []
-    for (const part of parts) {
-      if (part.type === "text" && typeof part.text === "string") {
-        texts.push(part.text)
-      }
+/** Extract text from message parts. Returns null if empty or already injected. */
+function extractMessageText(parts: { type: string; text?: string }[]): string | null {
+  const texts: string[] = []
+  for (const part of parts) {
+    if (part.type === "text" && typeof part.text === "string") {
+      texts.push(part.text)
     }
-    const joined = texts.join(" ").trim()
-    if (!joined) continue
-    // Idempotency: skip if already contains injection marker
-    if (joined.includes("<relevant-memories>")) return null
-    return joined
   }
-  return null
+  const joined = texts.join(" ").trim()
+  if (!joined) return null
+  if (joined.includes("<relevant-memories>")) return null
+  return joined
 }
 
 /** Perform search against OpenViking with a timeout guard. Returns empty on any failure. */
@@ -1663,17 +1644,47 @@ async function performRecallSearch(config: OpenVikingConfig, query: string): Pro
   }
 }
 
-/** Append injection text to the last text part of a message. */
-function appendToLastTextPart(message: RecallWithParts, injection: string): boolean {
-  const parts = message.parts ?? []
-  for (let i = parts.length - 1; i >= 0; i--) {
-    const part = parts[i]
-    if (part.type === "text" && typeof part.text === "string") {
-      part.text = `${part.text}\n\n${injection}`
-      return true
-    }
-  }
-  return false
+/** Run auto recall using chat.message hook — injects persistent synthetic part. */
+async function runAutoRecall(
+  input: { sessionID: string; messageID: string; parts: { type: string; text?: string }[] },
+  output: { parts: any[] },
+): Promise<void> {
+  const query = extractMessageText(input.parts ?? [])
+  if (!query) return
+
+  const rawResults = await performRecallSearch(config, query)
+  if (rawResults.length === 0) return
+
+  const ranked = pickMemoriesForInjection(
+    rawResults,
+    config.autoRecall.limit ?? 6,
+    query,
+    config.autoRecall.scoreThreshold ?? 0.15,
+  )
+  if (ranked.length === 0) return
+
+  const processed = postProcessMemories(
+    ranked,
+    config.autoRecall.maxContentChars ?? 500,
+    config.autoRecall.preferAbstract ?? true,
+  )
+
+  const block = formatMemoryBlock(
+    processed,
+    config.autoRecall.maxContentChars ?? 500,
+    config.autoRecall.tokenBudget ?? 2000,
+  )
+  if (!block) return
+
+  output.parts.unshift({
+    id: `prt-ov-recall-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type: "text",
+    text: block,
+    synthetic: true,
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+  })
+  log("INFO", "recall", `Injected ${processed.length} memories`)
 }
 
 // ============================================================================
@@ -2304,51 +2315,12 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
       ),
     },
 
-    "experimental.chat.messages.transform": async (_input: {}, output: { messages: RecallWithParts[] }) => {
+    "chat.message": async (input, output) => {
       try {
-        // 1. Check if autoRecall is enabled
         if (!config.autoRecall?.enabled) return
-
-        // 2. Extract latest user text
-        const query = extractLatestUserText(output.messages)
-        if (!query) return
-
-        // 3. Search OpenViking
-        const rawResults = await performRecallSearch(config, query)
-        if (rawResults.length === 0) return
-
-        // 4. Rank + dedup + filter
-        const ranked = pickMemoriesForInjection(
-          rawResults,
-          config.autoRecall.limit ?? 6,
-          query,
-          config.autoRecall.scoreThreshold ?? 0.15,
-        )
-        if (ranked.length === 0) return
-
-        // 5. Post-process (truncate content, prefer abstract)
-        const processed = postProcessMemories(
-          ranked,
-          config.autoRecall.maxContentChars ?? 500,
-          config.autoRecall.preferAbstract ?? true,
-        )
-
-        // 6. Format injection block
-        const block = formatMemoryBlock(
-          processed,
-          config.autoRecall.maxContentChars ?? 500,
-          config.autoRecall.tokenBudget ?? 2000,
-        )
-        if (!block) return
-
-        // 7. Find last user message and append
-        const lastUser = [...output.messages].reverse().find((m) => m.info.role === "user")
-        if (lastUser) {
-          appendToLastTextPart(lastUser, block)
-          log("info", "recall", `Injected ${processed.length} memories`)
-        }
+        await runAutoRecall(input, output)
       } catch (error: any) {
-        log("warn", "recall", "Auto recall failed, skipping silently", {
+        log("WARN", "recall", "Auto recall failed, skipping silently", {
           error: error?.message ?? String(error),
         })
       }


### PR DESCRIPTION
## Description

将记忆召回（auto recall）钩子从 `experimental.chat.messages.transform` 迁移到 `chat.message`，使用 `synthetic: true` 持久化注入，解决上下文漂移与重复搜索问题。

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 移除 `experimental.chat.messages.transform` 钩子
- 移除死代码：`RecallMessagePart`、`RecallWithParts` 接口、`extractLatestUserText`、`appendToLastTextPart` 函数
- 新增 `chat.message` 钩子，使用 `synthetic: true` 持久化注入 `<relevant-memories>`
- 新增 `runAutoRecall()` 共享函数
- 新增 `extractMessageText()` 替代 `extractLatestUserText()`，适配 `chat.message` 的 `input.parts` 签名
- 净减少 28 行（-82/+54）

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

### 问题根因

`experimental.chat.messages.transform` 是无状态钩子——修改仅作用于内存中的消息拷贝，不写回会话存储。每次 LLM API 调用（含工具调用续接）都会重新触发，导致：

1. 上下文不一致 — 每次工具调用回来，模型看到的记忆集合不同
2. 前序记忆丢失 — 上次注入的记忆在下一次调用时消失
3. KV-cache 命中差 — 消息内容持续变化，服务端缓存无效
4. 冗余 API 调用 — 同一轮对话反复调用 OpenViking search

### 方案

`chat.message` 钩子在用户消息创建时触发一次，`output.parts` 的修改持久化到会话历史。`synthetic: true` 的 part 在 TUI 中不可见，但对 LLM 作为 synthetic context 发送。

### 效果对比

```
# 旧方案
用户输入 → API#1: 搜索→A,B,C → 工具调用 → API#2: 重新搜索→A,D,E → ...

# 新方案
用户输入 → chat.message: 搜索→插入synthetic part(持久化)
         → API#1: 含A,B,C → 工具调用 → API#2: 仍含A,B,C ✓
```

### 关键约束

- **Part ID 前缀**：`prt-ov-recall-{ts}-{random}`，必须 `prt-` 开头（OpenCode schema 校验）
- **幂等性**：保留 `<relevant-memories>` 标记检测，防止重加载会话后重复注入
- **兼容性**：旧会话不含 synthetic part，`chat.message` 仅对新消息触发