### PR TITLE
fix(ov-cli): report missing CLI config before server requests

### DIFF
--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 
@@ -126,6 +126,16 @@ impl Config {
         Self::load_default()
     }
 
+    pub fn load_required() -> Result<Self> {
+        // Resolution order: env var > default path
+        if let Ok(env_path) = std::env::var(OPENVIKING_CLI_CONFIG_ENV) {
+            return Self::load_required_from_path(&PathBuf::from(env_path));
+        }
+
+        let config_path = default_config_path()?;
+        Self::load_required_from_path(&config_path)
+    }
+
     pub fn load_default() -> Result<Self> {
         // Resolution order: env var > default path
         if let Ok(env_path) = std::env::var(OPENVIKING_CLI_CONFIG_ENV) {
@@ -136,8 +146,23 @@ impl Config {
         }
 
         let config_path = default_config_path()?;
-        if config_path.exists() {
-            Self::from_file(&config_path.to_string_lossy())
+        Self::load_default_from_path(&config_path)
+    }
+
+    pub fn load_required_from_path(path: &Path) -> Result<Self> {
+        if path.exists() {
+            Self::from_file(&path.to_string_lossy())
+        } else {
+            Err(Error::Config(
+                "No CLI config file detected, please use `ov config setup-cli` to initialize ovcli.conf"
+                    .to_string(),
+            ))
+        }
+    }
+
+    pub fn load_default_from_path(path: &Path) -> Result<Self> {
+        if path.exists() {
+            Self::from_file(&path.to_string_lossy())
         } else {
             Ok(Self::default())
         }
@@ -184,6 +209,31 @@ pub fn get_or_create_machine_id() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{Config, merge_csv_options};
+
+    #[test]
+    fn load_required_from_path_reports_missing_cli_config() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("missing-ovcli.conf");
+
+        let error = Config::load_required_from_path(&path)
+            .expect_err("missing required config should fail")
+            .to_string();
+
+        assert!(error.contains("No CLI config file detected"));
+        assert!(error.contains("ov config setup-cli"));
+        assert!(error.contains("ovcli.conf"));
+    }
+
+    #[test]
+    fn load_default_from_path_keeps_default_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("missing-ovcli.conf");
+
+        let config = Config::load_default_from_path(&path)
+            .expect("default-loading path should still fall back");
+
+        assert_eq!(config.url, "http://localhost:1933");
+    }
 
     #[test]
     fn config_deserializes_account_and_user_fields() {

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -10,7 +10,6 @@ mod utils;
 
 use clap::{ArgAction, Args, Parser, Subcommand};
 use config::Config;
-use error::Result;
 use output::OutputFormat;
 use std::ffi::OsString;
 
@@ -29,32 +28,6 @@ pub struct CliContext {
 }
 
 impl CliContext {
-    pub fn new(
-        output_format: OutputFormat,
-        compact: bool,
-        account: Option<String>,
-        user: Option<String>,
-        agent_id: Option<String>,
-        sudo: bool,
-        show_progress: Option<bool>,
-        verbose: Option<bool>,
-        profile: Option<bool>,
-    ) -> Result<Self> {
-        let config = Config::load()?;
-        Ok(Self::from_config(
-            config,
-            output_format,
-            compact,
-            account,
-            user,
-            agent_id,
-            sudo,
-            show_progress,
-            verbose,
-            profile,
-        ))
-    }
-
     fn from_config(
         mut config: Config,
         output_format: OutputFormat,
@@ -1019,6 +992,17 @@ enum AdminCommands {
     },
 }
 
+impl Commands {
+    fn requires_cli_config_file(&self) -> bool {
+        !matches!(
+            self,
+            Commands::Config {
+                action: ConfigCommands::SetupCli | ConfigCommands::Switch,
+            } | Commands::Version
+        )
+    }
+}
+
 #[derive(Subcommand)]
 enum ConfigCommands {
     /// Show current configuration
@@ -1162,7 +1146,19 @@ async fn main() {
         std::process::exit(2);
     }
 
-    let ctx = match CliContext::new(
+    let config = match if cli.command.requires_cli_config_file() {
+        Config::load_required()
+    } else {
+        Config::load_default()
+    } {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(2);
+        }
+    };
+    let ctx = CliContext::from_config(
+        config,
         output_format,
         compact,
         cli.account.clone(),
@@ -1172,13 +1168,7 @@ async fn main() {
         None,
         None,
         if cli.profile { Some(true) } else { None },
-    ) {
-        Ok(ctx) => ctx,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            std::process::exit(2);
-        }
-    };
+    );
 
     // Check if --sudo is used but root_api_key is not configured
     if ctx.sudo && ctx.config.root_api_key.is_none() {
@@ -1544,6 +1534,28 @@ mod tests {
         assert_eq!(cli.account.as_deref(), Some("acme"));
         assert_eq!(cli.user.as_deref(), Some("alice"));
         assert_eq!(cli.agent_id.as_deref(), Some("assistant-1"));
+    }
+
+    #[test]
+    fn server_commands_require_existing_cli_config() {
+        let cli = Cli::try_parse_from(["ov", "ls"]).expect("ls should parse");
+        let health = Cli::try_parse_from(["ov", "health"]).expect("health should parse");
+
+        assert!(cli.command.requires_cli_config_file());
+        assert!(health.command.requires_cli_config_file());
+    }
+
+    #[test]
+    fn setup_switch_and_version_do_not_require_existing_cli_config() {
+        let setup = Cli::try_parse_from(["ov", "config", "setup-cli"])
+            .expect("config setup-cli should parse");
+        let switch =
+            Cli::try_parse_from(["ov", "config", "switch"]).expect("config switch should parse");
+        let version = Cli::try_parse_from(["ov", "version"]).expect("version should parse");
+
+        assert!(!setup.command.requires_cli_config_file());
+        assert!(!switch.command.requires_cli_config_file());
+        assert!(!version.command.requires_cli_config_file());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Normal `ov` commands currently fall back to the default localhost server when `~/.openviking/ovcli.conf` is missing. That hides the real setup problem behind a network error. This PR makes server-backed CLI commands require an explicit active CLI config file before constructing the runtime context.

## Related Issue

Fixes #2276

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Changes Made

- Added `Config::load_required()` for command paths that must have an active `ovcli.conf`.
- Kept `Config::load_default()` for setup-oriented paths that intentionally need the default config fallback.
- Gated normal commands through the required loader so missing `ovcli.conf` reports a configuration error instead of attempting `http://localhost:1933`.
- Preserved no-config behavior for `ov config setup-cli`, `ov config switch`, and `ov version`.
- Added regression tests for required vs default config loading and command gating.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```shell
cargo test -p ov_cli
cargo build -p ov_cli
git diff --check
```

Manual smoke with a temporary HOME:

```shell
HOME=/Users/bytedance/Desktop/cli/tmp-ovcli-missing-config-home ./target/debug/ov ls
HOME=/Users/bytedance/Desktop/cli/tmp-ovcli-missing-config-home ./target/debug/ov health
```

Both commands now report:

```text
Error: Configuration error: No CLI config file detected, please use `ov config setup-cli` to initialize ovcli.conf
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Documentation was not changed because this is a targeted CLI runtime bug fix. The existing setup command remains `ov config setup-cli` on current `main`, so the error message intentionally points to that command.