### PR TITLE
feat(semantic): batch file summary generation

### DIFF
--- a/openviking/prompts/templates/semantic/file_summary_batch.yaml
+++ b/openviking/prompts/templates/semantic/file_summary_batch.yaml
@@ -1,0 +1,48 @@
+metadata:
+  id: "semantic.file_summary_batch"
+  name: "Batched File Summary Generation"
+  description: "Generate summaries for multiple files in one LLM request"
+  version: "1.0.0"
+  language: "en"
+  category: "semantic"
+
+variables:
+  - name: "files_json"
+    type: "string"
+    description: "JSON array of file summary inputs"
+    required: true
+
+template: |
+  Summarize each file in the following JSON array.
+
+  Each item has:
+  - id: stable identifier that must be copied to the output
+  - name: file name
+  - file_type: code, code_ast, documentation, or other
+  - output_language: language for that file's summary
+  - content: file content or extracted code skeleton
+
+  Files:
+  {{ files_json }}
+
+  Output requirements:
+  - Return only valid JSON. Do not use markdown fences.
+  - Preserve every input id exactly once.
+  - For code files, summarize purpose, key components, dependencies, and role.
+  - For documentation files, summarize purpose, main topics, key sections, and audience.
+  - For other files, summarize what the file is, what it covers, and what it is used for.
+  - Include core keywords useful for semantic search.
+  - Each summary should be 50-200 words.
+
+  JSON schema:
+  {
+    "summaries": [
+      {
+        "id": "same id from input",
+        "summary": "plain text summary"
+      }
+    ]
+  }
+
+llm_config:
+  temperature: 0.0

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -467,9 +467,7 @@ class SemanticDagExecutor:
                 summary_by_path.setdefault(file_path, self._empty_file_summary(file_path))
         finally:
             self._stats.done_nodes += len(file_paths)
-            self._stats.in_progress_nodes = max(
-                0, self._stats.in_progress_nodes - len(file_paths)
-            )
+            self._stats.in_progress_nodes = max(0, self._stats.in_progress_nodes - len(file_paths))
 
         for file_path in file_paths:
             summary_dict = summary_by_path.get(file_path, self._empty_file_summary(file_path))
@@ -489,7 +487,9 @@ class SemanticDagExecutor:
                     )
                     await self._add_vectorize_task(task)
             except Exception as e:
-                logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
+                logger.error(
+                    f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True
+                )
             await self._on_file_done(parent_uri, file_path, summary_dict)
 
     @staticmethod

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -224,13 +224,11 @@ class SemanticDagExecutor:
                 self._schedule_overview(dir_uri)
                 return
 
-            for file_path in file_paths:
-                self._stats.total_nodes += 1
+            if file_paths:
+                self._stats.total_nodes += len(file_paths)
                 # File nodes are scheduled immediately: pending -> in_progress.
-                self._stats.pending_nodes += 1
-                self._stats.pending_nodes = max(0, self._stats.pending_nodes - 1)
-                self._stats.in_progress_nodes += 1
-                asyncio.create_task(self._file_summary_task(dir_uri, file_path))
+                self._stats.in_progress_nodes += len(file_paths)
+                asyncio.create_task(self._file_summary_batch_task(dir_uri, file_paths))
 
             if children_dirs:
                 if self._recursive:
@@ -425,52 +423,78 @@ class SemanticDagExecutor:
 
     async def _file_summary_task(self, parent_uri: str, file_path: str) -> None:
         """Generate file summary and notify parent completion."""
+        await self._file_summary_batch_task(parent_uri, [file_path])
 
-        file_name = file_path.split("/")[-1]
-        need_vectorize = True
+    async def _file_summary_batch_task(self, parent_uri: str, file_paths: List[str]) -> None:
+        """Generate file summaries for sibling files and notify parent completion."""
+        summary_by_path: Dict[str, Dict[str, str]] = {}
+        need_vectorize_by_path = dict.fromkeys(file_paths, True)
+        pending_paths: List[str] = []
         try:
-            summary_dict = None
-            if self._incremental_update:
-                content_changed = await self._check_file_content_changed(file_path)
-                self._file_change_status[file_path] = content_changed
+            for file_path in file_paths:
+                try:
+                    summary_dict = None
+                    if self._incremental_update:
+                        content_changed = await self._check_file_content_changed(file_path)
+                        self._file_change_status[file_path] = content_changed
 
-                if not content_changed:
-                    summary_dict = await self._read_existing_summary(file_path)
-                    if summary_dict is not None:
-                        need_vectorize = False
+                        if not content_changed:
+                            summary_dict = await self._read_existing_summary(file_path)
+                            if summary_dict is not None:
+                                need_vectorize_by_path[file_path] = False
+                            else:
+                                self._file_change_status[file_path] = True
                     else:
                         self._file_change_status[file_path] = True
-            else:
-                self._file_change_status[file_path] = True
-            if summary_dict is None:
-                summary_dict = await self._processor._generate_single_file_summary(
-                    file_path, llm_sem=self._llm_sem, ctx=self._ctx
-                )
-        except Exception as e:
-            logger.warning(f"Failed to generate summary for {file_path}: {e}")
-            summary_dict = {"name": file_name, "summary": ""}
-        finally:
-            self._stats.done_nodes += 1
-            self._stats.in_progress_nodes = max(0, self._stats.in_progress_nodes - 1)
 
-        try:
-            if need_vectorize:
-                use_summary = self._is_code_repo and bool(summary_dict.get("summary"))
-                task = VectorizeTask(
-                    task_type="file",
-                    uri=file_path,
-                    context_type=self._context_type,
-                    ctx=self._ctx,
-                    semantic_msg_id=self._semantic_msg_id,
-                    file_path=file_path,
-                    summary_dict=summary_dict,
-                    parent_uri=parent_uri,
-                    use_summary=use_summary,
+                    if summary_dict is None:
+                        pending_paths.append(file_path)
+                    else:
+                        summary_by_path[file_path] = summary_dict
+                except Exception as e:
+                    logger.warning(f"Failed to prepare summary for {file_path}: {e}")
+                    self._file_change_status[file_path] = True
+                    summary_by_path[file_path] = self._empty_file_summary(file_path)
+
+            if pending_paths:
+                generated_summaries = await self._processor._generate_file_summaries(
+                    pending_paths, llm_sem=self._llm_sem, ctx=self._ctx
                 )
-                await self._add_vectorize_task(task)
+                summary_by_path.update(generated_summaries)
         except Exception as e:
-            logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
-        await self._on_file_done(parent_uri, file_path, summary_dict)
+            logger.warning(f"Failed to generate summary batch under {parent_uri}: {e}")
+            for file_path in pending_paths:
+                summary_by_path.setdefault(file_path, self._empty_file_summary(file_path))
+        finally:
+            self._stats.done_nodes += len(file_paths)
+            self._stats.in_progress_nodes = max(
+                0, self._stats.in_progress_nodes - len(file_paths)
+            )
+
+        for file_path in file_paths:
+            summary_dict = summary_by_path.get(file_path, self._empty_file_summary(file_path))
+            try:
+                if need_vectorize_by_path.get(file_path, True):
+                    use_summary = self._is_code_repo and bool(summary_dict.get("summary"))
+                    task = VectorizeTask(
+                        task_type="file",
+                        uri=file_path,
+                        context_type=self._context_type,
+                        ctx=self._ctx,
+                        semantic_msg_id=self._semantic_msg_id,
+                        file_path=file_path,
+                        summary_dict=summary_dict,
+                        parent_uri=parent_uri,
+                        use_summary=use_summary,
+                    )
+                    await self._add_vectorize_task(task)
+            except Exception as e:
+                logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
+            await self._on_file_done(parent_uri, file_path, summary_dict)
+
+    @staticmethod
+    def _empty_file_summary(file_path: str) -> Dict[str, str]:
+        return {"name": file_path.split("/")[-1], "summary": ""}
 
     async def _on_file_done(
         self, parent_uri: str, file_path: str, summary_dict: Dict[str, str]

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -3,6 +3,7 @@
 """SemanticProcessor: Processes messages from SemanticQueue, generates .abstract.md and .overview.md."""
 
 import asyncio
+import json
 import threading
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -69,6 +70,17 @@ class DiffResult:
             "modified": self.updated_files,
             "deleted": self.deleted_files + self.deleted_dirs,
         }
+
+
+@dataclass
+class FileSummaryBatchInput:
+    """Text-like file payload that can be summarized with other files."""
+
+    file_path: str
+    file_name: str
+    file_type: str
+    output_language: str
+    content: str
 
 
 class RequestQueueStats:
@@ -619,27 +631,15 @@ class SemanticProcessor(DequeueHandlerBase):
                     f"(reused {len(file_paths) - len(pending_indices)} cached)"
                 )
 
-                async def _gen(idx: int, file_path: str) -> None:
-                    file_name = file_path.split("/")[-1]
-                    try:
-                        summary_dict = await self._generate_single_file_summary(
-                            file_path, llm_sem=llm_sem, ctx=ctx
-                        )
-                        file_summaries[idx] = summary_dict
-                        logger.debug(f"Generated summary for {file_name}")
-                    except Exception as e:
-                        logger.warning(f"Failed to generate summary for {file_path}: {e}")
-                        file_summaries[idx] = {"name": file_name, "summary": ""}
-
-                batch_size = max(1, min(self.max_concurrent_llm, 10))
-                for batch_start in range(0, len(pending_indices), batch_size):
-                    batch = pending_indices[batch_start : batch_start + batch_size]
-                    logger.info(
-                        f"[MemorySemantic] Processing batch {batch_start // batch_size + 1}/"
-                        f"{(len(pending_indices) + batch_size - 1) // batch_size} "
-                        f"({len(batch)} files)"
+                pending_paths = [file_path for _, file_path in pending_indices]
+                generated_summaries = await self._generate_file_summaries(
+                    pending_paths, llm_sem=llm_sem, ctx=ctx
+                )
+                for idx, file_path in pending_indices:
+                    file_summaries[idx] = generated_summaries.get(
+                        file_path, self._empty_file_summary(file_path)
                     )
-                    await asyncio.gather(*[_gen(i, fp) for i, fp in batch])
+                    logger.debug(f"Generated summary for {file_path.split('/')[-1]}")
 
             completed_summaries = [s for s in file_summaries if s is not None]
             # Incremental writes carry changes; full rebuild tasks do not.
@@ -948,6 +948,275 @@ class SemanticProcessor(DequeueHandlerBase):
             dir_name = child_uri.split("/")[-1]
             results.append({"name": dir_name, "abstract": abstract})
         return results
+
+    async def _generate_file_summaries(
+        self,
+        file_paths: List[str],
+        llm_sem: Optional[asyncio.Semaphore] = None,
+        ctx: Optional[RequestContext] = None,
+    ) -> Dict[str, Dict[str, str]]:
+        """Generate summaries for files, batching compatible text files when configured."""
+        if not file_paths:
+            return {}
+
+        config = get_openviking_config()
+        batch_size = max(1, int(getattr(config.semantic, "file_summary_batch_size", 1)))
+        if batch_size <= 1 or len(file_paths) == 1:
+            return await self._generate_file_summaries_individually(file_paths, llm_sem, ctx)
+
+        vlm = config.vlm
+        if not vlm.is_available():
+            logger.warning("VLM not available, using empty summaries")
+            return {path: self._empty_file_summary(path) for path in file_paths}
+
+        summaries: Dict[str, Dict[str, str]] = {}
+        batch_inputs: List[FileSummaryBatchInput] = []
+        fallback_paths: List[str] = []
+
+        for file_path in file_paths:
+            try:
+                prepared = await self._prepare_file_summary_batch_input(file_path, ctx=ctx)
+                if isinstance(prepared, dict):
+                    summaries[file_path] = prepared
+                elif isinstance(prepared, FileSummaryBatchInput):
+                    batch_inputs.append(prepared)
+                else:
+                    fallback_paths.append(file_path)
+            except Exception as e:
+                logger.debug(f"Falling back to single summary for {file_path}: {e}")
+                fallback_paths.append(file_path)
+
+        max_batch_chars = max(1, int(getattr(config.semantic, "max_file_summary_batch_chars", 1)))
+        batches, oversized_inputs = self._build_file_summary_batches(
+            batch_inputs,
+            max_batch_size=batch_size,
+            max_batch_chars=max_batch_chars,
+        )
+        fallback_paths.extend(item.file_path for item in oversized_inputs)
+
+        if batches:
+            logger.info(
+                "Generating %d file summaries in %d batched VLM request(s)",
+                sum(len(batch) for batch in batches),
+                len(batches),
+            )
+
+        if llm_sem is None:
+            llm_sem = asyncio.Semaphore(self.max_concurrent_llm)
+
+        batch_results = await asyncio.gather(
+            *[self._generate_file_summary_batch(batch, llm_sem) for batch in batches],
+            return_exceptions=True,
+        )
+        for batch, result in zip(batches, batch_results, strict=False):
+            if isinstance(result, Exception):
+                logger.warning(f"Failed to generate batched file summaries: {result}")
+                fallback_paths.extend(item.file_path for item in batch)
+                continue
+            summaries.update(result)
+            missing_paths = [item.file_path for item in batch if item.file_path not in result]
+            fallback_paths.extend(missing_paths)
+
+        if fallback_paths:
+            fallback_results = await self._generate_file_summaries_individually(
+                fallback_paths,
+                llm_sem,
+                ctx,
+            )
+            summaries.update(fallback_results)
+
+        return {path: summaries.get(path, self._empty_file_summary(path)) for path in file_paths}
+
+    async def _generate_file_summaries_individually(
+        self,
+        file_paths: List[str],
+        llm_sem: Optional[asyncio.Semaphore] = None,
+        ctx: Optional[RequestContext] = None,
+    ) -> Dict[str, Dict[str, str]]:
+        """Generate file summaries with the legacy one-file-per-request path."""
+        if not file_paths:
+            return {}
+
+        llm_sem = llm_sem or asyncio.Semaphore(self.max_concurrent_llm)
+        summaries: Dict[str, Dict[str, str]] = {}
+
+        async def _gen(file_path: str) -> None:
+            try:
+                summaries[file_path] = await self._generate_single_file_summary(
+                    file_path, llm_sem=llm_sem, ctx=ctx
+                )
+            except Exception as e:
+                logger.warning(f"Failed to generate summary for {file_path}: {e}")
+                summaries[file_path] = self._empty_file_summary(file_path)
+
+        await asyncio.gather(*[_gen(path) for path in file_paths])
+        return summaries
+
+    async def _prepare_file_summary_batch_input(
+        self,
+        file_path: str,
+        ctx: Optional[RequestContext] = None,
+    ) -> Optional[FileSummaryBatchInput | Dict[str, str]]:
+        """Prepare a text-like file for batched summary generation.
+
+        Returns a ready summary for no-LLM code AST mode, a batch input for
+        compatible text files, or None when the legacy single-file path is safer.
+        """
+        file_name = file_path.split("/")[-1]
+        if get_media_type(file_name, None) in {"image", "audio", "video"}:
+            return None
+
+        viking_fs = get_viking_fs()
+        active_ctx = ctx or self._current_ctx
+        content = await viking_fs.read_file(file_path, ctx=active_ctx)
+        if isinstance(content, bytes):
+            try:
+                content = content.decode("utf-8")
+            except UnicodeDecodeError:
+                logger.warning(f"Failed to decode file as UTF-8, skipping: {file_path}")
+                return self._empty_file_summary(file_path)
+
+        config = get_openviking_config()
+        max_chars = config.semantic.max_file_content_chars
+        if len(content) > max_chars:
+            content = content[:max_chars] + "\n...(truncated)"
+
+        file_type = self._detect_file_type(file_name)
+        if file_type == FILE_TYPE_CODE:
+            content_or_summary = await self._prepare_code_summary_content_for_batch(
+                file_path=file_path,
+                file_name=file_name,
+                content=content,
+                config=config,
+            )
+            if isinstance(content_or_summary, dict):
+                return content_or_summary
+            content = content_or_summary
+
+        from openviking.session.memory.utils.language import resolve_output_language
+
+        return FileSummaryBatchInput(
+            file_path=file_path,
+            file_name=file_name,
+            file_type=file_type,
+            output_language=resolve_output_language(content, config=config),
+            content=content,
+        )
+
+    async def _prepare_code_summary_content_for_batch(
+        self,
+        *,
+        file_path: str,
+        file_name: str,
+        content: str,
+        config: Any,
+    ) -> str | Dict[str, str]:
+        """Preserve AST code-summary behavior before optional batching."""
+        code_mode = config.code.code_summary_mode
+        if code_mode not in ("ast", "ast_llm") or len(content.splitlines()) < 100:
+            return content
+
+        from openviking.parse.parsers.code.ast import extract_skeleton
+
+        verbose = code_mode == "ast_llm"
+        skeleton_text = extract_skeleton(file_name, content, verbose=verbose)
+        if skeleton_text:
+            max_skeleton_chars = config.semantic.max_skeleton_chars
+            if len(skeleton_text) > max_skeleton_chars:
+                skeleton_text = skeleton_text[:max_skeleton_chars]
+            if code_mode == "ast":
+                return {"name": file_name, "summary": skeleton_text}
+            return skeleton_text
+
+        if skeleton_text is None:
+            logger.info("AST unsupported language, fallback to LLM: %s", file_path)
+        else:
+            logger.info("AST empty skeleton, fallback to LLM: %s", file_path)
+        return content
+
+    def _build_file_summary_batches(
+        self,
+        inputs: List[FileSummaryBatchInput],
+        *,
+        max_batch_size: int,
+        max_batch_chars: int,
+    ) -> Tuple[List[List[FileSummaryBatchInput]], List[FileSummaryBatchInput]]:
+        batches: List[List[FileSummaryBatchInput]] = []
+        oversized: List[FileSummaryBatchInput] = []
+        current: List[FileSummaryBatchInput] = []
+        current_chars = 0
+
+        for item in inputs:
+            item_chars = len(item.content) + len(item.file_name) + len(item.file_type) + 64
+            if item_chars > max_batch_chars:
+                oversized.append(item)
+                continue
+            if current and (
+                len(current) >= max_batch_size or current_chars + item_chars > max_batch_chars
+            ):
+                batches.append(current)
+                current = []
+                current_chars = 0
+            current.append(item)
+            current_chars += item_chars
+
+        if current:
+            batches.append(current)
+        return batches, oversized
+
+    async def _generate_file_summary_batch(
+        self,
+        batch: List[FileSummaryBatchInput],
+        llm_sem: asyncio.Semaphore,
+    ) -> Dict[str, Dict[str, str]]:
+        if not batch:
+            return {}
+
+        id_to_item = {f"file_{idx + 1}": item for idx, item in enumerate(batch)}
+        files_payload = [
+            {
+                "id": file_id,
+                "name": item.file_name,
+                "file_type": item.file_type,
+                "output_language": item.output_language,
+                "content": item.content,
+            }
+            for file_id, item in id_to_item.items()
+        ]
+        prompt = render_prompt(
+            "semantic.file_summary_batch",
+            {"files_json": json.dumps(files_payload, ensure_ascii=False, indent=2)},
+        )
+
+        vlm = get_openviking_config().vlm
+        async with llm_sem:
+            with bind_telemetry_stage("resource_summarize"):
+                response = await vlm.get_completion_async(prompt)
+
+        from openviking.models.vlm.llm import parse_json_from_response
+
+        data = parse_json_from_response(response)
+        if not isinstance(data, dict) or not isinstance(data.get("summaries"), list):
+            raise ValueError("batched file summary response is not a JSON object with summaries")
+
+        summaries: Dict[str, Dict[str, str]] = {}
+        for item in data["summaries"]:
+            if not isinstance(item, dict):
+                continue
+            file_id = str(item.get("id") or "")
+            summary = item.get("summary")
+            batch_item = id_to_item.get(file_id)
+            if batch_item is None or not isinstance(summary, str):
+                continue
+            summaries[batch_item.file_path] = {
+                "name": batch_item.file_name,
+                "summary": summary.strip(),
+            }
+        return summaries
+
+    @staticmethod
+    def _empty_file_summary(file_path: str) -> Dict[str, str]:
+        return {"name": file_path.split("/")[-1], "summary": ""}
 
     async def _generate_text_summary(
         self,

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -560,6 +560,13 @@ class SemanticConfig:
     max_file_content_chars: int = 30000
     """Maximum characters of file content sent to LLM for summary generation."""
 
+    file_summary_batch_size: int = 10
+    """Maximum number of text files summarized in one LLM request.
+    Set to 1 to disable file-summary batching."""
+
+    max_file_summary_batch_chars: int = 60000
+    """Maximum combined file content characters sent in one batched summary prompt."""
+
     max_skeleton_chars: int = 12000
     """Maximum characters of AST skeleton used for embedding (~3000 tokens)."""
 

--- a/tests/test_semantic_file_summary_batch.py
+++ b/tests/test_semantic_file_summary_batch.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for batched semantic file summary generation."""
+
+import json
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.session.memory.utils import language as language_utils
+from openviking.storage.queuefs import semantic_dag, semantic_processor
+from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils.config.parser_config import SemanticConfig
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeVLM:
+    def __init__(self, *, omit_last_batch_summary: bool = False):
+        self.prompts: list[str] = []
+        self.omit_last_batch_summary = omit_last_batch_summary
+
+    def is_available(self) -> bool:
+        return True
+
+    async def get_completion_async(self, prompt: str, **kwargs) -> str:
+        self.prompts.append(prompt)
+        ids = re.findall(r'"id":\s*"(file_\d+)"', prompt)
+        if ids:
+            if self.omit_last_batch_summary:
+                ids = ids[:-1]
+            return json.dumps(
+                {
+                    "summaries": [
+                        {"id": file_id, "summary": f"batch summary for {file_id}"}
+                        for file_id in ids
+                    ]
+                }
+            )
+        return "fallback summary"
+
+
+class _FakeFS:
+    def __init__(self, *, files: dict[str, str] | None = None, entries=None):
+        self.files = files or {}
+        self.entries = entries or {}
+
+    async def read_file(self, file_path: str, ctx=None):
+        return self.files[file_path]
+
+    async def ls(self, uri: str, ctx=None):
+        return self.entries.get(uri, [])
+
+
+def _config(vlm: _FakeVLM, *, batch_size: int = 10, batch_chars: int = 10000):
+    return SimpleNamespace(
+        vlm=vlm,
+        semantic=SemanticConfig(
+            file_summary_batch_size=batch_size,
+            max_file_summary_batch_chars=batch_chars,
+        ),
+        code=SimpleNamespace(code_summary_mode="llm"),
+        output_language_override="en",
+    )
+
+
+async def test_generate_file_summaries_batches_text_files(monkeypatch):
+    file_paths = [
+        "viking://resources/root/alpha.md",
+        "viking://resources/root/beta.txt",
+        "viking://resources/root/gamma.rst",
+    ]
+    fake_vlm = _FakeVLM()
+    fake_fs = _FakeFS(
+        files={
+            file_paths[0]: "# Alpha\nAlpha documentation.",
+            file_paths[1]: "Beta plain text.",
+            file_paths[2]: "Gamma reference text.",
+        }
+    )
+    monkeypatch.setattr(semantic_processor, "get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(semantic_processor, "get_openviking_config", lambda: _config(fake_vlm))
+    monkeypatch.setattr(language_utils, "get_openviking_config", lambda: _config(fake_vlm))
+
+    processor = SemanticProcessor(max_concurrent_llm=4)
+
+    summaries = await processor._generate_file_summaries(file_paths)
+
+    assert len(fake_vlm.prompts) == 1
+    assert all(path in summaries for path in file_paths)
+    assert summaries[file_paths[0]] == {"name": "alpha.md", "summary": "batch summary for file_1"}
+    assert summaries[file_paths[1]] == {"name": "beta.txt", "summary": "batch summary for file_2"}
+    assert summaries[file_paths[2]] == {"name": "gamma.rst", "summary": "batch summary for file_3"}
+
+
+async def test_generate_file_summaries_falls_back_for_missing_batch_result(monkeypatch):
+    file_paths = [
+        "viking://resources/root/alpha.md",
+        "viking://resources/root/beta.md",
+    ]
+    fake_vlm = _FakeVLM(omit_last_batch_summary=True)
+    fake_fs = _FakeFS(
+        files={
+            file_paths[0]: "# Alpha\nAlpha documentation.",
+            file_paths[1]: "# Beta\nBeta documentation.",
+        }
+    )
+    monkeypatch.setattr(semantic_processor, "get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(semantic_processor, "get_openviking_config", lambda: _config(fake_vlm))
+    monkeypatch.setattr(language_utils, "get_openviking_config", lambda: _config(fake_vlm))
+
+    processor = SemanticProcessor(max_concurrent_llm=4)
+
+    summaries = await processor._generate_file_summaries(file_paths)
+
+    assert len(fake_vlm.prompts) == 2
+    assert summaries[file_paths[0]] == {"name": "alpha.md", "summary": "batch summary for file_1"}
+    assert summaries[file_paths[1]] == {"name": "beta.md", "summary": "fallback summary"}
+
+
+async def test_semantic_dag_groups_sibling_files_for_summary(monkeypatch):
+    root_uri = "viking://resources/root"
+    file_paths = [
+        "viking://resources/root/alpha.md",
+        "viking://resources/root/beta.txt",
+    ]
+    fake_fs = _FakeFS(
+        entries={
+            root_uri: [
+                {"name": "alpha.md", "isDir": False},
+                {"name": "beta.txt", "isDir": False},
+            ]
+        }
+    )
+    monkeypatch.setattr(semantic_dag, "get_viking_fs", lambda: fake_fs)
+
+    async def _write_semantic_sidecars(**kwargs):
+        return True
+
+    monkeypatch.setattr(semantic_dag, "write_semantic_sidecars", _write_semantic_sidecars)
+
+    class _FakeProcessor:
+        def __init__(self):
+            self.summary_calls: list[list[str]] = []
+
+        async def _generate_file_summaries(self, paths, llm_sem=None, ctx=None):
+            self.summary_calls.append(list(paths))
+            return {
+                path: {"name": path.split("/")[-1], "summary": f"summary for {path}"}
+                for path in paths
+            }
+
+        async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+            return "# root\n\nOverview"
+
+        def _extract_abstract_from_overview(self, overview):
+            return "Overview"
+
+        def _enforce_size_limits(self, overview, abstract):
+            return overview, abstract
+
+    processor = _FakeProcessor()
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=4,
+        ctx=ctx,
+        skip_vectorization=True,
+    )
+
+    await executor.run(root_uri)
+
+    assert processor.summary_calls == [file_paths]


### PR DESCRIPTION
## Summary
- add configurable batching for text file summary generation
- summarize sibling files through a JSON batch prompt with single-file fallback
- wire resource DAG and memory semantic refresh paths through the batched summary helper

## Why
Large reindex jobs currently make one VLM request per file summary, which creates RPM pressure and high per-request quota usage.

## Validation
- /opt/homebrew/bin/python3.11 -m pytest -o addopts='' tests/test_semantic_file_summary_batch.py -q
- /opt/homebrew/bin/python3.11 -m ruff check openviking/storage/queuefs/semantic_processor.py openviking/storage/queuefs/semantic_dag.py openviking_cli/utils/config/parser_config.py tests/test_semantic_file_summary_batch.py
- /opt/homebrew/bin/python3.11 -m py_compile openviking/storage/queuefs/semantic_processor.py openviking/storage/queuefs/semantic_dag.py openviking_cli/utils/config/parser_config.py tests/test_semantic_file_summary_batch.py

Fixes #907
Refs #744
