### PR TITLE
docs(config): document Qdrant connection block and complete openGauss tuning fields

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1109,14 +1109,47 @@ In the official container, the initial `omm` user may be restricted for remote l
         "password": "your-password",
         "db_name": "postgres",
         "schema": "public",
-        "mode": "standalone"
+        "mode": "standalone",
+        "shard_count": 32,
+        "connect_timeout": 10,
+        "dense_vector_name": "vector",
+        "sparse_vector_name": "sparse_vector"
       }
     }
   }
 }
 ```
 
-Set `mode` to `"distributed"` for openGauss distributed deployments; OpenViking will attempt to mark metadata tables as reference tables and distribute collection tables by `id`.
+Set `mode` to `"distributed"` for openGauss distributed deployments; OpenViking will attempt to mark metadata tables as reference tables and distribute collection tables by `id` (`shard_count` controls the number of shards).
+</details>
+
+<details>
+<summary><b>Qdrant</b></summary>
+
+Connects to a running Qdrant service over its REST API.
+
+```json
+{
+  "storage": {
+    "vectordb": {
+      "name": "context",
+      "backend": "qdrant",
+      "project": "default",
+      "distance_metric": "cosine",
+      "dimension": 1024,
+      "qdrant": {
+        "url": "http://localhost:6333",
+        "api_key": "your-api-key",
+        "timeout_seconds": 10,
+        "dense_vector_name": "vector",
+        "sparse_vector_name": "sparse_vector",
+        "meta_collection_name": "__openviking_meta",
+        "enable_text_index": true
+      }
+    }
+  }
+}
+```
 </details>
 
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1080,14 +1080,47 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
         "password": "your-password",
         "db_name": "postgres",
         "schema": "public",
-        "mode": "standalone"
+        "mode": "standalone",
+        "shard_count": 32,
+        "connect_timeout": 10,
+        "dense_vector_name": "vector",
+        "sparse_vector_name": "sparse_vector"
       }
     }
   }
 }
 ```
 
-分布式 openGauss 部署可将 `mode` 设为 `"distributed"`；OpenViking 会尝试把元数据表标记为 reference table，并按 `id` 分布集合表。
+分布式 openGauss 部署可将 `mode` 设为 `"distributed"`；OpenViking 会尝试把元数据表标记为 reference table，并按 `id` 分布集合表（由 `shard_count` 控制分片数量）。
+</details>
+
+<details>
+<summary><b>Qdrant</b></summary>
+
+通过 REST API 连接运行中的 Qdrant 服务。
+
+```json
+{
+  "storage": {
+    "vectordb": {
+      "name": "context",
+      "backend": "qdrant",
+      "project": "default",
+      "distance_metric": "cosine",
+      "dimension": 1024,
+      "qdrant": {
+        "url": "http://localhost:6333",
+        "api_key": "your-api-key",
+        "timeout_seconds": 10,
+        "dense_vector_name": "vector",
+        "sparse_vector_name": "sparse_vector",
+        "meta_collection_name": "__openviking_meta",
+        "enable_text_index": true
+      }
+    }
+  }
+}
+```
 </details>
 
 


### PR DESCRIPTION
The recently merged Qdrant backend (#2350) and openGauss persistence improvements (#2367) shipped config fields that the vectordb section of `docs/{en,zh}/guides/01-configuration.md` doesn't yet cover:

- **Qdrant**: the backend is registered and `QdrantCollectionAdapter.from_config` reads `url`/`api_key`/`timeout_seconds`/`dense_vector_name`/`sparse_vector_name`/`meta_collection_name`/`enable_text_index`, but there is no `qdrant` connection example `<details>` (the comparable openGauss remote backend has a full one). Added one mirroring the openGauss block, using the defaults from `QdrantConfig`.
- **openGauss**: the existing example only shows `host/port/user/password/db_name/schema/mode`; added the shipped tuning fields `shard_count`/`connect_timeout`/`dense_vector_name`/`sparse_vector_name` (all real `Field(...)` defaults in `OpenGaussConfig`) and noted `shard_count` in the distributed clause.

Pure docs, EN + ZH mirrored. Field names and defaults verified against `openviking_cli/utils/config/vectordb_config.py`.