### PR TITLE
docs: fix broken LangChain integration link in README (404 since #2019 renumber)

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ To ensure optimal storage performance and data security, we recommend deploying 
 
 👉 **[View: Claude Code Memory Plugin Example](examples/claude-code-memory-plugin/README.md)**
 
-👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/05-langchain-langgraph.md)**
+👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/06-langchain-langgraph.md)**
 
 \--
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -558,7 +558,7 @@ ov chat
 
 👉 **[查看：Claude Code 记忆插件示例](examples/claude-code-memory-plugin/README_CN.md)**
 
-👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/05-langchain-langgraph.md)**
+👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/06-langchain-langgraph.md)**
 
 ## VikingBot 部署详情
 


### PR DESCRIPTION
The "View: LangChain / LangGraph Integration" link in both README.md and README_CN.md points to `docs/{en,zh}/agent-integrations/05-langchain-langgraph.md`, which 404s.

#2019 (dedicated agent-integrations pages) renumbered the LangChain page from `05-` to `06-langchain-langgraph.md` and took `05-` for `05-other-plugins.md`, but the two README links were left at the old `05-` path.

- README.md L635 → `05-langchain-langgraph.md` (404) — fixed to `06-`
- README_CN.md L561 → `05-langchain-langgraph.md` (404) — fixed to `06-`

`06-langchain-langgraph.md` is the live target (the in-repo `01-overview.md` table already links to `06-`). 2-line path fix, no content change.