### PR TITLE
fix Studio random UUID fallback on HTTP origins

### DIFF
--- a/web-studio/index.html
+++ b/web-studio/index.html
@@ -20,6 +20,52 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="OpenViking" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <!-- Runs before Vite's module graph so dependencies can safely call crypto.randomUUID. -->
+    <script>
+      ;(() => {
+        const cryptoObject = globalThis.crypto
+        if (!cryptoObject || typeof cryptoObject.randomUUID === 'function') {
+          return
+        }
+
+        const createUuid = () => {
+          const bytes = new Uint8Array(16)
+          if (typeof cryptoObject.getRandomValues === 'function') {
+            cryptoObject.getRandomValues(bytes)
+          } else {
+            for (let index = 0; index < bytes.length; index += 1) {
+              bytes[index] = Math.floor(Math.random() * 256)
+            }
+          }
+
+          bytes[6] = (bytes[6] & 0x0f) | 0x40
+          bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+          const hex = Array.from(bytes, (byte) =>
+            byte.toString(16).padStart(2, '0'),
+          )
+
+          return `${hex.slice(0, 4).join('')}-${hex
+            .slice(4, 6)
+            .join('')}-${hex.slice(6, 8).join('')}-${hex
+            .slice(8, 10)
+            .join('')}-${hex.slice(10, 16).join('')}`
+        }
+
+        try {
+          Object.defineProperty(cryptoObject, 'randomUUID', {
+            configurable: true,
+            value: createUuid,
+          })
+        } catch {
+          try {
+            cryptoObject.randomUUID = createUuid
+          } catch {
+            // Ignore browsers that expose a non-extensible Crypto object.
+          }
+        }
+      })()
+    </script>
     <title>OpenViking Studio</title>
   </head>
   <body>

--- a/web-studio/src/lib/browser-crypto.ts
+++ b/web-studio/src/lib/browser-crypto.ts
@@ -1,0 +1,43 @@
+type RandomUuid = ReturnType<Crypto['randomUUID']>
+
+function randomByte(): number {
+  return Math.floor(Math.random() * 256)
+}
+
+function createFallbackRandomUuid(): RandomUuid {
+  const browserCrypto =
+    typeof globalThis.crypto !== 'undefined' ? globalThis.crypto : undefined
+
+  const bytes = new Uint8Array(16)
+  if (typeof browserCrypto?.getRandomValues === 'function') {
+    browserCrypto.getRandomValues(bytes)
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = randomByte()
+    }
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'))
+
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex
+    .slice(6, 8)
+    .join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`
+}
+
+export function createRandomUuid(): RandomUuid {
+  const browserCrypto =
+    typeof globalThis.crypto !== 'undefined' ? globalThis.crypto : undefined
+
+  if (typeof browserCrypto?.randomUUID === 'function') {
+    return browserCrypto.randomUUID()
+  }
+
+  return createFallbackRandomUuid()
+}
+
+export function createBrowserId(prefix: string): string {
+  return `${prefix}_${createRandomUuid().replace(/-/g, '')}`
+}

--- a/web-studio/src/lib/sessions/use-chat.ts
+++ b/web-studio/src/lib/sessions/use-chat.ts
@@ -6,14 +6,11 @@ import { addMessage, sendChatStream, serializeParts } from './api'
 import { generateTitle } from './generate-title'
 import { parseSseStream, streamEventDataToText } from './sse'
 import { setSessionTitle } from './use-session-titles'
-
-function generateId(): string {
-  return `msg_${crypto.randomUUID().replace(/-/g, '')}`
-}
+import { createBrowserId } from '../browser-crypto'
 
 function createUserMessage(content: string): Message {
   return {
-    id: generateId(),
+    id: createBrowserId('msg'),
     role: 'user',
     parts: [{ type: 'text', text: content }],
     created_at: new Date().toISOString(),
@@ -51,7 +48,7 @@ function buildAssistantMessage(
   }
 
   return {
-    id: generateId(),
+    id: createBrowserId('msg'),
     role: 'assistant',
     parts,
     created_at: new Date().toISOString(),


### PR DESCRIPTION
## Description

Fix Web Studio chat failures on non-secure HTTP/IP origins where `crypto.randomUUID()` is not available.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add a browser UUID helper that uses native `crypto.randomUUID()` when available and falls back to a v4-compatible generator.
- Install an early `crypto.randomUUID` polyfill before Studio modules run, so dependencies and app code work on HTTP/IP origins.
- Switch Studio chat message IDs away from direct `crypto.randomUUID()` usage.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

Manual checks:

- `npx prettier --check index.html src/lib/browser-crypto.ts src/main.tsx src/lib/sessions/use-chat.ts`
- `npm run lint`
- `npm run build -- --base=/studio/`
- Rebuilt and validated the dev deployment at `http://10.37.244.186:8020/studio/`
- Verified `/studio/` loads its main JS/CSS from `/studio/assets/...` with HTTP 200 responses
- Verified `/health` and `/bot/v1/health` return HTTP 200
- Verified bot chat no longer throws when accessed through the HTTP/IP Studio URL

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Root cause: `crypto.randomUUID()` is only available in secure contexts in browsers, so accessing Studio through `http://10.37.244.186:8020/studio/` can make the API unavailable before any backend request is sent.

`npm run lint` still reports the existing literal-string warnings in `src/routes/resources/-components/file-preview.tsx`; this PR does not introduce new lint errors or warnings.
