### PR TITLE
docs(config): correct documented vlm.max_concurrent default 100 -> 64 (#2343)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ If you prefer manual configuration, create `~/.openviking/ov.conf`, remove the c
     "api_key"  : "<your-api-key>",     // Model service API Key (optional for openai-codex)
     "provider" : "<provider-type>",    // Provider type (volcengine, openai, openai-codex, kimi, glm, etc.)
     "model"    : "<model-name>",       // VLM model name (e.g., doubao-seed-2-0-pro-260215 or gpt-4-vision-preview)
-    "max_concurrent": 100              // Max concurrent LLM calls for semantic processing (default: 100)
+    "max_concurrent": 64              // Max concurrent LLM calls for semantic processing (default: 64)
   }
 }
 ```
@@ -370,7 +370,7 @@ If you prefer manual configuration, create `~/.openviking/ov.conf`, remove the c
     "api_key"  : "your-volcengine-api-key",
     "provider" : "volcengine",
     "model"    : "doubao-seed-2-0-pro-260215",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```
@@ -404,7 +404,7 @@ If you prefer manual configuration, create `~/.openviking/ov.conf`, remove the c
     "api_key"  : "your-openai-api-key",
     "provider" : "openai",
     "model"    : "gpt-4-vision-preview",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```
@@ -439,7 +439,7 @@ pip install "google-genai>=1.0.0"
     "api_key"  : "your-openai-api-key",
     "provider" : "openai",
     "model"    : "gpt-4o",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```
@@ -471,7 +471,7 @@ Use `openviking-server init` and choose `OpenAI Codex`, then run `openviking-ser
     "api_base" : "https://chatgpt.com/backend-api/codex",
     "provider" : "openai-codex",
     "model"    : "gpt-5.3-codex",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -288,7 +288,7 @@ openviking-server doctor
     "provider" : "<provider-type>",    // 提供商类型 (volcengine, openai, azure, openai-codex 等)
     "api_version": "2025-01-01-preview", // （仅 azure）API 版本，可选，默认 "2025-01-01-preview"
     "model"    : "<model-name>",       // VLM 模型名称或 Azure 部署名
-    "max_concurrent": 100              // 语义处理的最大并发 LLM 调用（默认：100）
+    "max_concurrent": 64              // 语义处理的最大并发 LLM 调用（默认：64）
   }
 }
 ```
@@ -326,7 +326,7 @@ openviking-server doctor
     "api_key"  : "your-volcengine-api-key",
     "provider" : "volcengine",
     "model"    : "doubao-seed-2-0-pro-260215",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```
@@ -360,7 +360,7 @@ openviking-server doctor
     "api_key"  : "your-openai-api-key",
     "provider" : "openai",
     "model"    : "gpt-4-vision-preview",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```
@@ -396,7 +396,7 @@ openviking-server doctor
     "provider" : "azure",
     "api_version": "2025-01-01-preview",
     "model"    : "gpt-4o",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```

--- a/README_JA.md
+++ b/README_JA.md
@@ -198,7 +198,7 @@ OpenAIの公式APIを使用：
     "api_key"  : "<your-api-key>",     // モデルサービスAPIキー
     "provider" : "<provider-type>",    // プロバイダータイプ（volcengine、openai、deepseek、anthropicなど）
     "model"    : "<model-name>",       // VLMモデル名（例：doubao-seed-2-0-pro-260215 または gpt-4-vision-preview）
-    "max_concurrent": 100              // セマンティック処理の最大同時LLM呼び出し数（デフォルト: 100）
+    "max_concurrent": 64              // セマンティック処理の最大同時LLM呼び出し数（デフォルト: 64）
   }
 }
 ```
@@ -236,7 +236,7 @@ OpenAIの公式APIを使用：
     "api_key"  : "your-volcengine-api-key",
     "provider" : "volcengine",
     "model"    : "doubao-seed-2-0-pro-260215",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```
@@ -270,7 +270,7 @@ OpenAIの公式APIを使用：
     "api_key"  : "your-openai-api-key",
     "provider" : "openai",
     "model"    : "gpt-4-vision-preview",
-    "max_concurrent": 100
+    "max_concurrent": 64
   }
 }
 ```

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -585,7 +585,7 @@ Vision Language Model for semantic extraction (L0/L1 generation).
 | `model` | str | Model name |
 | `api_base` | str | API endpoint (optional) |
 | `thinking` | bool | Enable thinking mode for VolcEngine models (default: `false`) |
-| `max_concurrent` | int | Maximum concurrent semantic LLM calls (default: `100`) |
+| `max_concurrent` | int | Maximum concurrent semantic LLM calls (default: `64`) |
 | `max_retries` | int | Maximum retry attempts for transient VLM provider errors (default: `3`; `0` disables retry) |
 | `backup` | object | Optional backup VLM configuration (same shape as `vlm`) for automatic failover when the primary fails with retryable errors such as rate limits, `5xx` responses, or connection/timeout failures. Only one level of failover is supported &mdash; the backup itself cannot define a nested `backup` |
 | `timeout` | float | Per-request HTTP timeout in seconds passed to the underlying OpenAI/LiteLLM client. Increase for slow endpoints (e.g., DashScope, local inference). Must be `> 0` (default: `60.0`) |
@@ -1421,7 +1421,7 @@ For detailed encryption explanations, see [Data Encryption](../concepts/10-encry
     "model": "string",
     "api_base": "string",
     "thinking": false,
-    "max_concurrent": 100,
+    "max_concurrent": 64,
     "max_retries": 3,
     "extra_headers": {},
     "extra_request_body": {},

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -556,7 +556,7 @@ openviking-server doctor
 | `model` | str | 模型名称 |
 | `api_base` | str | API 端点（可选） |
 | `thinking` | bool | 启用思考模式（仅对部分火山模型生效，默认：`false`） |
-| `max_concurrent` | int | 语义处理阶段 LLM 最大并发调用数（默认：`100`） |
+| `max_concurrent` | int | 语义处理阶段 LLM 最大并发调用数（默认：`64`） |
 | `max_retries` | int | VLM provider 瞬时错误的最大重试次数（默认：`3`；`0` 表示禁用重试） |
 | `backup` | object | 可选的备用 VLM 配置（结构与 `vlm` 相同），当主 VLM 遇到限流、`5xx`、超时或连接失败等可重试错误时自动切换。仅支持 1 层备用 &mdash; 备用 VLM 本身不能再嵌套 `backup` |
 | `timeout` | float | 单次 VLM API 请求的 HTTP 超时时间（秒），传递给底层 OpenAI/LiteLLM 客户端。慢端点（如 DashScope、本地推理）可调大。必须 `> 0`（默认：`60.0`） |
@@ -1393,7 +1393,7 @@ openviking add-resource ./docs --exclude "*.tmp"
     "model": "string",
     "api_base": "string",
     "thinking": false,
-    "max_concurrent": 100,
+    "max_concurrent": 64,
     "max_retries": 3,
     "extra_headers": {},
     "extra_request_body": {},


### PR DESCRIPTION
#2343 lowered the shipped default of `vlm.max_concurrent` (semantic-stage LLM concurrency) from `100` to `64` in `openviking_cli/utils/config/vlm_config.py`, but the configuration docs still document it as `100`.

This syncs the docs to the shipped value across the EN/ZH config references, the Full Schema block, and the README quickstart examples (EN/CN/JA).

`embedding.max_concurrent` (default `10`) is a separate knob and is left unchanged. Docs-only; no code changes.