### PR TITLE
docs(opencode-plugin): update Memory Recall section for chat.message hook (#1977)

### DIFF
--- a/examples/opencode-memory-plugin/README.md
+++ b/examples/opencode-memory-plugin/README.md
@@ -190,18 +190,18 @@ const result = await memcommit({})
 
 ## Memory Recall
 
-The plugin can automatically search OpenViking memories and inject relevant context into each user message before it reaches the LLM. This uses OpenCode's `experimental.chat.messages.transform` hook.
+The plugin can automatically search OpenViking memories and inject relevant context into each user message before it reaches the LLM. This uses OpenCode's `chat.message` hook to prepend a synthetic memory part to the outgoing message.
 
-> **Note**: This feature relies on an experimental OpenCode API. The hook signature or behavior may change in future OpenCode versions.
+> **Note**: This feature relies on OpenCode's `chat.message` hook contract. The hook signature or behavior may change in future OpenCode versions.
 
 ### How It Works
 
-1. On every user message, the plugin extracts the latest user text
+1. On every user message, the plugin extracts text from the message parts
 2. Searches OpenViking using semantic search (5-second timeout)
 3. Ranks results using multi-factor scoring (base score + leaf boost + temporal boost + preference boost + lexical overlap)
 4. Deduplicates results (abstract-based for regular memories, URI-based for events/cases)
 5. Formats matching memories as a `<relevant-memories>` XML block
-6. Appends the block to the user message's text part
+6. Prepends the block as a synthetic text part (`synthetic: true`) on the outgoing message so the memory persists across turns without polluting user input
 
 If OpenViking is unavailable or the search times out, the message is passed through unchanged.
 


### PR DESCRIPTION
Companion docs follow-up to #1977 (`refactor(opencode-plugin): migrate auto recall from chat.messages.transform to chat.message hook`).

After #1977 the OpenCode hook handler in `openviking-memory.ts` was renamed and rewritten:

- `experimental.chat.messages.transform` → `chat.message`
- `extractLatestUserText(messages: RecallWithParts[])` → `extractMessageText(parts)`
- `appendToLastTextPart(msg, injection)` → `output.parts.unshift({ type: "text", text: block, synthetic: true, ... })` inside `runAutoRecall`

But `examples/opencode-memory-plugin/README.md` still said:

> This uses OpenCode's `experimental.chat.messages.transform` hook.
> …
> 6. Appends the block to the user message's text part

That mismatch is user-facing: anyone reading the README to understand how recall works (or to copy the hook name into their own integration) gets a hook identifier that no longer exists in the code.

### Changes (single file, EN README only)

- Hook description in opening paragraph: `experimental.chat.messages.transform` → `chat.message` + brief mention that the block is prepended as a synthetic part.
- Note tweaked: the feature is no longer hanging off an `experimental.*` namespace; the caveat about hook contract evolution is kept.
- Step 1: "extracts the latest user text" → "extracts text from the message parts" (matches `extractMessageText(parts)`).
- Step 6: "Appends the block to the user message's text part" → "Prepends the block as a synthetic text part (`synthetic: true`) on the outgoing message so the memory persists across turns without polluting user input" (matches `output.parts.unshift({ ..., synthetic: true })` and the PR description "synthetic: true 持久化注入").

ZH `README_CN.md` has no Memory Recall section, so no parallel change needed there.

### Verification

- `chat.message` hook + `synthetic: true` prepending verified against the merged diff of #1977.
- ZH README scanned for parallel section: no recall-related content present.