### PR TITLE
fix(parse): 及时释放 PDF 页面缓存

### DIFF
--- a/openviking/parse/parsers/pdf.py
+++ b/openviking/parse/parsers/pdf.py
@@ -306,54 +306,57 @@ class PDFParser(BaseParser):
                     bookmarks_by_page[page].append(bm)
 
                 for page_num, page in enumerate(pdf.pages, 1):
-                    # Inject headings before page text
-                    page_bookmarks = bookmarks_by_page.get(page_num, [])
-                    for bm in page_bookmarks:
-                        heading_prefix = "#" * bm["level"]
-                        parts.append(f"\n{heading_prefix} {bm['title']}\n")
+                    try:
+                        # Inject headings before page text
+                        page_bookmarks = bookmarks_by_page.get(page_num, [])
+                        for bm in page_bookmarks:
+                            heading_prefix = "#" * bm["level"]
+                            parts.append(f"\n{heading_prefix} {bm['title']}\n")
 
-                    # Extract text
-                    text = page.extract_text()
-                    if text and text.strip():
-                        # Add page marker as HTML comment
-                        parts.append(f"<!-- Page {page_num} -->\n{text.strip()}")
-                        meta["pages_processed"] += 1
+                        # Extract text
+                        text = page.extract_text()
+                        if text and text.strip():
+                            # Add page marker as HTML comment
+                            parts.append(f"<!-- Page {page_num} -->\n{text.strip()}")
+                            meta["pages_processed"] += 1
 
-                    # Extract tables
-                    tables = page.extract_tables()
-                    for table_idx, table in enumerate(tables or []):
-                        if table and len(table) > 0:
-                            md_table = self._format_table_markdown(table)
-                            if md_table:
-                                parts.append(
-                                    f"<!-- Page {page_num} Table {table_idx + 1} -->\n{md_table}"
+                        # Extract tables
+                        tables = page.extract_tables()
+                        for table_idx, table in enumerate(tables or []):
+                            if table and len(table) > 0:
+                                md_table = self._format_table_markdown(table)
+                                if md_table:
+                                    parts.append(
+                                        f"<!-- Page {page_num} Table {table_idx + 1} -->\n{md_table}"
+                                    )
+                                    meta["tables_extracted"] += 1
+
+                        # Extract images
+                        images = page.images
+                        for img_idx, img in enumerate(images or []):
+                            try:
+                                # Extract image using underlying PDF object
+                                image_obj = self._extract_image_from_page(page, img)
+                                if image_obj:
+                                    # Save image
+                                    filename = f"page{page_num}_img{img_idx + 1}"
+                                    image_path = storage.save_image(
+                                        resource_name, image_obj, filename=filename
+                                    )
+
+                                    # Generate relative path for markdown
+                                    rel_path = image_path.relative_to(Path.cwd())
+                                    parts.append(
+                                        f"<!-- Page {page_num} Image {img_idx + 1} -->\n"
+                                        f"![Page {page_num} Image {img_idx + 1}]({rel_path})"
+                                    )
+                                    meta["images_extracted"] += 1
+                            except Exception as img_err:
+                                logger.warning(
+                                    f"Failed to extract image {img_idx + 1} on page {page_num}: {img_err}"
                                 )
-                                meta["tables_extracted"] += 1
-
-                    # Extract images
-                    images = page.images
-                    for img_idx, img in enumerate(images or []):
-                        try:
-                            # Extract image using underlying PDF object
-                            image_obj = self._extract_image_from_page(page, img)
-                            if image_obj:
-                                # Save image
-                                filename = f"page{page_num}_img{img_idx + 1}"
-                                image_path = storage.save_image(
-                                    resource_name, image_obj, filename=filename
-                                )
-
-                                # Generate relative path for markdown
-                                rel_path = image_path.relative_to(Path.cwd())
-                                parts.append(
-                                    f"<!-- Page {page_num} Image {img_idx + 1} -->\n"
-                                    f"![Page {page_num} Image {img_idx + 1}]({rel_path})"
-                                )
-                                meta["images_extracted"] += 1
-                        except Exception as img_err:
-                            logger.warning(
-                                f"Failed to extract image {img_idx + 1} on page {page_num}: {img_err}"
-                            )
+                    finally:
+                        self._release_page_cache(page)
 
             if not parts:
                 logger.warning(f"No content extracted from {pdf_path}")
@@ -374,6 +377,24 @@ class PDFParser(BaseParser):
         except Exception as e:
             logger.error(f"pdfplumber conversion failed: {e}")
             raise
+
+    @staticmethod
+    def _release_page_cache(page: Any) -> None:
+        """Release pdfplumber/pdfminer per-page caches when available."""
+        close = getattr(page, "close", None)
+        if callable(close):
+            try:
+                close()
+                return
+            except Exception:
+                pass
+
+        flush_cache = getattr(page, "flush_cache", None)
+        if callable(flush_cache):
+            try:
+                flush_cache()
+            except Exception:
+                pass
 
     def _extract_bookmarks(self, pdf) -> List[Dict[str, Any]]:
         """Extract bookmark structure from PDF outlines.
@@ -472,10 +493,13 @@ class PDFParser(BaseParser):
             size_counter: Counter = Counter()
             sample_pages = pdf.pages[::5]
             for page in sample_pages:
-                for char in page.chars:
-                    if char["text"].strip():
-                        rounded = round(char["size"] * 2) / 2
-                        size_counter[rounded] += 1
+                try:
+                    for char in page.chars:
+                        if char["text"].strip():
+                            rounded = round(char["size"] * 2) / 2
+                            size_counter[rounded] += 1
+                finally:
+                    self._release_page_cache(page)
 
             if not size_counter:
                 return []
@@ -533,35 +557,38 @@ class PDFParser(BaseParser):
                 )
 
             for page in pdf.pages:
-                page_num = page.page_number + 1
-                chars = sorted(page.chars, key=lambda c: (c["top"], c["x0"]))
+                try:
+                    page_num = page.page_number + 1
+                    chars = sorted(page.chars, key=lambda c: (c["top"], c["x0"]))
 
-                current_line_chars: list = []
-                current_top = None
+                    current_line_chars: list = []
+                    current_top = None
 
-                for char in chars:
-                    # Performance: headings won't appear in bottom 70% of page
-                    if char["top"] > page.height * 0.3:
-                        flush_line(current_line_chars, page_num)
-                        current_line_chars = []
-                        break
+                    for char in chars:
+                        # Performance: headings won't appear in bottom 70% of page
+                        if char["top"] > page.height * 0.3:
+                            flush_line(current_line_chars, page_num)
+                            current_line_chars = []
+                            break
 
-                    rounded_size = round(char["size"] * 2) / 2
-                    if rounded_size not in size_to_level:
-                        flush_line(current_line_chars, page_num)
-                        current_line_chars = []
-                        current_top = None
-                        continue
+                        rounded_size = round(char["size"] * 2) / 2
+                        if rounded_size not in size_to_level:
+                            flush_line(current_line_chars, page_num)
+                            current_line_chars = []
+                            current_top = None
+                            continue
 
-                    # Same line check (top offset < 2pt)
-                    if current_top is not None and abs(char["top"] - current_top) > 2:
-                        flush_line(current_line_chars, page_num)
-                        current_line_chars = []
+                        # Same line check (top offset < 2pt)
+                        if current_top is not None and abs(char["top"] - current_top) > 2:
+                            flush_line(current_line_chars, page_num)
+                            current_line_chars = []
 
-                    current_line_chars.append(char)
-                    current_top = char["top"]
+                        current_line_chars.append(char)
+                        current_top = char["top"]
 
-                flush_line(current_line_chars, page_num)
+                    flush_line(current_line_chars, page_num)
+                finally:
+                    self._release_page_cache(page)
 
             # Step 4: Deduplicate - filter headers appearing on >30% of pages
             title_page_count: Counter = Counter(h["title"] for h in headings)

--- a/tests/parse/test_pdf_bookmark_extraction.py
+++ b/tests/parse/test_pdf_bookmark_extraction.py
@@ -32,12 +32,31 @@ class _FakePage:
     def __init__(self, text: str):
         self._text = text
         self.images = []
+        self.close_count = 0
+        self.flush_count = 0
 
     def extract_text(self):
         return self._text
 
     def extract_tables(self):
         return []
+
+    def flush_cache(self):
+        self.flush_count += 1
+
+    def close(self):
+        self.close_count += 1
+        self.flush_cache()
+
+
+class _FakeFontPage(_FakePage):
+    """Minimal page stub with character layout data for font heading detection."""
+
+    def __init__(self, *, page_number: int, chars: list[dict], height: int = 1000):
+        super().__init__("")
+        self.page_number = page_number
+        self.chars = chars
+        self.height = height
 
 
 class TestExtractBookmarks:
@@ -247,3 +266,54 @@ class TestConvertLocalBookmarks:
         assert meta["bookmarks_unresolved"] == 1
         assert meta["headings_found"] == 1
         assert meta["heading_source"] == "font_analysis"
+
+    @pytest.mark.asyncio
+    async def test_convert_local_closes_page_after_each_page(self):
+        parser = PDFParser()
+        pages = [_FakePage("Page one"), _FakePage("Page two")]
+        fake_pdf = SimpleNamespace(pages=pages)
+        fake_pdfplumber = SimpleNamespace(open=lambda _path: nullcontext(fake_pdf))
+
+        with (
+            patch("openviking.parse.parsers.pdf.lazy_import", return_value=fake_pdfplumber),
+            patch.object(parser, "_extract_bookmarks", return_value=[]),
+            patch.object(parser, "_detect_headings_by_font", return_value=[]),
+        ):
+            await parser._convert_local("dummy.pdf", storage=MagicMock(), resource_name="dummy")
+
+        assert [page.close_count for page in pages] == [1, 1]
+        assert [page.flush_count for page in pages] == [1, 1]
+
+    def test_detect_headings_by_font_closes_pages(self):
+        parser = PDFParser()
+
+        def chars(text: str, size: float, top: float) -> list[dict]:
+            return [
+                {"text": char, "size": size, "top": top, "x0": idx} for idx, char in enumerate(text)
+            ]
+
+        pages = [
+            _FakeFontPage(
+                page_number=0,
+                chars=chars("Body text repeated", 10, 500) + chars("Heading", 14, 100),
+            ),
+            _FakeFontPage(
+                page_number=1,
+                chars=chars("Another heading", 14, 120),
+            ),
+            _FakeFontPage(
+                page_number=2,
+                chars=chars("Plain body", 10, 500),
+            ),
+            _FakeFontPage(
+                page_number=3,
+                chars=chars("More body", 10, 500),
+            ),
+        ]
+        fake_pdf = SimpleNamespace(pages=pages)
+
+        headings = parser._detect_headings_by_font(fake_pdf)
+
+        assert [heading["title"] for heading in headings] == ["Heading", "Another heading"]
+        assert [page.close_count for page in pages] == [2, 1, 1, 1]
+        assert [page.flush_count for page in pages] == [2, 1, 1, 1]


### PR DESCRIPTION
## Description

修复本地 PDF 解析时 pdfplumber 页面级缓存没有及时释放导致的 RSS 持续抬升问题。

根因是 `page.extract_text()` 会在 `pdfplumber.Page` 上缓存 textmap/layout 等对象；原实现遍历 `pdf.pages` 时没有在单页处理完成后释放这些缓存，导致同一个请求连续处理多个 PDF 时，进程峰值和结束后的 RSS 都明显偏高。现在在每页文本、表格、图片提取完成后调用 `page.close()`；字体标题检测里的采样页和遍历页也会在使用后释放页面缓存。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 在 `PDFParser._convert_local()` 的每页处理逻辑外层增加 `try/finally`，确保单页处理完成后释放 pdfplumber/pdfminer page cache。
- 新增 `_release_page_cache()`，优先使用 `page.close()`，兼容性回退到 `page.flush_cache()`。
- 字体标题检测 `_detect_headings_by_font()` 的采样阶段和页面遍历阶段同步释放页面缓存。
- 增加单测覆盖主解析流程和字体标题检测流程的页面关闭行为。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

本地执行：

```text
.venv/bin/python -m pytest tests/parse/test_pdf_bookmark_extraction.py
14 passed, 4 warnings in 2.81s

.venv/bin/ruff check openviking/parse/parsers/pdf.py tests/parse/test_pdf_bookmark_extraction.py
All checks passed!

.venv/bin/ruff format --check openviking/parse/parsers/pdf.py tests/parse/test_pdf_bookmark_extraction.py
2 files already formatted

git diff --check
passed
```

RSS 对比测试：使用临时合成 PDF，两份文件，每份 0.90 MB、35 页、60 行/页；前后两个模式分别在独立 Python worker 进程中执行，避免一组测试的 RSS 残留污染另一组。

| 模式 | start MB | peak MB | end MB | retained MB | 逐文件结果 |
| --- | ---: | ---: | ---: | ---: | --- |
| 优化前：不做单页释放 | 85.4 | 1856.9 | 1381.8 | +1296.4 | file1 after_gc=1247.2 MB；file2 after_gc=1383.8 MB |
| 优化后：每页 `page.close()` | 85.1 | 149.3 | 149.2 | +64.2 | file1 after_gc=149.1 MB；file2 after_gc=149.3 MB |

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

工作区里已有未提交的 `Cargo.lock` 修改，本 PR 没有 stage 或提交该文件。
