### PR TITLE
Bind storage and crypto keys to security context

### DIFF
--- a/openviking/crypto/providers.py
+++ b/openviking/crypto/providers.py
@@ -46,6 +46,9 @@ def _record_encryption_metrics(
 # HKDF related constants
 HKDF_SALT = b"openviking-kek-salt-v1"
 HKDF_INFO_PREFIX = b"openviking:kek:v1:"
+DEFAULT_KEY_PURPOSE = "file-encryption"
+DEFAULT_DERIVATION_VERSION = "v2"
+LEGACY_DERIVATION_VERSION = "v1"
 
 # Provider types
 PROVIDER_LOCAL = 0x01
@@ -62,22 +65,50 @@ class RootKeyProvider(ABC):
         pass
 
     @abc.abstractmethod
-    async def derive_account_key(self, account_id: str) -> bytes:
+    async def derive_account_key(
+        self,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> bytes:
         """Derive Account Key for the specified account."""
         pass
 
     @abc.abstractmethod
-    async def encrypt_file_key(self, plaintext_key: bytes, account_id: str) -> Tuple[bytes, bytes]:
+    async def encrypt_file_key(
+        self,
+        plaintext_key: bytes,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> Tuple[bytes, bytes]:
         """Encrypt File Key."""
         pass
 
     @abc.abstractmethod
-    async def decrypt_file_key(self, encrypted_key: bytes, iv: bytes, account_id: str) -> bytes:
+    async def decrypt_file_key(
+        self,
+        encrypted_key: bytes,
+        iv: bytes,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> bytes:
         """Decrypt File Key."""
         pass
 
     async def _hkdf_derive(
-        self, root_key: bytes, account_id: str, salt: bytes, info_prefix: bytes
+        self,
+        root_key: bytes,
+        account_id: str,
+        salt: bytes,
+        info_prefix: bytes,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
     ) -> bytes:
         """
         Derive key using HKDF.
@@ -87,6 +118,8 @@ class RootKeyProvider(ABC):
             account_id: Account ID
             salt: HKDF salt
             info_prefix: HKDF info prefix
+            key_purpose: Logical key purpose bound into HKDF info
+            derivation_version: Derivation domain version bound into HKDF info
 
         Returns:
             Derived key
@@ -101,7 +134,32 @@ class RootKeyProvider(ABC):
                 algorithm=hashes.SHA256(),
                 length=32,
                 salt=salt,
-                info=info_prefix + account_id.encode(),
+                info=(
+                    info_prefix
+                    + derivation_version.encode("utf-8")
+                    + b":"
+                    + key_purpose.encode("utf-8")
+                    + b":"
+                    + account_id.encode("utf-8")
+                ),
+            )
+            return hkdf.derive(root_key)
+        except ImportError:
+            raise ConfigError("cryptography library is required for encryption")
+
+    async def _hkdf_derive_legacy(
+        self, root_key: bytes, account_id: str, salt: bytes, info_prefix: bytes
+    ) -> bytes:
+        """Derive the pre-v2 account key for backwards-compatible decryption only."""
+        try:
+            from cryptography.hazmat.primitives import hashes
+            from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+            hkdf = HKDF(
+                algorithm=hashes.SHA256(),
+                length=32,
+                salt=salt,
+                info=info_prefix + account_id.encode("utf-8"),
             )
             return hkdf.derive(root_key)
         except ImportError:
@@ -146,7 +204,14 @@ class BaseProvider(RootKeyProvider):
         except Exception as e:
             raise AuthenticationFailedError(f"Decryption failed: {e}")
 
-    async def encrypt_file_key(self, plaintext_key: bytes, account_id: str) -> Tuple[bytes, bytes]:
+    async def encrypt_file_key(
+        self,
+        plaintext_key: bytes,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> Tuple[bytes, bytes]:
         """
         Encrypt File Key with Account Key.
 
@@ -157,12 +222,24 @@ class BaseProvider(RootKeyProvider):
         Returns:
             (encrypted_key, iv)
         """
-        account_key = await self.derive_account_key(account_id)
+        account_key = await self.derive_account_key(
+            account_id,
+            key_purpose=key_purpose,
+            derivation_version=derivation_version,
+        )
         iv = secrets.token_bytes(12)
         encrypted_key = await self._aes_gcm_encrypt(account_key, iv, plaintext_key)
         return encrypted_key, iv
 
-    async def decrypt_file_key(self, encrypted_key: bytes, iv: bytes, account_id: str) -> bytes:
+    async def decrypt_file_key(
+        self,
+        encrypted_key: bytes,
+        iv: bytes,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> bytes:
         """
         Decrypt File Key with Account Key.
 
@@ -174,8 +251,23 @@ class BaseProvider(RootKeyProvider):
         Returns:
             Decrypted File Key
         """
-        account_key = await self.derive_account_key(account_id)
-        return await self._aes_gcm_decrypt(account_key, iv, encrypted_key)
+        account_key = await self.derive_account_key(
+            account_id,
+            key_purpose=key_purpose,
+            derivation_version=derivation_version,
+        )
+        try:
+            return await self._aes_gcm_decrypt(account_key, iv, encrypted_key)
+        except AuthenticationFailedError:
+            if derivation_version != DEFAULT_DERIVATION_VERSION:
+                raise
+
+        legacy_key = await self.derive_account_key(
+            account_id,
+            key_purpose=key_purpose,
+            derivation_version=LEGACY_DERIVATION_VERSION,
+        )
+        return await self._aes_gcm_decrypt(legacy_key, iv, encrypted_key)
 
 
 class LocalFileProvider(BaseProvider):
@@ -245,10 +337,27 @@ class LocalFileProvider(BaseProvider):
             logger.info("Created new root key at %s", self.key_file)
             return root_key
 
-    async def derive_account_key(self, account_id: str) -> bytes:
+    async def derive_account_key(
+        self,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> bytes:
         """Derive Account Key from Root Key."""
         root_key = await self.get_root_key()
-        return await self._hkdf_derive(root_key, account_id, HKDF_SALT, HKDF_INFO_PREFIX)
+        if derivation_version == LEGACY_DERIVATION_VERSION:
+            return await self._hkdf_derive_legacy(
+                root_key, account_id, HKDF_SALT, HKDF_INFO_PREFIX
+            )
+        return await self._hkdf_derive(
+            root_key,
+            account_id,
+            HKDF_SALT,
+            HKDF_INFO_PREFIX,
+            key_purpose=key_purpose,
+            derivation_version=derivation_version,
+        )
 
 
 class VaultProvider(BaseProvider):
@@ -511,7 +620,13 @@ class VaultProvider(BaseProvider):
                 debug_message="Failed to record encryption key metrics for provider=vault",
             )
 
-    async def derive_account_key(self, account_id: str) -> bytes:
+    async def derive_account_key(
+        self,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> bytes:
         """
         Derive Account Key using HKDF.
 
@@ -522,7 +637,18 @@ class VaultProvider(BaseProvider):
             Derived Account Key
         """
         root_key = await self.get_root_key()
-        return await self._hkdf_derive(root_key, account_id, HKDF_SALT, HKDF_INFO_PREFIX)
+        if derivation_version == LEGACY_DERIVATION_VERSION:
+            return await self._hkdf_derive_legacy(
+                root_key, account_id, HKDF_SALT, HKDF_INFO_PREFIX
+            )
+        return await self._hkdf_derive(
+            root_key,
+            account_id,
+            HKDF_SALT,
+            HKDF_INFO_PREFIX,
+            key_purpose=key_purpose,
+            derivation_version=derivation_version,
+        )
 
 
 class VolcengineKMSProvider(BaseProvider):
@@ -765,7 +891,13 @@ class VolcengineKMSProvider(BaseProvider):
                 debug_message="Failed to record encryption key metrics for provider=volcengine_kms",
             )
 
-    async def derive_account_key(self, account_id: str) -> bytes:
+    async def derive_account_key(
+        self,
+        account_id: str,
+        *,
+        key_purpose: str = DEFAULT_KEY_PURPOSE,
+        derivation_version: str = DEFAULT_DERIVATION_VERSION,
+    ) -> bytes:
         """
         Derive Account Key using HKDF.
 
@@ -776,7 +908,18 @@ class VolcengineKMSProvider(BaseProvider):
             Derived Account Key
         """
         root_key = await self.get_root_key()
-        return await self._hkdf_derive(root_key, account_id, HKDF_SALT, HKDF_INFO_PREFIX)
+        if derivation_version == LEGACY_DERIVATION_VERSION:
+            return await self._hkdf_derive_legacy(
+                root_key, account_id, HKDF_SALT, HKDF_INFO_PREFIX
+            )
+        return await self._hkdf_derive(
+            root_key,
+            account_id,
+            HKDF_SALT,
+            HKDF_INFO_PREFIX,
+            key_purpose=key_purpose,
+            derivation_version=derivation_version,
+        )
 
 
 def create_root_key_provider(

--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -55,6 +55,7 @@ from openviking_cli.utils.logger import default_logger as logger
 
 # Use imported constants, no longer defined here
 AUTO_ID_KEY = SpecialFields.AUTO_ID.value
+SECURITY_CONTEXT_FIELDS = ("account_id", "context_type", "owner_space", "uri")
 
 
 def get_or_create_local_collection(
@@ -252,6 +253,39 @@ class LocalCollection(ICollection):
 
     def list_indexes(self) -> List[str]:
         return self.indexes.list_names()
+
+    def _security_context(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return {field: data.get(field) for field in SECURITY_CONTEXT_FIELDS if field in data}
+
+    def _security_context_changed(
+        self, existing_data: Dict[str, Any], new_data: Dict[str, Any]
+    ) -> bool:
+        for field in SECURITY_CONTEXT_FIELDS:
+            if field not in existing_data or field not in new_data:
+                continue
+            if existing_data.get(field) != new_data.get(field):
+                return True
+        return False
+
+    def _guard_security_context_rebind(self, labels: List[int], data_list: List[Dict[str, Any]]):
+        if not self.store_mgr:
+            raise RuntimeError("Store manager is not initialized")
+
+        existing_list = self.store_mgr.fetch_cands_data(labels)
+        for label, existing, data in zip(labels, existing_list, data_list):
+            if not existing or not existing.fields:
+                continue
+            try:
+                existing_data = json.loads(existing.fields)
+            except (TypeError, json.JSONDecodeError):
+                logger.warning("Existing candidate fields for label %s are invalid", label)
+                continue
+            if self._security_context_changed(existing_data, data):
+                raise ValueError(
+                    "Refusing to rebind existing primary key to a different security context: "
+                    f"label={label}, existing={self._security_context(existing_data)}, "
+                    f"new={self._security_context(data)}"
+                )
 
     def search_by_vector(
         self,
@@ -546,6 +580,7 @@ class LocalCollection(ICollection):
         pk = self.meta.primary_key
         vk = self.meta.vector_key
         svk = self.meta.sparse_vector_key
+        labels: List[int] = []
         for i, data in enumerate(data_list):
             if AUTO_ID_KEY in data:
                 label = data[AUTO_ID_KEY]
@@ -555,6 +590,7 @@ class LocalCollection(ICollection):
                 label = generate_auto_id()
                 data[AUTO_ID_KEY] = label
 
+            labels.append(label)
             cands_list[i].label = label
             if self.vectorizer_adapter:
                 if dense_emb:
@@ -574,6 +610,8 @@ class LocalCollection(ICollection):
 
         if not self.store_mgr:
             raise RuntimeError("Store manager is not initialized")
+        if pk != AUTO_ID_KEY:
+            self._guard_security_context_rebind(labels, data_list)
         need_record_delta = True if self.indexes.count() > 0 else False
         delta_list = self.store_mgr.add_cands_data(cands_list, ttl, need_record_delta)
 

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -245,6 +245,13 @@ class _SingleAccountBackend:
 
         if self._bound_account_id and not payload.get("account_id"):
             payload["account_id"] = self._bound_account_id
+        elif self._bound_account_id and payload.get("account_id") != self._bound_account_id:
+            logger.warning(
+                "Rejected cross-account upsert: payload.account_id=%s, bound_account_id=%s",
+                payload.get("account_id"),
+                self._bound_account_id,
+            )
+            return ""
         logger.debug(
             f"[_SingleAccountBackend.upsert] Final payload.account_id={payload.get('account_id')}"
         )

--- a/tests/storage/test_viking_vector_index_security.py
+++ b/tests/storage/test_viking_vector_index_security.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils.config.vectordb_config import VectorDBBackendConfig
+
+
+@pytest.mark.asyncio
+async def test_bound_account_backend_rejects_cross_account_upsert(tmp_path):
+    config = VectorDBBackendConfig(
+        backend="local",
+        name="security_ctx",
+        path=str(tmp_path),
+        dimension=4,
+    )
+    store = VikingVectorIndexBackend(config=config)
+    ctx = RequestContext(
+        user=UserIdentifier("acct_alpha", "user", "agent"),
+        role=Role.USER,
+    )
+
+    try:
+        rejected = await store.upsert(
+            {
+                "id": "shared-record-id",
+                "account_id": "acct_beta",
+                "uri": "viking://resources/b.md",
+                "context_type": "resource",
+                "owner_space": "",
+                "vector": [0.0, 1.0, 0.0, 0.0],
+                "sparse_vector": {},
+            },
+            ctx=ctx,
+        )
+
+        assert rejected == ""
+        assert await store.get(["shared-record-id"], ctx=ctx) == []
+    finally:
+        await store.close()

--- a/tests/unit/crypto/test_local_provider.py
+++ b/tests/unit/crypto/test_local_provider.py
@@ -68,3 +68,40 @@ async def test_local_file_provider_different_accounts(local_file_provider):
 
     decrypted2 = await local_file_provider.decrypt_file_key(encrypted_key2, iv2, account2)
     assert decrypted2 == plaintext_key
+
+
+@pytest.mark.asyncio
+async def test_local_file_provider_binds_key_purpose(local_file_provider):
+    """Account keys for different logical purposes must not share HKDF output."""
+    account_id = "test_account"
+
+    file_key = await local_file_provider.derive_account_key(
+        account_id,
+        key_purpose="file-encryption",
+        derivation_version="v2",
+    )
+    token_key = await local_file_provider.derive_account_key(
+        account_id,
+        key_purpose="token-signing",
+        derivation_version="v2",
+    )
+
+    assert file_key != token_key
+
+
+@pytest.mark.asyncio
+async def test_local_file_provider_keeps_legacy_decrypt_fallback(local_file_provider):
+    """Existing v1-wrapped file keys remain decryptable while new writes use v2."""
+    account_id = "test_account"
+    plaintext_key = b"test_file_key"
+
+    legacy_key = await local_file_provider.derive_account_key(
+        account_id,
+        derivation_version="v1",
+    )
+    iv = b"1" * 12
+    legacy_ciphertext = await local_file_provider._aes_gcm_encrypt(legacy_key, iv, plaintext_key)
+
+    decrypted = await local_file_provider.decrypt_file_key(legacy_ciphertext, iv, account_id)
+
+    assert decrypted == plaintext_key

--- a/tests/vectordb/test_local_collection_security.py
+++ b/tests/vectordb/test_local_collection_security.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from openviking.storage.vectordb.collection.local_collection import LocalCollection
+from openviking.storage.vectordb.store.data import CandidateData
+from openviking.storage.vectordb.utils.str_to_uint64 import str_to_uint64
+
+
+class _FakeStoreManager:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def fetch_cands_data(self, label_list):
+        return [self.rows.get(label) for label in label_list]
+
+
+def test_security_context_rebind_is_rejected_without_native_store():
+    label = str_to_uint64("shared-record-id")
+    existing = CandidateData(
+        label=label,
+        fields=json.dumps(
+            {
+                "id": "shared-record-id",
+                "account_id": "acct_alpha",
+                "uri": "viking://resources/a.md",
+                "context_type": "resource",
+                "owner_space": "",
+            }
+        ),
+    )
+    collection = object.__new__(LocalCollection)
+    collection.store_mgr = _FakeStoreManager({label: existing})
+
+    with pytest.raises(ValueError, match="different security context"):
+        collection._guard_security_context_rebind(
+            [label],
+            [
+                {
+                    "id": "shared-record-id",
+                    "account_id": "acct_beta",
+                    "uri": "viking://resources/b.md",
+                    "context_type": "resource",
+                    "owner_space": "",
+                }
+            ],
+        )
+
+
+def test_security_context_stable_update_is_allowed_without_native_store():
+    label = str_to_uint64("shared-record-id")
+    existing = CandidateData(
+        label=label,
+        fields=json.dumps(
+            {
+                "id": "shared-record-id",
+                "account_id": "acct_alpha",
+                "uri": "viking://resources/a.md",
+                "context_type": "resource",
+                "owner_space": "",
+                "description": "old",
+            }
+        ),
+    )
+    collection = object.__new__(LocalCollection)
+    collection.store_mgr = _FakeStoreManager({label: existing})
+
+    collection._guard_security_context_rebind(
+        [label],
+        [
+            {
+                "id": "shared-record-id",
+                "account_id": "acct_alpha",
+                "uri": "viking://resources/a.md",
+                "context_type": "resource",
+                "owner_space": "",
+                "description": "new",
+            }
+        ],
+    )


### PR DESCRIPTION
## Summary
- reject local VectorDB primary-key rebinding when an existing record's security context changes
- reject bound-account VectorDB upserts that explicitly target another account
- bind account key derivation to purpose and derivation version, with legacy v1 decrypt fallback

Fixes #2263

## Tests
- PYTHONPATH=. /tmp/openviking-codex-venv/bin/python -m pytest --no-cov tests/unit/crypto/test_local_provider.py tests/vectordb/test_local_collection_security.py tests/storage/test_viking_vector_index_security.py -q

Note: after rebasing onto current upstream main, repository-level tests/conftest.py imports optional VLM dependency `litellm` in this local no-build test environment; the focused tests above passed before the rebase and the branch patch itself was rebased without conflicts.