### PR TITLE
fix(embedding): ignore proxy env for Volcengine clients

### DIFF
--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -4,6 +4,7 @@
 
 from typing import Any, Dict, List, Optional
 
+import httpx
 import volcenginesdkarkruntime
 
 from openviking.models.embedder.base import (
@@ -95,9 +96,12 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
         ark_kwargs = {"api_key": self.api_key}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
-        self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
-        self._ark_kwargs = ark_kwargs
-        self._async_client = None
+        self._sync_http_client = httpx.Client(trust_env=False)
+        self._async_http_client = None
+        self.client = volcenginesdkarkruntime.Ark(
+            **ark_kwargs,
+            http_client=self._sync_http_client,
+        )
         self._ark_kwargs = ark_kwargs
         self._async_client = None
 
@@ -185,7 +189,11 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
 
     def _get_async_client(self):
         if self._async_client is None:
-            self._async_client = volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
+            self._async_http_client = httpx.AsyncClient(trust_env=False)
+            self._async_client = volcenginesdkarkruntime.AsyncArk(
+                **self._ark_kwargs,
+                http_client=self._async_http_client,
+            )
         return self._async_client
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
@@ -338,7 +346,12 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         ark_kwargs = {"api_key": self.api_key}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
-        self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
+        self._sync_http_client = httpx.Client(trust_env=False)
+        self._async_http_client = None
+        self.client = volcenginesdkarkruntime.Ark(
+            **ark_kwargs,
+            http_client=self._sync_http_client,
+        )
         self._ark_kwargs = ark_kwargs
         self._async_client = None
 
@@ -408,7 +421,11 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
 
     def _get_async_client(self):
         if self._async_client is None:
-            self._async_client = volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
+            self._async_http_client = httpx.AsyncClient(trust_env=False)
+            self._async_client = volcenginesdkarkruntime.AsyncArk(
+                **self._ark_kwargs,
+                http_client=self._async_http_client,
+            )
         return self._async_client
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
@@ -526,7 +543,12 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         ark_kwargs = {"api_key": self.api_key}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
-        self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
+        self._sync_http_client = httpx.Client(trust_env=False)
+        self._async_http_client = None
+        self.client = volcenginesdkarkruntime.Ark(
+            **ark_kwargs,
+            http_client=self._sync_http_client,
+        )
         self._ark_kwargs = ark_kwargs
         self._async_client = None
         self._dimension = dimension or 2048
@@ -602,7 +624,11 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
 
     def _get_async_client(self):
         if self._async_client is None:
-            self._async_client = volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
+            self._async_http_client = httpx.AsyncClient(trust_env=False)
+            self._async_client = volcenginesdkarkruntime.AsyncArk(
+                **self._ark_kwargs,
+                http_client=self._async_http_client,
+            )
         return self._async_client
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -2,10 +2,15 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Volcengine Embedder Implementation"""
 
+import asyncio
 from typing import Any, Dict, List, Optional
 
 import httpx
 import volcenginesdkarkruntime
+from volcenginesdkarkruntime._base_client import (
+    DefaultAsyncHttpxClient,
+    DefaultHttpxClient,
+)
 
 from openviking.models.embedder.base import (
     DenseEmbedderBase,
@@ -16,6 +21,35 @@ from openviking.models.embedder.base import (
 )
 from openviking.telemetry import get_current_telemetry
 from openviking_cli.utils.logger import default_logger as logger
+
+
+def _make_ark_http_client() -> httpx.Client:
+    # Preserve Ark SDK HTTP defaults while avoiding environment proxy parsing.
+    return DefaultHttpxClient(trust_env=False)
+
+
+def _make_async_ark_http_client() -> httpx.AsyncClient:
+    # Preserve Ark SDK HTTP defaults while avoiding environment proxy parsing.
+    return DefaultAsyncHttpxClient(trust_env=False)
+
+
+def _close_http_clients(
+    sync_http_client: httpx.Client,
+    async_http_client: Optional[httpx.AsyncClient],
+) -> None:
+    if not sync_http_client.is_closed:
+        sync_http_client.close()
+    if async_http_client is None or async_http_client.is_closed:
+        return
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop and loop.is_running():
+        loop.create_task(async_http_client.aclose())
+    else:
+        asyncio.run(async_http_client.aclose())
 
 
 def process_sparse_embedding(sparse_data: Any) -> Dict[str, float]:
@@ -96,7 +130,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
         ark_kwargs = {"api_key": self.api_key}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
-        self._sync_http_client = httpx.Client(trust_env=False)
+        self._sync_http_client = _make_ark_http_client()
         self._async_http_client = None
         self.client = volcenginesdkarkruntime.Ark(
             **ark_kwargs,
@@ -189,7 +223,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
 
     def _get_async_client(self):
         if self._async_client is None:
-            self._async_http_client = httpx.AsyncClient(trust_env=False)
+            self._async_http_client = _make_async_ark_http_client()
             self._async_client = volcenginesdkarkruntime.AsyncArk(
                 **self._ark_kwargs,
                 http_client=self._async_http_client,
@@ -309,6 +343,9 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
     def get_dimension(self) -> int:
         return self._dimension
 
+    def close(self):
+        _close_http_clients(self._sync_http_client, self._async_http_client)
+
 
 class VolcengineSparseEmbedder(SparseEmbedderBase):
     """Volcengine Sparse Embedder Implementation
@@ -346,7 +383,7 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         ark_kwargs = {"api_key": self.api_key}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
-        self._sync_http_client = httpx.Client(trust_env=False)
+        self._sync_http_client = _make_ark_http_client()
         self._async_http_client = None
         self.client = volcenginesdkarkruntime.Ark(
             **ark_kwargs,
@@ -421,7 +458,7 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
 
     def _get_async_client(self):
         if self._async_client is None:
-            self._async_http_client = httpx.AsyncClient(trust_env=False)
+            self._async_http_client = _make_async_ark_http_client()
             self._async_client = volcenginesdkarkruntime.AsyncArk(
                 **self._ark_kwargs,
                 http_client=self._async_http_client,
@@ -450,6 +487,9 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
             )
         except Exception as e:
             raise RuntimeError(f"Volcengine sparse embedding failed: {str(e)}") from e
+
+    def close(self):
+        _close_http_clients(self._sync_http_client, self._async_http_client)
 
     def embed_batch(self, texts: List[str], is_query: bool = False) -> List[EmbedResult]:
         """Batch sparse embedding
@@ -543,7 +583,7 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         ark_kwargs = {"api_key": self.api_key}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
-        self._sync_http_client = httpx.Client(trust_env=False)
+        self._sync_http_client = _make_ark_http_client()
         self._async_http_client = None
         self.client = volcenginesdkarkruntime.Ark(
             **ark_kwargs,
@@ -624,7 +664,7 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
 
     def _get_async_client(self):
         if self._async_client is None:
-            self._async_http_client = httpx.AsyncClient(trust_env=False)
+            self._async_http_client = _make_async_ark_http_client()
             self._async_client = volcenginesdkarkruntime.AsyncArk(
                 **self._ark_kwargs,
                 http_client=self._async_http_client,
@@ -710,3 +750,6 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
 
     def get_dimension(self) -> int:
         return self._dimension
+
+    def close(self):
+        _close_http_clients(self._sync_http_client, self._async_http_client)

--- a/tests/models/test_embedding_telemetry_usage.py
+++ b/tests/models/test_embedding_telemetry_usage.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import httpx
+
 from openviking.models.embedder.openai_embedders import OpenAIDenseEmbedder
 from openviking.models.embedder.volcengine_embedders import VolcengineDenseEmbedder
 from openviking.telemetry.backends.memory import MemoryOperationTelemetry
@@ -112,9 +113,7 @@ def test_volcengine_embedders_disable_env_proxy_clients(monkeypatch):
         created.append(("sync", kwargs["http_client"]))
         return SimpleNamespace(
             multimodal_embeddings=SimpleNamespace(
-                create=lambda **_: SimpleNamespace(
-                    data=SimpleNamespace(embedding=[0.4, 0.5, 0.6])
-                )
+                create=lambda **_: SimpleNamespace(data=SimpleNamespace(embedding=[0.4, 0.5, 0.6]))
             ),
         )
 

--- a/tests/models/test_embedding_telemetry_usage.py
+++ b/tests/models/test_embedding_telemetry_usage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import httpx
 from openviking.models.embedder.openai_embedders import OpenAIDenseEmbedder
 from openviking.models.embedder.volcengine_embedders import VolcengineDenseEmbedder
 from openviking.telemetry.backends.memory import MemoryOperationTelemetry
@@ -102,3 +103,37 @@ def test_volcengine_dense_embedder_reports_embedding_telemetry_usage_from_dict_u
     assert result.dense_vector == [0.4, 0.5, 0.6]
     summary = telemetry.finish().summary
     assert summary["tokens"]["embedding"] == {"total": 16}
+
+
+def test_volcengine_embedders_disable_env_proxy_clients(monkeypatch):
+    created = []
+
+    def fake_ark(**kwargs):
+        created.append(("sync", kwargs["http_client"]))
+        return SimpleNamespace(
+            multimodal_embeddings=SimpleNamespace(
+                create=lambda **_: SimpleNamespace(
+                    data=SimpleNamespace(embedding=[0.4, 0.5, 0.6])
+                )
+            ),
+        )
+
+    def fake_async_ark(**kwargs):
+        created.append(("async", kwargs["http_client"]))
+        return SimpleNamespace()
+
+    monkeypatch.setattr("volcenginesdkarkruntime.Ark", fake_ark)
+    monkeypatch.setattr("volcenginesdkarkruntime.AsyncArk", fake_async_ark)
+
+    embedder = VolcengineDenseEmbedder(
+        model_name="doubao-embedding-vision-251215",
+        api_key="test",
+        input_type="multimodal",
+        dimension=3,
+    )
+    embedder._get_async_client()
+
+    assert len(created) == 2
+    for kind, client in created:
+        assert isinstance(client, (httpx.Client, httpx.AsyncClient)), kind
+        assert client._trust_env is False


### PR DESCRIPTION
## Summary

- construct Volcengine Ark sync clients with an explicit `httpx.Client(trust_env=False)`
- construct Volcengine Ark async clients with an explicit `httpx.AsyncClient(trust_env=False)`
- add regression coverage that verifies Volcengine embedding clients do not inherit proxy environment variables

Fixes #2113

## Tests

- standalone no-network assertion that dense/sparse/hybrid Volcengine embedders pass `trust_env=False` sync/async httpx clients into Ark/AsyncArk
- `git diff --check`

Note: `python -m pytest tests/models/test_embedding_telemetry_usage.py -q` is blocked in this fresh worktree because editable install tries to build the Rust `ov` CLI with local Cargo 1.75, which cannot parse the repo's Rust 2024 edition crate. Running pytest directly with `PYTHONPATH=.` also hits the known missing bundled AGFS client/import dependency chain before test collection. The focused standalone assertion above avoids network calls and validates the changed client construction path directly.
