### PR TITLE
docs(mcp): document list_watches and cancel_watch in MCP integration table (#2110)

### DIFF
--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -103,7 +103,7 @@ no external proxy is needed.
 
 ## Available MCP Tools
 
-Once connected, OpenViking exposes 9 tools:
+Once connected, OpenViking exposes 11 tools:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
@@ -112,10 +112,14 @@ Once connected, OpenViking exposes 9 tools:
 | `list` | List entries under a `viking://` directory | `uri`, `recursive` (optional) |
 | `store` | Store messages into long-term memory (triggers extraction) | `messages` (list of `{role, content}`) |
 | `add_resource` | Add a local file or URL as a resource (local files trigger a progressive upload flow) | `path`, `temp_file_id` (optional), `description` (optional), `watch_interval` (optional, minutes — auto-refresh cadence for remote URLs), `to` (optional, target `viking://resources/...` URI; required when `watch_interval > 0`) |
+| `list_watches` | List watch tasks (auto-refresh subscriptions) visible to the current agent. Each entry shows target URI, refresh interval (minutes), active/paused status, and next scheduled execution time | none |
+| `cancel_watch` | Cancel (delete) a watch task by its target URI. To change the cadence or pause temporarily, cancel and re-add with a new `watch_interval` | `to_uri` (must match the watch task's `to` value, e.g. `viking://resources/...`) |
 | `grep` | Regex content search across `viking://` files | `uri`, `pattern` (string or array), `case_insensitive` |
 | `glob` | Find files matching a glob pattern | `pattern`, `uri` (optional scope) |
 | `forget` | Delete any `viking://` URI (use `search` to find it first; pass `recursive=true` to delete a directory) | `uri`, `recursive` (optional) |
 | `health` | Check OpenViking service health | none |
+
+> **Note**: MCP exposes the minimum closure for watch management (`list_watches` + `cancel_watch`). Pause / resume / trigger and the unified `update` verb are intentionally not exposed here — use the REST `/api/v1/watches/*` endpoints or the `ov task watch` CLI for those operations.
 
 ### Adding local-file resources (progressive upload)
 

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -95,7 +95,7 @@ claude mcp add --transport http openviking \
 
 ## 可用的 MCP 工具
 
-连接后，OpenViking MCP 端点暴露 9 个工具：
+连接后，OpenViking MCP 端点暴露 11 个工具：
 
 | 工具 | 说明 | 主要参数 |
 |------|------|----------|
@@ -104,10 +104,14 @@ claude mcp add --transport http openviking \
 | `list` | 列出 `viking://` 目录下的条目 | `uri`, `recursive`(可选) |
 | `store` | 存储消息到长期记忆（触发记忆提取） | `messages`（`{role, content}` 列表） |
 | `add_resource` | 添加本地文件或 URL 作为资源(本地文件触发渐进式上传流) | `path`, `temp_file_id`(可选), `description`(可选), `watch_interval`(可选,分钟数 — 远程 URL 的自动刷新周期), `to`(可选,目标 `viking://resources/...` URI；`watch_interval > 0` 时必填) |
+| `list_watches` | 列出当前 Agent 可见的 watch 任务（自动刷新订阅），每行显示目标 URI、刷新间隔（分钟）、active/paused 状态以及下一次调度时间 | 无 |
+| `cancel_watch` | 按目标 URI 取消（删除）watch 任务。若需调整刷新周期或临时暂停，请取消后使用新的 `watch_interval` 重新添加 | `to_uri`（必须匹配 watch 任务的 `to` 值，例如 `viking://resources/...`） |
 | `grep` | 在 `viking://` 文件中进行正则内容搜索 | `uri`, `pattern`（字符串或数组）, `case_insensitive` |
 | `glob` | 按 glob 模式匹配文件 | `pattern`, `uri`(可选范围) |
 | `forget` | 删除任意 `viking://` URI（先用 `search` 查找；删除目录需 `recursive=true`） | `uri`, `recursive`(可选) |
 | `health` | 检查 OpenViking 服务健康状态 | 无 |
+
+> **注**：MCP 仅暴露 watch 管理的最小闭包（`list_watches` + `cancel_watch`）。pause / resume / trigger 和统一的 `update` 动作刻意不在此处暴露，请通过 REST `/api/v1/watches/*` 接口或 `ov task watch` CLI 使用上述操作。
 
 ### 添加本地文件资源(渐进式上传)
 


### PR DESCRIPTION
## Summary

Updates the **Available MCP Tools** table in `docs/{en,zh}/guides/06-mcp-integration.md` to reflect the two new MCP tools added by #2110 (Watch Management API). Pre-#2110 the table claimed "9 tools" and listed 9 rows. After #2110 the MCP endpoint exposes 11 tools (`list_watches` + `cancel_watch` added in `openviking/server/mcp_endpoint.py` L618 / L655), so the integration guide that clients land on for tool discovery is now stale by 2 rows and a count.

This catch is scoped to the **client-facing setup guide** only. The deeper API reference (REST routes, CLI subcommands, MCP closure rationale) for the same feature is covered separately in #2123 under `docs/{en,zh}/api/02-resources.md`. Zero file overlap with #2123.

## Why this matters

A user wiring up an MCP client lands on `guides/06-mcp-integration.md` to discover what tools OpenViking advertises. The current table omits `list_watches` and `cancel_watch`, so:

- Agents auto-introspecting the table to plan tool use will miss the watch management surface entirely.
- Operators writing system prompts that enumerate "the X OpenViking MCP tools" will under-count or list stale parameters.
- The literal "9 tools" sentence directly contradicts the 11 tools actually exposed at runtime — a trivially-falsifiable claim that erodes doc trust.

## Source of truth

All description and parameter text is paraphrased verbatim from the docstrings on the two `@mcp.tool()` decorated functions in `openviking/server/mcp_endpoint.py` (commit fc5ed54):

- `list_watches() -> str` — no parameters, per-agent visibility, returns table-formatted lines.
- `cancel_watch(to_uri: str) -> str` — single required URI parameter, must match the watch task's `to` value.

The trailing note ("Pause / resume / trigger / update intentionally not exposed") is paraphrased from the source-of-truth comment block at `mcp_endpoint.py` L609-614, which explicitly says MCP exposes the minimum closure and points power users at REST or `ov task watch` CLI.

## Changes

- `docs/en/guides/06-mcp-integration.md`: `9 tools` → `11 tools`, insert 2 rows after the `add_resource` row, append a one-line note pointing watch power-users at REST / CLI for the remaining verbs.
- `docs/zh/guides/06-mcp-integration.md`: mirrored ZH update with the same byte-mirror structure.

Net: +8 LOC additive, 0 deletions other than the count number.

## Test plan

- [x] Both files render — table column alignment preserved, blockquote note renders.
- [x] EN/ZH parity verified — both tables now have 11 rows under the same heading.
- [x] Tool names + parameters verified against `openviking/server/mcp_endpoint.py` at HEAD (commit fc5ed54).
- [x] No code change — docs-only PR.
- [x] Pre-existing `add_resource` watch_interval parameter description left untouched; this PR only adds rows + count + closing note.
