### PR TITLE
docs(resources): note local directory uploads skip symlink entries (#2374)

### DIFF
--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -159,6 +159,7 @@ This endpoint is the core entry point for resource management, supporting adding
 - When `to` is specified and the target already exists, triggers incremental update
 - When `watch_interval > 0`, the watch task binds to `to` if provided; otherwise it binds to the `root_uri` returned by this import. If no stable `root_uri` is available, the request fails and asks for an explicit `to`.
 - For local directory inputs, scanning respects `.gitignore` files (root and nested) with standard Git semantics; `ignore_dirs`, `include`, and `exclude` further refine what is ingested.
+- Local directory inputs skip symlink entries (both file and directory symlinks); files reached through their real (non-symlink) path are still ingested. A directory whose entries are all symlinks yields an empty archive (logged as a warning).
 - To create or update plain text directly, use [content/write](03-filesystem.md#write) instead of `add_resource`. Semantic processing and embeddings are refreshed automatically after resource ingestion and content writes.
 
 #### 3. Usage Examples

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -152,6 +152,7 @@ URL/文件  Parser  TreeBuilder  AGFS    Summarizer/Vector
 - `path` 和 `temp_file_id` 不能同时指定，上传本地文件需要先通过 [temp_upload](#temp_upload) 上传获取 `temp_file_id`，在 SDK 和 CLI 中已经封装好。
 - `watch_interval > 0` 时，如果指定了 `to`，监控任务绑定该目标；如果未指定 `to`，监控任务绑定本次导入返回的 `root_uri`。如果无法得到稳定 `root_uri`，请求会报错并要求显式传 `to`。
 - 本地目录输入会遵循 `.gitignore`（根目录和子目录，标准 Git 语义）；`ignore_dirs`、`include`、`exclude` 会在此基础上进一步过滤。
+- 本地目录输入会跳过符号链接条目（文件和目录符号链接都会跳过）；通过真实（非符号链接）路径访问到的文件仍会被导入。如果某目录下的条目全是符号链接，生成的归档为空（会记录一条 warning）。
 - 如果要直接创建或更新纯文本内容，请使用 [content/write](03-filesystem.md#write)，不要使用 `add_resource`。资源导入和内容写入后都会自动刷新语义与 embedding。
 
 #### 3. 使用示例


### PR DESCRIPTION
#2374 (skip symlinks in directory uploads) changed what `add_resource` / `add_skill` ingest from a local directory, but the **Additional Notes** ingestion-contract list in `docs/{en,zh}/api/02-resources.md` only documents the `.gitignore` / `ignore_dirs` / `include` / `exclude` filters — not the new symlink skipping.

Adds one parallel EN+ZH bullet: symlink entries (file & directory) are skipped, real files are still ingested via their actual path, and an all-symlink directory yields an empty (warned) archive — grounded in `openviking_cli/client/http.py` `_zip_directory`.