### PR TITLE
fix(cli): preserve component status profile output

### DIFF
--- a/crates/ov_cli/src/output.rs
+++ b/crates/ov_cli/src/output.rs
@@ -101,11 +101,6 @@ fn print_table<T: Serialize>(result: T, compact: bool) {
                 return;
             }
 
-            if let Some(rendered) = value_to_table_with_profile(&value, compact) {
-                println!("{}", rendered);
-                return;
-            }
-
             // Rule 5: ComponentStatus (name + is_healthy + status)
             if obj.contains_key("name")
                 && obj.contains_key("is_healthy")
@@ -118,7 +113,10 @@ fn print_table<T: Serialize>(result: T, compact: bool) {
                 };
                 let name = obj["name"].as_str().unwrap_or("");
                 let status = obj["status"].as_str().unwrap_or("");
-                println!("[{}] ({})\n{}", name, health, status);
+                println!(
+                    "{}",
+                    append_profile_section(format!("[{}] ({})\n{}", name, health, status), obj)
+                );
                 return;
             }
 
@@ -151,6 +149,11 @@ fn print_table<T: Serialize>(result: T, compact: bool) {
                     }
                 }
                 println!("{}", append_profile_section(lines.join("\n"), obj));
+                return;
+            }
+
+            if let Some(rendered) = value_to_table_with_profile(&value, compact) {
+                println!("{}", rendered);
                 return;
             }
 


### PR DESCRIPTION
## Description

修复 Rust CLI 表格输出中带 `profile` 字段的组件状态渲染顺序，避免专用的 ComponentStatus/SystemStatus 展示被通用 profile 表格渲染提前接管。

## Related Issue

无

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 将通用 `value_to_table_with_profile` 渲染逻辑移动到 ComponentStatus/SystemStatus 专用格式之后
- 为 ComponentStatus 专用输出追加 `profile` section，保持 profiling 信息不丢失
- 保留普通对象和列表对象已有的 profile 输出路径

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

本地执行：

- `cargo test -p ov_cli`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用

## Additional Notes

`cargo test -p ov_cli` 通过，运行过程中仍有仓库已有的 dead_code / lifetime 相关 warning，本次变更未新增 warning。
