### PR TITLE
[security] fix(mcp): harden signed upload URL authority

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import ipaddress
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -378,27 +379,75 @@ async def remember(messages: list[StoreMessage]) -> str:
 _DEFAULT_UPLOAD_TTL_SECONDS = 600
 
 
+def _first_header_value(value: Optional[str]) -> Optional[str]:
+    """Return the first value from a potentially comma-separated HTTP header."""
+    if not value:
+        return None
+    head = value.split(",", 1)[0].strip()
+    return head or None
+
+
+def _is_loopback_authority(authority: str) -> bool:
+    """Return True for syntactically safe localhost/loopback Host authorities.
+
+    ``authority`` may include a numeric port (``localhost:1933``) or a bracketed
+    IPv6 literal (``[::1]:1933``). Non-loopback request authorities are not
+    trusted for signed upload URLs because they can be supplied by the client.
+    """
+    host = authority.strip()
+    if not host:
+        return False
+    # Reject characters that can change URL authority interpretation when the
+    # value is interpolated into ``http://{host}`` (userinfo, paths, fragments,
+    # queries, whitespace/control chars, or scheme-relative forms).
+    if any(ch in host for ch in "@/?#\\") or any(ch.isspace() for ch in host):
+        return False
+
+    if host.startswith("["):
+        end = host.find("]")
+        if end == -1:
+            return False
+        addr = host[1:end]
+        rest = host[end + 1 :]
+        if rest:
+            if not rest.startswith(":") or not rest[1:].isdigit():
+                return False
+        host = addr
+    elif ":" in host:
+        # Host headers with a single colon are host:port. Multiple colons without
+        # brackets are IPv6 literals; leave them intact for ipaddress parsing.
+        if host.count(":") == 1:
+            name, port = host.rsplit(":", 1)
+            if not port.isdigit():
+                return False
+            host = name
+
+    host = host.rstrip(".").lower()
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def _resolve_public_base_url() -> tuple[str, str]:
     """Pick the URL the agent should POST uploads to. Returns ``(base_url, source)``.
 
     Resolution order (first match wins):
-
     1. ``env`` — ``OPENVIKING_PUBLIC_BASE_URL`` environment variable. Operator-set,
        always wins.
     2. ``config`` — ``ServerConfig.public_base_url``. Operator-set baseline in ov.conf.
-    3. ``forwarded`` — ``X-Forwarded-Host`` (+ ``X-Forwarded-Proto``) from the request.
-       Set by reverse proxies (nginx, ALB, ingress controllers, MCP proxies). Reliable
-       when the proxy chain forwards these headers, which is the standard default.
-    4. ``host`` — the raw ``Host`` header from a direct connection. Reliable for
-       same-host MCP clients (e.g. local Claude Code talking to localhost server).
-    5. ``listen`` — ``http://{listen_host}:{listen_port}`` last-resort fallback.
-       Only produces an agent-reachable URL when the server is bound to a routable
-       address; commonly wrong behind reverse proxies.
+    3. ``host`` — a raw ``Host`` header only when it names localhost/loopback.
+       This preserves direct local MCP clients without letting arbitrary request
+       authorities control signed upload destinations.
+    4. ``listen`` — ``http://{listen_host}:{listen_port}`` last-resort fallback.
+       Reverse-proxy deployments that need an external upload URL should set
+       ``OPENVIKING_PUBLIC_BASE_URL`` or ``server.public_base_url`` explicitly.
 
-    Sources 1 and 2 are "explicit" — operator vouched for the URL. Sources 3-5 are
-    inferred and may be wrong when the proxy chain doesn't forward request headers.
-    Callers should append a "set OPENVIKING_PUBLIC_BASE_URL if upload fails" hint
-    in that case.
+    Sources 1 and 2 are "explicit" — operator vouched for the URL. Sources 3-4 are
+    inferred and may be wrong behind reverse proxies. Callers should append a
+    "set OPENVIKING_PUBLIC_BASE_URL if upload fails" hint in that case.
     """
     env_url = os.environ.get("OPENVIKING_PUBLIC_BASE_URL")
     if env_url:
@@ -409,22 +458,12 @@ def _resolve_public_base_url() -> tuple[str, str]:
 
     url_info = _request_url_ctx.get()
     if url_info:
-        # X-Forwarded-Host / -Proto can be comma-separated lists when the request
-        # crosses multiple proxy hops. Take the first (left-most original-client)
-        # value, matching the normalization in openviking.server.oauth.router.
-        def _first(value: Optional[str]) -> Optional[str]:
-            if not value:
-                return None
-            head = value.split(",", 1)[0].strip()
-            return head or None
-
-        xfh = _first(url_info.get("x_forwarded_host"))
-        xfp = _first(url_info.get("x_forwarded_proto"))
-        host_hdr = _first(url_info.get("host"))
-        if xfh:
-            proto = xfp or "https"
-            return f"{proto}://{xfh}", "forwarded"
-        if host_hdr:
+        # Do not infer signed upload destinations from X-Forwarded-* by default:
+        # untrusted clients can often supply these headers unless a deployment
+        # explicitly normalizes them. Operators behind proxies should configure a
+        # public base URL instead.
+        host_hdr = _first_header_value(url_info.get("host"))
+        if host_hdr and _is_loopback_authority(host_hdr):
             return f"http://{host_hdr}", "host"
 
     if config is not None:

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -361,7 +361,7 @@ async def test_add_resource_local_path_uses_config_when_env_unset(service, monke
     upload_token_store.clear()
 
 
-async def test_add_resource_local_path_infers_from_x_forwarded_headers(service, monkeypatch):
+async def test_add_resource_local_path_ignores_untrusted_forwarded_headers(service, monkeypatch):
     from openviking.server.mcp_endpoint import _request_url_ctx
     from openviking.server.upload_token_store import upload_token_store
 
@@ -371,7 +371,7 @@ async def test_add_resource_local_path_infers_from_x_forwarded_headers(service, 
     token = _request_url_ctx.set(
         {
             "x_forwarded_proto": "https",
-            "x_forwarded_host": "ov.public.example.com",
+            "x_forwarded_host": "attacker.example.com",
             "host": "internal:1933",
         }
     )
@@ -380,8 +380,59 @@ async def test_add_resource_local_path_infers_from_x_forwarded_headers(service, 
     finally:
         _request_url_ctx.reset(token)
 
-    assert "https://ov.public.example.com/api/v1/resources/temp_upload_signed" in result
+    assert "attacker.example.com" not in result
+    assert "http://127.0.0.1:1933/api/v1/resources/temp_upload_signed" in result
     # Inferred → hint must appear
+    assert "OPENVIKING_PUBLIC_BASE_URL" in result
+    upload_token_store.clear()
+
+
+async def test_add_resource_local_path_ignores_untrusted_host_header(service, monkeypatch):
+    from openviking.server.mcp_endpoint import _request_url_ctx
+    from openviking.server.upload_token_store import upload_token_store
+
+    upload_token_store.clear()
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": None,
+            "x_forwarded_host": None,
+            "host": "attacker.example.com",
+        }
+    )
+    try:
+        result = await add_resource(path="/tmp/x.pdf")
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert "attacker.example.com" not in result
+    assert "http://127.0.0.1:1933/api/v1/resources/temp_upload_signed" in result
+    assert "OPENVIKING_PUBLIC_BASE_URL" in result
+    upload_token_store.clear()
+
+
+async def test_add_resource_local_path_allows_loopback_host_for_local_clients(service, monkeypatch):
+    from openviking.server.mcp_endpoint import _request_url_ctx
+    from openviking.server.upload_token_store import upload_token_store
+
+    upload_token_store.clear()
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": "https",
+            "x_forwarded_host": "attacker.example.com",
+            "host": "localhost:1933",
+        }
+    )
+    try:
+        result = await add_resource(path="/tmp/x.pdf")
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert "attacker.example.com" not in result
+    assert "http://localhost:1933/api/v1/resources/temp_upload_signed" in result
     assert "OPENVIKING_PUBLIC_BASE_URL" in result
     upload_token_store.clear()
 

--- a/tests/unit/test_mcp_public_base_url_trust.py
+++ b/tests/unit/test_mcp_public_base_url_trust.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for MCP upload URL host trust."""
+
+from __future__ import annotations
+
+from openviking.server import dependencies
+from openviking.server.config import ServerConfig
+from openviking.server.mcp_endpoint import (
+    _is_loopback_authority,
+    _request_url_ctx,
+    _resolve_public_base_url,
+)
+
+
+def _set_config(monkeypatch, **kwargs) -> ServerConfig:
+    config = ServerConfig(**kwargs)
+    monkeypatch.setattr(dependencies, "_server_config", config)
+    return config
+
+
+def test_mcp_upload_url_does_not_trust_forwarded_host_without_public_base_url(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, host="127.0.0.1", port=1933, public_base_url=None)
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": "https",
+            "x_forwarded_host": "attacker.example",
+            "host": "openviking.example",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "http://127.0.0.1:1933"
+    assert source == "listen"
+
+
+def test_mcp_upload_url_does_not_trust_external_host_header_without_public_base_url(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, host="0.0.0.0", port=1933, public_base_url=None)
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": None,
+            "x_forwarded_host": None,
+            "host": "attacker.example",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "http://0.0.0.0:1933"
+    assert source == "listen"
+
+
+def test_mcp_upload_url_keeps_explicit_public_base_url_authoritative(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, public_base_url="https://openviking.example")
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": "https",
+            "x_forwarded_host": "attacker.example",
+            "host": "attacker.example",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "https://openviking.example"
+    assert source == "config"
+
+
+def test_mcp_upload_url_allows_loopback_host_for_local_clients(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, host="127.0.0.1", port=1933, public_base_url=None)
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": None,
+            "x_forwarded_host": None,
+            "host": "localhost:1933",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "http://localhost:1933"
+    assert source == "host"
+
+
+def test_loopback_authority_rejects_url_authority_confusion():
+    assert _is_loopback_authority("localhost:1933")
+    assert _is_loopback_authority("127.0.0.1:1933")
+    assert _is_loopback_authority("[::1]:1933")
+    assert not _is_loopback_authority("localhost:1933@attacker.example")
+    assert not _is_loopback_authority("localhost/path")
+    assert not _is_loopback_authority("localhost?next=attacker")
+    assert not _is_loopback_authority("localhost#attacker")
+    assert not _is_loopback_authority("localhost:not-a-port")
+    assert not _is_loopback_authority("[::1]extra")


### PR DESCRIPTION
## Summary
This PR hardens the MCP signed-upload URL authority boundary so upload instructions are not derived from attacker-controlled request authority headers.

- Stops `X-Forwarded-Host` / `X-Forwarded-Proto` from controlling the returned signed upload URL unless an operator explicitly configures a trusted public base URL.
- Preserves local MCP compatibility by allowing only syntactically safe loopback `Host` authorities such as `localhost:1933`, `127.0.0.1:1933`, and `[::1]:1933`.
- Adds regression coverage for malicious forwarded hosts, malicious raw hosts, configured `public_base_url` precedence, and authority-confusion inputs such as `localhost:1933@attacker.example`.
- This is related to the existing MCP upload/public-base-url feature work, but it fixes the trust boundary for request-derived URL authority rather than the upload flow itself.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| MCP signed upload URL authority poisoning | A request-controlled authority could be reflected into signed upload instructions, potentially sending clients and short-lived upload tokens to an attacker-controlled origin in exposed/proxied deployments. | High, deployment-dependent |

## Before this PR
- `_resolve_public_base_url()` could derive signed upload URLs from request headers.
- `X-Forwarded-Host` / `X-Forwarded-Proto` were trusted as URL authority inputs even though they can be supplied by clients unless sanitized by a trusted proxy.
- Raw `Host` fallback was needed for localhost clients, but it needed a strict authority parser before interpolation into `http://{host}`.
- Tests covered upload behavior, but not the signed URL trust boundary for hostile forwarded or malformed authorities.

## After this PR
- Operator-configured `OPENVIKING_PUBLIC_BASE_URL` / `server.public_base_url` remains the authoritative way to publish a non-local MCP upload origin.
- `X-Forwarded-Host` / `X-Forwarded-Proto` no longer control signed upload URLs by default.
- Raw request `Host` is accepted only for loopback/local authorities with safe syntax.
- Userinfo, path, query, fragment, backslash, whitespace, non-numeric ports, and malformed bracketed IPv6 suffixes are rejected before a request-derived authority is used.
- Regression tests now lock the safe fallback and hostile-header behavior in place.

## Explicit operator choice
- Secure default: when no public base URL is configured, non-loopback request authorities are ignored and OpenViking falls back to its configured server host/port.
- Trusted public deployment: operators can set `OPENVIKING_PUBLIC_BASE_URL` or `server.public_base_url` to the externally reachable base URL.
- Local clients: localhost/loopback `Host` values remain supported so local MCP clients can receive usable upload URLs without extra configuration.

## Why this matters
MCP `add_resource()` can return upload instructions containing a signed temporary upload URL. If that URL authority is chosen from untrusted request headers, an attacker who can influence those headers in a proxied or exposed deployment can cause clients to receive attacker-origin upload URLs. That can leak signed upload tokens and divert client uploads away from the intended OpenViking server.

## How this differs from related issue/PR
- #1847 introduced the progressive MCP upload flow; this PR hardens how that flow chooses the URL authority returned to clients.
- #2153 documented `public_base_url` / upload TTL behavior; this PR enforces that public origins come from explicit operator configuration rather than request-supplied forwarding headers.
- Duplicate checks for `public_base_url`, `X-Forwarded-Host`, and `Host poisoning` did not find an existing open PR fixing this request-authority trust boundary.

## Attack flow
```text
attacker-controlled or unsanitized request authority header
    -> MCP add_resource upload-instruction path
        -> signed upload URL generated from request-derived authority
            -> client receives attacker-origin upload URL
                -> short-lived upload token and upload traffic can be redirected
```

## Affected code

| Issue | Files |
|-------|-------|
| MCP signed upload URL authority poisoning | `openviking/server/mcp_endpoint.py`, `tests/server/test_mcp_endpoint.py`, `tests/unit/test_mcp_public_base_url_trust.py` |

## Root cause
MCP signed upload URL authority poisoning:
- The signed upload URL helper mixed operator configuration with request-derived authority headers.
- Forwarded authority headers are only trustworthy behind a correctly configured trusted proxy, but the MCP endpoint treated them as safe defaults.
- The localhost compatibility fallback needed stricter syntax validation before embedding the authority into a URL.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| MCP signed upload URL authority poisoning | 7.3 High, deployment-dependent | `CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N` |

Rationale:
- The issue requires a reachable MCP path and a deployment where request authority headers can influence the server-side request context.
- User interaction is modeled because a client must follow the returned upload instruction.
- Impact is primarily token/URL confidentiality and upload integrity for the affected signed upload operation; availability is not the focus of this patch.

## Safe reproduction steps
### 1. Forwarded authority poisoning
1. Configure OpenViking without `OPENVIKING_PUBLIC_BASE_URL` / `server.public_base_url`.
2. Call the MCP upload instruction path with a hostile `X-Forwarded-Host` such as `attacker.example`.
3. On vulnerable code, observe that the returned signed upload URL can use the attacker-controlled authority.

### 2. Raw Host authority confusion
1. Configure OpenViking without a public base URL.
2. Provide a raw `Host` value such as `localhost:1933@attacker.example` or `localhost/path`.
3. On vulnerable/insufficiently guarded code, these values risk being misinterpreted if inserted directly into `http://{host}`.

## Expected vulnerable behavior
- Signed upload instructions can be constructed with a request-controlled authority.
- Short-lived upload tokens can appear in URLs whose host is not the intended OpenViking server.
- Localhost compatibility can become unsafe if the raw authority is accepted without rejecting URL authority-confusion syntax.

## Changes in this PR
- Adds a request-context helper for the MCP endpoint's URL-resolution path.
- Gives explicit public base URL configuration precedence over request headers.
- Removes default trust in `X-Forwarded-Host` / `X-Forwarded-Proto` for signed upload URL authority generation.
- Adds strict loopback authority parsing for the raw `Host` fallback.
- Adds regression tests for configured public base URLs, malicious forwarded hosts, malicious raw hosts, loopback compatibility, and authority-confusion rejection.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| MCP endpoint hardening | `openviking/server/mcp_endpoint.py` | Hardened signed upload base URL resolution and loopback authority validation. |
| Server regression tests | `tests/server/test_mcp_endpoint.py` | Added endpoint-level coverage for upload URL authority behavior. |
| Unit regression tests | `tests/unit/test_mcp_public_base_url_trust.py` | Added focused tests for public base URL precedence, hostile headers, loopback fallback, and malformed authorities. |

## Maintainer impact
- The patch is scoped to MCP signed upload URL generation and its tests.
- Existing local MCP clients using loopback hosts continue to receive usable upload URLs.
- Public/reverse-proxy deployments should use the already-supported explicit public base URL setting rather than relying on request-forwarded authority headers.
- No unrelated storage, CLI, bot, or documentation behavior is changed.

## Fix rationale
- Signed upload URL authority is a trust boundary and should come from explicit operator configuration, not ambient request headers.
- The loopback exception keeps developer/local-client usability while avoiding broad trust in arbitrary `Host` values.
- Rejecting authority-confusion syntax before interpolation makes the fallback durable against URL parsing edge cases.
- The new tests cover both the expected compatibility path and the hostile inputs that previously lacked direct coverage.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] Focused public-base-url trust unit tests passed.
- [x] Ruff check passed on touched files.
- [ ] Full server MCP test file not run successfully in this local environment because the native `ragfs_python` binding is unavailable.

Executed with:
- `PYTHONPATH=. /Users/$USER/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/unit/test_mcp_public_base_url_trust.py -q`
- `/Users/$USER/.hermes/hermes-agent/venv/bin/python -m ruff check openviking/server/mcp_endpoint.py tests/server/test_mcp_endpoint.py tests/unit/test_mcp_public_base_url_trust.py`

Local result:
- `tests/unit/test_mcp_public_base_url_trust.py`: `5 passed`
- `ruff check`: `All checks passed!`

Not run successfully:
- `tests/server/test_mcp_endpoint.py` could not run locally because importing the server fixture path failed with `ImportError: ragfs_python native library is not available: Rust binding not available`.

## Disclosure notes
- This PR is bounded to signed upload URL authority derivation in the MCP upload flow.
- It does not claim unauthenticated reachability by itself; impact depends on how the MCP endpoint is exposed and whether request authority headers can be influenced before they reach OpenViking.
- No production systems were tested.
- No unrelated files were changed.
