### PR TITLE
fix(retrieval): bound search query embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ If you prefer manual configuration, create `~/.openviking/ov.conf`, remove the c
     },
     "max_concurrent": 10,              // Max concurrent embedding requests (default: 10)
     "text_source": "content_only",     // Text file vectorization source: content_only|summary_first|summary_only
-    "max_input_tokens": 4096           // Max estimated raw text tokens sent to embedding
+    "max_input_tokens": 4096,          // Max estimated raw text tokens sent to embedding
+    "query_max_input_tokens": 2048     // Optional max estimated search-query tokens sent to embedding
   },
   "vlm": {
     "api_base" : "<api-endpoint>",     // API endpoint address

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -195,6 +195,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
     "max_retries": 3,
     "text_source": "content_only",
     "max_input_tokens": 4096,
+    "query_max_input_tokens": 2048,
     "dense": {
       "provider": "volcengine",
       "api_key": "your-api-key",
@@ -214,6 +215,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 | `max_retries` | int | Maximum retry attempts for transient embedding provider errors (`embedding.max_retries`, default: `3`; `0` disables retry) |
 | `text_source` | str | Text used for vectorizing text files. `content_only` reads raw content, `summary_first` uses summary when available and falls back to content, `summary_only` uses only summary. Default: `content_only` |
 | `max_input_tokens` | int | Maximum estimated raw text tokens sent to the embedding model when content is used. Default: `4096` |
+| `query_max_input_tokens` | int | Optional maximum estimated search-query tokens sent to the embedding model. Defaults to `min(embedding.max_input_tokens, 2048)` |
 | `provider` | str | `"openai"`, `"azure"`, `"volcengine"`, `"vikingdb"`, `"jina"`, `"ollama"`, `"gemini"`, `"voyage"`, `"dashscope"`, `"minimax"`, `"cohere"`, `"litellm"`, or `"local"` |
 | `api_key` | str | API key |
 | `model` | str | Model name |
@@ -1346,6 +1348,7 @@ For detailed encryption explanations, see [Data Encryption](../concepts/10-encry
     "max_retries": 3,
     "text_source": "content_only",
     "max_input_tokens": 4096,
+    "query_max_input_tokens": 2048,
     "dense": {
       "provider": "volcengine",
       "api_key": "string",

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -196,6 +196,7 @@ openviking-server doctor
     "max_retries": 3,
     "text_source": "content_only",
     "max_input_tokens": 4096,
+    "query_max_input_tokens": 2048,
     "dense": {
       "provider": "volcengine",
       "api_key": "your-api-key",
@@ -216,6 +217,7 @@ openviking-server doctor
 | `max_retries` | int | Embedding provider 瞬时错误的最大重试次数（`embedding.max_retries`，默认：`3`；`0` 表示禁用重试） |
 | `text_source` | str | 文本文件向量化时使用的文本来源。`content_only` 读取原文内容；`summary_first` 优先使用摘要，没有摘要时回退到原文；`summary_only` 只使用摘要。默认：`content_only` |
 | `max_input_tokens` | int | 使用原文内容向量化时，发送给 embedding 模型的最大估算 token 数。默认：`4096` |
+| `query_max_input_tokens` | int | 可选的搜索查询 embedding 最大估算 token 数。默认：`min(embedding.max_input_tokens, 2048)` |
 | `provider` | str | `"openai"`、`"azure"`、`"volcengine"`、`"vikingdb"`、`"jina"`、`"ollama"`、`"gemini"`、`"voyage"`、`"dashscope"`、`"minimax"`、`"cohere"`、`"litellm"` 或 `"local"` |
 | `api_key` | str | API Key |
 | `model` | str | 模型名称 |
@@ -1318,6 +1320,7 @@ openviking add-resource ./docs --exclude "*.tmp"
     "max_retries": 3,
     "text_source": "content_only",
     "max_input_tokens": 4096,
+    "query_max_input_tokens": 2048,
     "dense": {
       "provider": "volcengine",
       "api_key": "string",

--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -24,6 +24,10 @@ from openviking.server.identity import RequestContext, Role
 from openviking.storage import VikingDBManager, VikingDBManagerProxy
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
+from openviking.utils.embedding_input import (
+    estimate_embedding_input_tokens,
+    truncate_embedding_input,
+)
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.retrieve.types import (
     ContextType,
@@ -59,6 +63,7 @@ class HierarchicalRetriever:
         embedder: Optional[Any],
         rerank_config: Optional[RerankConfig] = None,
         retrieval_config: Optional[RetrievalConfig] = None,
+        query_max_input_tokens: int = 2048,
     ):
         """Initialize hierarchical retriever with rerank_config.
 
@@ -67,11 +72,13 @@ class HierarchicalRetriever:
             embedder: Embedder instance (supports dense/sparse/hybrid)
             rerank_config: Rerank configuration (optional, will fallback to vector search only)
             retrieval_config: Retrieval ranking configuration.
+            query_max_input_tokens: Maximum estimated tokens for query embeddings.
         """
         self.vector_store = storage
         self.embedder = embedder
         self.rerank_config = rerank_config
         self.retrieval_config = retrieval_config or RetrievalConfig()
+        self.query_max_input_tokens = max(0, int(query_max_input_tokens or 0))
         self.hotness_alpha = self.retrieval_config.hotness_alpha
         self.score_propagation_alpha = self.retrieval_config.score_propagation_alpha
 
@@ -136,7 +143,8 @@ class HierarchicalRetriever:
         query_vector = None
         sparse_query_vector = None
         if self.embedder:
-            result: EmbedResult = await embed_compat(self.embedder, query.query, is_query=True)
+            embedding_query = self._bounded_query_for_embedding(query.query)
+            result: EmbedResult = await embed_compat(self.embedder, embedding_query, is_query=True)
             query_vector = result.dense_vector
             sparse_query_vector = result.sparse_vector
 
@@ -232,6 +240,23 @@ class HierarchicalRetriever:
             matched_contexts=final,
             searched_directories=root_uris,
         )
+
+    def _bounded_query_for_embedding(self, query: str) -> str:
+        """Bound search query text before sending it to the embedding backend."""
+        if not self.query_max_input_tokens:
+            return query
+        bounded = truncate_embedding_input(
+            query,
+            self.query_max_input_tokens,
+            suffix="",
+        )
+        if bounded != query:
+            logger.debug(
+                "[HierarchicalRetriever] Truncated query embedding input from ~%d to <=%d tokens",
+                estimate_embedding_input_tokens(query),
+                self.query_max_input_tokens,
+            )
+        return bounded
 
     async def _global_vector_search(
         self,

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -282,6 +282,7 @@ class OpenVikingService:
             rerank_config=config.rerank,
             vector_store=self._vikingdb_manager,
             retrieval_config=config.retrieval,
+            query_max_input_tokens=config.embedding.effective_query_max_input_tokens,
             enable_recorder=enable_recorder,
             encryptor=self._encryptor,
         )

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -121,6 +121,7 @@ def init_viking_fs(
     rerank_config: Optional["RerankConfig"] = None,
     vector_store: Optional["VikingVectorIndexBackend"] = None,
     retrieval_config: Optional["RetrievalConfig"] = None,
+    query_max_input_tokens: int = 2048,
     timeout: int = 10,
     enable_recorder: bool = False,
     encryptor: Optional[Any] = None,
@@ -133,6 +134,7 @@ def init_viking_fs(
         query_embedder: Embedder instance
         rerank_config: Rerank configuration
         retrieval_config: Retrieval ranking configuration
+        query_max_input_tokens: Maximum estimated tokens for query embeddings
         vector_store: Vector store instance
         enable_recorder: Whether to enable IO recording
         encryptor: FileEncryptor instance for encryption/decryption
@@ -145,6 +147,7 @@ def init_viking_fs(
         rerank_config=rerank_config,
         vector_store=vector_store,
         retrieval_config=retrieval_config,
+        query_max_input_tokens=query_max_input_tokens,
         encryptor=encryptor,
     )
 
@@ -217,6 +220,7 @@ class VikingFS:
         rerank_config: Optional["RerankConfig"] = None,
         vector_store: Optional["VikingVectorIndexBackend"] = None,
         retrieval_config: Optional["RetrievalConfig"] = None,
+        query_max_input_tokens: int = 2048,
         timeout: int = 10,
         encryptor: Optional[Any] = None,
     ):
@@ -226,6 +230,7 @@ class VikingFS:
         self.rerank_config = rerank_config
         self.vector_store = vector_store
         self.retrieval_config = retrieval_config
+        self.query_max_input_tokens = max(0, int(query_max_input_tokens or 0))
         self._encryptor = encryptor
         self._bound_ctx: contextvars.ContextVar[Optional[RequestContext]] = contextvars.ContextVar(
             "vikingfs_bound_ctx", default=None
@@ -1407,6 +1412,7 @@ class VikingFS:
             embedder=embedder,
             rerank_config=self.rerank_config,
             retrieval_config=self.retrieval_config,
+            query_max_input_tokens=self.query_max_input_tokens,
         )
 
         # Infer context_type (None = search all types)
@@ -1568,6 +1574,7 @@ class VikingFS:
             embedder=embedder,
             rerank_config=self.rerank_config,
             retrieval_config=self.retrieval_config,
+            query_max_input_tokens=self.query_max_input_tokens,
         )
 
         async def _execute(tq: TypedQuery):

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -386,8 +386,23 @@ class EmbeddingConfig(BaseModel):
         ge=100,
         description="Maximum estimated tokens sent to embeddings when raw text fallback is used",
     )
+    query_max_input_tokens: Optional[int] = Field(
+        default=None,
+        ge=100,
+        description=(
+            "Maximum estimated tokens sent to embeddings for search queries. "
+            "Defaults to min(max_input_tokens, 2048)."
+        ),
+    )
 
     model_config = {"extra": "forbid"}
+
+    @property
+    def effective_query_max_input_tokens(self) -> int:
+        """Return the query-side embedding token cap."""
+        if self.query_max_input_tokens is not None:
+            return self.query_max_input_tokens
+        return min(self.max_input_tokens, 2048)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/retrieve/test_hierarchical_retriever_query_truncation.py
+++ b/tests/retrieve/test_hierarchical_retriever_query_truncation.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Query-side embedding truncation regression tests."""
+
+import pytest
+
+from openviking.models.embedder.base import EmbedResult
+from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever
+from openviking.server.identity import RequestContext, Role
+from openviking.utils.embedding_input import estimate_embedding_input_tokens
+from openviking_cli.retrieve.types import ContextType, TypedQuery
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class CapturingEmbedder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bool]] = []
+
+    def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+        self.calls.append((text, is_query))
+        return EmbedResult(dense_vector=[1.0])
+
+
+class EmptyStorage:
+    collection_name = "context"
+
+    async def collection_exists_bound(self) -> bool:
+        return True
+
+    async def search_global_roots_in_tenant(
+        self,
+        ctx,
+        query_vector=None,
+        sparse_query_vector=None,
+        context_type=None,
+        target_directories=None,
+        extra_filter=None,
+        limit: int = 10,
+    ):
+        return []
+
+    async def search_children_in_tenant(
+        self,
+        ctx,
+        parent_uri: str,
+        query_vector=None,
+        sparse_query_vector=None,
+        context_type=None,
+        target_directories=None,
+        extra_filter=None,
+        limit: int = 10,
+    ):
+        return []
+
+
+async def _retrieve_with_query(query_text: str, max_tokens: int) -> str:
+    embedder = CapturingEmbedder()
+    retriever = HierarchicalRetriever(
+        storage=EmptyStorage(),
+        embedder=embedder,
+        rerank_config=None,
+        query_max_input_tokens=max_tokens,
+    )
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+
+    await retriever.retrieve(
+        TypedQuery(
+            query=query_text,
+            context_type=ContextType.RESOURCE,
+            intent="",
+            target_directories=["viking://resources"],
+        ),
+        ctx=ctx,
+        limit=3,
+    )
+
+    assert len(embedder.calls) == 1
+    embedded_text, is_query = embedder.calls[0]
+    assert is_query is True
+    return embedded_text
+
+
+@pytest.mark.asyncio
+async def test_ascii_query_is_truncated_before_embedding():
+    query = "release-triage " * 200
+
+    embedded_text = await _retrieve_with_query(query, max_tokens=50)
+
+    assert embedded_text != query
+    assert estimate_embedding_input_tokens(embedded_text) <= 50
+    assert "...(truncated for embedding)" not in embedded_text
+
+
+@pytest.mark.asyncio
+async def test_cjk_query_is_truncated_before_embedding():
+    query = "请分析这个发布回归问题" * 200
+
+    embedded_text = await _retrieve_with_query(query, max_tokens=50)
+
+    assert embedded_text != query
+    assert estimate_embedding_input_tokens(embedded_text) <= 50
+    assert "...(truncated for embedding)" not in embedded_text

--- a/tests/unit/test_embedding_vectorize_strategy.py
+++ b/tests/unit/test_embedding_vectorize_strategy.py
@@ -29,6 +29,8 @@ def test_embedding_text_source_defaults_to_content_only():
     cfg = _cfg()
     assert cfg.text_source == "content_only"
     assert cfg.max_input_tokens == 4096
+    assert cfg.query_max_input_tokens is None
+    assert cfg.effective_query_max_input_tokens == 2048
 
 
 @pytest.mark.parametrize("bad_value", ["summary", "content", "auto", ""])
@@ -45,3 +47,19 @@ def test_embedding_max_input_tokens_validation_accepts_reasonable_value():
 def test_embedding_max_input_tokens_validation_rejects_too_small_value():
     with pytest.raises(ValueError):
         _cfg(max_input_tokens=10)
+
+
+def test_embedding_query_max_input_tokens_overrides_default_query_cap():
+    cfg = _cfg(max_input_tokens=4096, query_max_input_tokens=1000)
+    assert cfg.query_max_input_tokens == 1000
+    assert cfg.effective_query_max_input_tokens == 1000
+
+
+def test_embedding_query_max_input_tokens_defaults_to_smaller_content_cap():
+    cfg = _cfg(max_input_tokens=1000)
+    assert cfg.effective_query_max_input_tokens == 1000
+
+
+def test_embedding_query_max_input_tokens_validation_rejects_too_small_value():
+    with pytest.raises(ValueError):
+        _cfg(query_max_input_tokens=10)


### PR DESCRIPTION
Closes #2251

## Summary
`/api/v1/search/find` embeds the incoming search text as a single query vector. If a client sends an oversized query, the embedding provider can reject it before retrieval starts. Search is best-effort, so OpenViking should enforce the query embedding budget before calling the provider.

This adds a query-specific guard while leaving document/content vectorization and the search API shape unchanged.

## Changes
- Add optional `embedding.query_max_input_tokens`.
- Default the effective query cap to `min(embedding.max_input_tokens, 2048)` when no query-specific value is set.
- Truncate query text before `embed_compat(..., is_query=True)` in hierarchical retrieval, without adding a visible truncation suffix.
- Document the new config key and cover ASCII/CJK truncation plus config default/override behavior in tests.

## Test Plan
- `python -m pytest tests/retrieve/test_hierarchical_retriever_query_truncation.py tests/unit/test_embedding_vectorize_strategy.py tests/server/test_api_search.py -q`