### PR TITLE
fix(embedding): include resource context in failure logs

### DIFF
--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -390,6 +390,29 @@ class TextEmbeddingHandler(DequeueHandlerBase):
             return uri if uri.endswith("/.overview.md") else f"{uri}/.overview.md"
         return uri
 
+    @staticmethod
+    def _embedding_msg_log_context(embedding_msg: Optional[EmbeddingMsg]) -> str:
+        """Return safe identifiers for embedding failure logs."""
+        if embedding_msg is None:
+            return "uri=<unknown>"
+
+        context_data = embedding_msg.context_data or {}
+        parts = [
+            f"uri={context_data.get('uri') or '<unknown>'}",
+            f"level={context_data.get('level', '<unknown>')}",
+            f"context_type={context_data.get('context_type') or '<unknown>'}",
+            f"account_id={context_data.get('account_id') or '<unknown>'}",
+        ]
+        return " ".join(parts)
+
+    @classmethod
+    def _embedding_error_msg(
+        cls,
+        embedding_msg: Optional[EmbeddingMsg],
+        message: str,
+    ) -> str:
+        return f"{message} ({cls._embedding_msg_log_context(embedding_msg)})"
+
     async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Process dequeued message and add embedding vector(s)."""
         if not data:
@@ -447,8 +470,12 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         report_success = True
                         return None
                     # No queue manager — cannot re-enqueue, drop with error
-                    request_failed_message = "Circuit breaker open and no queue manager"
-                    report_error_args = ("Circuit breaker open and no queue manager", data)
+                    error_msg = self._embedding_error_msg(
+                        embedding_msg,
+                        "Circuit breaker open and no queue manager",
+                    )
+                    request_failed_message = error_msg
+                    report_error_args = (error_msg, data)
                     return None
 
                 # Initialize embedder if not already initialized
@@ -478,7 +505,10 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         except Exception:
                             pass
                     except Exception as embed_err:
-                        error_msg = f"Failed to generate embedding: {embed_err}"
+                        error_msg = self._embedding_error_msg(
+                            embedding_msg,
+                            f"Failed to generate embedding: {embed_err}",
+                        )
                         error_class = classify_api_error(embed_err)
                         try:
                             from openviking.metrics.datasources import EmbeddingEventDataSource
@@ -513,12 +543,18 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                                 )
                                 self.report_requeue()
                                 logger.info(
-                                    f"Re-enqueued embedding message after transient error: {embedding_msg.id}"
+                                    "Re-enqueued embedding message after transient error "
+                                    f"({self._embedding_msg_log_context(embedding_msg)})"
                                 )
                                 report_success = True
                                 return None
                             except Exception as requeue_err:
-                                logger.error(f"Failed to re-enqueue message: {requeue_err}")
+                                logger.error(
+                                    self._embedding_error_msg(
+                                        embedding_msg,
+                                        f"Failed to re-enqueue message: {requeue_err}",
+                                    )
+                                )
 
                         self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
                         request_failed_message = error_msg
@@ -530,7 +566,11 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         inserted_data["vector"] = result.dense_vector
                         # Validate vector dimension
                         if len(result.dense_vector) != self._vector_dim:
-                            error_msg = f"Dense vector dimension mismatch: expected {self._vector_dim}, got {len(result.dense_vector)}"
+                            error_msg = self._embedding_error_msg(
+                                embedding_msg,
+                                "Dense vector dimension mismatch: "
+                                f"expected {self._vector_dim}, got {len(result.dense_vector)}",
+                            )
                             logger.error(error_msg)
                             self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
                             request_failed_message = error_msg
@@ -544,7 +584,10 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                             f"Generated sparse vector with {len(result.sparse_vector)} terms"
                         )
                 else:
-                    error_msg = "Embedder not initialized, skipping vector generation"
+                    error_msg = self._embedding_error_msg(
+                        embedding_msg,
+                        "Embedder not initialized, skipping vector generation",
+                    )
                     logger.warning(error_msg)
                     try:
                         from openviking.metrics.datasources import EmbeddingEventDataSource
@@ -586,10 +629,14 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         self._record_request_success(embedding_msg)
                         report_success = True
                         return None
-                    logger.error(f"Failed to write to vector database: {db_err}")
+                    error_msg = self._embedding_error_msg(
+                        embedding_msg,
+                        f"Failed to write to vector database: {db_err}",
+                    )
+                    logger.error(error_msg)
                     self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
-                    request_failed_message = str(db_err)
-                    report_error_args = (str(db_err), data)
+                    request_failed_message = error_msg
+                    report_error_args = (error_msg, data)
                     return None
                 except Exception as db_err:
                     if self._vikingdb.is_closing:
@@ -598,13 +645,17 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         self._record_request_success(embedding_msg)
                         report_success = True
                         return None
-                    logger.error(f"Failed to write to vector database: {db_err}")
+                    error_msg = self._embedding_error_msg(
+                        embedding_msg,
+                        f"Failed to write to vector database: {db_err}",
+                    )
+                    logger.error(error_msg)
                     import traceback
 
                     traceback.print_exc()
                     self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
-                    request_failed_message = str(db_err)
-                    report_error_args = (str(db_err), data)
+                    request_failed_message = error_msg
+                    report_error_args = (error_msg, data)
                     return None
 
                 self._merge_request_stats(embedding_msg.telemetry_id, processed=1)
@@ -614,14 +665,18 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                 return inserted_data
 
         except Exception as e:
-            logger.error(f"Error processing embedding message: {e}")
+            error_msg = self._embedding_error_msg(
+                embedding_msg,
+                f"Error processing embedding message: {e}",
+            )
+            logger.error(error_msg)
             import traceback
 
             traceback.print_exc()
             if embedding_msg is not None:
                 self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
-                request_failed_message = str(e)
-            report_error_args = (str(e), data)
+                request_failed_message = error_msg
+            report_error_args = (error_msg, data)
             return None
         finally:
             if embedding_msg is not None and request_failed_message is not None:

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -329,6 +329,12 @@ async def vectorize_directory_meta(
                         f"Failed to enqueue directory L1 (overview) for vectorization: {uri}: {e}",
                         exc_info=True,
                     )
+    except Exception as e:
+        logger.error(
+            f"Failed to vectorize directory metadata for {uri}: {e}",
+            exc_info=True,
+        )
+        raise
     finally:
         await _decrement_embedding_tracker(semantic_msg_id, expected - enqueued)
 


### PR DESCRIPTION
## Description

Add URI-focused context to embedding/vectorization failure logs so failed records are easier to identify.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Include `uri`, `level`, `context_type`, and `account_id` in embedding queue failure messages.
- Propagate the same context into request failure tracking and queue error callbacks.
- Add top-level directory metadata vectorization error logging with the target URI.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated with:

- `.venv/bin/python -m py_compile openviking/storage/collection_schemas.py openviking/utils/embedding_utils.py`
- pre-commit hooks during `git commit`: `ruff (legacy alias)`, `ruff format`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No tests were added because this change only enriches existing error messages.
