### PR TITLE
docs(readme): fix dead #lark-group/#wechat-group anchors in README_CN (point to 飞书群/微信群)

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -21,7 +21,7 @@
 
 👋 加入我们的社区
 
-📱 <a href="./docs/zh/about/01-about-us.md#lark-group">飞书群</a> · <a href="./docs/zh/about/01-about-us.md#wechat-group">微信群</a> · <a href="https://discord.com/invite/eHvx8E9XF3">Discord</a> · <a href="https://x.com/openvikingai">X</a>
+📱 <a href="./docs/zh/about/01-about-us.md#飞书群">飞书群</a> · <a href="./docs/zh/about/01-about-us.md#微信群">微信群</a> · <a href="https://discord.com/invite/eHvx8E9XF3">Discord</a> · <a href="https://x.com/openvikingai">X</a>
 
 </div>
 
@@ -829,8 +829,8 @@ OpenViking 仍处于早期阶段，有许多改进和探索的空间。我们真
 - 为我们点亮一颗珍贵的 **Star**，给我们前进的动力。
 - 访问我们的[**官网**](https://www.openviking.ai)了解我们传达的理念，并通过[**文档**](https://www.openviking.ai/docs)在您的项目中使用它。感受它带来的变化，并给我们最真实的体验反馈。
 - 加入我们的社区，分享您的见解，帮助回答他人的问题，共同创造开放互助的技术氛围：
-  - 📱 **飞书群**：扫码加入 → [查看二维码](./docs/zh/about/01-about-us.md#lark-group)
-  - 💬 **微信群**：扫码添加助手 → [查看二维码](./docs/zh/about/01-about-us.md#wechat-group)
+  - 📱 **飞书群**：扫码加入 → [查看二维码](./docs/zh/about/01-about-us.md#飞书群)
+  - 💬 **微信群**：扫码添加助手 → [查看二维码](./docs/zh/about/01-about-us.md#微信群)
   - 🎮 **Discord**：[加入 Discord 服务器](https://discord.com/invite/eHvx8E9XF3)
   - 🐦 **X (Twitter)**：[关注我们](https://x.com/openvikingai)
 - 成为**贡献者**，无论是提交错误修复还是贡献新功能，您的每一行代码都将是 OpenViking 成长的重要基石。


### PR DESCRIPTION
## 问题

`README_CN.md` 顶部「加入我们的社区」区块使用了英文锚点：

- L24: `<a href="./docs/zh/about/01-about-us.md#lark-group">飞书群</a> · <a href="...#wechat-group">微信群</a>`
- L832/L833: `[查看二维码](./docs/zh/about/01-about-us.md#lark-group)` / `#wechat-group`

但目标文档 `docs/zh/about/01-about-us.md` 的标题是中文 `##### 飞书群`（L114，二维码段）/ `##### 微信群`（L122，二维码段），GitHub 生成的锚点是 `#飞书群` / `#微信群`，并不存在 `lark-group` / `wechat-group`。中文用户点击「飞书群 / 微信群 → 查看二维码」会落到文档顶部而非二维码段，社群加入流程导航失败。

英文 `README.md` 与 `README_JA.md` 链接的是 `docs/en/.../01-about-us.md`，其标题 `##### Lark Group` / `##### WeChat Group` 解析为 `#lark-group` / `#wechat-group` 是正确的——本地化遗漏仅隔离在 `README_CN`（创建时从 EN 模板复制锚点未本地化）。

## 改动

将 `README_CN.md` 中 3 处指向 `01-about-us.md` 的锚点改为真实中文标题锚点 `#飞书群` / `#微信群`。纯文档，4 处锚点替换，无其它改动。