### PR TITLE
docs(cli-setup): document the `ov language` non-interactive gate (exit 2) and fix the exit-code table (EN+ZH)

### DIFF
--- a/docs/en/getting-started/05-cli-setup.md
+++ b/docs/en/getting-started/05-cli-setup.md
@@ -47,6 +47,8 @@ Expected result:
 - `ov health` confirms basic server reachability.
 - `ov status` shows the active config and server diagnostics.
 
+> **Note:** Recent CLI versions (v0.3.23+) require a saved display language before most commands will run. In an interactive terminal the CLI prompts you on first use; in a non-interactive shell (agent or CI) any non-exempt command exits `2` until you run `ov language en` or `ov language zh-CN`. Only `ov language`/`ov lang`, `ov config add|edit|delete|list`, and `ov config switch <name>` are exempt, so run `ov language <code>` before the `ov config validate`, `ov health`, and `ov status` checks above.
+
 ## Before You Start
 
 You need:
@@ -213,7 +215,7 @@ Agents should branch on the process exit code and the JSON `error.code`, not on 
 | Exit code | Meaning |
 |-----------|---------|
 | `0` | Success, or already in the desired state |
-| `2` | Bad input, missing value, invalid name, or unreadable secret source |
+| `2` | Bad input, missing value, invalid name, unreadable secret source, or no display language selected in a non-interactive shell (run `ov language <code>` first) |
 | `3` | A config with that name already exists with different values; pass `--force` only if replacement is intended |
 | `4` | Server unreachable or config validation failed |
 | `5` | Authentication or key-role mismatch, such as passing a root key where a user key is expected |

--- a/docs/zh/getting-started/05-cli-setup.md
+++ b/docs/zh/getting-started/05-cli-setup.md
@@ -47,6 +47,8 @@ ov status
 - `ov health` 确认服务端基础可达。
 - `ov status` 展示 active 配置和服务端诊断信息。
 
+> **注意：** 最近的 CLI 版本（v0.3.23+）要求在运行大多数命令前先保存一个显示语言。在交互式终端中，CLI 会在首次使用时提示你选择；在非交互式 shell（Agent 或 CI）中，任何非豁免命令都会以 `2` 退出，直到你运行 `ov language en` 或 `ov language zh-CN`。只有 `ov language`/`ov lang`、`ov config add|edit|delete|list` 和 `ov config switch <name>` 是豁免的，因此请在上面的 `ov config validate`、`ov health` 和 `ov status` 之前先运行 `ov language <code>`。
+
 ## 开始前
 
 你需要准备：
@@ -213,7 +215,7 @@ Agent 应该根据进程退出码和 JSON 中的 `error.code` 分支处理，不
 | 退出码 | 含义 |
 |--------|------|
 | `0` | 成功，或已经处于目标状态 |
-| `2` | 输入错误、缺少参数、名称非法，或无法读取密钥来源 |
+| `2` | 输入错误、缺少参数、名称非法、无法读取密钥来源，或在非交互式 shell 中尚未选择显示语言（请先运行 `ov language <code>`） |
 | `3` | 同名配置已经存在但内容不同；只有确认要替换时才传 `--force` |
 | `4` | 服务端不可达，或配置校验失败 |
 | `5` | 鉴权或 key 角色不匹配，例如把 root key 传到了需要 user key 的位置 |


### PR DESCRIPTION
## What

The CLI now gates commands on a saved display language. In `crates/ov_cli/src/main.rs`, `language_gate_action` exits `2` (`ExitNonInteractive`) for any non-exempt command when no language is saved and the shell is non-interactive; only `ov language`/`ov lang`, `ov config add|edit|delete|list`, and `ov config switch <name>` are exempt. The v0.3.23 release notes already call this out ("Non-interactive automation should run `ov language en` or `ov language zh-CN` before other commands").

The CLI setup guide does not mention it, which breaks its own documented flow:

- **Quick Path / Agent Checklist** run `ov config validate`, `ov health`, and `ov status` — all non-exempt, so on a fresh non-interactive install they hard-fail with an opaque exit-`2` message before any config work happens.
- The **exit-code table** labels `2` only as "Bad input, missing value, invalid name, or unreadable secret source", actively pointing the reader at input/auth debugging instead of running `ov language`.

## Change

- Add a short note in the Quick Path explaining the language requirement and the exempt commands.
- Extend the exit-code-table row for `2` to cover the language-gate case.
- EN + ZH mirrored.

Distinct from #2427, which documented the `ov language`/`lang` *command* in the CLI reference; this covers the *gate behavior* and the exit-code-table errata in the getting-started guide. Pure docs.