### PR TITLE
docs(en/metrics): add per-channel one-turn resolution PromQL example from #2037

### DIFF
--- a/docs/en/concepts/12-metrics.md
+++ b/docs/en/concepts/12-metrics.md
@@ -316,10 +316,14 @@ openviking_feedback_thumbs_down_rate{valid="1"}
 openviking_feedback_one_turn_resolution_rate{valid="1"}
 ```
 
-- per-channel coverage comparison:
+- per-channel coverage and resolution comparison:
 
 ```promql
 openviking_feedback_channel_coverage{valid="1"}
+```
+
+```promql
+openviking_feedback_channel_one_turn_resolution_rate{valid="1"}
 ```
 
 - detect fallback snapshots:


### PR DESCRIPTION
## Summary

`docs/zh/concepts/12-metrics.md` was updated in #2037 with a per-channel comparison block that lists **two** PromQL examples (coverage **and** one-turn resolution rate):

```
- 按 channel 对比 coverage 与 resolution：

    openviking_feedback_channel_coverage{valid="1"}
    openviking_feedback_channel_one_turn_resolution_rate{valid="1"}
```

`docs/en/concepts/12-metrics.md` only got the first one — the heading reads "per-channel coverage comparison" and only `openviking_feedback_channel_coverage` is shown. The `openviking_feedback_channel_one_turn_resolution_rate` metric exists (the metric family table earlier in the file enumerates "per-channel variants of response volume, feedback volume, negative outcomes, reasks, **coverage, thumb rates, and one-turn resolution**"), so the PromQL example for the per-channel resolution rate is missing parity.

This PR adds the second PromQL block + adjusts the heading to "per-channel coverage and resolution comparison" to mirror the ZH section verbatim.

## Changes

- `docs/en/concepts/12-metrics.md`: section heading + 1 extra PromQL block (4 LOC additive).

No source-code change, no behavior change.