### PR TITLE
fix(web-studio): drop client-side heatmap tz rebucket (post-#2178/#2190 double-shift)

### DIFF
--- a/web-studio/src/routes/home/-lib/normalize.ts
+++ b/web-studio/src/routes/home/-lib/normalize.ts
@@ -113,48 +113,26 @@ export function computeCommitHeatmapStats(
   )
 }
 
-// Re-bucket a UTC (date, hour) 4h commit row into the viewer's local
-// (date, hour). Backend's projection writes buckets by container tz
-// (effectively UTC in Railway), so a row at e.g. UTC 2026-05-21 hour=16
-// belongs to a UTC+8 viewer's 2026-05-22 hour=0. We can do this entirely
-// client-side because each bucket carries its full count — we only need
-// to relabel which local day it sums under.
-function shiftBucketToLocal(
-  utcDate: string,
-  utcHour: number,
-): { date: string; hour: number } {
-  const [y, m, d] = utcDate.split('-').map(Number)
-  const utcMs = Date.UTC(y, m - 1, d, utcHour, 0, 0)
-  const local = new Date(utcMs)
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return {
-    date: `${local.getFullYear()}-${pad(local.getMonth() + 1)}-${pad(local.getDate())}`,
-    hour: local.getHours(),
-  }
-}
-
 export function normalizeCommitHeatmapData(items: unknown): HeatMapDayValue[] {
   const rowsByDate = new Map<string, Required<ConsoleContextCommitItem>>()
 
   for (const item of normalizeCommitItems(items)) {
     if (!item.date) continue
 
-    const local = shiftBucketToLocal(item.date, item.hour)
-
-    const existing = rowsByDate.get(local.date) ?? {
+    const existing = rowsByDate.get(item.date) ?? {
       add_resource: 0,
       add_skill: 0,
-      date: local.date,
+      date: item.date,
       hour: 0,
       session_add_message: 0,
       session_commit: 0,
       total: 0,
     }
 
-    rowsByDate.set(local.date, {
+    rowsByDate.set(item.date, {
       add_resource: existing.add_resource + item.add_resource,
       add_skill: existing.add_skill + item.add_skill,
-      date: local.date,
+      date: item.date,
       hour: 0,
       session_add_message:
         existing.session_add_message + item.session_add_message,


### PR DESCRIPTION
## Summary
Hotfix: remove the client-side \`shiftBucketToLocal\` helper added in PR #2178.

PR #2190 (merge 0d63f0e3) introduced server-side UTC→viewer-tz re-bucketing for the commit heatmap. The earlier PR #2178 (merge 4e947340) already shipped a client-side equivalent. With both in place every row gets shifted twice — today's bucket lands under tomorrow's local date for UTC+ viewers.

The revert was prepared on PR #2178's branch (commit 37e04500) but pushed *after* the PR had merged, so it never made it onto main. This PR applies the same revert directly to main.

## Plan
\`web-studio/src/routes/home/-lib/normalize.ts\`:
- delete \`shiftBucketToLocal\` helper
- \`normalizeCommitHeatmapData\` keys the aggregation map by \`item.date\` as the server returns it (already viewer-tz post-#2190)

## Test plan
- [x] \`pnpm build\` clean
- [ ] @zaynjarvis to verify heatmap labels match local date after deploy