### PR TITLE
fix(reindex): add `force` flag to evict corrupted vector records before upsert

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -46,6 +46,9 @@ class ReindexRequest(BaseModel):
     uri: str
     mode: str = "vectors_only"
     wait: bool = True
+    # When true, every per-URI upsert during this reindex first deletes
+    # the existing vector record(s) for that URI before re-upserting.
+    force: bool = False
 
 
 router = APIRouter(prefix="/api/v1/content", tags=["content"])
@@ -211,6 +214,7 @@ async def reindex(
         uri=uri,
         mode=body.mode,
         wait=body.wait,
+        force=body.force,
         ctx=ctx,
     )
     return Response(status="ok", result=result)

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -409,9 +409,14 @@ class OpenVikingService:
         uri: str,
         mode: str = "vectors_only",
         wait: bool = True,
+        force: bool = False,
         ctx: RequestContext | None = None,
     ) -> dict[str, Any]:
-        """Reindex semantic/vector artifacts for a URI."""
+        """Reindex semantic/vector artifacts for a URI.
+
+        ``force=True`` causes every per-URI upsert to first delete the
+        existing vector record(s) at that URI before re-upserting.
+        """
         if not self._initialized:
             await self.initialize()
 
@@ -422,6 +427,7 @@ class OpenVikingService:
             uri=uri,
             mode=mode,
             wait=wait,
+            force=force,
             ctx=effective_ctx,
         )
 

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import time
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional
@@ -47,6 +48,17 @@ from openviking_cli.utils.config import get_openviking_config
 logger = get_logger(__name__)
 
 REINDEX_TASK_TYPE = "admin_reindex"
+
+# When set to True for the duration of a reindex run, every
+# ``_upsert_context`` call first deletes the existing vector record(s)
+# for its URI via ``viking_fs._delete_from_vector_store`` before
+# re-upserting. Threaded through with a contextvar (rather than a
+# parameter on every internal call) because _upsert_context is invoked
+# from many sites; using a contextvar keeps the call sites untouched
+# and is async-task safe (asyncio inherits contextvars per task).
+_FORCE_DROP_CORRUPT: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "openviking.reindex_force_drop_corrupt", default=False
+)
 
 _reindex_executor: "ReindexExecutor | None" = None
 
@@ -94,6 +106,7 @@ class ReindexExecutor:
         mode: str,
         wait: bool,
         ctx: RequestContext,
+        force: bool = False,
     ) -> dict[str, Any]:
         object_type = self._infer_target_type(uri)
         self._validate_mode(object_type, mode)
@@ -116,6 +129,7 @@ class ReindexExecutor:
                 object_type=object_type,
                 mode=mode,
                 ctx=ctx,
+                force=force,
             )
 
         task = await tracker.create_if_no_running(
@@ -138,6 +152,7 @@ class ReindexExecutor:
                 object_type=object_type,
                 mode=mode,
                 ctx=ctx,
+                force=force,
             )
         )
         return {
@@ -339,6 +354,7 @@ class ReindexExecutor:
         object_type: str,
         mode: str,
         ctx: RequestContext,
+        force: bool = False,
     ) -> dict[str, Any]:
         service = get_service()
         if service.viking_fs is None or service.vikingdb_manager is None:
@@ -358,6 +374,10 @@ class ReindexExecutor:
         if telemetry_id:
             wait_tracker.register_request(telemetry_id)
 
+        # Publish ``force`` to all nested _upsert_context calls via a
+        # contextvar (async-task safe; reset in finally so other reindex
+        # runs aren't affected).
+        force_token = _FORCE_DROP_CORRUPT.set(force)
         try:
             async with LockContext(get_lock_manager(), [path], lock_mode="tree") as lock_handle:
                 run = _ReindexRunContext(
@@ -421,6 +441,7 @@ class ReindexExecutor:
                         wait_tracker.build_queue_status(telemetry_id),
                     )
         finally:
+            _FORCE_DROP_CORRUPT.reset(force_token)
             if telemetry_id:
                 wait_tracker.cleanup(telemetry_id)
 
@@ -445,6 +466,7 @@ class ReindexExecutor:
         object_type: str,
         mode: str,
         ctx: RequestContext,
+        force: bool = False,
     ) -> None:
         tracker = get_task_tracker()
         await tracker.start(task_id, account_id=ctx.account_id, user_id=ctx.user.user_id)
@@ -454,6 +476,7 @@ class ReindexExecutor:
                 object_type=object_type,
                 mode=mode,
                 ctx=ctx,
+                force=force,
             )
             await tracker.complete(
                 task_id,
@@ -1310,6 +1333,20 @@ class ReindexExecutor:
     ) -> None:
         service = get_service()
         assert service.vikingdb_manager is not None
+
+        # ``force=True`` reindex pre-deletes any existing vector record(s)
+        # at this URI before re-upserting. This evicts corrupted records
+        # whose deserialization fails (see _FORCE_DROP_CORRUPT docstring
+        # at module top). Best-effort: a delete failure is logged but
+        # does not block the upsert.
+        if _FORCE_DROP_CORRUPT.get():
+            try:
+                viking_fs = get_viking_fs()
+                await viking_fs._delete_from_vector_store([uri], ctx=ctx)
+            except Exception as exc:
+                logger.warning(
+                    "[reindex force] pre-delete failed for %s: %s", uri, exc
+                )
 
         context = Context(
             uri=uri,

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -91,10 +91,11 @@ async def test_reindex_resource_vectors_only_wait_true(monkeypatch):
     seen = {}
 
     class FakeService:
-        async def reindex(self, *, uri, mode, wait, ctx):
+        async def reindex(self, *, uri, mode, wait, force, ctx):
             seen["uri"] = uri
             seen["mode"] = mode
             seen["wait"] = wait
+            seen["force"] = force
             seen["ctx"] = ctx
             return {
                 "status": "completed",
@@ -134,7 +135,7 @@ async def test_reindex_resource_vectors_only_wait_false(monkeypatch):
     from openviking.server.routers.content import ReindexRequest, reindex
 
     class FakeService:
-        async def reindex(self, *, uri, mode, wait, ctx):
+        async def reindex(self, *, uri, mode, wait, force, ctx):
             return {
                 "task_id": "rbld_123",
                 "status": "accepted",
@@ -1588,10 +1589,11 @@ async def test_openviking_service_reindex_uses_default_root_context(monkeypatch)
     seen = {}
 
     class FakeExecutor:
-        async def execute(self, *, uri, mode, wait, ctx):
+        async def execute(self, *, uri, mode, wait, force, ctx):
             seen["uri"] = uri
             seen["mode"] = mode
             seen["wait"] = wait
+            seen["force"] = force
             seen["ctx"] = ctx
             return {"status": "completed", "uri": uri}
 

--- a/tests/server/test_reindex_force_drop.py
+++ b/tests/server/test_reindex_force_drop.py
@@ -1,0 +1,334 @@
+"""Regression tests for the ReindexRequest ``force`` flag.
+
+The bug:
+  vector store records whose serialization is corrupted (uint16 length
+  overflow in C++ BytesRow → see openviking/storage/vectordb/store/
+  bytes_row.py) raise UnicodeDecodeError when read back during a
+  dedupe query. The dedupe layer catches that error and returns an
+  empty list, so reindex thinks "no record exists" and just upserts
+  another row — but the corrupted row is still in the store and any
+  later query keeps failing.
+
+  ``force=true`` makes every ``_upsert_context`` first delete the
+  existing vector record(s) for that URI via
+  ``viking_fs._delete_from_vector_store``, then upsert fresh. This
+  evicts any corrupted record that's been hiding behind the swallowed
+  decode error.
+
+These tests pin two behaviors:
+  1. ``ReindexRequest`` accepts ``force`` and the router forwards it
+     all the way down to ``ReindexExecutor.execute``.
+  2. With ``force=True`` propagated through ``_run``, every
+     ``_upsert_context`` call invokes ``_delete_from_vector_store``
+     for that URI before the upsert. With ``force=False`` (default),
+     no delete is made — preserving the existing fast path.
+"""
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.service.reindex_executor import (
+    ReindexExecutor,
+    _ReindexCounters,
+    _ReindexRunContext,
+)
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _make_ctx() -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice", agent_id="default"),
+        role=Role.ROOT,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 1. Router-level: ReindexRequest accepts `force` and forwards it
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_reindex_request_accepts_force_field():
+    from openviking.server.routers.content import ReindexRequest
+
+    body = ReindexRequest(uri="viking://resources/demo", force=True)
+    assert body.force is True
+
+    default_body = ReindexRequest(uri="viking://resources/demo")
+    assert default_body.force is False, "default must be False to keep current behavior"
+
+
+@pytest.mark.asyncio
+async def test_reindex_router_forwards_force_true(monkeypatch):
+    from openviking.server.routers.content import ReindexRequest, reindex
+
+    seen: dict = {}
+
+    class FakeService:
+        async def reindex(self, *, uri, mode, wait, force, ctx):
+            seen["uri"] = uri
+            seen["mode"] = mode
+            seen["wait"] = wait
+            seen["force"] = force
+            return {
+                "status": "completed",
+                "uri": uri,
+                "object_type": "resource",
+                "mode": mode,
+                "rebuilt_records": 0,
+                "scanned_records": 0,
+                "unsupported_records": 0,
+                "failed_records": 0,
+                "duration_ms": 1,
+                "warnings": [],
+            }
+
+    monkeypatch.setattr("openviking.server.routers.content.get_service", lambda: FakeService())
+    request = ReindexRequest(
+        uri="viking://resources/demo", mode="vectors_only", wait=True, force=True
+    )
+    response = await reindex(body=request, ctx=_make_ctx())
+
+    assert response.status == "ok"
+    assert seen["force"] is True
+
+
+@pytest.mark.asyncio
+async def test_reindex_router_forwards_force_default_false(monkeypatch):
+    from openviking.server.routers.content import ReindexRequest, reindex
+
+    seen: dict = {}
+
+    class FakeService:
+        async def reindex(self, *, uri, mode, wait, force, ctx):
+            seen["force"] = force
+            return {
+                "status": "completed",
+                "uri": uri,
+                "object_type": "resource",
+                "mode": mode,
+                "rebuilt_records": 0,
+                "scanned_records": 0,
+                "unsupported_records": 0,
+                "failed_records": 0,
+                "duration_ms": 1,
+                "warnings": [],
+            }
+
+    monkeypatch.setattr("openviking.server.routers.content.get_service", lambda: FakeService())
+    request = ReindexRequest(uri="viking://resources/demo")  # no force passed
+    await reindex(body=request, ctx=_make_ctx())
+    assert seen["force"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 2. Executor-level: force=True triggers pre-delete on each _upsert
+# ─────────────────────────────────────────────────────────────────────
+
+
+class _RecordingVikingFS:
+    """VikingFS stub that just records calls to _delete_from_vector_store."""
+
+    def __init__(self):
+        self.deleted_uri_batches: list[list[str]] = []
+
+    async def _delete_from_vector_store(self, uris, ctx=None):
+        self.deleted_uri_batches.append(list(uris))
+
+
+def _stub_upsert_callable_dependencies(monkeypatch, vikingdb=object()):
+    """Make _upsert_context's heavy enqueue path a no-op so we only
+    measure the pre-delete behavior."""
+
+    class _NoopMsg:
+        id = "msg-id"
+        telemetry_id = ""
+
+    class _NoopConverter:
+        @staticmethod
+        def from_context(_context):
+            return _NoopMsg()
+
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.EmbeddingMsgConverter",
+        _NoopConverter,
+    )
+
+    class _NoopWaitTracker:
+        def register_embedding_root(self, *a, **kw):
+            pass
+
+        def mark_embedding_failed(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_request_wait_tracker",
+        lambda: _NoopWaitTracker(),
+    )
+
+    class _Service:
+        viking_fs = None  # set per-test
+        vikingdb_manager = type(
+            "_DB",
+            (),
+            {
+                "enqueue_embedding_msg": staticmethod(
+                    lambda _msg: _async_true()
+                ),
+            },
+        )()
+
+    return _Service
+
+
+async def _async_true():
+    return True
+
+
+@pytest.mark.asyncio
+async def test_upsert_context_with_force_pre_deletes(monkeypatch):
+    """When force_drop_corrupt context is set, _upsert_context must
+    call viking_fs._delete_from_vector_store([uri]) before enqueuing."""
+    from openviking.core.context import ContextLevel
+    from openviking.service.reindex_executor import _FORCE_DROP_CORRUPT
+
+    fake_fs = _RecordingVikingFS()
+    service_cls = _stub_upsert_callable_dependencies(monkeypatch)
+    service_cls.viking_fs = fake_fs
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_service",
+        lambda: service_cls,
+    )
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_viking_fs",
+        lambda: fake_fs,
+    )
+
+    executor = ReindexExecutor()
+    token = _FORCE_DROP_CORRUPT.set(True)
+    try:
+        await executor._upsert_context(
+            uri="viking://resources/foo/bar.md",
+            parent_uri="viking://resources/foo",
+            abstract="abs",
+            vector_text="vec",
+            is_leaf=True,
+            context_type="resource",
+            level=ContextLevel.DETAIL,
+            ctx=_make_ctx(),
+        )
+    finally:
+        _FORCE_DROP_CORRUPT.reset(token)
+
+    assert fake_fs.deleted_uri_batches == [["viking://resources/foo/bar.md"]], (
+        "force=True must call delete_from_vector_store with exactly the URI being upserted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_context_without_force_does_not_pre_delete(monkeypatch):
+    """Default (force=False) path must NOT trigger any vector delete."""
+    from openviking.core.context import ContextLevel
+
+    fake_fs = _RecordingVikingFS()
+    service_cls = _stub_upsert_callable_dependencies(monkeypatch)
+    service_cls.viking_fs = fake_fs
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_service",
+        lambda: service_cls,
+    )
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_viking_fs",
+        lambda: fake_fs,
+    )
+
+    executor = ReindexExecutor()
+    # Do NOT set _FORCE_DROP_CORRUPT
+    await executor._upsert_context(
+        uri="viking://resources/foo/bar.md",
+        parent_uri="viking://resources/foo",
+        abstract="abs",
+        vector_text="vec",
+        is_leaf=True,
+        context_type="resource",
+        level=ContextLevel.DETAIL,
+        ctx=_make_ctx(),
+    )
+
+    assert fake_fs.deleted_uri_batches == [], (
+        "force=False (default) must NOT delete any vector record"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_sets_force_drop_contextvar(monkeypatch):
+    """_run(force=True) must set _FORCE_DROP_CORRUPT for the duration of
+    the run so nested _upsert_context calls see it; the var must be reset
+    on exit even when the body raises."""
+    from openviking.service.reindex_executor import _FORCE_DROP_CORRUPT
+
+    observed: list[bool] = []
+
+    async def fake_reindex_resource(self, *, uri, mode, run):
+        observed.append(_FORCE_DROP_CORRUPT.get())
+
+    monkeypatch.setattr(ReindexExecutor, "_reindex_resource", fake_reindex_resource)
+
+    # Bypass the heavy dependencies _run touches before dispatching
+    class _FakeVikingFS:
+        def _uri_to_path(self, uri, ctx=None):
+            return f"/local/test{uri.removeprefix('viking:/')}"
+
+    class _FakeDB:
+        has_queue_manager = True
+
+    class _FakeService:
+        viking_fs = _FakeVikingFS()
+        vikingdb_manager = _FakeDB()
+
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_service",
+        lambda: _FakeService(),
+    )
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_lock_manager",
+        lambda: object(),
+    )
+
+    class _NoopLockHandle:
+        pass
+
+    class _NoopLockContext:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return _NoopLockHandle()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.LockContext",
+        _NoopLockContext,
+    )
+
+    class _NoopTelemetry:
+        telemetry_id = ""
+
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_current_telemetry",
+        lambda: _NoopTelemetry(),
+    )
+
+    pre = _FORCE_DROP_CORRUPT.get()
+    await ReindexExecutor()._run(
+        uri="viking://resources/foo",
+        object_type="resource",
+        mode="vectors_only",
+        ctx=_make_ctx(),
+        force=True,
+    )
+    post = _FORCE_DROP_CORRUPT.get()
+
+    assert observed == [True], "_reindex_resource must observe force=True inside _run"
+    assert pre is False and post is False, "contextvar must be reset after _run returns"


### PR DESCRIPTION
## Summary

- 在 `ReindexRequest` 新增 `force: bool = False`。`force=True` 时，reindex 中的每次 `_upsert_context` 会先调用 `viking_fs._delete_from_vector_store([uri], ctx)` 清掉该 URI 在 vector store 的旧记录，再正常 upsert。
- 通过模块级 `contextvars.ContextVar` 透传 `force`，避免给 10+ 处 `_upsert_context` 调用点全部加签名；asyncio.Task 自动隔离 contextvar，多并发 reindex 互不干扰。
- 默认 `force=False`，**不影响现有行为**。

## 修复的问题

reindex 在 upsert 前会先 query 做去重检查；当 vector store 中存在已损坏的记录（C++ `BytesRow` uint16 长度溢出，详见 `openviking/storage/vectordb/store/bytes_row.py`）时，deserialize 会抛 `UnicodeDecodeError`。`_SingleAccountBackend.query` 用 try/except 静默吞掉返回 `[]`，reindex 误以为"没有现有记录"继续 upsert——但损坏的旧记录依然留在 vector store，后续任何查询都会持续失败，导致同一 URI 即使反复 reindex 也修不回来。

具体日志样本：
```
ERROR [_SingleAccountBackend.query] Error querying collection:
'utf-8' codec can't decode byte 0xe5 in position 37466: unexpected end of data
```

## 实现细节

- 改 5 个文件：
  - `openviking/server/routers/content.py` — `ReindexRequest.force` + handler 透传
  - `openviking/service/core.py` — `OpenVikingService.reindex` 加 `force` 参数
  - `openviking/service/reindex_executor.py` — `_FORCE_DROP_CORRUPT` ContextVar；`execute / _run / _run_tracked` 加 `force` 参数；`_run` 入口 set/finally reset；`_upsert_context` 在 `force=True` 时先 pre-delete
  - `tests/server/test_admin_rebuild_api.py` — 3 处 FakeService / FakeExecutor mock 加 `force=` 关键字以适配新签名
  - `tests/server/test_reindex_force_drop.py`（新增）— 6 个回归测试
- pre-delete 采用 best-effort：失败时仅 `logger.warning`，不阻塞 upsert
- **不走 `ov rm` CLI**，直接调源码函数 `viking_fs._delete_from_vector_store`——只删 vector store 记录，不动 FS 文件
- contextvars 模式让所有 `_upsert_context` 调用点签名不变，调用栈干净

## Test plan

- [x] `tests/server/test_reindex_force_drop.py`（6 个新测试全过）
  - `test_reindex_request_accepts_force_field`
  - `test_reindex_router_forwards_force_true`
  - `test_reindex_router_forwards_force_default_false`
  - `test_upsert_context_with_force_pre_deletes`
  - `test_upsert_context_without_force_does_not_pre_delete`
  - `test_run_sets_force_drop_contextvar`
- [x] `tests/server/test_admin_rebuild_api.py` 全套保持通过（34 → 40 passed；5 errors 同 baseline，是缺 Rust binding 的环境问题，与本改动无关）
- [ ] 真实 server 验证：对一条已知损坏的 URI 跑 `curl -d '{"uri":"...","mode":"vectors_only","wait":true,"force":true}'`，确认成功 + consistency 检查通过

## Usage

```bash
curl -X POST http://127.0.0.1:1935/api/v1/content/reindex \
  -H "X-API-Key: ..." \
  -H "Content-Type: application/json" \
  -d '{
        "uri": "viking://resources/path/to/file.md",
        "mode": "vectors_only",
        "wait": true,
        "force": true
      }'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)