### PR TITLE
docs: set README version to 0.3.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ To ensure optimal storage performance and data security, we recommend deploying 
 
 ## Evaluation Highlights
 
-OpenViking 1.0 has been evaluated across three scenarios: long-conversation user memory, agent experience memory, and knowledge-base QA.
+OpenViking has been evaluated across three scenarios: long-conversation user memory, agent experience memory, and knowledge-base QA.
 
 ### 1. User Memory on LoCoMo
 


### PR DESCRIPTION
## Summary
- update the root README evaluation wording to use `OpenViking 0.3.22`
- apply the same version wording to the Chinese and Japanese README files
- avoid exposing the unintended `OpenViking 1.0` wording while keeping an explicit public version number

## Testing
- grep repository README files for `OpenViking 1.0`
- verify `OpenViking 0.3.22` appears in README, README_CN, and README_JA
- check diagnostics for the edited README files