### PR TITLE
fix(docs): upload clean URL aliases to TOS

### DIFF
--- a/.github/workflows/docs-tos.yml
+++ b/.github/workflows/docs-tos.yml
@@ -106,6 +106,20 @@ jobs:
             --cache-control "${HTML_CACHE_CONTROL}" \
             --only-show-errors
 
+          while IFS= read -r -d '' html_file; do
+            rel_path="${html_file#${DIST_DIR}/}"
+            case "${rel_path}" in
+              index.html|404.html) continue ;;
+            esac
+
+            clean_path="${rel_path%.html}"
+            aws s3 cp "${html_file}" "s3://${TOS_BUCKET}/${clean_path}" \
+              --endpoint-url "https://${TOS_S3_ENDPOINT}" \
+              --content-type "text/html; charset=utf-8" \
+              --cache-control "${HTML_CACHE_CONTROL}" \
+              --only-show-errors
+          done < <(find "${DIST_DIR}" -type f -name "*.html" -print0)
+
           aws s3 cp "${DIST_DIR}/assets" "s3://${TOS_BUCKET}/assets/" \
             --endpoint-url "https://${TOS_S3_ENDPOINT}" \
             --recursive \


### PR DESCRIPTION
## Description

Fix clean URL routes on the TOS-hosted docs site by uploading extensionless HTML aliases for VitePress pages. This makes URLs such as `/zh/getting-started/02-quickstart` resolve on `docs.openviking.net`, matching the GitHub Pages behavior on `docs.openviking.ai`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Keep uploading the generated `.html` docs files to TOS.
- Upload an additional extensionless object for each generated page HTML file.
- Preserve `text/html; charset=utf-8` and the existing HTML revalidation cache policy for clean URL aliases.
- Leave `index.html`, `404.html`, and long-lived static asset handling unchanged.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation commands:

- `env PATH=/Users/bytedance/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run docs:build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-tos.yml"); puts "yaml ok"'`
- `git diff --check`
- Verified the upload loop maps `zh/getting-started/02-quickstart.html` to `zh/getting-started/02-quickstart`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Root cause: VitePress is configured with `cleanUrls: true`, so site links omit `.html`. GitHub Pages resolves those clean URLs automatically, but TOS currently performs exact object key lookup and returns `NoSuchKey` for extensionless page paths unless those aliases are uploaded.
