### PR TITLE
fix(cc-memory-plugin): record tool calls/results as structured tool parts

### DIFF
--- a/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
+++ b/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Long-term semantic memory for Claude Code, powered by OpenViking. Auto-recall relevant memories at session start and capture important information during conversations.",
   "author": {
     "name": "OpenViking",

--- a/examples/claude-code-memory-plugin/package-lock.json
+++ b/examples/claude-code-memory-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-openviking-memory",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^4.3.6"

--- a/examples/claude-code-memory-plugin/package.json
+++ b/examples/claude-code-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "OpenViking memory plugin for Claude Code — semantic long-term memory",
   "type": "module",
   "private": true

--- a/examples/claude-code-memory-plugin/scripts/auto-capture.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-capture.mjs
@@ -214,6 +214,86 @@ function extractToolResultText(content) {
     .join("\n");
 }
 
+// ---------------------------------------------------------------------------
+// Structured parts (parts-mode capture)
+//
+// Tool calls / results become dedicated `tool` parts (tool_id / tool_name /
+// tool_input / tool_output / tool_status) instead of being inlined into the
+// message content, so the server can process call vs result separately. The
+// `text` field above is kept only to drive the capture heuristics (length /
+// keyword); `parts` is what we actually send. Part shape mirrors openclaw-plugin
+// (examples/openclaw-plugin context-engine.ts afterTurn).
+// ---------------------------------------------------------------------------
+
+// Tool output retention for the part path. Unlike the legacy prose path
+// (TOOL_RESULT_MAX_CHARS, which drops outputs to keep the extractor's text
+// clean), results here land in a separable tool_output field, so we keep them —
+// bounded so we don't store whole files / web pages / command stdout verbatim.
+const TOOL_OUTPUT_PART_MAX_CHARS = 2000;
+
+function truncateToolOutput(s) {
+  if (typeof s !== "string") s = String(s ?? "");
+  if (s.length <= TOOL_OUTPUT_PART_MAX_CHARS) return s;
+  return (
+    s.slice(0, TOOL_OUTPUT_PART_MAX_CHARS) +
+    `\n... [truncated, ${s.length - TOOL_OUTPUT_PART_MAX_CHARS} more chars]`
+  );
+}
+
+// tool_result blocks carry only tool_use_id, not the tool name. Pre-scan all
+// messages so result parts can be labelled with the matching call's name.
+function collectToolNamesById(messages) {
+  const map = {};
+  for (const msg of messages) {
+    const content = msg?.content ?? msg?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (
+        block?.type === "tool_use" &&
+        typeof block.id === "string" &&
+        typeof block.name === "string"
+      ) {
+        map[block.id] = block.name;
+      }
+    }
+  }
+  return map;
+}
+
+function buildParts(content, toolNameById) {
+  const out = [];
+  if (typeof content === "string") {
+    if (content.trim()) out.push({ type: "text", text: content });
+    return out;
+  }
+  if (!Array.isArray(content)) return out;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      if (block.text.trim()) out.push({ type: "text", text: block.text });
+    } else if (block.type === "tool_use" && typeof block.name === "string") {
+      out.push({
+        type: "tool",
+        tool_id: typeof block.id === "string" ? block.id : undefined,
+        tool_name: block.name,
+        tool_input:
+          block.input && typeof block.input === "object" ? block.input : undefined,
+        tool_status: "running",
+      });
+    } else if (block.type === "tool_result") {
+      const id = typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+      out.push({
+        type: "tool",
+        tool_id: id,
+        tool_name: id ? toolNameById[id] : undefined,
+        tool_output: truncateToolOutput(extractToolResultText(block.content)),
+        tool_status: block.is_error ? "error" : "completed",
+      });
+    }
+  }
+  return out;
+}
+
 /**
  * Extract user/assistant turns. Captures plain text + tool_use input (verbatim) and,
  * if TOOL_RESULT_MAX_CHARS > 0, tool_result output (truncated). Tool blocks are inlined
@@ -221,6 +301,7 @@ function extractToolResultText(content) {
  * substance, not just tool names.
  */
 function extractAllTurns(messages) {
+  const toolNameById = collectToolNamesById(messages);
   const turns = [];
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") continue;
@@ -228,6 +309,7 @@ function extractAllTurns(messages) {
     let role = msg.role;
     let text = "";
     let toolNames = [];
+    let parts = [];
 
     const harvestContent = (content) => {
       if (typeof content === "string") {
@@ -253,16 +335,22 @@ function extractAllTurns(messages) {
       }
     };
 
+    let rawContent;
     if (msg.content !== undefined) {
-      harvestContent(msg.content);
+      rawContent = msg.content;
     } else if (typeof msg.message === "object" && msg.message) {
       role = msg.message.role || role;
-      harvestContent(msg.message.content);
+      rawContent = msg.message.content;
     }
+    harvestContent(rawContent);
+    parts = buildParts(rawContent, toolNameById);
 
     if (role !== "user" && role !== "assistant") continue;
-    if (!text.trim() && toolNames.length === 0) continue;
-    turns.push({ role, text: text.trim(), toolNames });
+    // Keep turns that carry any structured part. This also retains tool_result-
+    // only user turns (previously dropped because their inlined `text` was empty
+    // once TOOL_RESULT_MAX_CHARS=0), so tool outputs reach OV as tool parts.
+    if (parts.length === 0) continue;
+    turns.push({ role, text: text.trim(), toolNames, parts });
   }
   return turns;
 }
@@ -285,16 +373,32 @@ function formatTurnsAsText(turns) {
 // Persistent-session capture
 // ---------------------------------------------------------------------------
 
+// Strip plugin-injected blocks from text parts (tool parts pass through), and
+// drop parts that become empty. Mirrors the old content-path stripInjectedBlocks
+// + trim, but per text part so tool I/O is never collapsed.
+function sanitizePartsForSend(parts) {
+  const out = [];
+  for (const p of parts || []) {
+    if (p.type === "text") {
+      const t = stripInjectedBlocks(p.text).trim();
+      if (t) out.push({ type: "text", text: t });
+    } else {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
 async function pushTurnsToOv(ovSessionId, turns) {
   let ok = 0;
   let failed = 0;
   for (const turn of turns) {
-    // Tool input + tool_result are already inlined as `[tool: NAME]` / `[tool result]`
-    // blocks during harvesting, so no separate suffix is needed here.
-    const content = stripInjectedBlocks(turn.text).trim();
-    if (!content) continue;
+    // Send structured parts: tool calls/results are dedicated `tool` parts, not
+    // inlined into content, so the server can process them separately.
+    const parts = sanitizePartsForSend(turn.parts);
+    if (parts.length === 0) continue;
 
-    const res = await addMessage(fetchJSON, ovSessionId, { role: turn.role, content });
+    const res = await addMessage(fetchJSON, ovSessionId, { role: turn.role, parts });
     if (res.ok) ok++;
     else failed++;
   }

--- a/examples/claude-code-memory-plugin/scripts/subagent-stop.mjs
+++ b/examples/claude-code-memory-plugin/scripts/subagent-stop.mjs
@@ -101,6 +101,71 @@ function extractToolResultText(content) {
     .join("\n");
 }
 
+// Structured parts (parts-mode capture) — mirrors auto-capture.mjs. Tool calls /
+// results become dedicated `tool` parts instead of being inlined into content.
+const TOOL_OUTPUT_PART_MAX_CHARS = 2000;
+
+function truncateToolOutput(s) {
+  if (typeof s !== "string") s = String(s ?? "");
+  if (s.length <= TOOL_OUTPUT_PART_MAX_CHARS) return s;
+  return (
+    s.slice(0, TOOL_OUTPUT_PART_MAX_CHARS) +
+    `\n... [truncated, ${s.length - TOOL_OUTPUT_PART_MAX_CHARS} more chars]`
+  );
+}
+
+function collectToolNamesById(messages) {
+  const map = {};
+  for (const msg of messages) {
+    const content = msg?.content ?? msg?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (
+        block?.type === "tool_use" &&
+        typeof block.id === "string" &&
+        typeof block.name === "string"
+      ) {
+        map[block.id] = block.name;
+      }
+    }
+  }
+  return map;
+}
+
+function buildParts(content, toolNameById) {
+  const out = [];
+  if (typeof content === "string") {
+    if (content.trim()) out.push({ type: "text", text: content });
+    return out;
+  }
+  if (!Array.isArray(content)) return out;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      if (block.text.trim()) out.push({ type: "text", text: block.text });
+    } else if (block.type === "tool_use" && typeof block.name === "string") {
+      out.push({
+        type: "tool",
+        tool_id: typeof block.id === "string" ? block.id : undefined,
+        tool_name: block.name,
+        tool_input:
+          block.input && typeof block.input === "object" ? block.input : undefined,
+        tool_status: "running",
+      });
+    } else if (block.type === "tool_result") {
+      const id = typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+      out.push({
+        type: "tool",
+        tool_id: id,
+        tool_name: id ? toolNameById[id] : undefined,
+        tool_output: truncateToolOutput(extractToolResultText(block.content)),
+        tool_status: block.is_error ? "error" : "completed",
+      });
+    }
+  }
+  return out;
+}
+
 /**
  * Tier-1 parts extraction — shared shape with auto-capture.mjs.
  * Kept inline here so SubagentStop does not import auto-capture's globals.
@@ -108,12 +173,14 @@ function extractToolResultText(content) {
  * (TOOL_RESULT_MAX_CHARS = 0) and retained only if explicitly enabled.
  */
 function extractTurns(messages) {
+  const toolNameById = collectToolNamesById(messages);
   const turns = [];
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") continue;
     let role = msg.role;
     let text = "";
     const toolNames = [];
+    let parts = [];
 
     const harvestContent = (content) => {
       if (typeof content === "string") {
@@ -139,16 +206,19 @@ function extractTurns(messages) {
       }
     };
 
+    let rawContent;
     if (msg.content !== undefined) {
-      harvestContent(msg.content);
+      rawContent = msg.content;
     } else if (typeof msg.message === "object" && msg.message) {
       role = msg.message.role || role;
-      harvestContent(msg.message.content);
+      rawContent = msg.message.content;
     }
+    harvestContent(rawContent);
+    parts = buildParts(rawContent, toolNameById);
 
     if (role !== "user" && role !== "assistant") continue;
-    if (!text.trim() && toolNames.length === 0) continue;
-    turns.push({ role, text: text.trim(), toolNames });
+    if (parts.length === 0) continue;
+    turns.push({ role, text: text.trim(), toolNames, parts });
   }
   return turns;
 }
@@ -161,10 +231,13 @@ async function pushTurns(ovSessionId, ovAgentId, turns) {
   let ok = 0;
   let failed = 0;
   for (const turn of turns) {
-    // Tool input / result already inlined as `[tool: NAME]` / `[tool result]` during harvest.
-    const content = turn.text;
-    if (!content) continue;
-    const res = await addMessage(fetchJSON, ovSessionId, { role: turn.role, content });
+    // Send structured parts: tool calls/results are dedicated `tool` parts, not
+    // inlined into content, so the server can process them separately.
+    const parts = (turn.parts || []).filter(
+      (p) => p.type !== "text" || (p.text && p.text.trim()),
+    );
+    if (parts.length === 0) continue;
+    const res = await addMessage(fetchJSON, ovSessionId, { role: turn.role, parts });
     if (res.ok) ok++;
     else failed++;
   }

--- a/examples/claude-code-memory-plugin/setup-helper/install.sh
+++ b/examples/claude-code-memory-plugin/setup-helper/install.sh
@@ -305,17 +305,40 @@ install_legacy() {
 install_modern() {
   # `--scope` intentionally omitted. Default scope is already user; passing it
   # breaks older 2.0.x builds that don't recognize the flag.
-  info 'claude plugin marketplace add'
-  ( cd "$REPO_DIR" && claude plugin marketplace add "$REPO_DIR/examples" ) || \
-    warn 'marketplace add returned non-zero (likely already added) — continuing'
-  info 'claude plugin install'
-  ( cd "$REPO_DIR" && claude plugin install claude-code-memory-plugin@openviking-plugins-local ) || {
-    warn 'plugin install failed — falling back to legacy mode'
-    install_legacy
-    return $?
-  }
-  # Belt-and-suspenders: ensure enabled even if `install` left it disabled.
-  claude plugin enable claude-code-memory-plugin@openviking-plugins-local >/dev/null 2>&1 || true
+  local mp='openviking-plugins-local'
+  local plugin='claude-code-memory-plugin@openviking-plugins-local'
+
+  # Marketplace: add when missing, else UPDATE. `marketplace add` on an existing
+  # entry is a no-op that does NOT re-read the source, so a bumped plugin version
+  # in the checkout is never picked up on re-run. Re-running the installer is the
+  # supported upgrade path, so the already-present branch must re-sync the catalog.
+  if claude plugin marketplace list 2>/dev/null | grep -qF "$mp"; then
+    info "claude plugin marketplace update ($mp)"
+    claude plugin marketplace update "$mp" || \
+      warn 'marketplace update returned non-zero — continuing'
+  else
+    info 'claude plugin marketplace add'
+    ( cd "$REPO_DIR" && claude plugin marketplace add "$REPO_DIR/examples" ) || \
+      warn 'marketplace add returned non-zero — continuing'
+  fi
+
+  # Plugin: update when already installed, else install. `plugin install` is a
+  # no-op on an existing install (it will NOT pull a newer version), so an
+  # explicit `plugin update` is required for the re-run-to-upgrade path.
+  if claude plugin list 2>/dev/null | grep -qF "$plugin"; then
+    info "claude plugin update ($plugin)"
+    ( cd "$REPO_DIR" && claude plugin update "$plugin" ) || \
+      warn 'plugin update returned non-zero — continuing'
+  else
+    info 'claude plugin install'
+    ( cd "$REPO_DIR" && claude plugin install "$plugin" ) || {
+      warn 'plugin install failed — falling back to legacy mode'
+      install_legacy
+      return $?
+    }
+  fi
+  # Belt-and-suspenders: ensure enabled even if install/update left it disabled.
+  claude plugin enable "$plugin" >/dev/null 2>&1 || true
 }
 
 # Statusline registration. CC's plugin manifest doesn't accept a statusLine


### PR DESCRIPTION
## Description

The Claude Code memory plugin (`examples/claude-code-memory-plugin`) inlined tool I/O into the message **content** and sent content-only:

- `auto-capture.mjs` / `subagent-stop.mjs` turned each `tool_use` into `[tool: NAME]\n{input}` and each `tool_result` into `[tool result]` text, joined into one string, then called `addMessage({ role, content })`.
- The server therefore stored a whole turn (prose + tool call + tool result) as a single `text` part and could not separate calls from results.
- Tool results were additionally dropped entirely by default (`TOOL_RESULT_MAX_CHARS = 0`), so outputs never reached OV.

This records tool calls and results as structured `tool` parts instead, so the server can process them separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `auto-capture.mjs` / `subagent-stop.mjs`: add `buildParts()` producing structured parts — text blocks → `text` parts; `tool_use` → `tool` part (`tool_id` / `tool_name` / `tool_input`, status `running`); `tool_result` → `tool` part (`tool_id`, `tool_output`, status `completed`/`error`).
- `tool_result` blocks (which only carry `tool_use_id`) are labelled with the matching call name via a pre-scanned `tool_use_id -> name` map.
- Tool outputs are now captured (not dropped), bounded to 2000 chars, in a separable `tool_output` field.
- Send via parts-mode `addMessage({ role, parts })` — already supported by `lib/ov-session.mjs`.
- `auto-capture` strips plugin-injected blocks (`<relevant-memories>` etc.) per text part at send time, preventing the self-referential capture loop.
- The legacy inlined `text` string is kept solely to drive the existing capture heuristics (length / keyword); capture decisions are unchanged.
- Retain tool_result-only user turns (previously dropped once their inlined text was empty) so outputs reach OV as tool parts.

## Testing

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] macOS

No test harness exists in this example plugin. Verified by: `node --check` on both files, and running the harvest helpers (`collectToolNamesById` / `buildParts` / `sanitizePartsForSend`) against a synthetic Claude Code transcript — confirmed tool calls/results become structured parts, names backfill by `tool_use_id`, and injected `<relevant-memories>` blocks are stripped from text parts at send time.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Output retention is bounded (2000 chars) rather than unbounded: results land in a separable `tool_output` field the server can process independently, but we avoid storing whole files / web pages / command stdout verbatim. The previous behavior dropped them entirely.
