### PR TITLE
docs(observability): document server.observability.dump_body from #2052

### DIFF
--- a/docs/en/guides/05-observability.md
+++ b/docs/en/guides/05-observability.md
@@ -277,6 +277,7 @@ OpenViking groups signal-level observability configuration under `server.observa
 - `server.observability.metrics`: metrics subsystem and exporters
 - `server.observability.traces`: trace export configuration
 - `server.observability.logs`: log export configuration
+- `server.observability.dump_body`: attaches HTTP request/response bodies (filtered by content-type, truncated by bytes) as attributes on the active trace span so they can be inspected in trace UIs. Off by default — bodies may contain secrets and high-cardinality content
 
 Example:
 
@@ -322,6 +323,10 @@ Example:
         "endpoint": "otel-collector:4317",
         "service_name": "openviking-server",
         "headers": {}
+      },
+      "dump_body": {
+        "enabled": false,
+        "max_bytes": 4096
       }
     }
   }

--- a/docs/zh/guides/05-observability.md
+++ b/docs/zh/guides/05-observability.md
@@ -276,6 +276,7 @@ OpenViking 将信号级别的可观测性配置统一放在 `server.observabilit
 - `server.observability.metrics`：metrics 子系统与 exporter 配置
 - `server.observability.traces`：trace 导出配置
 - `server.observability.logs`：log 导出配置
+- `server.observability.dump_body`：把 HTTP 请求/响应 body（按 content-type 过滤、按字节截断）作为属性挂到当前 trace span 上，便于在 trace UI 中调试。默认关闭，因为 body 可能含密钥/高基数内容
 
 示例：
 
@@ -321,6 +322,10 @@ OpenViking 将信号级别的可观测性配置统一放在 `server.observabilit
         "endpoint": "otel-collector:4317",
         "service_name": "openviking-server",
         "headers": {}
+      },
+      "dump_body": {
+        "enabled": false,
+        "max_bytes": 4096
       }
     }
   }


### PR DESCRIPTION
## Summary

Documents the new `server.observability.dump_body` config sub-tree introduced by #2052 (feat(observability): dump HTTP query, request body, and response body to trace spans), MERGED 2026-05-14 by KCHENPENGFEI. The hierarchy bullet list and JSON example in `docs/{zh,en}/guides/05-observability.md` currently enumerate only `metrics` / `traces` / `logs` — `dump_body` was added to `ObservabilityConfig` (openviking/server/config.py L107-128) but not surfaced in user-facing docs.

## Changes

- `docs/zh/guides/05-observability.md`: add `server.observability.dump_body` bullet under "observability 配置层级" hierarchy + extend the JSON example block to include the new `dump_body` subsystem with both fields (`enabled: false`, `max_bytes: 4096`).
- `docs/en/guides/05-observability.md`: mirror addition (bullet + example).

Pure additive change, byte-mirror of the existing `metrics` / `traces` / `logs` 3-bullet + 3-block pattern in the same section. Defaults match `TraceDumpBodyConfig` (config.py L107-117) — `enabled: false` (opt-in for safety, bodies may contain secrets / high-cardinality content) and `max_bytes: 4096`.

## Notes

- `usage_audit` (added by #2016) is also under `ObservabilityConfig` but is a Dashboard BFF projection (product usage + audit), not a signal-level exporter — out of scope for this catch.
- Bullet description tracks #2052 PR body wording verbatim (content-type filtering, byte truncation, default-off rationale).
