### PR TITLE
fix(fs): normalize AGFS error handling

### DIFF
--- a/openviking/server/error_mapping.py
+++ b/openviking/server/error_mapping.py
@@ -6,10 +6,24 @@ import re
 from typing import Any, Iterator
 
 from openviking.pyagfs.exceptions import (
+    AGFSAlreadyExistsError,
     AGFSClientError,
+    AGFSConfigError,
     AGFSConnectionError,
+    AGFSDirectoryNotEmptyError,
     AGFSHTTPError,
+    AGFSInternalError,
+    AGFSInvalidOperationError,
+    AGFSInvalidPathError,
+    AGFSIoError,
+    AGFSIsADirectoryError,
+    AGFSMountPointNotFoundError,
+    AGFSNetworkError,
+    AGFSNotADirectoryError,
     AGFSNotFoundError,
+    AGFSPermissionDeniedError,
+    AGFSPluginError,
+    AGFSSerializationError,
     AGFSTimeoutError,
 )
 from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
@@ -398,6 +412,10 @@ def _not_found_error(resource: str | None, resource_type: str) -> NotFoundError:
     return NotFoundError(resource or "", resource_type)
 
 
+def _resource_details(resource: str | None) -> dict[str, str] | None:
+    return {"resource": resource} if resource else None
+
+
 def map_exception(
     exc: Exception,
     *,
@@ -454,6 +472,34 @@ def map_exception(
             )
         if exc.status_code in {500, 502, 503, 504}:
             return UnavailableError("storage backend", reason=str(exc))
+    if isinstance(exc, AGFSPermissionDeniedError):
+        return PermissionDeniedError(str(exc), resource=resource)
+    if isinstance(exc, AGFSAlreadyExistsError):
+        return ConflictError(str(exc), resource=resource)
+    if isinstance(exc, AGFSInvalidPathError):
+        message = str(exc)
+        return InvalidURIError(resource or message, message)
+    if isinstance(exc, AGFSNotADirectoryError):
+        return FailedPreconditionError(str(exc), details=_resource_details(resource))
+    if isinstance(exc, AGFSIsADirectoryError):
+        return InvalidArgumentError(str(exc), details=_resource_details(resource))
+    if isinstance(exc, AGFSDirectoryNotEmptyError):
+        return FailedPreconditionError(str(exc), details=_resource_details(resource))
+    if isinstance(exc, AGFSInvalidOperationError):
+        return InvalidArgumentError(str(exc), details=_resource_details(resource))
+    if isinstance(
+        exc,
+        (
+            AGFSConfigError,
+            AGFSInternalError,
+            AGFSIoError,
+            AGFSMountPointNotFoundError,
+            AGFSNetworkError,
+            AGFSPluginError,
+            AGFSSerializationError,
+        ),
+    ):
+        return UnavailableError("storage backend", reason=str(exc))
     if isinstance(exc, AGFSClientError):
         message = str(exc)
         if is_not_found_error(exc):
@@ -462,12 +508,21 @@ def map_exception(
             return InvalidURIError(resource or message, message)
         lowered = message.lower()
         if "not a directory" in lowered:
-            details = {"resource": resource} if resource else None
-            return FailedPreconditionError(message, details=details)
+            return FailedPreconditionError(message, details=_resource_details(resource))
+        if "is a directory" in lowered:
+            return InvalidArgumentError(message, details=_resource_details(resource))
+        if "directory not empty" in lowered:
+            return FailedPreconditionError(message, details=_resource_details(resource))
         if "permission denied" in lowered:
             return PermissionDeniedError(message, resource=resource)
         if "already exists" in lowered:
             return ConflictError(message, resource=resource)
+        if (
+            "invalid operation" in lowered
+            or "regex parse error" in lowered
+            or "invalid regular expression" in lowered
+        ):
+            return InvalidArgumentError(message, details=_resource_details(resource))
         if "timeout" in lowered or "connection refused" in lowered:
             return UnavailableError("storage backend", reason=message)
     upstream_mapped = _map_upstream_api_error(exc)

--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -16,6 +16,7 @@ from openviking.server.auth import (
     require_role,
 )
 from openviking.server.dependencies import get_service
+from openviking.server.error_mapping import map_exception
 from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.server.telemetry import run_operation
@@ -73,10 +74,9 @@ async def read(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
 
     if not raw:
@@ -110,10 +110,9 @@ async def abstract(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     return Response(status="ok", result=result)
 
@@ -131,10 +130,9 @@ async def overview(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     return Response(status="ok", result=result)
 
@@ -152,10 +150,9 @@ async def download(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
 
     # Try to get filename from stat

--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -50,10 +50,9 @@ async def ls(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     return Response(status="ok", result=result)
 
@@ -87,10 +86,9 @@ async def tree(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     return Response(status="ok", result=result)
 
@@ -110,10 +108,9 @@ async def stat(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     except Exception as exc:
         mapped = map_exception(exc, resource=uri)
@@ -141,10 +138,9 @@ async def mkdir(
     try:
         await service.fs.mkdir(uri, ctx=_ctx, description=request.description)
     except AGFSClientError as e:
-        # Handle common AGFS errors
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     return Response(status="ok", result={"uri": uri})
 
@@ -164,9 +160,9 @@ async def rm(
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(uri, "file")
+        mapped = map_exception(e, resource=uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     except Exception as exc:
         mapped = map_exception(exc, resource=uri)
@@ -202,10 +198,9 @@ async def mv(
     except AGFSNotFoundError:
         raise NotFoundError(from_uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(from_uri, "file")
+        mapped = map_exception(e, resource=from_uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     except Exception as exc:
         mapped = map_exception(exc, resource=from_uri)

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -232,10 +232,9 @@ async def grep(
     except AGFSNotFoundError:
         raise NotFoundError(resolved_uri, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(resolved_uri, "file")
+        mapped = map_exception(e, resource=resolved_uri, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     except Exception as exc:
         mapped = map_exception(exc, resource=resolved_uri, resource_type="file")
@@ -260,10 +259,9 @@ async def glob(
     except AGFSNotFoundError:
         raise NotFoundError(resolved_uri or request.pattern, "file")
     except AGFSClientError as e:
-        # Fallback for older versions without typed exceptions
-        err_msg = str(e).lower()
-        if "not found" in err_msg or "no such file or directory" in err_msg:
-            raise NotFoundError(resolved_uri or request.pattern, "file")
+        mapped = map_exception(e, resource=resolved_uri or request.pattern, resource_type="file")
+        if mapped is not None:
+            raise mapped from e
         raise
     except Exception as exc:
         mapped = map_exception(exc, resource=request.uri, resource_type="file")

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -559,6 +559,27 @@ class VikingFS:
                 raise
             raise FileNotFoundError(f"mv source not found: {old_uri}") from exc
 
+        if not is_dir:
+            if new_uri.rstrip("/") != new_uri:
+                raise InvalidArgumentError(
+                    f"mv destination for a file must include the target file name: {new_uri}",
+                    details={"from_uri": old_uri, "to_uri": new_uri},
+                )
+            try:
+                destination_stat = await self._async_agfs.stat(new_path)
+            except Exception as exc:
+                if not is_not_found_error(exc):
+                    mapped = map_exception(exc, resource=new_uri)
+                    if mapped is not None:
+                        raise mapped from exc
+                    raise
+            else:
+                if isinstance(destination_stat, dict) and destination_stat.get("isDir", False):
+                    raise InvalidArgumentError(
+                        f"mv destination for a file must include the target file name: {new_uri}",
+                        details={"from_uri": old_uri, "to_uri": new_uri},
+                    )
+
         lock_context = (
             LockContext(
                 get_lock_manager(),
@@ -908,6 +929,20 @@ class VikingFS:
                 else:
                     file_uris.append(entry_uri)
 
+        normalized_uri = self._normalize_uri(uri)
+        if excluded_prefix and (
+            normalized_uri == excluded_prefix or normalized_uri.startswith(excluded_prefix + "/")
+        ):
+            logger.debug(f"Skipping excluded uri during grep: {normalized_uri}")
+            return file_uris
+        try:
+            root_stat = await self.stat(normalized_uri, ctx=ctx)
+        except Exception:
+            return file_uris
+        if not root_stat.get("isDir", False):
+            file_uris.append(normalized_uri)
+            return file_uris
+
         await search_recursive(uri, 0)
         return file_uris
 
@@ -942,15 +977,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> tuple[List[Dict[str, Any]], int]:
         try:
-            self._ensure_access(entry_uri, ctx)
-            path = self._uri_to_path(entry_uri, ctx=ctx)
-            result = await self._async_agfs.read(path, 0, -1)
-            if isinstance(result, bytes):
-                content = result
-            elif result is not None and hasattr(result, "content"):
-                content = result.content
-            else:
-                content = b""
+            content = await self.read(entry_uri, ctx=ctx)
             if isinstance(content, bytes):
                 content = content.decode("utf-8", errors="replace")
 


### PR DESCRIPTION
## Description

本 PR 统一 AGFS 相关异常到 OpenViking API 的结构化错误映射，并修正文件系统操作在若干边界场景下的错误语义。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 扩展 AGFS typed exceptions 和常见 fallback 文案的映射，覆盖权限、冲突、路径非法、目录状态、无效操作和后端不可用等场景。
- 让 content / filesystem / search 路由复用统一的 `map_exception`，减少各接口重复且不完整的 AGFS 错误处理。
- 修正文件 `mv` 到目录式目标时的校验，并让 grep fallback 能正确处理文件根路径和文件读取路径。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已执行：
- `git commit` 触发的 pre-commit hooks：`ruff (legacy alias)` 通过，`ruff format` 通过。

曾尝试：
- `python -m pytest tests/server/test_error_mapping.py tests/storage/test_viking_fs_grep.py tests/misc/test_vikingfs_uri_guard.py`：本地系统 Python 因 `pydantic-core` 版本不匹配未进入用例执行。
- `.venv/bin/python -m pytest tests/server/test_error_mapping.py tests/storage/test_viking_fs_grep.py tests/misc/test_vikingfs_uri_guard.py`：执行到 `29 passed, 5 failed`，随后按要求未继续排查或重跑单测。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

N/A
