### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -302,7 +302,7 @@ Provider configuration is read from OpenViking config (`vlm` section in `ov.conf
 > - **Groq** provides free voice transcription via Whisper. If configured, Telegram voice messages will be automatically transcribed.
 > - **Zhipu Coding Plan**: If you're on Zhipu's coding plan, set `"apiBase": "https://open.bigmodel.cn/api/coding/paas/v4"` in your zhipu provider config.
 > - **MiniMax (Mainland China)**: If your API key is from MiniMax's mainland China platform (minimaxi.com), set `"apiBase": "https://api.minimaxi.com/v1"` in your minimax provider config.
-> - **MiniMax Recommended Models**: `MiniMax-M2.7` (peak performance) and `MiniMax-M2.7-highspeed` (faster, more agile). Configure with `"model": "MiniMax-M2.7"` in your agent config.
+> - **MiniMax Recommended Models**: `MiniMax-M3` (flagship, default), `MiniMax-M2.7` (peak performance) and `MiniMax-M2.7-highspeed` (faster, more agile). Configure with `"model": "MiniMax-M3"` in your agent config.
 
 | Provider | Purpose | Get API Key |
 |----------|---------|-------------|

--- a/bot/tests/test_minimax_provider.py
+++ b/bot/tests/test_minimax_provider.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Tests for MiniMax provider support (MiniMax-M2.7, MiniMax-M2.7-highspeed)."""
+"""Tests for MiniMax provider support (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed)."""
 
 from urllib.parse import urlparse
 
@@ -28,6 +28,12 @@ class TestMiniMaxRegistry:
         assert not spec.is_gateway
         assert not spec.is_local
 
+    def test_minimax_m3_matched_by_keyword(self):
+        """MiniMax-M3 should be matched to the minimax ProviderSpec."""
+        spec = find_by_model("MiniMax-M3")
+        assert spec is not None, "MiniMax-M3 not matched to any provider"
+        assert spec.name == "minimax"
+
     def test_minimax_m2_7_matched_by_keyword(self):
         """MiniMax-M2.7 should be matched to the minimax ProviderSpec."""
         spec = find_by_model("MiniMax-M2.7")
@@ -42,7 +48,7 @@ class TestMiniMaxRegistry:
 
     def test_minimax_keyword_is_case_insensitive(self):
         """Model name matching must be case-insensitive."""
-        for model in ("minimax-m2.7", "MINIMAX-M2.7", "MiniMax-M2.7"):
+        for model in ("minimax-m2.7", "MINIMAX-M2.7", "MiniMax-M2.7", "MiniMax-m3"):
             spec = find_by_model(model)
             assert spec is not None, f"{model!r} not matched"
             assert spec.name == "minimax"
@@ -70,6 +76,11 @@ class TestMiniMaxModelPrefixResolution:
             if not any(model.startswith(s) for s in spec.skip_prefixes):
                 model = f"{spec.litellm_prefix}/{model}"
         return model
+
+    def test_m3_gets_minimax_prefix(self):
+        """MiniMax-M3 should be prefixed as minimax/MiniMax-M3."""
+        resolved = self._resolve_model("MiniMax-M3")
+        assert resolved == "minimax/MiniMax-M3"
 
     def test_m2_7_gets_minimax_prefix(self):
         """MiniMax-M2.7 should be prefixed as minimax/MiniMax-M2.7."""
@@ -113,6 +124,18 @@ class TestMiniMaxSystemMessageHandling:
     # ------------------------------------------------------------------ #
     # LiteLLMProvider tests (model name after prefix resolution)
     # ------------------------------------------------------------------ #
+
+    def test_litellm_system_message_merged_for_m3(self):
+        """System message is merged into the first user message for minimax/MiniMax-M3."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+        ]
+        result = self._handle_system_litellm("minimax/MiniMax-M3", messages)
+        assert all(m["role"] != "system" for m in result), "System message not removed"
+        user_content = next(m["content"] for m in result if m["role"] == "user")
+        assert "You are a helpful assistant." in user_content
+        assert "Hello!" in user_content
 
     def test_litellm_system_message_merged_for_m2_7(self):
         """System message is merged into the first user message for minimax/MiniMax-M2.7."""

--- a/bot/vikingbot/providers/registry.py
+++ b/bot/vikingbot/providers/registry.py
@@ -242,14 +242,15 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     ),
     # MiniMax: needs "minimax/" prefix for LiteLLM routing.
     # Uses OpenAI-compatible API at api.minimax.io/v1.
-    # Recommended models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed (faster).
+    # Recommended models: MiniMax-M3 (default, flagship), MiniMax-M2.7 (alternative),
+    # MiniMax-M2.7-highspeed (faster).
     # Note: MiniMax does not support system messages; they are merged into the first user message.
     ProviderSpec(
         name="minimax",
         keywords=("minimax",),
         env_key="MINIMAX_API_KEY",
         display_name="MiniMax",
-        litellm_prefix="minimax",  # MiniMax-M2.7 → minimax/MiniMax-M2.7
+        litellm_prefix="minimax",  # MiniMax-M3 → minimax/MiniMax-M3
         skip_prefixes=("minimax/", "openrouter/"),
         env_extras=(),
         is_gateway=False,


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as the new default for the `minimax` provider, while keeping the existing `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` options available.

## Changes
- Add `MiniMax-M3` as the new flagship/default recommended model in the `minimax` provider entry of `bot/vikingbot/providers/registry.py`.
- Update `bot/README.md` recommended models block to suggest `MiniMax-M3` as the default while retaining `M2.7` and `M2.7-highspeed` as alternatives.
- Add unit tests covering `MiniMax-M3` keyword matching, LiteLLM prefix resolution (`minimax/MiniMax-M3`), and system message merging behavior.

## Why
`MiniMax-M3` is the new flagship MiniMax model with broader capabilities than `M2.7`, and surfacing it as the recommended default lets users opt in to the latest model without manual research.

## Testing
- `pytest bot/tests/test_minimax_provider.py` — 20 tests pass (including new `MiniMax-M3` cases).

## Type of Change
- [x] New feature (feat)
- [ ] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Checklist
- [x] Code follows project style guidelines (ruff clean)
- [x] Tests added for new functionality
- [x] Documentation updated (`bot/README.md`)
- [x] All tests pass