### PR TITLE
Add Claude Desktop Memory Integration Example Under examples/Claude-Desktop

### DIFF
--- a/examples/Claude-Desktop/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/examples/Claude-Desktop/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something is not working
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+A clear description of what is not working.
+
+## Environment
+- OS: Windows 10 / Windows 11
+- Python version: (run `python --version`)
+- Node.js version: (run `node --version`)
+- OpenViking version: (run `pip show openviking`)
+
+## Verify script output
+Run `verify-ov-hooks.ps1` and paste the full output:
+```
+[paste here]
+```
+
+## Relevant logs
+From `%USERPROFILE%\.claude-memory\logs\`:
+```
+[paste here]
+```
+
+## Steps to reproduce
+1.
+2.
+3.

--- a/examples/Claude-Desktop/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/examples/Claude-Desktop/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an improvement
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## What problem does this solve?
+
+## Proposed solution
+
+## Alternatives considered
+
+## Additional context

--- a/examples/Claude-Desktop/.github/workflows/verify.yml
+++ b/examples/Claude-Desktop/.github/workflows/verify.yml
@@ -1,0 +1,40 @@
+name: Verify
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check no API keys in repo
+        run: |
+          if grep -rE "jina_[a-zA-Z0-9]{20,}|sk-ant-api03-[a-zA-Z0-9_-]+" .; then
+            echo "FAIL: API keys found"; exit 1
+          fi
+          echo "PASS: No API keys found"
+
+      - name: Python syntax check
+        run: |
+          python3 -m py_compile server/openviking-bridge.py
+          python3 -m py_compile server/openviking-mcp.py
+          python3 -m py_compile server/openviking-watchdog.py
+          python3 -m py_compile hooks/ov_session.py
+          echo "PASS: Python syntax OK"
+
+      - name: Node.js syntax check
+        run: |
+          node --check hooks/ov-recall.js
+          node --check hooks/ov-capture.js
+          echo "PASS: JS syntax OK"
+
+      - name: JSON config examples valid
+        run: |
+          python3 -c "import json; json.load(open('config/ov.conf.example'))"
+          python3 -c "import json; json.load(open('config/ovcli.conf.example'))"
+          echo "PASS: Config JSON valid"

--- a/examples/Claude-Desktop/.gitignore
+++ b/examples/Claude-Desktop/.gitignore
@@ -1,0 +1,50 @@
+# OpenViking for Claude Desktop — .gitignore
+
+# Config with real API keys — NEVER commit these
+config/ov.conf
+config/ovcli.conf
+
+# Local data store — can be huge, contains personal data
+.claude-memory/
+*.claude-memory/
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+*.egg
+*.egg-info/
+dist/
+build/
+*.whl
+
+# Logs
+*.log
+logs/
+
+# Session state
+.session_state.json
+
+# Environment
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Windows
+$RECYCLE.BIN/
+
+# Node
+node_modules/

--- a/examples/Claude-Desktop/CONTRIBUTING.md
+++ b/examples/Claude-Desktop/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to openviking-claude-desktop
+
+Thank you for your interest in contributing.
+
+## Author
+
+**Sameh Khalifa**
+Dubai, UAE
+
+For questions, issues, or collaboration:
+- Email: chinasameh@gmail.com
+- GitHub Issues: preferred for bug reports and feature requests
+
+---
+
+## How to Contribute
+
+### Report a Bug
+Open an Issue with:
+- Your OS version (Windows 10/11)
+- Python version (`python --version`)
+- Node.js version (`node --version`)
+- OpenViking version (`pip show openviking`)
+- Output of `verify-ov-hooks.ps1`
+- Relevant log lines from `%USERPROFILE%\.claude-memory\logs\`
+
+### Suggest a Feature
+Open an Issue with the label `enhancement`.
+Describe the use case, not just the feature.
+
+### Submit a Pull Request
+1. Fork the repo
+2. Create a branch: `git checkout -b feature/your-feature-name`
+3. Make changes — keep to the existing style (PS 5.1 compatible, ES5 JS)
+4. Test with `verify-ov-hooks.ps1` — all checks must pass
+5. Open a PR with a clear description of what changed and why
+
+---
+
+## Development Guidelines
+
+### PowerShell (PS 5.1 only)
+- Never use `?.` or `??` operators
+- Never use `&` inside double-quoted `Write-Host` strings
+- Never use `-RunOnlyIfNetworkAvailable $false`
+- Always use `-UseBasicParsing` with `Invoke-WebRequest`
+- Always start scripts with `Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force`
+- Use `SafeGet` helper or explicit `.PSObject.Properties.Name -contains` checks
+
+### JavaScript (ES5 only)
+- No `async/await`, no arrow functions, no template literals
+- No optional chaining `?.`
+- Use `Promise` chains and `.then()/.catch()`
+- Use `var` not `let/const` (for maximum compatibility)
+
+### Python
+- Python 3.10+ compatible
+- No f-strings if targeting 3.5 compatibility — use `.format()`
+- All API calls must include all 4 required OpenViking headers
+
+### API Correctness
+- Message format: `{role, content}` — never `{role, parts: [...]}`
+- All 4 headers on every request: `Authorization`, `x-api-key`, `x-openviking-user`, `x-openviking-account`
+- `ov.conf` valid fields only: `storage`, `log`, `embedding`, `vlm`, `server`
+- Search results at `result.resources[]` and `result.memories[]`
+
+---
+
+## Areas Most Needed
+
+| Area | What would help |
+|------|----------------|
+| Linux/macOS | Bash equivalents of all .ps1 scripts + systemd/launchd for tasks |
+| Docker | Compose setup for the OpenViking server |
+| Testing | Automated tests for the MCP bridge |
+| OpenViking updates | Keep up with new API versions if response structure changes |
+| Embedding providers | Support for additional embedding providers beyond Jina and Ollama |
+
+---
+
+## Questions
+
+Email: chinasameh@gmail.com
+GitHub Issues: preferred for bug reports and feature requests
+Response time: best effort.

--- a/examples/Claude-Desktop/LICENSE
+++ b/examples/Claude-Desktop/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2026 Sameh Khalifa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This project builds upon OpenViking (https://github.com/volcengine/OpenViking)
+which is licensed under the Apache License, Version 2.0.
+A copy of the Apache License is included in LICENSES/Apache-2.0.txt.

--- a/examples/Claude-Desktop/LICENSES/Apache-2.0.txt
+++ b/examples/Claude-Desktop/LICENSES/Apache-2.0.txt
@@ -1,0 +1,105 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work.
+
+      "Derivative Works" shall mean any work that is based on the Work,
+      for which the editorial revisions, additions, substitutions, or other
+      modifications represent, as a whole, an original work of authorship.
+
+      "Contribution" shall mean any work of authorship submitted to the
+      Licensor for inclusion in the Work.
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      patent license to make, use, sell, offer for sale, import, and
+      otherwise transfer the Work.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work; and
+
+      (d) If the Work includes a NOTICE text file, You must include a
+          readable copy of the attribution notices contained within
+          such NOTICE file.
+
+   5. Submission of Contributions. Any Contribution intentionally submitted
+      for inclusion in the Work shall be under the terms of this License.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or agreed
+      to in writing, Licensor provides the Work on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      shall any Contributor be liable for damages, including any direct,
+      indirect, special, incidental, or exemplary damages arising out
+      of this License or out of the use or inability to use the Work.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work, You may offer acceptance of support, warranty, indemnity,
+      or other liability obligations consistent with this License.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Volcengine Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0

--- a/examples/Claude-Desktop/NOTICE
+++ b/examples/Claude-Desktop/NOTICE
@@ -1,0 +1,13 @@
+openviking-claude-desktop
+Copyright (c) 2026 Sameh Khalifa
+
+This software includes components derived from or built upon:
+
+  OpenViking
+  https://github.com/volcengine/OpenViking
+  Copyright (c) Volcengine Ltd.
+  Licensed under the Apache License, Version 2.0
+  http://www.apache.org/licenses/LICENSE-2.0
+
+This project is an independent integration and is not affiliated with,
+endorsed by, or officially connected to Volcengine or ByteDance in any way.

--- a/examples/Claude-Desktop/README.md
+++ b/examples/Claude-Desktop/README.md
@@ -1,0 +1,321 @@
+# OpenViking for Claude Desktop & Claude Code
+
+A custom integration connecting [OpenViking](https://github.com/volcengine/OpenViking)
+as a persistent memory layer for **Claude Desktop** (via MCP bridge) and
+**Claude Code** (via hook-based auto-recall and auto-capture).
+
+Works with **any data** — documents, notes, code snippets, research, transcripts,
+or any content you store in OpenViking. No domain-specific assumptions.
+
+---
+
+## What It Does
+
+**Claude Desktop** gets 12 OpenViking MCP tools (`ov_search`, `ov_find`, `ov_read`, etc.)
+so it can search and write to your memory store directly from any conversation.
+
+**Claude Code** automatically:
+- Searches your memory before every prompt (`UserPromptSubmit` hook)
+- Injects the top 6 most relevant results as context
+- Captures new knowledge at the end of every session (`Stop` hook)
+
+**Background services** keep everything running:
+- Watchdog monitors port 1933, restarts on crash, never permanently exits
+- Health alert checks every 15 min, shows Windows notification + auto-restarts
+- Autosave commits sessions every 30 min so no memory is ever lost
+- Embedding selector picks Ollama (local/free) first, falls back to Jina cloud
+
+---
+
+## Architecture
+
+```
+Claude Desktop
+    MCP bridge (openviking-bridge.py) — 12 ov_* tools over stdio
+        REST API -> localhost:1933
+
+Claude Code
+    UserPromptSubmit -> hooks/ov-recall.js
+        Searches all your data semantically
+        Injects top 6 results as system context before Claude responds
+    Stop -> hooks/ov-capture.js
+        Commits session -> OpenViking extracts and stores memories
+
+Background
+    openviking-watchdog.py       15s checks, auto-restart, never exits
+    scripts/ov-health-alert.ps1  15min task, Windows notification + restart
+    hooks/ov_session.py autosave 30min task, commit + new session
+```
+
+---
+
+## Prerequisites
+
+- Windows 10/11
+- Python 3.10+ (tested on 3.13 embeddable)
+- Node.js 16+
+- [OpenViking](https://github.com/volcengine/OpenViking) installed:
+  ```
+  pip install openviking openviking-cli
+  ```
+- Claude Desktop (latest)
+- Claude Code CLI
+
+**Embedding (choose one):**
+- [Ollama](https://ollama.ai) with `nomic-embed-text` — free, local, no API key
+- [Jina AI](https://jina.ai) API key — cloud, free tier available
+
+**VLM for memory extraction:**
+- Anthropic API key (Claude Sonnet used to extract structured memories from sessions)
+
+---
+
+## Installation
+
+### 1. Clone
+
+```
+git clone https://github.com/YOUR_USERNAME/openviking-claude-desktop.git
+cd openviking-claude-desktop
+```
+
+### 2. Create directories
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.openviking"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude-memory\logs"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude-memory\hooks"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\hooks"
+```
+
+### 3. Configure
+
+```powershell
+copy config\ov.conf.example   "$env:USERPROFILE\.openviking\ov.conf"
+copy config\ovcli.conf.example "$env:USERPROFILE\.openviking\ovcli.conf"
+```
+
+Edit `ov.conf` — replace all `YOUR_*` placeholders:
+- `YOUR_JINA_API_KEY` — from jina.ai (or switch provider to ollama)
+- `YOUR_ANTHROPIC_API_KEY` — from console.anthropic.com
+- `YOUR_LOCAL_API_KEY` — any string you choose (e.g. `my-local-key`)
+- `YOUR_USERNAME` — your Windows username
+
+### 4. Copy server files
+
+```powershell
+copy server\openviking-bridge.py   "$env:USERPROFILE\.openviking\"
+copy server\openviking-mcp.py      "$env:USERPROFILE\.openviking\"
+copy server\openviking-watchdog.py "$env:USERPROFILE\.openviking\"
+```
+
+### 5. Copy scripts
+
+```powershell
+copy scripts\*.ps1 "$env:USERPROFILE\.openviking\"
+```
+
+### 6. Copy hooks
+
+```powershell
+copy hooks\ov-recall.js  "$env:USERPROFILE\.claude\hooks\"
+copy hooks\ov-capture.js "$env:USERPROFILE\.claude\hooks\"
+copy hooks\ov_session.py "$env:USERPROFILE\.claude-memory\hooks\"
+```
+
+### 7. Configure Claude Desktop MCP
+
+Add to `%APPDATA%\Claude\claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "openviking-memory": {
+      "command": "python",
+      "args": ["C:\\Users\\YOUR_USERNAME\\.openviking\\openviking-bridge.py"],
+      "env": {
+        "OV_API_KEY": "YOUR_LOCAL_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### 8. Wire Claude Code hooks
+
+Add to `%USERPROFILE%\.claude\settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"C:/Users/YOUR_USERNAME/.claude/hooks/ov-recall.js\""
+        }]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"C:/Users/YOUR_USERNAME/.claude/hooks/ov-capture.js\""
+        }]
+      }
+    ]
+  }
+}
+```
+
+### 9. Register scheduled tasks (run PowerShell as Administrator)
+
+```powershell
+& "$env:USERPROFILE\.openviking\register-ov-watchdog.ps1"
+& "$env:USERPROFILE\.openviking\register-ov-autosave.ps1"
+& "$env:USERPROFILE\.openviking\register-ov-health-alert.ps1"
+```
+
+### 10. Start and verify
+
+```powershell
+& "$env:USERPROFILE\.openviking\restart-openviking.ps1"
+& "$env:USERPROFILE\.openviking\verify-ov-hooks.ps1"
+```
+
+All checks should pass.
+
+---
+
+## Adding Your Data
+
+OpenViking stores data as `.md` files in `%USERPROFILE%\.claude-memory\viking\default\resources\`.
+
+You can add data via:
+
+**MCP tool in Claude Desktop:**
+```
+ov_add_resource with your file path
+```
+
+**API directly:**
+```powershell
+$h = @{
+  "Authorization" = "Bearer YOUR_LOCAL_API_KEY"
+  "x-api-key" = "YOUR_LOCAL_API_KEY"
+  "x-openviking-user" = "default"
+  "x-openviking-account" = "default"
+}
+Invoke-RestMethod -Uri "http://localhost:1933/api/v1/resources" -Method POST `
+  -Headers $h -ContentType "application/json" `
+  -Body '{"path": "C:/your/file.md", "wait": true}' -UseBasicParsing
+```
+
+**Direct file placement:**
+Place `.md` files in `%USERPROFILE%\.claude-memory\viking\default\resources\YOUR_DIR\`
+then trigger re-indexing via `ov_add_resource`.
+
+---
+
+## File Reference
+
+### Server (`server/`)
+
+| File | Purpose |
+|------|---------|
+| `openviking-bridge.py` | MCP stdio bridge — 12 `ov_*` tools for Claude Desktop |
+| `openviking-mcp.py` | Alternative MCP — 5 simpler `memory_*` tools |
+| `openviking-watchdog.py` | Monitors port 1933, auto-restart, never permanently exits |
+
+### Scripts (`scripts/`)
+
+| File | Purpose |
+|------|---------|
+| `restart-openviking.ps1` | Kill, reselect embedding, start server |
+| `select-embedding.ps1` | Ollama-first selector, Jina cloud fallback |
+| `register-ov-watchdog.ps1` | Watchdog as scheduled task (at logon) |
+| `register-ov-autosave.ps1` | 30-min autosave task (Admin required) |
+| `register-ov-health-alert.ps1` | 15-min health check + auto-restart (Admin required) |
+| `ov-health-alert.ps1` | Health check — Windows balloon notification if down |
+| `verify-ov-hooks.ps1` | Full system verification (26 checks) |
+
+### Hooks (`hooks/`)
+
+| File | Install location | Purpose |
+|------|-----------------|---------|
+| `ov-recall.js` | `~/.claude/hooks/` | Auto-recall: searches all data, injects top 6 results |
+| `ov-capture.js` | `~/.claude/hooks/` | Auto-capture: commits session at Stop |
+| `ov_session.py` | `~/.claude-memory/hooks/` | Autosave: commit + new session every 30 min |
+
+---
+
+## Configuration Notes
+
+### ov.conf — valid fields only
+
+OpenViking v0.3.16 rejects any unrecognised config fields.
+Only these top-level keys are valid:
+
+```
+storage | log | embedding | vlm | server
+```
+
+Adding any other key (e.g. `claude_code`, `hooks`, `app`) crashes the server on startup.
+
+### API message format
+
+```json
+{ "role": "user", "content": "your text" }
+```
+
+Not `{ "role": "user", "parts": [...] }` — that returns an error.
+
+### All 4 headers required
+
+Every request to tenant-scoped APIs needs:
+
+```
+Authorization: Bearer YOUR_KEY
+x-api-key: YOUR_KEY
+x-openviking-user: default
+x-openviking-account: default
+```
+
+### Search response path
+
+Items are at `result.resources[]` and `result.memories[]`, not `result.items[]`.
+
+---
+
+## PowerShell 5.1 Compatibility
+
+All scripts target **Windows PowerShell 5.1**. These constructs are not supported:
+- `?.` null-conditional operator
+- `??` null-coalescing operator
+- `&` inside double-quoted `Write-Host` strings
+- `-RunOnlyIfNetworkAvailable $false` in `New-ScheduledTaskSettingsSet`
+
+---
+
+## License
+
+MIT
+
+---
+
+## Related
+
+- [OpenViking (official)](https://github.com/volcengine/OpenViking)
+- [Castor6/openviking-plugins](https://github.com/Castor6/openviking-plugins)
+- [Claude Desktop](https://claude.ai/download)
+- [Claude Code](https://docs.anthropic.com/claude-code)
+
+---
+
+## Author
+
+**Sameh Khalifa**
+Email: chinasameh@gmail.com
+GitHub Issues: preferred for bug reports and feature requests

--- a/examples/Claude-Desktop/config/ov.conf.example
+++ b/examples/Claude-Desktop/config/ov.conf.example
@@ -1,0 +1,38 @@
+{
+    "storage": {
+        "workspace": "C:/Users/YOUR_USERNAME/.claude-memory",
+        "vectordb": {
+            "name": "context",
+            "backend": "local"
+        }
+    },
+    "log": {
+        "level": "INFO",
+        "output": "C:/Users/YOUR_USERNAME/.claude-memory/logs/openviking.log",
+        "rotation": false
+    },
+    "embedding": {
+        "dense": {
+            "provider": "jina",
+            "api_key": "YOUR_JINA_API_KEY",
+            "api_base": "https://api.jina.ai/v1",
+            "model": "jina-embeddings-v3",
+            "dimension": 768,
+            "query_param": "retrieval.query",
+            "document_param": "retrieval.passage"
+        },
+        "max_concurrent": 1
+    },
+    "vlm": {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-20250514",
+        "api_key": "YOUR_ANTHROPIC_API_KEY",
+        "api_base": "https://api.anthropic.com/v1",
+        "max_concurrent": 10
+    },
+    "server": {
+        "host": "127.0.0.1",
+        "port": 1933,
+        "root_api_key": "YOUR_LOCAL_API_KEY"
+    }
+}

--- a/examples/Claude-Desktop/config/ovcli.conf.example
+++ b/examples/Claude-Desktop/config/ovcli.conf.example
@@ -1,0 +1,4 @@
+{
+  "url": "http://localhost:1933",
+  "api_key": "YOUR_LOCAL_API_KEY"
+}

--- a/examples/Claude-Desktop/docs/API_REFERENCE.md
+++ b/examples/Claude-Desktop/docs/API_REFERENCE.md
@@ -1,0 +1,236 @@
+# OpenViking API Reference (v0.3.16)
+
+Key facts confirmed from production use. Supplements the official docs.
+
+---
+
+## Required Headers (ALL tenant-scoped API requests)
+
+```
+Authorization: Bearer YOUR_API_KEY
+x-api-key: YOUR_API_KEY
+x-openviking-user: default
+x-openviking-account: default
+```
+
+Missing `x-openviking-user` or `x-openviking-account` returns:
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "INVALID_ARGUMENT",
+    "message": "ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers."
+  }
+}
+```
+
+---
+
+## Endpoints
+
+### Health
+```
+GET /health
+Response: {"status":"ok","healthy":true,"version":"0.3.16",...}
+```
+
+### System Status
+```
+GET /api/v1/system/status
+```
+
+### Search — find
+```
+POST /api/v1/search/find
+Body:
+{
+  "query": "your search query",
+  "limit": 6,
+  "target_uri": "viking://resources/OPTIONAL_SCOPE"   // optional
+}
+
+Response:
+{
+  "result": {
+    "resources": [...],   // stored files and documents
+    "memories":  [...],   // extracted knowledge from sessions
+    "skills":    [...],
+    "total": N
+  }
+}
+
+NOTE: items live at result.resources[] and result.memories[]
+      NOT at result.items[] — common mistake
+```
+
+### Search — search
+```
+POST /api/v1/search/search
+Body: {"query": "...", "limit": 6}
+Same response structure as /find
+```
+
+### Create Session
+```
+POST /api/v1/sessions
+Body: {}
+Response: {"result": {"session_id": "uuid-string"}}
+```
+
+### Add Message to Session
+```
+POST /api/v1/sessions/{session_id}/messages
+Body: {"role": "user", "content": "message text"}
+
+IMPORTANT: use {role, content} format
+NOT {role, parts:[{type:"text", text:"..."}]}  <- wrong, causes error
+```
+
+### Commit Session
+```
+POST /api/v1/sessions/{session_id}/commit
+Body: {}
+Response:
+{
+  "result": {
+    "memories_extracted": N,
+    "active_count_updated": N,
+    "archived": true/false
+  }
+}
+```
+
+### List Resources
+```
+GET /api/v1/fs/ls?uri=viking://
+Response: {"result": {"entries": [...]}}
+```
+
+### Read Resource
+```
+GET /api/v1/content/read?uri=viking://resources/DIR/FILE.md
+```
+
+### Add Resource
+```
+POST /api/v1/resources
+Body: {"path": "/local/path/to/file.md", "reason": "optional", "wait": true}
+```
+
+---
+
+## ov.conf — Valid Fields Only
+
+OpenViking v0.3.16 validates config strictly. Any unrecognised top-level key
+causes the server to fail on startup with `Unknown config field '...'`.
+
+Only these keys are valid:
+
+```json
+{
+  "storage":   { ... },
+  "log":       { ... },
+  "embedding": { ... },
+  "vlm":       { ... },
+  "server":    { ... }
+}
+```
+
+---
+
+## Embedding Configuration
+
+### Jina (cloud)
+```json
+"embedding": {
+  "dense": {
+    "provider":       "jina",
+    "api_key":        "YOUR_JINA_API_KEY",
+    "api_base":       "https://api.jina.ai/v1",
+    "model":          "jina-embeddings-v3",
+    "dimension":      768,
+    "query_param":    "retrieval.query",
+    "document_param": "retrieval.passage"
+  },
+  "max_concurrent": 1
+}
+```
+
+### Ollama (local)
+```json
+"embedding": {
+  "dense": {
+    "provider": "openai",
+    "api_key":  "ollama",
+    "api_base": "http://localhost:11434/v1",
+    "model":    "nomic-embed-text",
+    "dimension": 768
+  },
+  "max_concurrent": 1
+}
+```
+
+**Note:** When switching to Ollama, remove `query_param` and `document_param`
+from the config. These are Jina-specific and cause errors with the
+OpenAI-compatible provider tag.
+
+---
+
+## Server Entry Point
+
+```python
+# CORRECT:
+python -m openviking_cli.server_bootstrap
+
+# WRONG (ModuleNotFoundError):
+python -m uvicorn openviking.app:app
+python -m uvicorn openviking.server.app:app
+```
+
+---
+
+## Resource URI Format
+
+```
+viking://                               root
+viking://resources/                     all resources
+viking://resources/MY_DIR/              a directory
+viking://resources/MY_DIR/file.md       a specific file
+```
+
+---
+
+## Session State File
+
+`%USERPROFILE%\.claude-memory\.session_state.json`
+
+```json
+{
+  "current_session": "uuid or null",
+  "started_at": "ISO datetime or null",
+  "last_commit": {
+    "session_id": "uuid",
+    "committed_at": "ISO datetime",
+    "memories_extracted": 0
+  }
+}
+```
+
+---
+
+## MCP Tools (openviking-bridge.py)
+
+| Tool | Method | Endpoint |
+|------|--------|----------|
+| `ov_health` | GET | `/health` |
+| `ov_status` | GET | `/api/v1/system/status` |
+| `ov_search` | POST | `/api/v1/search/search` |
+| `ov_find` | POST | `/api/v1/search/find` |
+| `ov_ls` | GET | `/api/v1/fs/ls` |
+| `ov_read` | GET | `/api/v1/content/read` |
+| `ov_add_resource` | POST | `/api/v1/resources` |
+| `ov_mkdir` | POST | `/api/v1/fs/mkdir` |
+| `ov_create_session` | POST | `/api/v1/sessions` |
+| `ov_add_message` | POST | `/api/v1/sessions/{id}/messages` |
+| `ov_commit_session` | POST | `/api/v1/sessions/{id}/commit` |
+| `ov_grep` | POST | `/api/v1/search/grep` |

--- a/examples/Claude-Desktop/docs/TROUBLESHOOTING.md
+++ b/examples/Claude-Desktop/docs/TROUBLESHOOTING.md
@@ -1,0 +1,148 @@
+# Troubleshooting Guide
+
+## Server won't start
+
+**Symptom:** `restart-openviking.ps1` shows "FAILED: Unable to connect"
+
+Check the error log:
+```powershell
+Get-Content "$env:USERPROFILE\.claude-memory\logs\openviking-server-$(Get-Date -Format 'yyyyMMdd')-err.log" -Tail 20
+```
+
+Common causes:
+
+| Error | Fix |
+|-------|-----|
+| `Unknown config field '...'` | Remove invalid field from ov.conf. Only `storage/log/embedding/vlm/server` are valid |
+| `ModuleNotFoundError: openviking` | Run `pip install openviking openviking-cli` |
+| `Address already in use: 1933` | Kill old process: `Get-Process python | Stop-Process` |
+| `Invalid api_key` | Check `server.root_api_key` in ov.conf matches `OV_API_KEY` in scripts |
+| `Unknown config field 'claude_code'` | Remove the `claude_code` key from ov.conf entirely |
+
+---
+
+## Search returns 0 results
+
+**Symptom:** `verify-ov-hooks.ps1` shows search returning 0 resources
+
+Causes:
+1. **No data added yet** — add files via `ov_add_resource` or place `.md` files in the workspace directory
+2. **Wrong response path** — items are at `result.resources[]` not `result.items[]`
+3. **Missing headers** — all 4 headers required on every request:
+   `Authorization`, `x-api-key`, `x-openviking-user`, `x-openviking-account`
+4. **Embedding not working** — check Jina API key or Ollama model availability
+
+---
+
+## API returns 400 INVALID_ARGUMENT
+
+**Symptom:**
+```
+ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers
+```
+
+Fix: Send all 4 required headers with every request:
+```
+Authorization: Bearer YOUR_KEY
+x-api-key: YOUR_KEY
+x-openviking-user: default
+x-openviking-account: default
+```
+
+---
+
+## Claude Desktop MCP tools not appearing
+
+**Symptom:** `ov_search` and other tools not visible in Claude Desktop
+
+Steps:
+1. Verify config syntax: `Get-Content "$env:APPDATA\Claude\claude_desktop_config.json"`
+2. Confirm Python path is correct and `openviking-bridge.py` exists
+3. Fully quit Claude Desktop (system tray) and reopen
+4. Test bridge manually — run `python openviking-bridge.py` (should hang waiting for stdin)
+
+---
+
+## Watchdog keeps restarting
+
+**Symptom:** Watchdog log shows repeated restarts, server not staying up
+
+Check:
+1. `ov.conf` has no invalid fields — only `storage`, `log`, `embedding`, `vlm`, `server`
+2. Embedding API key is valid (Jina free tier has rate limits)
+3. Anthropic API key is valid and has available credits
+4. Port 1933 is not blocked by firewall or antivirus
+
+---
+
+## Session state shows `current_session: None`
+
+**Symptom:** `ov_session.py` logs "no active session"
+
+Normal after a commit. Create a new session:
+```powershell
+$PY = "$env:USERPROFILE\AppData\Local\Programs\Python\Python313\python.exe"
+& $PY "$env:USERPROFILE\.claude-memory\hooks\ov_session.py" autosave
+```
+
+---
+
+## ov-recall.js not firing in Claude Code
+
+**Symptom:** No `[OpenViking Memory - Auto-Recall]` blocks appearing in Claude Code
+
+Checklist:
+1. `settings.json` has `ov-recall.js` wired to `hooks.UserPromptSubmit`
+2. Node.js installed: `node --version`
+3. Hook file exists: `Test-Path "$env:USERPROFILE\.claude\hooks\ov-recall.js"`
+4. Server is up: `Invoke-WebRequest http://localhost:1933/health -UseBasicParsing`
+5. Check recall log: `Get-Content "$env:USERPROFILE\.claude-memory\logs\ov-recall.log" -Tail 20`
+
+---
+
+## ov-capture.js fails silently at session end
+
+**Symptom:** Sessions not being committed, `ov-capture.log` shows no entries
+
+Causes:
+1. Node.js version too old for ES2020 syntax — this repo uses ES5 throughout, should be fine on any Node
+2. `STATE_F` path wrong — confirm `.session_state.json` exists at `%USERPROFILE%\.claude-memory\`
+3. Session already committed by autosave before Stop hook fired — check `last_commit` in state file
+
+---
+
+## Embedding selector timeout
+
+**Symptom:** Watchdog log shows "Embedding selector timed out"
+
+The selector runs PowerShell which takes 1-3 seconds to start.
+The watchdog allows 45 seconds — if timing out, your machine may be under heavy load.
+
+Fix: Edit `EMBED_TIMEOUT` in `openviking-watchdog.py` and increase to 60 or 90.
+
+---
+
+## Health alert not showing notifications
+
+**Symptom:** Server goes down, no Windows balloon notification appears
+
+The notification uses `System.Windows.Forms.NotifyIcon`.
+Check:
+1. Script is running as interactive user (not SYSTEM account)
+2. Windows focus assist / do not disturb is off
+3. Test manually: `& "$env:USERPROFILE\.openviking\ov-health-alert.ps1"`
+
+---
+
+## PowerShell 5.1 compatibility errors
+
+This project targets **Windows PowerShell 5.1** (not PowerShell 7+).
+
+Never use in `.ps1` files on PS5.1:
+
+| Construct | Error | Fix |
+|-----------|-------|-----|
+| `$obj?.prop` | Unexpected token `?.` | Use `if ($obj) { $obj.prop }` |
+| `$a ?? $b` | Unexpected token `??` | Use `if ($null -ne $a) { $a } else { $b }` |
+| `"run & script"` | `&` not allowed in string | Use plain text or escape |
+| `-RunOnlyIfNetworkAvailable $false` | Positional parameter error | Remove this parameter entirely |

--- a/examples/Claude-Desktop/hooks/ov-capture.js
+++ b/examples/Claude-Desktop/hooks/ov-capture.js
@@ -1,0 +1,124 @@
+// ov-capture.js  v2.1  — Auto-capture for Claude Code
+// Hook: Stop
+//
+// Fires at end of every Claude Code session.
+// Commits the session so OpenViking extracts and stores memories.
+// Written in ES5 for compatibility with all Node.js versions.
+
+'use strict';
+var http = require('http');
+var fs   = require('fs');
+var path = require('path');
+var os   = require('os');
+
+var OV_HOST  = '127.0.0.1';
+var OV_PORT  = 1933;
+var OV_KEY   = process.env.OV_API_KEY || 'YOUR_LOCAL_API_KEY';
+var OV_USER  = 'default';
+var OV_ACCT  = 'default';
+var LOG_FILE = path.join(os.homedir(), '.claude-memory', 'logs', 'ov-capture.log');
+var STATE_F  = path.join(os.homedir(), '.claude-memory', '.session_state.json');
+
+function log(msg) {
+    try { fs.appendFileSync(LOG_FILE, '[' + new Date().toISOString() + '] ' + msg + '\n'); } catch (_) {}
+}
+
+function loadState() {
+    try { return JSON.parse(fs.readFileSync(STATE_F, 'utf8')); } catch (_) { return {}; }
+}
+
+function saveState(s) {
+    try { fs.writeFileSync(STATE_F, JSON.stringify(s, null, 2), 'utf8'); } catch (_) {}
+}
+
+function request(method, urlPath, body, timeoutMs) {
+    return new Promise(function(resolve, reject) {
+        var data = body ? JSON.stringify(body) : null;
+        var headers = {
+            'Authorization':        'Bearer ' + OV_KEY,
+            'x-api-key':            OV_KEY,
+            'x-openviking-user':    OV_USER,
+            'x-openviking-account': OV_ACCT
+        };
+        if (data) {
+            headers['Content-Type']   = 'application/json';
+            headers['Content-Length'] = Buffer.byteLength(data);
+        }
+        var opts = {
+            hostname: OV_HOST, port: OV_PORT,
+            path: urlPath, method: method,
+            headers: headers, timeout: timeoutMs || 45000
+        };
+        var req = http.request(opts, function(res) {
+            var buf = '';
+            res.on('data', function(c) { buf += c; });
+            res.on('end', function() {
+                try { resolve(JSON.parse(buf)); }
+                catch (e) { resolve({ _raw: buf }); }
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', function() { req.destroy(); reject(new Error('timeout')); });
+        if (data) req.write(data);
+        req.end();
+    });
+}
+
+function isUp() {
+    return request('GET', '/health', null, 4000)
+        .then(function() { return true; })
+        .catch(function() { return false; });
+}
+
+function safeGet(obj, prop) {
+    if (obj && typeof obj === 'object' && obj.hasOwnProperty(prop)) { return obj[prop]; }
+    return undefined;
+}
+
+(function() {
+    var state     = loadState();
+    var sessionId = safeGet(state, 'current_session');
+
+    if (!sessionId) {
+        log('No active session -- Stop hook done (nothing to commit)');
+        process.exit(0); return;
+    }
+
+    isUp().then(function(up) {
+        if (!up) { log('Server down -- capture skipped'); process.exit(0); return; }
+
+        log('Committing session ' + sessionId + '...');
+
+        return request('POST', '/api/v1/sessions/' + sessionId + '/commit', {}, 45000)
+            .then(function(result) {
+                var r         = safeGet(result, 'result') || result || {};
+                var extracted = safeGet(r, 'memories_extracted');
+                var updated   = safeGet(r, 'active_count_updated');
+                var archived  = safeGet(r, 'archived');
+
+                if (extracted === undefined) { extracted = 0; }
+                if (updated   === undefined) { updated   = 0; }
+                if (archived  === undefined) { archived  = false; }
+
+                log('Committed: ' + extracted + ' memories extracted, ' + updated + ' updated, archived=' + archived);
+
+                state.last_commit = {
+                    session_id:           sessionId,
+                    committed_at:         new Date().toISOString(),
+                    memories_extracted:   extracted,
+                    active_count_updated: updated
+                };
+                delete state.current_session;
+                delete state.started_at;
+                saveState(state);
+
+                if (extracted > 0) {
+                    process.stdout.write('[OpenViking] Session captured: ' + extracted + ' memories stored.\n');
+                }
+                process.exit(0);
+            });
+    }).catch(function(err) {
+        log('ov-capture.js error: ' + err.message);
+        process.exit(0);
+    });
+})();

--- a/examples/Claude-Desktop/hooks/ov-recall.js
+++ b/examples/Claude-Desktop/hooks/ov-recall.js
@@ -1,0 +1,198 @@
+// ov-recall.js  v2.2  — Auto-recall for Claude Code
+// Hook: UserPromptSubmit
+//
+// Fires before every user prompt. Searches OpenViking semantically
+// and injects the top results as system context for Claude Code.
+//
+// Response structure (OpenViking v0.3.16):
+//   result.resources[]  -- stored documents and files
+//   result.memories[]   -- extracted knowledge from past sessions
+//
+// Configuration: edit OV_KEY, RECALL_N, MIN_SCORE below.
+// No domain-specific keywords or scoping — searches all your data.
+
+'use strict';
+var http = require('http');
+var fs   = require('fs');
+var path = require('path');
+var os   = require('os');
+
+// ── Config ────────────────────────────────────────────────────────────────
+var OV_HOST   = '127.0.0.1';
+var OV_PORT   = 1933;
+var OV_KEY    = process.env.OV_API_KEY || 'YOUR_LOCAL_API_KEY';
+var OV_USER   = 'default';
+var OV_ACCT   = 'default';
+var RECALL_N  = 6;      // max results to inject per prompt
+var MIN_SCORE = 0.15;   // ignore results below this relevance score
+var LOG_FILE  = path.join(os.homedir(), '.claude-memory', 'logs', 'ov-recall.log');
+var STATE_F   = path.join(os.homedir(), '.claude-memory', '.session_state.json');
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function log(msg) {
+    try { fs.appendFileSync(LOG_FILE, '[' + new Date().toISOString() + '] ' + msg + '\n'); } catch (_) {}
+}
+
+function loadState() {
+    try { return JSON.parse(fs.readFileSync(STATE_F, 'utf8')); } catch (_) { return {}; }
+}
+
+function saveState(s) {
+    try { fs.writeFileSync(STATE_F, JSON.stringify(s, null, 2), 'utf8'); } catch (_) {}
+}
+
+function request(method, urlPath, body, timeoutMs) {
+    return new Promise(function(resolve, reject) {
+        var data = body ? JSON.stringify(body) : null;
+        var headers = {
+            'Authorization':        'Bearer ' + OV_KEY,
+            'x-api-key':            OV_KEY,
+            'x-openviking-user':    OV_USER,
+            'x-openviking-account': OV_ACCT
+        };
+        if (data) {
+            headers['Content-Type']   = 'application/json';
+            headers['Content-Length'] = Buffer.byteLength(data);
+        }
+        var opts = {
+            hostname: OV_HOST, port: OV_PORT,
+            path: urlPath, method: method,
+            headers: headers, timeout: timeoutMs || 8000
+        };
+        var req = http.request(opts, function(res) {
+            var buf = '';
+            res.on('data', function(c) { buf += c; });
+            res.on('end', function() {
+                try { resolve(JSON.parse(buf)); }
+                catch (e) { resolve({ _raw: buf }); }
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', function() { req.destroy(); reject(new Error('timeout')); });
+        if (data) req.write(data);
+        req.end();
+    });
+}
+
+function isUp() {
+    return request('GET', '/health', null, 3000)
+        .then(function() { return true; })
+        .catch(function() { return false; });
+}
+
+function readStdin() {
+    return new Promise(function(resolve) {
+        if (process.stdin.isTTY) { resolve(''); return; }
+        var data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', function(c) { data += c; });
+        process.stdin.on('end', function() { resolve(data.trim()); });
+        setTimeout(function() { resolve(data.trim()); }, 2500);
+    });
+}
+
+// Extract items from confirmed response: result.resources[] + result.memories[]
+function extractItems(res) {
+    var items = [];
+    if (!res) return items;
+    var result = (res && res.result) ? res.result : res;
+    var resources = (result && result.resources) ? result.resources : [];
+    var memories  = (result && result.memories)  ? result.memories  : [];
+    var i;
+    for (i = 0; i < resources.length; i++) { items.push(resources[i]); }
+    for (i = 0; i < memories.length;  i++) { items.push(memories[i]); }
+    return items;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+(function() {
+    readStdin().then(function(raw) {
+        var prompt = '';
+        if (raw) {
+            try {
+                var p = JSON.parse(raw);
+                prompt = ((p.prompt || p.message || p.text) || '').trim();
+            } catch (_) {
+                prompt = raw.slice(0, 600);
+            }
+        }
+
+        // Skip slash commands, empty prompts
+        if (!prompt || prompt.length < 6 || prompt.charAt(0) === '/') {
+            process.exit(0); return;
+        }
+
+        isUp().then(function(up) {
+            if (!up) { log('Server down - recall skipped'); process.exit(0); return; }
+
+            // Create session if none exists
+            var state = loadState();
+            var sessionPromise;
+            if (!state.current_session) {
+                sessionPromise = request('POST', '/api/v1/sessions', {}, 8000)
+                    .then(function(sess) {
+                        var id = null;
+                        var res = (sess && sess.result) ? sess.result : null;
+                        if (res) { id = res.session_id || res.id; }
+                        if (!id && sess) { id = sess.session_id || sess.id; }
+                        if (id) {
+                            state.current_session = id;
+                            state.started_at = new Date().toISOString();
+                            saveState(state);
+                            log('Session created: ' + id);
+                        }
+                    }).catch(function(e) { log('Session create error: ' + e.message); });
+            } else {
+                sessionPromise = Promise.resolve();
+            }
+
+            sessionPromise.then(function() {
+                // Search all data — no scoping, no keyword filtering
+                var searchBody = { query: prompt.slice(0, 400), limit: RECALL_N };
+
+                request('POST', '/api/v1/search/find', searchBody, 10000)
+                    .then(function(res) {
+                        var items = extractItems(res);
+                        var relevant = [];
+                        for (var i = 0; i < items.length; i++) {
+                            var s = (items[i].score !== undefined) ? items[i].score : 1;
+                            if (s >= MIN_SCORE) { relevant.push(items[i]); }
+                            if (relevant.length >= RECALL_N) break;
+                        }
+
+                        if (relevant.length > 0) {
+                            var lines = ['\n[OpenViking Memory - Auto-Recall]'];
+                            for (var j = 0; j < relevant.length; j++) {
+                                var item    = relevant[j];
+                                var uri     = item.uri || '';
+                                var title   = item.title || (uri ? uri.split('/').pop() : ('Result ' + (j+1)));
+                                var snippet = (item.abstract || item.content || item.snippet || '')
+                                    .slice(0, 350).replace(/\n+/g, ' ').trim();
+                                var score   = (item.score !== undefined) ? item.score.toFixed(2) : '?';
+                                lines.push('\n' + (j+1) + '. ' + title + '  [score: ' + score + ']');
+                                if (uri)     lines.push('   URI: ' + uri);
+                                if (snippet) lines.push('   ' + snippet);
+                            }
+                            lines.push('\n[End recalled context]');
+                            process.stdout.write(lines.join('\n') + '\n');
+                            log('Recalled ' + relevant.length + ' items for: "' + prompt.slice(0, 60) + '"');
+                        } else {
+                            log('No results above MIN_SCORE (' + MIN_SCORE + ') for: "' + prompt.slice(0, 60) + '"');
+                        }
+
+                        // Add user turn to active session
+                        state = loadState();
+                        if (state.current_session) {
+                            request('POST', '/api/v1/sessions/' + state.current_session + '/messages',
+                                { role: 'user', content: prompt.slice(0, 3000) }, 6000
+                            ).catch(function(e) { log('Add-message error: ' + e.message); });
+                        }
+                    })
+                    .catch(function(e) { log('Search error: ' + e.message); process.exit(0); });
+            });
+        });
+    }).catch(function(err) {
+        log('ov-recall.js fatal: ' + err.message);
+        process.exit(0);
+    });
+})();

--- a/examples/Claude-Desktop/hooks/ov_session.py
+++ b/examples/Claude-Desktop/hooks/ov_session.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+ov_session.py  v2.0  — OpenViking session manager
+Called by Windows Scheduled Task (autosave every 30 min) and manually.
+
+Commands:
+  python ov_session.py status               -- show current session state
+  python ov_session.py start                -- create new session
+  python ov_session.py commit [session_id]  -- commit session to extract memories
+  python ov_session.py autosave             -- commit if active + start new session
+  python ov_session.py add <id> <role> <text>
+
+API notes (OpenViking v0.3.16):
+  POST /api/v1/sessions                         -> create session
+  POST /api/v1/sessions/{id}/messages           -> add message {role, content}
+  POST /api/v1/sessions/{id}/commit             -> extract memories
+  GET  /health
+  All requests require 4 headers (see HEADERS below).
+"""
+import sys
+import json
+import os
+import urllib.request
+import urllib.error
+from pathlib import Path
+from datetime import datetime
+
+OV_URL     = os.environ.get("OV_URL",     "http://localhost:1933")
+OV_API_KEY = os.environ.get("OV_API_KEY", "YOUR_LOCAL_API_KEY")
+
+HOME       = Path(os.environ["USERPROFILE"])
+LOG_FILE   = HOME / ".claude-memory" / "logs" / "session-hooks.log"
+STATE_FILE = HOME / ".claude-memory" / ".session_state.json"
+
+HEADERS = {
+    "Content-Type":           "application/json",
+    "Authorization":          "Bearer " + OV_API_KEY,
+    "x-api-key":              OV_API_KEY,
+    "x-openviking-user":      "default",
+    "x-openviking-account":   "default",
+}
+
+
+def log(msg):
+    ts   = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    line = "[{}] {}".format(ts, msg)
+    print(line)
+    try:
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        pass
+
+
+def api_post(path, body=None):
+    data = json.dumps(body or {}).encode()
+    req  = urllib.request.Request(OV_URL + path, data=data, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def health_check():
+    try:
+        urllib.request.urlopen(OV_URL + "/health", timeout=4)
+        return True
+    except Exception:
+        return False
+
+
+def load_state():
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {}
+
+
+def save_state(state):
+    try:
+        STATE_FILE.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except Exception as e:
+        log("State save error: {}".format(e))
+
+
+def create_session():
+    try:
+        result = api_post("/api/v1/sessions")
+        sid = (result.get("result") or {}).get("session_id") or result.get("session_id")
+        return sid
+    except Exception as e:
+        log("Create session error: {}".format(e))
+        return None
+
+
+def commit_session(session_id):
+    try:
+        result    = api_post("/api/v1/sessions/{}/commit".format(session_id))
+        r         = result.get("result") or result or {}
+        extracted = r.get("memories_extracted", 0)
+        updated   = r.get("active_count_updated", 0)
+        archived  = r.get("archived", False)
+        log("Committed: {} memories extracted, {} updated, archived={}".format(extracted, updated, archived))
+        return True
+    except Exception as e:
+        log("Commit error: {}".format(e))
+        return False
+
+
+def add_message(session_id, role, content):
+    try:
+        # Important: use {role, content} format, NOT {role, parts:[{type, text}]}
+        api_post("/api/v1/sessions/{}/messages".format(session_id), {"role": role, "content": content})
+        return True
+    except Exception as e:
+        log("Add-message error: {}".format(e))
+        return False
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "status"
+
+    if cmd == "status":
+        state = load_state()
+        log("Server: {}".format("UP" if health_check() else "DOWN"))
+        log("Current session: {}".format(state.get("current_session", "None")))
+        log("Started at:      {}".format(state.get("started_at", "N/A")))
+        if "last_commit" in state:
+            lc = state["last_commit"]
+            log("Last commit: {} -- {} memories".format(lc.get("committed_at", "?"), lc.get("memories_extracted", 0)))
+
+    elif cmd == "start":
+        if not health_check():
+            log("Server not running -- start skipped")
+            sys.exit(0)
+        state = load_state()
+        if state.get("current_session"):
+            log("Session already active: {}".format(state["current_session"]))
+            sys.exit(0)
+        sid = create_session()
+        if sid:
+            state["current_session"] = sid
+            state["started_at"]      = datetime.now().isoformat()
+            save_state(state)
+            log("Session started: {}".format(sid))
+
+    elif cmd == "add":
+        if len(sys.argv) < 5:
+            log("Usage: ov_session.py add <session_id> <role> <text>")
+            sys.exit(1)
+        _, _, session_id, role, text = sys.argv[:5]
+        if not health_check():
+            sys.exit(0)
+        if add_message(session_id, role, text):
+            log("Message added to {}: {} ({} chars)".format(session_id, role, len(text)))
+
+    elif cmd == "commit":
+        session_id = sys.argv[2] if len(sys.argv) > 2 else None
+        if not session_id:
+            state      = load_state()
+            session_id = state.get("current_session")
+        if not session_id:
+            log("No session to commit")
+            sys.exit(0)
+        if not health_check():
+            log("Server not running -- commit skipped")
+            sys.exit(0)
+        if commit_session(session_id):
+            state = load_state()
+            state["last_commit"] = {"session_id": session_id, "committed_at": datetime.now().isoformat()}
+            state.pop("current_session", None)
+            state.pop("started_at", None)
+            save_state(state)
+
+    elif cmd == "autosave":
+        if not health_check():
+            log("Server not running -- autosave skipped")
+            sys.exit(0)
+        state      = load_state()
+        session_id = state.get("current_session")
+        if session_id:
+            log("Autosave: committing session {}".format(session_id))
+            if commit_session(session_id):
+                state["last_commit"] = {"session_id": session_id, "committed_at": datetime.now().isoformat()}
+                state.pop("current_session", None)
+                state.pop("started_at", None)
+                save_state(state)
+        log("Autosave: creating new session for next activity")
+        new_sid = create_session()
+        if new_sid:
+            state["current_session"] = new_sid
+            state["started_at"]      = datetime.now().isoformat()
+            save_state(state)
+            log("Autosave: session ready: {}".format(new_sid))
+
+    else:
+        log("Unknown command: {}".format(cmd))
+        sys.exit(1)

--- a/examples/Claude-Desktop/openviking-claude-desktop.md
+++ b/examples/Claude-Desktop/openviking-claude-desktop.md
@@ -1,0 +1,87 @@
+# OpenViking + Claude Desktop Integration
+
+This example demonstrates how to integrate Claude Desktop and Claude Code with OpenViking to enable persistent memory, automatic recall, automatic memory extraction, and Windows‑native automation.
+
+This file is located under `examples/Claude-Desktop/` to match the folder structure used for Claude Desktop–related examples.
+
+Repository: https://github.com/itzsamehfawzi/openviking-claude-desktop
+
+---
+
+## Overview
+
+This integration provides a Windows‑native bridge between Claude Desktop / Claude Code and OpenViking’s memory engine. It enables:
+
+- Persistent memory across sessions  
+- Automatic memory recall before every Claude Code prompt  
+- Automatic memory extraction and commit after each session  
+- A self‑healing watchdog that restarts the integration if it crashes  
+- Windows Task Scheduler automation for autosave and health checks  
+
+Built on **OpenViking v0.3.16** with full Apache 2.0 attribution.
+
+---
+
+## Features
+
+### MCP Bridge
+- Exposes **12 ov_*** tools to Claude Desktop via MCP.
+- Allows Claude Code to read and write memory through OpenViking.
+
+### Auto‑Recall
+- Before every Claude Code prompt, the integration performs a memory search.
+- Injects relevant memories into the prompt context automatically.
+
+### Auto‑Capture
+- At the end of each Claude Code session:
+  - Extracts memories  
+  - Commits them to OpenViking  
+  - Saves session summaries  
+
+### Self‑Healing Watchdog
+- Ensures the integration never permanently exits.
+- Automatically restarts after crashes.
+- Restart counter resets after 10 minutes of uptime.
+
+### Windows Task Scheduler Automation
+- Autosave every 30 minutes.
+- Health alerts every 15 minutes.
+- Fully Windows‑native (no cron or external schedulers).
+
+### Embedding Selector
+- Ollama‑first embedding generation.
+- Jina Cloud fallback when Ollama is unavailable.
+
+### Verification Script
+Includes a **26‑point verification script** that confirms:
+
+- MCP tools are registered  
+- Memory operations work  
+- Auto‑recall and auto‑capture are active  
+- Watchdog is functioning  
+- Scheduler tasks are installed  
+
+---
+
+## Requirements
+
+- Windows 11  
+- Python 3.13  
+- Node.js 20  
+- OpenViking v0.3.16  
+- Claude Desktop (latest)  
+- Claude Code extension enabled  
+
+---
+
+## Testing
+
+This integration was tested on:
+
+- Windows 11  
+- Python 3.13  
+- Node.js 20  
+- OpenViking v0.3.16  
+
+All **26 verification checks** passed successfully.
+

--- a/examples/Claude-Desktop/scripts/ov-health-alert.ps1
+++ b/examples/Claude-Desktop/scripts/ov-health-alert.ps1
@@ -1,0 +1,49 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+
+# ov-health-alert.ps1
+# Checks OpenViking health every 15 min (via scheduled task).
+# Shows a Windows notification and auto-restarts if server is down.
+# Register using: register-ov-health-alert.ps1
+
+$OV_KEY  = (Get-Content "$env:USERPROFILE\.openviking\ovcli.conf" -Raw | ConvertFrom-Json).api_key
+$OV_URL  = "http://127.0.0.1:1933/health"
+$LOG     = "$env:USERPROFILE\.claude-memory\logs\health-alert.log"
+$RESTART = "$env:USERPROFILE\.openviking\restart-openviking.ps1"
+
+function Write-Log($msg) {
+    $ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    Add-Content -Path $LOG -Value "[$ts] $msg" -Encoding UTF8 -ErrorAction SilentlyContinue
+}
+
+function Show-Notification($title, $msg) {
+    try {
+        Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+        $notify = New-Object System.Windows.Forms.NotifyIcon
+        $notify.Icon = [System.Drawing.SystemIcons]::Warning
+        $notify.BalloonTipTitle = $title
+        $notify.BalloonTipText  = $msg
+        $notify.BalloonTipIcon  = "Warning"
+        $notify.Visible = $true
+        $notify.ShowBalloonTip(8000)
+        Start-Sleep -Seconds 9
+        $notify.Visible = $false
+        $notify.Dispose()
+    } catch {}
+}
+
+$up = $false
+try {
+    $r  = Invoke-WebRequest -Uri $OV_URL `
+          -Headers @{ Authorization = "Bearer $OV_KEY" } `
+          -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+    $up = ($r.StatusCode -eq 200)
+} catch {}
+
+if ($up) {
+    Write-Log "Server UP"
+} else {
+    Write-Log "Server DOWN - alerting and auto-restarting"
+    Show-Notification "OpenViking DOWN" "Memory server offline. Auto-restarting now."
+    Start-Process powershell -ArgumentList "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RESTART`"" -WindowStyle Hidden
+    Write-Log "Restart launched."
+}

--- a/examples/Claude-Desktop/scripts/register-ov-autosave.ps1
+++ b/examples/Claude-Desktop/scripts/register-ov-autosave.ps1
@@ -1,0 +1,64 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+
+# register-ov-autosave.ps1
+# Registers autosave as a Windows Scheduled Task (every 30 min).
+# Commits active sessions and starts new ones to ensure memories are captured.
+# Requires Admin elevation.
+
+$PY     = "$env:USERPROFILE\AppData\Local\Programs\Python\Python313\python.exe"
+$SCRIPT = "$env:USERPROFILE\.claude-memory\hooks\ov_session.py"
+$TASK   = "OpenViking-AutoSave"
+
+Write-Host "=== OpenViking AutoSave Task Registration ===" -ForegroundColor Cyan
+Write-Host ""
+
+$oldNames = @("OpenViking-AutoSave","OpenViking-SessionCommit")
+foreach ($t in $oldNames) {
+    if (Get-ScheduledTask -TaskName $t -ErrorAction SilentlyContinue) {
+        Unregister-ScheduledTask -TaskName $t -Confirm:$false
+        Write-Host "  Removed old task: $t" -ForegroundColor Yellow
+    }
+}
+
+$action = New-ScheduledTaskAction `
+    -Execute $PY `
+    -Argument ('"' + $SCRIPT + '" autosave') `
+    -WorkingDirectory "$env:USERPROFILE\.claude-memory\hooks"
+
+$logonTrigger = New-ScheduledTaskTrigger -AtLogOn
+$repTrigger   = New-ScheduledTaskTrigger -RepetitionInterval (New-TimeSpan -Minutes 30) -Once -At (Get-Date)
+$logonTrigger.Repetition = $repTrigger.Repetition
+
+$settings = New-ScheduledTaskSettingsSet `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew
+
+$principal = New-ScheduledTaskPrincipal `
+    -UserId $env:USERNAME `
+    -LogonType Interactive `
+    -RunLevel Highest
+
+$reg = Register-ScheduledTask `
+    -TaskName $TASK `
+    -Action $action `
+    -Trigger $logonTrigger `
+    -Settings $settings `
+    -Principal $principal `
+    -Description "OpenViking autosave every 30min - commits session or starts new one." `
+    -Force
+
+if ($reg) {
+    Write-Host "  [OK] Task '$TASK' registered" -ForegroundColor Green
+} else {
+    Write-Host "  [FAIL] Registration failed" -ForegroundColor Red
+    Read-Host "Press Enter to exit"; exit 1
+}
+
+Write-Host ""
+Write-Host "  Running autosave now..." -ForegroundColor Yellow
+& $PY $SCRIPT autosave
+Write-Host ""
+Write-Host "=== Done ===" -ForegroundColor Green
+Write-Host ""
+Read-Host "Press Enter to close"

--- a/examples/Claude-Desktop/scripts/register-ov-health-alert.ps1
+++ b/examples/Claude-Desktop/scripts/register-ov-health-alert.ps1
@@ -1,0 +1,61 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+
+# register-ov-health-alert.ps1
+# Registers health check as a Windows Scheduled Task (every 15 min).
+# Shows Windows notification and auto-restarts if server is down.
+# Requires Admin elevation.
+
+$TASK   = "OpenViking-HealthAlert"
+$SCRIPT = "$env:USERPROFILE\.openviking\ov-health-alert.ps1"
+
+Write-Host "=== Register OpenViking Health Alert Task ===" -ForegroundColor Cyan
+Write-Host ""
+
+if (Get-ScheduledTask -TaskName $TASK -ErrorAction SilentlyContinue) {
+    Unregister-ScheduledTask -TaskName $TASK -Confirm:$false
+    Write-Host "  Removed existing task" -ForegroundColor Yellow
+}
+
+$action = New-ScheduledTaskAction `
+    -Execute "powershell.exe" `
+    -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$SCRIPT`""
+
+$trigger = New-ScheduledTaskTrigger `
+    -RepetitionInterval (New-TimeSpan -Minutes 15) `
+    -Once -At (Get-Date)
+
+$settings = New-ScheduledTaskSettingsSet `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 2) `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew
+
+$principal = New-ScheduledTaskPrincipal `
+    -UserId $env:USERNAME `
+    -LogonType Interactive `
+    -RunLevel Highest
+
+$reg = Register-ScheduledTask `
+    -TaskName $TASK `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Principal $principal `
+    -Description "Every 15 min: checks OpenViking health, alerts and auto-restarts if down." `
+    -Force
+
+if ($reg) {
+    Write-Host "  [OK] Task '$TASK' registered" -ForegroundColor Green
+    Write-Host "  Checks every 15 min, auto-restarts if server down" -ForegroundColor Gray
+    Write-Host "  Log: $env:USERPROFILE\.claude-memory\logs\health-alert.log" -ForegroundColor Gray
+} else {
+    Write-Host "  [FAIL] Registration failed" -ForegroundColor Red
+    Read-Host "Press Enter to exit"; exit 1
+}
+
+Write-Host ""
+Write-Host "  Running health check now..." -ForegroundColor Yellow
+& $SCRIPT
+Write-Host ""
+Write-Host "=== Done ===" -ForegroundColor Green
+Write-Host ""
+Read-Host "Press Enter to close"

--- a/examples/Claude-Desktop/scripts/register-ov-watchdog.ps1
+++ b/examples/Claude-Desktop/scripts/register-ov-watchdog.ps1
@@ -1,0 +1,53 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+
+# register-ov-watchdog.ps1
+# Registers OpenViking watchdog as a Windows Scheduled Task.
+# Runs at logon for the current user. Does NOT require Admin.
+
+$PYTHON = "$env:USERPROFILE\AppData\Local\Programs\Python\Python313\python.exe"
+$SCRIPT = "$env:USERPROFILE\.openviking\openviking-watchdog.py"
+$TASK   = "OpenViking-Watchdog"
+
+Write-Host "Registering OpenViking Watchdog as scheduled task..." -ForegroundColor Cyan
+
+$existing = Get-ScheduledTask -TaskName $TASK -ErrorAction SilentlyContinue
+if ($existing) {
+    Unregister-ScheduledTask -TaskName $TASK -Confirm:$false
+    Write-Host "  Removed existing task." -ForegroundColor Yellow
+}
+
+$action = New-ScheduledTaskAction `
+    -Execute $PYTHON `
+    -Argument "`"$SCRIPT`"" `
+    -WorkingDirectory "$env:USERPROFILE\.openviking"
+
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+
+$settings = New-ScheduledTaskSettingsSet `
+    -ExecutionTimeLimit ([TimeSpan]::Zero) `
+    -RestartCount 5 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew
+
+$principal = New-ScheduledTaskPrincipal `
+    -UserId $env:USERNAME `
+    -LogonType Interactive `
+    -RunLevel Limited
+
+Register-ScheduledTask `
+    -TaskName $TASK `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Principal $principal `
+    -Description "Auto-restarts OpenViking memory server on failure." `
+    -Force | Out-Null
+
+Write-Host "  [OK] Task '$TASK' registered." -ForegroundColor Green
+Write-Host "  Trigger: At logon for $env:USERNAME" -ForegroundColor Green
+Write-Host ""
+Write-Host "  To start now without rebooting:" -ForegroundColor Cyan
+Write-Host "  Start-ScheduledTask -TaskName '$TASK'"
+Write-Host ""
+Read-Host "Press Enter to close"

--- a/examples/Claude-Desktop/scripts/restart-openviking.ps1
+++ b/examples/Claude-Desktop/scripts/restart-openviking.ps1
@@ -1,0 +1,93 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+
+$PY  = "$env:USERPROFILE\AppData\Local\Programs\Python\Python313\python.exe"
+$OV  = "$env:USERPROFILE\.openviking"
+$LOG = "$env:USERPROFILE\.claude-memory\logs"
+
+Write-Host "=== OpenViking Restart ===" -ForegroundColor Cyan
+
+# Kill any existing stuck processes
+Write-Host "Killing old processes..." -ForegroundColor Yellow
+Get-Process python -ErrorAction SilentlyContinue | ForEach-Object {
+    $cmdLine = ""
+    try {
+        $wmi = Get-WmiObject Win32_Process -Filter "ProcessId=$($_.Id)" -EA SilentlyContinue
+        if ($wmi) { $cmdLine = $wmi.CommandLine }
+    } catch {}
+    if ($cmdLine -like "*openviking*" -or $cmdLine -like "*uvicorn*") {
+        $_.Kill()
+        Write-Host "  Killed PID $($_.Id)" -ForegroundColor Yellow
+    }
+}
+Start-Sleep -Seconds 3
+
+# Select embedding provider
+Write-Host "Selecting embedding provider..." -ForegroundColor Yellow
+& "$OV\select-embedding.ps1"
+
+# Test entry point
+Write-Host ""
+Write-Host "Testing entry point (openviking_cli.server_bootstrap)..." -ForegroundColor Yellow
+$test = & $PY -c "from openviking_cli.server_bootstrap import main; print('OK')" 2>&1
+if ($test -match "OK") {
+    Write-Host "  Module import: OK" -ForegroundColor Green
+} else {
+    Write-Host "  Module import FAILED: $test" -ForegroundColor Red
+}
+
+# Start server
+Write-Host ""
+Write-Host "Starting server on port 1933..." -ForegroundColor Yellow
+$logFile    = "$LOG\openviking-server-$(Get-Date -Format 'yyyyMMdd').log"
+$logFileErr = "$LOG\openviking-server-$(Get-Date -Format 'yyyyMMdd')-err.log"
+
+if (-not (Test-Path $LOG)) { New-Item -ItemType Directory -Path $LOG -Force | Out-Null }
+
+Start-Process -FilePath $PY -ArgumentList @("-m", "openviking_cli.server_bootstrap") `
+    -WorkingDirectory $OV `
+    -RedirectStandardOutput $logFile `
+    -RedirectStandardError  $logFileErr `
+    -WindowStyle Hidden
+
+Write-Host "  Waiting 15 seconds for server to initialize..."
+Start-Sleep -Seconds 15
+
+# Health check
+Write-Host ""
+Write-Host "Health check..." -ForegroundColor Yellow
+$OV_KEY = (Get-Content "$OV\ovcli.conf" -Raw | ConvertFrom-Json).api_key
+try {
+    $r = Invoke-WebRequest -Uri "http://localhost:1933/health" `
+         -Headers @{ Authorization = "Bearer $OV_KEY" } `
+         -TimeoutSec 5 -UseBasicParsing
+    Write-Host "  STATUS: $($r.StatusCode) - OpenViking is UP" -ForegroundColor Green
+} catch {
+    Write-Host "  FAILED: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host "  Last 10 lines of server log:" -ForegroundColor Yellow
+    foreach ($f in @($logFile, $logFileErr)) {
+        if (Test-Path $f) {
+            Write-Host "  [$f]" -ForegroundColor DarkGray
+            Get-Content $f -Tail 10 | ForEach-Object { Write-Host "    $_" }
+        }
+    }
+}
+
+# Restart watchdog task
+Write-Host ""
+Write-Host "Restarting watchdog task..." -ForegroundColor Yellow
+$WATCHDOG_TASK = "OpenViking-Watchdog"
+Stop-ScheduledTask  -TaskName $WATCHDOG_TASK -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+$task = Get-ScheduledTask -TaskName $WATCHDOG_TASK -ErrorAction SilentlyContinue
+if ($task) {
+    Start-ScheduledTask -TaskName $WATCHDOG_TASK -ErrorAction SilentlyContinue
+    Write-Host "  Watchdog task: $((Get-ScheduledTask -TaskName $WATCHDOG_TASK).State)" -ForegroundColor Green
+} else {
+    Write-Host "  Watchdog task not found - run register-ov-watchdog.ps1" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "=== Done ===" -ForegroundColor Cyan
+Write-Host "Restart Claude Desktop to reconnect openviking-memory MCP." -ForegroundColor Yellow
+Write-Host ""
+Read-Host "Press Enter to close"

--- a/examples/Claude-Desktop/scripts/select-embedding.ps1
+++ b/examples/Claude-Desktop/scripts/select-embedding.ps1
@@ -1,0 +1,70 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+
+# select-embedding.ps1  v1.1
+# Selects embedding provider: Ollama (local) first, Jina cloud as fallback.
+# Called automatically by restart-openviking.ps1 and openviking-watchdog.py.
+#
+# To use Ollama: install from https://ollama.ai, then: ollama pull nomic-embed-text
+# To use Jina: get a free API key from https://jina.ai
+
+$OV_CONF = "$env:USERPROFILE\.openviking\ov.conf"
+
+$JINA_EMBED = @{
+    provider       = "jina"
+    api_key        = $env:JINA_API_KEY    # set JINA_API_KEY as environment variable
+    api_base       = "https://api.jina.ai/v1"
+    model          = "jina-embeddings-v3"
+    dimension      = 768
+    query_param    = "retrieval.query"
+    document_param = "retrieval.passage"
+}
+
+$OLLAMA_EMBED = @{
+    provider  = "openai"    # Ollama uses OpenAI-compatible API
+    api_key   = "ollama"
+    api_base  = "http://localhost:11434/v1"
+    model     = "nomic-embed-text"
+    dimension = 768
+}
+
+# Check if Ollama is running with nomic-embed-text available
+$ollamaUp = $false
+try {
+    $r = Invoke-WebRequest -Uri "http://localhost:11434/api/tags" `
+         -TimeoutSec 2 -UseBasicParsing -ErrorAction Stop
+    if ($r.StatusCode -eq 200) {
+        $tags = $r.Content | ConvertFrom-Json
+        foreach ($m in $tags.models) {
+            if ($m.name -like "*nomic-embed-text*") { $ollamaUp = $true; break }
+        }
+    }
+} catch {}
+
+$conf = Get-Content $OV_CONF -Raw | ConvertFrom-Json
+
+if ($ollamaUp) {
+    Write-Host "  [Embedding] Ollama detected -> nomic-embed-text (local)" -ForegroundColor Cyan
+    $embed = $OLLAMA_EMBED
+    $conf.embedding.dense.provider  = $embed.provider
+    $conf.embedding.dense.api_key   = $embed.api_key
+    $conf.embedding.dense.api_base  = $embed.api_base
+    $conf.embedding.dense.model     = $embed.model
+    $conf.embedding.dense.dimension = $embed.dimension
+    # Remove Jina-specific params not valid for OpenAI-compatible provider
+    $denseProps = $conf.embedding.dense.PSObject.Properties.Name
+    if ($denseProps -contains "query_param")    { $conf.embedding.dense.PSObject.Properties.Remove("query_param") }
+    if ($denseProps -contains "document_param") { $conf.embedding.dense.PSObject.Properties.Remove("document_param") }
+} else {
+    Write-Host "  [Embedding] Ollama not available -> Jina cloud (jina-embeddings-v3)" -ForegroundColor Cyan
+    $embed = $JINA_EMBED
+    $conf.embedding.dense.provider  = $embed.provider
+    $conf.embedding.dense.api_key   = $embed.api_key
+    $conf.embedding.dense.api_base  = $embed.api_base
+    $conf.embedding.dense.model     = $embed.model
+    $conf.embedding.dense.dimension = $embed.dimension
+    $conf.embedding.dense | Add-Member -NotePropertyName query_param    -NotePropertyValue $embed.query_param    -Force
+    $conf.embedding.dense | Add-Member -NotePropertyName document_param -NotePropertyValue $embed.document_param -Force
+}
+
+$conf | ConvertTo-Json -Depth 10 | Set-Content $OV_CONF -Encoding UTF8
+Write-Host "  [Embedding] ov.conf updated" -ForegroundColor Green

--- a/examples/Claude-Desktop/scripts/verify-ov-hooks.ps1
+++ b/examples/Claude-Desktop/scripts/verify-ov-hooks.ps1
@@ -1,0 +1,469 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+
+# verify-ov-hooks.ps1
+# Full system verification for openviking-claude-desktop.
+# Auto-detects Python, Node.js, and all paths.
+# Run after installation to confirm everything works.
+# Expected result: all checks pass.
+
+$pass = 0; $fail = 0; $warn = 0
+
+# ── Auto-detect Python ────────────────────────────────────────────────────
+$PY = $null
+$pythonCandidates = @(
+    "python",
+    "python3",
+    "$env:USERPROFILE\AppData\Local\Programs\Python\Python313\python.exe",
+    "$env:USERPROFILE\AppData\Local\Programs\Python\Python312\python.exe",
+    "$env:USERPROFILE\AppData\Local\Programs\Python\Python311\python.exe",
+    "$env:USERPROFILE\AppData\Local\Programs\Python\Python310\python.exe",
+    "C:\Python313\python.exe",
+    "C:\Python312\python.exe",
+    "C:\Python311\python.exe"
+)
+foreach ($c in $pythonCandidates) {
+    try {
+        $v = & $c --version 2>&1
+        if ($v -match "Python 3\.") { $PY = $c; break }
+    } catch {}
+}
+
+# ── Auto-detect config paths ──────────────────────────────────────────────
+$OV_DIR     = "$env:USERPROFILE\.openviking"
+$MEM_DIR    = "$env:USERPROFILE\.claude-memory"
+$HOOKS_DIR  = "$env:USERPROFILE\.claude\hooks"
+$CONF_FILE  = "$OV_DIR\ov.conf"
+$CLI_CONF   = "$OV_DIR\ovcli.conf"
+$STATE_FILE = "$MEM_DIR\.session_state.json"
+
+# ── Auto-detect API key from ovcli.conf ──────────────────────────────────
+$OV_KEY = "local-key"
+if (Test-Path $CLI_CONF) {
+    try {
+        $cli = Get-Content $CLI_CONF -Raw | ConvertFrom-Json
+        if ($cli.api_key) { $OV_KEY = $cli.api_key }
+    } catch {}
+}
+
+$OV_URL  = "http://127.0.0.1:1933"
+$OV_USER = "default"
+$OV_ACCT = "default"
+
+$H = @{
+    "Authorization"        = "Bearer $OV_KEY"
+    "x-api-key"            = $OV_KEY
+    "x-openviking-user"    = $OV_USER
+    "x-openviking-account" = $OV_ACCT
+}
+
+function OV-Get($path) {
+    try {
+        return Invoke-RestMethod -Uri "$OV_URL$path" -Method GET `
+               -Headers $H -TimeoutSec 10 -UseBasicParsing
+    } catch { return $null }
+}
+
+function OV-Post($path, $bodyObj) {
+    try {
+        $body = $bodyObj | ConvertTo-Json -Compress
+        return Invoke-RestMethod -Uri "$OV_URL$path" -Method POST `
+               -Headers $H -ContentType "application/json" `
+               -Body $body -TimeoutSec 30 -UseBasicParsing
+    } catch { return $null }
+}
+
+function SafeGet($obj, $prop) {
+    if ($obj -and $obj.PSObject.Properties.Name -contains $prop) {
+        return $obj.$prop
+    }
+    return $null
+}
+
+function Show-OK($label, $detail) {
+    Write-Host "  OK   $label" -ForegroundColor Green
+    if ($detail) { Write-Host "       $detail" -ForegroundColor Gray }
+    $script:pass++
+}
+
+function Show-FAIL($label, $detail) {
+    Write-Host "  FAIL $label" -ForegroundColor Red
+    if ($detail) { Write-Host "       $detail" -ForegroundColor Yellow }
+    $script:fail++
+}
+
+function Show-WARN($label, $detail) {
+    Write-Host "  WARN $label" -ForegroundColor Yellow
+    if ($detail) { Write-Host "       $detail" -ForegroundColor Gray }
+    $script:warn++
+}
+
+# =========================================================================
+Write-Host ""
+Write-Host "=====================================================" -ForegroundColor Cyan
+Write-Host "  openviking-claude-desktop — System Verification" -ForegroundColor Cyan
+Write-Host "=====================================================" -ForegroundColor Cyan
+Write-Host ""
+
+# ── SECTION 1: Prerequisites ──────────────────────────────────────────────
+Write-Host "1. PREREQUISITES" -ForegroundColor Yellow
+
+# Python
+if ($PY) {
+    $pyVer = & $PY --version 2>&1
+    Show-OK "Python found: $pyVer" "Path: $PY"
+} else {
+    Show-FAIL "Python not found" "Install Python 3.10+ from python.org"
+}
+
+# Node.js
+try {
+    $nodeVer = node --version 2>&1
+    if ($nodeVer -match "v\d+") {
+        $major = [int]($nodeVer -replace "v(\d+).*",'$1')
+        if ($major -ge 16) {
+            Show-OK "Node.js $nodeVer"
+        } else {
+            Show-WARN "Node.js $nodeVer (v16+ recommended)" "Upgrade from nodejs.org"
+        }
+    } else { Show-FAIL "Node.js not found" "Install from nodejs.org" }
+} catch { Show-FAIL "Node.js not found" "Install from nodejs.org" }
+
+# OpenViking Python package
+if ($PY) {
+    $ovVer = & $PY -c "import openviking; print(openviking.__version__)" 2>&1
+    if ($ovVer -match "\d+\.\d+\.\d+") {
+        Show-OK "openviking package v$ovVer"
+    } else {
+        Show-FAIL "openviking package not installed" "Run: pip install openviking openviking-cli"
+    }
+    $ovCliVer = & $PY -c "import openviking_cli; print('ok')" 2>&1
+    if ($ovCliVer -match "ok") {
+        Show-OK "openviking_cli package installed"
+    } else {
+        Show-FAIL "openviking_cli not installed" "Run: pip install openviking-cli"
+    }
+}
+
+# ── SECTION 2: Files & Directories ───────────────────────────────────────
+Write-Host ""
+Write-Host "2. INSTALLATION FILES" -ForegroundColor Yellow
+
+$requiredFiles = [ordered]@{
+    "$OV_DIR\openviking-bridge.py"   = "MCP bridge (Claude Desktop)"
+    "$OV_DIR\openviking-watchdog.py" = "Server watchdog"
+    "$OV_DIR\restart-openviking.ps1" = "Manual restart script"
+    "$OV_DIR\select-embedding.ps1"   = "Embedding provider selector"
+    "$OV_DIR\ov.conf"                = "Server configuration"
+    "$OV_DIR\ovcli.conf"             = "CLI configuration"
+    "$HOOKS_DIR\ov-recall.js"        = "Claude Code auto-recall hook"
+    "$HOOKS_DIR\ov-capture.js"       = "Claude Code auto-capture hook"
+    "$MEM_DIR\hooks\ov_session.py"   = "Autosave session script"
+}
+
+foreach ($kv in $requiredFiles.GetEnumerator()) {
+    if (Test-Path $kv.Key) {
+        Show-OK (Split-Path $kv.Key -Leaf) $kv.Value
+    } else {
+        Show-FAIL (Split-Path $kv.Key -Leaf) "Missing: $($kv.Key)"
+    }
+}
+
+# ── SECTION 3: Configuration ──────────────────────────────────────────────
+Write-Host ""
+Write-Host "3. CONFIGURATION" -ForegroundColor Yellow
+
+if (Test-Path $CONF_FILE) {
+    try {
+        $conf = Get-Content $CONF_FILE -Raw | ConvertFrom-Json
+
+        # Check no invalid fields
+        $validFields = @("storage","log","embedding","vlm","server")
+        $confFields  = $conf.PSObject.Properties.Name
+        $invalidFields = $confFields | Where-Object { $validFields -notcontains $_ }
+
+        if ($invalidFields) {
+            Show-FAIL "ov.conf has invalid fields: $($invalidFields -join ', ')" `
+                      "Remove them — any extra field crashes the server"
+        } else {
+            Show-OK "ov.conf — no invalid fields"
+        }
+
+        # Check required sections
+        foreach ($f in $validFields) {
+            if ($confFields -contains $f) {
+                Show-OK "ov.conf.$f section present"
+            } else {
+                Show-FAIL "ov.conf.$f section missing"
+            }
+        }
+
+        # Check port
+        $port = SafeGet (SafeGet $conf "server") "port"
+        if ($port -eq 1933) {
+            Show-OK "server.port = 1933"
+        } else {
+            Show-WARN "server.port = $port (expected 1933)" "Update if intentional"
+        }
+
+        # Check API key not placeholder
+        $key = SafeGet (SafeGet $conf "server") "root_api_key"
+        if ($key -and $key -ne "YOUR_LOCAL_API_KEY" -and $key.Length -gt 4) {
+            Show-OK "server.root_api_key configured"
+        } else {
+            Show-FAIL "server.root_api_key not set" "Replace YOUR_LOCAL_API_KEY in ov.conf"
+        }
+
+        # Check embedding
+        $embProvider = SafeGet (SafeGet (SafeGet $conf "embedding") "dense") "provider"
+        $embKey      = SafeGet (SafeGet (SafeGet $conf "embedding") "dense") "api_key"
+        Show-OK "embedding.provider = $embProvider"
+        if ($embKey -and $embKey -ne "YOUR_JINA_API_KEY" -and $embKey -ne "ollama") {
+            Show-OK "embedding.api_key configured"
+        } elseif ($embKey -eq "ollama") {
+            Show-OK "embedding.api_key = ollama (local)"
+        } else {
+            Show-FAIL "embedding.api_key not set" "Replace YOUR_JINA_API_KEY in ov.conf"
+        }
+
+        # Check VLM
+        $vlmKey = SafeGet (SafeGet $conf "vlm") "api_key"
+        if ($vlmKey -and $vlmKey -ne "YOUR_ANTHROPIC_API_KEY" -and $vlmKey.Length -gt 10) {
+            Show-OK "vlm.api_key (Anthropic) configured"
+        } else {
+            Show-FAIL "vlm.api_key not set" "Replace YOUR_ANTHROPIC_API_KEY in ov.conf"
+        }
+
+    } catch {
+        Show-FAIL "ov.conf is not valid JSON" "Check syntax: $($_.Exception.Message)"
+    }
+} else {
+    Show-FAIL "ov.conf not found" "Copy config\ov.conf.example to $OV_DIR\ov.conf"
+}
+
+# Check Claude Desktop config
+$desktopConf = "$env:APPDATA\Claude\claude_desktop_config.json"
+if (Test-Path $desktopConf) {
+    $raw = Get-Content $desktopConf -Raw
+    if ($raw -match "openviking") {
+        Show-OK "Claude Desktop MCP config found"
+    } else {
+        Show-WARN "Claude Desktop config exists but no openviking entry" `
+                  "Add mcpServers entry per README"
+    }
+} else {
+    Show-WARN "Claude Desktop config not found" `
+              "Create %APPDATA%\Claude\claude_desktop_config.json"
+}
+
+# Check Claude Code settings
+$ccSettings = "$env:USERPROFILE\.claude\settings.json"
+if (Test-Path $ccSettings) {
+    $raw = Get-Content $ccSettings -Raw
+    $hasRecall  = $raw -match "ov-recall"
+    $hasCapture = $raw -match "ov-capture"
+    if ($hasRecall)  { Show-OK "ov-recall.js wired in settings.json" }
+    else             { Show-FAIL "ov-recall.js not found in settings.json" "Add UserPromptSubmit hook per README" }
+    if ($hasCapture) { Show-OK "ov-capture.js wired in settings.json" }
+    else             { Show-FAIL "ov-capture.js not found in settings.json" "Add Stop hook per README" }
+} else {
+    Show-WARN "Claude Code settings.json not found" "$ccSettings"
+}
+
+# ── SECTION 4: Server ─────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "4. SERVER STATUS" -ForegroundColor Yellow
+
+$health = OV-Get "/health"
+if ($health) {
+    $ver     = SafeGet $health "version"
+    $healthy = SafeGet $health "healthy"
+    if ($healthy -eq $true) {
+        Show-OK "Server running on port 1933  (v$ver)"
+    } else {
+        Show-FAIL "Server returned unhealthy status"
+    }
+} else {
+    Show-FAIL "Server not responding on port 1933" `
+              "Run: & '$OV_DIR\restart-openviking.ps1'"
+}
+
+$status = OV-Get "/api/v1/system/status"
+if ($status) { Show-OK "System status endpoint OK" }
+else         { Show-WARN "System status endpoint not responding" }
+
+# ── SECTION 5: API Endpoints ──────────────────────────────────────────────
+Write-Host ""
+Write-Host "5. API ENDPOINTS" -ForegroundColor Yellow
+
+if ($health) {
+    # Search find
+    $find = OV-Post "/api/v1/search/find" @{ query = "test"; limit = 3 }
+    if ($find) {
+        $res   = SafeGet $find "result"
+        $items = if ($res) { SafeGet $res "resources" } else { $null }
+        $count = if ($items) { @($items).Count } else { 0 }
+        Show-OK "/api/v1/search/find  ($count results)"
+    } else {
+        Show-FAIL "/api/v1/search/find failed" "Check headers and server logs"
+    }
+
+    # Search search
+    $search = OV-Post "/api/v1/search/search" @{ query = "test"; limit = 3 }
+    if ($search) { Show-OK "/api/v1/search/search" }
+    else         { Show-FAIL "/api/v1/search/search failed" }
+
+    # Session lifecycle
+    $sessCreate = OV-Post "/api/v1/sessions" @{}
+    $sessId = $null
+    if ($sessCreate) {
+        $res    = SafeGet $sessCreate "result"
+        $sessId = if ($res) { SafeGet $res "session_id" } else { $null }
+        if (-not $sessId) { $sessId = SafeGet $sessCreate "session_id" }
+    }
+
+    if ($sessId) {
+        Show-OK "Create session  (id: $($sessId.Substring(0,8))...)"
+
+        $addMsg = OV-Post "/api/v1/sessions/$sessId/messages" @{
+            role    = "user"
+            content = "verify-ov-hooks.ps1 test message"
+        }
+        if ($addMsg) { Show-OK "Add message  (role+content format)" }
+        else         { Show-FAIL "Add message failed" }
+
+        $commit    = OV-Post "/api/v1/sessions/$sessId/commit" @{}
+        $extracted = 0
+        if ($commit) {
+            $res = SafeGet $commit "result"
+            if ($res) {
+                $x = SafeGet $res "memories_extracted"
+                if ($null -ne $x) { $extracted = $x }
+            }
+            Show-OK "Commit session  ($extracted memories extracted)"
+        } else {
+            Show-FAIL "Commit session failed"
+        }
+    } else {
+        Show-FAIL "Create session failed" "Check API key and headers"
+    }
+} else {
+    Show-WARN "Skipping API tests — server not running" ""
+    $script:warn += 5
+}
+
+# ── SECTION 6: Session State ──────────────────────────────────────────────
+Write-Host ""
+Write-Host "6. SESSION STATE" -ForegroundColor Yellow
+
+if (Test-Path $STATE_FILE) {
+    try {
+        $s   = Get-Content $STATE_FILE -Raw | ConvertFrom-Json
+        $cur = SafeGet $s "current_session"
+        $lc  = SafeGet $s "last_commit"
+        Show-OK "State file exists"
+        Write-Host "       current_session : $(if ($cur) { $cur } else { 'None (will be created on next autosave)' })" -ForegroundColor Gray
+        if ($lc) {
+            $lat = SafeGet $lc "committed_at"
+            $mem = SafeGet $lc "memories_extracted"
+            Write-Host "       last_commit     : $lat  ($mem memories)" -ForegroundColor Gray
+        }
+    } catch {
+        Show-WARN "State file exists but could not be parsed" ""
+    }
+} else {
+    Show-WARN "State file not found yet" "Will be created automatically on first autosave"
+}
+
+# ── SECTION 7: Data Store ─────────────────────────────────────────────────
+Write-Host ""
+Write-Host "7. DATA STORE" -ForegroundColor Yellow
+
+$workspace = "$MEM_DIR\viking\default\resources"
+if (Test-Path $workspace) {
+    $dirs = @(Get-ChildItem $workspace -Directory -EA SilentlyContinue)
+    if ($dirs.Count -gt 0) {
+        $totalMd = @(Get-ChildItem $workspace -Recurse -File -Filter "*.md" -EA SilentlyContinue).Count
+        Show-OK "Resources directory  ($($dirs.Count) folders, $totalMd .md files)"
+        foreach ($d in $dirs | Select-Object -First 5) {
+            $mds  = @(Get-ChildItem $d.FullName -Recurse -File -Filter "*.md" -EA SilentlyContinue).Count
+            $subs = @(Get-ChildItem $d.FullName -Directory -EA SilentlyContinue).Count
+            Write-Host "       $($d.Name): $subs sub-dirs, $mds files" -ForegroundColor Gray
+        }
+        if ($dirs.Count -gt 5) {
+            Write-Host "       ... and $($dirs.Count - 5) more directories" -ForegroundColor DarkGray
+        }
+    } else {
+        Show-WARN "Resources directory is empty" "Add data via ov_add_resource or place .md files here"
+    }
+} else {
+    Show-WARN "Resources directory not found yet" "Will be created when you add first resource"
+}
+
+# ── SECTION 8: Scheduled Tasks ────────────────────────────────────────────
+Write-Host ""
+Write-Host "8. SCHEDULED TASKS" -ForegroundColor Yellow
+
+$tasks = @{
+    "OpenViking-Watchdog"     = "Server monitor (restarts on crash)"
+    "OpenViking-AutoSave"     = "Session autosave (every 30 min)"
+    "OpenViking-HealthAlert"  = "Health alert + auto-restart (every 15 min)"
+}
+foreach ($kv in $tasks.GetEnumerator()) {
+    $t = Get-ScheduledTask -TaskName $kv.Key -EA SilentlyContinue
+    if ($t) {
+        Show-OK "$($kv.Key)  [$($t.State)]" $kv.Value
+    } else {
+        Show-WARN "$($kv.Key) not registered" "Run register-ov-*.ps1 scripts"
+    }
+}
+
+# ── SECTION 9: Log Files ──────────────────────────────────────────────────
+Write-Host ""
+Write-Host "9. LOG FILES" -ForegroundColor Yellow
+
+$logDir = "$MEM_DIR\logs"
+if (Test-Path $logDir) {
+    $logs = @(Get-ChildItem $logDir -File -EA SilentlyContinue)
+    Show-OK "Log directory exists  ($($logs.Count) files)"
+
+    # Show last line of key logs
+    foreach ($lf in @("ov-recall.log","ov-capture.log","session-hooks.log","openviking-watchdog.log")) {
+        $fullPath = "$logDir\$lf"
+        if (Test-Path $fullPath) {
+            $last = Get-Content $fullPath -Tail 1 -EA SilentlyContinue
+            if ($last) {
+                Write-Host "       $lf" -ForegroundColor Cyan
+                Write-Host "         $last" -ForegroundColor DarkGray
+            }
+        }
+    }
+} else {
+    Show-WARN "Log directory not found" "Will be created automatically"
+}
+
+# ── SUMMARY ───────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "=====================================================" -ForegroundColor Cyan
+$color = if ($fail -eq 0) { "Green" } elseif ($fail -le 3) { "Yellow" } else { "Red" }
+Write-Host "  RESULT: $pass passed  |  $warn warnings  |  $fail failed" -ForegroundColor $color
+Write-Host "=====================================================" -ForegroundColor Cyan
+Write-Host ""
+
+if ($fail -eq 0 -and $warn -eq 0) {
+    Write-Host "  Perfect. All checks passed. System fully operational." -ForegroundColor Green
+} elseif ($fail -eq 0) {
+    Write-Host "  All critical checks passed. Review warnings above." -ForegroundColor Yellow
+} else {
+    Write-Host "  $fail critical check(s) failed. Fix FAIL items above." -ForegroundColor Red
+    Write-Host ""
+    if (-not $health) {
+        Write-Host "  Server is down. Start it:" -ForegroundColor Red
+        Write-Host "  & '$OV_DIR\restart-openviking.ps1'" -ForegroundColor White
+    }
+}
+
+Write-Host ""
+Write-Host "  Logs: $logDir" -ForegroundColor DarkGray
+Write-Host "  Docs: https://github.com/YOUR_USERNAME/openviking-claude-desktop" -ForegroundColor DarkGray
+Write-Host ""
+Read-Host "Press Enter to close"

--- a/examples/Claude-Desktop/server/openviking-bridge.py
+++ b/examples/Claude-Desktop/server/openviking-bridge.py
@@ -1,0 +1,303 @@
+"""
+openviking-bridge.py - MCP stdio bridge for OpenViking REST API
+Translates MCP JSON-RPC protocol into OpenViking HTTP calls.
+
+Exposes 12 ov_* tools to Claude Desktop via stdio MCP protocol.
+Configure OV_API_KEY to match server.root_api_key in your ov.conf.
+"""
+import sys
+import json
+import urllib.request
+import urllib.error
+import os
+
+OV_URL     = "http://localhost:1933"
+OV_API_KEY = os.environ.get("OV_API_KEY", "YOUR_LOCAL_API_KEY")
+OV_USER    = "default"
+OV_ACCOUNT = "default"
+
+# Redirect stderr to suppress Windows URI handler noise
+sys.stderr = open(os.devnull, "w")
+
+HEADERS = {
+    "Content-Type":        "application/json",
+    "Authorization":       "Bearer " + OV_API_KEY,
+    "x-api-key":           OV_API_KEY,
+    "x-openviking-user":   OV_USER,
+    "x-openviking-account": OV_ACCOUNT,
+}
+
+
+def ov_get(path, params=None):
+    url = OV_URL + path
+    if params:
+        qs = "&".join(k + "=" + urllib.request.quote(str(v)) for k, v in params.items())
+        url = url + "?" + qs
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def ov_post(path, body=None):
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(OV_URL + path, data=data, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def safe_call(fn, *args, **kwargs):
+    try:
+        return fn(*args, **kwargs)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        raise RuntimeError("HTTP " + str(e.code) + ": " + body)
+
+
+# ---------------------------------------------------------------------------
+# MCP tool definitions exposed to Claude Desktop
+# ---------------------------------------------------------------------------
+TOOLS = [
+    {
+        "name": "ov_health",
+        "description": "Check if OpenViking server is healthy and ready.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "ov_status",
+        "description": "Get OpenViking system status.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "ov_search",
+        "description": "Semantic search across OpenViking knowledge base.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query":      {"type": "string",  "description": "Search query"},
+                "target_uri": {"type": "string",  "description": "Scope URI (default: viking://)"},
+                "limit":      {"type": "integer", "description": "Max results (default 10)"},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "ov_find",
+        "description": "Semantic search without session context.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query":      {"type": "string",  "description": "Search query"},
+                "target_uri": {"type": "string",  "description": "Scope URI"},
+                "limit":      {"type": "integer", "description": "Max results (default 10)"},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "ov_ls",
+        "description": "List directory contents in the OpenViking filesystem.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "uri":       {"type": "string",  "description": "Viking URI (e.g. viking://)"},
+                "recursive": {"type": "boolean", "description": "List recursively"},
+            },
+            "required": ["uri"],
+        },
+    },
+    {
+        "name": "ov_read",
+        "description": "Read file content from OpenViking.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "uri":    {"type": "string",  "description": "Viking URI of the file"},
+                "offset": {"type": "integer", "description": "Starting line (0-indexed)"},
+                "limit":  {"type": "integer", "description": "Number of lines (-1 = all)"},
+            },
+            "required": ["uri"],
+        },
+    },
+    {
+        "name": "ov_add_resource",
+        "description": "Add a file or directory as a resource to OpenViking.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path":   {"type": "string", "description": "Local file/folder path"},
+                "reason": {"type": "string", "description": "Why this resource is being added"},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "ov_mkdir",
+        "description": "Create a directory in the OpenViking filesystem.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "uri": {"type": "string", "description": "Viking URI for the new directory"},
+            },
+            "required": ["uri"],
+        },
+    },
+    {
+        "name": "ov_create_session",
+        "description": "Create a new OpenViking session for context tracking.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "ov_add_message",
+        "description": "Add a message to an OpenViking session.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "Session ID"},
+                "role":       {"type": "string", "description": "user or assistant"},
+                "content":    {"type": "string", "description": "Message content"},
+            },
+            "required": ["session_id", "role", "content"],
+        },
+    },
+    {
+        "name": "ov_commit_session",
+        "description": "Commit an OpenViking session to extract and store memories.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "Session ID to commit"},
+            },
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "ov_grep",
+        "description": "Search file content by pattern in OpenViking.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "uri":              {"type": "string",  "description": "Viking URI"},
+                "pattern":          {"type": "string",  "description": "Search pattern"},
+                "case_insensitive": {"type": "boolean", "description": "Case insensitive"},
+            },
+            "required": ["uri", "pattern"],
+        },
+    },
+]
+
+
+def call_tool(name, args):
+    if name == "ov_health":
+        return json.dumps(safe_call(ov_get, "/health"))
+    elif name == "ov_status":
+        return json.dumps(safe_call(ov_get, "/api/v1/system/status"))
+    elif name == "ov_search":
+        body = {"query": args["query"]}
+        if "target_uri" in args: body["target_uri"] = args["target_uri"]
+        if "limit" in args:      body["limit"] = args["limit"]
+        return json.dumps(safe_call(ov_post, "/api/v1/search/search", body))
+    elif name == "ov_find":
+        body = {"query": args["query"]}
+        if "target_uri" in args: body["target_uri"] = args["target_uri"]
+        if "limit" in args:      body["limit"] = args["limit"]
+        return json.dumps(safe_call(ov_post, "/api/v1/search/find", body))
+    elif name == "ov_ls":
+        params = {"uri": args["uri"]}
+        if args.get("recursive"): params["recursive"] = "true"
+        return json.dumps(safe_call(ov_get, "/api/v1/fs/ls", params))
+    elif name == "ov_read":
+        params = {"uri": args["uri"]}
+        if "offset" in args: params["offset"] = args["offset"]
+        if "limit" in args:  params["limit"]  = args["limit"]
+        return json.dumps(safe_call(ov_get, "/api/v1/content/read", params))
+    elif name == "ov_add_resource":
+        body = {"path": args["path"], "reason": args.get("reason", ""), "wait": True}
+        return json.dumps(safe_call(ov_post, "/api/v1/resources", body))
+    elif name == "ov_mkdir":
+        return json.dumps(safe_call(ov_post, "/api/v1/fs/mkdir", {"uri": args["uri"]}))
+    elif name == "ov_create_session":
+        return json.dumps(safe_call(ov_post, "/api/v1/sessions"))
+    elif name == "ov_add_message":
+        return json.dumps(safe_call(
+            ov_post,
+            "/api/v1/sessions/" + args["session_id"] + "/messages",
+            {"role": args["role"], "content": args["content"]},
+        ))
+    elif name == "ov_commit_session":
+        return json.dumps(safe_call(ov_post, "/api/v1/sessions/" + args["session_id"] + "/commit"))
+    elif name == "ov_grep":
+        body = {
+            "uri": args["uri"],
+            "pattern": args["pattern"],
+            "case_insensitive": args.get("case_insensitive", False),
+        }
+        return json.dumps(safe_call(ov_post, "/api/v1/search/grep", body))
+    else:
+        raise RuntimeError("Unknown tool: " + name)
+
+
+def handle(msg):
+    method = msg.get("method", "")
+    msg_id = msg.get("id")
+    if msg_id is None:
+        return None
+
+    def ok(result):
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+    def err(code, message):
+        return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+    try:
+        if method == "initialize":
+            return ok({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "openviking-bridge", "version": "1.0.0"},
+            })
+        elif method == "tools/list":
+            return ok({"tools": TOOLS})
+        elif method == "tools/call":
+            params    = msg.get("params", {})
+            tool_name = params.get("name", "")
+            tool_args = params.get("arguments", params.get("input", {}))
+            result_text = call_tool(tool_name, tool_args)
+            return ok({"content": [{"type": "text", "text": result_text}], "isError": False})
+        elif method == "ping":
+            return ok({})
+        else:
+            return err(-32601, "Method not found: " + method)
+    except Exception as e:
+        return err(-32000, str(e))
+
+
+def write(obj):
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError as e:
+                write({"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error: " + str(e)}, "id": None})
+                continue
+            response = handle(msg)
+            if response is not None:
+                write(response)
+        except KeyboardInterrupt:
+            break
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/Claude-Desktop/server/openviking-mcp.py
+++ b/examples/Claude-Desktop/server/openviking-mcp.py
@@ -1,0 +1,200 @@
+"""
+openviking-mcp.py — Alternative MCP server for OpenViking
+Exposes 5 higher-level memory_* tools instead of the 12 low-level ov_* tools.
+Use this if you prefer a simpler interface in Claude Desktop.
+
+To use this instead of openviking-bridge.py, update claude_desktop_config.json
+to point to this file instead.
+"""
+import sys
+import json
+import urllib.request
+import urllib.error
+import os
+
+OV_URL     = "http://localhost:1933"
+OV_API_KEY = os.environ.get("OV_API_KEY", "YOUR_LOCAL_API_KEY")
+OV_USER    = "default"
+OV_ACCOUNT = "default"
+
+sys.stderr = open(os.devnull, "w")
+
+HEADERS = {
+    "Content-Type":        "application/json",
+    "Authorization":       "Bearer " + OV_API_KEY,
+    "x-api-key":           OV_API_KEY,
+    "x-openviking-user":   OV_USER,
+    "x-openviking-account": OV_ACCOUNT,
+}
+
+
+def ov_post(path, body=None):
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(OV_URL + path, data=data, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def safe_call(fn, *args, **kwargs):
+    try:
+        return fn(*args, **kwargs)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        raise RuntimeError("HTTP " + str(e.code) + ": " + body)
+
+
+TOOLS = [
+    {
+        "name": "memory_search",
+        "description": "Search your OpenViking memory store for relevant context.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "What to search for"},
+                "limit": {"type": "integer", "description": "Max results (default 6)"},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "memory_store",
+        "description": "Store new information in OpenViking memory.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "Content to store"},
+                "path":    {"type": "string", "description": "viking:// URI path to store at"},
+            },
+            "required": ["content", "path"],
+        },
+    },
+    {
+        "name": "memory_read",
+        "description": "Read a specific resource from OpenViking by URI.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "uri": {"type": "string", "description": "viking:// URI to read"},
+            },
+            "required": ["uri"],
+        },
+    },
+    {
+        "name": "memory_list",
+        "description": "List resources in OpenViking at a given path.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "uri": {"type": "string", "description": "viking:// URI to list (default: viking://)"},
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "memory_health",
+        "description": "Check OpenViking server health.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+]
+
+
+def call_tool(name, args):
+    if name == "memory_health":
+        req = urllib.request.Request(OV_URL + "/health", headers=HEADERS)
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    elif name == "memory_search":
+        body = {"query": args.get("query", ""), "limit": args.get("limit", 6)}
+        result = safe_call(ov_post, "/api/v1/search/find", body)
+        # Flatten resources and memories into a single list
+        r = (result.get("result") or result or {})
+        items = (r.get("resources") or []) + (r.get("memories") or [])
+        return {"items": items, "total": len(items)}
+    elif name == "memory_store":
+        body = {"path": args.get("path"), "content": args.get("content"), "wait": True}
+        return safe_call(ov_post, "/api/v1/resources", body)
+    elif name == "memory_read":
+        uri = args.get("uri", "viking://")
+        req = urllib.request.Request(
+            OV_URL + "/api/v1/content/read?uri=" + urllib.request.quote(uri, safe=":/"),
+            headers=HEADERS
+        )
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.loads(r.read())
+    elif name == "memory_list":
+        uri = args.get("uri", "viking://")
+        req = urllib.request.Request(
+            OV_URL + "/api/v1/fs/ls?uri=" + urllib.request.quote(uri, safe=":/"),
+            headers=HEADERS
+        )
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    else:
+        raise RuntimeError("Unknown tool: " + name)
+
+
+def handle(msg):
+    method = msg.get("method", "")
+    msg_id = msg.get("id")
+    if msg_id is None:
+        return None
+
+    def ok(result):
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+    def err(code, message):
+        return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+    try:
+        if method == "initialize":
+            return ok({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "openviking-mcp", "version": "1.0.0"},
+            })
+        elif method == "tools/list":
+            return ok({"tools": TOOLS})
+        elif method == "tools/call":
+            params    = msg.get("params", {})
+            tool_name = params.get("name", "")
+            tool_args = params.get("arguments", params.get("input", {}))
+            result_text = json.dumps(call_tool(tool_name, tool_args))
+            return ok({"content": [{"type": "text", "text": result_text}], "isError": False})
+        elif method == "ping":
+            return ok({})
+        else:
+            return err(-32601, "Method not found: " + method)
+    except Exception as e:
+        return err(-32000, str(e))
+
+
+def write(obj):
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError as e:
+                write({"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error: " + str(e)}, "id": None})
+                continue
+            response = handle(msg)
+            if response is not None:
+                write(response)
+        except KeyboardInterrupt:
+            break
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/Claude-Desktop/server/openviking-watchdog.py
+++ b/examples/Claude-Desktop/server/openviking-watchdog.py
@@ -1,0 +1,185 @@
+"""
+openviking-watchdog.py  v2.1
+Monitors the OpenViking REST server and restarts it on failure.
+
+Features:
+  - Checks server health every 15 seconds
+  - Restarts after 5 consecutive failures
+  - Restart counter resets after 10 min of stable uptime (never permanently exits)
+  - Runs embedding selector before each restart (Ollama or Jina fallback)
+  - Embedding selector uses -NoProfile to avoid slow PowerShell startup
+
+Usage:
+  python openviking-watchdog.py
+
+Register as a Windows Scheduled Task at logon using register-ov-watchdog.ps1.
+"""
+import subprocess
+import time
+import sys
+import os
+import logging
+import urllib.request
+from datetime import datetime
+
+# ── Config (edit paths to match your setup) ───────────────────────────────────
+OV_URL            = "http://localhost:1933/health"
+OV_API_KEY        = os.environ.get("OV_API_KEY", "YOUR_LOCAL_API_KEY")
+CHECK_INTERVAL    = 15    # seconds between health checks
+RESTART_DELAY     = 5     # seconds after kill before restarting
+STARTUP_WAIT      = 25    # seconds to wait for server after restart
+FAILURE_THRESHOLD = 5     # consecutive failures before restart
+EMBED_TIMEOUT     = 45    # seconds for PowerShell embedding selector
+STABLE_RESET_SECS = 600   # reset restart_count after 10 min of stable uptime
+
+# Edit these paths to match your installation
+BASE_DIR     = os.path.join(os.environ["USERPROFILE"], ".openviking")
+LOG_DIR      = os.path.join(os.environ["USERPROFILE"], ".claude-memory", "logs")
+PYTHON_EXE   = os.path.join(os.environ["USERPROFILE"],
+                            "AppData", "Local", "Programs", "Python",
+                            "Python313", "python.exe")
+WATCHDOG_LOG = os.path.join(LOG_DIR, "openviking-watchdog.log")
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+os.makedirs(LOG_DIR, exist_ok=True)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler(WATCHDOG_LOG, encoding="utf-8"),
+        logging.StreamHandler(sys.stdout),
+    ]
+)
+log = logging.getLogger("ov-watchdog")
+
+ov_process    = None
+restart_count = 0
+last_restart  = 0.0
+stable_since  = time.time()
+
+
+def is_server_up():
+    try:
+        req = urllib.request.Request(
+            OV_URL,
+            headers={"Authorization": "Bearer " + OV_API_KEY}
+        )
+        with urllib.request.urlopen(req, timeout=5) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def start_server():
+    global ov_process
+    log.info("Starting OpenViking server...")
+
+    # Run embedding selector before each start
+    select_script = os.path.join(BASE_DIR, "select-embedding.ps1")
+    if os.path.exists(select_script):
+        try:
+            subprocess.run(
+                ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", select_script],
+                timeout=EMBED_TIMEOUT,
+                capture_output=True
+            )
+            log.info("Embedding provider selected.")
+        except subprocess.TimeoutExpired:
+            log.warning("Embedding selector timed out (%ds) -- using existing ov.conf", EMBED_TIMEOUT)
+        except Exception as e:
+            log.warning("Embedding selector failed (%s) -- using existing ov.conf", e)
+
+    log_stdout = os.path.join(LOG_DIR, "openviking-server-" + datetime.now().strftime("%Y%m%d") + ".log")
+    log_stderr = os.path.join(LOG_DIR, "openviking-server-" + datetime.now().strftime("%Y%m%d") + "-err.log")
+
+    ov_process = subprocess.Popen(
+        [PYTHON_EXE, "-m", "openviking_cli.server_bootstrap"],
+        cwd=BASE_DIR,
+        stdout=open(log_stdout, "a", encoding="utf-8"),
+        stderr=open(log_stderr, "a", encoding="utf-8"),
+        env=dict(os.environ, OPENVIKING_CONFIG=os.path.join(BASE_DIR, "ov.conf"))
+    )
+    log.info("Server PID: %d  Log: %s", ov_process.pid, log_stdout)
+
+
+def stop_server():
+    global ov_process
+    if ov_process and ov_process.poll() is None:
+        log.info("Terminating server PID %d", ov_process.pid)
+        ov_process.terminate()
+        try:
+            ov_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            log.warning("Terminate timed out -- killing")
+            ov_process.kill()
+        ov_process = None
+
+
+def restart_server(reason):
+    global restart_count, last_restart, stable_since
+    restart_count += 1
+    last_restart   = time.time()
+    stable_since   = time.time()
+    log.warning("Restart #%d triggered: %s", restart_count, reason)
+    stop_server()
+    time.sleep(RESTART_DELAY)
+    start_server()
+    log.info("Waiting %ds for server to initialize...", STARTUP_WAIT)
+    time.sleep(STARTUP_WAIT)
+    if is_server_up():
+        log.info("Server restarted successfully (restart #%d).", restart_count)
+    else:
+        log.error("Server did not come up after restart #%d. Will keep trying.", restart_count)
+
+
+def main():
+    global restart_count, stable_since
+    log.info("OpenViking Watchdog v2.1 starting.")
+    log.info("Monitoring: %s  Interval: %ds  EmbedTimeout: %ds", OV_URL, CHECK_INTERVAL, EMBED_TIMEOUT)
+
+    if not is_server_up():
+        log.info("Server not running on startup -- starting it.")
+        start_server()
+        time.sleep(STARTUP_WAIT)
+        if not is_server_up():
+            log.error("Server failed to start on initial attempt. Will keep monitoring.")
+
+    consecutive_failures = 0
+
+    try:
+        while True:
+            time.sleep(CHECK_INTERVAL)
+
+            # Reset restart counter after sustained stable uptime
+            if restart_count > 0 and (time.time() - stable_since) > STABLE_RESET_SECS:
+                log.info("10 min stable uptime -- resetting restart counter (was %d).", restart_count)
+                restart_count = 0
+
+            if ov_process and ov_process.poll() is not None:
+                exit_code = ov_process.poll()
+                restart_server("process exited with code " + str(exit_code))
+                consecutive_failures = 0
+                stable_since = time.time()
+                continue
+
+            if not is_server_up():
+                consecutive_failures += 1
+                log.warning("Health check failed (%d/%d)", consecutive_failures, FAILURE_THRESHOLD)
+                if consecutive_failures >= FAILURE_THRESHOLD:
+                    restart_server(str(FAILURE_THRESHOLD) + " consecutive health check failures")
+                    consecutive_failures = 0
+                    stable_since = time.time()
+            else:
+                if consecutive_failures > 0:
+                    log.info("Server recovered after %d failures.", consecutive_failures)
+                    stable_since = time.time()
+                consecutive_failures = 0
+
+    except KeyboardInterrupt:
+        log.info("Watchdog stopped by user.")
+        stop_server()
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a full Claude Desktop memory‑integration example under examples/Claude-Desktop/, following the project’s contribution guidelines and the maintainer’s request to place Claude‑related examples inside the examples directory rather than the main README.

What’s included
A complete working integration between OpenViking and Claude Desktop

Automatic memory recall before Claude Code prompts

Automatic memory extraction and commit after each session

Windows‑native watchdog for self‑healing restarts

Windows Task Scheduler automation (autosave + health checks)

Embedding selector with Ollama‑first + Jina fallback

A 26‑point verification script to validate the integration

A dedicated Markdown example file documenting usage and setup

Why this belongs in examples/Claude-Desktop/
This integration is a standalone example demonstrating how to connect Claude Desktop to OpenViking’s memory engine.
It does not modify the core library and fits the structure used for other Claude‑related examples.

Folder structure
Code
examples/
  Claude-Desktop/
    openviking-claude-desktop.md
    <all integration scripts and files>
Notes
No changes were made to the main README.

All files are isolated to the example folder.

The branch contains only documentation + example code, no core logic changes.

Let me know if you prefer a different folder name or want the example split into submodules.