### PR TITLE
fix(openclaw-plugin): record assistant tool calls as structured tool parts

### DIFF
--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -223,7 +223,7 @@ describe("extractNewTurnTexts", () => {
 });
 
 describe("extractNewTurnMessages", () => {
-  it("keeps assistant toolCall messages that have no text block", () => {
+  it("emits a structured tool part for assistant toolCall messages with no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -240,12 +240,20 @@ describe("extractNewTurnMessages", () => {
     expect(extracted).toEqual([
       {
         role: "assistant",
-        parts: [{ type: "text", text: "[tool: read_file]" }],
+        parts: [
+          {
+            type: "tool",
+            toolCallId: "call_1",
+            toolName: "read_file",
+            toolInput: { path: "a.txt" },
+            toolStatus: "running",
+          },
+        ],
       },
     ]);
   });
 
-  it("keeps assistant toolUse messages that have no text block", () => {
+  it("emits a structured tool part for assistant toolUse messages with no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -262,12 +270,20 @@ describe("extractNewTurnMessages", () => {
     expect(extracted).toEqual([
       {
         role: "assistant",
-        parts: [{ type: "text", text: "[tool: grep]" }],
+        parts: [
+          {
+            type: "tool",
+            toolCallId: "call_2",
+            toolName: "grep",
+            toolInput: { pattern: "TODO" },
+            toolStatus: "running",
+          },
+        ],
       },
     ]);
   });
 
-  it("keeps multiple textless assistant tool calls in one placeholder", () => {
+  it("emits one tool part per call for multiple textless assistant tool calls in one message", () => {
     const messages = [
       {
         role: "assistant",
@@ -283,7 +299,10 @@ describe("extractNewTurnMessages", () => {
     expect(extracted).toEqual([
       {
         role: "assistant",
-        parts: [{ type: "text", text: "[tool: read_file, grep]" }],
+        parts: [
+          { type: "tool", toolCallId: "call_1", toolName: "read_file", toolStatus: "running" },
+          { type: "tool", toolCallId: "call_2", toolName: "grep", toolStatus: "running" },
+        ],
       },
     ]);
   });

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -327,8 +327,8 @@ type ExtractedMessage = {
     toolCallId?: string;
     toolName: string;
     toolInput?: Record<string, unknown>;
-    toolOutput: string;
-    toolStatus: string;
+    toolOutput?: string;
+    toolStatus?: string;
   }>;
 };
 
@@ -427,11 +427,11 @@ export function extractNewTurnMessages(
         });
       }
     } else {
-      /// 如果原始消息有 toolCall，提取所有工具名并生成占位符
+      // assistant 发起的 tool_use/toolCall：每个调用生成一个结构化 tool part，
+      // 而不是拼成 `[tool: ...]` 文本塞进 content，服务端可单独处理调用与结果。
       if (role === "assistant" && Array.isArray(content)) {
-        const toolNames: string[] = [];
-        
-        // 收集所有 toolCall 的 tool_name
+        const toolParts: ExtractedMessage["parts"] = [];
+
         for (const block of content) {
           const b = block as Record<string, unknown>;
           const blockType = b?.type as string;
@@ -441,23 +441,28 @@ export function extractNewTurnMessages(
             blockType === "tool_use" ||
             blockType === "tool_call"
           ) {
-            const name = b?.name as string || b?.toolName as string;
-            if (name && typeof name === "string" && name.trim()) {
-              toolNames.push(name.trim());
-            }
+            const name = (b?.name as string) || (b?.toolName as string);
+            if (!name || typeof name !== "string" || !name.trim()) continue;
+            const toolCallId =
+              (b.id as string) || (b.toolUseId as string) || (b.toolCallId as string) || undefined;
+            const rawInput = b.arguments ?? b.input ?? b.toolInput;
+            const toolInput =
+              rawInput && typeof rawInput === "object"
+                ? (rawInput as Record<string, unknown>)
+                : undefined;
+            toolParts.push({
+              type: "tool",
+              toolCallId,
+              toolName: name.trim(),
+              toolInput,
+              toolStatus: "running",
+            });
           }
         }
-        
-        // 只有找到 toolCall 时才添加占位符
-        if (toolNames.length > 0) {
-          const toolNamesStr = toolNames.join(", ");
-          result.push({
-            role: "assistant",
-            parts: [{
-              type: "text",
-              text: `[tool: ${toolNamesStr}]`,
-            }],
-          });
+
+        // 只有找到 toolCall 时才追加
+        if (toolParts.length > 0) {
+          result.push({ role: "assistant", parts: toolParts });
         }
       }
     }


### PR DESCRIPTION
## Description

In the openclaw example plugin, a textless assistant message containing `tool_use`/`toolCall` blocks was flattened into a `[tool: <names>]` text placeholder and recorded via the message `content`. This discarded the structured call info (`tool_id` / `tool_name` / `tool_input`) and mixed the tool call into `content` instead of a dedicated `tool` part, so the server could not process tool calls and results separately.

Tool **results** already produced `tool` parts; this change aligns the **call** side so both halves are structured and share the same `tool_id`.

## Related Issue

<!-- N/A -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `examples/openclaw-plugin/text-utils.ts`: in `extractNewTurnMessages`, emit one structured `tool` part per call (`toolCallId` / `toolName` / `toolInput`, `toolStatus: "running"`) for textless assistant tool-call messages, instead of a `[tool: ...]` text placeholder.
- Make `toolOutput` / `toolStatus` optional on the `ExtractedMessage` tool-part type (a call has no output yet).
- Update unit tests to assert structured tool parts instead of the text placeholder.

## Testing

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] macOS

`vitest run` (text-utils + tool-round-trip): 57 passed. `tsc -p tsconfig.json`: exit 0.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The `toolResult` branch still backfills `toolInput` on the result part, so a call's input appears on both the call and result parts (sharing `tool_id`). Kept as a defensive redundancy in case the call message is not captured.