### PR TITLE
Fix Codex VLM response stream parsing

### DIFF
--- a/openviking/models/vlm/backends/codex_responses_adapter.py
+++ b/openviking/models/vlm/backends/codex_responses_adapter.py
@@ -185,6 +185,35 @@ def _build_chat_completion_like_response(final_response: Any, model: str) -> Any
     )
 
 
+def _build_final_response_from_stream_events(
+    completed_response: Any,
+    collected_output_items: List[Any],
+    collected_text_deltas: List[str],
+    has_function_calls: bool,
+) -> Any:
+    output = getattr(completed_response, "output", None) if completed_response is not None else None
+    if output:
+        return completed_response
+
+    fallback_output: List[Any] = []
+    if collected_output_items:
+        fallback_output = list(collected_output_items)
+    elif collected_text_deltas and not has_function_calls:
+        fallback_output = [
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="".join(collected_text_deltas))],
+            )
+        ]
+
+    return SimpleNamespace(
+        output=fallback_output,
+        usage=getattr(completed_response, "usage", None) if completed_response is not None else None,
+    )
+
+
 class CodexCompletionsAdapter:
     def __init__(self, client_factory: Callable[[], Any], model: str):
         self._client_factory = client_factory
@@ -218,7 +247,9 @@ class CodexCompletionsAdapter:
         collected_output_items: List[Any] = []
         collected_text_deltas: List[str] = []
         has_function_calls = False
-        with client.responses.stream(**response_kwargs) as stream:
+        completed_response = None
+        stream = client.responses.create(**response_kwargs, stream=True)
+        try:
             for event in stream:
                 event_type = getattr(event, "type", "")
                 if event_type == "response.output_item.done":
@@ -233,22 +264,19 @@ class CodexCompletionsAdapter:
                     continue
                 if "function_call" in event_type:
                     has_function_calls = True
-            final_response = stream.get_final_response()
-        output = getattr(final_response, "output", None)
-        if not output:
-            if collected_output_items:
-                final_response.output = list(collected_output_items)
-            elif collected_text_deltas and not has_function_calls:
-                final_response.output = [
-                    SimpleNamespace(
-                        type="message",
-                        role="assistant",
-                        status="completed",
-                        content=[
-                            SimpleNamespace(type="output_text", text="".join(collected_text_deltas))
-                        ],
-                    )
-                ]
+                    continue
+                if event_type == "response.completed":
+                    completed_response = getattr(event, "response", None)
+        finally:
+            close = getattr(stream, "close", None)
+            if callable(close):
+                close()
+        final_response = _build_final_response_from_stream_events(
+            completed_response,
+            collected_output_items,
+            collected_text_deltas,
+            has_function_calls,
+        )
         return _build_chat_completion_like_response(final_response, model)
 
     def create(self, **kwargs) -> Any:

--- a/openviking/models/vlm/backends/codex_vlm.py
+++ b/openviking/models/vlm/backends/codex_vlm.py
@@ -13,8 +13,8 @@ The complexity in this file arises from the need to shim/adapt standard Chat Com
 requests (used by OpenViking) into Responses API requests. This involves:
 1. Converting `text` and `image_url` parts into `input_text` and `input_image`.
 2. Adapting tool calls and schemas.
-3. Translating the `client.responses.stream` event stream back into a format
-   compatible with standard Chat Completion responses.
+3. Translating raw `client.responses.create(stream=True)` events back into a
+   format compatible with standard Chat Completion responses.
 """
 
 from __future__ import annotations
@@ -90,6 +90,18 @@ class CodexVLM(OpenAIVLM):
         self.api_key = credentials["api_key"]
         self.api_base = explicit_api_base or credentials["base_url"]
         return self.api_key, self.api_base
+
+    def _build_text_kwargs(self, *args, **kwargs):
+        request_kwargs = super()._build_text_kwargs(*args, **kwargs)
+        if self.stream:
+            request_kwargs["stream"] = True
+        return request_kwargs
+
+    def _build_vision_kwargs(self, *args, **kwargs):
+        request_kwargs = super()._build_vision_kwargs(*args, **kwargs)
+        if self.stream:
+            request_kwargs["stream"] = True
+        return request_kwargs
 
     def get_client(self):
         if openai is None:

--- a/tests/models/vlm/test_timeout_config.py
+++ b/tests/models/vlm/test_timeout_config.py
@@ -131,7 +131,7 @@ def test_codex_vlm_propagates_config_timeout():
     )
 
     with mock.patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI") as fake:
-        fake.return_value.responses.stream.return_value = _MockResponsesStream(
+        fake.return_value.responses.create.return_value = _MockResponsesStream(
             _build_final_response("timeout ok")
         )
         assert vlm.get_completion("hello") == "timeout ok"

--- a/tests/unit/test_codex_vlm.py
+++ b/tests/unit/test_codex_vlm.py
@@ -17,6 +17,7 @@ from openviking_cli.utils.config.vlm_config import VLMConfig
 class _MockResponsesStream:
     def __init__(self, final_response):
         self._final_response = final_response
+        self.closed = False
 
     def __enter__(self):
         return self
@@ -25,10 +26,30 @@ class _MockResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        events = [
+            SimpleNamespace(type="response.output_item.done", item=item)
+            for item in self._final_response.output or []
+        ]
+        events.append(SimpleNamespace(type="response.completed", response=self._final_response))
+        return iter(events)
+
+    def close(self):
+        self.closed = True
 
     def get_final_response(self):
         return self._final_response
+
+
+class _MockResponsesEventStream:
+    def __init__(self, events):
+        self._events = events
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def close(self):
+        self.closed = True
 
 
 def _build_final_response(text: str):
@@ -45,7 +66,7 @@ def _build_final_response(text: str):
 
 def _build_fake_openai_client(text: str):
     client = MagicMock()
-    client.responses.stream.return_value = _MockResponsesStream(_build_final_response(text))
+    client.responses.create.return_value = _MockResponsesStream(_build_final_response(text))
     return client
 
 
@@ -57,7 +78,7 @@ def test_codex_text_completion_uses_responses_api(mock_resolve, mock_openai_clas
         "base_url": "https://chatgpt.com/backend-api/codex",
     }
     mock_real_client = MagicMock()
-    mock_real_client.responses.stream.return_value = _MockResponsesStream(
+    mock_real_client.responses.create.return_value = _MockResponsesStream(
         _build_final_response("hello from codex")
     )
     mock_openai_class.return_value = mock_real_client
@@ -66,10 +87,12 @@ def test_codex_text_completion_uses_responses_api(mock_resolve, mock_openai_clas
     result = vlm.get_completion("hello")
 
     assert result == "hello from codex"
-    call_kwargs = mock_real_client.responses.stream.call_args.kwargs
+    call_kwargs = mock_real_client.responses.create.call_args.kwargs
     assert call_kwargs["model"] == "gpt-5.3-codex"
     assert call_kwargs["input"] == [{"role": "user", "content": "hello"}]
+    assert call_kwargs["stream"] is True
     assert "messages" not in call_kwargs
+    mock_real_client.responses.stream.assert_not_called()
 
 
 @patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")
@@ -80,7 +103,7 @@ def test_codex_vision_completion_converts_images(mock_resolve, mock_openai_class
         "base_url": "https://chatgpt.com/backend-api/codex",
     }
     mock_real_client = MagicMock()
-    mock_real_client.responses.stream.return_value = _MockResponsesStream(
+    mock_real_client.responses.create.return_value = _MockResponsesStream(
         _build_final_response("image result")
     )
     mock_openai_class.return_value = mock_real_client
@@ -89,7 +112,7 @@ def test_codex_vision_completion_converts_images(mock_resolve, mock_openai_class
     result = vlm.get_vision_completion("describe", [b"\x89PNG\r\n\x1a\n0000"])
 
     assert result == "image result"
-    call_kwargs = mock_real_client.responses.stream.call_args.kwargs
+    call_kwargs = mock_real_client.responses.create.call_args.kwargs
     content = call_kwargs["input"][0]["content"]
     assert content[0]["type"] == "input_image"
     assert content[0]["image_url"].startswith("data:image/png;base64,")
@@ -108,7 +131,7 @@ async def test_codex_async_client_defers_runtime_credential_resolution(
         "base_url": "https://chatgpt.com/backend-api/codex",
     }
     mock_real_client = MagicMock()
-    mock_real_client.responses.stream.return_value = _MockResponsesStream(
+    mock_real_client.responses.create.return_value = _MockResponsesStream(
         _build_final_response("async hello")
     )
     mock_openai_class.return_value = mock_real_client
@@ -124,6 +147,42 @@ async def test_codex_async_client_defers_runtime_credential_resolution(
 
     assert response.choices[0].message.content == "async hello"
     mock_resolve.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")
+@patch("openviking.models.vlm.backends.codex_vlm.resolve_codex_runtime_credentials")
+async def test_codex_async_stream_uses_text_deltas_when_completed_output_is_none(
+    mock_resolve,
+    mock_openai_class,
+):
+    mock_resolve.return_value = {
+        "api_key": "oauth-token",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    final_response = SimpleNamespace(
+        output=None,
+        usage=SimpleNamespace(input_tokens=11, output_tokens=7, total_tokens=18),
+    )
+    mock_stream = _MockResponsesEventStream(
+        [
+            SimpleNamespace(type="response.output_text.delta", delta="overview "),
+            SimpleNamespace(type="response.output_text.delta", delta="ready"),
+            SimpleNamespace(type="response.completed", response=final_response),
+        ]
+    )
+    mock_real_client = MagicMock()
+    mock_real_client.responses.create.return_value = mock_stream
+    mock_openai_class.return_value = mock_real_client
+
+    vlm = CodexVLM({"provider": "openai-codex", "model": "gpt-5.3-codex"})
+    response = await vlm.get_completion_async("summarize")
+
+    assert response == "overview ready"
+    assert mock_stream.closed is True
+    call_kwargs = mock_real_client.responses.create.call_args.kwargs
+    assert call_kwargs["stream"] is True
+    mock_real_client.responses.stream.assert_not_called()
 
 
 @patch("openviking.models.vlm.backends.codex_auth.has_codex_auth_available", return_value=True)
@@ -384,7 +443,7 @@ def test_codex_streaming_is_rejected(mock_resolve, mock_openai_class):
     with pytest.raises(NotImplementedError, match="Streaming is not supported"):
         vlm.get_completion("hello")
 
-    mock_real_client.responses.stream.assert_not_called()
+    mock_real_client.responses.create.assert_not_called()
 
 
 @patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")
@@ -431,7 +490,7 @@ def test_codex_translates_tool_history_into_responses_input(mock_resolve, mock_o
         "base_url": "https://chatgpt.com/backend-api/codex",
     }
     mock_real_client = MagicMock()
-    mock_real_client.responses.stream.return_value = _MockResponsesStream(
+    mock_real_client.responses.create.return_value = _MockResponsesStream(
         _build_final_response("final answer")
     )
     mock_openai_class.return_value = mock_real_client
@@ -476,7 +535,7 @@ def test_codex_translates_tool_history_into_responses_input(mock_resolve, mock_o
     )
 
     assert response.content == "final answer"
-    input_items = mock_real_client.responses.stream.call_args.kwargs["input"]
+    input_items = mock_real_client.responses.create.call_args.kwargs["input"]
     assert input_items == [
         {"role": "user", "content": "What is the weather?"},
         {


### PR DESCRIPTION
## Summary
- switch the Codex VLM chat shim from the OpenAI SDK high-level `responses.stream()` helper to raw `responses.create(stream=True)` events
- synthesize a final chat-completions-shaped response from output items or text deltas when the completed Responses snapshot has `output=None`
- preserve the explicit Codex streaming rejection path and update tests/mocks for the raw Responses stream call

## Verification
- `python -m pytest tests/unit/test_codex_vlm.py tests/models/vlm/test_timeout_config.py`
- `python -m ruff check openviking/models/vlm/backends/codex_responses_adapter.py openviking/models/vlm/backends/codex_vlm.py tests/unit/test_codex_vlm.py tests/models/vlm/test_timeout_config.py`
- `git diff --check`
- runtime: started local `python -m openviking_cli.server_bootstrap --config ~/.openviking/ov.conf --host 127.0.0.1 --port 1933` and verified `/health` reported `0.3.15.dev1`
- runtime: with `OPENVIKING_CLI_CONFIG_FILE=~/.openviking/ovcli.conf.local`, `ov add-resource examples/basic-usage/README.md --to viking://resources/runtime-codex-vlm-smoke-20260601-154341.md --wait -o json` returned success, semantic processed 1 item, embedding processed 7 items, and queue errors were empty
- runtime: overview and scoped find results were useful for the imported resource using `openai-codex/gpt-5.5`

## Notes
A longer Claude Code plugin README import also generated useful overviews and retrieval hits, but that CLI `--wait` call ended with a client-side network error after server-side processing had already advanced. The shorter smoke import completed cleanly.