### PR TITLE
fix(examples): wait before quickstart preview

### DIFF
--- a/docs/en/getting-started/02-quickstart.md
+++ b/docs/en/getting-started/02-quickstart.md
@@ -152,8 +152,11 @@ try:
 
     # Add resource (supports URL, file, or directory)
     # Local directory scans respect .gitignore by default.
+    # Wait until semantic processing completes before inspecting the resource.
+    print("Wait for semantic processing...")
     add_result = client.add_resource(
-        path="https://raw.githubusercontent.com/volcengine/OpenViking/refs/heads/main/README.md"
+        path="https://raw.githubusercontent.com/volcengine/OpenViking/refs/heads/main/README.md",
+        wait=True,
     )
     root_uri = add_result['root_uri']
 
@@ -166,10 +169,6 @@ try:
     if glob_result['matches']:
         content = client.read(glob_result['matches'][0])
         print(f"Content preview: {content[:200]}...\n")
-
-    # Wait for semantic processing to complete
-    print("Wait for semantic processing...")
-    client.wait_processed()
 
     # Get abstract and overview of the resource
     abstract = client.abstract(root_uri)
@@ -198,12 +197,13 @@ python example.py
 ### Expected Output
 
 ```
+Wait for semantic processing...
+
 Directory structure:
 ...
 
 Content preview: ...
 
-Wait for semantic processing...
 Abstract:
 ...
 

--- a/docs/zh/getting-started/02-quickstart.md
+++ b/docs/zh/getting-started/02-quickstart.md
@@ -152,8 +152,11 @@ try:
 
     # Add resource (supports URL, file, or directory)
     # Local directory scans respect .gitignore by default.
+    # Wait until semantic processing completes before inspecting the resource.
+    print("Wait for semantic processing...")
     add_result = client.add_resource(
-        path="https://raw.githubusercontent.com/volcengine/OpenViking/refs/heads/main/README.md"
+        path="https://raw.githubusercontent.com/volcengine/OpenViking/refs/heads/main/README.md",
+        wait=True,
     )
     root_uri = add_result['root_uri']
 
@@ -166,10 +169,6 @@ try:
     if glob_result['matches']:
         content = client.read(glob_result['matches'][0])
         print(f"Content preview: {content[:200]}...\n")
-
-    # Wait for semantic processing to complete
-    print("Wait for semantic processing...")
-    client.wait_processed()
 
     # Get abstract and overview of the resource
     abstract = client.abstract(root_uri)
@@ -198,12 +197,13 @@ python example.py
 ### 预期输出
 
 ```
+Wait for semantic processing...
+
 Directory structure:
 ...
 
 Content preview: ...
 
-Wait for semantic processing...
 Abstract:
 ...
 

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -6,9 +6,11 @@ client = ov.OpenViking(path="./data")
 try:
     client.initialize()
 
-    # Add resource (URL, file, or directory)
+    # Add resource (URL, file, or directory) and wait until it is ready to inspect
+    print("Wait for semantic processing...")
     res = client.add_resource(
-        path="https://raw.githubusercontent.com/volcengine/OpenViking/refs/heads/main/README.md"
+        path="https://raw.githubusercontent.com/volcengine/OpenViking/refs/heads/main/README.md",
+        wait=True,
     )
     root_uri = res["root_uri"]
     res = client.ls(root_uri)  # Explore resource tree
@@ -18,9 +20,6 @@ try:
     if res["matches"]:
         content = client.read(res["matches"][0])
         print(f"Content preview: {content[:200]}...\n")
-
-    print(" Wait for semantic processing...")
-    client.wait_processed()
 
     abstract = client.abstract(root_uri)  # Get abstract
     overview = client.overview(root_uri)  # Get overview

--- a/tests/integration/test_quick_start_lite.py
+++ b/tests/integration/test_quick_start_lite.py
@@ -4,6 +4,8 @@ import shutil
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 # Ensure the project root is in sys.path
@@ -237,11 +239,18 @@ class TestQuickStartLite(unittest.TestCase):
             try:
                 os.chdir(os.path.dirname(script_path))
                 global_ns = {"__name__": "__main__", "__file__": script_path}
-                exec(code, global_ns)
+                output = StringIO()
+                with redirect_stdout(output):
+                    exec(code, global_ns)
             except Exception as e:
                 self.fail(f"Quick start script execution failed: {e}")
             finally:
                 os.chdir(original_cwd)
+
+            output_text = output.getvalue()
+            self.assertIn("Directory structure:", output_text)
+            self.assertNotIn("Directory structure:\n[]", output_text)
+            self.assertIn("Content preview:", output_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fix the quickstart example so it waits for resource processing before inspecting the imported resource. Previously, the example could print an empty directory structure and skip `Content preview` because `add_resource()` returned before the resource tree was ready.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Updated `examples/quick_start.py` to call `add_resource(..., wait=True)` before listing and previewing the resource.
- Updated English and Chinese quickstart docs to match the corrected execution order and expected output.
- Added regression assertions to the quickstart lite integration test to ensure the example prints a non-empty directory structure and `Content preview`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Local verification:
- `python -m py_compile examples/quick_start.py tests/integration/test_quick_start_lite.py`
- `git diff --check`

Could not run the full quickstart lite test locally because the current environment is missing test/runtime dependencies such as `loguru`, `pytest_asyncio`, and `ruff`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This change keeps the quickstart flow deterministic for first-time users by waiting for resource processing before calling `ls()`, `glob()`, and `read()`.