### PR TITLE
fix(vectordb): fix HttpCollection.fetch_data key mismatch causing update_uri_mapping to fail

### DIFF
--- a/openviking/storage/vectordb/collection/http_collection.py
+++ b/openviking/storage/vectordb/collection/http_collection.py
@@ -301,8 +301,8 @@ class HttpCollection(ICollection):
         fetch_result = FetchDataInCollectionResult()
 
         if isinstance(data, dict):
-            if "fetch" in data:
-                fetch = data.get("fetch", [])
+            if "items" in data:
+                fetch = data.get("items", [])
                 fetch_result.items = [
                     DataItem(
                         id=item.get("id"),


### PR DESCRIPTION
## Summary

- Fix `HttpCollection.fetch_data()` response parsing: the server serializes `FetchDataInCollectionResult` with `asdict()`, producing key `"items"`, but the client was looking for `"fetch"` — causing `fetch_data` to always return empty results in HTTP mode.
- This caused `update_uri_mapping` to fail for all records, preventing L2 vector embeddings from being renamed from temp URIs to final resource URIs.

## Test plan

- [ ] Deploy OpenViking with vikingdb as a separate pod (HTTP mode)
- [ ] Add a resource with `build_index=true`
- [ ] Verify no `update_uri_mapping failed to fetch full records` warnings in logs
- [ ] Verify L0, L1, and L2 embeddings are all retrievable after `add_resource` (no manual reindex needed)

Fixes #2261

🤖 Generated with [Claude Code](https://claude.com/claude-code)