### PR TITLE
docs: fix broken in-doc links in encryption & oauth guides (EN+ZH)

### DIFF
--- a/docs/en/concepts/10-encryption.md
+++ b/docs/en/concepts/10-encryption.md
@@ -211,10 +211,9 @@ Different accounts' data is encrypted with independent Account Keys:
 
 ## Configuration Example
 
-See [Configuration Guide](../guides/01-configuration.md#encryption) for detailed configuration.
+See [Configuration Guide](../guides/01-configuration.md#encryption-section) for detailed configuration.
 
 ## Related Documentation
 
 - [Storage Architecture](./05-storage.md) - VikingFS and AGFS architecture
 - [Configuration Guide](../guides/01-configuration.md) - Encryption configuration details
-- [Technical Design](../../design/multi-tenant-file-encryption-desigin.md) - Encryption technical design

--- a/docs/en/guides/08-encryption.md
+++ b/docs/en/guides/08-encryption.md
@@ -476,4 +476,3 @@ If using encrypted files created with an older OpenViking version, partial reads
 
 - [Data Encryption](../concepts/10-encryption.md) - Encryption concepts
 - [Configuration Guide](./01-configuration.md) - Complete configuration reference
-- [Technical Design](../../design/multi-tenant-file-encryption-desigin.md) - Encryption technical design

--- a/docs/en/guides/11-oauth.md
+++ b/docs/en/guides/11-oauth.md
@@ -156,7 +156,7 @@ OAuth 2.1 **requires HTTPS** for any non-localhost issuer. The
 [Public Access Guide](12-public-access.md) covers the full setup — Caddy,
 nginx, docker compose, CDN — in detail. The short version:
 
-1. Follow [Public Access Guide § Adding HTTPS](12-public-access.md#adding-https-for-public-access)
+1. Follow [Public Access Guide § Adding HTTPS](12-public-access.md)
    to get `https://your-domain.com` serving port 1934 over TLS.
 2. Enable OAuth: `{ "oauth": { "enabled": true } }` in `ov.conf`.
 3. Restart: `docker compose restart openviking`.

--- a/docs/zh/concepts/10-encryption.md
+++ b/docs/zh/concepts/10-encryption.md
@@ -211,10 +211,9 @@ ov crypto init-key --output ~/.openviking/master.key
 
 ## 配置示例
 
-详细配置说明请参考 [配置文档](../guides/01-configuration.md#encryption)。
+详细配置说明请参考 [配置文档](../guides/01-configuration.md#encryption-段)。
 
 ## 相关文档
 
 - [存储架构](./05-storage.md) - VikingFS 和 AGFS 架构
 - [配置指南](../guides/01-configuration.md) - 加密配置详解
-- [技术设计](../../design/multi-tenant-file-encryption-desigin.md) - 加密技术设计文档

--- a/docs/zh/guides/08-encryption.md
+++ b/docs/zh/guides/08-encryption.md
@@ -476,4 +476,3 @@ Error: KeyMismatchError
 
 - [数据加密](../concepts/10-encryption.md) - 加密概念说明
 - [配置指南](./01-configuration.md) - 完整配置参考
-- [技术设计](../../design/multi-tenant-file-encryption-desigin.md) - 加密技术设计文档

--- a/docs/zh/guides/11-oauth.md
+++ b/docs/zh/guides/11-oauth.md
@@ -139,7 +139,7 @@ OAuth 2.1 对非 localhost 的 issuer **强制要求 HTTPS**。
 [公网访问指南](12-public-access.md)详细介绍了 Caddy、nginx、docker compose、
 CDN 的配置方法。简要步骤：
 
-1. 按[公网访问指南 § 添加 HTTPS](12-public-access.md#添加-https公网访问)
+1. 按[公网访问指南 § 添加 HTTPS](12-public-access.md)
    配置好 `https://your-domain.com`，使 1934 端口走 TLS。
 2. 启用 OAuth：`ov.conf` 里 `{ "oauth": { "enabled": true } }`。
 3. 重启：`docker compose restart openviking`。


### PR DESCRIPTION
Several in-doc links in the encryption and OAuth guides currently 404. All replacements are source-verified against the current `main`.

**1. Encryption config anchor (EN+ZH)**
`concepts/10-encryption.md` links to `guides/01-configuration.md#encryption`, but the target heading is `## encryption Section` (EN) / `## encryption 段` (ZH) — so the correct anchors are `#encryption-section` / `#encryption-段`.

**2. Non-existent encryption design doc (EN+ZH, in both `concepts/10-encryption.md` and `guides/08-encryption.md`)**
The "Technical Design" item links to `../../design/multi-tenant-file-encryption-desigin.md` (note the `desigin` typo). No such file exists under `docs/design/` — the directory has `multi-tenant-design.md`, `memory-isolation-design.md`, etc., but no encryption-design file under either spelling. Dropped the dead list item, same remedy as #2436 / #2443.

**3. OAuth → public-access HTTPS anchor (EN+ZH)**
`guides/11-oauth.md` links to `12-public-access.md#adding-https-for-public-access`, but `12-public-access.md` has no such heading — HTTPS setup lives under `## Option A: bundled Caddy …` / `## 方式 A：…`. Dropped the dead fragment so the link resolves to the page itself, consistent with the bare `12-public-access.md` link already used in the sentence just above.

Pure docs, no code changes.
