### PR TITLE
docs(roadmap): fix dead Contributing link (404) in EN+ZH roadmap

### DIFF
--- a/docs/en/about/03-roadmap.md
+++ b/docs/en/about/03-roadmap.md
@@ -112,4 +112,4 @@ We welcome suggestions and feedback in issues.
 
 ## Contributing
 
-We welcome contributions to help achieve these goals. See [Contributing](contributing.md) for guidelines.
+We welcome contributions to help achieve these goals. See [Contributing](https://github.com/volcengine/OpenViking/blob/main/CONTRIBUTING.md) for guidelines.

--- a/docs/zh/about/03-roadmap.md
+++ b/docs/zh/about/03-roadmap.md
@@ -112,4 +112,4 @@
 
 ## 贡献
 
-我们欢迎贡献以帮助实现这些目标。请参阅 [贡献指南](contributing.md)。
+我们欢迎贡献以帮助实现这些目标。请参阅 [贡献指南](https://github.com/volcengine/OpenViking/blob/main/CONTRIBUTING_CN.md)。


### PR DESCRIPTION
## Problem

Both roadmap pages invite contributions, but the **Contributing** link 404s:

- `docs/en/about/03-roadmap.md` L115 — `See [Contributing](contributing.md) for guidelines.`
- `docs/zh/about/03-roadmap.md` L115 — `请参阅 [贡献指南](contributing.md)。`

Each link resolves relative to `docs/{en,zh}/about/` → `docs/{en,zh}/about/contributing.md`, which does not exist anywhere in the repo tree. The contribution guidelines actually live at the repo root (`CONTRIBUTING.md` / `CONTRIBUTING_CN.md`). A contributor who follows the roadmap's "We welcome contributions … See Contributing" call-to-action hits a dead page.

## Fix

Retarget each link to the canonical root file via its GitHub blob URL — the same convention `README.md` already uses for root-level repo resources (e.g. the `LICENSE` badge → `.../blob/main/LICENSE`):

- EN → `https://github.com/volcengine/OpenViking/blob/main/CONTRIBUTING.md`
- ZH → `https://github.com/volcengine/OpenViking/blob/main/CONTRIBUTING_CN.md`

Pure docs, 2 lines, no content change beyond the link target. Restores the contribution funnel on a stable nav page.
