### PR TITLE
docs(api): document add_messages batch endpoint

### DIFF
--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -700,6 +700,78 @@ ov session add-message a1b2c3d4 --role user --content "How do I authenticate use
 }
 ```
 
+### add_messages()
+
+#### 1. API Implementation Introduction
+
+Add multiple messages to the session in a single request. Each message follows the same format as `add_message()`, supporting both simple text mode and Parts mode. Batching replaces N round-trips with a single HTTP request and a single batched JSONL write. Missing sessions are auto-created on first add.
+
+**Code Entries:**
+- `openviking/session/session.py:Session.add_messages()` - Core implementation
+- `openviking/server/routers/sessions.py:batch_add_messages()` - HTTP route
+- `openviking_cli/client/base.py:BaseClient.batch_add_messages()` - Python SDK
+
+#### 2. Interface and Parameter Description
+
+**Parameters**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| session_id | str | Yes | - | Session ID |
+| messages | List[dict] | Yes | - | List of up to 100 messages. Each item accepts the same fields as `add_message()`: `role` (required), and `content`, `parts`, `created_at`, `role_id` (optional) |
+
+#### 3. Usage Examples
+
+**HTTP API**
+
+```http
+POST /api/v1/sessions/{session_id}/messages/batch
+```
+
+```bash
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/messages/batch \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "messages": [
+      {"role": "user", "content": "How do I authenticate users?"},
+      {"role": "assistant", "content": "You can configure OAuth in the settings."}
+    ]
+  }'
+```
+
+**Python SDK**
+
+```python
+import openviking as ov
+
+client = ov.Client(base_url="http://localhost:1933", api_key="your-key")
+
+await client.batch_add_messages(
+    session_id="a1b2c3d4",
+    messages=[
+        {"role": "user", "content": "How do I authenticate users?"},
+        {"role": "assistant", "content": "You can configure OAuth in the settings."},
+    ]
+)
+```
+
+**Response Example**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "session_id": "a1b2c3d4",
+    "message_count": 2,
+    "added": 2
+  },
+  "time": 0.1
+}
+```
+
+---
+
 ---
 
 ### used()

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -700,6 +700,78 @@ ov session add-message a1b2c3d4 --role user --content "How do I authenticate use
 }
 ```
 
+### add_messages()
+
+#### 1. API 实现介绍
+
+在单次请求中向 session 添加多条消息。每条消息的格式与 `add_message()` 相同，同时支持简单文本模式和 Parts 模式。批量写入用单次 HTTP 请求和单次批量 JSONL 写入替代 N 次往返。首次添加时会自动创建不存在的 session。
+
+**代码入口：**
+- `openviking/session/session.py:Session.add_messages()` - 核心实现
+- `openviking/server/routers/sessions.py:batch_add_messages()` - HTTP 路由
+- `openviking_cli/client/base.py:BaseClient.batch_add_messages()` - Python SDK
+
+#### 2. 接口和参数说明
+
+**参数**
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| session_id | str | 是 | - | Session ID |
+| messages | List[dict] | 是 | - | 最多 100 条消息的列表。每一项接受与 `add_message()` 相同的字段：`role`（必填），以及 `content`、`parts`、`created_at`、`role_id`（可选） |
+
+#### 3. 使用示例
+
+**HTTP API**
+
+```http
+POST /api/v1/sessions/{session_id}/messages/batch
+```
+
+```bash
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/messages/batch \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "messages": [
+      {"role": "user", "content": "How do I authenticate users?"},
+      {"role": "assistant", "content": "You can configure OAuth in the settings."}
+    ]
+  }'
+```
+
+**Python SDK**
+
+```python
+import openviking as ov
+
+client = ov.Client(base_url="http://localhost:1933", api_key="your-key")
+
+await client.batch_add_messages(
+    session_id="a1b2c3d4",
+    messages=[
+        {"role": "user", "content": "How do I authenticate users?"},
+        {"role": "assistant", "content": "You can configure OAuth in the settings."},
+    ]
+)
+```
+
+**响应示例**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "session_id": "a1b2c3d4",
+    "message_count": 2,
+    "added": 2
+  },
+  "time": 0.1
+}
+```
+
+---
+
 ---
 
 ### used()


### PR DESCRIPTION
PR #2213 added `POST /api/v1/sessions/{session_id}/messages/batch` and the `batch_add_messages()` SDK method, but `docs/{en,zh}/api/05-sessions.md` only document `add_message()` (single). This adds a parallel `add_messages()` section (EN + ZH) covering the HTTP endpoint, Python SDK usage, parameters (100-message cap, same per-message fields as `add_message()`), and the `added` count in the response.

Source: #2213 (sponge225). Verified params/route/SDK signature against `openviking/server/routers/sessions.py` (`BatchAddMessageRequest`, `batch_add_messages`) and `openviking_cli/client/{base,http,sync_http}.py`.