### PR TITLE
fix(helm): refresh OpenViking chart defaults

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -14,9 +14,23 @@ Deploy OpenViking on Kubernetes using Helm.
 
 ```bash
 helm install openviking ./deploy/helm/openviking \
-  --set config.server.root_api_key="YOUR_ROOT_API_KEY" \
-  --set config.embedding.dense.api_key="YOUR_VOLCENGINE_API_KEY" \
-  --set config.vlm.api_key="YOUR_VOLCENGINE_API_KEY"
+  --set-string config.server.root_api_key="YOUR_ROOT_API_KEY" \
+  --set-string config.embedding.dense.api_key="YOUR_VOLCENGINE_API_KEY" \
+  --set-string config.vlm.api_key="YOUR_VOLCENGINE_API_KEY"
+```
+
+The chart deploys `ghcr.io/volcengine/openviking:latest` by default. To choose
+a different image tag:
+
+```bash
+# newest image from the main branch
+helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=main
+
+# pinned release image
+helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=v0.3.17
+
+# use the default latest image
+helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=
 ```
 
 ### Install with Custom Values
@@ -40,7 +54,7 @@ persistence:
 
 config:
   storage:
-    workspace: /app/data/openviking_workspace
+    workspace: /app/.openviking/openviking_workspace
   log:
     level: INFO
     output: stdout
@@ -83,6 +97,7 @@ Kubernetes secrets instead:
 ```bash
 # Create a secret
 kubectl create secret generic openviking-api-keys \
+  --from-literal=root-api-key="YOUR_ROOT_API_KEY" \
   --from-literal=embedding-api-key="YOUR_KEY" \
   --from-literal=vlm-api-key="YOUR_KEY"
 ```
@@ -90,18 +105,36 @@ kubectl create secret generic openviking-api-keys \
 Then reference it in your values:
 
 ```yaml
+config:
+  server:
+    root_api_key: "${OPENVIKING_ROOT_API_KEY}"
+  embedding:
+    dense:
+      api_key: "${OPENVIKING_EMBEDDING_API_KEY}"
+  vlm:
+    api_key: "${OPENVIKING_VLM_API_KEY}"
+
 extraEnv:
-  - name: EMBEDDING_API_KEY
+  - name: OPENVIKING_ROOT_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: openviking-api-keys
+        key: root-api-key
+  - name: OPENVIKING_EMBEDDING_API_KEY
     valueFrom:
       secretKeyRef:
         name: openviking-api-keys
         key: embedding-api-key
-  - name: VLM_API_KEY
+  - name: OPENVIKING_VLM_API_KEY
     valueFrom:
       secretKeyRef:
         name: openviking-api-keys
         key: vlm-api-key
 ```
+
+OpenViking expands environment variables inside `ov.conf` at startup, so the
+ConfigMap can contain placeholders while the actual secrets stay in Kubernetes
+Secrets.
 
 ## Configuration
 
@@ -109,13 +142,15 @@ extraEnv:
 |-----------|-------------|---------|
 | `replicaCount` | Number of replicas | `1` |
 | `image.repository` | Container image repository | `ghcr.io/volcengine/openviking` |
-| `image.tag` | Container image tag | Chart appVersion |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | Container image tag (`latest`, `main`, pinned release, or empty for `latest`) | `latest` |
+| `image.pullPolicy` | Image pull policy | `Always` |
 | `service.type` | Kubernetes service type | `ClusterIP` |
 | `service.port` | Service port | `1933` |
 | `persistence.enabled` | Enable persistent storage | `true` |
 | `persistence.size` | PVC size | `20Gi` |
 | `persistence.storageClass` | Storage class name | `""` (default) |
+| `persistence.mountPath` | Container path for OpenViking persistent state | `/app/.openviking` |
+| `bot.enabled` | Start vikingbot alongside the API server | `false` |
 | `persistence.existingClaim` | Use an existing PVC | `""` |
 | `resources.limits.cpu` | CPU limit | `2` |
 | `resources.limits.memory` | Memory limit | `4Gi` |

--- a/deploy/helm/openviking/Chart.yaml
+++ b/deploy/helm/openviking/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: openviking
 description: OpenViking - The Context Database for AI Agents
 type: application
-version: 0.1.0
-appVersion: "0.1.18"
+version: 0.1.1
 keywords:
   - openviking
   - ai

--- a/deploy/helm/openviking/templates/_helpers.tpl
+++ b/deploy/helm/openviking/templates/_helpers.tpl
@@ -37,8 +37,9 @@ Common labels.
 {{- define "openviking.labels" -}}
 helm.sh/chart: {{ include "openviking.chart" . }}
 {{ include "openviking.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- $appVersion := include "openviking.appVersion" . }}
+{{- if $appVersion }}
+app.kubernetes.io/version: {{ $appVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
@@ -63,9 +64,16 @@ Create the name of the service account to use.
 {{- end }}
 
 {{/*
+Return the deployed app version label.
+*/}}
+{{- define "openviking.appVersion" -}}
+{{- default "latest" .Values.image.tag -}}
+{{- end }}
+
+{{/*
 Return the image name including tag.
 */}}
 {{- define "openviking.image" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- $tag := default "latest" .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end }}

--- a/deploy/helm/openviking/templates/deployment.yaml
+++ b/deploy/helm/openviking/templates/deployment.yaml
@@ -44,12 +44,15 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: {{ include "openviking.image" . }}
+          image: {{ include "openviking.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["openviking-server"]
           env:
             - name: OPENVIKING_CONFIG_FILE
-              value: /app/ov.conf
+              value: {{ printf "%s/ov.conf" .Values.persistence.mountPath | quote }}
+            - name: OPENVIKING_CLI_CONFIG_FILE
+              value: {{ printf "%s/ovcli.conf" .Values.persistence.mountPath | quote }}
+            - name: OPENVIKING_WITH_BOT
+              value: {{ ternary "1" "0" .Values.bot.enabled | quote }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -70,12 +73,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: config
-              mountPath: /app/ov.conf
-              subPath: ov.conf
-              readOnly: true
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
+            - name: config
+              mountPath: {{ printf "%s/ov.conf" .Values.persistence.mountPath | quote }}
+              subPath: ov.conf
+              readOnly: true
       volumes:
         - name: config
           configMap:

--- a/deploy/helm/openviking/values.yaml
+++ b/deploy/helm/openviking/values.yaml
@@ -4,9 +4,13 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/volcengine/openviking
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  # Use Always for the default moving tag. Pin a version and set IfNotPresent if
+  # you want Kubernetes to reuse cached immutable images.
+  pullPolicy: Always
+  # Image tag to deploy. Defaults to the latest released OpenViking image.
+  # Set to "main" for the newest image from the main branch, a version such as
+  # "v0.3.17" for a pinned release, or "" to use latest.
+  tag: latest
 
 imagePullSecrets: []
 nameOverride: ""
@@ -67,14 +71,21 @@ persistence:
   size: 20Gi
   # Existing PVC name. If set, no new PVC is created.
   existingClaim: ""
-  # Mount path inside the container for data directory.
-  mountPath: /app/data
+  # Mount path inside the container for OpenViking persistent state. The official
+  # Docker image expects ov.conf, ovcli.conf, and workspace data under this path.
+  mountPath: /app/.openviking
+
+bot:
+  # The Docker image can start vikingbot with the API server. Keep it disabled
+  # for Kubernetes by default so the chart exposes only the OpenViking API port.
+  enabled: false
 
 # OpenViking server configuration (ov.conf).
-# This is rendered into a ConfigMap and mounted at /app/ov.conf.
+# This is rendered into a ConfigMap and mounted at
+# ${persistence.mountPath}/ov.conf.
 config:
   storage:
-    workspace: /app/data/openviking_workspace
+    workspace: /app/.openviking/openviking_workspace
     vectordb:
       name: context
       backend: local
@@ -89,7 +100,9 @@ config:
     host: "0.0.0.0"
     port: 1933
     workers: 1
-    root_api_key: ""
+    # Required when host is 0.0.0.0. Prefer setting this via an environment
+    # variable placeholder plus extraEnv/Secret, e.g. ${OPENVIKING_ROOT_API_KEY}.
+    root_api_key: null
     cors_origins:
       - "*"
   embedding:
@@ -114,13 +127,11 @@ config:
 # Extra environment variables to set on the container.
 # Use this for secrets or overrides that should not be in the ConfigMap.
 extraEnv: []
-  # - name: OPENVIKING_CONFIG_FILE
-  #   value: /app/ov.conf
-  # - name: SOME_SECRET
+  # - name: OPENVIKING_ROOT_API_KEY
   #   valueFrom:
   #     secretKeyRef:
   #       name: my-secret
-  #       key: api-key
+  #       key: root-api-key
 
 # Liveness and readiness probes.
 livenessProbe:


### PR DESCRIPTION
## Summary
- default the Helm chart to `ghcr.io/volcengine/openviking:latest` and decouple image selection from `Chart.appVersion`
- document `latest` / `main` / pinned tags such as `v0.3.17`; an empty `image.tag` also falls back to `latest`
- align Kubernetes deployment with the current Docker image layout by using `/app/.openviking/ov.conf`, the image entrypoint, and `OPENVIKING_WITH_BOT=0` by default
- update persistence defaults/docs and secret-based API key examples so the Service still exposes only port 1933

## Validation
- `helm lint deploy/helm/openviking`
- `helm template openviking deploy/helm/openviking --namespace default`
- `helm template openviking deploy/helm/openviking --namespace default --set image.tag=` renders `ghcr.io/volcengine/openviking:latest`
- `git diff --check`
- deployed with `helm upgrade --install openviking ./deploy/helm/openviking --namespace default --set image.tag=main ... --wait --timeout 10m`
- verified `kubectl get svc` shows `ClusterIP` with only `1933/TCP`
- verified local port-forward `127.0.0.1:1933 -> svc/openviking:1933`, `/health`, `/ready`, and authenticated `/api/v1/system/status`
- verified installed `ov` CLI can connect via a temporary `ovcli.conf`, read/write `viking://resources/helm-smoke/cli-20260522T071348Z.md`, and retrieve it with `ov find`
- verified workspace persistence by restarting `deployment/openviking`, then reading and finding the same smoke-test resource after the new pod became Ready