### PR TITLE
docs(retrieval): note intent-analysis model is configurable via query_planner (#2224)

### DIFF
--- a/docs/en/concepts/07-retrieval.md
+++ b/docs/en/concepts/07-retrieval.md
@@ -38,7 +38,7 @@ results = await client.search(
 
 ## Intent Analysis
 
-IntentAnalyzer uses LLM to analyze query intent and generate 0-5 TypedQueries.
+IntentAnalyzer uses LLM to analyze query intent and generate 0-5 TypedQueries. The model used for this stage is separately configurable via the [`query_planner`](../guides/01-configuration.md#query_planner) config, falling back to `vlm` when unset.
 
 ### Input
 

--- a/docs/zh/concepts/07-retrieval.md
+++ b/docs/zh/concepts/07-retrieval.md
@@ -38,7 +38,7 @@ results = await client.search(
 
 ## 意图分析
 
-IntentAnalyzer 使用 LLM 分析查询意图，生成 0-5 个 TypedQuery。
+IntentAnalyzer 使用 LLM 分析查询意图，生成 0-5 个 TypedQuery。该阶段使用的模型可通过 [`query_planner`](../guides/01-configuration.md#query_planner) 配置项单独指定，未设置时回退到 `vlm`。
 
 ### 输入
 


### PR DESCRIPTION
The retrieval **concept** doc (`docs/{en,zh}/concepts/07-retrieval.md`) describes the Intent Analysis stage as "IntentAnalyzer uses LLM to analyze query intent", but #2224 (feat(search) Add lightweight query planner config for intent analysis) made the model for this exact stage separately configurable via the new `query_planner` config (rewiring `intent_analyzer.py` to call `config.get_query_planner()`, which falls back to `vlm`).

#2224 self-documented the knob in `guides/01-configuration.md` (### query_planner), but the concept doc that *explains the intent-analysis mechanism* still implies a single fixed LLM. Users reading this doc to understand/tune the stage won't discover they can point it at a cheaper dedicated model.

This adds a one-sentence note + cross-link to the configuration guide, in both EN and ZH (byte-structurally mirrored concept docs). Pure docs, no behavior change.