### PR TITLE
fix(resources): 加密代码仓库上传文件

### DIFF
--- a/openviking/parse/parsers/upload_utils.py
+++ b/openviking/parse/parsers/upload_utils.py
@@ -306,14 +306,13 @@ async def upload_directory(
     async def _upload_one(idx: int, file_path: Path, target_uri: str) -> None:
         async with sem:
 
-            def _do() -> None:
+            def _read_and_encode() -> bytes:
                 content = file_path.read_bytes()
-                encoded = detect_and_convert_encoding(content, file_path)
-                agfs_path = viking_fs._uri_to_path(target_uri)
-                viking_fs.agfs.write(agfs_path, encoded)
+                return detect_and_convert_encoding(content, file_path)
 
             try:
-                await asyncio.to_thread(_do)
+                encoded = await asyncio.to_thread(_read_and_encode)
+                await viking_fs.write_file_bytes(target_uri, encoded)
             except Exception as exc:
                 errors[idx] = f"Failed to upload {file_path}: {exc}"
 

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -42,6 +42,7 @@ class FakeVikingFS:
     def __init__(self) -> None:
         self.files: Dict[str, bytes] = {}
         self.dirs: List[str] = []
+        self.write_file_bytes_calls: List[str] = []
         self.agfs = FakeAGFS(self.files)
 
     def _uri_to_path(self, uri: str) -> str:
@@ -49,6 +50,7 @@ class FakeVikingFS:
         return uri
 
     async def write_file_bytes(self, uri: str, content: bytes) -> None:
+        self.write_file_bytes_calls.append(uri)
         self.files[uri] = content
 
     async def mkdir(self, uri: str, exist_ok: bool = False) -> None:
@@ -331,6 +333,27 @@ class TestUploadDirectory:
         assert "viking://temp/test/readme.md" in viking_fs.files
         assert "viking://temp/test/config.yaml" in viking_fs.files
         assert "viking://temp/test/src/main.go" in viking_fs.files
+        assert "viking://temp/test/hello.py" in viking_fs.write_file_bytes_calls
+
+    @pytest.mark.asyncio
+    async def test_uses_vikingfs_write_api_for_file_content(self, tmp_path: Path) -> None:
+        class GuardedAGFS(FakeAGFS):
+            def write(self, path: str, content: bytes) -> None:
+                raise AssertionError("upload_directory must not bypass VikingFS writes")
+
+        class GuardedVikingFS(FakeVikingFS):
+            def __init__(self) -> None:
+                super().__init__()
+                self.agfs = GuardedAGFS(self.files)
+
+        (tmp_path / "hello.py").write_text("print('hello')", encoding="utf-8")
+        viking_fs = GuardedVikingFS()
+
+        count, warnings = await upload_directory(tmp_path, "viking://temp/guarded", viking_fs)
+
+        assert count == 1
+        assert warnings == []
+        assert viking_fs.files["viking://temp/guarded/hello.py"] == b"print('hello')"
 
     @pytest.mark.asyncio
     async def test_skips_hidden_files(self, tmp_dir: Path, viking_fs: FakeVikingFS) -> None:
@@ -522,9 +545,6 @@ class TestUploadDirectoryEdgeCases:
             def mkdir(self, path: str) -> None:
                 pass
 
-            def write(self, path: str, content: bytes) -> None:
-                raise IOError("write error")
-
         class FailingWriteFS:
             agfs = FailingAGFS()
 
@@ -533,6 +553,9 @@ class TestUploadDirectoryEdgeCases:
 
             async def mkdir(self, uri: str, exist_ok: bool = False) -> None:
                 pass
+
+            async def write_file_bytes(self, uri: str, content: bytes) -> None:
+                raise IOError("write error")
 
         (tmp_path / "ok.py").write_text("print(1)", encoding="utf-8")
 


### PR DESCRIPTION
## Description

修复代码仓库上传绕过 `VikingFS` 写入接口的问题。开启 `encryption.enabled` 后，代码仓库上传到 temp/resource 流程中的文件内容会经过统一的 `write_file_bytes` 写入路径，从而触发加密逻辑。

## Related Issue

无

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 将 `upload_directory` 的文件内容写入从直接调用 `viking_fs.agfs.write(...)` 改为调用 `viking_fs.write_file_bytes(...)`。
- 保留文件读取和编码转换在线程中执行，避免阻塞事件循环，同时让写入阶段复用 `VikingFS` 的加密、访问控制和目录处理逻辑。
- 增加测试覆盖，确保上传目录不会绕过 `VikingFS` 写接口，并调整写入失败场景从统一写接口触发。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证命令和场景：

- `.venv/bin/python -m pytest tests/test_upload_utils.py -q`：55 passed。
- `.venv/bin/python -m pytest tests/misc/test_code_parser.py tests/parse/test_add_directory.py -q`：32 passed。
- 直接引用模块构造本地 `.git` 仓库、`MemoryAGFS`、`VikingFS` 和真实 `FileEncryptor` 验证：
  - `encryption_enabled=True` 时，底层 AGFS 内容以 `OVE1` 开头，不包含明文 `secret-token`，通过 `VikingFS.read_file_bytes()` 可正确读回原文。
  - `encryption_enabled=False` 时，底层 AGFS 保持明文，符合现有设计。
  - `DirectoryParser` 识别 `.git` 后委托 `CodeRepositoryParser` 的入口路径同样写入密文。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用

## Additional Notes

本次修复的设计原则是保持加密逻辑集中在 `VikingFS` 写入口，避免 parser/upload 工具层直接操作底层 AGFS 时遗漏加密能力。
