### PR TITLE
docs: fix broken LangChain link in README/README_CN (404 after #2217 renumber)

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ To ensure optimal storage performance and data security, we recommend deploying 
 
 👉 **[View: Claude Code Memory Plugin Example](examples/claude-code-memory-plugin/README.md)**
 
-👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/06-langchain-langgraph.md)**
+👉 **[View: LangChain / LangGraph Integration](./docs/en/agent-integrations/07-langchain-langgraph.md)**
 
 \--
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -558,7 +558,7 @@ ov chat
 
 👉 **[查看：Claude Code 记忆插件示例](examples/claude-code-memory-plugin/README_CN.md)**
 
-👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/06-langchain-langgraph.md)**
+👉 **[查看：LangChain / LangGraph 集成](./docs/zh/agent-integrations/07-langchain-langgraph.md)**
 
 ## VikingBot 部署详情
 


### PR DESCRIPTION
PR #2217 ("docs: overhaul agent-integrations section") inserted `06-mcp-clients.md` and renamed `06-langchain-langgraph.md` → `07-langchain-langgraph.md` (both `docs/en` and `docs/zh`), but the README links were not updated:

- `README.md` still points to `./docs/en/agent-integrations/06-langchain-langgraph.md` → 404 (file is now `07-`)
- `README_CN.md` still points to `./docs/zh/agent-integrations/06-langchain-langgraph.md` → 404 (file is now `07-`)

`06-` is now `06-mcp-clients.md`, so the old links silently resolve to the wrong page or 404. Fix bumps both to `07-langchain-langgraph.md`, matching the current file layout.

Verified the target files exist at `07-` in both `docs/en/agent-integrations/` and `docs/zh/agent-integrations/`. (README_JA.md has no LangChain integration link, so no change there.)