### PR TITLE
docs(api): add cached_tokens/reasoning_tokens to get_session() llm_token_usage example

### DIFF
--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -258,7 +258,9 @@ ov session get a1b2c3d4
     "llm_token_usage": {
       "prompt_tokens": 5200,
       "completion_tokens": 1800,
-      "total_tokens": 7000
+      "total_tokens": 7000,
+      "cached_tokens": 1200,
+      "reasoning_tokens": 800
     },
     "user": {
       "account_id": "default",

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -258,7 +258,9 @@ ov session get a1b2c3d4
     "llm_token_usage": {
       "prompt_tokens": 5200,
       "completion_tokens": 1800,
-      "total_tokens": 7000
+      "total_tokens": 7000,
+      "cached_tokens": 1200,
+      "reasoning_tokens": 800
     },
     "user": {
       "account_id": "default",


### PR DESCRIPTION
`#2305` added `cached_tokens` and `reasoning_tokens` to the `llm_token_usage` mapping on `SessionMeta` (default dict + `from_dict` in `openviking/session/session.py`), which is serialized via `to_dict()` and returned by `get_session()`. The `get_session()` **Response Example** in `docs/{en,zh}/api/05-sessions.md` still lists only `prompt_tokens` / `completion_tokens` / `total_tokens`, so the documented response shape is now incomplete.

This adds the two keys to the example (EN + ZH mirror) so the fields are discoverable — they let callers attribute prompt-cache savings (`cached_tokens`) and reasoning cost (`reasoning_tokens`) when reading `get_session()` output for LLM cost accounting.

Docs-only, scoped strictly to the `get_session()` `llm_token_usage` example block.