### PR TITLE
test(fs): strengthen count() semantics and add regression tests

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -31,7 +31,6 @@ from openviking.core.namespace import (
 from openviking.core.namespace import (
     is_accessible as namespace_is_accessible,
 )
-from openviking.storage.expr import PathScope
 from openviking.pyagfs.exceptions import (
     AGFSClientError,
     AGFSDirectoryNotEmptyError,
@@ -41,6 +40,7 @@ from openviking.pyagfs.exceptions import (
 from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.error_mapping import is_not_found_error, map_exception
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.expr import PathScope
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.time_utils import format_simplified, get_current_timestamp, parse_iso_datetime
 from openviking_cli.exceptions import (
@@ -1256,8 +1256,12 @@ class VikingFS:
             nonlocal files, dirs
             try:
                 entries = self._ls_entries(current_path)
-            except Exception:
-                return
+            except Exception as exc:
+                current_uri = self._path_to_uri(current_path, ctx=ctx)
+                mapped = map_exception(exc, resource=current_uri)
+                if mapped is not None:
+                    raise mapped from exc
+                raise
             for entry in entries:
                 name = entry.get("name", "")
                 if name in (".", ".."):
@@ -1266,7 +1270,7 @@ class VikingFS:
                 entry_uri = self._path_to_uri(f"{current_path}/{name}", ctx=ctx)
                 if not self._is_accessible(entry_uri, real_ctx):
                     continue
-                if not is_dir and name.startswith(".") and not show_all_hidden:
+                if name.startswith(".") and not show_all_hidden:
                     continue
                 if is_dir:
                     dirs += 1

--- a/tests/client/test_filesystem.py
+++ b/tests/client/test_filesystem.py
@@ -157,6 +157,101 @@ class TestTree:
         assert isinstance(tree, (list, dict))
 
 
+class TestCount:
+    """Test count operation (exact directory entry counting)."""
+
+    async def _build_tree(self, client: AsyncOpenViking) -> str:
+        """Create a deterministic tree under viking://resources/count_root.
+
+        Layout:
+            count_root/
+                visible_a.txt
+                visible_b.txt
+                .hidden_file.txt
+                visible_dir/
+                    nested.txt
+                    .hidden_nested.txt
+                .hidden_dir/
+                    inside_hidden.txt
+        """
+        ctx = client._client._ctx  # type: ignore[attr-defined]
+        viking_fs = client._service.viking_fs
+
+        root = "viking://resources/count_root"
+        await viking_fs.mkdir(root, ctx=ctx, exist_ok=True)
+        await viking_fs.write(f"{root}/visible_a.txt", "a", ctx=ctx)
+        await viking_fs.write(f"{root}/visible_b.txt", "b", ctx=ctx)
+        await viking_fs.write(f"{root}/.hidden_file.txt", "hf", ctx=ctx)
+
+        visible_dir = f"{root}/visible_dir"
+        await viking_fs.mkdir(visible_dir, ctx=ctx, exist_ok=True)
+        await viking_fs.write(f"{visible_dir}/nested.txt", "n", ctx=ctx)
+        await viking_fs.write(f"{visible_dir}/.hidden_nested.txt", "hn", ctx=ctx)
+
+        hidden_dir = f"{root}/.hidden_dir"
+        await viking_fs.mkdir(hidden_dir, ctx=ctx, exist_ok=True)
+        await viking_fs.write(f"{hidden_dir}/inside_hidden.txt", "ih", ctx=ctx)
+
+        return root
+
+    async def test_count_non_recursive_excludes_hidden(self, client: AsyncOpenViking):
+        """Default (recursive=False, show_all_hidden=False) counts only visible direct children."""
+        root = await self._build_tree(client)
+
+        result = await client.count(root)
+
+        # Visible direct children: visible_a.txt, visible_b.txt, visible_dir
+        assert result == {"files": 2, "dirs": 1, "total": 3}
+
+    async def test_count_non_recursive_with_hidden(self, client: AsyncOpenViking):
+        """show_all_hidden=True includes hidden files AND hidden directories."""
+        root = await self._build_tree(client)
+
+        result = await client.count(root, show_all_hidden=True)
+
+        # Direct children: 2 visible files + 1 hidden file + visible_dir + .hidden_dir
+        assert result == {"files": 3, "dirs": 2, "total": 5}
+
+    async def test_count_recursive_excludes_hidden_subtree(self, client: AsyncOpenViking):
+        """recursive=True must NOT descend into hidden directories when show_all_hidden=False."""
+        root = await self._build_tree(client)
+
+        result = await client.count(root, recursive=True)
+
+        # files: visible_a.txt, visible_b.txt, visible_dir/nested.txt
+        # dirs:  visible_dir
+        # hidden files & .hidden_dir/* are excluded
+        assert result == {"files": 3, "dirs": 1, "total": 4}
+
+    async def test_count_recursive_with_hidden(self, client: AsyncOpenViking):
+        """recursive=True + show_all_hidden=True walks every entry."""
+        root = await self._build_tree(client)
+
+        result = await client.count(root, recursive=True, show_all_hidden=True)
+
+        # files: visible_a, visible_b, .hidden_file, visible_dir/nested,
+        #        visible_dir/.hidden_nested, .hidden_dir/inside_hidden = 6
+        # dirs:  visible_dir, .hidden_dir = 2
+        assert result == {"files": 6, "dirs": 2, "total": 8}
+
+    async def test_count_on_file_raises(self, client: AsyncOpenViking):
+        """count() on a non-directory must raise (FailedPrecondition)."""
+        ctx = client._client._ctx  # type: ignore[attr-defined]
+        viking_fs = client._service.viking_fs
+
+        await viking_fs.mkdir("viking://resources/count_file_test", ctx=ctx, exist_ok=True)
+        file_uri = "viking://resources/count_file_test/file.txt"
+        await viking_fs.write(file_uri, "data", ctx=ctx)
+
+        with pytest.raises(Exception):  # noqa: B017
+            await client.count(file_uri)
+
+    async def test_count_missing_uri_raises(self, client: AsyncOpenViking):
+        """count() on a missing URI must raise (NotFound)."""
+        with pytest.raises(Exception):  # noqa: B017
+            await client.count("viking://resources/__count_missing__")
+
+
 async def test_local_client_mkdir_forwards_description():
     client = LocalClient.__new__(LocalClient)
     client._ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)

--- a/tests/server/test_api_fs_content_endpoint_suite.py
+++ b/tests/server/test_api_fs_content_endpoint_suite.py
@@ -269,3 +269,74 @@ async def test_reindex_async_returns_task_id(client, monkeypatch):
     assert body["result"]["status"] == "accepted"
     assert body["result"]["task_id"] == "task-123"
     assert body["result"]["mode"] == "vectors_only"
+
+
+async def test_count_missing_uri_returns_not_found(app, service, monkeypatch):
+    async def fake_count(*args, **kwargs):
+        raise FileNotFoundError("count target missing")
+
+    monkeypatch.setattr(service.fs, "count", fake_count)
+    response = await _request_with_handler(
+        app,
+        "GET",
+        "/api/v1/fs/count",
+        params={"uri": "viking://resources/__count_missing__"},
+    )
+    _assert_error(response, status_code=404, error_code="NOT_FOUND")
+
+
+async def test_count_on_file_returns_failed_precondition(app, service, monkeypatch):
+    from openviking_cli.exceptions import FailedPreconditionError
+
+    async def fake_count(uri, ctx, recursive=False, show_all_hidden=False):
+        raise FailedPreconditionError(
+            f"{uri} is not a directory",
+            details={"resource": uri, "expected": "directory"},
+        )
+
+    monkeypatch.setattr(service.fs, "count", fake_count)
+    response = await _request_with_handler(
+        app,
+        "GET",
+        "/api/v1/fs/count",
+        params={"uri": "viking://resources/file.txt"},
+    )
+    _assert_error(response, status_code=412, error_code="FAILED_PRECONDITION")
+
+
+async def test_count_returns_envelope_with_uri(app, service, monkeypatch):
+    captured: dict = {}
+
+    async def fake_count(uri, ctx, recursive=False, show_all_hidden=False):
+        captured["uri"] = uri
+        captured["recursive"] = recursive
+        captured["show_all_hidden"] = show_all_hidden
+        return {"files": 4, "dirs": 2, "total": 6}
+
+    monkeypatch.setattr(service.fs, "count", fake_count)
+    response = await _request_with_handler(
+        app,
+        "GET",
+        "/api/v1/fs/count",
+        params={
+            "uri": "viking://resources/dir",
+            "recursive": "true",
+            "show_all_hidden": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    # HTTP response envelope mirrors the SDK shape and additionally surfaces uri.
+    assert body["result"] == {
+        "uri": "viking://resources/dir",
+        "files": 4,
+        "dirs": 2,
+        "total": 6,
+    }
+    assert captured == {
+        "uri": "viking://resources/dir",
+        "recursive": True,
+        "show_all_hidden": True,
+    }


### PR DESCRIPTION
- Propagate underlying errors in viking_fs.count() via map_exception so a failing sub-tree no longer silently returns a smaller total.
- Make show_all_hidden also control hidden directories (and their recursive descent), aligning with the documented ls -a semantics.
- Add SDK and HTTP regression tests covering non-recursive/recursive counting, hidden-file/dir filtering, file/missing-URI error paths, and HTTP envelope shape to lock in exact-count semantics.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
