### PR TITLE
fix(blog): show agent thinking placeholder

### DIFF
--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -940,6 +940,41 @@ html {
   background: color-mix(in oklab, var(--th-accent) 16%, var(--th-bg-2));
 }
 
+.zouk-reader-message.is-thinking-placeholder .zouk-reader-message-profile {
+  max-width: 92%;
+}
+
+.zouk-reader-thinking-bubble {
+  border-color: color-mix(in oklab, var(--zouk-status-thinking) 36%, var(--th-line));
+  background: color-mix(in oklab, var(--zouk-status-thinking) 10%, var(--th-bg-2));
+  color: color-mix(in oklab, var(--th-ink) 82%, var(--zouk-status-thinking));
+  font-family: var(--th-font-mono);
+}
+
+.zouk-reader-thinking-text {
+  display: inline-flex;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.zouk-reader-thinking-dots {
+  display: inline-flex;
+  width: 1.2em;
+}
+
+.zouk-reader-thinking-dots span {
+  animation: zoukThinkingDot 1.2s ease-in-out infinite;
+  opacity: 0.25;
+}
+
+.zouk-reader-thinking-dots span:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+.zouk-reader-thinking-dots span:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
 .zouk-reader-thread {
   align-self: flex-start;
   max-width: 100%;
@@ -1368,5 +1403,15 @@ html {
   }
   to {
     transform: translate3d(0, calc(var(--zouk-blog-sheet-top) + var(--zouk-blog-drag, 0px)), 0);
+  }
+}
+
+@keyframes zoukThinkingDot {
+  0%, 80%, 100% {
+    opacity: 0.25;
+  }
+
+  40% {
+    opacity: 1;
   }
 }

--- a/blog/src/zouk-embed.jsx
+++ b/blog/src/zouk-embed.jsx
@@ -232,6 +232,11 @@ function agentIsLive(agent) {
   return agent.activity === 'working' || agent.activity === 'thinking' || agent.activity === 'error';
 }
 
+function agentIsThinking(agent) {
+  if (!agent || agent.status !== 'active') return false;
+  return agent.activity === 'working' || agent.activity === 'thinking';
+}
+
 function isSystemMessage(message) {
   return message?.senderType === 'system' || message?.senderName === 'system';
 }
@@ -526,6 +531,29 @@ function LiveAgents({ agents }) {
   );
 }
 
+function ThinkingMessage({ agent }) {
+  const label = agent?.displayName || agent?.name || 'agent';
+  const dotStatus = agentDotStatus(agent);
+  return (
+    <article className="zouk-reader-message is-thinking-placeholder" aria-live="polite">
+      <div className="zouk-reader-message-profile">
+        <Avatar name={label} src={agent?.avatarUrl} status={dotStatus} kind="agent" />
+        <div className="zouk-reader-bubble-column">
+          <div className="zouk-reader-sender">{label}</div>
+          <div className="zouk-reader-bubble zouk-reader-thinking-bubble">
+            <span className="zouk-reader-thinking-text" aria-label="thinking...">
+              <span>thinking</span>
+              <span className="zouk-reader-thinking-dots" aria-hidden="true">
+                <span>.</span><span>.</span><span>.</span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
 export function ZoukInteractiveBlog({ route }) {
   const [browserId] = useState(getBrowserId);
   const [open, setOpen] = useState(false);
@@ -546,12 +574,14 @@ export function ZoukInteractiveBlog({ route }) {
   const [lastContextUrl, setLastContextUrl] = useState('');
   const [selectionAction, setSelectionAction] = useState(null);
   const [headerSlot, setHeaderSlot] = useState(null);
+  const [dismissedThinkingKey, setDismissedThinkingKey] = useState('');
   const scrollRef = useRef(null);
   const textareaRef = useRef(null);
   const wsRef = useRef(null);
   const closeTimerRef = useRef(null);
   const dragRef = useRef(null);
   const sheetHeightRef = useRef(0);
+  const thinkingMessageKeyRef = useRef('');
   const target = `#${CONFIG.channel}`;
   const panelVisible = open || closing;
   const referencedText = compactText(selectedText);
@@ -583,6 +613,12 @@ export function ZoukInteractiveBlog({ route }) {
     () => agents.filter(agentIsLive),
     [agents],
   );
+  const thinkingAgent = useMemo(
+    () => liveAgents.find(agentIsThinking) || null,
+    [liveAgents],
+  );
+  const thinkingMessageKey = thinkingAgent ? thinkingAgent.id : '';
+  const showThinkingMessage = Boolean(thinkingAgent && thinkingMessageKey !== dismissedThinkingKey);
   const launcherStatus = useMemo(() => {
     const statuses = liveAgents.map(agentDotStatus);
     if (statuses.includes('error')) return 'error';
@@ -596,6 +632,11 @@ export function ZoukInteractiveBlog({ route }) {
     const next = currentSourceUrl();
     setSourceUrl(next);
     return next;
+  }, []);
+
+  const dismissThinkingMessage = useCallback(() => {
+    const key = thinkingMessageKeyRef.current;
+    if (key) setDismissedThinkingKey(key);
   }, []);
 
   const openChat = useCallback((nextSelectedText = '') => {
@@ -707,11 +748,15 @@ export function ZoukInteractiveBlog({ route }) {
         if ((packet.type === 'message' || packet.type === 'new_message') && packet.message) {
           const next = normalizeMessage(packet.message);
           if (next?.channelType === 'thread' && next.parentChannelName === CONFIG.channel) {
+            dismissThinkingMessage();
             setMessages((prev) => mergeThreadReply(prev, next));
             setThreadStates((prev) => mergeThreadStateReply(prev, next));
             return;
           }
-          if (next?.channelName === CONFIG.channel) setMessages((prev) => mergeMessage(prev, next));
+          if (next?.channelName === CONFIG.channel) {
+            dismissThinkingMessage();
+            setMessages((prev) => mergeMessage(prev, next));
+          }
         }
       } catch {
         // Ignore non-JSON websocket frames.
@@ -721,7 +766,15 @@ export function ZoukInteractiveBlog({ route }) {
       ws.close();
       if (wsRef.current === ws) wsRef.current = null;
     };
-  }, [token]);
+  }, [dismissThinkingMessage, token]);
+
+  useEffect(() => {
+    thinkingMessageKeyRef.current = thinkingMessageKey;
+  }, [thinkingMessageKey]);
+
+  useEffect(() => {
+    if (!thinkingAgent && dismissedThinkingKey) setDismissedThinkingKey('');
+  }, [dismissedThinkingKey, thinkingAgent]);
 
   useEffect(() => {
     if (!browserAvailable()) return undefined;
@@ -748,7 +801,7 @@ export function ZoukInteractiveBlog({ route }) {
   useEffect(() => {
     const node = scrollRef.current;
     if (node) node.scrollTop = node.scrollHeight;
-  }, [visibleMessages.length, panelVisible]);
+  }, [panelVisible, showThinkingMessage, visibleMessages.length]);
 
   useEffect(() => {
     const node = textareaRef.current;
@@ -901,6 +954,7 @@ export function ZoukInteractiveBlog({ route }) {
         body: JSON.stringify({ target, content }),
       });
       const body = await parseJsonResponse(res);
+      dismissThinkingMessage();
       setMessages((prev) => mergeMessage(prev, normalizeMessage(body.message)));
       if (nextIncludeUrl) setLastContextUrl(nextSourceUrl);
       setSelectedText('');
@@ -910,7 +964,7 @@ export function ZoukInteractiveBlog({ route }) {
       setStatus('error');
       setError(err instanceof Error ? err.message : 'Send failed');
     }
-  }, [authHeaders, composer, lastContextUrl, rememberSource, selectedText, status, target, token]);
+  }, [authHeaders, composer, dismissThinkingMessage, lastContextUrl, rememberSource, selectedText, status, target, token]);
 
   const loadThreadMessages = useCallback(async (parentMessage) => {
     const parentId = parentMessage?.id;
@@ -1083,6 +1137,7 @@ export function ZoukInteractiveBlog({ route }) {
                 </article>
               );
             })}
+            {showThinkingMessage ? <ThinkingMessage agent={thinkingAgent} /> : null}
           </div>
 
           <form className="zouk-reader-composer" onSubmit={onSubmit}>


### PR DESCRIPTION
## Summary
- render a temporary blog-only agent message while an agent is working or thinking
- animate the trailing dots in the `thinking...` bubble
- dismiss the temporary bubble when a real channel or thread message arrives, without adding it to persisted chat messages

## Validation
- npm run build
- git diff --check