### PR TITLE
fix(build): bundle Studio assets in release wheels

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -152,6 +152,7 @@ jobs:
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
         echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"
+        echo "OV_REQUIRE_STUDIO_BUILD=1" >> "$GITHUB_ENV"
         clang --version
         clang++ --version
 
@@ -164,6 +165,13 @@ jobs:
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         git fetch --force --tags
+
+    - name: Set up Node.js for Studio build (Linux)
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: npm
+        cache-dependency-path: web-studio/package-lock.json
 
     - name: Build CPython (Dynamic Selection)
       run: |
@@ -297,6 +305,7 @@ jobs:
         cd "$RUNNER_TEMP"
         "$PYTHON_BIN" - <<'PY'
         import importlib.util
+        from importlib.resources import files
 
         from openviking.pyagfs import get_binding_client
         import openviking.storage.vectordb.engine as engine
@@ -314,8 +323,13 @@ jobs:
         if backend_spec is None or backend_spec.origin is None:
             raise SystemExit(f"backend module {module_name} was not installed")
 
+        studio_index = files("openviking").joinpath("web_studio/dist/index.html")
+        if not studio_index.is_file():
+            raise SystemExit("Web Studio index.html was not installed")
+
         print(f"Imported backend module {module_name}")
         print(f"Backend module origin {backend_spec.origin}")
+        print(f"Bundled Web Studio index {studio_index}")
         PY
 
     - name: Store the distribution packages
@@ -385,6 +399,12 @@ jobs:
       uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: stable
+    - name: Set up Node.js for Studio build
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: npm
+        cache-dependency-path: web-studio/package-lock.json
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -408,7 +428,9 @@ jobs:
 
     - name: Require ragfs native artifact for wheel builds
       shell: bash
-      run: echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"
+      run: |
+        echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"
+        echo "OV_REQUIRE_STUDIO_BUILD=1" >> "$GITHUB_ENV"
 
     - name: Resolve OpenViking version for Rust CLI (macOS/Windows)
       shell: bash
@@ -479,6 +501,7 @@ jobs:
         cd "$RUNNER_TEMP"
         python - <<'PY'
         import importlib.util
+        from importlib.resources import files
 
         from openviking.pyagfs import get_binding_client
         import openviking.storage.vectordb.engine as engine
@@ -496,8 +519,13 @@ jobs:
         if backend_spec is None or backend_spec.origin is None:
             raise SystemExit(f"backend module {module_name} was not installed")
 
+        studio_index = files("openviking").joinpath("web_studio/dist/index.html")
+        if not studio_index.is_file():
+            raise SystemExit("Web Studio index.html was not installed")
+
         print(f"Imported backend module {module_name}")
         print(f"Backend module origin {backend_spec.origin}")
+        print(f"Bundled Web Studio index {studio_index}")
         PY
 
     - name: Smoke test built wheel (Windows)
@@ -510,6 +538,7 @@ jobs:
         cd "$RUNNER_TEMP"
         python - <<'PY'
         import importlib.util
+        from importlib.resources import files
 
         import openviking.storage.vectordb.engine as engine
 
@@ -521,8 +550,13 @@ jobs:
         if backend_spec is None or backend_spec.origin is None:
             raise SystemExit(f"backend module {module_name} was not installed")
 
+        studio_index = files("openviking").joinpath("web_studio/dist/index.html")
+        if not studio_index.is_file():
+            raise SystemExit("Web Studio index.html was not installed")
+
         print(f"Imported backend module {module_name}")
         print(f"Backend module origin {backend_spec.origin}")
+        print(f"Bundled Web Studio index {studio_index}")
         PY
 
     - name: Store the distribution packages

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -152,7 +152,6 @@ jobs:
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
         echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"
-        echo "OV_REQUIRE_STUDIO_BUILD=1" >> "$GITHUB_ENV"
         clang --version
         clang++ --version
 
@@ -428,9 +427,7 @@ jobs:
 
     - name: Require ragfs native artifact for wheel builds
       shell: bash
-      run: |
-        echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"
-        echo "OV_REQUIRE_STUDIO_BUILD=1" >> "$GITHUB_ENV"
+      run: echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"
 
     - name: Resolve OpenViking version for Rust CLI (macOS/Windows)
       shell: bash

--- a/setup.py
+++ b/setup.py
@@ -464,10 +464,18 @@ def _build_web_studio():
     """Build the web-studio SPA and copy dist into the Python package tree.
 
     Skipped when OV_SKIP_STUDIO_BUILD=1 or when the bundle already exists.
-    Falls back gracefully (warning, not error) when npm is unavailable.
+    Falls back gracefully (warning, not error) when npm is unavailable unless
+    OV_REQUIRE_STUDIO_BUILD=1 is set by release packaging.
     """
+    require_studio = os.environ.get("OV_REQUIRE_STUDIO_BUILD") == "1"
+
+    def _unavailable(message):
+        if require_studio:
+            raise RuntimeError(message)
+        print(message)
+
     if os.environ.get("OV_SKIP_STUDIO_BUILD") == "1":
-        print("  [SKIP] web-studio build disabled by OV_SKIP_STUDIO_BUILD=1")
+        _unavailable("  [SKIP] web-studio build disabled by OV_SKIP_STUDIO_BUILD=1")
         return
 
     dest = SETUP_DIR / "openviking" / "web_studio" / "dist"
@@ -477,12 +485,12 @@ def _build_web_studio():
 
     source = SETUP_DIR / "web-studio"
     if not (source / "package.json").is_file():
-        print("  [SKIP] web-studio source not found; /studio will be unavailable")
+        _unavailable("  [SKIP] web-studio source not found; /studio will be unavailable")
         return
 
     npm = shutil.which("npm")
     if not npm:
-        print("  [SKIP] npm not found; install Node.js to enable /studio")
+        _unavailable("  [SKIP] npm not found; install Node.js to enable /studio")
         return
 
     print("Building web-studio (Vite SPA)...")
@@ -493,12 +501,16 @@ def _build_web_studio():
             cwd=str(source),
         )
     except subprocess.CalledProcessError as exc:
-        print(f"  [WARNING] web-studio npm build failed ({exc}); /studio will be unavailable")
+        _unavailable(
+            f"  [WARNING] web-studio npm build failed ({exc}); /studio will be unavailable"
+        )
         return
 
     built = source / "dist"
     if not (built / "index.html").is_file():
-        print("  [WARNING] web-studio build produced no index.html; /studio will be unavailable")
+        _unavailable(
+            "  [WARNING] web-studio build produced no index.html; /studio will be unavailable"
+        )
         return
 
     dest.parent.mkdir(parents=True, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -464,18 +464,10 @@ def _build_web_studio():
     """Build the web-studio SPA and copy dist into the Python package tree.
 
     Skipped when OV_SKIP_STUDIO_BUILD=1 or when the bundle already exists.
-    Falls back gracefully (warning, not error) when npm is unavailable unless
-    OV_REQUIRE_STUDIO_BUILD=1 is set by release packaging.
+    Falls back gracefully (warning, not error) when npm is unavailable.
     """
-    require_studio = os.environ.get("OV_REQUIRE_STUDIO_BUILD") == "1"
-
-    def _unavailable(message):
-        if require_studio:
-            raise RuntimeError(message)
-        print(message)
-
     if os.environ.get("OV_SKIP_STUDIO_BUILD") == "1":
-        _unavailable("  [SKIP] web-studio build disabled by OV_SKIP_STUDIO_BUILD=1")
+        print("  [SKIP] web-studio build disabled by OV_SKIP_STUDIO_BUILD=1")
         return
 
     dest = SETUP_DIR / "openviking" / "web_studio" / "dist"
@@ -485,12 +477,12 @@ def _build_web_studio():
 
     source = SETUP_DIR / "web-studio"
     if not (source / "package.json").is_file():
-        _unavailable("  [SKIP] web-studio source not found; /studio will be unavailable")
+        print("  [SKIP] web-studio source not found; /studio will be unavailable")
         return
 
     npm = shutil.which("npm")
     if not npm:
-        _unavailable("  [SKIP] npm not found; install Node.js to enable /studio")
+        print("  [SKIP] npm not found; install Node.js to enable /studio")
         return
 
     print("Building web-studio (Vite SPA)...")
@@ -501,16 +493,12 @@ def _build_web_studio():
             cwd=str(source),
         )
     except subprocess.CalledProcessError as exc:
-        _unavailable(
-            f"  [WARNING] web-studio npm build failed ({exc}); /studio will be unavailable"
-        )
+        print(f"  [WARNING] web-studio npm build failed ({exc}); /studio will be unavailable")
         return
 
     built = source / "dist"
     if not (built / "index.html").is_file():
-        _unavailable(
-            "  [WARNING] web-studio build produced no index.html; /studio will be unavailable"
-        )
+        print("  [WARNING] web-studio build produced no index.html; /studio will be unavailable")
         return
 
     dest.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Description

Fix the remaining `/studio` packaging gap after #2238.

#2238 added the `setup.py` `build_py` hook that can build `web-studio` into `openviking/web_studio/dist`, but the Linux release wheel job runs inside an `ubuntu:20.04` container without Node/npm. The hook therefore skipped Studio silently, and the existing wheel smoke test only checked native bindings. The published PyPI 0.3.21 Linux wheel has no `openviking/web_studio/dist/*`, so `/studio` is not mounted after `pip install openviking` on Linux.

## Changes Made

- Install Node.js 22 in release wheel jobs before building the package, including the Linux container job.
- Keep `setup.py`'s existing graceful skip behavior for local/source installs: no extra `OV_REQUIRE_STUDIO_BUILD` switch or require-mode branch.
- Extend wheel smoke tests to assert `openviking/web_studio/dist/index.html` is installed, so a release wheel without Studio fails validation.

## Validation

- Confirmed current PyPI `openviking==0.3.21` macOS arm64 wheel includes 401 Studio files and `index.html`.
- Confirmed current PyPI `openviking==0.3.21` Windows amd64 wheel includes 401 Studio files and `index.html`.
- Confirmed current PyPI `openviking==0.3.21` manylinux x86_64 wheel includes 0 Studio files and no `index.html`.
- `rg -n "OV_REQUIRE_STUDIO_BUILD|REQUIRE_STUDIO_BUILD" -S .` returns no matches.
- `git diff --check`
- Parsed `.github/workflows/_build.yml` with PyYAML.
- `uvx ruff check setup.py`
- `python3 -m py_compile setup.py`
