### PR TITLE
docs(quickstart): note Web Studio `/studio` is available from pip/pipx server installs

### DIFF
--- a/docs/en/getting-started/03-quickstart-server.md
+++ b/docs/en/getting-started/03-quickstart-server.md
@@ -51,6 +51,8 @@ curl http://localhost:1933/health
 
 `openviking-server doctor` checks local configuration, model access, and auth readiness. `curl /health` only confirms that the server process is already running.
 
+Web Studio is also served at `http://localhost:1933/studio` (bundled with pip/pipx installs since v0.3.21 — no Docker required).
+
 ## Connect with Python SDK
 
 ```python

--- a/docs/zh/getting-started/03-quickstart-server.md
+++ b/docs/zh/getting-started/03-quickstart-server.md
@@ -51,6 +51,8 @@ curl http://localhost:1933/health
 
 `openviking-server doctor` 用于校验本地配置、模型访问和鉴权状态；`curl /health` 只表示服务进程已经启动。
 
+Web Studio 也会在 `http://localhost:1933/studio` 提供（自 v0.3.21 起 pip/pipx 安装即自带，无需 Docker）。
+
 ## 使用 Python SDK 连接
 
 ```python


### PR DESCRIPTION
## What
Add a one-line Web Studio (`/studio`) note to the **server-start** quickstart (EN + ZH).

## Why
Since **v0.3.21**, `pip`/`pipx` installs bundle the Web Studio static assets, so `/studio` works without Docker (release notes: "Web Studio ships with Python installs … `/studio` works from pip/pipx installs without Docker"). `docs/.../guides/03-deployment.md` already documents `/studio`, but the pip server-start quickstart never mentions it, so a pip user who just started the server has no way to discover the UI is already running at `/studio`.

## Change
One sentence appended to the **Verify** section of `docs/{en,zh}/getting-started/03-quickstart-server.md`. Placed in the server-start guide (not `02-quickstart.md` Option 1, which is library-only and starts no server). Docs-only.