### PR TITLE
docs(openclaw): document plugin-source / plugin-package and plugin-version auto-detect from #2072

### DIFF
--- a/docs/en/agent-integrations/03-openclaw.md
+++ b/docs/en/agent-integrations/03-openclaw.md
@@ -79,7 +79,9 @@ npm install -g openclaw-openviking-setup-helper@latest && ov-install -y
 | `--workdir PATH`           | Target OpenClaw data directory                                     |
 | `--version VER`            | Set plugin version (e.g. `0.2.9` → plugin `v0.2.9`)                |
 | `--current-version`        | Print the currently installed plugin version                       |
-| `--plugin-version REF`     | Set plugin version only — supports tag, branch, or commit          |
+| `--plugin-version REF`     | Set plugin version — auto-detected: npm version (e.g. `2026.5.8`) or npm dist-tag (e.g. `dev`) resolves via npm; other refs (e.g. `v0.3.16`, `main`) resolve via the GitHub repo; default `npm latest` |
+| `--plugin-source=npm\|github` | Plugin download source (default `npm`)                            |
+| `--plugin-package=NAME`    | npm plugin package name (default `@openviking/openclaw-plugin`)    |
 | `--github-repo owner/repo` | Use a different GitHub repo for plugin files (default `volcengine/OpenViking`) |
 | `--update`                 | Upgrade only the plugin                                            |
 | `-y`                       | Non-interactive mode, use default values                           |

--- a/docs/zh/agent-integrations/03-openclaw.md
+++ b/docs/zh/agent-integrations/03-openclaw.md
@@ -79,7 +79,9 @@ npm install -g openclaw-openviking-setup-helper@latest && ov-install -y
 | `--workdir PATH`           | OpenClaw 数据目录                                               |
 | `--version VER`            | 插件版本（如 `0.2.9` → 插件 `v0.2.9`）                          |
 | `--current-version`        | 查看当前已安装的插件版本                                        |
-| `--plugin-version REF`     | 仅指定插件版本，支持 tag、分支或 commit                         |
+| `--plugin-version REF`     | 仅指定插件版本，自动识别：npm 版本（如 `2026.5.8`）或 npm dist-tag（如 `dev`）走 npm；其它 ref（如 `v0.3.16`、`main`）走 GitHub 仓库；默认 `npm latest` |
+| `--plugin-source=npm\|github` | 插件下载来源（默认 `npm`）                                       |
+| `--plugin-package=NAME`    | npm 插件包名（默认 `@openviking/openclaw-plugin`）              |
 | `--github-repo owner/repo` | 指定插件来源仓库，默认 `volcengine/OpenViking`                  |
 | `--update`                 | 只升级插件                                                      |
 | `-y`                       | 非交互模式，使用默认配置                                        |


### PR DESCRIPTION
## Description

Docs catch of #2072 (LinQiang391, merged 2026-05-15 by qin-ctx). `setup-helper/install.js` gained npm-default install path and three new behaviors that were not reflected in `docs/{en,zh}/agent-integrations/03-openclaw.md`:

1. **Default source switched to npm.** `pluginSource` defaults to `"npm"` (install.js L34), installing `@openviking/openclaw-plugin@latest`. Previously docs implied GitHub source.
2. **`--plugin-version` auto-detects** between npm and GitHub: npm version (e.g. `2026.5.8`) or npm dist-tag (e.g. `dev`) → npm; other refs (e.g. `v0.3.16`, `main`) → GitHub. Previous doc text said "supports tag, branch, or commit", which is ambiguous for the new dual-source behavior.
3. **Two new flags surfaced in `--help`** (install.js L336-338) had no doc row:
   - `--plugin-source=npm|github`
   - `--plugin-package=NAME`

## Changes

- `docs/en/agent-integrations/03-openclaw.md`: tightened `--plugin-version` description; added `--plugin-source` + `--plugin-package` rows (+3 / -1).
- `docs/zh/agent-integrations/03-openclaw.md`: mirror in Chinese (+3 / -1).

Pipe character inside `` `--plugin-source=npm|github` `` is escaped (`npm\|github`) so the Markdown table row doesn't split.

## Verification

- Source: `examples/openclaw-plugin/setup-helper/install.js` after #2072 (L34 `pluginSource` default, L336-340 `--help` text, L182 `--plugin-version=` parsing).
- #2072 PR body example matrix (npm exact / dist-tag / GitHub tag / GitHub ref auto-detect).
- Pure docs, additive, no code paths touched.

## Related

- Builds on #2072 (LinQiang391/qin-ctx).
- Same catch pattern as #2063 (observability.dump_body / #2052) merged 5.94h prior by qin-ctx.

## Type of Change

- [x] Documentation update

Please feel free to close if a follow-up by the original author is preferred — happy to defer.