### PR TITLE
fix(ovpack): skip missing semantic sidecars

### DIFF
--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -69,6 +69,8 @@ from openviking_cli.utils.uri import VikingURI
 
 logger = get_logger(__name__)
 
+OPTIONAL_SEMANTIC_SIDECARS = frozenset({".abstract.md", ".overview.md"})
+
 
 def _index_records_by_level(
     index_records: list[dict[str, Any]], rel_path: str
@@ -146,6 +148,38 @@ def _exportable_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if not is_excluded_rel_path(rel_path):
             exportable.append(entry)
     return exportable
+
+
+def _is_optional_semantic_sidecar(entry: dict[str, Any]) -> bool:
+    if entry.get("isDir"):
+        return False
+    rel_path = str(entry.get("rel_path") or "")
+    return leaf_name(rel_path) in OPTIONAL_SEMANTIC_SIDECARS
+
+
+async def _filter_existing_optional_sidecars(
+    viking_fs,
+    root_uri: str,
+    entries: list[dict[str, Any]],
+    ctx: RequestContext,
+) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    for entry in entries:
+        if not _is_optional_semantic_sidecar(entry):
+            filtered.append(entry)
+            continue
+
+        rel_path = str(entry.get("rel_path") or "")
+        uri = entry.get("uri") or join_uri(root_uri, rel_path)
+        try:
+            exists = await viking_fs.exists(uri, ctx=ctx)
+        except Exception:
+            exists = False
+        if exists:
+            filtered.append(entry)
+        else:
+            logger.info(f"[ovpack] Skipping missing semantic sidecar: {uri}")
+    return filtered
 
 
 async def _enqueue_direct_vectorization(
@@ -475,6 +509,7 @@ async def export_ovpack(
             ctx=ctx,
         )
     )
+    entries = await _filter_existing_optional_sidecars(viking_fs, uri, entries, ctx)
     if include_vectors:
         ensure_dense_snapshot_supported(vector_store)
         report = await check_index_consistency(
@@ -529,6 +564,7 @@ async def backup_ovpack(
         to = ensure_ovpack_extension(to)
 
     entries = await _backup_entries(viking_fs, ctx)
+    entries = await _filter_existing_optional_sidecars(viking_fs, "viking://", entries, ctx)
     if include_vectors:
         ensure_dense_snapshot_supported(vector_store)
         report = await check_index_consistency(

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -111,6 +111,12 @@ class OverviewOnlyExportVikingFS(FakeExportVikingFS):
         }
 
 
+class MissingSidecarExportVikingFS(FakeExportVikingFS):
+    def __init__(self) -> None:
+        super().__init__()
+        self.text_files = {}
+
+
 class ReservedPathExportVikingFS(FakeExportVikingFS):
     def __init__(self) -> None:
         super().__init__()
@@ -211,6 +217,33 @@ class FakeBackupVikingFS:
 
     async def read_file_bytes(self, uri: str, ctx=None):
         return self.binary_files[uri]
+
+
+class MissingSidecarBackupVikingFS(FakeBackupVikingFS):
+    async def tree(
+        self,
+        uri: str,
+        show_all_hidden: bool = False,
+        node_limit=None,
+        level_limit=None,
+        ctx=None,
+    ):
+        if uri == "viking://agent":
+            return [
+                {
+                    "rel_path": ".overview.md",
+                    "uri": "viking://agent/.overview.md",
+                    "isDir": False,
+                    "size": 0,
+                }
+            ]
+        return await super().tree(
+            uri,
+            show_all_hidden=show_all_hidden,
+            node_limit=node_limit,
+            level_limit=level_limit,
+            ctx=ctx,
+        )
 
 
 class FakeRestoreVectorVikingFS(FakeVikingFS):
@@ -521,6 +554,28 @@ async def test_export_ovpack_writes_v2_manifest_with_semantic_sidecars(
 
 
 @pytest.mark.asyncio
+async def test_export_ovpack_skips_missing_semantic_sidecars(
+    temp_ovpack_path: Path,
+    request_ctx: RequestContext,
+):
+    await export_ovpack(
+        MissingSidecarExportVikingFS(),
+        "viking://resources/demo",
+        str(temp_ovpack_path),
+        ctx=request_ctx,
+    )
+
+    with zipfile.ZipFile(temp_ovpack_path, "r") as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("demo/_ovpack/manifest.json").decode("utf-8"))
+
+    manifest_paths = {entry["path"] for entry in manifest["entries"]}
+    assert "demo/files/notes.txt" in names
+    assert "demo/files/.overview.md" not in names
+    assert ".overview.md" not in manifest_paths
+
+
+@pytest.mark.asyncio
 async def test_backup_restore_contract(temp_ovpack_path: Path, request_ctx: RequestContext):
     await backup_ovpack(
         FakeBackupVikingFS(),
@@ -552,6 +607,27 @@ async def test_backup_restore_contract(temp_ovpack_path: Path, request_ctx: Requ
         "viking://session/sess_1/.meta.json",
     ]
     assert fake_fs.tree_calls == ["viking://resources", "viking://user", "viking://agent"]
+
+
+@pytest.mark.asyncio
+async def test_backup_skips_missing_semantic_sidecars(
+    temp_ovpack_path: Path,
+    request_ctx: RequestContext,
+):
+    await backup_ovpack(
+        MissingSidecarBackupVikingFS(),
+        str(temp_ovpack_path),
+        ctx=request_ctx,
+    )
+
+    with zipfile.ZipFile(temp_ovpack_path, "r") as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("openviking-backup/_ovpack/manifest.json").decode("utf-8"))
+
+    manifest_paths = {entry["path"] for entry in manifest["entries"]}
+    assert "openviking-backup/files/agent/.overview.md" not in names
+    assert "agent/.overview.md" not in manifest_paths
+    assert "agent" in manifest_paths
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Prevent OVPack export and backup from failing when generated semantic sidecar files are listed but no longer exist on disk.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Filter missing optional semantic sidecars (`.abstract.md`, `.overview.md`) before building OVPack manifests.
- Keep regular user files strict so missing non-sidecar files still fail export or backup.
- Add regression tests for export and backup packages that list missing semantic sidecars.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`.venv/bin/python -m pytest tests/misc/test_ovpack_import_policy.py -q`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The skipped files are generated semantic metadata. They are intentionally best-effort and should not block backup or export when absent.
