### PR TITLE
fix(embedding): 限制队列输入并停止超长重试

### DIFF
--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -33,7 +33,8 @@ from openviking.utils.circuit_breaker import (
     CircuitBreakerOpen,
     classify_api_error,
 )
-from openviking.utils.model_retry import ERROR_CLASS_PERMANENT
+from openviking.utils.embedding_input import truncate_embedding_input
+from openviking.utils.model_retry import ERROR_CLASS_INPUT_TOO_LARGE, ERROR_CLASS_PERMANENT
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config.open_viking_config import OpenVikingConfig
@@ -322,6 +323,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
         config = get_openviking_config()
         self._collection_name = config.storage.vectordb.name
         self._vector_dim = config.embedding.dimension
+        self._max_input_tokens = int(getattr(config.embedding, "max_input_tokens", 4096) or 4096)
         self._initialize_embedder(config)
         breaker_cfg = config.embedding.circuit_breaker
         self._circuit_breaker = CircuitBreaker(
@@ -498,8 +500,12 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         import time as _time
 
                         _embed_t0 = _time.monotonic()
+                        embedding_input = truncate_embedding_input(
+                            embedding_msg.message,
+                            self._max_input_tokens,
+                        )
                         result: EmbedResult = await embed_compat(
-                            self._embedder, embedding_msg.message, is_query=False
+                            self._embedder, embedding_input, is_query=False
                         )
                         _embed_elapsed = _time.monotonic() - _embed_t0
                         try:
@@ -526,6 +532,13 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                             )
                         except Exception:
                             pass
+
+                        if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
+                            logger.error(error_msg)
+                            self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
+                            request_failed_message = error_msg
+                            report_error_args = (error_msg, data)
+                            return None
 
                         if error_class == ERROR_CLASS_PERMANENT:
                             logger.critical(error_msg)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -43,7 +43,7 @@ from openviking.utils.circuit_breaker import (
     CircuitBreakerOpen,
     classify_api_error,
 )
-from openviking.utils.model_retry import ERROR_CLASS_PERMANENT
+from openviking.utils.model_retry import ERROR_CLASS_INPUT_TOO_LARGE, ERROR_CLASS_PERMANENT
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI
 from openviking_cli.utils.config import get_openviking_config
@@ -423,7 +423,18 @@ class SemanticProcessor(DequeueHandlerBase):
 
         except Exception as e:
             error_class = classify_api_error(e)
-            if error_class == ERROR_CLASS_PERMANENT:
+            if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
+                logger.error(
+                    f"Input too large processing semantic message, dropping: {e}",
+                    exc_info=True,
+                )
+                if msg is not None:
+                    self._merge_request_stats(msg.telemetry_id, error_count=1)
+                    get_request_wait_tracker().mark_semantic_failed(
+                        msg.telemetry_id, msg.id, str(e)
+                    )
+                self.report_error(str(e), data)
+            elif error_class == ERROR_CLASS_PERMANENT:
                 logger.critical(
                     f"Permanent API error processing semantic message, dropping: {e}",
                     exc_info=True,

--- a/openviking/utils/circuit_breaker.py
+++ b/openviking/utils/circuit_breaker.py
@@ -8,6 +8,7 @@ import threading
 import time
 
 from openviking.utils.model_retry import (
+    ERROR_CLASS_INPUT_TOO_LARGE,
     ERROR_CLASS_PERMANENT,
     ERROR_CLASS_QUOTA_EXCEEDED,
     classify_api_error,
@@ -94,6 +95,10 @@ class CircuitBreaker:
     def record_failure(self, error: Exception) -> None:
         """Record a failed API call. May trip the breaker."""
         error_class = classify_api_error(error)
+        if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
+            logger.info(f"Circuit breaker ignoring row-specific input error: {error}")
+            return
+
         with self._lock:
             self._failure_count += 1
             self._last_failure_time = time.monotonic()

--- a/openviking/utils/embedding_input.py
+++ b/openviking/utils/embedding_input.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Helpers for bounding text sent to embedding providers."""
+
+from __future__ import annotations
+
+import math
+
+EMBEDDING_TRUNCATION_SUFFIX = "\n...(truncated for embedding)"
+
+
+def estimate_embedding_input_tokens(text: str) -> int:
+    """Estimate tokens for the raw text embedding input guard."""
+    if not text:
+        return 0
+    cjk_chars = sum(
+        1
+        for char in text
+        if "\u4e00" <= char <= "\u9fff"
+        or "\u3040" <= char <= "\u30ff"
+        or "\uac00" <= char <= "\ud7af"
+    )
+    other_chars = len(text) - cjk_chars
+    return max(1, cjk_chars + math.ceil(other_chars / 4))
+
+
+def truncate_embedding_input(
+    text: str,
+    max_tokens: int,
+    suffix: str = EMBEDDING_TRUNCATION_SUFFIX,
+) -> str:
+    """Trim raw text before embedding using the local estimate above."""
+    if not text:
+        return text
+    if max_tokens <= 0:
+        return suffix.lstrip()
+    if estimate_embedding_input_tokens(text) <= max_tokens:
+        return text
+
+    low = 0
+    high = len(text)
+    while low < high:
+        mid = (low + high + 1) // 2
+        if estimate_embedding_input_tokens(text[:mid]) <= max_tokens:
+            low = mid
+        else:
+            high = mid - 1
+    return text[:low].rstrip() + suffix

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -6,7 +6,6 @@ Embedding utilities for OpenViking.
 Common logic for creating Context objects and enqueuing them to EmbeddingQueue.
 """
 
-import math
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -17,12 +16,12 @@ from openviking.server.identity import RequestContext
 from openviking.storage.queuefs import get_queue_manager
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking.storage.viking_fs import get_viking_fs
+from openviking.utils.embedding_input import truncate_embedding_input
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.utils import VikingURI, get_logger
 from openviking_cli.utils.config import get_openviking_config
 
 logger = get_logger(__name__)
-_EMBEDDING_TRUNCATION_SUFFIX = "\n...(truncated for embedding)"
 _PORTABLE_SCALAR_FIELDS = frozenset(
     {
         "type",
@@ -42,45 +41,6 @@ def _apply_scalar_overrides(embedding_msg, overrides: Optional[Dict[str, Any]]) 
         value = overrides.get(field)
         if value is not None:
             embedding_msg.context_data[field] = value
-
-
-def _estimate_embedding_input_tokens(text: str) -> int:
-    """Estimate tokens for the raw text embedding input guard."""
-    if not text:
-        return 0
-    cjk_chars = sum(
-        1
-        for char in text
-        if "\u4e00" <= char <= "\u9fff"
-        or "\u3040" <= char <= "\u30ff"
-        or "\uac00" <= char <= "\ud7af"
-    )
-    other_chars = len(text) - cjk_chars
-    return max(1, cjk_chars + math.ceil(other_chars / 4))
-
-
-def _truncate_embedding_input(
-    text: str,
-    max_tokens: int,
-    suffix: str = _EMBEDDING_TRUNCATION_SUFFIX,
-) -> str:
-    """Trim raw text before embedding using the local estimate above."""
-    if not text:
-        return text
-    if max_tokens <= 0:
-        return suffix.lstrip()
-    if _estimate_embedding_input_tokens(text) <= max_tokens:
-        return text
-
-    low = 0
-    high = len(text)
-    while low < high:
-        mid = (low + high + 1) // 2
-        if _estimate_embedding_input_tokens(text[:mid]) <= max_tokens:
-            low = mid
-        else:
-            high = mid - 1
-    return text[:low].rstrip() + suffix
 
 
 async def _decrement_embedding_tracker(semantic_msg_id: Optional[str], count: int) -> None:
@@ -417,7 +377,7 @@ async def vectorize_file(
                     content = await viking_fs.read_file(file_path, ctx=ctx)
                     if isinstance(content, bytes):
                         content = content.decode("utf-8", errors="replace")
-                    content = _truncate_embedding_input(content, max_input_tokens)
+                    content = truncate_embedding_input(content, max_input_tokens)
                     context.set_vectorize(Vectorize(text=content))
                 except Exception as e:
                     logger.warning(

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -45,7 +45,7 @@ PERMANENT_API_ERROR_PATTERNS = (
 )
 
 QUOTA_EXCEEDED_PATTERNS = (
-    "quotaexceeded", # also 429
+    "quotaexceeded",  # also 429
     "quota limit",
     "quota exceed",
     "usage quota",
@@ -286,9 +286,7 @@ class PrimaryBackupSwitcher:
         if error_class in (ERROR_CLASS_PERMANENT, ERROR_CLASS_QUOTA_EXCEEDED):
             with self._lock:
                 if not self._using_backup:
-                    logger.warning(
-                        f"Primary failed with {error_class}, switching to backup"
-                    )
+                    logger.warning(f"Primary failed with {error_class}, switching to backup")
                     self._using_backup = True
                 # Always reset timer and counter when we fail (whether initial fail or failback fail)
                 self._switch_to_backup_time = time.monotonic()

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -13,9 +13,27 @@ T = TypeVar("T")
 
 # Error classification categories returned by classify_api_error()
 ERROR_CLASS_PERMANENT = "permanent"
+ERROR_CLASS_INPUT_TOO_LARGE = "input_too_large"
 ERROR_CLASS_QUOTA_EXCEEDED = "quota_exceeded"
 ERROR_CLASS_TRANSIENT = "transient"
 ERROR_CLASS_UNKNOWN = "unknown"
+
+INPUT_TOO_LARGE_PATTERNS = (
+    "413",
+    "payload too large",
+    "request entity too large",
+    "content too large",
+    "contextwindowexceeded",
+    "context window exceeded",
+    "maximum context length",
+    "max input tokens",
+    "too many input tokens",
+    "input length exceeds",
+    "exceeds the context length",
+    "exceeds the max input length",
+    "is too large to process",
+    "expected maxlength",
+)
 
 PERMANENT_API_ERROR_PATTERNS = (
     "400",
@@ -66,6 +84,13 @@ def classify_api_error(error: Exception) -> str:
     texts = [str(error)]
     if error.__cause__ is not None:
         texts.append(str(error.__cause__))
+
+    for text in texts:
+        text_lower = text.lower()
+        text_compact = text_lower.replace(" ", "")
+        for pattern in INPUT_TOO_LARGE_PATTERNS:
+            if pattern in text_lower or pattern in text_compact:
+                return ERROR_CLASS_INPUT_TOO_LARGE
 
     for text in texts:
         text_lower = text.lower()

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -40,6 +40,7 @@ class _DummyConfig:
         embedder: _DummyEmbedder,
         backend: str = "volcengine",
         volcengine_data_api_key: str | None = None,
+        max_input_tokens: int = 4096,
     ):
         self.storage = SimpleNamespace(
             vectordb=SimpleNamespace(
@@ -58,6 +59,7 @@ class _DummyConfig:
             ),
             sparse=None,
             hybrid=None,
+            max_input_tokens=max_input_tokens,
             circuit_breaker=SimpleNamespace(
                 failure_threshold=5,
                 reset_timeout=60.0,
@@ -392,6 +394,91 @@ async def test_embedding_handler_propagates_account_id_on_error(monkeypatch):
     await handler.on_dequeue(_build_queue_payload_for_account("acct-embed-error"))
 
     assert captured["account_id"] == "acct-embed-error"
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_truncates_queue_input_before_embed(monkeypatch):
+    class _CapturingVikingDB:
+        is_closing = False
+
+        async def upsert(self, _data, *, ctx):
+            return "rec-1"
+
+    class _CapturingEmbedder:
+        def __init__(self):
+            self.text = None
+
+        def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+            del is_query
+            self.text = text
+            return EmbedResult(dense_vector=[0.1, 0.2])
+
+    embedder = _CapturingEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder, max_input_tokens=10),
+    )
+
+    handler = TextEmbeddingHandler(_CapturingVikingDB())
+    payload = _build_queue_payload()
+    queue_data = json.loads(payload["data"])
+    queue_data["message"] = " ".join(f"token-{idx}" for idx in range(200))
+    payload["data"] = json.dumps(queue_data)
+
+    await handler.on_dequeue(payload)
+
+    assert embedder.text is not None
+    assert embedder.text.endswith("...(truncated for embedding)")
+    assert "token-199" not in embedder.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "embed_error_message",
+    [
+        "Malformed input request: expected maxLength: 50000, actual: 75000",
+        "Error code: 413 - Payload Too Large",
+    ],
+)
+async def test_embedding_handler_drops_input_too_large_without_requeue(
+    monkeypatch, embed_error_message
+):
+    class _QueueingVikingDB:
+        is_closing = False
+        has_queue_manager = True
+
+        def __init__(self):
+            self.enqueued = []
+
+        async def enqueue_embedding_msg(self, msg):
+            self.enqueued.append(msg)
+            return None
+
+    class _OversizedInputEmbedder:
+        def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+            del text, is_query
+            raise RuntimeError(embed_error_message)
+
+    vikingdb = _QueueingVikingDB()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(_OversizedInputEmbedder()),
+    )
+
+    handler = TextEmbeddingHandler(vikingdb)
+    status = {"success": 0, "requeue": 0, "error": 0}
+    handler.set_callbacks(
+        on_success=lambda: status.__setitem__("success", status["success"] + 1),
+        on_requeue=lambda: status.__setitem__("requeue", status["requeue"] + 1),
+        on_error=lambda *_: status.__setitem__("error", status["error"] + 1),
+    )
+
+    result = await handler.on_dequeue(_build_queue_payload())
+
+    assert result is None
+    assert vikingdb.enqueued == []
+    assert status == {"success": 0, "requeue": 0, "error": 1}
+    assert handler._circuit_breaker._failure_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -433,16 +433,7 @@ async def test_embedding_handler_truncates_queue_input_before_embed(monkeypatch)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "embed_error_message",
-    [
-        "Malformed input request: expected maxLength: 50000, actual: 75000",
-        "Error code: 413 - Payload Too Large",
-    ],
-)
-async def test_embedding_handler_drops_input_too_large_without_requeue(
-    monkeypatch, embed_error_message
-):
+async def test_embedding_handler_drops_input_too_large_without_requeue(monkeypatch):
     class _QueueingVikingDB:
         is_closing = False
         has_queue_manager = True
@@ -457,7 +448,7 @@ async def test_embedding_handler_drops_input_too_large_without_requeue(
     class _OversizedInputEmbedder:
         def embed(self, text: str, is_query: bool = False) -> EmbedResult:
             del text, is_query
-            raise RuntimeError(embed_error_message)
+            raise RuntimeError("Malformed input request: expected maxLength: 50000, actual: 75000")
 
     vikingdb = _QueueingVikingDB()
     monkeypatch.setattr(

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -13,8 +13,8 @@ from openviking.utils.circuit_breaker import (
     classify_api_error,
 )
 from openviking.utils.model_retry import (
+    ERROR_CLASS_INPUT_TOO_LARGE,
     ERROR_CLASS_PERMANENT,
-    ERROR_CLASS_QUOTA_EXCEEDED,
     ERROR_CLASS_TRANSIENT,
     ERROR_CLASS_UNKNOWN,
 )
@@ -120,6 +120,11 @@ class TestClassifyApiError:
         error = Exception("403 Forbidden 429 timeout")
         assert classify_api_error(error) == ERROR_CLASS_PERMANENT
 
+    def test_classify_input_too_large(self):
+        """Test context-window errors are classified separately from provider failures."""
+        error = Exception("BadRequestError: 400 maximum context length is 8192 tokens")
+        assert classify_api_error(error) == ERROR_CLASS_INPUT_TOO_LARGE
+
 
 class TestCircuitBreaker:
     """Test CircuitBreaker class."""
@@ -165,6 +170,15 @@ class TestCircuitBreaker:
 
         with pytest.raises(CircuitBreakerOpen):
             cb.check()
+
+    def test_input_too_large_does_not_trip_or_increment(self):
+        """Test row-specific input errors do not affect global circuit state."""
+        cb = CircuitBreaker(failure_threshold=1)
+
+        cb.record_failure(Exception("expected maxLength: 50000, actual: 75000"))
+
+        cb.check()
+        assert cb._failure_count == 0
 
     def test_success_resets_failure_count(self):
         """Test success resets failure count."""

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -13,7 +13,6 @@ from openviking.utils.circuit_breaker import (
     classify_api_error,
 )
 from openviking.utils.model_retry import (
-    ERROR_CLASS_INPUT_TOO_LARGE,
     ERROR_CLASS_PERMANENT,
     ERROR_CLASS_TRANSIENT,
     ERROR_CLASS_UNKNOWN,
@@ -119,11 +118,6 @@ class TestClassifyApiError:
         """Test permanent error patterns are checked first."""
         error = Exception("403 Forbidden 429 timeout")
         assert classify_api_error(error) == ERROR_CLASS_PERMANENT
-
-    def test_classify_input_too_large(self):
-        """Test context-window errors are classified separately from provider failures."""
-        error = Exception("BadRequestError: 400 maximum context length is 8192 tokens")
-        assert classify_api_error(error) == ERROR_CLASS_INPUT_TOO_LARGE
 
 
 class TestCircuitBreaker:

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -5,10 +5,10 @@
 import pytest
 
 from openviking.utils.model_retry import (
+    ERROR_CLASS_INPUT_TOO_LARGE,
     ERROR_CLASS_PERMANENT,
     ERROR_CLASS_QUOTA_EXCEEDED,
     ERROR_CLASS_TRANSIENT,
-    ERROR_CLASS_UNKNOWN,
     classify_api_error,
     is_quota_exceeded_api_error,
     retry_async,
@@ -125,3 +125,33 @@ def test_quota_exceeded_case_insensitive():
     """Quota detection is case-insensitive."""
     assert classify_api_error(RuntimeError("QUOTA LIMIT")) == ERROR_CLASS_QUOTA_EXCEEDED
     assert classify_api_error(RuntimeError("Quota Exceed")) == ERROR_CLASS_QUOTA_EXCEEDED
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "ContextWindowExceededError: input too long",
+        "Malformed input request: expected maxLength: 50000, actual: 75000",
+        "Too many input tokens. Max input tokens: 8192, request input token count: 13000",
+        "BadRequestError: 400 maximum context length is 8192 tokens",
+        "Error code: 413 - Payload Too Large",
+        "413 Request Entity Too Large",
+        "the input length exceeds the context length",
+        "input (8129 tokens) is too large to process",
+    ],
+)
+def test_classify_input_too_large_errors(message):
+    assert classify_api_error(RuntimeError(message)) == ERROR_CLASS_INPUT_TOO_LARGE
+
+
+def test_retry_sync_does_not_retry_input_too_large():
+    attempts = {"count": 0}
+
+    def _call():
+        attempts["count"] += 1
+        raise RuntimeError("expected maxLength: 50000, actual: 75000")
+
+    with pytest.raises(RuntimeError, match="expected maxLength"):
+        retry_sync(_call, max_retries=5)
+
+    assert attempts["count"] == 1

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -130,14 +130,8 @@ def test_quota_exceeded_case_insensitive():
 @pytest.mark.parametrize(
     "message",
     [
-        "ContextWindowExceededError: input too long",
-        "Malformed input request: expected maxLength: 50000, actual: 75000",
-        "Too many input tokens. Max input tokens: 8192, request input token count: 13000",
         "BadRequestError: 400 maximum context length is 8192 tokens",
         "Error code: 413 - Payload Too Large",
-        "413 Request Entity Too Large",
-        "the input length exceeds the context length",
-        "input (8129 tokens) is too large to process",
     ],
 )
 def test_classify_input_too_large_errors(message):


### PR DESCRIPTION
## Description

修复 embedding 队列对超长输入缺少统一兜底的问题，避免单条超长内容在 provider 返回 413、context window 或 maxLength 错误后反复重入队列。

## Related Issue

Fixes #2154
Fixes #2132

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 抽出 embedding 输入估算和截断工具，并在 `vectorize_file` 与 `TextEmbeddingHandler` 调 provider 前统一应用 `max_input_tokens`
- 将 413、Payload Too Large、context window、maxLength 等错误归类为单条输入过大，避免进入普通重试和全局熔断统计
- embedding 队列和 semantic 队列遇到输入过大错误时标记失败并丢弃该条消息，不再反复 re-enqueue

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

手动执行：

- `.venv/bin/python -m pytest tests/unit/test_model_retry.py tests/unit/test_circuit_breaker.py tests/storage/test_collection_schemas.py tests/unit/test_vectorize_file_strategy.py`
- `.venv/bin/python -m ruff check openviking/utils/embedding_input.py openviking/utils/embedding_utils.py openviking/utils/model_retry.py openviking/utils/circuit_breaker.py openviking/storage/collection_schemas.py openviking/storage/queuefs/semantic_processor.py tests/unit/test_model_retry.py tests/unit/test_circuit_breaker.py tests/storage/test_collection_schemas.py tests/unit/test_vectorize_file_strategy.py`
- `.venv/bin/pre-commit run --files openviking/utils/embedding_input.py openviking/utils/embedding_utils.py openviking/utils/model_retry.py openviking/utils/circuit_breaker.py openviking/storage/collection_schemas.py openviking/storage/queuefs/semantic_processor.py tests/unit/test_model_retry.py tests/unit/test_circuit_breaker.py tests/storage/test_collection_schemas.py`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

已将 `pre-commit` 安装到本地 `.venv` 并重新安装 git hook；后续格式化补充提交已通过 pre-commit hook。
