### PR TITLE
fix(server): proxy namespace policy in tool context

### DIFF
--- a/openviking/server/identity.py
+++ b/openviking/server/identity.py
@@ -126,3 +126,7 @@ class ToolContext:
     @property
     def account_id(self) -> str:
         return self.request_ctx.user.account_id
+
+    @property
+    def namespace_policy(self) -> AccountNamespacePolicy:
+        return self.request_ctx.namespace_policy

--- a/tests/server/test_identity.py
+++ b/tests/server/test_identity.py
@@ -3,7 +3,13 @@
 
 """Tests for identity types (openviking/server/identity.py)."""
 
-from openviking.server.identity import RequestContext, ResolvedIdentity, Role
+from openviking.server.identity import (
+    AccountNamespacePolicy,
+    RequestContext,
+    ResolvedIdentity,
+    Role,
+    ToolContext,
+)
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -51,3 +57,23 @@ def test_request_context_account_id_property():
     assert ctx.account_id == "acme"
     assert ctx.role == Role.USER
     assert ctx.user.account_id == "acme"
+
+
+def test_tool_context_proxies_namespace_policy_from_request_context():
+    policy = AccountNamespacePolicy(
+        isolate_user_scope_by_agent=True,
+        isolate_agent_scope_by_user=True,
+    )
+    request_ctx = RequestContext(
+        user=UserIdentifier(
+            account_id="test-account",
+            user_id="test-user",
+            agent_id="test-agent",
+        ),
+        role=Role.USER,
+        namespace_policy=policy,
+    )
+
+    tool_ctx = ToolContext(viking_fs=object(), request_ctx=request_ctx)
+
+    assert tool_ctx.namespace_policy is policy


### PR DESCRIPTION
## Summary
- add a ToolContext.namespace_policy proxy to its wrapped RequestContext
- cover the proxy behavior in identity tests

## Related Issue
- Refs #1667

## Tests
- /Users/quemingjian/Source/OpenViking/.venv/bin/python -m ruff check openviking/server/identity.py tests/server/test_identity.py
- /Users/quemingjian/Source/OpenViking/.venv/bin/python -m pytest -q tests/server/test_identity.py