### PR TITLE
fix(cli): ignore null profile envelope metadata

### DIFF
--- a/crates/ov_cli/src/base_client.rs
+++ b/crates/ov_cli/src/base_client.rs
@@ -84,7 +84,7 @@ pub fn unwrap_success_envelope(json: Value, preserve_profile: bool) -> Value {
         return result.clone();
     }
 
-    let Some(profile) = json.get("profile") else {
+    let Some(profile) = json.get("profile").filter(|profile| !profile.is_null()) else {
         return result.clone();
     };
 
@@ -544,6 +544,26 @@ mod tests {
                     "line two"
                 ]
             })
+        );
+    }
+
+    #[test]
+    fn unwrap_success_envelope_drops_null_profile_for_value_results() {
+        let body = json!({
+            "status": "ok",
+            "result": [
+                {"id": "1"}
+            ],
+            "profile": null
+        });
+
+        let result = unwrap_success_envelope(body, true);
+
+        assert_eq!(
+            result,
+            json!([
+                {"id": "1"}
+            ])
         );
     }
 

--- a/crates/ov_cli/src/output.rs
+++ b/crates/ov_cli/src/output.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const MAX_COL_WIDTH: usize = 256;
@@ -22,7 +22,7 @@ impl From<&str> for OutputFormat {
 pub fn output_success<T: Serialize>(result: T, format: OutputFormat, compact: bool) {
     if matches!(format, OutputFormat::Json) {
         if compact {
-            println!("{}", json!({ "ok": true, "result": result }));
+            println!("{}", compact_success_value(result));
         } else {
             println!(
                 "{}",
@@ -32,6 +32,29 @@ pub fn output_success<T: Serialize>(result: T, format: OutputFormat, compact: bo
     } else {
         print_table(result, compact);
     }
+}
+
+fn compact_success_value<T: Serialize>(result: T) -> Value {
+    let mut obj = match serde_json::to_value(result).unwrap_or(Value::Null) {
+        Value::Object(obj) => obj,
+        value => return json!({ "ok": true, "result": value }),
+    };
+
+    let Some(profile) = obj.remove("profile") else {
+        return json!({ "ok": true, "result": Value::Object(obj) });
+    };
+
+    let result = if obj.len() == 1 && obj.contains_key("result") {
+        obj.remove("result").unwrap_or(Value::Null)
+    } else {
+        Value::Object(obj)
+    };
+
+    if profile.is_null() {
+        return json!({ "ok": true, "result": result });
+    }
+
+    json!({ "status": "ok", "result": result, "profile": profile })
 }
 
 #[allow(dead_code)]
@@ -975,6 +998,82 @@ mod tests {
                 ]
                 .join("\n")
             )
+        );
+    }
+
+    #[test]
+    fn test_compact_json_lifts_profile_next_to_result_for_list_payloads() {
+        let value = json!({
+            "result": [
+                {"id": "1", "name": "alpha"}
+            ],
+            "profile": [
+                "line one"
+            ]
+        });
+
+        let rendered = compact_success_value(value);
+
+        assert_eq!(
+            rendered,
+            json!({
+                "status": "ok",
+                "result": [
+                    {"id": "1", "name": "alpha"}
+                ],
+                "profile": [
+                    "line one"
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_compact_json_lifts_profile_next_to_result_for_object_payloads() {
+        let value = json!({
+            "healthy": true,
+            "version": "0.1.x",
+            "profile": [
+                "line one"
+            ]
+        });
+
+        let rendered = compact_success_value(value);
+
+        assert_eq!(
+            rendered,
+            json!({
+                "status": "ok",
+                "result": {
+                    "healthy": true,
+                    "version": "0.1.x"
+                },
+                "profile": [
+                    "line one"
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_compact_json_treats_null_profile_as_absent() {
+        let value = json!({
+            "result": [
+                {"id": "1", "name": "alpha"}
+            ],
+            "profile": null
+        });
+
+        let rendered = compact_success_value(value.clone());
+
+        assert_eq!(
+            rendered,
+            json!({
+                "ok": true,
+                "result": [
+                    {"id": "1", "name": "alpha"}
+                ]
+            })
         );
     }
 


### PR DESCRIPTION
## Summary
- Treat `profile: null` in success envelopes as absent when the Rust CLI unwraps dynamic JSON results.
- When real non-null profile metadata is preserved in compact JSON output, emit the server-style `status/result/profile` envelope instead of nesting profile inside `result`.
- Preserve existing no-profile compact CLI JSON output (`ok/result`) and existing table/text profile rendering behavior.
- Add regression tests for `ls`-style list responses, profiled object responses, and null profile handling.

## Root Cause
PR #2125 (`e9e6ce5`, "Feature/http profile middleware") added request-scoped HTTP profiling and introduced `profile` on the standard server response model. The server currently exposes success responses in this envelope shape:

```json
{"status":"ok","result":[...],"error":null,"telemetry":null,"profile":null}
```

When profiling is inactive, `profile` is serialized as `null`. The same PR also added CLI profile-preserving unwrap logic for `serde_json::Value`: if an envelope has any `profile` key, `unwrap_success_envelope()` wraps or merges the payload with `profile`. Because that check treated `profile: null` as meaningful, commands like `ls` rendered an extra nested `result` layer in compact JSON output:

```json
{"ok":true,"result":{"result":[...],"profile":null}}
```

A real non-null profile should also remain envelope metadata rather than becoming business payload. With this PR:

- inactive `profile: null` is treated as absent, so normal no-profile CLI output stays unchanged:

```json
{"ok":true,"result":[...]}
```

- real non-null profile metadata is emitted in a server-aligned envelope shape:

```json
{"status":"ok","result":[...],"profile":[...]}
```

This keeps the existing CLI compact `ok/result` convention for ordinary no-profile responses, but avoids inventing a second nested CLI envelope for profiled server metadata. This PR intentionally does not change the server response shape. PR #2215 only moved profile-aware table rendering order for component status output; it was not the source of this regression.

## Test Plan
- `cargo test -p ov_cli`
- `git diff --check`
- `cargo run -q -p ov_cli -- ls viking:// --output json`
- Raw server check: `GET /api/v1/fs/ls?uri=viking://` returns `status/result/error/telemetry/profile` envelope with `profile:null` when inactive.
