### PR TITLE
fix(memory): Handle missing tool call counts

### DIFF
--- a/openviking/prompts/templates/memory/tools.yaml
+++ b/openviking/prompts/templates/memory/tools.yaml
@@ -21,7 +21,7 @@ content_template: |
   Static Description:
   "{{ static_desc|default('N/A') }}"
 
-  - Success rate: {{ ((success_time|default(0) / (call_count|default(1) if call_count|default(0) > 0 else 1)) * 100)|round|int }}% ({{ success_time|default(0) }}/{{ call_count|default(0) }})
+  - Success rate: {{ (((success_time|default(0, true)) / ((call_count|default(0, true)) if (call_count|default(0, true)) > 0 else 1)) * 100)|round|int }}% ({{ success_time|default(0, true) }}/{{ call_count|default(0, true) }})
   - When to use: {{ when_to_use|default('N/A') }}
   - Optimal params: {{ optimal_params|default('N/A') }}
   - Common failures: {{ common_failures|default('N/A') }}

--- a/tests/session/memory/test_memory_tools_template.py
+++ b/tests/session/memory/test_memory_tools_template.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from pathlib import Path
+
+import yaml
+
+from openviking.session.memory.utils.content import serialize_with_metadata
+
+
+def _tools_content_template() -> str:
+    template_path = (
+        Path(__file__).resolve().parents[3]
+        / "openviking"
+        / "prompts"
+        / "templates"
+        / "memory"
+        / "tools.yaml"
+    )
+    return yaml.safe_load(template_path.read_text(encoding="utf-8"))["content_template"]
+
+
+def test_tools_template_treats_none_counts_as_zero():
+    rendered = serialize_with_metadata(
+        {
+            "tool_name": "read_file",
+            "static_desc": "Reads files",
+            "call_count": None,
+            "success_time": None,
+        },
+        content_template=_tools_content_template(),
+    )
+
+    assert "- Success rate: 0% (0/0)" in rendered
+
+
+def test_tools_template_keeps_success_rate_for_positive_counts():
+    rendered = serialize_with_metadata(
+        {
+            "tool_name": "read_file",
+            "static_desc": "Reads files",
+            "call_count": 4,
+            "success_time": 3,
+        },
+        content_template=_tools_content_template(),
+    )
+
+    assert "- Success rate: 75% (3/4)" in rendered


### PR DESCRIPTION
## Summary

- Treat `None`/missing `call_count` and `success_time` values as zero in the tool memory content template.
- Preserve the existing positive-count success-rate rendering behavior.
- Add regression coverage for the `None` count case and the normal `3/4 -> 75%` case.

Fixes #2095

## Tests

- `python - <<'PY' ... PY` standalone Jinja render assertions for `0% (0/0)` and `75% (3/4)`
- `git diff --check`

## Local test note

`python -m pytest tests/session/memory/test_memory_tools_template.py -q` could not run in this fresh worktree because the local environment is missing the bundled OpenViking AGFS client (`ImportError: Bundled OpenViking AGFS client is unavailable. Reinstall openviking or run 'pip install -e .' from the project root.`). I kept the focused pytest regression in the PR and verified the template behavior directly with Jinja2.