### PR TITLE
fix(web-studio): localize session composer placeholder

### DIFF
--- a/web-studio/src/routes/sessions/-components/composer.tsx
+++ b/web-studio/src/routes/sessions/-components/composer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 import { ArrowUpIcon, SquareIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import { cn } from '#/lib/utils'
 
@@ -10,6 +11,7 @@ interface ComposerProps {
 }
 
 export function Composer({ onSend, onCancel, isStreaming }: ComposerProps) {
+  const { t } = useTranslation('sessions')
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -56,7 +58,7 @@ export function Composer({ onSend, onCancel, isStreaming }: ComposerProps) {
         <textarea
           ref={textareaRef}
           autoFocus
-          placeholder="回复..."
+          placeholder={t('chat.placeholder')}
           rows={1}
           value={value}
           onChange={(e) => {


### PR DESCRIPTION
## Summary
- Replace the hardcoded Chinese session composer placeholder with the existing localized `sessions.chat.placeholder` string
- Keeps the existing English and Chinese locale values working through react-i18next

## Test Plan
- npm run lint -- --quiet
- npm run build