### PR TITLE
WIP feat(server): configure request io thread pool

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -214,7 +214,9 @@ def create_app(
         from openviking.metrics.global_api import (
             init_metrics_from_server_config,
         )
+        from openviking.utils.request_io import configure_request_io_executor
 
+        configure_request_io_executor(config.request_io_threads)
         init_metrics_from_server_config(config, app=app, service=service)
         if config.observability.metrics.enabled:
             logger.info("Prometheus metrics enabled at /metrics")

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -109,6 +109,14 @@ class ServerConfig(BaseModel):
     host: str = "127.0.0.1"
     port: int = 1933
     workers: int = 1
+    request_io_threads: int = Field(
+        default=64,
+        ge=1,
+        description=(
+            "Max workers for the asyncio default executor used by request-path "
+            "asyncio.to_thread/run_in_executor calls."
+        ),
+    )
     auth_mode: Optional[AuthMode] = None  # If None, auto-detect based on root_api_key
     root_api_key: Optional[str] = None
     cors_origins: List[str] = Field(default_factory=lambda: ["*"])

--- a/openviking/utils/request_io.py
+++ b/openviking/utils/request_io.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Configure asyncio's default executor for request-path blocking I/O."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_MAX_WORKERS = 64
+_executor: Optional[ThreadPoolExecutor] = None
+_max_workers: Optional[int] = None
+_lock = threading.Lock()
+
+
+def _normalize_max_workers(max_workers: Optional[int]) -> int:
+    if max_workers is None:
+        env_value = os.environ.get("OPENVIKING_REQUEST_IO_THREADS", "")
+        if env_value.strip().isdigit():
+            max_workers = int(env_value)
+        else:
+            max_workers = _DEFAULT_MAX_WORKERS
+    return max(1, int(max_workers))
+
+
+def configure_request_io_executor(max_workers: Optional[int] = None) -> None:
+    """Set the event loop default executor used by ``asyncio.to_thread``.
+
+    This does not move any code into threads by itself. It only controls the
+    concurrency of existing ``asyncio.to_thread`` and ``run_in_executor(None, ...)``
+    call sites.
+    """
+    global _executor, _max_workers
+
+    normalized = _normalize_max_workers(max_workers)
+    loop = asyncio.get_running_loop()
+    with _lock:
+        if _executor is not None and _max_workers == normalized:
+            loop.set_default_executor(_executor)
+            return
+
+        old_executor = _executor
+        _executor = ThreadPoolExecutor(
+            max_workers=normalized,
+            thread_name_prefix="ov-request-io",
+        )
+        _max_workers = normalized
+        loop.set_default_executor(_executor)
+
+    if old_executor is not None:
+        old_executor.shutdown(wait=False, cancel_futures=False)
+
+    logger.info("Configured request I/O default executor with max_workers=%d", normalized)
+
+
+__all__ = ["configure_request_io_executor"]


### PR DESCRIPTION
## Description

Adds a configurable request I/O thread pool by setting the asyncio default executor during server startup. Existing `asyncio.to_thread` / `run_in_executor(None, ...)` request paths can now scale concurrency under a single uvicorn worker without changing individual call sites.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- Added `server.request_io_threads` with a default of 64 workers.
- Configured the asyncio default executor during FastAPI lifespan startup.
- Added `openviking.utils.request_io` so existing `asyncio.to_thread` and default executor users share the configured pool.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Verification:
- [x] `.venv/bin/python -m py_compile openviking/server/app.py openviking/server/config.py openviking/utils/request_io.py`
- [x] Commit hooks passed: `ruff (legacy alias)`, `ruff format`

Note: focused pytest suites were not run because the system Python has an incompatible `pydantic-core` version and the local `.venv` is missing `pytest_asyncio`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This change only controls default executor capacity. It does not add new `to_thread` call sites; request-path offloading can be handled by the branch that already wraps blocking calls.
