### PR TITLE
docs(trae): restore previous zh guide version

### DIFF
--- a/docs/images/agents/zh/trae.md
+++ b/docs/images/agents/zh/trae.md
@@ -1,4 +1,3 @@
-
 ## 一、适用场景
 
 使用 OpenViking 实现：
@@ -13,43 +12,23 @@
 
 - 个人长期任务目标 / OKR / Roadmap 沉淀，Agent 在规划任务时自动对齐
 
----
+## 二、Trae 接入 OpenViking 操作步骤
 
-## 二、前置准备：获取 API Key
+**Trae** 是字节跳动推出的 AI IDE，原生支持通过 MCP 协议加载外部工具与上下文服务。请在 trae 按以下步骤操作：
 
-所有 MCP 客户端的接入都依赖同一个 **Authorization Token**，即 OpenViking 控制台中的 API Key。请先按以下步骤获取并妥善保存：
-
-1. 在左侧菜单选择 **用户管理**
-
-2. 在用户列表中找到对应用户（个人版默认为 `default` / `admin`），点击 API Key 列右侧的 **复制** 图标
-
-3. 将复制得到的 `ZGV\.\.\.hiMg` 形式的字符串妥善保存，作为后续所有 Agent 接入的 `Authorization` 值
-
-**安全提示**：API Key 等同于账户密钥，请勿提交到 Git 仓库或公开渠道。建议通过环境变量或加密配置注入。
-
-![获取 OpenViking API Key](https://docs.openviking.net/agents/image/trae/01-api-key.jpg)
-
----
-
-## 三、Trae 接入指南
-
-**Trae** 是字节跳动推出的 AI IDE，原生支持通过 MCP 协议加载外部工具与上下文服务。以下为 OpenViking 的标准接入流程。
-
-### 3\.1 接入步骤
-
-#### 步骤 1：打开设置
+### 步骤 1：打开 Trae 设置
 
 在 Trae 主界面右上角点击 **设置（齿轮图标）**，进入设置面板。
 
 ![打开 Trae 设置](https://docs.openviking.net/agents/image/trae/02-open-settings.jpg)
 
-#### 步骤 2：进入 MCP 配置页
+### 步骤 2：进入 MCP 配置页
 
 在左侧菜单中选择 **MCP**，进入 MCP Servers 管理页。
 
 ![进入 MCP 配置页](https://docs.openviking.net/agents/image/trae/03-mcp-settings.jpg)
 
-#### 步骤 3：新增 MCP Server
+### 步骤 3：新增 MCP Server
 
 点击右侧的 **\+ 添加** 按钮，在下拉菜单中选择 **手动配置**。
 
@@ -57,9 +36,9 @@
 
 ![选择手动配置](https://docs.openviking.net/agents/image/trae/05-manual-config.png)
 
-#### 步骤 4：粘贴配置 JSON
+### 步骤 4：粘贴配置 JSON
 
-在弹出的配置框中粘贴以下 JSON，并将 `Authorization` 替换为第二章中复制的 API Key：
+在弹出的配置框中粘贴以下 JSON：
 
 ```json
 {
@@ -74,25 +53,31 @@
 }
 ```
 
-**关键说明**：`Authorization` 的值需带上 `Bearer` 前缀（注意空格），完整格式为 `Bearer \&lt;API Key\&gt;`。
-
 ![粘贴 MCP JSON 配置](https://docs.openviking.net/agents/image/trae/06-paste-mcp-json.jpg)
 
-#### 步骤 5：确认并启用
+### 步骤 5：确认并启用
 
 点击 **确认** 按钮，Trae 会自动建立 MCP 连接并加载工具列表。连接成功后，`ov\-mcp\-server` 将出现在已配置的 MCP Servers 列表中。配置完成后，可在 MCP 管理页看到 `ov\-mcp\-server` 已加载并启用，右侧开关呈绿色：
 
 ![确认并启用 MCP Server](https://docs.openviking.net/agents/image/trae/07-enable-server.jpg)
 
-#### 步骤 6：MCP 连通性检查
+### 步骤 6：MCP 连通性检查
 
 接入后建议通过两个简单 query 快速验证 MCP 是否正常工作。在 Trae 对话框中依次输入：
 
-**① ****`ov ls`** — 列出 OpenViking 根目录内容，确认连接畅通、可正确返回目录结构。
+**① ****`ov ls`** — 列出 OpenViking 根目录内容，确认连接畅通、可正确返回目录结构：
+
+```bash
+ov ls
+```
 
 ![运行 ov ls 验证连接](https://docs.openviking.net/agents/image/trae/08-ov-ls.jpg)
 
-**② ****`ov health`** — 调用 health 工具，确认 OpenViking 服务端状态与当前用户身份。
+**② ****`ov health`** — 调用 health 工具，确认 OpenViking 服务端状态与当前用户身份：
+
+```bash
+ov health
+```
 
 ![运行 ov health 验证服务状态](https://docs.openviking.net/agents/image/trae/09-ov-health.jpg)
 
@@ -100,14 +85,16 @@
 
 
 
-### 3\.2 配置参数说明
+## 三、配置参数说明
 
 |字段|必填|说明|
 |---|---|---|
 |`mcpServers`|是|MCP Server 配置根节点|
 |`ov\-mcp\-server`|是|服务别名，可自定义；建议保持与上下文识别一致|
 |`url`|是|OpenViking MCP 服务端点；CN 区固定为 `https://api\.vikingdb\.cn\-beijing\.volces\.com/openviking/mcp`|
-|`headers\.Authorization`|是|格式 `Bearer \&lt;API Key\&gt;`|
+|`headers\.Authorization`|是|格式 `Bearer \&lt;API Key\&gt;`，来源见第二章|
+
+---
 
 
 ## 四、常见问题（FAQ）


### PR DESCRIPTION
## Description

This PR restores `docs/images/agents/zh/trae.md` to the previous version that was live after PR #2416. No other files are changed.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Reverted `docs/images/agents/zh/trae.md` from the current mainline version back to the previous version that was present after PR #2416.
- Removed the later Trae-specific structural rewrite that was introduced in the follow-up update.
- Kept all other files unchanged.

## Testing

Documentation-only change; no code execution or automated tests were run.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- Scope is intentionally limited to `docs/images/agents/zh/trae.md` only.
- This PR restores the version that was live before the later follow-up changes from PR #2419.
