### PR TITLE
feat(web-studio): auto-proxy mode for public deployments

### DIFF
--- a/web-studio/.dockerignore
+++ b/web-studio/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+dist
+.git
+.gitignore
+.env
+.env.*
+.DS_Store
+Dockerfile
+.dockerignore
+README.md
+README_CN.md
+*.log
+coverage
+.vite
+.cache

--- a/web-studio/Dockerfile
+++ b/web-studio/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage image for OpenViking Web Studio in auto-proxy mode.
+# Stage 1 builds the static SPA. Stage 2 ships only the runtime proxy +
+# pre-built dist/, on node:22-alpine for a small footprint (~150 MB).
+
+ARG NODE_VERSION=22
+
+FROM node:${NODE_VERSION}-alpine AS build
+WORKDIR /app
+# Copy lockfile + manifest first so npm cache layers stay reusable.
+COPY package.json package-lock.json* pnpm-lock.yaml* ./
+# pnpm-lock.yaml exists in the repo but the publish flow uses npm; prefer npm ci
+# for deterministic installs, fall back to npm install if the lockfile is stale.
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+COPY . .
+RUN npm run build
+
+FROM node:${NODE_VERSION}-alpine AS runtime
+ENV NODE_ENV=production \
+    OV_STUDIO_HOST=0.0.0.0
+WORKDIR /app
+COPY --from=build /app/server ./server
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+# proxy.mjs is zero-dep — no production node_modules needed.
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- "http://127.0.0.1:${PORT:-3000}/_studio/runtime-config.json" >/dev/null 2>&1 || exit 1
+CMD ["node", "server/proxy.mjs"]

--- a/web-studio/README.md
+++ b/web-studio/README.md
@@ -337,7 +337,35 @@ server {
 
 Do not set `VITE_OV_BASE_URL` to `https://ov.example.com/web-studio`. `/web-studio/` is only the frontend mount path; OpenViking API requests should still go to `https://ov.example.com/api/*` and `https://ov.example.com/bot/*`.
 
-### 6. Docker Server Dependency
+### 6. Auto-Proxy Mode (Single-Process Backend)
+
+Auto-proxy mode is a public-friendly deployment where:
+
+- The browser never receives the OpenViking root API key.
+- The frontend talks to the **same origin** with no `X-API-Key` of its own.
+- A thin Node.js backend (`server/proxy.mjs`) injects `X-API-Key` and forwards
+  requests to a configured upstream OpenViking Server.
+
+This is the right mode when you want anyone who can open the website to
+connect to the underlying OV cluster, with credentials kept on the server.
+
+```bash
+cd web-studio
+npm ci
+npm run build
+
+OV_STUDIO_UPSTREAM=https://ov-api.example.com \
+OV_STUDIO_API_KEY=$ROOT_API_KEY \
+npm run proxy
+```
+
+When the proxy is active, Web Studio reads `GET /_studio/runtime-config.json`
+at boot, hides the connection dialog form, and stops persisting credentials
+in browser storage. See [`server/README.md`](server/README.md) for env vars
+and threat model. Do not set `VITE_OV_BASE_URL` for auto-proxy builds — the
+SPA must call same-origin paths so the proxy can inject auth headers.
+
+### 7. Docker Server Dependency
 
 The official OpenViking image can be used as the API server dependency:
 

--- a/web-studio/README_CN.md
+++ b/web-studio/README_CN.md
@@ -337,7 +337,29 @@ server {
 
 不要把 `VITE_OV_BASE_URL` 设置成 `https://ov.example.com/web-studio`。`/web-studio/` 只是前端挂载路径；OpenViking API 请求仍应访问 `https://ov.example.com/api/*` 和 `https://ov.example.com/bot/*`。
 
-### 6. Docker 服务端依赖
+### 6. 自动代理模式（单进程后端）
+
+自动代理模式适用于希望公开访问的场景：
+
+- 浏览器始终拿不到 OpenViking 的根 API Key。
+- 前端只访问**同域**接口，不携带任何 `X-API-Key`。
+- 一个极简的 Node.js 后端（`server/proxy.mjs`）在服务端注入 `X-API-Key` 并转发到上游 OpenViking Server。
+
+适合让任何能打开网站的人都直接连上 OV 集群，凭据始终留在服务端。
+
+```bash
+cd web-studio
+npm ci
+npm run build
+
+OV_STUDIO_UPSTREAM=https://ov-api.example.com \
+OV_STUDIO_API_KEY=$ROOT_API_KEY \
+npm run proxy
+```
+
+启动后 Web Studio 会在启动时读取 `GET /_studio/runtime-config.json`，自动隐藏连接对话框中的字段，并不再把任何凭据写入浏览器存储。环境变量与威胁模型见 [`server/README.md`](server/README.md)。自动代理模式下不要设置 `VITE_OV_BASE_URL`，前端需要走同源路径，代理才能注入鉴权头。
+
+### 7. Docker 服务端依赖
 
 官方 OpenViking 镜像可以作为 API server 依赖：
 

--- a/web-studio/package.json
+++ b/web-studio/package.json
@@ -9,6 +9,7 @@
     "dev": "vite dev --port 3000",
     "build": "vite build",
     "preview": "vite preview",
+    "proxy": "node server/proxy.mjs",
     "test": "vitest run",
     "lint": "eslint src --ignore-pattern 'src/gen/**' --ignore-pattern 'src/routeTree.gen.ts' --ignore-pattern 'src/components/ui/**'",
     "format": "prettier --check 'src/**/*.{ts,tsx}'",

--- a/web-studio/railway.toml
+++ b/web-studio/railway.toml
@@ -1,0 +1,17 @@
+# Railway deployment config for OpenViking Web Studio auto-proxy mode.
+#
+# Use with a Railway service rooted at this directory (Settings → Service →
+# Root Directory = `web-studio`). Railway injects $PORT; the proxy honors it
+# automatically. Set OV_STUDIO_UPSTREAM and OV_STUDIO_API_KEY as service
+# variables before the first deploy.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "node server/proxy.mjs"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5
+healthcheckPath = "/_studio/runtime-config.json"
+healthcheckTimeout = 10

--- a/web-studio/server/README.md
+++ b/web-studio/server/README.md
@@ -57,6 +57,45 @@ Then open <http://localhost:3000>.
   `X-OpenViking-User` from incoming requests so a malicious client can't pass
   alternative credentials downstream.
 
+## Docker
+
+A multi-stage `Dockerfile` lives one level up at `web-studio/Dockerfile`.
+Build context is the `web-studio` directory.
+
+```bash
+cd web-studio
+docker build -t openviking-studio-proxy .
+docker run --rm -p 3000:3000 \
+  -e OV_STUDIO_UPSTREAM=https://ov-api.example.com \
+  -e OV_STUDIO_API_KEY=$ROOT_API_KEY \
+  openviking-studio-proxy
+```
+
+The runtime image is `node:22-alpine` + the built SPA + `server/proxy.mjs`.
+No production `node_modules` — the proxy is zero-dep — so the image stays
+around 150 MB.
+
+## Railway
+
+`web-studio/railway.toml` wires the Dockerfile build + healthcheck.
+
+1. On Railway, create a new service from the repo containing this branch.
+2. **Service → Settings → Source** → set **Root Directory** to `web-studio`.
+   Railway then auto-detects the Dockerfile.
+3. **Variables** → add:
+   - `OV_STUDIO_UPSTREAM` — your OV server origin, e.g. `https://ov.example.com`.
+   - `OV_STUDIO_API_KEY` — the root API key the proxy injects upstream.
+   - (optional) `OV_STUDIO_ACCOUNT_ID`, `OV_STUDIO_USER_ID` to pin identity.
+4. Deploy. Railway injects `$PORT`; the proxy honors it automatically (no
+   `OV_STUDIO_PORT` needed). The generated public URL is the studio entry —
+   anyone who can open it acts with the configured server identity.
+
+## Fly.io / Render / generic Docker host
+
+Anything that runs Docker works the same way. Pass the env vars above,
+expose port 3000 (or pass `PORT` / `OV_STUDIO_PORT`), and route HTTPS to the
+container.
+
 ## Why not nginx?
 
 The nginx layout in the main README is still the right answer when you already

--- a/web-studio/server/README.md
+++ b/web-studio/server/README.md
@@ -1,0 +1,65 @@
+# Web Studio Auto-Proxy Server
+
+`server/proxy.mjs` is an optional, zero-dependency Node.js server that lets you
+deploy Web Studio as a public site without exposing the OpenViking root API
+key to the browser.
+
+It does three things:
+
+1. Serves the built `dist/` SPA bundle on the same origin.
+2. Proxies OpenViking API paths to a configured upstream OV server, injecting
+   `X-API-Key` (and optional account / user) server-side. Incoming
+   `X-API-Key`, `Authorization`, `X-OpenViking-Account`, and `X-OpenViking-User`
+   headers are stripped before forwarding, so the browser can't override the
+   server-managed identity.
+3. Publishes `/_studio/runtime-config.json` so the SPA knows it is in
+   "auto-proxy mode" and:
+   - hides the connection dialog form,
+   - stops sending `X-API-Key` from the browser,
+   - never persists credentials in `localStorage` / `sessionStorage`.
+
+## Quick start
+
+```bash
+cd web-studio
+npm ci
+npm run build
+
+OV_STUDIO_UPSTREAM=https://ov-api.example.com \
+OV_STUDIO_API_KEY=$ROOT_API_KEY \
+npm run proxy
+```
+
+Then open <http://localhost:3000>.
+
+## Configuration
+
+| Env var                  | Default                                            | Purpose                                                     |
+| ------------------------ | -------------------------------------------------- | ----------------------------------------------------------- |
+| `OV_STUDIO_UPSTREAM`     | (required)                                         | Upstream OpenViking Server origin, e.g. `https://ov.api`.   |
+| `OV_STUDIO_API_KEY`      | (required)                                         | Root or scoped API key injected as `X-API-Key`.             |
+| `OV_STUDIO_ACCOUNT_ID`   | _unset_                                            | If set, forwarded as `X-OpenViking-Account`.                |
+| `OV_STUDIO_USER_ID`      | _unset_                                            | If set, forwarded as `X-OpenViking-User`.                   |
+| `OV_STUDIO_HOST`         | `0.0.0.0`                                          | Bind host.                                                  |
+| `OV_STUDIO_PORT`         | `3000`                                             | Bind port.                                                  |
+| `OV_STUDIO_DIST_DIR`     | `<web-studio>/dist`                                | Path to the built SPA.                                      |
+| `OV_STUDIO_PROXY_PATHS`  | `/api,/bot,/health,/ready,/openapi.json`           | Path prefixes proxied to upstream.                          |
+| `OV_STUDIO_CORS_ORIGINS` | _empty_                                            | Comma-separated allowlist; `*` allows any. Same-origin only by default. |
+| `OV_STUDIO_BASE_PATH`    | `/`                                                | SPA mount base, matches Vite `--base`.                      |
+
+## Threat model
+
+- The browser sees no API key, account, or user header.
+- Anyone able to reach the proxy origin can act with the configured identity.
+  This is intentional for "open studio" deployments. Lock the origin down with
+  network policy / SSO if you need finer access control.
+- The proxy strips `X-API-Key`, `Authorization`, `X-OpenViking-Account`, and
+  `X-OpenViking-User` from incoming requests so a malicious client can't pass
+  alternative credentials downstream.
+
+## Why not nginx?
+
+The nginx layout in the main README is still the right answer when you already
+have nginx in front. This Node script is for deployments that want the
+"static frontend + thin proxy" pattern as a single self-contained process —
+for example Render / Railway / Fly app instances or local demos.

--- a/web-studio/server/proxy.mjs
+++ b/web-studio/server/proxy.mjs
@@ -34,7 +34,8 @@ const PKG_ROOT = resolve(__dirname, '..')
 
 const env = process.env
 const HOST = env.OV_STUDIO_HOST || '0.0.0.0'
-const PORT = Number.parseInt(env.OV_STUDIO_PORT || '3000', 10)
+// Honor PORT first so Railway / Fly / Render / Heroku auto-injection works.
+const PORT = Number.parseInt(env.PORT || env.OV_STUDIO_PORT || '3000', 10)
 const DIST_DIR = resolve(env.OV_STUDIO_DIST_DIR || join(PKG_ROOT, 'dist'))
 const UPSTREAM = (env.OV_STUDIO_UPSTREAM || '').trim().replace(/\/+$/, '')
 const API_KEY = (env.OV_STUDIO_API_KEY || '').trim()

--- a/web-studio/server/proxy.mjs
+++ b/web-studio/server/proxy.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+// OpenViking Web Studio — auto-proxy server.
+//
+// Serves the built `dist/` bundle and proxies OpenViking API traffic to an
+// upstream OV server, injecting `X-API-Key` (and optional account / user) so
+// the browser never sees the root API key. Configured entirely via env vars
+// so a single static deployment can front any OV cluster.
+//
+// Usage:
+//   OV_STUDIO_UPSTREAM=https://ov.example.com \
+//   OV_STUDIO_API_KEY=root-key \
+//   node server/proxy.mjs
+//
+// Optional env:
+//   OV_STUDIO_HOST            (default 0.0.0.0)
+//   OV_STUDIO_PORT            (default 3000)
+//   OV_STUDIO_DIST_DIR        (default <package>/dist)
+//   OV_STUDIO_ACCOUNT_ID      forwarded as X-OpenViking-Account
+//   OV_STUDIO_USER_ID         forwarded as X-OpenViking-User
+//   OV_STUDIO_CORS_ORIGINS    comma-separated, default same-origin only
+//   OV_STUDIO_PROXY_PATHS     comma-separated path prefixes to forward
+//                             (default: /api,/bot,/health,/ready,/openapi.json)
+//   OV_STUDIO_BASE_PATH       SPA mount base, default "/"
+//
+import { createServer } from 'node:http'
+import { request as httpRequest } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import { existsSync, createReadStream, statSync } from 'node:fs'
+import { dirname, extname, join, normalize, resolve } from 'node:path'
+import { fileURLToPath, URL } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PKG_ROOT = resolve(__dirname, '..')
+
+const env = process.env
+const HOST = env.OV_STUDIO_HOST || '0.0.0.0'
+const PORT = Number.parseInt(env.OV_STUDIO_PORT || '3000', 10)
+const DIST_DIR = resolve(env.OV_STUDIO_DIST_DIR || join(PKG_ROOT, 'dist'))
+const UPSTREAM = (env.OV_STUDIO_UPSTREAM || '').trim().replace(/\/+$/, '')
+const API_KEY = (env.OV_STUDIO_API_KEY || '').trim()
+const ACCOUNT_ID = (env.OV_STUDIO_ACCOUNT_ID || '').trim()
+const USER_ID = (env.OV_STUDIO_USER_ID || '').trim()
+const BASE_PATH = normalizeBasePath(env.OV_STUDIO_BASE_PATH || '/')
+const PROXY_PATHS = parsePaths(
+  env.OV_STUDIO_PROXY_PATHS || '/api,/bot,/health,/ready,/openapi.json',
+)
+const CORS_ORIGINS = new Set(
+  (env.OV_STUDIO_CORS_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean),
+)
+const ALLOW_ANY_CORS = CORS_ORIGINS.has('*')
+
+if (!UPSTREAM) {
+  console.error('[ov-studio-proxy] OV_STUDIO_UPSTREAM is required')
+  process.exit(1)
+}
+if (!API_KEY) {
+  console.error('[ov-studio-proxy] OV_STUDIO_API_KEY is required')
+  process.exit(1)
+}
+if (!existsSync(DIST_DIR)) {
+  console.error(
+    `[ov-studio-proxy] dist directory not found: ${DIST_DIR}. Run "npm run build" first.`,
+  )
+  process.exit(1)
+}
+
+const upstreamUrl = new URL(UPSTREAM)
+const upstreamRequest = upstreamUrl.protocol === 'https:' ? httpsRequest : httpRequest
+const STRIPPED_REQUEST_HEADERS = new Set([
+  'host',
+  'connection',
+  'x-api-key',
+  'authorization',
+  'x-openviking-account',
+  'x-openviking-user',
+  'x-openviking-agent',
+  'cookie',
+])
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailers',
+  'transfer-encoding',
+  'upgrade',
+])
+
+const RUNTIME_CONFIG_PATH = joinPath(BASE_PATH, '_studio/runtime-config.json')
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+}
+
+const server = createServer((req, res) => {
+  try {
+    handle(req, res)
+  } catch (error) {
+    console.error('[ov-studio-proxy] unexpected error', error)
+    if (!res.headersSent) {
+      res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' })
+    }
+    res.end('Internal Studio proxy error')
+  }
+})
+
+server.listen(PORT, HOST, () => {
+  console.log(
+    `[ov-studio-proxy] listening on http://${HOST}:${PORT} → upstream ${UPSTREAM} (base ${BASE_PATH})`,
+  )
+})
+
+function handle(req, res) {
+  applyCors(req, res)
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204).end()
+    return
+  }
+
+  const pathname = safePathname(req.url)
+  if (pathname === RUNTIME_CONFIG_PATH) {
+    sendRuntimeConfig(res)
+    return
+  }
+
+  if (matchesPrefix(pathname, PROXY_PATHS)) {
+    proxyToUpstream(req, res)
+    return
+  }
+
+  serveStatic(req, res, pathname)
+}
+
+function sendRuntimeConfig(res) {
+  const body = JSON.stringify({
+    proxyMode: true,
+    baseUrl: '',
+    hasManagedAccount: Boolean(ACCOUNT_ID),
+    hasManagedUser: Boolean(USER_ID),
+  })
+  res.writeHead(200, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  })
+  res.end(body)
+}
+
+function proxyToUpstream(req, res) {
+  const targetPath = (req.url || '/').replace(/^\/+/, '/')
+  const headers = filterRequestHeaders(req.headers)
+  headers['x-api-key'] = API_KEY
+  if (ACCOUNT_ID) headers['x-openviking-account'] = ACCOUNT_ID
+  if (USER_ID) headers['x-openviking-user'] = USER_ID
+  headers['x-openviking-agent'] = 'web-studio-proxy'
+  headers.host = upstreamUrl.host
+
+  const upstream = upstreamRequest(
+    {
+      protocol: upstreamUrl.protocol,
+      hostname: upstreamUrl.hostname,
+      port: upstreamUrl.port || (upstreamUrl.protocol === 'https:' ? 443 : 80),
+      method: req.method,
+      path: targetPath,
+      headers,
+    },
+    (upstreamRes) => {
+      const responseHeaders = filterResponseHeaders(upstreamRes.headers)
+      res.writeHead(upstreamRes.statusCode || 502, responseHeaders)
+      upstreamRes.pipe(res)
+    },
+  )
+
+  upstream.on('error', (error) => {
+    console.error('[ov-studio-proxy] upstream error', error.message)
+    if (!res.headersSent) {
+      res.writeHead(502, { 'content-type': 'application/json; charset=utf-8' })
+    }
+    res.end(JSON.stringify({ status: 'error', error: { code: 'UPSTREAM_UNREACHABLE', message: error.message } }))
+  })
+
+  req.pipe(upstream)
+}
+
+function serveStatic(req, res, pathname) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.writeHead(405, { 'content-type': 'text/plain; charset=utf-8' })
+    res.end('Method not allowed')
+    return
+  }
+
+  const relative = pathname.replace(/^\/+/, '')
+  const filePath = normalize(join(DIST_DIR, relative))
+  if (!filePath.startsWith(DIST_DIR)) {
+    res.writeHead(403).end('Forbidden')
+    return
+  }
+
+  if (existsSync(filePath) && statSync(filePath).isFile()) {
+    return streamFile(res, filePath, req.method)
+  }
+
+  const fallback = join(DIST_DIR, 'index.html')
+  if (!existsSync(fallback)) {
+    res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' })
+    res.end('Not found')
+    return
+  }
+  streamFile(res, fallback, req.method)
+}
+
+function streamFile(res, filePath, method) {
+  const ext = extname(filePath).toLowerCase()
+  const mime = MIME[ext] || 'application/octet-stream'
+  const stat = statSync(filePath)
+  const headers = {
+    'content-type': mime,
+    'content-length': stat.size,
+    // Don't cache index.html — runtime config / SPA bundle hashes change.
+    'cache-control': ext === '.html' ? 'no-store' : 'public, max-age=300',
+  }
+  res.writeHead(200, headers)
+  if (method === 'HEAD') {
+    res.end()
+    return
+  }
+  createReadStream(filePath).pipe(res)
+}
+
+function applyCors(req, res) {
+  const origin = req.headers.origin
+  if (!origin) return
+  if (ALLOW_ANY_CORS) {
+    res.setHeader('access-control-allow-origin', origin)
+    res.setHeader('vary', 'Origin')
+  } else if (CORS_ORIGINS.has(origin)) {
+    res.setHeader('access-control-allow-origin', origin)
+    res.setHeader('vary', 'Origin')
+  } else {
+    return
+  }
+  res.setHeader('access-control-allow-credentials', 'true')
+  res.setHeader(
+    'access-control-allow-headers',
+    req.headers['access-control-request-headers'] ||
+      'content-type,accept,x-openviking-agent',
+  )
+  res.setHeader(
+    'access-control-allow-methods',
+    'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+  )
+}
+
+function filterRequestHeaders(input) {
+  const out = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (STRIPPED_REQUEST_HEADERS.has(key.toLowerCase())) continue
+    out[key] = value
+  }
+  return out
+}
+
+function filterResponseHeaders(input) {
+  const out = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (HOP_BY_HOP_RESPONSE_HEADERS.has(key.toLowerCase())) continue
+    out[key] = value
+  }
+  return out
+}
+
+function matchesPrefix(pathname, prefixes) {
+  for (const prefix of prefixes) {
+    if (pathname === prefix) return true
+    if (pathname.startsWith(prefix.endsWith('/') ? prefix : `${prefix}/`)) return true
+    if (prefix.includes('.') && pathname === prefix) return true
+  }
+  return false
+}
+
+function parsePaths(raw) {
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => (entry.startsWith('/') ? entry : `/${entry}`))
+}
+
+function normalizeBasePath(raw) {
+  const trimmed = raw.trim()
+  if (!trimmed || trimmed === '/') return '/'
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return withLeading.replace(/\/+$/, '')
+}
+
+function joinPath(base, suffix) {
+  const left = base === '/' ? '' : base
+  const right = suffix.startsWith('/') ? suffix : `/${suffix}`
+  return `${left}${right}`
+}
+
+function safePathname(rawUrl) {
+  try {
+    return new URL(rawUrl || '/', 'http://placeholder').pathname
+  } catch {
+    return '/'
+  }
+}

--- a/web-studio/src/components/connection-dialog.tsx
+++ b/web-studio/src/components/connection-dialog.tsx
@@ -32,6 +32,7 @@ export function ConnectionDialog() {
   const {
     connection,
     isConnectionDialogOpen,
+    proxyMode,
     saveConnection,
     serverMode,
     setConnectionDialogOpen,
@@ -49,6 +50,36 @@ export function ConnectionDialog() {
 
   const isDevImplicit = serverMode === 'dev'
   const showIdentityFields = !isDevImplicit || showAdvancedInDevMode
+
+  if (proxyMode) {
+    return (
+      <Dialog
+        open={isConnectionDialogOpen}
+        onOpenChange={setConnectionDialogOpen}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t('dialog.title', { ns: 'connection' })}</DialogTitle>
+          </DialogHeader>
+          <Card size="sm" className="gap-3 border bg-background/70 shadow-none">
+            <CardHeader className="gap-2">
+              <CardTitle className="text-sm">
+                {t('proxyMode.title', { ns: 'connection' })}
+              </CardTitle>
+              <CardDescription>
+                {t('proxyMode.description', { ns: 'connection' })}
+              </CardDescription>
+            </CardHeader>
+          </Card>
+          <DialogFooter>
+            <Button onClick={() => setConnectionDialogOpen(false)}>
+              {t('close', { ns: 'common', keyPrefix: 'action' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  }
 
   return (
     <Dialog

--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { isOvClientError, ovClient } from '#/lib/ov-client'
+import { getStudioRuntime } from '#/lib/studio-runtime'
 
 import { detectServerMode, normalizeBaseUrl } from './use-server-mode'
 import type { ServerMode } from './use-server-mode'
@@ -25,6 +26,7 @@ type AppConnectionContextValue = {
   connection: ConnectionDraft
   isConnectionDialogOpen: boolean
   openConnectionDialog: () => void
+  proxyMode: boolean
   saveConnection: (next: ConnectionDraft) => void
   serverMode: ServerMode
   setConnectionDialogOpen: (open: boolean) => void
@@ -66,8 +68,11 @@ function readStoredConnection(): Partial<ConnectionDraft> {
   }
 }
 
-function persistConnection(connection: ConnectionDraft): void {
-  if (!isBrowser()) {
+function persistConnection(
+  connection: ConnectionDraft,
+  proxyMode: boolean,
+): void {
+  if (!isBrowser() || proxyMode) {
     return
   }
 
@@ -81,6 +86,16 @@ function persistConnection(connection: ConnectionDraft): void {
   }
 }
 
+function buildProxyConnection(): ConnectionDraft {
+  return {
+    accountId: '',
+    agentId: DEFAULT_CONNECTION.agentId,
+    apiKey: '',
+    baseUrl: isBrowser() ? window.location.origin : '',
+    userId: '',
+  }
+}
+
 function normalizeConnectionDraft(connection: ConnectionDraft): ConnectionDraft {
   return {
     accountId: connection.accountId.trim(),
@@ -91,19 +106,26 @@ function normalizeConnectionDraft(connection: ConnectionDraft): ConnectionDraft 
   }
 }
 
-function applyConnection(connection: ConnectionDraft): void {
+function applyConnection(
+  connection: ConnectionDraft,
+  proxyMode: boolean,
+): void {
   ovClient.setOptions({
     baseUrl: connection.baseUrl,
+    proxyMode,
   })
   ovClient.setConnection({
-    accountId: connection.accountId,
+    accountId: proxyMode ? '' : connection.accountId,
     agentId: connection.agentId,
-    apiKey: connection.apiKey,
-    userId: connection.userId,
+    apiKey: proxyMode ? '' : connection.apiKey,
+    userId: proxyMode ? '' : connection.userId,
   })
 }
 
-function readInitialConnection(): ConnectionDraft {
+function readInitialConnection(proxyMode: boolean): ConnectionDraft {
+  if (proxyMode) {
+    return normalizeConnectionDraft(buildProxyConnection())
+  }
   const storedConnection = readStoredConnection()
   return normalizeConnectionDraft({
     ...DEFAULT_CONNECTION,
@@ -157,10 +179,11 @@ export function AppConnectionProvider({
   children: React.ReactNode
 }) {
   const queryClient = useQueryClient()
+  const proxyMode = getStudioRuntime().proxyMode
   const initialConnectionRef = React.useRef<ConnectionDraft | null>(null)
   if (initialConnectionRef.current === null) {
-    initialConnectionRef.current = readInitialConnection()
-    applyConnection(initialConnectionRef.current)
+    initialConnectionRef.current = readInitialConnection(proxyMode)
+    applyConnection(initialConnectionRef.current, proxyMode)
   }
 
   const [connection, setConnection] = React.useState<ConnectionDraft>(
@@ -171,10 +194,10 @@ export function AppConnectionProvider({
   const [serverMode, setServerMode] = React.useState<ServerMode>('checking')
 
   React.useEffect(() => {
-    applyConnection(connection)
-    persistConnection(connection)
+    applyConnection(connection, proxyMode)
+    persistConnection(connection, proxyMode)
     void queryClient.invalidateQueries()
-  }, [connection, queryClient])
+  }, [connection, proxyMode, queryClient])
 
   React.useEffect(() => {
     let cancelled = false
@@ -196,6 +219,7 @@ export function AppConnectionProvider({
       (response) => response,
       (error) => {
         if (
+          !proxyMode &&
           isOvClientError(error) &&
           (error.statusCode === 401 || error.statusCode === 403)
         ) {
@@ -208,19 +232,24 @@ export function AppConnectionProvider({
     return () => {
       ovClient.instance.interceptors.response.eject(interceptorId)
     }
-  }, [])
+  }, [proxyMode])
 
   const value = React.useMemo<AppConnectionContextValue>(
     () => ({
       connection,
       isConnectionDialogOpen,
       openConnectionDialog: () => setConnectionDialogOpen(true),
-      saveConnection: (next) =>
-        setConnection(normalizeConnectionDraft(next)),
+      proxyMode,
+      saveConnection: (next) => {
+        if (proxyMode) {
+          return
+        }
+        setConnection(normalizeConnectionDraft(next))
+      },
       serverMode,
       setConnectionDialogOpen,
     }),
-    [connection, isConnectionDialogOpen, serverMode],
+    [connection, isConnectionDialogOpen, proxyMode, serverMode],
   )
 
   return (

--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -40,6 +40,7 @@ const en = {
   common: {
     action: {
       cancel: 'Cancel',
+      close: 'Close',
       saveConnection: 'Save Connection',
       showAdvancedIdentityFields: 'Show Advanced Identity Fields',
     },
@@ -66,6 +67,11 @@ const en = {
     },
     dialog: {
       title: 'Connection & Identity',
+    },
+    proxyMode: {
+      title: 'Auto-proxy mode',
+      description:
+        'A same-origin proxy is forwarding requests to the OpenViking server with a server-managed API key. The browser never sees credentials, so connection settings are locked.',
     },
     identitySummary: {
       dev: 'Server-managed identity',

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -40,6 +40,7 @@ const zhCN = {
   common: {
     action: {
       cancel: '取消',
+      close: '关闭',
       saveConnection: '保存连接',
       showAdvancedIdentityFields: '显示高级身份字段',
     },
@@ -66,6 +67,11 @@ const zhCN = {
     },
     dialog: {
       title: '连接与身份',
+    },
+    proxyMode: {
+      title: '自动代理模式',
+      description:
+        '同域后端正在以服务端配置的 API Key 转发请求到 OpenViking Server。浏览器看不到任何凭证，连接设置已锁定。',
     },
     identitySummary: {
       dev: '服务端隐式身份',

--- a/web-studio/src/lib/ov-client/client.ts
+++ b/web-studio/src/lib/ov-client/client.ts
@@ -150,6 +150,7 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
     apiKeyStorageKey: options.apiKeyStorageKey || DEFAULT_API_KEY_STORAGE_KEY,
     baseUrl: normalizeBaseUrl(options.baseUrl),
     defaultTelemetry: options.defaultTelemetry ?? true,
+    proxyMode: options.proxyMode ?? false,
   }
 
   let connection: OvConnectionState = {
@@ -177,9 +178,15 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
       headers.set(key, value)
     }
 
-    setOptionalHeader(headers, 'X-API-Key', connection.apiKey)
-    setOptionalHeader(headers, 'X-OpenViking-Account', connection.accountId)
-    setOptionalHeader(headers, 'X-OpenViking-User', connection.userId)
+    if (!runtimeOptions.proxyMode) {
+      setOptionalHeader(headers, 'X-API-Key', connection.apiKey)
+      setOptionalHeader(headers, 'X-OpenViking-Account', connection.accountId)
+      setOptionalHeader(headers, 'X-OpenViking-User', connection.userId)
+    } else {
+      headers.delete('X-API-Key')
+      headers.delete('X-OpenViking-Account')
+      headers.delete('X-OpenViking-User')
+    }
     headers.set('X-OpenViking-Agent', connection.agentId || WEB_STUDIO_AGENT_ID)
 
     config.headers = headers
@@ -277,6 +284,7 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
           : runtimeOptions.baseUrl,
       defaultTelemetry:
         next.defaultTelemetry ?? runtimeOptions.defaultTelemetry,
+      proxyMode: next.proxyMode ?? runtimeOptions.proxyMode,
     }
 
     if (previousStorageKey !== runtimeOptions.apiKeyStorageKey) {

--- a/web-studio/src/lib/ov-client/types.ts
+++ b/web-studio/src/lib/ov-client/types.ts
@@ -19,6 +19,7 @@ export interface OvClientOptions {
   connection?: Partial<OvConnectionState>
   defaultHeaders?: Record<string, string>
   defaultTelemetry?: boolean
+  proxyMode?: boolean
 }
 
 export interface OvClientAdapter {
@@ -28,17 +29,17 @@ export interface OvClientAdapter {
   getConnection: () => Readonly<OvConnectionState>
   getOptions: () => Readonly<
     Required<
-      Pick<OvClientOptions, 'apiKeyStorageKey' | 'baseUrl' | 'defaultTelemetry'>
+      Pick<OvClientOptions, 'apiKeyStorageKey' | 'baseUrl' | 'defaultTelemetry' | 'proxyMode'>
     >
   >
   setConnection: (next: Partial<OvConnectionState>) => OvConnectionState
   setOptions: (
     next: Partial<
-      Pick<OvClientOptions, 'apiKeyStorageKey' | 'baseUrl' | 'defaultTelemetry'>
+      Pick<OvClientOptions, 'apiKeyStorageKey' | 'baseUrl' | 'defaultTelemetry' | 'proxyMode'>
     >,
   ) => Readonly<
     Required<
-      Pick<OvClientOptions, 'apiKeyStorageKey' | 'baseUrl' | 'defaultTelemetry'>
+      Pick<OvClientOptions, 'apiKeyStorageKey' | 'baseUrl' | 'defaultTelemetry' | 'proxyMode'>
     >
   >
 }

--- a/web-studio/src/lib/studio-runtime.ts
+++ b/web-studio/src/lib/studio-runtime.ts
@@ -1,0 +1,63 @@
+import { resolvePublicAsset } from '#/lib/public-path'
+
+export type StudioRuntimeConfig = {
+  proxyMode: boolean
+  baseUrl: string
+  hasManagedAccount: boolean
+  hasManagedUser: boolean
+}
+
+const DEFAULT_CONFIG: StudioRuntimeConfig = {
+  proxyMode: false,
+  baseUrl: '',
+  hasManagedAccount: false,
+  hasManagedUser: false,
+}
+
+const RUNTIME_CONFIG_PATH = '_studio/runtime-config.json'
+
+let cached: StudioRuntimeConfig | null = null
+let pending: Promise<StudioRuntimeConfig> | null = null
+
+export function getStudioRuntime(): StudioRuntimeConfig {
+  return cached ?? DEFAULT_CONFIG
+}
+
+export async function loadStudioRuntime(): Promise<StudioRuntimeConfig> {
+  if (cached) return cached
+  if (pending) return pending
+
+  pending = fetchRuntimeConfig().then((config) => {
+    cached = config
+    pending = null
+    return config
+  })
+  return pending
+}
+
+async function fetchRuntimeConfig(): Promise<StudioRuntimeConfig> {
+  if (typeof window === 'undefined' || typeof fetch === 'undefined') {
+    return DEFAULT_CONFIG
+  }
+
+  try {
+    const response = await fetch(resolvePublicAsset(RUNTIME_CONFIG_PATH), {
+      cache: 'no-store',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+    if (!response.ok) return DEFAULT_CONFIG
+    const raw: unknown = await response.json()
+    if (!raw || typeof raw !== 'object') return DEFAULT_CONFIG
+    const data = raw as Partial<StudioRuntimeConfig>
+    return {
+      ...DEFAULT_CONFIG,
+      proxyMode: Boolean(data.proxyMode),
+      hasManagedAccount: Boolean(data.hasManagedAccount),
+      hasManagedUser: Boolean(data.hasManagedUser),
+      baseUrl: typeof data.baseUrl === 'string' ? data.baseUrl : '',
+    }
+  } catch {
+    return DEFAULT_CONFIG
+  }
+}

--- a/web-studio/src/main.tsx
+++ b/web-studio/src/main.tsx
@@ -7,6 +7,7 @@ import { routeTree } from './routeTree.gen'
 import { TooltipProvider } from './components/ui/tooltip'
 import { queryClient } from './lib/query-client'
 import { getRouterBasePath } from './lib/public-path'
+import { loadStudioRuntime } from './lib/studio-runtime'
 
 // PWA: register the service worker at the SPA's base path so the scope
 // matches the manifest's start_url / scope. Production builds only — the
@@ -34,7 +35,10 @@ declare module '@tanstack/react-router' {
 
 const rootElement = document.getElementById('app')!
 
-if (!rootElement.innerHTML) {
+function renderApp() {
+  if (rootElement.innerHTML) {
+    return
+  }
   const root = ReactDOM.createRoot(rootElement)
   root.render(
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
@@ -46,3 +50,8 @@ if (!rootElement.innerHTML) {
     </ThemeProvider>,
   )
 }
+
+// Resolve the optional auto-proxy runtime config before bootstrapping so
+// AppConnectionProvider can synchronously decide whether to suppress the
+// connection dialog and skip persisting credentials in the browser.
+void loadStudioRuntime().finally(renderApp)


### PR DESCRIPTION
## Summary

Adds an optional **auto-proxy mode** to Web Studio so a single deployment can be exposed publicly without ever shipping the OpenViking root API key to the browser.

- New zero-dep Node.js backend `web-studio/server/proxy.mjs` serves the built SPA and proxies `/api`, `/bot`, `/health`, `/ready`, `/openapi.json` to a configured upstream OV server, injecting `X-API-Key` (and optional `X-OpenViking-Account` / `X-OpenViking-User`) server-side.
- Incoming `X-API-Key`, `Authorization`, `X-OpenViking-Account`, `X-OpenViking-User` are **stripped** before forwarding — browser callers cannot override the server-managed identity.
- New `/_studio/runtime-config.json` endpoint tells the SPA it is in proxy mode. The SPA then:
  - never sends `X-API-Key` from the browser,
  - never persists credentials in `localStorage` / `sessionStorage`,
  - replaces the connection dialog form with a read-only "auto-proxy mode" notice,
  - skips the 401-triggered dialog reopen interceptor.

All upstream addressing and credentials live in env vars (`OV_STUDIO_UPSTREAM`, `OV_STUDIO_API_KEY`, ...). See `web-studio/server/README.md` for the full env reference and threat model.

### Usage

```bash
cd web-studio
npm ci
npm run build

OV_STUDIO_UPSTREAM=https://ov-api.example.com \
OV_STUDIO_API_KEY=$ROOT_API_KEY \
npm run proxy   # default port 3000
```

### Files

- `web-studio/server/proxy.mjs` — proxy server (zero deps, ~325 LOC, Node built-ins only)
- `web-studio/server/README.md` — env reference + threat model
- `web-studio/src/lib/studio-runtime.ts` — boot-time fetch of `/_studio/runtime-config.json`
- `web-studio/src/lib/ov-client/{client,types}.ts` — new `proxyMode` option that suppresses `X-API-Key` header injection
- `web-studio/src/hooks/use-app-connection.tsx` — proxy-mode aware persistence / interceptor
- `web-studio/src/components/connection-dialog.tsx` — read-only notice in proxy mode
- `web-studio/src/main.tsx` — awaits runtime config before bootstrap
- `web-studio/src/i18n/locales/{en,zh-CN}.ts` — `connection.proxyMode.*` + `common.action.close`
- `web-studio/{README,README_CN}.md` — new "Auto-Proxy Mode" deployment section

## Test plan

- [x] `npm run lint` — 0 errors (the 15 remaining warnings are all pre-existing `i18next/no-literal-string` in `routes/resources/-components/file-preview.tsx`).
- [x] `npm run build` — succeeds, bundle contains `_studio/runtime-config.json` and `proxyMode` references.
- [x] `npm run proxy` smoke test against a stub upstream:
  - `GET /_studio/runtime-config.json` → `{"proxyMode":true,...}`.
  - `GET /` → built `index.html`.
  - `GET /some/spa/route` → SPA fallback (200 with `index.html`).
  - `POST /api/v1/search/find` with attacker-supplied `X-API-Key`, `Authorization`, `X-OpenViking-Account`: client headers stripped, server injects `X-API-Key=injected-key` + `X-OpenViking-Account=acme` + `X-OpenViking-User=alice` + `X-OpenViking-Agent=web-studio-proxy`; POST body forwarded intact.
  - Upstream unreachable → `502 {"status":"error","error":{"code":"UPSTREAM_UNREACHABLE",...}}` (matches OV error envelope shape).
- [ ] Manual browser run against a real `openviking-server --with-bot` upstream (deferred — submitting as draft for design feedback first).
- [ ] Review whether `oauth-setup-dialog` UX needs a proxy-mode adjustment (currently it still renders with `connection.apiKey=""`, which falls through to the "custom apiKey" mode — out of scope for this PR but flagged).

## Design notes / open questions

1. **Where does the proxy live?** Implemented as an opt-in Node script under `web-studio/server/`, mirroring the existing nginx layout in the README — no changes to `openviking-server`. Open to moving it into a separate package (`@openviking/web-studio-proxy`) if you'd prefer it published independently.
2. **Path prefix list.** Default `OV_STUDIO_PROXY_PATHS=/api,/bot,/health,/ready,/openapi.json` matches what Web Studio actually calls. Future bot websocket support would need an `upgrade` handler — easy to add but skipped for now since `openviking-server` has no `/ws` endpoint today.
3. **WebSocket.** Not needed by web-studio right now. If/when added, the proxy needs an `upgrade` event handler.
4. **Identity scoping.** Optional `OV_STUDIO_ACCOUNT_ID` / `OV_STUDIO_USER_ID` env vars let a deployment pin to a specific account/user. Without them, the upstream applies its own default identity attached to the root key.
5. **Same-process vs. external nginx.** The README keeps the nginx pattern as the recommended path when nginx is already in place. This mode is for "single container / single process" demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)