### PR TITLE
docs: fix broken crates/ov_cli/LICENSE link in README/README_CN/README_JA (404 since #1221 crates reorg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ For vulnerability reporting and supported versions, see [SECURITY.md](SECURITY.m
 The OpenViking project uses different licenses for different components:
 
 - **Main Project**: AGPLv3 - see the [LICENSE](./LICENSE) file for details
-- **crates/ov\_cli**: Apache 2.0 - see the [LICENSE](./crates/ov_cli/LICENSE) for details
+- **crates/ov\_cli**: Apache 2.0 - see the [LICENSE](./crates/LICENSE) for details
 - **examples**: Apache 2.0 - see the [LICENSE](./examples/LICENSE) for details
 - **third\_party**: Respective original licenses of third-party projects
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -768,7 +768,7 @@ OpenViking 仍处于早期阶段，有许多改进和探索的空间。我们真
 OpenViking 项目不同组件采用不同的开源协议：
 
 - **主项目**: AGPLv3 - 详情请参见 [LICENSE](./LICENSE) 文件
-- **crates/ov_cli**: Apache 2.0 - 详情请参见 [LICENSE](./crates/ov_cli/LICENSE) 文件
+- **crates/ov_cli**: Apache 2.0 - 详情请参见 [LICENSE](./crates/LICENSE) 文件
 - **examples**: Apache 2.0 - 详情请参见 [LICENSE](./examples/LICENSE) 文件
 - **third_party**: 保留各三方项目的原有协议
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -581,7 +581,7 @@ AIエージェントのコンテキスト管理の未来を共に定義し、構
 OpenVikingプロジェクトは、コンポーネントごとに異なるライセンスを使用しています：
 
 - **メインプロジェクト**: AGPLv3 - 詳細は[LICENSE](./LICENSE)ファイルを参照してください
-- **crates/ov_cli**: Apache 2.0 - 詳細は[LICENSE](./crates/ov_cli/LICENSE)ファイルを参照してください
+- **crates/ov_cli**: Apache 2.0 - 詳細は[LICENSE](./crates/LICENSE)ファイルを参照してください
 - **examples**: Apache 2.0 - 詳細は[LICENSE](./examples/LICENSE)ファイルを参照してください
 - **third_party**: 各サードパーティプロジェクトの元のライセンス
 


### PR DESCRIPTION
All 3 top-level READMEs link the `crates/ov_cli` Apache 2.0 license to `./crates/ov_cli/LICENSE`, which 404s since #1221 (2026-04-05, MaojiaSheng) consolidated the per-crate Apache LICENSEs up one level to `./crates/LICENSE` (one Apache 2.0 file now covers `ov_cli` + `ragfs` + `ragfs-python`).

Trilingual one-line path fix — each README changes `[LICENSE](./crates/ov_cli/LICENSE)` → `[LICENSE](./crates/LICENSE)`. The `**crates/ov_cli**: Apache 2.0` label wording is left untouched (minimal byte-grounded mirror of where the file actually lives — broaden the label scope in a follow-up if you prefer).

Verified live targets via `gh api repos/.../contents/`:
- `crates/LICENSE` → exists (Apache 2.0)
- `crates/ov_cli/LICENSE` → 404
- `examples/LICENSE` → exists (untouched in this PR)
