### PR TITLE
fix(web-studio): address #2309 review feedback + edge-case polish

### DIFF
--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -33,11 +33,11 @@ type AppConnectionContextValue = {
 const CONNECTION_STORAGE_KEY = 'ov_console_connection'
 
 const DEFAULT_CONNECTION: ConnectionDraft = {
-  accountId: 'default',
+  accountId: '',
   agentId: 'web-studio',
   apiKey: '',
   baseUrl: ovClient.getOptions().baseUrl,
-  userId: 'default',
+  userId: '',
 }
 
 const AppConnectionContext =

--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -215,6 +215,7 @@ const en = {
       accountCreated: 'Account created',
       connectionSaved: 'Connection saved',
       copied: 'Copied',
+      copyFailed: 'Could not copy to clipboard: {{message}}',
       keyRegenerated: 'API key regenerated',
       userCreated: 'User created',
     },

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -215,6 +215,7 @@ const zhCN = {
       accountCreated: 'Account 已创建',
       connectionSaved: '连接已保存',
       copied: '已复制',
+      copyFailed: '复制到剪贴板失败：{{message}}',
       keyRegenerated: 'API key 已重新生成',
       userCreated: 'User 已创建',
     },

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -417,15 +417,17 @@ function AddUserDialog({
     userId: '',
   })
 
+  const prevOpenRef = React.useRef(open)
   React.useEffect(() => {
-    if (open) {
+    if (open && !prevOpenRef.current) {
       setDraft({
         accountId: defaultAccountId || DEFAULT_ACCOUNT_ID,
         role: 'user',
         userId: '',
       })
     }
-  }, [open])
+    prevOpenRef.current = open
+  }, [defaultAccountId, open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -626,6 +626,16 @@ function SettingsRoute() {
   }, [accountOptions])
 
   React.useEffect(() => {
+    if (!accountsQuery.isError) {
+      return
+    }
+    const typed = draft.accountId.trim()
+    if (typed) {
+      setManagedAccountId(typed)
+    }
+  }, [accountsQuery.isError, draft.accountId])
+
+  React.useEffect(() => {
     const users = usersQuery.data
     if (!users?.length) {
       return
@@ -695,14 +705,14 @@ function SettingsRoute() {
   const users = usersQuery.data ?? []
   const managedUsers = managedUsersQuery.data ?? []
   const totalAccounts = accountOptions.length
-  const totalUsers =
-    accountOptions.reduce((sum, account) => sum + account.userCount, 0) ||
-    managedUsers.length
+  const totalUsers = accountOptions.length
+    ? accountOptions.reduce((sum, account) => sum + account.userCount, 0)
+    : managedUsers.length
   const visibleKeys = managedUsers.filter(
     (user) => user.apiKey || user.keyPrefix,
   ).length
-  const adminUnavailable =
-    !canQueryAdmin || accountsQuery.isError || managedUsersQuery.isError
+  const isRootRestricted = accountsQuery.isError
+  const adminUnavailable = !canQueryAdmin || managedUsersQuery.isError
 
   function updateDraft(next: Partial<ConnectionDraft>): void {
     setDraft((current) => ({ ...current, ...next }))
@@ -802,20 +812,33 @@ function SettingsRoute() {
               </FieldContent>
             </Field>
             <Field>
-              <FieldLabel>{t('fields.account')}</FieldLabel>
+              <FieldLabel htmlFor="settings-account-id">
+                {t('fields.account')}
+              </FieldLabel>
               <FieldContent>
-                <AccountSelect
-                  accounts={accountOptions}
-                  disabled={!canQueryAdmin || accountsQuery.isLoading}
-                  label={t('fields.account')}
-                  value={draft.accountId || DEFAULT_ACCOUNT_ID}
-                  onChange={(accountId) =>
-                    updateDraft({
-                      accountId,
-                      userId: DEFAULT_USER_ID,
-                    })
-                  }
-                />
+                {isRootRestricted ? (
+                  <Input
+                    id="settings-account-id"
+                    value={draft.accountId}
+                    onChange={(event) =>
+                      updateDraft({ accountId: event.target.value })
+                    }
+                    placeholder={t('placeholders.account')}
+                  />
+                ) : (
+                  <AccountSelect
+                    accounts={accountOptions}
+                    disabled={!canQueryAdmin || accountsQuery.isLoading}
+                    label={t('fields.account')}
+                    value={draft.accountId || DEFAULT_ACCOUNT_ID}
+                    onChange={(accountId) =>
+                      updateDraft({
+                        accountId,
+                        userId: DEFAULT_USER_ID,
+                      })
+                    }
+                  />
+                )}
               </FieldContent>
             </Field>
             <Field>
@@ -909,13 +932,24 @@ function SettingsRoute() {
             </div>
             <div className="flex flex-wrap items-center gap-2 lg:flex-nowrap lg:justify-end">
               <div className="min-w-40">
-                <AccountSelect
-                  accounts={accountOptions}
-                  disabled={!canQueryAdmin || accountsQuery.isLoading}
-                  label={t('management.accountFilter')}
-                  value={managedAccountId}
-                  onChange={setManagedAccountId}
-                />
+                {isRootRestricted ? (
+                  <Input
+                    aria-label={t('management.accountFilter')}
+                    value={managedAccountId}
+                    onChange={(event) =>
+                      setManagedAccountId(event.target.value)
+                    }
+                    placeholder={t('placeholders.account')}
+                  />
+                ) : (
+                  <AccountSelect
+                    accounts={accountOptions}
+                    disabled={!canQueryAdmin || accountsQuery.isLoading}
+                    label={t('management.accountFilter')}
+                    value={managedAccountId}
+                    onChange={setManagedAccountId}
+                  />
+                )}
               </div>
               <Button
                 type="button"
@@ -931,7 +965,7 @@ function SettingsRoute() {
               <Button
                 type="button"
                 onClick={() => setAddAccountOpen(true)}
-                disabled={!canQueryAdmin}
+                disabled={!canQueryAdmin || isRootRestricted}
               >
                 <PlusIcon />
                 {t('actions.addAccount')}

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -167,8 +167,12 @@ function KeyResultCard({
   }
 
   async function copyKey(): Promise<void> {
-    await navigator.clipboard.writeText(result.apiKey)
-    toast.success(t('toast.copied'))
+    try {
+      await navigator.clipboard.writeText(result.apiKey)
+      toast.success(t('toast.copied'))
+    } catch (error) {
+      toast.error(t('toast.copyFailed', { message: getErrorMessage(error) }))
+    }
   }
 
   return (
@@ -325,7 +329,13 @@ function AddAccountDialog({
           className="grid gap-4"
           onSubmit={(event) => {
             event.preventDefault()
-            onCreate(draft)
+            const accountId = draft.accountId.trim()
+            const adminUserId =
+              draft.adminUserId.trim() || DEFAULT_USER_ID
+            if (!accountId) {
+              return
+            }
+            onCreate({ accountId, adminUserId })
           }}
         >
           <Field>
@@ -415,7 +425,7 @@ function AddUserDialog({
         userId: '',
       })
     }
-  }, [defaultAccountId, open])
+  }, [open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -430,7 +440,12 @@ function AddUserDialog({
           className="grid gap-4"
           onSubmit={(event) => {
             event.preventDefault()
-            onCreate(draft)
+            const accountId = draft.accountId.trim()
+            const userId = draft.userId.trim()
+            if (!accountId || !userId) {
+              return
+            }
+            onCreate({ accountId, role: draft.role, userId })
           }}
         >
           <Field>
@@ -708,8 +723,12 @@ function SettingsRoute() {
     if (!value) {
       return
     }
-    await navigator.clipboard.writeText(value)
-    toast.success(t('toast.copied'))
+    try {
+      await navigator.clipboard.writeText(value)
+      toast.success(t('toast.copied'))
+    } catch (error) {
+      toast.error(t('toast.copyFailed', { message: getErrorMessage(error) }))
+    }
   }
 
   return (
@@ -736,7 +755,7 @@ function SettingsRoute() {
                   variant="outline"
                   className="border-primary/25 bg-background/80 text-primary"
                 >
-                  {t(`serverMode.${serverMode}`)}
+                  {t(`serverMode.${serverMode}`, { defaultValue: serverMode })}
                 </Badge>
               </div>
               <CardDescription className="mt-1">


### PR DESCRIPTION
## Description

Follow-up PR for #2309. Originally just edge-case polish for the settings page; expanded to address the two blocking review comments from @qin-ctx on #2309 (auth-boundary regressions) plus the qodo bot's totalUsers bug.

## Related Issue

Follow-up to #2309. Addresses inline review comments on:
- `web-studio/src/hooks/use-app-connection.tsx#L36` — non-default keys getting `default/default` headers
- `web-studio/src/routes/settings/route.tsx#L687` — account-admin keys locked out by root-only `accountsQuery`
- `web-studio/src/routes/settings/route.tsx#R682-R684` (qodo) — `totalUsers || managedUsers.length` masks legitimate 0

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

### Blocker fixes (from @qin-ctx)

1. **Restore empty transport defaults.** `DEFAULT_CONNECTION` had `accountId: 'default'` and `userId: 'default'`, which made `ovClient` send `X-OpenViking-Account: default` / `X-OpenViking-User: default` headers on every request. Any user with a non-default API key (e.g. `acme/alice`) would get those headers overriding their key's identity and the server would reject the call before the user even chose anything. Reverted to empty strings; the settings UI still shows `default` as a display fallback via `value || DEFAULT_X`, so the visual behavior is unchanged.

2. **Decouple account-admin flow from root-only `GET /admin/accounts`.** Previously `accountsQuery.isError` fed into `adminUnavailable`, so an account-admin key (whose root-only call returns 403) saw the empty `Admin access required` state and couldn't manage users in their own account. New `isRootRestricted = accountsQuery.isError` flag splits the two cases:
   - Connection card account field and management filter both render a free-text `<Input>` (instead of a `<Select>`) when `isRootRestricted`, so the user can type their accountId.
   - "Add account" button is disabled when `isRootRestricted` (the underlying `POST /admin/accounts` is root-only). "Add user" and "Regenerate" stay enabled — they're per-account and account-admins can use them on their own account.
   - New effect syncs `managedAccountId` to whatever the user types in the connection card when `isRootRestricted`, so an account admin doesn't have to enter the same accountId twice.

3. **Fix `totalUsers` fallback.** `accountOptions.reduce(...) || managedUsers.length` would mask a legitimate sum of 0 from the reduce with the managed users count. Switched to a ternary so the fallback only kicks in when there's no visible account list at all.

### Edge-case polish (original scope)

4. **Clipboard errors no longer disappear.** `navigator.clipboard.writeText` can reject (permission denied, insecure context, locked-down browser). Both `copyKey` callers were `await`-ing the call and then immediately `toast.success`, but in the table the click handler used `() => void copyKey(user.apiKey)` which discarded the rejection — the user saw nothing. Both call sites now `try/catch` and emit `toast.error(t('toast.copyFailed', { message }))`.

5. **Trim account / user IDs before submitting the dialogs.** `AddAccountDialog` and `AddUserDialog` used to pass `draft` straight to `onCreate`, so leading/trailing whitespace would have been persisted as part of `account_id` / `user_id`.

6. **`AddUserDialog` reset effect: only fire on closed→open.** Now uses a `prevOpenRef` so a parent re-render with a new `managedAccountId` while the dialog is open no longer wipes whatever the user already typed. `defaultAccountId` stays in the deps to satisfy `react-hooks/exhaustive-deps` if/when it's ever enabled.

7. **Robust `serverMode` label.** `t(\`serverMode.${serverMode}\`)` now passes `defaultValue: serverMode` so a future mode (e.g. `oauth`) renders as the mode key instead of the raw translation path.

8. **i18n strings.** Added `settings.toast.copyFailed` for both `en` and `zh-CN` to back the new error toast.

## Testing

- [ ] Added tests (zayn confirmed UT is out of scope for this frontend-integration PR)
- [x] Existing checks pass locally
- [x] macOS

Commands run on this iMac (darwin-arm64, Node 22.22.0, pnpm 10.33.0):

- `node_modules/.bin/tsc --noEmit` — clean
- `pnpm run lint` — 0 errors, 15 warnings (the same 15 pre-existing `i18next/no-literal-string` warnings in `src/routes/resources/-components/file-preview.tsx` flagged in #2309)
- `pnpm run build` — green
- Playwright smoke at `http://localhost:3000/settings`:
  - Empty state renders cleanly; H1 `Connection & Identity`, both account/user dropdowns show `default` fallback, all stats show `-`.
  - With a fake API key (forces `accountsQuery` to 404 → `isRootRestricted=true`): Account field becomes a typeable `<Input>` with `team-account` placeholder, management filter becomes a typeable `<Input>`, "Add account" is correctly disabled, "Add user" stays enabled.

I did not run live admin mutations — these fixes are pure client-side identity routing and UI gating and don't change request shapes.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My code follows the repo convention of putting "why" in commit messages rather than inline comments
- [x] My changes generate no new warnings