### PR TITLE
docs(vlm): document backup config for automatic failover from #2040

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -540,6 +540,7 @@ Vision Language Model for semantic extraction (L0/L1 generation).
 | `thinking` | bool | Enable thinking mode for VolcEngine models (default: `false`) |
 | `max_concurrent` | int | Maximum concurrent semantic LLM calls (default: `100`) |
 | `max_retries` | int | Maximum retry attempts for transient VLM provider errors (default: `3`; `0` disables retry) |
+| `backup` | object | Optional backup VLM configuration (same shape as `vlm`) for automatic failover when the primary fails with retryable errors such as rate limits, `5xx` responses, or connection/timeout failures. Only one level of failover is supported &mdash; the backup itself cannot define a nested `backup` |
 | `timeout` | float | Per-request HTTP timeout in seconds passed to the underlying OpenAI/LiteLLM client. Increase for slow endpoints (e.g., DashScope, local inference). Must be `> 0` (default: `60.0`) |
 | `extra_headers` | object | Custom HTTP headers for compatible HTTP providers. `kimi` also accepts header overrides, but already injects the required subscription headers by default |
 | `extra_request_body` | object | Extra JSON body fields for OpenAI-compatible completion requests, useful for provider-specific options such as Ollama `{"think": false}` |

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -512,6 +512,7 @@ openviking-server doctor
 | `thinking` | bool | 启用思考模式（仅对部分火山模型生效，默认：`false`） |
 | `max_concurrent` | int | 语义处理阶段 LLM 最大并发调用数（默认：`100`） |
 | `max_retries` | int | VLM provider 瞬时错误的最大重试次数（默认：`3`；`0` 表示禁用重试） |
+| `backup` | object | 可选的备用 VLM 配置（结构与 `vlm` 相同），当主 VLM 遇到限流、`5xx`、超时或连接失败等可重试错误时自动切换。仅支持 1 层备用 &mdash; 备用 VLM 本身不能再嵌套 `backup` |
 | `timeout` | float | 单次 VLM API 请求的 HTTP 超时时间（秒），传递给底层 OpenAI/LiteLLM 客户端。慢端点（如 DashScope、本地推理）可调大。必须 `> 0`（默认：`60.0`） |
 | `extra_headers` | object | 兼容 HTTP provider 的自定义请求头。`kimi` 默认已注入所需订阅请求头，也支持在这里覆盖或扩展 |
 | `extra_request_body` | object | 传给 OpenAI 兼容 completion 请求的额外 JSON body 字段，可用于 Ollama `{"think": false}` 等 provider 专有参数 |


### PR DESCRIPTION
PR #2040 (MaojiaSheng, merged 2026-05-14T07:38Z by qin-ctx) added an optional `backup` field to `VLMConfig` so callers can configure automatic failover to a second VLM when the primary fails with retryable errors. The field is wired through `openviking/models/vlm/base.py::FailoverVLM` (rate-limit / `5xx` / timeout / connection patterns), `openviking_cli/utils/config/vlm_config.py::VLMConfig.backup` with a `validate_no_recursive_backup` guard, and `get_vlm_instance` wrapping the primary in `FailoverVLM` when `backup._has_any_config()`.

`docs/{en,zh}/guides/01-configuration.md::### vlm::Parameters` lists every other `VLMConfig` Field but does not mention `backup`, so users with the merged feature have to read source to know it exists.

This PR adds one `backup` row per language to the `### vlm` parameters table, ordered next to `max_retries` so retry/failover semantics stay together. The description is grounded in the source: failover triggers paraphrase `_should_failover` (rate limit / `5xx` / timeout / connection); the one-level limit paraphrases `validate_no_recursive_backup`'s `ValueError` message.

No code change. No example config rewrite — the existing canonical config block stays as the minimal/required shape; the new row documents the optional field alongside the rest.
