### PR TITLE
fix(openclaw-plugin): gate noisy recall resources

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -1,6 +1,9 @@
 import type { FindResult, FindResultItem, OpenVikingClient } from "./client.js";
 import type { MemoryOpenVikingConfig } from "./config.js";
 import {
+  clampScore,
+  isVagueRecallQuery,
+  passesRecallScoreThreshold,
   pickMemoriesForInjection,
   postProcessMemories,
   summarizeInjectionMemories,
@@ -11,6 +14,7 @@ import { sanitizeUserTextForCapture } from "./text-utils.js";
 
 const AUTO_RECALL_TIMEOUT_MS = 5_000;
 const RECALL_QUERY_MAX_CHARS = 4_000;
+const VAGUE_RECALL_SCORE_FLOOR = 0.6;
 export const AUTO_RECALL_SOURCE_MARKER = "Source: openviking-auto-recall";
 
 type Logger = {
@@ -95,7 +99,8 @@ export async function buildMemoryLines(
   const lines: string[] = [];
   for (const item of memories) {
     const content = await resolveMemoryContent(item, readFn, options);
-    lines.push(`- [${item.category ?? "memory"}] ${content}`);
+    const category = item.category?.trim() || "memory";
+    lines.push(`- [${category}] ${content}`);
   }
   return lines;
 }
@@ -128,7 +133,8 @@ export async function buildMemoryLinesWithBudget(
     }
 
     const content = await resolveMemoryContent(item, readFn, options);
-    const line = `- [${item.category ?? "memory"}] ${content}`;
+    const category = item.category?.trim() || "memory";
+    const line = `- [${category}] ${content}`;
     const separatorChars = lines.length > 0 ? 1 : 0;
     const projectedChars = totalChars + separatorChars + line.length;
 
@@ -215,13 +221,27 @@ export async function buildAutoRecallContext(params: {
         index === self.findIndex((m) => m.uri === memory.uri)
       );
       const leafOnly = uniqueMemories.filter((m) => !m.level || m.level === 2);
-      const processed = postProcessMemories(leafOnly, {
+      const thresholded = leafOnly.filter((memory) =>
+        passesRecallScoreThreshold(memory, cfg.recallScoreThreshold)
+      );
+      const processed = postProcessMemories(thresholded, {
         limit: candidateLimit,
-        scoreThreshold: cfg.recallScoreThreshold,
+        scoreThreshold: 0,
       });
       const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
 
       if (memories.length === 0) {
+        return { memoryCount: 0, estimatedTokens: 0 };
+      }
+      if (
+        isVagueRecallQuery(queryText) &&
+        memories.every((memory) => clampScore(memory.score) < VAGUE_RECALL_SCORE_FLOOR)
+      ) {
+        verbose?.(
+          `openviking: skipping auto-recall injection for vague query; bestScore=${Math.max(
+            ...memories.map((memory) => clampScore(memory.score)),
+          ).toFixed(3)} threshold=${VAGUE_RECALL_SCORE_FLOOR}`,
+        );
         return { memoryCount: 0, estimatedTokens: 0 };
       }
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./text-utils.js";
 import {
   clampScore,
+  passesRecallScoreThreshold,
   postProcessMemories,
   pickMemoriesForInjection,
 } from "./memory-ranking.js";
@@ -1090,10 +1091,12 @@ const contextEnginePlugin = {
             };
           }
 
-          const leafOnly = (result.memories ?? []).filter((m) => !m.level || m.level === 2);
+          const leafOnly = (result.memories ?? [])
+            .filter((m) => !m.level || m.level === 2)
+            .filter((m) => passesRecallScoreThreshold(m, scoreThreshold));
           const processed = postProcessMemories(leafOnly, {
             limit: requestLimit,
-            scoreThreshold,
+            scoreThreshold: 0,
           });
           const memories = pickMemoriesForInjection(processed, limit, query);
           if (memories.length === 0) {

--- a/examples/openclaw-plugin/memory-ranking.ts
+++ b/examples/openclaw-plugin/memory-ranking.ts
@@ -145,10 +145,25 @@ function isLeafLikeMemory(item: FindResultItem): boolean {
   return item.level === 2;
 }
 
-const PREFERENCE_QUERY_RE = /prefer|preference|favorite|favourite|like|偏好|喜欢|爱好|更倾向/i;
+export function isResourceMemory(item: FindResultItem): boolean {
+  return item.uri.startsWith("viking://resources/");
+}
+
+export const RESOURCE_RECALL_SCORE_FLOOR = 0.56;
+
+export function recallScoreThresholdForItem(item: FindResultItem, baseThreshold: number): number {
+  return isResourceMemory(item) ? Math.max(baseThreshold, RESOURCE_RECALL_SCORE_FLOOR) : baseThreshold;
+}
+
+export function passesRecallScoreThreshold(item: FindResultItem, baseThreshold: number): boolean {
+  return clampScore(item.score) >= recallScoreThresholdForItem(item, baseThreshold);
+}
+
+const PREFERENCE_QUERY_RE =
+  /prefer|preference|favorite|favourite|like|решил|решила|предпочита|люблю|нравит|хочу|выбрал|выбрала|偏好|喜欢|爱好|更倾向/i;
 const TEMPORAL_QUERY_RE =
-  /when|what time|date|day|month|year|yesterday|today|tomorrow|last|next|什么时候|何时|哪天|几月|几年|昨天|今天|明天|上周|下周|上个月|下个月|去年|明年/i;
-const QUERY_TOKEN_RE = /[a-z0-9]{2,}/gi;
+  /when|what time|date|day|month|year|yesterday|today|tomorrow|last|next|когда|дата|день|месяц|год|вчера|сегодня|завтра|прошл|следующ|недел|什么时候|何时|哪天|几月|几年|昨天|今天|明天|上周|下周|上个月|下个月|去年|明年/i;
+const QUERY_TOKEN_RE = /[\p{L}\p{N}][\p{L}\p{N}_-]+/giu;
 const QUERY_TOKEN_STOPWORDS = new Set([
   "what",
   "when",
@@ -174,7 +189,48 @@ const QUERY_TOKEN_STOPWORDS = new Set([
   "this",
   "your",
   "you",
+  "что",
+  "это",
+  "как",
+  "где",
+  "когда",
+  "там",
+  "тут",
+  "мне",
+  "меня",
+  "мой",
+  "моя",
+  "мои",
+  "про",
+  "для",
+  "или",
+  "если",
+  "уже",
+  "еще",
+  "ещё",
+  "надо",
+  "нужно",
+  "давай",
+  "посмотри",
+  "проверь",
+  "подскажи",
 ]);
+const VAGUE_QUERY_TOKEN_STOPWORDS = new Set([
+  ...QUERY_TOKEN_STOPWORDS,
+  "было",
+  "будет",
+  "дальше",
+  "сделай",
+  "разберись",
+  "разобраться",
+  "проверим",
+  "проверить",
+  "сейчас",
+  "раньше",
+  "после",
+]);
+const VAGUE_QUERY_RE =
+  /^(посмотри|проверь|подскажи|разберись|давай|что дальше|what now|check|look|tell me)\b/i;
 
 type RecallQueryProfile = {
   tokens: string[];
@@ -191,6 +247,16 @@ function buildRecallQueryProfile(query: string): RecallQueryProfile {
     wantsPreference: PREFERENCE_QUERY_RE.test(text),
     wantsTemporal: TEMPORAL_QUERY_RE.test(text),
   };
+}
+
+export function isVagueRecallQuery(queryText: string): boolean {
+  const text = queryText.trim();
+  if (!text) {
+    return true;
+  }
+  const tokens = text.toLowerCase().match(QUERY_TOKEN_RE) ?? [];
+  const meaningfulTokens = tokens.filter((token) => !VAGUE_QUERY_TOKEN_STOPWORDS.has(token));
+  return meaningfulTokens.length <= 1 || (VAGUE_QUERY_RE.test(text) && meaningfulTokens.length <= 2);
 }
 
 function lexicalOverlapBoost(tokens: string[], text: string): number {

--- a/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
+++ b/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
@@ -130,6 +130,17 @@ describe("buildMemoryLines", () => {
 
     expect(lines[0]).toContain("[memory]");
   });
+
+  it("defaults blank category to 'memory'", async () => {
+    const memories = [makeMemory({ category: "" })];
+    const readFn = vi.fn();
+
+    const lines = await buildMemoryLines(memories, readFn, {
+      recallPreferAbstract: true,
+    });
+
+    expect(lines[0]).toBe("- [memory] Test memory abstract");
+  });
 });
 
 describe("buildMemoryLinesWithBudget", () => {
@@ -224,5 +235,21 @@ describe("buildMemoryLinesWithBudget", () => {
 
     expect(lines).toHaveLength(0);
     expect(estimatedTokens).toBe(0);
+  });
+
+  it("defaults blank category while applying the budget", async () => {
+    const memories = [makeMemory({ category: "", abstract: "short" })];
+    const readFn = vi.fn();
+
+    const { lines } = await buildMemoryLinesWithBudget(
+      memories,
+      readFn,
+      {
+        recallPreferAbstract: true,
+        recallMaxInjectedChars: 100,
+      },
+    );
+
+    expect(lines[0]).toBe("- [memory] short");
   });
 });

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -155,6 +155,125 @@ describe("context-engine assemble()", () => {
     }
   });
 
+  it("skips low-score resources during auto-recall", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: "ok" }),
+      }),
+    );
+    try {
+      const { engine, client } = makeEngine(
+        {
+          latest_archive_overview: "unused",
+          pre_archive_abstracts: [],
+          messages: [],
+          estimatedTokens: 0,
+          stats: makeStats(),
+        },
+        {
+          cfgOverrides: {
+            autoRecall: true,
+            recallResources: true,
+            recallScoreThreshold: 0.5,
+            recallPreferAbstract: true,
+          },
+        },
+      );
+      client.find
+        .mockResolvedValueOnce({ memories: [], total: 0 })
+        .mockResolvedValueOnce({ memories: [], total: 0 })
+        .mockResolvedValueOnce({
+          resources: [
+            {
+              uri: "viking://resources/second-brain/noisy-transcript.md",
+              level: 2,
+              category: "",
+              abstract: "A loose raw transcript with unrelated meeting chatter.",
+              score: 0.55,
+            },
+          ],
+          total: 1,
+        });
+
+      const sourceMessages = [
+        { role: "assistant", content: "Previous answer." },
+        { role: "user", content: "Посмотри что там было и подскажи" },
+      ];
+
+      const result = await engine.assemble({
+        sessionId: "session-low-score-resource",
+        messages: sourceMessages,
+      });
+
+      expect(result.messages).toBe(sourceMessages);
+      expect(client.find).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("still injects strong user memories for Russian OpenViking queries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: "ok" }),
+      }),
+    );
+    try {
+      const { engine, client } = makeEngine(
+        {
+          latest_archive_overview: "unused",
+          pre_archive_abstracts: [],
+          messages: [],
+          estimatedTokens: 0,
+          stats: makeStats(),
+        },
+        {
+          cfgOverrides: {
+            autoRecall: true,
+            recallResources: true,
+            recallScoreThreshold: 0.5,
+            recallPreferAbstract: true,
+          },
+        },
+      );
+      client.find
+        .mockResolvedValueOnce({
+          memories: [
+            {
+              uri: "viking://user/default/memories/entities/openviking/docker_regression_test.md",
+              level: 2,
+              category: "",
+              abstract: "OV Docker regression marker survived the migration.",
+              score: 0.68,
+            },
+          ],
+          total: 1,
+        })
+        .mockResolvedValueOnce({ memories: [], total: 0 })
+        .mockResolvedValueOnce({ resources: [], total: 0 });
+
+      const sourceMessages = [
+        { role: "assistant", content: "Previous answer." },
+        { role: "user", content: "Напомни контрольную метку OV Docker regression test после миграции" },
+      ];
+
+      const result = await engine.assemble({
+        sessionId: "session-russian-ov-query",
+        messages: sourceMessages,
+      });
+
+      expect(result.messages[1]?.content).toMatch(/^<relevant-memories>/);
+      expect(result.messages[1]?.content).toContain("[memory] OV Docker regression marker");
+      expect(result.messages[1]?.content).toContain(sourceMessages[1]!.content);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("passes through transformContext messages when the latest message is not user", async () => {
     const { engine, getClient } = makeEngine(
       {

--- a/examples/openclaw-plugin/tests/ut/memory-ranking.test.ts
+++ b/examples/openclaw-plugin/tests/ut/memory-ranking.test.ts
@@ -9,6 +9,9 @@ import {
   summarizeInjectionMemories,
   summarizeExtractedMemories,
   pickMemoriesForInjection,
+  isResourceMemory,
+  isVagueRecallQuery,
+  passesRecallScoreThreshold,
 } from "../../memory-ranking.js";
 import type { FindResultItem } from "../../client.js";
 
@@ -254,5 +257,44 @@ describe("pickMemoriesForInjection", () => {
     ];
     const result = pickMemoriesForInjection(items, 1, "When did the user deploy?");
     expect(result[0]!.uri).toBe("event");
+  });
+
+  it("uses Cyrillic query terms for lexical overlap", () => {
+    const items = [
+      mem({ uri: "generic", category: "facts", score: 0.76, abstract: "OpenViking diagnostics" }),
+      mem({
+        uri: "badminton",
+        category: "facts",
+        score: 0.7,
+        abstract: "Пользователь обсуждал бадминтон и календарь тренировок",
+      }),
+    ];
+    const result = pickMemoriesForInjection(items, 1, "что я решил про бадминтон и календарь");
+    expect(result[0]!.uri).toBe("badminton");
+  });
+
+  it("detects vague Russian recall prompts", () => {
+    expect(isVagueRecallQuery("Посмотри что там было и подскажи")).toBe(true);
+    expect(isVagueRecallQuery("как настроен OpenClaw плагин OpenViking")).toBe(false);
+  });
+
+  it("detects shared resource memories by URI", () => {
+    expect(isResourceMemory(mem({ uri: "viking://resources/second-brain/note.md" }))).toBe(true);
+    expect(isResourceMemory(mem({ uri: "viking://user/default/memories/note.md" }))).toBe(false);
+  });
+
+  it("requires a stronger score for shared resource memories", () => {
+    expect(
+      passesRecallScoreThreshold(
+        mem({ uri: "viking://resources/second-brain/noisy.md", score: 0.55 }),
+        0.5,
+      ),
+    ).toBe(false);
+    expect(
+      passesRecallScoreThreshold(
+        mem({ uri: "viking://user/default/memories/useful.md", score: 0.55 }),
+        0.5,
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes noisy OpenClaw plugin auto-recall when shared `viking://resources` are enabled.

The patch adds lightweight query-aware recall gating:
- supports Cyrillic tokens for lexical overlap ranking
- recognizes Russian temporal/preference recall phrasing
- skips vague low-confidence recall prompts before injecting context
- requires a slightly stronger score for shared resource memories than for user/agent memories
- applies the same resource score floor to explicit `memory_recall`
- renders blank memory categories as `[memory]` instead of `[]`

## Root Cause

OpenClaw auto-recall searched user memories, agent memories, and shared resources with the same low score threshold. For vague prompts, shared resource transcripts and logs around ~0.53 score could be injected even when they were not actionable. Russian queries also did not get lexical-overlap help because the token regex only matched ASCII.

## Verification

- `pnpm install`
- `pnpm test tests/ut`
- `pnpm build`

Also verified locally against a running OpenViking/OpenClaw setup:
- vague Russian prompt no longer injected transcript noise
- exact OpenViking Docker regression recall still injected the expected memories
- Russian badminton/resource query still recalled the relevant resource summary
