### PR TITLE
fix: guard against empty choices and message=None in LoCaMo LLM judge

### DIFF
--- a/benchmark/locomo/mem0/eval.py
+++ b/benchmark/locomo/mem0/eval.py
@@ -494,9 +494,12 @@ def judge_answer(
             temperature=0,
             timeout=60,
         )
-        if not resp.choices or resp.choices[0].message is None:
+        if not resp.choices:
             raise ValueError("LLM returned empty or filtered response")
-        content = resp.choices[0].message.content.strip()
+        message = resp.choices[0].message
+        if message is None or message.content is None:
+            raise ValueError("LLM returned empty or filtered response")
+        content = message.content.strip()
         start, end = content.find("{"), content.rfind("}")
         if start != -1 and end != -1:
             parsed = json.loads(content[start : end + 1])

--- a/benchmark/locomo/mem0/eval.py
+++ b/benchmark/locomo/mem0/eval.py
@@ -494,6 +494,8 @@ def judge_answer(
             temperature=0,
             timeout=60,
         )
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         content = resp.choices[0].message.content.strip()
         start, end = content.find("{"), content.rfind("}")
         if start != -1 and end != -1:

--- a/benchmark/locomo/supermemory/eval.py
+++ b/benchmark/locomo/supermemory/eval.py
@@ -456,9 +456,12 @@ def judge_answer(
             temperature=0,
             timeout=60,
         )
-        if not resp.choices or resp.choices[0].message is None:
+        if not resp.choices:
             raise ValueError("LLM returned empty or filtered response")
-        content = resp.choices[0].message.content.strip()
+        message = resp.choices[0].message
+        if message is None or message.content is None:
+            raise ValueError("LLM returned empty or filtered response")
+        content = message.content.strip()
         start, end = content.find("{"), content.rfind("}")
         if start != -1 and end != -1:
             parsed = json.loads(content[start : end + 1])

--- a/benchmark/locomo/supermemory/eval.py
+++ b/benchmark/locomo/supermemory/eval.py
@@ -456,6 +456,8 @@ def judge_answer(
             temperature=0,
             timeout=60,
         )
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         content = resp.choices[0].message.content.strip()
         start, end = content.find("{"), content.rfind("}")
         if start != -1 and end != -1:


### PR DESCRIPTION
## Problem

In the LoCaMo benchmark evaluation harness, the LLM judge response is accessed without a guard:

- `benchmark/locomo/mem0/eval.py`: `resp.choices[0].message.content.strip()`
- `benchmark/locomo/supermemory/eval.py`: same

These raise `IndexError` (empty choices) or `AttributeError` (message=None on filtered content), aborting benchmark runs.

## Fix

Adds the two-condition guard before each access:

```python
if not resp.choices or resp.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

**4 lines added, 0 deleted.**

Detected by [pact](https://github.com/qizwiz/pact) static analysis.