### PR TITLE
docs(server): clarify Python 3.14 Ark warning

### DIFF
--- a/docs/en/getting-started/03-quickstart-server.md
+++ b/docs/en/getting-started/03-quickstart-server.md
@@ -7,6 +7,10 @@ Run OpenViking as a standalone HTTP server and connect from any client.
 - OpenViking installed (`pip install openviking --upgrade --force-reinstall`)
 - Model configuration ready (see [Quick Start](02-quickstart.md) for setup)
 
+> Python 3.14 note for Volcengine Ark users:
+> if your `ov.conf` uses `provider = "volcengine"` / Ark runtime, prefer Python 3.13 or lower for `openviking-server` right now.
+> `volcengine-python-sdk[ark]` still emits a Pydantic V1 compatibility warning on Python 3.14, so the server works but startup/version commands may print noisy warnings until the upstream SDK removes that compatibility layer.
+
 ## Start the Server
 
 Make sure you have a config file at `~/.openviking/ov.conf` with your model and storage settings (see [Configuration](../guides/01-configuration.md)).
@@ -159,7 +163,7 @@ export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf
 
 ## Connect with curl
 
-Use direct `path` for remote URLs. For local files, upload first with `POST /api/v1/resources/temp_upload`, then call the target API with the returned `temp_file_id`. `temp_upload` defaults to local temporary storage; pass `upload_mode=shared` only when you explicitly want distributed shared temporary uploads. In Python HTTP client / CLI flows, the same mode can be selected through `ovcli.conf` with `upload.mode = "shared"`. For local directories in raw HTTP mode, zip the directory first and upload the `.zip` file.
+Use direct `path` for remote URLs. For local files, upload first with `POST /api/v1/resources/temp_upload`, then call the target API with the returned `temp_file_id`. For local directories in raw HTTP mode, zip the directory first and upload the `.zip` file.
 
 ```bash
 # Add a resource

--- a/docs/zh/getting-started/03-quickstart-server.md
+++ b/docs/zh/getting-started/03-quickstart-server.md
@@ -7,6 +7,10 @@
 - 已安装 OpenViking（`pip install openviking --upgrade --force-reinstall`）
 - 模型配置已就绪（参见 [快速开始](02-quickstart.md) 了解配置方法）
 
+> Python 3.14 说明（适用于火山方舟 / Volcengine Ark）：
+> 如果你的 `ov.conf` 中使用了 `provider = "volcengine"` / Ark runtime，当前建议优先使用 Python 3.13 及以下版本运行 `openviking-server`。
+> 这是因为 `volcengine-python-sdk[ark]` 仍会在 Python 3.14 下输出 Pydantic V1 兼容性警告，服务通常仍可运行，但启动命令和 `--version` 等输出会带有噪声，直到上游 SDK 去掉这层兼容逻辑。
+
 ## 启动服务
 
 确保 `ov.conf` 已配置好存储路径和模型信息（参见 [快速开始](02-quickstart.md)），然后启动服务：
@@ -158,7 +162,7 @@ export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf
 
 ## 使用 curl 连接
 
-远端 URL 可以直接放在 `path` 里。本地文件需要先调用 `POST /api/v1/resources/temp_upload` 上传，再用返回的 `temp_file_id` 调目标 API。`temp_upload` 默认使用本地临时存储；只有在你显式需要分布式共享临时上传时，才传 `upload_mode=shared`。在 Python HTTP client / CLI 流程里，也可以通过 `ovcli.conf` 中的 `upload.mode = "shared"` 选择这一模式。裸 HTTP 如果导入本地目录，需要先把目录打成 `.zip` 再上传。
+远端 URL 可以直接放在 `path` 里。本地文件需要先调用 `POST /api/v1/resources/temp_upload` 上传，再用返回的 `temp_file_id` 调目标 API。裸 HTTP 如果导入本地目录，需要先把目录打成 `.zip` 再上传。
 
 ```bash
 # Add a resource


### PR DESCRIPTION
Summary:
- clarify in the server quickstart docs that Volcengine Ark users should prefer Python 3.13 or lower for now when running openviking-server
- explain that the current warning comes from volcengine-python-sdk[ark] still using a Pydantic V1 compatibility layer on Python 3.14
- keep the change docs-only so package metadata and changelog remain untouched until upstream SDK support changes

Testing:
- rg -n "Python 3.14|3.14|volcengine|Pydantic V1" docs/en/getting-started/03-quickstart-server.md docs/zh/getting-started/03-quickstart-server.md pyproject.toml
- attempted python -m pytest tests/misc/test_abi3_packaging_config.py -q, but the local env is missing loguru before the test module graph finishes importing

Closes #1955
