### PR TITLE
fix(openclaw): preserve user turn in afterTurn capture

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -1317,7 +1317,9 @@ export function createMemoryOpenVikingContextEngine(params: {
             ? afterTurnParams.prePromptMessageCount
             : 0;
 
-        const { messages: extractedMessagesRaw, newCount } = extractNewTurnMessages(messages, start);
+        const { messages: extractedMessagesRaw, newCount } = extractNewTurnMessages(messages, start, {
+          ensureLastUserMessage: true,
+        });
         const extractedMessages = coalesceConsecutiveToolMessages(extractedMessagesRaw);
 
         if (extractedMessages.length === 0) {
@@ -1336,7 +1338,17 @@ export function createMemoryOpenVikingContextEngine(params: {
           const r = (m as Record<string, unknown>).role as string;
           return r === "user" || r === "assistant";
         }) as AgentMessage[];
-        const newMsgFull = messageDigest(newMessages);
+        const capturedMessagesForDigest = extractedMessages.map((msg) => ({
+          role: msg.role,
+          content: msg.parts.map((part) =>
+            part.type === "text"
+              ? { type: "text", text: part.text }
+              : { type: "toolResult", content: part.toolOutput, name: part.toolName },
+          ),
+        })) as AgentMessage[];
+        const newMsgFull = messageDigest(
+          capturedMessagesForDigest.length > 0 ? capturedMessagesForDigest : newMessages,
+        );
         const newTurnTokens = newMsgFull.reduce((s, d) => s + d.tokens, 0);
 
         diag("afterTurn_entry", OVSessionId, {

--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -176,6 +176,28 @@ describe("context-engine afterTurn()", () => {
     expect(client.addSessionMessage.mock.calls[1][2][0].text).toContain("hi there");
   });
 
+  it("includes the latest user message when prePromptMessageCount starts at the assistant reply", async () => {
+    const { engine, client } = makeEngine();
+
+    const messages = [
+      { role: "user", content: "My grandmother's name is Li Jiulin." },
+      { role: "assistant", content: [{ type: "text", text: "Got it, I noted that down." }] },
+    ];
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages,
+      prePromptMessageCount: 1,
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("user");
+    expect(client.addSessionMessage.mock.calls[0][2][0].text).toContain("Li Jiulin");
+    expect(client.addSessionMessage.mock.calls[1][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[1][2][0].text).toContain("noted");
+  });
+
   it("passes the latest non-system message timestamp to addSessionMessage as ISO string", async () => {
     const { engine, client } = makeEngine();
 

--- a/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
@@ -1,5 +1,6 @@
 import { once } from "node:events";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { pathToFileURL } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -10,6 +11,44 @@ type RequestRecord = {
   method: string;
   path: string;
 };
+
+type PluginService = {
+  start: () => Promise<void>;
+  stop?: () => Promise<void> | void;
+};
+
+type RegisteredContextEngine = {
+  afterTurn: (params: {
+    sessionId: string;
+    sessionFile: string;
+    messages: Array<{ role: string; content: unknown; timestamp?: number }>;
+    prePromptMessageCount: number;
+  }) => Promise<void>;
+};
+
+async function loadOpenClawE2EModules(): Promise<{
+  buildPluginApi: (params: Record<string, unknown>) => unknown;
+  finalizeHarnessContextEngineTurn: (params: Record<string, unknown>) => Promise<{ postTurnFinalizationSucceeded: boolean }>;
+}> {
+  const distDir = process.env.OPENVIKING_OPENCLAW_DIST_DIR;
+  if (!distDir) {
+    throw new Error("OPENVIKING_OPENCLAW_DIST_DIR is required for this e2e test");
+  }
+
+  const pluginRuntime = await import(
+    pathToFileURL(`${distDir.replace(/\/$/, "")}/plugin-sdk/plugin-test-runtime.js`).href
+  );
+  const agentHarness = await import(
+    pathToFileURL(`${distDir.replace(/\/$/, "")}/plugin-sdk/agent-harness.js`).href
+  );
+
+  return {
+    buildPluginApi: pluginRuntime.buildPluginApi as (params: Record<string, unknown>) => unknown,
+    finalizeHarnessContextEngineTurn: agentHarness.finalizeHarnessContextEngineTurn as (
+      params: Record<string, unknown>,
+    ) => Promise<{ postTurnFinalizationSucceeded: boolean }>,
+  };
+}
 
 function makeStats() {
   return {
@@ -289,4 +328,176 @@ describe("plugin normal flow with healthy backend", () => {
 
     await service?.stop?.();
   });
+
+  it("captures the latest user turn when OpenClaw prePromptMessageCount starts at assistant", async () => {
+    let service:
+      | {
+          start: () => Promise<void>;
+          stop?: () => Promise<void> | void;
+        }
+      | null = null;
+    let contextEngineFactory: (() => unknown) | null = null;
+
+    plugin.register({
+      logger: {
+        debug: () => {},
+        error: () => {},
+        info: () => {},
+        warn: () => {},
+      },
+      on: () => {},
+      pluginConfig: {
+        autoCapture: true,
+        autoRecall: false,
+        baseUrl,
+        commitTokenThreshold: 20000,
+        mode: "remote",
+      },
+      registerContextEngine: (_id, factory) => {
+        contextEngineFactory = factory as () => unknown;
+      },
+      registerService: (entry) => {
+        service = entry;
+      },
+      registerTool: () => {},
+    });
+
+    expect(service).toBeTruthy();
+    expect(contextEngineFactory).toBeTruthy();
+
+    await service!.start();
+
+    const contextEngine = contextEngineFactory!() as {
+      afterTurn: (params: {
+        sessionId: string;
+        sessionFile: string;
+        messages: Array<{ role: string; content: unknown; timestamp?: number }>;
+        prePromptMessageCount: number;
+      }) => Promise<void>;
+    };
+
+    await contextEngine.afterTurn({
+      sessionId: "session-skipped-user",
+      sessionFile: "",
+      messages: [
+        {
+          role: "user",
+          content: "My grandmother's name is Li Jiulin.",
+          timestamp: Date.parse("2026-04-07T09:00:00Z"),
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Got it, I noted that down." }],
+          timestamp: Date.parse("2026-04-07T09:00:01Z"),
+        },
+      ],
+      prePromptMessageCount: 1,
+    });
+
+    const addMessageRequests = requests.filter(
+      (entry) => entry.method === "POST" && entry.path === "/api/v1/sessions/session-skipped-user/messages",
+    );
+    expect(addMessageRequests).toHaveLength(2);
+
+    const firstBody = JSON.parse(addMessageRequests[0]!.body ?? "{}");
+    const secondBody = JSON.parse(addMessageRequests[1]!.body ?? "{}");
+    expect(firstBody.role).toBe("user");
+    expect(firstBody.parts?.[0]?.text).toContain("Li Jiulin");
+    expect(secondBody.role).toBe("assistant");
+    expect(secondBody.parts?.[0]?.text).toContain("noted");
+
+    await service?.stop?.();
+  });
+
+  const openClawE2E = process.env.OPENVIKING_OPENCLAW_DIST_DIR ? it : it.skip;
+
+  openClawE2E("captures the skipped user turn through OpenClaw harness finalization", async () => {
+    const { buildPluginApi, finalizeHarnessContextEngineTurn } = await loadOpenClawE2EModules();
+
+    let service: PluginService | null = null;
+    let contextEngineFactory: (() => unknown) | null = null;
+
+    const api = buildPluginApi({
+      id: "openviking",
+      name: "OpenViking",
+      version: "test",
+      description: "OpenViking test plugin",
+      source: "source",
+      rootDir: process.cwd(),
+      registrationMode: "source",
+      config: {},
+      pluginConfig: {
+        autoCapture: true,
+        autoRecall: false,
+        baseUrl,
+        commitTokenThreshold: 20000,
+        mode: "remote",
+      },
+      runtime: {},
+      logger: {
+        debug: () => {},
+        error: () => {},
+        info: () => {},
+        warn: () => {},
+      },
+      resolvePath: (input: string) => input,
+      handlers: {
+        registerContextEngine: (_id: string, factory: () => unknown) => {
+          contextEngineFactory = factory;
+        },
+        registerService: (entry: PluginService) => {
+          service = entry;
+        },
+      },
+    });
+
+    plugin.register(api as Parameters<typeof plugin.register>[0]);
+
+    expect(service).toBeTruthy();
+    expect(contextEngineFactory).toBeTruthy();
+
+    await service!.start();
+
+    const contextEngine = contextEngineFactory!() as RegisteredContextEngine;
+    const result = await finalizeHarnessContextEngineTurn({
+      contextEngine,
+      promptError: false,
+      aborted: false,
+      yieldAborted: false,
+      sessionIdUsed: "session-openclaw-harness",
+      sessionFile: "",
+      messagesSnapshot: [
+        {
+          role: "user",
+          content: "My grandmother's name is Li Jiulin, her birthday is the 7th day of the 7th lunar month.",
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Got it, I noted that down." }],
+        },
+      ],
+      prePromptMessageCount: 1,
+      runMaintenance: async () => undefined,
+      warn: (message: string) => {
+        throw new Error(message);
+      },
+    });
+
+    expect(result.postTurnFinalizationSucceeded).toBe(true);
+
+    const addMessageRequests = requests.filter(
+      (entry) => entry.method === "POST" && entry.path === "/api/v1/sessions/session-openclaw-harness/messages",
+    );
+    expect(addMessageRequests).toHaveLength(2);
+
+    const firstBody = JSON.parse(addMessageRequests[0]!.body ?? "{}");
+    const secondBody = JSON.parse(addMessageRequests[1]!.body ?? "{}");
+    expect(firstBody.role).toBe("user");
+    expect(firstBody.parts?.[0]?.text).toContain("Li Jiulin");
+    expect(firstBody.parts?.[0]?.text).toContain("7th lunar month");
+    expect(secondBody.role).toBe("assistant");
+    expect(secondBody.parts?.[0]?.text).toContain("noted");
+
+    await service?.stop?.();
+  }, 20000);
 });

--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -223,6 +223,54 @@ describe("extractNewTurnTexts", () => {
 });
 
 describe("extractNewTurnMessages", () => {
+  it("prepends latest user text when startIndex skipped the current user turn", () => {
+    const messages = [
+      { role: "user", content: "My grandmother's name is Li Jiulin." },
+      { role: "assistant", content: "Got it, I noted that down." },
+    ];
+
+    const { messages: extracted, newCount } = extractNewTurnMessages(messages, 1, {
+      ensureLastUserMessage: true,
+    });
+
+    expect(newCount).toBe(2);
+    expect(extracted).toEqual([
+      {
+        role: "user",
+        parts: [{ type: "text", text: "My grandmother's name is Li Jiulin." }],
+      },
+      {
+        role: "assistant",
+        parts: [{ type: "text", text: "Got it, I noted that down." }],
+      },
+    ]);
+  });
+
+  it("does not prepend a prior user when the captured window already has user text", () => {
+    const messages = [
+      { role: "user", content: "old fact" },
+      { role: "assistant", content: "old reply" },
+      { role: "user", content: "new fact" },
+      { role: "assistant", content: "new reply" },
+    ];
+
+    const { messages: extracted, newCount } = extractNewTurnMessages(messages, 2, {
+      ensureLastUserMessage: true,
+    });
+
+    expect(newCount).toBe(2);
+    expect(extracted).toEqual([
+      {
+        role: "user",
+        parts: [{ type: "text", text: "new fact" }],
+      },
+      {
+        role: "assistant",
+        parts: [{ type: "text", text: "new reply" }],
+      },
+    ]);
+  });
+
   it("keeps assistant toolCall messages that have no text block", () => {
     const messages = [
       {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -332,6 +332,62 @@ type ExtractedMessage = {
   }>;
 };
 
+type ExtractNewTurnMessagesOptions = {
+  /**
+   * OpenClaw may report a prePromptMessageCount that starts after the user
+   * prompt for the just-finished turn. When the captured window has no user
+   * text, prepend the nearest preceding user text so extraction sees the fact
+   * source rather than only the assistant acknowledgement.
+   */
+  ensureLastUserMessage?: boolean;
+};
+
+function extractTextMessage(msg: Record<string, unknown>): ExtractedMessage | undefined {
+  const role = msg.role as string;
+  if (role !== "user" && role !== "assistant") {
+    return undefined;
+  }
+
+  const text = extractPartText(msg.content);
+  if (!text) {
+    return undefined;
+  }
+
+  const cleanedText = sanitizeUserTextForCapture(text);
+  if (!cleanedText) {
+    return undefined;
+  }
+
+  return {
+    role: role === "assistant" ? "assistant" : "user",
+    parts: [{
+      type: "text",
+      text: cleanedText,
+    }],
+  };
+}
+
+function hasUserTextMessage(messages: ExtractedMessage[]): boolean {
+  return messages.some((message) =>
+    message.role === "user" && message.parts.some((part) => part.type === "text" && part.text.trim()),
+  );
+}
+
+function findLatestUserTextBefore(messages: unknown[], startIndex: number): ExtractedMessage | undefined {
+  const end = Math.min(messages.length - 1, Math.max(0, startIndex - 1));
+  for (let i = end; i >= 0; i -= 1) {
+    const msg = messages[i] as Record<string, unknown>;
+    if (!msg || typeof msg !== "object" || msg.role !== "user") {
+      continue;
+    }
+    const extracted = extractTextMessage(msg);
+    if (extracted) {
+      return extracted;
+    }
+  }
+  return undefined;
+}
+
 /**
  * 提取从 startIndex 开始的新消息，返回结构化消息。
  * - 用户输入 → type: "text"
@@ -342,6 +398,7 @@ type ExtractedMessage = {
 export function extractNewTurnMessages(
   messages: unknown[],
   startIndex: number,
+  options: ExtractNewTurnMessagesOptions = {},
 ): { messages: ExtractedMessage[]; newCount: number } {
   const result: ExtractedMessage[] = [];
   let count = 0;
@@ -410,22 +467,10 @@ export function extractNewTurnMessages(
 
     // user/assistant -> type: "text"
     const content = msg.content;
-    const text = extractPartText(content);
+    const textMessage = extractTextMessage(msg);
 
-    if (text) {
-      // 使用 sanitizeUserTextForCapture 清理所有噪音（Sender 元数据、时间戳等）
-      const cleanedText = sanitizeUserTextForCapture(text);
-      if (cleanedText) {
-        // 保持原始 role，assistant 保持 assistant，user 保持 user
-        const ovRole: "user" | "assistant" = role === "assistant" ? "assistant" : "user";
-        result.push({
-          role: ovRole,
-          parts: [{
-            type: "text",
-            text: cleanedText,
-          }],
-        });
-      }
+    if (textMessage) {
+      result.push(textMessage);
     } else {
       /// 如果原始消息有 toolCall，提取所有工具名并生成占位符
       if (role === "assistant" && Array.isArray(content)) {
@@ -460,6 +505,14 @@ export function extractNewTurnMessages(
           });
         }
       }
+    }
+  }
+
+  if (options.ensureLastUserMessage && result.length > 0 && !hasUserTextMessage(result)) {
+    const latestUser = findLatestUserTextBefore(messages, startIndex);
+    if (latestUser) {
+      result.unshift(latestUser);
+      count += 1;
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #1248.

This is a clean replacement for the stale #1256 patch. The approach is the same defensive idea, but it is applied to the current structured `extractNewTurnMessages()` path instead of the old `extractNewTurnTexts()` path.

When OpenClaw reports a `prePromptMessageCount` that starts at the assistant reply, the plugin previously captured only the assistant acknowledgement. That can cause memory extraction to miss user-provided facts. With this change, if the captured afterTurn window has messages but no user text, the extractor prepends the nearest preceding user text before writing the turn to OpenViking.

## Details

- Add `ensureLastUserMessage` to `extractNewTurnMessages()`
- Enable it from OpenClaw `afterTurn` auto-capture
- Keep existing behavior when the captured window already contains user text
- Avoid resurrecting an old user when the captured window has no extractable messages at all
- Include the supplemented user message in diagnostics digest so logs match what is actually captured

## Verification

- `npm test -- --run tests/ut/text-utils.test.ts tests/ut/context-engine-afterTurn.test.ts tests/ut/plugin-normal-flow-real-server.test.ts`
- `OPENVIKING_OPENCLAW_DIST_DIR=/Users/quemingjian/.npm/lib/node_modules/openclaw/dist npm test -- --run tests/ut/plugin-normal-flow-real-server.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`

@a31c8j this should address the scenario you reported: with `prePromptMessageCount=1`, OpenViking now receives the user fact first and the assistant acknowledgement second.