### PR TITLE
fix(blog): make Zouk thread replies visible

### DIFF
--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -891,8 +891,9 @@ html {
   gap: 6px;
   margin-top: 5px;
   padding: 3px 7px;
-  border-color: transparent;
-  border-radius: 6px;
+  border-color: color-mix(in oklab, var(--th-accent) 18%, transparent);
+  border-radius: 7px;
+  background: color-mix(in oklab, var(--th-bg-2) 58%, transparent);
   text-align: left;
 }
 
@@ -904,8 +905,10 @@ html {
 .zouk-reader-thread__preview strong {
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  white-space: normal;
   font-weight: 400;
 }
 

--- a/blog/src/zouk-embed.jsx
+++ b/blog/src/zouk-embed.jsx
@@ -436,11 +436,19 @@ function MessageBody({ content }) {
   );
 }
 
+function previewThreadContent(content) {
+  const parsed = parseInjectedMessage(content);
+  return compactText(parsed.body || content, 220);
+}
+
 function ThreadBlock({ message, state, agentsBySender, onToggle }) {
-  const replyCount = message.replyCount || message.replies?.length || 0;
+  const inlineReplies = Array.isArray(message.replies) ? message.replies : [];
+  const stateReplies = Array.isArray(state?.messages) ? state.messages : [];
+  const availableReplies = stateReplies.length ? stateReplies : inlineReplies;
+  const replyCount = message.replyCount || availableReplies.length || 0;
   if (!replyCount) return null;
   const expanded = Boolean(state?.open);
-  const replies = expanded ? (state?.messages || message.replies || []) : (message.replies || []).slice(-1);
+  const replies = expanded ? availableReplies : availableReplies.slice(-1);
   const label = replyCount === 1 ? '1 reply' : `${replyCount} replies`;
   return (
     <div className={`zouk-reader-thread${expanded ? ' is-expanded' : ''}`}>
@@ -457,7 +465,7 @@ function ThreadBlock({ message, state, agentsBySender, onToggle }) {
         <div className="zouk-reader-thread__body">
           {state?.loading ? <div className="zouk-reader-thread__state">Loading thread...</div> : null}
           {state?.error ? <div className="zouk-reader-thread__state is-error">{state.error}</div> : null}
-          {!state?.loading && !state?.error && replies.map((reply) => {
+          {!state?.loading && replies.map((reply) => {
             const replyAgent = agentsBySender.get(senderKey(reply.senderName));
             const avatarKind = replyAgent || reply.senderType === 'agent' ? 'agent' : 'human';
             return (
@@ -484,9 +492,10 @@ function ThreadBlock({ message, state, agentsBySender, onToggle }) {
           type="button"
           className="zouk-reader-thread__preview"
           onClick={() => onToggle(message)}
+          aria-label={`Expand ${label}`}
         >
           <span>{replies[0].senderName}</span>
-          <strong>{replies[0].content}</strong>
+          <strong>{previewThreadContent(replies[0].content)}</strong>
         </button>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary\n- show a visible two-line preview for inline Zouk thread replies under parent messages\n- keep expand/collapse behavior so clicking the reply count or preview loads the full thread and shows full reply text\n- strip injected context from collapsed previews so the snippet focuses on the actual reply body\n\n## Test\n- npm run build