### PR TITLE
docs(encryption): fix dead Technical Design link (404) in EN/ZH encryption pages

### DIFF
--- a/docs/en/concepts/10-encryption.md
+++ b/docs/en/concepts/10-encryption.md
@@ -217,4 +217,4 @@ See [Configuration Guide](../guides/01-configuration.md#encryption) for detailed
 
 - [Storage Architecture](./05-storage.md) - VikingFS and AGFS architecture
 - [Configuration Guide](../guides/01-configuration.md) - Encryption configuration details
-- [Technical Design](../../design/multi-tenant-file-encryption-desigin.md) - Encryption technical design
+- [Technical Design](../../design/multi-tenant-design.md) - Encryption technical design

--- a/docs/en/guides/08-encryption.md
+++ b/docs/en/guides/08-encryption.md
@@ -476,4 +476,4 @@ If using encrypted files created with an older OpenViking version, partial reads
 
 - [Data Encryption](../concepts/10-encryption.md) - Encryption concepts
 - [Configuration Guide](./01-configuration.md) - Complete configuration reference
-- [Technical Design](../../design/multi-tenant-file-encryption-desigin.md) - Encryption technical design
+- [Technical Design](../../design/multi-tenant-design.md) - Encryption technical design

--- a/docs/zh/concepts/10-encryption.md
+++ b/docs/zh/concepts/10-encryption.md
@@ -217,4 +217,4 @@ ov crypto init-key --output ~/.openviking/master.key
 
 - [存储架构](./05-storage.md) - VikingFS 和 AGFS 架构
 - [配置指南](../guides/01-configuration.md) - 加密配置详解
-- [技术设计](../../design/multi-tenant-file-encryption-desigin.md) - 加密技术设计文档
+- [技术设计](../../design/multi-tenant-design.md) - 加密技术设计文档

--- a/docs/zh/guides/08-encryption.md
+++ b/docs/zh/guides/08-encryption.md
@@ -476,4 +476,4 @@ Error: KeyMismatchError
 
 - [数据加密](../concepts/10-encryption.md) - 加密概念说明
 - [配置指南](./01-configuration.md) - 完整配置参考
-- [技术设计](../../design/multi-tenant-file-encryption-desigin.md) - 加密技术设计文档
+- [技术设计](../../design/multi-tenant-design.md) - 加密技术设计文档


### PR DESCRIPTION
## What

Four canonical encryption docs link **Technical Design / 技术设计** to `../../design/multi-tenant-file-encryption-desigin.md`, which 404s — that file never existed (note the `desigin` typo). The real encryption design lives at `docs/design/multi-tenant-design.md` (two-layer AES-GCM file encryption + Argon2id API-key hashing, §两层加密架构).

This repoints all four links to the correct existing file. Link text is unchanged; this is a value-preserving fix, not a removal.

## Files

- `docs/en/concepts/10-encryption.md`
- `docs/en/guides/08-encryption.md`
- `docs/zh/concepts/10-encryption.md`
- `docs/zh/guides/08-encryption.md`

## Verification

- `docs/design/multi-tenant-file-encryption-desigin.md` → 404 (does not exist)
- `docs/design/multi-tenant-design.md` → exists, documents the encryption technical design