### PR TITLE
docs(prompt-guide): document trajectories memory schema

### DIFF
--- a/docs/en/guides/10-prompt-guide.md
+++ b/docs/en/guides/10-prompt-guide.md
@@ -248,6 +248,12 @@ These YAML files define the structure of different memory types. They are not si
   - Purpose: defines the storage structure for tool call statistics and tool-usage experience
   - Key fields: `tool_name`, `static_desc`, `call_count`, `success_time`, `when_to_use`, `optimal_params`
 
+- `trajectories`
+  - Effective stage: agent trajectory memory persistence stage (agent-only, add-only)
+  - Affects: reusable operation contracts distilled from agent task trajectories — multi-step decisions, tool calls, and execution traces
+  - Purpose: defines compact trajectory memory for "what reusable operation/contract emerged from a task trajectory"
+  - Key fields: `trajectory_name`, `outcome`, `retrieval_anchor`, `content`
+
 ### Parsing
 
 These prompts are mainly used to convert raw resource content into structured nodes, chapters, summaries, or image overviews that are easier to retrieve and understand.

--- a/docs/zh/guides/10-prompt-guide.md
+++ b/docs/zh/guides/10-prompt-guide.md
@@ -248,6 +248,12 @@ operation_mode: "upsert"
   - 作用：定义工具调用统计和工具使用经验的存储结构
   - 关键字段：`tool_name`、`static_desc`、`call_count`、`success_time`、`when_to_use`、`optimal_params`
 
+- `trajectories`
+  - 生效环节：agent 轨迹型记忆落盘阶段（agent_only，仅追加）
+  - 影响能力：agent 任务轨迹中可复用的操作契约沉淀——多步决策、工具调用、执行链路
+  - 作用：定义"任务轨迹中提炼出哪些可复用的操作/契约"这一类轨迹型记忆
+  - 关键字段：`trajectory_name`、`outcome`、`retrieval_anchor`、`content`
+
 ### Parsing
 
 这一类 prompt 主要用于把原始资源内容转成适合检索和理解的结构化节点、章节、摘要或图像概述。


### PR DESCRIPTION
## Summary

Canonical prompt-guide ### Memory section lists 10 memory schemas (`cases`/`entities`/`events`/`identity`/`patterns`/`preferences`/`profile`/`skills`/`soul`/`tools`) but omits `trajectories`, which has shipped since #1880 (2026-05-08, two-phase trajectory/experience pipeline) and got another enhancement this week:

- #2017 (2026-05-21) — `feat(memory): upgrade trajectory extraction to beat no-memory baseline`
- #2221 (2026-05-25) — `feat(memory): tighten trajectory operation boundaries`
- #2255 (2026-05-27) — `feat(memory): add trajectory retrieval anchor` (added `retrieval_anchor` field + `embedding_template`)

The canonical guide hasn't been updated, so users browsing the ### Memory menu can't discover that agent-trajectory memory is a first-class schema or what its fields are.

This PR inserts a single `- trajectories` bullet after the `tools` entry in each ### Memory listing (EN + ZH), mirroring the 4-line form used by neighbors (Effective stage / Affects / Purpose / Key fields). Schema values are grounded directly from `openviking/prompts/templates/memory/trajectories.yaml` (`memory_type: trajectories` L1, `enabled: true` L15, `operation_mode: add_only` L16, `agent_only: true` L17, fields `trajectory_name` / `outcome` / `retrieval_anchor` / `content`).

## Files

- `docs/en/guides/10-prompt-guide.md` (+6)
- `docs/zh/guides/10-prompt-guide.md` (+6)

Pure docs, ~10 LOC additive. No code change.