### PR TITLE
docs(bot): document `gateway.token` (required when host is non-localhost)

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -171,6 +171,7 @@ All configurations are under the `bot` field in `ov.conf`, with default values f
 - `gateway`: Gateway configuration
   - `host`: Gateway listening address, default value is `0.0.0.0`
   - `port`: Gateway listening port, default value is `18790`
+  - `token`: Gateway authentication token. Required when `host` is non-localhost (such as the default `0.0.0.0`) — the gateway refuses to start without it (`SECURITY: bot.gateway.token is required when gateway.host is non-localhost`). Set a random secret; clients then send it in the `X-Gateway-Token` header.
 - `sandbox`: Sandbox configuration
   - `mode`: Sandbox mode, optional values are `shared` (all sessions share workspace) or `private` (private, workspace isolated by Channel and session). Default value is `shared`.
 - `ov_server`: OpenViking Server configuration.

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -174,6 +174,7 @@ bot 将连接到远程 OpenViking Server，使用前请先启动 OpenViking Serv
 - `gateway`：Gateway 配置
   - host：Gateway 监听地址，默认值为 `0.0.0.0`
   - port：Gateway 监听端口，默认值为 `18790`
+  - token：Gateway 鉴权 token。当 `host` 为非 localhost 地址（例如默认的 `0.0.0.0`）时必须设置——否则网关会拒绝启动（`SECURITY: bot.gateway.token is required when gateway.host is non-localhost`）。请设置为随机密钥；客户端通过 `X-Gateway-Token` 请求头携带。
 - `sandbox`：沙箱配置
   - `mode`：沙箱模式，可选值为 `shared`（所有 session 共享工作空间）或 `private`（私有，按 Channel、session 隔离工作空间）。默认值为 `shared`。
 - `ov_server`：OpenViking Server 配置


### PR DESCRIPTION
## What
Document `bot.gateway.token` in the Bot Configuration bullet list (EN + CN).

## Why
The gateway config bullets list only `host` and `port`, but `token` is **required when `host` is non-localhost** — and the default `host` is `0.0.0.0`. Without it the gateway aborts on startup:
```
SECURITY: bot.gateway.token is required when gateway.host is non-localhost.
```
This is enforced in `bot/vikingbot/cli/commands.py` via `requires_gateway_token`, and the `X-Gateway-Token` header is checked in `bot/vikingbot/channels/openapi.py`. The JSON example already shows `"token": "<set-a-random-gateway-token>"`, but the bullet list never explains the field, so operators following the example hit the startup error with no documented cause.

## Change
One `token` bullet added after `port` in `bot/README.md` and `bot/README_CN.md`. Docs-only.