### PR TITLE
Allowing the evaluation to not call commit_tool

### DIFF
--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -197,11 +197,16 @@ class AgentLoop:
             progress to users during long-running operations.
 
         Example:
-            >>> await self._publish_thinking_event(
-            ...     session_key=SessionKey(channel="telegram", chat_id="123"),
-            ...     event_type=OutboundEventType.TOOL_START,
-            ...     content="Executing web search..."
-            ... )
+            async def notify_tool_call() -> None:
+                await self._publish_thinking_event(
+                    session_key=SessionKey(
+                        type="telegram",
+                        channel_id="default",
+                        chat_id="123",
+                    ),
+                    event_type=OutboundEventType.TOOL_CALL,
+                    content="Executing web search...",
+                )
         """
         await self.bus.publish_outbound(
             OutboundMessage(
@@ -267,6 +272,7 @@ class AgentLoop:
         sender_id: str | None = None,
         ov_tools_enable: bool = True,
         memory_user_ids: list[str] | None = None,
+        disabled_tools: list[str] | None = None,
     ) -> tuple[str | None, str | None, list[dict], dict[str, int], int]:
         """
         Run the core agent loop: call LLM, execute tools, repeat until done.
@@ -277,6 +283,7 @@ class AgentLoop:
             publish_events: Whether to publish ITERATION/REASONING/TOOL_CALL events to the bus
             ov_tools_enable: Whether to enable OpenViking tools for this session
             memory_user_ids: List of user IDs for memory retrieval
+            disabled_tools: Tool names to hide from the model for this request
 
         Returns:
             tuple of (final_content, final_reasoning_content, tools_used, token_usage, iteration)
@@ -306,7 +313,10 @@ class AgentLoop:
 
             response = await self.provider.chat(
                 messages=messages,
-                tools=self.tools.get_definitions(ov_tools_enable=ov_tools_enable),
+                tools=self.tools.get_definitions(
+                    ov_tools_enable=ov_tools_enable,
+                    disabled_tools=disabled_tools,
+                ),
                 model=self.model,
                 session_id=session_key.safe_name(),
             )
@@ -516,6 +526,9 @@ class AgentLoop:
             session = self.sessions.get_or_create(session_key, skip_heartbeat=skip_heartbeat)
 
             ov_tools_enable = self._get_ov_tools_enable(session_key)
+            disabled_tools = msg.metadata.get("disabled_tools", []) if msg.metadata else []
+            if not isinstance(disabled_tools, list):
+                disabled_tools = []
             # Get profile_user_list from channel config
             profile_user_list = []
             # Try to get memory_users from message metadata first (CLI mode), then from channel config
@@ -668,6 +681,7 @@ class AgentLoop:
                     sender_id=msg.sender_id,
                     ov_tools_enable=ov_tools_enable,
                     memory_user_ids=memory_user,
+                    disabled_tools=disabled_tools,
                 )
 
             # Log response preview
@@ -925,9 +939,17 @@ class AgentLoop:
 
             prompt = f"""You are a memory consolidation agent. Process this conversation and return a JSON object with exactly two keys:
 
-1. "history_entry": A paragraph (2-5 sentences) summarizing the key events/decisions/topics. Start with a timestamp like [YYYY-MM-DD HH:MM]. Include enough detail to be useful when found by grep search later.
+1. "history_entry": A paragraph (2-5 sentences) summarizing the key events, decisions, constraints, and outcomes. Start with a timestamp like [YYYY-MM-DD HH:MM]. Include concrete nouns, document names, project names, roles, dates, decisions, unresolved items, and user wording that would make the entry easy to find with semantic search or grep later.
 
-2. "memory_update": The updated long-term memory content. Add any new facts: user location, preferences, personal info, habits, project context, technical decisions, tools/services used. If nothing new, return the existing content unchanged.
+2. "memory_update": The updated long-term memory content. Add durable facts, user preferences, project context, technical decisions, tools/services used, and reusable working rules. If nothing new is worth remembering, return the existing content unchanged.
+
+When updating memory, prefer reusable, evidence-backed rules over vague summaries:
+- Preserve the scope of each rule: mark whether it is general, project-specific, document-specific, role/audience-specific, time-bounded, or only true for the current turn.
+- Record both positive and negative constraints when stated or strongly implied, such as what the user wants, what they reject, what must stay separate, what must stay consistent, what can remain pending, and what must not be inferred.
+- Turn repeated corrections into concise preference rules, but do not overgeneralize one-off instructions into permanent habits.
+- Keep important anchors searchable: names of files, artifacts, workstreams, roles, audiences, fields, dates, and user phrases.
+- For incomplete or ambiguous inputs, record the handling rule instead of inventing missing facts.
+- Do not store these consolidation instructions as memory.
 
 ## Current Long-term Memory
 {current_memory or "(empty)"}

--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -939,17 +939,9 @@ class AgentLoop:
 
             prompt = f"""You are a memory consolidation agent. Process this conversation and return a JSON object with exactly two keys:
 
-1. "history_entry": A paragraph (2-5 sentences) summarizing the key events, decisions, constraints, and outcomes. Start with a timestamp like [YYYY-MM-DD HH:MM]. Include concrete nouns, document names, project names, roles, dates, decisions, unresolved items, and user wording that would make the entry easy to find with semantic search or grep later.
+1. "history_entry": A paragraph (2-5 sentences) summarizing the key events/decisions/topics. Start with a timestamp like [YYYY-MM-DD HH:MM]. Include enough detail to be useful when found by grep search later.
 
-2. "memory_update": The updated long-term memory content. Add durable facts, user preferences, project context, technical decisions, tools/services used, and reusable working rules. If nothing new is worth remembering, return the existing content unchanged.
-
-When updating memory, prefer reusable, evidence-backed rules over vague summaries:
-- Preserve the scope of each rule: mark whether it is general, project-specific, document-specific, role/audience-specific, time-bounded, or only true for the current turn.
-- Record both positive and negative constraints when stated or strongly implied, such as what the user wants, what they reject, what must stay separate, what must stay consistent, what can remain pending, and what must not be inferred.
-- Turn repeated corrections into concise preference rules, but do not overgeneralize one-off instructions into permanent habits.
-- Keep important anchors searchable: names of files, artifacts, workstreams, roles, audiences, fields, dates, and user phrases.
-- For incomplete or ambiguous inputs, record the handling rule instead of inventing missing facts.
-- Do not store these consolidation instructions as memory.
+2. "memory_update": The updated long-term memory content. Add any new facts: user location, preferences, personal info, habits, project context, technical decisions, tools/services used. If nothing new, return the existing content unchanged.
 
 ## Current Long-term Memory
 {current_memory or "(empty)"}

--- a/bot/vikingbot/agent/tools/registry.py
+++ b/bot/vikingbot/agent/tools/registry.py
@@ -100,7 +100,11 @@ class ToolRegistry:
         """
         return name in self._tools
 
-    def get_definitions(self, ov_tools_enable: bool = True) -> list[dict[str, Any]]:
+    def get_definitions(
+        self,
+        ov_tools_enable: bool = True,
+        disabled_tools: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Get all tool definitions in OpenAI format.
 
@@ -110,6 +114,7 @@ class ToolRegistry:
         Args:
             ov_tools_enable: Whether to include OpenViking tools. If False,
                 tools with names starting with "openviking_" will be excluded.
+            disabled_tools: Tool names to hide from the model for this request.
 
         Returns:
             List of tool schemas in OpenAI format, where each schema contains
@@ -123,6 +128,9 @@ class ToolRegistry:
         tools = self._tools.values()
         if not ov_tools_enable:
             tools = [tool for tool in tools if not tool.name.startswith("openviking_")]
+        if disabled_tools:
+            disabled = set(disabled_tools)
+            tools = [tool for tool in tools if tool.name not in disabled]
         return [tool.to_schema() for tool in tools]
 
     async def execute(

--- a/bot/vikingbot/channels/openapi.py
+++ b/bot/vikingbot/channels/openapi.py
@@ -48,6 +48,7 @@ class PendingResponse:
         self.final_content: Optional[str] = None
         self.response_id: Optional[str] = None
         self.relevant_memories: Optional[str] = None
+        self.token_usage: Dict[str, int] = {}
         self.event = asyncio.Event()
         self.stream_queue: asyncio.Queue[Optional[ChatStreamEvent]] = asyncio.Queue()
 
@@ -202,6 +203,7 @@ class OpenAPIChannel(BaseChannel):
             ):
                 pending.set_response_id(msg.response_id)
                 pending.relevant_memories = (msg.metadata or {}).get("relevant_memories")
+                pending.token_usage = msg.token_usage
                 await pending.add_event(
                     "response",
                     {"content": msg.content or "", "response_id": msg.response_id},
@@ -227,6 +229,7 @@ class OpenAPIChannel(BaseChannel):
         if msg.event_type == OutboundEventType.RESPONSE:
             # Final response - add to stream first
             pending.set_response_id(msg.response_id)
+            pending.token_usage = msg.token_usage
             pending.relevant_memories = (msg.metadata or {}).get("relevant_memories")
             await pending.add_event(
                 "response",
@@ -479,6 +482,7 @@ class OpenAPIChannel(BaseChannel):
                 session_key=session_key,
                 sender_id=user_id,
                 content=content,
+                metadata={"disabled_tools": request.disabled_tools},
             )
 
             await self.bus.publish_inbound(msg)
@@ -498,6 +502,7 @@ class OpenAPIChannel(BaseChannel):
                 message=response_content,
                 events=pending.events if pending.events else None,
                 relevant_memories=pending.relevant_memories,
+                token_usage=pending.token_usage,
             )
 
         except HTTPException:
@@ -543,6 +548,7 @@ class OpenAPIChannel(BaseChannel):
                     session_key=session_key,
                     sender_id=user_id,
                     content=request.message,
+                    metadata={"disabled_tools": request.disabled_tools},
                 )
 
                 await self.bus.publish_inbound(msg)
@@ -622,6 +628,7 @@ class OpenAPIChannel(BaseChannel):
                 sender_id=user_id,
                 content=content,
                 need_reply=request.need_reply,
+                metadata={"disabled_tools": request.disabled_tools},
             )
 
             await self.bus.publish_inbound(msg)
@@ -641,6 +648,7 @@ class OpenAPIChannel(BaseChannel):
                 message=response_content,
                 events=pending.events if pending.events else None,
                 relevant_memories=pending.relevant_memories,
+                token_usage=pending.token_usage,
             )
 
         except HTTPException:
@@ -693,6 +701,7 @@ class OpenAPIChannel(BaseChannel):
                     session_key=session_key,
                     sender_id=user_id,
                     content=request.message,
+                    metadata={"disabled_tools": request.disabled_tools},
                 )
 
                 await self.bus.publish_inbound(msg)

--- a/bot/vikingbot/channels/openapi_models.py
+++ b/bot/vikingbot/channels/openapi_models.py
@@ -60,6 +60,10 @@ class ChatRequest(BaseModel):
     channel_id: Optional[str] = Field(
         default=None, description="Channel ID for multi-channel routing (optional)"
     )
+    disabled_tools: List[str] = Field(
+        default_factory=list,
+        description="Tool names to hide for this request",
+    )
 
 
 class ChatResponse(BaseModel):
@@ -74,6 +78,10 @@ class ChatResponse(BaseModel):
     relevant_memories: Optional[str] = Field(
         default=None,
         description="OpenViking memories assembled during _process_message",
+    )
+    token_usage: Dict[str, int] = Field(
+        default_factory=dict,
+        description="Token usage statistics (prompt_tokens, completion_tokens, total_tokens)",
     )
     timestamp: datetime = Field(default_factory=datetime.now, description="Response timestamp")
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
When calling vikingbot for evaluation, the bot invokes the commit tool, which can corrupt memories. This should be prevented.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
