### PR TITLE
docs(storage): add qdrant and vikingdb to vector Backend Support table

### DIFF
--- a/docs/en/concepts/05-storage.md
+++ b/docs/en/concepts/05-storage.md
@@ -137,7 +137,9 @@ index_meta = {
 |---------|-------------|
 | `local` | Local persistence |
 | `http` | HTTP remote service |
+| `qdrant` | Qdrant vector database |
 | `volcengine` | Volcengine VikingDB |
+| `vikingdb` | VikingDB private deployment |
 
 ## Vector Synchronization
 

--- a/docs/zh/concepts/05-storage.md
+++ b/docs/zh/concepts/05-storage.md
@@ -135,7 +135,9 @@ index_meta = {
 |------|------|
 | `local` | 本地持久化 |
 | `http` | HTTP 远程服务 |
+| `qdrant` | Qdrant 向量数据库 |
 | `volcengine` | 火山引擎 VikingDB |
+| `vikingdb` | VikingDB 私有化部署 |
 
 ## 向量同步
 


### PR DESCRIPTION
#2350 (`add Qdrant vectordb support`) registered `qdrant` in the vector backend factory (`openviking/storage/vectordb_adapters/factory.py` `_ADAPTER_REGISTRY`), and `qdrant` is now a valid value of `VectorDBBackendConfig.backend`. The canonical **Backend Support** table in `docs/{en,zh}/concepts/05-storage.md` still lists only `local`/`http`/`volcengine`, so the new `qdrant` backend is invisible to users choosing a vector backend.

This adds the `qdrant` row, plus the `vikingdb` row that was already registered (`VikingDBPrivateCollectionAdapter`) but never documented, so the table matches `_ADAPTER_REGISTRY` exactly (`local`, `http`, `qdrant`, `volcengine`, `vikingdb`) in both the EN and ZH docs.