### PR TITLE
bugfix: enable parent folder creation in resource upload & no wait for file change

### DIFF
--- a/web-studio/src/routes/resources/-components/add-resource-page.tsx
+++ b/web-studio/src/routes/resources/-components/add-resource-page.tsx
@@ -164,6 +164,7 @@ export function AddResourceForm({
   const buildCommonBody = () => {
     const body: Record<string, unknown> = {
       parent: targetUri.trim() || undefined,
+      create_parent: true,
       strict,
       telemetry: true,
       wait: false,

--- a/web-studio/src/routes/resources/-lib/api.ts
+++ b/web-studio/src/routes/resources/-lib/api.ts
@@ -207,7 +207,7 @@ export async function saveFileContent(
           uri,
           content,
           mode: 'replace',
-          wait: true,
+          wait: false,
         },
       }),
     )


### PR DESCRIPTION
## Description

上传资源时自动创建父目录、修改文件时不等待向量索引

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Testing

- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
