### PR TITLE
fix(storage): detect overview language from child summaries

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1179,14 +1179,21 @@ class SemanticProcessor(DequeueHandlerBase):
             file_summaries_lines.append(f"[{idx}] {item['name']}: {item['summary']}")
         file_summaries_str = "\n".join(file_summaries_lines) if file_summaries_lines else "None"
 
-        output_language = resolve_output_language(file_summaries_str, config=config)
-
         # Build subdirectory summary string
         children_abstracts_str = (
             "\n".join(f"- {item['name']}/: {item['abstract']}" for item in children_abstracts)
             if children_abstracts
             else "None"
         )
+
+        language_source_parts = []
+        if file_summaries:
+            language_source_parts.append(file_summaries_str)
+        if children_abstracts:
+            language_source_parts.append(children_abstracts_str)
+        if not language_source_parts:
+            language_source_parts.append(dir_uri.split("/")[-1])
+        output_language = resolve_output_language("\n".join(language_source_parts), config=config)
 
         # Budget guard: check if prompt would be oversized
         estimated_size = len(file_summaries_str) + len(children_abstracts_str)


### PR DESCRIPTION
## Description

Fix directory overview language detection for resource directories that contain only child directories. The semantic processor now considers child directory abstracts when resolving the output language, so Chinese-only directory trees do not fall back to English just because there are no direct file summaries.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Include child directory abstracts in overview output-language detection.
- Keep file summaries as the primary detection source when present.
- Fall back to the directory name only when neither files nor child summaries exist.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Command run:

```bash
.venv/bin/python -m pytest tests/storage/test_semantic_processor_language.py
```

Result: 33 passed, 4 existing warnings.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally keeps the fix scoped to `semantic_processor.py` only.
