### PR TITLE
docs(changelog): add v0.3.20-v0.3.23 entries (EN+ZH)

### DIFF
--- a/docs/en/about/02-changelog.md
+++ b/docs/en/about/02-changelog.md
@@ -3,6 +3,45 @@
 All notable changes to OpenViking will be documented in this file.
 This changelog is automatically generated from [GitHub Releases](https://github.com/volcengine/OpenViking/releases).
 
+## v0.3.21 (2026-05-27)
+
+### Highlights
+
+- **More retrievable trajectory memory**: The trajectory schema now has `retrieval_anchor` and an `embedding_template`, so vector indexing uses `trajectory_name + retrieval_anchor` instead of the full operation contract. Experiences and trajectories are connected with system-managed `derived_from` `StoredLink` records (forward `links` + reverse `backlinks`), replacing fragile `source_trajectories` metadata.
+- **Batch session message ingestion**: Added `POST /api/v1/sessions/{session_id}/messages/batch` and `ov session add-messages` to add multiple messages in one call (useful for history import and memory extraction); `ov add-memory` now uses the same stricter JSON message parser.
+- **OpenClaw search is now `ov_search`**: The OpenViking OpenClaw plugin no longer registers `memory_search`, avoiding collisions with OpenClaw built-ins. Use `ov_search` or `/ov-search` after importing resources or skills.
+- **Stronger URL and document parsing**: HTTP import detection now recognizes image, audio, video, Office, EPUB, and zip downloads, and re-checks headers after `GET` when `HEAD` is unreliable. Local Word/PowerPoint/Excel/EPUB/legacy-doc conversions now run in worker threads so they no longer block the event loop.
+- **Web Studio ships with Python installs**: `setup`/`build` now builds and bundles the Web Studio static assets, so `/studio` works from pip/pipx installs without Docker.
+- **NVIDIA NIM through LiteLLM VLM**: Model names containing `nvidia_nim` or `nemotron` now route through the NVIDIA NIM LiteLLM prefix and `NVIDIA_NIM_API_KEY`.
+- **tau2/VikingBot benchmark runner**: Added `benchmark/tau2/vikingbot` for cold start, train trajectory commits, repeated test averaging, and cross-epoch self-improvement; the previous tau2 LLM harness moved to `benchmark/tau2/llm`.
+
+### Upgrade Notes
+
+- OpenClaw users should migrate `/memory-search` and `memory_search` calls to `/ov-search` and `ov_search`.
+- pip/pipx and Docker builds now produce the Web Studio bundle through the Python build path; set `OV_SKIP_STUDIO_BUILD=1` to skip the Studio build during local development.
+- `content.read` adds a `raw=true` parameter; default reads still hide memory internals for compatibility.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.3.20...v0.3.21)
+
+## v0.3.20 (2026-05-25)
+
+### Highlights
+
+- **Request-scoped HTTP profiling**: Servers can enable `server.profile_enabled`; requests with `profile=1` then run `cProfile` for only that HTTP request and append `profile` lines to JSON responses. The `ov` CLI can enable and display this with `--profile`.
+- **Batch Session message ingestion**: Added `POST /api/v1/sessions/{session_id}/messages/batch` plus Python HTTP client and Session wrapper support via `batch_add_messages` (up to 100 messages per request), reducing HTTP round trips for LangChain/LangGraph-style integrations.
+- **Memory embedding templates**: Memory schemas now support a top-level `embedding_template`, replacing field-level `searchable` flags. The built-in `entities`, `events`, and `preferences` templates include key fields plus final content in embedding input.
+- **Semantic indexing reliability**: Resource processing now syncs temp source trees into the target before running the semantic DAG (diff results use target URIs); stale semantic lock handoffs can be recovered by reacquiring tree locks, and lock acquisition failures requeue work instead of tripping the API circuit breaker.
+- **Embedding input guardrails**: Embedding queue input is truncated according to `embedding.max_input_tokens`, and oversized-input errors are classified as `input_too_large` to avoid repeated retries for unrecoverable payloads.
+
+### Upgrade Notes
+
+- If a custom memory schema still uses field-level `searchable: true`, migrate it to top-level `embedding_template`; field-level `searchable` no longer contributes to embedding text generation.
+- Rename `memory.enable_role_id_memory_isolate` to `memory.role_id_memory_isolation_enabled` in custom `ov.conf` files.
+- Treat `profile=1` as a debugging tool, not a high-traffic production default. Profile output is capped at about 16 KiB.
+- The batch message endpoint accepts up to 100 messages per request.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.3.19...v0.3.20)
+
 ## v0.3.19 (2026-05-22)
 
 ### Highlights

--- a/docs/en/about/02-changelog.md
+++ b/docs/en/about/02-changelog.md
@@ -3,6 +3,42 @@
 All notable changes to OpenViking will be documented in this file.
 This changelog is automatically generated from [GitHub Releases](https://github.com/volcengine/OpenViking/releases).
 
+## v0.3.23 (2026-06-03)
+
+### Highlights
+
+- **Native `ov` CLI refresh**: `ov config` is now the interactive configuration manager for adding, editing, deleting, and switching saved configs, while `ov config show`, `ov config validate`, and `ov config switch` remain explicit subcommands. New `ov language` / `ov lang` selects the display language, `ov status [--verbose]` provides aggregated diagnostics, and `ov health` plus runtime errors render with clearer guidance.
+- **Web Studio Playground and identity management**: Studio adds a Playground with a context tree, Terminal, and Agent panel, plus a Connection & Identity page that can save connection state, select account/user/agent, create accounts and users, and copy or regenerate API keys.
+- **Config-driven VikingBot experience recall**: New `bot.ov_server.recall_exp_first_round_only`, `exp_recall_limit`, and `exp_recall_max_chars` inject agent experience only on the first turn, and both local and remote modes isolate experience namespaces by incoming `agent_id`.
+- **Simpler resource watches**: `add_resource` no longer requires an explicit `to` when `watch_interval > 0`; when the import returns a stable `root_uri`, the watch task binds to it automatically, with CLI, MCP, and docs examples updated to match.
+- **Structured plugin tool results and CJK token estimation**: Claude Code and OpenClaw plugins now write structured tool parts instead of flattening calls and results into text only, and CJK-aware token estimation is shared across Python and plugin code to reduce budget underestimation for Chinese, Japanese, and Korean sessions.
+
+### Upgrade Notes
+
+- `ov config setup-cli` has been removed; use bare `ov config` for setup. On first use the new CLI prompts for a display language in interactive shells, so non-interactive automation should run `ov language en` or `ov language zh-CN` first.
+- `ov status` now defaults to a curated diagnostic view; use `ov status --verbose` or `-o json` for raw component data.
+- `ovcli.conf` defaults to `http://127.0.0.1:1933`, and config serialization now omits default and empty fields.
+- Semantic processing concurrency now defaults to 64 instead of 100, and the documented `vlm.max_concurrent` default is corrected to 64. Local directory uploads now skip symlinks to avoid recursive, duplicate, or out-of-scope ingestion.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.3.22...v0.3.23)
+
+## v0.3.22 (2026-05-29)
+
+### Highlights
+
+- **Configurable retrieval query planner**: Added a lightweight query-planner config so the intent-analysis model used during retrieval can be selected and tuned.
+- **Legacy Memory V1 removed**: The deprecated memory v1 path was removed, and the memory `version` field now rejects `v1` payloads.
+- **LangChain reliability**: Stale OpenViking clients are now recovered automatically, and LangChain integrations can perform local batch message writes.
+- **VikingDB robustness**: Vector search now skips candidates with corrupted JSON fields, and `ap-southeast-1` region host mappings were added for VikingDB.
+- **CLI and server polish**: The `ov` CLI reports a missing CLI config before issuing server requests, server-mode terminology was clarified from `dev-implicit` to `dev`, and embedding input truncation was unified.
+
+### Upgrade Notes
+
+- Memory V1 has been removed; callers must use the current memory `version`, and `v1` payloads are now rejected.
+- Server-mode wording changed from `dev-implicit` to `dev`; update scripts or dashboards that match on the previous term.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.3.21...v0.3.22)
+
 ## v0.3.21 (2026-05-27)
 
 ### Highlights

--- a/docs/zh/about/02-changelog.md
+++ b/docs/zh/about/02-changelog.md
@@ -3,6 +3,42 @@
 OpenViking 的所有重要变更都将记录在此文件中。
 此更新日志从 [GitHub Releases](https://github.com/volcengine/OpenViking/releases) 自动生成。
 
+## v0.3.23 (2026-06-03)
+
+### 重点更新
+
+- **原生 `ov` CLI 体验重构**：`ov config` 现在是配置管理入口，可交互式添加、编辑、删除、切换配置；`ov config show`、`ov config validate`、`ov config switch` 保留为显式子命令。新增 `ov language` / `ov lang` 选择显示语言，`ov status [--verbose]` 提供聚合诊断视图，`ov health` 与错误提示改为更可读的渲染。
+- **Web Studio Playground 与身份管理**：Studio 侧边栏新增 Playground，可查看上下文树、运行 Terminal 操作并与 Agent 面板交互；Connection & Identity 页面支持保存连接、选择 account/user/agent、创建 account/user、复制或重新生成 API key。
+- **VikingBot 经验召回配置化**：新增 `bot.ov_server.recall_exp_first_round_only`、`exp_recall_limit`、`exp_recall_max_chars`，用于在单任务/评测场景中只在第一轮注入 agent experience；本地与远端模式都按传入 `agent_id` 做经验命名空间隔离。
+- **资源 Watch 更易用**：`add_resource` 设置 `watch_interval > 0` 时不再强制要求显式 `to`；如果导入结果返回稳定 `root_uri`，watch task 会自动绑定到该 URI，CLI/MCP/文档示例同步更新。
+- **插件结构化工具结果与 CJK token 估算**：Claude Code / OpenClaw 插件改为向 OpenViking 写入结构化 tool parts，工具调用与结果不再只能内联到文本；CJK-aware token 估算覆盖 Python 与插件侧，降低中文、日文、韩文会话的预算低估风险。
+
+### 升级说明
+
+- `ov config setup-cli` 已移除，请使用裸 `ov config` 进行配置。首次使用新 CLI 时，交互环境会提示选择显示语言；非交互自动化应先运行 `ov language en` 或 `ov language zh-CN`。
+- `ov status` 默认展示整理后的诊断视图；需要原始组件数据时使用 `ov status --verbose` 或 `-o json`。
+- `ovcli.conf` 默认 URL 统一为 `http://127.0.0.1:1933`，配置序列化会跳过默认值和空字段。
+- 语义处理默认并发从 100 调整为 64，文档中 `vlm.max_concurrent` 默认值同步修正为 64；本地目录上传现在会跳过 symlink。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.3.22...v0.3.23)
+
+## v0.3.22 (2026-05-29)
+
+### 重点更新
+
+- **检索 query planner 可配置**：新增轻量 query planner 配置，可选择并调整检索阶段意图分析所用的模型。
+- **移除 legacy Memory V1**：删除已废弃的 memory v1 路径，memory `version` 字段现在会拒绝 `v1` 负载。
+- **LangChain 可靠性**：自动恢复失效的 OpenViking client，并支持 LangChain 集成的本地批量消息写入。
+- **VikingDB 健壮性**：向量检索会跳过 fields 损坏的候选，并为 VikingDB 增加 `ap-southeast-1` region host 映射。
+- **CLI 与 server 打磨**：`ov` CLI 在向 server 发请求前先报告缺失的 CLI 配置，server mode 术语从 `dev-implicit` 统一为 `dev`，并统一 embedding 输入截断逻辑。
+
+### 升级说明
+
+- Memory V1 已移除；调用方需使用当前的 memory `version`，`v1` 负载会被拒绝。
+- server mode 术语由 `dev-implicit` 改为 `dev`；请更新匹配旧术语的脚本或仪表盘。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.3.21...v0.3.22)
+
 ## v0.3.21 (2026-05-27)
 
 ### 重点更新

--- a/docs/zh/about/02-changelog.md
+++ b/docs/zh/about/02-changelog.md
@@ -3,6 +3,45 @@
 OpenViking 的所有重要变更都将记录在此文件中。
 此更新日志从 [GitHub Releases](https://github.com/volcengine/OpenViking/releases) 自动生成。
 
+## v0.3.21 (2026-05-27)
+
+### 重点更新
+
+- **Trajectory 记忆更适合检索与复盘**：trajectory schema 新增 `retrieval_anchor` 和 `embedding_template`，索引文本从完整内容收敛为 `trajectory_name + retrieval_anchor`；experience 与 trajectory 之间改为系统维护的 `derived_from` `StoredLink`，写入正向 `links` 与反向 `backlinks`，替代易丢失的 `source_trajectories` 元数据。
+- **会话消息支持批量写入**：REST API 新增 `POST /api/v1/sessions/{session_id}/messages/batch`，CLI 新增 `ov session add-messages`，适合导入历史对话或一次写入多轮消息；`ov add-memory` 也复用同一套严格 JSON 消息解析。
+- **OpenClaw 搜索工具改名为 `ov_search`**：OpenViking OpenClaw 插件不再注册 `memory_search`，避免与 OpenClaw 内置工具冲突；导入 resource/skill 后统一使用 `ov_search` 和 `/ov-search`。
+- **资源解析与二进制 URL 判断增强**：HTTP accessor 扩展图片、音频、视频和 Office/EPUB/zip 文档类型识别；当 `HEAD` 不可靠时会在 `GET` 后用响应头重新判断。Word、PowerPoint、Excel、EPUB、legacy doc 等本地转换路径改为线程中执行，不再阻塞事件循环。
+- **Web Studio 随 Python 安装包分发**：`setup`/`build` 会构建并打包 Web Studio 静态资源，pip/pipx 安装后 `/studio` 可直接使用，无需 Docker。
+- **LiteLLM VLM 增加 NVIDIA NIM 路由**：模型名中包含 `nvidia_nim` 或 `nemotron` 时可自动走 NVIDIA NIM 的 LiteLLM 前缀和 `NVIDIA_NIM_API_KEY` 环境变量。
+- **tau2/VikingBot 评测升级**：新增 `benchmark/tau2/vikingbot` 端到端 runner，支持 cold start、train trajectory commit、test 多次平均和跨 epoch 自改进评测；原 tau2 LLM harness 移到 `benchmark/tau2/llm`。
+
+### 升级说明
+
+- OpenClaw 用户需要把旧的 `/memory-search` 和 `memory_search` 调用迁移到 `/ov-search` 与 `ov_search`。
+- pip/pipx 和 Docker 构建链路现在统一通过 Python build 流程产出 Web Studio bundle；本地开发若不希望构建 Studio，可使用 `OV_SKIP_STUDIO_BUILD=1` 跳过。
+- `content.read` 新增 `raw=true` 参数；默认行为仍会隐藏 memory 内部字段，兼容已有调用方。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.3.20...v0.3.21)
+
+## v0.3.20 (2026-05-25)
+
+### 重点更新
+
+- **请求级 HTTP profiling**：服务端新增 `server.profile_enabled` 开关。开启后，请求带 `profile=1` 时会对当前 HTTP 请求启用 `cProfile`，并在 JSON 响应中追加 `profile` 行数组。`ov` CLI 新增 `--profile` 入口并能保留、展示 profile 输出。
+- **批量 Session 消息写入**：新增 `POST /api/v1/sessions/{session_id}/messages/batch` 和 Python HTTP client / Session wrapper 的 `batch_add_messages`，一次请求最多写入 100 条消息，减少 LangChain/LangGraph 等集成连续写消息时的 HTTP 往返。
+- **记忆向量化输入模板**：记忆 schema 新增顶层 `embedding_template`，替代字段级 `searchable` 标记。默认的 `entities`、`events`、`preferences` 模板现在会把关键字段和正文一起用于 embedding，提高语义召回命中。
+- **语义索引与锁稳定性**：resource 处理会先把 temp source 同步到 target 后再执行语义 DAG，diff 结果使用 target URI；语义锁 handoff 失效时会尝试重新获取 tree lock，锁冲突类错误会重排队而不是误触发 API circuit breaker。
+- **Embedding 输入保护**：embedding 队列会按 `embedding.max_input_tokens` 截断输入，并把过大输入错误分类为 `input_too_large`，避免对不可恢复的大输入反复重试。
+
+### 升级说明
+
+- 自定义 memory schema 如果还在字段上使用 `searchable: true`，应迁移到顶层 `embedding_template`。字段级 `searchable` 已不再参与 embedding 文本生成。
+- 配置项 `memory.enable_role_id_memory_isolate` 已统一为 `memory.role_id_memory_isolation_enabled`，请更新自定义 `ov.conf`。
+- `profile=1` 是调试能力，不建议在高流量生产路径默认开启；返回内容最多保留约 16 KiB profile 文本。
+- 批量消息 API 单次最多接受 100 条消息。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.3.19...v0.3.20)
+
 ## v0.3.19 (2026-05-22)
 
 ### 重点更新


### PR DESCRIPTION
The canonical changelog tops out at `v0.3.19`, but four stable releases have shipped since. This adds all of them to the EN and ZH changelogs, mirroring the existing `Highlights` / `Upgrade Notes` / `Full Changelog` format, with content condensed from the official GitHub Release notes.

- **v0.3.23** (2026-06-03, current `Latest`) — native `ov` CLI refresh (`ov config` manager, `ov language`/`ov lang`, `ov status --verbose`), Web Studio Playground + Connection & Identity, config-driven VikingBot experience recall, simpler `add_resource` watches, structured plugin tool parts + CJK token estimation.
- **v0.3.22** (2026-05-29) — configurable retrieval query planner, legacy Memory V1 removal, LangChain stale-client recovery + local batch writes, VikingDB robustness (corrupted-field skip, `ap-southeast-1` hosts), CLI/server polish.
- **v0.3.21** (2026-05-27) — Memory V2 trajectory `retrieval_anchor`/`embedding_template`, `ov session add-messages` batch ingestion, OpenClaw `memory_search` → `ov_search` rename, Web Studio bundled into pip/pipx installs, NVIDIA NIM VLM routing.
- **v0.3.20** (2026-05-25) — request-scoped HTTP profiling, batch Session message API, memory `embedding_template`, semantic indexing/lock reliability, embedding input guardrails.

User-facing upgrade notes (e.g. `searchable` → `embedding_template`, `ov config setup-cli` removal, `dev-implicit` → `dev`, Memory V1 removal) are included per release. Precedent: `#2088` (`add v0.3.17 entry`) and maintainer `#2195` (`v0.3.18`/`v0.3.19`) are manually maintained changelog PRs. Pure docs.
