### PR TITLE
docs(config): correct documented agent_memory_enabled default false → true (#2456)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1156,7 +1156,7 @@ For memory-related settings, add a `memory` section in `ov.conf`:
 {
   "memory": {
     "version": "v2",
-    "agent_memory_enabled": false
+    "agent_memory_enabled": true
   }
 }
 ```
@@ -1164,7 +1164,7 @@ For memory-related settings, add a `memory` section in `ov.conf`:
 | Field | Description | Default |
 |-------|-------------|---------|
 | `version` | Memory implementation version. Only `"v2"` is supported (legacy `"v1"` removed in #2264 — passing `"v1"` now raises a `ValueError` at config load). | `"v2"` |
-| `agent_memory_enabled` | Enables trajectory/experience memory extraction after user-memory extraction. | `false` |
+| `agent_memory_enabled` | Enables trajectory/experience memory extraction after user-memory extraction. | `true` |
 
 ### ovcli.conf
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1128,7 +1128,7 @@ openviking-server --config /path/to/ov.conf
 {
   "memory": {
     "version": "v2",
-    "agent_memory_enabled": false
+    "agent_memory_enabled": true
   }
 }
 ```
@@ -1136,7 +1136,7 @@ openviking-server --config /path/to/ov.conf
 | 字段 | 说明 | 默认值 |
 |------|------|--------|
 | `version` | 记忆实现版本。仅支持 `"v2"`（#2264 已移除旧版 `"v1"`；传入 `"v1"` 会在配置加载时抛出 `ValueError`）。 | `"v2"` |
-| `agent_memory_enabled` | 在用户记忆抽取之后启用 trajectory/experience 记忆抽取。 | `false` |
+| `agent_memory_enabled` | 在用户记忆抽取之后启用 trajectory/experience 记忆抽取。 | `true` |
 
 ### ovcli.conf
 


### PR DESCRIPTION
#2456 flipped `MemoryConfig.agent_memory_enabled` to default `True` — trajectory/experience memory extraction (a two-phase pipeline that runs after user-memory extraction) is now **on by default** — but the configuration reference still documents the default as `false` in both EN and ZH.

Source of truth: `openviking_cli/utils/config/memory_config.py:35`
```python
agent_memory_enabled: bool = Field(
    default=True,
    description="Enable trajectory/experience memory extraction. When true (default), ...",
)
```

This syncs the documented default (table cell + example snippet) to the shipped behavior, so users budgeting cost/latency or reasoning about what memory gets written are not misled.

- `docs/en/guides/01-configuration.md`: default cell + example `false` → `true`
- `docs/zh/guides/01-configuration.md`: 同上

Pure docs, no code changes.