### PR TITLE
docs: remove broken agent doc links

### DIFF
--- a/docs/images/agents/en/claude-code.md
+++ b/docs/images/agents/en/claude-code.md
@@ -28,7 +28,7 @@ If you prefer to install manually:
 
 3. **Start Claude Code** and run `/mcp` to confirm the OpenViking entry shows your server URL.
 
-> No `ovcli.conf` yet? Create it first via [Deployment Guide -> CLI](../guides/03-deployment.md#cli).
+> No `ovcli.conf` yet? Create it first via Deployment Guide -> CLI.
 >
 > Pure local mode (`http://127.0.0.1:1933`, no auth)? Skip step 1. The plugin silently uses the local defaults.
 >
@@ -92,5 +92,3 @@ The plugin renders OpenViking status below the Claude Code input box: connection
 - [Blog: OpenViking for Claude Code / Codex](https://blog.openviking.ai/post/openviking-coding-agent/) - Why and how to add long-term memory to your coding agent
 - [Plugin README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md) - Full environment variable table, hook details, and architecture diagram
 - [Migration guide](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION.md) - Upgrade from the old plugin
-- [MCP Clients](./06-mcp-clients.md) - MCP tool parameters and other clients
-- [Deployment Guide -> CLI](../guides/03-deployment.md#cli) - `ovcli.conf` configuration

--- a/docs/images/agents/en/codex.md
+++ b/docs/images/agents/en/codex.md
@@ -76,5 +76,3 @@ For tuning options such as `OPENVIKING_RECALL_LIMIT` and `OPENVIKING_CAPTURE_ASS
 - [Blog: OpenViking for Claude Code / Codex](https://blog.openviking.ai/post/openviking-coding-agent/) - Why and how to add long-term memory to your coding agent
 - [Plugin README](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/README.md) - Full environment variables and architecture diagram
 - [DESIGN.md](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/DESIGN.md) - Commit decision tree
-- [MCP Clients](./06-mcp-clients.md) - MCP protocol, tool list, and other clients
-- [Deployment Guide -> CLI](../guides/03-deployment.md#cli) - `ovcli.conf` configuration

--- a/docs/images/agents/en/hermes.md
+++ b/docs/images/agents/en/hermes.md
@@ -25,5 +25,3 @@ After configuration, Hermes automatically uses OpenViking as long-term memory. M
 ## Reference docs
 
 - [Hermes - OpenViking memory provider documentation](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers#openviking) - Full configuration guide
-- [Deployment Guide](../guides/03-deployment.md) - Set up the OpenViking service
-- [Authentication](../guides/04-authentication.md) - API Key settings for remote access

--- a/docs/images/agents/zh/claude-code.md
+++ b/docs/images/agents/zh/claude-code.md
@@ -28,7 +28,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/e
 
 3. **启动 Claude Code**，执行 `/mcp` 确认 OpenViking 这一项显示的是你的服务器 URL。
 
-> 还没有 `ovcli.conf`？先按 [部署指南 → CLI](../guides/03-deployment.md#cli) 创建。
+> 还没有 `ovcli.conf`？先按部署指南 → CLI 创建。
 >
 > 纯本地模式（`http://127.0.0.1:1933`，无鉴权）？跳过第 1 步——插件会静默使用本地默认值。
 >
@@ -97,5 +97,3 @@ type claude        # 期望输出：claude is a shell function
 - [博客：在 Claude Code / Codex 中接入 OpenViking](https://blog.openviking.ai/post/openviking-coding-agent/) — 为什么以及如何给你的 Coding Agent 加上长期记忆
 - [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md) — 完整环境变量表、hook 细节、架构图
 - [迁移说明](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION.md) — 从旧版插件升级
-- [MCP 客户端](./06-mcp-clients.md) — MCP 工具参数与其他客户端
-- [部署指南 → CLI](../guides/03-deployment.md#cli) — `ovcli.conf` 配置

--- a/docs/images/agents/zh/codex.md
+++ b/docs/images/agents/zh/codex.md
@@ -81,5 +81,3 @@ type codex         # 期望输出：codex is a shell function
 - [博客：在 Claude Code / Codex 中接入 OpenViking](https://blog.openviking.ai/post/openviking-coding-agent/) — 为什么以及如何给你的 Coding Agent 加上长期记忆
 - [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/README.md) — 完整环境变量、架构图
 - [DESIGN.md](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/DESIGN.md) — commit 决策树
-- [MCP 客户端](./06-mcp-clients.md) — MCP 协议、工具列表、其他客户端
-- [部署指南 → CLI](../guides/03-deployment.md#cli) — `ovcli.conf` 配置

--- a/docs/images/agents/zh/hermes.md
+++ b/docs/images/agents/zh/hermes.md
@@ -27,5 +27,3 @@ hermes memory status
 ## 参考文档
 
 - [Hermes — OpenViking memory provider 文档](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers#openviking) — 完整配置指南
-- [部署指南](../guides/03-deployment.md) — 搭建 OpenViking 服务
-- [鉴权](../guides/04-authentication.md) — 远程访问的 API Key 设置


### PR DESCRIPTION
## Description

Remove broken relative links from localized agent documentation assets. These docs are served from `docs/images/agents/{zh,en}`, so links such as `./06-mcp-clients.md` and `../guides/*.md` resolve to missing files in the static asset tree.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Removed broken MCP clients, deployment guide, and authentication guide references from `Reference docs` sections in Chinese and English agent docs.
- Converted the inline `ovcli.conf` setup note in Claude Code docs from a broken link to plain text.
- Left same-page `#安装` / `#install` anchors unchanged, per review scope.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `git diff --check upstream/main...HEAD`
- `rg "06-mcp-clients|\.\./guides/03-deployment|\.\./guides/04-authentication" docs/images/agents/zh docs/images/agents/en` returned no matches
- Local Markdown link check now only reports existing same-page anchors `#安装` / `#install`, which were intentionally left untouched

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR only updates localized static agent Markdown assets and does not change runtime code.