### PR TITLE
fix(storage): sync semantic target before DAG

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -4,7 +4,7 @@
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from openviking.server.identity import RequestContext
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
@@ -82,7 +82,6 @@ class SemanticDagExecutor:
         recursive: bool = True,
         lock: LockLease = NO_LOCK,
         is_code_repo: bool = False,
-        sync_to_target: bool = False,
         changes: Optional[Dict[str, List[str]]] = None,
         skip_vectorization: bool = False,
         coalesce_key: str = "",
@@ -99,7 +98,6 @@ class SemanticDagExecutor:
         self._recursive = recursive
         self._lock = lock
         self._is_code_repo = is_code_repo
-        self._sync_to_target = sync_to_target
         self._changes = changes or {}
         self._skip_vectorization = skip_vectorization
         self._coalesce_key = coalesce_key
@@ -123,50 +121,6 @@ class SemanticDagExecutor:
         self._overview_cache: Dict[str, Dict[str, str]] = {}
         self._overview_cache_lock = asyncio.Lock()
 
-    def _create_on_complete_callback(self) -> Callable[[], Awaitable[None]]:
-        """Create on_complete callback for incremental update or full update."""
-
-        async def noop_callback() -> None:
-            return
-
-        if not self._target_uri or not self._root_uri:
-            return noop_callback
-
-        if self._target_uri == self._root_uri:
-            return noop_callback
-
-        # Full resource updates may still need a deferred temp -> target sync
-        # when semantic generation owns the resource lock.
-        if not self._incremental_update and not self._sync_to_target:
-            return noop_callback
-
-        async def sync_diff_callback() -> None:
-            try:
-                diff = await self._processor._sync_topdown_recursive(
-                    self._root_uri,
-                    self._target_uri,
-                    ctx=self._ctx,
-                    file_change_status=self._file_change_status,
-                    lock=self._lock,
-                )
-                logger.info(
-                    f"[SyncDiff] Diff computed: "
-                    f"added_files={len(diff.added_files)}, "
-                    f"deleted_files={len(diff.deleted_files)}, "
-                    f"updated_files={len(diff.updated_files)}, "
-                    f"added_dirs={len(diff.added_dirs)}, "
-                    f"deleted_dirs={len(diff.deleted_dirs)}"
-                )
-            except Exception as e:
-                logger.error(
-                    f"[SyncDiff] Error in sync_diff_callback: "
-                    f"root_uri={self._root_uri}, target_uri={self._target_uri} "
-                    f"error={e}",
-                    exc_info=True,
-                )
-
-        return sync_diff_callback
-
     async def run(self, root_uri: str) -> None:
         """Run DAG execution starting from root_uri."""
         self._root_uri = root_uri
@@ -179,13 +133,9 @@ class SemanticDagExecutor:
             await self._lock.close()
             raise
 
-        original_on_complete = self._create_on_complete_callback()
-
         # Release owned semantic locks after downstream vectorization finishes.
         async def wrapped_on_complete() -> None:
             try:
-                if original_on_complete:
-                    await original_on_complete()
                 if self._telemetry_id and self._semantic_msg_id:
                     get_request_wait_tracker().mark_semantic_done(
                         self._telemetry_id, self._semantic_msg_id
@@ -325,13 +275,13 @@ class SemanticDagExecutor:
                 f"Invalid target_uri or root_uri for incremental update: target_uri={self._target_uri}, root_uri={self._root_uri}"
             )
             return None
-        try:
-            relative_path = current_uri[len(self._root_uri) :]
-            if relative_path.startswith("/"):
-                relative_path = relative_path[1:]
-            return f"{self._target_uri}/{relative_path}" if relative_path else self._target_uri
-        except Exception:
+        if self._target_uri != self._root_uri:
+            logger.warning(
+                "Incremental semantic update expects target_uri == root_uri: "
+                f"target_uri={self._target_uri}, root_uri={self._root_uri}"
+            )
             return None
+        return current_uri
 
     def _is_direct_incremental_update(self) -> bool:
         return (

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -62,6 +62,13 @@ class DiffResult:
     added_dirs: List[str] = field(default_factory=list)
     deleted_dirs: List[str] = field(default_factory=list)
 
+    def to_changes(self) -> Dict[str, List[str]]:
+        return {
+            "added": self.added_files + self.added_dirs,
+            "modified": self.updated_files,
+            "deleted": self.deleted_files + self.deleted_dirs,
+        }
+
 
 class RequestQueueStats:
     processed: int = 0
@@ -352,24 +359,36 @@ class SemanticProcessor(DequeueHandlerBase):
                         else:
                             is_incremental = False
                             target_uri = msg.target_uri
+                            run_uri = msg.uri
+                            changes = msg.changes
                             viking_fs = get_viking_fs()
                             if msg.target_uri:
                                 target_exists = await viking_fs.exists(
                                     msg.target_uri, ctx=self._current_ctx
                                 )
-                                # Check if target URI exists and is not the same as the source URI（避免重复处理）
                                 if msg.uri != msg.target_uri:
-                                    if msg.target_preexisting is None:
-                                        target_preexisting = target_exists
-                                    else:
-                                        target_preexisting = bool(msg.target_preexisting)
-                                else:
-                                    target_preexisting = target_exists
-                                if target_preexisting and msg.uri != msg.target_uri:
-                                    is_incremental = True
                                     logger.info(
-                                        f"Target URI exists, using incremental update: {msg.target_uri}"
+                                        "Syncing semantic source into target before processing: "
+                                        f"{msg.uri} -> {msg.target_uri}"
                                     )
+                                    diff = await self._sync_topdown_recursive(
+                                        msg.uri,
+                                        msg.target_uri,
+                                        ctx=self._current_ctx,
+                                        lock=semantic_lock.lock,
+                                    )
+                                    logger.info(
+                                        "[SyncDiff] Diff computed: "
+                                        f"added_files={len(diff.added_files)}, "
+                                        f"deleted_files={len(diff.deleted_files)}, "
+                                        f"updated_files={len(diff.updated_files)}, "
+                                        f"added_dirs={len(diff.added_dirs)}, "
+                                        f"deleted_dirs={len(diff.deleted_dirs)}"
+                                    )
+                                    changes = diff.to_changes()
+                                    is_incremental = True
+                                    target_uri = msg.target_uri
+                                    run_uri = msg.target_uri
                                 elif target_exists and msg.changes and msg.uri == msg.target_uri:
                                     is_incremental = True
                                     logger.info(
@@ -394,18 +413,17 @@ class SemanticProcessor(DequeueHandlerBase):
                                 recursive=msg.recursive,
                                 lock=semantic_lock.lock,
                                 is_code_repo=msg.is_code_repo,
-                                sync_to_target=bool(target_uri and msg.uri != target_uri),
-                                changes=msg.changes,
+                                changes=changes,
                                 skip_vectorization=msg.skip_vectorization,
                                 coalesce_key=msg.coalesce_key,
                                 coalesce_version=msg.coalesce_version,
                             )
                             self._dag_executor = executor
                             lock_transferred = True
-                            await executor.run(msg.uri)
+                            await executor.run(run_uri)
                             self._cache_dag_stats(
                                 msg.telemetry_id,
-                                msg.uri,
+                                run_uri,
                                 executor.get_stats(),
                             )
                             if not executor.stale:
@@ -712,7 +730,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 name = entry.get("name", "")
                 if not name or name in [".", ".."]:
                     continue
-                if name.startswith(".") and name not in [".abstract.md", ".overview.md"]:
+                if name.startswith("."):
                     continue
                 item_uri = VikingURI(dir_uri).join(name).uri
                 if entry.get("isDir", False):
@@ -724,18 +742,6 @@ class SemanticProcessor(DequeueHandlerBase):
         async def sync_dir(root_dir: str, target_dir: str) -> None:
             root_files, root_dirs = await list_children(root_dir)
             target_files, target_dirs = await list_children(target_dir)
-
-            try:
-                await viking_fs._mv_vector_store_l0_l1(
-                    root_dir,
-                    target_dir,
-                    ctx=ctx,
-                    lock_handle=lock_handle,
-                )
-            except Exception as e:
-                logger.error(
-                    f"[SyncDiff] Failed to move L0/L1 index: {root_dir} -> {target_dir}, error={e}"
-                )
 
             file_names = set(root_files.keys()) | set(target_files.keys())
             for name in sorted(file_names):
@@ -793,7 +799,7 @@ class SemanticProcessor(DequeueHandlerBase):
                             )
                             changed = False
                     if changed:
-                        diff.updated_files.append(root_file)
+                        diff.updated_files.append(target_file)
                         try:
                             await viking_fs.rm(target_file, ctx=ctx, lock_handle=lock_handle)
                         except Exception as e:
@@ -814,8 +820,8 @@ class SemanticProcessor(DequeueHandlerBase):
                     continue
 
                 if root_file and not target_file:
-                    diff.added_files.append(root_file)
                     target_file_uri = VikingURI(target_dir).join(name).uri
+                    diff.added_files.append(target_file_uri)
                     try:
                         await viking_fs.mv(
                             root_file,
@@ -865,8 +871,8 @@ class SemanticProcessor(DequeueHandlerBase):
                     continue
 
                 if root_subdir and not target_subdir:
-                    diff.added_dirs.append(root_subdir)
                     target_subdir_uri = VikingURI(target_dir).join(name).uri
+                    diff.added_dirs.append(target_subdir_uri)
                     try:
                         await viking_fs.mv(
                             root_subdir,
@@ -888,7 +894,7 @@ class SemanticProcessor(DequeueHandlerBase):
             parent_uri = VikingURI(target_uri).parent
             if parent_uri:
                 await viking_fs.mkdir(parent_uri.uri, exist_ok=True, ctx=ctx)
-            diff.added_dirs.append(root_uri)
+            diff.added_dirs.append(target_uri)
             await viking_fs.mv(root_uri, target_uri, ctx=ctx, lock_handle=lock_handle)
             return diff
 

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -255,6 +255,7 @@ class ResourceProcessor:
             candidate_uri = getattr(context_tree, "_candidate_uri", None) if context_tree else None
             resource_lock: LockLease = NO_LOCK
             target_preexisting = False
+            source_committed = False
 
             if root_uri and temp_uri:
                 from openviking.storage.transaction import get_lock_manager
@@ -276,6 +277,11 @@ class ResourceProcessor:
                         resource_lock = await self._acquire_resource_lock(
                             lock_manager, dst_path, uri=root_uri
                         )
+                    if not target_preexisting:
+                        await viking_fs.persist_temp_tree(temp_uri, root_uri, ctx=ctx)
+                        await viking_fs.delete_temp(parse_result.temp_dir_path, ctx=ctx)
+                        temp_uri = root_uri
+                        source_committed = True
                 except Exception:
                     stage_status = "error"
                     raise
@@ -334,7 +340,7 @@ class ResourceProcessor:
                         pass
 
             if resource_lock.active:
-                if not should_summarize and temp_uri:
+                if not should_summarize and temp_uri and not source_committed:
                     viking_fs = get_viking_fs()
                     await viking_fs.persist_temp_tree(temp_uri, root_uri, ctx=ctx)
                     await viking_fs.delete_temp(parse_result.temp_dir_path, ctx=ctx)

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -90,17 +90,13 @@ class _FakeLockManager:
 class _FakeVikingFS:
     def __init__(self, *, exists_result=False, existing_uris=None):
         self.agfs = SimpleNamespace(
-            cat=MagicMock(return_value=b"content"),
-            ls=MagicMock(return_value=[{"name": "content.md", "isDir": False}]),
-            mkdir=MagicMock(return_value={"status": "ok"}),
-            mv=MagicMock(return_value={"status": "ok"}),
-            stat=MagicMock(return_value={"isDir": True}),
             write=MagicMock(return_value={"status": "ok"}),
         )
-        self.mv = AsyncMock(return_value={})
         self._exists_result = exists_result
         self._existing_uris = set(existing_uris or [])
         self.exists_calls = []
+        self.persist_calls = []
+        self.delete_temp_calls = []
 
     def bind_request_context(self, ctx):
         return _CtxMgr()
@@ -115,9 +111,11 @@ class _FakeVikingFS:
         return None
 
     async def delete_temp(self, temp_dir_path, ctx=None):
+        self.delete_temp_calls.append(temp_dir_path)
         return None
 
     async def persist_temp_tree(self, temp_uri, target_uri, ctx=None):
+        self.persist_calls.append((temp_uri, target_uri))
         self.agfs.write(self._uri_to_path(target_uri, ctx=ctx), b"content")
 
     def _uri_to_path(self, uri, ctx=None):
@@ -125,11 +123,12 @@ class _FakeVikingFS:
 
 
 @pytest.mark.asyncio
-async def test_resource_processor_first_add_persist_does_not_await_agfs_mv(monkeypatch):
+async def test_resource_processor_first_add_summarizes_from_committed_uri(monkeypatch):
     from openviking.utils.resource_processor import ResourceProcessor
 
     fake_fs = _FakeVikingFS()
     fake_lock_manager = _FakeLockManager()
+    summarize_calls = []
 
     monkeypatch.setattr(
         "openviking.utils.resource_processor.get_current_telemetry",
@@ -152,22 +151,27 @@ async def test_resource_processor_first_add_persist_does_not_await_agfs_mv(monke
             warnings=[],
         )
     )
-
-    context_tree = SimpleNamespace(
-        root=SimpleNamespace(uri="viking://resources/root", temp_uri="viking://temp/root_tmp")
+    rp.tree_builder.finalize_from_temp = AsyncMock(
+        return_value=SimpleNamespace(
+            root=SimpleNamespace(uri="viking://resources/root", temp_uri="viking://temp/root_tmp")
+        )
     )
-    rp.tree_builder.finalize_from_temp = AsyncMock(return_value=context_tree)
+    rp._summarizer = SimpleNamespace(
+        summarize=AsyncMock(
+            side_effect=lambda *args, **kwargs: (
+                summarize_calls.append(kwargs) or {"status": "success"}
+            )
+        )
+    )
 
-    ctx = object()
-    result = await rp.process_resource(path="x", ctx=ctx, build_index=False, summarize=False)
+    result = await rp.process_resource(path="x", ctx=object(), build_index=True)
 
     assert result["status"] == "success"
     assert result["root_uri"] == "viking://resources/root"
-    fake_fs.agfs.mv.assert_not_called()
-    fake_fs.agfs.write.assert_called_once()
-    fake_fs.mv.assert_not_awaited()
-    assert fake_lock_manager.acquired_exact_paths == []
-    assert fake_lock_manager.acquired_tree_paths == ["/mock/resources/root"]
+    assert fake_fs.persist_calls == [("viking://temp/root_tmp", "viking://resources/root")]
+    assert fake_fs.delete_temp_calls == ["viking://temp/tmpdir"]
+    assert summarize_calls[0]["temp_uris"] == ["viking://resources/root"]
+    assert summarize_calls[0]["target_preexisting"] is False
 
 
 @pytest.mark.asyncio
@@ -218,11 +222,7 @@ async def test_resource_processor_second_add_preserves_temp_uri_for_incremental(
     assert result["root_uri"] == "viking://resources/root"
     assert summarize_calls[0]["temp_uris"] == ["viking://temp/root_tmp"]
     assert summarize_calls[0]["target_preexisting"] is True
-    fake_fs.agfs.mv.assert_not_called()
-    fake_fs.agfs.write.assert_not_called()
-    fake_fs.mv.assert_not_awaited()
-    assert fake_lock_manager.acquired_exact_paths == []
-    assert fake_lock_manager.acquired_tree_paths == ["/mock/resources/root"]
+    assert fake_fs.persist_calls == []
 
 
 @pytest.mark.asyncio
@@ -283,5 +283,6 @@ async def test_resource_processor_auto_candidate_skips_existing_and_busy(monkeyp
     ]
     assert fake_lock_manager.acquired_exact_paths == []
     assert fake_lock_manager.acquired_tree_paths == ["/mock/resources/root_2"]
-    assert summarize_calls[0]["temp_uris"] == ["viking://temp/root_tmp"]
+    assert summarize_calls[0]["temp_uris"] == ["viking://resources/root_2"]
     assert summarize_calls[0]["target_preexisting"] is False
+    assert fake_fs.persist_calls == [("viking://temp/root_tmp", "viking://resources/root_2")]

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -112,60 +112,6 @@ class _FakeProcessor:
 
 
 @pytest.mark.asyncio
-async def test_incremental_missing_summary_triggers_overview_regen(monkeypatch):
-    _mock_transaction_layer(monkeypatch)
-
-    root_uri = "viking://resources/root"
-    target_uri = "viking://resources/target"
-    tree = {
-        root_uri: [{"name": "a.txt", "isDir": False}],
-        target_uri: [{"name": "a.txt", "isDir": False}],
-    }
-
-    fake_fs = _FakeVikingFS(
-        tree=tree,
-        file_contents={
-            f"{root_uri}/a.txt": "hello",
-            f"{target_uri}/a.txt": "hello",
-            f"{target_uri}/.overview.md": "FILES:\n",
-            f"{target_uri}/.abstract.md": "old-abstract",
-        },
-    )
-    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
-
-    processor = _FakeProcessor(fake_fs)
-    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
-
-    executor1 = SemanticDagExecutor(
-        processor=processor,
-        context_type="resource",
-        max_concurrent_llm=2,
-        ctx=ctx,
-        incremental_update=True,
-        target_uri=target_uri,
-    )
-    monkeypatch.setattr(executor1, "_add_vectorize_task", AsyncMock())
-    await executor1.run(root_uri)
-
-    assert "- a.txt:" in fake_fs._file_contents[f"{root_uri}/.overview.md"]
-    assert "- a.txt:" in fake_fs._file_contents[f"{target_uri}/.overview.md"]
-    first_run_calls = len(processor.summarized_files)
-
-    executor2 = SemanticDagExecutor(
-        processor=processor,
-        context_type="resource",
-        max_concurrent_llm=2,
-        ctx=ctx,
-        incremental_update=True,
-        target_uri=target_uri,
-    )
-    monkeypatch.setattr(executor2, "_add_vectorize_task", AsyncMock())
-    await executor2.run(root_uri)
-
-    assert len(processor.summarized_files) == first_run_calls
-
-
-@pytest.mark.asyncio
 async def test_direct_incremental_update_uses_changes_without_temp_sync(monkeypatch):
     _mock_transaction_layer(monkeypatch)
 
@@ -208,43 +154,6 @@ async def test_direct_incremental_update_uses_changes_without_temp_sync(monkeypa
     overview = fake_fs._file_contents[f"{root_uri}/.overview.md"]
     assert "- a.txt: summary" in overview
     assert "- b.txt: old-b" in overview
-
-
-@pytest.mark.asyncio
-async def test_full_update_can_still_sync_temp_to_target(monkeypatch):
-    _mock_transaction_layer(monkeypatch)
-
-    root_uri = "viking://temp/root"
-    target_uri = "viking://resources/target"
-    tree = {
-        root_uri: [{"name": "a.txt", "isDir": False}],
-    }
-
-    fake_fs = _FakeVikingFS(
-        tree=tree,
-        file_contents={
-            f"{root_uri}/a.txt": "hello",
-        },
-    )
-    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
-
-    processor = _FakeProcessor(fake_fs)
-    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
-    executor = SemanticDagExecutor(
-        processor=processor,
-        context_type="resource",
-        max_concurrent_llm=2,
-        ctx=ctx,
-        incremental_update=False,
-        target_uri=target_uri,
-        sync_to_target=True,
-        skip_vectorization=True,
-    )
-
-    await executor.run(root_uri)
-
-    assert processor.sync_calls == [(root_uri, target_uri)]
-    assert fake_fs._file_contents[f"{target_uri}/a.txt"] == "hello"
 
 
 if __name__ == "__main__":

--- a/tests/storage/test_semantic_processor_target_preexisting.py
+++ b/tests/storage/test_semantic_processor_target_preexisting.py
@@ -3,8 +3,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from openviking.storage.queuefs.semantic_processor import SemanticProcessor
 from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.queuefs.semantic_processor import DiffResult, SemanticProcessor
 from openviking.storage.transaction import NO_LOCK
 
 
@@ -13,8 +13,58 @@ class _FakeVikingFS:
         return True
 
 
+class _SyncVikingFS:
+    def __init__(self):
+        self.contents = {
+            "viking://temp/import/a.md": "new",
+            "viking://temp/import/b.md": "same",
+            "viking://resources/root/a.md": "old",
+            "viking://resources/root/b.md": "same",
+            "viking://resources/root/.overview.md": "FILES:\n- b.md: old summary",
+            "viking://resources/root/.abstract.md": "old abstract",
+        }
+        self.entries = {
+            "viking://temp/import": [
+                {"name": "a.md", "isDir": False},
+                {"name": "b.md", "isDir": False},
+            ],
+            "viking://resources/root": [
+                {"name": "a.md", "isDir": False},
+                {"name": "b.md", "isDir": False},
+                {"name": ".overview.md", "isDir": False},
+                {"name": ".abstract.md", "isDir": False},
+            ],
+        }
+        self.deleted_temp = []
+
+    async def exists(self, uri, ctx=None):
+        return uri in self.entries
+
+    async def ls(self, uri, show_all_hidden=False, ctx=None):
+        return self.entries.get(uri, [])
+
+    async def stat(self, uri, ctx=None):
+        return {"size": len(self.contents.get(uri, ""))}
+
+    async def read_file(self, uri, ctx=None):
+        return self.contents.get(uri, "")
+
+    async def rm(self, uri, recursive=False, ctx=None, lock_handle=None):
+        self.contents.pop(uri, None)
+
+    async def mv(self, src, dst, ctx=None, lock_handle=None):
+        self.contents[dst] = self.contents.pop(src)
+
+    async def mkdir(self, uri, exist_ok=False, ctx=None):
+        self.entries.setdefault(uri, [])
+
+    async def delete_temp(self, uri, ctx=None):
+        self.deleted_temp.append(uri)
+
+
 class _FakeDagExecutor:
     calls = []
+    runs = []
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
@@ -23,6 +73,7 @@ class _FakeDagExecutor:
 
     async def run(self, root_uri):
         self.root_uri = root_uri
+        _FakeDagExecutor.runs.append(root_uri)
 
     def get_stats(self):
         from openviking.storage.queuefs.semantic_dag import DagStats
@@ -31,7 +82,7 @@ class _FakeDagExecutor:
 
 
 @pytest.mark.asyncio
-async def test_target_preexisting_controls_incremental_detection(monkeypatch):
+async def test_target_source_syncs_before_semantic_dag(monkeypatch):
     monkeypatch.setattr(
         "openviking.storage.queuefs.semantic_processor.get_viking_fs",
         lambda: _FakeVikingFS(),
@@ -45,18 +96,56 @@ async def test_target_preexisting_controls_incremental_detection(monkeypatch):
         AsyncMock(return_value=SimpleNamespace(lock=NO_LOCK, close=AsyncMock())),
     )
 
-    for target_preexisting, expected_incremental in [(False, False), (True, True)]:
-        _FakeDagExecutor.calls = []
-        processor = SemanticProcessor()
-        processor._enqueue_parent_refresh = AsyncMock()
-        msg = SemanticMsg(
-            uri="viking://temp/import_root/repository",
-            target_uri="viking://resources/org/repo",
-            context_type="resource",
-            target_preexisting=target_preexisting,
+    _FakeDagExecutor.calls = []
+    _FakeDagExecutor.runs = []
+    processor = SemanticProcessor()
+    processor._enqueue_parent_refresh = AsyncMock()
+    processor._sync_topdown_recursive = AsyncMock(
+        return_value=DiffResult(
+            updated_files=["viking://resources/org/repo/a.md"],
         )
+    )
+    msg = SemanticMsg(
+        uri="viking://temp/import_root/repository",
+        target_uri="viking://resources/org/repo",
+        context_type="resource",
+        target_preexisting=True,
+    )
 
-        await processor.on_dequeue(msg.to_dict())
+    await processor.on_dequeue(msg.to_dict())
 
-        assert _FakeDagExecutor.calls[0]["incremental_update"] is expected_incremental
-        assert _FakeDagExecutor.calls[0]["sync_to_target"] is True
+    assert _FakeDagExecutor.calls[0]["incremental_update"] is True
+    assert _FakeDagExecutor.calls[0]["target_uri"] == "viking://resources/org/repo"
+    assert _FakeDagExecutor.calls[0]["changes"] == {
+        "added": [],
+        "modified": ["viking://resources/org/repo/a.md"],
+        "deleted": [],
+    }
+    assert _FakeDagExecutor.runs == ["viking://resources/org/repo"]
+
+
+@pytest.mark.asyncio
+async def test_sync_diff_reports_target_uris_and_preserves_sidecars(monkeypatch):
+    fake_fs = _SyncVikingFS()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+
+    diff = await SemanticProcessor()._sync_topdown_recursive(
+        "viking://temp/import",
+        "viking://resources/root",
+        lock=NO_LOCK,
+    )
+
+    assert diff.to_changes() == {
+        "added": [],
+        "modified": ["viking://resources/root/a.md"],
+        "deleted": [],
+    }
+    assert fake_fs.contents["viking://resources/root/a.md"] == "new"
+    assert fake_fs.contents["viking://resources/root/.overview.md"] == (
+        "FILES:\n- b.md: old summary"
+    )
+    assert fake_fs.contents["viking://resources/root/.abstract.md"] == "old abstract"
+    assert fake_fs.deleted_temp == ["viking://temp/import"]


### PR DESCRIPTION
## Description

Fix semantic target synchronization for resource imports so temp-source updates are synced into the target before semantic DAG processing. This makes incremental semantic processing operate on final resource URIs and preserves existing semantic sidecar files during target sync.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Sync source-to-target content before semantic DAG execution when `uri` and `target_uri` differ, and pass the resulting target URI changes into incremental DAG processing.
- Report sync diffs with target URIs while preserving semantic sidecars such as `.overview.md` and `.abstract.md`.
- Persist first-time resource temp trees before summarization while keeping existing-target imports on temp URIs for incremental handling.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Tested with:

```bash
.venv/bin/python -m pytest tests/misc/test_resource_processor_mv.py tests/storage/test_semantic_dag_incremental.py tests/storage/test_semantic_processor_target_preexisting.py
```

Note: `python -m pytest ...` using the system Python did not start because the local global environment has incompatible `pydantic` / `pydantic-core` versions; the same tests passed with the repository virtual environment.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

N/A
