### PR TITLE
refactor(langchain): clarify session commit policy helper

### DIFF
--- a/openviking/integrations/langchain/client.py
+++ b/openviking/integrations/langchain/client.py
@@ -158,12 +158,12 @@ def ensure_client(connection: OpenVikingConnection) -> Any:
     return client
 
 
-def maybe_commit_session(
+def apply_commit_policy(
     client: Any,
     session_id: str,
     policy: OpenVikingCommitPolicy | None,
 ) -> dict[str, Any] | None:
-    """Commit a session if the configured policy says the live tail is ready."""
+    """Apply the configured session commit policy."""
 
     if policy is None or policy.mode == "never":
         return None

--- a/openviking/integrations/langchain/history.py
+++ b/openviking/integrations/langchain/history.py
@@ -25,10 +25,10 @@ except ImportError as exc:  # pragma: no cover - exercised by optional import pa
 from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
     OpenVikingConnection,
+    apply_commit_policy,
     call_openviking,
     ensure_client,
     extract_message_text,
-    maybe_commit_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
                 session_id=self.session_id,
                 messages=batch,
             )
-            maybe_commit_session(client, self.session_id, self.commit_policy)
+            apply_commit_policy(client, self.session_id, self.commit_policy)
 
     def clear(self) -> None:
         client = self._get_client()

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -26,11 +26,11 @@ except ImportError as exc:  # pragma: no cover - exercised by optional import pa
 from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
     OpenVikingConnection,
+    apply_commit_policy,
     call_openviking,
     ensure_client,
     extract_message_text,
     get_latest_user_text,
-    maybe_commit_session,
 )
 from openviking.integrations.langchain.context import (
     OPENVIKING_CONTEXT_MARKER,
@@ -203,7 +203,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 added += 1
         self._captured_signatures[session_id] = current_signatures
         if added:
-            maybe_commit_session(client, session_id, self.commit_policy)
+            apply_commit_policy(client, session_id, self.commit_policy)
         return None
 
     def _resolve_session_id(self, state: dict[str, Any], runtime: Any) -> str:

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -9,6 +9,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 from langchain_core.runnables import RunnableLambda
 from langgraph.store.base import PutOp
 
+import openviking.integrations.langchain.client as client_helpers
 from openviking.integrations.langchain import (
     InMemoryOpenVikingClient,
     OpenVikingChatMessageHistory,
@@ -22,9 +23,9 @@ from openviking.integrations.langchain import (
 )
 from openviking.integrations.langchain.client import (
     OpenVikingConnection,
+    apply_commit_policy,
     call_openviking,
     ensure_client,
-    maybe_commit_session,
 )
 from openviking.integrations.langchain.history import (
     langchain_message_to_openviking,
@@ -32,6 +33,11 @@ from openviking.integrations.langchain.history import (
 )
 from openviking.integrations.langchain.middleware import _message_signature
 from openviking.integrations.langchain.tools import _archive_grep_pattern
+
+
+def test_langchain_client_exposes_apply_commit_policy_without_legacy_alias():
+    assert hasattr(client_helpers, "apply_commit_policy")
+    assert not hasattr(client_helpers, "maybe_commit_session")
 
 
 def test_retriever_returns_langchain_documents():
@@ -958,7 +964,7 @@ def test_langgraph_store_uses_create_first_and_preserves_created_at_on_replace()
 
 def test_pending_token_commit_does_not_create_missing_session():
     client = InMemoryOpenVikingClient()
-    result = maybe_commit_session(
+    result = apply_commit_policy(
         client,
         "missing-commit-session",
         OpenVikingCommitPolicy(mode="pending_tokens", pending_token_threshold=1),


### PR DESCRIPTION
## Summary

- Rename the LangChain session commit helper from `maybe_commit_session` to `apply_commit_policy`.
- Update `OpenVikingChatMessageHistory` and `OpenVikingContextMiddleware` to call the renamed helper after message capture.
- Add regression coverage that the new helper is exposed and the legacy helper name is no longer present.

## Rationale

The helper does more than opportunistically commit a session: it applies the configured `OpenVikingCommitPolicy` across `never`, `always`, and `pending_tokens` modes. The new name better matches the behavior used by both the chat history adapter and LangGraph middleware, and keeps the lifecycle API easier to reason about before adding more integration surfaces.

## Validation

- `uv run --extra dev ruff format openviking/integrations/langchain/client.py openviking/integrations/langchain/history.py openviking/integrations/langchain/middleware.py tests/unit/test_langchain_integration.py`
- `uv run --extra dev ruff check openviking/integrations/langchain/client.py openviking/integrations/langchain/history.py openviking/integrations/langchain/middleware.py tests/unit/test_langchain_integration.py`
- `uv run --extra test pytest tests/unit/test_langchain_integration.py --no-cov -q`
