### PR TITLE
docs(agents): consolidate zh guide follow-up edits

### DIFF
--- a/docs/images/agents/zh/claude-code.md
+++ b/docs/images/agents/zh/claude-code.md
@@ -1,3 +1,4 @@
+# Claude Code 接入
 
 为 [Claude Code](https://docs.claude.com/zh-CN/docs/claude-code/overview) 提供跨项目、跨 session 的长期记忆，越用越聪明。安装一次，每次对话自动召回和捕获，模型不需要主动调用任何工具。
 

--- a/docs/images/agents/zh/cursor.md
+++ b/docs/images/agents/zh/cursor.md
@@ -1,40 +1,19 @@
+## 一、Cursor 接入 OpenViking 操作步骤
 
-## 一、前置准备：获取 API Key
+将 OpenViking 接入 Cursor 的流程，请在 Cursor 中按以下步骤操作：
 
-所有 MCP 客户端的接入都依赖同一个 **Authorization Token**，即 OpenViking 控制台中的 API Key。请先按以下步骤获取并妥善保存。
-
-### 1\.1 操作路径
-
-1. 在左侧菜单选择 **用户管理**
-
-2. 在用户列表中找到对应用户（个人版默认为 `default` / `admin`），点击 API Key 列右侧的 **复制** 图标
-
-3. 将复制得到的 `ZGV\.\.\.hiMg` 形式的字符串妥善保存，作为后续所有 Agent 接入的 `Authorization` 值
-
-**安全提示**：API Key 等同于账户密钥，请勿提交到 Git 仓库或公开渠道。建议通过环境变量或加密配置注入。
-
-![复制 OpenViking API Key](https://docs.openviking.net/agents/image/cursor/01-api-key.jpg)
-
-
-
-## 二、接入 Cursor 指南
-
-以下为 OpenViking 标准接入 Cursor 的流程。
-
-### 2\.1 接入步骤
-
-#### 步骤 1：打开设置
+### 步骤 1：打开 Cursor 设置
 
 在 Cursor 主界面右上角点击 **设置（齿轮图标）**，进入设置面板
 
 ![打开 Cursor 设置](https://docs.openviking.net/agents/image/cursor/02-open-settings.png)
 
-#### 步骤 2：新增 MCP Server
+
+### 步骤 2：新增 MCP Server
 
 在左侧菜单中选择 **Tools \&amp; MCPs**，进入 MCP Servers 管理页。
 
 ![进入 Tools and MCPs 页面](https://docs.openviking.net/agents/image/cursor/03-tools-and-mcps.png)
-
 
 
 点击 **Add Custom MCP** 按钮。
@@ -42,10 +21,9 @@
 ![添加自定义 MCP Server](https://docs.openviking.net/agents/image/cursor/04-add-custom-mcp.png)
 
 
+### 步骤 3：粘贴配置 JSON
 
-#### 步骤 3：粘贴配置 JSON
-
-在弹出的 **mcp\.json** 文件中粘贴以下 JSON，并将 `Authorization` 替换为第一章中复制的 API Key：
+在弹出的 **mcp\.json** 文件中粘贴以下 JSON，其中 `Authorization` 等字段已经自动填入 API Key 值：
 
 ```json
 {
@@ -60,33 +38,38 @@
 }
 ```
 
-**关键说明**：`Authorization` 的值需带上 `Bearer` 前缀（注意空格），完整格式为 `Bearer \&lt;API Key\&gt;`。
-
-![粘贴 MCP JSON 配置](https://docs.openviking.net/agents/image/cursor/05-paste-mcp-json.jpg)
-
-#### 步骤 4：确认并启用
+### 步骤 4：确认并启用
 
 保存 mcp\.json 配置文件并关闭后，Cursor 会自动建立 MCP 连接并加载工具列表。连接成功后，**`ov\-mcp\-server`** 会出现在 **Installed MCP Servers** 列表中，同时会显示已启用的工具数量（图中的 “10 tools enabled”）。配置完成后，可直接看到 `ov\-mcp\-server` 条目旁的开关呈绿色开启状态，代表服务已正常加载并就绪：
 
 ![确认并启用 MCP Server](https://docs.openviking.net/agents/image/cursor/06-enable-server.png)
 
-#### 步骤 5：MCP 连通性检查
+### 步骤 5：MCP 连通性检查
 
 接入后建议通过两个简单 query 快速验证 MCP 是否正常工作。在 Cursor 对话框中依次输入：
 
-**① ** **`ov ls`** — 列出 OpenViking 根目录内容，确认连接畅通、可正确返回目录结构。
+**① ** **`ov ls`** — 列出 OpenViking 根目录内容，确认连接畅通、可正确返回目录结构：
+```bash
+ov ls
+```
 
 ![运行 ov ls 验证连接](https://docs.openviking.net/agents/image/cursor/07-ov-ls.png)
 
-**② ****`ov health`** — 调用 health 工具，确认 OpenViking 服务端状态与当前用户身份。
+**② ****`ov health`** — 调用 health 工具，确认 OpenViking 服务端状态与当前用户身份：
+```bash
+ov health
+```
 
 ![运行 ov health 验证服务状态](https://docs.openviking.net/agents/image/cursor/08-ov-health.png)
 
-**验收标准**：`ov ls` 能返回 `agent / resources / session / user` 等目录；`ov health` 返回 `service initialized` 与当前用户名，即表示接入成功。
+
+### 步骤 6：验收标准
+
+`ov ls` 能返回 `agent / resources / session / user` 等目录；`ov health` 返回 `service initialized` 与当前用户名，即表示接入成功。
 
 
 
-### 2\.2 配置参数说明
+## 二、配置参数说明
 
 |字段|必填|说明|
 |---|---|---|

--- a/docs/images/agents/zh/trae.md
+++ b/docs/images/agents/zh/trae.md
@@ -13,43 +13,24 @@
 
 - 个人长期任务目标 / OKR / Roadmap 沉淀，Agent 在规划任务时自动对齐
 
----
 
-## 二、前置准备：获取 API Key
+## 二、Trae 接入 OpenViking 操作步骤
 
-所有 MCP 客户端的接入都依赖同一个 **Authorization Token**，即 OpenViking 控制台中的 API Key。请先按以下步骤获取并妥善保存：
+**Trae** 是字节跳动推出的 AI IDE，原生支持通过 MCP 协议加载外部工具与上下文服务。请在 trae 按以下步骤操作：
 
-1. 在左侧菜单选择 **用户管理**
-
-2. 在用户列表中找到对应用户（个人版默认为 `default` / `admin`），点击 API Key 列右侧的 **复制** 图标
-
-3. 将复制得到的 `ZGV\.\.\.hiMg` 形式的字符串妥善保存，作为后续所有 Agent 接入的 `Authorization` 值
-
-**安全提示**：API Key 等同于账户密钥，请勿提交到 Git 仓库或公开渠道。建议通过环境变量或加密配置注入。
-
-![获取 OpenViking API Key](https://docs.openviking.net/agents/image/trae/01-api-key.jpg)
-
----
-
-## 三、Trae 接入指南
-
-**Trae** 是字节跳动推出的 AI IDE，原生支持通过 MCP 协议加载外部工具与上下文服务。以下为 OpenViking 的标准接入流程。
-
-### 3\.1 接入步骤
-
-#### 步骤 1：打开设置
+### 步骤 1：打开 Trae 设置
 
 在 Trae 主界面右上角点击 **设置（齿轮图标）**，进入设置面板。
 
 ![打开 Trae 设置](https://docs.openviking.net/agents/image/trae/02-open-settings.jpg)
 
-#### 步骤 2：进入 MCP 配置页
+### 步骤 2：进入 MCP 配置页
 
 在左侧菜单中选择 **MCP**，进入 MCP Servers 管理页。
 
 ![进入 MCP 配置页](https://docs.openviking.net/agents/image/trae/03-mcp-settings.jpg)
 
-#### 步骤 3：新增 MCP Server
+### 步骤 3：新增 MCP Server
 
 点击右侧的 **\+ 添加** 按钮，在下拉菜单中选择 **手动配置**。
 
@@ -57,9 +38,9 @@
 
 ![选择手动配置](https://docs.openviking.net/agents/image/trae/05-manual-config.png)
 
-#### 步骤 4：粘贴配置 JSON
+### 步骤 4：粘贴配置 JSON
 
-在弹出的配置框中粘贴以下 JSON，并将 `Authorization` 替换为第二章中复制的 API Key：
+在弹出的配置框中粘贴以下 JSON：
 
 ```json
 {
@@ -74,33 +55,38 @@
 }
 ```
 
-**关键说明**：`Authorization` 的值需带上 `Bearer` 前缀（注意空格），完整格式为 `Bearer \&lt;API Key\&gt;`。
-
 ![粘贴 MCP JSON 配置](https://docs.openviking.net/agents/image/trae/06-paste-mcp-json.jpg)
 
-#### 步骤 5：确认并启用
+### 步骤 5：确认并启用
 
 点击 **确认** 按钮，Trae 会自动建立 MCP 连接并加载工具列表。连接成功后，`ov\-mcp\-server` 将出现在已配置的 MCP Servers 列表中。配置完成后，可在 MCP 管理页看到 `ov\-mcp\-server` 已加载并启用，右侧开关呈绿色：
 
 ![确认并启用 MCP Server](https://docs.openviking.net/agents/image/trae/07-enable-server.jpg)
 
-#### 步骤 6：MCP 连通性检查
+### 步骤 6：MCP 连通性检查
 
 接入后建议通过两个简单 query 快速验证 MCP 是否正常工作。在 Trae 对话框中依次输入：
 
-**① ****`ov ls`** — 列出 OpenViking 根目录内容，确认连接畅通、可正确返回目录结构。
+**① ****`ov ls`** — 列出 OpenViking 根目录内容，确认连接畅通、可正确返回目录结构：
+```bash
+ov ls
+```
 
 ![运行 ov ls 验证连接](https://docs.openviking.net/agents/image/trae/08-ov-ls.jpg)
 
-**② ****`ov health`** — 调用 health 工具，确认 OpenViking 服务端状态与当前用户身份。
+**② ****`ov health`** — 调用 health 工具，确认 OpenViking 服务端状态与当前用户身份：
+```bash
+ov health
+```
 
 ![运行 ov health 验证服务状态](https://docs.openviking.net/agents/image/trae/09-ov-health.jpg)
 
-**验收标准**：`ov ls` 能返回 `agent / resources / session / user` 等目录；`ov health` 返回 `service initialized` 与当前用户名，即表示接入成功。
+### 步骤：验收标准
+`ov ls` 能返回 `agent / resources / session / user` 等目录；`ov health` 返回 `service initialized` 与当前用户名，即表示接入成功。
 
 
 
-### 3\.2 配置参数说明
+## 三、配置参数说明
 
 |字段|必填|说明|
 |---|---|---|


### PR DESCRIPTION
## Description

This PR consolidates the follow-up GitHub web edits to the Chinese agent setup guides into one reviewable change set. The changes are limited to documentation updates in the existing zh guide files.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Combined the GitHub web edits from `patch-16`, `patch-17`, and `patch-18` into one PR.
- Updated `docs/images/agents/zh/claude-code.md` with the latest follow-up wording adjustment.
- Updated `docs/images/agents/zh/cursor.md` and `docs/images/agents/zh/trae.md` with the latest follow-up formatting and content edits.

## Testing

Documentation-only change; no code execution or automated tests were run.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- This PR consolidates the pending changes currently living on `patch-16`, `patch-17`, and `patch-18`.
- Scope is limited to documentation files under `docs/images/agents/zh/`.
