### PR TITLE
fix(config): Point missing config help to openviking.ai docs

### DIFF
--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -84,7 +84,7 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
         raise FileNotFoundError(
             f"OpenViking configuration file not found.\n"
             f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-            f"See: https://openviking.dev/docs/guides/configuration"
+            f"See: https://openviking.ai/docs"
         )
 
     data = load_json_config(path)

--- a/openviking_cli/utils/config/config_loader.py
+++ b/openviking_cli/utils/config/config_loader.py
@@ -121,6 +121,6 @@ def require_config(
         raise FileNotFoundError(
             f"OpenViking {purpose} configuration file not found.\n"
             f"Please create {default_path_user} or {default_path_system}, or set {env_var}.\n"
-            f"See: https://openviking.dev/docs/guides/configuration"
+            f"See: https://openviking.ai/docs"
         )
     return load_json_config(path)

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -287,7 +287,7 @@ class OpenVikingConfigSingleton:
                         raise FileNotFoundError(
                             f"OpenViking configuration file not found.\n"
                             f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-                            f"See: https://openviking.dev/docs/guides/configuration"
+                            f"See: https://openviking.ai/docs"
                         )
         return cls._instance
 
@@ -316,7 +316,7 @@ class OpenVikingConfigSingleton:
                     raise FileNotFoundError(
                         f"OpenViking configuration file not found.\n"
                         f"Please create {default_path_user} or {default_path_system}, or set {OPENVIKING_CONFIG_ENV}.\n"
-                        f"See: https://openviking.dev/docs/guides/configuration"
+                        f"See: https://openviking.ai/docs"
                     )
         return cls._instance
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -218,3 +218,19 @@ def test_openviking_config_singleton_missing_message_uses_openviking_ai_docs(tmp
             OpenVikingConfigSingleton.get_instance()
     finally:
         OpenVikingConfigSingleton.reset_instance()
+
+
+def test_openviking_config_singleton_initialize_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.open_viking_config as config_module
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(config_module, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    OpenVikingConfigSingleton.reset_instance()
+    try:
+        with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+            OpenVikingConfigSingleton.initialize()
+    finally:
+        OpenVikingConfigSingleton.reset_instance()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -180,3 +180,41 @@ def test_openviking_config_singleton_preserves_value_error_for_bad_config(tmp_pa
     with pytest.raises(ValueError, match="server"):
         OpenVikingConfigSingleton.initialize(config_path=str(config_path))
     OpenVikingConfigSingleton.reset_instance()
+
+
+def test_require_config_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.config_loader as loader
+
+    monkeypatch.delenv("TEST_MISSING_ENV", raising=False)
+    monkeypatch.setattr(loader, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(loader, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+        loader.require_config(None, "TEST_MISSING_ENV", "missing.conf", "test")
+
+
+def test_load_server_config_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking.server.config as server_config
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(server_config, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(server_config, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+        server_config.load_server_config()
+
+
+def test_openviking_config_singleton_missing_message_uses_openviking_ai_docs(tmp_path, monkeypatch):
+    import openviking_cli.utils.config.open_viking_config as config_module
+    from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+    monkeypatch.delenv("OPENVIKING_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_DIR", tmp_path / "user")
+    monkeypatch.setattr(config_module, "SYSTEM_CONFIG_DIR", tmp_path / "system")
+
+    OpenVikingConfigSingleton.reset_instance()
+    try:
+        with pytest.raises(FileNotFoundError, match=r"https://openviking\.ai/docs"):
+            OpenVikingConfigSingleton.get_instance()
+    finally:
+        OpenVikingConfigSingleton.reset_instance()


### PR DESCRIPTION
## Summary

Replaces the stale `openviking.dev/docs/guides/configuration` URL in missing-configuration errors with the current `https://openviking.ai/docs` documentation URL.

This updates the server config loader, CLI config loader, and `OpenVikingConfigSingleton` messages, with regression coverage for each missing-config path.

## Verification

- `PYTHONPATH=. .venv/bin/python - <<'PY' ... PY` direct config-loader assertion (`openviking_config_docs_url_checks_ok`)
- Attempted `python -m pytest tests/test_config_loader.py -q` after installing pytest dependencies; it initially required package installation because `tests/conftest.py` imports `openviking`.
- Attempted `. .venv/bin/activate && pip install -e . -q && python -m pytest tests/test_config_loader.py -q`; editable installation failed while building the Rust `ov_cli` artifact because this machine has Cargo 1.75.0 and the project requires the stabilized 2024 edition support. The failure is in local toolchain setup, not in the Python config-message change.