### PR TITLE
docs(server): document `public_base_url` and `upload_signed_ttl_seconds` (#1847)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1168,6 +1168,8 @@ When running OpenViking as an HTTP service, add a `server` section to `ov.conf`:
     "auth_mode": "api_key",
     "root_api_key": "your-secret-root-key",
     "cors_origins": ["*"],
+    "public_base_url": "https://ov.example.com",
+    "upload_signed_ttl_seconds": 600,
     "temp_upload": {
       "default_mode": "local",
       "shared_max_size_bytes": 536870912,
@@ -1184,6 +1186,8 @@ When running OpenViking as an HTTP service, add a `server` section to `ov.conf`:
 | `auth_mode` | str | Authentication mode: `"api_key"` or `"trusted"`. Default is `"api_key"` | `"api_key"` |
 | `root_api_key` | str | Root API key for multi-tenant auth in `api_key` mode. In `trusted` mode it is optional on localhost, but required for any non-localhost deployment; it does not become the source of user identity | `null` |
 | `cors_origins` | list | Allowed CORS origins | `["*"]` |
+| `public_base_url` | str | Public-facing base URL emitted in MCP-issued upload instructions. Resolution order: env var `OPENVIKING_PUBLIC_BASE_URL` → this field → `X-Forwarded-Host`/`X-Forwarded-Proto` request headers → `Host` request header → listen-address fallback. Set this (or the env var) when the server runs behind a reverse proxy that does not forward `X-Forwarded-*` headers. | `null` |
+| `upload_signed_ttl_seconds` | int | TTL in seconds for one-shot tokens minted by the MCP `add_resource` tool for local-file uploads via the signed `POST /api/v1/resources/temp_upload_signed` endpoint. | `600` (10 minutes) |
 | `temp_upload.default_mode` | str | Server-side default for `POST /api/v1/resources/temp_upload` when the client does not send `upload_mode`: `"local"` (per-instance disk, current single-node behavior) or `"shared"` (distributed shared store usable across replicas). | `"local"` |
 | `temp_upload.shared_max_size_bytes` | int | Maximum size accepted in `shared` mode, in bytes. Requests above this size are rejected before object-store write. | `536870912` (512 MiB) |
 | `temp_upload.shared_prefix` | str | URI prefix used when allocating shared `temp_file_id` objects. | `"viking://upload"` |

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1140,6 +1140,8 @@ openviking add-resource ./docs --exclude "*.tmp"
     "auth_mode": "api_key",
     "root_api_key": "your-secret-root-key",
     "cors_origins": ["*"],
+    "public_base_url": "https://ov.example.com",
+    "upload_signed_ttl_seconds": 600,
     "temp_upload": {
       "default_mode": "local",
       "shared_max_size_bytes": 536870912,
@@ -1156,6 +1158,8 @@ openviking add-resource ./docs --exclude "*.tmp"
 | `auth_mode` | str | 认证模式：`"api_key"` 或 `"trusted"`。默认值为 `"api_key"` | `"api_key"` |
 | `root_api_key` | str | Root API Key。在 `api_key` 模式下启用多租户认证；在 `trusted` 模式下它只是可选附加保护，不负责解析普通用户身份 | `null` |
 | `cors_origins` | list | CORS 允许的来源 | `["*"]` |
+| `public_base_url` | str | MCP `add_resource` 工具向客户端返回的上传指令里使用的对外可见 base URL。解析顺序：环境变量 `OPENVIKING_PUBLIC_BASE_URL` → 本字段 → 请求头 `X-Forwarded-Host` / `X-Forwarded-Proto` → 请求头 `Host` → 监听地址兜底。当 server 部署在反向代理后且代理不转发 `X-Forwarded-*` 时，请显式设置本字段（或环境变量）。 | `null` |
+| `upload_signed_ttl_seconds` | int | MCP `add_resource` 为本地文件上传 mint 的一次性 token 在签名端点 `POST /api/v1/resources/temp_upload_signed` 上的过期时间（秒）。 | `600`（10 分钟） |
 | `temp_upload.default_mode` | str | `POST /api/v1/resources/temp_upload` 的服务端默认模式（客户端未显式传 `upload_mode` 时使用）：`"local"`（仅当前实例本地磁盘，单机默认行为）或 `"shared"`（分布式共享存储，多副本部署可跨实例消费）。 | `"local"` |
 | `temp_upload.shared_max_size_bytes` | int | `shared` 模式下接受的最大文件大小（字节）。超过此阈值的请求会在写入对象存储之前被拒绝。 | `536870912`（512 MiB） |
 | `temp_upload.shared_prefix` | str | 分配 shared `temp_file_id` 对象时使用的 URI 前缀。 | `"viking://upload"` |


### PR DESCRIPTION
docs: document `server.public_base_url` and `server.upload_signed_ttl_seconds` (#1847)

#1847 (`feat(mcp): progressive single-entrypoint upload for local files`) added two
new top-level fields on `ServerConfig`:

- `public_base_url: Optional[str] = None`
- `upload_signed_ttl_seconds: int = 600`

`docs/{en,zh}/guides/06-mcp-integration.md` already covers the env-var
side (`OPENVIKING_PUBLIC_BASE_URL` resolution chain) per #1847, but the
canonical server-config reference in `docs/{en,zh}/guides/01-configuration.md`
— the section that begins with `## server Section` and lists the JSON example
+ field table — still shows only the pre-1847 fields (`host`, `port`,
`auth_mode`, `root_api_key`, `cors_origins`, `temp_upload.*`).

This PR syncs that reference:

- Adds both fields to the `server` JSON example block.
- Adds two table rows describing each field, defaults verbatim from
  `openviking/server/config.py` (`public_base_url=None`,
  `upload_signed_ttl_seconds=600`).
- Resolution-order prose for `public_base_url` mirrors the inline comment
  block in `config.py` (env var → field → `X-Forwarded-Host`/`-Proto` →
  `Host` header → listen-address fallback).
- Mirrors EN and ZH so the canonical reference matches the existing
  06-mcp-integration.md narrative.

Pure docs catch — no code change, no logic decision.