### PR TITLE
feat: add web studio account user management

### DIFF
--- a/web-studio/src/components/app-shell.tsx
+++ b/web-studio/src/components/app-shell.tsx
@@ -506,7 +506,7 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
           <div className="flex items-center gap-3">
             <div
               aria-label={t('language.label', { ns: 'common' })}
-              className="flex h-10 items-center rounded-2xl border border-border/80 bg-muted/60 p-1 text-base shadow-xs"
+              className="flex h-10 items-center rounded-2xl border border-border/80 bg-muted/60 p-1 text-sm shadow-xs"
               role="group"
             >
               {LANGUAGE_OPTIONS.map((item) => {

--- a/web-studio/src/components/app-shell.tsx
+++ b/web-studio/src/components/app-shell.tsx
@@ -57,10 +57,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '#/components/ui/sidebar'
-import {
-  AppConnectionProvider,
-  useAppConnection,
-} from '#/hooks/use-app-connection'
+import { AppConnectionProvider } from '#/hooks/use-app-connection'
 import {
   useSessionList,
   useCreateSession,
@@ -353,7 +350,6 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   })
-  const { openConnectionDialog } = useAppConnection()
   const { setTheme, resolvedTheme } = useTheme()
   const currentLanguage = resolveLanguage(
     i18n.resolvedLanguage ?? i18n.language,
@@ -362,6 +358,7 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
     LANGUAGE_OPTIONS.find((item) => item.value === currentLanguage) ??
     LANGUAGE_OPTIONS[0]
   const [oauthSetupOpen, setOauthSetupOpen] = React.useState(false)
+  const settingsActive = pathname === '/settings'
   const oauthSetupActive =
     pathname === '/oauth/setup' || pathname.startsWith('/oauth/setup/')
 
@@ -456,7 +453,8 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton
-                onClick={openConnectionDialog}
+                render={<Link to="/settings" />}
+                isActive={settingsActive}
                 tooltip={t('footer.connection', { ns: 'appShell' })}
                 className="text-base"
               >

--- a/web-studio/src/components/app-shell.tsx
+++ b/web-studio/src/components/app-shell.tsx
@@ -506,7 +506,7 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
           <div className="flex items-center gap-3">
             <div
               aria-label={t('language.label', { ns: 'common' })}
-              className="flex h-10 items-center rounded-2xl border border-border/80 bg-muted/60 p-1 text-sm shadow-xs"
+              className="flex h-10 items-center rounded-2xl border border-border/80 bg-muted/60 p-1 text-xs shadow-xs"
               role="group"
             >
               {LANGUAGE_OPTIONS.map((item) => {
@@ -518,7 +518,7 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
                     type="button"
                     aria-pressed={isActive}
                     className={cn(
-                      'h-8 min-w-12 rounded-xl px-3 font-semibold text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                      'h-8 min-w-10 rounded-xl px-2 text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                       isActive && 'bg-foreground text-background shadow-sm',
                     )}
                     onClick={() => {

--- a/web-studio/src/components/app-shell.tsx
+++ b/web-studio/src/components/app-shell.tsx
@@ -28,7 +28,6 @@ import {
 } from '#/components/ui/collapsible'
 import { ConnectionDialog } from '#/components/connection-dialog'
 import { OAuthSetupDialog } from '#/components/oauth-setup-dialog'
-import { buttonVariants } from '#/components/ui/button'
 import { ScrollArea } from '#/components/ui/scroll-area'
 import {
   Sidebar,
@@ -128,6 +127,9 @@ const LANGUAGE_OPTIONS = [
     value: 'en',
   },
 ] as const
+
+const HEADER_ICON_BUTTON_CLASS =
+  'relative inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/80 bg-muted/60 text-muted-foreground shadow-xs transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
 function resolveLanguage(
   value: string | undefined,
@@ -501,22 +503,10 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
       <SidebarInset className="min-h-0 flex-1 overflow-hidden rounded-none border-0 bg-background shadow-none ring-0 md:m-0 md:ml-0">
         <header className="flex h-12 shrink-0 items-center justify-end border-b border-border/70 bg-background px-4 backdrop-blur-md md:px-6">
           <SidebarTrigger className="mr-auto shrink-0 md:hidden" />
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              aria-label={t('theme.toggle', { ns: 'common' })}
-              className={buttonVariants({ size: 'sm', variant: 'ghost' })}
-              onClick={() =>
-                setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
-              }
-            >
-              <SunIcon className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-              <MoonIcon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-            </button>
-
+          <div className="flex items-center gap-3">
             <div
               aria-label={t('language.label', { ns: 'common' })}
-              className="flex h-9 items-center rounded-full border border-border/80 bg-muted/60 p-1 text-sm"
+              className="flex h-10 items-center rounded-2xl border border-border/80 bg-muted/60 p-1 text-base shadow-xs"
               role="group"
             >
               {LANGUAGE_OPTIONS.map((item) => {
@@ -528,7 +518,7 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
                     type="button"
                     aria-pressed={isActive}
                     className={cn(
-                      'h-7 min-w-10 rounded-full px-3 font-semibold text-muted-foreground transition-colors hover:text-foreground',
+                      'h-8 min-w-12 rounded-xl px-3 font-semibold text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                       isActive && 'bg-foreground text-background shadow-sm',
                     )}
                     onClick={() => {
@@ -542,6 +532,28 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
                 )
               })}
             </div>
+
+            <button
+              type="button"
+              aria-label={t('theme.toggle', { ns: 'common' })}
+              className={HEADER_ICON_BUTTON_CLASS}
+              onClick={() =>
+                setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+              }
+            >
+              <MoonIcon className="size-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+              <SunIcon className="absolute size-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            </button>
+
+            <a
+              href="https://github.com/volcengine/OpenViking"
+              target="_blank"
+              rel="noreferrer"
+              aria-label={t('footer.github', { ns: 'appShell' })}
+              className={HEADER_ICON_BUTTON_CLASS}
+            >
+              <GithubIcon className="size-5" />
+            </a>
           </div>
         </header>
 

--- a/web-studio/src/components/app-shell.tsx
+++ b/web-studio/src/components/app-shell.tsx
@@ -30,14 +30,6 @@ import {
 import { ConnectionDialog } from '#/components/connection-dialog'
 import { OAuthSetupDialog } from '#/components/oauth-setup-dialog'
 import { buttonVariants } from '#/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from '#/components/ui/dropdown-menu'
 import { ScrollArea } from '#/components/ui/scroll-area'
 import {
   Sidebar,
@@ -58,6 +50,7 @@ import {
   SidebarTrigger,
 } from '#/components/ui/sidebar'
 import { AppConnectionProvider } from '#/hooks/use-app-connection'
+import { cn } from '#/lib/utils'
 import {
   useSessionList,
   useCreateSession,
@@ -354,9 +347,6 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
   const currentLanguage = resolveLanguage(
     i18n.resolvedLanguage ?? i18n.language,
   )
-  const currentLanguageOption =
-    LANGUAGE_OPTIONS.find((item) => item.value === currentLanguage) ??
-    LANGUAGE_OPTIONS[0]
   const [oauthSetupOpen, setOauthSetupOpen] = React.useState(false)
   const settingsActive = pathname === '/settings'
   const oauthSetupActive =
@@ -525,46 +515,35 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
               <MoonIcon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
             </button>
 
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                aria-label={t('language.label', { ns: 'common' })}
-                className={buttonVariants({ size: 'sm', variant: 'ghost' })}
-              >
-                <LanguagesIcon />
-                <span className="hidden sm:inline">
-                  {currentLanguageOption.shortLabel}
-                </span>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-32 min-w-32">
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel>
-                    {t('language.label', { ns: 'common' })}
-                  </DropdownMenuLabel>
-                  {LANGUAGE_OPTIONS.map((item) => {
-                    const isActive = item.value === currentLanguage
+            <div
+              aria-label={t('language.label', { ns: 'common' })}
+              className="flex h-9 items-center gap-0.5 rounded-md border bg-muted/60 p-0.5 text-sm"
+              role="group"
+            >
+              <LanguagesIcon className="mx-1 size-4 text-muted-foreground" />
+              {LANGUAGE_OPTIONS.map((item) => {
+                const isActive = item.value === currentLanguage
 
-                    return (
-                      <DropdownMenuItem
-                        key={item.value}
-                        className="justify-between"
-                        onClick={() => {
-                          if (!isActive) {
-                            void i18n.changeLanguage(item.value)
-                          }
-                        }}
-                      >
-                        <span>{item.title}</span>
-                        {isActive ? (
-                          <span className="text-xs text-muted-foreground">
-                            {t('language.current', { ns: 'common' })}
-                          </span>
-                        ) : null}
-                      </DropdownMenuItem>
-                    )
-                  })}
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                return (
+                  <button
+                    key={item.value}
+                    type="button"
+                    aria-pressed={isActive}
+                    className={cn(
+                      'h-7 rounded-sm px-2 font-medium text-muted-foreground transition-colors hover:text-foreground',
+                      isActive && 'bg-background text-foreground shadow-xs',
+                    )}
+                    onClick={() => {
+                      if (!isActive) {
+                        void i18n.changeLanguage(item.value)
+                      }
+                    }}
+                  >
+                    {item.shortLabel}
+                  </button>
+                )
+              })}
+            </div>
           </div>
         </header>
 

--- a/web-studio/src/components/app-shell.tsx
+++ b/web-studio/src/components/app-shell.tsx
@@ -8,7 +8,6 @@ import {
   HomeIcon,
   GithubIcon,
   KeyRoundIcon,
-  LanguagesIcon,
   LoaderIcon,
   MessageSquareIcon,
   MoonIcon,
@@ -119,14 +118,14 @@ const NAV_ITEMS: readonly NavItem[] = [
 
 const LANGUAGE_OPTIONS = [
   {
+    shortLabel: '中',
+    title: '中文',
+    value: 'zh-CN',
+  },
+  {
     shortLabel: 'EN',
     title: 'English',
     value: 'en',
-  },
-  {
-    shortLabel: '中文',
-    title: '中文',
-    value: 'zh-CN',
   },
 ] as const
 
@@ -517,10 +516,9 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
 
             <div
               aria-label={t('language.label', { ns: 'common' })}
-              className="flex h-9 items-center gap-0.5 rounded-md border bg-muted/60 p-0.5 text-sm"
+              className="flex h-9 items-center rounded-full border border-border/80 bg-muted/60 p-1 text-sm"
               role="group"
             >
-              <LanguagesIcon className="mx-1 size-4 text-muted-foreground" />
               {LANGUAGE_OPTIONS.map((item) => {
                 const isActive = item.value === currentLanguage
 
@@ -530,8 +528,8 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
                     type="button"
                     aria-pressed={isActive}
                     className={cn(
-                      'h-7 rounded-sm px-2 font-medium text-muted-foreground transition-colors hover:text-foreground',
-                      isActive && 'bg-background text-foreground shadow-xs',
+                      'h-7 min-w-10 rounded-full px-3 font-semibold text-muted-foreground transition-colors hover:text-foreground',
+                      isActive && 'bg-foreground text-background shadow-sm',
                     )}
                     onClick={() => {
                       if (!isActive) {

--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -33,11 +33,11 @@ type AppConnectionContextValue = {
 const CONNECTION_STORAGE_KEY = 'ov_console_connection'
 
 const DEFAULT_CONNECTION: ConnectionDraft = {
-  accountId: '',
+  accountId: 'default',
   agentId: 'web-studio',
   apiKey: '',
   baseUrl: ovClient.getOptions().baseUrl,
-  userId: '',
+  userId: 'default',
 }
 
 const AppConnectionContext =

--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -111,6 +111,114 @@ const en = {
       generateError: 'Could not generate OTP: {{message}}',
     },
   },
+  settings: {
+    actions: {
+      addAccount: 'Add account',
+      addUser: 'Add user',
+      cancel: 'Cancel',
+      copy: 'Copy',
+      refresh: 'Refresh',
+      regenerate: 'Regenerate',
+      save: 'Save',
+      use: 'Use',
+    },
+    connection: {
+      adminError: 'Could not load admin identities: {{message}}',
+      description:
+        'Select the account and user that Studio should send with OpenViking requests.',
+      noKey:
+        'Enter an API key with admin access to load account and user choices.',
+      title: 'Connection settings',
+    },
+    dialogs: {
+      addAccount: {
+        description:
+          'Create a workspace account and its first admin user. The new key will be shown once.',
+        title: 'Add account',
+      },
+      addUser: {
+        description:
+          'Register a user under an existing account. The generated key will be shown once.',
+        title: 'Add user',
+      },
+      regenerate: {
+        description:
+          'Regenerate the API key for {{account}} / {{user}}. The current key stops working immediately.',
+        title: 'Regenerate API key?',
+      },
+    },
+    empty: {
+      adminDescription:
+        'Use a root or account admin API key to list users, copy keys, add identities, or regenerate credentials.',
+      adminTitle: 'Admin access required',
+      usersDescription: 'Create a user to mint the first API key.',
+      usersTitle: 'No users in this account',
+    },
+    fields: {
+      account: 'Account',
+      adminUser: 'Admin user',
+      agent: 'Agent',
+      apiKey: 'API key',
+      baseUrl: 'Server URL',
+      role: 'Role',
+      user: 'User',
+    },
+    keyResult: {
+      description:
+        'Copy it now. OpenViking may only show a prefix after you leave this state.',
+      dismiss: 'Dismiss',
+      title: 'New API key',
+    },
+    loading: 'Loading identities...',
+    management: {
+      accountFilter: 'Managed account',
+      description:
+        'Review users and credentials for one account, then add users or rotate keys from the web UI.',
+      title: 'User management',
+    },
+    page: {
+      description:
+        'Configure the active OpenViking identity and manage accounts, users, and API keys from Studio.',
+      title: 'Connection & Identity',
+    },
+    placeholders: {
+      account: 'team-account',
+      agent: 'web-studio',
+      apiKey: 'Enter X-API-Key or Bearer token',
+      baseUrl: 'http://127.0.0.1:1933',
+      user: 'default',
+    },
+    roles: {
+      admin: 'Admin',
+      user: 'User',
+    },
+    serverMode: {
+      api_key: 'API key mode',
+      checking: 'Checking...',
+      dev: 'Development mode',
+      offline: 'Offline',
+      trusted: 'Trusted mode',
+    },
+    stats: {
+      accounts: 'Total accounts',
+      apiKeys: 'Visible API keys',
+      users: 'Users',
+    },
+    table: {
+      account: 'Account',
+      actions: 'Actions',
+      apiKey: 'API key',
+      role: 'Role',
+      user: 'User',
+    },
+    toast: {
+      accountCreated: 'Account created',
+      connectionSaved: 'Connection saved',
+      copied: 'Copied',
+      keyRegenerated: 'API key regenerated',
+      userCreated: 'User created',
+    },
+  },
   oauthSetup: {
     page: {
       title: 'OAuth setup',

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -111,6 +111,114 @@ const zhCN = {
       generateError: '生成 OTP 失败：{{message}}',
     },
   },
+  settings: {
+    actions: {
+      addAccount: '新增 account',
+      addUser: '新增 user',
+      cancel: '取消',
+      copy: '复制',
+      refresh: '刷新',
+      regenerate: '重新生成',
+      save: '保存',
+      use: '使用',
+    },
+    connection: {
+      adminError: '加载 admin 身份失败：{{message}}',
+      description:
+        '选择 Studio 调用 OpenViking API 时要携带的 account 和 user。',
+      noKey:
+        '输入具备 admin 权限的 API key 后，可以加载 account 和 user 可选项。',
+      title: '连接设置',
+    },
+    dialogs: {
+      addAccount: {
+        description:
+          '创建一个工作区 account 和第一个 admin user。新 key 只会在创建后展示一次。',
+        title: '新增 account',
+      },
+      addUser: {
+        description:
+          '在已有 account 下注册 user。生成的 key 只会在创建后展示一次。',
+        title: '新增 user',
+      },
+      regenerate: {
+        description:
+          '要重新生成 {{account}} / {{user}} 的 API key 吗？当前 key 会立即失效。',
+        title: '重新生成 API key？',
+      },
+    },
+    empty: {
+      adminDescription:
+        '使用 root 或 account admin API key 后，可以列出用户、复制 key、新增身份或轮换凭证。',
+      adminTitle: '需要 admin 权限',
+      usersDescription: '创建一个 user 来生成第一个 API key。',
+      usersTitle: '当前 account 下没有 user',
+    },
+    fields: {
+      account: 'Account',
+      adminUser: 'Admin user',
+      agent: 'Agent',
+      apiKey: 'API key',
+      baseUrl: '服务地址',
+      role: '角色',
+      user: 'User',
+    },
+    keyResult: {
+      description:
+        '请现在复制保存。离开当前状态后，OpenViking 可能只展示前缀。',
+      dismiss: '收起',
+      title: '新的 API key',
+    },
+    loading: '正在加载身份...',
+    management: {
+      accountFilter: '管理的 account',
+      description:
+        '查看某个 account 下的 users 和凭证，并在网页端新增 user 或轮换 key。',
+      title: '用户管理',
+    },
+    page: {
+      description:
+        '在 Studio 中配置当前 OpenViking 身份，并管理 accounts、users 和 API keys。',
+      title: '连接与身份',
+    },
+    placeholders: {
+      account: 'team-account',
+      agent: 'web-studio',
+      apiKey: '输入 X-API-Key 或 Bearer token',
+      baseUrl: 'http://127.0.0.1:1933',
+      user: 'default',
+    },
+    roles: {
+      admin: 'Admin',
+      user: 'User',
+    },
+    serverMode: {
+      api_key: 'API key 模式',
+      checking: '检查中...',
+      dev: '开发模式',
+      offline: '离线',
+      trusted: 'Trusted 模式',
+    },
+    stats: {
+      accounts: 'Accounts 总数',
+      apiKeys: '可见 API keys',
+      users: 'Users',
+    },
+    table: {
+      account: 'Account',
+      actions: '操作',
+      apiKey: 'API key',
+      role: '角色',
+      user: 'User',
+    },
+    toast: {
+      accountCreated: 'Account 已创建',
+      connectionSaved: '连接已保存',
+      copied: '已复制',
+      keyRegenerated: 'API key 已重新生成',
+      userCreated: 'User 已创建',
+    },
+  },
   oauthSetup: {
     page: {
       title: 'OAuth 设置',

--- a/web-studio/src/routeTree.gen.ts
+++ b/web-studio/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SettingsRouteRouteImport } from './routes/settings/route'
 import { Route as SessionsRouteRouteImport } from './routes/sessions/route'
 import { Route as RetrievalRouteRouteImport } from './routes/retrieval/route'
 import { Route as ResourcesRouteRouteImport } from './routes/resources/route'
@@ -21,6 +22,11 @@ import { Route as OauthVerifyRouteImport } from './routes/oauth/verify'
 import { Route as OauthSetupRouteImport } from './routes/oauth/setup'
 import { Route as OauthConsentRouteImport } from './routes/oauth/consent'
 
+const SettingsRouteRoute = SettingsRouteRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SessionsRouteRoute = SessionsRouteRouteImport.update({
   id: '/sessions',
   path: '/sessions',
@@ -84,6 +90,7 @@ export interface FileRoutesByFullPath {
   '/resources': typeof ResourcesRouteRouteWithChildren
   '/retrieval': typeof RetrievalRouteRoute
   '/sessions': typeof SessionsRouteRouteWithChildren
+  '/settings': typeof SettingsRouteRoute
   '/oauth/consent': typeof OauthConsentRoute
   '/oauth/setup': typeof OauthSetupRoute
   '/oauth/verify': typeof OauthVerifyRoute
@@ -95,6 +102,7 @@ export interface FileRoutesByTo {
   '/home': typeof HomeRouteRoute
   '/request-logs': typeof RequestLogsRouteRoute
   '/retrieval': typeof RetrievalRouteRoute
+  '/settings': typeof SettingsRouteRoute
   '/oauth/consent': typeof OauthConsentRoute
   '/oauth/setup': typeof OauthSetupRoute
   '/oauth/verify': typeof OauthVerifyRoute
@@ -109,6 +117,7 @@ export interface FileRoutesById {
   '/resources': typeof ResourcesRouteRouteWithChildren
   '/retrieval': typeof RetrievalRouteRoute
   '/sessions': typeof SessionsRouteRouteWithChildren
+  '/settings': typeof SettingsRouteRoute
   '/oauth/consent': typeof OauthConsentRoute
   '/oauth/setup': typeof OauthSetupRoute
   '/oauth/verify': typeof OauthVerifyRoute
@@ -124,6 +133,7 @@ export interface FileRouteTypes {
     | '/resources'
     | '/retrieval'
     | '/sessions'
+    | '/settings'
     | '/oauth/consent'
     | '/oauth/setup'
     | '/oauth/verify'
@@ -135,6 +145,7 @@ export interface FileRouteTypes {
     | '/home'
     | '/request-logs'
     | '/retrieval'
+    | '/settings'
     | '/oauth/consent'
     | '/oauth/setup'
     | '/oauth/verify'
@@ -148,6 +159,7 @@ export interface FileRouteTypes {
     | '/resources'
     | '/retrieval'
     | '/sessions'
+    | '/settings'
     | '/oauth/consent'
     | '/oauth/setup'
     | '/oauth/verify'
@@ -162,6 +174,7 @@ export interface RootRouteChildren {
   ResourcesRouteRoute: typeof ResourcesRouteRouteWithChildren
   RetrievalRouteRoute: typeof RetrievalRouteRoute
   SessionsRouteRoute: typeof SessionsRouteRouteWithChildren
+  SettingsRouteRoute: typeof SettingsRouteRoute
   OauthConsentRoute: typeof OauthConsentRoute
   OauthSetupRoute: typeof OauthSetupRoute
   OauthVerifyRoute: typeof OauthVerifyRoute
@@ -169,6 +182,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/sessions': {
       id: '/sessions'
       path: '/sessions'
@@ -280,6 +300,7 @@ const rootRouteChildren: RootRouteChildren = {
   ResourcesRouteRoute: ResourcesRouteRouteWithChildren,
   RetrievalRouteRoute: RetrievalRouteRoute,
   SessionsRouteRoute: SessionsRouteRouteWithChildren,
+  SettingsRouteRoute: SettingsRouteRoute,
   OauthConsentRoute: OauthConsentRoute,
   OauthSetupRoute: OauthSetupRoute,
   OauthVerifyRoute: OauthVerifyRoute,

--- a/web-studio/src/routes/resources/-components/file-tree.tsx
+++ b/web-studio/src/routes/resources/-components/file-tree.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 
 import { cn } from '#/lib/utils'
 
-import { fileNameFromUri } from '../-lib/normalize'
 import { usePrefetchVikingFsList, useVikingFsList } from '../-hooks/viking-fm'
 import type { VikingFsEntry } from '../-types/viking-fm'
 

--- a/web-studio/src/routes/resources/-components/viking-file-manager.tsx
+++ b/web-studio/src/routes/resources/-components/viking-file-manager.tsx
@@ -420,7 +420,7 @@ export function VikingFileManager({
   )
 
   return (
-    <div className="web-studio-resource-fs -mx-4 -my-6 flex h-[calc(100svh-6rem)] flex-col md:-mx-6">
+    <div className="web-studio-resource-fs -mx-4 -my-6 flex h-[calc(100svh-3rem)] flex-col md:-mx-6">
       <div ref={layoutRef} className="flex min-h-0 flex-1 flex-col md:flex-row">
         <section
           className="flex h-[var(--resource-tree-height)] min-h-[190px] min-w-0 flex-col bg-muted/30 md:h-auto md:min-h-0 md:w-[var(--resource-tree-width)] md:min-w-[var(--resource-tree-width)]"

--- a/web-studio/src/routes/settings/-lib/admin.ts
+++ b/web-studio/src/routes/settings/-lib/admin.ts
@@ -1,0 +1,239 @@
+import axios from 'axios'
+
+import { createClient } from '#/gen/ov-client/client'
+import {
+  getAdminAccountIdUsers,
+  getAdminAccounts,
+  getOvResult,
+  postAdminAccountIdUserIdKey,
+  postAdminAccountIdUsers,
+  postAdminAccounts,
+} from '#/lib/ov-client'
+
+export type AdminConnection = {
+  accountId: string
+  agentId: string
+  apiKey: string
+  baseUrl: string
+  userId: string
+}
+
+export type AdminAccount = {
+  accountId: string
+  createdAt?: string
+  isolateAgentScopeByUser: boolean
+  isolateUserScopeByAgent: boolean
+  userCount: number
+}
+
+export type AdminUser = {
+  accountId: string
+  apiKey?: string
+  keyPrefix?: string
+  role: string
+  userId: string
+}
+
+export type CreateAccountInput = {
+  accountId: string
+  adminUserId: string
+}
+
+export type CreateUserInput = {
+  accountId: string
+  role: string
+  userId: string
+}
+
+export type KeyResult = {
+  accountId?: string
+  apiKey: string
+  userId?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, '')
+}
+
+function setOptionalHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: string,
+): void {
+  const trimmed = value.trim()
+  if (trimmed) {
+    headers[name] = trimmed
+  }
+}
+
+function createAdminClient(connection: AdminConnection) {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'X-OpenViking-Agent': connection.agentId.trim() || 'web-studio',
+  }
+  setOptionalHeader(headers, 'X-API-Key', connection.apiKey)
+  setOptionalHeader(headers, 'X-OpenViking-Account', connection.accountId)
+  setOptionalHeader(headers, 'X-OpenViking-User', connection.userId)
+
+  return createClient({
+    axios: axios.create(),
+    baseURL: normalizeBaseUrl(connection.baseUrl),
+    headers,
+    throwOnError: true,
+  })
+}
+
+function normalizeAccount(value: unknown): AdminAccount | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const accountId = asString(value.account_id)
+  if (!accountId) {
+    return null
+  }
+
+  return {
+    accountId,
+    createdAt: asString(value.created_at),
+    isolateAgentScopeByUser: asBoolean(value.isolate_agent_scope_by_user),
+    isolateUserScopeByAgent: asBoolean(value.isolate_user_scope_by_agent),
+    userCount: asNumber(value.user_count),
+  }
+}
+
+function normalizeUser(accountId: string, value: unknown): AdminUser | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const userId = asString(value.user_id)
+  if (!userId) {
+    return null
+  }
+
+  return {
+    accountId,
+    apiKey: asString(value.api_key),
+    keyPrefix: asString(value.key_prefix),
+    role: asString(value.role) || 'user',
+    userId,
+  }
+}
+
+function normalizeKeyResult(value: unknown): KeyResult {
+  if (!isRecord(value)) {
+    return { apiKey: '' }
+  }
+
+  return {
+    accountId: asString(value.account_id),
+    apiKey: asString(value.user_key) || asString(value.api_key) || '',
+    userId: asString(value.user_id) || asString(value.admin_user_id),
+  }
+}
+
+export async function fetchAdminAccounts(
+  connection: AdminConnection,
+): Promise<AdminAccount[]> {
+  const result = await getOvResult<unknown[]>(
+    getAdminAccounts({
+      client: createAdminClient(connection),
+    }),
+  )
+  return result
+    .map((item) => normalizeAccount(item))
+    .filter((item): item is AdminAccount => Boolean(item))
+}
+
+export async function fetchAdminUsers(
+  connection: AdminConnection,
+  accountId: string,
+): Promise<AdminUser[]> {
+  const result = await getOvResult<unknown[]>(
+    getAdminAccountIdUsers({
+      client: createAdminClient(connection),
+      path: {
+        account_id: accountId,
+      },
+      query: {
+        limit: 500,
+      },
+    }),
+  )
+  return result
+    .map((item) => normalizeUser(accountId, item))
+    .filter((item): item is AdminUser => Boolean(item))
+}
+
+export async function createAdminAccount(
+  connection: AdminConnection,
+  input: CreateAccountInput,
+): Promise<KeyResult> {
+  const result = await getOvResult<unknown>(
+    postAdminAccounts({
+      body: {
+        account_id: input.accountId,
+        admin_user_id: input.adminUserId,
+      },
+      client: createAdminClient(connection),
+    }),
+  )
+  return normalizeKeyResult(result)
+}
+
+export async function createAdminUser(
+  connection: AdminConnection,
+  input: CreateUserInput,
+): Promise<KeyResult> {
+  const result = await getOvResult<unknown>(
+    postAdminAccountIdUsers({
+      body: {
+        role: input.role,
+        user_id: input.userId,
+      },
+      client: createAdminClient(connection),
+      path: {
+        account_id: input.accountId,
+      },
+    }),
+  )
+  return normalizeKeyResult(result)
+}
+
+export async function regenerateAdminUserKey(
+  connection: AdminConnection,
+  accountId: string,
+  userId: string,
+): Promise<KeyResult> {
+  const result = await getOvResult<unknown>(
+    postAdminAccountIdUserIdKey({
+      client: createAdminClient(connection),
+      path: {
+        account_id: accountId,
+        user_id: userId,
+      },
+    }),
+  )
+  return normalizeKeyResult({
+    ...(isRecord(result) ? result : {}),
+    account_id: accountId,
+    user_id: userId,
+  })
+}

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -723,7 +723,7 @@ function SettingsRoute() {
         </p>
       </header>
 
-      <Card className="overflow-hidden border-primary/25 bg-primary/[0.025] shadow-sm ring-1 ring-primary/10">
+      <Card className="gap-0 overflow-hidden border-primary/25 bg-primary/[0.025] py-0 shadow-sm ring-1 ring-primary/10">
         <CardHeader className="gap-2 border-b border-primary/15 bg-primary/[0.07] px-5 py-3.5">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0">

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import {
-  CheckIcon,
   CopyIcon,
   KeyRoundIcon,
   PlusIcon,
@@ -1006,21 +1005,6 @@ function SettingsRoute() {
                       </TableCell>
                       <TableCell>
                         <div className="flex justify-end gap-2">
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() =>
-                              setDraft((current) => ({
-                                ...current,
-                                accountId: user.accountId,
-                                userId: user.userId,
-                              }))
-                            }
-                          >
-                            <CheckIcon />
-                            {t('actions.use')}
-                          </Button>
                           <Button
                             type="button"
                             variant="outline"

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -724,17 +724,31 @@ function SettingsRoute() {
         </p>
       </header>
 
-      <Card>
-        <CardHeader className="gap-1.5 border-b bg-muted/20">
+      <Card className="overflow-hidden border-primary/25 bg-primary/[0.025] shadow-sm ring-1 ring-primary/10">
+        <CardHeader className="gap-2 border-b border-primary/15 bg-primary/[0.07] px-5 py-3.5">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <CardTitle>{t('connection.title')}</CardTitle>
-              <CardDescription>{t('connection.description')}</CardDescription>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
+                  <KeyRoundIcon className="size-4" />
+                </div>
+                <CardTitle>{t('connection.title')}</CardTitle>
+                <Badge
+                  variant="outline"
+                  className="border-primary/25 bg-background/80 text-primary"
+                >
+                  {t(`serverMode.${serverMode}`)}
+                </Badge>
+              </div>
+              <CardDescription className="mt-1">
+                {t('connection.description')}
+              </CardDescription>
             </div>
             <div className="flex flex-wrap gap-2">
               <Button
                 type="button"
                 variant="outline"
+                size="sm"
                 onClick={() => void refreshAdmin()}
                 disabled={!canQueryAdmin || accountsQuery.isFetching}
               >
@@ -743,15 +757,15 @@ function SettingsRoute() {
                 />
                 {t('actions.refresh')}
               </Button>
-              <Button type="button" onClick={handleSave}>
+              <Button type="button" size="sm" onClick={handleSave}>
                 <SaveIcon />
                 {t('actions.save')}
               </Button>
             </div>
           </div>
         </CardHeader>
-        <CardContent className="grid gap-4 pt-6">
-          <div className="grid gap-4 xl:grid-cols-[minmax(16rem,1.2fr)_minmax(12rem,0.8fr)_minmax(12rem,0.8fr)_minmax(11rem,0.8fr)]">
+        <CardContent className="grid gap-3 px-5 py-4">
+          <div className="grid gap-3 xl:grid-cols-[minmax(16rem,1.2fr)_minmax(12rem,0.8fr)_minmax(12rem,0.8fr)_minmax(11rem,0.8fr)]">
             <Field>
               <FieldLabel htmlFor="settings-base-url">
                 {t('fields.baseUrl')}
@@ -812,7 +826,7 @@ function SettingsRoute() {
               </FieldContent>
             </Field>
           </div>
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_12rem]">
+          <div className="grid gap-3">
             <Field>
               <FieldLabel htmlFor="settings-api-key">
                 {t('fields.apiKey')}
@@ -829,11 +843,6 @@ function SettingsRoute() {
                 />
               </FieldContent>
             </Field>
-            <div className="flex items-end">
-              <Badge variant="outline" className="h-9 px-3">
-                {t(`serverMode.${serverMode}`)}
-              </Badge>
-            </div>
           </div>
           {!canQueryAdmin ? (
             <p className="text-sm text-muted-foreground">

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -1,0 +1,1086 @@
+import * as React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  CheckIcon,
+  CopyIcon,
+  KeyRoundIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  RotateCwIcon,
+  SaveIcon,
+  ServerIcon,
+  UserRoundIcon,
+  UsersRoundIcon,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '#/components/ui/badge'
+import { Button } from '#/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '#/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#/components/ui/dialog'
+import { Field, FieldContent, FieldLabel } from '#/components/ui/field'
+import { Input } from '#/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '#/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '#/components/ui/table'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '#/components/ui/alert-dialog'
+import { useAppConnection } from '#/hooks/use-app-connection'
+import { cn } from '#/lib/utils'
+import type { ConnectionDraft } from '#/hooks/use-app-connection'
+
+import {
+  createAdminAccount,
+  createAdminUser,
+  fetchAdminAccounts,
+  fetchAdminUsers,
+  regenerateAdminUserKey,
+} from './-lib/admin'
+import type {
+  AdminConnection,
+  AdminAccount,
+  AdminUser,
+  CreateAccountInput,
+  CreateUserInput,
+  KeyResult,
+} from './-lib/admin'
+
+export const Route = createFileRoute('/settings')({
+  component: SettingsRoute,
+})
+
+const DEFAULT_ACCOUNT_ID = 'default'
+const DEFAULT_USER_ID = 'default'
+const USER_ROLES = ['user', 'admin'] as const
+
+type AddAccountDraft = CreateAccountInput
+type AddUserDraft = CreateUserInput
+
+function uniqueOptions(
+  values: readonly string[],
+  fallback: string,
+): readonly string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const rawValue of [fallback, ...values]) {
+    const value = rawValue.trim()
+    if (!value || seen.has(value)) {
+      continue
+    }
+    seen.add(value)
+    result.push(value)
+  }
+
+  return result
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function maskApiKey(value: string | undefined): string {
+  if (!value) {
+    return '-'
+  }
+
+  if (value.length <= 16) {
+    return value
+  }
+
+  return `${value.slice(0, 10)}...${value.slice(-6)}`
+}
+
+function resolveKeyLabel(user: AdminUser): string {
+  return user.apiKey ? maskApiKey(user.apiKey) : user.keyPrefix || '-'
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: React.ReactNode
+}) {
+  return (
+    <Card className="bg-card/70 py-4">
+      <CardContent className="flex items-center justify-between gap-4 px-5">
+        <div>
+          <p className="text-sm text-muted-foreground">{label}</p>
+          <p className="mt-1 text-2xl font-semibold tabular-nums">{value}</p>
+        </div>
+        <div className="flex size-10 items-center justify-center rounded-md border bg-background/70 text-primary">
+          {icon}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function KeyResultCard({
+  onClear,
+  result,
+}: {
+  onClear: () => void
+  result: KeyResult
+}) {
+  const { t } = useTranslation('settings')
+
+  if (!result.apiKey) {
+    return null
+  }
+
+  async function copyKey(): Promise<void> {
+    await navigator.clipboard.writeText(result.apiKey)
+    toast.success(t('toast.copied'))
+  }
+
+  return (
+    <Card className="border-primary/20 bg-primary/5 py-4">
+      <CardContent className="grid gap-3 px-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="font-medium">{t('keyResult.title')}</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t('keyResult.description')}
+            </p>
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={onClear}>
+            {t('keyResult.dismiss')}
+          </Button>
+        </div>
+        <div className="flex min-w-0 flex-col gap-2 rounded-md border bg-background/80 p-3 sm:flex-row sm:items-center">
+          <code className="min-w-0 flex-1 truncate font-mono text-sm">
+            {result.apiKey}
+          </code>
+          <Button type="button" variant="outline" size="sm" onClick={copyKey}>
+            <CopyIcon />
+            {t('actions.copy')}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function AccountSelect({
+  accounts,
+  disabled,
+  label,
+  onChange,
+  value,
+}: {
+  accounts: readonly AdminAccount[]
+  disabled?: boolean
+  label: string
+  onChange: (value: string) => void
+  value: string
+}) {
+  const options = uniqueOptions(
+    accounts.map((account) => account.accountId),
+    value || DEFAULT_ACCOUNT_ID,
+  )
+
+  return (
+    <Select
+      value={value || DEFAULT_ACCOUNT_ID}
+      onValueChange={(next) => {
+        if (next) {
+          onChange(next)
+        }
+      }}
+    >
+      <SelectTrigger
+        aria-label={label}
+        className="h-9 w-full"
+        disabled={disabled}
+      >
+        <SelectValue>{value || DEFAULT_ACCOUNT_ID}</SelectValue>
+      </SelectTrigger>
+      <SelectContent alignItemWithTrigger>
+        {options.map((item) => (
+          <SelectItem key={item} value={item}>
+            {item}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function UserSelect({
+  disabled,
+  label,
+  onChange,
+  users,
+  value,
+}: {
+  disabled?: boolean
+  label: string
+  onChange: (value: string) => void
+  users: readonly AdminUser[]
+  value: string
+}) {
+  const options = uniqueOptions(
+    users.map((user) => user.userId),
+    value || DEFAULT_USER_ID,
+  )
+
+  return (
+    <Select
+      value={value || DEFAULT_USER_ID}
+      onValueChange={(next) => {
+        if (next) {
+          onChange(next)
+        }
+      }}
+    >
+      <SelectTrigger
+        aria-label={label}
+        className="h-9 w-full"
+        disabled={disabled}
+      >
+        <SelectValue>{value || DEFAULT_USER_ID}</SelectValue>
+      </SelectTrigger>
+      <SelectContent alignItemWithTrigger>
+        {options.map((item) => (
+          <SelectItem key={item} value={item}>
+            {item}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function AddAccountDialog({
+  isPending,
+  onCreate,
+  onOpenChange,
+  open,
+}: {
+  isPending: boolean
+  onCreate: (draft: AddAccountDraft) => void
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}) {
+  const { t } = useTranslation('settings')
+  const [draft, setDraft] = React.useState<AddAccountDraft>({
+    accountId: '',
+    adminUserId: DEFAULT_USER_ID,
+  })
+
+  React.useEffect(() => {
+    if (open) {
+      setDraft({ accountId: '', adminUserId: DEFAULT_USER_ID })
+    }
+  }, [open])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('dialogs.addAccount.title')}</DialogTitle>
+          <DialogDescription>
+            {t('dialogs.addAccount.description')}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            onCreate(draft)
+          }}
+        >
+          <Field>
+            <FieldLabel htmlFor="settings-add-account-id">
+              {t('fields.account')}
+            </FieldLabel>
+            <FieldContent>
+              <Input
+                id="settings-add-account-id"
+                value={draft.accountId}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    accountId: event.target.value,
+                  }))
+                }
+                placeholder={t('placeholders.account')}
+                required
+              />
+            </FieldContent>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="settings-add-account-admin">
+              {t('fields.adminUser')}
+            </FieldLabel>
+            <FieldContent>
+              <Input
+                id="settings-add-account-admin"
+                value={draft.adminUserId}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    adminUserId: event.target.value,
+                  }))
+                }
+                placeholder={DEFAULT_USER_ID}
+                required
+              />
+            </FieldContent>
+          </Field>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              {t('actions.cancel')}
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              <PlusIcon />
+              {t('actions.addAccount')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function AddUserDialog({
+  accounts,
+  defaultAccountId,
+  isPending,
+  onCreate,
+  onOpenChange,
+  open,
+}: {
+  accounts: readonly AdminAccount[]
+  defaultAccountId: string
+  isPending: boolean
+  onCreate: (draft: AddUserDraft) => void
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}) {
+  const { t } = useTranslation('settings')
+  const [draft, setDraft] = React.useState<AddUserDraft>({
+    accountId: defaultAccountId || DEFAULT_ACCOUNT_ID,
+    role: 'user',
+    userId: '',
+  })
+
+  React.useEffect(() => {
+    if (open) {
+      setDraft({
+        accountId: defaultAccountId || DEFAULT_ACCOUNT_ID,
+        role: 'user',
+        userId: '',
+      })
+    }
+  }, [defaultAccountId, open])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('dialogs.addUser.title')}</DialogTitle>
+          <DialogDescription>
+            {t('dialogs.addUser.description')}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            onCreate(draft)
+          }}
+        >
+          <Field>
+            <FieldLabel>{t('fields.account')}</FieldLabel>
+            <FieldContent>
+              <AccountSelect
+                accounts={accounts}
+                label={t('fields.account')}
+                value={draft.accountId}
+                onChange={(accountId) =>
+                  setDraft((current) => ({ ...current, accountId }))
+                }
+              />
+            </FieldContent>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="settings-add-user-id">
+              {t('fields.user')}
+            </FieldLabel>
+            <FieldContent>
+              <Input
+                id="settings-add-user-id"
+                value={draft.userId}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    userId: event.target.value,
+                  }))
+                }
+                placeholder={t('placeholders.user')}
+                required
+              />
+            </FieldContent>
+          </Field>
+          <Field>
+            <FieldLabel>{t('fields.role')}</FieldLabel>
+            <FieldContent>
+              <Select
+                value={draft.role}
+                onValueChange={(role) => {
+                  if (role) {
+                    setDraft((current) => ({ ...current, role }))
+                  }
+                }}
+              >
+                <SelectTrigger
+                  aria-label={t('fields.role')}
+                  className="h-9 w-full"
+                >
+                  <SelectValue>{t(`roles.${draft.role}`)}</SelectValue>
+                </SelectTrigger>
+                <SelectContent alignItemWithTrigger>
+                  {USER_ROLES.map((role) => (
+                    <SelectItem key={role} value={role}>
+                      {t(`roles.${role}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FieldContent>
+          </Field>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              {t('actions.cancel')}
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              <PlusIcon />
+              {t('actions.addUser')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function SettingsRoute() {
+  const { t } = useTranslation('settings')
+  const queryClient = useQueryClient()
+  const { connection, saveConnection, serverMode } = useAppConnection()
+  const [draft, setDraft] = React.useState<ConnectionDraft>(connection)
+  const [managedAccountId, setManagedAccountId] = React.useState(
+    connection.accountId || DEFAULT_ACCOUNT_ID,
+  )
+  const [addAccountOpen, setAddAccountOpen] = React.useState(false)
+  const [addUserOpen, setAddUserOpen] = React.useState(false)
+  const [keyResult, setKeyResult] = React.useState<KeyResult | null>(null)
+  const [pendingRegenerateUser, setPendingRegenerateUser] =
+    React.useState<AdminUser | null>(null)
+
+  React.useEffect(() => {
+    setDraft(connection)
+  }, [connection])
+
+  const canQueryAdmin = Boolean(draft.apiKey.trim())
+  const adminConnection = React.useMemo<AdminConnection>(
+    () => ({
+      accountId: draft.accountId || DEFAULT_ACCOUNT_ID,
+      agentId: draft.agentId || 'web-studio',
+      apiKey: draft.apiKey,
+      baseUrl: draft.baseUrl,
+      userId: draft.userId || DEFAULT_USER_ID,
+    }),
+    [draft.accountId, draft.agentId, draft.apiKey, draft.baseUrl, draft.userId],
+  )
+
+  const accountsQuery = useQuery({
+    enabled: canQueryAdmin,
+    queryFn: () => fetchAdminAccounts(adminConnection),
+    queryKey: [
+      'admin-accounts',
+      adminConnection.baseUrl,
+      adminConnection.apiKey,
+      adminConnection.accountId,
+      adminConnection.userId,
+      adminConnection.agentId,
+    ],
+    retry: false,
+  })
+
+  const accountOptions = accountsQuery.data ?? []
+  const selectedAccountId = draft.accountId || DEFAULT_ACCOUNT_ID
+
+  const usersQuery = useQuery({
+    enabled: canQueryAdmin && Boolean(selectedAccountId),
+    queryFn: () => fetchAdminUsers(adminConnection, selectedAccountId),
+    queryKey: [
+      'admin-users',
+      adminConnection.baseUrl,
+      adminConnection.apiKey,
+      adminConnection.accountId,
+      adminConnection.userId,
+      adminConnection.agentId,
+      selectedAccountId,
+    ],
+    retry: false,
+  })
+
+  const managedUsersQuery = useQuery({
+    enabled: canQueryAdmin && Boolean(managedAccountId),
+    queryFn: () => fetchAdminUsers(adminConnection, managedAccountId),
+    queryKey: [
+      'admin-users',
+      adminConnection.baseUrl,
+      adminConnection.apiKey,
+      adminConnection.accountId,
+      adminConnection.userId,
+      adminConnection.agentId,
+      managedAccountId,
+    ],
+    retry: false,
+  })
+
+  React.useEffect(() => {
+    if (!accountOptions.length) {
+      return
+    }
+
+    const accountIds = accountOptions.map((account) => account.accountId)
+    const preferred = accountIds.includes(DEFAULT_ACCOUNT_ID)
+      ? DEFAULT_ACCOUNT_ID
+      : accountIds[0]
+
+    setDraft((current) =>
+      current.accountId && accountIds.includes(current.accountId)
+        ? current
+        : { ...current, accountId: preferred },
+    )
+    setManagedAccountId((current) =>
+      current && accountIds.includes(current) ? current : preferred,
+    )
+  }, [accountOptions])
+
+  React.useEffect(() => {
+    const users = usersQuery.data
+    if (!users?.length) {
+      return
+    }
+
+    const userIds = users.map((user) => user.userId)
+    const preferred = userIds.includes(DEFAULT_USER_ID)
+      ? DEFAULT_USER_ID
+      : userIds[0]
+    setDraft((current) =>
+      current.userId && userIds.includes(current.userId)
+        ? current
+        : { ...current, userId: preferred },
+    )
+  }, [usersQuery.data])
+
+  const createAccountMutation = useMutation({
+    mutationFn: (input: CreateAccountInput) =>
+      createAdminAccount(adminConnection, input),
+    onError: (error) => toast.error(getErrorMessage(error)),
+    onSuccess: async (result, variables) => {
+      setKeyResult(result)
+      setManagedAccountId(variables.accountId)
+      setDraft((current) => ({
+        ...current,
+        accountId: variables.accountId,
+        userId: variables.adminUserId,
+      }))
+      setAddAccountOpen(false)
+      toast.success(t('toast.accountCreated'))
+      await queryClient.invalidateQueries({ queryKey: ['admin-accounts'] })
+      await queryClient.invalidateQueries({ queryKey: ['admin-users'] })
+    },
+  })
+
+  const createUserMutation = useMutation({
+    mutationFn: (input: CreateUserInput) =>
+      createAdminUser(adminConnection, input),
+    onError: (error) => toast.error(getErrorMessage(error)),
+    onSuccess: async (result, variables) => {
+      setKeyResult(result)
+      setManagedAccountId(variables.accountId)
+      setDraft((current) => ({
+        ...current,
+        accountId: variables.accountId,
+        userId: variables.userId,
+      }))
+      setAddUserOpen(false)
+      toast.success(t('toast.userCreated'))
+      await queryClient.invalidateQueries({ queryKey: ['admin-accounts'] })
+      await queryClient.invalidateQueries({ queryKey: ['admin-users'] })
+    },
+  })
+
+  const regenerateMutation = useMutation({
+    mutationFn: (user: AdminUser) =>
+      regenerateAdminUserKey(adminConnection, user.accountId, user.userId),
+    onError: (error) => toast.error(getErrorMessage(error)),
+    onSuccess: async (result) => {
+      setKeyResult(result)
+      setPendingRegenerateUser(null)
+      toast.success(t('toast.keyRegenerated'))
+      await queryClient.invalidateQueries({ queryKey: ['admin-users'] })
+    },
+  })
+
+  const users = usersQuery.data ?? []
+  const managedUsers = managedUsersQuery.data ?? []
+  const totalAccounts = accountOptions.length
+  const totalUsers =
+    accountOptions.reduce((sum, account) => sum + account.userCount, 0) ||
+    managedUsers.length
+  const visibleKeys = managedUsers.filter(
+    (user) => user.apiKey || user.keyPrefix,
+  ).length
+  const adminUnavailable =
+    !canQueryAdmin || accountsQuery.isError || managedUsersQuery.isError
+
+  function updateDraft(next: Partial<ConnectionDraft>): void {
+    setDraft((current) => ({ ...current, ...next }))
+  }
+
+  function handleSave(): void {
+    saveConnection(draft)
+    toast.success(t('toast.connectionSaved'))
+  }
+
+  async function refreshAdmin(): Promise<void> {
+    await Promise.all([
+      accountsQuery.refetch(),
+      usersQuery.refetch(),
+      managedUsersQuery.refetch(),
+    ])
+  }
+
+  async function copyKey(value: string | undefined): Promise<void> {
+    if (!value) {
+      return
+    }
+    await navigator.clipboard.writeText(value)
+    toast.success(t('toast.copied'))
+  }
+
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-5">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t('page.title')}
+        </h1>
+        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+          {t('page.description')}
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader className="gap-1.5 border-b bg-muted/20">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <CardTitle>{t('connection.title')}</CardTitle>
+              <CardDescription>{t('connection.description')}</CardDescription>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void refreshAdmin()}
+                disabled={!canQueryAdmin || accountsQuery.isFetching}
+              >
+                <RefreshCwIcon
+                  className={cn(accountsQuery.isFetching && 'animate-spin')}
+                />
+                {t('actions.refresh')}
+              </Button>
+              <Button type="button" onClick={handleSave}>
+                <SaveIcon />
+                {t('actions.save')}
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4 pt-6">
+          <div className="grid gap-4 xl:grid-cols-[minmax(16rem,1.2fr)_minmax(12rem,0.8fr)_minmax(12rem,0.8fr)_minmax(11rem,0.8fr)]">
+            <Field>
+              <FieldLabel htmlFor="settings-base-url">
+                {t('fields.baseUrl')}
+              </FieldLabel>
+              <FieldContent>
+                <Input
+                  id="settings-base-url"
+                  value={draft.baseUrl}
+                  onChange={(event) =>
+                    updateDraft({ baseUrl: event.target.value })
+                  }
+                  placeholder={t('placeholders.baseUrl')}
+                />
+              </FieldContent>
+            </Field>
+            <Field>
+              <FieldLabel>{t('fields.account')}</FieldLabel>
+              <FieldContent>
+                <AccountSelect
+                  accounts={accountOptions}
+                  disabled={!canQueryAdmin || accountsQuery.isLoading}
+                  label={t('fields.account')}
+                  value={draft.accountId || DEFAULT_ACCOUNT_ID}
+                  onChange={(accountId) =>
+                    updateDraft({
+                      accountId,
+                      userId: DEFAULT_USER_ID,
+                    })
+                  }
+                />
+              </FieldContent>
+            </Field>
+            <Field>
+              <FieldLabel>{t('fields.user')}</FieldLabel>
+              <FieldContent>
+                <UserSelect
+                  disabled={!canQueryAdmin || usersQuery.isLoading}
+                  label={t('fields.user')}
+                  users={users}
+                  value={draft.userId || DEFAULT_USER_ID}
+                  onChange={(userId) => updateDraft({ userId })}
+                />
+              </FieldContent>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="settings-agent-id">
+                {t('fields.agent')}
+              </FieldLabel>
+              <FieldContent>
+                <Input
+                  id="settings-agent-id"
+                  value={draft.agentId}
+                  onChange={(event) =>
+                    updateDraft({ agentId: event.target.value })
+                  }
+                  placeholder={t('placeholders.agent')}
+                />
+              </FieldContent>
+            </Field>
+          </div>
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_12rem]">
+            <Field>
+              <FieldLabel htmlFor="settings-api-key">
+                {t('fields.apiKey')}
+              </FieldLabel>
+              <FieldContent>
+                <Input
+                  id="settings-api-key"
+                  type="password"
+                  value={draft.apiKey}
+                  onChange={(event) =>
+                    updateDraft({ apiKey: event.target.value })
+                  }
+                  placeholder={t('placeholders.apiKey')}
+                />
+              </FieldContent>
+            </Field>
+            <div className="flex items-end">
+              <Badge variant="outline" className="h-9 px-3">
+                {t(`serverMode.${serverMode}`)}
+              </Badge>
+            </div>
+          </div>
+          {!canQueryAdmin ? (
+            <p className="text-sm text-muted-foreground">
+              {t('connection.noKey')}
+            </p>
+          ) : accountsQuery.isError ? (
+            <p className="text-sm text-destructive">
+              {t('connection.adminError', {
+                message: getErrorMessage(accountsQuery.error),
+              })}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <StatCard
+          label={t('stats.accounts')}
+          value={totalAccounts || '-'}
+          icon={<ServerIcon className="size-4" />}
+        />
+        <StatCard
+          label={t('stats.users')}
+          value={totalUsers || '-'}
+          icon={<UsersRoundIcon className="size-4" />}
+        />
+        <StatCard
+          label={t('stats.apiKeys')}
+          value={visibleKeys || '-'}
+          icon={<KeyRoundIcon className="size-4" />}
+        />
+      </div>
+
+      {keyResult ? (
+        <KeyResultCard result={keyResult} onClear={() => setKeyResult(null)} />
+      ) : null}
+
+      <Card className="overflow-hidden">
+        <CardHeader className="gap-4 border-b bg-muted/20">
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
+            <div className="min-w-0">
+              <CardTitle>{t('management.title')}</CardTitle>
+              <CardDescription>{t('management.description')}</CardDescription>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 lg:flex-nowrap lg:justify-end">
+              <div className="min-w-40">
+                <AccountSelect
+                  accounts={accountOptions}
+                  disabled={!canQueryAdmin || accountsQuery.isLoading}
+                  label={t('management.accountFilter')}
+                  value={managedAccountId}
+                  onChange={setManagedAccountId}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void refreshAdmin()}
+                disabled={!canQueryAdmin || managedUsersQuery.isFetching}
+              >
+                <RefreshCwIcon
+                  className={cn(managedUsersQuery.isFetching && 'animate-spin')}
+                />
+                {t('actions.refresh')}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => setAddAccountOpen(true)}
+                disabled={!canQueryAdmin}
+              >
+                <PlusIcon />
+                {t('actions.addAccount')}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => setAddUserOpen(true)}
+                disabled={!canQueryAdmin}
+              >
+                <PlusIcon />
+                {t('actions.addUser')}
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {adminUnavailable ? (
+            <div className="flex min-h-56 flex-col items-center justify-center gap-2 px-6 text-center">
+              <div className="flex size-11 items-center justify-center rounded-lg border bg-muted/30 text-muted-foreground">
+                <KeyRoundIcon className="size-5" />
+              </div>
+              <p className="font-medium">{t('empty.adminTitle')}</p>
+              <p className="max-w-lg text-sm text-muted-foreground">
+                {t('empty.adminDescription')}
+              </p>
+            </div>
+          ) : managedUsersQuery.isLoading ? (
+            <div className="flex min-h-56 items-center justify-center text-sm text-muted-foreground">
+              {t('loading')}
+            </div>
+          ) : managedUsers.length === 0 ? (
+            <div className="flex min-h-56 flex-col items-center justify-center gap-2 px-6 text-center">
+              <div className="flex size-11 items-center justify-center rounded-lg border bg-muted/30 text-muted-foreground">
+                <UserRoundIcon className="size-5" />
+              </div>
+              <p className="font-medium">{t('empty.usersTitle')}</p>
+              <p className="text-sm text-muted-foreground">
+                {t('empty.usersDescription')}
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/20 hover:bg-muted/20">
+                    <TableHead>{t('table.account')}</TableHead>
+                    <TableHead>{t('table.user')}</TableHead>
+                    <TableHead>{t('table.role')}</TableHead>
+                    <TableHead>{t('table.apiKey')}</TableHead>
+                    <TableHead className="text-right">
+                      {t('table.actions')}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {managedUsers.map((user) => (
+                    <TableRow key={`${user.accountId}:${user.userId}`}>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
+                        {user.accountId}
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {user.userId}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            user.role === 'admin' ? 'secondary' : 'outline'
+                          }
+                        >
+                          {t(`roles.${user.role}`, {
+                            defaultValue: user.role,
+                          })}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex min-w-0 items-center gap-2">
+                          <code className="max-w-[20rem] truncate rounded-md border bg-muted/40 px-2 py-1 font-mono text-xs">
+                            {resolveKeyLabel(user)}
+                          </code>
+                          {user.apiKey ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              aria-label={t('actions.copy')}
+                              onClick={() => void copyKey(user.apiKey)}
+                            >
+                              <CopyIcon />
+                            </Button>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              setDraft((current) => ({
+                                ...current,
+                                accountId: user.accountId,
+                                userId: user.userId,
+                              }))
+                            }
+                          >
+                            <CheckIcon />
+                            {t('actions.use')}
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setPendingRegenerateUser(user)}
+                            disabled={regenerateMutation.isPending}
+                          >
+                            <RotateCwIcon />
+                            {t('actions.regenerate')}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <AddAccountDialog
+        open={addAccountOpen}
+        onOpenChange={setAddAccountOpen}
+        isPending={createAccountMutation.isPending}
+        onCreate={(next) => createAccountMutation.mutate(next)}
+      />
+      <AddUserDialog
+        open={addUserOpen}
+        onOpenChange={setAddUserOpen}
+        accounts={accountOptions}
+        defaultAccountId={managedAccountId}
+        isPending={createUserMutation.isPending}
+        onCreate={(next) => createUserMutation.mutate(next)}
+      />
+      <AlertDialog
+        open={Boolean(pendingRegenerateUser)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingRegenerateUser(null)
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('dialogs.regenerate.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('dialogs.regenerate.description', {
+                account: pendingRegenerateUser?.accountId,
+                user: pendingRegenerateUser?.userId,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('actions.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingRegenerateUser) {
+                  regenerateMutation.mutate(pendingRegenerateUser)
+                }
+              }}
+              disabled={regenerateMutation.isPending}
+            >
+              <RotateCwIcon />
+              {t('actions.regenerate')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Adds a first-class Web Studio settings page for OpenViking connection identity and admin-side account/user management.

## Related Issue

Requested by @zaynjarvis in Zouk task #609.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Adds `/settings` as `Connection & Identity`, linked from the sidebar footer.
- Defaults Studio identity to `default / default / web-studio` and loads account/user choices from the admin APIs.
- Adds a user-management table with account/user/role/API key visibility, copy actions, regenerate confirmation, add account, and add user dialogs.
- Uses the current settings form draft for admin API calls so changing URL/key in the page can refresh choices before saving global Studio connection.
- Aligns the header controls with openviking.ai: language toggle, theme toggle, and GitHub shortcut.
- Removes extra top spacing from the connection settings card and lets Context Management fill the viewport without the bottom white gutter.
- Adds English and Simplified Chinese strings for the new settings surface.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `npx tsc --noEmit`
- `npm run build`
- `npm run lint` (passes with the existing 15 `i18next/no-literal-string` warnings in `src/routes/resources/-components/file-preview.tsx`)
- Local visual smoke tests with Playwright screenshots at `http://127.0.0.1:3000/settings` and `http://127.0.0.1:3000/resources?uri=viking%3A%2F%2F`

I also verified the admin read API shape against the test server:

- `GET /api/v1/admin/accounts`
- `GET /api/v1/admin/accounts/default/users`

I did not run live create/regenerate mutations against the shared test admin service to avoid changing real credentials during verification.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots

![Connection & Identity settings preview](https://raw.githubusercontent.com/volcengine/OpenViking/zeus/pr-2309-assets/.github/pr-assets/2309-settings-preview-v2.png)

Implemented after generating an imagegen design mock and then matching the current Studio sidebar/card/table style from the provided reference image.

## Additional Notes

The generated route tree is included because this project tracks `routeTree.gen.ts`.
