### PR TITLE
fix(build): bundle web-studio in pip/pipx installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 openviking/bin/
+openviking/web_studio/dist/
 third_party/agfs/bin/
 test_scripts/
 examples/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,17 @@
 # ragfs-python's default S3-enabled dependency set currently requires rustc >= 1.91.1.
 FROM rust:1.91.1-trixie AS rust-toolchain
 
-# Stage 2: build web-studio static bundle (Vite SPA). Runs before py-builder so
-# the dist can be copied into openviking/web_studio/dist/ and included in the
-# python wheel via package-data — no separate runtime COPY required.
-#
-# WEB_STUDIO_BASE_PATH is passed to `vite build --base=...` and is also
-# consumed at runtime by getRouterBasePath() through import.meta.env.BASE_URL,
-# so the SPA's asset URLs and TanStack Router basepath stay in sync.
-FROM node:20-bookworm-slim AS web-studio-builder
-WORKDIR /web-studio
-ARG TARGETPLATFORM
-ARG WEB_STUDIO_BASE_PATH=/studio/
-
-COPY web-studio/package.json web-studio/package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm,id=npm-${TARGETPLATFORM} \
-    npm ci
-
-COPY web-studio/ ./
-RUN npm run build -- --base="${WEB_STUDIO_BASE_PATH}"
-
-# Stage 3: build Python environment with uv (builds Rust CLI + C++ extension from source)
+# Stage 2: build Python environment with uv (builds Rust CLI + C++ extension + web-studio from source)
 FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim AS py-builder
 
 # Reuse Rust toolchain from stage 1 so setup.py can compile ov CLI in-place.
 COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
 COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
+# Provide Node.js so setup.py build_py can build web-studio SPA in-tree.
+COPY --from=node:24-trixie-slim /usr/local/bin/node /usr/local/bin/
+COPY --from=node:24-trixie-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH="/app/.venv/bin:/usr/local/cargo/bin:${PATH}"
@@ -67,17 +53,15 @@ COPY openviking/ openviking/
 COPY openviking_cli/ openviking_cli/
 COPY src/ src/
 COPY third_party/ third_party/
+COPY web-studio/ web-studio/
 
-# Bundle the prebuilt web-studio dist into the openviking python package so the
-# wheel produced by `uv sync` ships /studio assets out of the box (parallel to
-# the legacy openviking/console/static layout, just for the new SPA).
-COPY --from=web-studio-builder /web-studio/dist /app/openviking/web_studio/dist
-
-# Install project and dependencies (triggers setup.py artifact builds + build_extension).
+# Install project and dependencies (triggers setup.py build_py → web-studio
+# SPA build + build_ext → native extensions).
 # Default to auto-refreshing uv.lock inside the ephemeral build context when it is
 # stale, so Docker builds stay unblocked after dependency changes. Set
 # UV_LOCK_STRATEGY=locked to keep fail-fast reproducibility checks.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
+    --mount=type=cache,target=/root/.npm,id=npm-${TARGETPLATFORM} \
     --mount=type=cache,target=/cargo-target,id=cargo-target-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
@@ -106,7 +90,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
             ;; \
     esac
 
-# Stage 4: runtime
+# Stage 3: runtime
 FROM python:3.13-slim-trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ CLEAN_DIRS := \
 	*.egg-info/ \
 	openviking/bin/ \
 	openviking/lib/ \
+	openviking/web_studio/dist/ \
 	$(OV_CLI_DIR)/target/ \
 	src/cmake_build/ \
 	.pytest_cache/ \
@@ -27,7 +28,7 @@ CLEAN_DIRS := \
 	**/__pycache__/
 
 .PHONY: all build clean help check-pip check-deps
-.PHONY: build-cli
+.PHONY: build-cli build-studio
 
 all: build
 
@@ -35,6 +36,7 @@ help:
 	@echo "Available targets:"
 	@echo "  build           - Build ragfs-python and C++ extensions using setup.py"
 	@echo "  build-cli       - Build Rust CLI (ov) in development mode (fast) and copy to openviking/bin/"
+	@echo "  build-studio    - Build web-studio SPA and copy into openviking/web_studio/dist/"
 	@echo "  clean           - Remove build artifacts and temporary files"
 	@echo "  check-deps      - Check if required dependencies (Rust, CMake, etc.) are installed"
 	@echo "  help            - Show this help message"
@@ -83,7 +85,7 @@ check-deps:
 		echo "Error: C++ compiler (GCC or Clang) is required."; exit 1; \
 	fi
 
-build: check-deps check-pip
+build: check-deps check-pip build-studio
 	@echo "Starting build process via setup.py..."
 	$(PYTHON) $(SETUP_PY) build_ext --inplace
 	@if command -v uv > /dev/null 2>&1 && uv pip --help > /dev/null 2>&1; then \
@@ -140,6 +142,25 @@ clean:
 	@find . -name "*.pyc" -delete
 	@find . -name "__pycache__" -type d -exec rm -rf {} +
 	@echo "Cleanup completed."
+
+# Web Studio target
+build-studio:
+	@if [ "$$OV_SKIP_STUDIO_BUILD" = "1" ]; then \
+		echo "  [SKIP] web-studio build disabled by OV_SKIP_STUDIO_BUILD=1"; \
+	elif [ -f openviking/web_studio/dist/index.html ]; then \
+		echo "  [OK] web-studio bundle already present"; \
+	elif ! command -v npm > /dev/null 2>&1; then \
+		echo "  [SKIP] npm not found; install Node.js to enable /studio"; \
+	elif [ ! -f web-studio/package.json ]; then \
+		echo "  [SKIP] web-studio source not found"; \
+	else \
+		echo "Building web-studio (Vite SPA)..."; \
+		cd web-studio && npm ci && npm run build -- --base="/studio/" && cd ..; \
+		mkdir -p openviking/web_studio; \
+		rm -rf openviking/web_studio/dist; \
+		cp -r web-studio/dist openviking/web_studio/dist; \
+		echo "  [OK] web-studio bundle copied to openviking/web_studio/dist/"; \
+	fi
 
 # Rust CLI targets
 build-cli:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
+from setuptools.command.build_py import build_py
 
 try:
     from wheel.bdist_wheel import bdist_wheel
@@ -459,6 +460,60 @@ class OpenVikingBuildExt(build_ext):
         self.spawn([self.cmake_executable] + build_args)
 
 
+def _build_web_studio():
+    """Build the web-studio SPA and copy dist into the Python package tree.
+
+    Skipped when OV_SKIP_STUDIO_BUILD=1 or when the bundle already exists.
+    Falls back gracefully (warning, not error) when npm is unavailable.
+    """
+    if os.environ.get("OV_SKIP_STUDIO_BUILD") == "1":
+        print("  [SKIP] web-studio build disabled by OV_SKIP_STUDIO_BUILD=1")
+        return
+
+    dest = SETUP_DIR / "openviking" / "web_studio" / "dist"
+    if (dest / "index.html").is_file():
+        print("  [OK] web-studio bundle already present")
+        return
+
+    source = SETUP_DIR / "web-studio"
+    if not (source / "package.json").is_file():
+        print("  [SKIP] web-studio source not found; /studio will be unavailable")
+        return
+
+    npm = shutil.which("npm")
+    if not npm:
+        print("  [SKIP] npm not found; install Node.js to enable /studio")
+        return
+
+    print("Building web-studio (Vite SPA)...")
+    try:
+        subprocess.check_call([npm, "ci"], cwd=str(source))
+        subprocess.check_call(
+            [npm, "run", "build", "--", "--base=/studio/"],
+            cwd=str(source),
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"  [WARNING] web-studio npm build failed ({exc}); /studio will be unavailable")
+        return
+
+    built = source / "dist"
+    if not (built / "index.html").is_file():
+        print("  [WARNING] web-studio build produced no index.html; /studio will be unavailable")
+        return
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(built, dest)
+    print(f"  [OK] web-studio bundle copied to {dest}")
+
+
+class OpenVikingBuildPy(build_py):
+    def run(self):
+        _build_web_studio()
+        super().run()
+
+
 if bdist_wheel is not None:
 
     class OpenVikingBdistWheel(bdist_wheel):
@@ -471,6 +526,7 @@ else:
 
 cmdclass = {
     "build_ext": OpenVikingBuildExt,
+    "build_py": OpenVikingBuildPy,
 }
 if OpenVikingBdistWheel is not None:
     cmdclass["bdist_wheel"] = OpenVikingBdistWheel


### PR DESCRIPTION
## Description

Fix `/studio` being inaccessible when installing via `pip install` / `pipx install` / `uv run` from source. Only Docker builds previously included the web-studio SPA bundle.

## Related Issue

N/A — reported internally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- **setup.py**: Add `OpenVikingBuildPy` build hook that auto-builds web-studio (`npm ci && npm run build`) during `pip install` / wheel creation. Gracefully skips when npm is unavailable (`OV_SKIP_STUDIO_BUILD=1` to force-skip).
- **Makefile**: Add `build-studio` target; wire it as a dependency of `build`; add `openviking/web_studio/dist/` to `clean`.
- **Dockerfile**: Remove dedicated `web-studio-builder` stage (4 stages → 3). Node.js provided via multi-stage COPY from `node:24-trixie-slim`. Web-studio now built by the same `build_py` hook during `uv sync`.
- **.gitignore**: Exclude `openviking/web_studio/dist/` (generated build artifact).

## Testing

- [x] `make build-studio` — builds and copies SPA bundle
- [x] `make build-studio` (idempotent) — skips when bundle exists
- [x] `OV_SKIP_STUDIO_BUILD=1 make build-studio` — respects skip flag
- [x] `docker build` — full image build succeeds (3-stage)
- [x] `docker run` + `curl /studio/` — 200, SPA loads correctly
- [x] `curl /` — 302 redirect to `/studio/`
- [x] `curl /studio/assets/*` — 200, static assets served
- [x] `curl /health`, `/ready`, `/api/v1/fs/ls`, `/api/v1/search/search`, `/api/v1/sessions` — all 200
- [x] I have tested this on the following platforms:
  - [x] macOS (Colima Docker)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The single `_build_web_studio()` function in `setup.py` is now the single source of truth for web-studio builds across all install paths (Docker, pip, make). Node 20 → Node 24 LTS (maintained until 2028-04).