### PR TITLE
docs: fix Chinese quickstart authentication links

### DIFF
--- a/docs/zh/getting-started/03-quickstart-server.md
+++ b/docs/zh/getting-started/03-quickstart-server.md
@@ -77,7 +77,7 @@ client = ov.SyncHTTPClient(
 )
 ```
 
-> `user_key` 通过 Admin API 创建（参见 [认证文档](../../guides/04-authentication.md)），服务端可自动识别其所属租户。
+> `user_key` 通过 Admin API 创建（参见 [认证文档](../guides/04-authentication.md)），服务端可自动识别其所属租户。
 
 **管理操作：使用 `root_key`**
 
@@ -97,7 +97,7 @@ client = ov.SyncHTTPClient(
 > ⚠️ 使用 `root_key` 调用 `add_resource`、`find` 等租户级 API 时，如果未提供 `account`/`user`，会收到：
 > `ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers`
 
-更多认证细节（trusted 模式、CLI 配置等）请参见 [认证文档](../../guides/04-authentication.md)。
+更多认证细节（trusted 模式、CLI 配置等）请参见 [认证文档](../guides/04-authentication.md)。
 
 **完整示例（使用 `user_key`）：**
 


### PR DESCRIPTION
## Description

Fixes two broken relative links to the Chinese authentication guide in the server quickstart documentation.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Updated two authentication guide links in `docs/zh/getting-started/03-quickstart-server.md`
- Changed the relative path from `../../guides/04-authentication.md` to `../guides/04-authentication.md`

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Manual validation performed:

- Verified the target file exists at `docs/zh/guides/04-authentication.md`
- Verified the diff only updates the two broken links

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Docs-only change.