### PR TITLE
docs(api): document observer.filesystem from #2045

### DIFF
--- a/docs/en/api/07-system.md
+++ b/docs/en/api/07-system.md
@@ -820,6 +820,64 @@ ov observer retrieval
 
 ---
 
+### observer.filesystem
+
+#### 1. API Implementation Overview
+
+Get filesystem operation metrics.
+
+**Code Entry Points**:
+- `openviking/server/routers/observer.py:observer_filesystem` - HTTP route
+- `openviking/service/debug_service.py:ObserverService.filesystem` - Core implementation
+- `openviking/storage/observers/filesystem_observer.py` - Filesystem observer
+- `crates/ov_cli/src/commands/observer.rs` - CLI command
+
+#### 2. Interface and Parameters
+
+No parameters.
+
+#### 3. Usage Examples
+
+**HTTP API**
+
+```
+GET /api/v1/observer/filesystem
+```
+
+```bash
+curl -X GET http://localhost:1933/api/v1/observer/filesystem \
+  -H "X-API-Key: your-key"
+```
+
+**Python SDK**
+
+```python
+print(client.observer.filesystem)
+```
+
+**CLI**
+
+```bash
+ov observer filesystem
+```
+
+**Response Example**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "name": "filesystem",
+    "is_healthy": true,
+    "has_errors": false,
+    "status": "..."
+  },
+  "time": 0.1
+}
+```
+
+---
+
 ### observer.system
 
 #### 1. API Implementation Overview

--- a/docs/en/concepts/12-metrics.md
+++ b/docs/en/concepts/12-metrics.md
@@ -313,6 +313,7 @@ Typical `component` values include:
 - `lock`
 - `retrieval`
 - `vikingdb`
+- `filesystem`
 
 ### VikingDB and Model Usage Statistics
 

--- a/docs/zh/api/07-system.md
+++ b/docs/zh/api/07-system.md
@@ -814,6 +814,64 @@ ov observer retrieval
 
 ---
 
+### observer.filesystem
+
+#### 1. API 实现介绍
+
+获取文件系统操作指标。
+
+**代码入口**:
+- `openviking/server/routers/observer.py:observer_filesystem` - HTTP 路由
+- `openviking/service/debug_service.py:ObserverService.filesystem` - 核心实现
+- `openviking/storage/observers/filesystem_observer.py` - 文件系统观察者
+- `crates/ov_cli/src/commands/observer.rs` - CLI 命令
+
+#### 2. 接口和参数说明
+
+无参数。
+
+#### 3. 使用示例
+
+**HTTP API**
+
+```
+GET /api/v1/observer/filesystem
+```
+
+```bash
+curl -X GET http://localhost:1933/api/v1/observer/filesystem \
+  -H "X-API-Key: your-key"
+```
+
+**Python SDK**
+
+```python
+print(client.observer.filesystem)
+```
+
+**CLI**
+
+```bash
+ov observer filesystem
+```
+
+**响应示例**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "name": "filesystem",
+    "is_healthy": true,
+    "has_errors": false,
+    "status": "..."
+  },
+  "time": 0.1
+}
+```
+
+---
+
 ### observer.system
 
 #### 1. API 实现介绍

--- a/docs/zh/concepts/12-metrics.md
+++ b/docs/zh/concepts/12-metrics.md
@@ -316,6 +316,7 @@ scrape_configs:
 - `lock`
 - `retrieval`
 - `vikingdb`
+- `filesystem`
 
 ### VikingDB 与模型使用统计
 


### PR DESCRIPTION
### Summary

`#2045` (feat: add `ov observer filesystem`, and optimize mkdir frequency, by MaojiaSheng / merged by zhoujh01 2026-05-14) added a new `filesystem` observer subcomponent and a corresponding `ov observer filesystem` CLI subcommand. The API reference docs and the metrics component list missed it.

This PR documents the new observer endpoint to match the existing `observer.queue` / `observer.vikingdb` / `observer.models` / `observer.retrieval` / `observer.system` sections, and lists `filesystem` as a typical `component` label in the metrics reference.

### Changes

- `docs/{en,zh}/api/07-system.md`: add `observer.filesystem` section between `observer.retrieval` and `observer.system`, byte-mirroring the existing observer.* section template (HTTP API + Python SDK + CLI usage + response example).
- `docs/{en,zh}/concepts/12-metrics.md`: append `filesystem` to the typical `component` label values for `openviking_component_errors` / `openviking_observer_components_*` metric families.

### Grounding

- HTTP route: `@router.get("/filesystem")` → `observer_filesystem()` in `openviking/server/routers/observer.py`.
- Service: `ObserverService.filesystem` property in `openviking/service/debug_service.py` returning `ComponentStatus(name="filesystem", ...)`.
- Observer: new `openviking/storage/observers/filesystem_observer.py` (added by #2045).
- CLI: `pub async fn filesystem(...)` in `crates/ov_cli/src/commands/observer.rs` + `Filesystem` variant in `ObserverCommands` enum in `crates/ov_cli/src/main.rs` (doc: "Get filesystem operation metrics").

Pure docs change; if this has already been queued in a parallel patch or is intentionally deferred (preview/internal), feel free to close and mark accordingly.