### PR TITLE
Fix Docker latest tag policy

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -68,6 +68,39 @@ jobs:
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Docker tag policy
+        id: docker-tag-policy
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+        run: |
+          set -euo pipefail
+          publish_latest=false
+
+          if [ "$REF_TYPE" = "tag" ]; then
+            publish_latest=true
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            input_version="${INPUT_VERSION#v}"
+            latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)"
+            if [ -n "$latest_tag" ]; then
+              latest_version="${latest_tag#v}"
+              latest_sha="$(git rev-list -n 1 "$latest_tag")"
+              head_sha="$(git rev-parse HEAD)"
+
+              if [ "$input_version" = "$latest_version" ] && [ "$head_sha" = "$latest_sha" ]; then
+                publish_latest=true
+              elif [ "$input_version" = "$latest_version" ]; then
+                echo "::error::Refusing to publish ${INPUT_VERSION}: the latest release tag is ${latest_tag}, but this workflow is running at ${head_sha}, not ${latest_sha}. Re-run the workflow from the ${latest_tag} ref."
+                exit 1
+              fi
+            fi
+          fi
+
+          echo "publish_latest=${publish_latest}" >> "$GITHUB_OUTPUT"
+          echo "publish_latest=${publish_latest}"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -91,7 +124,7 @@ jobs:
           tags: |
             type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable=${{ steps.docker-tag-policy.outputs.publish_latest == 'true' }}
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up Docker Buildx
@@ -160,6 +193,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Normalize image name
@@ -182,6 +216,39 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Resolve Docker tag policy
+        id: docker-tag-policy
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+        run: |
+          set -euo pipefail
+          publish_latest=false
+
+          if [ "$REF_TYPE" = "tag" ]; then
+            publish_latest=true
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            input_version="${INPUT_VERSION#v}"
+            latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)"
+            if [ -n "$latest_tag" ]; then
+              latest_version="${latest_tag#v}"
+              latest_sha="$(git rev-list -n 1 "$latest_tag")"
+              head_sha="$(git rev-parse HEAD)"
+
+              if [ "$input_version" = "$latest_version" ] && [ "$head_sha" = "$latest_sha" ]; then
+                publish_latest=true
+              elif [ "$input_version" = "$latest_version" ]; then
+                echo "::error::Refusing to publish ${INPUT_VERSION}: the latest release tag is ${latest_tag}, but this workflow is running at ${head_sha}, not ${latest_sha}. Re-run the workflow from the ${latest_tag} ref."
+                exit 1
+              fi
+            fi
+          fi
+
+          echo "publish_latest=${publish_latest}" >> "$GITHUB_OUTPUT"
+          echo "publish_latest=${publish_latest}"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
@@ -192,7 +259,7 @@ jobs:
           tags: |
             type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable=${{ steps.docker-tag-policy.outputs.publish_latest == 'true' }}
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary
- Fix standalone Docker workflow tag policy so `latest` is not left stale when rebuilding the current release through `workflow_dispatch`.
- Keep `main` scoped to main-branch pushes.
- Refuse manual latest-release rebuilds from the wrong ref, so a `version` input cannot accidentally publish a release tag or `latest` from unrelated branch contents.

## Root cause
`build-docker-image.yml` only emitted `latest` on tag-triggered runs. If the tag-triggered Docker workflow failed and maintainers manually rebuilt the release image with `workflow_dispatch`, the explicit version tag could be updated while `latest` stayed on the previous digest.

## Validation
- `python - <<'PY' ... yaml.safe_load(...)` passed for `.github/workflows/build-docker-image.yml`.
- `git diff --check` passed.
- Verified current registry state: GHCR `latest` currently points to the same digest as `v0.3.22`; `main` points to the latest main image digest separately.
