### PR TITLE
docs(en): enumerate Video/Audio parser extensions in 06-extraction (match #2341 ZH + source)

### DIFF
--- a/docs/en/concepts/06-extraction.md
+++ b/docs/en/concepts/06-extraction.md
@@ -28,8 +28,8 @@ Parser handles document format conversion and structuring, creating file structu
 | HTML | HTMLParser | .html, .htm | Supported |
 | Code | CodeRepositoryParser | .py, .js, .go, etc. | Respects `.gitignore` and ignores common non-code directories |
 | Image | ImageParser | .png, .jpg, etc. |  |
-| Video | VideoParser | .mp4, .avi, etc. |  |
-| Audio | AudioParser | .mp3, .wav, etc. |  |
+| Video | VideoParser | .mp4, .avi, .mov, .mkv, .webm, .flv, .wmv |  |
+| Audio | AudioParser | .mp3, .wav, .ogg, .flac, .aac, .m4a, .opus |  |
 
 ### Core Flow (Document Example)
 


### PR DESCRIPTION
The EN Parser table truncates the Video/Audio extensions as `.mp4, .avi, etc.` / `.mp3, .wav, etc.`. #2341 just enumerated the ZH table to the full lists, and `openviking/parse/parsers/media/constants.py` defines all seven each (`VIDEO_EXTENSIONS`, `AUDIO_EXTENSIONS`). This mirrors them to EN so readers can see the supported `.mov` / `.mkv` / `.webm` / `.flv` / `.wmv` and `.ogg` / `.flac` / `.aac` / `.m4a` / `.opus` formats. The Image row is left as-is to match #2341's scope.