### PR TITLE
Fix docs about image links

### DIFF
--- a/docs/en/about/01-about-us.md
+++ b/docs/en/about/01-about-us.md
@@ -115,7 +115,7 @@ We warmly invite developers worldwide to join the OpenViking community and co-bu
 
 Scan the QR code below to join the Lark group and communicate with the core development team in real time:
 
-![Join via Lark QR](/lark-group-qrcode.png)
+![Join via Lark QR](../../images/lark-group-qrcode.png)
 
 *Note: Please ensure you have installed the [Lark client](https://www.feishu.cn/) before joining.*
 
@@ -123,7 +123,7 @@ Scan the QR code below to join the Lark group and communicate with the core deve
 
 Scan the QR code below to add the assistant on WeChat, mention "OpenViking" and you will be invited to the WeChat group:
 
-![Join via WeChat QR](/wechat-group-qrcode.png)
+![Join via WeChat QR](../../images/wechat-group-qrcode.png)
 
 **Discord**
 

--- a/docs/zh/about/01-about-us.md
+++ b/docs/zh/about/01-about-us.md
@@ -115,7 +115,7 @@ Haojie Qin, Jiahui Zhou, Linggang Wang, Maojia Sheng, Yaohui Sun
 
 扫描下方二维码加入飞书群组，与核心开发团队实时交流：
 
-![飞书扫码加群](/lark-group-qrcode.png)
+![飞书扫码加群](../../images/lark-group-qrcode.png)
 
 *注：加入群组前请确保已安装 [飞书客户端](https://www.feishu.cn/)*
 
@@ -123,7 +123,7 @@ Haojie Qin, Jiahui Zhou, Linggang Wang, Maojia Sheng, Yaohui Sun
 
 扫描下方二维码添加小助手微信，备注「OpenViking」后即可加入微信交流群：
 
-![微信扫码加群](/wechat-group-qrcode.png)
+![微信扫码加群](../../images/wechat-group-qrcode.png)
 
 **Discord**
 


### PR DESCRIPTION
## Description

Fix broken QR code image rendering in GitHub Markdown previews for the About pages. The docs site served these images correctly from VitePress public assets, but GitHub interpreted the root-relative image paths as repository-root paths and showed broken images.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Updated English About page QR code image links to use repository-relative image paths.
- Updated Chinese About page QR code image links to use repository-relative image paths.
- Kept the image sources under docs/images so both GitHub preview and VitePress rendering can resolve them.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- Ran `vitepress build .` from `docs/`; build completed successfully.
- Started the local docs site and verified the About page rendered correctly locally.
- Confirmed the PR diff only contains the two About page Markdown files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The previous `/lark-group-qrcode.png` and `/wechat-group-qrcode.png` links worked on the published VitePress site because those files are served from the site root. GitHub Markdown preview resolves root-relative links against the repository root, so it could not find the images there.
