### PR TITLE
fix(observability): store usage audit sqlite under system data

### DIFF
--- a/openviking/observability/usage_audit/README.md
+++ b/openviking/observability/usage_audit/README.md
@@ -83,7 +83,7 @@ Observability Event Bus
 | --- | --- | --- |
 | `enabled` | `true` | 是否启用 Usage/Audit |
 | `backend` | `"sqlite"` | 当前仅支持 SQLite |
-| `sqlite_path` | `null` | SQLite 文件路径；为空时使用 OpenViking workspace 下的 `usage_audit.sqlite3` |
+| `sqlite_path` | `null` | SQLite 文件路径；为空时使用 OpenViking workspace 下的 `_system/usage_audit/usage_audit.sqlite3` |
 | `queue_size` | `10000` | 后台写入队列大小 |
 | `batch_size` | `500` | 单次批量写入的最大事件数 |
 | `flush_interval_seconds` | `1.0` | worker 定时 flush 间隔 |
@@ -409,7 +409,7 @@ Console BFF 查询的是账号级聚合和审计明细，当前只允许 `ROOT` 
 如果没有配置 `sqlite_path`，默认在 OpenViking workspace 下：
 
 ```text
-<workspace>/usage_audit.sqlite3
+<workspace>/_system/usage_audit/usage_audit.sqlite3
 ```
 
 可以通过 `server.observability.usage_audit.sqlite_path` 显式指定。

--- a/openviking/observability/usage_audit/runtime.py
+++ b/openviking/observability/usage_audit/runtime.py
@@ -24,6 +24,7 @@ from .worker import UsageAuditWorker
 logger = logging.getLogger(__name__)
 
 _SUBSCRIBER_NAME = "usage_audit"
+_DEFAULT_SQLITE_RELATIVE_PATH = Path("_system") / "usage_audit" / "usage_audit.sqlite3"
 
 
 @dataclass(slots=True)
@@ -45,7 +46,7 @@ def _resolve_sqlite_path(config: ServerConfig) -> Path:
         workspace = Path(ov_config.storage.workspace).expanduser().resolve()
     except Exception:  # noqa: BLE001
         workspace = DEFAULT_CONFIG_DIR
-    return workspace / "usage_audit.sqlite3"
+    return workspace / _DEFAULT_SQLITE_RELATIVE_PATH
 
 
 async def init_usage_audit_from_server_config(


### PR DESCRIPTION
## Description

Move the default Usage/Audit SQLite database from the workspace root into the workspace `_system` area so runtime data follows the same internal-storage layout as QueueFS.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Updated the default Usage/Audit SQLite path to `<workspace>/_system/usage_audit/usage_audit.sqlite3`.
- Kept explicit `server.observability.usage_audit.sqlite_path` behavior unchanged.
- Updated Usage/Audit README default-path documentation.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

```bash
.venv/bin/python -m py_compile openviking/observability/usage_audit/runtime.py
```

Note: local pre-commit hook could not run because it is installed against system Python without the `pre_commit` module.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This change does not add legacy path migration because Usage/Audit has not been formally released yet.
