### PR TITLE
docs(benchmark/locomo): add mem0/supermemory/claudecode to README directory tree

### DIFF
--- a/benchmark/locomo/README.md
+++ b/benchmark/locomo/README.md
@@ -15,14 +15,17 @@ benchmark/locomo/
 │   ├── run_full_eval.sh        # 一键运行完整评测流程
 │   ├── data/           # 测试数据目录
 │   └── result/         # 评测结果目录
-└── openclaw/           # OpenClaw 评测脚本
-    ├── import_to_ov.py # 导入数据到 OpenViking
-    ├── eval.py         # OpenClaw 评估脚本 (ingest/qa)
-    ├── judge.py        # LLM 裁判打分（适配 OpenClaw）
-    ├── stat_judge_result.py    # 统计评分结果和 token 使用
-    ├── run_full_eval.sh        # 一键运行完整评测流程
-    ├── data/           # 测试数据目录
-    └── result/         # 评测结果目录
+├── openclaw/           # OpenClaw 评测脚本
+│   ├── import_to_ov.py # 导入数据到 OpenViking
+│   ├── eval.py         # OpenClaw 评估脚本 (ingest/qa)
+│   ├── judge.py        # LLM 裁判打分（适配 OpenClaw）
+│   ├── stat_judge_result.py    # 统计评分结果和 token 使用
+│   ├── run_full_eval.sh        # 一键运行完整评测流程
+│   ├── data/           # 测试数据目录
+│   └── result/         # 评测结果目录
+├── mem0/               # mem0 评测脚本（详见 mem0/README.md）
+├── supermemory/        # Supermemory 评测脚本（详见 supermemory/README.md）
+└── claudecode/         # Claude Code 评测脚本（详见 claudecode/README.md）
 ```
 
 ---


### PR DESCRIPTION
## Summary

The top-level `benchmark/locomo/README.md` directory tree under `## 目录结构` enumerates **only `vikingbot/` + `openclaw/`**, but the directory actually contains **5 active subdirs**. The other three accumulated as merged drift:

- `mem0/` added 2026-04-08 by #1290 (4.7 KB README)
- `supermemory/` added 2026-04-13 by #1401 (5.5 KB README)
- `claudecode/` added 2026-05-12 by #1990 (5.3 KB README)

The top README opens with "本目录包含 LoCoMo（Long-Term Conversation Memory）评测脚本" (i.e., describes the whole `benchmark/locomo/` directory), so listing 2/5 actively-maintained eval paths is a real discoverability gap for users browsing the dir from the repo root.

## Scope of this patch

Minimal additive — 3 new tree entries plus the box-drawing prefix flip on the `openclaw/` block (└──/    → ├──/│   ) now that `openclaw/` is no longer the last child. Each new entry is a one-liner pointing readers at the subdir's own README:

```
├── mem0/               # mem0 评测脚本（详见 mem0/README.md）
├── supermemory/        # Supermemory 评测脚本（详见 supermemory/README.md）
└── claudecode/         # Claude Code 评测脚本（详见 claudecode/README.md）
```

The subdir READMEs (mem0 4.7 KB, supermemory 5.5 KB, claudecode 5.3 KB) remain authoritative for per-mode prerequisites / ingest / eval / stats — this patch does **not** duplicate that content into the top README. Only the missing tree entries are added to restore the canonical entry point for directory browsing.

## Note on in-flight PRs

Two open PRs would extend this directory further; both touch only files inside their own new subdirs (no conflict with this README change):

- #1985 `feat(benchmark): add Hermes OpenViking LoCoMo scripts` — adds `benchmark/locomo/hermes/`
- #1937 `feat(exp): add LongMemEval and LoCoMo expr` — adds `benchmark/locomo/openviking/`

If either lands, a follow-up 1-line tree update will be needed. This PR only adds the 3 entries whose source PRs are already merged on main.

## Test plan

- [ ] Render check: the box-drawing tree remains a valid 5-entry single tree, code fence boundaries unchanged, no other section touched.
- [ ] No internal anchors / cross-references in the rest of the file rely on `openclaw/` being the last tree entry (grep confirms none).