### PR TITLE
docs(prompt-guide): document embedding_template memory-schema field

### DIFF
--- a/docs/en/guides/10-prompt-guide.md
+++ b/docs/en/guides/10-prompt-guide.md
@@ -108,6 +108,8 @@ fields:
 filename_template: "profile.md"
 content_template: |
   ...
+embedding_template: |
+  ...
 directory: "viking://user/{{ user_space }}/memories/..."
 enabled: true
 operation_mode: "upsert"
@@ -125,6 +127,8 @@ Field meanings:
   - The template used to generate the file name
 - `content_template`
   - The body template used when writing the memory file
+- `embedding_template`
+  - The template used to render the text that is embedded for semantic retrieval; when unset, a default representation is used
 - `directory`
   - The directory where this memory type is stored
 - `enabled`

--- a/docs/zh/guides/10-prompt-guide.md
+++ b/docs/zh/guides/10-prompt-guide.md
@@ -108,6 +108,8 @@ fields:
 filename_template: "profile.md"
 content_template: |
   ...
+embedding_template: |
+  ...
 directory: "viking://user/{{ user_space }}/memories/..."
 enabled: true
 operation_mode: "upsert"
@@ -125,6 +127,8 @@ operation_mode: "upsert"
   - 生成文件名时使用的模板
 - `content_template`
   - 落盘时使用的正文模板
+- `embedding_template`
+  - 用于渲染参与语义检索的向量化（embedding）文本的模板；未设置时使用默认表示
 - `directory`
   - 该类记忆写入的目录
 - `enabled`


### PR DESCRIPTION
## Summary

#2193 added `embedding_template` to the memory-schema YAML (replacing the old per-field `searchable` mechanism) and shipped it in the built-in `entities`/`events`/`preferences` templates, but the **Memory Schema YAML** section in `docs/{en,zh}/guides/10-prompt-guide.md` still lists every other field (`content_template`, `filename_template`, `directory`, `enabled`, `operation_mode`) without it.

This adds `embedding_template` to both the schematic example and the field-meanings list (EN + ZH). It renders the text used for semantic-retrieval embedding; when unset a default representation is used — directly relevant to the section's stated focus on keeping memories searchable.

Pure docs, no logic change.