### PR TITLE
feat: add batch add_messages API for faster message ingestion

### DIFF
--- a/crates/ov_cli/src/commands/session.rs
+++ b/crates/ov_cli/src/commands/session.rs
@@ -167,16 +167,18 @@ pub async fn add_memory(
         crate::error::Error::Api("Failed to get session_id from new session response".to_string())
     })?;
 
-    // 2. Add messages
-    for (role, content) in &messages {
-        let path = format!("/api/v1/sessions/{}/messages", url_encode(session_id));
-        let body = json!({
-            "role": role,
-            "content": content
-        });
-        let response: serde_json::Value = client.post(&path, &body).await?;
-        profile_lines.extend(extract_profile_lines(&response));
-    }
+    // 2. Add messages (batch)
+    let path = format!(
+        "/api/v1/sessions/{}/messages/batch",
+        url_encode(session_id)
+    );
+    let messages_json: Vec<serde_json::Value> = messages
+        .iter()
+        .map(|(role, content)| json!({"role": role, "content": content}))
+        .collect();
+    let body = json!({"messages": messages_json});
+    let response: serde_json::Value = client.post(&path, &body).await?;
+    profile_lines.extend(extract_profile_lines(&response));
 
     // 3. Commit (async — don't read response)
     let commit_path = format!("/api/v1/sessions/{}/commit", url_encode(session_id));

--- a/openviking/client/session.py
+++ b/openviking/client/session.py
@@ -74,6 +74,24 @@ class Session:
             role_id=role_id,
         )
 
+    async def batch_add_messages(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Add multiple messages to the session in a single request.
+
+        Args:
+            messages: List of dicts, each with "role" and optionally "content",
+                      "parts", "created_at", "role_id".
+
+        Returns:
+            Result dict with session_id, message_count, and added count.
+        """
+        return await self._client.batch_add_messages(
+            self.session_id,
+            messages=messages,
+        )
+
     async def commit(self, telemetry: TelemetryRequest = False) -> Dict[str, Any]:
         """Commit the session (archive messages and extract memories).
 

--- a/openviking/integrations/langchain/history.py
+++ b/openviking/integrations/langchain/history.py
@@ -98,12 +98,12 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
 
     def add_messages(self, messages: Sequence[BaseMessage]) -> None:
         client = self._get_client()
-        added = 0
         pending_context_parts = (
             list(self.context_parts_provider(self.session_id))
             if self.context_parts_provider
             else []
         )
+        batch = []
         for message in messages:
             for payload in langchain_message_to_openviking(
                 message,
@@ -112,15 +112,15 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
                 if pending_context_parts and payload["role"] == "assistant":
                     payload["parts"].extend(pending_context_parts)
                     pending_context_parts = []
-                call_openviking(
-                    client,
-                    "add_message",
-                    session_id=self.session_id,
-                    role=payload["role"],
-                    parts=payload["parts"],
-                )
-                added += 1
-        if added:
+                batch.append(payload)
+
+        if batch:
+            call_openviking(
+                client,
+                "batch_add_messages",
+                session_id=self.session_id,
+                messages=batch,
+            )
             maybe_commit_session(client, self.session_id, self.commit_policy)
 
     def clear(self) -> None:

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Body, Depends, Path, Query, Request
 from pydantic import BaseModel, Field, model_validator
 
 from openviking.core.path_variables import resolve_path_variables
-from openviking.message.part import TextPart, part_from_dict
+from openviking.message.part import Part, TextPart, part_from_dict
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import AuthMode, RequestContext
@@ -96,6 +96,13 @@ class AddMessageRequest(BaseModel):
         return self
 
 
+class BatchAddMessageRequest(BaseModel):
+    """Request model for adding multiple messages in a single request."""
+
+    messages: List[AddMessageRequest] = Field(..., max_length=100)
+    telemetry: TelemetryRequest = False
+
+
 class UsedRequest(BaseModel):
     """Request model for recording usage."""
 
@@ -108,6 +115,24 @@ class CreateSessionRequest(BaseModel):
 
     session_id: Optional[str] = None
     telemetry: TelemetryRequest = False
+
+
+def _resolve_message_parts(msg_request: AddMessageRequest) -> List[Part]:
+    """Resolve parts from an AddMessageRequest, handling path variables."""
+    if msg_request.parts is not None:
+        resolved_parts = []
+        for p in msg_request.parts:
+            part_copy = dict(p)
+            if part_copy.get("type") == "context" and "uri" in part_copy:
+                part_copy["uri"] = resolve_path_variables(part_copy["uri"])
+            if part_copy.get("type") == "tool":
+                if "tool_uri" in part_copy:
+                    part_copy["tool_uri"] = resolve_path_variables(part_copy["tool_uri"])
+                if "skill_uri" in part_copy:
+                    part_copy["skill_uri"] = resolve_path_variables(part_copy["skill_uri"])
+            resolved_parts.append(part_copy)
+        return [part_from_dict(p) for p in resolved_parts]
+    return [TextPart(text=msg_request.content or "")]
 
 
 def _to_jsonable(value: Any) -> Any:
@@ -393,32 +418,14 @@ async def add_message(
     async def _add() -> dict[str, Any]:
         session = await service.sessions.get(session_id, _ctx, auto_create=True)
         role_id = _ctx.resolve_role_id(request.role, request.role_id)
+        parts = _resolve_message_parts(request)
 
-        if request.parts is not None:
-            # Resolve path variables in URIs within parts
-            resolved_parts = []
-            for p in request.parts:
-                part_copy = dict(p)
-                # Resolve uri in context parts
-                if part_copy.get("type") == "context" and "uri" in part_copy:
-                    part_copy["uri"] = resolve_path_variables(part_copy["uri"])
-                # Resolve tool_uri and skill_uri in tool parts
-                if part_copy.get("type") == "tool":
-                    if "tool_uri" in part_copy:
-                        part_copy["tool_uri"] = resolve_path_variables(part_copy["tool_uri"])
-                    if "skill_uri" in part_copy:
-                        part_copy["skill_uri"] = resolve_path_variables(part_copy["skill_uri"])
-                resolved_parts.append(part_copy)
-            parts = [part_from_dict(p) for p in resolved_parts]
-        else:
-            parts = [TextPart(text=request.content or "")]
-
-        session.add_message(
-            request.role,
-            parts,
-            role_id=role_id,
-            created_at=request.created_at,
-        )
+        session.add_messages([{
+            "role": request.role,
+            "parts": parts,
+            "role_id": role_id,
+            "created_at": request.created_at,
+        }])
         return {
             "session_id": session_id,
             "message_count": len(session.messages),
@@ -428,6 +435,46 @@ async def add_message(
         operation="session.add_message",
         telemetry=request.telemetry,
         fn=_add,
+    )
+    return Response(status="ok", result=execution.result, telemetry=execution.telemetry)
+
+
+@router.post("/{session_id}/messages/batch")
+async def batch_add_messages(
+    request: BatchAddMessageRequest,
+    session_id: str = Path(..., description="Session ID"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Add multiple messages to a session in a single request.
+
+    Accepts a list of messages, each following the same format as AddMessageRequest.
+    Missing sessions are auto-created on first add.
+    """
+    service = get_service()
+
+    async def _batch_add() -> dict[str, Any]:
+        session = await service.sessions.get(session_id, _ctx, auto_create=True)
+        specs = []
+        for msg_request in request.messages:
+            role_id = _ctx.resolve_role_id(msg_request.role, msg_request.role_id)
+            parts = _resolve_message_parts(msg_request)
+            specs.append({
+                "role": msg_request.role,
+                "parts": parts,
+                "role_id": role_id,
+                "created_at": msg_request.created_at,
+            })
+        msgs = session.add_messages(specs)
+        return {
+            "session_id": session_id,
+            "message_count": len(session.messages),
+            "added": len(msgs),
+        }
+
+    execution = await run_operation(
+        operation="session.batch_add_messages",
+        telemetry=request.telemetry,
+        fn=_batch_add,
     )
     return Response(status="ok", result=execution.result, telemetry=execution.telemetry)
 

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -758,34 +758,74 @@ class Session:
             role == "user" and len(parts) > 1 and all(isinstance(part, ToolPart) for part in parts)
         )
 
-    def _append_message(self, msg: Message) -> None:
-        self._messages.append(msg)
-        self._record_participant(msg)
+    def _append_messages(self, messages: List[Message]) -> None:
+        """Append multiple messages: update lists, stats, JSONL, meta."""
+        for msg in messages:
+            self._messages.append(msg)
+            self._record_participant(msg)
 
-        # Update statistics
-        if msg.role == "user":
-            self._stats.total_turns += 1
-        msg_tokens = int(msg.estimated_tokens or 0)
-        self._stats.total_tokens += msg_tokens
+            if msg.role == "user":
+                self._stats.total_turns += 1
+            msg_tokens = int(msg.estimated_tokens or 0)
+            self._stats.total_tokens += msg_tokens
 
-        # WM v2: maintain pending_tokens via sliding window.
-        # keep_recent_count == 0 (never-committed or compact path that chose 0):
-        #   every new message contributes to pending.
-        # keep_recent_count > 0:
-        #   only the message pushed OUT of the tail-keep window contributes.
-        keep = int(self._meta.keep_recent_count or 0)
-        if keep <= 0:
-            self._meta.pending_tokens += msg_tokens
-        elif len(self._messages) > keep:
-            pushed_out = self._messages[-(keep + 1)]
-            self._meta.pending_tokens += int(pushed_out.estimated_tokens or 0)
+            keep = int(self._meta.keep_recent_count or 0)
+            if keep <= 0:
+                self._meta.pending_tokens += msg_tokens
+            elif len(self._messages) > keep:
+                pushed_out = self._messages[-(keep + 1)]
+                self._meta.pending_tokens += int(pushed_out.estimated_tokens or 0)
 
-        self._append_to_jsonl(msg)
+        self._append_messages_to_jsonl_batch(messages)
 
         self._meta.message_count = len(self._messages)
         if self._meta.total_message_count is not None:
-            self._meta.total_message_count += 1
+            self._meta.total_message_count += len(messages)
         self._save_meta_sync()
+
+    def add_messages(
+        self,
+        messages_spec: List[dict],
+    ) -> List[Message]:
+        """Add multiple messages in a single batch.
+
+        Args:
+            messages_spec: List of dicts, each with keys:
+                role, parts, role_id (optional), created_at (optional)
+        """
+        all_messages = []
+        for spec in messages_spec:
+            role = spec["role"]
+            parts = spec["parts"]
+            role_id = spec.get("role_id")
+            created_at = spec.get("created_at") or datetime.now(timezone.utc).isoformat()
+
+            if self._is_tool_result_aggregate(role, parts):
+                msgs = [
+                    Message(
+                        id=f"msg_{uuid4().hex}",
+                        role=role,
+                        parts=[part],
+                        role_id=role_id,
+                        created_at=created_at,
+                    )
+                    for part in parts
+                ]
+                self._externalize_large_tool_output_group(msgs)
+                all_messages.extend(msgs)
+            else:
+                msg = Message(
+                    id=f"msg_{uuid4().hex}",
+                    role=role,
+                    parts=parts,
+                    role_id=role_id,
+                    created_at=created_at,
+                )
+                self._externalize_large_tool_outputs(msg)
+                all_messages.append(msg)
+
+        self._append_messages(all_messages)
+        return all_messages
 
     def add_message(
         self,
@@ -799,33 +839,13 @@ class Session:
         A user message containing only multiple tool results is treated as a
         transport aggregate and stored as one message per tool result.
         """
-        created = created_at or datetime.now(timezone.utc).isoformat()
-        if self._is_tool_result_aggregate(role, parts):
-            messages = [
-                Message(
-                    id=f"msg_{uuid4().hex}",
-                    role=role,
-                    parts=[part],
-                    role_id=role_id,
-                    created_at=created,
-                )
-                for part in parts
-            ]
-            self._externalize_large_tool_output_group(messages)
-            for msg in messages:
-                self._append_message(msg)
-            return messages[0]
-
-        msg = Message(
-            id=f"msg_{uuid4().hex}",
-            role=role,
-            parts=parts,
-            role_id=role_id,
-            created_at=created,
-        )
-        self._externalize_large_tool_outputs(msg)
-        self._append_message(msg)
-        return msg
+        msgs = self.add_messages([{
+            "role": role,
+            "parts": parts,
+            "role_id": role_id,
+            "created_at": created_at,
+        }])
+        return msgs[0]
 
     def _record_participant(self, msg: Message) -> None:
         if msg.role == "user" and msg.role_id:
@@ -3058,14 +3078,15 @@ class Session:
             ctx=self.ctx,
         )
 
-    def _append_to_jsonl(self, msg: Message) -> None:
-        """Append to messages.jsonl."""
+    def _append_messages_to_jsonl_batch(self, messages: List[Message]) -> None:
+        """Append multiple messages to messages.jsonl in a single write."""
         if not self._viking_fs:
             return
+        batch_content = "".join(msg.to_jsonl() + "\n" for msg in messages)
         run_async(
             self._viking_fs.append_file(
                 f"{self._session_uri}/messages.jsonl",
-                msg.to_jsonl() + "\n",
+                batch_content,
                 ctx=self.ctx,
             )
         )

--- a/openviking_cli/client/base.py
+++ b/openviking_cli/client/base.py
@@ -295,6 +295,26 @@ class BaseClient(ABC):
         """
         ...
 
+    @abstractmethod
+    async def batch_add_messages(
+        self,
+        session_id: str,
+        messages: list[dict],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Add multiple messages to a session in a single request.
+
+        Args:
+            session_id: Session ID
+            messages: List of message dicts, each with "role" and optionally
+                      "content", "parts", "created_at", "role_id".
+            telemetry: Whether to attach operation telemetry data to the result.
+
+        Returns:
+            Result dict with session_id, message_count, and added count.
+        """
+        ...
+
     # ============= Pack =============
 
     @abstractmethod

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -439,6 +439,35 @@ class AsyncHTTPClient(BaseClient):
         response_data = self._handle_response_data(response)
         return self._attach_telemetry(response_data.get("result"), response_data)
 
+    async def batch_add_messages(
+        self,
+        session_id: str,
+        messages: list[dict],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Add multiple messages to a session in a single request.
+
+        Args:
+            session_id: Session ID
+            messages: List of message dicts, each with "role" and optionally
+                      "content", "parts", "created_at", "role_id".
+            telemetry: Whether to attach operation telemetry data to the result.
+
+        Returns:
+            Result dict with session_id, message_count, and added count.
+        """
+        telemetry = self._validate_telemetry(telemetry)
+        payload: Dict[str, Any] = {"messages": messages}
+        if telemetry is not False:
+            payload["telemetry"] = telemetry
+
+        response = await self._http.post(
+            f"/api/v1/sessions/{session_id}/messages/batch",
+            json=payload,
+        )
+        response_data = self._handle_response_data(response)
+        return self._attach_telemetry(response_data.get("result"), response_data)
+
     async def add_skill(
         self,
         data: Any,

--- a/openviking_cli/client/sync_http.py
+++ b/openviking_cli/client/sync_http.py
@@ -149,6 +149,31 @@ class SyncHTTPClient:
             )
         )
 
+    def batch_add_messages(
+        self,
+        session_id: str,
+        messages: list[dict],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Add multiple messages to a session in a single request.
+
+        Args:
+            session_id: Session ID
+            messages: List of message dicts, each with "role" and optionally
+                      "content", "parts", "created_at", "role_id".
+            telemetry: Whether to attach operation telemetry data to the result.
+
+        Returns:
+            Result dict with session_id, message_count, and added count.
+        """
+        return run_async(
+            self._async_client.batch_add_messages(
+                session_id,
+                messages,
+                telemetry,
+            )
+        )
+
     def get_task(self, task_id: str) -> Optional[Dict[str, Any]]:
         """Query background task status."""
         return run_async(self._async_client.get_task(task_id))


### PR DESCRIPTION
## Description

新增 `POST /api/v1/sessions/{session_id}/messages/batch` 接口，支持单次请求添加多条消息。

优化点：
- 单次 HTTP 请求替代 N 次往返
- `_append_messages` 批量写入 JSONL，避免每条消息 open→write→close
- 统一 `add_messages` 入口，`add_message` 内部调 `add_messages([1条])`，消除单条/批量两套逻辑

## Related Issue


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- **`openviking/session/session.py`**：新增 `add_messages(specs)` 批量入口和 `_append_messages(msgs)` 内部方法，统一处理消息追加 + JSONL 批量写入 + meta 保存；`add_message` 恢复上游原始签名，内部调 `add_messages`；删除 `_append_message`、`_append_to_jsonl`、`_defer` 参数、`_pending_messages`、`flush_pending_messages`
- **`openviking/server/routers/sessions.py`**：新增 `BatchAddMessageRequest`（上限 100 条）、`batch_add_messages` 端点；提取 `_resolve_message_parts()` 消除重复代码；两个端点统一调 `session.add_messages`
- **`openviking_cli/client/base.py`**：新增 `batch_add_messages` 抽象方法
- **`openviking_cli/client/http.py`**：新增 `batch_add_messages` 异步实现
- **`openviking_cli/client/sync_http.py`**：新增 `batch_add_messages` 同步封装
- **`openviking/client/session.py`**：新增 `batch_add_messages` 封装方法
- **`openviking/integrations/langchain/history.py`**：`add_messages()` 改用批量接口
- **`crates/ov_cli/src/commands/session.rs`**：`add_memory` 内部消息添加改用 `POST /messages/batch`

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

远程服务器，100 条消息性能对比：

<img width="519" height="310" alt="image" src="https://github.com/user-attachments/assets/36a541d3-82ea-4a31-ba16-3baf3c714e69" />


## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

无

## Additional Notes

- 批量大小上限 100 条（`max_length=100`），超过需分批调用
- 接口完全向后兼容，原有 `add_message` 单条接口不受影响
- `add_message` 恢复为上游原始签名，不含任何新增参数

用法示例：

```bash
# HTTP API
curl -X POST http://localhost:8000/api/v1/sessions/{session_id}/messages/batch \
  -H "Content-Type: application/json" \
  -d '{"messages": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}]}'
```

```bash
# CLI
ov add-memory '[{"role":"user","content":"Hello"},{"role":"assistant","content":"Hi"}]'
```

```python
# Python 客户端
from openviking_cli.client.sync_http import SyncHTTPClient

client = SyncHTTPClient(base_url="http://localhost:8000")
client.batch_add_messages(
    session_id="your-session-id",
    messages=[{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}],
)
```