### PR TITLE
fix(opencode): preserve pending messages on session error

### DIFF
--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -705,6 +705,104 @@ function cleanupOrphanedMessageBuffers(now: number): void {
   }
 }
 
+function hasUnsavedSessionWork(mapping: SessionMapping): boolean {
+  return mapping.capturedMessages.size > 0 ||
+    mapping.pendingMessages.size > 0 ||
+    mapping.commitInFlight === true
+}
+
+function inferAssistantRoleForPendingMessages(
+  opencodeSessionId: string,
+  mapping: SessionMapping,
+  reason: string,
+): number {
+  const inferredMessageIds: string[] = []
+
+  for (const [messageId, content] of mapping.pendingMessages.entries()) {
+    if (mapping.messageRoles.has(messageId) || !content.trim()) {
+      continue
+    }
+
+    // On session.error, assistant text parts can arrive before finish=stop records the role.
+    mapping.messageRoles.set(messageId, "assistant")
+    inferredMessageIds.push(messageId)
+  }
+
+  if (inferredMessageIds.length > 0) {
+    debouncedSaveSessionMap()
+    log("INFO", "message", "Inferred assistant role for pending messages", {
+      session_id: opencodeSessionId,
+      reason,
+      count: inferredMessageIds.length,
+      message_ids: inferredMessageIds,
+    })
+  }
+
+  return inferredMessageIds.length
+}
+
+async function completePendingCleanup(
+  mapping: SessionMapping,
+  opencodeSessionId: string,
+  config: OpenVikingConfig,
+  reason: string,
+  startFollowUpCommit: boolean,
+): Promise<void> {
+  if (!mapping.pendingCleanup) {
+    return
+  }
+
+  if (mapping.capturedMessages.size > 0) {
+    if (startFollowUpCommit) {
+      log("INFO", "session", "Starting follow-up commit before session cleanup", {
+        openviking_session: mapping.ovSessionId,
+        opencode_session: opencodeSessionId,
+        reason,
+        captured_messages_count: mapping.capturedMessages.size,
+      })
+
+      const commitStart = await startBackgroundCommit(mapping, opencodeSessionId, config)
+      if (!commitStart) {
+        log("ERROR", "session", "Deferring session cleanup because follow-up commit could not start", {
+          openviking_session: mapping.ovSessionId,
+          opencode_session: opencodeSessionId,
+          reason,
+          captured_messages_count: mapping.capturedMessages.size,
+        })
+      }
+    } else {
+      log("INFO", "session", "Deferring session cleanup because captured messages still need commit", {
+        openviking_session: mapping.ovSessionId,
+        opencode_session: opencodeSessionId,
+        reason,
+        captured_messages_count: mapping.capturedMessages.size,
+      })
+      debouncedSaveSessionMap()
+    }
+    return
+  }
+
+  if (mapping.pendingMessages.size > 0) {
+    log("INFO", "session", "Deferring session cleanup because pending messages remain", {
+      openviking_session: mapping.ovSessionId,
+      opencode_session: opencodeSessionId,
+      reason,
+      pending_messages_count: mapping.pendingMessages.size,
+    })
+    debouncedSaveSessionMap()
+    return
+  }
+
+  sessionMap.delete(opencodeSessionId)
+  sessionMessageBuffer.delete(opencodeSessionId)
+  await saveSessionMap()
+  log("INFO", "session", "Cleaned up session mapping after pending cleanup", {
+    openviking_session: mapping.ovSessionId,
+    opencode_session: opencodeSessionId,
+    reason,
+  })
+}
+
 function getAutoCommitIntervalMinutes(config: OpenVikingConfig): number {
   const configured = Number(config.autoCommit?.intervalMinutes ?? DEFAULT_CONFIG.autoCommit?.intervalMinutes ?? 10)
   if (!Number.isFinite(configured)) {
@@ -877,15 +975,13 @@ async function finalizeCommitSuccess(
 
   await flushPendingMessages(opencodeSessionId, mapping, config)
 
-  if (mapping.pendingCleanup) {
-    sessionMap.delete(opencodeSessionId)
-    sessionMessageBuffer.delete(opencodeSessionId)
-    await saveSessionMap()
-    log("INFO", "session", "Cleaned up session mapping after commit completion", {
-      openviking_session: mapping.ovSessionId,
-      opencode_session: opencodeSessionId,
-    })
-  }
+  await completePendingCleanup(
+    mapping,
+    opencodeSessionId,
+    config,
+    "commit completion",
+    true,
+  )
 }
 
 async function runSynchronousCommit(
@@ -1142,15 +1238,13 @@ async function pollCommitTaskOnce(
     clearCommitState(mapping)
     debouncedSaveSessionMap()
 
-    if (mapping.pendingCleanup) {
-      sessionMap.delete(opencodeSessionId)
-      sessionMessageBuffer.delete(opencodeSessionId)
-      await saveSessionMap()
-      log("INFO", "session", "Cleaned up session mapping after failed commit", {
-        openviking_session: mapping.ovSessionId,
-        opencode_session: opencodeSessionId,
-      })
-    }
+    await completePendingCleanup(
+      mapping,
+      opencodeSessionId,
+      config,
+      "failed commit",
+      false,
+    )
 
     return task.status
   } catch (error: unknown) {
@@ -1854,13 +1948,10 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
             openviking_session: mapping.ovSessionId,
             session_info: safeStringify(event.properties?.info)
           })
+          inferAssistantRoleForPendingMessages(sessionId, mapping, "session.error")
           await flushPendingMessages(sessionId, mapping, config)
 
-          if (
-            mapping.capturedMessages.size > 0 ||
-            mapping.pendingMessages.size > 0 ||
-            mapping.commitInFlight
-          ) {
+          if (hasUnsavedSessionWork(mapping)) {
             mapping.pendingCleanup = true
             if (!mapping.commitInFlight) {
               await startBackgroundCommit(mapping, sessionId, config)

--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -711,98 +711,6 @@ function hasUnsavedSessionWork(mapping: SessionMapping): boolean {
     mapping.commitInFlight === true
 }
 
-function inferAssistantRoleForPendingMessages(
-  opencodeSessionId: string,
-  mapping: SessionMapping,
-  reason: string,
-): number {
-  const inferredMessageIds: string[] = []
-
-  for (const [messageId, content] of mapping.pendingMessages.entries()) {
-    if (mapping.messageRoles.has(messageId) || !content.trim()) {
-      continue
-    }
-
-    // On session.error, assistant text parts can arrive before finish=stop records the role.
-    mapping.messageRoles.set(messageId, "assistant")
-    inferredMessageIds.push(messageId)
-  }
-
-  if (inferredMessageIds.length > 0) {
-    debouncedSaveSessionMap()
-    log("INFO", "message", "Inferred assistant role for pending messages", {
-      session_id: opencodeSessionId,
-      reason,
-      count: inferredMessageIds.length,
-      message_ids: inferredMessageIds,
-    })
-  }
-
-  return inferredMessageIds.length
-}
-
-async function completePendingCleanup(
-  mapping: SessionMapping,
-  opencodeSessionId: string,
-  config: OpenVikingConfig,
-  reason: string,
-  startFollowUpCommit: boolean,
-): Promise<void> {
-  if (!mapping.pendingCleanup) {
-    return
-  }
-
-  if (mapping.capturedMessages.size > 0) {
-    if (startFollowUpCommit) {
-      log("INFO", "session", "Starting follow-up commit before session cleanup", {
-        openviking_session: mapping.ovSessionId,
-        opencode_session: opencodeSessionId,
-        reason,
-        captured_messages_count: mapping.capturedMessages.size,
-      })
-
-      const commitStart = await startBackgroundCommit(mapping, opencodeSessionId, config)
-      if (!commitStart) {
-        log("ERROR", "session", "Deferring session cleanup because follow-up commit could not start", {
-          openviking_session: mapping.ovSessionId,
-          opencode_session: opencodeSessionId,
-          reason,
-          captured_messages_count: mapping.capturedMessages.size,
-        })
-      }
-    } else {
-      log("INFO", "session", "Deferring session cleanup because captured messages still need commit", {
-        openviking_session: mapping.ovSessionId,
-        opencode_session: opencodeSessionId,
-        reason,
-        captured_messages_count: mapping.capturedMessages.size,
-      })
-      debouncedSaveSessionMap()
-    }
-    return
-  }
-
-  if (mapping.pendingMessages.size > 0) {
-    log("INFO", "session", "Deferring session cleanup because pending messages remain", {
-      openviking_session: mapping.ovSessionId,
-      opencode_session: opencodeSessionId,
-      reason,
-      pending_messages_count: mapping.pendingMessages.size,
-    })
-    debouncedSaveSessionMap()
-    return
-  }
-
-  sessionMap.delete(opencodeSessionId)
-  sessionMessageBuffer.delete(opencodeSessionId)
-  await saveSessionMap()
-  log("INFO", "session", "Cleaned up session mapping after pending cleanup", {
-    openviking_session: mapping.ovSessionId,
-    opencode_session: opencodeSessionId,
-    reason,
-  })
-}
-
 function getAutoCommitIntervalMinutes(config: OpenVikingConfig): number {
   const configured = Number(config.autoCommit?.intervalMinutes ?? DEFAULT_CONFIG.autoCommit?.intervalMinutes ?? 10)
   if (!Number.isFinite(configured)) {
@@ -975,13 +883,20 @@ async function finalizeCommitSuccess(
 
   await flushPendingMessages(opencodeSessionId, mapping, config)
 
-  await completePendingCleanup(
-    mapping,
-    opencodeSessionId,
-    config,
-    "commit completion",
-    true,
-  )
+  if (mapping.pendingCleanup) {
+    if (hasUnsavedSessionWork(mapping)) {
+      debouncedSaveSessionMap()
+      return
+    }
+
+    sessionMap.delete(opencodeSessionId)
+    sessionMessageBuffer.delete(opencodeSessionId)
+    await saveSessionMap()
+    log("INFO", "session", "Cleaned up session mapping after commit completion", {
+      openviking_session: mapping.ovSessionId,
+      opencode_session: opencodeSessionId,
+    })
+  }
 }
 
 async function runSynchronousCommit(
@@ -1238,13 +1153,15 @@ async function pollCommitTaskOnce(
     clearCommitState(mapping)
     debouncedSaveSessionMap()
 
-    await completePendingCleanup(
-      mapping,
-      opencodeSessionId,
-      config,
-      "failed commit",
-      false,
-    )
+    if (mapping.pendingCleanup && !hasUnsavedSessionWork(mapping)) {
+      sessionMap.delete(opencodeSessionId)
+      sessionMessageBuffer.delete(opencodeSessionId)
+      await saveSessionMap()
+      log("INFO", "session", "Cleaned up session mapping after failed commit", {
+        openviking_session: mapping.ovSessionId,
+        opencode_session: opencodeSessionId,
+      })
+    }
 
     return task.status
   } catch (error: unknown) {
@@ -1948,7 +1865,16 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
             openviking_session: mapping.ovSessionId,
             session_info: safeStringify(event.properties?.info)
           })
-          inferAssistantRoleForPendingMessages(sessionId, mapping, "session.error")
+          // Assistant text parts can arrive before finish=stop records the role.
+          let inferredRole = false
+          for (const [messageId, content] of mapping.pendingMessages.entries()) {
+            if (!mapping.messageRoles.has(messageId) && content.trim()) {
+              mapping.messageRoles.set(messageId, "assistant")
+              inferredRole = true
+            }
+          }
+          if (inferredRole) debouncedSaveSessionMap()
+
           await flushPendingMessages(sessionId, mapping, config)
 
           if (hasUnsavedSessionWork(mapping)) {

--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -1856,7 +1856,11 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
           })
           await flushPendingMessages(sessionId, mapping, config)
 
-          if (mapping.capturedMessages.size > 0 || mapping.commitInFlight) {
+          if (
+            mapping.capturedMessages.size > 0 ||
+            mapping.pendingMessages.size > 0 ||
+            mapping.commitInFlight
+          ) {
             mapping.pendingCleanup = true
             if (!mapping.commitInFlight) {
               await startBackgroundCommit(mapping, sessionId, config)


### PR DESCRIPTION
## Description

Preserve pending OpenCode messages when a `session.error` event occurs.

Before this change, the `session.error` handler only treated `capturedMessages` and `commitInFlight` as unsaved work. If a session had messages in `pendingMessages` but no captured messages yet, the session mapping could be cleaned up and those pending messages could be lost.

This change includes `pendingMessages.size > 0` in the unsaved-work check so the plugin triggers a best-effort background commit instead of deleting the session mapping.

## Related Issue

Fixes #2093

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Updated the `session.error` handler in `examples/opencode-memory-plugin/openviking-memory.ts`
- Treat `pendingMessages` as unsaved work before session cleanup
- Preserve pending messages by triggering the existing background commit path

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Manual verification:

- Ran `git diff --check`
- Verified the change is scoped to the `session.error` handler
- Verified the existing `session.deleted` behavior is unchanged

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No tests were added because this example plugin does not appear to have a dedicated test harness in this directory. The change is intentionally scoped to the existing `session.error` recovery condition.