### PR TITLE
docs(changelog): add v0.3.17 entry (EN+ZH)

### DIFF
--- a/docs/en/about/02-changelog.md
+++ b/docs/en/about/02-changelog.md
@@ -3,6 +3,27 @@
 All notable changes to OpenViking will be documented in this file.
 This changelog is automatically generated from [GitHub Releases](https://github.com/volcengine/OpenViking/releases).
 
+## v0.3.17 (2026-05-15)
+
+### Highlights
+
+- **Agent Integrations**: New LangChain and LangGraph integration via `openviking.integrations.langchain` (`OpenVikingRetriever`, `with_openviking_context()`, `OpenVikingChatMessageHistory`, `OpenVikingContextMiddleware`, `OpenVikingStore` as a LangGraph store, `create_openviking_tools()`); revamped Codex / OpenCode plugins use lifecycle hooks for auto-recall, incremental capture, and PreCompact commit, and connect directly to the native `/mcp` endpoint.
+- **OVPack v2 and full backup/restore**: `ov export` / `ov import` support v2 manifests, file checksums, portable index scalar fields, optional dense vector snapshots, and conflict policies; new `ov backup` / `ov restore` cover full public-scope migration.
+- **Native CLI distribution**: New `@openviking/cli` npm package installs the platform `ov` binary via `npm i -g @openviking/cli`; Rust CLI release pipeline adds Linux musl artifacts, npm trusted publishing, and a broader integration test suite.
+- **Retrieval and filesystem**: `find` / `search` accept a `level` filter for L0 abstracts, L1 overviews, and L2 file hits. Resource files gained a Phase 1 WebDAV adapter, and `observer.filesystem` exposes filesystem-level observability.
+- **Console and Usage/Audit**: New Usage/Audit module and `/api/v1/console/*` BFF aggregate token usage, retrieval counts, context commit heatmaps, request audit logs, and context inventory from the existing observability event bus.
+- **Storage and concurrency reliability**: Strengthened exact-path and lifecycle locks fix content-write races; blocking backend calls moved off the event loop; QueueFS SQLite persistence expanded; `storage.task_tracker.backend` adds a `persistent` backend for cross-instance task lookup.
+
+### Upgrade Notes
+
+- `storage.task_tracker.backend` is new. Single-instance deployments can keep the default `memory`; multi-instance or restart-survivable deployments should switch to `persistent`.
+- `vlm.backup` is a single-tier failover and only triggers on retryable errors (rate limit, `5xx`, connection failure, timeout). Auth, authorization, and billing failures do not trigger failover.
+- `vlm.extra_request_body` is merged into the OpenAI SDK / LiteLLM `extra_body`, useful for Ollama, OpenAI-compatible gateways, and providers requiring extra JSON fields.
+- New Codex memory plugin deployments should prefer `OPENVIKING_*` environment variables for tuning; the legacy `codex.*` block in `ov.conf` remains supported for backward compatibility but is no longer recommended.
+- OVPack dense vector snapshots require pure dense indexes; embedding provider, model, input, parameters, and dimension must match. Mismatches fall back to recompute under `--vector-mode auto` or fail under `--vector-mode require`.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.3.16...v0.3.17)
+
 ## v0.3.14 (2026-04-30)
 
 ### Highlights

--- a/docs/zh/about/02-changelog.md
+++ b/docs/zh/about/02-changelog.md
@@ -3,6 +3,27 @@
 OpenViking 的所有重要变更都将记录在此文件中。
 此更新日志从 [GitHub Releases](https://github.com/volcengine/OpenViking/releases) 自动生成。
 
+## v0.3.17 (2026-05-15)
+
+### 重点更新
+
+- **Agent 集成**：新增 LangChain 与 LangGraph 集成 `openviking.integrations.langchain`（`OpenVikingRetriever`、`with_openviking_context()`、`OpenVikingChatMessageHistory`、`OpenVikingContextMiddleware`、`OpenVikingStore`（LangGraph store）、`create_openviking_tools()`）；Codex / OpenCode 插件改造为通过生命周期 hooks 做自动召回、逐轮捕获和 PreCompact 前提交，并直接连接 OpenViking 原生 `/mcp` 端点。
+- **OVPack v2 与完整备份恢复**：`ov export` / `ov import` 支持 v2 manifest、文件校验、portable index scalar、可选 dense vector snapshot 和冲突策略；新增 `ov backup` / `ov restore` 用于公共 scope 的完整迁移。
+- **原生 CLI 分发**：新增 `@openviking/cli` npm 包，可通过 `npm i -g @openviking/cli` 使用 `ov`；Rust CLI 发布流水线扩展 Linux musl 构建、npm trusted publishing 和 CLI 集成测试。
+- **检索与文件系统能力**：`find` / `search` 新增 `level` 过滤，可限定 L0 abstract、L1 overview 或 L2 文件命中；资源文件增加 Phase 1 WebDAV 适配；`observer.filesystem` 暴露文件系统观测入口。
+- **Console 与 Usage/Audit**：新增 Usage/Audit 模块和 `/api/v1/console/*` BFF，基于现有 observability event bus 统计 token、检索次数、上下文提交热力图、请求审计和上下文库存。
+- **存储与并发可靠性**：增强精确路径锁和生命周期锁修复内容写入并发覆盖；阻塞后端调用移出 event loop；QueueFS SQLite 持久化扩展；`storage.task_tracker.backend` 新增 `persistent` 后端支持多实例 task 查询。
+
+### 升级说明
+
+- `storage.task_tracker.backend` 是新增配置。单实例部署可继续使用默认 `memory`；多实例或需要重启后查询 `task_id` 的部署可切换到 `persistent`。
+- `vlm.backup` 只支持一层 backup，且只在 rate limit、`5xx`、连接失败和 timeout 等可重试错误上触发；认证、权限和计费类错误不会自动切换。
+- `vlm.extra_request_body` 会合并到 OpenAI SDK / LiteLLM 的 `extra_body`，适合接入 Ollama、OpenAI-compatible gateway 或其他需要额外 JSON 字段的 provider。
+- Codex 插件新部署建议使用 `OPENVIKING_*` 环境变量调优；旧的 `ov.conf` 中 `codex.*` 配置仍保留兼容，但不再推荐作为首选。
+- OVPack dense vector snapshot 只支持纯 dense index；embedding provider、model、input、参数和 dimension 不兼容时，在 `--vector-mode auto` 下回退重算，在 `--vector-mode require` 下失败。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.3.16...v0.3.17)
+
 ## v0.3.14 (2026-04-30)
 
 ### 重点更新


### PR DESCRIPTION
## Summary

Adds a `v0.3.17 (2026-05-15)` entry to both `docs/en/about/02-changelog.md` and `docs/zh/about/02-changelog.md`, mirroring the format of the existing `v0.3.14` entry (Highlights + Upgrade Notes + Full Changelog compare link).

The new entry summarizes the six headline areas from the release notes — LangChain/LangGraph integration, OVPack v2 with backup/restore, native `@openviking/cli` npm distribution, retrieval `level` filter + Phase 1 WebDAV + `observer.filesystem`, Console Usage/Audit + `/api/v1/console/*` BFF, and the storage/concurrency reliability work (exact-path locks, off-event-loop blocking calls, QueueFS SQLite persistence, `storage.task_tracker.backend`).

Upgrade Notes call out behavior most likely to affect existing operators:
- `storage.task_tracker.backend` — new `memory` (default) vs `persistent` for multi-instance/restart-survivable lookup
- `vlm.backup` — single-tier failover; retryable errors only (rate limit / 5xx / connection failure / timeout), not auth/billing
- `vlm.extra_request_body` — merged into OpenAI SDK / LiteLLM `extra_body`
- Codex memory plugin — new deployments should prefer `OPENVIKING_*` env vars; legacy `codex.*` in `ov.conf` stays for compat
- OVPack dense vector snapshots — pure dense indexes only; mismatches recompute under `--vector-mode auto` or fail under `--vector-mode require`

## Notes

- The file header says "automatically generated from GitHub Releases", but the commit history shows the changelog is maintained manually (e.g., commit `0f21cf66` on 2026-05-04 by Zayn Jarvis manually added the `v0.3.13`/`v0.3.14` entries about 5 days after `v0.3.14` was tagged). This PR follows that same manual cadence for `v0.3.17`.
- `v0.3.15` and `v0.3.16` are intentionally **not** included in this PR to keep the diff focused and reviewable. Happy to send a follow-up PR for those if you'd prefer them filled in here.
- The entry's wording is paraphrased from the bilingual release notes to keep one canonical source per language; the EN bullet style stays parallel to `v0.3.14`'s `### Highlights` / `### Upgrade Notes`, and the ZH mirror tracks the same six categories.
