### PR TITLE
fix(vectordb): reject oversized bytes row strings

### DIFF
--- a/openviking/storage/vectordb/store/bytes_row.py
+++ b/openviking/storage/vectordb/store/bytes_row.py
@@ -12,6 +12,7 @@ FLOAT32_SIZE = 4
 UINT32_SIZE = 4  # Used for string/binary length and offset
 UINT16_SIZE = 2  # Used for list length and string/binary length inside lists
 BOOL_SIZE = 1
+STRING_MAX_UINT16_LENGTH = 0xFFFF
 
 
 @dataclass
@@ -146,6 +147,10 @@ class _PyBytesRow:
                 fix_region_offset += UINT32_SIZE
                 bytes_item = value.encode("utf-8")
                 bytes_item_len = len(bytes_item)
+                if bytes_item_len > STRING_MAX_UINT16_LENGTH:
+                    raise ValueError(
+                        f"string field '{field_meta.name}' exceeds 65535 bytes"
+                    )
                 var_fmt_list.append("H")
                 var_val_list.append(bytes_item_len)
                 variable_region_offset += UINT16_SIZE

--- a/src/store/bytes_row.cpp
+++ b/src/store/bytes_row.cpp
@@ -123,9 +123,13 @@ std::string BytesRow::serialize(const std::vector<Value>& row_data) const {
     switch (meta.data_type) {
       case FieldType::STRING: {
         if (std::holds_alternative<std::string>(val)) {
-          int len = std::get<std::string>(val).length();
-          var_infos[i] = {variable_region_offset, len};
-          variable_region_offset += UINT16_SIZE + len;
+          size_t len = std::get<std::string>(val).length();
+          if (len > STRING_MAX_UINT16_LENGTH) {
+            throw std::invalid_argument("string field '" + meta.name +
+                                        "' exceeds 65535 bytes");
+          }
+          var_infos[i] = {variable_region_offset, static_cast<int>(len)};
+          variable_region_offset += UINT16_SIZE + static_cast<int>(len);
         } else {
           var_infos[i] = {variable_region_offset, 0};
           variable_region_offset += UINT16_SIZE;

--- a/src/store/bytes_row.h
+++ b/src/store/bytes_row.h
@@ -7,8 +7,11 @@
 #include <memory>
 #include <cstdint>
 #include <cstring>
+#include <stdexcept>
 
 namespace vectordb {
+
+constexpr uint32_t STRING_MAX_UINT16_LENGTH = 0xFFFF;
 
 enum class FieldType {
   INT64 = 0,
@@ -117,10 +120,11 @@ class BytesRow {
     };
 
     auto write_string_value = [](const std::string& s, char* dest) {
-      uint16_t len = static_cast<uint16_t>(s.length());
-      std::memcpy(dest, &len, 2);
-      if (len > 0) {
-        std::memcpy(dest + 2, s.data(), len);
+      uint32_t len = static_cast<uint32_t>(s.length());
+      uint16_t short_len = static_cast<uint16_t>(len);
+      std::memcpy(dest, &short_len, 2);
+      if (short_len > 0) {
+        std::memcpy(dest + 2, s.data(), short_len);
       }
     };
 
@@ -188,6 +192,10 @@ class BytesRow {
             len = accessor.get_string_len(row, i);
           } else if (const auto* def = get_default_string(meta.default_value)) {
             len = static_cast<int>(def->length());
+          }
+          if (len > static_cast<int>(STRING_MAX_UINT16_LENGTH)) {
+            throw std::invalid_argument("string field '" + meta.name +
+                                        "' exceeds 65535 bytes");
           }
           var_infos[i] = {variable_region_offset, len};
           variable_region_offset += 2 + len;  // UINT16_SIZE

--- a/tests/vectordb/test_bytes_row.py
+++ b/tests/vectordb/test_bytes_row.py
@@ -108,6 +108,23 @@ class TestBytesRow(unittest.TestCase):
         val = UnicodeData.bytes_row.deserialize_field(serialized, "text")
         self.assertEqual(val, text)
 
+    def test_oversized_string_serialization_raises(self):
+        @serializable
+        @dataclass
+        class LargeStringData:
+            text: str = ""
+
+        text = "x" * 65536
+        with self.assertRaisesRegex(
+            (RuntimeError, ValueError), "text.*exceeds 65535 bytes"
+        ):
+            LargeStringData(text=text).serialize()
+
+        py_schema = _PySchema([{"name": "text", "data_type": _PyFieldType.string, "id": 0}])
+        py_row = _PyBytesRow(py_schema)
+        with self.assertRaisesRegex(ValueError, "text.*exceeds 65535 bytes"):
+            py_row.serialize({"text": text})
+
     def test_binary_data(self):
         @serializable
         @dataclass

--- a/tests/vectordb/test_filter_ops.py
+++ b/tests/vectordb/test_filter_ops.py
@@ -13,6 +13,7 @@ db_path_basic = "./test_data/db_test_filters_basic/"
 db_path_complex = "./test_data/db_test_filters_complex/"
 db_path_lifecycle = "./test_data/db_test_filters_lifecycle/"
 db_path_scale = "./test_data/db_test_filters_scale/"
+db_path_large_fields = "./test_data/db_test_filters_large_fields/"
 
 
 def clean_dir(path):
@@ -112,6 +113,47 @@ class TestFilterOpsBasic(unittest.TestCase):
         self.assertEqual(
             self._search({"op": "contains", "field": "val_str", "substring": "er"}), [3, 5]
         )  # chERry, eldERbERry
+
+
+class TestFilterOpsLargeFields(unittest.TestCase):
+    def setUp(self):
+        clean_dir(db_path_large_fields)
+        self.path = db_path_large_fields
+        self.collection = self._create_collection()
+
+    def tearDown(self):
+        if self.collection:
+            self.collection.drop()
+        clean_dir(self.path)
+
+    def _create_collection(self):
+        collection_meta = {
+            "CollectionName": "test_filters_large_fields",
+            "Fields": [
+                {"FieldName": "id", "FieldType": "int64", "IsPrimaryKey": True},
+                {"FieldName": "embedding", "FieldType": "vector", "Dim": 4},
+                {"FieldName": "uri", "FieldType": "string"},
+                {"FieldName": "abstract", "FieldType": "string"},
+            ],
+        }
+        return get_or_create_local_collection(meta_data=collection_meta, path=self.path)
+
+    def test_upsert_record_with_oversized_json_field_raises(self):
+        large_abstract = 'prefix "quoted" \\\\ path\n' + ("x" * 66000)
+        uri = "viking://user/memories/large.md"
+        with self.assertRaisesRegex(
+            (RuntimeError, ValueError), "fields.*exceeds 65535 bytes"
+        ):
+            self.collection.upsert_data(
+                [
+                    {
+                        "id": 1,
+                        "embedding": [1.0, 0, 0, 0],
+                        "uri": uri,
+                        "abstract": large_abstract,
+                    }
+                ]
+            )
 
 
 class TestFilterOpsComplex(unittest.TestCase):


### PR DESCRIPTION
## Description

Reject oversized BytesRow string fields before serialization so local vectordb cannot persist truncated JSON fields that later fail with JSON parse errors during index/query flows.

## Related Issue

Fixes #2117

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added explicit 65535-byte string length checks to native BytesRow serialization.
- Added the same oversized string guard to the Python BytesRow fallback.
- Added focused regression coverage for oversized string serialization and local collection upsert.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally keeps the existing BytesRow binary format and fails fast for oversized string fields to avoid writing dirty data. Longer text storage can be handled in a follow-up design without changing this guard.
