### PR TITLE
fix(blog): scope live agents to embed channel

### DIFF
--- a/blog/src/posts/openviking-too-many-agents/index.jsx
+++ b/blog/src/posts/openviking-too-many-agents/index.jsx
@@ -223,7 +223,7 @@ function AgentSpread({ t }) {
       {agents.map(name => (
         <div className="ovta-agent" key={name}>
           <div className="ovta-agent__name">{name}</div>
-          <div className="ovta-agent__state">{t({ en: 'fresh context unless connected', zh: '不连接就重新建上下文' })}</div>
+          <div className="ovta-agent__state">{t({ en: 'fresh context unless connected', zh: '接入前各用各的上下文' })}</div>
         </div>
       ))}
     </div>
@@ -237,14 +237,14 @@ function SharedSpine({ t }) {
         <p className="ovta-spine__title">{t({ en: 'Before', zh: '接入前' })}</p>
         <p className="ovta-spine__body">{t({
           en: 'Each agent keeps its own session, tool state, memory habit, and local prompt layer. Switching tools means rebuilding context from zero or pasting summaries by hand.',
-          zh: '每个 agent 都有自己的 session、工具状态、记忆习惯和本地 prompt 层。切换工具时，要么从零重建上下文，要么靠人手动粘摘要。',
+          zh: '每个 agent 都有自己的会话、工具状态、记忆习惯和本地提示词规则。切换工具时，常常要重新交代背景，或者手动整理摘要再贴过去。',
         })}</p>
       </div>
       <div className="ovta-spine__card ovta-spine__card--accent">
         <p className="ovta-spine__title">{t({ en: 'After OpenViking', zh: '接入 OpenViking 后' })}</p>
         <p className="ovta-spine__body">{t({
           en: 'Dialogues, docs, code, files, and distilled preferences enter one governed context layer. Agents retrieve the same durable background through plugins, hooks, or MCP.',
-          zh: '对话、文档、代码、文件和提炼后的偏好进入同一层可治理上下文。不同 agent 通过插件、hooks 或 MCP 读取同一份长期背景。',
+          zh: '对话、文档、代码、文件和提炼后的偏好会沉淀到同一层可治理的上下文里。不同 agent 可以通过插件、hooks 或 MCP 读取同一份长期背景。',
         })}</p>
       </div>
     </div>
@@ -254,19 +254,19 @@ function SharedSpine({ t }) {
 function LayerComparison({ t }) {
   const rows = [
     {
-      layer: t({ en: 'Agent harnesses', zh: 'Agent harness' }),
-      belongs: t({ en: 'Runtime guidance such as project conventions, command preferences, local tools, and agent-specific rules.', zh: '项目约定、命令偏好、本地工具和 agent 专属规则等运行约束。' }),
-      matters: t({ en: 'They steer behavior in one workspace. OpenViking handles durable recall across agents.', zh: '它们约束单个工作区里的行为。跨 agent 的长期召回交给 OpenViking。' }),
+      layer: t({ en: 'Agent harnesses', zh: 'Agent 运行约束' }),
+      belongs: t({ en: 'Runtime guidance such as project conventions, command preferences, local tools, and agent-specific rules.', zh: '项目约定、命令偏好、本地工具、agent 专属规则等运行时约束。' }),
+      matters: t({ en: 'They steer behavior in one workspace. OpenViking handles durable recall across agents.', zh: '这层约束单个工作区里的行为；跨 agent 的长期记忆交给 OpenViking。' }),
     },
     {
       layer: t({ en: 'OpenViking memory', zh: 'OpenViking 记忆' }),
       belongs: t({ en: 'User preferences, decisions, handoffs, resources, summaries, and reusable lessons.', zh: '用户偏好、决策、交接、资源、摘要和可复用经验。' }),
-      matters: t({ en: 'They survive sessions and can be retrieved by multiple agents under governed identity.', zh: '它们跨 session 存活，并能在受治理身份下被多个 agent 检索。' }),
+      matters: t({ en: 'They survive sessions and can be retrieved by multiple agents under governed identity.', zh: '它们跨 session 保留下来，并能在受治理的身份边界内给多个 agent 取用。' }),
     },
     {
       layer: t({ en: 'MCP and plugins', zh: 'MCP 与插件' }),
-      belongs: t({ en: 'The connection surface for Claude Code, Codex, Manus, Lovable, Bolt, and other clients.', zh: 'Claude Code、Codex、Manus、Lovable、Bolt 等客户端的连接面。' }),
-      matters: t({ en: 'They let agents read and write context without hand-built copy-paste workflows.', zh: '它们让 agent 不靠手写复制粘贴流程也能读写上下文。' }),
+      belongs: t({ en: 'The connection surface for Claude Code, Codex, Manus, Lovable, Bolt, and other clients.', zh: 'Claude Code、Codex、Manus、Lovable、Bolt 等客户端接入 OpenViking 的接口层。' }),
+      matters: t({ en: 'They let agents read and write context without hand-built copy-paste workflows.', zh: '它们让 agent 能直接读写上下文，不再靠人来回复制粘贴。' }),
     },
   ];
 
@@ -303,16 +303,16 @@ function SetupSteps({ t }) {
       title: t({ en: 'Use the official OpenViking image', zh: '使用 OpenViking 官方镜像' }),
       body: t({
         en: <>Use the <A href={OPENVIKING_IMAGE}>official OpenViking image</A> first; add a custom service layer only if needed.</>,
-        zh: <>先用 <A href={OPENVIKING_IMAGE}>OpenViking 官方镜像</A>跑起来，需要时再加自己的服务层。</>,
+        zh: <>先用 <A href={OPENVIKING_IMAGE}>OpenViking 官方镜像</A>把服务跑起来，需要时再接自己的服务层。</>,
       }),
     },
     {
       title: t({ en: 'Attach a persistent volume', zh: '挂载持久化 Volume' }),
-      body: t({ en: 'Memory and resources are only useful when they survive restarts, deploys, and infrastructure churn.', zh: '记忆和资源必须跨重启、部署和基础设施变动继续存在，才真正有价值。' }),
+      body: t({ en: 'Memory and resources are only useful when they survive restarts, deploys, and infrastructure churn.', zh: '记忆和资源只有跨过重启、部署和基础设施变动还在，才算真的可用。' }),
     },
     {
       title: t({ en: 'Initialize the server once', zh: '初始化服务' }),
-      body: t({ en: 'Run the init command in the deployment shell, then wire clients through the documented integrations.', zh: '在部署 shell 中执行初始化命令，然后按官方集成文档把客户端接进来。' }),
+      body: t({ en: 'Run the init command in the deployment shell, then wire clients through the documented integrations.', zh: '在部署 shell 里初始化一次，然后按官方集成文档接入客户端。' }),
     },
   ];
   return (
@@ -333,15 +333,15 @@ function ProofStrip({ t }) {
   const rows = [
     {
       label: t({ en: 'Deploy', zh: '部署' }),
-      text: t({ en: 'Docker image plus a volume gives the memory plane a stable home.', zh: 'Docker 镜像加 Volume，让 memory plane 有稳定落点。' }),
+      text: t({ en: 'Docker image plus a volume gives the memory plane a stable home.', zh: 'Docker 镜像加 Volume，让记忆层有稳定落点。' }),
     },
     {
       label: t({ en: 'Connect', zh: '连接' }),
-      text: t({ en: 'Plugins, hooks, and MCP let different agent loops use the same context surface.', zh: '插件、hooks 和 MCP 让不同 agent loop 接入同一个上下文界面。' }),
+      text: t({ en: 'Plugins, hooks, and MCP let different agent loops use the same context surface.', zh: '插件、hooks 和 MCP 让不同 agent 运行链路连接到同一层上下文。' }),
     },
     {
       label: t({ en: 'Inspect', zh: '检查' }),
-      text: t({ en: 'Web Studio makes the context filesystem visible on desktop and phone.', zh: 'Web Studio 让上下文文件系统在桌面和手机上都可检查。' }),
+      text: t({ en: 'Web Studio makes the context filesystem visible on desktop and phone.', zh: 'Web Studio 让团队在桌面和手机上都能查看上下文文件系统。' }),
     },
   ];
   return (
@@ -365,30 +365,30 @@ const OpenVikingTooManyAgents = ({ t }) => {
 
       <Lead>{T({
         en: 'The hard part now is keeping context, memory, and project knowledge consistent while work moves between Claude Code, Codex, Hermes Agent, Manus, Lovable, Cursor, and whatever comes next.',
-        zh: '现在的难点是在工作跨 Claude Code、Codex、Hermes Agent、Manus、Lovable、Cursor 以及下一个工具流转时，保持上下文、记忆和项目知识一致。',
+        zh: '现在真正麻烦的是：工作在 Claude Code、Codex、Hermes Agent、Manus、Lovable、Cursor 和下一个工具之间来回切换时，怎么让上下文、记忆和项目知识不散掉。',
       })}</Lead>
 
-      <H2>{T({ en: 'The real cost of too many agents', zh: 'Agent 太多的真实成本' })}</H2>
+      <H2>{T({ en: 'The real cost of too many agents', zh: 'Agent 多起来后的真实成本' })}</H2>
 
       <P dropCap>{T({
         en: 'Every new agent gives you a different interface and a different strength. The hidden cost is that each one starts with a partial view of the world. A coding agent may know the current repository. A browser agent may know the page. A workflow agent may know its tool call. None of that automatically becomes shared memory.',
-        zh: '每出现一个新 agent，就多一种界面和一类能力。隐藏成本是：每个 agent 都只带着局部世界观开始工作。代码 agent 可能知道当前仓库，浏览器 agent 可能知道当前页面，工作流 agent 可能知道自己的工具调用。但这些不会自动变成共享记忆。',
+        zh: '每多用一个 agent，就多一种入口和一类能力。麻烦在于，它们一开始看到的世界都不完整：代码 agent 知道当前仓库，浏览器 agent 知道当前页面，工作流 agent 知道自己的工具调用，但这些信息不会自动沉淀成共享记忆。',
       })}</P>
 
       <AgentSpread t={T} />
 
       <P>{T({
         en: 'That creates a coordination tax. Humans become the copy-paste bus between tools, and agents repeat discovery work that another agent already paid for.',
-        zh: '于是出现了协作税。人变成工具之间的复制粘贴总线，agent 也会重复另一位 agent 已经做过的探索。',
+        zh: '结果是协作成本被转嫁给人：人要在工具之间搬运背景和摘要，agent 也会重复做别的 agent 已经做过的探索。',
       })}</P>
 
-      <H2>{T({ en: 'OpenViking as the shared context layer', zh: 'OpenViking 作为共享上下文层' })}</H2>
+      <H2>{T({ en: 'OpenViking as the shared context layer', zh: '用 OpenViking 做共享上下文层' })}</H2>
 
       <SharedSpine t={T} />
 
       <P>{T({
         en: 'OpenViking is useful here because it does not demand that every agent loop become the same product. It can listen quietly, store distilled memory, index resources, and expose the result through interfaces agents already understand.',
-        zh: 'OpenViking 的价值在于，它不要求每个 agent loop 变成同一个产品。它可以安静地监听、写入提炼后的记忆、索引资源，再通过 agent 已经能理解的接口把结果暴露出来。',
+        zh: 'OpenViking 的价值在于，不需要把所有 agent 运行链路都改造成同一个产品。它可以在旁边持续沉淀对话里的关键信息、索引资源，再通过 agent 熟悉的接口把上下文拿出来用。',
       })}</P>
 
       <LayerComparison t={T} />
@@ -397,7 +397,7 @@ const OpenVikingTooManyAgents = ({ t }) => {
 
       <P>{T({
         en: 'The reference deployment is intentionally simple: run the official container image, attach durable storage, initialize once, then point agents at the service.',
-        zh: '部署非常简单：运行官方容器镜像，挂上持久化存储，初始化一次，然后把 agent 指向这个服务。',
+        zh: '部署非常简单：用官方容器镜像启动，挂上持久化存储，初始化一次，然后让 agent 连接这个服务。',
       })}</P>
 
       <Figure
@@ -405,7 +405,7 @@ const OpenVikingTooManyAgents = ({ t }) => {
         size="wide"
         frame="plain"
         alt={T({ en: 'Railway deployment screen showing OpenViking running from the official container image with a connected volume.', zh: 'Railway 部署界面，展示 OpenViking 通过官方容器镜像运行并挂载 Volume。' })}
-        caption={T({ en: 'A minimal hosted setup: official image, persistent volume, and a public endpoint for clients.', zh: '最小托管形态：官方镜像、持久化 Volume，以及给客户端使用的公开 endpoint。' })}
+        caption={T({ en: 'A minimal hosted setup: official image, persistent volume, and a public endpoint for clients.', zh: '最小托管形态：官方镜像、持久化 Volume，加一个给客户端访问的公开 endpoint。' })}
       />
 
       <SetupSteps t={T} />
@@ -418,7 +418,7 @@ openviking-server init`}</Pre>
 
       <P>{T({
         en: 'After that, use the plugin or hook path for coding agents, and use MCP when the client speaks MCP directly.',
-        zh: '之后，代码 agent 走插件或 hook 路径；原生支持 MCP 的客户端直接走 MCP。',
+        zh: '之后，代码 agent 走插件或 hook；原生支持 MCP 的客户端直接走 MCP。',
       })}</P>
 
       <Ul>
@@ -431,7 +431,7 @@ openviking-server init`}</Pre>
 
       <P>{T({
         en: 'A shared context layer should not be a black box. Web Studio is bundled with the Docker image so teams can inspect the OpenViking filesystem, upload resources, review processing tasks, and check what memory has actually been captured.',
-        zh: '共享上下文层不应该是黑盒。Web Studio 已打包在 Docker 镜像里，团队可以检查 OpenViking 文件系统、上传资源、查看处理任务，并确认到底捕获了哪些记忆。',
+        zh: '共享上下文层不能是黑盒。Web Studio 已经打进 Docker 镜像，团队可以查看 OpenViking 文件系统、上传资源、检查处理任务，也能确认系统到底记住了什么。',
       })}</P>
 
       <Figure
@@ -439,7 +439,7 @@ openviking-server init`}</Pre>
         size="wide"
         frame="plain"
         alt={T({ en: 'OpenViking Studio desktop view showing the viking resource tree and an L0/L1 overview panel.', zh: 'OpenViking Studio 桌面视图，展示 viking 资源树和 L0/L1 概览面板。' })}
-        caption={T({ en: 'Desktop Web Studio turns the context database into a browsable filesystem: resource trees, abstracts, overviews, and evidence stay inspectable.', zh: '桌面 Web Studio 把上下文数据库变成可浏览文件系统：资源树、abstract、overview 和证据都能被检查。' })}
+        caption={T({ en: 'Desktop Web Studio turns the context database into a browsable filesystem: resource trees, abstracts, overviews, and evidence stay inspectable.', zh: '桌面 Web Studio 把上下文数据库变成可浏览的文件系统：资源树、abstract、overview 和证据都能查。' })}
       />
 
       <Figure
@@ -447,7 +447,7 @@ openviking-server init`}</Pre>
         size="sm"
         frame="plain"
         alt={T({ en: 'OpenViking Studio PWA on a phone showing a session history tree and a messages.jsonl reader.', zh: '手机上的 OpenViking Studio PWA，展示 session history 树和 messages.jsonl 阅读器。' })}
-        caption={T({ en: 'The same inspection path works as a PWA, which matters when memory debugging happens away from the desktop.', zh: '同一套检查路径也能以 PWA 运行；当记忆排查不在桌面前发生时，这一点很重要。' })}
+        caption={T({ en: 'The same inspection path works as a PWA, which matters when memory debugging happens away from the desktop.', zh: '同一套查看路径也可以作为 PWA 在手机上用；排查记忆问题不一定总在电脑前。' })}
       />
 
       <ProofStrip t={T} />
@@ -456,7 +456,7 @@ openviking-server init`}</Pre>
 
       <P>{T({
         en: 'The useful mental model is simple: agent harnesses steer behavior; OpenViking stores durable context; MCP and plugins make that context reachable. Keep those responsibilities separate and the system stays explainable.',
-        zh: '有用的心智模型很简单：agent harness 负责约束行为；OpenViking 负责保存长期上下文；MCP 和插件负责让上下文可达。把这些职责分清，系统才容易解释。',
+        zh: '心智模型可以很简单：Agent 运行约束管行为，OpenViking 保存长期上下文，MCP 和插件负责把上下文接到 agent 手里。职责分清，系统才好解释、好排查。',
       })}</P>
 
       <Table
@@ -466,16 +466,16 @@ openviking-server init`}</Pre>
         ]}
         rows={[
           [
-            T({ en: 'Persist the context plane', zh: '持久化上下文层' }),
-            T({ en: 'Attach storage before trusting memory. A stateless context service is a demo, not a memory system.', zh: '先挂存储，再信任记忆。无状态上下文服务只是 demo，不是记忆系统。' }),
+            T({ en: 'Persist the context plane', zh: '先让上下文持久化' }),
+            T({ en: 'Attach storage before trusting memory. A stateless context service is a demo, not a memory system.', zh: '先挂存储，再谈记忆。无状态上下文服务只能演示，不能当记忆系统。' }),
           ],
           [
-            T({ en: 'Give agents scoped identities', zh: '给 agent 有边界的身份' }),
-            T({ en: 'Shared users are convenient; distinct users are better when recall, ownership, and audit boundaries matter.', zh: '共享用户很方便；当召回、归属和审计边界重要时，独立用户更好。' }),
+            T({ en: 'Give agents scoped identities', zh: '给 agent 清晰的身份边界' }),
+            T({ en: 'Shared users are convenient; distinct users are better when recall, ownership, and audit boundaries matter.', zh: '早期共用一个用户最省事；一旦涉及召回、归属和审计，就应该拆成独立用户。' }),
           ],
           [
-            T({ en: 'Expose evidence, not only summaries', zh: '暴露证据，不只暴露摘要' }),
-            T({ en: 'L0/L1 summaries help routing, and original resources or session files can still be used when precision matters.', zh: 'L0/L1 摘要适合路由；需要精确判断时，也能继续使用原始资源和 session 文件。' }),
+            T({ en: 'Expose evidence, not only summaries', zh: '保留证据，不只给摘要' }),
+            T({ en: 'L0/L1 summaries help routing, and original resources or session files can still be used when precision matters.', zh: 'L0/L1 摘要适合做路由；需要精确判断时，还要能回到原始资源和 session 文件。' }),
           ],
         ]}
       />
@@ -486,7 +486,7 @@ openviking-server init`}</Pre>
 
       <P>{T({
         en: 'If your work already crosses multiple agents, OpenViking is most valuable when you install it before the next context handoff. Put the repository, docs, and prior session memory into the same layer, then let each agent retrieve only what it needs.',
-        zh: '如果你的工作已经跨多个 agent，OpenViking 最好在下一次上下文交接前就装好。把仓库、文档和历史 session 记忆放进同一层，再让每个 agent 只检索自己需要的部分。',
+        zh: '如果你的工作已经在多个 agent 之间流转，最好在下一次交接前就把 OpenViking 接上。把仓库、文档和历史 session 记忆放到同一层，让每个 agent 只取自己需要的部分。',
       })}</P>
 
       <Ul>
@@ -498,7 +498,7 @@ openviking-server init`}</Pre>
       <Callout type="tip" title={T({ en: 'Rule of thumb', zh: '经验法则' })}>
         <P>{T({
           en: 'When an agent produces context that another agent will need later, write it to OpenViking instead of leaving it trapped in a chat transcript.',
-          zh: '当一个 agent 产出的上下文之后会被另一个 agent 用到，就把它写进 OpenViking，不要让它困在聊天记录里。',
+          zh: '当一个 agent 产出的上下文以后还会被其他 agent 用到，就写进 OpenViking，不要只留在聊天记录里。',
         })}</P>
       </Callout>
     </Article>
@@ -515,7 +515,7 @@ export default {
     },
     description: {
       en: 'A practical OpenViking deployment and Web Studio walkthrough for sharing context across Claude Code, Codex, Hermes Agent, Manus, Lovable, Cursor, and MCP clients.',
-      zh: '一次 OpenViking 部署与 Web Studio 实践：把上下文共享给 Claude Code、Codex、Hermes Agent、Manus、Lovable、Cursor 和 MCP 客户端。',
+      zh: '一次 OpenViking 部署和 Web Studio 实践：把上下文共享给 Claude Code、Codex、Hermes Agent、Manus、Lovable、Cursor 和 MCP 客户端。',
     },
     cover: COVER,
     cardCover: COVER,

--- a/blog/src/zouk-embed.jsx
+++ b/blog/src/zouk-embed.jsx
@@ -134,6 +134,16 @@ function senderKey(value = '') {
   return String(value || '').replace(/^@/, '').trim().toLowerCase();
 }
 
+function normalizeChannelName(value = '') {
+  return String(value || '').replace(/^#/, '').trim().toLowerCase();
+}
+
+function normalizeAgentChannel(value) {
+  if (typeof value === 'string') return normalizeChannelName(value);
+  if (value && typeof value === 'object') return normalizeChannelName(value.name || value.channelName || value.channel_name || '');
+  return '';
+}
+
 function normalizeAgentActivity(value = '') {
   const activity = String(value || '').trim().toLowerCase();
   return ['thinking', 'working', 'online', 'offline', 'error'].includes(activity)
@@ -158,8 +168,16 @@ function normalizeAgent(agent) {
     status: String(agent.status || 'inactive'),
     activity: normalizeAgentActivity(agent.activity),
     activityDetail: String(agent.activityDetail || agent.activity_detail || '').trim(),
-    channels: Array.isArray(agent.channels) ? agent.channels : [],
+    channels: Array.isArray(agent.channels)
+      ? agent.channels.map(normalizeAgentChannel).filter(Boolean)
+      : [],
   };
+}
+
+function agentBelongsToChannel(agent, channelName) {
+  const normalizedChannel = normalizeChannelName(channelName);
+  if (!normalizedChannel || !Array.isArray(agent?.channels)) return false;
+  return agent.channels.includes(normalizedChannel);
 }
 
 function agentSortWeight(agent) {
@@ -599,19 +617,23 @@ export function ZoukInteractiveBlog({ route }) {
     () => messages.filter((message) => !isSystemMessage(message)),
     [messages],
   );
+  const channelAgents = useMemo(
+    () => agents.filter((agent) => agentBelongsToChannel(agent, CONFIG.channel)),
+    [agents],
+  );
   const agentsBySender = useMemo(() => {
     const next = new Map();
-    agents.forEach((agent) => {
+    channelAgents.forEach((agent) => {
       [agent.name, agent.displayName, agent.id].forEach((key) => {
         const normalized = senderKey(key);
         if (normalized && !next.has(normalized)) next.set(normalized, agent);
       });
     });
     return next;
-  }, [agents]);
+  }, [channelAgents]);
   const liveAgents = useMemo(
-    () => agents.filter(agentIsLive),
-    [agents],
+    () => channelAgents.filter(agentIsLive),
+    [channelAgents],
   );
   const thinkingAgent = useMemo(
     () => liveAgents.find(agentIsThinking) || null,


### PR DESCRIPTION
## Summary
- normalize agent channel names from Zouk websocket payloads
- derive a channel-scoped agent list for the blog embed
- use only current-channel agents for LIVE, launcher status, thinking placeholder, and message avatar status matching
- polish the Chinese copy in the Too Many Agents post to reduce translationese, including the coordination/copy-paste-bus paragraph

## Investigation
The LIVE / thinking bug is possible: the blog embed received workspace-level agents from websocket init/activity packets and derived live/thinking UI from all of them, without checking whether each agent belongs to the configured embed channel.

## Validation
- npm run build
- git diff --check