### PR TITLE
ci(blog): set TOS cache headers

### DIFF
--- a/.github/workflows/blog-build.yml
+++ b/.github/workflows/blog-build.yml
@@ -93,9 +93,25 @@ jobs:
           : "${TOS_ENDPOINT:?Missing TOS_ENDPOINT value}"
           : "${TOS_S3_ENDPOINT:?Missing TOS_S3_ENDPOINT value}"
 
-          aws s3 cp blog/dist "s3://${TOS_BUCKET}/" \
+          DIST_DIR="blog/dist"
+          HTML_CACHE_CONTROL="public, max-age=0, must-revalidate"
+          STATIC_CACHE_CONTROL="public, max-age=31536000, immutable"
+
+          aws s3 cp "${DIST_DIR}" "s3://${TOS_BUCKET}/" \
             --endpoint-url "https://${TOS_S3_ENDPOINT}" \
             --recursive \
+            --exclude "assets/*.css" \
+            --exclude "assets/*.js" \
+            --cache-control "${HTML_CACHE_CONTROL}" \
+            --only-show-errors
+
+          aws s3 cp "${DIST_DIR}" "s3://${TOS_BUCKET}/" \
+            --endpoint-url "https://${TOS_S3_ENDPOINT}" \
+            --recursive \
+            --exclude "*" \
+            --include "assets/*.css" \
+            --include "assets/*.js" \
+            --cache-control "${STATIC_CACHE_CONTROL}" \
             --only-show-errors
 
       - name: Report TOS deployment failure


### PR DESCRIPTION
## Description

Set explicit Cache-Control metadata when the blog site is uploaded to TOS. HTML and other non-hashed entries keep a revalidation policy, while hashed Vite JS/CSS assets get long-lived immutable caching.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- Split the blog TOS upload into non-JS/CSS and hashed JS/CSS upload groups.
- Set `public, max-age=0, must-revalidate` for HTML, XML, TXT, and non-hashed assets such as public images.
- Set `public, max-age=31536000, immutable` for `assets/*.js` and `assets/*.css`.
- Verified the blog build already emits hashed JS/CSS filenames.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation commands:

- `npm ci`
- `npm run build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/blog-build.yml"); puts "yaml ok"'`
- `git diff --check`
- `find blog/dist/assets -maxdepth 1 -type f \( -name '*.js' -o -name '*.css' \) -exec basename {} \; | rg '^[^-]+-[A-Za-z0-9_-]+\.(css|js)$'`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The blog build produces hashed JS/CSS files such as `index-Bl7YvDM6.js` and `index-DeFtHzP0.css`. Public images are copied without hashed filenames, so they intentionally stay on the revalidation cache policy.
