### PR TITLE
feat(parse): 保留文档图片附件

### DIFF
--- a/openviking/parse/base.py
+++ b/openviking/parse/base.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
 # Common utility functions
 # ============================================================================
 
+RESOURCE_ROOT_PLACEHOLDER = "__OPENVIKING_RESOURCE_ROOT__"
+RESOURCE_ATTACHMENTS_META_KEY = "_attachments"
+RESOURCE_ROOT_PLACEHOLDER_META_KEY = "resource_root_placeholder"
+
 
 def calculate_media_strategy(image_count: int, line_count: int) -> str:
     """

--- a/openviking/parse/converter.py
+++ b/openviking/parse/converter.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 
 
 class DocumentConverter:
-    """Converts documents to PDF for consistent rendering (DOCX/MD/PPTX -> PDF)."""
+    """Converts documents to PDF for consistent rendering."""
 
     def __init__(self, temp_dir: Optional[Path] = None):
         self.temp_dir = temp_dir
@@ -24,7 +24,7 @@ class DocumentConverter:
 
         if ext == ".pdf":
             return file_path
-        elif ext in (".docx", ".pptx"):
+        elif ext in (".doc", ".docx", ".pptx"):
             return await self._convert_with_libreoffice(file_path)
         elif ext in (".md", ".markdown"):
             return await self._convert_markdown_to_pdf(file_path)

--- a/openviking/parse/parsers/image_attachments.py
+++ b/openviking/parse/parsers/image_attachments.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Helpers for parser-produced image attachments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from openviking.parse.base import RESOURCE_ROOT_PLACEHOLDER
+
+SUPPORTED_IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg"})
+
+_CONTENT_TYPE_EXTENSIONS = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/gif": ".gif",
+    "image/bmp": ".bmp",
+    "image/webp": ".webp",
+    "image/svg+xml": ".svg",
+}
+
+
+def image_media_path(index: int, extension: str) -> str:
+    """Return the canonical parser-produced media path."""
+    return f"media/images/image-{index}{_normalize_extension(extension)}"
+
+
+def markdown_image_reference(media_path: str, alt_text: str = "image") -> str:
+    """Return a Markdown image reference that will be rewritten to the resource URI."""
+    return f"![{alt_text}]({RESOURCE_ROOT_PLACEHOLDER}/{media_path})"
+
+
+def image_attachment(media_path: str, content: bytes) -> Dict[str, Any]:
+    """Return the parser-produced attachment payload used by MarkdownParser."""
+    return {"path": media_path, "content": content}
+
+
+def image_extension_from_name_type_or_data(
+    name: str = "",
+    content_type: str = "",
+    data: Optional[bytes] = None,
+) -> str:
+    """Choose a stable supported image extension from metadata or bytes."""
+    suffix = Path(name).suffix.lower()
+    if suffix in SUPPORTED_IMAGE_EXTENSIONS:
+        return ".jpg" if suffix == ".jpeg" else suffix
+
+    ext = _CONTENT_TYPE_EXTENSIONS.get(content_type.lower())
+    if ext:
+        return ext
+
+    if data:
+        return detect_image_extension(data)
+
+    return ".png"
+
+
+def detect_image_extension(data: bytes) -> str:
+    """Detect a supported image extension from file signatures."""
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return ".png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return ".jpg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return ".gif"
+    if data.startswith(b"BM"):
+        return ".bmp"
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return ".webp"
+    if data.lstrip().startswith((b"<svg", b"<?xml")):
+        return ".svg"
+    return ".png"
+
+
+def _normalize_extension(extension: str) -> str:
+    ext = extension.lower()
+    if not ext.startswith("."):
+        ext = f".{ext}"
+    return ".jpg" if ext == ".jpeg" else ext

--- a/openviking/parse/parsers/legacy_doc.py
+++ b/openviking/parse/parsers/legacy_doc.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from openviking.parse.base import ParseResult
+from openviking.parse.converter import DocumentConverter
 from openviking.parse.parsers.base_parser import BaseParser
 from openviking_cli.utils.config.parser_config import ParserConfig
 from openviking_cli.utils.logger import get_logger
@@ -50,9 +51,16 @@ class LegacyDocParser(BaseParser):
         path = Path(source)
 
         if path.exists():
+            converted = await self._parse_converted_pdf(path, instruction, kwargs)
+            if converted:
+                return converted
+
             text = await asyncio.to_thread(self._extract_text, path)
             result = await self._md_parser.parse_content(
-                text, source_path=str(path), instruction=instruction, **kwargs
+                text,
+                source_path=str(path),
+                instruction=instruction,
+                **kwargs,
             )
         else:
             result = await self._md_parser.parse_content(
@@ -61,6 +69,33 @@ class LegacyDocParser(BaseParser):
         result.source_format = "doc"
         result.parser_name = "LegacyDocParser"
         return result
+
+    async def _parse_converted_pdf(
+        self,
+        path: Path,
+        instruction: str,
+        kwargs: dict,
+    ) -> Optional[ParseResult]:
+        """Try LibreOffice conversion and reuse the PDF parser for richer .doc parsing."""
+        pdf_path = await self._convert_to_pdf(path)
+        if not pdf_path:
+            return None
+
+        result = await self._parse_pdf(pdf_path, instruction=instruction, **kwargs)
+        result.source_path = str(path)
+        result.source_format = "doc"
+        result.parser_name = "LegacyDocParser"
+        result.meta["converted_from"] = "doc"
+        result.meta["intermediate_format"] = "pdf"
+        return result
+
+    async def _convert_to_pdf(self, path: Path) -> Optional[Path]:
+        return await DocumentConverter().to_pdf(path)
+
+    async def _parse_pdf(self, path: Path, instruction: str = "", **kwargs) -> ParseResult:
+        from openviking.parse.parsers.pdf import PDFParser
+
+        return await PDFParser().parse(path, instruction=instruction, **kwargs)
 
     async def parse_content(
         self, content: str, source_path: Optional[str] = None, instruction: str = "", **kwargs

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -20,16 +20,31 @@ The parser handles scenarios:
 import hashlib
 import re
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import unquote, urlparse
 
 from openviking.parse.accessors.mime_types import IANA_MEDIA_TYPE_TO_EXTENSION
-from openviking.parse.base import NodeType, ParseResult, ResourceNode, create_parse_result
+from openviking.parse.base import (
+    RESOURCE_ROOT_PLACEHOLDER,
+    RESOURCE_ROOT_PLACEHOLDER_META_KEY,
+    NodeType,
+    ParseResult,
+    ResourceNode,
+    create_parse_result,
+)
 from openviking.parse.parsers.base_parser import BaseParser
 from openviking.parse.parsers.constants import (
     CODE_EXTENSIONS,
     DOCUMENTATION_EXTENSIONS,
     IGNORE_EXTENSIONS,
+)
+from openviking.parse.parsers.image_attachments import (
+    SUPPORTED_IMAGE_EXTENSIONS,
+    image_attachment,
+    image_extension_from_name_type_or_data,
+    image_media_path,
+    markdown_image_reference,
 )
 from openviking_cli.utils.config.parser_config import ParserConfig
 from openviking_cli.utils.logger import get_logger
@@ -195,6 +210,25 @@ class MarkdownParser(BaseParser):
                         f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}"
                     )
 
+            attachments = list(kwargs.get("attachments") or [])
+            if base_dir:
+                content, local_attachments, image_warnings = self._attach_local_images(
+                    content,
+                    base_dir=Path(base_dir),
+                    start_index=self._next_image_index(attachments),
+                )
+                attachments.extend(local_attachments)
+                warnings.extend(image_warnings)
+                if local_attachments:
+                    meta["images_extracted"] = len(local_attachments)
+
+            if attachments:
+                meta[RESOURCE_ROOT_PLACEHOLDER_META_KEY] = RESOURCE_ROOT_PLACEHOLDER
+                meta.setdefault(
+                    "images_extracted",
+                    self._count_image_attachments(attachments),
+                )
+
             # Collect metadata
             # images = list(self._image_pattern.finditer(content))
             # image_count = len(images)
@@ -241,6 +275,7 @@ class MarkdownParser(BaseParser):
                 source_path,
                 doc_name=self._sanitize_for_path(doc_title),
             )
+            await self._write_attachments(root_dir, attachments)
 
             parse_time = time.time() - start_time
             logger.info(f"[MarkdownParser] Parse completed in {parse_time:.2f}s")
@@ -513,6 +548,135 @@ class MarkdownParser(BaseParser):
         # Process sections with merge logic
         await self._process_sections_with_merge(
             content, headings, root_dir, sections, doc_name, max_size, min_size
+        )
+
+    async def _write_attachments(self, root_dir: str, attachments: List[Dict[str, Any]]) -> None:
+        """Write parser-produced binary attachments into the same temp resource tree."""
+        if not attachments:
+            return
+
+        viking_fs = self._get_viking_fs()
+        written = 0
+        for attachment in attachments:
+            rel_path = str(attachment.get("path") or "").strip()
+            posix_path = PurePosixPath(rel_path)
+            if (
+                not rel_path
+                or posix_path.is_absolute()
+                or any(part in {"", ".", ".."} for part in posix_path.parts)
+            ):
+                logger.warning("[MarkdownParser] Skipping unsafe attachment path: %r", rel_path)
+                continue
+
+            content = attachment.get("content")
+            if not isinstance(content, (bytes, bytearray)):
+                logger.warning("[MarkdownParser] Skipping non-binary attachment: %s", rel_path)
+                continue
+
+            await viking_fs.write_file_bytes(
+                f"{root_dir}/{posix_path.as_posix()}",
+                bytes(content),
+            )
+            written += 1
+
+        if written:
+            logger.info("[MarkdownParser] Wrote %d attachment(s) into temp tree", written)
+
+    def _attach_local_images(
+        self,
+        content: str,
+        base_dir: Path,
+        start_index: int,
+    ) -> Tuple[str, List[Dict[str, Any]], List[str]]:
+        """Copy local Markdown image references into parser-produced attachments."""
+        attachments: List[Dict[str, Any]] = []
+        warnings: List[str] = []
+        copied: Dict[Path, str] = {}
+        next_index = start_index
+
+        def replace(match: re.Match[str]) -> str:
+            nonlocal next_index
+            alt_text = match.group(1) or "image"
+            raw_target = match.group(2)
+            image_path = self._resolve_local_image_path(raw_target, base_dir)
+            if not image_path:
+                return match.group(0)
+
+            try:
+                resolved_path = image_path.resolve()
+                if resolved_path in copied:
+                    media_path = copied[resolved_path]
+                else:
+                    image_bytes = resolved_path.read_bytes()
+                    extension = image_extension_from_name_type_or_data(
+                        name=resolved_path.name,
+                        data=image_bytes,
+                    )
+                    next_index += 1
+                    media_path = image_media_path(next_index, extension)
+                    attachments.append(image_attachment(media_path, image_bytes))
+                    copied[resolved_path] = media_path
+            except Exception as exc:
+                warnings.append(f"Failed to attach local image '{raw_target}': {exc}")
+                return match.group(0)
+
+            return markdown_image_reference(media_path, alt_text=alt_text)
+
+        return self._image_pattern.sub(replace, content), attachments, warnings
+
+    def _resolve_local_image_path(self, raw_target: str, base_dir: Path) -> Optional[Path]:
+        """Resolve a Markdown image target when it points to a supported local file."""
+        target = self._extract_markdown_link_destination(raw_target)
+        if not target or target.startswith("#"):
+            return None
+
+        parsed = urlparse(target)
+        if parsed.scheme and parsed.scheme != "file":
+            return None
+        if parsed.netloc:
+            return None
+
+        raw_path = unquote(parsed.path if parsed.scheme == "file" else target)
+        if not raw_path:
+            return None
+
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = base_dir / path
+
+        if path.suffix.lower() not in SUPPORTED_IMAGE_EXTENSIONS:
+            return None
+        if not path.is_file():
+            return None
+        return path
+
+    @staticmethod
+    def _extract_markdown_link_destination(raw_target: str) -> str:
+        target = raw_target.strip()
+        if target.startswith("<"):
+            end = target.find(">")
+            if end > 0:
+                return target[1:end].strip()
+        if " " not in target:
+            return target
+        return target.split(maxsplit=1)[0].strip()
+
+    @staticmethod
+    def _next_image_index(attachments: List[Dict[str, Any]]) -> int:
+        highest = 0
+        for attachment in attachments:
+            path = str(attachment.get("path") or "")
+            match = re.search(r"(?:^|/)image-(\d+)\.[^/]+$", path)
+            if match:
+                highest = max(highest, int(match.group(1)))
+        return highest
+
+    @staticmethod
+    def _count_image_attachments(attachments: List[Dict[str, Any]]) -> int:
+        return sum(
+            1
+            for attachment in attachments
+            if str(attachment.get("path", "")).startswith("media/images/")
         )
 
     async def _process_sections_with_merge(

--- a/openviking/parse/parsers/pdf.py
+++ b/openviking/parse/parsers/pdf.py
@@ -13,6 +13,7 @@ to the MarkdownParser after conversion.
 """
 
 import asyncio
+import io
 import re
 import time
 from collections import Counter, defaultdict
@@ -20,6 +21,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.parse.base import (
+    RESOURCE_ATTACHMENTS_META_KEY,
+    RESOURCE_ROOT_PLACEHOLDER,
+    RESOURCE_ROOT_PLACEHOLDER_META_KEY,
     NodeType,
     ParseResult,
     ResourceNode,
@@ -27,6 +31,12 @@ from openviking.parse.base import (
     lazy_import,
 )
 from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.image_attachments import (
+    detect_image_extension,
+    image_attachment,
+    image_media_path,
+    markdown_image_reference,
+)
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config.parser_config import PDFConfig
 
@@ -125,6 +135,7 @@ class PDFParser(BaseParser):
                 pdf_path,
                 resource_name=resource_name,
             )
+            attachments = conversion_meta.pop(RESOURCE_ATTACHMENTS_META_KEY, [])
 
             # Step 2: Parse Markdown using MarkdownParser, pass through resource name
             md_parser = self._get_markdown_parser()
@@ -133,6 +144,7 @@ class PDFParser(BaseParser):
                 source_path=str(pdf_path),
                 resource_name=resource_name,
                 source_name=resource_name,
+                attachments=attachments,
             )
 
             # Step 3: Update metadata for PDF origin
@@ -174,7 +186,7 @@ class PDFParser(BaseParser):
 
         Args:
             pdf_path: Path to PDF file
-            resource_name: Optional resource name for organizing saved images
+            resource_name: Optional resource name for conversion strategies that need it
 
         Returns:
             Tuple of (markdown_content, metadata_dict)
@@ -183,7 +195,7 @@ class PDFParser(BaseParser):
             ValueError: If all conversion strategies fail
         """
         if self.config.strategy == "local":
-            return await self._convert_local(pdf_path, resource_name=resource_name)
+            return await asyncio.to_thread(self._convert_local, pdf_path)
 
         elif self.config.strategy == "mineru":
             return await self._convert_mineru(pdf_path, resource_name=resource_name)
@@ -191,7 +203,7 @@ class PDFParser(BaseParser):
         elif self.config.strategy == "auto":
             # Try local first
             try:
-                return await self._convert_local(pdf_path, resource_name=resource_name)
+                return await asyncio.to_thread(self._convert_local, pdf_path)
             except Exception as e:
                 logger.warning(f"Local conversion failed: {e}")
 
@@ -207,38 +219,21 @@ class PDFParser(BaseParser):
         else:
             raise ValueError(f"Unknown strategy: {self.config.strategy}")
 
-    async def _convert_local(
-        self, pdf_path: Path, storage=None, resource_name: Optional[str] = None
-    ) -> tuple[str, Dict[str, Any]]:
-        # pdfplumber / pdfminer 的解析与图片/表格提取通常是 CPU/IO 密集且为同步实现，
-        # 放到线程池中执行，避免阻塞事件循环。
-        return await asyncio.to_thread(self._convert_local_sync, pdf_path, storage, resource_name)
-
-    def _convert_local_sync(
-        self, pdf_path: Path, storage=None, resource_name: Optional[str] = None
-    ) -> tuple[str, Dict[str, Any]]:
-        """同步版：用 pdfplumber 将 PDF 转 Markdown。
-
-        该方法会在 :meth:`_convert_local` 中通过 asyncio.to_thread 调用。
-        """
+    def _convert_local(self, pdf_path: Path) -> tuple[str, Dict[str, Any]]:
+        """Convert PDF to Markdown with local pdfplumber extraction."""
         pdfplumber = lazy_import("pdfplumber")
 
-        # Import storage utilities
-        if storage is None:
-            from openviking_cli.utils.storage import get_storage
-
-            storage = get_storage()
-
-        if resource_name is None:
-            resource_name = pdf_path.stem
-
         parts = []
+        attachments: List[Dict[str, Any]] = []
         meta = {
             "strategy": "local",
             "library": "pdfplumber",
             "pages_processed": 0,
             "images_extracted": 0,
+            "images_failed": 0,
             "tables_extracted": 0,
+            "table_images_extracted": 0,
+            "table_images_failed": 0,
             "bookmarks_found": 0,
             "bookmarks_resolved": 0,
             "bookmarks_unresolved": 0,
@@ -297,6 +292,7 @@ class PDFParser(BaseParser):
                         continue
                     bookmarks_by_page[page].append(bm)
 
+                image_count = 0
                 for page_num, page in enumerate(pdf.pages, 1):
                     try:
                         # Inject headings before page text
@@ -312,16 +308,45 @@ class PDFParser(BaseParser):
                             parts.append(f"<!-- Page {page_num} -->\n{text.strip()}")
                             meta["pages_processed"] += 1
 
-                        # Extract tables
-                        tables = page.extract_tables()
-                        for table_idx, table in enumerate(tables or []):
-                            if table and len(table) > 0:
-                                md_table = self._format_table_markdown(table)
-                                if md_table:
-                                    parts.append(
-                                        f"<!-- Page {page_num} Table {table_idx + 1} -->\n{md_table}"
-                                    )
-                                    meta["tables_extracted"] += 1
+                        # Extract tables and render their visual regions when available.
+                        table_items = self._extract_table_items(page)
+                        for table_idx, table_item in enumerate(table_items):
+                            table = table_item["table"]
+                            if not table or len(table) == 0:
+                                continue
+
+                            md_table = self._format_table_markdown(table)
+                            if not md_table:
+                                continue
+
+                            parts.append(md_table)
+                            meta["tables_extracted"] += 1
+
+                            bbox = table_item.get("bbox")
+                            if not bbox:
+                                continue
+
+                            try:
+                                table_image = self._render_page_region_image(page, bbox)
+                            except Exception as table_img_err:
+                                table_image = None
+                                meta["table_images_failed"] += 1
+                                logger.warning(
+                                    "Failed to render table %d on page %d: %s",
+                                    table_idx + 1,
+                                    page_num,
+                                    table_img_err,
+                                )
+
+                            if not table_image:
+                                continue
+
+                            image_count += 1
+                            media_path = image_media_path(image_count, ".png")
+                            attachments.append(image_attachment(media_path, table_image))
+                            parts.append(markdown_image_reference(media_path))
+                            meta["images_extracted"] += 1
+                            meta["table_images_extracted"] += 1
 
                         # Extract images
                         images = page.images
@@ -330,20 +355,16 @@ class PDFParser(BaseParser):
                                 # Extract image using underlying PDF object
                                 image_obj = self._extract_image_from_page(page, img)
                                 if image_obj:
-                                    # Save image
-                                    filename = f"page{page_num}_img{img_idx + 1}"
-                                    image_path = storage.save_image(
-                                        resource_name, image_obj, filename=filename
-                                    )
-
-                                    # Generate relative path for markdown
-                                    rel_path = image_path.relative_to(Path.cwd())
-                                    parts.append(
-                                        f"<!-- Page {page_num} Image {img_idx + 1} -->\n"
-                                        f"![Page {page_num} Image {img_idx + 1}]({rel_path})"
-                                    )
+                                    extension = self._detect_image_extension(image_obj)
+                                    image_count += 1
+                                    media_path = image_media_path(image_count, extension)
+                                    attachments.append(image_attachment(media_path, image_obj))
+                                    parts.append(markdown_image_reference(media_path))
                                     meta["images_extracted"] += 1
+                                else:
+                                    meta["images_failed"] += 1
                             except Exception as img_err:
+                                meta["images_failed"] += 1
                                 logger.warning(
                                     f"Failed to extract image {img_idx + 1} on page {page_num}: {img_err}"
                                 )
@@ -355,12 +376,17 @@ class PDFParser(BaseParser):
                 return "", meta
 
             markdown_content = "\n\n".join(parts)
+            if attachments:
+                meta[RESOURCE_ATTACHMENTS_META_KEY] = attachments
+                meta[RESOURCE_ROOT_PLACEHOLDER_META_KEY] = RESOURCE_ROOT_PLACEHOLDER
             logger.info(
                 f"Local conversion: {meta['pages_processed']}/{meta['total_pages']} pages, "
                 f"{meta['headings_found']} headings ({meta['heading_source']}, "
                 f"bookmarks={meta['bookmarks_found']}, "
                 f"resolved={meta['bookmarks_resolved']}), "
-                f"{meta['images_extracted']} images, {meta['tables_extracted']} tables → "
+                f"{meta['images_extracted']} images "
+                f"({meta['table_images_extracted']} rendered table images), "
+                f"{meta['tables_extracted']} tables → "
                 f"{len(markdown_content)} chars"
             )
 
@@ -387,6 +413,73 @@ class PDFParser(BaseParser):
                 flush_cache()
             except Exception:
                 pass
+
+    def _extract_table_items(self, page: Any) -> List[Dict[str, Any]]:
+        """Extract table contents and best-effort visual regions from a pdfplumber page."""
+        find_tables = getattr(page, "find_tables", None)
+        if callable(find_tables):
+            try:
+                table_items = []
+                for table_obj in find_tables() or []:
+                    extract = getattr(table_obj, "extract", None)
+                    table = extract() if callable(extract) else None
+                    if table:
+                        table_items.append(
+                            {
+                                "table": table,
+                                "bbox": getattr(table_obj, "bbox", None),
+                            }
+                        )
+                if table_items:
+                    return table_items
+            except Exception as e:
+                logger.debug("Failed to extract table objects with bboxes: %s", e)
+
+        try:
+            return [{"table": table, "bbox": None} for table in page.extract_tables() or []]
+        except Exception as e:
+            logger.debug("Failed to extract tables: %s", e)
+            return []
+
+    @staticmethod
+    def _render_page_region_image(page: Any, bbox: Any) -> Optional[bytes]:
+        """Render a PDF page region to PNG bytes for downstream image parsing."""
+        crop_bbox = PDFParser._clamp_bbox(bbox, getattr(page, "bbox", None))
+        if crop_bbox is None:
+            return None
+
+        cropped_page = page.crop(crop_bbox)
+        page_image = cropped_page.to_image(resolution=144)
+        image = getattr(page_image, "original", page_image)
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+    @staticmethod
+    def _clamp_bbox(bbox: Any, page_bbox: Any) -> Optional[tuple[float, float, float, float]]:
+        """Clamp a pdfplumber bbox to the page bounds."""
+        if not bbox or len(bbox) != 4:
+            return None
+
+        try:
+            x0, top, x1, bottom = (float(value) for value in bbox)
+        except (TypeError, ValueError):
+            return None
+
+        if page_bbox and len(page_bbox) == 4:
+            try:
+                px0, ptop, px1, pbottom = (float(value) for value in page_bbox)
+            except (TypeError, ValueError):
+                px0 = ptop = px1 = pbottom = None
+            if px0 is not None:
+                x0 = max(x0, px0)
+                top = max(top, ptop)
+                x1 = min(x1, px1)
+                bottom = min(bottom, pbottom)
+
+        if x1 <= x0 or bottom <= top:
+            return None
+        return (x0, top, x1, bottom)
 
     def _extract_bookmarks(self, pdf) -> List[Dict[str, Any]]:
         """Extract bookmark structure from PDF outlines.
@@ -633,6 +726,11 @@ class PDFParser(BaseParser):
         except Exception as e:
             logger.debug(f"Image extraction error: {e}")
             return None
+
+    @staticmethod
+    def _detect_image_extension(image_data: bytes) -> str:
+        """Detect a stable image extension from file signatures."""
+        return detect_image_extension(image_data)
 
     async def _convert_mineru(
         self,

--- a/openviking/parse/parsers/word.py
+++ b/openviking/parse/parsers/word.py
@@ -9,10 +9,16 @@ Inspired by microsoft/markitdown approach.
 
 import asyncio
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from openviking.parse.base import ParseResult
 from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.image_attachments import (
+    image_attachment,
+    image_extension_from_name_type_or_data,
+    image_media_path,
+    markdown_image_reference,
+)
 from openviking_cli.utils.config.parser_config import ParserConfig
 from openviking_cli.utils.logger import get_logger
 
@@ -47,9 +53,19 @@ class WordParser(BaseParser):
         if path.exists():
             import docx
 
-            markdown_content = await asyncio.to_thread(self._convert_to_markdown, path, docx)
+            converted = await asyncio.to_thread(self._convert_to_markdown, path, docx)
+            if isinstance(converted, tuple):
+                markdown_content, attachments = converted
+            else:
+                markdown_content, attachments = converted, []
+            md_kwargs = dict(kwargs)
+            attachments = list(md_kwargs.pop("attachments", []) or []) + attachments
             result = await self._md_parser.parse_content(
-                markdown_content, source_path=str(path), instruction=instruction, **kwargs
+                markdown_content,
+                source_path=str(path),
+                instruction=instruction,
+                attachments=attachments,
+                **md_kwargs,
             )
         else:
             result = await self._md_parser.parse_content(
@@ -68,7 +84,7 @@ class WordParser(BaseParser):
         result.parser_name = "WordParser"
         return result
 
-    def _convert_to_markdown(self, path: Path, docx) -> str:
+    def _convert_to_markdown(self, path: Path, docx) -> tuple[str, List[Dict[str, Any]]]:
         """Convert Word document to Markdown string.
 
         Iterates the document body in order so that tables appear in their
@@ -76,6 +92,9 @@ class WordParser(BaseParser):
         """
         doc = docx.Document(path)
         markdown_parts = []
+        attachments: List[Dict[str, Any]] = []
+        image_refs: Dict[str, str] = {}
+        image_state = {"count": 0}
 
         # Map XML table elements to python-docx Table objects for O(1) lookup
         table_by_element = {table._tbl: table for table in doc.tables}
@@ -89,24 +108,38 @@ class WordParser(BaseParser):
                 from docx.text.paragraph import Paragraph
 
                 paragraph = Paragraph(child, doc)
-                if not paragraph.text.strip():
+                text = self._convert_formatted_text(
+                    paragraph,
+                    doc,
+                    attachments,
+                    image_refs,
+                    image_state,
+                )
+                if not text.strip():
                     continue
 
                 style_name = paragraph.style.name if paragraph.style else "Normal"
 
-                if style_name.startswith("Heading"):
+                if style_name.startswith("Heading") and paragraph.text.strip():
                     level = self._extract_heading_level(style_name)
                     markdown_parts.append(f"{'#' * level} {paragraph.text}")
                 else:
-                    text = self._convert_formatted_text(paragraph)
                     markdown_parts.append(text)
 
             elif child.tag == qn("w:tbl"):
                 # It's a table
                 if child in table_by_element:
-                    markdown_parts.append(self._convert_table(table_by_element[child]))
+                    markdown_parts.append(
+                        self._convert_table(
+                            table_by_element[child],
+                            doc,
+                            attachments,
+                            image_refs,
+                            image_state,
+                        )
+                    )
 
-        return "\n\n".join(markdown_parts)
+        return "\n\n".join(markdown_parts), attachments
 
     def _extract_heading_level(self, style_name: str) -> int:
         """Extract heading level from style name."""
@@ -120,32 +153,112 @@ class WordParser(BaseParser):
             pass
         return 1
 
-    def _convert_formatted_text(self, paragraph) -> str:
+    def _convert_formatted_text(
+        self,
+        paragraph,
+        doc=None,
+        attachments: Optional[List[Dict[str, Any]]] = None,
+        image_refs: Optional[Dict[str, str]] = None,
+        image_state: Optional[Dict[str, int]] = None,
+    ) -> str:
         """Convert paragraph with formatting to markdown."""
         text_parts = []
         for run in paragraph.runs:
             text = run.text
-            if not text:
-                continue
-            if run.bold:
-                text = f"**{text}**"
-            if run.italic:
-                text = f"*{text}*"
-            if run.underline:
-                text = f"<ins>{text}</ins>"
-            text_parts.append(text)
+            if text:
+                if run.bold:
+                    text = f"**{text}**"
+                if run.italic:
+                    text = f"*{text}*"
+                if run.underline:
+                    text = f"<ins>{text}</ins>"
+                text_parts.append(text)
+
+            if doc is not None and attachments is not None and image_refs is not None:
+                text_parts.extend(
+                    self._extract_run_images(run, doc, attachments, image_refs, image_state)
+                )
         return "".join(text_parts)
 
-    def _convert_table(self, table) -> str:
+    def _convert_table(
+        self,
+        table,
+        doc=None,
+        attachments: Optional[List[Dict[str, Any]]] = None,
+        image_refs: Optional[Dict[str, str]] = None,
+        image_state: Optional[Dict[str, int]] = None,
+    ) -> str:
         """Convert Word table to markdown format."""
         if not table.rows:
             return ""
 
         rows = []
         for row in table.rows:
-            row_data = [cell.text.strip() for cell in row.cells]
+            row_data = []
+            for cell in row.cells:
+                cell_parts = []
+                for paragraph in cell.paragraphs:
+                    text = self._convert_formatted_text(
+                        paragraph,
+                        doc,
+                        attachments,
+                        image_refs,
+                        image_state,
+                    )
+                    if text.strip():
+                        cell_parts.append(text.strip())
+                row_data.append("<br>".join(cell_parts))
             rows.append(row_data)
 
         from openviking.parse.base import format_table_to_markdown
 
         return format_table_to_markdown(rows, has_header=True)
+
+    def _extract_run_images(
+        self,
+        run,
+        doc,
+        attachments: List[Dict[str, Any]],
+        image_refs: Dict[str, str],
+        image_state: Optional[Dict[str, int]],
+    ) -> List[str]:
+        image_markdown = []
+        for rel_id in self._iter_run_image_relationship_ids(run):
+            image_part = doc.part.related_parts.get(rel_id)
+            if not image_part:
+                continue
+
+            part_name = str(getattr(image_part, "partname", rel_id))
+            if part_name in image_refs:
+                media_path = image_refs[part_name]
+            else:
+                image_bytes = getattr(image_part, "blob", b"")
+                if not image_bytes:
+                    continue
+                extension = image_extension_from_name_type_or_data(
+                    name=part_name,
+                    content_type=getattr(image_part, "content_type", ""),
+                    data=image_bytes,
+                )
+                if image_state is None:
+                    image_state = {"count": 0}
+                image_state["count"] += 1
+                media_path = image_media_path(image_state["count"], extension)
+                attachments.append(image_attachment(media_path, image_bytes))
+                image_refs[part_name] = media_path
+
+            image_markdown.append(markdown_image_reference(media_path))
+        return image_markdown
+
+    @staticmethod
+    def _iter_run_image_relationship_ids(run) -> List[str]:
+        from docx.oxml.ns import qn
+
+        rel_ids: List[str] = []
+        for element in run._element.iter():
+            if element.tag != qn("a:blip"):
+                continue
+            rel_id = element.get(qn("r:embed")) or element.get(qn("r:link"))
+            if rel_id:
+                rel_ids.append(rel_id)
+        return rel_ids

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -3,9 +3,11 @@
 """Semantic DAG executor with event-driven lazy dispatch."""
 
 import asyncio
+import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from openviking.parse.parsers.media.utils import get_media_type
 from openviking.server.identity import RequestContext
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
 from openviking.storage.transaction import NO_LOCK, LockLease
@@ -20,6 +22,42 @@ logger = get_logger(__name__)
 # These are canonical archives (e.g. session transcripts) whose content provides
 # no additional retrieval value and would only waste tokens and add latency.
 _SKIP_FILENAMES = frozenset({"messages.jsonl"})
+_MARKDOWN_EXTENSIONS = (".md", ".markdown", ".mdown", ".mkd")
+_MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\(([^)]+)\)")
+_IMAGE_SUMMARY_COMMENT_PATTERN = re.compile(r"<!--\s*image-summary:.*?-->", re.DOTALL)
+_SKIP_IMAGE_SUMMARIES = frozenset({"", "Image summary generation failed"})
+_REFERENCED_FROM_MARKER = "Referenced from:"
+
+
+def _format_image_summary_comment(summary: str, max_chars: int = 500) -> str:
+    text = " ".join(str(summary or "").split())
+    text = text.replace("--", "-")
+    if len(text) > max_chars:
+        text = text[: max_chars - 3].rstrip() + "..."
+    return f"<!-- image-summary: {text} -->"
+
+
+def _append_referenced_from(summary: str, markdown_uris: List[str]) -> str:
+    base_summary = _strip_referenced_from(summary)
+    refs = [uri for uri in dict.fromkeys(markdown_uris) if uri]
+    if not refs:
+        return base_summary
+
+    if len(refs) == 1:
+        reference_block = f"{_REFERENCED_FROM_MARKER} {refs[0]}"
+    else:
+        reference_block = "\n".join([_REFERENCED_FROM_MARKER, *[f"- {uri}" for uri in refs]])
+    return f"{base_summary}\n\n{reference_block}" if base_summary else reference_block
+
+
+def _strip_referenced_from(summary: str) -> str:
+    text = str(summary or "").strip()
+    marker_index = text.find(f"\n\n{_REFERENCED_FROM_MARKER}")
+    if marker_index >= 0:
+        return text[:marker_index].rstrip()
+    if text.startswith(_REFERENCED_FROM_MARKER):
+        return ""
+    return text
 
 
 @dataclass
@@ -129,6 +167,7 @@ class SemanticDagExecutor:
         try:
             await self._dispatch_dir(root_uri, parent_uri=None)
             await self._root_done.wait()
+            await self._embed_image_summaries_in_markdown()
         except Exception:
             await self._lock.close()
             raise
@@ -282,6 +321,127 @@ class SemanticDagExecutor:
             )
             return None
         return current_uri
+
+    async def _embed_image_summaries_in_markdown(self) -> None:
+        """Write generated image summaries next to markdown image references."""
+        image_summary_dicts: Dict[str, Dict[str, str]] = {}
+        image_summaries: Dict[str, str] = {}
+        markdown_files: List[str] = []
+
+        for node in self._nodes.values():
+            for file_path, summary_dict in zip(node.file_paths, node.file_summaries, strict=False):
+                if not summary_dict:
+                    continue
+
+                file_name = file_path.rsplit("/", 1)[-1]
+                if get_media_type(file_name, None) == "image":
+                    summary = str(summary_dict.get("summary") or "").strip()
+                    if summary not in _SKIP_IMAGE_SUMMARIES:
+                        image_summary_dicts[file_path] = summary_dict
+                        image_summaries[file_path] = summary
+                    continue
+
+                if file_name.lower().endswith(_MARKDOWN_EXTENSIONS):
+                    markdown_files.append(file_path)
+
+        if not image_summaries or not markdown_files:
+            return
+
+        markdown_refs: Dict[str, List[str]] = {image_uri: [] for image_uri in image_summaries}
+        for markdown_uri in markdown_files:
+            try:
+                content = await self._viking_fs.read_file(markdown_uri, ctx=self._ctx)
+                if isinstance(content, bytes):
+                    content = content.decode("utf-8", errors="replace")
+                for image_uri in self._image_uris_in_markdown(content, image_summaries):
+                    markdown_refs.setdefault(image_uri, []).append(markdown_uri)
+                updated = self._insert_image_summary_comments(content, image_summaries)
+                if updated != content:
+                    await self._viking_fs.write_file(markdown_uri, updated, ctx=self._ctx)
+                    logger.info("Embedded image summaries into markdown: %s", markdown_uri)
+            except Exception as e:
+                logger.warning(
+                    "Failed to embed image summaries into markdown %s: %s",
+                    markdown_uri,
+                    e,
+                )
+
+        for image_uri, refs in markdown_refs.items():
+            if refs and image_uri in image_summary_dicts:
+                summary_dict = image_summary_dicts[image_uri]
+                summary_dict["summary"] = _append_referenced_from(
+                    str(summary_dict.get("summary") or ""),
+                    refs,
+                )
+
+    @classmethod
+    def _insert_image_summary_comments(cls, content: str, image_summaries: Dict[str, str]) -> str:
+        lines = content.splitlines()
+        trailing_newline = content.endswith("\n")
+        updated_lines: List[str] = []
+        changed = False
+        idx = 0
+
+        while idx < len(lines):
+            line = lines[idx]
+            updated_lines.append(line)
+            comments = cls._comments_for_markdown_image_line(line, image_summaries)
+
+            if not comments:
+                idx += 1
+                continue
+
+            next_idx = idx + 1
+            if next_idx < len(lines) and _IMAGE_SUMMARY_COMMENT_PATTERN.fullmatch(
+                lines[next_idx].strip()
+            ):
+                replacement = comments[0]
+                if lines[next_idx] != replacement:
+                    changed = True
+                updated_lines.append(replacement)
+                for extra_comment in comments[1:]:
+                    updated_lines.append(extra_comment)
+                    changed = True
+                idx += 2
+                continue
+
+            updated_lines.extend(comments)
+            changed = True
+            idx += 1
+
+        if not changed:
+            return content
+
+        updated = "\n".join(updated_lines)
+        if trailing_newline:
+            updated += "\n"
+        return updated
+
+    @staticmethod
+    def _image_uris_in_markdown(content: str, image_summaries: Dict[str, str]) -> List[str]:
+        image_uris = []
+        for match in _MARKDOWN_IMAGE_PATTERN.finditer(content):
+            image_uri = match.group(1).strip()
+            if image_uri.startswith("<") and image_uri.endswith(">"):
+                image_uri = image_uri[1:-1].strip()
+            if image_uri in image_summaries:
+                image_uris.append(image_uri)
+        return image_uris
+
+    @staticmethod
+    def _comments_for_markdown_image_line(
+        line: str,
+        image_summaries: Dict[str, str],
+    ) -> List[str]:
+        comments = []
+        for match in _MARKDOWN_IMAGE_PATTERN.finditer(line):
+            image_uri = match.group(1).strip()
+            if image_uri.startswith("<") and image_uri.endswith(">"):
+                image_uri = image_uri[1:-1].strip()
+            summary = image_summaries.get(image_uri)
+            if summary:
+                comments.append(_format_image_summary_comment(summary))
+        return comments
 
     def _is_direct_incremental_update(self) -> bool:
         return (

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -10,6 +10,7 @@ as described in the OpenViking design document.
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from openviking.parse.base import RESOURCE_ROOT_PLACEHOLDER, RESOURCE_ROOT_PLACEHOLDER_META_KEY
 from openviking.parse.tree_builder import TreeBuilder
 from openviking.server.identity import RequestContext
 from openviking.storage import VikingDBManager
@@ -27,6 +28,7 @@ from openviking.utils.summarizer import Summarizer
 from openviking_cli.exceptions import OpenVikingError
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.storage import StoragePath
+from openviking_cli.utils.uri import VikingURI
 
 if TYPE_CHECKING:
     from openviking.parse.vlm import VLMProcessor
@@ -87,6 +89,68 @@ class ResourceProcessor:
                 storage=self.media_storage,
             )
         return self._media_processor
+
+    async def _rewrite_resource_root_placeholders(
+        self,
+        temp_uri: str,
+        root_uri: str,
+        ctx: RequestContext,
+    ) -> None:
+        """Replace parser placeholders in generated markdown with the final resource URI."""
+        viking_fs = get_viking_fs()
+        replacement = root_uri.rstrip("/")
+
+        async def _ls(uri: str) -> List[Dict[str, Any]]:
+            try:
+                return await viking_fs.ls(uri, show_all_hidden=True, ctx=ctx)
+            except TypeError:
+                try:
+                    return await viking_fs.ls(uri, ctx=ctx)
+                except TypeError:
+                    return await viking_fs.ls(uri)
+
+        async def _read(uri: str) -> str:
+            try:
+                content = await viking_fs.read_file(uri, ctx=ctx)
+            except TypeError:
+                content = await viking_fs.read_file(uri)
+            if isinstance(content, bytes):
+                return content.decode("utf-8", errors="replace")
+            return content
+
+        async def _write(uri: str, content: str) -> None:
+            try:
+                await viking_fs.write_file(uri, content, ctx=ctx)
+            except TypeError:
+                await viking_fs.write_file(uri, content)
+
+        async def _rewrite_dir(uri: str) -> int:
+            rewritten = 0
+            for entry in await _ls(uri):
+                name = entry.get("name", "")
+                if not name or name in {".", ".."}:
+                    continue
+                child_uri = entry.get("uri") or VikingURI(uri).join(name).uri
+                if entry.get("isDir") or entry.get("type") == "directory":
+                    rewritten += await _rewrite_dir(child_uri)
+                    continue
+                if not name.endswith(".md"):
+                    continue
+
+                content = await _read(child_uri)
+                if RESOURCE_ROOT_PLACEHOLDER not in content:
+                    continue
+                await _write(child_uri, content.replace(RESOURCE_ROOT_PLACEHOLDER, replacement))
+                rewritten += 1
+            return rewritten
+
+        rewritten = await _rewrite_dir(temp_uri)
+        if rewritten:
+            logger.info(
+                "Rewrote resource root placeholders in %d markdown file(s) under %s",
+                rewritten,
+                temp_uri,
+            )
 
     async def build_index(
         self, resource_uris: List[str], ctx: RequestContext, **kwargs
@@ -282,6 +346,8 @@ class ResourceProcessor:
                         resource_lock = await self._acquire_resource_lock(
                             lock_manager, dst_path, uri=root_uri
                         )
+                    if parse_result.meta.get(RESOURCE_ROOT_PLACEHOLDER_META_KEY) and temp_uri:
+                        await self._rewrite_resource_root_placeholders(temp_uri, root_uri, ctx)
                     if not target_preexisting:
                         await viking_fs.persist_temp_tree(temp_uri, root_uri, ctx=ctx)
                         await viking_fs.delete_temp(parse_result.temp_dir_path, ctx=ctx)

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -286,3 +286,66 @@ async def test_resource_processor_auto_candidate_skips_existing_and_busy(monkeyp
     assert summarize_calls[0]["temp_uris"] == ["viking://resources/root_2"]
     assert summarize_calls[0]["target_preexisting"] is False
     assert fake_fs.persist_calls == [("viking://temp/root_tmp", "viking://resources/root_2")]
+
+
+@pytest.mark.asyncio
+async def test_resource_processor_rewrites_resource_root_placeholders(monkeypatch):
+    from openviking.parse.base import RESOURCE_ROOT_PLACEHOLDER
+    from openviking.utils.resource_processor import ResourceProcessor
+
+    class FakeTreeFS:
+        def __init__(self):
+            self.files = {
+                "viking://temp/root/doc.md": (
+                    f"![image]({RESOURCE_ROOT_PLACEHOLDER}/media/images/image-1.png)"
+                ),
+                "viking://temp/root/media/images/image-1.png": b"image",
+            }
+            self.dirs = {
+                "viking://temp/root",
+                "viking://temp/root/media",
+                "viking://temp/root/media/images",
+            }
+
+        async def ls(self, uri, show_all_hidden=False, ctx=None):
+            prefix = uri.rstrip("/") + "/"
+            names = {}
+            for item in list(self.dirs) + list(self.files):
+                if not item.startswith(prefix):
+                    continue
+                rest = item[len(prefix) :]
+                if not rest:
+                    continue
+                name = rest.split("/", 1)[0]
+                child_uri = f"{uri.rstrip('/')}/{name}"
+                names[name] = child_uri in self.dirs
+            return [
+                {
+                    "name": name,
+                    "uri": f"{uri.rstrip('/')}/{name}",
+                    "isDir": is_dir,
+                    "type": "directory" if is_dir else "file",
+                }
+                for name, is_dir in sorted(names.items())
+            ]
+
+        async def read_file(self, uri, ctx=None):
+            return self.files[uri]
+
+        async def write_file(self, uri, content, ctx=None):
+            self.files[uri] = content
+
+    fake_fs = FakeTreeFS()
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+
+    rp = ResourceProcessor(vikingdb=_DummyVikingDB(), media_storage=None)
+    await rp._rewrite_resource_root_placeholders(
+        "viking://temp/root",
+        "viking://resources/papers/demo",
+        ctx=object(),
+    )
+
+    assert fake_fs.files["viking://temp/root/doc.md"] == (
+        "![image](viking://resources/papers/demo/media/images/image-1.png)"
+    )
+    assert fake_fs.files["viking://temp/root/media/images/image-1.png"] == b"image"

--- a/tests/parse/test_document_image_attachments.py
+++ b/tests/parse/test_document_image_attachments.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for document parsers that produce image attachments."""
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from openviking.parse.base import (
+    RESOURCE_ROOT_PLACEHOLDER,
+    NodeType,
+    ResourceNode,
+    create_parse_result,
+)
+from openviking.parse.parsers.legacy_doc import LegacyDocParser
+from openviking.parse.parsers.word import WordParser
+
+_PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/gL+X7QAAAAASUVORK5CYII="
+)
+
+
+def test_word_parser_extracts_docx_images_in_place(tmp_path: Path):
+    docx = pytest.importorskip("docx")
+
+    image_path = tmp_path / "diagram.png"
+    image_path.write_bytes(_PNG_1X1)
+    docx_path = tmp_path / "sample.docx"
+
+    doc = docx.Document()
+    paragraph = doc.add_paragraph("before ")
+    paragraph.add_run().add_picture(str(image_path))
+    paragraph.add_run(" after")
+    doc.save(docx_path)
+
+    markdown, attachments = WordParser()._convert_to_markdown(docx_path, docx)
+
+    assert attachments == [{"path": "media/images/image-1.png", "content": _PNG_1X1}]
+    assert (
+        f"before ![image]({RESOURCE_ROOT_PLACEHOLDER}/media/images/image-1.png) after" in markdown
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_doc_parser_reuses_pdf_conversion_when_available(
+    monkeypatch,
+    tmp_path: Path,
+):
+    doc_path = tmp_path / "legacy.doc"
+    doc_path.write_bytes(b"placeholder")
+    pdf_path = tmp_path / "legacy.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    parser = LegacyDocParser()
+
+    async def convert_to_pdf(path):
+        assert path == doc_path
+        return pdf_path
+
+    async def parse_pdf(path, instruction="", **kwargs):
+        assert path == pdf_path
+        assert instruction == "extract images"
+        assert kwargs["resource_name"] == "legacy"
+        return create_parse_result(
+            root=ResourceNode(type=NodeType.ROOT),
+            source_path=str(path),
+            source_format="pdf",
+            parser_name="PDFParser",
+            meta={"images_extracted": 1},
+        )
+
+    monkeypatch.setattr(parser, "_convert_to_pdf", convert_to_pdf)
+    monkeypatch.setattr(parser, "_parse_pdf", parse_pdf)
+
+    result = await parser.parse(doc_path, instruction="extract images", resource_name="legacy")
+
+    assert result.source_path == str(doc_path)
+    assert result.source_format == "doc"
+    assert result.parser_name == "LegacyDocParser"
+    assert result.meta["images_extracted"] == 1
+    assert result.meta["intermediate_format"] == "pdf"

--- a/tests/parse/test_document_parser_threading.py
+++ b/tests/parse/test_document_parser_threading.py
@@ -171,6 +171,10 @@ async def test_legacy_doc_parser_offloads_doc_extraction(monkeypatch, tmp_path: 
     def extract(path: Path) -> str:
         return "# converted doc"
 
+    async def parse_converted_pdf(path, instruction, kwargs):
+        return None
+
+    monkeypatch.setattr(parser, "_parse_converted_pdf", parse_converted_pdf)
     monkeypatch.setattr(parser, "_extract_text", extract)
     source = tmp_path / "sample.doc"
     source.write_bytes(b"placeholder")

--- a/tests/parse/test_markdown_attachments.py
+++ b/tests/parse/test_markdown_attachments.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for parser-produced attachments in MarkdownParser."""
+
+import pytest
+
+from openviking.parse.base import RESOURCE_ROOT_PLACEHOLDER, RESOURCE_ROOT_PLACEHOLDER_META_KEY
+from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.markdown import MarkdownParser
+from openviking_cli.utils.config.parser_config import ParserConfig
+
+
+class _FakeVikingFS:
+    def __init__(self):
+        self.dirs = []
+        self.files = {}
+
+    def create_temp_uri(self):
+        return "viking://temp/attachments"
+
+    async def mkdir(self, uri, exist_ok=False):
+        if uri not in self.dirs:
+            self.dirs.append(uri)
+
+    async def write_file(self, uri, content):
+        self.files[uri] = content.encode("utf-8") if isinstance(content, str) else content
+
+    async def write_file_bytes(self, uri, content):
+        self.files[uri] = content
+
+
+@pytest.mark.asyncio
+async def test_markdown_parser_persists_safe_parser_attachments(monkeypatch):
+    fake_fs = _FakeVikingFS()
+    monkeypatch.setattr(BaseParser, "_get_viking_fs", lambda _self: fake_fs)
+    parser = MarkdownParser(config=ParserConfig())
+
+    result = await parser.parse_content(
+        "hello",
+        source_path="paper.pdf",
+        resource_name="paper",
+        attachments=[
+            {"path": "../outside.png", "content": b"bad"},
+            {"path": "/absolute.png", "content": b"bad"},
+            {"path": "media/images/image-1.png", "content": b"image-bytes"},
+        ],
+    )
+
+    assert result.temp_dir_path == "viking://temp/attachments"
+    assert (
+        fake_fs.files["viking://temp/attachments/paper/media/images/image-1.png"] == b"image-bytes"
+    )
+    assert fake_fs.files["viking://temp/attachments/paper/paper.md"] == b"hello"
+    assert result.meta[RESOURCE_ROOT_PLACEHOLDER_META_KEY] == RESOURCE_ROOT_PLACEHOLDER
+    assert all("outside" not in uri for uri in fake_fs.files)
+    assert all("absolute" not in uri for uri in fake_fs.files)
+
+
+@pytest.mark.asyncio
+async def test_markdown_parser_copies_local_image_references(monkeypatch, tmp_path):
+    fake_fs = _FakeVikingFS()
+    monkeypatch.setattr(BaseParser, "_get_viking_fs", lambda _self: fake_fs)
+    parser = MarkdownParser(config=ParserConfig())
+
+    image_path = tmp_path / "diagram.png"
+    image_bytes = b"\x89PNG\r\n\x1a\nfake-png"
+    image_path.write_bytes(image_bytes)
+    markdown_path = tmp_path / "paper.md"
+    markdown_path.write_text("intro\n\n![diagram](diagram.png)\n", encoding="utf-8")
+
+    result = await parser.parse(markdown_path)
+
+    markdown = fake_fs.files["viking://temp/attachments/paper/paper.md"].decode("utf-8")
+    assert (
+        markdown == f"intro\n\n![diagram]({RESOURCE_ROOT_PLACEHOLDER}/media/images/image-1.png)\n"
+    )
+    assert fake_fs.files["viking://temp/attachments/paper/media/images/image-1.png"] == image_bytes
+    assert result.meta[RESOURCE_ROOT_PLACEHOLDER_META_KEY] == RESOURCE_ROOT_PLACEHOLDER

--- a/tests/parse/test_pdf_bookmark_extraction.py
+++ b/tests/parse/test_pdf_bookmark_extraction.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from openviking.parse.base import RESOURCE_ATTACHMENTS_META_KEY, RESOURCE_ROOT_PLACEHOLDER
 from openviking.parse.parsers.pdf import PDFParser
 
 
@@ -249,9 +250,7 @@ class TestConvertLocalBookmarks:
                 ],
             ),
         ):
-            markdown, meta = await parser._convert_local(
-                "dummy.pdf", storage=MagicMock(), resource_name="dummy"
-            )
+            markdown, meta = parser._convert_local("dummy.pdf")
 
         assert "Broken Bookmark" not in markdown
         assert "\n# Chapter 2\n" in markdown
@@ -280,9 +279,7 @@ class TestConvertLocalBookmarks:
                 return_value=[{"level": 1, "title": "Font Heading", "page_num": 2}],
             ),
         ):
-            markdown, meta = await parser._convert_local(
-                "dummy.pdf", storage=MagicMock(), resource_name="dummy"
-            )
+            markdown, meta = parser._convert_local("dummy.pdf")
 
         assert "Broken Bookmark" not in markdown
         assert "\n# Font Heading\n" in markdown
@@ -304,10 +301,67 @@ class TestConvertLocalBookmarks:
             patch.object(parser, "_extract_bookmarks", return_value=[]),
             patch.object(parser, "_detect_headings_by_font", return_value=[]),
         ):
-            await parser._convert_local("dummy.pdf", storage=MagicMock(), resource_name="dummy")
+            parser._convert_local("dummy.pdf")
 
         assert [page.close_count for page in pages] == [1, 1]
         assert [page.flush_count for page in pages] == [1, 1]
+
+    @pytest.mark.asyncio
+    async def test_convert_local_extracts_images_as_resource_attachments(self):
+        parser = PDFParser()
+        page = _FakePage("Page one")
+        page.images = [{"name": "Im1"}]
+        fake_pdf = SimpleNamespace(pages=[page])
+        fake_pdfplumber = SimpleNamespace(open=lambda _path: nullcontext(fake_pdf))
+        image_data = b"\x89PNG\r\n\x1a\nimage-bytes"
+
+        with (
+            patch("openviking.parse.parsers.pdf.lazy_import", return_value=fake_pdfplumber),
+            patch.object(parser, "_extract_bookmarks", return_value=[]),
+            patch.object(parser, "_detect_headings_by_font", return_value=[]),
+            patch.object(parser, "_extract_image_from_page", return_value=image_data),
+        ):
+            markdown, meta = parser._convert_local("dummy.pdf")
+
+        media_path = "media/images/image-1.png"
+        assert f"{RESOURCE_ROOT_PLACEHOLDER}/{media_path}" in markdown
+        assert f"![image]({RESOURCE_ROOT_PLACEHOLDER}/{media_path})" in markdown
+        assert "Page 1 Image 1" not in markdown
+        assert meta["images_extracted"] == 1
+        assert meta["images_failed"] == 0
+        assert meta[RESOURCE_ATTACHMENTS_META_KEY] == [{"path": media_path, "content": image_data}]
+
+    @pytest.mark.asyncio
+    async def test_convert_local_renders_table_regions_as_resource_attachments(self):
+        parser = PDFParser()
+        page = _FakePage("Page one")
+        page.find_tables = lambda: [
+            SimpleNamespace(
+                extract=lambda: [["Name", "Value"], ["CXL", "42"]],
+                bbox=(1, 2, 3, 4),
+            )
+        ]
+        fake_pdf = SimpleNamespace(pages=[page])
+        fake_pdfplumber = SimpleNamespace(open=lambda _path: nullcontext(fake_pdf))
+        table_image = b"\x89PNG\r\n\x1a\ntable-image"
+
+        with (
+            patch("openviking.parse.parsers.pdf.lazy_import", return_value=fake_pdfplumber),
+            patch.object(parser, "_extract_bookmarks", return_value=[]),
+            patch.object(parser, "_detect_headings_by_font", return_value=[]),
+            patch.object(parser, "_render_page_region_image", return_value=table_image),
+        ):
+            markdown, meta = parser._convert_local("dummy.pdf")
+
+        media_path = "media/images/image-1.png"
+        assert "| Name | Value |" in markdown
+        assert f"{RESOURCE_ROOT_PLACEHOLDER}/{media_path}" in markdown
+        assert f"![image]({RESOURCE_ROOT_PLACEHOLDER}/{media_path})" in markdown
+        assert "Page 1 Table 1" not in markdown
+        assert meta["tables_extracted"] == 1
+        assert meta["table_images_extracted"] == 1
+        assert meta["images_extracted"] == 1
+        assert meta[RESOURCE_ATTACHMENTS_META_KEY] == [{"path": media_path, "content": table_image}]
 
     def test_detect_headings_by_font_closes_pages(self):
         parser = PDFParser()

--- a/tests/storage/test_semantic_dag_stats.py
+++ b/tests/storage/test_semantic_dag_stats.py
@@ -12,14 +12,19 @@ from openviking_cli.session.user_id import UserIdentifier
 
 
 class _FakeVikingFS:
-    def __init__(self, tree):
+    def __init__(self, tree, files=None):
         self._tree = tree
+        self.files = dict(files or {})
         self.writes = []
 
     async def ls(self, uri, ctx=None):
         return self._tree.get(uri, [])
 
+    async def read_file(self, path, ctx=None):
+        return self.files[path]
+
     async def write_file(self, path, content, ctx=None):
+        self.files[path] = content
         self.writes.append((path, content))
 
     def _uri_to_path(self, uri, ctx=None):
@@ -30,8 +35,14 @@ class _FakeProcessor:
     def __init__(self):
         self.vectorized_dirs = []
         self.vectorized_files = []
+        self.vectorized_file_summaries = {}
 
     async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        if file_path.endswith(".png"):
+            return {
+                "name": file_path.split("/")[-1],
+                "summary": "A CXL memory pool diagram -- with GPU allocation details.\nSecond line.",
+            }
         return {"name": file_path.split("/")[-1], "summary": "summary"}
 
     async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
@@ -59,6 +70,7 @@ class _FakeProcessor:
         use_summary=False,
     ):
         self.vectorized_files.append(file_path)
+        self.vectorized_file_summaries[file_path] = summary_dict["summary"]
 
     async def _vectorize_directory_simple(self, uri, context_type, abstract, overview, ctx=None):
         await self._vectorize_directory(uri, context_type, abstract, overview, ctx=ctx)
@@ -186,6 +198,59 @@ async def test_semantic_dag_skip_vectorization_does_not_schedule_tasks(monkeypat
     assert processor.vectorized_dirs == []
     assert processor.vectorized_files == []
     assert tracker.register_calls == []
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_embeds_image_summaries_in_markdown_before_vectorizing(monkeypatch):
+    root_uri = "viking://resources/root"
+    image_uri = f"{root_uri}/media/images/image-2.png"
+    markdown_uri = f"{root_uri}/doc.md"
+    tree = {
+        root_uri: [
+            {"name": "doc.md", "isDir": False},
+            {"name": "media", "isDir": True},
+        ],
+        f"{root_uri}/media": [
+            {"name": "images", "isDir": True},
+        ],
+        f"{root_uri}/media/images": [
+            {"name": "image-2.png", "isDir": False},
+        ],
+    }
+    fake_fs = _FakeVikingFS(
+        tree,
+        files={
+            markdown_uri: f"Intro\n\n![image]({image_uri})\n\nText\n",
+            image_uri: b"image",
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _DummyTracker(),
+    )
+
+    processor = _FakeProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+    )
+    await executor.run(root_uri)
+    await asyncio.sleep(0)
+
+    assert fake_fs.files[markdown_uri] == (
+        f"Intro\n\n![image]({image_uri})\n"
+        "<!-- image-summary: A CXL memory pool diagram - with GPU allocation details. "
+        "Second line. -->\n\nText\n"
+    )
+    assert markdown_uri in processor.vectorized_files
+    assert processor.vectorized_file_summaries[image_uri] == (
+        "A CXL memory pool diagram -- with GPU allocation details.\nSecond line.\n\n"
+        f"Referenced from: {markdown_uri}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

本 PR 保留文档解析过程中产生或引用的图片附件，并让 Markdown、PDF、Word、legacy `.doc` 的图片可以跟随资源一起落盘、迁移和参与后续语义处理。

示例：

上传 `paper.md`，内容包含：

```markdown
本文介绍 CXL 内存池。

![架构图](diagram.png)
```

解析后会把本地图片复制到资源树内，并把 Markdown 改写为稳定资源 URI：

```markdown
本文介绍 CXL 内存池。

![架构图](viking://resources/papers/paper/media/images/image-1.png)
<!-- image-summary: A CXL memory pool diagram - with GPU allocation details. -->
```

这样图片不会再停留在临时目录或本地相对路径里，后续检索也能通过图片摘要理解这张图和正文的关系。

## Related Issue

暂无

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 新增统一的文档图片附件工具，标准化图片扩展名识别、`media/images/image-N.ext` 路径和 Markdown 图片引用生成。
- Markdown 解析支持复制本地图片引用，并安全写入 parser 产生的二进制附件；PDF/Word 解析将提取出的图片、表格区域图片作为附件交给 Markdown 解析落盘。
- 资源持久化前把临时 `RESOURCE_ROOT_PLACEHOLDER` 替换成最终 `viking://resources/...` URI，并在 Semantic DAG 中把图片摘要写回 Markdown 图片引用旁边。
- legacy `.doc` 优先尝试 LibreOffice 转 PDF 后复用 PDF parser，保留图片和表格视觉内容；保留原有文本抽取作为 fallback。
- 补充 Markdown、PDF、Word、legacy `.doc`、资源 URI 重写和图片摘要回写的单元测试。

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

测试命令：

```bash
.venv/bin/python -m pytest tests/parse/test_markdown_attachments.py tests/parse/test_document_image_attachments.py tests/parse/test_pdf_bookmark_extraction.py tests/misc/test_resource_processor_mv.py tests/storage/test_semantic_dag_stats.py tests/parse/test_document_parser_threading.py
```

结果：37 passed。测试过程中仍有项目既有的 `requests` 依赖版本提示和 Pydantic deprecation warnings。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用

## Additional Notes

这次改动刻意让解析阶段先使用占位符 URI，再由 `ResourceProcessor` 在资源最终落盘前统一改写为目标资源 URI，避免 parser 提前猜测最终路径。
