### PR TITLE
fix(client): skip symlinks in directory uploads

### DIFF
--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -39,7 +39,7 @@ from openviking_cli.exceptions import (
 )
 from openviking_cli.retrieve.types import FindResult
 from openviking_cli.session.user_id import UserIdentifier
-from openviking_cli.utils import run_async
+from openviking_cli.utils import get_logger, run_async
 from openviking_cli.utils.config.ovcli_config import load_ovcli_config
 from openviking_cli.utils.uri import VikingURI
 
@@ -66,6 +66,8 @@ ERROR_CODE_TO_EXCEPTION = {
     "SESSION_EXPIRED": SessionExpiredError,
     "UNKNOWN": OpenVikingError,
 }
+
+logger = get_logger(__name__)
 
 
 class _HTTPObserver:
@@ -344,15 +346,26 @@ class AsyncHTTPClient(BaseClient):
         if not dir_path.is_dir():
             raise ValueError(f"Path {dir_path} is not a directory")
 
+        root = dir_path.resolve()
         temp_dir = tempfile.gettempdir()
         zip_path = Path(temp_dir) / f"temp_upload_{uuid.uuid4().hex}.zip"
 
+        entry_count = 0
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             for file_path in dir_path.rglob("*"):
+                if file_path.is_symlink():
+                    continue
                 if file_path.is_file():
-                    arcname = file_path.relative_to(dir_path)
-                    arcname = str(arcname).replace("\\", "/")
+                    # Defense-in-depth: drop files whose real path escapes the selected root
+                    # if traversal behavior changes or this walk implementation is replaced.
+                    if not file_path.resolve().is_relative_to(root):
+                        continue
+                    arcname = str(file_path.relative_to(dir_path)).replace("\\", "/")
                     zipf.write(file_path, arcname=arcname)
+                    entry_count += 1
+
+        if entry_count == 0:
+            logger.warning("Created empty directory upload archive for %s", dir_path)
 
         return str(zip_path)
 

--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -1,5 +1,7 @@
 import asyncio
 import threading
+import zipfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -18,6 +20,61 @@ from openviking_cli.utils.config import OPENVIKING_CLI_CONFIG_ENV
 def clear_ovcli_config(monkeypatch):
     monkeypatch.delenv(OPENVIKING_CLI_CONFIG_ENV, raising=False)
     monkeypatch.setattr(http_module, "load_ovcli_config", lambda: None)
+
+
+def test_async_http_client_zip_directory_skips_symlinked_entries(tmp_path):
+    root = tmp_path / "upload"
+    root.mkdir()
+    (root / "keep.txt").write_text("keep", encoding="utf-8")
+    nested = root / "nested"
+    nested.mkdir()
+    (nested / "nested.txt").write_text("nested", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+
+    try:
+        (root / "inside-link.txt").symlink_to(root / "keep.txt")
+        (root / "outside-link.txt").symlink_to(outside)
+        (root / "dir-link").symlink_to(tmp_path, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks are not available in this environment: {exc}")
+
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    zip_path = Path(client._zip_directory(str(root)))
+    try:
+        with zipfile.ZipFile(zip_path) as zipf:
+            names = sorted(zipf.namelist())
+    finally:
+        zip_path.unlink(missing_ok=True)
+
+    assert names == ["keep.txt", "nested/nested.txt"]
+
+
+def test_async_http_client_zip_directory_warns_when_archive_is_empty(tmp_path):
+    root = tmp_path / "upload"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+
+    try:
+        (root / "outside-link.txt").symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks are not available in this environment: {exc}")
+
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    with patch.object(http_module.logger, "warning") as mock_warning:
+        zip_path = Path(client._zip_directory(str(root)))
+    try:
+        with zipfile.ZipFile(zip_path) as zipf:
+            names = sorted(zipf.namelist())
+    finally:
+        zip_path.unlink(missing_ok=True)
+
+    assert names == []
+    mock_warning.assert_called_once_with(
+        "Created empty directory upload archive for %s",
+        root,
+    )
 
 
 async def test_async_openviking_reindex_forwards_to_local_client(tmp_path):


### PR DESCRIPTION
## Summary
- Skip file and directory symlink entries when the HTTP client zips a local directory for upload.
- Keep uploaded directory archives bounded to real files under the selected root before sending them to `/api/v1/resources/temp_upload`.
- Warn when directory packaging produces an empty archive, such as a directory containing only skipped symlinks.
- Add regression coverage for file symlinks, out-of-root symlinks, directory symlinks, and empty archives.

## Why
Directory uploads are packaged on the client before they reach the server. Once a symlink target is followed into the zip, the server only sees a regular archive entry and cannot tell whether it came from outside the chosen directory. This keeps the local upload boundary enforced at packaging time.

Symlink entries are skipped as aliases, whether they point at files or directories. Real files under the selected root are still included through their normal paths, so in-root symlink targets are not lost. For example, if `upload/alias` points at `upload/data`, the archive includes `data/...` when that real path is walked, but not duplicate `alias/...` entries.

This PR intentionally does not change the existing behavior for files that vanish or become unreadable while the archive is being written. That `zipf.write(...)` race predates this patch and has different upload-completeness semantics from symlink hardening.

## Validation
- `uv run --frozen --extra dev ruff check openviking_cli/client/http.py tests/client/test_rebuild_clients.py`
- `uv run --frozen --extra dev ruff format --check openviking_cli/client/http.py tests/client/test_rebuild_clients.py`
- `uv run --frozen --extra test pytest tests/client/test_rebuild_clients.py --no-cov -q`
- Local server smoke with temporary `HOME`, config, and storage under `/tmp/ov-symlink-smoke.*`: uploaded a directory containing regular files plus file, external, and directory symlinks; both the client-created zip and server-stored temp upload contained only `keep.txt` and `nested/nested.txt`.

Additional broader check:
- `OPENVIKING_CLI_CONFIG_FILE=/tmp/openviking-nonexistent-ovcli.conf uv run --frozen --extra test pytest tests/client --no-cov -q` currently reports 109 passed and 2 failures in existing relation/watch tests outside this upload path.
