### PR TITLE
fix(Dockerfile): add git to runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ FROM python:3.13-slim-trixie
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    git \
     libstdc++6 \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The runtime stage (Stage 3) was missing the git package, which is required by GitAccessor at runtime for git clone/fetch/checkout operations. Without it, any attempt to clone a repository would fail with 'git: command not found'.
