### PR TITLE
fix: reload full records when updating uri mapping

### DIFF
--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -65,22 +65,10 @@ FETCH_BY_URI_OUTPUT_FIELDS = [
 ]
 
 URI_REWRITE_OUTPUT_FIELDS = [
+    "id",
     "uri",
-    "type",
-    "context_type",
-    "vector",
-    "sparse_vector",
-    "created_at",
-    "updated_at",
-    "active_count",
     "level",
-    "name",
-    "description",
-    "tags",
-    "abstract",
     "account_id",
-    "owner_user_id",
-    "owner_agent_id",
 ]
 
 
@@ -980,6 +968,25 @@ class VikingVectorIndexBackend:
         )
         if not records:
             return False
+        record_ids = [str(record["id"]) for record in records if record.get("id")]
+        if not record_ids:
+            logger.warning(
+                "update_uri_mapping found records without ids: uri=%s new_uri=%s account_id=%s",
+                canonical_uri,
+                canonical_new_uri,
+                ctx.account_id,
+            )
+            return False
+        full_records = await self.get(record_ids, ctx=ctx)
+        if not full_records:
+            logger.warning(
+                "update_uri_mapping failed to fetch full records: uri=%s new_uri=%s account_id=%s ids=%s",
+                canonical_uri,
+                canonical_new_uri,
+                ctx.account_id,
+                record_ids,
+            )
+            return False
 
         def _seed_uri_for_id(uri: str, level: int) -> str:
             if level == 0:
@@ -990,7 +997,7 @@ class VikingVectorIndexBackend:
 
         success = False
         ids_to_delete: List[str] = []
-        for record in records:
+        for record in full_records:
             if "id" not in record:
                 continue
             raw_level = record.get("level", 2)
@@ -1008,6 +1015,17 @@ class VikingVectorIndexBackend:
                 "id": new_id,
                 "uri": canonical_new_uri,
             }
+            vector = updated.get("vector")
+            if not vector:
+                logger.warning(
+                    "update_uri_mapping skipped record without dense vector: old_uri=%s new_uri=%s level=%s account_id=%s id=%s",
+                    canonical_uri,
+                    canonical_new_uri,
+                    level,
+                    ctx.account_id,
+                    record.get("id"),
+                )
+                continue
             if await self.upsert(updated, ctx=ctx):
                 success = True
                 old_id = record.get("id")


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-update_uri_mapping 不再直接拿查询出来的精简记录做 URI 重写，而是先收集记录 id，再通过
  self.get(...) 拉取完整记录后再 upsert。另外补了两层保护：
  如果没查到有效 id，直接告警并返回；
  如果完整记录里缺少 dense vector，就跳过该条并打 warning。
  它解决的问题是：URI 改名时，原先用的是字段不全的记录，可能缺少向量等关键数据，导致新记录写入失败、写入残
  缺数据，或者 URI 映射迁移不完整。现在改成先补全原记录再写，能保证 URI 映射更新基于完整数据执行，并且在关
  键字段缺失时显式失败或跳过，不再静默出错。
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
