### PR TITLE
docs(openclaw-plugin): list openviking_tool_result_read/search/list in plugin tool tables (#2058)

### DIFF
--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -41,6 +41,9 @@ Once installed, the plugin provides these agent tools:
 | `add_resource` | Import documents, URLs, or Git repos |
 | `add_skill` | Import agent skills |
 | `ov_search` | Search imported resources and skills |
+| `openviking_tool_result_read` | Restore the full original content of an externalized tool result |
+| `openviking_tool_result_search` | Search inside an externalized tool result by keyword |
+| `openviking_tool_result_list` | List externalized tool results in the current session |
 
 ## Data Flow & Privacy
 

--- a/examples/openclaw-plugin/README_CN.md
+++ b/examples/openclaw-plugin/README_CN.md
@@ -41,6 +41,9 @@ Agent 会自动完成安装 → 配置 → 重启 → 验证。详见 [INSTALL-A
 | `add_resource` | 导入文档、URL 或 Git 仓库 |
 | `add_skill` | 导入 agent 技能 |
 | `ov_search` | 检索已导入的 resources 和 skills |
+| `openviking_tool_result_read` | 还原被 OpenViking 外置的工具结果的完整原始内容 |
+| `openviking_tool_result_search` | 按关键词在外置的工具结果中检索 |
+| `openviking_tool_result_list` | 列出当前会话中外置的工具结果 |
 
 ## 数据流与隐私
 


### PR DESCRIPTION
## What

The `examples/openclaw-plugin` README tool tables list 8 tools, but `openclaw.plugin.json` registers **11** — the externalized-tool-result drilldown trio added in #2058 (`openviking_tool_result_read` / `_search` / `_list`) has never appeared in the tables. This adds the three missing rows to both `README.md` and `README_CN.md` so the canonical tool tables match the actual registered/exposed surface.

## Grounding

- `examples/openclaw-plugin/openclaw.plugin.json` registers all 11 tools, including `openviking_tool_result_read/search/list`.
- `examples/openclaw-plugin/index.ts` registers the three as first-class tools with descriptions: read = "Restore the full original content of a tool result that was externalized by OpenViking" (L1606); search = "Search inside an externalized tool result for a keyword" (L1703); list = "List externalized tool results for the current session" (L1807).
- The sibling drilldown tools `ov_archive_search` / `ov_archive_expand` are already in the table, so the three new rows follow the existing convention rather than introducing a new one.

## Scope

Strictly the tool tables (the exhaustive canonical reference of registered tools). The curated "Tools and Expandability" prose subset is left untouched — it already omits some registered tools by design. Pure docs, dual-doc EN + zh.
