### PR TITLE
docs(api): document structured details on read() directory-URI error

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -134,7 +134,7 @@ Read L2 full content.
 
 **Notes**
 
-- `read()` accepts file URIs only. Passing an existing directory URI returns `INVALID_ARGUMENT` (`400`), not `NOT_FOUND`.
+- `read()` accepts file URIs only. Passing an existing directory URI returns `INVALID_ARGUMENT` (`400`), not `NOT_FOUND`. This error carries a structured `details` payload — `details.expected` is `"file"`, `details.actual` is `"directory"`, and `details.resource` is the offending URI (present on the HTTP path) — so clients can detect a file-vs-directory mismatch programmatically (for example, fall back to `list`) instead of string-matching the message.
 - Public URI parameters accept `resources`, `user`, `agent`, and `session` scopes. Internal scopes such as `temp` and `queue` return `INVALID_URI`.
 
 **Python SDK (Embedded / HTTP)**

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -134,7 +134,7 @@ openviking overview viking://resources/docs/
 
 **说明**
 
-- `read()` 只接受文件 URI。传入已存在的目录 URI 时返回 `INVALID_ARGUMENT`（`400`），而不是 `NOT_FOUND`。
+- `read()` 只接受文件 URI。传入已存在的目录 URI 时返回 `INVALID_ARGUMENT`（`400`），而不是 `NOT_FOUND`。该错误会携带结构化的 `details` 字段——`details.expected` 为 `"file"`，`details.actual` 为 `"directory"`，`details.resource` 为出错的 URI（HTTP 路径上会带上）——客户端据此即可以编程方式判断"文件 vs 目录"不匹配（例如回退到 `list`），而无需对错误消息做字符串匹配。
 - 公开 URI 参数只接受 `resources`、`user`、`agent`、`session` 作用域。`temp`、`queue` 等内部作用域会返回 `INVALID_URI`。
 
 **Python SDK (Embedded / HTTP)**


### PR DESCRIPTION
`read()` on a directory URI now returns a machine-readable `error.details` payload (added in #2300, `error_mapping.py` `_file_directory_details`): `details.expected="file"`, `details.actual="directory"`, and `details.resource=<uri>` (on the HTTP path). The canonical `read()` docs only mentioned the `INVALID_ARGUMENT`/`400` status, not the new fields, so HTTP/SDK clients couldn't branch on the structured contract without string-matching the message.

This extends the `read()` Notes bullet in `docs/en/api/03-filesystem.md` and its `docs/zh` mirror to document `details.expected/actual/resource`, consistent with the existing structured-error convention (`error.details.validation_errors` in `01-overview.md`). Pure docs, EN + ZH.
