### PR TITLE
docs(api): document `raw` query param on /content/read (#2225)

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -130,6 +130,7 @@ Read L2 full content.
 | uri | str | Yes | - | Viking URI |
 | offset | int | No | 0 | Starting line number (0-indexed) |
 | limit | int | No | -1 | Number of lines to read, `-1` means read to end |
+| raw | bool | No | false | Return raw stored content without memory-field cleanup. HTTP API only (Python SDK does not expose it yet). |
 
 **Notes**
 

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -130,6 +130,7 @@ openviking overview viking://resources/docs/
 | uri | str | 是 | - | Viking URI |
 | offset | int | 否 | 0 | 起始行号（0 开始） |
 | limit | int | 否 | -1 | 读取的行数，`-1` 表示读到结尾 |
+| raw | bool | 否 | false | 返回未过滤 MEMORY_FIELDS 的原始存储内容（仅 HTTP API，Python SDK 暂未暴露）。 |
 
 **说明**
 


### PR DESCRIPTION
## Summary

Document the new `raw` query parameter on `GET /api/v1/content/read`, added by #2225 (qin-ctx → ZaynJarvis, merged 2026-05-25). The API reference table in `docs/{en,zh}/api/03-filesystem.md` still lists only `uri/offset/limit`; users hitting the REST endpoint have no way to discover `raw=true` from the docs.

## Source

`openviking/server/routers/content.py:66`:

```python
raw: bool = Query(False, description="Return raw stored content without memory-field cleanup"),
```

The handler then gates `MEMORY_FIELDS` cleanup behind `if not raw:`. The flag is HTTP-only — the Python SDK (`openviking_cli/client/sync_http.py:read`) does not yet pass it through.

## Changes

- `docs/en/api/03-filesystem.md`: +1 row in the `read()` Parameters table.
- `docs/zh/api/03-filesystem.md`: +1 row, mirrored.

2 LOC total, additive, byte-grounded against the FastAPI `Query` description.

## Notes

- Pure docs; no behavior change.
- Single author `r266-tech` (no co-author trailer).
