### PR TITLE
docs: replace legacy console / port 8020 refs with Web Studio (/studio)

### DIFF
--- a/docs/en/getting-started/04-setup-for-agent.md
+++ b/docs/en/getting-started/04-setup-for-agent.md
@@ -221,7 +221,6 @@ If the user already has a local config directory, prefer:
 ```bash
 docker run --rm \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   ghcr.io/volcengine/openviking:latest
 ```
@@ -230,12 +229,13 @@ Notes:
 - The default config path inside the container is `/app/.openviking/ov.conf`
 - Inside the container, `HOME=/app`
 - Prefer mounting host `~/.openviking` to container `/app/.openviking` so config, CLI config, and workspace data persist
+- Web Studio is served by the OV server itself at `http://127.0.0.1:1933/studio` — no extra port needed
 
 ##### Option 2: Use `docker-compose.yml`
 
 If the user prefers compose, the repo already includes an example with:
 - image: `ghcr.io/volcengine/openviking:latest`
-- ports: `1933:1933`, `8020:8020`
+- ports: `1933:1933`
 - volume: `~/.openviking:/app/.openviking`
 
 In that case, have the user run this from the repo root:

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -190,15 +190,13 @@ OpenViking provides pre-built Docker images published to GitHub Container Regist
 docker run -d \
   --name openviking \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
 ```
 
 By default, the Docker image starts:
-- OpenViking HTTP service on port `1933` (bound to `0.0.0.0`)
-- OpenViking Console on port `8020`
+- OpenViking HTTP service on port `1933` (bound to `0.0.0.0`), also serving the Web Studio UI at `/studio`
 - `vikingbot` gateway
 
 Since the server binds to `0.0.0.0` inside the container (required for Docker port-mapping to work), you **must** set `root_api_key` in your `ov.conf`:
@@ -227,7 +225,6 @@ If you want to disable `vikingbot` for a specific container run, you can use eit
 docker run -d \
   --name openviking \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest \
@@ -239,7 +236,6 @@ docker run -d \
   --name openviking \
   -e OPENVIKING_WITH_BOT=0 \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
@@ -255,7 +251,6 @@ Some managed platforms (Railway, Fly.io, Heroku-style PaaS) don't let you bind-m
 docker run -d \
   --name openviking \
   -p 1933:1933 \
-  -p 8020:8020 \
   -e OPENVIKING_CONF_CONTENT="$(cat ~/.openviking/ov.conf)" \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
@@ -267,7 +262,7 @@ docker run -d \
 docker exec -it openviking openviking-server init
 ```
 
-As soon as `ov.conf` appears, the entrypoint resumes and starts the server + console automatically.
+As soon as `ov.conf` appears, the entrypoint resumes and starts the server automatically.
 
 You can also use Docker Compose, which provides a `docker-compose.yml` in the project root:
 
@@ -276,9 +271,9 @@ docker compose up -d
 ```
 
 After startup, you can access:
-- Aggregated entry point: `http://localhost:1934` (Caddy merges API + Console)
-- API service (direct): `http://localhost:1933`
-- Console UI (direct): `http://localhost:8020`
+- API service: `http://localhost:1933`
+- Web Studio: `http://localhost:1933/studio` (same origin as the API)
+- Legacy entry point: `http://localhost:1934` (Caddy reverse proxy to 1933, kept for existing deployments)
 
 For public HTTPS access, see the [Public Access Guide](12-public-access.md).
 

--- a/docs/en/guides/05-observability.md
+++ b/docs/en/guides/05-observability.md
@@ -5,7 +5,7 @@ This guide collects the current OpenViking observability entry points in one pla
 - service health and component status
 - request-level `telemetry`
 - terminal-side `ov tui`
-- web-side `OpenViking Console`
+- web-side `Web Studio` (served by the OV server at `/studio`)
 - `/metrics` time-series metrics
 
 If you just want to know where to look first, start with the table below.
@@ -16,7 +16,7 @@ If you just want to know where to look first, start with the table below.
 | --- | --- | --- |
 | `/health`, `observer/*` | service health, queue backlog, VikingDB and VLM status | deployment validation, on-call checks |
 | `ov tui` | `viking://` trees, directory summaries, file content, vector records, image preview for supported image files | development debugging, verifying that data actually landed |
-| `OpenViking Console` | web UI for browsing, search, resource import, tenants, and system state | interactive investigation without typing every command |
+| `Web Studio` (`/studio`) | same-origin web UI on the OV server: Home shows token / retrieval / context-commit trends; Resources browses URIs; Retrieval runs find; Request Logs shows audit | interactive investigation without typing every command |
 | `telemetry` | per-request duration, token usage, vector retrieval, ingestion stages | debugging one specific slow or unexpected call |
 | `/metrics` | request trends, error rates, latency distribution, queue and probe state | Prometheus scraping, Grafana dashboards, alert rules |
 
@@ -158,46 +158,29 @@ A typical debugging flow is:
 
 TUI is primarily for data-plane inspection. It helps answer "did the resource really land?" and "were vectors really written?" but it does not directly show token totals or per-stage request timing.
 
-## Use OpenViking Console for web-based investigation
+## Use Web Studio for web-based investigation
 
-The repo also contains a standalone web console. It is not wired into the main CLI and must be started separately:
-
-```bash
-python -m openviking.console.bootstrap \
-  --host 127.0.0.1 \
-  --port 8020 \
-  --openviking-url http://127.0.0.1:1933
-```
-
-Then open:
+The OV server serves the Web Studio frontend at `/studio` on its own port — no separate process to start.
 
 ```text
-http://127.0.0.1:8020/
+http://127.0.0.1:1933/studio
 ```
 
-On first use, go to `Settings` and set your `X-API-Key`.
+On first use, open the Connection dialog in the top right and set your `X-API-Key`. The base URL defaults to the current same origin (the URL you loaded `/studio` from).
 
-The most useful panels for observability are:
+The most useful pages for observability are:
 
-- `FileSystem`: browse URIs, directories, and files
-- `Find`: run retrieval requests and inspect results
-- `Add Resource`: import resources and inspect responses
-- `Add Memory`: submit content through a session commit and inspect the memory flow
-- `Tenants` / `Monitor`: inspect tenant, user, and system state
+- `Home` (`/studio`): today's token usage, retrieval counts, context-commit trends, agent access summary — backed by the `/api/v1/console/*` BFF
+- `Request Logs` (`/studio/request-logs`): audit logs filterable by account / user / agent / route, backed by `/api/v1/console/audit`
+- `Resources` (`/studio/resources`): browse URIs, view directories and files, upload resources
+- `Retrieval` (`/studio/retrieval`): run find / search / grep requests and inspect results
+- `Sessions` (`/studio/sessions`): browse session history, inspect message and memory commit flow
 
-If you need write operations such as `Add Resource`, `Add Memory`, or tenant/user administration, start the console with `--write-enabled`:
+Write operations (`Add Resource`, `Add Memory`, tenant/user administration) are gated by the API key currently signed in — there's no separate `--write-enabled` switch.
 
-```bash
-python -m openviking.console.bootstrap \
-  --host 127.0.0.1 \
-  --port 8020 \
-  --openviking-url http://127.0.0.1:1933 \
-  --write-enabled
-```
+From an observability standpoint, Studio talks to the same `/api/v1/console/*` BFF (dashboard summary, token series, context commits, audit logs) the old standalone console used — only the UI changed. For operations such as `find`, `add-resource`, and `session commit`, you can expand the result panel to inspect `telemetry.summary`.
 
-From an observability standpoint, one useful detail is that the console result panel shows raw API responses. For operations such as `find`, `add-resource`, and `session commit`, the proxy layer requests `telemetry` by default, so you can usually inspect `telemetry.summary` directly in the UI.
-
-Console is best for interactive click-through debugging. If you need to feed observability data into your own logs or automation, prefer the HTTP API or SDK and request telemetry explicitly.
+Studio is best for interactive click-through debugging. If you need to feed observability data into your own logs or automation, prefer the HTTP API or SDK and request telemetry explicitly.
 
 ## Request-level telemetry
 

--- a/docs/zh/getting-started/04-setup-for-agent.md
+++ b/docs/zh/getting-started/04-setup-for-agent.md
@@ -221,7 +221,6 @@ openviking-server
 ```bash
 docker run --rm \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   ghcr.io/volcengine/openviking:latest
 ```
@@ -230,12 +229,13 @@ docker run --rm \
 - 容器内默认配置路径是 `/app/.openviking/ov.conf`
 - 容器内 `HOME=/app`
 - 建议把宿主机 `~/.openviking` 挂载到容器 `/app/.openviking` 持久化配置、CLI 配置和 workspace 数据
+- Web Studio 由 OV server 自身在 `http://127.0.0.1:1933/studio` 提供，不需要额外端口
 
 ##### 方案 2：使用 `docker-compose.yml`
 
 如果用户希望使用 compose，仓库里已有示例：
 - 镜像：`ghcr.io/volcengine/openviking:latest`
-- 端口：`1933:1933`、`8020:8020`
+- 端口：`1933:1933`
 - volume：`~/.openviking:/app/.openviking`
 
 此时直接让用户基于仓库根目录执行：

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -188,15 +188,13 @@ OpenViking 提供预构建的 Docker 镜像，发布在 GitHub Container Registr
 docker run -d \
   --name openviking \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
 ```
 
 Docker 镜像默认会同时启动：
-- OpenViking HTTP 服务，端口 `1933`（绑定 `0.0.0.0`）
-- OpenViking Console，端口 `8020`
+- OpenViking HTTP 服务，端口 `1933`（绑定 `0.0.0.0`），同时在 `/studio` 提供 Web Studio 前端
 - `vikingbot` gateway
 
 由于容器内服务绑定 `0.0.0.0`（Docker 端口映射所必需），你**必须**在 `ov.conf` 中设置 `root_api_key`：
@@ -225,7 +223,6 @@ docker rm -f openviking
 docker run -d \
   --name openviking \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest \
@@ -237,7 +234,6 @@ docker run -d \
   --name openviking \
   -e OPENVIKING_WITH_BOT=0 \
   -p 1933:1933 \
-  -p 8020:8020 \
   -v ~/.openviking:/app/.openviking \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
@@ -253,7 +249,6 @@ docker run -d \
 docker run -d \
   --name openviking \
   -p 1933:1933 \
-  -p 8020:8020 \
   -e OPENVIKING_CONF_CONTENT="$(cat ~/.openviking/ov.conf)" \
   --restart unless-stopped \
   ghcr.io/volcengine/openviking:latest
@@ -265,7 +260,7 @@ docker run -d \
 docker exec -it openviking openviking-server init
 ```
 
-`ov.conf` 出现后，entrypoint 会自动恢复并启动 server 与 console。
+`ov.conf` 出现后，entrypoint 会自动恢复并启动 server。
 
 也可以使用 Docker Compose，项目根目录提供了 `docker-compose.yml`：
 
@@ -274,9 +269,9 @@ docker compose up -d
 ```
 
 启动后可以访问：
-- 聚合入口：`http://localhost:1934`（Caddy 合并 API + Console）
-- API 服务（直连）：`http://localhost:1933`
-- Console 界面（直连）：`http://localhost:8020`
+- API 服务：`http://localhost:1933`
+- Web Studio：`http://localhost:1933/studio`（与 API 同源）
+- 兼容入口：`http://localhost:1934`（Caddy 反代到 1933，仅为已有部署保留）
 
 如需公网 HTTPS 访问，请参考 [公网访问指南](12-public-access.md)。
 

--- a/docs/zh/guides/05-observability.md
+++ b/docs/zh/guides/05-observability.md
@@ -5,7 +5,7 @@
 - 服务健康检查与组件状态
 - 请求级 `telemetry`
 - 终端侧 `ov tui`
-- Web 侧 `OpenViking Console`
+- Web 侧 `Web Studio`（同 OV server，路径 `/studio`）
 - `/metrics` 时序指标
 
 如果你只想快速判断“该看哪里”，先看下面这张表。
@@ -16,7 +16,7 @@
 | --- | --- | --- |
 | `/health`、`observer/*` | 服务是否健康、队列是否堆积、VikingDB/VLM 状态 | 部署验收、值班巡检 |
 | `ov tui` | `viking://` 文件树、目录摘要、文件正文、向量记录、受支持图片文件的预览 | 开发调试、核对资源是否真正落库 |
-| `OpenViking Console` | Web UI 里的文件浏览、检索、资源导入、租户与系统状态 | 不想手敲命令时做交互式排查 |
+| `Web Studio`（`/studio`） | 同 OV server 的 Web UI：Home 看 token / 检索 / context commits 趋势，Resources 浏览 URI，Retrieval 直接发 find，Request Logs 看审计日志 | 不想手敲命令时做交互式排查 |
 | `telemetry` | 单次请求耗时、token、向量检索、资源处理阶段 | 排查一次具体调用为什么慢、为什么结果异常 |
 | `/metrics` | 请求量趋势、错误率、时延分布、队列与探针状态 | Prometheus 抓取、Grafana 看板、告警规则 |
 
@@ -158,46 +158,29 @@ ov tui viking://resources
 
 TUI 更偏“数据面排查”。它适合回答“资源到底有没有进去”“向量到底有没有写进去”，但不直接展示单次请求的 token 或阶段耗时。
 
-## 用 OpenViking Console 做 Web 观测
+## 用 Web Studio 做 Web 观测
 
-仓库里还有一个独立的 Web Console，它不是主 CLI 的一部分，需要单独启动：
-
-```bash
-python -m openviking.console.bootstrap \
-  --host 127.0.0.1 \
-  --port 8020 \
-  --openviking-url http://127.0.0.1:1933
-```
-
-然后打开：
+OV server 自身在 `/studio` 提供 Web Studio 前端 —— 不需要单独进程，跟着 `openviking-server` 一起起来就行。
 
 ```text
-http://127.0.0.1:8020/
+http://127.0.0.1:1933/studio
 ```
 
-第一次使用时，在 `Settings` 面板里填入 `X-API-Key`。
+第一次使用时，在右上角 Connection 对话框里填入 `X-API-Key`，base URL 默认就是当前同源（也就是 `/studio` 来自哪个域名，API 就走那个域名）。
 
-当前比较适合观测的面板有：
+当前比较适合观测的页面有：
 
-- `FileSystem`：浏览 URI、查看目录和文件
-- `Find`：直接发检索请求并查看结果
-- `Add Resource`：导入资源并查看返回结果
-- `Add Memory`：通过 session 提交一段内容，观察 memory 提交流程
-- `Tenants` / `Monitor`：查看租户、用户以及系统状态
+- `Home`（`/studio`）：今日 token 消耗、检索次数、context commits 趋势、agent 访问汇总 —— 直接读 `/api/v1/console/*` BFF
+- `Request Logs`（`/studio/request-logs`）：审计日志、按 account / user / agent / route 过滤，对应 `/api/v1/console/audit`
+- `Resources`（`/studio/resources`）：浏览 URI、查看目录和文件、上传资源
+- `Retrieval`（`/studio/retrieval`）：直接发 find / search / grep 请求并查看结果
+- `Sessions`（`/studio/sessions`）：浏览 session 历史、查看 message / memory 提交流程
 
-如果你要执行写操作，例如 `Add Resource`、`Add Memory`、租户或用户管理，需要带 `--write-enabled` 启动：
+写操作（`Add Resource`、`Add Memory`、租户/用户管理）通过当前已登录的 API key 鉴权，没有额外的 `--write-enabled` 开关需要打开。
 
-```bash
-python -m openviking.console.bootstrap \
-  --host 127.0.0.1 \
-  --port 8020 \
-  --openviking-url http://127.0.0.1:1933 \
-  --write-enabled
-```
+从观测角度看，Studio 的一个优点是直接调用 `/api/v1/console/*` BFF 的统计接口（dashboard summary、token series、context commits、audit logs），跟旧 console 复用同一套数据，只是 UI 换了。对于 `find`、`add-resource` 和 `session commit` 这类操作，结果面板可以展开看 `telemetry.summary`。
 
-从观测角度看，Console 的一个优点是结果面板会直接显示接口返回值。对于 `find`、`add-resource` 和 `session commit` 这类操作，Console 代理层会默认帮你请求 `telemetry`，所以页面结果里通常可以直接看到 `telemetry.summary`。
-
-Console 更适合“边点边看”的交互式排查；如果你要把观测数据接到自己的日志系统或自动化链路，建议直接调用 HTTP API 或 SDK，并显式请求 telemetry。
+Studio 更适合“边点边看”的交互式排查；如果你要把观测数据接到自己的日志系统或自动化链路，建议直接调用 HTTP API 或 SDK，并显式请求 telemetry。
 
 ## 请求级 Telemetry
 


### PR DESCRIPTION
## Description

Follow-up to #2160 (console package + port 8020 removal) and #2170 (OAuth UI moved into web-studio). Six guides still showed the old `python -m openviking.console.bootstrap` launch + `-p 8020:8020` docker run snippets, which now fail because the console package is gone and the image no longer exposes 8020. This PR rewrites those six pages to point readers at Web Studio (`/studio`, same-origin as the OV server) instead.

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/{en,zh}/getting-started/04-setup-for-agent.md` — drop `-p 8020:8020` from the docker run example and the "ports: 1933:1933, 8020:8020" summary; note that Web Studio is served at `/studio` so no extra port is needed.
- `docs/{en,zh}/guides/03-deployment.md` — drop 4× `-p 8020:8020` snippets, replace "OpenViking Console on port 8020" with the inline `/studio` mention, and update the "access this after startup" list to point at `http://localhost:1933/studio` (with 1934 documented as a legacy Caddy fallback, consistent with the updated `12-public-access.md`).
- `docs/{en,zh}/guides/05-observability.md` — rewrite the "Use OpenViking Console for web-based investigation" section. The standalone-bootstrap launch is gone; instead direct readers to `/studio` and its observability-relevant pages: `Home` (token / retrieval / context-commit trends, backed by `/api/v1/console/*` BFF), `Request Logs` (audit), `Resources`, `Retrieval`, `Sessions`. The "choose an entry point" table at the top is updated to match.

`docs/design/mcp-oauth2-1.md` is intentionally **untouched** — it's a historical design document explaining the original console-based OAuth flow. `openviking/observability/usage_audit/README.md` and `docs/{en,zh}/guides/12-public-access.md` were already updated in earlier PRs.

## Testing

- [x] `grep -rn '8020\|openviking\.console' docs/` returns only matches under `docs/design/` (intentional).
- [x] Reviewed each rewritten section for accuracy against the current `web-studio` routes (`/home`, `/request-logs`, `/resources`, `/retrieval`, `/sessions`, `/oauth/consent`).

## Additional Notes

Diff is +44 / −88; net reduction since the standalone-console launch instructions go away.