### PR TITLE
feat(memory): tighten trajectory operation boundaries

### DIFF
--- a/openviking/prompts/templates/memory/trajectories.yaml
+++ b/openviking/prompts/templates/memory/trajectories.yaml
@@ -19,7 +19,7 @@ fields:
       Must be written in {{ language }}.
       {% if language == 'en' %}Use lowercase snake_case, max 5 words.{% else %}Use a concise noun phrase, max 15 characters.{% endif %}
       Do not create near-duplicate names for the same task.
-      Good: "duplicate_request_resolution", "pytest_asyncio_cancel_hang_fix", "重复请求处理".
+      Good: "duplicate_request_resolution", "async_task_hang_fix", "重复请求处理".
     merge_op: immutable
 
   - name: outcome
@@ -34,12 +34,12 @@ fields:
       Procedure-like operation contract in EXACTLY this format:
 
       # <trajectory_name>
-      - Domain: <task domain or product area, e.g. customer support, commerce operations, software tooling>
+      - Domain: <task domain, execution area, or system area>
       - Trigger: <the reusable user intent or task situation — one sentence>
       - Operation Intent:
-        - Family: <exactly one of read_verify_only, create_new_object, update_existing_object, cancel_existing_object, replace_existing_object, attribute_append_remove, compensation_or_refund, read_then_transfer, final_response_only>
-        - Primary object: <the object whose state or lifecycle this record is about>
-        - Target object/lifecycle: <the intended final state, lifecycle transition, or handoff target>
+        - Family: <exactly one of read_verify_only, create_new_object, update_existing_object, close_or_deactivate_object, replace_existing_object, attribute_append_remove, corrective_adjustment, handoff_after_verification, final_response_only>
+        - Primary object: <the narrowest object or sub-object whose state, membership, or lifecycle this record changes, verifies, creates, closes/deactivates, replaces, hands off, or reports>
+        - Target object/lifecycle: <the single intended final state, lifecycle transition, handoff target, or read result for that primary object>
       - Preconditions:
         1. <state, identity, policy, tool-observation, or confirmation prerequisite>
         2. <...>
@@ -59,19 +59,24 @@ fields:
       - Negative Applicability:
         - <nearby intent, object lifecycle, policy state, permission state, or target object where this memory must not be applied>
       - Result: <final outcome and important side effects — one sentence>
-      - Evidence: <brief generalized source note from this session, including success/failure/partial status>
+      - Evidence: <brief generalized source note from this session, including success/failure/partial status, without digits, raw identifiers, personal names, contact values, exact amounts, exact counts, exact dates, locations, paths, or other instance-local values>
 
       Rules:
       - Write for future agent execution. Capture the reusable contract: trigger -> prerequisites -> read/verify -> confirm if needed -> one primary write, handoff, or final response -> verify/communicate result.
-      - Extract one record per primary user intent, object, and lifecycle transition. Split separable intents, pivots, follow-ups, enabling writes, and final writes; omit low-value side work.
-      - Family must be exactly one listed enum value. Do not invent compound labels. Use read_then_transfer when the reusable path ends in handoff after verification.
+      - Extract one record per reusable operation boundary: one primary user intent, one primary tool-effect target, and one lifecycle or reporting boundary. The boundary is narrower than the Family enum: two actions with the same Family still need separate records when they affect different sub-objects, collections, lifecycle states, write-field provenance, or continuation policies.
+      - Split separable intents, pivots, follow-ups, prerequisite-only reads, state-changing actions, and final user-visible responses when they are independently reusable; omit low-value side work. The split rule is structural: separate by target, effect, provenance, lifecycle, and continuation boundary, not by any domain-specific workflow name.
+      - Do not create an additional umbrella record that summarizes multiple separately reusable operations from the same session. If a session contains several independent tool-effect targets, output the separate target-level records and omit the broad whole-session summary.
+      - Do not combine multiple state-changing tool effects in one record when they affect different primary targets, sub-objects, collections, lifecycle transitions, write-field provenance scopes, or continuation policies. Mention cross-boundary ordering only as prerequisite, boundary, or negative applicability.
+      - A coordinated multi-target request is not one reusable procedure record. Output target-level records and put shared confirmation, dependency, or ordering constraints only in Preconditions, Applicability Boundary, Anti-patterns, or Negative Applicability.
+      - Use replace_existing_object only for an atomic replacement operation on one primary object boundary. If the session implements replacement through separate tool effects that close/deactivate one object and create another object, emit separate close/deactivate and create records; do not set Primary object to a joined source-and-target phrase.
+      - Family must be exactly one listed enum value. Do not invent compound labels. Use handoff_after_verification when the reusable path ends in handoff after verification.
       - Procedure must describe only the primary operation in this record. Mention other operations only as prerequisites, consequences, boundaries, or negative applicability.
-      - Stop each record at its family boundary: update_existing_object stops after update verification, cancel_existing_object after cancellation verification, create_new_object after creation verification, replace_existing_object after replacement verification, read_then_transfer after handoff verification.
+      - Stop each record at its family boundary: update_existing_object stops after update verification, close_or_deactivate_object after closure/deactivation verification, create_new_object after creation verification, replace_existing_object after replacement verification, handoff_after_verification after handoff verification.
       - Do not include a second lifecycle-changing write in the Procedure, Target, Result, or Evidence of the same record, even when that later write happened immediately after the first one.
       - Do not let a later operation in the same session rename, narrow, or extend this record's Trigger, Target, Procedure, Result, or Evidence. Put the later operation in a separate record.
       - Put immutable facts and write/user-visible field sources in their dedicated sections. Do not copy fields from a previous/source object into a new/replacement object without current user request or explicit confirmation.
       - Keep blocked actions and failed lessons in Anti-patterns / Negative Applicability / Evidence, not as positive procedure steps. Do not invent a corrected path when the session did not demonstrate one.
-      - Generalize the session: remove raw identifiers, names, contact values, exact dates, case-specific amounts, exact routes/locations, product names, and raw tool payloads. Keep tool names only when they are part of the reusable path.
+      - Generalize the session: remove raw identifiers, names, contact values, exact dates, case-specific amounts/counts, exact locations/paths, product names, and raw tool payloads. Use semantic placeholders such as requested quantity, selected object, calculated amount, source object, target object, or applicable policy instead of copying concrete values. Keep tool names only when they are part of the reusable path. Evidence must also stay generalized and should not contain digits; do not use it to preserve instance-local ids, names, counts, amounts, locations, or dates.
       - Use exactly the title, Domain line, and 11 labels above in this exact order.
       - Trigger, Result, and Evidence are ONE sentence each.
       - No extra headings, free paragraphs, or closing remarks.


### PR DESCRIPTION
## Summary
This PR narrows the agent trajectory memory prompt so extracted trajectory cards are split by reusable operation boundaries rather than broad session workflows.

- use more domain-neutral operation family names (`close_or_deactivate_object`, `handoff_after_verification`, `corrective_adjustment`)
- define the primary object as the narrowest object/sub-object affected by the reusable operation
- require splitting by target, tool effect, provenance, lifecycle/reporting boundary, and continuation policy
- keep multi-target / multi-lifecycle sessions as separate target-level cards instead of one umbrella trajectory
- strengthen evidence/generalization rules to avoid instance-local values

## Why
Agent trajectory memories are later used as execution guidance. If one card mixes adjacent operations, future retrieval can over-apply the wrong lifecycle or action boundary. This keeps the default protocol general: it does not mention TAU-2, airline/retail, task ids, or benchmark-specific rules.

## Tests
- `PATH=/Users/bytedance/.local/bin:$PATH uv run python - <<'PY' ... yaml.safe_load ...`
- `HOME="$TMP_HOME" PATH=/Users/bytedance/.local/bin:$PATH uv run python - <<'PY' ... MemoryTypeRegistry(load_schemas=True) ...`
- `HOME="$TMP_HOME" PATH=/Users/bytedance/.local/bin:$PATH uv run pytest tests/test_prompt_manager.py -q` (`13 passed`)
- `git diff --check -- openviking/prompts/templates/memory/trajectories.yaml`