### PR TITLE
fix(storage): 按事件循环隔离异步客户端

### DIFF
--- a/openviking/models/embedder/cohere_embedders.py
+++ b/openviking/models/embedder/cohere_embedders.py
@@ -7,12 +7,12 @@ Supports embed-v4.0 and embed-english-v3.0 models with input_type
 for asymmetric retrieval.
 """
 
-import asyncio
 from typing import Any, Dict, List, Optional
 
 import httpx
 
 from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult, truncate_and_normalize
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -91,7 +91,7 @@ class CohereDenseEmbedder(DenseEmbedderBase):
             },
             timeout=60.0,
         )
-        self._async_client: Optional[httpx.AsyncClient] = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
     def _build_payload(self, texts: List[str], input_type: str) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
@@ -111,8 +111,8 @@ class CohereDenseEmbedder(DenseEmbedderBase):
         return data["embeddings"]["float"]
 
     async def _call_api_async(self, texts: List[str], input_type: str) -> List[List[float]]:
-        if self._async_client is None:
-            self._async_client = httpx.AsyncClient(
+        client = self._async_client_cache.get(
+            lambda: httpx.AsyncClient(
                 base_url=self.api_base,
                 headers={
                     "Authorization": f"Bearer {self.api_key}",
@@ -120,9 +120,8 @@ class CohereDenseEmbedder(DenseEmbedderBase):
                 },
                 timeout=60.0,
             )
-        resp = await self._async_client.post(
-            "/v2/embed", json=self._build_payload(texts, input_type)
         )
+        resp = await client.post("/v2/embed", json=self._build_payload(texts, input_type))
         resp.raise_for_status()
         data = resp.json()
         return data["embeddings"]["float"]
@@ -248,15 +247,7 @@ class CohereDenseEmbedder(DenseEmbedderBase):
     def close(self):
         """Close the httpx client connection pool."""
         self._client.close()
-        if self._async_client is not None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
-            if loop and loop.is_running():
-                loop.create_task(self._async_client.aclose())
-            else:
-                asyncio.run(self._async_client.aclose())
+        self._async_client_cache.close_all_with_aclose()
 
     def get_dimension(self) -> int:
         return self._dimension

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -17,6 +17,7 @@ from openviking.models.embedder.base import (
     truncate_and_normalize,
 )
 from openviking.telemetry import get_current_telemetry
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils.logger import default_logger as logger
 
 _DASHSCOPE_DIMENSIONS: Dict[str, int] = {
@@ -97,9 +98,9 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
             f"{self.api_base}/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding"
         )
 
-        # --- async clients (lazy) ---
-        self._async_openai_client: Optional[openai.AsyncOpenAI] = None
-        self._async_httpx_client: Optional[httpx.AsyncClient] = None
+        # --- async clients (lazy, event-loop scoped) ---
+        self._async_openai_client_cache = LoopScopedAsyncClientCache()
+        self._async_httpx_client_cache = LoopScopedAsyncClientCache()
 
     # ------------------------------------------------------------------
     # Token telemetry
@@ -174,20 +175,20 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # ------------------------------------------------------------------
 
     def _get_async_openai_client(self) -> openai.AsyncOpenAI:
-        if self._async_openai_client is None:
-            self._async_openai_client = openai.AsyncOpenAI(
+        return self._async_openai_client_cache.get(
+            lambda: openai.AsyncOpenAI(
                 api_key=self.api_key,
                 base_url=f"{self.api_base}/compatible-mode/v1",
             )
-        return self._async_openai_client
+        )
 
     def _get_async_httpx_client(self) -> httpx.AsyncClient:
-        if self._async_httpx_client is None:
-            self._async_httpx_client = httpx.AsyncClient(
+        return self._async_httpx_client_cache.get(
+            lambda: httpx.AsyncClient(
                 headers={"Authorization": f"Bearer {self.api_key}"},
                 timeout=60.0,
             )
-        return self._async_httpx_client
+        )
 
     # ------------------------------------------------------------------
     # embed
@@ -415,20 +416,5 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
             self._openai_client.close()
         if self._httpx_client is not None:
             self._httpx_client.close()
-        # --- async clients (event-loop-aware cleanup) ---
-        import asyncio
-
-        async def _close_async_clients() -> None:
-            if self._async_openai_client is not None:
-                await self._async_openai_client.close()
-            if self._async_httpx_client is not None:
-                await self._async_httpx_client.aclose()
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-        if loop and loop.is_running():
-            loop.create_task(_close_async_clients())
-        else:
-            asyncio.run(_close_async_clients())
+        self._async_openai_client_cache.close_all_with_close()
+        self._async_httpx_client_cache.close_all_with_aclose()

--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -10,6 +10,7 @@ from openviking.models.embedder.base import (
     DenseEmbedderBase,
     EmbedResult,
 )
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -121,7 +122,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             api_key=self.api_key,
             base_url=self.api_base,
         )
-        self._async_client = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
         # Determine dimension
         max_dim = JINA_MODEL_DIMENSIONS.get(model_name, 1024)
@@ -158,12 +159,12 @@ class JinaDenseEmbedder(DenseEmbedderBase):
         return kwargs
 
     def _get_async_client(self):
-        if self._async_client is None:
-            self._async_client = openai.AsyncOpenAI(
+        return self._async_client_cache.get(
+            lambda: openai.AsyncOpenAI(
                 api_key=self.api_key,
                 base_url=self.api_base,
             )
-        return self._async_client
+        )
 
     def _raise_task_error(self, error: openai.APIError) -> None:
         """Raise an actionable error if a 422 indicates an invalid task type."""

--- a/openviking/models/embedder/minimax_embedders.py
+++ b/openviking/models/embedder/minimax_embedders.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """MiniMax Embedder Implementation via HTTP API"""
 
-import asyncio
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -11,6 +10,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils.logger import default_logger as logger
 
 
@@ -80,7 +80,7 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
 
         # Initialize session with retry logic
         self.session = self._create_session()
-        self._async_client: Optional[httpx.AsyncClient] = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
         # Auto-detect dimension if not provided
         if self._dimension is None:
@@ -172,11 +172,10 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
         }
 
     async def _call_api_async(self, texts: List[str], is_query: bool = False) -> List[List[float]]:
-        if self._async_client is None:
-            self._async_client = httpx.AsyncClient(timeout=60.0)
+        client = self._async_client_cache.get(lambda: httpx.AsyncClient(timeout=60.0))
 
         try:
-            response = await self._async_client.post(
+            response = await client.post(
                 self.api_base,
                 headers=self._build_headers(),
                 params=self._build_params(),
@@ -281,12 +280,4 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
 
     def close(self):
         self.session.close()
-        if self._async_client is not None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
-            if loop and loop.is_running():
-                loop.create_task(self._async_client.aclose())
-            else:
-                asyncio.run(self._async_client.aclose())
+        self._async_client_cache.close_all_with_aclose()

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -14,6 +14,7 @@ from openviking.models.embedder.base import (
 )
 from openviking.models.vlm.registry import DEFAULT_AZURE_API_VERSION
 from openviking.telemetry import get_current_telemetry
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -147,7 +148,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             if extra_headers:
                 self._client_kwargs["default_headers"] = extra_headers
             self.client = openai.OpenAI(**self._client_kwargs)
-        self._async_client = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
         # Auto-detect dimension
         self._dimension = dimension
@@ -283,12 +284,12 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         return bool(self.api_base)
 
     def _get_async_client(self):
-        if self._async_client is None:
+        def _build_async_client():
             if self._provider == "azure":
-                self._async_client = openai.AsyncAzureOpenAI(**self._client_kwargs)
-            else:
-                self._async_client = openai.AsyncOpenAI(**self._client_kwargs)
-        return self._async_client
+                return openai.AsyncAzureOpenAI(**self._client_kwargs)
+            return openai.AsyncOpenAI(**self._client_kwargs)
+
+        return self._async_client_cache.get(_build_async_client)
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         """Perform dense embedding on text

--- a/openviking/models/embedder/vikingdb_embedders.py
+++ b/openviking/models/embedder/vikingdb_embedders.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """VikingDB Embedder Implementation via HTTP API"""
 
-import asyncio
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -17,6 +16,7 @@ from openviking.storage.vectordb.collection.volcengine_clients import (
     DEFAULT_TIMEOUT,
     ClientForDataApi,
 )
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils.logger import default_logger as logger
 
 
@@ -39,7 +39,7 @@ class VikingDBClientMixin:
             raise ValueError("AK and SK are required for VikingDB Embedder")
 
         self.client = ClientForDataApi(self.ak, self.sk, self.region, self.host)
-        self._async_client: Optional[httpx.AsyncClient] = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
     def _call_api(
         self,
@@ -93,10 +93,9 @@ class VikingDBClientMixin:
             req_body["sparse_model"] = sparse_model
 
         req = self.client.prepare_request(method="POST", path=path, data=req_body)
-        if self._async_client is None:
-            self._async_client = httpx.AsyncClient(timeout=DEFAULT_TIMEOUT)
+        client = self._async_client_cache.get(lambda: httpx.AsyncClient(timeout=DEFAULT_TIMEOUT))
 
-        response = await self._async_client.request(
+        response = await client.request(
             method=req.method,
             url=f"https://{self.host}{req.path}",
             headers=req.headers,
@@ -638,12 +637,4 @@ class VikingDBHybridEmbedder(HybridEmbedderBase, VikingDBClientMixin):
         return self.dimension if self.dimension else 2048
 
     def close(self):
-        if getattr(self, "_async_client", None) is not None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
-            if loop and loop.is_running():
-                loop.create_task(self._async_client.aclose())
-            else:
-                asyncio.run(self._async_client.aclose())
+        self._async_client_cache.close_all_with_aclose()

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -14,6 +14,7 @@ from openviking.models.embedder.base import (
     truncate_and_normalize,
 )
 from openviking.telemetry import get_current_telemetry
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils.logger import default_logger as logger
 
 
@@ -97,9 +98,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
             ark_kwargs["base_url"] = self.api_base
         self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
         self._ark_kwargs = ark_kwargs
-        self._async_client = None
-        self._ark_kwargs = ark_kwargs
-        self._async_client = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
         # Auto-detect dimension
         self._dimension = dimension
@@ -184,9 +183,9 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
             raise RuntimeError(f"Volcengine embedding failed: {str(e)}") from e
 
     def _get_async_client(self):
-        if self._async_client is None:
-            self._async_client = volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
-        return self._async_client
+        return self._async_client_cache.get(
+            lambda: volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
+        )
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
         client = self._get_async_client()
@@ -340,7 +339,7 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
             ark_kwargs["base_url"] = self.api_base
         self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
         self._ark_kwargs = ark_kwargs
-        self._async_client = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
     def _update_telemetry_token_usage(self, response) -> None:
         usage = getattr(response, "usage", None)
@@ -407,9 +406,9 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
             raise RuntimeError(f"Volcengine sparse embedding failed: {str(e)}") from e
 
     def _get_async_client(self):
-        if self._async_client is None:
-            self._async_client = volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
-        return self._async_client
+        return self._async_client_cache.get(
+            lambda: volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
+        )
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
         client = self._get_async_client()
@@ -528,7 +527,7 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
             ark_kwargs["base_url"] = self.api_base
         self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
         self._ark_kwargs = ark_kwargs
-        self._async_client = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
         self._dimension = dimension or 2048
 
     def _update_telemetry_token_usage(self, response) -> None:
@@ -601,9 +600,9 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
             raise RuntimeError(f"Volcengine hybrid embedding failed: {str(e)}") from e
 
     def _get_async_client(self):
-        if self._async_client is None:
-            self._async_client = volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
-        return self._async_client
+        return self._async_client_cache.get(
+            lambda: volcenginesdkarkruntime.AsyncArk(**self._ark_kwargs)
+        )
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
         client = self._get_async_client()

--- a/openviking/models/embedder/voyage_embedders.py
+++ b/openviking/models/embedder/voyage_embedders.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 import openai
 
 from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -82,7 +83,7 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
             api_key=self.api_key,
             base_url=self.api_base,
         )
-        self._async_client = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
 
         self._dimension = dimension or get_voyage_model_default_dimension(normalized_model_name)
 
@@ -93,12 +94,12 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
         return kwargs
 
     def _get_async_client(self):
-        if self._async_client is None:
-            self._async_client = openai.AsyncOpenAI(
+        return self._async_client_cache.get(
+            lambda: openai.AsyncOpenAI(
                 api_key=self.api_key,
                 base_url=self.api_base,
             )
-        return self._async_client
+        )
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         """Perform dense embedding on text."""

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from openviking.telemetry import tracer
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils import get_logger
 
 try:
@@ -79,7 +80,7 @@ class OpenAIVLM(VLMBase):
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
         self._sync_client = None
-        self._async_client = None
+        self._async_client_cache = LoopScopedAsyncClientCache()
         self.api_version = config.get("api_version")
         self.reasoning_effort = config.get("reasoning_effort", "low")
 
@@ -102,24 +103,25 @@ class OpenAIVLM(VLMBase):
                 self._sync_client = openai.OpenAI(**kwargs)
         return self._sync_client
 
+    def _build_async_client(self):
+        """Create an async client for the current backend."""
+        if openai is None:
+            raise ImportError("Please install openai: pip install openai")
+        kwargs = _build_openai_client_kwargs(
+            self.provider,
+            self.api_key,
+            self.api_base,
+            self.api_version,
+            self.extra_headers,
+            self.timeout,
+        )
+        if self.provider == "azure":
+            return openai.AsyncAzureOpenAI(**kwargs)
+        return openai.AsyncOpenAI(**kwargs)
+
     def get_async_client(self):
-        """Get async client"""
-        if self._async_client is None:
-            if openai is None:
-                raise ImportError("Please install openai: pip install openai")
-            kwargs = _build_openai_client_kwargs(
-                self.provider,
-                self.api_key,
-                self.api_base,
-                self.api_version,
-                self.extra_headers,
-                self.timeout,
-            )
-            if self.provider == "azure":
-                self._async_client = openai.AsyncAzureOpenAI(**kwargs)
-            else:
-                self._async_client = openai.AsyncOpenAI(**kwargs)
-        return self._async_client
+        """Get an async client scoped to the current event loop."""
+        return self._async_client_cache.get(self._build_async_client)
 
     def _supports_enable_thinking(self) -> bool:
         """Return True for OpenAI-compatible DashScope endpoints that accept enable_thinking."""

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -24,7 +24,6 @@ class VolcEngineVLM(OpenAIVLM):
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
         self._sync_client = None
-        self._async_client = None
         self.provider = "volcengine"
 
         if not self.api_base:
@@ -85,20 +84,18 @@ class VolcEngineVLM(OpenAIVLM):
             )
         return self._sync_client
 
-    def get_async_client(self):
-        """Get async client"""
-        if self._async_client is None:
-            try:
-                import volcenginesdkarkruntime
-            except ImportError:
-                raise ImportError(
-                    "Please install volcenginesdkarkruntime: pip install volcenginesdkarkruntime"
-                )
-            self._async_client = volcenginesdkarkruntime.AsyncArk(
-                api_key=self.api_key,
-                base_url=self.api_base,
+    def _build_async_client(self):
+        """Create an async client for the current event loop."""
+        try:
+            import volcenginesdkarkruntime
+        except ImportError:
+            raise ImportError(
+                "Please install volcenginesdkarkruntime: pip install volcenginesdkarkruntime"
             )
-        return self._async_client
+        return volcenginesdkarkruntime.AsyncArk(
+            api_key=self.api_key,
+            base_url=self.api_base,
+        )
 
     def get_completion(
         self,

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -4,21 +4,14 @@
 
 import logging
 import re
-import threading
-import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.utils.model_retry import (
-    classify_api_error,
-    ERROR_CLASS_QUOTA_EXCEEDED,
-    ERROR_CLASS_TRANSIENT,
-    ERROR_CLASS_PERMANENT,
     PrimaryBackupSwitcher,
 )
-from openviking.utils.time_utils import format_iso8601
 from openviking_cli.utils import get_logger
 
 from .token_usage import TokenUsageTracker
@@ -367,12 +360,7 @@ class FailoverVLM(VLMBase):
             failback_request_count=failback_request_count,
         )
 
-    def _get_completion_with_failover(
-        self,
-        method_name: str,
-        *args,
-        **kwargs
-    ):
+    def _get_completion_with_failover(self, method_name: str, *args, **kwargs):
         """Execute a VLM method with failover support.
 
         Args:
@@ -414,12 +402,7 @@ class FailoverVLM(VLMBase):
             self._logger.error(f"Backup VLM also failed with error: {e}")
             raise last_error
 
-    async def _get_completion_with_failover_async(
-        self,
-        method_name: str,
-        *args,
-        **kwargs
-    ):
+    async def _get_completion_with_failover_async(self, method_name: str, *args, **kwargs):
         """Execute an async VLM method with failover support.
 
         Args:
@@ -567,9 +550,9 @@ class FailoverVLM(VLMBase):
     def get_token_usage(self) -> Dict[str, Any]:
         """Get combined token usage from both primary and backup instances."""
         from openviking.models.vlm.token_usage import TokenUsageTracker
+
         merged_tracker = TokenUsageTracker.merge(
-            self.primary._token_tracker,
-            self.backup._token_tracker
+            self.primary._token_tracker, self.backup._token_tracker
         )
         return merged_tracker.to_dict()
 

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -13,13 +13,11 @@ from openviking.server.identity import RequestContext
 from openviking.session.memory.utils.content import deserialize_full, serialize_with_metadata
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
-from openviking.storage.queuefs.semantic_processor import SemanticProcessor
 from openviking.storage.transaction import get_lock_manager
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import build_queue_status_payload
-from openviking.utils.embedding_utils import vectorize_file
 from openviking_cli.exceptions import (
     AlreadyExistsError,
     DeadlineExceededError,
@@ -483,50 +481,6 @@ class ContentWriteCoordinator:
             raise DeadlineExceededError("queue processing", timeout) from exc
         return tracker.build_queue_status(telemetry_id)
 
-    async def _vectorize_single_file(
-        self,
-        uri: str,
-        *,
-        context_type: str,
-        ctx: RequestContext,
-    ) -> None:
-        parent = VikingURI(uri).parent
-        if parent is None:
-            raise InvalidArgumentError(f"file has no parent directory: {uri}")
-        summary_dict = await self._summary_dict_for_vectorize(
-            uri, context_type=context_type, ctx=ctx
-        )
-        await vectorize_file(
-            file_path=uri,
-            summary_dict=summary_dict,
-            parent_uri=parent.uri,
-            context_type=context_type,
-            ctx=ctx,
-            preserve_existing_created_at=True,
-        )
-
-    async def _summary_dict_for_vectorize(
-        self,
-        uri: str,
-        *,
-        context_type: str,
-        ctx: RequestContext,
-    ) -> Dict[str, str]:
-        file_name = os.path.basename(uri)
-        if context_type != "memory":
-            return {"name": file_name}
-
-        try:
-            processor = SemanticProcessor(max_concurrent_llm=1)
-            return await processor._generate_single_file_summary(uri, ctx=ctx)
-        except Exception:
-            logger.warning(
-                "Failed to generate summary for memory write vector refresh: %s",
-                uri,
-                exc_info=True,
-            )
-            return {"name": file_name}
-
     async def _write_memory_with_refresh(
         self,
         *,
@@ -553,7 +507,6 @@ class ContentWriteCoordinator:
             if wait and telemetry_id:
                 get_request_wait_tracker().register_request(telemetry_id)
             await self._write_in_place(uri, content, mode=mode, ctx=ctx)
-            await self._vectorize_single_file(uri, context_type="memory", ctx=ctx)
             await self._enqueue_memory_refresh(
                 root_uri=root_uri,
                 modified_uri=uri,

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -82,6 +82,7 @@ class SemanticDagExecutor:
         recursive: bool = True,
         lock: LockLease = NO_LOCK,
         is_code_repo: bool = False,
+        sync_to_target: bool = False,
         changes: Optional[Dict[str, List[str]]] = None,
         skip_vectorization: bool = False,
         coalesce_key: str = "",
@@ -98,6 +99,7 @@ class SemanticDagExecutor:
         self._recursive = recursive
         self._lock = lock
         self._is_code_repo = is_code_repo
+        self._sync_to_target = sync_to_target
         self._changes = changes or {}
         self._skip_vectorization = skip_vectorization
         self._coalesce_key = coalesce_key
@@ -133,8 +135,9 @@ class SemanticDagExecutor:
         if self._target_uri == self._root_uri:
             return noop_callback
 
-        # If full update, move temp uri to target uri has been handled in the processor
-        if not self._incremental_update:
+        # Full resource updates may still need a deferred temp -> target sync
+        # when semantic generation owns the resource lock.
+        if not self._incremental_update and not self._sync_to_target:
             return noop_callback
 
         async def sync_diff_callback() -> None:

--- a/openviking/storage/queuefs/semantic_msg.py
+++ b/openviking/storage/queuefs/semantic_msg.py
@@ -54,6 +54,7 @@ class SemanticMsg:
     target_uri: str = ""
     lock_handoff: Optional[LockHandoffRef] = None
     is_code_repo: bool = False
+    target_preexisting: Optional[bool] = None
     coalesce_key: str = ""
     coalesce_version: int = 0
     changes: Optional[Dict[str, List[str]]] = (
@@ -74,6 +75,7 @@ class SemanticMsg:
         target_uri: str = "",
         lock_handoff: Optional[LockHandoffRef] = None,
         is_code_repo: bool = False,
+        target_preexisting: Optional[bool] = None,
         coalesce_key: str = "",
         coalesce_version: int = 0,
         changes: Optional[Dict[str, List[str]]] = None,
@@ -91,6 +93,7 @@ class SemanticMsg:
         self.target_uri = target_uri
         self.lock_handoff = lock_handoff
         self.is_code_repo = is_code_repo
+        self.target_preexisting = target_preexisting
         self.coalesce_key = coalesce_key
         self.coalesce_version = coalesce_version
         self.changes = changes
@@ -133,6 +136,7 @@ class SemanticMsg:
             target_uri=data.get("target_uri", ""),
             lock_handoff=LockHandoffRef.from_value(data.get("lock_handoff")),
             is_code_repo=data.get("is_code_repo", False),
+            target_preexisting=data.get("target_preexisting"),
             coalesce_key=data.get("coalesce_key", ""),
             coalesce_version=data.get("coalesce_version", 0),
             changes=data.get("changes"),

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -29,9 +29,9 @@ from openviking.prompts import render_prompt
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
+from openviking.storage.queuefs.semantic_lock import SemanticLockScope
 from openviking.storage.queuefs.semantic_msg import SemanticMsg, build_semantic_coalesce_key
 from openviking.storage.queuefs.semantic_queue import is_semantic_msg_stale
-from openviking.storage.queuefs.semantic_lock import SemanticLockScope
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
 from openviking.storage.transaction import NO_LOCK, LockLease
 from openviking.storage.viking_fs import get_viking_fs
@@ -358,7 +358,14 @@ class SemanticProcessor(DequeueHandlerBase):
                                     msg.target_uri, ctx=self._current_ctx
                                 )
                                 # Check if target URI exists and is not the same as the source URI（避免重复处理）
-                                if target_exists and msg.uri != msg.target_uri:
+                                if msg.uri != msg.target_uri:
+                                    if msg.target_preexisting is None:
+                                        target_preexisting = target_exists
+                                    else:
+                                        target_preexisting = bool(msg.target_preexisting)
+                                else:
+                                    target_preexisting = target_exists
+                                if target_preexisting and msg.uri != msg.target_uri:
                                     is_incremental = True
                                     logger.info(
                                         f"Target URI exists, using incremental update: {msg.target_uri}"
@@ -387,6 +394,7 @@ class SemanticProcessor(DequeueHandlerBase):
                                 recursive=msg.recursive,
                                 lock=semantic_lock.lock,
                                 is_code_repo=msg.is_code_repo,
+                                sync_to_target=bool(target_uri and msg.uri != target_uri),
                                 changes=msg.changes,
                                 skip_vectorization=msg.skip_vectorization,
                                 coalesce_key=msg.coalesce_key,
@@ -578,6 +586,16 @@ class SemanticProcessor(DequeueHandlerBase):
                     await asyncio.gather(*[_gen(i, fp) for i, fp in batch])
 
             completed_summaries = [s for s in file_summaries if s is not None]
+            # Incremental writes carry changes; full rebuild tasks do not.
+            if msg.changes:
+                paths_to_vectorize = changed_files
+            else:
+                paths_to_vectorize = set(file_paths)
+            file_vectorize_items = [
+                (file_path, summary)
+                for file_path, summary in zip(file_paths, file_summaries, strict=False)
+                if file_path in paths_to_vectorize and summary is not None
+            ]
             overview = await self._generate_overview(
                 dir_uri, completed_summaries, [], llm_sem=llm_sem
             )
@@ -616,9 +634,19 @@ class SemanticProcessor(DequeueHandlerBase):
                 tracker = EmbeddingTaskTracker.get_instance()
                 await tracker.register(
                     semantic_msg_id=msg.id,
-                    total_count=2,
+                    total_count=2 + len(file_vectorize_items),
                     on_complete=_on_complete,
                     metadata={"uri": dir_uri},
+                )
+            for file_path, summary_dict in file_vectorize_items:
+                await self._vectorize_single_file(
+                    parent_uri=dir_uri,
+                    context_type="memory",
+                    file_path=file_path,
+                    summary_dict=summary_dict,
+                    ctx=ctx,
+                    semantic_msg_id=msg.id,
+                    preserve_existing_created_at=True,
                 )
             await self._vectorize_directory(
                 uri=dir_uri,
@@ -1392,6 +1420,7 @@ class SemanticProcessor(DequeueHandlerBase):
         ctx: Optional[RequestContext] = None,
         semantic_msg_id: Optional[str] = None,
         use_summary: bool = False,
+        preserve_existing_created_at: bool = False,
     ) -> None:
         """Vectorize a single file using its content or summary."""
         from openviking.utils.embedding_utils import vectorize_file
@@ -1405,4 +1434,5 @@ class SemanticProcessor(DequeueHandlerBase):
             ctx=active_ctx,
             semantic_msg_id=semantic_msg_id,
             use_summary=use_summary,
+            preserve_existing_created_at=preserve_existing_created_at,
         )

--- a/openviking/utils/async_client_cache.py
+++ b/openviking/utils/async_client_cache.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Event-loop scoped cache for reusable async clients."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+import weakref
+from collections.abc import Callable
+from typing import Any, Protocol
+
+
+class Closeable(Protocol):
+    def close(self) -> Any: ...
+
+
+class AsyncCloseable(Protocol):
+    def aclose(self) -> Any: ...
+
+
+def _close_client(client: Closeable) -> Any:
+    return client.close()
+
+
+def _aclose_client(client: AsyncCloseable) -> Any:
+    return client.aclose()
+
+
+class LoopScopedAsyncClientCache:
+    """Cache async clients per running event loop.
+
+    Clients such as httpx.AsyncClient and OpenAI AsyncOpenAI can bind internal
+    asyncio primitives to the loop that first uses them. Sharing one client
+    across worker threads with separate event loops can then fail at runtime.
+    """
+
+    def __init__(self) -> None:
+        self._clients_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, Any] = (
+            weakref.WeakKeyDictionary()
+        )
+        self._fallback_client: Any = None
+        self._lock = threading.Lock()
+
+    def get(self, factory: Callable[[], Any]) -> Any:
+        """Return a client for the current loop, creating it with factory if needed."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            with self._lock:
+                if self._fallback_client is None:
+                    self._fallback_client = factory()
+                return self._fallback_client
+
+        with self._lock:
+            client = self._clients_by_loop.get(loop)
+            if client is None:
+                client = factory()
+                self._clients_by_loop[loop] = client
+            return client
+
+    def pop_all(self) -> list[Any]:
+        """Remove and return all cached clients."""
+        with self._lock:
+            clients = list(self._clients_by_loop.values())
+            self._clients_by_loop.clear()
+            if self._fallback_client is not None:
+                clients.append(self._fallback_client)
+                self._fallback_client = None
+            return clients
+
+    @staticmethod
+    async def _close_clients(clients: list[Any], close_client: Callable[[Any], Any]) -> None:
+        seen: set[int] = set()
+        for client in clients:
+            client_id = id(client)
+            if client_id in seen:
+                continue
+            seen.add(client_id)
+
+            result = close_client(client)
+            if inspect.isawaitable(result):
+                await result
+
+    def close_all(self, close_client: Callable[[Any], Any]) -> None:
+        """Close and clear all cached clients on a best-effort basis."""
+        clients = self.pop_all()
+        if not clients:
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            loop.create_task(self._close_clients(clients, close_client))
+        else:
+            asyncio.run(self._close_clients(clients, close_client))
+
+    def close_all_with_close(self) -> None:
+        self.close_all(_close_client)
+
+    def close_all_with_aclose(self) -> None:
+        self.close_all(_aclose_client)

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from openviking.parse.tree_builder import TreeBuilder
 from openviking.server.identity import RequestContext
-from openviking.storage.errors import LockAcquisitionError
 from openviking.storage import VikingDBManager
+from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.transaction import NO_LOCK, LockLease, OwnedLockLease
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
@@ -255,6 +255,7 @@ class ResourceProcessor:
             original_temp_uri = temp_uri  # 保存原始 temp_uri 用于最终输出
             candidate_uri = getattr(context_tree, "_candidate_uri", None) if context_tree else None
             resource_lock: LockLease = NO_LOCK
+            target_preexisting = False
 
             if root_uri and temp_uri:
                 from openviking.storage.transaction import get_lock_manager
@@ -271,6 +272,7 @@ class ResourceProcessor:
                         )
                         result["root_uri"] = root_uri
                     else:
+                        target_preexisting = await viking_fs.exists(root_uri, ctx=ctx)
                         dst_path = viking_fs._uri_to_path(root_uri, ctx=ctx)
                         resource_lock = await self._acquire_resource_lock(
                             lock_manager, dst_path, uri=root_uri
@@ -307,6 +309,7 @@ class ResourceProcessor:
                             lock=resource_lock,
                             temp_uris=[temp_uri_for_summarize],
                             is_code_repo=is_code_repo,
+                            target_preexisting=target_preexisting,
                             **kwargs,
                         )
                         if (

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -5,7 +5,7 @@
 Handles summarization and key information extraction.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from openviking.core.namespace import context_type_for_uri
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
@@ -61,6 +61,20 @@ class Summarizer:
 
         telemetry = get_current_telemetry()
         lock_handoff = lock.to_handoff()
+        target_preexisting_arg = kwargs.get("target_preexisting")
+
+        def resolve_target_preexisting(index: int, target_uri: str) -> Optional[bool]:
+            if target_preexisting_arg is None:
+                return None
+            if isinstance(target_preexisting_arg, dict):
+                value = target_preexisting_arg.get(target_uri)
+                return None if value is None else bool(value)
+            if isinstance(target_preexisting_arg, (list, tuple)):
+                if index >= len(target_preexisting_arg):
+                    return None
+                value = target_preexisting_arg[index]
+                return None if value is None else bool(value)
+            return bool(target_preexisting_arg)
 
         def is_resources_root(uri: str) -> bool:
             return (uri or "").rstrip("/") == "viking://resources"
@@ -95,7 +109,7 @@ class Summarizer:
             else:
                 enqueue_units.append((uri, temp_uri))
 
-            for target_uri, source_uri in enqueue_units:
+            for idx, (target_uri, source_uri) in enumerate(enqueue_units):
                 msg = SemanticMsg(
                     uri=source_uri,
                     context_type=context_type,
@@ -108,6 +122,7 @@ class Summarizer:
                     target_uri=target_uri if target_uri != source_uri else None,
                     lock_handoff=lock_handoff,
                     is_code_repo=kwargs.get("is_code_repo", False),
+                    target_preexisting=resolve_target_preexisting(idx, target_uri),
                 )
                 if msg.telemetry_id:
                     get_request_wait_tracker().register_semantic_root(msg.telemetry_id, msg.id)

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -214,6 +214,7 @@ async def test_resource_processor_second_add_preserves_temp_uri_for_incremental(
     assert result["status"] == "success"
     assert result["root_uri"] == "viking://resources/root"
     assert summarize_calls[0]["temp_uris"] == ["viking://temp/root_tmp"]
+    assert summarize_calls[0]["target_preexisting"] is True
     fake_fs.agfs.mv.assert_not_called()
     fake_fs.agfs.write.assert_not_called()
     fake_fs.mv.assert_not_awaited()
@@ -280,3 +281,4 @@ async def test_resource_processor_auto_candidate_skips_existing_and_busy(monkeyp
     assert fake_lock_manager.acquired_exact_paths == []
     assert fake_lock_manager.acquired_tree_paths == ["/mock/resources/root_2"]
     assert summarize_calls[0]["temp_uris"] == ["viking://temp/root_tmp"]
+    assert summarize_calls[0]["target_preexisting"] is False

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -116,58 +116,6 @@ async def test_memory_append_preserves_metadata(service):
     assert stored_result.memory_fields == expected_metadata
 
 
-@pytest.mark.asyncio
-async def test_memory_write_vector_refresh_includes_generated_summary(monkeypatch):
-    file_uri = "viking://user/default/memories/preferences/theme.md"
-    root_uri = "viking://user/default/memories/preferences"
-    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
-    coordinator = ContentWriteCoordinator(
-        viking_fs=_FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
-    )
-
-    captured = {}
-
-    async def _fake_generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
-        del self, llm_sem, ctx
-        return {"name": "theme.md", "summary": f"summary for {file_path}"}
-
-    async def _fake_vectorize_file(
-        *,
-        file_path,
-        summary_dict,
-        parent_uri,
-        context_type,
-        ctx,
-        semantic_msg_id=None,
-        use_summary=False,
-        preserve_existing_created_at=False,
-    ):
-        del ctx, semantic_msg_id, use_summary, preserve_existing_created_at
-        captured["file_path"] = file_path
-        captured["summary_dict"] = summary_dict
-        captured["parent_uri"] = parent_uri
-        captured["context_type"] = context_type
-
-    monkeypatch.setattr(
-        "openviking.storage.queuefs.semantic_processor.SemanticProcessor._generate_single_file_summary",
-        _fake_generate_single_file_summary,
-    )
-    monkeypatch.setattr(
-        "openviking.storage.content_write.vectorize_file",
-        _fake_vectorize_file,
-    )
-
-    await coordinator._vectorize_single_file(file_uri, context_type="memory", ctx=ctx)
-
-    assert captured["file_path"] == file_uri
-    assert captured["parent_uri"] == root_uri
-    assert captured["context_type"] == "memory"
-    assert captured["summary_dict"] == {
-        "name": "theme.md",
-        "summary": f"summary for {file_uri}",
-    }
-
-
 class _FakeHandle:
     def __init__(self, handle_id: str):
         self.id = handle_id
@@ -443,10 +391,6 @@ async def test_memory_write_timeout_after_enqueue_releases_write_lock(monkeypatc
         del uri, content, mode, ctx
         return None
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del uri, context_type, ctx
-        return None
-
     async def _fake_enqueue_memory_refresh(**kwargs):
         del kwargs
         return None
@@ -456,7 +400,6 @@ async def test_memory_write_timeout_after_enqueue_releases_write_lock(monkeypatc
         raise DeadlineExceededError("queue processing", timeout)
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_request", _fake_wait_for_request)
 
@@ -539,10 +482,6 @@ async def test_create_mode_new_file_success(monkeypatch):
         write_calls.append((uri, content))
         return content
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del uri, context_type, ctx
-        return None
-
     async def _fake_enqueue_memory_refresh(**kwargs):
         del kwargs
         return None
@@ -552,7 +491,6 @@ async def test_create_mode_new_file_success(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -581,18 +519,12 @@ async def test_create_mode_canonicalizes_user_shorthand_memory_uri(monkeypatch):
     monkeypatch.setattr("openviking.storage.content_write.get_lock_manager", lambda: lock_manager)
 
     write_calls = []
-    vectorize_calls = []
     refresh_calls = []
 
     async def _fake_write_in_place(uri, content, *, mode, ctx):
         del mode, ctx
         write_calls.append((uri, content))
         return content
-
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del ctx
-        vectorize_calls.append((uri, context_type))
-        return None
 
     async def _fake_enqueue_memory_refresh(**kwargs):
         refresh_calls.append(kwargs)
@@ -603,7 +535,6 @@ async def test_create_mode_canonicalizes_user_shorthand_memory_uri(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -615,7 +546,6 @@ async def test_create_mode_canonicalizes_user_shorthand_memory_uri(monkeypatch):
     assert result["root_uri"] == root_uri
     assert result["context_type"] == "memory"
     assert write_calls == [(canonical_uri, "new content")]
-    assert vectorize_calls == [(canonical_uri, "memory")]
     assert refresh_calls[0]["root_uri"] == root_uri
     assert refresh_calls[0]["modified_uri"] == canonical_uri
 
@@ -632,10 +562,6 @@ async def test_create_mode_existing_file_raises_409(monkeypatch):
         del uri, content, mode, ctx
         return None
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del uri, context_type, ctx
-        return None
-
     async def _fake_enqueue_memory_refresh(**kwargs):
         del kwargs
         return None
@@ -645,7 +571,6 @@ async def test_create_mode_existing_file_raises_409(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -665,10 +590,6 @@ async def test_create_mode_invalid_extension_raises_400(monkeypatch):
         del uri, content, mode, ctx
         return None
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del uri, context_type, ctx
-        return None
-
     async def _fake_enqueue_memory_refresh(**kwargs):
         del kwargs
         return None
@@ -678,7 +599,6 @@ async def test_create_mode_invalid_extension_raises_400(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -704,10 +624,6 @@ async def test_create_mode_parent_dirs_auto_created(monkeypatch):
         write_calls.append((uri, content))
         return content
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del uri, context_type, ctx
-        return None
-
     async def _fake_enqueue_memory_refresh(**kwargs):
         del kwargs
         return None
@@ -717,7 +633,6 @@ async def test_create_mode_parent_dirs_auto_created(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -753,10 +668,6 @@ async def test_create_mode_valid_extensions_pass(monkeypatch):
             del uri, mode, ctx
             return content
 
-        async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-            del uri, context_type, ctx
-            return None
-
         async def _fake_enqueue_memory_refresh(**kwargs):
             del kwargs
             return None
@@ -766,7 +677,6 @@ async def test_create_mode_valid_extensions_pass(monkeypatch):
             return None
 
         monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-        monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
         monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
         monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -791,14 +701,10 @@ async def test_create_mode_memory_scope(monkeypatch):
         del uri, mode, ctx
         return content
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        # Verify memory-scope URIs take the memory write path
-        assert context_type == "memory"
-        del uri, ctx
-        return None
+    refresh_calls = []
 
     async def _fake_enqueue_memory_refresh(**kwargs):
-        del kwargs
+        refresh_calls.append(kwargs)
         return None
 
     async def _fake_wait_for_queues(*, timeout):
@@ -806,7 +712,6 @@ async def test_create_mode_memory_scope(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -814,6 +719,8 @@ async def test_create_mode_memory_scope(monkeypatch):
         uri=file_uri, content="content", mode="create", ctx=ctx, wait=True
     )
     assert result["context_type"] == "memory"
+    assert refresh_calls[0]["root_uri"] == root_uri
+    assert refresh_calls[0]["modified_uri"] == file_uri
 
 
 @pytest.mark.asyncio
@@ -867,10 +774,6 @@ async def test_create_mode_regression_replace_unchanged(monkeypatch):
         del uri, content, ctx
         return None
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del uri, context_type, ctx
-        return None
-
     async def _fake_enqueue_memory_refresh(**kwargs):
         del kwargs
         return None
@@ -880,7 +783,6 @@ async def test_create_mode_regression_replace_unchanged(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 
@@ -908,10 +810,6 @@ async def test_create_mode_regression_append_unchanged(monkeypatch):
         del uri, content, ctx
         return None
 
-    async def _fake_vectorize_single_file(uri, *, context_type, ctx):
-        del uri, context_type, ctx
-        return None
-
     async def _fake_enqueue_memory_refresh(**kwargs):
         del kwargs
         return None
@@ -921,7 +819,6 @@ async def test_create_mode_regression_append_unchanged(monkeypatch):
         return None
 
     monkeypatch.setattr(coordinator, "_write_in_place", _fake_write_in_place)
-    monkeypatch.setattr(coordinator, "_vectorize_single_file", _fake_vectorize_single_file)
     monkeypatch.setattr(coordinator, "_enqueue_memory_refresh", _fake_enqueue_memory_refresh)
     monkeypatch.setattr(coordinator, "_wait_for_queues", _fake_wait_for_queues)
 

--- a/tests/storage/test_semantic_dag_incremental_missing_summary.py
+++ b/tests/storage/test_semantic_dag_incremental_missing_summary.py
@@ -210,5 +210,42 @@ async def test_direct_incremental_update_uses_changes_without_temp_sync(monkeypa
     assert "- b.txt: old-b" in overview
 
 
+@pytest.mark.asyncio
+async def test_full_update_can_still_sync_temp_to_target(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+
+    root_uri = "viking://temp/root"
+    target_uri = "viking://resources/target"
+    tree = {
+        root_uri: [{"name": "a.txt", "isDir": False}],
+    }
+
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "hello",
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=False,
+        target_uri=target_uri,
+        sync_to_target=True,
+        skip_vectorization=True,
+    )
+
+    await executor.run(root_uri)
+
+    assert processor.sync_calls == [(root_uri, target_uri)]
+    assert fake_fs._file_contents[f"{target_uri}/a.txt"] == "hello"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/storage/test_semantic_processor_target_preexisting.py
+++ b/tests/storage/test_semantic_processor_target_preexisting.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.transaction import NO_LOCK
+
+
+class _FakeVikingFS:
+    async def exists(self, uri, ctx=None):
+        return True
+
+
+class _FakeDagExecutor:
+    calls = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.stale = False
+        _FakeDagExecutor.calls.append(kwargs)
+
+    async def run(self, root_uri):
+        self.root_uri = root_uri
+
+    def get_stats(self):
+        from openviking.storage.queuefs.semantic_dag import DagStats
+
+        return DagStats()
+
+
+@pytest.mark.asyncio
+async def test_target_preexisting_controls_incremental_detection(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: _FakeVikingFS(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticDagExecutor",
+        _FakeDagExecutor,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticLockScope.resolve",
+        AsyncMock(return_value=SimpleNamespace(lock=NO_LOCK, close=AsyncMock())),
+    )
+
+    for target_preexisting, expected_incremental in [(False, False), (True, True)]:
+        _FakeDagExecutor.calls = []
+        processor = SemanticProcessor()
+        processor._enqueue_parent_refresh = AsyncMock()
+        msg = SemanticMsg(
+            uri="viking://temp/import_root/repository",
+            target_uri="viking://resources/org/repo",
+            context_type="resource",
+            target_preexisting=target_preexisting,
+        )
+
+        await processor.on_dequeue(msg.to_dict())
+
+        assert _FakeDagExecutor.calls[0]["incremental_update"] is expected_incremental
+        assert _FakeDagExecutor.calls[0]["sync_to_target"] is True

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -250,3 +250,67 @@ async def test_memory_directory_summarizes_all_uncached_files(monkeypatch):
     )
 
     assert [item["name"] for item in summaries] == ["first.md", "second.md"]
+
+
+@pytest.mark.asyncio
+async def test_memory_directory_vectorizes_changed_files_with_generated_summary(monkeypatch):
+    processor = SemanticProcessor(max_concurrent_llm=4)
+    dir_uri = "viking://user/default/memories/preferences"
+    changed_uri = f"{dir_uri}/first.md"
+    captured_file_vectorize = []
+    captured_directory_vectorize = []
+
+    async def generate_file_summary(file_path, llm_sem=None, ctx=None):
+        del llm_sem, ctx
+        name = file_path.rsplit("/", 1)[-1]
+        return {"name": name, "summary": f"summary:{name}"}
+
+    async def generate_overview(dir_uri, file_summaries, children_abstracts, llm_sem=None):
+        del dir_uri, file_summaries, children_abstracts, llm_sem
+        return "overview"
+
+    async def write_semantics(**kwargs):
+        del kwargs
+        return True
+
+    async def vectorize_single_file(**kwargs):
+        captured_file_vectorize.append(kwargs)
+
+    async def vectorize_directory(**kwargs):
+        captured_directory_vectorize.append(kwargs)
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: _FakeMemoryDirFS(),
+    )
+    monkeypatch.setattr(processor, "_generate_single_file_summary", generate_file_summary)
+    monkeypatch.setattr(processor, "_generate_overview", generate_overview)
+    monkeypatch.setattr(processor, "_extract_abstract_from_overview", lambda overview: "abstract")
+    monkeypatch.setattr(
+        processor,
+        "_enforce_size_limits",
+        lambda overview, abstract: (overview, abstract),
+    )
+    monkeypatch.setattr(processor, "_write_memory_directory_semantics", write_semantics)
+    monkeypatch.setattr(processor, "_vectorize_single_file", vectorize_single_file)
+    monkeypatch.setattr(processor, "_vectorize_directory", vectorize_directory)
+
+    await processor._process_memory_directory(
+        SemanticMsg(
+            uri=dir_uri,
+            context_type="memory",
+            changes={"modified": [changed_uri]},
+        )
+    )
+
+    assert len(captured_file_vectorize) == 1
+    assert captured_file_vectorize[0]["parent_uri"] == dir_uri
+    assert captured_file_vectorize[0]["context_type"] == "memory"
+    assert captured_file_vectorize[0]["file_path"] == changed_uri
+    assert captured_file_vectorize[0]["summary_dict"] == {
+        "name": "first.md",
+        "summary": "summary:first.md",
+    }
+    assert captured_file_vectorize[0]["preserve_existing_created_at"] is True
+    assert len(captured_directory_vectorize) == 1
+    assert captured_directory_vectorize[0]["uri"] == dir_uri

--- a/tests/unit/test_async_client_cache.py
+++ b/tests/unit/test_async_client_cache.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for event-loop scoped async client caching."""
+
+import asyncio
+import threading
+
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
+
+
+def test_loop_scoped_async_client_cache_reuses_within_loop_and_isolates_between_loops():
+    cache = LoopScopedAsyncClientCache()
+    created = []
+
+    class Client:
+        def close(self):
+            return None
+
+    def build_client():
+        client = Client()
+        created.append(client)
+        return client
+
+    async def get_twice():
+        return cache.get(build_client), cache.get(build_client)
+
+    main_first, main_second = asyncio.run(get_twice())
+    worker_results = []
+
+    def run_in_thread_loop():
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            worker_results.append(loop.run_until_complete(get_twice()))
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+    thread = threading.Thread(target=run_in_thread_loop)
+    thread.start()
+    thread.join()
+
+    assert main_first is main_second
+    assert worker_results[0][0] is worker_results[0][1]
+    assert main_first is not worker_results[0][0]
+    assert len(created) == 2

--- a/tests/unit/test_extra_headers_embedding.py
+++ b/tests/unit/test_extra_headers_embedding.py
@@ -146,7 +146,7 @@ class TestExtraHeadersViaFactory:
             patch("openviking.models.embedder.openai_embedders.logger.warning") as mock_warning,
             patch(
                 "openviking.models.embedder.base.time.monotonic",
-                side_effect=[0.0, 0.0, 0.0, 1.2],
+                side_effect=[0.0, 0.0, 0.0, 3.2],
             ),
         ):
             await embedder.embed_async("hello")

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Tests for VLM extra_headers support."""
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from openviking.models.vlm.backends.litellm_vlm import (
@@ -9,6 +11,7 @@ from openviking.models.vlm.backends.litellm_vlm import (
     detect_provider_by_model,
 )
 from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+from openviking.models.vlm.backends.volcengine_vlm import VolcEngineVLM
 
 
 class TestVLMExtraHeaders:
@@ -239,6 +242,79 @@ class TestOpenAIVLMClientRetries:
 
         call_kwargs = mock_async_openai_class.call_args.kwargs
         assert call_kwargs["max_retries"] == 0
+
+    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
+    def test_openai_async_client_is_scoped_to_event_loop(self, mock_async_openai_class):
+        main_loop_client = MagicMock(name="main_loop_client")
+        worker_loop_client = MagicMock(name="worker_loop_client")
+        mock_async_openai_class.side_effect = [main_loop_client, worker_loop_client]
+
+        vlm = OpenAIVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+
+        async def get_twice():
+            return vlm.get_async_client(), vlm.get_async_client()
+
+        first, second = asyncio.run(get_twice())
+        result = []
+
+        def run_in_thread_loop():
+            loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                result.append(loop.run_until_complete(get_twice()))
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+
+        thread = threading.Thread(target=run_in_thread_loop)
+        thread.start()
+        thread.join()
+
+        assert first is main_loop_client
+        assert second is main_loop_client
+        assert result == [(worker_loop_client, worker_loop_client)]
+        assert mock_async_openai_class.call_count == 2
+
+    def test_volcengine_async_client_is_scoped_to_event_loop(self, monkeypatch):
+        main_loop_client = MagicMock(name="main_loop_client")
+        worker_loop_client = MagicMock(name="worker_loop_client")
+        build_async_client = MagicMock(side_effect=[main_loop_client, worker_loop_client])
+
+        vlm = VolcEngineVLM(
+            {
+                "api_key": "sk-test",
+                "api_base": "https://ark.cn-beijing.volces.com/api/v3",
+            }
+        )
+        monkeypatch.setattr(vlm, "_build_async_client", build_async_client)
+
+        async def get_client():
+            return vlm.get_async_client()
+
+        first = asyncio.run(get_client())
+        result = []
+
+        def run_in_thread_loop():
+            loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                result.append(loop.run_until_complete(get_client()))
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+
+        thread = threading.Thread(target=run_in_thread_loop)
+        thread.start()
+        thread.join()
+
+        assert first is main_loop_client
+        assert result == [worker_loop_client]
+        assert build_async_client.call_count == 2
 
     @patch("openviking.models.vlm.backends.openai_vlm.openai.AzureOpenAI")
     def test_azure_sync_client_disables_sdk_retries(self, mock_azure_openai_class):


### PR DESCRIPTION
## Description

修复异步 Embedding/VLM 客户端在多线程、多事件循环场景下复用同一个 async client 的问题，并调整语义刷新链路，让 memory 文件向量化和 resource temp -> target 同步都在语义队列处理中保持一致。

## Related Issue

Fixes #2135

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 新增 `LoopScopedAsyncClientCache`，让 `httpx.AsyncClient`、OpenAI/Ark 等异步客户端按当前事件循环缓存，避免跨 worker thread/event loop 复用导致运行时错误。
- 将 memory 写入后的单文件向量刷新收敛到 `SemanticProcessor`，使用生成后的 summary 对变更文件向量化，并保留目录级向量刷新。
- 在 resource 语义任务中传递 `target_preexisting` 和 `sync_to_target`，确保 full update 仍可在语义生成持有资源锁时完成 temp -> target 同步，同时保留已有 target 的 incremental 判断。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行过：

```bash
.venv/bin/python -m pytest tests/unit/test_async_client_cache.py tests/unit/test_extra_headers_embedding.py tests/unit/test_extra_headers_vlm.py tests/storage/test_semantic_processor_target_preexisting.py tests/storage/test_semantic_dag_incremental_missing_summary.py tests/storage/test_semantic_queue_memory_dedupe.py tests/misc/test_resource_processor_mv.py tests/server/test_content_write_service.py
```

结果：`78 passed, 4 warnings in 8.55s`。warnings 为现有依赖/Pydantic deprecation 类提示。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用

## Additional Notes

本地 pre-commit hook 绑定的系统 Python 和当前 `.venv` 都没有安装 `pre_commit` 模块，因此提交时使用了 `--no-verify`；相关测试已在本地通过。
