### PR TITLE
docs(mcp): document code_outline / code_search / code_expand from #2146

### DIFF
--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -103,7 +103,7 @@ no external proxy is needed.
 
 ## Available MCP Tools
 
-Once connected, OpenViking exposes 11 tools:
+Once connected, OpenViking exposes 14 tools:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
@@ -117,6 +117,9 @@ Once connected, OpenViking exposes 11 tools:
 | `grep` | Regex content search across `viking://` files | `uri`, `pattern` (string or array), `case_insensitive` |
 | `glob` | Find files matching a glob pattern | `pattern`, `uri` (optional scope) |
 | `forget` | Delete any `viking://` URI (use `search` to find it first; pass `recursive=true` to delete a directory) | `uri`, `recursive` (optional) |
+| `code_outline` | Show a file's symbol structure (classes, functions, methods, line ranges) without reading bodies. Survey a file before deciding what to `read`. | `uri` (must be a `viking://` **file** URI) |
+| `code_search` | Search symbol names (class / function / method) by substring across a `viking://` directory. Returns symbol type, class context, file URI, line range. Scans up to 200 source files. | `query`, `uri` (must be a `viking://` directory; narrow to subdir for deeper coverage) |
+| `code_expand` | Return the full source of a single named symbol, avoiding reading the entire file. | `uri` (file), `symbol` (`bar` for top-level or `Foo.bar` for a method) |
 | `health` | Check OpenViking service health | none |
 
 > **Note**: MCP exposes the minimum closure for watch management (`list_watches` + `cancel_watch`). Pause / resume / trigger and the unified `update` verb are intentionally not exposed here — use the REST `/api/v1/watches/*` endpoints or the `ov task watch` CLI for those operations.

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -95,7 +95,7 @@ claude mcp add --transport http openviking \
 
 ## 可用的 MCP 工具
 
-连接后，OpenViking MCP 端点暴露 11 个工具：
+连接后，OpenViking MCP 端点暴露 14 个工具：
 
 | 工具 | 说明 | 主要参数 |
 |------|------|----------|
@@ -109,6 +109,9 @@ claude mcp add --transport http openviking \
 | `grep` | 在 `viking://` 文件中进行正则内容搜索 | `uri`, `pattern`（字符串或数组）, `case_insensitive` |
 | `glob` | 按 glob 模式匹配文件 | `pattern`, `uri`(可选范围) |
 | `forget` | 删除任意 `viking://` URI（先用 `search` 查找；删除目录需 `recursive=true`） | `uri`, `recursive`(可选) |
+| `code_outline` | 显示文件的符号结构（类、函数、方法及其行号范围），不读取实现体。在决定 `read` 之前用于快速浏览文件。 | `uri`（必须是 `viking://` **文件** URI） |
+| `code_search` | 在 `viking://` 目录下按子串搜索符号名（类 / 函数 / 方法），返回符号类型、所属类、文件 URI、行号范围。最多扫描 200 个源文件。 | `query`, `uri`（必须是 `viking://` 目录；缩小到子目录可获得更深覆盖） |
+| `code_expand` | 返回单个命名符号的完整源码，避免读取整个文件。 | `uri`（文件）, `symbol`（`bar` 表示顶层，`Foo.bar` 表示方法） |
 | `health` | 检查 OpenViking 服务健康状态 | 无 |
 
 > **注**：MCP 仅暴露 watch 管理的最小闭包（`list_watches` + `cancel_watch`）。pause / resume / trigger 和统一的 `update` 动作刻意不在此处暴露，请通过 REST `/api/v1/watches/*` 接口或 `ov task watch` CLI 使用上述操作。


### PR DESCRIPTION
## Summary

Updates the **Available MCP Tools** table in `docs/{en,zh}/guides/06-mcp-integration.md` to reflect the three new MCP tools added by #2146 (`code_outline` / `code_search` / `code_expand`). Pre-#2146 the table claimed "11 tools" and listed 11 rows; after #2146 the MCP endpoint exposes the three additional code-navigation tools at `openviking/server/mcp_endpoint.py` L840 / L864 / L914. The client-facing setup guide users land on for tool discovery is now stale by three rows and a count.

## Why this matters

The integration guide is where MCP clients (Claude / Manus / OpenClaw / VikingBot) discover what tools the endpoint actually exposes. Without these three rows agents miss the `code_search → code_outline → code_expand` workflow this PR was specifically designed to enable; users have to read `openviking/server/mcp_endpoint.py` to find out the tools exist.

Same form as #2134 (`list_watches` + `cancel_watch` catch of #2110) — narrow scope, dual-doc parity, no semantic change to the prose around the table.

## Changes

- EN + ZH `docs/.../guides/06-mcp-integration.md`: count `11` → `14`; insert 3 rows between `forget` and `health` matching source-file order in `mcp_endpoint.py`.
- Row content grounded byte-for-byte in the docstrings and signatures introduced by #2146:
  - `code_outline(uri)` — file URI, returns symbol structure without bodies.
  - `code_search(query, uri)` — directory URI, scans up to 200 source files, narrow uri for deeper coverage.
  - `code_expand(uri, symbol)` — file URI, `symbol` accepts `bar` (top-level) or `Foo.bar` (method).
- Surrounding "Note" about watch-management closure is unchanged (different surface).

12 LOC (6 EN + 6 ZH — 3 row inserts + count edits, each side).