### PR TITLE
fix(web-studio): 支持按 agent 预览原始记忆

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -62,6 +62,7 @@ async def read(
     uri: str = Query(..., description="Viking URI"),
     offset: int = Query(0, description="Starting line number (0-indexed)"),
     limit: int = Query(-1, description="Number of lines to read, -1 means read to end"),
+    raw: bool = Query(False, description="Return raw stored content without memory-field cleanup"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Read file content (L2)."""
@@ -78,19 +79,20 @@ async def read(
             raise NotFoundError(uri, "file")
         raise
 
-    # 清理MEMORY_FIELDS隐藏注释（v2记忆加工过程中的临时内部数据，不暴露给外部用户）
-    if isinstance(result, bytes):
-        text = result.decode("utf-8")
-    elif isinstance(result, str):
-        text = result
-    else:
-        text = None
+    if not raw:
+        # 清理MEMORY_FIELDS隐藏注释（v2记忆加工过程中的临时内部数据，不暴露给外部用户）
+        if isinstance(result, bytes):
+            text = result.decode("utf-8")
+        elif isinstance(result, str):
+            text = result
+        else:
+            text = None
 
-    if text:
-        from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+        if text:
+            from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 
-        mf = MemoryFileUtils.read(text)
-        result = mf.content
+            mf = MemoryFileUtils.read(text)
+            result = mf.content
 
     return Response(status="ok", result=result)
 

--- a/web-studio/src/components/connection-dialog.tsx
+++ b/web-studio/src/components/connection-dialog.tsx
@@ -95,7 +95,7 @@ export function ConnectionDialog() {
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="grid flex-1 content-start gap-3">
-                    <div className="grid gap-3 md:grid-cols-2">
+                    <div className="grid gap-3 md:grid-cols-3">
                       <Field>
                         <FieldLabel htmlFor="ov-account-id">
                           {t('fields.accountId.label', { ns: 'connection' })}
@@ -131,6 +131,26 @@ export function ConnectionDialog() {
                               setDraft((current) => ({
                                 ...current,
                                 userId: event.target.value,
+                              }))
+                            }
+                          />
+                        </FieldContent>
+                      </Field>
+                      <Field>
+                        <FieldLabel htmlFor="ov-agent-id">
+                          {t('fields.agentId.label', { ns: 'connection' })}
+                        </FieldLabel>
+                        <FieldContent>
+                          <Input
+                            id="ov-agent-id"
+                            placeholder={t('fields.agentId.placeholder', {
+                              ns: 'connection',
+                            })}
+                            value={draft.agentId}
+                            onChange={(event) =>
+                              setDraft((current) => ({
+                                ...current,
+                                agentId: event.target.value,
                               }))
                             }
                           />
@@ -209,4 +229,3 @@ export function ConnectionDialog() {
     </Dialog>
   )
 }
-

--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -8,6 +8,7 @@ import type { ServerMode } from './use-server-mode'
 
 export type ConnectionDraft = {
   accountId: string
+  agentId: string
   apiKey: string
   baseUrl: string
   userId: string
@@ -33,6 +34,7 @@ const CONNECTION_STORAGE_KEY = 'ov_console_connection'
 
 const DEFAULT_CONNECTION: ConnectionDraft = {
   accountId: '',
+  agentId: 'web-studio',
   apiKey: '',
   baseUrl: ovClient.getOptions().baseUrl,
   userId: '',
@@ -82,6 +84,7 @@ function persistConnection(connection: ConnectionDraft): void {
 function normalizeConnectionDraft(connection: ConnectionDraft): ConnectionDraft {
   return {
     accountId: connection.accountId.trim(),
+    agentId: connection.agentId.trim() || DEFAULT_CONNECTION.agentId,
     apiKey: connection.apiKey.trim(),
     baseUrl: normalizeBaseUrl(connection.baseUrl),
     userId: connection.userId.trim(),
@@ -94,6 +97,7 @@ function applyConnection(connection: ConnectionDraft): void {
   })
   ovClient.setConnection({
     accountId: connection.accountId,
+    agentId: connection.agentId,
     apiKey: connection.apiKey,
     userId: connection.userId,
   })
@@ -119,7 +123,11 @@ export function summarizeConnectionIdentity(
     return { labelKey: 'identitySummary.devImplicit' }
   }
 
-  const segments = [connection.accountId, connection.userId].filter(Boolean)
+  const segments = [
+    connection.accountId,
+    connection.userId,
+    connection.agentId,
+  ].filter(Boolean)
   if (!segments.length) {
     return { labelKey: 'identitySummary.unset' }
   }

--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -83,6 +83,10 @@ const en = {
         label: 'Account',
         placeholder: 'default',
       },
+      agentId: {
+        label: 'Agent',
+        placeholder: 'web-studio',
+      },
       apiKey: {
         label: 'API Key',
         placeholder: 'Enter X-API-Key or Bearer token',

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -83,6 +83,10 @@ const zhCN = {
         label: 'Account',
         placeholder: 'default',
       },
+      agentId: {
+        label: 'Agent',
+        placeholder: 'web-studio',
+      },
       apiKey: {
         label: 'API Key',
         placeholder: '输入 X-API-Key 或 Bearer token',

--- a/web-studio/src/lib/ov-client/client.ts
+++ b/web-studio/src/lib/ov-client/client.ts
@@ -157,6 +157,7 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
       options.connection?.apiKey ??
       readSessionStorage(runtimeOptions.apiKeyStorageKey),
     accountId: options.connection?.accountId ?? '',
+    agentId: options.connection?.agentId ?? WEB_STUDIO_AGENT_ID,
     userId: options.connection?.userId ?? '',
   }
 
@@ -179,7 +180,7 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
     setOptionalHeader(headers, 'X-API-Key', connection.apiKey)
     setOptionalHeader(headers, 'X-OpenViking-Account', connection.accountId)
     setOptionalHeader(headers, 'X-OpenViking-User', connection.userId)
-    headers.set('X-OpenViking-Agent', WEB_STUDIO_AGENT_ID)
+    headers.set('X-OpenViking-Agent', connection.agentId || WEB_STUDIO_AGENT_ID)
 
     config.headers = headers
     maybeInjectTelemetry(config, runtimeOptions.defaultTelemetry)
@@ -252,6 +253,7 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
     connection = {
       apiKey: '',
       accountId: '',
+      agentId: WEB_STUDIO_AGENT_ID,
       userId: '',
     }
     persistApiKey()

--- a/web-studio/src/lib/ov-client/types.ts
+++ b/web-studio/src/lib/ov-client/types.ts
@@ -7,6 +7,7 @@ export const DEFAULT_API_KEY_STORAGE_KEY = 'ov_console_api_key'
 export interface OvConnectionState {
   apiKey: string
   accountId: string
+  agentId: string
   userId: string
 }
 

--- a/web-studio/src/lib/sessions/api.ts
+++ b/web-studio/src/lib/sessions/api.ts
@@ -123,7 +123,7 @@ function buildFetchHeaders(): Record<string, string> {
   if (conn.apiKey) headers['X-API-Key'] = conn.apiKey
   if (conn.accountId) headers['X-OpenViking-Account'] = conn.accountId
   if (conn.userId) headers['X-OpenViking-User'] = conn.userId
-  headers['X-OpenViking-Agent'] = 'web-studio'
+  headers['X-OpenViking-Agent'] = conn.agentId || 'web-studio'
   return headers
 }
 

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -391,6 +391,41 @@ function escapeHtml(raw: string): string {
   return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
+const MEMORY_FIELDS_RE = /<!--\s*MEMORY_FIELDS\s*([\s\S]*?)\s*-->/
+
+function parseMemoryFields(content: string): Record<string, unknown> | null {
+  const match = MEMORY_FIELDS_RE.exec(content)
+  if (!match?.[1]) return null
+
+  try {
+    const parsed = JSON.parse(match[1].trim()) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function stripMemoryFields(content: string): string {
+  return content.replace(MEMORY_FIELDS_RE, '').trim()
+}
+
+function memoryFieldsDisplayContent(content: string): string {
+  const fields = parseMemoryFields(content)
+  if (!fields) return content
+
+  const body = stripMemoryFields(content)
+  if (body) return body
+
+  const fieldContent = fields.content
+  if (typeof fieldContent === 'string' && fieldContent.trim()) {
+    return fieldContent.trim()
+  }
+
+  return JSON.stringify(fields, null, 2)
+}
+
 function textFromReactNode(node: ReactNode): string {
   if (typeof node === 'string' || typeof node === 'number') {
     return String(node)
@@ -861,11 +896,21 @@ export function FilePreview({
   showCloseButton = true,
 }: FilePreviewProps) {
   const { t } = useTranslation('resources')
-  const previewQuery = useVikingFilePreview(file, {
-    maxAutoReadBytes: 2 * 1024 * 1024,
-    defaultReadLimit: -1,
-  })
+  const previewQuery = useVikingFilePreview(
+    file,
+    {
+      maxAutoReadBytes: 2 * 1024 * 1024,
+      defaultReadLimit: -1,
+    },
+    {
+      raw: true,
+    },
+  )
   const preview = previewQuery.preview
+  const displayContent = useMemo(
+    () => memoryFieldsDisplayContent(preview?.content || ''),
+    [preview?.content],
+  )
   const directoryPreview = useDirectoryPreview(file)
   const [markdownMode, setMarkdownMode] = useState<'preview' | 'source'>(
     'preview',
@@ -918,7 +963,7 @@ export function FilePreview({
       return
     }
 
-    const content = preview.content || ''
+    const content = displayContent || ''
     if (!content) {
       setHighlightedCodeHtml('')
       return
@@ -945,7 +990,7 @@ export function FilePreview({
     return () => {
       cancelled = true
     }
-  }, [preview, file?.name, needsHighlight])
+  }, [preview, file?.name, needsHighlight, displayContent])
 
   useEffect(() => {
     let alive = true
@@ -1316,7 +1361,7 @@ export function FilePreview({
                     },
                   }}
                 >
-                  {preview.content || emptyFileText}
+                  {displayContent || emptyFileText}
                 </ReactMarkdown>
               </article>
             ) : null}
@@ -1331,7 +1376,7 @@ export function FilePreview({
                   dangerouslySetInnerHTML={{
                     __html:
                       highlightedCodeHtml ||
-                      escapeHtml(preview.content || emptyFileText),
+                      escapeHtml(displayContent || emptyFileText),
                   }}
                 />
               </pre>
@@ -1344,7 +1389,9 @@ export function FilePreview({
                 <code
                   className="hljs block"
                   dangerouslySetInnerHTML={{
-                    __html: highlightedCodeHtml || escapeHtml(emptyFileText),
+                    __html:
+                      highlightedCodeHtml ||
+                      escapeHtml(displayContent || emptyFileText),
                   }}
                 />
               </pre>
@@ -1353,7 +1400,7 @@ export function FilePreview({
             {!previewQuery.isLoading &&
             preview?.fileType === 'jsonl' &&
             preview.shouldAutoRead ? (
-              <JsonlPreview content={preview.content || ''} />
+              <JsonlPreview content={displayContent || ''} />
             ) : null}
 
             {!previewQuery.isLoading &&
@@ -1364,7 +1411,7 @@ export function FilePreview({
             preview.fileType !== 'code' &&
             preview.shouldAutoRead ? (
               <pre className="whitespace-pre-wrap break-words text-xs leading-6">
-                {preview.content || emptyFileText}
+                {displayContent || emptyFileText}
               </pre>
             ) : null}
           </div>

--- a/web-studio/src/routes/resources/-hooks/viking-fm.ts
+++ b/web-studio/src/routes/resources/-hooks/viking-fm.ts
@@ -94,8 +94,9 @@ export function useVikingFilePreview(
     () => ({
       offset: readOptions.offset ?? 0,
       limit: readOptions.limit ?? defaultReadLimit,
+      raw: readOptions.raw,
     }),
-    [readOptions.offset, readOptions.limit, defaultReadLimit],
+    [readOptions.offset, readOptions.limit, readOptions.raw, defaultReadLimit],
   )
 
   const autoRead = useMemo(

--- a/web-studio/src/routes/resources/-lib/api.ts
+++ b/web-studio/src/routes/resources/-lib/api.ts
@@ -123,7 +123,8 @@ export async function fetchFileContent(
           uri,
           offset,
           limit,
-        },
+          raw: options.raw,
+        } as Parameters<typeof getContentRead>[0]['query'] & { raw?: boolean },
       }),
     )
 

--- a/web-studio/src/routes/resources/-types/viking-fm.ts
+++ b/web-studio/src/routes/resources/-types/viking-fm.ts
@@ -41,6 +41,7 @@ export interface VikingTreeQueryOptions {
 export interface VikingReadQueryOptions {
   offset?: number
   limit?: number
+  raw?: boolean
 }
 
 export interface VikingListResult {


### PR DESCRIPTION
## Description

修复 Web Studio 在查看记忆文件时可能显示为空的问题，并允许控制台配置实际使用的 Agent ID，避免请求固定落到 `web-studio` agent。

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 为 `/api/v1/content/read` 增加 `raw=true` 选项，默认行为保持清理 `MEMORY_FIELDS` 不变。
- Web Studio 文件预览改为读取 raw 内容，并在正文为空时解析 `MEMORY_FIELDS` 展示记忆字段。
- 连接配置增加 Agent ID，并将 `X-OpenViking-Agent` 按配置透传到普通请求和 session 请求。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已执行：

- `npm run lint`，通过；仅保留既有 `file-preview.tsx` i18n literal string warnings。
- `npm run build`，通过；仅保留既有 chunk size warning。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

本次改动不改变 `/content/read` 的默认返回语义；只有显式传入 `raw=true` 时才返回原始存储内容。
