### PR TITLE
fix(plugin/codex): raise auto-recall score threshold

### DIFF
--- a/examples/codex-memory-plugin/scripts/config.mjs
+++ b/examples/codex-memory-plugin/scripts/config.mjs
@@ -210,7 +210,7 @@ export function loadConfig() {
     ))),
     scoreThreshold: Math.min(1, Math.max(0, num(
       process.env.OPENVIKING_SCORE_THRESHOLD,
-      num(cx.scoreThreshold, 0.01),
+      num(cx.scoreThreshold, 0.35),
     ))),
     minQueryLength: Math.max(1, Math.floor(num(
       process.env.OPENVIKING_MIN_QUERY_LENGTH,


### PR DESCRIPTION
## Summary
- Raise the Codex memory plugin auto-recall default score threshold from 0.01 to 0.35.
- Keep OPENVIKING_SCORE_THRESHOLD and codex.scoreThreshold overrides unchanged.

## Verification
- env OPENVIKING_CLI_CONFIG_FILE=/tmp/openviking-missing-ovcli.conf OPENVIKING_CONFIG_FILE=/tmp/openviking-missing-ov.conf node --input-type=module -e "import('./examples/codex-memory-plugin/scripts/config.mjs').then(({loadConfig})=>console.log(JSON.stringify({scoreThreshold:loadConfig().scoreThreshold, recallLimit:loadConfig().recallLimit, minQueryLength:loadConfig().minQueryLength})))"
- env OPENVIKING_CLI_CONFIG_FILE=/tmp/openviking-missing-ovcli.conf OPENVIKING_CONFIG_FILE=/tmp/openviking-missing-ov.conf OPENVIKING_SCORE_THRESHOLD=0.2 node --input-type=module -e "import('./examples/codex-memory-plugin/scripts/config.mjs').then(({loadConfig})=>console.log(JSON.stringify({scoreThreshold:loadConfig().scoreThreshold})))"
- git diff --check