### PR TITLE
fix(vlm): initialize Codex async client cache

### DIFF
--- a/openviking/models/vlm/backends/codex_vlm.py
+++ b/openviking/models/vlm/backends/codex_vlm.py
@@ -44,6 +44,7 @@ class CodexVLM(OpenAIVLM):
         if not normalized.get("api_base"):
             normalized["api_base"] = DEFAULT_CODEX_BASE_URL
         super().__init__(normalized)
+        self._async_client = None
 
     def _build_responses_client(self, api_key: str, api_base: str):
         kwargs = _build_openai_client_kwargs(


### PR DESCRIPTION
## Summary

Initializes the `CodexVLM` async client cache in the constructor.

`CodexVLM._get_or_create_async_responses_client()` checks `self._async_client`, but the attribute is not initialized before first use. This causes the async Codex path to fail with:

```text
AttributeError: 'CodexVLM' object has no attribute '_async_client'
```

## Type of Change

- [x] Bug fix (fix)
- [ ] New feature (feat)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Testing

- [x] Focused unit test passes:

```bash
uv run pytest tests/unit/test_codex_vlm.py::test_codex_async_client_defers_runtime_credential_resolution -q
```

Result:

```text
1 passed
```

- [x] Ruff passes for the changed file:

```bash
uv run ruff check openviking/models/vlm/backends/codex_vlm.py
```

Result:

```text
All checks passed!
```

Note: `uv run pytest tests/unit/test_codex_vlm.py -q` currently has one unrelated pre-existing failure in `test_codex_streaming_is_rejected`; I verified that failure also occurs on unmodified upstream `main`, so it is not caused by this change.

## Related Issues

None linked.

## Checklist

- [x] Code follows project style guidelines
- [x] Existing focused regression test passes
- [ ] All tests pass
