### PR TITLE
fix(vlm): guard Codex null response output

### DIFF
--- a/openviking/models/vlm/backends/codex_responses_adapter.py
+++ b/openviking/models/vlm/backends/codex_responses_adapter.py
@@ -8,6 +8,41 @@ import json
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional
 
+_OPENAI_NULL_OUTPUT_GUARD_APPLIED = False
+
+
+def _ensure_openai_response_output_null_guard() -> None:
+    """Guard OpenAI SDK parsing for Codex responses whose final output is null."""
+    global _OPENAI_NULL_OUTPUT_GUARD_APPLIED
+    if _OPENAI_NULL_OUTPUT_GUARD_APPLIED:
+        return
+    try:
+        from openai.lib._parsing import _responses as parsing_module
+        from openai.resources.responses import responses as responses_module
+    except Exception:
+        _OPENAI_NULL_OUTPUT_GUARD_APPLIED = True
+        return
+
+    original_parse_response = parsing_module.parse_response
+    if getattr(original_parse_response, "_openviking_null_output_guard", False):
+        _OPENAI_NULL_OUTPUT_GUARD_APPLIED = True
+        return
+
+    def guarded_parse_response(*args: Any, **kwargs: Any) -> Any:
+        response = kwargs.get("response")
+        if response is not None and getattr(response, "output", None) is None:
+            try:
+                response.output = []
+            except Exception:
+                pass
+        return original_parse_response(*args, **kwargs)
+
+    guarded_parse_response._openviking_null_output_guard = True  # type: ignore[attr-defined]
+    parsing_module.parse_response = guarded_parse_response
+    if getattr(responses_module, "parse_response", None) is original_parse_response:
+        responses_module.parse_response = guarded_parse_response
+    _OPENAI_NULL_OUTPUT_GUARD_APPLIED = True
+
 
 def _convert_content_for_responses(content: Any) -> Any:
     if isinstance(content, str):
@@ -218,6 +253,7 @@ class CodexCompletionsAdapter:
         collected_output_items: List[Any] = []
         collected_text_deltas: List[str] = []
         has_function_calls = False
+        _ensure_openai_response_output_null_guard()
         with client.responses.stream(**response_kwargs) as stream:
             for event in stream:
                 event_type = getattr(event, "type", "")

--- a/tests/unit/test_codex_vlm.py
+++ b/tests/unit/test_codex_vlm.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from openviking.models.vlm.backends import codex_auth
+from openviking.models.vlm.backends import codex_responses_adapter
 from openviking.models.vlm.backends.codex_auth import resolve_codex_runtime_credentials
 from openviking.models.vlm.backends.codex_vlm import CodexVLM
 from openviking_cli.utils.config.vlm_config import VLMConfig
@@ -361,6 +362,34 @@ def test_codex_auth_refresh_requires_persisted_client_id(tmp_path, monkeypatch):
 
     with pytest.raises(codex_auth.CodexAuthError, match="client_id"):
         resolve_codex_runtime_credentials(force_refresh=True)
+
+
+def test_codex_response_parser_accepts_null_output(monkeypatch):
+    import openai.lib._parsing._responses as parsing_module
+    import openai.resources.responses.responses as responses_module
+
+    def _sdk_parse_response(*args, **kwargs):
+        response = kwargs["response"]
+        for _output in response.output:
+            pass
+        return response
+
+    monkeypatch.setattr(parsing_module, "parse_response", _sdk_parse_response)
+    monkeypatch.setattr(responses_module, "parse_response", _sdk_parse_response)
+    monkeypatch.setattr(codex_responses_adapter, "_OPENAI_NULL_OUTPUT_GUARD_APPLIED", False)
+
+    codex_responses_adapter._ensure_openai_response_output_null_guard()
+
+    response = SimpleNamespace(output=None)
+    parsed = parsing_module.parse_response(
+        text_format=None,
+        input_tools=None,
+        response=response,
+    )
+
+    assert parsed is response
+    assert response.output == []
+    assert parsing_module.parse_response is responses_module.parse_response
 
 
 @patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")


### PR DESCRIPTION
## Summary
- Guard OpenAI SDK response parsing for Codex streams where the final completed response has `output: null`.
- Keep the existing adapter fallback path that reconstructs output from streamed output items/text deltas.
- Add a focused regression test for the parser guard.

## Context
When OpenViking uses the `openai-codex` VLM backend against the ChatGPT/Codex endpoint, the Responses stream can finish with a completed response whose `output` field is null. The OpenAI Python SDK parser currently iterates `response.output` without a null guard, which raises `TypeError: 'NoneType' object is not iterable` before OpenViking can use the collected streamed output.\n\n## Local validation\n- `git diff --check`\n- `python3 -m py_compile openviking/models/vlm/backends/codex_responses_adapter.py tests/unit/test_codex_vlm.py`\n\nNote: I could not run the pytest target in this local checkout because `uv`, `pytest`, and `ruff` are not installed in the available environment.\n\n## Live validation\nValidated the same guard on a local OpenViking 0.3.21 deployment using `openai-codex/gpt-5.3-codex`: a session commit that previously failed with the null-output TypeError completed and extracted memory successfully (`memory_write: 4`).