### PR TITLE
docs: prefer npm package for CLI install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,8 @@ Even if you do not plan to use `ov` directly, the Rust toolchain is still requir
 # Build and install from source
 cargo install --path crates/ov_cli
 
-# Or use the quick install script (downloads pre-built binary)
-curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+# Or install the published npm CLI package (downloads pre-built binary)
+npm i -g @openviking/cli
 ```
 
 After installation, run `ov --help` to see all available commands. CLI connection config goes in `~/.openviking/ovcli.conf`.

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -121,8 +121,8 @@ Rust CLI (`ov`) 提供高性能的命令行客户端，用于连接 OpenViking S
 # 从源码编译安装
 cargo install --path crates/ov_cli
 
-# 或者使用一键安装脚本（下载预编译二进制）
-curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+# 或者安装已发布的 npm CLI 包（下载预编译二进制）
+npm i -g @openviking/cli
 ```
 
 安装后通过 `ov --help` 查看所有可用命令。CLI 连接配置见 `~/.openviking/ovcli.conf`。

--- a/CONTRIBUTING_JA.md
+++ b/CONTRIBUTING_JA.md
@@ -123,8 +123,8 @@ Rust CLI（`ov`）は、OpenViking Serverとやり取りするための高性能
 # ソースからビルドしてインストール
 cargo install --path crates/ov_cli
 
-# またはクイックインストールスクリプトを使用（プリビルドバイナリをダウンロード）
-curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+# または公開済みの npm CLI パッケージをインストール（プリビルドバイナリをダウンロード）
+npm i -g @openviking/cli
 ```
 
 インストール後、`ov --help`を実行して利用可能なすべてのコマンドを確認できます。CLI接続設定は`~/.openviking/ovcli.conf`に記述します。

--- a/README.md
+++ b/README.md
@@ -632,6 +632,8 @@ To ensure optimal storage performance and data security, we recommend deploying 
 
 👉 **[View: Claude Code Memory Plugin Example](examples/claude-code-memory-plugin/README.md)**
 
+👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/05-langchain-langgraph.md)**
+
 \--
 
 ## Core Concepts

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ pip install openviking --upgrade --force-reinstall
 #### Rust CLI (Optional)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+npm i -g @openviking/cli
 ```
 
 Or build from source:
@@ -631,8 +631,6 @@ To ensure optimal storage performance and data security, we recommend deploying 
 👉 **[View: OpenCode Memory Plugin Example](examples/opencode-memory-plugin/README.md)**
 
 👉 **[View: Claude Code Memory Plugin Example](examples/claude-code-memory-plugin/README.md)**
-
-👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/05-langchain-langgraph.md)**
 
 \--
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -558,6 +558,8 @@ ov chat
 
 👉 **[查看：Claude Code 记忆插件示例](examples/claude-code-memory-plugin/README_CN.md)**
 
+👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/05-langchain-langgraph.md)**
+
 ## VikingBot 部署详情
 
 OpenViking 有一个类似 nanobot 的机器人用于交互工作，现已可用。

--- a/README_CN.md
+++ b/README_CN.md
@@ -78,7 +78,7 @@ pip install openviking --upgrade --force-reinstall
 #### Rust CLI（可选）
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+npm i -g @openviking/cli
 ```
 
 或从源码构建：
@@ -557,8 +557,6 @@ ov chat
 👉 **[查看：OpenCode 记忆插件示例](examples/opencode-memory-plugin/README_CN.md)**
 
 👉 **[查看：Claude Code 记忆插件示例](examples/claude-code-memory-plugin/README_CN.md)**
-
-👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/05-langchain-langgraph.md)**
 
 ## VikingBot 部署详情
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -80,7 +80,7 @@ pip install openviking --upgrade --force-reinstall
 #### Rust CLI（オプション）
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+npm i -g @openviking/cli
 ```
 
 またはソースからビルド：

--- a/crates/ov_cli/README.md
+++ b/crates/ov_cli/README.md
@@ -4,10 +4,10 @@ Command-line interface for [OpenViking](https://github.com/volcengine/OpenViking
 
 ## Installation
 
-### Quick Install (Linux/macOS)
+### Install from npm (macOS/Linux/Windows)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+npm i -g @openviking/cli
 ```
 
 ### From Source

--- a/crates/ov_cli/install.sh
+++ b/crates/ov_cli/install.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -e
 
-# OpenViking CLI Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/<OWNER>/<REPO>/refs/tags/<TAG>/crates/ov_cli/install.sh | bash
-# Example: curl -fsSL https://raw.githubusercontent.com/volcengine/openviking/refs/tags/cli@0.1.0/crates/ov_cli/install.sh | bash
-# Skip checksum: curl -fsSL ... | SKIP_CHECKSUM=1 bash
+# OpenViking CLI Installer (legacy GitHub Releases path)
+# Prefer npm for new installs:
+#   npm i -g @openviking/cli
+# Alternative TOS installer:
+#   curl -fsSL http://openviking.tos-cn-beijing.volces.com/cli/install.sh | bash
+# Skip checksum: SKIP_CHECKSUM=1 bash install.sh
 # Custom repo: REPO=owner/repo curl -fsSL ... | bash
 
 REPO="${REPO:-volcengine/openviking}"

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -339,8 +339,8 @@ _LOCAL_FILE_HINT = (
     "For local files or directories, use the `ov` CLI:\n"
     "  1. Try first: ov add-resource <path>\n"
     "     (if `ov` is already on PATH, this is all you need)\n"
-    "  2. If `ov` is not installed, run:\n"
-    "     curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash\n"
+    "  2. If `ov` is not installed, install the npm CLI package:\n"
+    "     npm i -g @openviking/cli\n"
     "  3. Only if connecting to a remote / multi-tenant OpenViking server, "
     "configure ~/.openviking/ovcli.conf:\n"
     '       {"url": "https://your-host", "api_key": "your-key"}'

--- a/openviking_cli/rust_cli.py
+++ b/openviking_cli/rust_cli.py
@@ -98,8 +98,8 @@ def main():
         1. 使用预构建 wheel（推荐）：
    pip install openviking --upgrade --force-reinstall
 
-        2. 使用官方安装脚本（零 Python 开销）：
-   curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/crates/ov_cli/install.sh | bash
+        2. 使用 npm 安装原生 CLI 包（零 Python 开销）：
+   npm i -g @openviking/cli
 
         3. 从 GitHub Releases 下载（零 Python 开销）：
    https://github.com/volcengine/OpenViking/releases


### PR DESCRIPTION
Updates CLI installation docs and runtime hints to prefer the published npm package instead of the raw GitHub install script. Also marks the legacy GitHub release installer as a fallback and points to the TOS installer as an alternative.