### PR TITLE
docs: fix Claude agent documentation links

### DIFF
--- a/docs/en/agent-integrations/02-claude-code.md
+++ b/docs/en/agent-integrations/02-claude-code.md
@@ -93,6 +93,5 @@ The plugin renders an OpenViking status indicator under your Claude Code input b
 
 - [Blog: OpenViking in Claude Code / Codex](https://blog.openviking.ai/post/openviking-coding-agent/) — motivation, architecture overview, and demo
 - [Plugin README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md) — full env-var tables, hook details, architecture diagram
-- [Migration notes](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION.md) — upgrading from earlier plugin versions
 - [MCP Clients](./06-mcp-clients.md) — for MCP tool parameters and other clients
 - [Deployment Guide → CLI](../guides/03-deployment.md#cli) — `ovcli.conf` setup

--- a/docs/images/agents/en/claude-code.md
+++ b/docs/images/agents/en/claude-code.md
@@ -91,4 +91,3 @@ The plugin renders OpenViking status below the Claude Code input box: connection
 
 - [Blog: OpenViking for Claude Code / Codex](https://blog.openviking.ai/post/openviking-coding-agent/) - Why and how to add long-term memory to your coding agent
 - [Plugin README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md) - Full environment variable table, hook details, and architecture diagram
-- [Migration guide](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION.md) - Upgrade from the old plugin

--- a/docs/images/agents/zh/api.md
+++ b/docs/images/agents/zh/api.md
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import requests
 
-url = " `https://api.vikingdb.cn-beijing.volces.com/openviking` "
+url = "https://api.vikingdb.cn-beijing.volces.com/openviking"
 api_key = "[TODO]your-api-key"
 agent_id = "[TODO]your-agent-id"
 file_path = Path("[TODO]your-file-path") # e.g. test.txt

--- a/docs/images/agents/zh/claude-code.md
+++ b/docs/images/agents/zh/claude-code.md
@@ -96,4 +96,3 @@ type claude        # 期望输出：claude is a shell function
 
 - [博客：在 Claude Code / Codex 中接入 OpenViking](https://blog.openviking.ai/post/openviking-coding-agent/) — 为什么以及如何给你的 Coding Agent 加上长期记忆
 - [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md) — 完整环境变量表、hook 细节、架构图
-- [迁移说明](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION.md) — 从旧版插件升级

--- a/docs/images/agents/zh/sdk.md
+++ b/docs/images/agents/zh/sdk.md
@@ -11,7 +11,7 @@ pip install openviking --upgrade --force-reinstall
 ```python
 from openviking.client import SyncHTTPClient
 
-url = " `https://api.vikingdb.cn-beijing.volces.com/openviking` "
+url = "https://api.vikingdb.cn-beijing.volces.com/openviking"
 api_key = "[TODO]your-api-key"
 agent_id = "[TODO]your-agent-id"
 

--- a/docs/zh/agent-integrations/02-claude-code.md
+++ b/docs/zh/agent-integrations/02-claude-code.md
@@ -93,6 +93,5 @@ type claude        # 期望输出：claude is a shell function
 
 - [博客：在 Claude Code / Codex 中接入 OpenViking](https://blog.openviking.ai/post/openviking-coding-agent/) — 为什么以及如何给你的 Coding Agent 加上长期记忆
 - [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md) — 完整环境变量表、hook 细节、架构图
-- [迁移说明](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION.md) — 从旧版插件升级
 - [MCP 客户端](./06-mcp-clients.md) — MCP 工具参数与其他客户端
 - [部署指南 → CLI](../guides/03-deployment.md#cli) — `ovcli.conf` 配置


### PR DESCRIPTION
## Description

Fix two Claude agent documentation issues:

- Correct malformed Volcengine OpenViking Cloud URL examples in the Chinese API and SDK agent docs.
- Remove references to the missing Claude Code memory plugin migration document, which currently resolves to 404.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Fixed `url = " `https://api.vikingdb.cn-beijing.volces.com/openviking` "` examples to valid Python strings.
- Removed broken `examples/claude-code-memory-plugin/MIGRATION.md` links from Chinese and English Claude Code integration docs.
- Kept generated agent docs and site integration docs consistent across zh/en surfaces.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `git diff --check upstream/main...HEAD`
- `rg -n "claude-code-memory-plugin/MIGRATION\.md|迁移说明\]\(https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION\.md\)|Migration (notes|guide)\]\(https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/MIGRATION\.md\)" .` returned no matches
- `rg -n 'url\s*=\s*"\s*`|`\s*"\s*$' docs/images/agents/zh/api.md docs/images/agents/zh/sdk.md` returned no matches

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Documentation-only change. Unit tests were not run because this PR only updates Markdown content.