### PR TITLE
docs(telemetry): document summary.tokens.llm.prompt_cached and completion_reasoning (#2305)

### DIFF
--- a/docs/en/guides/07-operation-telemetry.md
+++ b/docs/en/guides/07-operation-telemetry.md
@@ -31,7 +31,9 @@ Typical response shape:
         "llm": {
           "input": 12,
           "output": 6,
-          "total": 18
+          "total": 18,
+          "prompt_cached": 8,
+          "completion_reasoning": 4
         }
       },
       "vector": {
@@ -163,6 +165,8 @@ Only fields that are actually produced by an operation are returned. Missing gro
 | `summary.tokens.llm.input` | Total LLM input tokens |
 | `summary.tokens.llm.output` | Total LLM output tokens |
 | `summary.tokens.llm.total` | Total LLM tokens |
+| `summary.tokens.llm.prompt_cached` | Cached prompt tokens reported by the provider |
+| `summary.tokens.llm.completion_reasoning` | Reasoning tokens in the completion reported by the provider |
 | `summary.tokens.embedding.total` | Total embedding-model tokens |
 
 ### `summary.vector`

--- a/docs/zh/guides/07-operation-telemetry.md
+++ b/docs/zh/guides/07-operation-telemetry.md
@@ -31,7 +31,9 @@ Telemetry 是按需返回的。只有你显式请求时，OpenViking 才会在�
         "llm": {
           "input": 12,
           "output": 6,
-          "total": 18
+          "total": 18,
+          "prompt_cached": 8,
+          "completion_reasoning": 4
         }
       },
       "vector": {
@@ -163,6 +165,8 @@ summary 顶层这 3 个基础字段总会存在：
 | `summary.tokens.llm.input` | LLM 输入 token 总量 |
 | `summary.tokens.llm.output` | LLM 输出 token 总量 |
 | `summary.tokens.llm.total` | LLM token 总量 |
+| `summary.tokens.llm.prompt_cached` | 服务方返回的命中缓存的 prompt token 数 |
+| `summary.tokens.llm.completion_reasoning` | 服务方返回的 completion 中的推理 token 数 |
 | `summary.tokens.embedding.total` | embedding 模型 token 总量 |
 
 ### `summary.vector`


### PR DESCRIPTION
## What

`#2305` started serializing two new LLM token counters in the operation-telemetry `summary`, but the telemetry guide still lists only `input` / `output` / `total`. This adds the two missing fields to the EN + ZH guides so developers can discover them.

## Drift

In `openviking/telemetry/operation.py`, `OperationTelemetry.build()` now emits:

```python
"llm": {
    "input": llm_input_tokens,
    "output": llm_output_tokens,
    "total": llm_total_tokens,
    "prompt_cached": llm_prompt_cached_tokens,            # tokens.llm.prompt_cached
    "completion_reasoning": llm_completion_reasoning_tokens,  # tokens.llm.completion_reasoning
},
```

These are sourced from provider usage details (`add_token_usage_by_source(..., prompt_cached_tokens, completion_reasoning_tokens)`, recorded only when `source == "llm"`; see `models/vlm/base.py` docstring: *"Number of cached prompt tokens / reasoning completion tokens from provider usage details"*). But `docs/{en,zh}/guides/07-operation-telemetry.md` documented neither field, so anyone reading the telemetry summary to attribute LLM cost (cache savings / reasoning-token spend) couldn't find them.

## Change (docs only, EN + ZH mirror)

- Add `summary.tokens.llm.prompt_cached` and `summary.tokens.llm.completion_reasoning` rows to the `summary.tokens` field table in both guides.
- Add the two keys to the JSON example's `llm` block.
- Example values are **non-zero** (`prompt_cached: 8`, `completion_reasoning: 4`) on purpose — the guide states "numeric `0` values are omitted from the response", so a `0`-valued example would contradict that contract.

No code or behavior change.
