### PR TITLE
feat: Watch Management API — REST + ov CLI + MCP (RFC #2104)

### DIFF
--- a/crates/ov_cli/src/base_client.rs
+++ b/crates/ov_cli/src/base_client.rs
@@ -405,6 +405,46 @@ impl BaseClient {
 
         self.handle_response(response).await
     }
+
+    pub async fn patch<B: serde::Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+        params: &[(String, String)],
+    ) -> Result<T> {
+        let url = format!("{}{}", self.base_url, path);
+        let response = self
+            .http
+            .patch(&url)
+            .headers(self.build_headers())
+            .query(params)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| Error::Network(format!("HTTP request failed: {}", e)))?;
+
+        self.handle_response(response).await
+    }
+
+    pub async fn post_with_query<B: serde::Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+        params: &[(String, String)],
+    ) -> Result<T> {
+        let url = format!("{}{}", self.base_url, path);
+        let response = self
+            .http
+            .post(&url)
+            .headers(self.build_headers())
+            .query(params)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| Error::Network(format!("HTTP request failed: {}", e)))?;
+
+        self.handle_response(response).await
+    }
 }
 
 // ============ FileUploader ============

--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -106,6 +106,24 @@ impl HttpClient {
         self.base.delete_with_body(path, body).await
     }
 
+    pub async fn patch<B: serde::Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+        params: &[(String, String)],
+    ) -> Result<T> {
+        self.base.patch(path, body, params).await
+    }
+
+    pub async fn post_with_query<B: serde::Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+        params: &[(String, String)],
+    ) -> Result<T> {
+        self.base.post_with_query(path, body, params).await
+    }
+
     // ============ File Helper Methods ============
 
     fn create_uploader(&self) -> FileUploader {
@@ -1042,6 +1060,66 @@ impl HttpClient {
         );
         let body = serde_json::json!({ "version": version });
         self.post(&path, &body).await
+    }
+
+    // ============ Watch Management (RFC #2104) ============
+
+    pub async fn list_watches(&self, active_only: bool) -> Result<serde_json::Value> {
+        let mut params = vec![];
+        if active_only {
+            params.push(("active_only".to_string(), "true".to_string()));
+        }
+        self.get("/api/v1/watches", &params).await
+    }
+
+    pub async fn get_watch_by_id(&self, task_id: &str) -> Result<serde_json::Value> {
+        let path = format!("/api/v1/watches/{}", task_id);
+        self.get(&path, &[]).await
+    }
+
+    pub async fn get_watch_by_uri(&self, to_uri: &str) -> Result<serde_json::Value> {
+        let params = vec![("to_uri".to_string(), to_uri.to_string())];
+        self.get("/api/v1/watches", &params).await
+    }
+
+    pub async fn patch_watch_by_id(
+        &self,
+        task_id: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let path = format!("/api/v1/watches/{}", task_id);
+        self.patch(&path, body, &[]).await
+    }
+
+    pub async fn patch_watch_by_uri(
+        &self,
+        to_uri: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let params = vec![("to_uri".to_string(), to_uri.to_string())];
+        self.patch("/api/v1/watches", body, &params).await
+    }
+
+    pub async fn delete_watch_by_id(&self, task_id: &str) -> Result<serde_json::Value> {
+        let path = format!("/api/v1/watches/{}", task_id);
+        self.delete(&path, &[]).await
+    }
+
+    pub async fn delete_watch_by_uri(&self, to_uri: &str) -> Result<serde_json::Value> {
+        let params = vec![("to_uri".to_string(), to_uri.to_string())];
+        self.delete("/api/v1/watches", &params).await
+    }
+
+    pub async fn trigger_watch_by_id(&self, task_id: &str) -> Result<serde_json::Value> {
+        let path = format!("/api/v1/watches/{}/trigger", task_id);
+        let empty = serde_json::json!({});
+        self.post(&path, &empty).await
+    }
+
+    pub async fn trigger_watch_by_uri(&self, to_uri: &str) -> Result<serde_json::Value> {
+        let params = vec![("to_uri".to_string(), to_uri.to_string())];
+        let empty = serde_json::json!({});
+        self.post_with_query("/api/v1/watches/trigger", &empty, &params).await
     }
 }
 

--- a/crates/ov_cli/src/commands/mod.rs
+++ b/crates/ov_cli/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod search;
 pub mod session;
 pub mod system;
 pub mod task;
+pub mod watch;

--- a/crates/ov_cli/src/commands/watch.rs
+++ b/crates/ov_cli/src/commands/watch.rs
@@ -1,0 +1,140 @@
+// Watch management subcommand handlers (RFC #2104).
+//
+// Mirrors the REST `/watches` endpoints with full parity. Each handler
+// auto-detects whether `key` is a viking:// URI or a task_id and routes to
+// the appropriate `*_by_uri` or `*_by_id` HTTP client method.
+
+use crate::client::HttpClient;
+use crate::error::Result;
+use crate::output::{OutputFormat, output_success};
+use serde_json::json;
+
+/// Classify a positional key argument: viking:// prefix means it's a `to_uri`,
+/// everything else is treated as an opaque task_id.
+fn is_uri(key: &str) -> bool {
+    key.starts_with("viking://")
+}
+
+pub async fn ls(
+    client: &HttpClient,
+    active_only: bool,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let response = client.list_watches(active_only).await?;
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+pub async fn show(
+    client: &HttpClient,
+    key: &str,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let response = if is_uri(key) {
+        client.get_watch_by_uri(key).await?
+    } else {
+        client.get_watch_by_id(key).await?
+    };
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+pub async fn rm(
+    client: &HttpClient,
+    key: &str,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let response = if is_uri(key) {
+        client.delete_watch_by_uri(key).await?
+    } else {
+        client.delete_watch_by_id(key).await?
+    };
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+pub async fn pause(
+    client: &HttpClient,
+    key: &str,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let body = json!({"is_active": false});
+    let response = if is_uri(key) {
+        client.patch_watch_by_uri(key, &body).await?
+    } else {
+        client.patch_watch_by_id(key, &body).await?
+    };
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+pub async fn resume(
+    client: &HttpClient,
+    key: &str,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let body = json!({"is_active": true});
+    let response = if is_uri(key) {
+        client.patch_watch_by_uri(key, &body).await?
+    } else {
+        client.patch_watch_by_id(key, &body).await?
+    };
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+pub async fn set_interval(
+    client: &HttpClient,
+    key: &str,
+    minutes: f64,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let body = json!({"watch_interval": minutes});
+    let response = if is_uri(key) {
+        client.patch_watch_by_uri(key, &body).await?
+    } else {
+        client.patch_watch_by_id(key, &body).await?
+    };
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+pub async fn trigger(
+    client: &HttpClient,
+    key: &str,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let response = if is_uri(key) {
+        client.trigger_watch_by_uri(key).await?
+    } else {
+        client.trigger_watch_by_id(key).await?
+    };
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_uri;
+
+    #[test]
+    fn uri_prefix_detected() {
+        assert!(is_uri("viking://resources/foo/bar"));
+        assert!(is_uri("viking://resources"));
+    }
+
+    #[test]
+    fn non_uri_classified_as_task_id() {
+        assert!(!is_uri("550e8400-e29b-41d4-a716-446655440000"));
+        assert!(!is_uri("abc-123"));
+        assert!(!is_uri("http://example.com")); // wrong scheme isn't viking://
+        assert!(!is_uri(""));
+    }
+}

--- a/crates/ov_cli/src/commands/watch.rs
+++ b/crates/ov_cli/src/commands/watch.rs
@@ -5,7 +5,7 @@
 // the appropriate `*_by_uri` or `*_by_id` HTTP client method.
 
 use crate::client::HttpClient;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::output::{OutputFormat, output_success};
 use serde_json::json;
 
@@ -95,6 +95,11 @@ pub async fn set_interval(
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
+    if !(minutes > 0.0) {
+        return Err(Error::Parse(format!(
+            "minutes must be > 0 (got {minutes}). To pause a watch task, use `ov watch pause`."
+        )));
+    }
     let body = json!({"watch_interval": minutes});
     let response = if is_uri(key) {
         client.patch_watch_by_uri(key, &body).await?
@@ -136,5 +141,18 @@ mod tests {
         assert!(!is_uri("abc-123"));
         assert!(!is_uri("http://example.com")); // wrong scheme isn't viking://
         assert!(!is_uri(""));
+    }
+
+    #[test]
+    fn non_positive_minutes_rejected() {
+        // Sanity-check the local guard. Because the `if !(minutes > 0.0)` check
+        // sits ahead of any HTTP call, we can verify rejection purely via the
+        // boolean predicate without spinning up a client.
+        for bad in [0.0_f64, -1.0, -42.5, f64::NAN] {
+            assert!(!(bad > 0.0), "guard expects to reject: {bad}");
+        }
+        for ok in [0.0001_f64, 1.0, 60.0, 1440.0] {
+            assert!(ok > 0.0, "guard expects to accept: {ok}");
+        }
     }
 }

--- a/crates/ov_cli/src/commands/watch.rs
+++ b/crates/ov_cli/src/commands/watch.rs
@@ -9,10 +9,45 @@ use crate::error::{Error, Result};
 use crate::output::{OutputFormat, output_success};
 use serde_json::json;
 
-/// Classify a positional key argument: viking:// prefix means it's a `to_uri`,
-/// everything else is treated as an opaque task_id.
-fn is_uri(key: &str) -> bool {
-    key.starts_with("viking://")
+/// How a positional `<key>` arg should be routed.
+#[derive(Debug, PartialEq, Eq)]
+enum KeyKind {
+    /// Routes to `*_by_uri` HTTP method.
+    Uri,
+    /// Routes to `*_by_id` HTTP method (treated as opaque task_id).
+    TaskId,
+}
+
+/// Classify a positional key. Case-insensitive `viking://` matches as a URI;
+/// any other `://`-bearing string is rejected as a likely typo (avoids the
+/// silent "task_id not found" experience when the user meant a URI but used
+/// the wrong scheme / capitalization / single-slash).
+fn classify_key(key: &str) -> Result<KeyKind> {
+    if key.starts_with("viking://") {
+        return Ok(KeyKind::Uri);
+    }
+    if key.to_ascii_lowercase().starts_with("viking://") {
+        return Err(Error::Parse(format!(
+            "URI scheme is case-sensitive — use lowercase `viking://` (got {key:?})"
+        )));
+    }
+    if key.contains("://") {
+        return Err(Error::Parse(format!(
+            "Key {key:?} looks like a URI but does not start with `viking://`. \
+             If you meant a task_id, drop the scheme."
+        )));
+    }
+    Ok(KeyKind::TaskId)
+}
+
+/// Validate `ov watch set-interval` minutes. Rejects 0, negatives, and NaN.
+fn validate_interval_minutes(minutes: f64) -> Result<()> {
+    if !(minutes > 0.0) {
+        return Err(Error::Parse(format!(
+            "minutes must be > 0 (got {minutes}). To pause a watch task, use `ov watch pause`."
+        )));
+    }
+    Ok(())
 }
 
 pub async fn ls(
@@ -32,10 +67,9 @@ pub async fn show(
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
-    let response = if is_uri(key) {
-        client.get_watch_by_uri(key).await?
-    } else {
-        client.get_watch_by_id(key).await?
+    let response = match classify_key(key)? {
+        KeyKind::Uri => client.get_watch_by_uri(key).await?,
+        KeyKind::TaskId => client.get_watch_by_id(key).await?,
     };
     output_success(&response, output_format, compact);
     Ok(())
@@ -47,10 +81,9 @@ pub async fn rm(
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
-    let response = if is_uri(key) {
-        client.delete_watch_by_uri(key).await?
-    } else {
-        client.delete_watch_by_id(key).await?
+    let response = match classify_key(key)? {
+        KeyKind::Uri => client.delete_watch_by_uri(key).await?,
+        KeyKind::TaskId => client.delete_watch_by_id(key).await?,
     };
     output_success(&response, output_format, compact);
     Ok(())
@@ -63,10 +96,9 @@ pub async fn pause(
     compact: bool,
 ) -> Result<()> {
     let body = json!({"is_active": false});
-    let response = if is_uri(key) {
-        client.patch_watch_by_uri(key, &body).await?
-    } else {
-        client.patch_watch_by_id(key, &body).await?
+    let response = match classify_key(key)? {
+        KeyKind::Uri => client.patch_watch_by_uri(key, &body).await?,
+        KeyKind::TaskId => client.patch_watch_by_id(key, &body).await?,
     };
     output_success(&response, output_format, compact);
     Ok(())
@@ -79,10 +111,9 @@ pub async fn resume(
     compact: bool,
 ) -> Result<()> {
     let body = json!({"is_active": true});
-    let response = if is_uri(key) {
-        client.patch_watch_by_uri(key, &body).await?
-    } else {
-        client.patch_watch_by_id(key, &body).await?
+    let response = match classify_key(key)? {
+        KeyKind::Uri => client.patch_watch_by_uri(key, &body).await?,
+        KeyKind::TaskId => client.patch_watch_by_id(key, &body).await?,
     };
     output_success(&response, output_format, compact);
     Ok(())
@@ -95,16 +126,11 @@ pub async fn set_interval(
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
-    if !(minutes > 0.0) {
-        return Err(Error::Parse(format!(
-            "minutes must be > 0 (got {minutes}). To pause a watch task, use `ov watch pause`."
-        )));
-    }
+    validate_interval_minutes(minutes)?;
     let body = json!({"watch_interval": minutes});
-    let response = if is_uri(key) {
-        client.patch_watch_by_uri(key, &body).await?
-    } else {
-        client.patch_watch_by_id(key, &body).await?
+    let response = match classify_key(key)? {
+        KeyKind::Uri => client.patch_watch_by_uri(key, &body).await?,
+        KeyKind::TaskId => client.patch_watch_by_id(key, &body).await?,
     };
     output_success(&response, output_format, compact);
     Ok(())
@@ -116,10 +142,9 @@ pub async fn trigger(
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
-    let response = if is_uri(key) {
-        client.trigger_watch_by_uri(key).await?
-    } else {
-        client.trigger_watch_by_id(key).await?
+    let response = match classify_key(key)? {
+        KeyKind::Uri => client.trigger_watch_by_uri(key).await?,
+        KeyKind::TaskId => client.trigger_watch_by_id(key).await?,
     };
     output_success(&response, output_format, compact);
     Ok(())
@@ -127,32 +152,63 @@ pub async fn trigger(
 
 #[cfg(test)]
 mod tests {
-    use super::is_uri;
+    use super::{KeyKind, classify_key, validate_interval_minutes};
+    use crate::error::Error;
 
     #[test]
-    fn uri_prefix_detected() {
-        assert!(is_uri("viking://resources/foo/bar"));
-        assert!(is_uri("viking://resources"));
+    fn classify_viking_uri_as_uri() {
+        assert_eq!(
+            classify_key("viking://resources/foo/bar").unwrap(),
+            KeyKind::Uri
+        );
+        assert_eq!(classify_key("viking://resources").unwrap(), KeyKind::Uri);
     }
 
     #[test]
-    fn non_uri_classified_as_task_id() {
-        assert!(!is_uri("550e8400-e29b-41d4-a716-446655440000"));
-        assert!(!is_uri("abc-123"));
-        assert!(!is_uri("http://example.com")); // wrong scheme isn't viking://
-        assert!(!is_uri(""));
+    fn classify_plain_id_as_task_id() {
+        assert_eq!(
+            classify_key("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            KeyKind::TaskId
+        );
+        assert_eq!(classify_key("abc-123").unwrap(), KeyKind::TaskId);
+        assert_eq!(classify_key("").unwrap(), KeyKind::TaskId);
     }
 
     #[test]
-    fn non_positive_minutes_rejected() {
-        // Sanity-check the local guard. Because the `if !(minutes > 0.0)` check
-        // sits ahead of any HTTP call, we can verify rejection purely via the
-        // boolean predicate without spinning up a client.
-        for bad in [0.0_f64, -1.0, -42.5, f64::NAN] {
-            assert!(!(bad > 0.0), "guard expects to reject: {bad}");
+    fn classify_rejects_uppercase_viking_scheme() {
+        let err = classify_key("Viking://resources/foo").expect_err("should reject");
+        match err {
+            Error::Parse(msg) => assert!(msg.contains("case-sensitive"), "got: {msg}"),
+            other => panic!("expected Parse error, got {other:?}"),
         }
-        for ok in [0.0001_f64, 1.0, 60.0, 1440.0] {
-            assert!(ok > 0.0, "guard expects to accept: {ok}");
+    }
+
+    #[test]
+    fn classify_rejects_other_schemes() {
+        for bad in ["http://example.com", "https://example.com", "file:///etc"] {
+            let err = classify_key(bad).expect_err("should reject");
+            match err {
+                Error::Parse(msg) => assert!(msg.contains("looks like a URI"), "got: {msg}"),
+                other => panic!("expected Parse error, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn validate_interval_accepts_positive() {
+        for ok in [0.0001_f64, 1.0, 60.0, 1440.0, 1e9] {
+            assert!(validate_interval_minutes(ok).is_ok(), "should accept: {ok}");
+        }
+    }
+
+    #[test]
+    fn validate_interval_rejects_zero_negative_nan() {
+        for bad in [0.0_f64, -1.0, -42.5, f64::NAN] {
+            let err = validate_interval_minutes(bad).expect_err("should reject");
+            match err {
+                Error::Parse(msg) => assert!(msg.contains("minutes must be > 0"), "got: {msg}"),
+                other => panic!("expected Parse error, got {other:?}"),
+            }
         }
     }
 }

--- a/crates/ov_cli/src/commands/watch.rs
+++ b/crates/ov_cli/src/commands/watch.rs
@@ -119,15 +119,49 @@ pub async fn resume(
     Ok(())
 }
 
-pub async fn set_interval(
+/// Build the PATCH body for `ov task watch update`. Validates each field and
+/// guards against the no-op case (caller passed no flags). Exposed as a
+/// standalone helper so the validation paths can be unit-tested without an
+/// HTTP client.
+fn build_update_body(
+    interval: Option<f64>,
+    active: Option<bool>,
+    reason: Option<&str>,
+    instruction: Option<&str>,
+) -> Result<serde_json::Value> {
+    let mut body = serde_json::Map::new();
+    if let Some(i) = interval {
+        validate_interval_minutes(i)?;
+        body.insert("watch_interval".into(), json!(i));
+    }
+    if let Some(a) = active {
+        body.insert("is_active".into(), json!(a));
+    }
+    if let Some(r) = reason {
+        body.insert("reason".into(), json!(r));
+    }
+    if let Some(ins) = instruction {
+        body.insert("instruction".into(), json!(ins));
+    }
+    if body.is_empty() {
+        return Err(Error::Parse(
+            "At least one of --interval, --active, --reason, --instruction is required".into(),
+        ));
+    }
+    Ok(serde_json::Value::Object(body))
+}
+
+pub async fn update(
     client: &HttpClient,
     key: &str,
-    minutes: f64,
+    interval: Option<f64>,
+    active: Option<bool>,
+    reason: Option<String>,
+    instruction: Option<String>,
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
-    validate_interval_minutes(minutes)?;
-    let body = json!({"watch_interval": minutes});
+    let body = build_update_body(interval, active, reason.as_deref(), instruction.as_deref())?;
     let response = match classify_key(key)? {
         KeyKind::Uri => client.patch_watch_by_uri(key, &body).await?,
         KeyKind::TaskId => client.patch_watch_by_id(key, &body).await?,
@@ -152,7 +186,7 @@ pub async fn trigger(
 
 #[cfg(test)]
 mod tests {
-    use super::{KeyKind, classify_key, validate_interval_minutes};
+    use super::{KeyKind, build_update_body, classify_key, validate_interval_minutes};
     use crate::error::Error;
 
     #[test]
@@ -209,6 +243,45 @@ mod tests {
                 Error::Parse(msg) => assert!(msg.contains("minutes must be > 0"), "got: {msg}"),
                 other => panic!("expected Parse error, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn update_body_requires_at_least_one_flag() {
+        let err = build_update_body(None, None, None, None).expect_err("should reject");
+        match err {
+            Error::Parse(msg) => assert!(msg.contains("At least one"), "got: {msg}"),
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_body_includes_each_field_when_set() {
+        let body = build_update_body(Some(120.0), Some(false), Some("r"), Some("i")).unwrap();
+        let obj = body.as_object().unwrap();
+        assert_eq!(obj["watch_interval"], 120.0);
+        assert_eq!(obj["is_active"], false);
+        assert_eq!(obj["reason"], "r");
+        assert_eq!(obj["instruction"], "i");
+        assert_eq!(obj.len(), 4);
+    }
+
+    #[test]
+    fn update_body_omits_unset_fields() {
+        // Only --active=true given — only is_active should appear in the body
+        let body = build_update_body(None, Some(true), None, None).unwrap();
+        let obj = body.as_object().unwrap();
+        assert_eq!(obj["is_active"], true);
+        assert_eq!(obj.len(), 1);
+        assert!(!obj.contains_key("watch_interval"));
+    }
+
+    #[test]
+    fn update_body_validates_interval() {
+        let err = build_update_body(Some(0.0), None, None, None).expect_err("should reject");
+        match err {
+            Error::Parse(msg) => assert!(msg.contains("minutes must be > 0"), "got: {msg}"),
+            other => panic!("expected Parse error, got {other:?}"),
         }
     }
 }

--- a/crates/ov_cli/src/commands/watch.rs
+++ b/crates/ov_cli/src/commands/watch.rs
@@ -40,11 +40,12 @@ fn classify_key(key: &str) -> Result<KeyKind> {
     Ok(KeyKind::TaskId)
 }
 
-/// Validate `ov watch set-interval` minutes. Rejects 0, negatives, and NaN.
+/// Validate the `--interval` value of `ov task watch update`. Rejects 0,
+/// negatives, and NaN.
 fn validate_interval_minutes(minutes: f64) -> Result<()> {
     if !(minutes > 0.0) {
         return Err(Error::Parse(format!(
-            "minutes must be > 0 (got {minutes}). To pause a watch task, use `ov watch pause`."
+            "minutes must be > 0 (got {minutes}). To pause a watch task, use `ov task watch pause`."
         )));
     }
     Ok(())

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -615,6 +615,11 @@ enum Commands {
         #[arg(long, default_value_t = true, action = ArgAction::Set)]
         wait: bool,
     },
+    /// [Data] Watch task management (auto-refresh subscriptions)
+    Watch {
+        #[command(subcommand)]
+        action: WatchCommands,
+    },
 }
 
 impl Commands {
@@ -733,6 +738,48 @@ enum SessionCommands {
     Commit {
         /// Session ID
         session_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum WatchCommands {
+    /// List watch tasks (auto-refresh subscriptions)
+    Ls {
+        /// Only show active (non-paused) tasks
+        #[arg(long, default_value_t = false)]
+        active_only: bool,
+    },
+    /// Show details of a single watch task
+    Show {
+        /// task_id (UUID) or to_uri (viking:// URI)
+        key: String,
+    },
+    /// Delete a watch task
+    Rm {
+        /// task_id (UUID) or to_uri (viking:// URI)
+        key: String,
+    },
+    /// Pause a watch task (preserves cadence, stops scheduling)
+    Pause {
+        /// task_id (UUID) or to_uri (viking:// URI)
+        key: String,
+    },
+    /// Resume a paused watch task
+    Resume {
+        /// task_id (UUID) or to_uri (viking:// URI)
+        key: String,
+    },
+    /// Change the refresh interval (minutes) of a watch task
+    SetInterval {
+        /// task_id (UUID) or to_uri (viking:// URI)
+        key: String,
+        /// New refresh interval in minutes (must be > 0)
+        minutes: f64,
+    },
+    /// Trigger an immediate refresh, bypassing the schedule
+    Trigger {
+        /// task_id (UUID) or to_uri (viking:// URI)
+        key: String,
     },
 }
 
@@ -1139,6 +1186,39 @@ async fn main() {
                 .await
             }
         },
+        Commands::Watch { action } => {
+            let client = ctx.get_client();
+            match action {
+                WatchCommands::Ls { active_only } => {
+                    commands::watch::ls(&client, active_only, ctx.output_format, ctx.compact).await
+                }
+                WatchCommands::Show { key } => {
+                    commands::watch::show(&client, &key, ctx.output_format, ctx.compact).await
+                }
+                WatchCommands::Rm { key } => {
+                    commands::watch::rm(&client, &key, ctx.output_format, ctx.compact).await
+                }
+                WatchCommands::Pause { key } => {
+                    commands::watch::pause(&client, &key, ctx.output_format, ctx.compact).await
+                }
+                WatchCommands::Resume { key } => {
+                    commands::watch::resume(&client, &key, ctx.output_format, ctx.compact).await
+                }
+                WatchCommands::SetInterval { key, minutes } => {
+                    commands::watch::set_interval(
+                        &client,
+                        &key,
+                        minutes,
+                        ctx.output_format,
+                        ctx.compact,
+                    )
+                    .await
+                }
+                WatchCommands::Trigger { key } => {
+                    commands::watch::trigger(&client, &key, ctx.output_format, ctx.compact).await
+                }
+            }
+        }
         Commands::Status => {
             let client = ctx.get_client();
             commands::observer::system(&client, ctx.output_format, ctx.compact).await

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -615,11 +615,6 @@ enum Commands {
         #[arg(long, default_value_t = true, action = ArgAction::Set)]
         wait: bool,
     },
-    /// [Data] Watch task management (auto-refresh subscriptions)
-    Watch {
-        #[command(subcommand)]
-        action: WatchCommands,
-    },
 }
 
 impl Commands {
@@ -647,6 +642,11 @@ enum TaskCommands {
         /// Filter by status (pending, running, completed, failed)
         #[arg(long)]
         status: Option<String>,
+    },
+    /// Watch task management (auto-refresh subscriptions)
+    Watch {
+        #[command(subcommand)]
+        action: WatchCommands,
     },
 }
 
@@ -769,12 +769,23 @@ enum WatchCommands {
         /// task_id (UUID) or to_uri (viking:// URI)
         key: String,
     },
-    /// Change the refresh interval (minutes) of a watch task
-    SetInterval {
+    /// Update one or more mutable fields of a watch task.
+    /// At least one flag is required.
+    Update {
         /// task_id (UUID) or to_uri (viking:// URI)
         key: String,
         /// New refresh interval in minutes (must be > 0)
-        minutes: f64,
+        #[arg(long)]
+        interval: Option<f64>,
+        /// Set active (true) / paused (false) — alternative to pause/resume shortcuts
+        #[arg(long)]
+        active: Option<bool>,
+        /// Human-readable reason for the watch task
+        #[arg(long)]
+        reason: Option<String>,
+        /// Processing instruction forwarded to the refresh handler
+        #[arg(long)]
+        instruction: Option<String>,
     },
     /// Trigger an immediate refresh, bypassing the schedule
     Trigger {
@@ -1185,40 +1196,64 @@ async fn main() {
                 )
                 .await
             }
-        },
-        Commands::Watch { action } => {
-            let client = ctx.get_client();
-            match action {
-                WatchCommands::Ls { active_only } => {
-                    commands::watch::ls(&client, active_only, ctx.output_format, ctx.compact).await
-                }
-                WatchCommands::Show { key } => {
-                    commands::watch::show(&client, &key, ctx.output_format, ctx.compact).await
-                }
-                WatchCommands::Rm { key } => {
-                    commands::watch::rm(&client, &key, ctx.output_format, ctx.compact).await
-                }
-                WatchCommands::Pause { key } => {
-                    commands::watch::pause(&client, &key, ctx.output_format, ctx.compact).await
-                }
-                WatchCommands::Resume { key } => {
-                    commands::watch::resume(&client, &key, ctx.output_format, ctx.compact).await
-                }
-                WatchCommands::SetInterval { key, minutes } => {
-                    commands::watch::set_interval(
-                        &client,
-                        &key,
-                        minutes,
-                        ctx.output_format,
-                        ctx.compact,
-                    )
-                    .await
-                }
-                WatchCommands::Trigger { key } => {
-                    commands::watch::trigger(&client, &key, ctx.output_format, ctx.compact).await
+            TaskCommands::Watch { action } => {
+                let client = ctx.get_client();
+                match action {
+                    WatchCommands::Ls { active_only } => {
+                        commands::watch::ls(
+                            &client,
+                            active_only,
+                            ctx.output_format,
+                            ctx.compact,
+                        )
+                        .await
+                    }
+                    WatchCommands::Show { key } => {
+                        commands::watch::show(&client, &key, ctx.output_format, ctx.compact)
+                            .await
+                    }
+                    WatchCommands::Rm { key } => {
+                        commands::watch::rm(&client, &key, ctx.output_format, ctx.compact).await
+                    }
+                    WatchCommands::Pause { key } => {
+                        commands::watch::pause(&client, &key, ctx.output_format, ctx.compact)
+                            .await
+                    }
+                    WatchCommands::Resume { key } => {
+                        commands::watch::resume(&client, &key, ctx.output_format, ctx.compact)
+                            .await
+                    }
+                    WatchCommands::Update {
+                        key,
+                        interval,
+                        active,
+                        reason,
+                        instruction,
+                    } => {
+                        commands::watch::update(
+                            &client,
+                            &key,
+                            interval,
+                            active,
+                            reason,
+                            instruction,
+                            ctx.output_format,
+                            ctx.compact,
+                        )
+                        .await
+                    }
+                    WatchCommands::Trigger { key } => {
+                        commands::watch::trigger(
+                            &client,
+                            &key,
+                            ctx.output_format,
+                            ctx.compact,
+                        )
+                        .await
+                    }
                 }
             }
-        }
+        },
         Commands::Status => {
             let client = ctx.get_client();
             commands::observer::system(&client, ctx.output_format, ctx.compact).await

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -45,6 +45,7 @@ from openviking.server.routers import (
     stats_router,
     system_router,
     tasks_router,
+    watches_router,
     webdav_router,
 )
 from openviking.service.core import OpenVikingService
@@ -511,6 +512,7 @@ def create_app(
     app.include_router(observer_router)
     app.include_router(metrics_router)
     app.include_router(tasks_router)
+    app.include_router(watches_router)
     app.include_router(webdav_router)
     app.include_router(bot_router, prefix="/bot/v1")
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -388,6 +388,11 @@ async def add_resource(
         path = require_remote_resource_source(path)
     except PermissionDeniedError:
         return f"Error: {_LOCAL_FILE_HINT}"
+    if watch_interval < 0:
+        return (
+            "Error: watch_interval must be >= 0. Use 0 for one-shot add (no watch); "
+            "use a positive number of minutes (>=1440 recommended) to subscribe to auto-refresh."
+        )
     if watch_interval > 0 and not to:
         return f"Error: {_WATCH_REQUIRES_TO_HINT}"
     try:
@@ -487,7 +492,10 @@ async def cancel_watch(to_uri: str) -> str:
     if task is None:
         return f"No watch task found for {to_uri}"
     try:
-        ok = await wm.delete_task(
+        # ok=False here means the task was removed between our lookup and delete
+        # (concurrent cancel). Treat as success — the post-condition the caller
+        # wanted ("no watch on this URI") holds either way.
+        await wm.delete_task(
             task.task_id,
             ctx.account_id,
             ctx.user.user_id,
@@ -496,7 +504,7 @@ async def cancel_watch(to_uri: str) -> str:
         )
     except _wm_mod.PermissionDeniedError:
         return f"Permission denied for {to_uri}"
-    return f"Watch cancelled: {to_uri}" if ok else f"Failed to cancel: {to_uri}"
+    return f"Watch cancelled: {to_uri}"
 
 
 # -- grep ------------------------------------------------------------------

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -355,10 +355,31 @@ _LOCAL_FILE_HINT = (
     '       {"url": "https://your-host", "api_key": "your-key"}'
 )
 
+_WATCH_REQUIRES_TO_HINT = (
+    "watch_interval > 0 requires `to` to be specified (the stable target URI to refresh into). "
+    "Pick a deterministic URI under viking://resources/. For example:\n"
+    "  - https://github.com/<org>/<repo>  -> to='viking://resources/<org>/<repo>'\n"
+    "  - https://example.com/docs/api     -> to='viking://resources/example.com/docs/api'\n"
+    "Tip: call add_resource without watch_interval first, observe the returned URI, "
+    "then call again with watch_interval=<minutes> and to=<that URI>."
+)
+
 
 @mcp.tool()
-async def add_resource(path: str, description: str = "") -> str:
-    """Add a remote resource (HTTP/HTTPS URL or git URL) to OpenViking. Asynchronous — processed in the background. Local file paths are not supported here; use the `ov add-resource` CLI for local files."""
+async def add_resource(
+    path: str,
+    description: str = "",
+    watch_interval: float = 0,
+    to: str = "",
+) -> str:
+    """Add a remote resource (HTTP/HTTPS URL or git URL) to OpenViking. Asynchronous — processed in the background. Local file paths are not supported here; use the `ov add-resource` CLI for local files.
+
+    Args:
+        path: Remote URL (http(s):// or git URL).
+        description: Optional human-readable reason for adding the resource.
+        watch_interval: Auto-refresh cadence in minutes. 0 (default) = no watch. >0 = periodically re-fetch the resource at that cadence (full re-ingest each time). Prefer >=1440 (24h) unless the source genuinely changes faster — every refresh re-embeds the entire resource. Requires `to`.
+        to: Target URI under viking://resources/ (e.g. "viking://resources/volcengine/OpenViking"). Required when watch_interval > 0. Leave empty for one-shot adds — the system will auto-derive a URI from the source.
+    """
     from openviking.server.local_input_guard import require_remote_resource_source
 
     service = get_service()
@@ -367,19 +388,27 @@ async def add_resource(path: str, description: str = "") -> str:
         path = require_remote_resource_source(path)
     except PermissionDeniedError:
         return f"Error: {_LOCAL_FILE_HINT}"
+    if watch_interval > 0 and not to:
+        return f"Error: {_WATCH_REQUIRES_TO_HINT}"
     try:
         result = await service.resources.add_resource(
             path=path,
             ctx=ctx,
+            to=to or None,
             reason=description,
             wait=False,
+            watch_interval=watch_interval,
             enforce_public_remote_targets=True,
         )
         root_uri = result.get("root_uri", "")
+        if watch_interval > 0:
+            watch_suffix = f" (watch enabled, refresh every {watch_interval:g} minute(s))"
+        else:
+            watch_suffix = ""
         return (
-            f"Resource added: {root_uri}"
+            f"Resource added: {root_uri}{watch_suffix}"
             if root_uri
-            else "Resource added (processing in background)."
+            else f"Resource added (processing in background){watch_suffix}."
         )
     except Exception as e:
         return f"Error adding resource: {e}"

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -420,10 +420,11 @@ async def add_resource(
 
 
 # -- watch management ------------------------------------------------------
-# MCP exposes the minimum closure: list + cancel. Pause/resume/trigger/
-# set-interval are intentionally NOT exposed — they're either low-value for
-# agents or invite unwanted autonomous decisions. Power users should reach
-# for the REST API or `ov watch` CLI for those operations.
+# MCP exposes the minimum closure: list + cancel. Pause/resume/trigger and
+# the unified `update` verb are intentionally NOT exposed — they're either
+# low-value for agents or invite unwanted autonomous decisions. Power users
+# should reach for the REST API or the `ov task watch *` CLI (`pause`,
+# `resume`, `trigger`, `update --interval`, etc.) for those operations.
 
 
 @mcp.tool()

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -433,8 +433,6 @@ async def list_watches() -> str:
     Each line shows: target URI, refresh interval (minutes), active/paused status,
     and the next scheduled execution time. Returns "No watch tasks." when empty.
     """
-    from openviking.resource import watch_manager as _wm_mod
-
     service = get_service()
     ctx = _get_ctx()
     scheduler = getattr(service, "watch_scheduler", None)
@@ -443,16 +441,16 @@ async def list_watches() -> str:
     wm = scheduler.watch_manager
     if wm is None:
         return "Error: Watch scheduler not running"
-    try:
-        tasks = await wm.get_all_tasks(
-            ctx.account_id,
-            ctx.user.user_id,
-            ctx.role.value,
-            active_only=False,
-            agent_id=ctx.user.agent_id,
-        )
-    except _wm_mod.PermissionDeniedError as e:
-        return f"Permission denied: {e}"
+    # get_all_tasks does not raise PermissionDeniedError — it silently filters
+    # tasks the caller cannot see (watch_manager.py:596-624), so we just
+    # accept the filtered list.
+    tasks = await wm.get_all_tasks(
+        ctx.account_id,
+        ctx.user.user_id,
+        ctx.role.value,
+        active_only=False,
+        agent_id=ctx.user.agent_id,
+    )
     if not tasks:
         return "No watch tasks."
     lines = []
@@ -492,10 +490,13 @@ async def cancel_watch(to_uri: str) -> str:
     if task is None:
         return f"No watch task found for {to_uri}"
     try:
-        # ok=False here means the task was removed between our lookup and delete
-        # (concurrent cancel). Treat as success — the post-condition the caller
-        # wanted ("no watch on this URI") holds either way.
-        await wm.delete_task(
+        # Return value (bool) is intentionally ignored: delete_task returns
+        # False only when the task was removed between our lookup and the
+        # delete call (a concurrent cancel from another caller). In that case
+        # the post-condition the caller wanted ("no watch on this URI") still
+        # holds, so we report the same success message either way. Permission
+        # errors still surface via the explicit except below.
+        _ = await wm.delete_task(
             task.task_id,
             ctx.account_id,
             ctx.user.user_id,

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -414,6 +414,91 @@ async def add_resource(
         return f"Error adding resource: {e}"
 
 
+# -- watch management ------------------------------------------------------
+# MCP exposes the minimum closure: list + cancel. Pause/resume/trigger/
+# set-interval are intentionally NOT exposed — they're either low-value for
+# agents or invite unwanted autonomous decisions. Power users should reach
+# for the REST API or `ov watch` CLI for those operations.
+
+
+@mcp.tool()
+async def list_watches() -> str:
+    """List watch tasks (auto-refresh subscriptions) visible to the current agent.
+
+    Each line shows: target URI, refresh interval (minutes), active/paused status,
+    and the next scheduled execution time. Returns "No watch tasks." when empty.
+    """
+    from openviking.resource import watch_manager as _wm_mod
+
+    service = get_service()
+    ctx = _get_ctx()
+    scheduler = getattr(service, "watch_scheduler", None)
+    if scheduler is None or not scheduler.is_running:
+        return "Error: Watch scheduler not running"
+    wm = scheduler.watch_manager
+    if wm is None:
+        return "Error: Watch scheduler not running"
+    try:
+        tasks = await wm.get_all_tasks(
+            ctx.account_id,
+            ctx.user.user_id,
+            ctx.role.value,
+            active_only=False,
+            agent_id=ctx.user.agent_id,
+        )
+    except _wm_mod.PermissionDeniedError as e:
+        return f"Permission denied: {e}"
+    if not tasks:
+        return "No watch tasks."
+    lines = []
+    for t in tasks:
+        status = "active" if t.is_active else "paused"
+        nxt = t.next_execution_time.isoformat() if t.next_execution_time else "n/a"
+        lines.append(
+            f"- {t.to_uri or '(no uri)'}  interval={t.watch_interval:g}m  {status}  next={nxt}"
+        )
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def cancel_watch(to_uri: str) -> str:
+    """Cancel (delete) a watch task by its target URI.
+
+    The URI must match the watch task's `to` value (e.g. "viking://resources/volcengine/OpenViking").
+    To change the cadence or pause temporarily, cancel and re-add with a new watch_interval.
+    """
+    from openviking.resource import watch_manager as _wm_mod
+
+    service = get_service()
+    ctx = _get_ctx()
+    scheduler = getattr(service, "watch_scheduler", None)
+    if scheduler is None or not scheduler.is_running:
+        return "Error: Watch scheduler not running"
+    wm = scheduler.watch_manager
+    if wm is None:
+        return "Error: Watch scheduler not running"
+    task = await wm.get_task_by_uri(
+        to_uri,
+        ctx.account_id,
+        ctx.user.user_id,
+        ctx.role.value,
+        ctx.user.agent_id,
+    )
+    if task is None:
+        return f"No watch task found for {to_uri}"
+    try:
+        ok = await wm.delete_task(
+            task.task_id,
+            ctx.account_id,
+            ctx.user.user_id,
+            ctx.role.value,
+            ctx.user.agent_id,
+        )
+    except _wm_mod.PermissionDeniedError:
+        return f"Permission denied for {to_uri}"
+    return f"Watch cancelled: {to_uri}" if ok else f"Failed to cancel: {to_uri}"
+
+
 # -- grep ------------------------------------------------------------------
 
 

--- a/openviking/server/routers/__init__.py
+++ b/openviking/server/routers/__init__.py
@@ -19,6 +19,7 @@ from openviking.server.routers.sessions import router as sessions_router
 from openviking.server.routers.stats import router as stats_router
 from openviking.server.routers.system import router as system_router
 from openviking.server.routers.tasks import router as tasks_router
+from openviking.server.routers.watches import router as watches_router
 from openviking.server.routers.webdav import router as webdav_router
 
 __all__ = [
@@ -39,5 +40,6 @@ __all__ = [
     "metrics_router",
     "observer_router",
     "tasks_router",
+    "watches_router",
     "webdav_router",
 ]

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Watch management endpoints for OpenViking HTTP Server.
+
+Implements RFC #2104 (Watch Management API) on the REST control plane.
+Routes mirror WatchManager primitives with dual-key support: every
+single-resource endpoint accepts either path parameter ``{task_id}`` or
+query parameter ``?to_uri=``. Cross-key conflict returns 400.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Body, Depends, Path, Query
+from pydantic import BaseModel, ConfigDict
+
+from openviking.resource import watch_manager as wm_mod
+from openviking.resource.watch_manager import WatchManager, WatchTask
+from openviking.server.auth import get_request_context
+from openviking.server.dependencies import get_service
+from openviking.server.identity import RequestContext
+from openviking.server.models import Response
+from openviking_cli.exceptions import (
+    FailedPreconditionError,
+    InvalidArgumentError,
+    NotFoundError,
+    PermissionDeniedError,
+)
+
+router = APIRouter(prefix="/api/v1", tags=["watches"])
+
+
+class UpdateWatchRequest(BaseModel):
+    """Partial-update body for PATCH /watches.
+
+    Any field left unset is preserved on the underlying task. ``is_active``
+    and ``watch_interval`` are orthogonal: flip ``is_active`` to pause/resume
+    without losing the configured cadence.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    watch_interval: Optional[float] = None
+    is_active: Optional[bool] = None
+    reason: Optional[str] = None
+    instruction: Optional[str] = None
+
+
+def _wm() -> WatchManager:
+    svc = get_service()
+    scheduler = getattr(svc, "watch_scheduler", None)
+    if scheduler is None or not scheduler.is_running:
+        raise FailedPreconditionError("Watch scheduler not running")
+    wm = scheduler.watch_manager
+    if wm is None:
+        raise FailedPreconditionError("Watch scheduler not running")
+    return wm
+
+
+def _scheduler():
+    svc = get_service()
+    scheduler = getattr(svc, "watch_scheduler", None)
+    if scheduler is None or not scheduler.is_running:
+        raise FailedPreconditionError("Watch scheduler not running")
+    return scheduler
+
+
+def _identity(ctx: RequestContext):
+    return (ctx.account_id, ctx.user.user_id, ctx.role.value, ctx.user.agent_id)
+
+
+async def _resolve_task(
+    task_id: Optional[str],
+    to_uri: Optional[str],
+    ctx: RequestContext,
+) -> WatchTask:
+    """Return the task identified by either task_id (path) or to_uri (query).
+
+    Raises:
+        InvalidArgumentError: both keys supplied, or neither supplied.
+        NotFoundError: no task matches (or caller lacks visibility).
+    """
+    if task_id and to_uri:
+        raise InvalidArgumentError("Specify either path {task_id} or query ?to_uri=, not both")
+    if not task_id and not to_uri:
+        raise InvalidArgumentError("Either {task_id} or ?to_uri= is required")
+
+    wm = _wm()
+    account_id, user_id, role, agent_id = _identity(ctx)
+    if task_id:
+        task = await wm.get_task(task_id, account_id, user_id, role, agent_id)
+    else:
+        task = await wm.get_task_by_uri(to_uri, account_id, user_id, role, agent_id)
+    if task is None:
+        raise NotFoundError(task_id or to_uri or "", "watch_task")
+    return task
+
+
+def _translate_perm(exc: wm_mod.PermissionDeniedError, target: str) -> PermissionDeniedError:
+    """Convert watch_manager's own PermissionDeniedError (plain Exception)
+    into the OpenVikingError-rooted one so the global handler renders 403.
+    """
+    return PermissionDeniedError(str(exc) or "Permission denied", resource=target)
+
+
+@router.get("/watches")
+async def list_or_get_watch(
+    active_only: bool = Query(False, description="Only return tasks with is_active=true"),
+    to_uri: Optional[str] = Query(None, description="If set, return the single task with this URI"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """List watch tasks, or look one up by ``to_uri``.
+
+    Without ``to_uri`` returns ``{tasks: [...], total: N}``. With ``to_uri``
+    returns the single matching task object (404 if missing).
+    """
+    wm = _wm()
+    account_id, user_id, role, agent_id = _identity(_ctx)
+    if to_uri:
+        task = await wm.get_task_by_uri(to_uri, account_id, user_id, role, agent_id)
+        if task is None:
+            raise NotFoundError(to_uri, "watch_task")
+        return Response(status="ok", result=task.to_dict())
+    tasks = await wm.get_all_tasks(
+        account_id, user_id, role, active_only=active_only, agent_id=agent_id
+    )
+    return Response(
+        status="ok", result={"tasks": [t.to_dict() for t in tasks], "total": len(tasks)}
+    )
+
+
+@router.get("/watches/{task_id}")
+async def get_watch(
+    task_id: str = Path(..., description="Watch task ID"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Get a single watch task by ID."""
+    task = await _resolve_task(task_id, None, _ctx)
+    return Response(status="ok", result=task.to_dict())
+
+
+async def _patch_impl(target: WatchTask, body: UpdateWatchRequest, ctx: RequestContext):
+    wm = _wm()
+    account_id, user_id, role, agent_id = _identity(ctx)
+    try:
+        updated = await wm.update_task(
+            target.task_id,
+            account_id,
+            user_id,
+            role,
+            agent_id=agent_id,
+            watch_interval=body.watch_interval,
+            is_active=body.is_active,
+            reason=body.reason,
+            instruction=body.instruction,
+        )
+    except wm_mod.PermissionDeniedError as e:
+        raise _translate_perm(e, target.to_uri or target.task_id) from e
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg.lower():
+            raise NotFoundError(target.task_id, "watch_task") from e
+        raise InvalidArgumentError(msg) from e
+    return Response(status="ok", result=updated.to_dict())
+
+
+@router.patch("/watches/{task_id}")
+async def patch_watch_by_id(
+    task_id: str = Path(..., description="Watch task ID"),
+    body: UpdateWatchRequest = Body(...),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Partial update by task_id. Fields left null are preserved."""
+    task = await _resolve_task(task_id, None, _ctx)
+    return await _patch_impl(task, body, _ctx)
+
+
+@router.patch("/watches")
+async def patch_watch_by_uri(
+    to_uri: str = Query(..., description="Target URI of the watch task"),
+    body: UpdateWatchRequest = Body(...),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Partial update by to_uri (query parameter)."""
+    task = await _resolve_task(None, to_uri, _ctx)
+    return await _patch_impl(task, body, _ctx)
+
+
+async def _delete_impl(target: WatchTask, ctx: RequestContext):
+    wm = _wm()
+    account_id, user_id, role, agent_id = _identity(ctx)
+    try:
+        ok = await wm.delete_task(target.task_id, account_id, user_id, role, agent_id)
+    except wm_mod.PermissionDeniedError as e:
+        raise _translate_perm(e, target.to_uri or target.task_id) from e
+    if not ok:
+        raise NotFoundError(target.task_id, "watch_task")
+    return Response(
+        status="ok",
+        result={"task_id": target.task_id, "to_uri": target.to_uri, "deleted": True},
+    )
+
+
+@router.delete("/watches/{task_id}")
+async def delete_watch_by_id(
+    task_id: str = Path(..., description="Watch task ID"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Delete a watch task by ID."""
+    task = await _resolve_task(task_id, None, _ctx)
+    return await _delete_impl(task, _ctx)
+
+
+@router.delete("/watches")
+async def delete_watch_by_uri(
+    to_uri: str = Query(..., description="Target URI of the watch task"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Delete a watch task by to_uri."""
+    task = await _resolve_task(None, to_uri, _ctx)
+    return await _delete_impl(task, _ctx)
+
+
+async def _trigger_impl(target: WatchTask):
+    scheduler = _scheduler()
+    ok = await scheduler.schedule_task(target.task_id)
+    return Response(
+        status="ok",
+        result={"task_id": target.task_id, "to_uri": target.to_uri, "scheduled": ok},
+    )
+
+
+@router.post("/watches/{task_id}/trigger")
+async def trigger_watch_by_id(
+    task_id: str = Path(..., description="Watch task ID"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Immediately schedule the watch task for execution.
+
+    Returns ``scheduled=false`` if the task is already running or unknown to
+    the scheduler. Does not wait for completion.
+    """
+    task = await _resolve_task(task_id, None, _ctx)
+    return await _trigger_impl(task)
+
+
+@router.post("/watches/trigger")
+async def trigger_watch_by_uri(
+    to_uri: str = Query(..., description="Target URI of the watch task"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Trigger by to_uri."""
+    task = await _resolve_task(None, to_uri, _ctx)
+    return await _trigger_impl(task)

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -8,6 +8,7 @@ single-resource endpoint accepts either path parameter ``{task_id}`` or
 query parameter ``?to_uri=``. Cross-key conflict returns 400.
 """
 
+import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Path, Query
@@ -93,6 +94,13 @@ async def _resolve_task(
         task = await wm.get_task(task_id, account_id, user_id, role, agent_id)
     else:
         task = await wm.get_task_by_uri(to_uri, account_id, user_id, role, agent_id)
+    # `wm.get_task*` return None for both "task does not exist" and "task
+    # exists but the caller fails the permission check" (watch_manager.py
+    # `_check_permission`). Collapsing both into 404 is deliberate: it avoids
+    # leaking the existence of another tenant's task to an unauthorized
+    # caller. The trade-off is that callers see 404 instead of 403 on a
+    # cross-tenant access attempt, which matches the security-first stance
+    # used elsewhere in OpenViking.
     if task is None:
         raise NotFoundError(task_id or to_uri or "", "watch_task")
     if task_id and to_uri and task.to_uri != to_uri:
@@ -140,8 +148,12 @@ async def get_watch(
     task_id: str = Path(..., description="Watch task ID"),
     to_uri: Optional[str] = Query(
         None,
-        description="Optional. When supplied together with {task_id} the two must "
-        "refer to the same task, otherwise 400. Use it as a cross-key sanity check.",
+        description=(
+            "Optional cross-key sanity check. If supplied, must equal the "
+            "task's current `to_uri`; otherwise the request is rejected with "
+            "400. Useful when the caller has both pieces of information and "
+            "wants to guard against acting on a stale task_id."
+        ),
     ),
     _ctx: RequestContext = Depends(get_request_context),
 ):
@@ -188,7 +200,17 @@ async def _patch_impl(target: WatchTask, body: UpdateWatchRequest, ctx: RequestC
 @router.patch("/watches/{task_id}")
 async def patch_watch_by_id(
     task_id: str = Path(..., description="Watch task ID"),
-    to_uri: Optional[str] = Query(None, description="Optional cross-key check; see GET."),
+    to_uri: Optional[str] = Query(
+        None,
+        description=(
+            "Optional cross-key sanity check. If supplied, must equal the "
+            "task's current `to_uri`; otherwise the request is rejected with "
+            "400. Useful when the caller has both pieces of information and "
+            "wants to guard against acting on a stale task_id — but a wrong "
+            "value here will block DELETE/PATCH/trigger on an otherwise valid "
+            "task, so omit it unless the cross-check is desired."
+        ),
+    ),
     body: UpdateWatchRequest = Body(...),
     _ctx: RequestContext = Depends(get_request_context),
 ):
@@ -226,7 +248,17 @@ async def _delete_impl(target: WatchTask, ctx: RequestContext):
 @router.delete("/watches/{task_id}")
 async def delete_watch_by_id(
     task_id: str = Path(..., description="Watch task ID"),
-    to_uri: Optional[str] = Query(None, description="Optional cross-key check; see GET."),
+    to_uri: Optional[str] = Query(
+        None,
+        description=(
+            "Optional cross-key sanity check. If supplied, must equal the "
+            "task's current `to_uri`; otherwise the request is rejected with "
+            "400. Useful when the caller has both pieces of information and "
+            "wants to guard against acting on a stale task_id — but a wrong "
+            "value here will block DELETE/PATCH/trigger on an otherwise valid "
+            "task, so omit it unless the cross-check is desired."
+        ),
+    ),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Delete a watch task by ID."""
@@ -245,24 +277,44 @@ async def delete_watch_by_uri(
 
 
 async def _trigger_impl(target: WatchTask):
+    """Dispatch a scheduling request without waiting for execution.
+
+    `WatchScheduler.schedule_task` awaits `_execute_task` inline, which runs
+    the full re-ingest (re-fetch + re-parse + re-embed) and can take many
+    seconds. We don't want HTTP requests blocked for that long, so the call
+    is fired off via `asyncio.create_task` and the response returns
+    immediately with ``scheduled=true``. Actual success/failure is observable
+    via subsequent `GET /watches/{task_id}` (last_execution_time updates).
+    """
     scheduler = _scheduler()
-    ok = await scheduler.schedule_task(target.task_id)
+    asyncio.create_task(scheduler.schedule_task(target.task_id))
     return Response(
         status="ok",
-        result={"task_id": target.task_id, "to_uri": target.to_uri, "scheduled": ok},
+        result={"task_id": target.task_id, "to_uri": target.to_uri, "scheduled": True},
     )
 
 
 @router.post("/watches/{task_id}/trigger")
 async def trigger_watch_by_id(
     task_id: str = Path(..., description="Watch task ID"),
-    to_uri: Optional[str] = Query(None, description="Optional cross-key check; see GET."),
+    to_uri: Optional[str] = Query(
+        None,
+        description=(
+            "Optional cross-key sanity check. If supplied, must equal the "
+            "task's current `to_uri`; otherwise the request is rejected with "
+            "400. Useful when the caller has both pieces of information and "
+            "wants to guard against acting on a stale task_id — but a wrong "
+            "value here will block DELETE/PATCH/trigger on an otherwise valid "
+            "task, so omit it unless the cross-check is desired."
+        ),
+    ),
     _ctx: RequestContext = Depends(get_request_context),
 ):
-    """Immediately schedule the watch task for execution.
+    """Immediately schedule the watch task for execution (fire-and-forget).
 
-    Returns ``scheduled=false`` if the task is already running or unknown to
-    the scheduler. Does not wait for completion.
+    Dispatches the scheduling request asynchronously and returns right away;
+    the actual re-fetch runs in the background. Poll
+    ``GET /watches/{task_id}.last_execution_time`` to confirm completion.
     """
     task = await _resolve_task(task_id, to_uri, _ctx)
     return await _trigger_impl(task)
@@ -273,6 +325,6 @@ async def trigger_watch_by_uri(
     to_uri: str = Query(..., description="Target URI of the watch task"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
-    """Trigger by to_uri."""
+    """Trigger by to_uri (fire-and-forget; see by-id variant for semantics)."""
     task = await _resolve_task(None, to_uri, _ctx)
     return await _trigger_impl(task)

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -29,6 +29,14 @@ from openviking_cli.exceptions import (
 
 router = APIRouter(prefix="/api/v1", tags=["watches"])
 
+# Strong refs for in-flight fire-and-forget trigger tasks. Python asyncio
+# only keeps weak references to tasks created via asyncio.create_task, so a
+# task without an external strong reference can be garbage-collected
+# mid-execution and silently aborted. We hold each task here until it
+# completes and discard via done_callback. See
+# https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+_BACKGROUND_TRIGGER_TASKS: set[asyncio.Task] = set()
+
 
 class UpdateWatchRequest(BaseModel):
     """Partial-update body for PATCH /watches.
@@ -126,13 +134,15 @@ async def list_or_get_watch(
     """List watch tasks, or look one up by ``to_uri``.
 
     Without ``to_uri`` returns ``{tasks: [...], total: N}``. With ``to_uri``
-    returns the single matching task object (404 if missing).
+    returns the single matching task object (404 if missing). When both
+    ``to_uri`` and ``active_only=true`` are supplied, a paused task at that
+    URI still 404s — the active-only filter stays consistent in both modes.
     """
     wm = _wm()
     account_id, user_id, role, agent_id = _identity(_ctx)
     if to_uri:
         task = await wm.get_task_by_uri(to_uri, account_id, user_id, role, agent_id)
-        if task is None:
+        if task is None or (active_only and not task.is_active):
             raise NotFoundError(to_uri, "watch_task")
         return Response(status="ok", result=task.to_dict())
     tasks = await wm.get_all_tasks(
@@ -287,7 +297,9 @@ async def _trigger_impl(target: WatchTask):
     via subsequent `GET /watches/{task_id}` (last_execution_time updates).
     """
     scheduler = _scheduler()
-    asyncio.create_task(scheduler.schedule_task(target.task_id))
+    task = asyncio.create_task(scheduler.schedule_task(target.task_id))
+    _BACKGROUND_TRIGGER_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TRIGGER_TASKS.discard)
     return Response(
         status="ok",
         result={"task_id": target.task_id, "to_uri": target.to_uri, "scheduled": True},

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -75,12 +75,15 @@ async def _resolve_task(
 ) -> WatchTask:
     """Return the task identified by either task_id (path) or to_uri (query).
 
+    When both keys are given they must refer to the same task — this enables
+    callers to double-key cross-validate. Rejection happens only when the
+    two keys disagree, not just because both are present.
+
     Raises:
-        InvalidArgumentError: both keys supplied, or neither supplied.
+        InvalidArgumentError: neither key supplied, or both supplied but they
+            resolve to different tasks.
         NotFoundError: no task matches (or caller lacks visibility).
     """
-    if task_id and to_uri:
-        raise InvalidArgumentError("Specify either path {task_id} or query ?to_uri=, not both")
     if not task_id and not to_uri:
         raise InvalidArgumentError("Either {task_id} or ?to_uri= is required")
 
@@ -92,6 +95,10 @@ async def _resolve_task(
         task = await wm.get_task_by_uri(to_uri, account_id, user_id, role, agent_id)
     if task is None:
         raise NotFoundError(task_id or to_uri or "", "watch_task")
+    if task_id and to_uri and task.to_uri != to_uri:
+        raise InvalidArgumentError(
+            f"task_id {task_id} maps to to_uri={task.to_uri!r}, not {to_uri!r}"
+        )
     return task
 
 
@@ -131,14 +138,32 @@ async def list_or_get_watch(
 @router.get("/watches/{task_id}")
 async def get_watch(
     task_id: str = Path(..., description="Watch task ID"),
+    to_uri: Optional[str] = Query(
+        None,
+        description="Optional. When supplied together with {task_id} the two must "
+        "refer to the same task, otherwise 400. Use it as a cross-key sanity check.",
+    ),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Get a single watch task by ID."""
-    task = await _resolve_task(task_id, None, _ctx)
+    task = await _resolve_task(task_id, to_uri, _ctx)
     return Response(status="ok", result=task.to_dict())
 
 
 async def _patch_impl(target: WatchTask, body: UpdateWatchRequest, ctx: RequestContext):
+    """Forward to WatchManager.update_task.
+
+    Exception translation: `watch_manager.PermissionDeniedError` is a plain
+    Exception (not an OpenVikingError) so the global handler would not turn it
+    into a 403 — we translate it explicitly. Any other watch_manager exception
+    that already inherits from OpenVikingError (e.g. ConflictError) bubbles
+    untouched and the global handler maps it to the right HTTP status.
+
+    `ValueError` from update_task is currently only used for "task not found"
+    after the inner lock acquires, which is a race window past the
+    `_resolve_task` pre-check (e.g. another caller deleted the task). We map
+    it to 404 to stay consistent with the pre-check behavior.
+    """
     wm = _wm()
     account_id, user_id, role, agent_id = _identity(ctx)
     try:
@@ -156,21 +181,19 @@ async def _patch_impl(target: WatchTask, body: UpdateWatchRequest, ctx: RequestC
     except wm_mod.PermissionDeniedError as e:
         raise _translate_perm(e, target.to_uri or target.task_id) from e
     except ValueError as e:
-        msg = str(e)
-        if "not found" in msg.lower():
-            raise NotFoundError(target.task_id, "watch_task") from e
-        raise InvalidArgumentError(msg) from e
+        raise NotFoundError(target.task_id, "watch_task") from e
     return Response(status="ok", result=updated.to_dict())
 
 
 @router.patch("/watches/{task_id}")
 async def patch_watch_by_id(
     task_id: str = Path(..., description="Watch task ID"),
+    to_uri: Optional[str] = Query(None, description="Optional cross-key check; see GET."),
     body: UpdateWatchRequest = Body(...),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Partial update by task_id. Fields left null are preserved."""
-    task = await _resolve_task(task_id, None, _ctx)
+    task = await _resolve_task(task_id, to_uri, _ctx)
     return await _patch_impl(task, body, _ctx)
 
 
@@ -203,10 +226,11 @@ async def _delete_impl(target: WatchTask, ctx: RequestContext):
 @router.delete("/watches/{task_id}")
 async def delete_watch_by_id(
     task_id: str = Path(..., description="Watch task ID"),
+    to_uri: Optional[str] = Query(None, description="Optional cross-key check; see GET."),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Delete a watch task by ID."""
-    task = await _resolve_task(task_id, None, _ctx)
+    task = await _resolve_task(task_id, to_uri, _ctx)
     return await _delete_impl(task, _ctx)
 
 
@@ -232,6 +256,7 @@ async def _trigger_impl(target: WatchTask):
 @router.post("/watches/{task_id}/trigger")
 async def trigger_watch_by_id(
     task_id: str = Path(..., description="Watch task ID"),
+    to_uri: Optional[str] = Query(None, description="Optional cross-key check; see GET."),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Immediately schedule the watch task for execution.
@@ -239,7 +264,7 @@ async def trigger_watch_by_id(
     Returns ``scheduled=false`` if the task is already running or unknown to
     the scheduler. Does not wait for completion.
     """
-    task = await _resolve_task(task_id, None, _ctx)
+    task = await _resolve_task(task_id, to_uri, _ctx)
     return await _trigger_impl(task)
 
 

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -12,7 +12,7 @@ import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Path, Query
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from openviking.resource import watch_manager as wm_mod
 from openviking.resource.watch_manager import WatchManager, WatchTask
@@ -52,6 +52,22 @@ class UpdateWatchRequest(BaseModel):
     is_active: Optional[bool] = None
     reason: Optional[str] = None
     instruction: Optional[str] = None
+
+    @field_validator("watch_interval")
+    @classmethod
+    def _interval_must_be_positive(cls, value: Optional[float]) -> Optional[float]:
+        # `None` means "leave unchanged" — only validate when the caller
+        # actually supplied a value. Mirrors the CLI/MCP boundary checks so
+        # the three control planes agree on "non-positive is invalid".
+        # Without this, PATCH would persist `watch_interval <= 0`, which then
+        # makes a later `is_active=true` resume fail inside update_task with
+        # ValueError and surface as 404.
+        if value is not None and value <= 0:
+            raise ValueError(
+                "watch_interval must be > 0 (use is_active=false to pause "
+                "without losing the cadence)"
+            )
+        return value
 
 
 def _wm() -> WatchManager:

--- a/tests/server/test_api_watches.py
+++ b/tests/server/test_api_watches.py
@@ -136,22 +136,23 @@ async def test_active_only_filter(client: httpx.AsyncClient, watch_manager):
     assert paused.task_id in ids
 
 
-async def test_dual_key_conflict_returns_400(client: httpx.AsyncClient, watch_manager):
-    """PATCH /watches/{task_id} cannot also accept ?to_uri=. They're separate routes —
-    here we check that the explicit conflict on the by-uri PATCH (with a path-shaped key
-    in the URL fragment) returns 400 via _resolve_task's guard.
-
-    Note: FastAPI routes path vs query parameter URLs separately, so the only true
-    "both keys" scenario is a manual fetch with both — exercised here via DELETE with
-    both id path and to_uri query.
-    """
-    task = await _seed(watch_manager, to_uri="viking://resources/test/dual")
-    resp = await client.delete(f"/api/v1/watches/{task.task_id}", params={"to_uri": task.to_uri})
-    # FastAPI matches the path-with-id route first; that route ignores extra ?to_uri.
-    # The conflict is enforced only when _resolve_task receives both values. Since
-    # the path-id route does NOT pass to_uri to the resolver, this scenario actually
-    # succeeds. Verify the path route deletes cleanly.
+async def test_dual_key_matching_accepted(client: httpx.AsyncClient, watch_manager):
+    """When both {task_id} and ?to_uri= are supplied and resolve to the SAME task,
+    the request succeeds (useful as a cross-key sanity check from clients that
+    have both pieces of information)."""
+    task = await _seed(watch_manager, to_uri="viking://resources/test/dual-ok")
+    resp = await client.get(f"/api/v1/watches/{task.task_id}", params={"to_uri": task.to_uri})
     assert resp.status_code == 200
+    assert resp.json()["result"]["task_id"] == task.task_id
+
+
+async def test_dual_key_mismatch_returns_400(client: httpx.AsyncClient, watch_manager):
+    """When {task_id} and ?to_uri= refer to DIFFERENT tasks, return 400."""
+    a = await _seed(watch_manager, to_uri="viking://resources/test/dual-a")
+    b = await _seed(watch_manager, to_uri="viking://resources/test/dual-b")
+    # Use a's task_id but b's to_uri — they disagree.
+    resp = await client.get(f"/api/v1/watches/{a.task_id}", params={"to_uri": b.to_uri})
+    assert resp.status_code == 400
 
 
 async def test_delete_missing_key_400(client: httpx.AsyncClient):
@@ -170,16 +171,21 @@ async def test_not_found_404(client: httpx.AsyncClient):
     assert resp.status_code == 404
 
 
-async def test_patch_to_uri_conflict_returns_409(client: httpx.AsyncClient, watch_manager):
-    a = await _seed(watch_manager, to_uri="viking://resources/test/a")
-    b = await _seed(watch_manager, to_uri="viking://resources/test/b")
-    # Try to rename b's to_uri to collide with a — currently exposed via PATCH? No:
-    # UpdateWatchRequest only allows watch_interval / is_active / reason / instruction.
-    # Watch_manager.update_task supports to_uri but we deliberately don't expose it.
-    # So we cannot trigger ConflictError via the REST PATCH. Verify the request just
-    # ignores the disallowed field (extra="forbid") with 422.
-    resp = await client.patch(f"/api/v1/watches/{b.task_id}", json={"to_uri": a.to_uri})
-    assert resp.status_code == 422  # extra fields forbidden
+async def test_patch_rejects_unknown_field(client: httpx.AsyncClient, watch_manager):
+    """UpdateWatchRequest has extra='forbid'; passing a field outside the allowed
+    set (watch_interval / is_active / reason / instruction) returns 422.
+
+    Note: `to_uri` is intentionally NOT exposed via PATCH. WatchManager's
+    update_task supports rebinding to_uri (which is the only mutation that can
+    raise ConflictError on the watch side), but we want to-uri assignment to
+    be a delete-and-recreate operation for clarity, not an in-place mutation.
+    """
+    task = await _seed(watch_manager, to_uri="viking://resources/test/forbid")
+    resp = await client.patch(
+        f"/api/v1/watches/{task.task_id}",
+        json={"to_uri": "viking://resources/test/other"},
+    )
+    assert resp.status_code == 422
 
 
 async def test_trigger_by_uri(client: httpx.AsyncClient, watch_manager, monkeypatch):

--- a/tests/server/test_api_watches.py
+++ b/tests/server/test_api_watches.py
@@ -179,6 +179,26 @@ async def test_not_found_404(client: httpx.AsyncClient):
     assert resp.status_code == 404
 
 
+async def test_patch_rejects_non_positive_watch_interval(client: httpx.AsyncClient, watch_manager):
+    """REST PATCH must reject `watch_interval <= 0` at the request boundary.
+
+    Without the field_validator, a negative or zero value would be forwarded
+    to WatchManager.update_task, which deactivates the task and stores the
+    bad cadence. A later resume (`is_active=true`) then fails inside
+    update_task with ValueError → 404, misleading callers about the root
+    cause. Reject upfront with 422 instead, matching CLI/MCP semantics.
+    """
+    task = await _seed(watch_manager, to_uri="viking://resources/test/nonpos")
+    for bad in [-1, 0, -42.5]:
+        resp = await client.patch(
+            f"/api/v1/watches/{task.task_id}",
+            json={"watch_interval": bad},
+        )
+        assert resp.status_code == 422, (
+            f"watch_interval={bad} should be 422, got {resp.status_code}: {resp.text[:200]}"
+        )
+
+
 async def test_patch_rejects_unknown_field(client: httpx.AsyncClient, watch_manager):
     """UpdateWatchRequest has extra='forbid'; passing a field outside the allowed
     set (watch_interval / is_active / reason / instruction) returns 422.

--- a/tests/server/test_api_watches.py
+++ b/tests/server/test_api_watches.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for watch management endpoints (RFC #2104)."""
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def watch_manager(service):
+    wm = service.watch_scheduler.watch_manager
+    assert wm is not None, "WatchScheduler must be running for these tests"
+    return wm
+
+
+async def _seed(
+    wm,
+    *,
+    to_uri="viking://resources/test/foo",
+    account="default",
+    user="default",
+    agent="default",
+    role="user",
+    interval=60.0,
+    path="https://example.com/foo",
+):
+    return await wm.create_task(
+        path=path,
+        account_id=account,
+        user_id=user,
+        agent_id=agent,
+        original_role=role,
+        to_uri=to_uri,
+        watch_interval=interval,
+    )
+
+
+async def test_list_empty(client: httpx.AsyncClient):
+    resp = await client.get("/api/v1/watches")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"] == {"tasks": [], "total": 0}
+
+
+async def test_full_lifecycle(client: httpx.AsyncClient, watch_manager, monkeypatch):
+    task = await _seed(watch_manager)
+
+    # List
+    resp = await client.get("/api/v1/watches")
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["total"] == 1
+    assert body["result"]["tasks"][0]["task_id"] == task.task_id
+    assert body["result"]["tasks"][0]["to_uri"] == task.to_uri
+
+    # Get by ID
+    resp = await client.get(f"/api/v1/watches/{task.task_id}")
+    assert resp.status_code == 200
+    assert resp.json()["result"]["task_id"] == task.task_id
+
+    # Get by URI (via list endpoint with ?to_uri=)
+    resp = await client.get("/api/v1/watches", params={"to_uri": task.to_uri})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["task_id"] == task.task_id
+
+    # PATCH watch_interval
+    resp = await client.patch(
+        f"/api/v1/watches/{task.task_id}",
+        json={"watch_interval": 4320},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"]["watch_interval"] == 4320
+
+    # PATCH is_active=false (pause)
+    resp = await client.patch(
+        f"/api/v1/watches/{task.task_id}",
+        json={"is_active": False},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"]["is_active"] is False
+    assert resp.json()["result"]["next_execution_time"] is None
+
+    # POST trigger — monkeypatch scheduler so we don't actually run a fetch
+    triggered = []
+
+    async def fake_schedule(task_id):
+        triggered.append(task_id)
+        return True
+
+    monkeypatch.setattr(
+        "openviking.resource.watch_scheduler.WatchScheduler.schedule_task",
+        fake_schedule,
+    )
+    resp = await client.post(f"/api/v1/watches/{task.task_id}/trigger")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["scheduled"] is True
+    assert triggered == [task.task_id]
+
+    # DELETE
+    resp = await client.delete(f"/api/v1/watches/{task.task_id}")
+    assert resp.status_code == 200
+    assert resp.json()["result"]["deleted"] is True
+
+    # Subsequent GET → 404
+    resp = await client.get(f"/api/v1/watches/{task.task_id}")
+    assert resp.status_code == 404
+
+
+async def test_get_by_uri_returns_single_object(client: httpx.AsyncClient, watch_manager):
+    task = await _seed(watch_manager, to_uri="viking://resources/test/uri-keyed")
+    resp = await client.get("/api/v1/watches", params={"to_uri": task.to_uri})
+    assert resp.status_code == 200
+    body = resp.json()
+    # When to_uri is given, result is single object (not the {tasks, total} envelope)
+    assert "task_id" in body["result"]
+    assert "tasks" not in body["result"]
+
+
+async def test_active_only_filter(client: httpx.AsyncClient, watch_manager):
+    active = await _seed(watch_manager, to_uri="viking://resources/test/active")
+    paused = await _seed(watch_manager, to_uri="viking://resources/test/paused")
+    await watch_manager.update_task(paused.task_id, "default", "default", "root", is_active=False)
+
+    resp = await client.get("/api/v1/watches", params={"active_only": "true"})
+    ids = {t["task_id"] for t in resp.json()["result"]["tasks"]}
+    assert active.task_id in ids
+    assert paused.task_id not in ids
+
+    resp = await client.get("/api/v1/watches", params={"active_only": "false"})
+    ids = {t["task_id"] for t in resp.json()["result"]["tasks"]}
+    assert active.task_id in ids
+    assert paused.task_id in ids
+
+
+async def test_dual_key_conflict_returns_400(client: httpx.AsyncClient, watch_manager):
+    """PATCH /watches/{task_id} cannot also accept ?to_uri=. They're separate routes —
+    here we check that the explicit conflict on the by-uri PATCH (with a path-shaped key
+    in the URL fragment) returns 400 via _resolve_task's guard.
+
+    Note: FastAPI routes path vs query parameter URLs separately, so the only true
+    "both keys" scenario is a manual fetch with both — exercised here via DELETE with
+    both id path and to_uri query.
+    """
+    task = await _seed(watch_manager, to_uri="viking://resources/test/dual")
+    resp = await client.delete(f"/api/v1/watches/{task.task_id}", params={"to_uri": task.to_uri})
+    # FastAPI matches the path-with-id route first; that route ignores extra ?to_uri.
+    # The conflict is enforced only when _resolve_task receives both values. Since
+    # the path-id route does NOT pass to_uri to the resolver, this scenario actually
+    # succeeds. Verify the path route deletes cleanly.
+    assert resp.status_code == 200
+
+
+async def test_delete_missing_key_400(client: httpx.AsyncClient):
+    """DELETE /watches without {task_id} path and without ?to_uri= must 400."""
+    resp = await client.delete("/api/v1/watches")
+    # The by-uri route requires to_uri as a Query(...) so FastAPI will 422 it.
+    assert resp.status_code == 422
+
+
+async def test_not_found_404(client: httpx.AsyncClient):
+    resp = await client.delete("/api/v1/watches/no-such-task-id")
+    assert resp.status_code == 404
+    resp = await client.get("/api/v1/watches/no-such-task-id")
+    assert resp.status_code == 404
+    resp = await client.patch("/api/v1/watches/no-such-task-id", json={"is_active": False})
+    assert resp.status_code == 404
+
+
+async def test_patch_to_uri_conflict_returns_409(client: httpx.AsyncClient, watch_manager):
+    a = await _seed(watch_manager, to_uri="viking://resources/test/a")
+    b = await _seed(watch_manager, to_uri="viking://resources/test/b")
+    # Try to rename b's to_uri to collide with a — currently exposed via PATCH? No:
+    # UpdateWatchRequest only allows watch_interval / is_active / reason / instruction.
+    # Watch_manager.update_task supports to_uri but we deliberately don't expose it.
+    # So we cannot trigger ConflictError via the REST PATCH. Verify the request just
+    # ignores the disallowed field (extra="forbid") with 422.
+    resp = await client.patch(f"/api/v1/watches/{b.task_id}", json={"to_uri": a.to_uri})
+    assert resp.status_code == 422  # extra fields forbidden
+
+
+async def test_trigger_by_uri(client: httpx.AsyncClient, watch_manager, monkeypatch):
+    task = await _seed(watch_manager, to_uri="viking://resources/test/trig")
+
+    triggered = []
+
+    async def fake_schedule(self, task_id):
+        triggered.append(task_id)
+        return True
+
+    monkeypatch.setattr(
+        "openviking.resource.watch_scheduler.WatchScheduler.schedule_task",
+        fake_schedule,
+    )
+    resp = await client.post("/api/v1/watches/trigger", params={"to_uri": task.to_uri})
+    assert resp.status_code == 200
+    assert triggered == [task.task_id]
+
+
+async def test_patch_partial_preserves_unset_fields(client: httpx.AsyncClient, watch_manager):
+    task = await _seed(watch_manager, to_uri="viking://resources/test/partial")
+    original_interval = task.watch_interval
+
+    # PATCH only is_active — interval should not change
+    resp = await client.patch(f"/api/v1/watches/{task.task_id}", json={"is_active": False})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["watch_interval"] == original_interval
+    assert body["result"]["is_active"] is False

--- a/tests/server/test_api_watches.py
+++ b/tests/server/test_api_watches.py
@@ -3,6 +3,8 @@
 
 """Tests for watch management endpoints (RFC #2104)."""
 
+import asyncio
+
 import httpx
 import pytest
 
@@ -83,11 +85,15 @@ async def test_full_lifecycle(client: httpx.AsyncClient, watch_manager, monkeypa
     assert resp.json()["result"]["is_active"] is False
     assert resp.json()["result"]["next_execution_time"] is None
 
-    # POST trigger — monkeypatch scheduler so we don't actually run a fetch
+    # POST trigger — monkeypatch scheduler so we don't actually run a fetch.
+    # Class-level setattr means the function is bound as a method, so the
+    # fake must accept `self` (the WatchScheduler instance) as first arg.
     triggered = []
+    schedule_started = asyncio.Event()
 
-    async def fake_schedule(task_id):
+    async def fake_schedule(_self, task_id):
         triggered.append(task_id)
+        schedule_started.set()
         return True
 
     monkeypatch.setattr(
@@ -98,6 +104,8 @@ async def test_full_lifecycle(client: httpx.AsyncClient, watch_manager, monkeypa
     assert resp.status_code == 200
     body = resp.json()
     assert body["result"]["scheduled"] is True
+    # Trigger is fire-and-forget — wait briefly for the background task to run.
+    await asyncio.wait_for(schedule_started.wait(), timeout=2.0)
     assert triggered == [task.task_id]
 
     # DELETE
@@ -192,9 +200,11 @@ async def test_trigger_by_uri(client: httpx.AsyncClient, watch_manager, monkeypa
     task = await _seed(watch_manager, to_uri="viking://resources/test/trig")
 
     triggered = []
+    schedule_started = asyncio.Event()
 
-    async def fake_schedule(self, task_id):
+    async def fake_schedule(_self, task_id):
         triggered.append(task_id)
+        schedule_started.set()
         return True
 
     monkeypatch.setattr(
@@ -203,6 +213,7 @@ async def test_trigger_by_uri(client: httpx.AsyncClient, watch_manager, monkeypa
     )
     resp = await client.post("/api/v1/watches/trigger", params={"to_uri": task.to_uri})
     assert resp.status_code == 200
+    await asyncio.wait_for(schedule_started.wait(), timeout=2.0)
     assert triggered == [task.task_id]
 
 

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -335,6 +335,22 @@ async def test_add_resource_watch_requires_to(service):
     assert "watch_interval > 0 requires `to`" in result
 
 
+async def test_add_resource_rejects_negative_watch_interval(service):
+    """watch_interval < 0 is rejected at the MCP boundary, even when `to` is given.
+
+    Without this guard, a negative value would bypass the `> 0 requires to`
+    check (passing the `> 0` comparison as false) and be forwarded into
+    the service layer with undefined semantics.
+    """
+    result = await add_resource(
+        path="https://example.com/foo",
+        watch_interval=-1,
+        to="viking://resources/test/neg",
+    )
+    assert "error" in result.lower()
+    assert "watch_interval must be >= 0" in result
+
+
 # ---------------------------------------------------------------------------
 # list_watches / cancel_watch tools
 # ---------------------------------------------------------------------------

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -20,10 +20,12 @@ from openviking.server.mcp_endpoint import (
     _get_ctx,
     _mcp_ctx,
     add_resource,
+    cancel_watch,
     forget,
     glob,
     grep,
     health,
+    list_watches,
     read,
     remember,
     search,
@@ -321,6 +323,61 @@ async def test_add_resource_rejects_bare_filename_with_cli_hint(service):
     result = await add_resource(path="some_local_file.md")
     assert "error" in result.lower()
     assert "ov add-resource" in result
+
+
+async def test_add_resource_watch_requires_to(service):
+    """watch_interval > 0 without `to` returns hint about deterministic URI."""
+    result = await add_resource(
+        path="https://example.com/foo",
+        watch_interval=1440,
+    )
+    assert "error" in result.lower()
+    assert "watch_interval > 0 requires `to`" in result
+
+
+# ---------------------------------------------------------------------------
+# list_watches / cancel_watch tools
+# ---------------------------------------------------------------------------
+
+
+async def _seed_watch(service, to_uri="viking://resources/test/foo"):
+    wm = service.watch_scheduler.watch_manager
+    return await wm.create_task(
+        path="https://example.com/foo",
+        account_id=DEFAULT_CTX.account_id,
+        user_id=DEFAULT_CTX.user.user_id,
+        agent_id=DEFAULT_CTX.user.agent_id,
+        original_role="root",
+        to_uri=to_uri,
+        watch_interval=1440.0,
+    )
+
+
+async def test_list_watches_empty(service):
+    result = await list_watches()
+    assert "no watch" in result.lower()
+
+
+async def test_list_watches_with_seed(service):
+    task = await _seed_watch(service, to_uri="viking://resources/test/list")
+    result = await list_watches()
+    assert task.to_uri in result
+    assert "active" in result.lower()
+    assert "1440" in result
+
+
+async def test_cancel_watch_by_uri(service):
+    task = await _seed_watch(service, to_uri="viking://resources/test/cancel")
+    result = await cancel_watch(to_uri=task.to_uri)
+    assert "cancelled" in result.lower()
+    # Verify it's actually gone
+    follow_up = await list_watches()
+    assert task.to_uri not in follow_up
+
+
+async def test_cancel_watch_not_found(service):
+    result = await cancel_watch(to_uri="viking://resources/never/existed")
+    assert "no watch task found" in result.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Implements [RFC #2104 — Watch Management API](https://github.com/volcengine/OpenViking/discussions/2104) across all three control planes (REST / ov CLI / MCP). Watch tasks created via `POST /resources` with `watch_interval` previously had no list / pause / delete / trigger / update endpoint — this PR closes that gap.

**Zero backend changes.** `WatchManager` already exposes every primitive needed. This PR is purely a router / MCP-tool / CLI-command layer.

## Related Issue

Implements RFC discussion: https://github.com/volcengine/OpenViking/discussions/2104

(See the [v2 follow-up comment](https://github.com/volcengine/OpenViking/discussions/2104#discussioncomment-16959561) for the 4 design deltas finalized during PR review — dual-key relaxation, fire-and-forget trigger, CLI nesting under `ov task`, and the `set-interval` → `update` rename.)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**P1 + P2 — REST `/api/v1/watches`** (`openviking/server/routers/watches.py`):
- `GET /watches` — list (with `?active_only=`); also acts as single-lookup via `?to_uri=`. When both are supplied a paused task at that URI also 404s, keeping the active_only contract consistent across branches.
- `GET /watches/{task_id}` (with optional `?to_uri=` cross-key sanity check)
- `PATCH /watches/{task_id}` or `?to_uri=` — partial update of `watch_interval`, `is_active`, `reason`, `instruction`. `is_active` is orthogonal to `watch_interval` for pause-without-losing-cadence.
- `DELETE /watches/{task_id}` or `?to_uri=`
- `POST /watches/{task_id}/trigger` or `/watches/trigger?to_uri=` — **fire-and-forget**, returns immediately. Background task held via a module-level `_BACKGROUND_TRIGGER_TASKS: set` with `add_done_callback(discard)` so the asyncio loop's weak-ref policy doesn't GC the refresh mid-execution.
- Dual-key semantics: when both `{task_id}` and `?to_uri=` are supplied, accept if they refer to the same task (cross-key sanity check); reject with 400 only on disagreement.

**P3 — MCP `add_resource` gains watch params** (`openviking/server/mcp_endpoint.py`):
- Net-new `watch_interval: float = 0` + `to: str = ""` parameters. Negative values rejected with a clear error; `watch_interval > 0` requires `to` (server-side hard constraint with hint message for agents). Main branch's MCP had no watch entrypoint.

**P4 — MCP minimum closure** (`openviking/server/mcp_endpoint.py`):
- `list_watches()` — one line per task, no `task_id` exposed (agents use URI)
- `cancel_watch(to_uri)` — delete by URI; idempotent on race-removal
- Pause/resume/trigger/update are intentionally NOT in MCP — those are power-user operations belonging on the CLI; keeps agent system prompt small.

**P5 — `ov task watch` subcommand group** (`crates/ov_cli/src/commands/watch.rs`):
- Nested under `ov task` (sibling of `ov task status` / `ov task list`) since watch is a form of background work tracking, parallel to single-execution task records.
- Subcommands: `ls [--active-only]`, `show`, `rm`, `pause`, `resume`, `update`, `trigger`
- `update <key> [--interval N] [--active true|false] [--reason ...] [--instruction ...]` unifies all four mutable PATCH fields (replacing the original `set-interval` single-field verb). At-least-one-flag enforced.
- `<key>` auto-classification (`classify_key` helper): `viking://` prefix → by-URI route; other-scheme `://` keys (`http://`, `Viking://`, etc.) rejected locally with a clear Parse error instead of silently 404ing server-side.
- Adds `BaseClient::patch` and `BaseClient::post_with_query` (PATCH was absent; the latter supports `POST .../trigger?to_uri=`).

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

**Test coverage:**
- `tests/server/test_api_watches.py` (new, 11 tests) — empty list, full lifecycle, by-URI lookup, active_only filter (both branches), dual-key matching accepted, dual-key mismatch 400, missing key (422), 404 cases, extra-fields rejection (422), trigger-by-URI fire-and-forget timing, partial PATCH preserves unset fields
- `tests/server/test_mcp_endpoint.py` (extended, 6 new tests) — `watch_interval` requires `to`, negative `watch_interval` rejected, `list_watches` empty + with seed, `cancel_watch` by URI, `cancel_watch` not-found
- `crates/ov_cli/src/commands/watch.rs` — Rust unit tests for `classify_key` (uri/task_id/case-insensitive reject/other-scheme reject) and `validate_interval_minutes` and `build_update_body` (no-flag rejection / full-field / partial-field / interval validation). 10 tests total.
- `cargo build -p ov_cli` clean; `cargo test -p ov_cli commands::watch::` passes
- `uvx ruff format --check` + `uvx ruff check` clean on all modified files

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (PermissionDeniedError class duplication, dual-key resolution, 404-collapse-on-no-permission rationale, fire-and-forget task ref retention)
- [ ] I have made corresponding changes to the documentation (RFC #2104 carries the design; a [v2 delta comment](https://github.com/volcengine/OpenViking/discussions/2104#discussioncomment-16959561) records the post-review adjustments. Per-endpoint OpenAPI is auto-generated from FastAPI signatures.)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (none — backend unchanged)

## Additional Notes

**Key design decisions** (full rationale in RFC #2104 + the v2 delta comment):

1. **Dual-key REST**: every single-resource endpoint accepts either `{task_id}` in path or `?to_uri=` in query. `WatchManager` already maintains both indexes, so zero added cost. When both are supplied they must refer to the same task — useful as a cross-key sanity check from clients with both pieces of information; only mismatch returns 400.
2. **`PermissionDeniedError` translation**: `openviking/resource/watch_manager.py:104` defines its own `PermissionDeniedError(Exception)` which is NOT a subclass of `OpenVikingError`. Without explicit translation in the router, it falls through the global exception handler as 500. Each REST handler catches `wm_mod.PermissionDeniedError` and re-raises `openviking_cli.exceptions.PermissionDeniedError` so the global handler returns 403.
3. **`DELETE` returns 404 on missing**: `WatchManager.delete_task` returns `bool`; `False` is translated to `NotFoundError` rather than `{ok: false}`, avoiding contract drift for CLI consumers.
4. **404 vs 403 on cross-tenant access**: `_resolve_task` deliberately collapses "doesn't exist" and "no permission" into 404 to avoid leaking task existence to unauthorized callers — a security-first stance documented inline.
5. **Fire-and-forget trigger**: `WatchScheduler.schedule_task` awaits `_execute_task` inline (full re-ingest, can take many seconds). The HTTP handler dispatches via `asyncio.create_task` and returns immediately. Strong refs held in `_BACKGROUND_TRIGGER_TASKS: set` because asyncio only retains weak refs.
6. **CLI nesting**: `ov task watch *` rather than top-level `ov watch *`. Watch (recurring subscription) and task (single-execution record) are both background-activity tracking concepts; co-locating them simplifies the top-level command tree.
7. **`update` over `set-interval`**: the underlying PATCH covers four fields; one `update` subcommand with flags scales better than a `set-X` verb per field. `pause`/`resume` retained as high-frequency shortcuts.
8. **Three-tier strategy**: REST = full functionality; ov CLI = REST parity for power users; MCP = minimum closure (add + list + cancel) to control agent system-prompt size and decision noise.

**Out of scope (RFC §6 Open Questions, follow-ups):**
- Trigger rate-limiting
- List pagination
- Batch operations
- `POST /resources.watch_interval` long-term deprecation
- Audit logging via telemetry

**Commit layout** (logical phases, for reviewer-friendly diffing):
1. `feat(mcp): add watch_interval + to params to add_resource` (P3)
2. `feat(server): add REST /watches management endpoints` (P1+P2)
3. `feat(mcp): add list_watches and cancel_watch tools` (P4)
4. `feat(cli): add ov watch subcommand group` (P5)
5. `fix: address Copilot review on PR #2110`
6. `fix: address second round of Copilot review on PR #2110`
7. `fix: address third round of Copilot review on PR #2110`
8. `refactor(cli): nest watch under task; replace set-interval with update`