### PR TITLE
fix(storage): 使用文件级锁处理 content/write

### DIFF
--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -179,15 +179,16 @@ class ContentWriteCoordinator:
     ) -> Dict[str, Any]:
         lock_manager = get_lock_manager()
         handle = lock_manager.create_handle()
-        lock_path = self._viking_fs._uri_to_path(root_uri, ctx=ctx)
-        acquired = await lock_manager.acquire_tree(handle, lock_path)
+        lock_path = self._viking_fs._uri_to_path(uri, ctx=ctx)
+        acquired = await lock_manager.acquire_exact_path(handle, lock_path)
         if not acquired:
             await lock_manager.release(handle)
             raise InvalidArgumentError(f"resource is busy and cannot be written now: {uri}")
 
         previous_content: Optional[str] = None
         content_written = False
-        lock_transferred = False
+        semantic_enqueued = False
+        lock_released = False
         try:
             if mode != "create":
                 previous_content = await self._viking_fs.read_file(uri, ctx=ctx)
@@ -200,10 +201,12 @@ class ContentWriteCoordinator:
                 changed_uri=uri,
                 context_type=context_type,
                 ctx=ctx,
-                lifecycle_lock_handle_id=handle.id,
+                lifecycle_lock_handle_id="",
                 change_type="added" if mode == "create" else "modified",
             )
-            lock_transferred = True
+            semantic_enqueued = True
+            await lock_manager.release(handle)
+            lock_released = True
             queue_status = (
                 await self._wait_for_request(telemetry_id=telemetry_id, timeout=timeout)
                 if wait
@@ -219,7 +222,7 @@ class ContentWriteCoordinator:
                 queue_status=queue_status,
             )
         except Exception:
-            if not lock_transferred and content_written:
+            if not semantic_enqueued and content_written:
                 await self._rollback_direct_write(
                     uri=uri,
                     previous_content=previous_content,
@@ -227,7 +230,7 @@ class ContentWriteCoordinator:
                     ctx=ctx,
                     lock_handle=handle,
                 )
-            if not lock_transferred:
+            if not lock_released:
                 await lock_manager.release(handle)
             raise
         finally:

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -285,7 +285,7 @@ async def test_resource_write_semantic_refresh_uses_coalesce_key(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_write_timeout_after_enqueue_does_not_release_resource_lock(monkeypatch):
+async def test_write_timeout_after_enqueue_releases_resource_lock(monkeypatch):
     file_uri = "viking://resources/demo/doc.md"
     root_uri = "viking://resources/demo"
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
@@ -317,7 +317,7 @@ async def test_write_timeout_after_enqueue_does_not_release_resource_lock(monkey
             wait=True,
         )
 
-    assert lock_manager.release_calls == []
+    assert lock_manager.release_calls == ["lock-1"]
     assert viking_fs.delete_temp_calls == []
     assert viking_fs.content[file_uri] == "updated"
 
@@ -358,7 +358,7 @@ async def test_resource_write_updates_target_and_queues_refresh_before_return(mo
     assert captured_enqueue["changed_uri"] == file_uri
     assert captured_enqueue["change_type"] == "modified"
     assert viking_fs.delete_temp_calls == []
-    assert lock_manager.release_calls == []
+    assert lock_manager.release_calls == ["lock-1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

修复 #2029 合入后遗漏的一处资源写入锁粒度问题：`content/write` 写入 `viking://resources/...` 下的普通文件时，不再对资源根目录持有 `TreeLock`，改为只对目标文件路径持有 `ExactPathLock`。

举例：

- 修复前：`viking://resources/docs/api1.md` 和 `viking://resources/docs/api2.md` 都会竞争 `viking://resources/docs` 的树锁，第二个请求容易返回 `resource is busy`。
- 修复后：两个请求分别锁 `api1.md` 和 `api2.md`，不同文件可以并发写入；同一个文件、或遇到上层树锁时仍然会互斥。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 将资源 `content/write` 的锁路径从 `root_uri` 改为当前写入的 `uri`，锁类型从 `TreeLock` 改为 `ExactPathLock`。
- 写入并投递语义刷新消息后立即释放文件级锁，不再把该锁作为生命周期锁转交给后台语义任务。
- 更新已有服务层单测断言，匹配写入完成后释放文件锁的预期行为。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

未额外运行单测。这个分支只补回 #2029 之后遗漏的 `content/write` 文件级锁修复，并更新了已有测试的锁释放预期。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

这个修复只覆盖直接文件写入路径。目录级资源生命周期保护、后台语义刷新 coalesce、以及上层树锁冲突判断仍沿用 #2029 的实现。
