### PR TITLE
docs: add Claude Desktop + Claude Code integration to community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,3 +816,7 @@ The OpenViking project uses different licenses for different components:
 - **third\_party**: Respective original licenses of third-party projects
 
 <!-- Link Definitions -->
+## Community Integrations
+
+- [openviking-claude-desktop](https://github.com/itzsamehfawzi/openviking-claude-desktop)
+  — Claude Desktop MCP bridge + Claude Code auto-recall/capture for Windows (by Sameh Khalifa)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Note:** Looking for a Claude Desktop + Claude Code integration?
+> See [openviking-claude-desktop](https://github.com/itzsamehfawzi/openviking-claude-desktop)
+> — MCP bridge, auto-recall hooks, watchdog, Windows native.
 <div align="center">
 
 <a href="https://openviking.ai/" target="_blank">

--- a/README.md
+++ b/README.md
@@ -819,4 +819,4 @@ The OpenViking project uses different licenses for different components:
 ## Community Integrations
 
 - [openviking-claude-desktop](https://github.com/itzsamehfawzi/openviking-claude-desktop)
-  — Claude Desktop MCP bridge + Claude Code auto-recall/capture for Windows (by Sameh Khalifa.)
+  — Claude Desktop MCP bridge + Claude Code auto-recall/capture for Windows (by Sameh Khalifa)

--- a/README.md
+++ b/README.md
@@ -819,4 +819,4 @@ The OpenViking project uses different licenses for different components:
 ## Community Integrations
 
 - [openviking-claude-desktop](https://github.com/itzsamehfawzi/openviking-claude-desktop)
-  — Claude Desktop MCP bridge + Claude Code auto-recall/capture for Windows (by Sameh Khalifa)
+  — Claude Desktop MCP bridge + Claude Code auto-recall/capture for Windows (by Sameh Khalifa.)


### PR DESCRIPTION
## Summary

Adds openviking-claude-desktop to the community integrations section of the README.

## What this integration provides

A Windows-native integration that gives Claude Desktop and Claude Code 
persistent memory via OpenViking:

- **MCP bridge** — 12 `ov_*` tools exposed to Claude Desktop
- **Auto-recall** — searches memory before every Claude Code prompt (UserPromptSubmit hook)
- **Auto-capture** — commits sessions and extracts memories at session end (Stop hook)  
- **Self-healing watchdog** — never permanently exits, restart counter resets after 10 min uptime
- **Windows Task Scheduler** — autosave every 30 min + health alerts every 15 min
- **Embedding selector** — Ollama-first, Jina cloud fallback
- **26-point verification script** — confirms everything works

Built on OpenViking v0.3.16 with full Apache 2.0 attribution (NOTICE file included).

## Repository

https://github.com/itzsamehfawzi/openviking-claude-desktop

## Testing

Tested on Windows 11, Python 3.13, Node.js 20, OpenViking v0.3.16.
All 26 verification checks pass.