### PR TITLE
fix(embedder): support dimensions param for OpenAI-compatible endpoints with custom api_base

### DIFF
--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -279,7 +279,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
     def _should_send_dimensions(self) -> bool:
         # Preserve existing behavior for official OpenAI embeddings: only custom
         # OpenAI-compatible backends and Azure send explicit dimensions.
-        if self._provider == "openai":
+        if self._provider == "openai" and not self.api_base:
             return False
         return bool(self.api_base)
 

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -615,7 +615,12 @@ class EmbeddingConfig(BaseModel):
                     "api_key": cfg.api_key
                     or "no-key",  # Ollama ignores the key, but client requires non-empty
                     "api_base": cfg.api_base or "http://localhost:11434/v1",
+                    # Configured dimension is sent with the request (unlike LiteLLM's
+                    # "don't send, truncate client-side" strategy in litellm_embedders
+                    # _build_kwargs; some Ollama models don't support matryoshka
+                    # representation and may error -- handle as a separate issue).
                     "dimension": cfg.dimension,
+                    "provider": "ollama",  # fix self._provider attribution (was defaulting to "openai")
                     "configured_provider": "ollama",
                     "config": dict(runtime_config),
                 },

--- a/tests/unit/test_ollama_embedding_factory.py
+++ b/tests/unit/test_ollama_embedding_factory.py
@@ -171,3 +171,72 @@ class TestOllamaFactoryApiBase:
 
         call_kwargs = mock_openai_class.call_args[1]
         assert call_kwargs["base_url"] == "http://gpu-server:11434/v1"
+
+
+@patch("openai.OpenAI")
+class TestOllamaFactoryProviderAttribution:
+    """Provider attribution for the ollama factory.
+
+    Regression for PR #2317: the ollama factory branch omitted the ``provider``
+    kwarg, so ``OpenAIDenseEmbedder`` defaulted ``self._provider`` to ``"openai"``
+    while ``self.provider`` was correctly ``"ollama"``. This mislabeled embedding
+    token-usage attribution (metrics recorded under ``provider="openai"``).
+    """
+
+    def test_provider_attribution_is_ollama(self, mock_openai_class):
+        """A (regression catcher, fails before fix): _provider and provider must be 'ollama'."""
+        mock_client = MagicMock()
+        mock_client.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.1] * 8)], usage=None
+        )
+        mock_openai_class.return_value = mock_client
+
+        cfg = _make_ollama_cfg()
+        embedder = EmbeddingConfig(dense=cfg)._create_embedder("ollama", "dense", cfg)
+
+        # Note: this asserts OpenAIDenseEmbedder._provider (factory-layer kwarg),
+        # distinct from EmbeddingModelConfig.provider (model-layer field).
+        assert embedder._provider == "ollama"  # was "openai" before fix
+        assert embedder.provider == "ollama"
+
+    def test_dimensions_sent_in_request(self, mock_openai_class):
+        """B (behavior contract, always true, NOT a regression catcher):
+        ollama sends the ``dimensions`` param when dimension is configured."""
+        mock_client = MagicMock()
+        mock_client.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.1] * 768)], usage=None
+        )
+        mock_openai_class.return_value = mock_client
+
+        cfg = _make_ollama_cfg(dimension=768)
+        embedder = EmbeddingConfig(dense=cfg)._create_embedder("ollama", "dense", cfg)
+        embedder.embed("hello")
+
+        call_kwargs = mock_client.embeddings.create.call_args[1]
+        assert call_kwargs["dimensions"] == 768
+
+    def test_token_usage_attribution_is_ollama(self, mock_openai_class):
+        """C (regression catcher, fails before fix): update_token_usage receives provider='ollama'.
+
+        The mock response MUST carry ``usage`` (dict branch). Do NOT reuse
+        ``_make_mock_openai_class`` -- its ``usage=None`` makes
+        ``_update_telemetry_token_usage`` return early at
+        ``openai_embedders.py`` ``if not usage: return``, so ``update_token_usage``
+        is never invoked and the spy assertion would spuriously fail. A bare
+        MagicMock usage would hit ``int(MagicMock)`` -> TypeError, hence the dict.
+        """
+        mock_client = MagicMock()
+        mock_client.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.1] * 8)],
+            usage={"prompt_tokens": 7, "total_tokens": 9},
+        )
+        mock_openai_class.return_value = mock_client
+
+        cfg = _make_ollama_cfg(dimension=768)
+        embedder = EmbeddingConfig(dense=cfg)._create_embedder("ollama", "dense", cfg)
+
+        with patch.object(embedder, "update_token_usage") as spy:
+            embedder.embed("hello")
+
+        spy.assert_called_once()
+        assert spy.call_args.kwargs["provider"] == "ollama"  # was "openai" before fix


### PR DESCRIPTION
## Summary

Fixes the `OpenAIDenseEmbedder._should_send_dimensions()` method so that the `dimensions` parameter is sent to OpenAI-compatible endpoints when a custom `api_base` is configured.

## Problem

When using a custom OpenAI-compatible embedding provider (e.g. xf-yun, SiliconFlow, etc.) with `provider: "openai"` in the config, the `_should_send_dimensions()` method always returned `False` due to this condition:

```python
if self._provider == "openai":
    return False
```

This prevented the `dimensions` parameter from being sent to the API, causing the API to return its default dimension instead of the configured `dimension` value (e.g. 768 instead of 4096).

## Solution

Added a check for `api_base` to preserve official OpenAI behavior while enabling custom endpoints:

```python
if self._provider == "openai" and not self.api_base:
    return False
```

Dimensions are now sent when:
- Provider is NOT `"openai"`, OR
- Provider is `"openai"` AND a custom `api_base` is configured

Official OpenAI API behavior (no dimensions, fixed output) is preserved because it uses `provider="openai"` with no custom `api_base`.

## Test case

- Provider: xf-yun MaaS (`provider: "openai"`, `api_base: "https://maas-api.cn-huabei-1.xf-yun.com/v2"`)
- Model: `xop3qwen8bembedding`
- Configured dimension: 4096
- Before fix: API returned 768 (default) → `DimensionMismatchError`
- After fix: API correctly returns 4096

## Checklist

- [x] Code follows project style
- [x] Changes are minimal (1-line fix)
- [ ] Tests added/updated (embedder tests may need updating)
- [x] Documentation updated if applicable