### PR TITLE
fix(http-accessor): detect binary URLs by magic bytes when HEAD lies

### DIFF
--- a/openviking/parse/accessors/http_accessor.py
+++ b/openviking/parse/accessors/http_accessor.py
@@ -24,6 +24,11 @@ from urllib.parse import unquote, urlparse
 
 from openviking.parse.base import lazy_import
 from openviking.parse.parsers.constants import CODE_EXTENSIONS
+from openviking.parse.parsers.media.constants import (
+    AUDIO_EXTENSIONS,
+    IMAGE_EXTENSIONS,
+    VIDEO_EXTENSIONS,
+)
 from openviking.utils.network_guard import build_httpx_request_validation_hooks
 from openviking_cli.exceptions import PermissionDeniedError
 from openviking_cli.utils.logger import get_logger
@@ -42,6 +47,7 @@ class URLType(Enum):
     DOWNLOAD_MD = "download_md"  # Markdown file download link
     DOWNLOAD_TXT = "download_txt"  # Text file download link
     DOWNLOAD_HTML = "download_html"  # HTML file download link
+    DOWNLOAD_BINARY = "download_binary"  # Non-text binary (image/audio/video/octet-stream)
     UNKNOWN = "unknown"  # Unknown or unsupported type
 
 
@@ -65,6 +71,9 @@ class URLTypeDetector:
     # (e.g., .html/.htm -> DOWNLOAD_HTML instead of DOWNLOAD_TXT)
     EXTENSION_MAP: Dict[str, URLType] = {
         **dict.fromkeys(CODE_EXTENSIONS, URLType.DOWNLOAD_TXT),
+        **dict.fromkeys(IMAGE_EXTENSIONS, URLType.DOWNLOAD_BINARY),
+        **dict.fromkeys(AUDIO_EXTENSIONS, URLType.DOWNLOAD_BINARY),
+        **dict.fromkeys(VIDEO_EXTENSIONS, URLType.DOWNLOAD_BINARY),
         ".pdf": URLType.DOWNLOAD_PDF,
         ".md": URLType.DOWNLOAD_MD,
         ".markdown": URLType.DOWNLOAD_MD,
@@ -95,6 +104,11 @@ class URLTypeDetector:
         # Plain text
         "text/plain": URLType.DOWNLOAD_TXT,
         "text/*": URLType.DOWNLOAD_TXT,
+        # Non-text binary payloads — must not be parsed as HTML/text
+        "image/*": URLType.DOWNLOAD_BINARY,
+        "audio/*": URLType.DOWNLOAD_BINARY,
+        "video/*": URLType.DOWNLOAD_BINARY,
+        "application/octet-stream": URLType.DOWNLOAD_BINARY,
     }
 
     # URLType to file extension mapping
@@ -104,6 +118,7 @@ class URLTypeDetector:
         URLType.DOWNLOAD_MD: ".md",
         URLType.DOWNLOAD_TXT: ".txt",
         URLType.DOWNLOAD_HTML: ".html",
+        URLType.DOWNLOAD_BINARY: ".bin",
         URLType.UNKNOWN: ".html",
     }
 
@@ -165,14 +180,24 @@ class URLTypeDetector:
 
             async with httpx.AsyncClient(**client_kwargs) as client:
                 response = await client.head(url)
+                meta["status_code"] = response.status_code
 
-                # Get raw headers for debugging
+                # Only trust HEAD headers on a 2xx response. Some signed-URL providers
+                # (e.g. Aliyun OSS signs the verb, so HEAD on a GET-signed URL 403s)
+                # return error-document headers (e.g. application/xml) that would
+                # otherwise misroute the real binary payload to a text parser.
+                if not (200 <= response.status_code < 300):
+                    meta["head_status_skipped"] = response.status_code
+                    raise RuntimeError(
+                        f"HEAD returned status {response.status_code}; "
+                        "headers not trusted for type detection"
+                    )
+
                 content_type_raw = response.headers.get("content-type", "")
                 content_disposition = response.headers.get("content-disposition", "")
 
                 meta["content_type_raw"] = content_type_raw
                 meta["content_disposition_raw"] = content_disposition
-                meta["status_code"] = response.status_code
 
                 # === Step 2a: Check Content-Disposition for filename (RFC 6266) ===
                 filename_from_disposition = self._extract_filename_from_disposition(
@@ -487,6 +512,19 @@ class HTTPAccessor(DataAccessor):
                 # Write to temp file
                 Path(temp_path).write_bytes(response.content)
 
+            # Auto-detect actual content type from the GET response and bytes.
+            # This is the only reliable signal for sources where HEAD lies or
+            # fails (e.g. Aliyun OSS GET-signed URLs 403 on HEAD, CDNs without
+            # extensions, URLs whose path extension misrepresents the payload).
+            temp_path, url_type, ext = self._reconcile_actual_type(
+                temp_path=temp_path,
+                current_ext=ext,
+                current_url_type=url_type,
+                response_content_type=response.headers.get("content-type", ""),
+                content=response.content,
+                meta=meta,
+            )
+
             return temp_path, url_type, meta
         except Exception:
             # Clean up on error
@@ -497,6 +535,144 @@ class HTTPAccessor(DataAccessor):
             except Exception:
                 pass
             raise
+
+    # === Magic-byte signatures for the most common binary payloads we see
+    # delivered without a trustworthy URL extension or HEAD. Each entry is
+    # (signature_bytes, offset, extension). Order matters only for tie-breaking;
+    # signatures are otherwise unambiguous.
+    _MAGIC_SIGNATURES: Tuple[Tuple[bytes, str], ...] = (
+        (b"\x89PNG\r\n\x1a\n", ".png"),
+        (b"\xff\xd8\xff", ".jpg"),
+        (b"GIF87a", ".gif"),
+        (b"GIF89a", ".gif"),
+        (b"BM", ".bmp"),
+        (b"%PDF", ".pdf"),
+        (b"PK\x03\x04", ".zip"),
+        (b"PK\x05\x06", ".zip"),
+        (b"\x1f\x8b", ".gz"),
+        (b"ID3", ".mp3"),
+        (b"\xff\xfb", ".mp3"),
+        (b"<svg", ".svg"),
+    )
+
+    @classmethod
+    def _sniff_magic_extension(cls, content: bytes) -> Optional[str]:
+        """Return a file extension based on magic bytes, or None if unrecognised.
+
+        Composite containers (RIFF, ISO base media) are disambiguated explicitly
+        because the leading bytes alone are ambiguous (RIFF is shared by WEBP /
+        WAV / AVI; the ISO `ftyp` box appears at offset 4 with a brand selecting
+        MP4 vs MOV).
+        """
+        if not content:
+            return None
+        head = content[:64]
+        # RIFF container — disambiguate WEBP / WAV / AVI by the form tag at offset 8.
+        if head[:4] == b"RIFF" and len(head) >= 12:
+            form = head[8:12]
+            if form == b"WEBP":
+                return ".webp"
+            if form == b"WAVE":
+                return ".wav"
+            if form == b"AVI ":
+                return ".avi"
+        # ISO base media (MP4/MOV/etc.): a `ftyp` box lives at offset 4.
+        if len(head) >= 12 and head[4:8] == b"ftyp":
+            brand = head[8:12]
+            if brand == b"qt  ":
+                return ".mov"
+            return ".mp4"
+        # XML preamble that's actually SVG.
+        if head.lstrip().startswith(b"<?xml") and b"<svg" in content[:512]:
+            return ".svg"
+        for signature, ext in cls._MAGIC_SIGNATURES:
+            if head.startswith(signature):
+                return ext
+        return None
+
+    @classmethod
+    def _reconcile_actual_type(
+        cls,
+        temp_path: str,
+        current_ext: str,
+        current_url_type: URLType,
+        response_content_type: str,
+        content: bytes,
+        meta: Dict[str, Any],
+    ) -> Tuple[str, URLType, str]:
+        """Refine the temp file extension and URL type using actual GET response
+        signals (Content-Type + magic bytes).
+
+        Detection precedence:
+            1. Magic bytes on the response body (most authoritative).
+            2. Content-Type on the GET response.
+        Either signal can override the earlier guess derived from URL path / HEAD.
+
+        Args:
+            temp_path: Current temp file path (already written).
+            current_ext: Extension used to create the temp file.
+            current_url_type: URLType detected before download.
+            response_content_type: Content-Type from the GET response.
+            content: Downloaded bytes (first chunk is enough for sniffing).
+            meta: Mutable metadata dict; this method records the reconciliation.
+
+        Returns:
+            (possibly renamed temp_path, possibly updated URLType, final extension).
+        """
+        sniffed_ext = cls._sniff_magic_extension(content)
+        if sniffed_ext:
+            meta["sniffed_ext"] = sniffed_ext
+
+        # Decide the authoritative extension.
+        # Magic bytes win; otherwise fall back to GET Content-Type → ext.
+        authoritative_ext: Optional[str] = sniffed_ext
+        if not authoritative_ext and response_content_type:
+            iana_ext = get_preferred_extension(response_content_type)
+            if iana_ext:
+                authoritative_ext = iana_ext
+                meta["response_content_type"] = response_content_type
+
+        if not authoritative_ext:
+            return temp_path, current_url_type, current_ext
+
+        # Decide the authoritative URLType. For known binary media, route to
+        # DOWNLOAD_BINARY so downstream picks the right parser (image/audio/video).
+        media_ext_set = set(IMAGE_EXTENSIONS) | set(AUDIO_EXTENSIONS) | set(VIDEO_EXTENSIONS)
+        if authoritative_ext in media_ext_set or authoritative_ext in {
+            ".bin",
+            ".zip",
+            ".gz",
+            ".pdf",
+        }:
+            if authoritative_ext == ".pdf":
+                new_url_type = URLType.DOWNLOAD_PDF
+            else:
+                new_url_type = URLType.DOWNLOAD_BINARY
+        else:
+            new_url_type = current_url_type
+
+        if authoritative_ext.lower() == current_ext.lower():
+            # Same extension, still update url_type if it changed (e.g. WEBPAGE→DOWNLOAD_BINARY)
+            if new_url_type != current_url_type:
+                meta["url_type_corrected_from"] = current_url_type.value
+            return temp_path, new_url_type, current_ext
+
+        # Rename temp file to the correct extension so downstream parser dispatch
+        # picks the right parser (e.g. ImageParser for .png).
+        new_path = str(Path(temp_path).with_suffix(authoritative_ext))
+        try:
+            Path(temp_path).rename(new_path)
+            meta["extension_corrected_from"] = current_ext
+            meta["extension"] = authoritative_ext
+            if new_url_type != current_url_type:
+                meta["url_type_corrected_from"] = current_url_type.value
+            return new_path, new_url_type, authoritative_ext
+        except OSError as e:
+            logger.warning(
+                f"[HTTPAccessor] Failed to rename temp file with corrected extension: {e}. "
+                f"Keeping {current_ext}."
+            )
+            return temp_path, current_url_type, current_ext
 
     def _determine_file_extension(
         self,

--- a/tests/unit/test_accessors_http.py
+++ b/tests/unit/test_accessors_http.py
@@ -3,11 +3,12 @@
 """Unit tests for HTTPAccessor."""
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from openviking.parse.accessors import AccessorRegistry, GitAccessor, HTTPAccessor
+from openviking.parse.accessors.http_accessor import URLType, URLTypeDetector
 
 
 def _mock_config():
@@ -174,3 +175,218 @@ class TestHTTPAccessorPriorityRouting:
         assert len(accessors) == 2
         assert accessors[0].__class__.__name__ == "GitAccessor"
         assert accessors[1].__class__.__name__ == "HTTPAccessor"
+
+
+def _mock_async_httpx(head_status: int, head_headers: dict) -> MagicMock:
+    """Build a context-manager AsyncClient mock that returns the given HEAD response."""
+    response = MagicMock()
+    response.status_code = head_status
+    response.headers = head_headers
+
+    client = MagicMock()
+    client.head = AsyncMock(return_value=response)
+
+    async_cm = MagicMock()
+    async_cm.__aenter__ = AsyncMock(return_value=client)
+    async_cm.__aexit__ = AsyncMock(return_value=None)
+
+    httpx_module = MagicMock()
+    httpx_module.AsyncClient = MagicMock(return_value=async_cm)
+    return httpx_module
+
+
+class TestURLTypeDetectorBinaryURLs:
+    """Tests covering non-text binary URLs (image/audio/video) and signed-URL edge cases.
+
+    Regression: an Aliyun OSS GET-signed PNG URL was being treated as text. The
+    URL ended with `.png?OSSAccessKeyId=...&Signature=...`, HEAD failed 403 with
+    `Content-Type: application/xml` (OSS error doc), and the detector defaulted
+    to WEBPAGE/.html so the binary PNG was chunked by the text parser.
+    """
+
+    @pytest.mark.parametrize(
+        "ext",
+        [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".mp3", ".mp4", ".mov"],
+    )
+    def test_extension_map_routes_media_to_binary(self, ext: str) -> None:
+        assert URLTypeDetector.EXTENSION_MAP[ext] == URLType.DOWNLOAD_BINARY
+
+    def test_url_type_to_ext_has_binary_fallback(self) -> None:
+        assert URLTypeDetector.URL_TYPE_TO_EXT[URLType.DOWNLOAD_BINARY] == ".bin"
+
+    @pytest.mark.parametrize(
+        "content_type",
+        ["image/png", "image/jpeg", "audio/mpeg", "video/mp4", "application/octet-stream"],
+    )
+    def test_media_type_map_routes_binary_content_types(self, content_type: str) -> None:
+        detector = URLTypeDetector()
+        meta: dict = {}
+        assert detector._detect_from_media_type(content_type, meta) == URLType.DOWNLOAD_BINARY
+
+    def test_determine_file_extension_preserves_png_for_signed_url(self) -> None:
+        """Signed OSS URL ending with `.png?Signature=...` must keep its `.png` extension."""
+        from openviking.parse.accessors.http_accessor import HTTPAccessor
+
+        accessor = HTTPAccessor()
+        url = (
+            "http://yunweitool.oss-cn-shenzhen.aliyuncs.com/yunwei/abc.png"
+            "?OSSAccessKeyId=LTAI&Expires=1779533415&Signature=R0kmK%3D"
+        )
+        # Even if upstream wrongly classified as WEBPAGE, the URL path extension
+        # is now a recognised media extension, so it should win.
+        ext = accessor._determine_file_extension(url, URLType.WEBPAGE, detect_meta={})
+        assert ext == ".png"
+
+    @pytest.mark.anyio
+    async def test_detect_extension_fast_path_skips_head(self) -> None:
+        """URLs whose path ends in a known media extension must not require HEAD."""
+        detector = URLTypeDetector()
+        # No httpx patch — if it tries HEAD, the test fails (lazy_import will succeed,
+        # but the call wouldn't be intercepted, and any network/extra branch is unwanted).
+        # We force `lazy_import` to raise to assert HEAD path isn't taken.
+        with patch(
+            "openviking.parse.accessors.http_accessor.lazy_import",
+            side_effect=AssertionError("HEAD should not be attempted"),
+        ):
+            url_type, meta = await detector.detect(
+                "http://example.com/yunwei/abc.png?Signature=R0kmK"
+            )
+        assert url_type == URLType.DOWNLOAD_BINARY
+        assert meta["detected_by"] == "extension"
+        assert meta["extension"] == ".png"
+
+    @pytest.mark.anyio
+    async def test_detect_ignores_non_2xx_head_headers(self) -> None:
+        """When HEAD returns 4xx/5xx, its headers describe the error response, not the
+        real file — they must not be trusted for type detection."""
+        detector = URLTypeDetector()
+        # OSS-style 403 with error-doc Content-Type
+        httpx_mock = _mock_async_httpx(
+            head_status=403,
+            head_headers={"content-type": "application/xml"},
+        )
+        with patch(
+            "openviking.parse.accessors.http_accessor.lazy_import",
+            return_value=httpx_mock,
+        ):
+            # Use a URL with no extension so step 1 doesn't short-circuit
+            url_type, meta = await detector.detect("http://example.com/opaque-id")
+
+        # Detector must NOT trust the 403's application/xml content-type
+        assert meta.get("head_status_skipped") == 403
+        assert "content_type_raw" not in meta
+        assert url_type == URLType.WEBPAGE  # default fallback when no signal is trustworthy
+
+    @pytest.mark.anyio
+    async def test_detect_image_content_type_routes_to_binary(self) -> None:
+        """A 2xx HEAD with `Content-Type: image/png` must route to DOWNLOAD_BINARY."""
+        detector = URLTypeDetector()
+        httpx_mock = _mock_async_httpx(
+            head_status=200,
+            head_headers={"content-type": "image/png"},
+        )
+        with patch(
+            "openviking.parse.accessors.http_accessor.lazy_import",
+            return_value=httpx_mock,
+        ):
+            url_type, meta = await detector.detect("http://example.com/opaque-image-id")
+
+        assert url_type == URLType.DOWNLOAD_BINARY
+        assert meta["content_type_raw"] == "image/png"
+
+
+class TestHTTPAccessorActualTypeReconciliation:
+    """Tests for post-GET auto-detection: even when HEAD lies and the URL path
+    has no usable extension, the response body's magic bytes / Content-Type are
+    the source of truth."""
+
+    @pytest.mark.parametrize(
+        "head, ext",
+        [
+            (b"\x89PNG\r\n\x1a\n" + b"\x00" * 16, ".png"),
+            (b"\xff\xd8\xff\xe0" + b"\x00" * 12, ".jpg"),
+            (b"GIF89a" + b"\x00" * 16, ".gif"),
+            (b"%PDF-1.4\n" + b"\x00" * 16, ".pdf"),
+            (b"PK\x03\x04" + b"\x00" * 16, ".zip"),
+            (b"\x1f\x8b\x08\x00" + b"\x00" * 16, ".gz"),
+            (b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 8, ".webp"),
+            (b"RIFF\x00\x00\x00\x00WAVE" + b"\x00" * 8, ".wav"),
+            (b"\x00\x00\x00\x20ftypmp42" + b"\x00" * 8, ".mp4"),
+        ],
+    )
+    def test_sniff_magic_extension(self, head: bytes, ext: str) -> None:
+        assert HTTPAccessor._sniff_magic_extension(head) == ext
+
+    def test_sniff_magic_extension_returns_none_for_html(self) -> None:
+        assert HTTPAccessor._sniff_magic_extension(b"<!DOCTYPE html>\n<html>") is None
+
+    def test_reconcile_renames_html_temp_to_png_when_bytes_are_png(self, tmp_path) -> None:
+        """The signature regression: temp file was created as .html (because HEAD
+        returned an OSS error doc), but the GET body is PNG. Reconcile must rename
+        to .png and switch url_type to DOWNLOAD_BINARY."""
+        # Create a fake temp file with .html suffix
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        wrong_temp = tmp_path / "fake.html"
+        wrong_temp.write_bytes(png_bytes)
+
+        meta: dict = {"extension": ".html"}
+        new_path, new_url_type, new_ext = HTTPAccessor._reconcile_actual_type(
+            temp_path=str(wrong_temp),
+            current_ext=".html",
+            current_url_type=URLType.WEBPAGE,
+            response_content_type="application/xml",  # OSS error mime, untrusted
+            content=png_bytes,
+            meta=meta,
+        )
+
+        assert new_ext == ".png"
+        assert new_url_type == URLType.DOWNLOAD_BINARY
+        assert new_path.endswith(".png")
+        assert not wrong_temp.exists()  # original path removed via rename
+        assert meta["extension"] == ".png"
+        assert meta["extension_corrected_from"] == ".html"
+        assert meta["url_type_corrected_from"] == "webpage"
+
+    def test_reconcile_no_change_when_extension_already_correct(self, tmp_path) -> None:
+        """A correctly-typed download must not be renamed (no churn)."""
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        good_temp = tmp_path / "ok.png"
+        good_temp.write_bytes(png_bytes)
+
+        meta: dict = {"extension": ".png"}
+        new_path, new_url_type, new_ext = HTTPAccessor._reconcile_actual_type(
+            temp_path=str(good_temp),
+            current_ext=".png",
+            current_url_type=URLType.DOWNLOAD_BINARY,
+            response_content_type="image/png",
+            content=png_bytes,
+            meta=meta,
+        )
+
+        assert new_ext == ".png"
+        assert new_url_type == URLType.DOWNLOAD_BINARY
+        assert new_path == str(good_temp)
+        assert good_temp.exists()
+        assert "extension_corrected_from" not in meta
+
+    def test_reconcile_uses_response_content_type_when_no_magic_signature(self, tmp_path) -> None:
+        """For payloads without magic bytes (e.g. plain text), fall back to the
+        GET response's Content-Type."""
+        text_bytes = b"some random text without any signature"
+        wrong_temp = tmp_path / "fake.html"
+        wrong_temp.write_bytes(text_bytes)
+
+        meta: dict = {"extension": ".html"}
+        new_path, new_url_type, new_ext = HTTPAccessor._reconcile_actual_type(
+            temp_path=str(wrong_temp),
+            current_ext=".html",
+            current_url_type=URLType.WEBPAGE,
+            response_content_type="text/plain; charset=utf-8",
+            content=text_bytes,
+            meta=meta,
+        )
+
+        # text/plain → .txt
+        assert new_ext == ".txt"
+        assert new_path.endswith(".txt")
+        assert meta["extension_corrected_from"] == ".html"


### PR DESCRIPTION
## Summary

- Adding an Aliyun OSS GET-signed PNG URL (e.g. `https://...png?OSSAccessKeyId=...&Signature=...`) was silently ingested as text and chunked into ~98 `.md` fragments. Root cause was three compounding bugs in the URL→file-type detection in `HTTPAccessor`.
- The fix routes binary media correctly using URL-path extension, IANA media-type wildcards, and — most importantly — a post-GET reconciliation pass using magic bytes on the response body. The actual GET response is now treated as the source of truth for content type.

## What was wrong

1. `URLTypeDetector.EXTENSION_MAP` lacked image/audio/video extensions, so `.png` in the URL path was not recognised as a binary download.
2. The detector trusted HEAD response headers without checking status code. OSS signs the verb, so HEAD on a GET-signed URL returns `403 SignatureDoesNotMatch` with `Content-Type: application/xml` (the OSS error document) — and that mime was being used to type the real PNG.
3. `MEDIA_TYPE_MAP` had no `image/* | audio/* | video/*` wildcards, so even a clean image content-type fell through to default `WEBPAGE` → `.html`.

## What the fix does

- Adds `URLType.DOWNLOAD_BINARY`; maps image/audio/video extensions and `image/* | audio/* | video/* | application/octet-stream` media types to it.
- Rejects HEAD response headers when status is non-2xx, so error-document content-type can no longer misroute the real payload.
- After GET, reconciles the temp-file extension and URLType against authoritative signals — magic bytes on the response body (most reliable), falling back to the GET response's `Content-Type` — and renames the temp file when the earlier guess was wrong. This handles OSS-signed URLs, CDN links without extensions, and URLs whose path extension misrepresents the payload.

## Test plan

- [x] All 48 unit tests in `tests/unit/test_accessors_http.py` pass, including new coverage for: image/audio/video extension mapping, `image/* | audio/* | video/*` MIME wildcards, the OSS-style 403 \"don't trust HEAD\" path, magic-byte sniffing for PNG/JPG/GIF/PDF/ZIP/GZIP/RIFF/ISO base media, and post-GET temp-file rename.
- [x] End-to-end smoke test against the real OSS-signed PNG URL via the installed binary: temp file lands with `.png` suffix, `url_type=download_binary`, real PNG magic bytes, ~498 KB. Same URL on `main` previously produced 98 garbled `.md` chunks; with the fix the resource directory no longer contains binary-as-text fragments.
- [x] `https://example.com/` regression check — still routes to `WEBPAGE` / `.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)