### PR TITLE
docs(config): document supported VikingDB regions (add ap-southeast-1 from #2297)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1082,6 +1082,9 @@ Supports cloud-deployed VikingDB on Volcengine
   }
 }
 ```
+
+**Supported regions** (`volcengine` backend): `cn-beijing`, `cn-shanghai`, `cn-guangzhou`, and `ap-southeast-1` (Southeast Asia). When no explicit `host` is set, `region` selects the built-in VikingDB API host and should be one of these values.
+
 </details>
 
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1053,6 +1053,9 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
   }
 }
 ```
+
+**支持的区域**（`volcengine` 后端）：`cn-beijing`、`cn-shanghai`、`cn-guangzhou` 和 `ap-southeast-1`（东南亚）。未显式设置 `host` 时，`region` 用于选择内置的 VikingDB API 主机，应为上述值之一。
+
 </details>
 
 


### PR DESCRIPTION
Merged PR #2297 added `ap-southeast-1` host mappings to the VikingDB clients, but the configuration guide's `volcengine` vectordb backend example only ever shows `region: cn-beijing` and never enumerates which regions are supported — so users outside Beijing (e.g. the new Southeast Asia region) have no way to discover the option from the docs.

This adds a short supported-regions note (EN + ZH) inside the existing **volcengine vikingDB** example block. The region set is sourced from `openviking/storage/vectordb/collection/volcengine_clients.py`:

- `ClientForConsoleApi._global_host` and `ClientForDataApi._global_host` both enumerate `cn-beijing`, `cn-shanghai`, `cn-guangzhou`, `ap-southeast-1`.

The note is qualified ("when no explicit `host` is set") since the clients do `host if host else _global_host[region]`, so a custom-host deployment isn't restricted to the built-in region keys.

Pure docs, no code change.
