### PR TITLE
fix(queuefs): stream semantic vectorize dispatch

### DIFF
--- a/openviking/storage/queuefs/embedding_tracker.py
+++ b/openviking/storage/queuefs/embedding_tracker.py
@@ -168,6 +168,30 @@ class EmbeddingTaskTracker:
         if record_to_finalize is not None:
             await self._run_on_complete(semantic_msg_id, record_to_finalize)
 
+    async def add_tasks(self, semantic_msg_id: str, count: int) -> Optional[int]:
+        """Add embedding tasks to an existing SemanticMsg tracker record."""
+        if count <= 0:
+            return None
+
+        with self._lock:
+            record = self._tasks.get(semantic_msg_id)
+            if record is None:
+                logger.warning(
+                    "Cannot add %s embedding tasks to missing SemanticMsg %s",
+                    count,
+                    semantic_msg_id,
+                )
+                return None
+
+            record.remaining += count
+            record.total += count
+            return record.remaining
+
+    async def clear(self, semantic_msg_id: str) -> None:
+        """Remove a SemanticMsg tracker record without running its completion callback."""
+        with self._lock:
+            self._tasks.pop(semantic_msg_id, None)
+
     async def decrement(self, semantic_msg_id: str) -> Optional[int]:
         """Decrement the remaining task count for a SemanticMsg.
 

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -203,11 +203,10 @@ class SemanticDagExecutor:
         self._closed = False
         self._failure: Optional[Exception] = None
         self._stats = DagStats()
-        self._vectorize_task_count: int = 0
-        self._pending_vectorize_tasks: List[VectorizeTask] = []
+        self._vectorize_tracker_registered = False
         self._pending_vectorize_work = 0
-        self._vectorize_done: Optional[asyncio.Event] = None
-        self._vectorize_lock = asyncio.Lock()
+        self._vectorize_done = asyncio.Event()
+        self._vectorize_done.set()
         self._file_change_status: Dict[str, bool] = {}
         self._dir_change_status: Dict[str, bool] = {}
         self._overview_cache: Dict[str, Dict[str, str]] = {}
@@ -221,12 +220,6 @@ class SemanticDagExecutor:
 
         try:
             self._register_active()
-            self._schedule_dir(root_uri, parent_uri=None)
-            await self._root_done.wait()
-            if self._failure:
-                raise self._failure
-
-            # Release owned semantic locks after downstream vectorization finishes.
             async def wrapped_on_complete() -> None:
                 try:
                     if self._telemetry_id and self._semantic_msg_id:
@@ -236,30 +229,23 @@ class SemanticDagExecutor:
                 finally:
                     await self._lock.close()
 
-            async with self._vectorize_lock:
-                task_count = self._vectorize_task_count
-                tasks = list(self._pending_vectorize_tasks)
+            await self._register_vectorize_tracker(root_uri, wrapped_on_complete)
+            self._schedule_dir(root_uri, parent_uri=None)
+            await self._root_done.wait()
+            if self._failure:
+                raise self._failure
 
-            if task_count > 0:
-                from .embedding_tracker import EmbeddingTaskTracker
-
-                tracker = EmbeddingTaskTracker.get_instance()
-                await tracker.register(
-                    semantic_msg_id=self._semantic_msg_id,
-                    total_count=task_count,
-                    on_complete=wrapped_on_complete,
-                    metadata={"uri": root_uri},
-                )
-
-                await self._dispatch_vectorize_tasks(tasks)
+            if self._vectorize_tracker_registered:
+                await self._finish_vectorize_scheduling()
+                await self._wait_vectorize_work()
             else:
-                # No vectorize tasks — release lock immediately (via wrapped callback)
                 try:
                     await wrapped_on_complete()
                 except Exception as e:
                     logger.error(f"Error in on_complete callback: {e}", exc_info=True)
         except BaseException:
             self._closed = True
+            await self._clear_vectorize_tracker()
             try:
                 await self._lock.close()
             except Exception:
@@ -316,8 +302,50 @@ class SemanticDagExecutor:
         self._closed = True
         if self._root_done:
             self._root_done.set()
-        if self._vectorize_done:
+        self._vectorize_done.set()
+
+    async def _register_vectorize_tracker(self, root_uri: str, on_complete) -> None:
+        if self._skip_vectorization or not self._semantic_msg_id:
+            return
+        from .embedding_tracker import EmbeddingTaskTracker
+
+        tracker = EmbeddingTaskTracker.get_instance()
+        await tracker.register(
+            semantic_msg_id=self._semantic_msg_id,
+            total_count=1,
+            on_complete=on_complete,
+            metadata={"uri": root_uri},
+        )
+        self._vectorize_tracker_registered = True
+
+    async def _finish_vectorize_scheduling(self) -> None:
+        if not self._vectorize_tracker_registered or not self._semantic_msg_id:
+            return
+        from .embedding_tracker import EmbeddingTaskTracker
+
+        tracker = EmbeddingTaskTracker.get_instance()
+        await tracker.decrement(self._semantic_msg_id)
+
+    async def _clear_vectorize_tracker(self) -> None:
+        if not self._vectorize_tracker_registered or not self._semantic_msg_id:
+            return
+        from .embedding_tracker import EmbeddingTaskTracker
+
+        tracker = EmbeddingTaskTracker.get_instance()
+        await tracker.clear(self._semantic_msg_id)
+
+    def _mark_vectorize_work_scheduled(self) -> None:
+        self._pending_vectorize_work += 1
+        self._vectorize_done.clear()
+
+    def _mark_vectorize_work_done(self) -> None:
+        self._pending_vectorize_work = max(0, self._pending_vectorize_work - 1)
+        if self._pending_vectorize_work == 0:
             self._vectorize_done.set()
+
+    async def _wait_vectorize_work(self) -> None:
+        if self._pending_vectorize_work > 0:
+            await self._vectorize_done.wait()
 
     def _register_active(self) -> None:
         with self._active_lock:
@@ -372,19 +400,6 @@ class SemanticDagExecutor:
         self._mark_node_done()
         logger.warning("Unknown semantic DAG work kind: %s", work.kind)
 
-    async def _dispatch_vectorize_tasks(self, tasks: List[VectorizeTask]) -> None:
-        self._vectorize_done = asyncio.Event()
-        self._pending_vectorize_work = len(tasks)
-        for task in tasks:
-            self._schedule_work(
-                DagWork(
-                    kind="vectorize",
-                    dir_uri=task.uri,
-                    vectorize_task=task,
-                )
-            )
-        await self._vectorize_done.wait()
-
     async def _run_vectorize_work(self, task: Optional[VectorizeTask]) -> None:
         try:
             if task is not None:
@@ -392,9 +407,7 @@ class SemanticDagExecutor:
         except Exception as exc:
             logger.error("Vectorization dispatch task failed: %s", exc, exc_info=True)
         finally:
-            self._pending_vectorize_work = max(0, self._pending_vectorize_work - 1)
-            if self._pending_vectorize_work == 0 and self._vectorize_done:
-                self._vectorize_done.set()
+            self._mark_vectorize_work_done()
 
     async def _run_vectorize_task(self, task: VectorizeTask) -> None:
         if task.task_type == "file":
@@ -857,19 +870,33 @@ class SemanticDagExecutor:
         self._release_dir_node(dir_uri)
 
     async def _add_vectorize_task(self, task: VectorizeTask) -> None:
-        """Add a vectorize task to the pending list."""
+        """Schedule vectorization work without retaining a root-sized task list."""
         if self._skip_vectorization:
             logger.info(
                 "Skipping vectorization task for %s (requested via SemanticMsg)",
                 task.uri,
             )
             return
-        async with self._vectorize_lock:
-            self._pending_vectorize_tasks.append(task)
-            if task.task_type == "file":
-                self._vectorize_task_count += 1
-            else:  # directory
-                self._vectorize_task_count += 2
+
+        expected_embeddings = 1 if task.task_type == "file" else 2
+        self._mark_vectorize_work_scheduled()
+        try:
+            if self._vectorize_tracker_registered and self._semantic_msg_id:
+                from .embedding_tracker import EmbeddingTaskTracker
+
+                tracker = EmbeddingTaskTracker.get_instance()
+                await tracker.add_tasks(self._semantic_msg_id, expected_embeddings)
+
+            self._schedule_work(
+                DagWork(
+                    kind="vectorize",
+                    dir_uri=task.uri,
+                    vectorize_task=task,
+                )
+            )
+        except Exception:
+            self._mark_vectorize_work_done()
+            raise
 
     def get_stats(self) -> DagStats:
         return DagStats(

--- a/tests/storage/test_embedding_tracker.py
+++ b/tests/storage/test_embedding_tracker.py
@@ -179,6 +179,34 @@ async def test_tracker_supports_sync_callback_and_missing_task():
 
 
 @pytest.mark.asyncio
+async def test_tracker_adds_tasks_after_registration():
+    tracker = EmbeddingTaskTracker.get_instance()
+    callback_calls = []
+
+    await tracker.register("semantic-msg", 1, on_complete=lambda: callback_calls.append("done"))
+
+    assert await tracker.add_tasks("semantic-msg", 2) == 3
+    assert await tracker.decrement("semantic-msg") == 2
+    assert callback_calls == []
+    assert await tracker.decrement("semantic-msg") == 1
+    assert callback_calls == []
+    assert await tracker.decrement("semantic-msg") == 0
+    assert callback_calls == ["done"]
+
+
+@pytest.mark.asyncio
+async def test_tracker_clear_removes_record_without_callback():
+    tracker = EmbeddingTaskTracker.get_instance()
+    callback_calls = []
+
+    await tracker.register("semantic-msg", 1, on_complete=lambda: callback_calls.append("done"))
+    await tracker.clear("semantic-msg")
+
+    assert await tracker.decrement("semantic-msg") is None
+    assert callback_calls == []
+
+
+@pytest.mark.asyncio
 async def test_tracker_clears_zero_task_entry_without_callback():
     tracker = EmbeddingTaskTracker.get_instance()
 

--- a/tests/storage/test_semantic_dag_stats.py
+++ b/tests/storage/test_semantic_dag_stats.py
@@ -83,9 +83,24 @@ class _TrackingProcessor(_FakeProcessor):
 class _DummyTracker:
     def __init__(self):
         self.register_calls = []
+        self.add_calls = []
+        self.decrement_calls = []
+        self.clear_calls = []
 
     async def register(self, **_kwargs):
         self.register_calls.append(_kwargs)
+        return None
+
+    async def add_tasks(self, semantic_msg_id, count):
+        self.add_calls.append({"semantic_msg_id": semantic_msg_id, "count": count})
+        return None
+
+    async def decrement(self, semantic_msg_id):
+        self.decrement_calls.append(semantic_msg_id)
+        return None
+
+    async def clear(self, semantic_msg_id):
+        self.clear_calls.append(semantic_msg_id)
         return None
 
 
@@ -223,6 +238,46 @@ async def test_semantic_dag_shares_node_scheduler_across_roots(monkeypatch):
     assert processor.max_active_summaries <= 4
     assert executor_a.get_stats().done_nodes == 21
     assert executor_b.get_stats().done_nodes == 21
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_streams_vectorize_work_to_tracker(monkeypatch):
+    root_uri = "viking://resources/root"
+    tree = {
+        root_uri: [
+            {"name": "a.txt", "isDir": False},
+            {"name": "b.txt", "isDir": False},
+        ],
+    }
+    fake_fs = _FakeVikingFS(tree)
+    tracker = _DummyTracker()
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    processor = _FakeProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        semantic_msg_id="semantic-msg",
+    )
+    await executor.run(root_uri)
+
+    assert len(tracker.register_calls) == 1
+    assert tracker.register_calls[0]["semantic_msg_id"] == "semantic-msg"
+    assert tracker.register_calls[0]["total_count"] == 1
+    assert sum(call["count"] for call in tracker.add_calls) == 4
+    assert tracker.decrement_calls == ["semantic-msg"]
+    assert tracker.clear_calls == []
+    assert processor.vectorized_dirs == [root_uri]
+    assert sorted(processor.vectorized_files) == sorted(
+        [f"{root_uri}/a.txt", f"{root_uri}/b.txt"]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

本 PR 是 #2343 合并后的后续优化：继续降低语义 DAG 阶段的常驻对象数量。

#2343 已经把 node work 收敛到共享 worker 池，但 vectorize work 仍会先保存在 `_pending_vectorize_tasks` 列表里，等 root DAG 完成后再统一注册 tracker 和派发。大仓库里这会额外保留上万个 `VectorizeTask` 及其 summary/context 引用。

本次改为流式派发：生成一个 vectorize work，就立即追加 embedding tracker 计数并放入共享调度队列，不再维护 root 级 vectorize task list。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 删除 `SemanticDagExecutor` 中 root 级 `_pending_vectorize_tasks` 列表，vectorize work 生成后直接进入共享 node scheduler。
- 给 `EmbeddingTaskTracker` 增加 `add_tasks()` 和 `clear()`，支持先注册 barrier，再随 semantic 生成过程动态追加 embedding 任务数。
- 成功路径 root 完成后只释放 barrier；失败路径清理 tracker，避免已计数但未派发的 vectorize work 卡住完成回调。
- 增加 tracker 动态计数测试和 DAG 流式 vectorize 派发测试。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

本地验证：

- `.venv/bin/python -m py_compile openviking/storage/queuefs/semantic_dag.py openviking/storage/queuefs/embedding_tracker.py tests/storage/test_semantic_dag_stats.py tests/storage/test_embedding_tracker.py`：通过
- `git diff --check`：通过
- `.venv/bin/python -m pytest tests/storage/test_embedding_tracker.py tests/storage/test_semantic_dag_stats.py tests/storage/test_semantic_dag_skip_files.py tests/storage/test_semantic_queue_memory_dedupe.py -q`：22 passed, 4 warnings

额外说明：

- 也尝试运行了 `tests/storage/test_collection_schemas.py`，其中 5 个用例失败；失败点均为测试内 `_DummyEmbedder` 缺少 `prepare_embedding_input`，发生在进入 tracker/semantic DAG 逻辑之前，和本 PR 改动无关。
- 本 PR 未重新跑完整 openclaw 真实压测；它是在 #2343 的真实压测结果基础上，继续减少 semantic 后半段的 vectorize task 常驻列表。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

这个改动仍然保持“一层共享并发”的设计：semantic node work 和 vectorize enqueue work 都进入同一个 scheduler，不再引入每个 add 任务自己的并发池。
