### PR TITLE
Improve trajectory memory retrieval with name anchors

### DIFF
--- a/benchmark/tau2/llm/README.md
+++ b/benchmark/tau2/llm/README.md
@@ -5,7 +5,8 @@ evaluation. The scope is intentionally narrow:
 
 - fresh OpenViking Memory V2 experience-only baseline;
 - Memory V2 pre-write recall treatment.
-- trajectory memory retrieval treatment for the refined extraction prompt.
+- trajectory memory retrieval treatment for the refined extraction prompt and
+  retrieval-anchor embedding text.
 
 Category rerank and other harness-only diagnostics are intentionally left out.
 
@@ -133,6 +134,10 @@ The PR-B headline and content-shape ablation use
 `config/prb_content_matrix_new_prompt.yaml`. It runs the no-memory control plus
 trajectory first-user top4 / pre-write top2, experience top2, and representative
 4000-character budget ablation routes across `retail + airline` with 8 repeats.
+The current trajectory prompt indexes `trajectory_name + retrieval_anchor`
+instead of the full procedure body. This keeps retrieval focused on the positive
+operation boundary and reduces broad terminal-handoff / cancellation-like memory
+matches.
 
 ### 1. Bootstrap fixed-first-user fixtures
 
@@ -219,6 +224,11 @@ The main result is written to
 Per-cell execution records live under `cell_results/`, raw TAU-2 result JSON
 lives under `memory_cells/`, and corpus identity / generated memory checks live
 under `memory_corpora/`.
+
+For the strongest trajectory-only treatment, inspect the
+`new_traj_fixed_first_user_prewrite` row. It uses trajectory top4 at the first
+user turn, trajectory top4 retrieval before writes, pre-write injection top2,
+fixed-first-user fixtures, and the generic scope prompt.
 
 For a small E2E smoke, keep both the eval and train slices tiny:
 

--- a/openviking/prompts/templates/memory/trajectories.yaml
+++ b/openviking/prompts/templates/memory/trajectories.yaml
@@ -5,6 +5,11 @@ description: |
   Extract when the agent worked through identifiable tasks involving decisions, tool calls, or multi-step actions.
   Skip pure chitchat or simple Q&A with no execution trace.
 
+embedding_template: |-
+  {{ trajectory_name }}
+
+  {{ retrieval_anchor }}
+
 directory: "viking://agent/{{ agent_space }}/memories/trajectories"
 filename_template: "{{ trajectory_name }}_{{ extract_context.get_session_timestamp() }}.md"
 enabled: true
@@ -20,12 +25,27 @@ fields:
       {% if language == 'en' %}Use lowercase snake_case, max 5 words.{% else %}Use a concise noun phrase, max 15 characters.{% endif %}
       Do not create near-duplicate names for the same task.
       Good: "duplicate_request_resolution", "async_task_hang_fix", "重复请求处理".
+      Prefer the reusable operation or decision boundary over raw instance wording from the opening request.
     merge_op: immutable
 
   - name: outcome
     type: string
     description: |
       Use exactly one of: success, failure, partial, unfinished, unknown.
+    merge_op: immutable
+
+  - name: retrieval_anchor
+    type: string
+    description: |
+      Positive semantic retrieval text for this record, written for embedding rather than display.
+      Format: "Stage: <opening|after_read|before_write|after_write|terminal_handoff|final_response>; Boundary: <verified reusable condition>; Capability: <operation, check, handoff, or response this record can guide>; Target: <primary object or sub-object>."
+
+      Rules:
+      - Keep it shorter and more retrieval-focused than content.
+      - Describe when the record should be retrieved using positive applies-when language only.
+      - Do not write negative examples, nearby intents, unrelated alternative requests, or broad exclusions here; keep those in Negative Applicability inside content.
+      - Do not copy the opening request when the reusable lesson only becomes valid after reads, verification, failure, or a terminal boundary; anchor on the condition that was actually established.
+      - Generalize identifiers, names, numbers, dates, places, amounts, and raw tool payloads as strictly as content.
     merge_op: immutable
 
   - name: content
@@ -76,6 +96,7 @@ fields:
       - Do not let a later operation in the same session rename, narrow, or extend this record's Trigger, Target, Procedure, Result, or Evidence. Put the later operation in a separate record.
       - Put immutable facts and write/user-visible field sources in their dedicated sections. Do not copy fields from a previous/source object into a new/replacement object without current user request or explicit confirmation.
       - Keep blocked actions and failed lessons in Anti-patterns / Negative Applicability / Evidence, not as positive procedure steps. Do not invent a corrected path when the session did not demonstrate one.
+      - Keep retrieval-specific wording out of content. Use retrieval_anchor for positive indexed text, and keep nearby non-applicable intents only in Negative Applicability.
       - Generalize the session: remove raw identifiers, names, contact values, exact dates, case-specific amounts/counts, exact locations/paths, product names, and raw tool payloads. Use semantic placeholders such as requested quantity, selected object, calculated amount, source object, target object, or applicable policy instead of copying concrete values. Keep tool names only when they are part of the reusable path. Evidence must also stay generalized and should not contain digits; do not use it to preserve instance-local ids, names, counts, amounts, locations, or dates.
       - Use exactly the title, Domain line, and 11 labels above in this exact order.
       - Trigger, Result, and Evidence are ONE sentence each.

--- a/tests/unit/session/memory/test_embedding_template.py
+++ b/tests/unit/session/memory/test_embedding_template.py
@@ -29,6 +29,7 @@ class TestEmbeddingTemplateYamlParsing:
         self.registry.load_from_yaml(str(memory_dir / "events.yaml"))
         self.registry.load_from_yaml(str(memory_dir / "preferences.yaml"))
         self.registry.load_from_yaml(str(memory_dir / "entities.yaml"))
+        self.registry.load_from_yaml(str(memory_dir / "trajectories.yaml"))
 
     def test_events_exposes_embedding_template(self):
         schema = self.registry.get("events")
@@ -41,6 +42,10 @@ class TestEmbeddingTemplateYamlParsing:
     def test_entities_exposes_embedding_template(self):
         schema = self.registry.get("entities")
         assert schema.embedding_template == "{{ category }}\n\n{{ name }}\n\n{{ content }}"
+
+    def test_trajectories_exposes_retrieval_anchor_template(self):
+        schema = self.registry.get("trajectories")
+        assert schema.embedding_template == "{{ trajectory_name }}\n\n{{ retrieval_anchor }}"
 
 
 class TestContentTemplateRendering:


### PR DESCRIPTION
## Summary

This PR adds a compact retrieval surface for trajectory memories:

- adds an immutable `retrieval_anchor` field to `trajectories.yaml`
- indexes trajectory memories with `trajectory_name + retrieval_anchor` instead of the full procedure body
- updates the TAU-2 benchmark README to call out the current PR-B reproduction route
- adds a unit test that the trajectory schema exposes the embedding template

## Problem

TAU-2 full8 reruns showed large score swings that were not explained by corpus graph health or broken links. The clearest failure mode was retrieval surface drift: full trajectory bodies can over-index broad terminal handoff notes, cancellation-like policy text, or nearby negative applicability, so a memory that is only useful after verification can be retrieved too early or for the wrong operation boundary.

This PR does not add a TAU-specific filter. It keeps the memory content intact for the LLM, but makes vector search use a shorter positive applicability surface: `trajectory_name + retrieval_anchor`.

## TAU-2 benchmark best practice

For the current trajectory-memory reproduction route, use:

- fixed-first-user fixtures
- generic scope prompt
- success-only train corpus
- trajectory top4 retrieval
- pre-write injection top2
- `trajectory_name + retrieval_anchor` embedding text

The README now points readers to the `new_traj_fixed_first_user_prewrite` row and the fixed-first-user bootstrap flow.

## Validation

Unit test:

```bash
/Users/bytedance/Documents/OpenViking-memory-versioned-apply-ci/.venv/bin/python -m pytest tests/unit/session/memory/test_embedding_template.py -q
```

TAU-2 clean full8 comparison, all with fixed-first-user, generic scope, success-only train corpus, trajectory top4, pre-write top2, retail + airline, 8 repeats:

| Setting | Retail reward | Airline reward | Task-weighted reward | Task-weighted DB | Valid cells |
| --- | ---: | ---: | ---: | ---: | ---: |
| current master trajectory prompt, hi80 rerun | 0.84688 | 0.76875 | 0.82083 | 0.82292 | 16/16 |
| pre-#2221 trajectory prompt | 0.86250 | 0.75625 | 0.82708 | 0.82708 | 16/16 |
| `trajectory_name + retrieval_anchor` | 0.88438 | 0.78750 | 0.85208 | 0.85417 | 16/16 |
| pre-#2221 prompt + `trajectory_name + retrieval_anchor` | 0.86250 | 0.76875 | 0.83125 | 0.83542 | 16/16 |

The current-master control row was refreshed with `strategy_concurrency=16` and per-cell `max_concurrency=5`; it replaces the earlier lower-concurrency control row (`0.80625` task-weighted reward). The anchor setting remains ahead of this refreshed control by `+0.03125` task-weighted reward.

The additional pre-#2221 + anchor row uses the same train source as the anchor row. It is slightly above pre-#2221 prompt-only (`+0.00417`) but remains below the current prompt + anchor setting (`-0.02083`), so this matrix does not support reverting #2221.

Corpus graph-health checks for all four retail/airline corpora were clean: no broken endpoints, missing backlinks, missing forward links, parse errors, duplicate links, or source-linkless experiences.

## Notes

This PR intentionally does not include category rerank, controller logic, failure-experience overlays, or corpus-write efficiency changes. Those remain separate experimental lines.
