### PR TITLE
fix(server): serve favicons under /mcp/ for connector-relative clients

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -594,12 +594,18 @@ def create_app(
         logger.warning("Skipping OAuth router registration: %s", e)
 
     # Favicon: shared with the console static assets so 1933/console use the same logo.
+    # Some MCP clients (claude.ai connector cards) resolve the icon relative to the
+    # connector URL (e.g. {mcp_url}/favicon.ico) rather than the origin, so the same
+    # files are also exposed under /mcp/.
     _static_dir = Path(__file__).resolve().parent.parent / "console" / "static"
     _favicon_headers = {"Cache-Control": "public, max-age=86400"}
     _favicon_files = {
         "/favicon.ico": ("favicon.ico", "image/x-icon"),
         "/favicon.png": ("favicon-32.png", "image/png"),
         "/apple-touch-icon.png": ("apple-touch-icon.png", "image/png"),
+        "/mcp/favicon.ico": ("favicon.ico", "image/x-icon"),
+        "/mcp/favicon.png": ("favicon-32.png", "image/png"),
+        "/mcp/apple-touch-icon.png": ("apple-touch-icon.png", "image/png"),
     }
 
     def _make_favicon_handler(filename: str, media_type: str):


### PR DESCRIPTION
## Description

`/mcp` is registered as a single Starlette `Route` with exact-path semantics (compiled regex `^/mcp$`), so any sub-path like `/mcp/favicon.ico` does not fall through to a static handler — it goes straight to the default JSON 404. Some MCP clients (e.g. claude.ai's connector cards) resolve the connector icon relative to the connector URL rather than relative to the origin, so those clients ended up rendering a generic placeholder even though the origin `/favicon.ico` was working correctly.

Add `/mcp/favicon.ico`, `/mcp/favicon.png`, and `/mcp/apple-touch-icon.png` as additional entries in `_favicon_files`, reusing the exact same files already served at the origin root (`favicon.ico` / `favicon-32.png` / `apple-touch-icon.png` under `openviking/console/static/`). No new assets, no copies — just three more route registrations.

Verified empirically before the change:

```
GET https://<host>/favicon.ico              → 200 image/x-icon       (works)
GET https://<host>/console/favicon.ico      → 200 image/vnd.microsoft.icon (works, standalone console)
GET https://<host>/mcp/favicon.ico          → 404 application/json   (broken — this PR)
```

## Related Issue

N/A — discovered while inspecting connector card icons against a running deployment.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking/server/app.py`: extend `_favicon_files` with three additional `/mcp/`-prefixed entries pointing to the same static files. Add a short comment explaining why endpoint-relative paths are necessary in addition to the origin-relative ones. No other code paths touched.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Manual verification of the route-matching argument (Starlette's `compile_path`):

```
Route("/mcp") regex: ^/mcp$
  matches /mcp:            True
  matches /mcp/favicon.ico: False
Route("/mcp/favicon.ico") regex: ^/mcp/favicon\.ico$
  matches /mcp:            False
  matches /mcp/favicon.ico: True
```

The two paths are entirely independent — `/mcp/favicon.ico` cannot be swallowed by the `/mcp` MCP endpoint, and the favicon routes cannot intercept real MCP traffic. The favicon routes are also registered before the `/mcp` `Route` in `app.routes`, so even under loosest-match semantics the favicon wins for its own path. After this change, the same `GET /mcp/favicon.ico` returns 200 with the OV-branded icon.

`uvx ruff check` and `uvx ruff format --check` pass.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A — the change is server-side route plumbing; the icon bytes are unchanged and were updated separately by #2067.

## Additional Notes

- `/console/favicon.ico` remains served by the standalone console app (`openviking/console/app.py`) via its `/console/{path:path}` handler. That path is not affected by this PR.
- Closing the loop on #1879 (root `/favicon.ico`) — this is the missing endpoint-relative variant for MCP clients that don't fetch from the origin.