### PR TITLE
Make OpenClaw auto-recall timeout configurable

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -10,7 +10,6 @@ import { quickRecallPrecheck, withTimeout } from "./process-manager.js";
 import { sanitizeUserTextForCapture } from "./text-utils.js";
 import { estimateTextTokens } from "./token-estimator.js";
 
-const AUTO_RECALL_TIMEOUT_MS = 5_000;
 const RECALL_QUERY_MAX_CHARS = 4_000;
 export const AUTO_RECALL_SOURCE_MARKER = "Source: openviking-auto-recall";
 
@@ -285,7 +284,7 @@ export async function buildAutoRecallContext(params: {
 
       return { block, memoryCount: memoryLines.length, estimatedTokens };
     })(),
-    AUTO_RECALL_TIMEOUT_MS,
+    cfg.autoRecallTimeoutMs,
     "openviking: auto-recall search timeout",
   );
 }

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -16,6 +16,8 @@ export type MemoryOpenVikingConfig = {
   captureMode?: "semantic" | "keyword";
   captureMaxLength?: number;
   autoRecall?: boolean;
+  /** Outer time budget for the whole auto-recall flow, including search, ranking, and reads. */
+  autoRecallTimeoutMs?: number;
   /** Include resources in auto-recall and default memory_recall search. Default false. */
   recallResources?: boolean;
   recallLimit?: number;
@@ -50,6 +52,7 @@ const DEFAULT_TARGET_URI = "viking://user/memories";
 const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_CAPTURE_MODE = "semantic";
 const DEFAULT_CAPTURE_MAX_LENGTH = 24000;
+const DEFAULT_AUTO_RECALL_TIMEOUT_MS = 5000;
 const DEFAULT_RECALL_LIMIT = 6;
 const DEFAULT_RECALL_SCORE_THRESHOLD = 0.15;
 const DEFAULT_RECALL_MAX_CONTENT_CHARS = 5000;
@@ -172,6 +175,7 @@ export const memoryOpenVikingConfigSchema = {
         "captureMode",
         "captureMaxLength",
         "autoRecall",
+        "autoRecallTimeoutMs",
         "recallResources",
         "recallLimit",
         "recallScoreThreshold",
@@ -246,6 +250,10 @@ export const memoryOpenVikingConfigSchema = {
         Math.min(200_000, Math.floor(toNumber(cfg.captureMaxLength, DEFAULT_CAPTURE_MAX_LENGTH))),
       ),
       autoRecall: cfg.autoRecall !== false,
+      autoRecallTimeoutMs: Math.max(
+        1000,
+        Math.min(300_000, Math.floor(toNumber(cfg.autoRecallTimeoutMs, DEFAULT_AUTO_RECALL_TIMEOUT_MS))),
+      ),
       recallResources: cfg.recallResources === true || envFlag("OPENVIKING_RECALL_RESOURCES"),
       recallLimit: Math.max(1, Math.floor(toNumber(cfg.recallLimit, DEFAULT_RECALL_LIMIT))),
       recallScoreThreshold: Math.min(
@@ -353,6 +361,12 @@ export const memoryOpenVikingConfigSchema = {
     autoRecall: {
       label: "Auto-Recall",
       help: "Inject relevant OpenViking memories into agent context",
+    },
+    autoRecallTimeoutMs: {
+      label: "Auto-Recall Timeout (ms)",
+      placeholder: String(DEFAULT_AUTO_RECALL_TIMEOUT_MS),
+      advanced: true,
+      help: "Outer time budget for the whole auto-recall flow, including search, ranking, and memory reads.",
     },
     recallResources: {
       label: "Recall Resources",

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -136,6 +136,12 @@
       "label": "Auto-Recall",
       "help": "Inject relevant OpenViking memories into agent context"
     },
+    "autoRecallTimeoutMs": {
+      "label": "Auto-Recall Timeout (ms)",
+      "placeholder": "5000",
+      "advanced": true,
+      "help": "Outer time budget for the whole auto-recall flow, including search, ranking, and memory reads."
+    },
     "recallResources": {
       "label": "Recall Resources",
       "help": "Include resources (viking://resources) in auto-recall and default memory_recall search. Enables account-level shared knowledge retrieval.",
@@ -258,6 +264,11 @@
       },
       "autoRecall": {
         "type": "boolean"
+      },
+      "autoRecallTimeoutMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 300000
       },
       "recallResources": {
         "type": "boolean"

--- a/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
+++ b/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
@@ -514,6 +514,7 @@ These are the keys under `plugins.entries.openviking.config` in `openclaw.json`.
 | `captureMode` | `"semantic"` | Filter mode used by the server-side extraction pipeline: `semantic` or `keyword`. |
 | `captureMaxLength` | `24000` | Max text length per archived turn. |
 | `autoRecall` | `true` | Auto-recall and inject memories before reply. |
+| `autoRecallTimeoutMs` | `5000` | Outer timeout for the whole auto-recall flow. Increase for slow local embedding hardware. |
 | `recallLimit` | `6` | Max memories injected per recall. |
 | `recallScoreThreshold` | `0.15` | Min relevance score to inject. |
 | `recallMaxInjectedChars` | (plugin default) | Hard cap on injected character count. |

--- a/examples/openclaw-plugin/tests/ut/config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/config.test.ts
@@ -22,6 +22,7 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
     expect(cfg.commitTokenThreshold).toBe(20000);
     expect(cfg.captureMode).toBe("semantic");
     expect(cfg.captureMaxLength).toBe(24000);
+    expect(cfg.autoRecallTimeoutMs).toBe(5000);
     expect(cfg.recallMaxContentChars).toBe(5000);
     expect(cfg.peer_role).toBe("none");
     expect(cfg.peer_prefix).toBe("");
@@ -137,6 +138,18 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
   it("clamps timeoutMs to minimum 1000", () => {
     const cfg = memoryOpenVikingConfigSchema.parse({ timeoutMs: 100 });
     expect(cfg.timeoutMs).toBe(1000);
+  });
+
+  it("uses autoRecallTimeoutMs as the outer auto-recall budget", () => {
+    const cfg = memoryOpenVikingConfigSchema.parse({ autoRecallTimeoutMs: 30000 });
+    expect(cfg.autoRecallTimeoutMs).toBe(30000);
+  });
+
+  it("clamps autoRecallTimeoutMs within bounds", () => {
+    const cfgLow = memoryOpenVikingConfigSchema.parse({ autoRecallTimeoutMs: 100 });
+    expect(cfgLow.autoRecallTimeoutMs).toBe(1000);
+    const cfgHigh = memoryOpenVikingConfigSchema.parse({ autoRecallTimeoutMs: 999999 });
+    expect(cfgHigh.autoRecallTimeoutMs).toBe(300000);
   });
 
   it("treats undefined/null as empty config", () => {


### PR DESCRIPTION
## Summary
- add `autoRecallTimeoutMs` to the OpenClaw plugin config with a default of 5000ms
- use the configured value as the outer budget for the auto-recall flow
- expose the option in the plugin manifest and installation skill config table

Closes volcengine/OpenViking#2391

## Tests
- `node -e "JSON.parse(require('fs').readFileSync('examples/openclaw-plugin/openclaw.plugin.json','utf8')); console.log('manifest json ok')"`
- `npm test -- --run tests/ut/config.test.ts`
- `npm run typecheck`
- `npm run build`