### PR TITLE
fix(blog): improve Chinese line breaking

### DIFF
--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -540,6 +540,8 @@ html[lang="zh"] body {
   font-size: 18px;
   line-height: 1.62;
   letter-spacing: 0.02em;
+  line-break: loose;
+  word-break: normal;
 }
 
 html[lang="zh"] .b-lead,
@@ -548,17 +550,24 @@ html[lang="zh"] .b-post__sub,
 html[lang="zh"] .b-card__excerpt {
   line-height: 1.58;
   letter-spacing: 0.03em;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
 }
 
 html[lang="zh"] :is(.b-h, .b-post__title, .b-card__title, .b-brand__name, .b-post__navcard__title) {
   letter-spacing: 0;
 }
 
+html[lang="zh"] :is(.b-article, .b-post__head, .b-card__body, .b-hero) {
+  word-break: normal;
+  word-break: auto-phrase;
+}
+
 html[lang="zh"] :is(.b-hero__title, .b-post__title, .b-card__title, .b-post__navcard__title) {
-  overflow-wrap: anywhere;
-  text-wrap: wrap;
-  word-break: keep-all;
+  overflow-wrap: break-word;
+  text-wrap: balance;
+  word-break: normal;
+  word-break: auto-phrase;
 }
 
 /* ===========================================================


### PR DESCRIPTION
## Summary
- 修复中文标题层 `word-break: keep-all` 导致移动端 CJK 只在空格/标点处换行的问题
- 中文正文使用 `line-break: loose` 与 `auto-phrase`，保留语义优先的短语断行
- 将 `overflow-wrap:anywhere` 收敛为应急断行，避免中英文混排被任意硬切

## Verification
- `cd blog && npm run build`
- Playwright 本地检查 `/post/openviking-too-many-agents/?lang=zh` 的 390px/1280px 视口：无横向溢出，标题 `wordBreak=auto-phrase`
