### PR TITLE
修复缺失role_id的bug，bot开启agent memory检索

### DIFF
--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -365,7 +365,7 @@ class VikingClient:
     async def search_memory(
         self, query: str, user_ids: str | list[str], agent_user_id: str, limit: int = 10
     ) -> dict[str, list[Any]]:
-        """通过上下文消息，检索viking 的user memory（agent memory 已关闭自动检索）。"""
+        """通过上下文消息，检索viking 的user memory 和 agent memory。"""
         await self._load_namespace_policy()
 
         def _extract_memories(result: Any) -> list[Any]:
@@ -399,7 +399,15 @@ class VikingClient:
             )
             all_user_memories.extend(_extract_memories(user_memory))
 
-        return {"user_memory": all_user_memories, "agent_memory": []}
+        uri_agent_memory = self._agent_memory_target_uri(agent_user_id)
+        agent_memory_result = await self.client.find(
+            query=query,
+            target_uri=uri_agent_memory,
+            limit=limit,
+        )
+        all_agent_memories = _extract_memories(agent_memory_result)
+
+        return {"user_memory": all_user_memories, "agent_memory": all_agent_memories}
 
     async def search_experiences(self, query: str, limit: int = 5) -> list[Any]:
         """用 query 检索 agent experience 记忆。"""

--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -46,7 +46,7 @@ class MemoryIsolationHandler:
             return
         messages = self._extract_context.messages if self._extract_context else []
         for msg in messages:
-            msg.role_id = None
+            msg.role_id = self.ctx.resolve_role_id(msg.role, msg.role_id) if self.ctx else None
 
     def get_read_scope(self) -> RoleScope:
         user_ids = set()


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

1. When enable_role_id_memory_isolate is False, role_id should be ctx.user.user_id instead of None
2. When using bot for auto recall, agent memory is needed

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
