### PR TITLE
fix(storage): glob walks beyond depth 3

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1052,7 +1052,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> Dict:
         """File pattern matching, supports **/*.md recursive."""
-        entries = await self.tree(uri, node_limit=1000000, ctx=ctx)
+        entries = await self.tree(uri, node_limit=1000000, level_limit=None, ctx=ctx)
         base_uri = uri.rstrip("/")
         matches = []
         for entry in entries:


### PR DESCRIPTION
## Summary

`VikingFS.glob()` calls `self.tree()` without passing `level_limit`, so it inherits `tree`'s default `level_limit=3`. Files at depth >3 from the base URI are never walked, and glob silently returns zero hits even when the file exists.

Example: querying

```http
POST /api/v1/search/glob
{
  "pattern": "**/foo/bar/*",
  "uri": "viking://resources/novels/x/"
}
```

against a tree where the actual file is at `x/foo/bar/file.md` (4 segments deep from the base) returns an empty result, because `_walk` short-circuits at `current_depth >= 3` before reaching the file.

## Fix

Pass `level_limit=None` from `glob()` to `tree()` so the walk is unbounded by depth. `glob` already caps the walk via `node_limit=1_000_000`, so this doesn't loosen any other bound — it just stops the depth filter from hiding entries that the pattern is supposed to match.

```diff
-        entries = await self.tree(uri, node_limit=1000000, ctx=ctx)
+        entries = await self.tree(uri, node_limit=1000000, level_limit=None, ctx=ctx)
```

## Test plan

- [ ] Start a server with content at depth ≥4 below the glob base URI
- [ ] Confirm `POST /api/v1/search/glob` with a deep-matching pattern now returns the expected file
- [ ] Confirm shallow patterns still match (no regression)

## Notes

- A complementary improvement — exposing `level_limit` as an explicit body parameter on `/api/v1/search/glob` so callers can tighten the walk when needed — is intentionally left for a follow-up to keep this PR a focused bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)