### PR TITLE
fix(embedding): use word-boundary matching for numeric error patterns in classify_api_error

### DIFF
--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import re
 import threading
 import time
 from typing import Awaitable, Callable, TypeVar
@@ -68,6 +69,30 @@ TRANSIENT_API_ERROR_PATTERNS = (
     "connection reset",
 )
 
+# Pre-compile regex for purely numeric patterns to avoid substring false positives
+# (e.g. "413" matching inside a hex request ID like "d7c9130f344...").
+_NUMERIC_PATTERN_RE: dict[str, re.Pattern] = {}
+
+
+def _get_numeric_pattern_re(pattern: str) -> re.Pattern:
+    if pattern not in _NUMERIC_PATTERN_RE:
+        _NUMERIC_PATTERN_RE[pattern] = re.compile(r'\b' + re.escape(pattern) + r'\b')
+    return _NUMERIC_PATTERN_RE[pattern]
+
+
+def _pattern_matches(text_lower: str, text_compact: str, pattern: str) -> bool:
+    """Check if pattern matches in text, using word-boundary for numeric-only patterns.
+
+    Numeric-only patterns (e.g. ``"413"``) are matched with ``\\b`` word boundaries
+    to prevent false positives inside request IDs or hex strings.  Non-numeric
+    patterns use plain substring matching as before.
+    """
+    if pattern.isdigit():
+        return bool(_get_numeric_pattern_re(pattern).search(text_lower)) or bool(
+            _get_numeric_pattern_re(pattern).search(text_compact)
+        )
+    return pattern in text_lower or pattern in text_compact
+
 
 def classify_api_error(error: Exception) -> str:
     """Classify an API error as permanent, quota_exceeded, transient, or unknown.
@@ -89,13 +114,14 @@ def classify_api_error(error: Exception) -> str:
         text_lower = text.lower()
         text_compact = text_lower.replace(" ", "")
         for pattern in INPUT_TOO_LARGE_PATTERNS:
-            if pattern in text_lower or pattern in text_compact:
+            if _pattern_matches(text_lower, text_compact, pattern):
                 return ERROR_CLASS_INPUT_TOO_LARGE
 
     for text in texts:
         text_lower = text.lower()
+        text_compact = text_lower.replace(" ", "")
         for pattern in PERMANENT_API_ERROR_PATTERNS:
-            if pattern in text_lower:
+            if _pattern_matches(text_lower, text_compact, pattern):
                 return ERROR_CLASS_PERMANENT
 
     # Check quota_exceeded *before* transient so that "429 … AccountQuotaExceeded"
@@ -108,8 +134,9 @@ def classify_api_error(error: Exception) -> str:
 
     for text in texts:
         text_lower = text.lower()
+        text_compact = text_lower.replace(" ", "")
         for pattern in TRANSIENT_API_ERROR_PATTERNS:
-            if pattern in text_lower:
+            if _pattern_matches(text_lower, text_compact, pattern):
                 return ERROR_CLASS_TRANSIENT
 
     return ERROR_CLASS_UNKNOWN

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -69,23 +69,26 @@ TRANSIENT_API_ERROR_PATTERNS = (
     "connection reset",
 )
 
-# Pre-compile regex for purely numeric patterns to avoid substring false positives
-# (e.g. "413" matching inside a hex request ID like "d7c9130f344...").
+# Pre-compile regex for numeric status-code patterns to avoid substring false positives
+# (e.g. "413" matching inside request IDs like "d7c9130f344..." or "req-413-abcd").
 _NUMERIC_PATTERN_RE: dict[str, re.Pattern] = {}
 
 
 def _get_numeric_pattern_re(pattern: str) -> re.Pattern:
     if pattern not in _NUMERIC_PATTERN_RE:
-        _NUMERIC_PATTERN_RE[pattern] = re.compile(r"\b" + re.escape(pattern) + r"\b")
+        escaped = re.escape(pattern)
+        _NUMERIC_PATTERN_RE[pattern] = re.compile(
+            rf"(?:\b(?:error\s*code|status(?:\s*code)?|http(?:\s*status)?|code)"
+            rf"\s*[:=]?\s*{escaped}(?!\w)|(?<![\w-]){escaped}(?![\w-]))"
+        )
     return _NUMERIC_PATTERN_RE[pattern]
 
 
 def _pattern_matches(text_lower: str, text_compact: str, pattern: str) -> bool:
-    """Check if pattern matches in text, using word-boundary for numeric-only patterns.
+    """Check if pattern matches in text, using token-aware matching for numeric patterns.
 
-    Numeric-only patterns (e.g. ``"413"``) are matched with ``\\b`` word boundaries
-    to prevent false positives inside request IDs or hex strings.  Non-numeric
-    patterns use plain substring matching as before.
+    Numeric-only patterns (e.g. ``"413"``) must look like HTTP status codes, not
+    request ID fragments. Non-numeric patterns use plain substring matching as before.
     """
     if pattern.isdigit():
         return bool(_get_numeric_pattern_re(pattern).search(text_lower)) or bool(

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -76,7 +76,7 @@ _NUMERIC_PATTERN_RE: dict[str, re.Pattern] = {}
 
 def _get_numeric_pattern_re(pattern: str) -> re.Pattern:
     if pattern not in _NUMERIC_PATTERN_RE:
-        _NUMERIC_PATTERN_RE[pattern] = re.compile(r'\b' + re.escape(pattern) + r'\b')
+        _NUMERIC_PATTERN_RE[pattern] = re.compile(r"\b" + re.escape(pattern) + r"\b")
     return _NUMERIC_PATTERN_RE[pattern]
 
 

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -154,3 +154,26 @@ def test_retry_sync_does_not_retry_input_too_large():
         retry_sync(_call, max_retries=5)
 
     assert attempts["count"] == 1
+
+
+# --- numeric pattern word-boundary tests ---
+
+
+def test_429_with_request_id_containing_413_is_transient():
+    """A 429 error whose request ID happens to contain '413' must NOT be
+    misclassified as INPUT_TOO_LARGE (the original bug)."""
+    error = RuntimeError(
+        "Volcengine hybrid embedding failed: Error code: 429 - "
+        "{'error': {'code': 'ModelAccountRpmRateLimitExceeded', "
+        "'message': 'RPM limit exceeded', 'param': '', "
+        "'type': 'TooManyRequests'}, "
+        "'request_id': '0217801248873024288fe53d7c9130f34413480585e683685bc95'}"
+    )
+    assert classify_api_error(error) == ERROR_CLASS_TRANSIENT
+
+
+def test_numeric_status_code_inside_longer_number_is_not_matched():
+    """Status code patterns must not match inside longer numbers
+    (e.g. '400' must not match '1400')."""
+    assert classify_api_error(RuntimeError("status: 1400 OK")) == "unknown"
+    assert classify_api_error(RuntimeError("status: 5020 OK")) == "unknown"

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -172,8 +172,25 @@ def test_429_with_request_id_containing_413_is_transient():
     assert classify_api_error(error) == ERROR_CLASS_TRANSIENT
 
 
+def test_429_with_hyphenated_request_id_containing_413_is_transient():
+    """Numeric status codes must not match hyphen-delimited request ID fragments."""
+    error = RuntimeError(
+        "Volcengine hybrid embedding failed: Error code: 429 - "
+        "{'error': {'code': 'ModelAccountRpmRateLimitExceeded', "
+        "'message': 'RPM limit exceeded', 'type': 'TooManyRequests'}, "
+        "'request_id': 'req-413-abcd'}"
+    )
+    assert classify_api_error(error) == ERROR_CLASS_TRANSIENT
+
+
 def test_numeric_status_code_inside_longer_number_is_not_matched():
     """Status code patterns must not match inside longer numbers
     (e.g. '400' must not match '1400')."""
     assert classify_api_error(RuntimeError("status: 1400 OK")) == "unknown"
     assert classify_api_error(RuntimeError("status: 5020 OK")) == "unknown"
+
+
+def test_numeric_status_code_with_compact_error_code_context_still_matches():
+    assert classify_api_error(RuntimeError("Error code:413-Payload Too Large")) == (
+        ERROR_CLASS_INPUT_TOO_LARGE
+    )


### PR DESCRIPTION
## Description

Fix `classify_api_error()` in `openviking/utils/model_retry.py` to use regex word-boundary matching (`\b`) for purely numeric error patterns (e.g. `"413"`, `"400"`, `"429"`). Previously, bare substring matching via Python's `in` operator caused false positives when API error messages contained request IDs or hex strings that coincidentally included those digit sequences (e.g., `"413"` appearing inside request ID `d7c9130f344...`).

This caused 429 (RPM rate limit) errors to be misclassified as `INPUT_TOO_LARGE` when the request ID contained `"413"`. In `TextEmbeddingHandler.on_dequeue()`, `INPUT_TOO_LARGE` errors are permanently dropped without re-enqueue, while `TRANSIENT` errors are re-enqueued for retry. During a full reindex of ~476K records, **2,741 embedding messages were permanently lost** due to this bug.

## Related Issue

Fixes #2369

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `openviking/utils/model_retry.py`
  - Added `_pattern_matches()` helper: numeric-only patterns use `\b` word-boundary regex, non-numeric patterns keep substring matching
  - Applied `_pattern_matches()` to all 4 pattern-matching locations in `classify_api_error()` (INPUT_TOO_LARGE, PERMANENT, TRANSIENT)
  - Also applied to `PERMANENT` and `TRANSIENT` patterns which had the same latent risk (`"400"` could match inside `"1400"`, etc.)

- `tests/unit/test_model_retry.py`
  - Added `test_429_with_request_id_containing_413_is_transient`: reproduces the exact bug scenario
  - Added `test_numeric_status_code_inside_longer_number_is_not_matched`: verifies `"400"` does not match `"1400"`, `"502"` does not match `"5020"`

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (19 passed)
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

This bug was discovered during production debugging of a full reindex operation. The fix is minimal and backward-compatible — all existing text-based patterns continue to use substring matching, and all numeric patterns produce the same results for "clean" error messages (e.g., `"Error code: 413 - Payload Too Large"` still correctly classifies as `INPUT_TOO_LARGE`).

Related to closed issue #2132 which originally added `"413"` to `INPUT_TOO_LARGE_PATTERNS` but did not anticipate the substring matching false positive.