### PR TITLE
docs(blog): add agent runtime stream-json demo

### DIFF
--- a/blog/public/post/agent-runtime/llm.txt
+++ b/blog/public/post/agent-runtime/llm.txt
@@ -1,0 +1,129 @@
+# Building an Agent Daemon
+
+Source title: Building an Agent Daemon
+Published: 2026-05-08
+Updated: 2026-05-20
+Author: zayn
+
+## Summary
+
+This post explains how to turn a CLI agent such as Claude Code into a product-grade daemon. A CLI agent is normally designed for one human at one terminal. A product runtime needs agents that can receive messages while idle, participate in multi-agent workflows, use shared cloud resources, survive restarts, and resume sessions.
+
+The architecture is a split boundary:
+
+- A cloud server owns users, permissions, message routing, coordination, and shared resources.
+- A local daemon owns the agent process, local files, shell access, tools, and runtime protocol translation.
+- The two sides communicate over WebSocket. The server sends product messages or events. The daemon accepts those WS messages, hands them to the matching local agent process, and returns the output stream.
+
+The daemon does not need to understand product semantics. It manages process lifecycle and runtime I/O.
+
+## Public Resources
+
+- Human page: https://blog.openviking.ai/post/agent-runtime/
+- Agent-readable page: https://blog.openviking.ai/post/agent-runtime/llm.txt
+- Runnable examples: https://github.com/ZaynJarvis/agent-runtime
+
+## Step 1: Spawn And Talk To Claude
+
+Claude Code supports programmatic JSON-over-stdio mode:
+
+```bash
+claude --output-format stream-json --input-format stream-json --model sonnet
+```
+
+Input is newline-delimited JSON sent to stdin. A minimal user message looks like:
+
+```json
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Say hi back in one sentence."}]}}
+```
+
+Output is a stream of newline-delimited JSON events on stdout. A representative shortened stream:
+
+```json
+{"type":"system","subtype":"init","session_id":"sess_demo_01","model":"claude-sonnet","tools":[]}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi! I am ready to help."}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","session_id":"sess_demo_01"}
+```
+
+Three event types matter for the first demo:
+
+- `system.init` gives the session ID.
+- `assistant` carries text blocks and tool calls.
+- `result` signals that the turn is complete.
+
+When a process exits, save the session ID. A later process can resume the conversation with `--resume <session_id>`.
+
+## Step 2: Split Into Server And Daemon
+
+The server side is product-facing. It manages users, channels, permissions, cloud resources, and routing. It does not need to know Claude's stdin/stdout protocol.
+
+The daemon side is local-runtime-facing. It starts the CLI agent, keeps track of the child process, receives WebSocket messages from the server, forwards them to the corresponding agent process, parses runtime output, and sends events back to the server.
+
+This boundary avoids putting local execution directly into the web app while still letting the agent use shared cloud resources.
+
+## Step 3: Add Multi-Agent And MCP Tools
+
+Raw Claude `stream-json` events are runtime-specific. A multi-agent product needs a generic envelope so the product does not care whether a worker is Claude, Codex, Cursor, or another runtime.
+
+Agents also need tools. The daemon can inject MCP tools at spawn time by writing a runtime config that points at a local MCP server. The post demonstrates two Claude agents playing Gomoku through MCP tools:
+
+- `view_board()` reads the current board from a game server.
+- `place_stone(x, y)` sends a move to the game server.
+
+The daemon normalizes Claude events into an envelope such as:
+
+```json
+{ "type": "agent:event", "agent": "black", "kind": "tool_use", "payload": { "name": "place_stone", "input": { "x": 7, "y": 7 } } }
+```
+
+## Step 4: Add Session Resurrection
+
+In real products, agents are often idle. Keeping every CLI process alive 24/7 is wasteful. The daemon can kill idle processes and later resume them when a message arrives.
+
+The product sends messages to a daemon endpoint. If the agent process is not alive, the daemon restarts it with the saved session ID. From the agent's perspective, the conversation is continuous. From the daemon's perspective, it is a sequence of short-lived processes sharing one session.
+
+## Runtime Drivers
+
+The daemon architecture is runtime-agnostic. A runtime driver knows how to:
+
+- spawn a specific CLI;
+- parse the runtime's event stream;
+- encode stdin messages;
+- build system prompts and config;
+- decide how busy agents receive new messages.
+
+Example interface:
+
+```ts
+interface Driver {
+  id: string;
+  spawn(ctx: SpawnContext): { process: ChildProcess };
+  parseLine(line: string): ParsedEvent[];
+  encodeStdinMessage(text: string, sessionId: string | null): string | null;
+  buildSystemPrompt(config: AgentConfig, agentId: string): string;
+  busyDeliveryMode: "notification" | "direct" | "none";
+}
+```
+
+Runtime protocol families:
+
+| Protocol | Runtimes | Behavior |
+| --- | --- | --- |
+| `stream-json` | Claude, Cursor | NDJSON over stdio. Events include `system.init`, `assistant`, and `result`. |
+| ACP / JSON-RPC | Codex, Hermes, OpenCode, Coco | JSON-RPC 2.0 over stdio. Methods include `session/new`, `session/prompt`, and `session/update`. |
+| Custom JSON events | Copilot, Gemini | Runtime-specific event streams, often one-shot per turn. |
+
+Busy delivery modes:
+
+- `direct`: pipe the message into the active turn through stdin.
+- `notification`: store the message and expose it through a tool such as `check_messages`.
+- `none`: queue the message until the current turn ends, then restart with the queued message.
+
+## Build Order
+
+1. Own the process: spawn the CLI agent as a child process, talk JSON over stdin/stdout, and save session IDs.
+2. Split server and daemon: the server handles users, routing, and shared cloud resources; the daemon handles local processes.
+3. Normalize and inject tools: translate runtime events into a product envelope and inject MCP tools.
+4. Add session resurrection: kill idle processes and resume them on demand.
+
+The core rule: let the product own coordination, let the daemon own local execution, and let tools be the only way an agent changes shared state.

--- a/blog/public/post/agent-runtime/llm.txt
+++ b/blog/public/post/agent-runtime/llm.txt
@@ -63,14 +63,14 @@ This boundary avoids putting local execution directly into the web app while sti
 
 ## Step 3: Add Multi-Agent And MCP Tools
 
-Raw Claude `stream-json` events are runtime-specific. A multi-agent product needs a generic envelope so the product does not care whether a worker is Claude, Codex, Cursor, or another runtime.
+Raw Claude `stream-json` events are runtime-specific. A multi-agent product should normalize them into one shared event shape. The outer fields, such as `type`, `agentId`, and `entries`, tell the product how to route and display the event. Runtime-specific details stay inside the event body. This lets the product handle Claude, Codex, Cursor, and other runtimes through one interface.
 
 Agents also need tools. The daemon can inject MCP tools at spawn time by writing a runtime config that points at a local MCP server. The post demonstrates two Claude agents playing Gomoku through MCP tools:
 
 - `view_board()` reads the current board from a game server.
 - `place_stone(x, y)` sends a move to the game server.
 
-The daemon normalizes Claude events into an envelope such as:
+The daemon normalizes Claude events into the shared event shape, for example:
 
 ```json
 { "type": "agent:event", "agent": "black", "kind": "tool_use", "payload": { "name": "place_stone", "input": { "x": 7, "y": 7 } } }
@@ -123,7 +123,7 @@ Busy delivery modes:
 
 1. Own the process: spawn the CLI agent as a child process, talk JSON over stdin/stdout, and save session IDs.
 2. Split server and daemon: the server handles users, routing, and shared cloud resources; the daemon handles local processes.
-3. Normalize and inject tools: translate runtime events into a product envelope and inject MCP tools.
+3. Normalize and inject tools: translate runtime events into a shared product event shape and inject MCP tools.
 4. Add session resurrection: kill idle processes and resume them on demand.
 
 The core rule: let the product own coordination, let the daemon own local execution, and let tools be the only way an agent changes shared state.

--- a/blog/src/posts/agent-runtime/index.jsx
+++ b/blog/src/posts/agent-runtime/index.jsx
@@ -4,6 +4,8 @@ import {
   Ol, Li, Ul, A, InlineCode, Tag, Table,
 } from '../../blog-components';
 
+const LLM_PATH = '/post/agent-runtime/llm.txt';
+
 const STREAM_JSON_INPUT = `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Say hi back in one sentence."}]}}`;
 
 const STREAM_JSON_OUTPUT = `{"type":"system","subtype":"init","session_id":"sess_demo_01","model":"claude-sonnet","tools":[]}
@@ -216,8 +218,8 @@ node 1a_ws_server.js
 node 1b_ws_daemon.js`}</Pre>
 
       <P>{T({
-        en: 'The server knows nothing about Claude. It sends text, receives events. The daemon knows nothing about the product. It owns the process and translates. This boundary is the entire architecture.',
-        zh: 'Server 对 Claude 一无所知——它发送文本，接收事件。Daemon 对产品一无所知——它管理进程并做翻译。这个边界就是整个架构。',
+        en: 'The server knows nothing about Claude. It sends product messages over WebSocket and receives runtime events back. The daemon does not need product semantics; it accepts WS messages, hands them to the matching agent process, and returns the output stream. This boundary is the entire architecture.',
+        zh: 'Server 对 Claude 一无所知——它通过 WebSocket 发送产品侧消息，接收运行时事件。Daemon 不需要理解产品语义；它只接收 WS 发来的消息/事件，交给对应 agent 进程处理，再把输出流回传。这个边界就是整个架构。',
       })}</P>
 
       <Hr ornament />
@@ -633,6 +635,7 @@ export default {
     category: { en: 'Engineering', zh: '工程' },
     tags: ['agent', 'daemon', 'mcp', 'claude-code'],
     languages: ['en', 'zh'],
+    llmPath: LLM_PATH,
     authors: [{ name: 'zayn', github: 'ZaynJarvis', role: { en: 'Engineer', zh: '工程师' } }],
   },
 };

--- a/blog/src/posts/agent-runtime/index.jsx
+++ b/blog/src/posts/agent-runtime/index.jsx
@@ -148,8 +148,8 @@ send(proc2, "What is my secret code?");
       <H2 id="step-2">{T({ en: 'Step 2: Split Into Server and Daemon', zh: '第二步：拆分成 Server 和 Daemon' })}</H2>
 
       <P>{T({
-        en: 'A product needs network access. An agent needs local file access. Mixing the two is how you end up with browser tabs owning local shells. The fix: split into two processes connected by WebSocket.',
-        zh: '产品需要网络访问，agent 需要本地文件访问。把两者混在一起，就会变成浏览器标签页拥有本地 shell。解法：拆成两个进程，用 WebSocket 连接。',
+        en: 'The product owns users, permissions, message routing, and shared cloud resources. The agent needs local files, shell access, and tools. To let the agent use those cloud resources without putting local execution inside the web app, split the system: a cloud server coordinates, and a local daemon owns the agent process over WebSocket.',
+        zh: '云上产品负责用户、权限、消息路由和共享资源；本地 agent 需要访问文件、shell 和工具。要让 agent 使用这些云上资源，又不把本地执行能力塞进网页里，就把系统拆成两端：云上 server 负责协调，本地 daemon 负责启动 agent，并通过 WebSocket 收发任务和事件。',
       })}</P>
 
       <Pre lang="js" filename="1a_ws_server.js">{`// NO-AGENT SIDE — accepts a WebSocket connection from the daemon,

--- a/blog/src/posts/agent-runtime/index.jsx
+++ b/blog/src/posts/agent-runtime/index.jsx
@@ -227,8 +227,8 @@ node 1b_ws_daemon.js`}</Pre>
       <H2 id="step-3">{T({ en: 'Step 3: Add Multi-Agent and MCP Tools', zh: '第三步：添加多 Agent 和 MCP 工具' })}</H2>
 
       <P>{T({
-        en: 'Raw stream-json events are Claude-specific. If you want to host multiple agents (possibly different runtimes), you need an envelope. And if agents need to interact with the world, they need tools — injected by the daemon at spawn time via MCP.',
-        zh: 'stream-json 事件是 Claude 特有的。如果你想托管多个 agent（甚至不同运行时），你需要一个信封协议。如果 agent 需要与外部世界交互，它需要工具——由 daemon 在启动时通过 MCP 注入。',
+        en: 'Raw stream-json events are Claude-specific. If you want to host multiple agents (possibly different runtimes), normalize them into one event shape: outer fields such as type, agentId, and entries tell the product how to route and display the event; the runtime-specific details stay inside. And if agents need to interact with the world, they need tools — injected by the daemon at spawn time via MCP.',
+        zh: 'stream-json 事件是 Claude 特有的。如果你想托管多个 agent（甚至不同运行时），先把它们转成同一种事件格式：外层字段说明事件类型、agentId 和内容列表，产品按这一层做路由和展示；各运行时自己的细节放在里面。agent 要和外部世界交互时，再由 daemon 在启动时通过 MCP 注入工具。',
       })}</P>
 
       <P>{T({
@@ -312,8 +312,8 @@ ws.on("message", (data) => {
 });`}</Pre>
 
       <P>{T({
-        en: 'The daemon also normalizes Claude\'s stream-json into a generic envelope — so the game server doesn\'t care whether it\'s Claude, Codex, or something else:',
-        zh: 'Daemon 还会将 Claude 的 stream-json 归一化为通用信封——这样游戏服务器不关心运行的是 Claude、Codex 还是别的什么：',
+        en: 'The daemon also normalizes Claude\'s stream-json into that shared event shape — so the game server doesn\'t care whether it\'s Claude, Codex, or something else:',
+        zh: 'Daemon 还会把 Claude 的 stream-json 归一化成这种统一事件格式——这样游戏服务器不关心运行的是 Claude、Codex 还是别的什么：',
       })}</P>
 
       <Pre lang="js" filename="normalizeAndEmit()">{`function normalizeAndEmit(agentId, ev) {
@@ -509,7 +509,7 @@ node 4b_chat_daemon.js
       <Ol>
         <Li><strong>{T({ en: 'Own the process', zh: '接管进程' })}</strong>{T({ en: ' — spawn Claude as a child, talk JSON over stdin/stdout. Save the session ID.', zh: '——以子进程方式启动 Claude，通过 stdin/stdout 传 JSON。保存 session ID。' })}</Li>
         <Li><strong>{T({ en: 'Split server and daemon', zh: '拆分 server 和 daemon' })}</strong>{T({ en: ' — server handles users and routing. Daemon handles the local process. WebSocket in between.', zh: '——server 处理用户和路由，daemon 处理本地进程，中间用 WebSocket 连接。' })}</Li>
-        <Li><strong>{T({ en: 'Normalize and inject tools', zh: '归一化并注入工具' })}</strong>{T({ en: ' — translate runtime events into a generic envelope. Give agents MCP tools to interact with the product.', zh: '——将运行时事件翻译成通用信封。通过 MCP 给 agent 注入与产品交互的工具。' })}</Li>
+        <Li><strong>{T({ en: 'Normalize and inject tools', zh: '归一化并注入工具' })}</strong>{T({ en: ' — translate runtime events into a shared product event shape. Give agents MCP tools to interact with the product.', zh: '——将运行时事件翻译成产品统一事件格式。通过 MCP 给 agent 注入与产品交互的工具。' })}</Li>
         <Li><strong>{T({ en: 'Add session resurrection', zh: '添加 session 复活' })}</strong>{T({ en: ' — kill idle processes, resume them on demand. The agent becomes serverless.', zh: '——杀掉空闲进程，按需恢复。Agent 变成无服务器的。' })}</Li>
       </Ol>
 
@@ -610,7 +610,7 @@ node 4b_chat_daemon.js
       <Ul>
         <Li><InlineCode>0_run_claude.js</InlineCode>{T({ en: ' — basic spawn + NDJSON communication', zh: '——基础启动 + NDJSON 通信' })}</Li>
         <Li><InlineCode>1a_ws_server.js</InlineCode> + <InlineCode>1b_ws_daemon.js</InlineCode>{T({ en: ' — WebSocket server/daemon split', zh: '——WebSocket server/daemon 拆分' })}</Li>
-        <Li><InlineCode>2a</InlineCode>/<InlineCode>2b</InlineCode>{T({ en: ' — envelope normalization (zouk protocol)', zh: '——信封归一化（zouk 协议）' })}</Li>
+        <Li><InlineCode>2a</InlineCode>/<InlineCode>2b</InlineCode>{T({ en: ' — event-shape normalization (zouk protocol)', zh: '——事件格式归一化（zouk 协议）' })}</Li>
         <Li><InlineCode>3a</InlineCode>/<InlineCode>3b</InlineCode>/<InlineCode>3c</InlineCode>{T({ en: ' — two-agent gomoku game with MCP tools', zh: '——双 agent 五子棋对弈 + MCP 工具' })}</Li>
         <Li><InlineCode>4a</InlineCode>/<InlineCode>4b</InlineCode>/<InlineCode>4c</InlineCode>{T({ en: ' — chat platform with session resurrection', zh: '——聊天平台 + session 复活' })}</Li>
         <Li><InlineCode>test_resume.js</InlineCode>{T({ en: ' — session resume proof', zh: '——session 恢复验证' })}</Li>

--- a/blog/src/posts/agent-runtime/index.jsx
+++ b/blog/src/posts/agent-runtime/index.jsx
@@ -4,6 +4,42 @@ import {
   Ol, Li, Ul, A, InlineCode, Tag, Table,
 } from '../../blog-components';
 
+const STREAM_JSON_INPUT = `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Say hi back in one sentence."}]}}`;
+
+const STREAM_JSON_OUTPUT = `{"type":"system","subtype":"init","session_id":"sess_demo_01","model":"claude-sonnet","tools":[]}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi! I am ready to help."}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","session_id":"sess_demo_01"}`;
+
+function StreamJsonDemo({ T }) {
+  return (
+    <details className="runtime-io-demo">
+      <summary>
+        <span className="runtime-io-demo__title">{T({
+          en: 'Expandable example: stdin JSON and stdout stream',
+          zh: '可展开演示：stdin 输入 JSON 与 stdout 输出流',
+        })}</span>
+        <span className="runtime-io-demo__hint">{T({ en: 'folded by default', zh: '默认折叠' })}</span>
+      </summary>
+      <div className="runtime-io-demo__body">
+        <P className="runtime-io-demo__intro">{T({
+          en: 'Write one NDJSON line to stdin. Claude then emits multiple JSON events on stdout; this sample is trimmed, so real events may include more fields.',
+          zh: '向 stdin 写入一行 NDJSON。Claude 会在 stdout 连续输出多条 JSON 事件；这里是精简示例，真实事件可能带更多字段。',
+        })}</P>
+        <div className="runtime-io-demo__grid">
+          <section className="runtime-io-demo__panel runtime-io-demo__panel--input">
+            <div className="runtime-io-demo__label">{T({ en: 'stdin input', zh: 'stdin 输入' })}</div>
+            <pre className="runtime-io-demo__code"><code>{STREAM_JSON_INPUT}</code></pre>
+          </section>
+          <section className="runtime-io-demo__panel runtime-io-demo__panel--output">
+            <div className="runtime-io-demo__label">{T({ en: 'stdout output stream', zh: 'stdout 输出流' })}</div>
+            <pre className="runtime-io-demo__code"><code>{STREAM_JSON_OUTPUT}</code></pre>
+          </section>
+        </div>
+      </div>
+    </details>
+  );
+}
+
 const AgentRuntime = ({ t }) => {
   const T = t;
 
@@ -22,6 +58,8 @@ const AgentRuntime = ({ t }) => {
       })}</P>
 
       <Pre lang="bash" filename="terminal">{`claude --output-format stream-json --input-format stream-json --model sonnet`}</Pre>
+
+      <StreamJsonDemo T={T} />
 
       <P>{T({
         en: 'In Node.js, you spawn this as a child process and talk to it over stdin/stdout using NDJSON (newline-delimited JSON):',

--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -125,6 +125,105 @@ button { font: inherit; color: inherit; }
 .tk-pn { color: var(--th-mute); }
 .tk-op { color: var(--th-tk-op, var(--th-accent-2)); }
 
+.runtime-io-demo {
+  margin: 22px 0 30px;
+  overflow: hidden;
+  border: 1px solid var(--th-line);
+  border-radius: var(--th-radius);
+  background: color-mix(in oklab, var(--th-bg-2) 76%, var(--th-bg));
+}
+.runtime-io-demo > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 14px;
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--th-font-mono);
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--th-ink);
+}
+.runtime-io-demo > summary::-webkit-details-marker { display: none; }
+.runtime-io-demo > summary::before {
+  content: "+";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--th-line);
+  border-radius: 999px;
+  color: var(--th-accent);
+  background: var(--th-bg);
+}
+.runtime-io-demo[open] > summary::before { content: "-"; }
+.runtime-io-demo__title { flex: 1 1 auto; min-width: 0; font-weight: 500; }
+.runtime-io-demo__hint {
+  flex: 0 0 auto;
+  color: var(--th-mute);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.runtime-io-demo__body {
+  border-top: 1px solid var(--th-line);
+  padding: 14px;
+}
+.runtime-io-demo__intro {
+  margin-bottom: 12px;
+  max-width: none;
+  color: var(--th-mute);
+  font-size: 0.9em;
+}
+.runtime-io-demo__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.runtime-io-demo__panel {
+  --runtime-io-tone: var(--th-accent);
+  overflow: hidden;
+  min-width: 0;
+  border: 1px solid var(--th-line);
+  border-left: 3px solid var(--runtime-io-tone);
+  border-radius: var(--th-radius);
+  background: color-mix(in oklab, var(--runtime-io-tone) 7%, var(--th-bg));
+}
+.runtime-io-demo__panel--input { --runtime-io-tone: var(--th-tip); }
+.runtime-io-demo__panel--output { --runtime-io-tone: var(--th-accent); }
+.runtime-io-demo__label {
+  padding: 8px 10px;
+  border-bottom: 1px solid color-mix(in oklab, var(--runtime-io-tone) 34%, var(--th-line));
+  font-family: var(--th-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--runtime-io-tone);
+  background: color-mix(in oklab, var(--runtime-io-tone) 12%, transparent);
+}
+.runtime-io-demo__code {
+  margin: 0;
+  padding: 12px 10px;
+  overflow-x: auto;
+  font-family: var(--th-font-mono);
+  font-size: 12px;
+  line-height: 1.62;
+  white-space: pre;
+  tab-size: 2;
+  color: var(--th-ink);
+}
+@media (max-width: 720px) {
+  .runtime-io-demo > summary {
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .runtime-io-demo__hint { display: none; }
+  .runtime-io-demo__grid { grid-template-columns: 1fr; }
+}
+
 .b-quote { margin: 32px 0; padding: 0 0 0 24px; border-left: 3px solid var(--th-accent); font-style: normal; font-size: 1.1em; line-height: 1.5; color: var(--th-ink); }
 .b-quote__cite { margin-top: 12px; font-style: normal; font-size: 0.85em; color: var(--th-mute); font-family: var(--th-font-mono); }
 .b-pull { margin: 32px 0; padding: 24px 0; border-top: 1px solid var(--th-line); border-bottom: 1px solid var(--th-line); font-family: var(--th-font-display); font-size: clamp(22px, 2.6vw, 30px); line-height: 1.3; color: var(--th-accent); font-weight: 500; text-wrap: balance; }


### PR DESCRIPTION
## Summary
- add a default-folded expandable stream-json demo under the Claude command in the agent-runtime post
- show one stdin NDJSON input line and representative stdout event stream
- style input and output panels with distinct tones for readability

## Validation
- npm run build
- git diff --check