### PR TITLE
fix(lock): restore timeout=None passthrough to eliminate spurious WARNING logs

### DIFF
--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -150,7 +150,7 @@ class LockManager:
                 locks_before = set(handle.locks)
                 success = await self._path_lock.acquire_subtree(
                     path, handle,
-                    timeout=timeout if timeout is not None else self._lock_timeout,
+                    timeout=timeout,
                 )
                 if not success:
                     await self._path_lock.release_selected(handle, acquired_lock_paths)
@@ -191,12 +191,12 @@ class LockManager:
                 if is_subtree:
                     success = await self._path_lock.acquire_subtree(
                         path, handle,
-                        timeout=timeout if timeout is not None else self._lock_timeout,
+                        timeout=timeout,
                     )
                 else:
                     success = await self._path_lock.acquire_point(
                         path, handle,
-                        timeout=timeout if timeout is not None else self._lock_timeout,
+                        timeout=timeout,
                     )
                 if not success:
                     await self._path_lock.release_selected(handle, acquired_lock_paths)


### PR DESCRIPTION
## Problem

After #1966, `acquire_subtree_batch` and the new `acquire_mixed_batch` both converted `timeout=None` to `self._lock_timeout` (default `0.0`) before passing it to the underlying `acquire_point`/`acquire_subtree`:

```python
timeout=timeout if timeout is not None else self._lock_timeout,
```

With `timeout=0.0`, `acquire_point/subtree` sets `deadline = now`, hits it on the first check, and logs:

```
WARNING [POINT] Timeout waiting for lock on: /local/default/user/John/memories
WARNING Failed to acquire memory locks, retrying (attempt=510, max=unlimited)...
```

This fires every 200 ms for as long as any other session holds the memory lock, producing hundreds of spurious WARNING logs per contended session.

## Root cause

`compressor_v2.py` calls both batch methods with `timeout=None` (meaning "wait indefinitely"). Before #1966, `acquire_subtree_batch` passed `timeout` directly to `acquire_subtree`, which internally looped with `asyncio.sleep` until the lock was acquired — no WARNING ever fired. The outer retry loop in `compressor_v2` was effectively dead code.

## Fix

Remove the `if timeout is not None else self._lock_timeout` fallback and pass `timeout` directly:

```python
# before
timeout=timeout if timeout is not None else self._lock_timeout,

# after
timeout=timeout,
```

This restores the pre-#1966 behavior:
- `timeout=None` → `deadline=inf` → blocks internally, no WARNING
- `timeout=<float>` → unchanged (not None, so no difference)
- POINT vs SUBTREE lock selection logic in `acquire_mixed_batch` is untouched

## Impact

- No functional change: lock acquisition still completes eventually
- `max_retries` / `retry_interval` configs remain dead code for `timeout=None` callers, as they were before #1966
- The new POINT-lock optimization for fixed-filename schemas (soul.md, identity.md) introduced in #1966 is fully preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)