### PR TITLE
Fix missing session context response

### DIFF
--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -296,7 +296,7 @@ async def get_session_context(
         )
 
     service = get_service()
-    session = await service.sessions.get(session_id, _ctx, auto_create=False)
+    session = await service.sessions.get(session_id, _ctx, auto_create=True)
     result = await session.get_session_context(token_budget=token_budget)
     return Response(status="ok", result=_to_jsonable(result))
 

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -172,6 +172,19 @@ async def test_get_session_context(client: httpx.AsyncClient):
     assert [m["parts"][0]["text"] for m in body["result"]["messages"]] == ["Current live message"]
 
 
+async def test_get_session_context_nonexistent_returns_empty_context(client: httpx.AsyncClient):
+    resp = await client.get("/api/v1/sessions/nonexistent-session-xyz/context")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["latest_archive_overview"] == ""
+    assert body["result"]["pre_archive_abstracts"] == []
+    assert body["result"]["messages"] == []
+    assert body["result"]["estimatedTokens"] == 0
+    assert body["result"]["stats"]["activeTokens"] == 0
+
+
 async def test_get_session_context_rejects_negative_token_budget(client: httpx.AsyncClient):
     resp = await client.get("/api/v1/sessions/any-session/context?token_budget=-1")
 


### PR DESCRIPTION
## Summary
- return an empty session context instead of 404 for missing session context requests
- add a regression test for the nonexistent session context contract

## Tests
- pytest tests/server/test_api_sessions.py::test_get_session_context_nonexistent_returns_empty_context tests/server/test_api_sessions.py::test_get_session_context -q