### PR TITLE
fix(openclaw-plugin): report memory_store zero extraction

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -1276,8 +1276,27 @@ const contextEnginePlugin = {
             if (memoriesCount === 0) {
               api.logger.warn(
                 `openviking: memory_store committed but 0 memories extracted (sessionId=${sessionId}). ` +
-                  "Check OpenViking server logs for embedding/extract errors (e.g. 401 API key, or extraction pipeline).",
+                  "No OpenViking-managed long-term memory was created. Check memory.extraction_enabled, VLM configuration/API keys, or whether the text was judged not durable.",
               );
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text:
+                      `Memory extraction completed for session ${sessionId}, but produced 0 memories. ` +
+                      "No OpenViking-managed long-term memory was stored. Check memory.extraction_enabled, VLM configuration/API keys, or whether the text is durable enough to remember.",
+                  },
+                ],
+                details: {
+                  action: "failed",
+                  sessionId,
+                  status: commitResult.status,
+                  error: "no_memories_extracted",
+                  memoriesCount,
+                  archived: commitResult.archived ?? false,
+                  usedTempSession,
+                },
+              };
             } else {
               api.logger.info?.(`openviking: memory_store committed, memories=${memoriesCount}`);
             }

--- a/examples/openclaw-plugin/tests/ut/tools.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tools.test.ts
@@ -347,7 +347,7 @@ describe("Tool: memory_store (behavioral)", () => {
       requesterSenderId: "wx/user-01@abc",
     });
 
-    await tool.execute("tc-memory-store", { text: "hello from tool" });
+    const result = await tool.execute("tc-memory-store", { text: "hello from tool" }) as ToolResult;
 
     const messageCall = fetchMock.mock.calls.find(([url]) =>
       String(url).includes("/api/v1/sessions/") && String(url).includes("/messages"),
@@ -357,6 +357,9 @@ describe("Tool: memory_store (behavioral)", () => {
     const body = JSON.parse(String(init.body));
     expect(body.role).toBe("user");
     expect(body.role_id).toBe("wx_user-01_abc");
+    expect(result.content[0]!.text).toContain("committed 1 memories");
+    expect(result.details.action).toBe("stored");
+    expect(result.details.memoriesCount).toBe(1);
   });
 
   it("uses a temporary session by default instead of the current tool session", async () => {
@@ -368,7 +371,7 @@ describe("Tool: memory_store (behavioral)", () => {
         return okResponse({ session_id: "sess-1" });
       }
       if (url.endsWith("/commit")) {
-        return okResponse({ status: "completed", archived: false, memories_extracted: {} });
+        return okResponse({ status: "completed", archived: false, memories_extracted: { core: 1 } });
       }
       return okResponse({});
     });
@@ -398,7 +401,7 @@ describe("Tool: memory_store (behavioral)", () => {
         return okResponse({ session_id: "sess-1" });
       }
       if (url.endsWith("/commit")) {
-        return okResponse({ status: "completed", archived: false, memories_extracted: {} });
+        return okResponse({ status: "completed", archived: false, memories_extracted: { core: 1 } });
       }
       return okResponse({});
     });
@@ -422,6 +425,111 @@ describe("Tool: memory_store (behavioral)", () => {
     expect(String(messageCall?.[0])).not.toContain("runtime-session");
     expect(String(messageCall?.[0])).not.toContain("agent%3Amain%3Amain");
     expect(String(messageCall?.[0])).toMatch(/\/api\/v1\/sessions\/[a-f0-9]{64}\/messages$/);
+  });
+
+  it("returns a tool-visible failure when commit extracts zero memories", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/v1/system/status")) {
+        return okResponse({ user: "default" });
+      }
+      if (url.includes("/messages")) {
+        return okResponse({ session_id: "sess-1" });
+      }
+      if (url.endsWith("/commit")) {
+        return okResponse({ status: "completed", archived: true, memories_extracted: {} });
+      }
+      return okResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { factoryTools, api } = setupPlugin();
+    contextEnginePlugin.register(api as any);
+    const tool = factoryTools.get("memory_store")!({
+      sessionId: "runtime-session",
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("tc-memory-store-zero", {
+      text: "Remember this important thing",
+    }) as ToolResult;
+
+    expect(result.content[0]!.text).toContain("produced 0 memories");
+    expect(result.content[0]!.text).toContain("No OpenViking-managed long-term memory was stored");
+    expect(result.details.action).toBe("failed");
+    expect(result.details.error).toBe("no_memories_extracted");
+    expect(result.details.memoriesCount).toBe(0);
+    expect(result.details.archived).toBe(true);
+  });
+
+  it("returns commit failure details to the model", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/v1/system/status")) {
+        return okResponse({ user: "default" });
+      }
+      if (url.includes("/messages")) {
+        return okResponse({ session_id: "sess-1" });
+      }
+      if (url.endsWith("/commit")) {
+        return okResponse({
+          status: "failed",
+          error: "memory extraction provider unavailable",
+        });
+      }
+      return okResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { factoryTools, api } = setupPlugin();
+    contextEnginePlugin.register(api as any);
+    const tool = factoryTools.get("memory_store")!({
+      sessionId: "runtime-session",
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("tc-memory-store-failed", {
+      text: "Remember this important thing",
+    }) as ToolResult;
+
+    expect(result.content[0]!.text).toContain("Memory extraction failed");
+    expect(result.content[0]!.text).toContain("memory extraction provider unavailable");
+    expect(result.details.action).toBe("failed");
+    expect(result.details.status).toBe("failed");
+    expect(result.details.error).toBe("memory extraction provider unavailable");
+  });
+
+  it("returns commit timeout details to the model", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/v1/system/status")) {
+        return okResponse({ user: "default" });
+      }
+      if (url.includes("/messages")) {
+        return okResponse({ session_id: "sess-1" });
+      }
+      if (url.endsWith("/commit")) {
+        return okResponse({
+          status: "timeout",
+        });
+      }
+      return okResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { factoryTools, api } = setupPlugin();
+    contextEnginePlugin.register(api as any);
+    const tool = factoryTools.get("memory_store")!({
+      sessionId: "runtime-session",
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("tc-memory-store-timeout", {
+      text: "Remember this important thing",
+    }) as ToolResult;
+
+    expect(result.content[0]!.text).toContain("Memory extraction timed out");
+    expect(result.content[0]!.text).toContain("task_id=none");
+    expect(result.details.action).toBe("timeout");
+    expect(result.details.status).toBe("timeout");
+    expect(result.details.taskId).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- keep `memory_store` on the OpenViking session commit/extraction path
- treat `completed` commits with `memories_extracted == 0` as a tool-visible failure instead of reporting success
- add OpenClaw plugin tests for successful extraction, zero extraction, failed commit, and timeout responses

## Why

`memory_store` should only tell the model a long-term memory was stored when OpenViking's managed extraction pipeline actually produced memory records. If commit completes but extraction returns zero memories, the model now gets a clear failure with `error: "no_memories_extracted"` and hints to check extraction/VLM configuration or whether the text is durable enough.

## Tests

- `npm test -- --run tests/ut/tools.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

OpenClaw e2e:

- Command: `python3 examples/openclaw-plugin/tests/e2e/test-memory-chain.py --phase all --gateway http://127.0.0.1:19792 --openviking http://127.0.0.1:1935 --user-id codex-ms-e2e-final-172442 --delay 1`
- Setup: isolated OpenClaw gateway loading this branch's built `examples/openclaw-plugin/dist/index.js`, OpenViking with local GGUF embedding, and a deterministic local OpenAI-compatible extraction VLM. The local VLM was used because the external Volcengine VLM account quota was exhausted during verification.
- Result: passed, `31/31` assertions.
- Covered: afterTurn session writes, session commit, extraction with `memories_extracted.total=6`, archive overview, assemble, session-id consistency, and cross-session recall.
