### PR TITLE
docs(deployment): document embedding + ollama probes on /ready from #1910

### DIFF
--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -302,7 +302,7 @@ For a detailed cloud deployment guide (including Volcengine TOS + VikingDB + Ark
 | Endpoint | Auth | Purpose |
 |----------|------|---------|
 | `GET /health` | No | Liveness probe — returns `{"status": "ok"}` immediately |
-| `GET /ready` | No | Readiness probe — checks AGFS, VectorDB, APIKeyManager |
+| `GET /ready` | No | Readiness probe — checks AGFS, VectorDB, APIKeyManager, Embedding, Ollama |
 
 ```bash
 # Liveness
@@ -310,7 +310,7 @@ curl http://localhost:1933/health
 
 # Readiness
 curl http://localhost:1933/ready
-# {"status": "ready", "checks": {"agfs": "ok", "vectordb": "ok", "api_key_manager": "ok"}}
+# {"status": "ready", "checks": {"agfs": "ok", "vectordb": "ok", "api_key_manager": "ok", "embedding": "ok", "ollama": "ok"}}
 ```
 
 Use `/health` for Kubernetes liveness probes and `/ready` for readiness probes.

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -300,7 +300,7 @@ helm install openviking ./examples/k8s-helm \
 | 端点 | 认证 | 用途 |
 |------|------|------|
 | `GET /health` | 否 | 存活探针 — 立即返回 `{"status": "ok"}` |
-| `GET /ready` | 否 | 就绪探针 — 检查 AGFS、VectorDB、APIKeyManager |
+| `GET /ready` | 否 | 就绪探针 — 检查 AGFS、VectorDB、APIKeyManager、Embedding、Ollama |
 
 ```bash
 # 存活探针
@@ -308,7 +308,7 @@ curl http://localhost:1933/health
 
 # 就绪探针
 curl http://localhost:1933/ready
-# {"status": "ready", "checks": {"agfs": "ok", "vectordb": "ok", "api_key_manager": "ok"}}
+# {"status": "ready", "checks": {"agfs": "ok", "vectordb": "ok", "api_key_manager": "ok", "embedding": "ok", "ollama": "ok"}}
 ```
 
 在 Kubernetes 中，使用 `/health` 作为存活探针，`/ready` 作为就绪探针。


### PR DESCRIPTION
## Summary

Document the `embedding` + `ollama` probes that `/ready` returns alongside the
existing `agfs` / `vectordb` / `api_key_manager` keys, mirroring the live
`readiness_check()` body in `openviking/server/routers/system.py` after
#1910.

## Drift

In `openviking/server/routers/system.py::readiness_check()`, the `checks`
dict currently writes five probes (lines 111/121/131/147/164):

```python
checks["agfs"] = "ok"
checks["vectordb"] = "ok" | "unhealthy" | "not_configured"
checks["api_key_manager"] = "ok" | "not_configured"
checks["embedding"] = <probe_result> | "not_configured" | "error: probe timed out (provider unreachable)"
checks["ollama"] = "ok" | "unreachable at <host>:<port>" | "not_configured"
```

The `ollama` probe landed via #1353 (2026-04-14, embedded under
`openviking-server init` interactive setup wizard), and the `embedding`
probe just landed via #1910 (2026-05-15, fix(server): add embedding
connectivity probe to /ready endpoint).

The Kubernetes deployment guide (`docs/{en,zh}/guides/03-deployment.md`)
still only lists `AGFS, VectorDB, APIKeyManager` in the `GET /ready` row
and shows a 3-key example response. A reader checking the docs to wire up
a k8s readiness probe will see a smaller surface than what `curl /ready`
actually returns, and won't know that misconfigured embedding/ollama
providers will surface here.

## Fix

Dual-doc EN + ZH:

- table row: append `, Embedding, Ollama` to the probe list
- example `# {...}` curl output: append `"embedding": "ok", "ollama": "ok"`
  to the `checks` dict, preserving the existing `"ok"` happy-path style

Pure docs, byte-for-byte mirror of the live code keys. No logic changes.

## Changes

- `docs/en/guides/03-deployment.md` (+2/-2)
- `docs/zh/guides/03-deployment.md` (+2/-2)