### PR TITLE
Support Vaka memory templates via a switch

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,1 +1,4 @@
 results/
+/vaka/vikingbot/analysis/
+/vaka/vikingbot/result*/
+/vaka/vikingbot/docs

--- a/openviking/prompts/templates/memory/vaka/entities.yaml
+++ b/openviking/prompts/templates/memory/vaka/entities.yaml
@@ -32,28 +32,28 @@ fields:
     description: |
       - Detailed Zettelkasten card content in markdown format.
       - Keep the card self-contained, factual, neutral, and useful after retrieval.
-      - For people or evaluative content, do not output only a "问题" field. Pair any evaluation, risk, weakness, or recommendation with "依据/证据".
+      - For people or evaluative content, do not output only an "Issue" field. Pair any evaluation, risk, weakness, or recommendation with "Evidence".
       - Prefer objective facts, metrics, dates, user-provided context, or quoted requirements over labels.
-      - If evidence is missing or weak, omit the judgment or write "信息不足，需核实"; do not overgeneralize.
-      - Avoid hostile or blaming wording such as "拖后腿", "很差", "不行", or "无法胜任"; prefer neutral wording such as "产出低于目标/同组水平" or "需要进一步观察".
+      - If evidence is missing or weak, omit the judgment or write "Insufficient information, needs verification"; do not overgeneralize.
+      - Avoid hostile or blaming wording such as "dragging down", "very poor", "not good", or "incapable"; prefer neutral wording such as "output below target/peer level" or "needs further observation".
 
       Preferred shape for evaluative person entities:
       # <Entity Name>
-      - 评估结论：<neutral conclusion, if supported by evidence>
-      - 依据：
+      - Evaluation conclusion: <neutral conclusion, if supported by evidence>
+      - Evidence:
         - <objective fact, metric, date/context, or quoted requirement>
-      - 待关注/风险：<neutral risk statement, optional; include only if supported>
+      - Concerns/Risks: <neutral risk statement, optional; include only if supported>
 
       Bad example:
       # Kevin D. Wallace
-      - 评估等级：待改进
-      - 问题：第四季度以来工作效率明显下滑，同组其他同事产出稳定，其状态波动较大，拖了团队后腿
+      - Evaluation level: Needs improvement
+      - Issue: Since Q4, work efficiency has declined noticeably; other colleagues in the same group have stable output, while his state has fluctuated significantly, dragging the team down.
 
       Good example:
       # Kevin D. Wallace
-      - 评估结论：当前表现需进一步关注
-      - 依据：
-        - 用户提到其第四季度以来工作效率明显下滑
-        - 用户提到同组其他同事产出稳定，而其状态波动较大
-      - 待关注/风险：团队产出节奏可能受影响，需结合最新绩效数据复核
+      - Evaluation conclusion: Current performance needs further attention
+      - Evidence:
+        - User mentioned that his work efficiency has declined noticeably since Q4
+        - User mentioned that other colleagues in the same group have stable output, while his state has fluctuated significantly
+      - Concerns/Risks: Team output pace may be affected; needs to be reviewed with the latest performance data
     merge_op: patch

--- a/openviking/prompts/templates/memory/vaka/entities.yaml
+++ b/openviking/prompts/templates/memory/vaka/entities.yaml
@@ -1,0 +1,59 @@
+memory_type: entities
+description: |
+  Wikipedia article - manages page using Zettelkasten method.
+  Each page represents an article with relative path links to events.
+  Entity should be rich and distributed - avoid putting all info in one entity.
+directory: "viking://user/{{ user_space }}/memories/entities"
+filename_template: "{{ category }}/{{ name }}.md"
+enabled: true
+
+overview_template: |-
+  # Entities Overview
+  {% if items %}**Category:** {{ items[0].file_content.category }}{% endif %}
+  {% for item in items %}
+  - [{{ item.file_content.name }}](./{{ item.file_name }})
+  {% endfor %}
+
+fields:
+  - name: category
+    type: string
+    description: |
+      - Category name in Chinese or English. If English, use lowercase with underscores, max 3 words.
+    merge_op: immutable
+
+  - name: name
+    type: string
+    description: |
+      - Entity name in Chinese or English. If English, use lowercase with underscores, max 3 words.
+    merge_op: immutable
+
+  - name: content
+    type: string
+    description: |
+      - Detailed Zettelkasten card content in markdown format.
+      - Keep the card self-contained, factual, neutral, and useful after retrieval.
+      - For people or evaluative content, do not output only a "问题" field. Pair any evaluation, risk, weakness, or recommendation with "依据/证据".
+      - Prefer objective facts, metrics, dates, user-provided context, or quoted requirements over labels.
+      - If evidence is missing or weak, omit the judgment or write "信息不足，需核实"; do not overgeneralize.
+      - Avoid hostile or blaming wording such as "拖后腿", "很差", "不行", or "无法胜任"; prefer neutral wording such as "产出低于目标/同组水平" or "需要进一步观察".
+
+      Preferred shape for evaluative person entities:
+      # <Entity Name>
+      - 评估结论：<neutral conclusion, if supported by evidence>
+      - 依据：
+        - <objective fact, metric, date/context, or quoted requirement>
+      - 待关注/风险：<neutral risk statement, optional; include only if supported>
+
+      Bad example:
+      # Kevin D. Wallace
+      - 评估等级：待改进
+      - 问题：第四季度以来工作效率明显下滑，同组其他同事产出稳定，其状态波动较大，拖了团队后腿
+
+      Good example:
+      # Kevin D. Wallace
+      - 评估结论：当前表现需进一步关注
+      - 依据：
+        - 用户提到其第四季度以来工作效率明显下滑
+        - 用户提到同组其他同事产出稳定，而其状态波动较大
+      - 待关注/风险：团队产出节奏可能受影响，需结合最新绩效数据复核
+    merge_op: patch

--- a/openviking/prompts/templates/memory/vaka/profile.yaml
+++ b/openviking/prompts/templates/memory/vaka/profile.yaml
@@ -1,0 +1,54 @@
+memory_type: profile
+description: |
+  # Task Objective
+  User profile memory - captures relatively stable information about "who the user is" and how the user works.
+  Extract stable personal/work attributes that help future answers understand the user's role, work scope, communication style, and recurring work habits.
+  Include: profession, stable work scope, experience level, technical/business background, communication style, work habits, recurring delivery preferences, etc.
+
+  Do NOT include one-off project events, temporary conversation details, or temporary mood states.
+
+  # Rules
+  - Each item: self-contained, declarative sentence, < 30 words
+  - Extract only facts stated/confirmed by user; no guesses
+  - Focus on persistent information, not temporary situations
+  - Do not narrow the user's whole profile to one recent topic if broader repeated evidence shows multiple workstreams
+  - If multiple conversations show the user repeatedly works across several domains or delivery types, summarize this as stable work scope
+  - Do not copy dated project history into profile; specific dated project progress belongs in events/entities
+  - Forbidden: only-assistant content, sensitive/private info, trivial updates
+  - Merge similar items; keep latest only when the same stable attribute truly conflicts
+
+directory: "viking://user/{{ user_space }}/memories"
+filename_template: "profile.md"
+enabled: true
+fields:
+  - name: content
+    type: string
+    description: |
+      User profile content in Markdown format describing relatively stable information about the user.
+
+      Should include stable attributes such as:
+      - Current occupation or broad role
+      - Stable work scope
+      - Recurring work mode
+      - Communication style
+      - Work habits
+      - Long-term delivery preferences
+
+      If multiple conversations repeatedly show the user working across different domains, audiences, or delivery types, profile may summarize that as broad stable work scope.
+      Do not collapse the user into a single narrow domain only because the latest conversation is about one topic.
+
+      Good example:
+      # 用户个人信息
+      - 职业/工作范围：用户经常处理跨领域、跨受众或跨交付类型的工作，不应归纳为单一业务场景。
+      - 工作习惯：重视先判断任务阶段，再决定是继续探索、收口核验、交付还是交接。
+      - 沟通风格：偏好结论明确、依据清楚、风险点前置的回答。
+
+      Bad example:
+      # 用户个人信息
+      - 职业：某个最近话题对应的单一岗位
+
+      The bad example is too narrow if it is only supported by one recent topic while broader memories show many workstreams.
+
+      Only record objective or repeatedly supported statuses.
+      For changeable statuses, include the last updated time in the format: (as of YYYY-MM-DD).
+    merge_op: patch

--- a/openviking/prompts/templates/memory/vaka/profile.yaml
+++ b/openviking/prompts/templates/memory/vaka/profile.yaml
@@ -38,14 +38,14 @@ fields:
       Do not collapse the user into a single narrow domain only because the latest conversation is about one topic.
 
       Good example:
-      # 用户个人信息
-      - 职业/工作范围：用户经常处理跨领域、跨受众或跨交付类型的工作，不应归纳为单一业务场景。
-      - 工作习惯：重视先判断任务阶段，再决定是继续探索、收口核验、交付还是交接。
-      - 沟通风格：偏好结论明确、依据清楚、风险点前置的回答。
+      # User Personal Information
+      - Profession/Work scope: The user frequently handles work across different domains, audiences, or delivery types, and should not be reduced to a single business scenario.
+      - Work habits: Values first determining the task stage, then deciding whether to continue exploring, wrap up and verify, deliver, or hand off.
+      - Communication style: Prefers answers with clear conclusions, clear evidence, and risk points raised upfront.
 
       Bad example:
-      # 用户个人信息
-      - 职业：某个最近话题对应的单一岗位
+      # User Personal Information
+      - Profession: A single role corresponding to a recent topic
 
       The bad example is too narrow if it is only supported by one recent topic while broader memories show many workstreams.
 

--- a/openviking/session/memory/memory_type_registry.py
+++ b/openviking/session/memory/memory_type_registry.py
@@ -57,6 +57,13 @@ class MemoryTypeRegistry:
             )
         logger.info(f"Loaded {loaded} memory schemas from templates: {memory_templates_dir}")
 
+        # Load vaka templates if enabled (overrides default for matching memory_types)
+        if config.memory.enable_vaka_template:
+            vaka_dir = str(Path(memory_templates_dir) / "vaka")
+            if os.path.exists(vaka_dir):
+                vaka_loaded = self.load_from_directory(vaka_dir, replace=True)
+                logger.info(f"Loaded {vaka_loaded} vaka memory schemas from: {vaka_dir}")
+
         if custom_dir:
             custom_dir_expanded = os.path.expanduser(custom_dir)
             if os.path.exists(custom_dir_expanded):

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -478,6 +478,10 @@ After exploring, analyze the conversation and output ALL memory write/edit/delet
             config = get_openviking_config()
             custom_dir = config.memory.custom_templates_dir
             self._schema_directories = [memory_templates_dir]
+            if config.memory.enable_vaka_template:
+                vaka_dir = os.path.join(memory_templates_dir, "vaka")
+                if os.path.exists(vaka_dir):
+                    self._schema_directories.append(vaka_dir)
             if custom_dir:
                 custom_dir_expanded = os.path.expanduser(custom_dir)
                 if os.path.exists(custom_dir_expanded):

--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -75,6 +75,13 @@ class MemoryConfig(BaseModel):
             "stateless deployments."
         ),
     )
+    enable_vaka_template: bool = Field(
+        default=False,
+        description=(
+            "When enabled, use vaka-specific memory templates (entities, profile) "
+            "from the bundled vaka/ subdirectory to override default templates."
+        ),
+    )
     enable_role_id_memory_isolate: bool = Field(
         default=False,
         description=(

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -159,7 +159,9 @@ def test_memory_type_registry_loads_schemas_from_prompt_manager_resolved_templat
     )
     monkeypatch.setattr(
         "openviking_cli.utils.config.get_openviking_config",
-        lambda: SimpleNamespace(memory=SimpleNamespace(custom_templates_dir="")),
+        lambda: SimpleNamespace(
+            memory=SimpleNamespace(custom_templates_dir="", enable_vaka_template=False)
+        ),
     )
 
     registry = MemoryTypeRegistry(load_schemas=True)
@@ -208,7 +210,9 @@ def test_memory_type_registry_prefers_custom_memory_dir_over_prompt_manager_temp
     monkeypatch.setattr(
         "openviking_cli.utils.config.get_openviking_config",
         lambda: SimpleNamespace(
-            memory=SimpleNamespace(custom_templates_dir=str(custom_memory_dir))
+            memory=SimpleNamespace(
+                custom_templates_dir=str(custom_memory_dir), enable_vaka_template=False
+            )
         ),
     )
 
@@ -223,6 +227,7 @@ def test_context_provider_schema_directories_use_prompt_manager_resolved_templat
 ):
     resolved_templates_dir = tmp_path / "resolved-prompts"
     expected_memory_dir = resolved_templates_dir / "memory"
+    expected_memory_dir.mkdir(parents=True)
 
     monkeypatch.setattr(
         PromptManager,
@@ -232,13 +237,22 @@ def test_context_provider_schema_directories_use_prompt_manager_resolved_templat
     monkeypatch.setattr(
         "openviking.session.memory.session_extract_context_provider.get_openviking_config",
         lambda: SimpleNamespace(
-            memory=SimpleNamespace(custom_templates_dir="", eager_prefetch=False)
+            memory=SimpleNamespace(
+                custom_templates_dir="",
+                eager_prefetch=False,
+                prefetch_search_topn=5,
+                enable_vaka_template=False,
+            )
         ),
     )
 
     provider = SessionExtractContextProvider(messages=[])
 
-    assert provider.get_schema_directories() == [str(expected_memory_dir)]
+    bundled_memory_dir = str(PromptManager._get_bundled_templates_dir() / "memory")
+    dirs = provider.get_schema_directories()
+    # Bundled is always first; resolved is appended when different from bundled
+    assert dirs[0] == bundled_memory_dir
+    assert str(expected_memory_dir) in dirs
 
 
 def test_context_provider_schema_directories_prefer_custom_memory_dir_over_prompt_manager_root(
@@ -258,6 +272,8 @@ def test_context_provider_schema_directories_prefer_custom_memory_dir_over_promp
             memory=SimpleNamespace(
                 custom_templates_dir=str(custom_memory_dir),
                 eager_prefetch=False,
+                prefetch_search_topn=5,
+                enable_vaka_template=False,
             )
         ),
     )
@@ -273,3 +289,61 @@ def test_context_provider_schema_directories_prefer_custom_memory_dir_over_promp
         str(PromptManager._get_bundled_templates_dir() / "memory"),
         str(custom_memory_dir),
     ]
+
+
+def test_memory_type_registry_loads_vaka_templates_when_enabled(monkeypatch):
+    """When enable_vaka_template is True, vaka templates override defaults."""
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: SimpleNamespace(
+            memory=SimpleNamespace(custom_templates_dir="", enable_vaka_template=True)
+        ),
+    )
+
+    registry = MemoryTypeRegistry(load_schemas=True)
+
+    # entities and profile should be loaded (overridden by vaka versions)
+    entities = registry.get("entities")
+    profile = registry.get("profile")
+    assert entities is not None
+    assert profile is not None
+    # Vaka entities has specific description mentioning Zettelkasten
+    assert "Zettelkasten" in entities.description
+
+
+def test_memory_type_registry_does_not_load_vaka_when_disabled(monkeypatch):
+    """When enable_vaka_template is False, default templates are used as-is."""
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: SimpleNamespace(
+            memory=SimpleNamespace(custom_templates_dir="", enable_vaka_template=False)
+        ),
+    )
+
+    registry = MemoryTypeRegistry(load_schemas=True)
+
+    entities = registry.get("entities")
+    assert entities is not None
+
+
+def test_context_provider_includes_vaka_dir_when_enabled(monkeypatch):
+    """When enable_vaka_template is True, schema directories include vaka subdir."""
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: SimpleNamespace(
+            memory=SimpleNamespace(
+                custom_templates_dir="",
+                eager_prefetch=False,
+                prefetch_search_topn=5,
+                enable_vaka_template=True,
+            )
+        ),
+    )
+
+    provider = SessionExtractContextProvider(messages=[])
+    dirs = provider.get_schema_directories()
+
+    bundled_memory_dir = str(PromptManager._get_bundled_templates_dir() / "memory")
+    vaka_dir = str(PromptManager._get_bundled_templates_dir() / "memory" / "vaka")
+    assert bundled_memory_dir in dirs
+    assert vaka_dir in dirs


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Using `enable_vaka_template` field as a switch to enable custom memory templates for Vaka.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
