### PR TITLE
feat(blog): sync shared language and theme preferences

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,7 +1,16 @@
 <!doctype html>
-<html lang="en" data-theme="kami">
+<html lang="en" data-theme="kami" class="blog-preference-booting">
 <head>
   <meta charset="utf-8" />
+  <style>
+    html.blog-preference-booting,
+    html.blog-preference-booting *,
+    html.blog-preference-booting *::before,
+    html.blog-preference-booting *::after {
+      transition: none !important;
+      animation: none !important;
+    }
+  </style>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenViking Blog</title>
   <meta name="description" content="Technical notes from the OpenViking team." />
@@ -19,6 +28,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-dark.png" media="(prefers-color-scheme: dark)" />
   <script>
     (() => {
+      const root = document.documentElement;
       const cookieKey = 'openviking-preferences';
       const readCookiePreference = () => {
         const cookie = document.cookie.split('; ').find((item) => item.startsWith(cookieKey + '='));
@@ -41,12 +51,15 @@
           : preference.theme === 'light'
             ? 'kami'
             : localStorage.getItem('blog.theme');
-        if (lang) document.documentElement.lang = lang;
+        if (lang) root.lang = lang;
         if (theme === 'kami' || theme === 'washi') {
-          document.documentElement.setAttribute('data-theme', theme);
-          document.documentElement.style.colorScheme = theme === 'washi' ? 'dark' : 'light';
+          root.setAttribute('data-theme', theme);
+          root.style.colorScheme = theme === 'washi' ? 'dark' : 'light';
         }
       } catch {}
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => root.classList.remove('blog-preference-booting'));
+      });
     })();
 
     if (location.hash.startsWith('#/')) {

--- a/blog/index.html
+++ b/blog/index.html
@@ -18,6 +18,37 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/favicon-32.png" media="(prefers-color-scheme: light)" />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-dark.png" media="(prefers-color-scheme: dark)" />
   <script>
+    (() => {
+      const cookieKey = 'openviking-preferences';
+      const readCookiePreference = () => {
+        const cookie = document.cookie.split('; ').find((item) => item.startsWith(cookieKey + '='));
+        if (!cookie) return {};
+        return JSON.parse(decodeURIComponent(cookie.slice(cookieKey.length + 1)));
+      };
+      try {
+        const preference = readCookiePreference();
+        const queryLang = new URLSearchParams(location.search).get('lang');
+        const storedLang = localStorage.getItem('blog.lang');
+        const lang = ['en', 'zh'].includes(queryLang)
+          ? queryLang
+          : ['en', 'zh'].includes(preference.lang)
+            ? preference.lang
+            : ['en', 'zh'].includes(storedLang)
+              ? storedLang
+              : '';
+        const theme = preference.theme === 'dark'
+          ? 'washi'
+          : preference.theme === 'light'
+            ? 'kami'
+            : localStorage.getItem('blog.theme');
+        if (lang) document.documentElement.lang = lang;
+        if (theme === 'kami' || theme === 'washi') {
+          document.documentElement.setAttribute('data-theme', theme);
+          document.documentElement.style.colorScheme = theme === 'washi' ? 'dark' : 'light';
+        }
+      } catch {}
+    })();
+
     if (location.hash.startsWith('#/')) {
       const [legacyPath, legacyQuery = ''] = location.hash.slice(1).split('?');
       const cleanPath = legacyPath.replace(/\/$/, '') + '/';

--- a/blog/scripts/render-static.mjs
+++ b/blog/scripts/render-static.mjs
@@ -104,7 +104,10 @@ function managedHead(meta) {
 
 function injectPage({ html, meta, body }) {
   let out = html
-    .replace(/<html[^>]*>/, `<html lang="${escapeAttr(meta.lang)}" data-theme="kami">`)
+    .replace(
+      /<html[^>]*>/,
+      `<html lang="${escapeAttr(meta.lang)}" data-theme="kami" class="blog-preference-booting">`
+    )
     .replace(/\s*<title>[\s\S]*?<\/title>/, '')
     .replace(/\s*<meta name="description" content="[\s\S]*?" \/>/, '');
 

--- a/blog/src/shell-core.jsx
+++ b/blog/src/shell-core.jsx
@@ -205,14 +205,114 @@ export function estimateReadingMinutes(text = '', lang = 'en') {
 
 export const THEME_LIGHT = 'kami';
 export const THEME_DARK = 'washi';
+const PREFERENCE_COOKIE_KEY = 'openviking-preferences';
+const SHARED_THEME_LIGHT = 'light';
+const SHARED_THEME_DARK = 'dark';
+
+function isBrowser() {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function isLanguage(value) {
+  return LANGS.some(lang => lang.code === value);
+}
+
+function isBlogTheme(value) {
+  return value === THEME_LIGHT || value === THEME_DARK;
+}
+
+function isSharedTheme(value) {
+  return value === SHARED_THEME_LIGHT || value === SHARED_THEME_DARK;
+}
+
+export function sharedThemeToBlogTheme(theme) {
+  if (theme === SHARED_THEME_DARK) return THEME_DARK;
+  if (theme === SHARED_THEME_LIGHT) return THEME_LIGHT;
+  return undefined;
+}
+
+export function blogThemeToSharedTheme(theme) {
+  if (theme === THEME_DARK) return SHARED_THEME_DARK;
+  if (theme === THEME_LIGHT) return SHARED_THEME_LIGHT;
+  return undefined;
+}
+
+function mergePreferences(base, incoming) {
+  return {
+    lang: incoming.lang ?? base.lang,
+    theme: incoming.theme ?? base.theme,
+  };
+}
+
+function readLocalPreferences() {
+  if (!isBrowser()) return {};
+
+  const lang = localStorage.getItem('blog.lang');
+  const theme = localStorage.getItem('blog.theme');
+  return {
+    lang: isLanguage(lang) ? lang : undefined,
+    theme: isBlogTheme(theme) ? blogThemeToSharedTheme(theme) : undefined,
+  };
+}
+
+export function readCookiePreferences() {
+  if (!isBrowser()) return {};
+
+  const cookie = document.cookie
+    .split('; ')
+    .find(item => item.startsWith(`${PREFERENCE_COOKIE_KEY}=`));
+
+  if (!cookie) return {};
+
+  try {
+    const preference = JSON.parse(decodeURIComponent(cookie.slice(PREFERENCE_COOKIE_KEY.length + 1)));
+    return {
+      lang: isLanguage(preference.lang) ? preference.lang : undefined,
+      theme: isSharedTheme(preference.theme) ? preference.theme : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function cookieDomain() {
+  const hostname = window.location.hostname;
+  if (hostname === 'localhost' || hostname === '127.0.0.1') return '';
+  if (hostname.endsWith('.openviking.ai') || hostname === 'openviking.ai') return 'Domain=.openviking.ai';
+  if (hostname.endsWith('.openviking.net') || hostname === 'openviking.net') return 'Domain=.openviking.net';
+  return '';
+}
+
+export function writeCookiePreferences(preference) {
+  if (!isBrowser()) return;
+
+  const nextPreference = mergePreferences(readCookiePreferences(), preference);
+  document.cookie = [
+    `${PREFERENCE_COOKIE_KEY}=${encodeURIComponent(JSON.stringify(nextPreference))}`,
+    'Path=/',
+    'Max-Age=31536000',
+    'SameSite=Lax',
+    cookieDomain(),
+  ].filter(Boolean).join('; ');
+}
+
+export function readPersistedPreferences() {
+  return mergePreferences(readLocalPreferences(), readCookiePreferences());
+}
+
+export function getInitialLang(queryLang) {
+  if (isLanguage(queryLang)) return queryLang;
+  return readPersistedPreferences().lang || 'en';
+}
 
 export function getSystemTheme() {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? THEME_DARK : THEME_LIGHT;
 }
 
 export function getInitialTheme() {
-  const stored = localStorage.getItem('blog.theme');
-  if (stored === THEME_LIGHT || stored === THEME_DARK) return stored;
+  const sharedTheme = readPersistedPreferences().theme;
+  const sharedBlogTheme = sharedThemeToBlogTheme(sharedTheme);
+  if (sharedBlogTheme) return sharedBlogTheme;
   return getSystemTheme();
 }
 

--- a/blog/src/shell-ui.jsx
+++ b/blog/src/shell-ui.jsx
@@ -6,7 +6,8 @@ import {
 import {
   LANGS, THEME_LIGHT, THEME_DARK,
   useSiteRouter, useShellStrings, makeFormatDate, applyTheme, getInitialTheme, isDark,
-  buildPath, postPath, estimateReadingMinutes,
+  buildPath, postPath, estimateReadingMinutes, getInitialLang, readPersistedPreferences,
+  sharedThemeToBlogTheme, blogThemeToSharedTheme, writeCookiePreferences,
 } from './shell-core';
 import { ZoukInteractiveBlog } from './zouk-embed';
 
@@ -351,16 +352,42 @@ export function BlogShell({ router, lang, theme, onLang = () => {}, onToggleThem
 
 export default function App() {
   const router = useSiteRouter();
-  const initialLang = router.query.lang || localStorage.getItem('blog.lang') || 'en';
-  const [lang, setLang] = useState(LANGS.some(l => l.code === initialLang) ? initialLang : 'en');
+  const [lang, setLang] = useState(() => getInitialLang(router.query.lang));
   const [theme, setTheme] = useState(getInitialTheme);
 
-  useEffect(() => { applyTheme(theme); localStorage.setItem('blog.theme', theme); }, [theme]);
-  useEffect(() => { document.documentElement.lang = lang; localStorage.setItem('blog.lang', lang); }, [lang]);
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem('blog.theme', theme);
+    writeCookiePreferences({ theme: blogThemeToSharedTheme(theme) });
+  }, [theme]);
 
   useEffect(() => {
-    if (router.query.lang && router.query.lang !== lang) setLang(router.query.lang);
+    document.documentElement.lang = lang;
+    localStorage.setItem('blog.lang', lang);
+    writeCookiePreferences({ lang });
+  }, [lang]);
+
+  useEffect(() => {
+    const queryLang = router.query.lang;
+    if (LANGS.some(l => l.code === queryLang) && queryLang !== lang) setLang(queryLang);
   }, [router.query.lang]);
+
+  useEffect(() => {
+    const syncFromSharedPreferences = () => {
+      const preference = readPersistedPreferences();
+      if (preference.lang && preference.lang !== lang) setLang(preference.lang);
+
+      const nextTheme = sharedThemeToBlogTheme(preference.theme);
+      if (nextTheme && nextTheme !== theme) setTheme(nextTheme);
+    };
+
+    window.addEventListener('pageshow', syncFromSharedPreferences);
+    window.addEventListener('focus', syncFromSharedPreferences);
+    return () => {
+      window.removeEventListener('pageshow', syncFromSharedPreferences);
+      window.removeEventListener('focus', syncFromSharedPreferences);
+    };
+  }, [lang, theme]);
 
   const onLang = (code) => { setLang(code); router.setQuery({ lang: code }); };
   const onToggleTheme = () => setTheme(t => t === THEME_LIGHT ? THEME_DARK : THEME_LIGHT);


### PR DESCRIPTION
## Description

Synchronizes the OpenViking blog site with the shared language and theme preference cookie used by the main site and docs site.

The blog now reads and writes `openviking-preferences`, mapping the shared `light` / `dark` theme values to the blog's internal `kami` / `washi` themes. This keeps language and theme selections consistent across `www.openviking.ai`, `docs.openviking.ai`, and `blog.openviking.ai`, while also supporting the `.openviking.net` China domain and localhost development.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- Added shared `openviking-preferences` cookie read/write support for the blog shell.
- Mapped shared theme values `light` / `dark` to blog themes `kami` / `washi`.
- Used shared preferences as the initial language/theme source, with `?lang=` still taking precedence for language.
- Added a head bootstrap script to apply persisted language/theme before React hydration and reduce visual flicker.
- Synced changes back to shared preferences when users switch language or theme in the blog.
- Re-synced preferences on `pageshow` and `focus` so browser back/forward or returning from another site reflects the latest shared cookie.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation commands run locally:

```bash
npm ci
npm run build
```

`npm run build` passes with the existing Vite large chunk warning.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR targets the `blog` branch and contains the blog-site side of the shared preference synchronization flow.