### PR TITLE
feat(langchain): implement local batch message writes

### DIFF
--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -551,6 +551,68 @@ class LocalClient(BaseClient):
             "message_count": len(session.messages),
         }
 
+    async def batch_add_messages(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        telemetry: TelemetryRequest = False,
+    ) -> Dict[str, Any]:
+        """Add multiple messages to a session in one batch."""
+        execution = await run_with_telemetry(
+            operation="session.batch_add_messages",
+            telemetry=telemetry,
+            fn=lambda: self._batch_add_messages_impl(session_id, messages),
+        )
+        return attach_telemetry_payload(
+            execution.result,
+            execution.telemetry,
+        )
+
+    async def _batch_add_messages_impl(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        from openviking.message.part import Part, TextPart, part_from_dict
+
+        session = await self._service.sessions.get(session_id, self._ctx, auto_create=True)
+        specs: list[dict[str, Any]] = []
+
+        for index, message in enumerate(messages):
+            role = message.get("role")
+            if not role:
+                raise ValueError(f"messages[{index}]: missing required key 'role'")
+
+            message_parts: list[Part]
+            if message.get("parts") is not None:
+                message_parts = [part_from_dict(part) for part in message["parts"]]
+            elif message.get("content") is not None:
+                message_parts = [TextPart(text=str(message["content"]))]
+            else:
+                raise ValueError(f"messages[{index}]: either content or parts must be provided")
+
+            role_id = message.get("role_id")
+            if role_id is None and role == "user":
+                role_id = self._ctx.user.user_id
+            elif role_id is None and role == "assistant":
+                role_id = self._ctx.user.agent_id
+
+            specs.append(
+                {
+                    "role": role,
+                    "parts": message_parts,
+                    "role_id": role_id,
+                    "created_at": message.get("created_at"),
+                }
+            )
+
+        added = session.add_messages(specs)
+        return {
+            "session_id": session_id,
+            "message_count": len(session.messages),
+            "added": len(added),
+        }
+
     # ============= Pack =============
 
     async def export_ovpack(

--- a/openviking/integrations/langchain/testing.py
+++ b/openviking/integrations/langchain/testing.py
@@ -226,6 +226,8 @@ class InMemoryOpenVikingClient:
         role: str,
         content: str | None = None,
         parts: list[dict] | None = None,
+        created_at: str | None = None,
+        role_id: str | None = None,
         **_: Any,
     ) -> dict[str, Any]:
         message_parts = list(parts or [{"type": "text", "text": content or ""}])
@@ -233,8 +235,10 @@ class InMemoryOpenVikingClient:
             "id": f"msg_{uuid.uuid4().hex}",
             "role": role,
             "parts": message_parts,
-            "created_at": datetime.now(timezone.utc).isoformat(),
+            "created_at": created_at or datetime.now(timezone.utc).isoformat(),
         }
+        if role_id is not None:
+            message["role_id"] = role_id
         self.sessions.setdefault(session_id, []).append(message)
         self.pending_tokens[session_id] += max(1, len(_message_text(message)) // 4)
         return {
@@ -256,6 +260,8 @@ class InMemoryOpenVikingClient:
                 role=message["role"],
                 content=message.get("content"),
                 parts=message.get("parts"),
+                created_at=message.get("created_at"),
+                role_id=message.get("role_id"),
             )
             added += 1
         return {

--- a/openviking/integrations/langchain/testing.py
+++ b/openviking/integrations/langchain/testing.py
@@ -243,6 +243,27 @@ class InMemoryOpenVikingClient:
             "message_count": len(self.sessions[session_id]),
         }
 
+    def batch_add_messages(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        **_: Any,
+    ) -> dict[str, Any]:
+        added = 0
+        for message in messages:
+            self.add_message(
+                session_id=session_id,
+                role=message["role"],
+                content=message.get("content"),
+                parts=message.get("parts"),
+            )
+            added += 1
+        return {
+            "session_id": session_id,
+            "message_count": len(self.sessions[session_id]),
+            "added": added,
+        }
+
     def get_session(self, session_id: str, auto_create: bool = False) -> dict[str, Any]:
         if auto_create:
             self.create_session(session_id=session_id)

--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -77,6 +77,46 @@ async def test_local_client_reindex_forwards_to_service():
     client._service.reindex.assert_awaited_once()
 
 
+async def test_local_client_batch_add_messages_forwards_to_session():
+    class FakeSession:
+        def __init__(self):
+            self.messages = []
+
+        def add_messages(self, specs):
+            self.messages.extend(specs)
+            return specs
+
+    fake_session = FakeSession()
+
+    class FakeSessions:
+        async def get(self, session_id, ctx, auto_create=False):
+            assert session_id == "batch-session"
+            assert ctx is client._ctx
+            assert auto_create is True
+            return fake_session
+
+    client = LocalClient.__new__(LocalClient)
+    client._service = SimpleNamespace(sessions=FakeSessions())
+    client._ctx = SimpleNamespace(user=SimpleNamespace(user_id="user-1", agent_id="agent-1"))
+
+    result = await LocalClient.batch_add_messages(
+        client,
+        "batch-session",
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "parts": [{"type": "text", "text": "hi"}]},
+        ],
+    )
+
+    assert result == {"session_id": "batch-session", "message_count": 2, "added": 2}
+    assert fake_session.messages[0]["role"] == "user"
+    assert fake_session.messages[0]["role_id"] == "user-1"
+    assert fake_session.messages[0]["parts"][0].text == "hello"
+    assert fake_session.messages[1]["role"] == "assistant"
+    assert fake_session.messages[1]["role_id"] == "agent-1"
+    assert fake_session.messages[1]["parts"][0].text == "hi"
+
+
 async def test_async_http_client_reindex_posts_content_reindex():
     client = AsyncHTTPClient(url="http://localhost:1933")
     fake_http = SimpleNamespace(post=AsyncMock(return_value=object()))

--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -103,18 +103,51 @@ async def test_local_client_batch_add_messages_forwards_to_session():
         client,
         "batch-session",
         [
-            {"role": "user", "content": "hello"},
+            {
+                "role": "user",
+                "content": "hello",
+                "role_id": "explicit-user",
+                "created_at": "2026-05-28T00:00:00+00:00",
+            },
             {"role": "assistant", "parts": [{"type": "text", "text": "hi"}]},
         ],
     )
 
     assert result == {"session_id": "batch-session", "message_count": 2, "added": 2}
     assert fake_session.messages[0]["role"] == "user"
-    assert fake_session.messages[0]["role_id"] == "user-1"
+    assert fake_session.messages[0]["role_id"] == "explicit-user"
+    assert fake_session.messages[0]["created_at"] == "2026-05-28T00:00:00+00:00"
     assert fake_session.messages[0]["parts"][0].text == "hello"
     assert fake_session.messages[1]["role"] == "assistant"
     assert fake_session.messages[1]["role_id"] == "agent-1"
     assert fake_session.messages[1]["parts"][0].text == "hi"
+
+
+async def test_async_http_client_batch_add_messages_posts_batch_payload():
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    fake_http = SimpleNamespace(post=AsyncMock(return_value=object()))
+    client._http = fake_http
+    client._handle_response_data = lambda _response: {
+        "result": {"session_id": "batch-session", "message_count": 2, "added": 2}
+    }
+
+    messages = [
+        {
+            "role": "user",
+            "content": "hello",
+            "role_id": "explicit-user",
+            "created_at": "2026-05-28T00:00:00+00:00",
+        },
+        {"role": "assistant", "parts": [{"type": "text", "text": "hi"}]},
+    ]
+
+    result = await client.batch_add_messages("batch-session", messages)
+
+    assert result == {"session_id": "batch-session", "message_count": 2, "added": 2}
+    fake_http.post.assert_awaited_once_with(
+        "/api/v1/sessions/batch-session/messages/batch",
+        json={"messages": messages},
+    )
 
 
 async def test_async_http_client_reindex_posts_content_reindex():
@@ -162,6 +195,34 @@ def test_sync_http_client_reindex_forwards_to_async_client():
     assert result == {"status": "accepted"}
     assert mock_run.called
     assert mock_reindex.called
+
+
+def test_sync_http_client_batch_add_messages_forwards_to_async_client():
+    client = SyncHTTPClient(url="http://localhost:1933")
+    messages = [
+        {
+            "role": "user",
+            "content": "hello",
+            "role_id": "explicit-user",
+            "created_at": "2026-05-28T00:00:00+00:00",
+        },
+        {"role": "assistant", "parts": [{"type": "text", "text": "hi"}]},
+    ]
+
+    with patch.object(
+        client._async_client,
+        "batch_add_messages",
+        return_value={"session_id": "batch-session", "message_count": 2, "added": 2},
+    ) as mock_batch:
+        with patch(
+            "openviking_cli.client.sync_http.run_async",
+            return_value={"session_id": "batch-session", "message_count": 2, "added": 2},
+        ) as mock_run:
+            result = client.batch_add_messages("batch-session", messages)
+
+    assert result == {"session_id": "batch-session", "message_count": 2, "added": 2}
+    assert mock_run.called
+    mock_batch.assert_called_once_with("batch-session", messages, False)
 
 
 def test_run_async_from_foreign_event_loop_uses_shared_background_loop():

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -359,6 +359,26 @@ def test_retriever_recovers_from_stale_cached_remote_client(monkeypatch):
     assert instances[0].closed is True
 
 
+def test_in_memory_openviking_client_batch_add_messages_records_messages():
+    client = InMemoryOpenVikingClient()
+
+    result = client.batch_add_messages(
+        "batch-session",
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "parts": [{"type": "text", "text": "hi"}]},
+        ],
+    )
+
+    assert result == {"session_id": "batch-session", "message_count": 2, "added": 2}
+    assert [message["role"] for message in client.sessions["batch-session"]] == [
+        "user",
+        "assistant",
+    ]
+    assert client.sessions["batch-session"][0]["parts"][0]["text"] == "hello"
+    assert client.sessions["batch-session"][1]["parts"][0]["text"] == "hi"
+
+
 def test_chat_message_history_preserves_tool_parts():
     client = InMemoryOpenVikingClient()
     history = OpenVikingChatMessageHistory(session_id="history-session", client=client)

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -366,7 +366,12 @@ def test_in_memory_openviking_client_batch_add_messages_records_messages():
         "batch-session",
         [
             {"role": "user", "content": "hello"},
-            {"role": "assistant", "parts": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "hi"}],
+                "role_id": "agent-1",
+                "created_at": "2026-05-26T00:00:00+00:00",
+            },
         ],
     )
 
@@ -377,6 +382,8 @@ def test_in_memory_openviking_client_batch_add_messages_records_messages():
     ]
     assert client.sessions["batch-session"][0]["parts"][0]["text"] == "hello"
     assert client.sessions["batch-session"][1]["parts"][0]["text"] == "hi"
+    assert client.sessions["batch-session"][1]["role_id"] == "agent-1"
+    assert client.sessions["batch-session"][1]["created_at"] == "2026-05-26T00:00:00+00:00"
 
 
 def test_chat_message_history_preserves_tool_parts():


### PR DESCRIPTION
## Summary

- Add `batch_add_messages` to the embedded `LocalClient` so it matches the `BaseClient` session-write contract.
- Add the same method to the LangChain `InMemoryOpenVikingClient` used by tests and examples.
- Cover batch-write behavior across local, in-memory, async HTTP, and sync HTTP client paths.

## Why

The remote HTTP client already supports `batch_add_messages`, and LangChain chat history code can call the method through the shared client contract. Local and in-memory clients should not require separate handling for the same operation.

Fixes #2249.

## Test Plan

- `uv run --extra test pytest tests/client/test_rebuild_clients.py tests/unit/test_langchain_integration.py --no-cov -q`
- `uv run --extra dev ruff check openviking/client/local.py openviking/integrations/langchain/testing.py openviking_cli/client/http.py openviking_cli/client/sync_http.py tests/client/test_rebuild_clients.py tests/unit/test_langchain_integration.py`
- `uv run ruff format --check openviking/client/local.py openviking/integrations/langchain/testing.py openviking_cli/client/http.py openviking_cli/client/sync_http.py tests/client/test_rebuild_clients.py tests/unit/test_langchain_integration.py`
- `git diff --check`
