### PR TITLE
docs(cli): document `ov language`/`lang` command in CLI reference

### DIFF
--- a/crates/ov_cli/README.md
+++ b/crates/ov_cli/README.md
@@ -105,6 +105,9 @@ ov read viking://resources/...
 - `config show` - Show configuration
 - `config validate` - Validate config
 
+### Display
+- `language` (`lang`) - Choose CLI display language (`en` / `zh-CN`)
+
 ## Output Formats
 
 ```bash

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -82,6 +82,7 @@ ov grep "TODO"
 | `health` | Quick health check |
 | `status` | Show server components status |
 | `config` | Configuration management |
+| `language` | Choose CLI display language (alias: `lang`) |
 | `version` | Show CLI and server version |
 | `task` | Track async processing tasks |
 


### PR DESCRIPTION
The `ov language` / `ov lang` command (choose CLI display language, `en` / `zh-CN`) is wired and user-visible in `crates/ov_cli/src/main.rs` — top-level `Language` command with `#[command(alias = "lang")]` — but it is absent from both CLI command references:

- `crates/ov_cli/README.md` (Command Groups)
- `npm/cli/README.md` (Status table)

This adds the missing entry to both references. Description and language codes are taken verbatim from the command's help text. Docs-only, no code change.