### PR TITLE
docs(api): document Watch Management endpoints from #2110

### DIFF
--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -334,6 +334,99 @@ temp_uri     viking://temp/shengmaojia/04291108_b62dc7/01-overview
 
 ---
 
+### Watch Management
+
+List, inspect, update, and trigger watch tasks created via [`add_resource`](#add_resource) with `watch_interval > 0`. The control plane is mirrored across REST (`/api/v1/watches`), the `ov task watch` CLI subcommand group, and a minimum-closure MCP surface (`list_watches` / `cancel_watch`) for agents.
+
+#### 1. API Implementation Overview
+
+This control plane wraps the `WatchManager` primitives without changing any server-side behavior. Every endpoint and CLI command resolves the target task by either its `task_id` (path) or its `to_uri` (query). The two keys are interchangeable; if both are supplied they must refer to the same task, otherwise the request is rejected with 400.
+
+**Operations**:
+- **List** (`GET /api/v1/watches`) — returns `{tasks, total}`; pass `?active_only=true` to filter; pass `?to_uri=...` to collapse to a single-task lookup
+- **Show** (`GET /api/v1/watches/{task_id}`) — inspect one task; optional `?to_uri=` performs a cross-key sanity check
+- **Update** (`PATCH /api/v1/watches/{task_id}` or `PATCH /api/v1/watches?to_uri=...`) — partial update of `watch_interval`, `is_active`, `reason`, `instruction`. `is_active` is orthogonal to `watch_interval`: flip `is_active` to pause/resume without losing the configured cadence.
+- **Delete** (`DELETE /api/v1/watches/{task_id}` or `DELETE /api/v1/watches?to_uri=...`)
+- **Trigger** (`POST /api/v1/watches/{task_id}/trigger` or `POST /api/v1/watches/trigger?to_uri=...`) — fire-and-forget refresh; returns immediately while the underlying re-ingest runs in the background
+
+**Code Entry Points**:
+- `openviking/server/routers/watches.py` — REST router for `/api/v1/watches`
+- `crates/ov_cli/src/commands/watch.rs` — `ov task watch` CLI subcommand group
+- `openviking/server/mcp_endpoint.py` — MCP `list_watches` / `cancel_watch` tools and the `watch_interval` / `to` parameters on `add_resource`
+- `openviking/resource/watch_manager.py:WatchManager` — task persistence and scheduling primitives
+
+#### 2. Interface and Parameter Description
+
+For every single-task endpoint the path `{task_id}` can be replaced with a `?to_uri=` query argument. The CLI `<key>` argument is auto-classified: any value starting with `viking://` routes to the by-URI path, anything else is treated as a task ID (other URI schemes such as `http://` are rejected locally to avoid silent 404s).
+
+**`PATCH /watches` body** (all fields optional; at least one is required)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| watch_interval | float | New cadence in minutes. Must be `> 0`; use `is_active=false` to pause without losing the cadence. |
+| is_active | bool | Toggle activation without losing the cadence (pause / resume). |
+| reason | string | Update the recorded reason for the watch. |
+| instruction | string | Update the semantic processing instruction. |
+
+Unrecognized fields are rejected with 422 (`extra="forbid"`). Fields left unset preserve their current values.
+
+#### 3. Usage Examples
+
+**HTTP API**
+
+```bash
+# List active watch tasks (drop ?active_only to include paused ones)
+curl -s "http://localhost:1933/api/v1/watches?active_only=true" \
+  -H "X-API-Key: your-key"
+
+# Pause a watch without losing its cadence
+curl -X PATCH "http://localhost:1933/api/v1/watches/<task_id>" \
+  -H "X-API-Key: your-key" -H "Content-Type: application/json" \
+  -d '{"is_active": false}'
+
+# Trigger an immediate refresh (fire-and-forget; returns before the re-ingest finishes)
+curl -X POST "http://localhost:1933/api/v1/watches/<task_id>/trigger" \
+  -H "X-API-Key: your-key"
+
+# Resolve by URI instead of task ID
+curl -X DELETE "http://localhost:1933/api/v1/watches?to_uri=viking://resources/guide.md" \
+  -H "X-API-Key: your-key"
+```
+
+**CLI** (subcommands of `ov task watch`)
+
+```bash
+# List active watches (drop --active-only to include paused ones)
+ov task watch ls --active-only
+
+# Inspect a single watch (key may be either a viking:// URI or a task_id)
+ov task watch show viking://resources/guide.md
+
+# Pause / resume without losing the cadence
+ov task watch pause viking://resources/guide.md
+ov task watch resume viking://resources/guide.md
+
+# Update the cadence (or any combination of --active / --reason / --instruction)
+ov task watch update viking://resources/guide.md --interval 30
+
+# Trigger an immediate fire-and-forget refresh
+ov task watch trigger viking://resources/guide.md
+
+# Remove a watch task entirely
+ov task watch rm viking://resources/guide.md
+```
+
+**MCP** (agent control plane — minimum closure only)
+
+```text
+list_watches()                                            # one line per task; URIs only, no task_ids surfaced
+cancel_watch(to_uri="viking://resources/guide.md")        # idempotent removal by URI
+```
+
+Pause / resume / trigger / update are intentionally not exposed via MCP — those power-user operations live on the CLI/REST surface to keep the agent system prompt compact. Creating a watch or changing its cadence from the agent side still goes through [`add_resource`](#add_resource) with `watch_interval` and `to`.
+
+---
+
 ### add_skill
 
 Add a skill to the knowledge base.

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -327,6 +327,99 @@ temp_uri     viking://temp/shengmaojia/04291108_b62dc7/01-overview
 
 ---
 
+### Watch Management（监控任务管理）
+
+列出、查看、更新和触发通过 [`add_resource`](#add_resource) 配合 `watch_interval > 0` 创建的监控任务。控制面在 REST（`/api/v1/watches`）、`ov task watch` CLI 子命令组以及面向 Agent 的最小闭包 MCP 接口（`list_watches` / `cancel_watch`）三处镜像。
+
+#### 1. API 实现介绍
+
+此控制面封装了 `WatchManager` 原语，未改动任何服务端行为。每个端点和 CLI 命令都支持通过 `task_id`（路径）或 `to_uri`（查询参数）定位目标任务，两种键可以互换；如果同时提供，二者必须指向同一任务，否则返回 400。
+
+**操作**：
+- **列出**（`GET /api/v1/watches`）— 返回 `{tasks, total}`；可传 `?active_only=true` 过滤；传 `?to_uri=...` 时降级为单任务查找
+- **查看**（`GET /api/v1/watches/{task_id}`）— 查看单个任务；可选 `?to_uri=` 做跨键一致性校验
+- **更新**（`PATCH /api/v1/watches/{task_id}` 或 `PATCH /api/v1/watches?to_uri=...`）— 部分更新 `watch_interval`、`is_active`、`reason`、`instruction`。`is_active` 与 `watch_interval` 正交：翻转 `is_active` 可在不丢失配置周期的前提下暂停/恢复任务。
+- **删除**（`DELETE /api/v1/watches/{task_id}` 或 `DELETE /api/v1/watches?to_uri=...`）
+- **触发**（`POST /api/v1/watches/{task_id}/trigger` 或 `POST /api/v1/watches/trigger?to_uri=...`）— 触发即返回（fire-and-forget），重新摄取在后台异步执行
+
+**代码入口**：
+- `openviking/server/routers/watches.py` — `/api/v1/watches` REST 路由
+- `crates/ov_cli/src/commands/watch.rs` — `ov task watch` CLI 子命令组
+- `openviking/server/mcp_endpoint.py` — MCP `list_watches` / `cancel_watch` 工具，以及 `add_resource` 上的 `watch_interval` / `to` 参数
+- `openviking/resource/watch_manager.py:WatchManager` — 任务持久化与调度原语
+
+#### 2. 接口和参数说明
+
+对每个单任务端点，路径中的 `{task_id}` 都可用查询参数 `?to_uri=` 替代。CLI 的 `<key>` 参数会自动分类：任何以 `viking://` 开头的值走 by-URI 路径，其他值视为 task_id（其它 scheme 如 `http://` 会在本地直接报错，避免静默 404）。
+
+**`PATCH /watches` 请求体**（字段均可选，至少需提供一个）
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| watch_interval | float | 新的检查周期（分钟），必须 `> 0`；如需暂停而保留周期请改用 `is_active=false`。 |
+| is_active | bool | 切换激活状态而保留配置周期（暂停 / 恢复）。 |
+| reason | string | 更新该监控任务的记录原因。 |
+| instruction | string | 更新语义处理指令。 |
+
+未识别字段会被 422 拒绝（`extra="forbid"`）。未传字段保留原值。
+
+#### 3. 使用示例
+
+**HTTP API**
+
+```bash
+# 列出活跃监控任务（去掉 ?active_only 可同时包含已暂停的任务）
+curl -s "http://localhost:1933/api/v1/watches?active_only=true" \
+  -H "X-API-Key: your-key"
+
+# 暂停一个监控任务而保留其检查周期
+curl -X PATCH "http://localhost:1933/api/v1/watches/<task_id>" \
+  -H "X-API-Key: your-key" -H "Content-Type: application/json" \
+  -d '{"is_active": false}'
+
+# 触发一次立即刷新（fire-and-forget，立即返回，再次摄取在后台执行）
+curl -X POST "http://localhost:1933/api/v1/watches/<task_id>/trigger" \
+  -H "X-API-Key: your-key"
+
+# 按 URI 而非 task_id 定位任务
+curl -X DELETE "http://localhost:1933/api/v1/watches?to_uri=viking://resources/guide.md" \
+  -H "X-API-Key: your-key"
+```
+
+**CLI**（`ov task watch` 子命令）
+
+```bash
+# 列出活跃监控任务（去掉 --active-only 可同时包含已暂停的任务）
+ov task watch ls --active-only
+
+# 查看单个监控任务（key 可以是 viking:// URI 或 task_id）
+ov task watch show viking://resources/guide.md
+
+# 暂停 / 恢复，不丢失配置周期
+ov task watch pause viking://resources/guide.md
+ov task watch resume viking://resources/guide.md
+
+# 更新周期（或 --active / --reason / --instruction 的任意组合）
+ov task watch update viking://resources/guide.md --interval 30
+
+# 触发一次立即刷新（fire-and-forget）
+ov task watch trigger viking://resources/guide.md
+
+# 删除监控任务
+ov task watch rm viking://resources/guide.md
+```
+
+**MCP**（Agent 控制面——仅最小闭包）
+
+```text
+list_watches()                                            # 每个任务一行；只暴露 URI，不暴露 task_id
+cancel_watch(to_uri="viking://resources/guide.md")        # 按 URI 幂等删除
+```
+
+暂停 / 恢复 / 触发 / 更新故意不通过 MCP 暴露——这些 power-user 操作放在 CLI/REST 一侧，以保持 Agent 系统提示词的紧凑。Agent 侧若需创建监控任务或调整周期，仍走 [`add_resource`](#add_resource) 配合 `watch_interval` 和 `to`。
+
+---
+
 ### add_skill
 
 向知识库添加技能。


### PR DESCRIPTION
## Description

Documents the Watch Management surface introduced in #2110 (REST `/api/v1/watches/*`, the `ov task watch` CLI subcommand group, and the MCP `list_watches` / `cancel_watch` tools). All three control planes are net-new and currently undocumented in `docs/{en,zh}/api/02-resources.md`, where users land for everything `watch_interval`-related.

The new section follows the [API documentation writing guide](https://github.com/volcengine/OpenViking/blob/main/docs/en/api/99-api-doc-writing-guide.md): Implementation Overview / Code Entry Points / Interface and Parameter Description / Usage Examples (HTTP + CLI + MCP). EN and ZH are mirrored.

## Related Issue

Documents the changes from #2110 (RFC #2104 — Watch Management API).

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/en/api/02-resources.md`: insert a `### Watch Management` section between `### add_resource` and `### add_skill` (~93 lines added)
- `docs/zh/api/02-resources.md`: mirrored Chinese section (~93 lines added)

Specifically captured:
- 5 REST routes (list / show / update / delete / trigger), each with both `{task_id}` and `?to_uri=` variants
- `PATCH /watches` body schema with field semantics (notably `watch_interval` must be `> 0`; `is_active` orthogonal to the cadence for pause/resume; `extra="forbid"` → 422)
- `ov task watch` subcommands (`ls / show / rm / pause / resume / update / trigger`) with the `<key>` auto-classification (`viking://` URI vs task_id)
- MCP minimum closure (`list_watches`, `cancel_watch`) and an explicit note that pause / resume / trigger / update are intentionally CLI/REST-only
- Cross-reference back to [`add_resource`](#add_resource) as the watch-creation entry point

## Testing

- [x] No code changes; docs-only PR
- [x] Verified endpoint paths, verbs, body fields, validator messages, CLI subcommand names, and CLI flag names against `openviking/server/routers/watches.py` and `crates/ov_cli/src/commands/watch.rs` at HEAD
- [x] EN/ZH parity check: same operations, same field semantics, same examples

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
