### PR TITLE
fix(language): strip hash-like tokens before language detection

### DIFF
--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -228,12 +228,39 @@ def _detect_latin_language(text: str, fallback_language: str) -> str:
     return "en"
 
 
+_HEX_TOKEN_RE = re.compile(r"[0-9a-f]{8,}", re.IGNORECASE)
+
+
+def _strip_hash_like_tokens(text: str) -> str:
+    """Remove hash / UUID / message-id fragments before language detection.
+
+    Bot integrations (e.g. IM channel adapters) often inject metadata such as
+    ``[message_id: om_x100b6eb5f06fc8acb29491741d6eb30]`` or open IDs like
+    ``ou_a56ad44f6de54e96b53508d5e3cff3cb`` into user message content. These
+    hex runs are pure latin characters from the detector's point of view, but
+    their 2-letter substrings ("de", "do", "da", ...) collide with European
+    stopwords used by :func:`_detect_latin_language`, biasing detection toward
+    Portuguese / French / Spanish even when the actual user content is
+    Chinese, Japanese, Korean, etc.
+
+    Stripping any run of 8+ hexadecimal characters removes UUIDs (32),
+    message_ids (~32), short SHA prefixes (\u22658), etc., while leaving regular
+    English / Latin words intact (no real word is 8+ chars and uses only
+    ``[0-9a-f]``).
+    """
+    if not text:
+        return text
+    return _HEX_TOKEN_RE.sub(" ", text)
+
+
 def _detect_language_from_text(user_text: str, fallback_language: str) -> str:
     """Internal shared helper to detect dominant language from text."""
     fallback = (fallback_language or "en").strip() or "en"
 
     if not user_text:
         return fallback
+
+    user_text = _strip_hash_like_tokens(user_text)
 
     counts = {
         "zh-CN": len(re.findall(r"[\u4e00-\u9fff]", user_text)),

--- a/tests/session/memory/test_language_detection.py
+++ b/tests/session/memory/test_language_detection.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Tests for language detection utilities — regression coverage for
+hash-token pollution from bot adapters (Feishu, Slack, etc.) that inject
+message IDs / open IDs into user message content.
+"""
+
+import pytest
+
+from openviking.session.memory.utils.language import (
+    _detect_language_from_text,
+    _strip_hash_like_tokens,
+)
+
+
+class TestStripHashLikeTokens:
+    """Verify the hex-token stripper isolates real text from ID metadata."""
+
+    def test_strips_uuid_like_run(self):
+        out = _strip_hash_like_tokens("ou_a56ad44f6de54e96b53508d5e3cff3cb hello")
+        assert "a56ad44f" not in out
+        assert "hello" in out
+
+    def test_strips_feishu_message_id(self):
+        text = "[message_id: om_x100b6eb5f06fc8acb29491741d6eb30] hello"
+        out = _strip_hash_like_tokens(text)
+        assert "100b6eb5" not in out
+        assert "hello" in out
+
+    def test_leaves_real_english_words_intact(self):
+        # No regular English word is 8+ chars long using only [0-9a-f].
+        text = "facade deadbeef cabbage portuguese español"
+        out = _strip_hash_like_tokens(text)
+        # 'deadbeef' is 8 hex chars — stripped (intentional, it's hash-like).
+        assert "deadbeef" not in out
+        # 'facade' is only 6 chars — kept.
+        assert "facade" in out
+        # 'cabbage' contains 'g' (non-hex) — kept.
+        assert "cabbage" in out
+        assert "portuguese" in out
+        assert "español" in out
+
+    def test_empty_input(self):
+        assert _strip_hash_like_tokens("") == ""
+
+    def test_no_hex_content(self):
+        text = "我有哪些喜好"
+        assert _strip_hash_like_tokens(text) == text
+
+
+class TestDetectLanguageWithHashPollution:
+    """Regression: hash-like tokens (message IDs, UUIDs, OAuth open IDs) must
+    not bias language detection toward Latin languages when the actual user
+    content is in a non-Latin script.
+
+    Real-world trigger: IM bot adapters prepend metadata like
+    ``[message_id: om_xxx] ou_xxx:`` to every user message body before the
+    text is stored as the message ``content``. Without filtering, hex digits
+    dominate the latin-char count, ``_passes_threshold`` fails for zh-CN, and
+    ``_detect_latin_language`` pattern-matches stopword-like fragments
+    (e.g. ``de`` / ``do``) → returns ``pt`` / ``fr`` / ``es``. Downstream
+    prompts then instruct the LLM to emit memories in the wrong language.
+    """
+
+    def test_chinese_with_feishu_message_id_detected_as_chinese(self):
+        text = (
+            "[message_id: om_x100b6eb5f06fc8acb29491741d6eb30] "
+            "ou_a56ad44f6de54e96b53508d5e3cff3cb: 我有哪些喜好\n"
+            "[message_id: om_x100b6eb5b58cb4a0b3c719778034103] "
+            "ou_a56ad44f6de54e96b53508d5e3cff3cb: 我爱吃苹果"
+        )
+        assert _detect_language_from_text(text, "en") == "zh-CN"
+
+    def test_pure_hash_content_falls_back(self):
+        # Content that is *only* hash-like should not bias toward any specific
+        # latin language — fall back to the fallback (en here).
+        text = (
+            "om_x100b6eb5f06fc8acb29491741d6eb30 "
+            "ou_a56ad44f6de54e96b53508d5e3cff3cb"
+        )
+        assert _detect_language_from_text(text, "en") == "en"
+
+    def test_real_portuguese_still_detects_pt(self):
+        # Sanity: the stripper must not break legitimate latin-language
+        # detection. Real Portuguese stopwords + accents should still resolve
+        # to pt.
+        text = (
+            "Olá, este documento é para o usuário. As preferências do "
+            "projeto são importantes e devem ser registradas com cuidado, "
+            "para que cada usuário possa consultá-las."
+        )
+        assert _detect_language_from_text(text, "en") == "pt"
+
+    def test_korean_with_hash_pollution_detected_as_korean(self):
+        # ko isn't in _PRIMARY_LANGUAGES, so it only wins via the strong
+        # dominance path (>=10 chars AND >=95% ratio of non-latin signal).
+        # The stripper must remove the hex pollution so Korean dominates.
+        text = (
+            "[message_id: a56ad44f6de54e96b53508d5e3cff3cb] "
+            "안녕하세요 어떻게 지내세요 오늘 날씨가 정말 좋네요 점심 같이 먹어요"
+        )
+        assert _detect_language_from_text(text, "ko") == "ko"


### PR DESCRIPTION
## Description

`_detect_language_from_text` (in `openviking/session/memory/utils/language.py`) misclassifies Chinese user content as Portuguese (or other European languages) when the input contains hash-like tokens such as message IDs / UUIDs / OAuth open IDs.

This breaks memory extraction for any deployment that ingests user messages through IM bot adapters (Feishu, Slack, ...) where adapters prepend metadata like `[message_id: om_xxx]` to every message body.

## Reproduction (against current `main`)

```python
from openviking.session.memory.utils.language import _detect_language_from_text

text = (
    "[message_id: om_x100b6eb5f06fc8acb29491741d6eb30] "
    "ou_a56ad44f6de54e96b53508d5e3cff3cb: 我有哪些喜好\n"
    "[message_id: om_x100b6eb5b58cb4a0b3c719778034103] "
    "ou_a56ad44f6de54e96b53508d5e3cff3cb: 我爱吃苹果"
)
# Before fix:
#   Chinese chars: 11, latin chars (mostly hex): 79
#   Chinese ratio: 12.22% < 20% threshold
#   _passes_threshold fails for zh-CN → falls to _detect_latin_language
#   Hex digits like "de" / "do" collide with pt/fr/es stopwords
print(_detect_language_from_text(text, 'en'))   # → 'pt' ❌

# After fix:
print(_detect_language_from_text(text, 'en'))   # → 'zh-CN' ✅
```

End-to-end impact observed in production:

1. Memory extraction prompt is rendered with `output_language=pt`
2. LLM (gpt-class) obediently outputs all extracted memories in Portuguese
3. Files are written under paths like `viking://user/{user}/memories/preferences/{user}/preferências alimentares.md` — content, filename, and resulting vector embeddings all in Portuguese
4. Subsequent Chinese-query recall over these memories fails because the query embedding never aligns with the Portuguese stored vectors

## Root Cause

Regression introduced in #2164 (commit 3acc63c, merged 2026-05-21 — first released in v0.3.20). Prior versions returned `zh-CN` whenever any Han character was present in the user text, so the hex pollution from bot adapters never tipped the scale.

The new logic requires a 20% Chinese-script ratio before returning `zh-CN`, and falls through to `_detect_latin_language` otherwise. That fallback scans words like `de` (which appears frequently inside 32-char hex runs), and `de` is a stopword for `pt`, `fr`, and `es`. Whichever Latin language happens to win the stopword count gets returned — typically `pt`.

## Fix

Strip any run of 8+ hexadecimal characters before counting script signal. This removes UUIDs (32 chars), Feishu message_ids (~32 chars), and SHA prefixes (≥8 chars), while leaving normal English / European words intact — no real word is 8+ chars and uses only `[0-9a-f]`.

```python
_HEX_TOKEN_RE = re.compile(r"[0-9a-f]{8,}", re.IGNORECASE)

def _strip_hash_like_tokens(text: str) -> str:
    if not text:
        return text
    return _HEX_TOKEN_RE.sub(" ", text)


def _detect_language_from_text(user_text: str, fallback_language: str) -> str:
    ...
    user_text = _strip_hash_like_tokens(user_text)
    ...
```

## Tests

New file `tests/session/memory/test_language_detection.py` with 9 cases covering:

- `_strip_hash_like_tokens` correctness (UUID runs, Feishu message_ids, preservation of real English words, edge cases)
- Chinese-with-Feishu-metadata → zh-CN
- Pure-hash content → fallback (en)
- Real Portuguese (with stopwords + accents, no hex) → still pt (no regression)
- Korean-with-pollution → ko (when fallback is ko)

All 9 new tests pass. All 68 existing tests in `tests/storage/test_semantic_processor_language.py` continue to pass — the fix is additive.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented the new helper to explain why it exists
- [x] My changes generate no new warnings
- [x] I have added regression tests