### PR TITLE
fix PDF XObject image extraction

### DIFF
--- a/openviking/parse/parsers/pdf.py
+++ b/openviking/parse/parsers/pdf.py
@@ -622,13 +622,18 @@ class PDFParser(BaseParser):
                 resources = page.page_obj.resources
                 if resources and "XObject" in resources:
                     xobjects = resources["XObject"]
-                    for obj_name in xobjects:
-                        obj = xobjects[obj_name]
+                    target_name = img_info.get("name") if isinstance(img_info, dict) else None
+                    normalized_target = str(target_name).lstrip("/") if target_name else None
+                    for obj_name, obj in xobjects.items():
+                        if normalized_target and str(obj_name).lstrip("/") != normalized_target:
+                            continue
                         if hasattr(obj, "resolve"):
                             resolved = obj.resolve()
                             if resolved.get("Subtype") and resolved["Subtype"].name == "Image":
+                                if hasattr(resolved, "get_data"):
+                                    return resolved.get_data()
                                 data = resolved.get("stream")
-                                if data:
+                                if data and hasattr(data, "get_data"):
                                     return data.get_data()
 
             return None

--- a/tests/parse/test_pdf_bookmark_extraction.py
+++ b/tests/parse/test_pdf_bookmark_extraction.py
@@ -26,6 +26,31 @@ def _make_ref(objid):
     return SimpleNamespace(objid=objid)
 
 
+class _FakePDFStream(dict):
+    """Minimal pdfminer PDFStream-like object."""
+
+    def __init__(self, data: bytes, subtype: str = "Image"):
+        super().__init__({"Subtype": SimpleNamespace(name=subtype)})
+        self._data = data
+
+    def get_data(self):
+        return self._data
+
+
+class _FakePDFObjectRef:
+    """Minimal PDF object reference with a resolve() method."""
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def resolve(self):
+        return self._stream
+
+
+def _make_image_page(xobjects):
+    return SimpleNamespace(page_obj=SimpleNamespace(resources={"XObject": xobjects}))
+
+
 class _FakePage:
     """Minimal pdfplumber page stub for _convert_local tests."""
 
@@ -317,3 +342,47 @@ class TestConvertLocalBookmarks:
         assert [heading["title"] for heading in headings] == ["Heading", "Another heading"]
         assert [page.close_count for page in pages] == [2, 1, 1, 1]
         assert [page.flush_count for page in pages] == [2, 1, 1, 1]
+
+
+class TestExtractImages:
+    """Test PDF XObject image extraction."""
+
+    def setup_method(self):
+        self.parser = PDFParser()
+
+    def test_extract_image_reads_resolved_pdfstream_data(self):
+        page = _make_image_page(
+            {
+                "Im1": _FakePDFObjectRef(_FakePDFStream(b"first-image")),
+            }
+        )
+
+        assert self.parser._extract_image_from_page(page, {"name": "Im1"}) == b"first-image"
+
+    def test_extract_image_matches_requested_xobject_name(self):
+        page = _make_image_page(
+            {
+                "Im1": _FakePDFObjectRef(_FakePDFStream(b"first-image")),
+                "Im2": _FakePDFObjectRef(_FakePDFStream(b"second-image")),
+            }
+        )
+
+        assert self.parser._extract_image_from_page(page, {"name": "Im2"}) == b"second-image"
+
+    def test_extract_image_allows_leading_slash_name_variants(self):
+        page = _make_image_page(
+            {
+                "/Im1": _FakePDFObjectRef(_FakePDFStream(b"slash-image")),
+            }
+        )
+
+        assert self.parser._extract_image_from_page(page, {"name": "Im1"}) == b"slash-image"
+
+    def test_extract_image_returns_none_for_non_image_xobject(self):
+        page = _make_image_page(
+            {
+                "Form1": _FakePDFObjectRef(_FakePDFStream(b"form-data", subtype="Form")),
+            }
+        )
+
+        assert self.parser._extract_image_from_page(page, {"name": "Form1"}) is None


### PR DESCRIPTION
## Summary
- Extract embedded PDF image bytes from the resolved XObject stream.
- Match pdfplumber image metadata to the requested XObject name so multi-image pages do not reuse the first image.
- Add regression coverage for stream extraction, XObject matching, slash-prefixed names, and non-image XObjects.

## Root Cause
pdfminer resolves PDF image XObjects to PDFStream objects. The previous implementation looked for a nested stream field on the resolved object, which is not present on PDFStream, so embedded image bytes were skipped.

## Validation
- `/tmp/openviking-pr-venv/bin/python -m py_compile openviking/parse/parsers/pdf.py tests/parse/test_pdf_bookmark_extraction.py`
- Focused parser regression run: 18 tests passed using the real parser module with an isolated package import to avoid unrelated sparse-checkout/native-extension imports.

Refs #2181
