### PR TITLE
docs(ragfs): fix broken c4pt0r upstream link in ORIGIN.md

### DIFF
--- a/crates/ragfs/ORIGIN.md
+++ b/crates/ragfs/ORIGIN.md
@@ -1,6 +1,6 @@
 # RAGFS Origin
 
-This crate (RAGFS) is a Rust reimplementation of the AGFS project originally authored by [c44pt0r](https://github.com/c44pt0r).
+This crate (RAGFS) is a Rust reimplementation of the AGFS project originally authored by [c4pt0r](https://github.com/c4pt0r).
 
 ## Source
 


### PR DESCRIPTION
## Description

Fix a broken link in `crates/ragfs/ORIGIN.md`. The original AGFS author's GitHub username was misspelled as `c44pt0r`, which returns 404. The correct account is `c4pt0r`, who maintains https://github.com/c4pt0r/agfs.

## Related Issue

N/A

## Type of Change

- [x] Documentation update

## Changes Made

- `crates/ragfs/ORIGIN.md`: corrected username `c44pt0r` → `c4pt0r` in both the link text and URL.

## Testing

- [x] Verified `https://github.com/c44pt0r` returns 404
- [x] Verified `https://github.com/c4pt0r/agfs` exists and matches the description ("Aggregated File System ... A tribute to Plan 9")
- [x] Cross-checked plugin layout in `crates/ragfs/src/plugins/` (kvfs, queuefs, sqlfs, memfs, s3fs, localfs, serverinfofs) matches the upstream AGFS plugin set, confirming `c4pt0r/agfs` is the actual upstream

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings