### PR TITLE
fix(storage): sanitize vectordb unicode recovery

### DIFF
--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -41,6 +41,7 @@ from openviking.storage.vectordb.utils.constants import (
 from openviking.storage.vectordb.utils.data_processor import DataProcessor
 from openviking.storage.vectordb.utils.dict_utils import ThreadSafeDictManager
 from openviking.storage.vectordb.utils.id_generator import generate_auto_id
+from openviking.storage.vectordb.utils.json_safety import safe_json_dumps
 from openviking.storage.vectordb.utils.path_safety import (
     resolve_storage_path,
     safe_join,
@@ -568,7 +569,7 @@ class LocalCollection(ICollection):
                     if sparse_dict and isinstance(sparse_dict, dict):
                         cands_list[i].sparse_raw_terms = list(sparse_dict.keys())
                         cands_list[i].sparse_values = list(sparse_dict.values())
-            cands_list[i].fields = json.dumps(data)
+            cands_list[i].fields = safe_json_dumps(data, ensure_ascii=False)
             cands_list[i].expire_ns_ts = time.time_ns() + ttl * 1000000000 if ttl > 0 else 0
 
         if not self.store_mgr:
@@ -1004,14 +1005,22 @@ class PersistCollection(LocalCollection):
             for data in delta_list:
                 if data.type == OpType.PUT.value:
                     if delete_list:
-                        index.delete_data(delete_list)
-                        _processed += len(delete_list)
+                        _processed += self._replay_recovery_records(
+                            index_name=index_name,
+                            index=index,
+                            records=delete_list,
+                            operation="delete",
+                        )
                         delete_list = []
                     upsert_list.append(data)
                 elif data.type == OpType.DEL.value:
                     if upsert_list:
-                        index.upsert_data(upsert_list)
-                        _processed += len(upsert_list)
+                        _processed += self._replay_recovery_records(
+                            index_name=index_name,
+                            index=index,
+                            records=upsert_list,
+                            operation="upsert",
+                        )
                         upsert_list = []
                     delete_list.append(data)
                 now = time.time()
@@ -1024,13 +1033,62 @@ class PersistCollection(LocalCollection):
                     )
                     _last_log = now
             if upsert_list:
-                index.upsert_data(upsert_list)
-                _processed += len(upsert_list)
+                _processed += self._replay_recovery_records(
+                    index_name=index_name,
+                    index=index,
+                    records=upsert_list,
+                    operation="upsert",
+                )
             if delete_list:
-                index.delete_data(delete_list)
-                _processed += len(delete_list)
+                _processed += self._replay_recovery_records(
+                    index_name=index_name,
+                    index=index,
+                    records=delete_list,
+                    operation="delete",
+                )
             logger.info("Index '%s': replay complete (%d records)", index_name, _processed)
             self.indexes.set(index_name, index)
+
+    def _replay_recovery_records(
+        self,
+        *,
+        index_name: str,
+        index: PersistentIndex,
+        records: List[DeltaRecord],
+        operation: str,
+    ) -> int:
+        if not records:
+            return 0
+
+        replay = index.upsert_data if operation == "upsert" else index.delete_data
+        try:
+            replay(records)
+            return len(records)
+        except Exception as exc:
+            logger.warning(
+                "Index '%s': failed to replay %d %s delta records as a batch: %s; "
+                "retrying individually",
+                index_name,
+                len(records),
+                operation,
+                exc,
+            )
+
+        processed = 0
+        for record in records:
+            try:
+                replay([record])
+                processed += 1
+            except Exception as exc:
+                logger.warning(
+                    "Index '%s': skipping corrupt %s delta record label=%s type=%s: %s",
+                    index_name,
+                    operation,
+                    getattr(record, "label", None),
+                    getattr(record, "type", None),
+                    exc,
+                )
+        return processed
 
     def _persist_all_indexes(self):
         """Persist all indexes.

--- a/openviking/storage/vectordb/utils/data_processor.py
+++ b/openviking/storage/vectordb/utils/data_processor.py
@@ -17,6 +17,10 @@ from pydantic import (
 )
 
 from openviking.storage.vectordb.utils.id_generator import generate_auto_id
+from openviking.storage.vectordb.utils.json_safety import (
+    safe_json_dumps,
+    sanitize_unicode_for_json,
+)
 
 
 def get_pydantic_type(field_type: str) -> Type:
@@ -158,7 +162,7 @@ class DataProcessor:
         # Pydantic Validation (Type check, Defaults, Unknown fields, Custom format checks)
         # model_validate will raise ValidationError on failure
         validated_obj = self._validator_model.model_validate(data)
-        processed_data = validated_obj.model_dump()
+        processed_data = sanitize_unicode_for_json(validated_obj.model_dump())
 
         return processed_data
 
@@ -334,9 +338,9 @@ class DataProcessor:
     def convert_fields_for_index(self, fields_json: str) -> str:
         if not fields_json:
             return fields_json
-        data = json.loads(fields_json)
+        data = sanitize_unicode_for_json(json.loads(fields_json))
         converted = self.convert_fields_dict_for_index(data)
-        return json.dumps(converted, ensure_ascii=False)
+        return safe_json_dumps(converted, ensure_ascii=False)
 
     def _convert_time_range_node(self, node: Dict[str, Any], field_type: str) -> Dict[str, Any]:
         if field_type != "date_time":

--- a/openviking/storage/vectordb/utils/json_safety.py
+++ b/openviking/storage/vectordb/utils/json_safety.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""JSON helpers that keep vectordb fields UTF-8 safe."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def sanitize_unicode_for_json(value: Any) -> Any:
+    """Replace isolated UTF-16 surrogate code points before JSON storage.
+
+    Python's JSON decoder accepts lone surrogates such as ``"\\ud800"`` and
+    represents them as surrogate code points in ``str``. Those strings cannot be
+    encoded as valid UTF-8 and can break lower-level index recovery. The UTF-16
+    round trip keeps valid non-BMP characters intact while replacing isolated
+    surrogates with U+FFFD.
+    """
+    if isinstance(value, str):
+        return value.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+    if isinstance(value, dict):
+        return {
+            sanitize_unicode_for_json(key): sanitize_unicode_for_json(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [sanitize_unicode_for_json(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_unicode_for_json(item) for item in value)
+    return value
+
+
+def safe_json_dumps(value: Any, **kwargs: Any) -> str:
+    """Dump JSON after removing UTF-8-invalid surrogate code points."""
+    return json.dumps(sanitize_unicode_for_json(value), **kwargs)

--- a/tests/vectordb/test_data_processor.py
+++ b/tests/vectordb/test_data_processor.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import json
 import shutil
 import unittest
 from datetime import datetime, timezone
@@ -23,6 +24,7 @@ class TestDataProcessor(unittest.TestCase):
             "geo": {"FieldType": "geo_point"},
             "uri": {"FieldType": "path"},
             "tags": {"FieldType": "list<string>"},
+            "abstract": {"FieldType": "string"},
         }
         self.processor = DataProcessor(self.fields_dict)
 
@@ -105,6 +107,32 @@ class TestDataProcessor(unittest.TestCase):
         }
         with self.assertRaises(ValidationError):
             self.processor.validate_and_process(data_invalid_dt)
+
+    def test_validate_and_process_sanitizes_lone_surrogates(self):
+        processed = self.processor.validate_and_process(
+            {"abstract": "bad \ud800", "tags": ["ok \udc00"], "uri": "/tmp/test"}
+        )
+
+        self.assertEqual(processed["abstract"], "bad \ufffd")
+        self.assertEqual(processed["tags"], ["ok \ufffd"])
+        processed["abstract"].encode("utf-8")
+
+    def test_convert_fields_for_index_sanitizes_lone_surrogates(self):
+        fields_json = '{"abstract": "bad \\ud800", "tags": ["ok \\udc00"], "uri": "/tmp/test"}'
+
+        converted_json = self.processor.convert_fields_for_index(fields_json)
+        converted_json.encode("utf-8")
+        converted = json.loads(converted_json)
+
+        self.assertEqual(converted["abstract"], "bad \ufffd")
+        self.assertEqual(converted["tags"], ["ok \ufffd"])
+
+    def test_convert_fields_for_index_preserves_valid_emoji(self):
+        fields_json = json.dumps({"abstract": "face \U0001f600", "uri": "/tmp/test"})
+
+        converted = json.loads(self.processor.convert_fields_for_index(fields_json))
+
+        self.assertEqual(converted["abstract"], "face \U0001f600")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

修复本地 vectordb 在写入和恢复字段 JSON 时对孤立 Unicode surrogate 处理不稳的问题。

本次改动将 `session commit` 后进入 context collection 的字段数据在写入前统一做 Unicode 清洗：正常中文和 emoji 会原样保留，孤立 surrogate（例如 `\ud800`）会被替换为 `\ufffd`，避免后续 JSON/UTF-8/index replay 链路遇到不可编码字符。

同时增强本地 index recovery：恢复时仍优先批量 replay delta；如果某批数据因为历史脏记录失败，会自动降级为逐条 replay，跳过坏记录并打印 warning，避免一条脏数据阻断整个 collection/index 恢复。

举例：

- 正常数据：`{"abstract": "face 😀"}` 会继续保留为 `face 😀`
- 异常数据：`{"abstract": "bad \ud800"}` 会清洗为 `bad �`
- 历史恢复：如果一批 delta 中只有一条坏记录，其他正常记录仍会继续恢复，服务不会因为该批 replay 失败而整体启动失败

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 新增 vectordb JSON 安全序列化工具，递归清洗字符串中的孤立 UTF-16 surrogate，并保留合法非 BMP 字符（如 emoji）。
- 本地 collection fields 写入改为安全 JSON dump，并使用 `ensure_ascii=False` 避免正常中文/emoji 被拆成 `\uXXXX` 转义。
- `DataProcessor.convert_fields_for_index()` 在 JSON 反序列化后进行 Unicode 清洗，再做字段类型转换和序列化。
- `PersistCollection._recover()` 增加批量失败后的逐条 replay 降级逻辑，单条坏 delta 会被跳过并记录 warning。
- 补充单元测试，覆盖孤立 surrogate 清洗和合法 emoji 保留。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

测试命令：

```bash
.venv/bin/python -m pytest tests/vectordb/test_data_processor.py
```

额外验证：

- 手动创建本地 collection + index，写入 `bad \ud800 ok 😀`，读取结果为 `bad � ok 😀`
- 关闭后重新打开 collection，并通过 `search_by_vector` 验证 index 恢复和搜索正常
- `git diff --check` 通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

这次修复分为两个层次：

1. 写入侧避免新脏数据继续进入 vectordb。
2. 恢复侧容忍已经存在的历史脏 delta，避免单条坏记录影响服务启动。

`ensure_ascii=False` 本身不是完整修复，因此在序列化前先做 surrogate 清洗；否则孤立 surrogate 仍可能在 UTF-8 编码或底层 index 处理时失败。
