### PR TITLE
fix(cli): `ov config switch` reports invalid skip

### DIFF
--- a/crates/ov_cli/src/config_command_ui.rs
+++ b/crates/ov_cli/src/config_command_ui.rs
@@ -177,6 +177,7 @@ pub(crate) fn render_validate_failure_with_language(
 pub(crate) fn render_switch_header(
     active_name: Option<&str>,
     active_kind: Option<ConfigKind>,
+    invalid_config_names: &[String],
 ) -> String {
     let language = Language::current();
     let mut lines = Vec::new();
@@ -197,6 +198,10 @@ pub(crate) fn render_switch_header(
             theme::muted(copy(language, "Active:", "当前配置：")),
             unknown_value(copy(language, "none", "无"))
         )),
+    }
+    if let Some(warning) = invalid_saved_configs_notice(language, invalid_config_names) {
+        lines.push(String::new());
+        lines.push(warning);
     }
     format!("{}\n", lines.join("\n"))
 }
@@ -222,7 +227,7 @@ pub(crate) fn switch_labels(rows: &[SwitchConfigRow]) -> Vec<String> {
         .collect()
 }
 
-pub(crate) fn render_no_saved_configs() -> String {
+pub(crate) fn render_no_saved_configs(invalid_config_names: &[String]) -> String {
     let language = Language::current();
     let mut lines = Vec::new();
     lines.push(title(copy(
@@ -244,6 +249,10 @@ pub(crate) fn render_no_saved_configs() -> String {
             "请先运行 ov config 添加并保存配置。",
         ))
     ));
+    if let Some(warning) = invalid_saved_configs_notice(language, invalid_config_names) {
+        lines.push(String::new());
+        lines.push(warning);
+    }
     format!("{}\n", lines.join("\n"))
 }
 
@@ -310,6 +319,30 @@ fn copy_target_validation_failed(language: Language, name: &str) -> String {
         Language::En => format!("Target config '{name}' failed validation."),
         Language::ZhCn => format!("目标配置 '{name}' 验证失败。"),
     }
+}
+
+fn invalid_saved_configs_notice(language: Language, invalid_config_names: &[String]) -> Option<String> {
+    if invalid_config_names.is_empty() {
+        return None;
+    }
+
+    let names = invalid_config_names.join(", ");
+    Some(match language {
+        Language::En => format!(
+            "  {}",
+            theme::warning(format!(
+                "Note: Saved configs with damaged JSON structure were skipped: {names}."
+            ))
+            .bold()
+        ),
+        Language::ZhCn => format!(
+            "  {}",
+            theme::warning(format!(
+                "提示：以下已保存配置因 JSON 结构损坏已跳过：{names}。"
+            ))
+            .bold()
+        ),
+    })
 }
 
 fn title(value: &str) -> String {

--- a/crates/ov_cli/src/config_wizard/store.rs
+++ b/crates/ov_cli/src/config_wizard/store.rs
@@ -70,6 +70,18 @@ pub struct ConfigEntry {
 }
 
 #[derive(Debug, Clone)]
+pub struct InvalidSavedConfig {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigListReport {
+    pub configs: Vec<ConfigEntry>,
+    pub invalid_configs: Vec<InvalidSavedConfig>,
+}
+
+#[derive(Debug, Clone)]
 pub struct ConfigStore {
     config_dir: PathBuf,
     active_path: PathBuf,
@@ -128,10 +140,25 @@ impl ConfigStore {
     }
 
     pub fn list_configs(&self) -> Result<Vec<ConfigEntry>> {
+        let report = self.list_configs_report()?;
+        for invalid in &report.invalid_configs {
+            eprintln!(
+                "Warning: skipped invalid OpenViking config '{}'",
+                invalid.path.display()
+            );
+        }
+        Ok(report.configs)
+    }
+
+    pub fn list_configs_report(&self) -> Result<ConfigListReport> {
         let mut configs = Vec::new();
+        let mut invalid_configs = Vec::new();
 
         if !self.config_dir.exists() {
-            return Ok(configs);
+            return Ok(ConfigListReport {
+                configs,
+                invalid_configs,
+            });
         }
 
         for entry in fs::read_dir(&self.config_dir)? {
@@ -152,10 +179,10 @@ impl ConfigStore {
             }
 
             let Ok(config) = Config::from_file(&path.to_string_lossy()) else {
-                eprintln!(
-                    "Warning: skipped invalid OpenViking config '{}'",
-                    path.display()
-                );
+                invalid_configs.push(InvalidSavedConfig {
+                    name: name.to_string(),
+                    path,
+                });
                 continue;
             };
 
@@ -178,8 +205,12 @@ impl ConfigStore {
         }
 
         configs.sort_by(|left, right| left.name.cmp(&right.name));
+        invalid_configs.sort_by(|left, right| left.name.cmp(&right.name));
         normalize_active_config(&mut configs);
-        Ok(configs)
+        Ok(ConfigListReport {
+            configs,
+            invalid_configs,
+        })
     }
 
     pub fn save_named_config(&self, name: &str, config: &Config) -> Result<()> {

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -724,10 +724,19 @@ fn language_no_change(language: Language) -> &'static str {
 /// Interactive configuration switcher
 async fn handle_config_switch() -> Result<()> {
     let store = ConfigStore::new()?;
-    let configs = store.list_configs()?;
+    let report = store.list_configs_report()?;
+    let invalid_config_names: Vec<String> = report
+        .invalid_configs
+        .iter()
+        .map(|config| config.name.clone())
+        .collect();
+    let configs = report.configs;
 
     if configs.is_empty() {
-        print!("{}", config_command_ui::render_no_saved_configs());
+        print!(
+            "{}",
+            config_command_ui::render_no_saved_configs(&invalid_config_names)
+        );
         return Ok(());
     }
 
@@ -737,6 +746,7 @@ async fn handle_config_switch() -> Result<()> {
         config_command_ui::render_switch_header(
             active.map(|config| config.name.as_str()),
             active.map(|config| config.kind),
+            &invalid_config_names,
         )
     );
 

--- a/examples/skills/ov-add-data/SKILL.md
+++ b/examples/skills/ov-add-data/SKILL.md
@@ -80,6 +80,32 @@ ov add-resource /User/volcengine/Photo/Travels/2026/2026-01-01/ --to "viking://r
 ov add-resource /User/volcengine/Photo/Travels/2026/2026-01-02/ --parent "viking://resources/2026/"
 ```
 
+### Scheduled refresh with `--watch-interval`
+
+Use `--watch-interval <minutes>` to create or update a watch task so OpenViking re-imports the same source periodically.
+
+- `--watch-interval` is measured in **minutes**.
+- When the value is **greater than 0**, OV creates or updates a watch task.
+- When `--to` is provided, the watch task is bound to that exact target URI.
+- When `--to` is omitted, OV binds the watch task to the `root_uri` returned by this import.
+- Use `--watch-interval 0` together with the same `--to` target to cancel an existing watch task.
+- Prefer `--to` for long-term watched imports, because it gives the task a stable destination.
+
+```bash
+# Refresh a remote repository every 60 minutes and bind the watch to a fixed URI
+ov add-resource https://github.com/volcengine/OpenViking \
+  --to "viking://resources/repos/OpenViking" \
+  --watch-interval 60
+
+# Refresh every 30 minutes and bind the watch to the imported root_uri automatically
+ov add-resource https://example.com/product-spec.md --watch-interval 30
+
+# Cancel the watch task for the same target URI
+ov add-resource https://github.com/volcengine/OpenViking \
+  --to "viking://resources/repos/OpenViking" \
+  --watch-interval 0
+```
+
 ## CLI Output
 
 Returns the root URI of the imported resource, like:


### PR DESCRIPTION
ov config switch
支持提示探测到的不合法因而无法选择的配置文件
<img width="1070" height="450" alt="image" src="https://github.com/user-attachments/assets/6134679f-92d5-45ea-b902-965af30986ff" />
