### PR TITLE
feat(docs): The main site and the documentation site share cookie configurations (theme colors & Chinese/English switching).

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,8 @@ import { defineConfig, type DefaultTheme } from 'vitepress'
 const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const repo = process.env.GITHUB_REPOSITORY || 'volcengine/OpenViking'
 const base = process.env.DOCS_BASE || '/'
+const withTrailingSlash = (url: string) => (url.endsWith('/') ? url : `${url}/`)
+const mainSiteBase = withTrailingSlash(process.env.OPENVIKING_SITE_BASE || 'https://www.openviking.ai/')
 const preferenceBootstrapScript = `;(() => {
   const prefix = 'openviking-preferences:'
   const cookieKey = 'openviking-preferences'
@@ -262,7 +264,7 @@ export default defineConfig({
   },
   themeConfig: {
     logo: '/ov-logo.png',
-    logoLink: 'https://www.openviking.ai/',
+    logoLink: mainSiteBase,
     search: {
       provider: 'local'
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,25 @@ import { defineConfig, type DefaultTheme } from 'vitepress'
 const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const repo = process.env.GITHUB_REPOSITORY || 'volcengine/OpenViking'
 const base = process.env.DOCS_BASE || '/'
+const preferenceBootstrapScript = `;(() => {
+  const prefix = 'openviking-preferences:'
+  const cookieKey = 'openviking-preferences'
+  const readCookiePreference = () => {
+    const cookie = document.cookie.split('; ').find((item) => item.startsWith(cookieKey + '='))
+    if (!cookie) return {}
+    return JSON.parse(decodeURIComponent(cookie.slice(cookieKey.length + 1)))
+  }
+  const readTransferPreference = () => {
+    if (!window.name.startsWith(prefix)) return {}
+    return JSON.parse(window.name.slice(prefix.length))
+  }
+  try {
+    const preference = { ...readCookiePreference(), ...readTransferPreference() }
+    if (preference.theme !== 'light' && preference.theme !== 'dark') return
+    localStorage.setItem('vitepress-theme-appearance', preference.theme)
+    document.documentElement.classList.toggle('dark', preference.theme === 'dark')
+  } catch {}
+})()`
 
 const sectionNames: Record<string, string> = {
   'getting-started': 'Getting Started',
@@ -206,7 +225,8 @@ export default defineConfig({
   head: [
     ['link', { rel: 'icon', type: 'image/x-icon', href: `${base}favicon.ico` }],
     ['link', { rel: 'icon', type: 'image/png', sizes: '32x32', href: `${base}favicon-32.png` }],
-    ['link', { rel: 'apple-touch-icon', href: `${base}apple-touch-icon.png` }]
+    ['link', { rel: 'apple-touch-icon', href: `${base}apple-touch-icon.png` }],
+    ['script', {}, preferenceBootstrapScript]
   ],
   transformPageData(pageData, { siteConfig }) {
     const srcPath = path.join(siteConfig.srcDir, pageData.relativePath)
@@ -242,7 +262,7 @@ export default defineConfig({
   },
   themeConfig: {
     logo: '/ov-logo.png',
-    logoLink: 'https://openviking.ai/',
+    logoLink: 'https://www.openviking.ai/',
     search: {
       provider: 'local'
     },

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,6 +4,293 @@ import CopyMarkdownButton from './CopyMarkdownButton.vue'
 import LlmsTxtLink from './LlmsTxtLink.vue'
 import './custom.css'
 
+type OpenVikingPreference = {
+  lang?: 'zh' | 'en'
+  theme?: 'light' | 'dark'
+}
+
+const PREFERENCE_SESSION_KEY = 'openviking-preferences'
+const PREFERENCE_COOKIE_KEY = 'openviking-preferences'
+const PREFERENCE_TRANSFER_PREFIX = 'openviking-preferences:'
+const VITEPRESS_THEME_KEY = 'vitepress-theme-appearance'
+const LOCAL_PLAYGROUND_URL = 'http://localhost:8080/'
+const MAIN_SITE_HOSTS = new Set([
+  'www.openviking.ai',
+  'openviking.ai',
+  'www.openviking.net',
+  'openviking.net',
+  'localhost:8080',
+  '127.0.0.1:8080'
+])
+
+function normalizeLang(value: string | null): OpenVikingPreference['lang'] {
+  if (value === 'zh' || value === 'en') return value
+  return undefined
+}
+
+function normalizeTheme(value: string | null): OpenVikingPreference['theme'] {
+  if (value === 'light' || value === 'dark') return value
+  return undefined
+}
+
+function readStoredPreference(): OpenVikingPreference {
+  const rawPreference = sessionStorage.getItem(PREFERENCE_SESSION_KEY)
+  if (!rawPreference) return {}
+
+  try {
+    const preference = JSON.parse(rawPreference) as OpenVikingPreference
+    return {
+      lang: normalizeLang(preference.lang ?? null),
+      theme: normalizeTheme(preference.theme ?? null)
+    }
+  } catch {
+    return {}
+  }
+}
+
+function cookieDomain() {
+  const hostname = window.location.hostname
+  if (hostname === 'localhost' || hostname === '127.0.0.1') return ''
+  if (hostname.endsWith('.openviking.ai') || hostname === 'openviking.ai') {
+    return 'Domain=.openviking.ai'
+  }
+  if (hostname.endsWith('.openviking.net') || hostname === 'openviking.net') {
+    return 'Domain=.openviking.net'
+  }
+  return ''
+}
+
+function readCookiePreference(): OpenVikingPreference {
+  const cookie = document.cookie
+    .split('; ')
+    .find((item) => item.startsWith(`${PREFERENCE_COOKIE_KEY}=`))
+
+  if (!cookie) return {}
+
+  try {
+    const rawPreference = decodeURIComponent(cookie.slice(PREFERENCE_COOKIE_KEY.length + 1))
+    const preference = JSON.parse(rawPreference) as OpenVikingPreference
+    return {
+      lang: normalizeLang(preference.lang ?? null),
+      theme: normalizeTheme(preference.theme ?? null)
+    }
+  } catch {
+    return {}
+  }
+}
+
+function writeCookiePreference(preference: OpenVikingPreference) {
+  const nextPreference = mergePreferences(readCookiePreference(), preference)
+  document.cookie = [
+    `${PREFERENCE_COOKIE_KEY}=${encodeURIComponent(JSON.stringify(nextPreference))}`,
+    'Path=/',
+    'Max-Age=31536000',
+    'SameSite=Lax',
+    cookieDomain()
+  ]
+    .filter(Boolean)
+    .join('; ')
+}
+
+function mergePreferences(
+  base: OpenVikingPreference,
+  incoming: OpenVikingPreference
+): OpenVikingPreference {
+  return {
+    lang: incoming.lang ?? base.lang,
+    theme: incoming.theme ?? base.theme
+  }
+}
+
+function writeStoredPreference(preference: OpenVikingPreference) {
+  const nextPreference = mergePreferences(readStoredPreference(), preference)
+  sessionStorage.setItem(PREFERENCE_SESSION_KEY, JSON.stringify(nextPreference))
+  writeCookiePreference(nextPreference)
+}
+
+function readTransferredPreference(): OpenVikingPreference {
+  if (typeof window === 'undefined') return {}
+  if (!window.name.startsWith(PREFERENCE_TRANSFER_PREFIX)) return {}
+
+  try {
+    const preference = JSON.parse(
+      window.name.slice(PREFERENCE_TRANSFER_PREFIX.length)
+    ) as OpenVikingPreference
+    return {
+      lang: normalizeLang(preference.lang ?? null),
+      theme: normalizeTheme(preference.theme ?? null)
+    }
+  } catch {
+    return {}
+  }
+}
+
+function writeTransferredPreference(preference: OpenVikingPreference) {
+  if (!preference.lang && !preference.theme) return
+
+  window.name = `${PREFERENCE_TRANSFER_PREFIX}${JSON.stringify(preference)}`
+}
+
+function readPersistedPreference() {
+  return mergePreferences(
+    mergePreferences(readStoredPreference(), readCookiePreference()),
+    readTransferredPreference()
+  )
+}
+
+function applyPreference(preference: OpenVikingPreference) {
+  const normalizedPreference: OpenVikingPreference = {
+    lang: normalizeLang(preference.lang ?? null),
+    theme: normalizeTheme(preference.theme ?? null)
+  }
+
+  if (normalizedPreference.lang || normalizedPreference.theme) {
+    writeStoredPreference(normalizedPreference)
+    writeTransferredPreference(mergePreferences(readStoredPreference(), normalizedPreference))
+  }
+
+  if (normalizedPreference.theme) {
+    localStorage.setItem(VITEPRESS_THEME_KEY, normalizedPreference.theme)
+    document.documentElement.classList.toggle('dark', normalizedPreference.theme === 'dark')
+  }
+
+  const lang = normalizedPreference.lang
+  if (!lang) return
+
+  const targetPath = resolveLocalizedPath(window.location.pathname, lang)
+  const targetUrl = `${targetPath}${window.location.search}${window.location.hash}`
+  const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`
+
+  if (targetUrl !== currentUrl) {
+    window.location.replace(targetUrl)
+  }
+}
+
+function syncPreferenceFromPeerSite() {
+  if (typeof window === 'undefined') return
+
+  applyPreference(readPersistedPreference())
+}
+
+function resolveLocalizedPath(pathname: string, lang?: OpenVikingPreference['lang']) {
+  if (lang === 'zh') {
+    if (pathname.startsWith('/en/')) return pathname.replace(/^\/en\//, '/zh/')
+  }
+
+  if (lang === 'en') {
+    if (pathname.startsWith('/zh/')) return pathname.replace(/^\/zh\//, '/en/')
+  }
+
+  return pathname
+}
+
+function currentDocsLang(): OpenVikingPreference['lang'] {
+  if (window.location.pathname.startsWith('/zh/')) return 'zh'
+  if (window.location.pathname.startsWith('/en/')) return 'en'
+  return undefined
+}
+
+function currentDocsTheme(): OpenVikingPreference['theme'] {
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+}
+
+function syncCurrentDocsPreference() {
+  const preference = mergePreferences(readPersistedPreference(), {
+    lang: currentDocsLang(),
+    theme: currentDocsTheme()
+  })
+  writeStoredPreference(preference)
+  writeTransferredPreference(preference)
+}
+
+function patchHistoryForPreferenceSync() {
+  const originalPushState = window.history.pushState
+  const originalReplaceState = window.history.replaceState
+
+  window.history.pushState = function patchedPushState(...args) {
+    const result = originalPushState.apply(this, args)
+    window.setTimeout(syncCurrentDocsPreference)
+    return result
+  }
+
+  window.history.replaceState = function patchedReplaceState(...args) {
+    const result = originalReplaceState.apply(this, args)
+    window.setTimeout(syncCurrentDocsPreference)
+    return result
+  }
+
+  window.addEventListener('popstate', () => window.setTimeout(syncCurrentDocsPreference))
+}
+
+function watchThemePreference() {
+  const observer = new MutationObserver(syncCurrentDocsPreference)
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class']
+  })
+}
+
+function mainSiteUrlWithPreference(href: string) {
+  const url = new URL(href, window.location.href)
+  const isLocalDocs = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+  const isMainSite = MAIN_SITE_HOSTS.has(url.host)
+
+  if (!isMainSite) return undefined
+
+  if (
+    isLocalDocs &&
+    ['www.openviking.ai', 'openviking.ai', 'www.openviking.net', 'openviking.net'].includes(
+      url.hostname
+    )
+  ) {
+    return new URL(LOCAL_PLAYGROUND_URL)
+  }
+
+  return url
+}
+
+function syncPreferenceToMainSiteLinks() {
+  document.addEventListener(
+    'click',
+    (event) => {
+      const link = event.target instanceof Element ? event.target.closest('a') : null
+      if (!link) return
+
+      const url = mainSiteUrlWithPreference(link.href)
+      if (!url) return
+
+      const preference = mergePreferences(readPersistedPreference(), {
+        lang: currentDocsLang(),
+        theme: currentDocsTheme()
+      })
+      writeStoredPreference(preference)
+      writeTransferredPreference(preference)
+
+      link.href = url.toString()
+    },
+    true
+  )
+}
+
+function startPreferenceSync() {
+  syncPreferenceFromPeerSite()
+  syncCurrentDocsPreference()
+  patchHistoryForPreferenceSync()
+  watchThemePreference()
+  syncPreferenceToMainSiteLinks()
+  window.addEventListener('pageshow', syncPreferenceFromPeerSite)
+}
+
+syncPreferenceFromPeerSite()
+
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startPreferenceSync, { once: true })
+  } else {
+    startPreferenceSync()
+  }
+}
+
 export default {
   extends: DefaultTheme,
   Layout() {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -243,7 +243,11 @@ function mainSiteUrlWithPreference(href: string) {
       url.hostname
     )
   ) {
-    return new URL(LOCAL_PLAYGROUND_URL)
+    const localUrl = new URL(LOCAL_PLAYGROUND_URL)
+    localUrl.pathname = url.pathname
+    localUrl.search = url.search
+    localUrl.hash = url.hash
+    return localUrl
   }
 
   return url


### PR DESCRIPTION
## Description

Synchronizes language and theme preferences between the OpenViking main site and the documentation site.

The docs site now reads and writes the shared `openviking-preferences` cookie, allowing language and light/dark theme selections made in docs to be reused by the main site. This keeps the preference state consistent across `www.openviking.ai` and `docs.openviking.ai`, while also supporting local development between `localhost:8080` and `localhost:5173`.

This PR also adds an early docs theme bootstrap script to reduce light/dark mode flicker during initial render, updates the docs logo link to the production main-site domain, and preserves path/search/hash when local docs rewrite main-site links to the local playground URL.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- Added shared `openviking-preferences` cookie support in the docs VitePress theme, including `.openviking.ai` and `.openviking.net` domain handling for production and localhost support for local development.
- Synced docs language changes back to shared preferences so the main site can apply the latest language selection after navigation or browser back/forward restoration.
- Synced docs light/dark theme changes back to shared preferences by observing VitePress theme state changes.
- Added an early docs theme bootstrap script that applies the persisted light/dark preference before VitePress hydration to reduce visual flicker.
- Updated the docs logo link to `https://www.openviking.ai/` and recognized `www.openviking.ai` / `www.openviking.net` as main-site hosts.
- Preserved path, search params, and hash when rewriting production main-site links to `http://localhost:8080/` during local docs development.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation commands run locally:

```bash
npm run docs:build
```

`npm run docs:build` passes. The build still prints existing VitePress syntax-highlighting fallback warnings for languages such as `promql` and `caddyfile`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Main site changes are maintained in the separate playground repository. This PR contains the documentation-site side of the preference synchronization flow.