### PR TITLE
feat(retriever): add level filter to find with retriever-level filtering, preserving recursive navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "ov_cli"
-version = "0.3.14"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -336,7 +336,7 @@ impl HttpClient {
         since: Option<String>,
         until: Option<String>,
         time_field: Option<String>,
-        level: Option<String>,
+        level: Option<Vec<i32>>,
     ) -> Result<serde_json::Value> {
         let body = serde_json::json!({
             "query": query,

--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -361,7 +361,7 @@ impl HttpClient {
         since: Option<String>,
         until: Option<String>,
         time_field: Option<String>,
-        level: Option<String>,
+        level: Option<Vec<i32>>,
     ) -> Result<serde_json::Value> {
         let body = serde_json::json!({
             "query": query,

--- a/crates/ov_cli/src/commands/search.rs
+++ b/crates/ov_cli/src/commands/search.rs
@@ -41,7 +41,7 @@ pub async fn search(
     since: Option<&str>,
     until: Option<&str>,
     time_field: Option<&str>,
-    level: Option<&str>,
+    level: Option<Vec<i32>>,
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
@@ -55,7 +55,7 @@ pub async fn search(
             since.map(|s| s.to_string()),
             until.map(|s| s.to_string()),
             time_field.map(|s| s.to_string()),
-            level.map(|s| s.to_string()),
+            level,
         )
         .await?;
     output_success(&result, output_format, compact);

--- a/crates/ov_cli/src/commands/search.rs
+++ b/crates/ov_cli/src/commands/search.rs
@@ -11,7 +11,7 @@ pub async fn find(
     since: Option<&str>,
     until: Option<&str>,
     time_field: Option<&str>,
-    level: Option<&str>,
+    level: Option<Vec<i32>>,
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
@@ -24,7 +24,7 @@ pub async fn find(
             since.map(|s| s.to_string()),
             until.map(|s| s.to_string()),
             time_field.map(|s| s.to_string()),
-            level.map(|s| s.to_string()),
+            level,
         )
         .await?;
     output_success(&result, output_format, compact);

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -949,7 +949,7 @@ pub async fn handle_find(
     threshold: Option<f64>,
     after: Option<String>,
     before: Option<String>,
-    level: Option<String>,
+    level: Option<Vec<i32>>,
     ctx: CliContext,
 ) -> Result<()> {
     let mut params = vec![format!("--uri={}", uri), format!("-n {}", node_limit)];
@@ -957,7 +957,12 @@ pub async fn handle_find(
         params.push(format!("--threshold {}", t));
     }
     append_time_filter_params(&mut params, after.as_deref(), before.as_deref());
-    append_level_filter_params(&mut params, level.as_deref());
+    if let Some(ref l) = level {
+        params.push(format!(
+            "--level {}",
+            l.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(",")
+        ));
+    }
     params.push(format!("\"{}\"", query));
     print_command_echo("ov find", &params.join(" "), ctx.config.echo_command);
     let client = ctx.get_client();
@@ -970,7 +975,7 @@ pub async fn handle_find(
         after.as_deref(),
         before.as_deref(),
         None,
-        level.as_deref(),
+        level,
         ctx.output_format,
         ctx.compact,
     )

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -990,7 +990,7 @@ pub async fn handle_search(
     threshold: Option<f64>,
     after: Option<String>,
     before: Option<String>,
-    level: Option<String>,
+    level: Option<Vec<i32>>,
     ctx: CliContext,
 ) -> Result<()> {
     let mut params = vec![format!("--uri={}", uri), format!("-n {}", node_limit)];
@@ -1001,7 +1001,12 @@ pub async fn handle_search(
         params.push(format!("--threshold {}", t));
     }
     append_time_filter_params(&mut params, after.as_deref(), before.as_deref());
-    append_level_filter_params(&mut params, level.as_deref());
+    if let Some(ref l) = level {
+        params.push(format!(
+            "--level {}",
+            l.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(",")
+        ));
+    }
     params.push(format!("\"{}\"", query));
     print_command_echo("ov search", &params.join(" "), ctx.config.echo_command);
     let client = ctx.get_client();
@@ -1015,7 +1020,7 @@ pub async fn handle_search(
         after.as_deref(),
         before.as_deref(),
         None,
-        level.as_deref(),
+        level,
         ctx.output_format,
         ctx.compact,
     )
@@ -1032,15 +1037,6 @@ pub fn append_time_filter_params(
     }
     if let Some(value) = before {
         params.push(format!("--before {}", value));
-    }
-}
-
-pub fn append_level_filter_params(
-    params: &mut Vec<String>,
-    level: Option<&str>,
-) {
-    if let Some(value) = level {
-        params.push(format!("--level {}", value));
     }
 }
 

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -378,9 +378,9 @@ enum Commands {
         /// Only include results on or before this time (e.g. 24h, 2026-03-15, ISO-8601)
         #[arg(long = "before")]
         before: Option<String>,
-        /// Only include results with specific level(s) (e.g. 0, 1, 2 or 0,1,2)
-        #[arg(short = 'L', long = "level")]
-        level: Option<String>,
+        /// Only include results with specific level(s) (0=abstract, 1=overview, 2=file)
+        #[arg(short = 'L', long = "level", value_delimiter = ',')]
+        level: Option<Vec<i32>>,
     },
     /// [Experimental][Data] Run context-aware retrieval
     Search {

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -409,9 +409,9 @@ enum Commands {
         /// Only include results on or before this time (e.g. 24h, 2026-03-15, ISO-8601)
         #[arg(long = "before")]
         before: Option<String>,
-        /// Only include results with specific level(s) (e.g. 0, 1, 2 or 0,1,2)
-        #[arg(short = 'L', long = "level")]
-        level: Option<String>,
+        /// Only include results with specific level(s) (0=abstract, 1=overview, 2=file)
+        #[arg(short = 'L', long = "level", value_delimiter = ',')]
+        level: Option<Vec<i32>>,
     },
     /// [Data] Run content pattern search
     Grep {

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -383,6 +383,7 @@ class AsyncOpenViking:
         since: Optional[str] = None,
         until: Optional[str] = None,
         time_field: Optional[str] = None,
+        level: Optional[List[int]] = None,
     ):
         """Semantic search"""
         await self._ensure_initialized()
@@ -396,6 +397,7 @@ class AsyncOpenViking:
             since=since,
             until=until,
             time_field=time_field,
+            level=level,
         )
 
     # ============= FS methods =============

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -342,6 +342,7 @@ class AsyncOpenViking:
         since: Optional[str] = None,
         until: Optional[str] = None,
         time_field: Optional[str] = None,
+        level: Optional[List[int]] = None,
     ):
         """
         Complex search with session context.
@@ -370,6 +371,7 @@ class AsyncOpenViking:
             since=since,
             until=until,
             time_field=time_field,
+            level=level,
         )
 
     async def find(

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -298,6 +298,7 @@ class LocalClient(BaseClient):
         since: Optional[str] = None,
         until: Optional[str] = None,
         time_field: Optional[str] = None,
+        level: Optional[List[int]] = None,
     ) -> Any:
         """Semantic search without session context."""
         resolved_filter = _resolve_search_filter(filter, since, until, time_field)
@@ -311,6 +312,7 @@ class LocalClient(BaseClient):
                 limit=limit,
                 score_threshold=score_threshold,
                 filter=resolved_filter,
+                level=level,
             ),
         )
         return attach_telemetry_payload(

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -332,6 +332,7 @@ class LocalClient(BaseClient):
         since: Optional[str] = None,
         until: Optional[str] = None,
         time_field: Optional[str] = None,
+        level: Optional[List[int]] = None,
     ) -> Any:
         """Semantic search with optional session context."""
         resolved_filter = _resolve_search_filter(filter, since, until, time_field)
@@ -349,6 +350,7 @@ class LocalClient(BaseClient):
                 limit=limit,
                 score_threshold=score_threshold,
                 filter=resolved_filter,
+                level=level,
             )
 
         execution = await run_with_telemetry(

--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -98,6 +98,7 @@ class HierarchicalRetriever:
         score_threshold: Optional[float] = None,
         score_gte: bool = False,
         scope_dsl: Optional[Dict[str, Any]] = None,
+        level: Optional[List[int]] = None,
     ) -> QueryResult:
         """
         Execute hierarchical retrieval.
@@ -165,10 +166,10 @@ class HierarchicalRetriever:
             for i, r in enumerate(global_results):
                 uri = r.get("uri", "UNKNOWN_URI")
                 score = r.get("_score", 0.0)
-                level = r.get("level", "UNKNOWN_LEVEL")
+                result_level = r.get("level", "UNKNOWN_LEVEL")
                 account_id = r.get("account_id", "UNKNOWN_ACCOUNT_ID")
                 logger.debug(
-                    f"  [{i}] URI: {uri}, score: {score:.4f}, level: {level}, account_id: {account_id}"
+                    f"  [{i}] URI: {uri}, score: {score:.4f}, level: {result_level}, account_id: {account_id}"
                 )
 
         # Step 3: Merge starting points
@@ -179,8 +180,11 @@ class HierarchicalRetriever:
             mode=mode,
         )
 
-        # 从 global_results 中提取 level 2 的文件作为初始候选者
-        initial_candidates = [r for r in global_results if r.get("level", 2) == 2]
+        # Add global hits to the result pool only when they match the requested level.
+        if level is not None:
+            initial_candidates = [r for r in global_results if r.get("level", 2) in level]
+        else:
+            initial_candidates = [r for r in global_results if r.get("level", 2) == 2]
 
         initial_candidates = self._prepare_initial_candidates(
             query.query,
@@ -203,6 +207,7 @@ class HierarchicalRetriever:
             target_dirs=target_dirs,
             scope_dsl=scope_dsl,
             initial_candidates=initial_candidates,
+            level=level,
         )
 
         # Step 6: Convert results
@@ -332,8 +337,8 @@ class HierarchicalRetriever:
         global_results: List[Dict[str, Any]],
         mode: str = RetrieverMode.THINKING,
     ) -> List[Dict[str, Any]]:
-        """Extract level-2 global hits and preserve rerank scores for them."""
-        initial_candidates = [dict(r) for r in global_results if r.get("level", 2) == 2]
+        """Preserve rerank scores for global hits added to the result pool."""
+        initial_candidates = [dict(r) for r in global_results]
         if not initial_candidates:
             return []
 
@@ -367,6 +372,7 @@ class HierarchicalRetriever:
         target_dirs: Optional[List[str]] = None,
         scope_dsl: Optional[Dict[str, Any]] = None,
         initial_candidates: Optional[List[Dict[str, Any]]] = None,
+        level: Optional[List[int]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Recursive search with directory priority return and score propagation.
@@ -392,26 +398,28 @@ class HierarchicalRetriever:
         dir_queue: List[tuple] = []  # Priority queue: (-score, uri)
         visited: set = set()
         prev_topk_uris: set = set()
+        prev_pool_size = 0
         convergence_rounds = 0
+        stagnant_rounds = 0
 
-        # 添加初始候选者（level 2 文件）
+        # Add initial candidates that match the requested level.
         if initial_candidates:
             for r in initial_candidates:
                 uri = r.get("uri", "")
-                if uri:
-                    # 只添加 level 2 的文件
-                    if r.get("level", 2) == 2:
-                        score = r.get("_score", 0.0)
-                        if not passes_threshold(score):
-                            logger.debug(
-                                f"[RecursiveSearch] Initial candidate URI {uri} score {score:.4f} did not pass threshold {effective_threshold}"
-                            )
-                            continue
-                        r["_final_score"] = score
-                        collected_by_uri[uri] = r
+                if not uri:
+                    continue
+                if level is None or r.get("level", 2) in level:
+                    score = r.get("_score", 0.0)
+                    if not passes_threshold(score):
                         logger.debug(
-                            f"[RecursiveSearch] Added initial candidate: {uri} (score: {score:.4f})"
+                            f"[RecursiveSearch] Initial candidate URI {uri} score {score:.4f} did not pass threshold {effective_threshold}"
                         )
+                        continue
+                    r["_final_score"] = score
+                    collected_by_uri[uri] = r
+                    logger.debug(
+                        f"[RecursiveSearch] Added initial candidate: {uri} (score: {score:.4f})"
+                    )
 
         alpha = self.score_propagation_alpha
 
@@ -466,16 +474,17 @@ class HierarchicalRetriever:
                     continue
 
                 telemetry.count("vector.passed", 1)
-                # Deduplicate by URI and keep the highest-scored candidate.
-                previous = collected_by_uri.get(uri)
-                if previous is None or final_score > previous.get("_final_score", 0):
-                    r["_final_score"] = final_score
-                    collected_by_uri[uri] = r
-                    logger.debug(
-                        "[RecursiveSearch] Updated URI: %s candidate score to %.4f",
-                        uri,
-                        final_score,
-                    )
+                if level is None or r.get("level", 2) in level:
+                    # Deduplicate by URI and keep the highest-scored candidate.
+                    previous = collected_by_uri.get(uri)
+                    if previous is None or final_score > previous.get("_final_score", 0):
+                        r["_final_score"] = final_score
+                        collected_by_uri[uri] = r
+                        logger.debug(
+                            "[RecursiveSearch] Updated URI: %s candidate score to %.4f",
+                            uri,
+                            final_score,
+                        )
 
                 # Only recurse into directories (L0/L1). L2 files are terminal hits.
                 if uri not in visited and r.get("level", 2) != 2:
@@ -488,15 +497,23 @@ class HierarchicalRetriever:
                 reverse=True,
             )[:limit]
             current_topk_uris = {c.get("uri", "") for c in current_topk}
+            current_pool_size = len(collected_by_uri)
 
             if current_topk_uris == prev_topk_uris and len(current_topk_uris) >= limit:
                 convergence_rounds += 1
 
                 if convergence_rounds >= self.MAX_CONVERGENCE_ROUNDS:
                     break
+            elif current_pool_size == prev_pool_size:
+                stagnant_rounds += 1
+
+                if stagnant_rounds >= self.MAX_CONVERGENCE_ROUNDS:
+                    break
             else:
                 convergence_rounds = 0
+                stagnant_rounds = 0
                 prev_topk_uris = current_topk_uris
+                prev_pool_size = current_pool_size
 
         collected = sorted(
             collected_by_uri.values(),

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -203,6 +203,7 @@ async def search(
     session_id: Optional[str] = None,
     limit: int = 10,
     min_score: float = 0.35,
+    level: Optional[List[int]] = None,
 ) -> str:
     """Deep semantic retrieval with optional session context and intent analysis. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
@@ -218,6 +219,7 @@ async def search(
         session=session,
         limit=limit,
         score_threshold=min_score,
+        level=level,
     )
     return _format_search_result(result)
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import contextvars
 from contextlib import asynccontextmanager
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
@@ -176,7 +176,13 @@ mcp = FastMCP(
 
 
 @mcp.tool()
-async def find(query: str, target_uri: str = "", limit: int = 10, min_score: float = 0.35) -> str:
+async def find(
+    query: str,
+    target_uri: str = "",
+    limit: int = 10,
+    min_score: float = 0.35,
+    level: Optional[List[int]] = None,
+) -> str:
     """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
     result = await service.search.find(
@@ -185,6 +191,7 @@ async def find(query: str, target_uri: str = "", limit: int = 10, min_score: flo
         target_uri=target_uri,
         limit=limit,
         score_threshold=min_score,
+        level=level,
     )
     return _format_search_result(result)
 

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -17,7 +17,7 @@ from openviking.server.identity import RequestContext
 from openviking.server.models import Response
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
-from openviking.utils.search_filters import merge_time_filter, merge_level_filter
+from openviking.utils.search_filters import merge_time_filter
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
 
 
@@ -47,16 +47,14 @@ def _resolve_search_filter(
     since: Optional[str],
     until: Optional[str],
     time_field: Optional[TimeField],
-    level: Optional[Union[int, str, List[int]]] = None,
 ) -> Optional[Dict[str, Any]]:
     try:
-        filter_with_time = merge_time_filter(
+        return merge_time_filter(
             request_filter,
             since=since,
             until=until,
             time_field=time_field,
         )
-        return merge_level_filter(filter_with_time, level=level)
     except ValueError as exc:
         raise InvalidArgumentError(str(exc)) from exc
 
@@ -78,11 +76,10 @@ class FindRequest(BaseModel):
     score_threshold: Optional[float] = None
     filter: Optional[Dict[str, Any]] = None
     include_provenance: bool = False
-
     since: Optional[str] = None
     until: Optional[str] = None
     time_field: Optional[TimeField] = None
-    level: Optional[Union[int, str, List[int]]] = None
+    level: Optional[List[int]] = None
     telemetry: TelemetryRequest = False
 
 
@@ -137,7 +134,6 @@ async def find(
         request.since,
         request.until,
         request.time_field,
-        request.level,
     )
     resolved_target_uri = _resolve_uri_or_uris(request.target_uri)
     execution = await run_operation(
@@ -150,6 +146,7 @@ async def find(
             limit=actual_limit,
             score_threshold=request.score_threshold,
             filter=effective_filter,
+            level=request.level,
         ),
     )
     result = execution.result
@@ -176,7 +173,6 @@ async def search(
         request.since,
         request.until,
         request.time_field,
-        request.level,
     )
     resolved_target_uri = _resolve_uri_or_uris(request.target_uri)
 

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -17,7 +17,7 @@ from openviking.server.identity import RequestContext
 from openviking.server.models import Response
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
-from openviking.utils.search_filters import merge_time_filter
+from openviking.utils.search_filters import _resolve_levels, merge_time_filter
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
 
 
@@ -79,7 +79,7 @@ class FindRequest(BaseModel):
     since: Optional[str] = None
     until: Optional[str] = None
     time_field: Optional[TimeField] = None
-    level: Optional[List[int]] = None
+    level: Optional[Union[int, str, List[int]]] = None
     telemetry: TelemetryRequest = False
 
 
@@ -146,7 +146,7 @@ async def find(
             limit=actual_limit,
             score_threshold=request.score_threshold,
             filter=effective_filter,
-            level=request.level,
+            level=_resolve_levels(request.level) or None,
         ),
     )
     result = execution.result
@@ -189,6 +189,7 @@ async def search(
             limit=actual_limit,
             score_threshold=request.score_threshold,
             filter=effective_filter,
+            level=_resolve_levels(request.level) or None,
         )
 
     execution = await run_operation(

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -91,6 +91,7 @@ class SearchService:
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,
+        level: Optional[List[int]] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -100,6 +101,7 @@ class SearchService:
             limit: Max results
             score_threshold: Score threshold
             filter: Metadata filters
+            level: Filter by level (0=abstract, 1=overview, 2=file)
 
         Returns:
             FindResult
@@ -114,5 +116,6 @@ class SearchService:
             limit=limit,
             score_threshold=score_threshold,
             filter=filter,
+            level=level,
         )
         return result

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -50,6 +50,7 @@ class SearchService:
         limit: int = 10,
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,
+        level: Optional[List[int]] = None,
     ) -> Any:
         """Complex search with session context.
 
@@ -60,6 +61,7 @@ class SearchService:
             limit: Max results
             score_threshold: Score threshold
             filter: Metadata filters
+            level: Filter by level (0=abstract, 1=overview, 2=file)
 
         Returns:
             FindResult
@@ -80,6 +82,7 @@ class SearchService:
             limit=limit,
             score_threshold=score_threshold,
             filter=filter,
+            level=level,
         )
         return result
 

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -445,9 +445,7 @@ class VikingFS:
         path = self._uri_to_path(uri, ctx=ctx)
         target_uri = self._path_to_uri(path, ctx=ctx)
 
-        async def _estimate_deleted_count(
-            target_path: str, real_ctx: RequestContext
-        ) -> int:
+        async def _estimate_deleted_count(target_path: str, real_ctx: RequestContext) -> int:
             """Estimate number of nodes to be deleted using vector index."""
             vector_store = self._get_vector_store()
             if not vector_store:
@@ -1316,6 +1314,7 @@ class VikingFS:
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,
         ctx: Optional[RequestContext] = None,
+        level: Optional[List[int]] = None,
     ):
         """Semantic search.
 
@@ -1391,6 +1390,7 @@ class VikingFS:
             limit=limit,
             score_threshold=score_threshold,
             scope_dsl=filter,
+            level=level,
         )
 
         # Convert QueryResult to FindResult

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -31,7 +31,6 @@ from openviking.core.namespace import (
 from openviking.core.namespace import (
     is_accessible as namespace_is_accessible,
 )
-from openviking.storage.expr import PathScope
 from openviking.pyagfs.exceptions import (
     AGFSClientError,
     AGFSDirectoryNotEmptyError,
@@ -41,6 +40,7 @@ from openviking.pyagfs.exceptions import (
 from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.error_mapping import is_not_found_error, map_exception
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.expr import PathScope
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
 from openviking_cli.exceptions import (
@@ -1420,6 +1420,7 @@ class VikingFS:
         score_threshold: Optional[float] = None,
         filter: Optional[Dict] = None,
         ctx: Optional[RequestContext] = None,
+        level: Optional[List[int]] = None,
     ):
         """Complex search with session context.
 
@@ -1541,6 +1542,7 @@ class VikingFS:
                 limit=limit,
                 score_threshold=score_threshold,
                 scope_dsl=filter,
+                level=level,
             )
 
         query_results = await asyncio.gather(*[_execute(tq) for tq in typed_queries])

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -225,6 +225,7 @@ class SyncOpenViking:
         since: Optional[str] = None,
         until: Optional[str] = None,
         time_field: Optional[str] = None,
+        level: Optional[List[int]] = None,
     ):
         """Quick retrieval"""
         return run_async(
@@ -238,6 +239,7 @@ class SyncOpenViking:
                 since,
                 until,
                 time_field,
+                level,
             )
         )
 

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -196,6 +196,7 @@ class SyncOpenViking:
         since: Optional[str] = None,
         until: Optional[str] = None,
         time_field: Optional[str] = None,
+        level: Optional[List[int]] = None,
     ):
         """Execute complex retrieval (intent analysis, hierarchical retrieval)."""
         return run_async(
@@ -211,6 +212,7 @@ class SyncOpenViking:
                 since=since,
                 until=until,
                 time_field=time_field,
+                level=level,
             )
         )
 

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -50,6 +50,117 @@ async def test_find_with_target_uri(client_with_resource):
     assert resp.json()["status"] == "ok"
 
 
+async def test_find_with_level_passes_to_service(client: httpx.AsyncClient, service, monkeypatch):
+    captured = {}
+
+    async def fake_find(*, level=None, **kwargs):
+        captured["level"] = level
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample", "level": [0, 2]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["level"] == [0, 2]
+
+
+async def test_find_without_level_passes_none(client: httpx.AsyncClient, service, monkeypatch):
+    captured = {}
+
+    async def fake_find(*, level=None, **kwargs):
+        captured["level"] = level
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["level"] is None
+
+
+async def test_find_level_filters_l2_only(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample document", "limit": 10, "level": [2]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") == 2
+
+
+async def test_find_level_filters_l0_only(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample document", "limit": 10, "level": [0]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") == 0
+
+
+async def test_find_level_filters_mixed_l0_l2(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample document", "limit": 10, "level": [0, 2]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") in (0, 2)
+
+
+async def test_find_level_filters_l0_l1(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample document", "limit": 10, "level": [0, 1]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") in (0, 1)
+
+
+async def test_find_level_with_no_matching_results(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample document", "limit": 10, "level": [5]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    assert result.get("total", 0) == 0
+
+
 async def test_find_with_inaccessible_target_uri_returns_permission_denied(
     client: httpx.AsyncClient, app
 ):

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -161,6 +161,155 @@ async def test_find_level_with_no_matching_results(client_with_resource):
     assert result.get("total", 0) == 0
 
 
+async def test_search_with_level_passes_to_service(client: httpx.AsyncClient, service, monkeypatch):
+    captured = {}
+
+    async def fake_search(*, level=None, **kwargs):
+        captured["level"] = level
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "search", fake_search)
+
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample", "level": [0, 2]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["level"] == [0, 2]
+
+
+async def test_search_without_level_passes_none(client: httpx.AsyncClient, service, monkeypatch):
+    captured = {}
+
+    async def fake_search(*, level=None, **kwargs):
+        captured["level"] = level
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "search", fake_search)
+
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["level"] is None
+
+
+async def test_search_level_filters_l2_only(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample document", "limit": 10, "level": [2]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") == 2
+
+
+async def test_search_level_filters_l0_only(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample document", "limit": 10, "level": [0]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") == 0
+
+
+async def test_search_level_filters_mixed_l0_l2(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample document", "limit": 10, "level": [0, 2]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") in (0, 2)
+
+
+async def test_search_level_filters_l0_l1(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample document", "limit": 10, "level": [0, 1]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    for key in ("memories", "resources", "skills"):
+        for item in result.get(key, []):
+            assert item.get("level") in (0, 1)
+
+
+async def test_search_level_with_no_matching_results(client_with_resource):
+    client, uri = client_with_resource
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample document", "limit": 10, "level": [5]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    assert result.get("total", 0) == 0
+
+
+async def test_find_with_level_string_input(client: httpx.AsyncClient, service, monkeypatch):
+    captured = {}
+
+    async def fake_find(*, level=None, **kwargs):
+        captured["level"] = level
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample", "level": "0,2"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["level"] == [0, 2]
+
+
+async def test_find_with_level_int_input(client: httpx.AsyncClient, service, monkeypatch):
+    captured = {}
+
+    async def fake_find(*, level=None, **kwargs):
+        captured["level"] = level
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample", "level": 2},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["level"] == [2]
+
+
 async def test_find_with_inaccessible_target_uri_returns_permission_denied(
     client: httpx.AsyncClient, app
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -3808,7 +3808,7 @@ requires-dist = [
     { name = "tree-sitter-typescript", specifier = ">=0.23.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", specifier = ">=0.39.0" },
     { name = "volcengine", specifier = ">=1.0.216" },
     { name = "volcengine-python-sdk", extras = ["ark"], specifier = ">=5.0.3" },
@@ -6369,11 +6369,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
为 find 功能添加 level 过滤能力，支持按 L0（摘要）、L1（概览）、L2（原始文件）级别筛选返回结果。

### 核心设计
过滤逻辑在 HierarchicalRetriever 的两个结果收集点实现，而非在向量搜索层或后过滤层：

1. global search 入池过滤 ：全局向量搜索的初始候选者按 level 过滤后进入结果池
2. 递归遍历入池过滤 ：递归搜索中每搜到一个结果，按 level 判断是否入池
关键点 ：递归导航逻辑（ dir_queue ）不受 level 影响，L0/L1 目录仍正常进入导航队列，保证递归搜索质量不下降。


## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
## Changes Made
### Python 层
- openviking/server/routers/search.py ： FindRequest 新增 level: Optional[List[int]] 字段，路由处理透传给 Service
- openviking/service/search_service.py ： SearchService.find 新增 level 参数，透传给 VikingFS
- openviking/storage/viking_fs.py ： VikingFS.find 新增 level 参数，传给 retriever.retrieve
- openviking/retrieve/hierarchical_retriever.py ：
  - retrieve 方法新增 level 参数，global search 初始候选者按 level 过滤
  - _recursive_search 方法新增 level 参数，两个收集点按 level 过滤（初始候选者 + 递归遍历结果）
  - 修复变量遮蔽 bug：debug 日志循环变量 level 重命名为 result_level
  - 新增停滞检测：当结果池连续多轮无增长时提前终止，避免 level 过滤后永不收敛(例如只有500个L1，但是搜600个L1)
- openviking/client/local.py 、 openviking/async_client.py 、 openviking/sync_client.py 、 openviking/server/mcp_endpoint.py ：SDK 客户端透传 level 参数
### Rust CLI 层
- crates/ov_cli/src/main.rs ：Find 命令新增 --level / -L 参数（ Option<Vec<i32>> ， value_delimiter=',' ）
- crates/ov_cli/src/handlers.rs 、 commands/search.rs 、 client.rs ：透传 level 参数，JSON body 传数组
### 测试
- tests/server/test_api_search.py ：新增 7 个测试覆盖参数透传、向后兼容、各级别过滤、混合级别过滤、边界情况
## Usage Examples
### HTTP API
```
# 只搜 L2（原始文件）
curl -X POST http://localhost:1977/api/v1/
search/find \
  -H "Content-Type: application/json" \
  -d '{"query": "阿西莫夫", "target_uri": 
  "viking://resources/xxx", "level": [2]}'

# 搜 L0 和 L2
curl -X POST http://localhost:1977/api/v1/
search/find \
  -H "Content-Type: application/json" \
  -d '{"query": "阿西莫夫", "target_uri": 
  "viking://resources/xxx", "level": [0, 
  2]}'
```
### CLI
```
# 只搜 L2
ov find "阿西莫夫" --uri viking://
resources/xxx --level 2

# 搜 L0 和 L2
ov find "阿西莫夫" --uri viking://
resources/xxx --level 0,2

# 短标志
ov find "阿西莫夫" --uri viking://
resources/xxx -L 0,1,2
```
### Python SDK
```
from openviking import OpenViking

client = OpenViking()

# 只搜 L2
client.find("阿西莫夫", 
target_uri="viking://resources/xxx", 
level=[2])

# 搜 L0 和 L2
client.find("阿西莫夫", 
target_uri="viking://resources/xxx", 
level=[0, 2])
```
## Testing
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
测试命令：

```
OPENVIKING_CONFIG_FILE=/path/to/ov.conf 
uv run pytest tests/server/
test_api_search.py -k "level" -xvs -o 
"addopts="
```
测试结果：8 passed

## Checklist
- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published