### PR TITLE
docs(readme): link LangChain / LangGraph integration page from top README (#1964)

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,8 @@ To ensure optimal storage performance and data security, we recommend deploying 
 
 👉 **[View: Claude Code Memory Plugin Example](examples/claude-code-memory-plugin/README.md)**
 
+👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/05-langchain-langgraph.md)**
+
 \--
 
 ## Core Concepts

--- a/README_CN.md
+++ b/README_CN.md
@@ -558,6 +558,8 @@ ov chat
 
 👉 **[查看：Claude Code 记忆插件示例](examples/claude-code-memory-plugin/README_CN.md)**
 
+👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/05-langchain-langgraph.md)**
+
 ## VikingBot 部署详情
 
 OpenViking 有一个类似 nanobot 的机器人用于交互工作，现已可用。


### PR DESCRIPTION
## Description

Adds a top-level README entry pointing to the new LangChain / LangGraph integration page introduced in #1964 (ehz0ah → ZaynJarvis, merged 2026-05-12). Both `README.md` and `README_CN.md` already list pointer links for the OpenClaw / OpenCode / Claude Code plugins; the new LangChain/LangGraph integration ships with first-class docs at `docs/{en,zh}/agent-integrations/05-langchain-langgraph.md` but is not yet discoverable from the top README.

## Changes

- `README.md` (EN): +1 line `👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/05-langchain-langgraph.md)**`, placed under the existing plugin pointer cluster.
- `README_CN.md` (ZH): mirror +1 line `👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/05-langchain-langgraph.md)**`.

Both links target the canonical EN/ZH docs page added in #1964 (also linked from `docs/en/agent-integrations/01-overview.md`). No examples README exists under `examples/langchain-langgraph/` (unlike the other plugin examples), so the docs page is the right discovery entry point.

## Why

Users skimming the top README to find first-party integration options currently see OpenClaw, OpenCode, and Claude Code plugins but no LangChain/LangGraph link, even though #1964 shipped a full integration with examples (`langchain/{context-backend,message-history,rag}`, `langgraph/{agent,middleware}`) and dual-language docs. This is a pure cross-link drift catch, no behavior change.

## Test plan

- [x] EN link target verified: `docs/en/agent-integrations/05-langchain-langgraph.md` exists on main (from #1964).
- [x] ZH link target verified: `docs/zh/agent-integrations/05-langchain-langgraph.md` exists on main.
- [x] Pattern mirrors existing pointer cluster style (👉 **[View: ...](...)**).