### PR TITLE
docs(vikingbot): document ov_server experience-recall config keys from #2380

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -181,6 +181,9 @@ All configurations are under the `bot` field in `ov.conf`, with default values f
     - `account_id`: Defaults to `default`, which is the OpenViking account ID. All users under the same OpenViking account share resources.
     - `api_key_type`: Optional `root` or `user`, default `root`. `root` keeps the original root-key fanout behavior; `user` switches the bot to the user-key flow for OpenViking client calls. For a hosted remote OpenViking service, `user` is usually the recommended choice.
     - exp_write_tools: Optional list of tool names that trigger experience-memory injection before the call (self-evolving agent memory loop, see #2007). Defaults to `["write_file", "edit_file"]`. Injection only fires when the OpenViking server has `memory.agent_memory_enabled` set; otherwise this list is harmless.
+    - `recall_exp_first_round_only`: Optional. When `true`, `ContextBuilder._build_user_memory` skips per-turn user/agent experience recall and injects experiences only once on the first user turn. Defaults to `false`.
+    - `exp_recall_limit`: Optional. Number of experiences to retrieve per task during recall. Defaults to `5`.
+    - `exp_recall_max_chars`: Optional. Character budget for the formatted experience block injected into context. Defaults to `2000`.
 - `channels`: Message platform configuration, see [Message Platform Configuration](bot/docs/CHANNEL.md) for details
 
 ```json

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -184,6 +184,9 @@ bot 将连接到远程 OpenViking Server，使用前请先启动 OpenViking Serv
     - `account_id`：默认值为 `default`，即 OpenViking 的账号 ID。同一 OpenViking account 下的所有 user 共享 resources。
     - `api_key_type`：可选 `root` 或 `user`，默认 `root`。`root` 保留原有的 root-key fanout 行为；`user` 切换 bot 走 user-key 流程调用 OpenViking 客户端。对于托管型远端 OpenViking 服务，通常推荐使用 `user`。
     - `exp_write_tools`：可选，触发经验记忆注入的工具名列表（自演化 agent memory 循环，详见 #2007）。默认 `["write_file", "edit_file"]`。注入仅在 OpenViking Server 启用 `memory.agent_memory_enabled` 时生效，否则此列表无作用。
+    - `recall_exp_first_round_only`：可选。为 `true` 时，`ContextBuilder._build_user_memory` 跳过每轮 user/agent 经验召回，仅在首个 user turn 注入一次经验。默认 `false`。
+    - `exp_recall_limit`：可选。召回时每个任务检索的经验条数。默认 `5`。
+    - `exp_recall_max_chars`：可选。注入到上下文的格式化经验块的字符预算。默认 `2000`。
 - `channels`：消息平台配置，详见 [消息平台配置](bot/docs/CHANNEL.md)
 
 ```json


### PR DESCRIPTION
#2380 added three `ov_server` config keys to `OpenVikingConfig` (`bot/vikingbot/config/schema.py`) — `recall_exp_first_round_only`, `exp_recall_limit`, `exp_recall_max_chars` — wired in `agent/context.py` and `agent/memory.py`. They were documented in the benchmark harness README but not in `bot/README.md` / `bot/README_CN.md`, whose `ov_server` field list already documents the sibling `exp_write_tools`.

Adds the three keys (with defaults) to the `ov_server` field list in both READMEs. Defaults grounded from `schema.py` (`false` / `5` / `2000`).