### PR TITLE
feat(cli): rename config providers

### DIFF
--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use crate::error::{Error, Result};
 
 const OPENVIKING_CLI_CONFIG_ENV: &str = "OPENVIKING_CLI_CONFIG_FILE";
-pub const DEFAULT_SELF_MANAGED_PORT: &str = "1933";
-pub const DEFAULT_SELF_MANAGED_URL: &str = "http://127.0.0.1:1933";
+pub const DEFAULT_CUSTOM_PORT: &str = "1933";
+pub const DEFAULT_CUSTOM_URL: &str = "http://127.0.0.1:1933";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UploadConfig {
@@ -90,7 +90,7 @@ pub(crate) struct EffectiveAuth {
 }
 
 fn default_url() -> String {
-    DEFAULT_SELF_MANAGED_URL.to_string()
+    DEFAULT_CUSTOM_URL.to_string()
 }
 
 fn default_timeout() -> f64 {
@@ -144,7 +144,7 @@ fn is_default_profile(value: &bool) -> bool {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            url: DEFAULT_SELF_MANAGED_URL.to_string(),
+            url: DEFAULT_CUSTOM_URL.to_string(),
             api_key: None,
             root_api_key: None,
             account: None,

--- a/crates/ov_cli/src/config_agent.rs
+++ b/crates/ov_cli/src/config_agent.rs
@@ -169,7 +169,7 @@ pub(crate) fn switch(name: String, _ctx: &CliContext) -> AgentResult<AgentOutput
     Ok(AgentOutput::Switch(SwitchResult {
         action: "switch",
         name,
-        kind: ConfigKind::from_config(&config).label(),
+        kind: ConfigKind::from_config(&config).compact_label(),
         url: config.url,
         active_path: path_string(store.active_path()),
         activated: true,
@@ -184,7 +184,7 @@ pub(crate) fn list(_ctx: &CliContext) -> AgentResult<AgentOutput> {
         .into_iter()
         .map(|entry| ListEntry {
             name: entry.name,
-            kind: entry.kind.label(),
+            kind: entry.kind.compact_label(),
             url: entry.config.url,
             active: entry.is_active,
         })
@@ -714,7 +714,7 @@ fn add_edit_result(
     AddEditResult {
         action,
         name: name.to_string(),
-        kind: kind.label(),
+        kind: kind.compact_label(),
         url: config.url.clone(),
         saved_path: store
             .saved_config_path(name)
@@ -855,7 +855,7 @@ fn config_name_or_generate(
 
     let prefix = match kind {
         ConfigKind::OpenVikingService => "ov-service",
-        ConfigKind::Custom => "local",
+        ConfigKind::Custom => "custom",
     };
     for _ in 0..32 {
         let suffix = Uuid::new_v4().simple().to_string();
@@ -1032,10 +1032,35 @@ mod tests {
         let dir = unique_dir("name");
         fs::create_dir_all(&dir).expect("dir should exist");
         let store = ConfigStore::for_config_dir(dir);
+
         let name = config_name_or_generate(&store, None, ConfigKind::OpenVikingService)
             .expect("name should generate");
         assert!(name.starts_with("ov-service-"));
         validate_config_name(&name).expect("generated name should be valid");
+
+        let name =
+            config_name_or_generate(&store, None, ConfigKind::Custom).expect("name should generate");
+        assert!(name.starts_with("custom-"));
+        validate_config_name(&name).expect("generated name should be valid");
+    }
+
+    #[test]
+    fn agent_json_kind_uses_compact_provider_label() {
+        let dir = unique_dir("json-kind");
+        fs::create_dir_all(&dir).expect("dir should exist");
+        let store = ConfigStore::for_config_dir(dir);
+        let config = sample_config(OPENVIKING_SERVICE_URL, Some("key"));
+
+        let result = add_edit_result(
+            &store,
+            "add",
+            "serverless",
+            ConfigKind::OpenVikingService,
+            &config,
+            false,
+        );
+
+        assert_eq!(result.kind, "OpenViking Service");
     }
 
     #[test]

--- a/crates/ov_cli/src/config_agent.rs
+++ b/crates/ov_cli/src/config_agent.rs
@@ -10,14 +10,14 @@ use serde_json::json;
 use uuid::Uuid;
 
 use crate::{
-    CliContext, ConfigAddCloudArgs, ConfigAddSelfManagedArgs, ConfigAddTarget, ConfigDeleteArgs,
+    CliContext, ConfigAddCustomArgs, ConfigAddOvServiceArgs, ConfigAddTarget, ConfigDeleteArgs,
     ConfigEditArgs,
-    config::{Config, DEFAULT_SELF_MANAGED_URL, display_config_home},
+    config::{Config, DEFAULT_CUSTOM_URL, display_config_home},
     config_wizard::{
-        ApiKeyRole, ConfigKind, ConfigStore, VOLCENGINE_CLOUD_URL, configs_equivalent,
-        normalize_self_managed_url, self_managed_allows_empty_api_key,
-        self_managed_requires_api_key, validate_account_id_value,
-        validate_candidate_config_with_role, validate_config_name, validate_user_id_value,
+        ApiKeyRole, ConfigKind, ConfigStore, OPENVIKING_SERVICE_URL, configs_equivalent,
+        custom_allows_empty_api_key, custom_requires_api_key, normalize_custom_url,
+        validate_account_id_value, validate_candidate_config_with_role, validate_config_name,
+        validate_user_id_value,
     },
     error::Error,
     output::OutputFormat,
@@ -148,8 +148,8 @@ pub(crate) enum AgentOutput {
 pub(crate) async fn add(target: ConfigAddTarget, _ctx: &CliContext) -> AgentResult<AgentOutput> {
     let store = ConfigStore::new().map_err(config_error)?;
     let result = match target {
-        ConfigAddTarget::Cloud(args) => add_cloud(&store, args).await?,
-        ConfigAddTarget::SelfManaged(args) => add_self_managed(&store, args).await?,
+        ConfigAddTarget::OvService(args) => add_ov_service(&store, args).await?,
+        ConfigAddTarget::Custom(args) => add_custom(&store, args).await?,
     };
     Ok(AgentOutput::AddEdit(result))
 }
@@ -308,16 +308,19 @@ pub(crate) fn print_error(error: &AgentError, ctx: &CliContext) {
     }
 }
 
-async fn add_cloud(store: &ConfigStore, args: ConfigAddCloudArgs) -> AgentResult<AddEditResult> {
-    let name = config_name_or_generate(store, args.name, ConfigKind::VolcengineCloud)?;
+async fn add_ov_service(
+    store: &ConfigStore,
+    args: ConfigAddOvServiceArgs,
+) -> AgentResult<AddEditResult> {
+    let name = config_name_or_generate(store, args.name, ConfigKind::OpenVikingService)?;
     let api_key = read_required_secret(
         secret_input(args.api_key_stdin, args.api_key_env.as_deref()),
-        "cloud API key",
+        "OpenViking Service API key",
     )?;
     validate_optional_identity(args.account.as_deref(), args.user.as_deref())?;
 
     let config = Config {
-        url: VOLCENGINE_CLOUD_URL.to_string(),
+        url: OPENVIKING_SERVICE_URL.to_string(),
         api_key: Some(api_key),
         root_api_key: None,
         account: args.account,
@@ -328,7 +331,7 @@ async fn add_cloud(store: &ConfigStore, args: ConfigAddCloudArgs) -> AgentResult
     if let Some(result) = existing_add_preflight(
         store,
         &name,
-        ConfigKind::VolcengineCloud,
+        ConfigKind::OpenVikingService,
         &config,
         args.activate,
         args.force,
@@ -336,11 +339,11 @@ async fn add_cloud(store: &ConfigStore, args: ConfigAddCloudArgs) -> AgentResult
         return Ok(result);
     }
 
-    validate_config_for_write(&config, ConfigKind::VolcengineCloud, true).await?;
+    validate_config_for_write(&config, ConfigKind::OpenVikingService, true).await?;
     save_new_config(
         store,
         &name,
-        ConfigKind::VolcengineCloud,
+        ConfigKind::OpenVikingService,
         &config,
         args.activate,
         args.force,
@@ -348,11 +351,8 @@ async fn add_cloud(store: &ConfigStore, args: ConfigAddCloudArgs) -> AgentResult
     )
 }
 
-async fn add_self_managed(
-    store: &ConfigStore,
-    args: ConfigAddSelfManagedArgs,
-) -> AgentResult<AddEditResult> {
-    let name = config_name_or_generate(store, args.name, ConfigKind::SelfManaged)?;
+async fn add_custom(store: &ConfigStore, args: ConfigAddCustomArgs) -> AgentResult<AddEditResult> {
+    let name = config_name_or_generate(store, args.name, ConfigKind::Custom)?;
     validate_optional_identity(args.account.as_deref(), args.user.as_deref())?;
     let api_key = read_optional_secret(
         secret_input(args.api_key_stdin, args.api_key_env.as_deref()),
@@ -362,14 +362,14 @@ async fn add_self_managed(
         secret_input(args.root_api_key_stdin, args.root_api_key_env.as_deref()),
         "root API key",
     )?;
-    let url = normalize_self_managed_url(args.url.as_deref().unwrap_or(DEFAULT_SELF_MANAGED_URL));
+    let url = normalize_custom_url(args.url.as_deref().unwrap_or(DEFAULT_CUSTOM_URL));
 
-    let config = build_self_managed_config(url, api_key, root_api_key, args.account, args.user)?;
+    let config = build_custom_config(url, api_key, root_api_key, args.account, args.user)?;
 
     if let Some(result) = existing_add_preflight(
         store,
         &name,
-        ConfigKind::SelfManaged,
+        ConfigKind::Custom,
         &config,
         args.activate,
         args.force,
@@ -377,12 +377,12 @@ async fn add_self_managed(
         return Ok(result);
     }
 
-    validate_config_for_write(&config, ConfigKind::SelfManaged, false).await?;
+    validate_config_for_write(&config, ConfigKind::Custom, false).await?;
 
     save_new_config(
         store,
         &name,
-        ConfigKind::SelfManaged,
+        ConfigKind::Custom,
         &config,
         args.activate,
         args.force,
@@ -410,9 +410,9 @@ async fn edit_saved_config(
     validate_config_name(&new_name).map_err(config_error)?;
     validate_optional_identity(args.account.as_deref(), args.user.as_deref())?;
 
-    if old_kind == ConfigKind::VolcengineCloud && args.url.is_some() {
+    if old_kind == ConfigKind::OpenVikingService && args.url.is_some() {
         return Err(AgentError::bad_input(
-            "Volcengine Cloud configs use a fixed server URL.",
+            "OpenViking Service configs use a fixed server URL.",
         ));
     }
 
@@ -427,7 +427,7 @@ async fn edit_saved_config(
 
     let mut edited = existing.clone();
     if let Some(url) = args.url.as_deref() {
-        edited.url = normalize_self_managed_url(url);
+        edited.url = normalize_custom_url(url);
     }
     if args.clear_api_key {
         edited.api_key = None;
@@ -462,10 +462,10 @@ async fn edit_saved_config(
     }
 
     let new_kind = ConfigKind::from_config(&edited);
-    if new_kind == ConfigKind::SelfManaged {
-        finalize_self_managed_identity(&mut edited)?;
+    if new_kind == ConfigKind::Custom {
+        finalize_custom_identity(&mut edited)?;
     }
-    validate_config_for_write(&edited, new_kind, new_kind == ConfigKind::VolcengineCloud).await?;
+    validate_config_for_write(&edited, new_kind, new_kind == ConfigKind::OpenVikingService).await?;
 
     save_edited_config(
         store,
@@ -477,20 +477,20 @@ async fn edit_saved_config(
     )
 }
 
-fn build_self_managed_config(
+fn build_custom_config(
     url: String,
     api_key: Option<String>,
     root_api_key: Option<String>,
     mut account: Option<String>,
     mut user: Option<String>,
 ) -> AgentResult<Config> {
-    if api_key.is_none() && root_api_key.is_none() && self_managed_requires_api_key(&url) {
+    if api_key.is_none() && root_api_key.is_none() && custom_requires_api_key(&url) {
         return Err(AgentError::bad_input(
-            "Remote self-managed servers require --api-key-stdin, --api-key-env, --root-api-key-stdin, or --root-api-key-env.",
+            "Remote custom servers require --api-key-stdin, --api-key-env, --root-api-key-stdin, or --root-api-key-env.",
         ));
     }
 
-    if api_key.is_none() && root_api_key.is_none() && self_managed_allows_empty_api_key(&url) {
+    if api_key.is_none() && root_api_key.is_none() && custom_allows_empty_api_key(&url) {
         account.get_or_insert_with(|| "default".to_string());
         user.get_or_insert_with(|| "default".to_string());
     }
@@ -504,12 +504,12 @@ fn build_self_managed_config(
         ..Config::default()
     };
 
-    finalize_self_managed_identity(&mut config)?;
+    finalize_custom_identity(&mut config)?;
 
     Ok(config)
 }
 
-fn finalize_self_managed_identity(config: &mut Config) -> AgentResult<()> {
+fn finalize_custom_identity(config: &mut Config) -> AgentResult<()> {
     if config.api_key.is_none() {
         config.api_key = config.root_api_key.clone();
     }
@@ -547,7 +547,7 @@ async fn validate_config_for_write(
         Err(error) => return Err(validation_error(kind, error)),
     };
 
-    if kind == ConfigKind::SelfManaged
+    if kind == ConfigKind::Custom
         && api_key_role == Some(ApiKeyRole::Root)
         && !root_as_normal(config)
     {
@@ -854,8 +854,8 @@ fn config_name_or_generate(
     }
 
     let prefix = match kind {
-        ConfigKind::VolcengineCloud => "cloud",
-        ConfigKind::SelfManaged => "local",
+        ConfigKind::OpenVikingService => "ov-service",
+        ConfigKind::Custom => "local",
     };
     for _ in 0..32 {
         let suffix = Uuid::new_v4().simple().to_string();
@@ -888,15 +888,15 @@ fn validation_error(kind: ConfigKind, error: Error) -> AgentError {
         Error::Api { message, .. } => AgentError::auth(format!(
             "{} {message}",
             match kind {
-                ConfigKind::VolcengineCloud => "Check the API key.",
-                ConfigKind::SelfManaged => "Check the API key, account, and user.",
+                ConfigKind::OpenVikingService => "Check the API key.",
+                ConfigKind::Custom => "Check the API key, account, and user.",
             }
         )),
         Error::Network(message) => AgentError::validation(format!(
             "{} {message}",
             match kind {
-                ConfigKind::VolcengineCloud => "Could not reach Volcengine Cloud.",
-                ConfigKind::SelfManaged => "Could not reach the self-managed server.",
+                ConfigKind::OpenVikingService => "Could not reach OpenViking Service.",
+                ConfigKind::Custom => "Could not reach the custom server.",
             }
         )),
         Error::Config(message) => AgentError::bad_input(message),
@@ -1032,9 +1032,9 @@ mod tests {
         let dir = unique_dir("name");
         fs::create_dir_all(&dir).expect("dir should exist");
         let store = ConfigStore::for_config_dir(dir);
-        let name = config_name_or_generate(&store, None, ConfigKind::VolcengineCloud)
+        let name = config_name_or_generate(&store, None, ConfigKind::OpenVikingService)
             .expect("name should generate");
-        assert!(name.starts_with("cloud-"));
+        assert!(name.starts_with("ov-service-"));
         validate_config_name(&name).expect("generated name should be valid");
     }
 
@@ -1051,7 +1051,7 @@ mod tests {
         let result = save_new_config(
             &store,
             "local",
-            ConfigKind::SelfManaged,
+            ConfigKind::Custom,
             &config,
             false,
             false,
@@ -1078,7 +1078,7 @@ mod tests {
         let error = save_new_config(
             &store,
             "local",
-            ConfigKind::SelfManaged,
+            ConfigKind::Custom,
             &sample_config("http://127.0.0.1:1933", Some("new")),
             false,
             false,
@@ -1090,15 +1090,15 @@ mod tests {
     }
 
     #[test]
-    fn self_managed_root_only_config_populates_normal_and_root_keys() {
-        let config = build_self_managed_config(
+    fn custom_root_only_config_populates_normal_and_root_keys() {
+        let config = build_custom_config(
             "http://127.0.0.1:1933".to_string(),
             None,
             Some("root-key".to_string()),
             Some("acme".to_string()),
             Some("alice".to_string()),
         )
-        .expect("root-only self-managed config should build");
+        .expect("root-only custom config should build");
 
         assert_eq!(config.api_key.as_deref(), Some("root-key"));
         assert_eq!(config.root_api_key.as_deref(), Some("root-key"));
@@ -1107,23 +1107,23 @@ mod tests {
     }
 
     #[test]
-    fn self_managed_user_and_root_keys_stay_separate() {
-        let config = build_self_managed_config(
+    fn custom_user_and_root_keys_stay_separate() {
+        let config = build_custom_config(
             "https://ov.example.com".to_string(),
             Some("user-key".to_string()),
             Some("root-key".to_string()),
             Some("acme".to_string()),
             Some("alice".to_string()),
         )
-        .expect("self-managed config with both keys should build");
+        .expect("custom config with both keys should build");
 
         assert_eq!(config.api_key.as_deref(), Some("user-key"));
         assert_eq!(config.root_api_key.as_deref(), Some("root-key"));
     }
 
     #[test]
-    fn self_managed_root_key_requires_explicit_identity() {
-        let error = build_self_managed_config(
+    fn custom_root_key_requires_explicit_identity() {
+        let error = build_custom_config(
             "http://127.0.0.1:1933".to_string(),
             None,
             Some("root-key".to_string()),
@@ -1136,25 +1136,25 @@ mod tests {
     }
 
     #[test]
-    fn self_managed_finalization_promotes_root_only_to_root_as_normal() {
+    fn custom_finalization_promotes_root_only_to_root_as_normal() {
         let mut config = sample_config("http://127.0.0.1:1933", None);
         config.root_api_key = Some("root-key".to_string());
         config.account = Some("acme".to_string());
         config.user = Some("alice".to_string());
 
-        finalize_self_managed_identity(&mut config).expect("root-only config should finalize");
+        finalize_custom_identity(&mut config).expect("root-only config should finalize");
 
         assert_eq!(config.api_key.as_deref(), Some("root-key"));
         assert_eq!(config.root_api_key.as_deref(), Some("root-key"));
     }
 
     #[test]
-    fn self_managed_finalization_rejects_root_as_normal_without_identity() {
+    fn custom_finalization_rejects_root_as_normal_without_identity() {
         let mut config = sample_config("http://127.0.0.1:1933", None);
         config.root_api_key = Some("root-key".to_string());
         config.user = Some("alice".to_string());
 
-        let error = finalize_self_managed_identity(&mut config)
+        let error = finalize_custom_identity(&mut config)
             .expect_err("root-as-normal requires explicit account and user");
 
         assert_eq!(error.exit_code(), EXIT_AUTH);
@@ -1162,7 +1162,7 @@ mod tests {
 
     #[test]
     fn add_and_edit_finalization_converge_on_root_as_normal_shape() {
-        let add_config = build_self_managed_config(
+        let add_config = build_custom_config(
             "http://127.0.0.1:1933".to_string(),
             None,
             Some("root-key".to_string()),
@@ -1175,7 +1175,7 @@ mod tests {
         edit_config.root_api_key = Some("root-key".to_string());
         edit_config.account = Some("acme".to_string());
         edit_config.user = Some("alice".to_string());
-        finalize_self_managed_identity(&mut edit_config)
+        finalize_custom_identity(&mut edit_config)
             .expect("edit path should finalize to root-as-normal config");
 
         assert_eq!(edit_config.api_key, add_config.api_key);
@@ -1247,7 +1247,7 @@ mod tests {
         let error = save_new_config(
             &store,
             "local",
-            ConfigKind::SelfManaged,
+            ConfigKind::Custom,
             &sample_config("http://127.0.0.1:1933", Some("new")),
             false,
             true,

--- a/crates/ov_cli/src/config_command_ui.rs
+++ b/crates/ov_cli/src/config_command_ui.rs
@@ -299,10 +299,10 @@ fn unknown(language: Language) -> &'static str {
 
 fn kind_label(kind: ConfigKind, language: Language) -> &'static str {
     match language {
-        Language::En => kind.label(),
+        Language::En => kind.compact_label(),
         Language::ZhCn => match kind {
-            ConfigKind::VolcengineCloud => "火山引擎云",
-            ConfigKind::SelfManaged => "自托管",
+            ConfigKind::OpenVikingService => "OpenViking 服务",
+            ConfigKind::Custom => "自定义",
         },
     }
 }
@@ -321,7 +321,10 @@ fn copy_target_validation_failed(language: Language, name: &str) -> String {
     }
 }
 
-fn invalid_saved_configs_notice(language: Language, invalid_config_names: &[String]) -> Option<String> {
+fn invalid_saved_configs_notice(
+    language: Language,
+    invalid_config_names: &[String],
+) -> Option<String> {
     if invalid_config_names.is_empty() {
         return None;
     }
@@ -476,7 +479,7 @@ mod tests {
 
         let plain = strip_ansi(&rendered);
         assert!(plain.contains("OPENVIKING CONFIG CHECK"));
-        assert!(plain.contains("Active        VPS (Self-Managed)"));
+        assert!(plain.contains("Active        VPS (Custom)"));
         assert!(plain.contains("Server        http://127.0.0.1:1933"));
         assert!(plain.contains("Config file   valid"));
         assert!(plain.contains("Server        reachable"));
@@ -507,19 +510,24 @@ mod tests {
         let labels = super::switch_labels(&[
             super::SwitchConfigRow {
                 name: "local".to_string(),
-                kind: ConfigKind::SelfManaged,
+                kind: ConfigKind::Custom,
                 is_active: true,
             },
             super::SwitchConfigRow {
-                name: "cloud-799f84".to_string(),
-                kind: ConfigKind::VolcengineCloud,
+                name: "ov-service-799f84".to_string(),
+                kind: ConfigKind::OpenVikingService,
                 is_active: false,
             },
         ]);
 
         let plain = strip_ansi(&labels.join("\n"));
-        assert!(plain.contains("local            Self-Managed      [Active]"));
-        assert!(plain.contains("cloud-799f84     VolcEngine Cloud"));
+        assert!(plain.lines().any(|line| line.contains("local")
+            && line.contains("Custom")
+            && line.contains("[Active]")));
+        assert!(plain.lines().any(|line| line.contains("ov-service-799f84")
+            && line.contains("OpenViking Service")
+            && !line.contains("VolcEngine Cloud")
+            && !line.contains("[Active]")));
         assert_eq!(plain.matches("[Active]").count(), 1);
         assert!(!plain.contains("http://"));
         assert!(!plain.contains("https://"));

--- a/crates/ov_cli/src/config_wizard/mod.rs
+++ b/crates/ov_cli/src/config_wizard/mod.rs
@@ -2,10 +2,10 @@ mod store;
 mod wizard;
 
 pub(crate) use store::{
-    ApiKeyRole, ConfigKind, ConfigStore, VOLCENGINE_CLOUD_URL, configs_equivalent,
-    normalize_self_managed_url, self_managed_allows_empty_api_key,
-    self_managed_requires_api_key, validate_account_id_value,
-    validate_candidate_config_with_role, validate_config_name, validate_user_id_value,
+    ApiKeyRole, ConfigKind, ConfigStore, OPENVIKING_SERVICE_URL, configs_equivalent,
+    custom_allows_empty_api_key, custom_requires_api_key, normalize_custom_url,
+    validate_account_id_value, validate_candidate_config_with_role, validate_config_name,
+    validate_user_id_value,
 };
 pub use store::{redacted_config_value, validate_config};
 pub use wizard::run_config_wizard;

--- a/crates/ov_cli/src/config_wizard/store.rs
+++ b/crates/ov_cli/src/config_wizard/store.rs
@@ -9,31 +9,38 @@ use url::Url;
 
 use crate::{
     base_client::BaseClient,
-    config::{Config, DEFAULT_SELF_MANAGED_PORT, default_config_path},
+    config::{Config, DEFAULT_CUSTOM_PORT, default_config_path},
     error::{Error, Result},
 };
 
-pub const VOLCENGINE_CLOUD_URL: &str = "https://api.vikingdb.cn-beijing.volces.com/openviking";
+pub const OPENVIKING_SERVICE_URL: &str = "https://api.vikingdb.cn-beijing.volces.com/openviking";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigKind {
-    VolcengineCloud,
-    SelfManaged,
+    OpenVikingService,
+    Custom,
 }
 
 impl ConfigKind {
     pub(crate) fn label(self) -> &'static str {
         match self {
-            Self::VolcengineCloud => "VolcEngine Cloud",
-            Self::SelfManaged => "Self-Managed",
+            Self::OpenVikingService => "OpenViking Service (VolcEngine Cloud)",
+            Self::Custom => "Custom",
+        }
+    }
+
+    pub(crate) fn compact_label(self) -> &'static str {
+        match self {
+            Self::OpenVikingService => "OpenViking Service",
+            Self::Custom => "Custom",
         }
     }
 
     pub(crate) fn from_config(config: &Config) -> Self {
-        if config.url.trim_end_matches('/') == VOLCENGINE_CLOUD_URL {
-            Self::VolcengineCloud
+        if config.url.trim_end_matches('/') == OPENVIKING_SERVICE_URL {
+            Self::OpenVikingService
         } else {
-            Self::SelfManaged
+            Self::Custom
         }
     }
 }
@@ -438,29 +445,31 @@ pub fn build_config(draft: &ConfigDraft) -> Result<Config> {
     let account = non_empty_option(draft.account.as_deref());
     let user = non_empty_option(draft.user.as_deref());
     match draft.kind {
-        ConfigKind::VolcengineCloud => {
+        ConfigKind::OpenVikingService => {
             let api_key = non_empty_option(draft.api_key.as_deref()).ok_or_else(|| {
-                Error::Config("VolcEngine Cloud configs require an API key".to_string())
+                Error::Config(
+                    "OpenViking Service (VolcEngine Cloud) configs require an API key".to_string(),
+                )
             })?;
-            config.url = VOLCENGINE_CLOUD_URL.to_string();
+            config.url = OPENVIKING_SERVICE_URL.to_string();
             config.api_key = Some(api_key);
             config.root_api_key = None;
             config.account = account;
             config.user = user;
         }
-        ConfigKind::SelfManaged => {
-            let url = normalize_self_managed_url(&draft.url);
+        ConfigKind::Custom => {
+            let url = normalize_custom_url(&draft.url);
             if url.is_empty() {
                 return Err(Error::Config(
-                    "Self-managed configs require a server URL".to_string(),
+                    "Custom configs require a server URL".to_string(),
                 ));
             }
             let root_api_key = non_empty_option(draft.root_api_key.as_deref());
             let api_key =
                 non_empty_option(draft.api_key.as_deref()).or_else(|| root_api_key.clone());
-            if api_key.is_none() && self_managed_requires_api_key(&url) {
+            if api_key.is_none() && custom_requires_api_key(&url) {
                 return Err(Error::Config(
-                    "Remote self-managed configs require an API key".to_string(),
+                    "Remote custom configs require an API key".to_string(),
                 ));
             }
             config.url = url.trim_end_matches('/').to_string();
@@ -474,12 +483,12 @@ pub fn build_config(draft: &ConfigDraft) -> Result<Config> {
     Ok(config)
 }
 
-pub(crate) fn self_managed_requires_api_key(url: &str) -> bool {
-    !self_managed_allows_empty_api_key(url)
+pub(crate) fn custom_requires_api_key(url: &str) -> bool {
+    !custom_allows_empty_api_key(url)
 }
 
-pub(crate) fn self_managed_allows_empty_api_key(url: &str) -> bool {
-    let normalized = normalize_self_managed_url(url);
+pub(crate) fn custom_allows_empty_api_key(url: &str) -> bool {
+    let normalized = normalize_custom_url(url);
     let Ok(parsed) = Url::parse(&normalized) else {
         return false;
     };
@@ -489,10 +498,10 @@ pub(crate) fn self_managed_allows_empty_api_key(url: &str) -> bool {
     )
 }
 
-pub(crate) fn normalize_self_managed_url(url: &str) -> String {
+pub(crate) fn normalize_custom_url(url: &str) -> String {
     let trimmed = url.trim().trim_end_matches('/');
     if trimmed.eq_ignore_ascii_case("::1") || trimmed.eq_ignore_ascii_case("[::1]") {
-        return format!("http://[::1]:{DEFAULT_SELF_MANAGED_PORT}");
+        return format!("http://[::1]:{DEFAULT_CUSTOM_PORT}");
     }
     if let Some(port) = trimmed.strip_prefix("[::1]:")
         && !port.trim().is_empty()
@@ -515,7 +524,7 @@ pub(crate) fn normalize_self_managed_url(url: &str) -> String {
         "localhost" | "127.0.0.1"
     ) {
         if port.trim().is_empty() {
-            format!("http://{host}:{DEFAULT_SELF_MANAGED_PORT}")
+            format!("http://{host}:{DEFAULT_CUSTOM_PORT}")
         } else {
             format!("http://{host}:{port}")
         }
@@ -609,7 +618,7 @@ fn admin_probe_regular_key_status(status: u16) -> bool {
         status,
         // 401/403 means the key works but does not have admin access.
         401 | 403
-            // Some self-managed deployments may not expose the admin endpoint.
+            // Some custom deployments may not expose the admin endpoint.
             // Treat explicit absence as regular access rather than blocking a
             // valid non-admin setup.
             | 404
@@ -639,10 +648,10 @@ fn should_run_authenticated_probe(
 
 pub(crate) fn validation_error_copy(kind: ConfigKind, _error: &Error) -> String {
     match kind {
-        ConfigKind::VolcengineCloud => {
+        ConfigKind::OpenVikingService => {
             "Validation failed. Check your API key and try again.".to_string()
         }
-        ConfigKind::SelfManaged => {
+        ConfigKind::Custom => {
             "Validation failed. Check the server URL and API key if required.".to_string()
         }
     }
@@ -696,7 +705,7 @@ fn non_empty_option(value: Option<&str>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApiKeyRole, ConfigDraft, ConfigKind, ConfigStore, VOLCENGINE_CLOUD_URL,
+        ApiKeyRole, ConfigDraft, ConfigKind, ConfigStore, OPENVIKING_SERVICE_URL,
         admin_probe_ambiguous_status, admin_probe_regular_key_status, build_config,
         should_run_authenticated_probe, validate_candidate_config,
         validate_candidate_config_with_role, validate_config_name, validation_error_copy,
@@ -724,8 +733,15 @@ mod tests {
     }
 
     #[test]
-    fn cloud_provider_label_uses_product_casing() {
-        assert_eq!(ConfigKind::VolcengineCloud.label(), "VolcEngine Cloud");
+    fn openviking_service_provider_label_uses_product_casing() {
+        assert_eq!(
+            ConfigKind::OpenVikingService.label(),
+            "OpenViking Service (VolcEngine Cloud)"
+        );
+        assert_eq!(
+            ConfigKind::OpenVikingService.compact_label(),
+            "OpenViking Service"
+        );
     }
 
     fn write_config(path: &Path, config: &Config) {
@@ -815,19 +831,19 @@ mod tests {
     }
 
     #[test]
-    fn cloud_config_listing_marks_only_one_duplicate_as_active() {
-        let dir = unique_dir("duplicate-cloud-active");
+    fn openviking_service_config_listing_marks_only_one_duplicate_as_active() {
+        let dir = unique_dir("duplicate-ov-service-active");
         let store = ConfigStore::for_config_dir(dir.clone());
-        let config = sample_config(VOLCENGINE_CLOUD_URL, Some("cloud-key"));
+        let config = sample_config(OPENVIKING_SERVICE_URL, Some("service-key"));
         store
-            .save_named_config("cloud", &config)
-            .expect("cloud config should save");
+            .save_named_config("ov-service", &config)
+            .expect("ov-service config should save");
         store
-            .save_named_config("cloud-copy", &config)
-            .expect("cloud copy config should save");
+            .save_named_config("ov-service-copy", &config)
+            .expect("ov-service copy config should save");
         store
-            .activate_config("cloud")
-            .expect("cloud config should become active");
+            .activate_config("ov-service")
+            .expect("ov-service config should become active");
 
         let configs = store.list_configs().expect("configs should load");
         let active = configs
@@ -836,11 +852,15 @@ mod tests {
             .map(|entry| entry.name.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(active, vec!["cloud"]);
-        assert!(store.is_config_name_active("cloud").expect("active check"));
+        assert_eq!(active, vec!["ov-service"]);
+        assert!(
+            store
+                .is_config_name_active("ov-service")
+                .expect("active check")
+        );
         assert!(
             !store
-                .is_config_name_active("cloud-copy")
+                .is_config_name_active("ov-service-copy")
                 .expect("copy active check")
         );
     }
@@ -856,10 +876,10 @@ mod tests {
     }
 
     #[test]
-    fn volcengine_config_uses_fixed_url_and_requires_api_key() {
+    fn openviking_service_config_uses_fixed_url_and_requires_api_key() {
         let missing_key = ConfigDraft {
-            name: "cloud".to_string(),
-            kind: ConfigKind::VolcengineCloud,
+            name: "ov-service".to_string(),
+            kind: ConfigKind::OpenVikingService,
             url: String::new(),
             api_key: None,
             root_api_key: None,
@@ -872,24 +892,24 @@ mod tests {
             api_key: Some("viking-key".to_string()),
             ..missing_key
         };
-        let config = build_config(&draft).expect("cloud config should build");
+        let config = build_config(&draft).expect("ov-service config should build");
 
-        assert_eq!(config.url, VOLCENGINE_CLOUD_URL);
+        assert_eq!(config.url, OPENVIKING_SERVICE_URL);
         assert_eq!(config.api_key.as_deref(), Some("viking-key"));
     }
 
     #[test]
-    fn self_managed_config_accepts_custom_url_and_optional_key() {
+    fn custom_config_accepts_custom_url_and_optional_key() {
         let draft = ConfigDraft {
             name: "local".to_string(),
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
             url: "http://127.0.0.1:1933".to_string(),
             api_key: None,
             root_api_key: None,
             account: Some("default".to_string()),
             user: Some("default".to_string()),
         };
-        let without_key = build_config(&draft).expect("self-managed config should build");
+        let without_key = build_config(&draft).expect("custom config should build");
         assert_eq!(without_key.url, "http://127.0.0.1:1933");
         assert!(without_key.api_key.is_none());
         assert_eq!(without_key.account.as_deref(), Some("default"));
@@ -902,17 +922,17 @@ mod tests {
             user: None,
             ..draft
         })
-        .expect("self-managed config with key should build");
+        .expect("custom config with key should build");
         assert_eq!(with_key.api_key.as_deref(), Some("local-key"));
         assert!(with_key.account.is_none());
         assert!(with_key.user.is_none());
     }
 
     #[test]
-    fn remote_self_managed_config_requires_api_key() {
+    fn remote_custom_config_requires_api_key() {
         let draft = ConfigDraft {
             name: "remote".to_string(),
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
             url: "https://openviking.example.com".to_string(),
             api_key: None,
             root_api_key: None,
@@ -920,13 +940,13 @@ mod tests {
             user: Some("default".to_string()),
         };
 
-        let error = build_config(&draft).expect_err("remote self-managed requires key");
+        let error = build_config(&draft).expect_err("remote custom requires key");
 
         assert!(error.to_string().contains("API key"));
     }
 
     #[test]
-    fn bare_loopback_self_managed_urls_are_local_and_get_default_port() {
+    fn bare_loopback_custom_urls_are_local_and_get_default_port() {
         for (input, expected) in [
             ("127.0.0.1", "http://127.0.0.1:1933"),
             ("localhost", "http://localhost:1933"),
@@ -937,7 +957,7 @@ mod tests {
         ] {
             let draft = ConfigDraft {
                 name: "local".to_string(),
-                kind: ConfigKind::SelfManaged,
+                kind: ConfigKind::Custom,
                 url: input.to_string(),
                 api_key: None,
                 root_api_key: None,
@@ -988,13 +1008,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn self_managed_config_with_api_key_validates_authenticated_probe() {
+    async fn custom_config_with_api_key_validates_authenticated_probe() {
         let url = spawn_auth_probe_server("good-key").await;
         let config = sample_config(&url, Some("bad-key"));
 
         let error = validate_candidate_config(&config, false)
             .await
-            .expect_err("bad self-managed API key should fail validation");
+            .expect_err("bad custom API key should fail validation");
 
         assert!(matches!(error, crate::error::Error::Api { .. }));
     }
@@ -1051,19 +1071,19 @@ mod tests {
                 .to_string(),
         );
 
-        let cloud = validation_error_copy(ConfigKind::VolcengineCloud, &error);
-        let self_managed = validation_error_copy(ConfigKind::SelfManaged, &error);
+        let cloud = validation_error_copy(ConfigKind::OpenVikingService, &error);
+        let custom = validation_error_copy(ConfigKind::Custom, &error);
 
         assert_eq!(
             cloud,
             "Validation failed. Check your API key and try again."
         );
         assert_eq!(
-            self_managed,
+            custom,
             "Validation failed. Check the server URL and API key if required."
         );
         assert!(!cloud.contains("Request ID"));
-        assert!(!self_managed.contains("AuthenticationError"));
+        assert!(!custom.contains("AuthenticationError"));
     }
 
     #[test]

--- a/crates/ov_cli/src/config_wizard/wizard.rs
+++ b/crates/ov_cli/src/config_wizard/wizard.rs
@@ -246,7 +246,7 @@ fn compact_kind_label(kind: ConfigKind) -> &'static str {
 
 fn provider_labels(language: Language) -> [&'static str; 2] {
     match language {
-        Language::En => ["OpenViking Service (VolcEngine Cloud)", "Custom"],
+        Language::En => [ConfigKind::OpenVikingService.label(), "Custom"],
         Language::ZhCn => ["OpenViking 服务（火山引擎云）", "自定义"],
     }
 }
@@ -3088,7 +3088,7 @@ fn prompt_add_config_name(
 pub(crate) fn allocate_config_name(store: &ConfigStore, kind: ConfigKind) -> Result<String> {
     let prefix = match kind {
         ConfigKind::OpenVikingService => "ov-service",
-        ConfigKind::Custom => "local",
+        ConfigKind::Custom => "custom",
     };
 
     for _ in 0..32 {
@@ -4411,8 +4411,8 @@ mod tests {
         let name = allocate_config_name(&store, ConfigKind::Custom)
             .expect("generated name should be available");
 
-        assert!(name.starts_with("local-"));
-        assert_eq!(name.len(), "local-".len() + 6);
+        assert!(name.starts_with("custom-"));
+        assert_eq!(name.len(), "custom-".len() + 6);
         validate_config_name(&name).expect("generated name should be valid");
     }
 

--- a/crates/ov_cli/src/config_wizard/wizard.rs
+++ b/crates/ov_cli/src/config_wizard/wizard.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use crate::{
     base_client::BaseClient,
-    config::{Config, DEFAULT_SELF_MANAGED_URL},
+    config::{Config, DEFAULT_CUSTOM_URL},
     error::{Error, Result},
     i18n::{self, Language, copy},
     theme::{self, Rgb},
@@ -25,12 +25,12 @@ use serde_json::Value;
 
 use super::store::{
     ApiKeyRole, ConfigDraft, ConfigEntry, ConfigKind, ConfigStore, IdentityField,
-    VOLCENGINE_CLOUD_URL, build_config, self_managed_allows_empty_api_key,
-    validate_candidate_config, validate_candidate_config_with_role, validate_config_name,
-    validate_identity_value, validation_error_copy,
+    OPENVIKING_SERVICE_URL, build_config, custom_allows_empty_api_key, validate_candidate_config,
+    validate_candidate_config_with_role, validate_config_name, validate_identity_value,
+    validation_error_copy,
 };
 
-const VOLCENGINE_API_KEY_URL: &str =
+const OPENVIKING_SERVICE_API_KEY_URL: &str =
     "https://console.volcengine.com/vikingdb/openviking/region:openviking+cn-beijing";
 const HEADER_TAGLINE: &str = "Context Database for AI Agents";
 const HEADER_TAGLINE_ZH: &str = "AI Agent 上下文数据库";
@@ -43,14 +43,14 @@ enum IdentityMode {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum SelfManagedKeyMode {
+enum CustomKeyMode {
     NoKey,
     UserKey,
     RootKey,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum SelfManagedEditKeyAction {
+enum CustomEditKeyAction {
     Keep,
     SetUserKey,
     SetRootKey,
@@ -234,20 +234,20 @@ fn section_delete() -> &'static str {
     )
 }
 
-fn kind_label(kind: ConfigKind) -> &'static str {
+fn compact_kind_label(kind: ConfigKind) -> &'static str {
     match Language::current() {
-        Language::En => kind.label(),
+        Language::En => kind.compact_label(),
         Language::ZhCn => match kind {
-            ConfigKind::VolcengineCloud => "火山引擎云",
-            ConfigKind::SelfManaged => "自托管",
+            ConfigKind::OpenVikingService => "OpenViking 服务",
+            ConfigKind::Custom => "自定义",
         },
     }
 }
 
 fn provider_labels(language: Language) -> [&'static str; 2] {
     match language {
-        Language::En => ["VolcEngine Cloud", "Self-Managed"],
-        Language::ZhCn => ["火山引擎云", "自托管"],
+        Language::En => ["OpenViking Service (VolcEngine Cloud)", "Custom"],
+        Language::ZhCn => ["OpenViking 服务（火山引擎云）", "自定义"],
     }
 }
 
@@ -260,42 +260,39 @@ fn api_key_label(optional: bool) -> &'static str {
     }
 }
 
-fn self_managed_api_key_input_label(mode: SelfManagedKeyMode) -> &'static str {
+fn custom_api_key_input_label(mode: CustomKeyMode) -> &'static str {
     match (Language::current(), mode) {
-        (Language::En, SelfManagedKeyMode::RootKey) => "Root API key",
-        (Language::En, SelfManagedKeyMode::UserKey) => "User API key",
-        (Language::En, SelfManagedKeyMode::NoKey) => "API key",
-        (Language::ZhCn, SelfManagedKeyMode::RootKey) => "Root API Key",
-        (Language::ZhCn, SelfManagedKeyMode::UserKey) => "User API Key",
-        (Language::ZhCn, SelfManagedKeyMode::NoKey) => "API Key",
+        (Language::En, CustomKeyMode::RootKey) => "Root API key",
+        (Language::En, CustomKeyMode::UserKey) => "User API key",
+        (Language::En, CustomKeyMode::NoKey) => "API key",
+        (Language::ZhCn, CustomKeyMode::RootKey) => "Root API Key",
+        (Language::ZhCn, CustomKeyMode::UserKey) => "User API Key",
+        (Language::ZhCn, CustomKeyMode::NoKey) => "API Key",
     }
 }
 
-fn self_managed_api_key_input_helper_lines(mode: SelfManagedKeyMode) -> Vec<String> {
+fn custom_api_key_input_helper_lines(mode: CustomKeyMode) -> Vec<String> {
     let copy = match (Language::current(), mode) {
-        (Language::En, SelfManagedKeyMode::RootKey) => {
+        (Language::En, CustomKeyMode::RootKey) => {
             "For self-hosted admin setup and --sudo commands."
         }
-        (Language::En, SelfManagedKeyMode::UserKey) => "For normal OpenViking commands.",
-        (Language::En, SelfManagedKeyMode::NoKey) => {
+        (Language::En, CustomKeyMode::UserKey) => "For normal OpenViking commands.",
+        (Language::En, CustomKeyMode::NoKey) => {
             "Optional for local servers. Add one if auth is enabled."
         }
-        (Language::ZhCn, SelfManagedKeyMode::RootKey) => "用于自托管管理初始化和 --sudo 命令。",
-        (Language::ZhCn, SelfManagedKeyMode::UserKey) => "用于常规 OpenViking 命令。",
-        (Language::ZhCn, SelfManagedKeyMode::NoKey) => "本地服务可不填；如果启用了认证，请填写。",
+        (Language::ZhCn, CustomKeyMode::RootKey) => "用于自定义管理初始化和 --sudo 命令。",
+        (Language::ZhCn, CustomKeyMode::UserKey) => "用于常规 OpenViking 命令。",
+        (Language::ZhCn, CustomKeyMode::NoKey) => "本地服务可不填；如果启用了认证，请填写。",
     };
     vec![theme::muted(copy).to_string()]
 }
 
 #[cfg(test)]
-fn self_managed_key_mode_labels(allow_empty: bool) -> Vec<&'static str> {
-    self_managed_key_mode_labels_for_language(allow_empty, Language::En)
+fn custom_key_mode_labels(allow_empty: bool) -> Vec<&'static str> {
+    custom_key_mode_labels_for_language(allow_empty, Language::En)
 }
 
-fn self_managed_key_mode_labels_for_language(
-    allow_empty: bool,
-    language: Language,
-) -> Vec<&'static str> {
+fn custom_key_mode_labels_for_language(allow_empty: bool, language: Language) -> Vec<&'static str> {
     match (allow_empty, language) {
         (true, Language::En) => vec!["No key / local dev", "User API key", "Root API key"],
         (false, Language::En) => vec!["User API key", "Root API key"],
@@ -304,69 +301,65 @@ fn self_managed_key_mode_labels_for_language(
     }
 }
 
-fn self_managed_key_mode_for_selection(allow_empty: bool, index: usize) -> SelfManagedKeyMode {
+fn custom_key_mode_for_selection(allow_empty: bool, index: usize) -> CustomKeyMode {
     match (allow_empty, index) {
-        (true, 0) => SelfManagedKeyMode::NoKey,
-        (true, 1) | (false, 0) => SelfManagedKeyMode::UserKey,
-        _ => SelfManagedKeyMode::RootKey,
+        (true, 0) => CustomKeyMode::NoKey,
+        (true, 1) | (false, 0) => CustomKeyMode::UserKey,
+        _ => CustomKeyMode::RootKey,
     }
 }
 
-fn edit_self_managed_key_actions(
+fn edit_custom_key_actions(
     has_normal_user_key: bool,
     has_root_key: bool,
-) -> Vec<SelfManagedEditKeyAction> {
+) -> Vec<CustomEditKeyAction> {
     if !has_normal_user_key && !has_root_key {
         return vec![
-            SelfManagedEditKeyAction::SetUserKey,
-            SelfManagedEditKeyAction::SetRootKey,
+            CustomEditKeyAction::SetUserKey,
+            CustomEditKeyAction::SetRootKey,
         ];
     }
 
     let mut actions = vec![
-        SelfManagedEditKeyAction::Keep,
-        SelfManagedEditKeyAction::SetUserKey,
-        SelfManagedEditKeyAction::SetRootKey,
+        CustomEditKeyAction::Keep,
+        CustomEditKeyAction::SetUserKey,
+        CustomEditKeyAction::SetRootKey,
     ];
     if has_normal_user_key && has_root_key {
-        actions.push(SelfManagedEditKeyAction::UseRootForNormal);
+        actions.push(CustomEditKeyAction::UseRootForNormal);
     }
     if has_root_key {
-        actions.push(SelfManagedEditKeyAction::ClearRootKey);
+        actions.push(CustomEditKeyAction::ClearRootKey);
     }
-    actions.push(SelfManagedEditKeyAction::ClearAllKeys);
+    actions.push(CustomEditKeyAction::ClearAllKeys);
     actions
 }
 
 #[cfg(test)]
-fn edit_self_managed_key_action_labels(
+fn edit_custom_key_action_labels(
     has_normal_user_key: bool,
     has_root_key: bool,
 ) -> Vec<&'static str> {
-    edit_self_managed_key_actions(has_normal_user_key, has_root_key)
+    edit_custom_key_actions(has_normal_user_key, has_root_key)
         .into_iter()
-        .map(self_managed_edit_key_action_label)
+        .map(custom_edit_key_action_label)
         .collect()
 }
 
-fn self_managed_edit_key_action_label(action: SelfManagedEditKeyAction) -> &'static str {
+fn custom_edit_key_action_label(action: CustomEditKeyAction) -> &'static str {
     match (Language::current(), action) {
-        (Language::En, SelfManagedEditKeyAction::Keep) => "Keep existing API keys",
-        (Language::En, SelfManagedEditKeyAction::SetUserKey) => "Set normal user API key",
-        (Language::En, SelfManagedEditKeyAction::SetRootKey) => "Set root API key",
-        (Language::En, SelfManagedEditKeyAction::UseRootForNormal) => {
-            "Use root key for normal commands"
-        }
-        (Language::En, SelfManagedEditKeyAction::ClearRootKey) => "Clear root API key",
-        (Language::En, SelfManagedEditKeyAction::ClearAllKeys) => "Clear all API keys",
-        (Language::ZhCn, SelfManagedEditKeyAction::Keep) => "保留现有 API Key",
-        (Language::ZhCn, SelfManagedEditKeyAction::SetUserKey) => "设置普通用户 API Key",
-        (Language::ZhCn, SelfManagedEditKeyAction::SetRootKey) => "设置 Root API Key",
-        (Language::ZhCn, SelfManagedEditKeyAction::UseRootForNormal) => {
-            "使用 Root Key 执行常规命令"
-        }
-        (Language::ZhCn, SelfManagedEditKeyAction::ClearRootKey) => "清除 Root API Key",
-        (Language::ZhCn, SelfManagedEditKeyAction::ClearAllKeys) => "清除所有 API Key",
+        (Language::En, CustomEditKeyAction::Keep) => "Keep existing API keys",
+        (Language::En, CustomEditKeyAction::SetUserKey) => "Set normal user API key",
+        (Language::En, CustomEditKeyAction::SetRootKey) => "Set root API key",
+        (Language::En, CustomEditKeyAction::UseRootForNormal) => "Use root key for normal commands",
+        (Language::En, CustomEditKeyAction::ClearRootKey) => "Clear root API key",
+        (Language::En, CustomEditKeyAction::ClearAllKeys) => "Clear all API keys",
+        (Language::ZhCn, CustomEditKeyAction::Keep) => "保留现有 API Key",
+        (Language::ZhCn, CustomEditKeyAction::SetUserKey) => "设置普通用户 API Key",
+        (Language::ZhCn, CustomEditKeyAction::SetRootKey) => "设置 Root API Key",
+        (Language::ZhCn, CustomEditKeyAction::UseRootForNormal) => "使用 Root Key 执行常规命令",
+        (Language::ZhCn, CustomEditKeyAction::ClearRootKey) => "清除 Root API Key",
+        (Language::ZhCn, CustomEditKeyAction::ClearAllKeys) => "清除所有 API Key",
     }
 }
 
@@ -408,21 +401,21 @@ fn user_key_redirect_helper_lines() -> Vec<String> {
 
 fn should_confirm_detected_root_key(
     kind: ConfigKind,
-    key_mode: Option<SelfManagedKeyMode>,
+    key_mode: Option<CustomKeyMode>,
     api_key_role: Option<ApiKeyRole>,
 ) -> bool {
-    kind == ConfigKind::SelfManaged
-        && key_mode == Some(SelfManagedKeyMode::UserKey)
+    kind == ConfigKind::Custom
+        && key_mode == Some(CustomKeyMode::UserKey)
         && api_key_role == Some(ApiKeyRole::Root)
 }
 
 fn should_confirm_detected_user_key(
     kind: ConfigKind,
-    key_mode: Option<SelfManagedKeyMode>,
+    key_mode: Option<CustomKeyMode>,
     api_key_role: Option<ApiKeyRole>,
 ) -> bool {
-    kind == ConfigKind::SelfManaged
-        && key_mode == Some(SelfManagedKeyMode::RootKey)
+    kind == ConfigKind::Custom
+        && key_mode == Some(CustomKeyMode::RootKey)
         && api_key_role == Some(ApiKeyRole::Regular)
 }
 
@@ -450,24 +443,26 @@ fn main_action_labels_for_language(language: Language) -> [&'static str; 3] {
     }
 }
 
-pub(crate) fn cloud_validation_failure_choices() -> [&'static str; 2] {
+pub(crate) fn openviking_service_validation_failure_choices() -> [&'static str; 2] {
     ["Retry API key", "Cancel"]
 }
 
-fn cloud_validation_failure_choices_for_language(language: Language) -> [&'static str; 2] {
+fn openviking_service_validation_failure_choices_for_language(
+    language: Language,
+) -> [&'static str; 2] {
     match language {
-        Language::En => cloud_validation_failure_choices(),
+        Language::En => openviking_service_validation_failure_choices(),
         Language::ZhCn => ["重新输入 API Key", "取消"],
     }
 }
 
-pub(crate) fn self_managed_validation_failure_choices() -> [&'static str; 3] {
+pub(crate) fn custom_validation_failure_choices() -> [&'static str; 3] {
     ["Edit server URL", "Edit API key", "Cancel"]
 }
 
-fn self_managed_validation_failure_choices_for_language(language: Language) -> [&'static str; 3] {
+fn custom_validation_failure_choices_for_language(language: Language) -> [&'static str; 3] {
     match language {
-        Language::En => self_managed_validation_failure_choices(),
+        Language::En => custom_validation_failure_choices(),
         Language::ZhCn => ["修改服务器 URL", "修改 API Key", "取消"],
     }
 }
@@ -481,8 +476,8 @@ pub(crate) fn edit_api_key_choice_labels(
     }
 
     match kind {
-        ConfigKind::VolcengineCloud => vec!["Keep existing API key", "Replace API key"],
-        ConfigKind::SelfManaged => {
+        ConfigKind::OpenVikingService => vec!["Keep existing API key", "Replace API key"],
+        ConfigKind::Custom => {
             vec!["Keep existing API key", "Replace API key", "Clear API key"]
         }
     }
@@ -502,8 +497,8 @@ fn edit_api_key_choice_labels_for_language(
     }
 
     match kind {
-        ConfigKind::VolcengineCloud => vec!["保留现有 API Key", "替换 API Key"],
-        ConfigKind::SelfManaged => vec!["保留现有 API Key", "替换 API Key", "清除 API Key"],
+        ConfigKind::OpenVikingService => vec!["保留现有 API Key", "替换 API Key"],
+        ConfigKind::Custom => vec!["保留现有 API Key", "替换 API Key", "清除 API Key"],
     }
 }
 
@@ -1449,11 +1444,15 @@ pub(crate) fn active_summary_lines(
     let active_line = match active {
         Some(config) => {
             if let Some(entry) = configs.iter().find(|entry| entry.is_active) {
-                format!("Active: {} ({})", entry.name, kind_label(entry.kind))
+                format!(
+                    "Active: {} ({})",
+                    entry.name,
+                    compact_kind_label(entry.kind)
+                )
             } else {
                 format!(
                     "Active: unnamed ({})",
-                    kind_label(ConfigKind::from_config(config))
+                    compact_kind_label(ConfigKind::from_config(config))
                 )
             }
         }
@@ -1476,15 +1475,15 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
     }
 
     let mut stage = Stage::Kind;
-    let mut kind = ConfigKind::SelfManaged;
+    let mut kind = ConfigKind::Custom;
     let mut name: Option<String> = None;
-    let mut url = DEFAULT_SELF_MANAGED_URL.to_string();
+    let mut url = DEFAULT_CUSTOM_URL.to_string();
     let mut api_key: Option<String> = None;
     let mut root_api_key: Option<String> = None;
     let mut account: Option<String> = None;
     let mut user: Option<String> = None;
     let mut identity_mode: Option<IdentityMode> = None;
-    let mut key_mode: Option<SelfManagedKeyMode> = None;
+    let mut key_mode: Option<CustomKeyMode> = None;
 
     loop {
         match stage {
@@ -1501,8 +1500,8 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                 &[],
             )? {
                 PromptResult::Value(0) => {
-                    kind = ConfigKind::VolcengineCloud;
-                    url = VOLCENGINE_CLOUD_URL.to_string();
+                    kind = ConfigKind::OpenVikingService;
+                    url = OPENVIKING_SERVICE_URL.to_string();
                     name = None;
                     api_key = None;
                     root_api_key = None;
@@ -1513,8 +1512,8 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                     stage = Stage::Name;
                 }
                 PromptResult::Value(1) => {
-                    kind = ConfigKind::SelfManaged;
-                    url = DEFAULT_SELF_MANAGED_URL.to_string();
+                    kind = ConfigKind::Custom;
+                    url = DEFAULT_CUSTOM_URL.to_string();
                     name = None;
                     api_key = None;
                     root_api_key = None;
@@ -1535,7 +1534,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                 match prompt_add_config_name(ui, section_add(), add_config_name_label())? {
                     PromptResult::Value(value) => {
                         name = value;
-                        stage = if kind == ConfigKind::VolcengineCloud {
+                        stage = if kind == ConfigKind::OpenVikingService {
                             Stage::ApiKey
                         } else {
                             Stage::Url
@@ -1549,7 +1548,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                         user = None;
                         identity_mode = None;
                         key_mode = None;
-                        url = DEFAULT_SELF_MANAGED_URL.to_string();
+                        url = DEFAULT_CUSTOM_URL.to_string();
                         stage = Stage::Kind;
                     }
                     PromptResult::Quit => {
@@ -1579,33 +1578,30 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                 }
             },
             Stage::KeyMode => {
-                let allow_empty_api_key = self_managed_allows_empty_api_key(&url);
-                let labels = self_managed_key_mode_labels_for_language(
-                    allow_empty_api_key,
-                    Language::current(),
-                );
+                let allow_empty_api_key = custom_allows_empty_api_key(&url);
+                let labels =
+                    custom_key_mode_labels_for_language(allow_empty_api_key, Language::current());
                 match prompt_select(
                     ui,
                     section_add(),
                     copy(Language::current(), "API key type", "API Key 类型"),
                     &labels,
                     0,
-                    &self_managed_api_key_helper_lines(allow_empty_api_key),
+                    &custom_api_key_helper_lines(allow_empty_api_key),
                 )? {
                     PromptResult::Value(index) => {
-                        let selected =
-                            self_managed_key_mode_for_selection(allow_empty_api_key, index);
+                        let selected = custom_key_mode_for_selection(allow_empty_api_key, index);
                         key_mode = Some(selected);
                         api_key = None;
                         root_api_key = None;
                         account = None;
                         user = None;
                         match selected {
-                            SelfManagedKeyMode::NoKey => {
+                            CustomKeyMode::NoKey => {
                                 identity_mode = Some(IdentityMode::LocalNoKey);
                                 stage = Stage::Account;
                             }
-                            SelfManagedKeyMode::UserKey | SelfManagedKeyMode::RootKey => {
+                            CustomKeyMode::UserKey | CustomKeyMode::RootKey => {
                                 identity_mode = None;
                                 stage = Stage::ApiKey;
                             }
@@ -1619,18 +1615,14 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                 }
             }
             Stage::ApiKey => {
-                let helper_lines = if kind == ConfigKind::VolcengineCloud {
-                    volcengine_api_key_helper_lines()
+                let helper_lines = if kind == ConfigKind::OpenVikingService {
+                    openviking_service_api_key_helper_lines()
                 } else {
-                    self_managed_api_key_input_helper_lines(
-                        key_mode.unwrap_or(SelfManagedKeyMode::UserKey),
-                    )
+                    custom_api_key_input_helper_lines(key_mode.unwrap_or(CustomKeyMode::UserKey))
                 };
 
-                let label = if kind == ConfigKind::SelfManaged {
-                    self_managed_api_key_input_label(
-                        key_mode.unwrap_or(SelfManagedKeyMode::UserKey),
-                    )
+                let label = if kind == ConfigKind::Custom {
+                    custom_api_key_input_label(key_mode.unwrap_or(CustomKeyMode::UserKey))
                 } else {
                     api_key_label(false)
                 };
@@ -1646,8 +1638,8 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                 )? {
                     PromptResult::Value(value) => {
                         api_key = empty_to_none(value);
-                        root_api_key = if kind == ConfigKind::SelfManaged
-                            && key_mode == Some(SelfManagedKeyMode::RootKey)
+                        root_api_key = if kind == ConfigKind::Custom
+                            && key_mode == Some(CustomKeyMode::RootKey)
                         {
                             api_key.clone()
                         } else {
@@ -1659,7 +1651,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                         stage = Stage::Validate;
                     }
                     PromptResult::Back => {
-                        stage = if kind == ConfigKind::VolcengineCloud {
+                        stage = if kind == ConfigKind::OpenVikingService {
                             Stage::Name
                         } else {
                             Stage::KeyMode
@@ -1755,7 +1747,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                                 &root_key_redirect_helper_lines(),
                             )? {
                                 PromptResult::Value(0) => {
-                                    key_mode = Some(SelfManagedKeyMode::RootKey);
+                                    key_mode = Some(CustomKeyMode::RootKey);
                                     root_api_key = api_key.clone();
                                     identity_mode = Some(IdentityMode::RootKey);
                                     account = None;
@@ -1764,7 +1756,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                                     continue;
                                 }
                                 PromptResult::Value(1) | PromptResult::Back => {
-                                    key_mode = Some(SelfManagedKeyMode::UserKey);
+                                    key_mode = Some(CustomKeyMode::UserKey);
                                     root_api_key = None;
                                     identity_mode = None;
                                     stage = Stage::ApiKey;
@@ -1792,7 +1784,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                                 &user_key_redirect_helper_lines(),
                             )? {
                                 PromptResult::Value(0) => {
-                                    key_mode = Some(SelfManagedKeyMode::UserKey);
+                                    key_mode = Some(CustomKeyMode::UserKey);
                                     root_api_key = None;
                                     identity_mode = None;
                                     account = None;
@@ -1801,7 +1793,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                                     continue;
                                 }
                                 PromptResult::Value(1) | PromptResult::Back => {
-                                    key_mode = Some(SelfManagedKeyMode::RootKey);
+                                    key_mode = Some(CustomKeyMode::RootKey);
                                     api_key = None;
                                     root_api_key = None;
                                     identity_mode = None;
@@ -1853,7 +1845,7 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                             PromptResult::Back => {
                                 stage = if identity_mode.is_some() {
                                     Stage::User
-                                } else if kind == ConfigKind::SelfManaged {
+                                } else if kind == ConfigKind::Custom {
                                     Stage::KeyMode
                                 } else {
                                     Stage::ApiKey
@@ -1869,11 +1861,14 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                         let helper_lines = vec![
                             theme::error(localized_validation_error(kind, &error)).to_string(),
                         ];
-                        let choices: Vec<&str> = if kind == ConfigKind::VolcengineCloud {
-                            cloud_validation_failure_choices_for_language(Language::current())
-                                .to_vec()
+                        let choices: Vec<&str> = if kind == ConfigKind::OpenVikingService {
+                            openviking_service_validation_failure_choices_for_language(
+                                Language::current(),
+                            )
+                            .to_vec()
                         } else {
-                            self_managed_validation_failure_choices_for_language(Language::current()).to_vec()
+                            custom_validation_failure_choices_for_language(Language::current())
+                                .to_vec()
                         };
                         match prompt_select(
                             ui,
@@ -1888,26 +1883,26 @@ async fn run_add_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool
                             &helper_lines,
                         )? {
                             PromptResult::Value(0) => {
-                                stage = if kind == ConfigKind::VolcengineCloud {
+                                stage = if kind == ConfigKind::OpenVikingService {
                                     Stage::ApiKey
                                 } else {
                                     Stage::Url
                                 };
                             }
                             PromptResult::Value(1) => {
-                                stage = if kind == ConfigKind::VolcengineCloud {
+                                stage = if kind == ConfigKind::OpenVikingService {
                                     print_cancelled(ui)?;
                                     return Ok(true);
                                 } else {
                                     Stage::KeyMode
                                 };
                             }
-                            PromptResult::Value(2) if kind == ConfigKind::SelfManaged => {
+                            PromptResult::Value(2) if kind == ConfigKind::Custom => {
                                 print_cancelled(ui)?;
                                 return Ok(true);
                             }
                             PromptResult::Back => {
-                                stage = if kind == ConfigKind::SelfManaged {
+                                stage = if kind == ConfigKind::Custom {
                                     Stage::KeyMode
                                 } else {
                                     Stage::ApiKey
@@ -1966,15 +1961,15 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
     let mut stage = Stage::Select;
     let mut selected = 0usize;
     let mut name = String::new();
-    let mut kind = ConfigKind::SelfManaged;
+    let mut kind = ConfigKind::Custom;
     let mut url = String::new();
     let mut api_key: Option<String> = None;
     let mut root_api_key: Option<String> = None;
     let mut account: Option<String> = None;
     let mut user: Option<String> = None;
     let mut identity_mode: Option<IdentityMode> = None;
-    let mut key_mode: Option<SelfManagedKeyMode> = None;
-    let mut key_edit_action: Option<SelfManagedEditKeyAction> = None;
+    let mut key_mode: Option<CustomKeyMode> = None;
+    let mut key_edit_action: Option<CustomEditKeyAction> = None;
     let mut api_key_was_entered = false;
 
     loop {
@@ -2000,9 +1995,9 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                     user = config.config.user.clone();
                     identity_mode = None;
                     key_mode = if root_api_key.is_some() {
-                        Some(SelfManagedKeyMode::RootKey)
+                        Some(CustomKeyMode::RootKey)
                     } else if api_key.is_some() {
-                        Some(SelfManagedKeyMode::UserKey)
+                        Some(CustomKeyMode::UserKey)
                     } else {
                         None
                     };
@@ -2025,7 +2020,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                 )? {
                     PromptResult::Value(value) => {
                         name = value;
-                        stage = if kind == ConfigKind::VolcengineCloud {
+                        stage = if kind == ConfigKind::OpenVikingService {
                             Stage::ApiKeyChoice
                         } else {
                             Stage::Url
@@ -2059,7 +2054,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                 }
             },
             Stage::ApiKeyChoice => {
-                if kind == ConfigKind::SelfManaged {
+                if kind == ConfigKind::Custom {
                     let has_root_key = has_non_empty(root_api_key.as_deref());
                     let has_normal_user_key =
                         has_normal_user_key(api_key.as_deref(), root_api_key.as_deref());
@@ -2069,11 +2064,11 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                         continue;
                     }
 
-                    let actions = edit_self_managed_key_actions(has_normal_user_key, has_root_key);
+                    let actions = edit_custom_key_actions(has_normal_user_key, has_root_key);
                     let labels: Vec<&str> = actions
                         .iter()
                         .copied()
-                        .map(self_managed_edit_key_action_label)
+                        .map(custom_edit_key_action_label)
                         .collect();
                     match prompt_select(
                         ui,
@@ -2081,50 +2076,50 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                         copy(Language::current(), "API keys", "API Key"),
                         &labels,
                         0,
-                        &self_managed_api_key_helper_lines(self_managed_allows_empty_api_key(&url)),
+                        &custom_api_key_helper_lines(custom_allows_empty_api_key(&url)),
                     )? {
                         PromptResult::Value(index) => {
                             let action = actions[index];
                             key_edit_action = Some(action);
                             api_key_was_entered = false;
                             match action {
-                                SelfManagedEditKeyAction::Keep => {
+                                CustomEditKeyAction::Keep => {
                                     stage = Stage::Validate;
                                 }
-                                SelfManagedEditKeyAction::SetUserKey => {
-                                    key_mode = Some(SelfManagedKeyMode::UserKey);
+                                CustomEditKeyAction::SetUserKey => {
+                                    key_mode = Some(CustomKeyMode::UserKey);
                                     identity_mode = None;
                                     stage = Stage::ApiKeyInput;
                                 }
-                                SelfManagedEditKeyAction::SetRootKey => {
-                                    key_mode = Some(SelfManagedKeyMode::RootKey);
+                                CustomEditKeyAction::SetRootKey => {
+                                    key_mode = Some(CustomKeyMode::RootKey);
                                     identity_mode = None;
                                     stage = Stage::ApiKeyInput;
                                 }
-                                SelfManagedEditKeyAction::UseRootForNormal => {
+                                CustomEditKeyAction::UseRootForNormal => {
                                     api_key = root_api_key.clone();
-                                    key_mode = Some(SelfManagedKeyMode::RootKey);
+                                    key_mode = Some(CustomKeyMode::RootKey);
                                     identity_mode = None;
                                     stage = Stage::Validate;
                                 }
-                                SelfManagedEditKeyAction::ClearRootKey => {
+                                CustomEditKeyAction::ClearRootKey => {
                                     if api_key.as_deref() == root_api_key.as_deref() {
                                         api_key = None;
                                     }
                                     root_api_key = None;
                                     key_mode = if api_key.is_some() {
-                                        Some(SelfManagedKeyMode::UserKey)
+                                        Some(CustomKeyMode::UserKey)
                                     } else {
                                         None
                                     };
                                     identity_mode = None;
                                     stage = Stage::Validate;
                                 }
-                                SelfManagedEditKeyAction::ClearAllKeys => {
+                                CustomEditKeyAction::ClearAllKeys => {
                                     api_key = None;
                                     root_api_key = None;
                                     key_mode = None;
-                                    if self_managed_allows_empty_api_key(&url) {
+                                    if custom_allows_empty_api_key(&url) {
                                         identity_mode = Some(IdentityMode::LocalNoKey);
                                         stage = Stage::Account;
                                     } else {
@@ -2143,10 +2138,10 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                     continue;
                 }
 
-                let helper_lines = if kind == ConfigKind::VolcengineCloud {
-                    volcengine_api_key_helper_lines()
+                let helper_lines = if kind == ConfigKind::OpenVikingService {
+                    openviking_service_api_key_helper_lines()
                 } else {
-                    self_managed_api_key_helper_lines(self_managed_allows_empty_api_key(&url))
+                    custom_api_key_helper_lines(custom_allows_empty_api_key(&url))
                 };
 
                 let has_existing = api_key.as_deref().is_some_and(|value| !value.is_empty())
@@ -2154,7 +2149,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                         .as_deref()
                         .is_some_and(|value| !value.is_empty());
                 if !has_existing {
-                    stage = if kind == ConfigKind::SelfManaged {
+                    stage = if kind == ConfigKind::Custom {
                         Stage::KeyMode
                     } else {
                         Stage::ApiKeyInput
@@ -2179,7 +2174,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                         stage = Stage::Validate;
                     }
                     PromptResult::Value(1) => {
-                        stage = if kind == ConfigKind::SelfManaged {
+                        stage = if kind == ConfigKind::Custom {
                             Stage::KeyMode
                         } else {
                             Stage::ApiKeyInput
@@ -2191,9 +2186,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                         key_mode = None;
                         key_edit_action = None;
                         api_key_was_entered = false;
-                        if kind == ConfigKind::SelfManaged
-                            && self_managed_allows_empty_api_key(&url)
-                        {
+                        if kind == ConfigKind::Custom && custom_allows_empty_api_key(&url) {
                             identity_mode = Some(IdentityMode::LocalNoKey);
                             stage = Stage::Account;
                         } else {
@@ -2202,7 +2195,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                         }
                     }
                     PromptResult::Back => {
-                        stage = if kind == ConfigKind::VolcengineCloud {
+                        stage = if kind == ConfigKind::OpenVikingService {
                             Stage::Name
                         } else {
                             Stage::Url
@@ -2215,33 +2208,30 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                 }
             }
             Stage::KeyMode => {
-                let allow_empty_api_key = self_managed_allows_empty_api_key(&url);
-                let labels = self_managed_key_mode_labels_for_language(
-                    allow_empty_api_key,
-                    Language::current(),
-                );
+                let allow_empty_api_key = custom_allows_empty_api_key(&url);
+                let labels =
+                    custom_key_mode_labels_for_language(allow_empty_api_key, Language::current());
                 match prompt_select(
                     ui,
                     section_edit(),
                     copy(Language::current(), "API key type", "API Key 类型"),
                     &labels,
                     0,
-                    &self_managed_api_key_helper_lines(allow_empty_api_key),
+                    &custom_api_key_helper_lines(allow_empty_api_key),
                 )? {
                     PromptResult::Value(index) => {
-                        let selected =
-                            self_managed_key_mode_for_selection(allow_empty_api_key, index);
+                        let selected = custom_key_mode_for_selection(allow_empty_api_key, index);
                         key_mode = Some(selected);
                         api_key = None;
                         root_api_key = None;
                         key_edit_action = None;
                         api_key_was_entered = false;
                         match selected {
-                            SelfManagedKeyMode::NoKey => {
+                            CustomKeyMode::NoKey => {
                                 identity_mode = Some(IdentityMode::LocalNoKey);
                                 stage = Stage::Account;
                             }
-                            SelfManagedKeyMode::UserKey | SelfManagedKeyMode::RootKey => {
+                            CustomKeyMode::UserKey | CustomKeyMode::RootKey => {
                                 identity_mode = None;
                                 stage = Stage::ApiKeyInput;
                             }
@@ -2259,19 +2249,15 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                     || root_api_key
                         .as_deref()
                         .is_some_and(|value| !value.is_empty());
-                let label = if kind == ConfigKind::SelfManaged {
-                    self_managed_api_key_input_label(
-                        key_mode.unwrap_or(SelfManagedKeyMode::UserKey),
-                    )
+                let label = if kind == ConfigKind::Custom {
+                    custom_api_key_input_label(key_mode.unwrap_or(CustomKeyMode::UserKey))
                 } else {
                     api_key_label(false)
                 };
-                let helper_lines = if kind == ConfigKind::VolcengineCloud {
-                    volcengine_api_key_helper_lines()
+                let helper_lines = if kind == ConfigKind::OpenVikingService {
+                    openviking_service_api_key_helper_lines()
                 } else {
-                    self_managed_api_key_input_helper_lines(
-                        key_mode.unwrap_or(SelfManagedKeyMode::UserKey),
-                    )
+                    custom_api_key_input_helper_lines(key_mode.unwrap_or(CustomKeyMode::UserKey))
                 };
                 match prompt_text(
                     ui,
@@ -2286,11 +2272,11 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                     PromptResult::Value(value) => {
                         let entered_key = empty_to_none(value);
                         match key_edit_action {
-                            Some(SelfManagedEditKeyAction::SetUserKey) => {
+                            Some(CustomEditKeyAction::SetUserKey) => {
                                 api_key = entered_key;
                                 api_key_was_entered = api_key.is_some();
                             }
-                            Some(SelfManagedEditKeyAction::SetRootKey) => {
+                            Some(CustomEditKeyAction::SetRootKey) => {
                                 let keep_normal_user_key = has_normal_user_key(
                                     api_key.as_deref(),
                                     root_api_key.as_deref(),
@@ -2303,8 +2289,8 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                             }
                             _ => {
                                 api_key = entered_key;
-                                root_api_key = if kind == ConfigKind::SelfManaged
-                                    && key_mode == Some(SelfManagedKeyMode::RootKey)
+                                root_api_key = if kind == ConfigKind::Custom
+                                    && key_mode == Some(CustomKeyMode::RootKey)
                                 {
                                     api_key.clone()
                                 } else {
@@ -2319,7 +2305,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                     PromptResult::Back => {
                         stage = if has_existing {
                             Stage::ApiKeyChoice
-                        } else if kind == ConfigKind::VolcengineCloud {
+                        } else if kind == ConfigKind::OpenVikingService {
                             Stage::Name
                         } else {
                             Stage::KeyMode
@@ -2414,8 +2400,8 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                                 &root_key_redirect_helper_lines(),
                             )? {
                                 PromptResult::Value(0) => {
-                                    key_mode = Some(SelfManagedKeyMode::RootKey);
-                                    key_edit_action = Some(SelfManagedEditKeyAction::SetRootKey);
+                                    key_mode = Some(CustomKeyMode::RootKey);
+                                    key_edit_action = Some(CustomEditKeyAction::SetRootKey);
                                     root_api_key = api_key.clone();
                                     identity_mode = Some(IdentityMode::RootKey);
                                     account = None;
@@ -2424,7 +2410,7 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                                     continue;
                                 }
                                 PromptResult::Value(1) | PromptResult::Back => {
-                                    key_mode = Some(SelfManagedKeyMode::UserKey);
+                                    key_mode = Some(CustomKeyMode::UserKey);
                                     api_key = None;
                                     identity_mode = None;
                                     stage = Stage::ApiKeyInput;
@@ -2462,8 +2448,8 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                                             api_key.as_deref() != Some(existing_root_key.as_str())
                                                 && !existing_root_key.trim().is_empty()
                                         });
-                                    key_mode = Some(SelfManagedKeyMode::UserKey);
-                                    key_edit_action = Some(SelfManagedEditKeyAction::SetUserKey);
+                                    key_mode = Some(CustomKeyMode::UserKey);
+                                    key_edit_action = Some(CustomEditKeyAction::SetUserKey);
                                     api_key_was_entered = api_key.is_some();
                                     identity_mode = None;
                                     account = None;
@@ -2472,8 +2458,8 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                                     continue;
                                 }
                                 PromptResult::Value(1) | PromptResult::Back => {
-                                    key_mode = Some(SelfManagedKeyMode::RootKey);
-                                    key_edit_action = Some(SelfManagedEditKeyAction::SetRootKey);
+                                    key_mode = Some(CustomKeyMode::RootKey);
+                                    key_edit_action = Some(CustomEditKeyAction::SetRootKey);
                                     if api_key.as_deref() == root_api_key.as_deref() {
                                         api_key = None;
                                     }
@@ -2563,11 +2549,14 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                         let helper_lines = vec![
                             theme::error(localized_validation_error(kind, &error)).to_string(),
                         ];
-                        let choices = if kind == ConfigKind::VolcengineCloud {
-                            cloud_validation_failure_choices_for_language(Language::current())
-                                .to_vec()
+                        let choices = if kind == ConfigKind::OpenVikingService {
+                            openviking_service_validation_failure_choices_for_language(
+                                Language::current(),
+                            )
+                            .to_vec()
                         } else {
-                            self_managed_validation_failure_choices_for_language(Language::current()).to_vec()
+                            custom_validation_failure_choices_for_language(Language::current())
+                                .to_vec()
                         };
                         match prompt_select(
                             ui,
@@ -2582,21 +2571,21 @@ async fn run_edit_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<boo
                             &helper_lines,
                         )? {
                             PromptResult::Value(0) => {
-                                stage = if kind == ConfigKind::VolcengineCloud {
+                                stage = if kind == ConfigKind::OpenVikingService {
                                     Stage::ApiKeyInput
                                 } else {
                                     Stage::Url
                                 };
                             }
                             PromptResult::Value(1) => {
-                                stage = if kind == ConfigKind::VolcengineCloud {
+                                stage = if kind == ConfigKind::OpenVikingService {
                                     print_cancelled(ui)?;
                                     return Ok(true);
                                 } else {
                                     Stage::ApiKeyChoice
                                 };
                             }
-                            PromptResult::Value(2) if kind == ConfigKind::SelfManaged => {
+                            PromptResult::Value(2) if kind == ConfigKind::Custom => {
                                 print_cancelled(ui)?;
                                 return Ok(true);
                             }
@@ -2736,9 +2725,8 @@ async fn validate_draft(
     draft: &ConfigDraft,
 ) -> Result<ValidatedConfig> {
     let mut config = build_config(draft)?;
-    let require_api_key = draft.kind == ConfigKind::VolcengineCloud
-        || (draft.kind == ConfigKind::SelfManaged
-            && !self_managed_allows_empty_api_key(&draft.url));
+    let require_api_key = draft.kind == ConfigKind::OpenVikingService
+        || (draft.kind == ConfigKind::Custom && !custom_allows_empty_api_key(&draft.url));
     ui.render(&status_live_lines(
         section,
         copy(
@@ -2963,7 +2951,7 @@ fn least_privilege_user_key_notice() -> String {
 }
 
 fn root_key_used_for_normal_commands(config: &Config) -> bool {
-    if ConfigKind::from_config(config) != ConfigKind::SelfManaged {
+    if ConfigKind::from_config(config) != ConfigKind::Custom {
         return false;
     }
 
@@ -3034,13 +3022,13 @@ fn add_config_name_helper_lines() -> Vec<String> {
     ]
 }
 
-pub(crate) fn volcengine_api_key_helper_lines() -> Vec<String> {
+pub(crate) fn openviking_service_api_key_helper_lines() -> Vec<String> {
     let language = Language::current();
     vec![
         format!(
             "{} {}",
             theme::muted(copy(language, "Get your API key:", "获取 API Key：")),
-            VOLCENGINE_API_KEY_URL
+            OPENVIKING_SERVICE_API_KEY_URL
         ),
         theme::muted(copy(
             language,
@@ -3051,7 +3039,7 @@ pub(crate) fn volcengine_api_key_helper_lines() -> Vec<String> {
     ]
 }
 
-pub(crate) fn self_managed_api_key_helper_lines(allow_empty: bool) -> Vec<String> {
+pub(crate) fn custom_api_key_helper_lines(allow_empty: bool) -> Vec<String> {
     let copy = if allow_empty {
         copy(
             Language::current(),
@@ -3061,8 +3049,8 @@ pub(crate) fn self_managed_api_key_helper_lines(allow_empty: bool) -> Vec<String
     } else {
         copy(
             Language::current(),
-            "Required for remote self-managed servers.",
-            "远程自托管服务需要 API Key。",
+            "Required for remote custom servers.",
+            "远程自定义服务需要 API Key。",
         )
     };
     vec![theme::muted(copy).to_string()]
@@ -3099,8 +3087,8 @@ fn prompt_add_config_name(
 
 pub(crate) fn allocate_config_name(store: &ConfigStore, kind: ConfigKind) -> Result<String> {
     let prefix = match kind {
-        ConfigKind::VolcengineCloud => "cloud",
-        ConfigKind::SelfManaged => "local",
+        ConfigKind::OpenVikingService => "ov-service",
+        ConfigKind::Custom => "local",
     };
 
     for _ in 0..32 {
@@ -3224,7 +3212,7 @@ fn prompt_config_select(
 }
 
 fn config_select_label(entry: &ConfigEntry) -> String {
-    let label = format!("{} - {}", entry.name, kind_label(entry.kind));
+    let label = format!("{} - {}", entry.name, compact_kind_label(entry.kind));
     if entry.is_active {
         format!("{} {}", label, theme::error(active_badge()).bold())
     } else {
@@ -3270,10 +3258,8 @@ fn localized_validation_error(kind: ConfigKind, error: &Error) -> String {
     match Language::current() {
         Language::En => validation_error_copy(kind, error),
         Language::ZhCn => match kind {
-            ConfigKind::VolcengineCloud => "验证失败。请检查 API Key 后重试。".to_string(),
-            ConfigKind::SelfManaged => {
-                "验证失败。请检查服务器 URL，以及是否需要 API Key。".to_string()
-            }
+            ConfigKind::OpenVikingService => "验证失败。请检查 API Key 后重试。".to_string(),
+            ConfigKind::Custom => "验证失败。请检查服务器 URL，以及是否需要 API Key。".to_string(),
         },
     }
 }
@@ -3764,30 +3750,31 @@ impl Drop for RawPrompt {
 #[cfg(test)]
 mod tests {
     use super::{
-        IdentityMode, InputValueLabel, OV_LOGO_LINES, Rgb, SelfManagedKeyMode, StatusBoxRuntime,
+        CustomKeyMode, IdentityMode, InputValueLabel, OV_LOGO_LINES, Rgb, StatusBoxRuntime,
         active_delete_block_helper_lines, active_summary_lines, active_summary_render_parts,
         add_config_name_label, add_save_action_labels, allocate_config_name, box_content_line,
-        box_footer_line, box_title_line, cloud_validation_failure_choices, config_select_label,
-        display_config_home, display_width, edit_api_key_choice_labels, edit_save_action_labels,
-        edit_self_managed_key_action_labels, erase_sequence_for_char,
-        extract_models_from_status_payload, identity_prompt_parts, input_live_lines,
-        logo_glass_color_for_theme, main_action_labels, next_step_copy, ov_logo_width,
-        root_key_normal_command_notice_lines, root_key_redirect_labels, saved_summary_render_parts,
-        select_live_lines, self_managed_api_key_helper_lines,
-        self_managed_api_key_input_helper_lines, self_managed_key_mode_labels,
-        self_managed_validation_failure_choices, should_confirm_detected_user_key,
-        should_prompt_root_identity, status_box_lines, status_box_lines_with_runtime,
-        status_box_width, status_payload_is_healthy, styled_logo_to_width_for_color_level,
-        styled_wordmark_line_for_color_level, tagline_ice_color_for_theme,
-        user_key_redirect_labels, validate_config_name, validate_draft,
-        volcengine_api_key_helper_lines, wizard_header_lines, wordmark_gradient_color_for_theme,
-        wordmark_lines, wordmark_width,
+        box_footer_line, box_title_line, config_select_label, custom_api_key_helper_lines,
+        custom_api_key_input_helper_lines, custom_key_mode_labels,
+        custom_validation_failure_choices, display_config_home, display_width,
+        edit_api_key_choice_labels, edit_custom_key_action_labels, edit_save_action_labels,
+        erase_sequence_for_char, extract_models_from_status_payload, identity_prompt_parts,
+        input_live_lines, logo_glass_color_for_theme, main_action_labels, next_step_copy,
+        openviking_service_api_key_helper_lines, openviking_service_validation_failure_choices,
+        ov_logo_width, provider_labels, root_key_normal_command_notice_lines,
+        root_key_redirect_labels, saved_summary_render_parts, select_live_lines,
+        should_confirm_detected_user_key, should_prompt_root_identity, status_box_lines,
+        status_box_lines_with_runtime, status_box_width, status_payload_is_healthy,
+        styled_logo_to_width_for_color_level, styled_wordmark_line_for_color_level,
+        tagline_ice_color_for_theme, user_key_redirect_labels, validate_config_name,
+        validate_draft, wizard_header_lines, wordmark_gradient_color_for_theme, wordmark_lines,
+        wordmark_width,
     };
     use crate::config::Config;
     use crate::config_wizard::store::{
-        ApiKeyRole, ConfigDraft, ConfigEntry, ConfigKind, ConfigStore, validate_account_id_value,
-        validate_user_id_value,
+        ApiKeyRole, ConfigDraft, ConfigEntry, ConfigKind, ConfigStore, OPENVIKING_SERVICE_URL,
+        validate_account_id_value, validate_user_id_value,
     };
+    use crate::i18n::Language;
     use crate::theme::{self, ThemeColor};
     use colored::Colorize;
     use serde_json::json;
@@ -3874,7 +3861,7 @@ mod tests {
                 name: "test".to_string(),
                 config: config.clone(),
                 is_active: true,
-                kind: ConfigKind::SelfManaged,
+                kind: ConfigKind::Custom,
             }],
             "~/.openviking",
         );
@@ -3913,7 +3900,7 @@ mod tests {
     fn status_box_cjk_lines_align_to_display_width() {
         let width = status_box_width();
         let title = box_title_line("AI Agent 上下文数据库", width);
-        let content = box_content_line("", "当前配置： VPS_ROOT (自托管)", width);
+        let content = box_content_line("", "当前配置： VPS_ROOT (自定义)", width);
         let footer = box_footer_line("v0.0.0", width);
 
         for line in [title, content, footer] {
@@ -3933,14 +3920,14 @@ mod tests {
                 name: "orange".to_string(),
                 config: config.clone(),
                 is_active: true,
-                kind: ConfigKind::SelfManaged,
+                kind: ConfigKind::Custom,
             }],
             "~/.openviking",
         );
         let text = lines.join("\n");
 
         assert!(text.contains("Active:"));
-        assert!(text.contains("orange (Self-Managed)"));
+        assert!(text.contains("orange (Custom)"));
         assert!(text.contains("Status:"));
         assert!(text.contains("VLM:"));
         assert!(text.contains("Embedding:"));
@@ -3988,7 +3975,7 @@ mod tests {
                 name: "vps".to_string(),
                 config: config.clone(),
                 is_active: true,
-                kind: ConfigKind::SelfManaged,
+                kind: ConfigKind::Custom,
             }],
             "~/.openviking",
             &runtime,
@@ -4046,7 +4033,7 @@ mod tests {
                 name: "orange".to_string(),
                 config: config.clone(),
                 is_active: true,
-                kind: ConfigKind::SelfManaged,
+                kind: ConfigKind::Custom,
             }],
             "~/.openviking",
         );
@@ -4061,7 +4048,7 @@ mod tests {
             active_index + 6 < lines.len() - 1,
             "details should not end at the bottom"
         );
-        assert!(lines[active_index].contains("Active: orange (Self-Managed)"));
+        assert!(lines[active_index].contains("Active: orange (Custom)"));
         assert!(lines[active_index + 1].contains("Status: Unknown"));
         assert!(lines[active_index + 2].contains("VLM: Unknown"));
         assert!(lines[active_index + 3].contains("Embedding: Unknown"));
@@ -4325,11 +4312,11 @@ mod tests {
                 name: "local".to_string(),
                 config: config.clone(),
                 is_active: true,
-                kind: ConfigKind::SelfManaged,
+                kind: ConfigKind::Custom,
             }],
         );
 
-        assert_eq!(lines[0], "Active: local (Self-Managed)");
+        assert_eq!(lines[0], "Active: local (Custom)");
         assert_eq!(lines[1], "Saved configs: 1");
         assert!(!lines[0].contains("127.0.0.1"));
         assert!(!lines[0].starts_with(' '));
@@ -4337,15 +4324,38 @@ mod tests {
     }
 
     #[test]
+    fn active_summary_uses_compact_openviking_service_kind() {
+        let mut config = Config::default();
+        config.url = OPENVIKING_SERVICE_URL.to_string();
+        let lines = active_summary_lines(
+            Some(&config),
+            &[ConfigEntry {
+                name: "serverless".to_string(),
+                config: config.clone(),
+                is_active: true,
+                kind: ConfigKind::OpenVikingService,
+            }],
+        );
+
+        assert_eq!(lines[0], "Active: serverless (OpenViking Service)");
+        assert!(!lines[0].contains("VolcEngine Cloud"));
+
+        let active = active_summary_render_parts(&lines[0])
+            .expect("compact OpenViking Service summary should split");
+        assert_eq!(active.name, "serverless");
+        assert_eq!(active.kind.as_deref(), Some("(OpenViking Service)"));
+    }
+
+    #[test]
     fn summary_render_parts_split_config_name_type_and_count() {
-        let active = active_summary_render_parts("Active: test (Self-Managed)")
+        let active = active_summary_render_parts("Active: test (Custom)")
             .expect("active summary should split");
         let saved =
             saved_summary_render_parts("Saved configs: 2").expect("saved summary should split");
 
         assert_eq!(active.label, "Active:");
         assert_eq!(active.name, "test");
-        assert_eq!(active.kind.as_deref(), Some("(Self-Managed)"));
+        assert_eq!(active.kind.as_deref(), Some("(Custom)"));
         assert_eq!(saved.label, "Saved configs:");
         assert_eq!(saved.count, "2");
     }
@@ -4398,7 +4408,7 @@ mod tests {
         fs::create_dir_all(&dir).expect("dir should exist");
         let store = ConfigStore::for_config_dir(dir);
 
-        let name = allocate_config_name(&store, ConfigKind::SelfManaged)
+        let name = allocate_config_name(&store, ConfigKind::Custom)
             .expect("generated name should be available");
 
         assert!(name.starts_with("local-"));
@@ -4407,55 +4417,59 @@ mod tests {
     }
 
     #[test]
-    fn provider_helper_copy_is_minimal_and_self_managed_is_clear() {
-        let cloud = volcengine_api_key_helper_lines();
-        let local_self_managed = self_managed_api_key_helper_lines(true);
-        let remote_self_managed = self_managed_api_key_helper_lines(false);
+    fn provider_helper_copy_is_minimal_and_custom_is_clear() {
+        let cloud = openviking_service_api_key_helper_lines();
+        let local_custom = custom_api_key_helper_lines(true);
+        let remote_custom = custom_api_key_helper_lines(false);
 
+        assert_eq!(
+            provider_labels(Language::En)[0],
+            "OpenViking Service (VolcEngine Cloud)"
+        );
         assert!(cloud.iter().any(|line| line.contains("Get your API key:")));
         assert!(cloud.iter().any(|line| {
             line.contains("Go to User Management → API Key to view and copy your key.")
         }));
         assert!(!cloud.iter().any(|line| line.contains("Server URL")));
         assert!(
-            local_self_managed.iter().any(
+            local_custom.iter().any(
                 |line| line.contains("Optional for local servers. Add one if auth is enabled.")
             )
         );
         assert!(
-            remote_self_managed
+            remote_custom
                 .iter()
-                .any(|line| line.contains("Required for remote self-managed servers."))
+                .any(|line| line.contains("Required for remote custom servers."))
         );
         assert!(
-            !remote_self_managed
+            !remote_custom
                 .iter()
                 .any(|line| line.contains("Usually not needed locally"))
         );
         assert!(
-            !local_self_managed
+            !local_custom
                 .iter()
-                .chain(remote_self_managed.iter())
+                .chain(remote_custom.iter())
                 .any(|line| line.contains(';'))
         );
     }
 
     #[test]
-    fn self_managed_key_mode_choices_distinguish_no_key_user_key_and_root_key() {
+    fn custom_key_mode_choices_distinguish_no_key_user_key_and_root_key() {
         assert_eq!(
-            self_managed_key_mode_labels(true),
+            custom_key_mode_labels(true),
             ["No key / local dev", "User API key", "Root API key"]
         );
         assert_eq!(
-            self_managed_key_mode_labels(false),
+            custom_key_mode_labels(false),
             ["User API key", "Root API key"]
         );
     }
 
     #[test]
-    fn self_managed_key_input_copy_explains_storage_target() {
-        let user_key = self_managed_api_key_input_helper_lines(SelfManagedKeyMode::UserKey);
-        let root_key = self_managed_api_key_input_helper_lines(SelfManagedKeyMode::RootKey);
+    fn custom_key_input_copy_explains_storage_target() {
+        let user_key = custom_api_key_input_helper_lines(CustomKeyMode::UserKey);
+        let root_key = custom_api_key_input_helper_lines(CustomKeyMode::RootKey);
 
         assert!(user_key.iter().any(|line| line.contains("normal")));
         assert!(!user_key.iter().any(|line| line.contains("api_key")));
@@ -4466,14 +4480,14 @@ mod tests {
     }
 
     #[test]
-    fn add_self_managed_api_key_rendering_has_no_existing_value_placeholder() {
+    fn add_custom_api_key_rendering_has_no_existing_value_placeholder() {
         let lines = input_live_lines(
             "Create a new OpenViking config.",
             "API key (optional)",
             None,
             None,
             true,
-            &self_managed_api_key_helper_lines(true),
+            &custom_api_key_helper_lines(true),
             None,
         );
         let text = lines.join("\n");
@@ -4525,14 +4539,14 @@ mod tests {
     #[test]
     fn validation_failure_choices_are_kind_specific() {
         assert_eq!(
-            cloud_validation_failure_choices(),
+            openviking_service_validation_failure_choices(),
             ["Retry API key", "Cancel"]
         );
         assert_eq!(
-            self_managed_validation_failure_choices(),
+            custom_validation_failure_choices(),
             ["Edit server URL", "Edit API key", "Cancel"]
         );
-        assert!(!cloud_validation_failure_choices().contains(&"Edit config name"));
+        assert!(!openviking_service_validation_failure_choices().contains(&"Edit config name"));
     }
 
     #[test]
@@ -4545,22 +4559,22 @@ mod tests {
             name: "VPS".to_string(),
             config: config.clone(),
             is_active: true,
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
         };
         let inactive = ConfigEntry {
             name: "local".to_string(),
             config,
             is_active: false,
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
         };
 
         let active_label = config_select_label(&active);
-        assert!(active_label.contains("VPS - Self-Managed"));
+        assert!(active_label.contains("VPS - Custom"));
         assert!(active_label.contains("[Active]"));
         assert!(!active_label.contains("* "));
 
         let inactive_label = config_select_label(&inactive);
-        assert_eq!(inactive_label, "local - Self-Managed");
+        assert_eq!(inactive_label, "local - Custom");
         assert!(!inactive_label.contains("[Active]"));
     }
 
@@ -4675,26 +4689,26 @@ mod tests {
 
     #[test]
     fn edit_api_key_choices_match_kind_and_existing_key_state() {
-        assert!(edit_api_key_choice_labels(ConfigKind::SelfManaged, false).is_empty());
-        assert!(edit_api_key_choice_labels(ConfigKind::VolcengineCloud, false).is_empty());
+        assert!(edit_api_key_choice_labels(ConfigKind::Custom, false).is_empty());
+        assert!(edit_api_key_choice_labels(ConfigKind::OpenVikingService, false).is_empty());
         assert_eq!(
-            edit_api_key_choice_labels(ConfigKind::SelfManaged, true),
+            edit_api_key_choice_labels(ConfigKind::Custom, true),
             ["Keep existing API key", "Replace API key", "Clear API key"]
         );
         assert_eq!(
-            edit_api_key_choice_labels(ConfigKind::VolcengineCloud, true),
+            edit_api_key_choice_labels(ConfigKind::OpenVikingService, true),
             ["Keep existing API key", "Replace API key"]
         );
     }
 
     #[test]
-    fn edit_self_managed_key_actions_preserve_separate_credential_roles() {
+    fn edit_custom_key_actions_preserve_separate_credential_roles() {
         assert_eq!(
-            edit_self_managed_key_action_labels(false, false),
+            edit_custom_key_action_labels(false, false),
             ["Set normal user API key", "Set root API key"]
         );
         assert_eq!(
-            edit_self_managed_key_action_labels(true, true),
+            edit_custom_key_action_labels(true, true),
             [
                 "Keep existing API keys",
                 "Set normal user API key",
@@ -4705,7 +4719,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            edit_self_managed_key_action_labels(true, false),
+            edit_custom_key_action_labels(true, false),
             [
                 "Keep existing API keys",
                 "Set normal user API key",
@@ -4734,23 +4748,23 @@ mod tests {
     #[test]
     fn root_key_route_detects_regular_user_key() {
         assert!(should_confirm_detected_user_key(
-            ConfigKind::SelfManaged,
-            Some(SelfManagedKeyMode::RootKey),
+            ConfigKind::Custom,
+            Some(CustomKeyMode::RootKey),
             Some(ApiKeyRole::Regular),
         ));
         assert!(!should_confirm_detected_user_key(
-            ConfigKind::SelfManaged,
-            Some(SelfManagedKeyMode::UserKey),
+            ConfigKind::Custom,
+            Some(CustomKeyMode::UserKey),
             Some(ApiKeyRole::Regular),
         ));
         assert!(!should_confirm_detected_user_key(
-            ConfigKind::SelfManaged,
-            Some(SelfManagedKeyMode::RootKey),
+            ConfigKind::Custom,
+            Some(CustomKeyMode::RootKey),
             Some(ApiKeyRole::Root),
         ));
         assert!(!should_confirm_detected_user_key(
-            ConfigKind::VolcengineCloud,
-            Some(SelfManagedKeyMode::RootKey),
+            ConfigKind::OpenVikingService,
+            Some(CustomKeyMode::RootKey),
             Some(ApiKeyRole::Regular),
         ));
     }
@@ -4800,7 +4814,7 @@ mod tests {
         let url = spawn_root_probe_server("root-key").await;
         let draft = ConfigDraft {
             name: "local".to_string(),
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
             url,
             api_key: Some("root-key".to_string()),
             root_api_key: None,
@@ -4823,7 +4837,7 @@ mod tests {
         let url = spawn_dual_key_probe_server("user-key", "root-key").await;
         let draft = ConfigDraft {
             name: "local".to_string(),
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
             url,
             api_key: Some("user-key".to_string()),
             root_api_key: Some("root-key".to_string()),
@@ -4848,7 +4862,7 @@ mod tests {
         let url = spawn_dual_key_probe_server("user-key", "root-key").await;
         let draft = ConfigDraft {
             name: "local".to_string(),
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
             url,
             api_key: Some("user-key".to_string()),
             root_api_key: Some("user-key".to_string()),
@@ -4875,7 +4889,7 @@ mod tests {
                 .await;
         let draft = ConfigDraft {
             name: "local".to_string(),
-            kind: ConfigKind::SelfManaged,
+            kind: ConfigKind::Custom,
             url,
             api_key: Some("existing-user-key".to_string()),
             root_api_key: Some("entered-user-key".to_string()),

--- a/crates/ov_cli/src/help_ui.rs
+++ b/crates/ov_cli/src/help_ui.rs
@@ -1570,8 +1570,8 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
                 description: "Open the interactive config manager.",
             },
             HelpItem {
-                label: "ov config add cloud --api-key-stdin --activate",
-                description: "Create and activate a cloud config from stdin.",
+                label: "ov config add ov-service --api-key-stdin --activate",
+                description: "Create and activate an OpenViking Service config from stdin.",
             },
             HelpItem {
                 label: "ov config list -o json",
@@ -1604,7 +1604,7 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
             },
             HelpItem {
                 label: "add",
-                description: "Add a cloud or self-managed config without prompts.",
+                description: "Add an OpenViking Service or custom config without prompts.",
             },
             HelpItem {
                 label: "edit",
@@ -1736,15 +1736,15 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
     CommandHelpSpec {
         path: &["config", "add"],
         purpose: "Create a saved CLI config without opening the interactive wizard.",
-        usage: "ov config add <cloud|self-managed> [options]",
+        usage: "ov config add <ov-service|custom> [options]",
         examples: &[
             HelpItem {
-                label: "printf '%s' \"$OV_KEY\" | ov config add cloud --api-key-stdin --activate",
-                description: "Create and activate a Volcengine Cloud config.",
+                label: "printf '%s' \"$OV_KEY\" | ov config add ov-service --api-key-stdin --activate",
+                description: "Create and activate an OpenViking Service config.",
             },
             HelpItem {
-                label: "ov config add self-managed --name local --url http://127.0.0.1:1933 --activate",
-                description: "Create and activate a local self-managed config.",
+                label: "ov config add custom --name local --url http://127.0.0.1:1933 --activate",
+                description: "Create and activate a local custom config.",
             },
         ],
         arguments: &[],
@@ -1752,36 +1752,36 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
         advanced_options: &[],
         subcommands: &[
             HelpItem {
-                label: "cloud",
-                description: "Use the fixed Volcengine Cloud endpoint.",
+                label: "ov-service",
+                description: "Use the fixed OpenViking Service endpoint.",
             },
             HelpItem {
-                label: "self-managed",
-                description: "Use a local or hosted self-managed endpoint.",
+                label: "custom",
+                description: "Use a local or hosted custom endpoint.",
             },
         ],
         next_steps: &[
             HelpItem {
-                label: "ov config add cloud --help",
-                description: "See cloud-specific flags.",
+                label: "ov config add ov-service --help",
+                description: "See OpenViking Service flags.",
             },
             HelpItem {
-                label: "ov config add self-managed --help",
-                description: "See self-managed flags.",
+                label: "ov config add custom --help",
+                description: "See custom flags.",
             },
         ],
     },
     CommandHelpSpec {
-        path: &["config", "add", "cloud"],
-        purpose: "Create a Volcengine Cloud config without prompts.",
-        usage: "ov config add cloud [--name <name>] (--api-key-stdin|--api-key-env <env>) [--account <account> --user <user>] [--activate] [--force]",
+        path: &["config", "add", "ov-service"],
+        purpose: "Create an OpenViking Service config without prompts.",
+        usage: "ov config add ov-service [--name <name>] (--api-key-stdin|--api-key-env <env>) [--account <account> --user <user>] [--activate] [--force]",
         examples: &[
             HelpItem {
-                label: "printf '%s' \"$OV_KEY\" | ov config add cloud --name prod --api-key-stdin --activate",
+                label: "printf '%s' \"$OV_KEY\" | ov config add ov-service --name prod --api-key-stdin --activate",
                 description: "Read the API key from stdin and make the config active.",
             },
             HelpItem {
-                label: "ov config add cloud --api-key-env OV_KEY -o json",
+                label: "ov config add ov-service --api-key-env OV_KEY -o json",
                 description: "Read the API key from an environment variable and print JSON.",
             },
         ],
@@ -1831,17 +1831,17 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
         ],
     },
     CommandHelpSpec {
-        path: &["config", "add", "self-managed"],
-        purpose: "Create a self-managed config without prompts.",
-        usage: "ov config add self-managed [--name <name>] [--url <url>] [--api-key-stdin|--api-key-env <env>] [--root-api-key-stdin|--root-api-key-env <env>] [--account <account>] [--user <user>] [--activate] [--force]",
+        path: &["config", "add", "custom"],
+        purpose: "Create a custom config without prompts.",
+        usage: "ov config add custom [--name <name>] [--url <url>] [--api-key-stdin|--api-key-env <env>] [--root-api-key-stdin|--root-api-key-env <env>] [--account <account>] [--user <user>] [--activate] [--force]",
         examples: &[
             HelpItem {
-                label: "ov config add self-managed --name local --url http://127.0.0.1:1933 --activate",
+                label: "ov config add custom --name local --url http://127.0.0.1:1933 --activate",
                 description: "Create a local no-key config.",
             },
             HelpItem {
-                label: "ov config add self-managed --url https://ov.example.com --api-key-env OV_KEY --activate",
-                description: "Create a hosted self-managed config with an API key.",
+                label: "ov config add custom --url https://ov.example.com --api-key-env OV_KEY --activate",
+                description: "Create a hosted custom config with an API key.",
             },
         ],
         arguments: &[],
@@ -1922,7 +1922,7 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
             },
             HelpItem {
                 label: "--url <url>",
-                description: "Replace the self-managed server URL.",
+                description: "Replace the custom server URL.",
             },
             HelpItem {
                 label: "--api-key-stdin / --api-key-env <env> / --clear-api-key",
@@ -2402,8 +2402,10 @@ fn localized_command_purpose(spec: &CommandHelpSpec, language: Language) -> &str
         ["config", "switch"] => "切换到已保存的 CLI 配置。",
         ["config", "list"] => "列出已保存的 CLI 配置，并标记当前配置。",
         ["config", "add"] => "不打开交互式向导，创建已保存的 CLI 配置。",
-        ["config", "add", "cloud"] => "不打开交互式向导，创建火山引擎云配置。",
-        ["config", "add", "self-managed"] => "不打开交互式向导，创建自托管配置。",
+        ["config", "add", "ov-service"] => {
+            "不打开交互式向导，创建 OpenViking 服务（火山引擎云）配置。"
+        }
+        ["config", "add", "custom"] => "不打开交互式向导，创建自定义配置。",
         ["config", "edit"] => "不打开交互式向导，编辑已保存的 CLI 配置。",
         ["config", "delete"] => "不打开交互式向导，删除已保存的 CLI 配置。",
         ["health"] => "快速检查服务器是否可连接。",
@@ -2428,11 +2430,11 @@ fn localized_help_item_description<'a>(
         "validate" => "探测当前服务器和认证配置。",
         "switch" => "切换当前已保存配置。",
         "list" => "列出已保存的配置。",
-        "add" => "不打开提示，添加云端或自托管配置。",
+        "add" => "不打开提示，添加 OpenViking 服务或自定义配置。",
         "edit" => "不打开提示，编辑已保存配置。",
         "delete" => "不打开提示，删除已保存配置。",
-        "cloud" => "使用固定的火山引擎云端地址。",
-        "self-managed" => "使用本地或远程自托管地址。",
+        "ov-service" => "使用固定的 OpenViking 服务（火山引擎云）地址。",
+        "custom" => "使用本地或远程自定义地址。",
         "ov --help" => "查看所有命令。",
         "ov health" => "快速健康检查。",
         "ov status" => "查看详细后端状态。",
@@ -2441,8 +2443,8 @@ fn localized_help_item_description<'a>(
         "ov config list" => "查看已保存配置。",
         "ov config list -o json" => "以 JSON 返回已保存配置，便于自动化。",
         "ov config add --help" => "创建新的已保存配置。",
-        "ov config add cloud --help" => "查看云端配置专用参数。",
-        "ov config add self-managed --help" => "查看自托管配置专用参数。",
+        "ov config add ov-service --help" => "查看 OpenViking 服务配置专用参数。",
+        "ov config add custom --help" => "查看自定义配置专用参数。",
         "ov config switch <name>" => "激活已保存的配置。",
         "ov language" => "打开语言选择器。",
         "ov language zh-CN" => "将显示语言切换为简体中文。",
@@ -2651,8 +2653,13 @@ fn command_help_path(args: &[OsString]) -> Option<Vec<String>> {
     }
 
     let has_help_flag = tokens.iter().skip(1).any(|token| is_help_flag(token));
-    if has_help_flag && let Some(path) = config_help_path(&tokens) {
-        return Some(path);
+    if has_help_flag {
+        if has_invalid_config_add_provider(&tokens) {
+            return None;
+        }
+        if let Some(path) = config_help_path(&tokens) {
+            return Some(path);
+        }
     }
 
     let mut path = Vec::new();
@@ -2761,8 +2768,8 @@ fn config_help_path(tokens: &[String]) -> Option<Vec<String>> {
                     _ => return Some(path),
                 },
                 [base, add] if base == "config" && add == "add" => match token.as_str() {
-                    "cloud" | "self-managed" => path.push(token.clone()),
-                    _ => return Some(path),
+                    "ov-service" | "custom" => path.push(token.clone()),
+                    _ => return None,
                 },
                 _ => return Some(path),
             }
@@ -2772,6 +2779,60 @@ fn config_help_path(tokens: &[String]) -> Option<Vec<String>> {
     }
 
     None
+}
+
+fn has_invalid_config_add_provider(tokens: &[String]) -> bool {
+    let mut i = 1;
+    let mut saw_config = false;
+    let mut saw_add = false;
+
+    while i < tokens.len() {
+        let token = &tokens[i];
+        if is_help_flag(token) {
+            return false;
+        }
+        if token == "--sudo" || token == "--progress" || token == "--no-progress" || token == "-v" {
+            i += 1;
+            continue;
+        }
+        if consumes_value(token)
+            || matches!(
+                token.as_str(),
+                "--name"
+                    | "--new-name"
+                    | "--url"
+                    | "--api-key-env"
+                    | "--root-api-key-env"
+                    | "--account"
+                    | "--user"
+            )
+        {
+            i += if token.contains('=') { 1 } else { 2 };
+            continue;
+        }
+        if token.starts_with('-') {
+            i += 1;
+            continue;
+        }
+
+        if !saw_config {
+            saw_config = canonical_command_token(token) == "config";
+            if !saw_config {
+                return false;
+            }
+        } else if !saw_add {
+            saw_add = token == "add";
+            if !saw_add {
+                return false;
+            }
+        } else {
+            return !matches!(token.as_str(), "ov-service" | "custom");
+        }
+
+        i += 1;
+    }
+
+    false
 }
 
 fn command_spec(path: &[String]) -> Option<&'static CommandHelpSpec> {
@@ -3041,31 +3102,45 @@ mod tests {
             &render_command_help_request(&os_args(&["ov", "config", "add", "--help"]))
                 .expect("config add help should render"),
         );
-        assert!(config.contains("ov config add <cloud|self-managed>"));
-        assert!(config.contains("cloud"));
-        assert!(config.contains("self-managed"));
+        assert!(config.contains("ov config add <ov-service|custom>"));
+        assert!(config.contains("ov-service"));
+        assert!(config.contains("custom"));
 
         let cloud = strip_ansi(
-            &render_command_help_request(&os_args(&["ov", "config", "add", "cloud", "--help"]))
-                .expect("config add cloud help should render"),
+            &render_command_help_request(&os_args(&[
+                "ov",
+                "config",
+                "add",
+                "ov-service",
+                "--help",
+            ]))
+            .expect("config add ov-service help should render"),
         );
-        assert!(cloud.contains("ov config add cloud"));
+        assert!(cloud.contains("ov config add ov-service"));
         assert!(cloud.contains("--api-key-stdin"));
         assert!(cloud.contains("--api-key-env <env>"));
 
-        let self_managed = strip_ansi(
-            &render_command_help_request(&os_args(&[
+        let custom = strip_ansi(
+            &render_command_help_request(&os_args(&["ov", "config", "add", "custom", "--help"]))
+                .expect("config add custom help should render"),
+        );
+        assert!(custom.contains("ov config add custom"));
+        assert!(custom.contains("--root-api-key-stdin"));
+        assert!(!custom.contains("--use-root-key-for-normal-commands"));
+        assert!(
+            render_command_help_request(&os_args(&["ov", "config", "add", "cloud", "--help"]))
+                .is_none()
+        );
+        assert!(
+            render_command_help_request(&os_args(&[
                 "ov",
                 "config",
                 "add",
                 "self-managed",
                 "--help",
             ]))
-            .expect("config add self-managed help should render"),
+            .is_none()
         );
-        assert!(self_managed.contains("ov config add self-managed"));
-        assert!(self_managed.contains("--root-api-key-stdin"));
-        assert!(!self_managed.contains("--use-root-key-for-normal-commands"));
 
         let edit = strip_ansi(
             &render_command_help_request(&os_args(&["ov", "config", "edit", "prod", "--help"]))

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1052,14 +1052,14 @@ enum ConfigCommands {
 
 #[derive(Subcommand)]
 enum ConfigAddTarget {
-    /// Add a Volcengine Cloud config
-    Cloud(ConfigAddCloudArgs),
-    /// Add a self-managed config
-    SelfManaged(ConfigAddSelfManagedArgs),
+    /// Add an OpenViking Service config
+    OvService(ConfigAddOvServiceArgs),
+    /// Add a custom config
+    Custom(ConfigAddCustomArgs),
 }
 
 #[derive(Args, Debug, Clone)]
-struct ConfigAddCloudArgs {
+struct ConfigAddOvServiceArgs {
     /// Saved config name. Agents should pass this for idempotent retries; generated when omitted.
     #[arg(long)]
     name: Option<String>,
@@ -1084,7 +1084,7 @@ struct ConfigAddCloudArgs {
 }
 
 #[derive(Args, Debug, Clone)]
-struct ConfigAddSelfManagedArgs {
+struct ConfigAddCustomArgs {
     /// Saved config name. Agents should pass this for idempotent retries; generated when omitted.
     #[arg(long)]
     name: Option<String>,
@@ -1124,7 +1124,7 @@ struct ConfigEditArgs {
     /// Rename the saved config
     #[arg(long)]
     new_name: Option<String>,
-    /// New server URL. Volcengine Cloud configs use a fixed URL.
+    /// New server URL. OpenViking Service configs use a fixed URL.
     #[arg(long)]
     url: Option<String>,
     /// Read replacement API key from stdin
@@ -2326,7 +2326,7 @@ mod tests {
         legacy_upload_option_error, plain_help_misuse, pre_parse_requires_cli_config_file,
         preprocess_privacy_args,
     };
-    use crate::config::{Config, DEFAULT_SELF_MANAGED_URL};
+    use crate::config::{Config, DEFAULT_CUSTOM_URL};
     use crate::handlers;
     use crate::output::OutputFormat;
     use clap::{CommandFactory, Parser};
@@ -2398,52 +2398,52 @@ mod tests {
 
     #[test]
     fn config_agent_commands_parse_without_secret_value_flags() {
-        let add_cloud = Cli::try_parse_from([
+        let add_ov_service = Cli::try_parse_from([
             "ov",
             "config",
             "add",
-            "cloud",
+            "ov-service",
             "--name",
             "prod",
             "--api-key-stdin",
             "--activate",
         ])
-        .expect("cloud add should parse");
+        .expect("ov-service add should parse");
         let Commands::Config {
             action:
                 Some(ConfigCommands::Add {
-                    target: ConfigAddTarget::Cloud(cloud),
+                    target: ConfigAddTarget::OvService(ov_service),
                 }),
-        } = add_cloud.command
+        } = add_ov_service.command
         else {
-            panic!("expected cloud add command");
+            panic!("expected ov-service add command");
         };
-        assert_eq!(cloud.name.as_deref(), Some("prod"));
-        assert!(cloud.api_key_stdin);
-        assert!(cloud.activate);
+        assert_eq!(ov_service.name.as_deref(), Some("prod"));
+        assert!(ov_service.api_key_stdin);
+        assert!(ov_service.activate);
 
-        let add_self_managed = Cli::try_parse_from([
+        let add_custom = Cli::try_parse_from([
             "ov",
             "config",
             "add",
-            "self-managed",
+            "custom",
             "--url",
             "https://ov.example.com",
             "--api-key-env",
             "OV_KEY",
         ])
-        .expect("self-managed add should parse");
+        .expect("custom add should parse");
         let Commands::Config {
             action:
                 Some(ConfigCommands::Add {
-                    target: ConfigAddTarget::SelfManaged(self_managed),
+                    target: ConfigAddTarget::Custom(custom),
                 }),
-        } = add_self_managed.command
+        } = add_custom.command
         else {
-            panic!("expected self-managed add command");
+            panic!("expected custom add command");
         };
-        assert_eq!(self_managed.url.as_deref(), Some("https://ov.example.com"));
-        assert_eq!(self_managed.api_key_env.as_deref(), Some("OV_KEY"));
+        assert_eq!(custom.url.as_deref(), Some("https://ov.example.com"));
+        assert_eq!(custom.api_key_env.as_deref(), Some("OV_KEY"));
 
         let edit = Cli::try_parse_from([
             "ov",
@@ -2465,15 +2465,24 @@ mod tests {
         assert!(edit.activate);
 
         assert!(
-            Cli::try_parse_from(["ov", "config", "add", "cloud", "--api-key", "secret"]).is_err(),
+            Cli::try_parse_from(["ov", "config", "add", "ov-service", "--api-key", "secret"])
+                .is_err(),
             "plain API key flag must stay rejected"
+        );
+        assert!(
+            Cli::try_parse_from(["ov", "config", "add", "cloud", "--api-key-stdin"]).is_err(),
+            "old cloud provider subcommand must stay rejected"
+        );
+        assert!(
+            Cli::try_parse_from(["ov", "config", "add", "self-managed"]).is_err(),
+            "old self-managed provider subcommand must stay rejected"
         );
         assert!(
             Cli::try_parse_from([
                 "ov",
                 "config",
                 "add",
-                "self-managed",
+                "custom",
                 "--use-root-key-for-normal-commands",
             ])
             .is_err(),
@@ -2648,7 +2657,7 @@ mod tests {
             &["ov", "config", "switch", "prod"],
             &["ov", "config", "list"],
             &["ov", "config", "delete", "prod"],
-            &["ov", "config", "add", "cloud", "--api-key-stdin"],
+            &["ov", "config", "add", "ov-service", "--api-key-stdin"],
             &["ov", "config", "edit", "prod", "--activate"],
             &["ov", "config", "setup-cli"],
             &["ov", "version"],
@@ -2877,8 +2886,8 @@ mod tests {
     #[test]
     fn language_gate_allows_config_agent_commands_without_saved_language() {
         for args in [
-            &["ov", "config", "add", "cloud", "--api-key-stdin"][..],
-            &["ov", "config", "add", "self-managed"],
+            &["ov", "config", "add", "ov-service", "--api-key-stdin"][..],
+            &["ov", "config", "add", "custom"],
             &["ov", "config", "edit", "prod", "--activate"],
             &["ov", "config", "delete", "prod"],
             &["ov", "config", "list"],
@@ -3004,7 +3013,7 @@ mod tests {
     #[test]
     fn cli_context_overrides_identity_from_cli_flags() {
         let config = Config {
-            url: DEFAULT_SELF_MANAGED_URL.to_string(),
+            url: DEFAULT_CUSTOM_URL.to_string(),
             api_key: Some("test-key".to_string()),
             root_api_key: None,
             account: Some("from-config-account".to_string()),
@@ -3038,7 +3047,7 @@ mod tests {
     #[test]
     fn cli_context_uses_root_api_key_with_sudo() {
         let config = Config {
-            url: DEFAULT_SELF_MANAGED_URL.to_string(),
+            url: DEFAULT_CUSTOM_URL.to_string(),
             api_key: Some("user-key".to_string()),
             root_api_key: Some("root-key".to_string()),
             account: None,

--- a/crates/ov_cli/src/status_ui.rs
+++ b/crates/ov_cli/src/status_ui.rs
@@ -303,10 +303,10 @@ fn unknown(language: Language) -> &'static str {
 
 fn kind_label(kind: ConfigKind, language: Language) -> &'static str {
     match language {
-        Language::En => kind.label(),
+        Language::En => kind.compact_label(),
         Language::ZhCn => match kind {
-            ConfigKind::VolcengineCloud => "火山引擎云",
-            ConfigKind::SelfManaged => "自托管",
+            ConfigKind::OpenVikingService => "OpenViking 服务",
+            ConfigKind::Custom => "自定义",
         },
     }
 }
@@ -825,7 +825,7 @@ mod tests {
 
         assert!(rendered.contains("OPENVIKING STATUS"));
         assert!(rendered.contains("Config"));
-        assert!(rendered.contains("Active        unknown (Self-Managed)"));
+        assert!(rendered.contains("Active        unknown (Custom)"));
         assert!(rendered.contains("Server        http://127.0.0.1:1933"));
         assert!(rendered.contains("System"));
         assert!(rendered.contains("Status        Connected (Healthy)"));
@@ -861,7 +861,7 @@ mod tests {
             .expect("status should render");
         let rendered = strip_ansi(&rendered);
 
-        assert!(rendered.contains("Active        local (Self-Managed)"));
+        assert!(rendered.contains("Active        local (Custom)"));
         assert!(rendered.contains("Pending       unknown"));
         assert!(rendered.contains("queue          healthy    unknown"));
         assert!(rendered.contains("models         unknown    unknown"));
@@ -879,7 +879,7 @@ mod tests {
 
         let plain = strip_ansi(&rendered);
         assert!(plain.contains("OPENVIKING STATUS"));
-        assert!(plain.contains("Active        local (Self-Managed)"));
+        assert!(plain.contains("Active        local (Custom)"));
         assert!(plain.contains("queue          healthy    64 pending, 9 running, 0 errors"));
         assert!(plain.contains("ov status --verbose       Show full component tables"));
     }

--- a/docs/en/agent-integrations/05-hermes.md
+++ b/docs/en/agent-integrations/05-hermes.md
@@ -12,7 +12,7 @@ hermes memory setup
 
 The wizard prompts for:
 
-- **OpenViking server URL** — your self-hosted server (default `http://127.0.0.1:1933`) or Volcengine OpenViking Cloud
+- **OpenViking server URL** — your self-hosted server (default `http://127.0.0.1:1933`) or OpenViking Service (VolcEngine Cloud)
 - **API key** — leave blank for local dev mode
 - **Tenant account / user / agent IDs** — for multi-tenant deployments
 

--- a/docs/en/getting-started/05-cli-setup.md
+++ b/docs/en/getting-started/05-cli-setup.md
@@ -2,7 +2,7 @@
 
 This guide helps you install the OpenViking CLI, configure it, and verify that it can connect to OpenViking.
 
-`ov` is the client CLI. It connects to an existing OpenViking server or to VolcEngine Cloud. It does not replace server setup. If you still need to install or start a self-managed server, follow the [Quick Start](02-quickstart.md) or the [Server Mode guide](03-quickstart-server.md) first.
+`ov` is the client CLI. It connects to an existing OpenViking server or to OpenViking Service (VolcEngine Cloud). It does not replace server setup. If you still need to install or start a custom OpenViking server, follow the [Quick Start](02-quickstart.md) or the [Server Mode guide](03-quickstart-server.md) first.
 
 Use this page in either of two ways:
 
@@ -27,9 +27,9 @@ Choose the OpenViking target before running setup commands.
 
 Agents should ask the user which target they want unless it has already been specified. Existing configs, active configs, local files, default ports, and running services can inform follow-up questions, but they are not consent for the agent to choose a target, switch or replace configs, probe local services, start servers, or write data.
 
-### VolcEngine Cloud
+### OpenViking Service (VolcEngine Cloud)
 
-Choose this when you want OpenViking hosted on VolcEngine Cloud.
+Choose this when you want OpenViking hosted as a managed service on VolcEngine Cloud.
 
 - Server endpoint used by `ov`: `https://api.vikingdb.cn-beijing.volces.com/openviking`
 - Console page for API keys: https://console.volcengine.com/vikingdb/openviking/region:openviking+cn-beijing
@@ -37,21 +37,21 @@ Choose this when you want OpenViking hosted on VolcEngine Cloud.
 - API key is required.
 - Standard setup only needs the API key. Do not ask for `--account` or `--user` unless the user's administrator specifically provides identity override values.
 
-### Remote Self-Managed
+### Remote Custom
 
-Choose this when you connect to a self-managed OpenViking server hosted somewhere other than the current machine.
+Choose this when you connect to a custom OpenViking server hosted somewhere other than the current machine.
 
 - Server URL is provided by the user or server administrator.
 - API key may be required.
 - Root-key-only configs require `--account` and `--user`.
 
-### Local Self-Managed
+### Local Custom
 
-Choose this only when the user wants to connect to a self-managed OpenViking server on the current machine.
+Choose this only when the user wants to connect to a custom OpenViking server on the current machine.
 
 - Default local URL: `http://127.0.0.1:1933`
 - API key is usually not needed for a local unauthenticated server.
-- Agents should not probe local ports, curl local health endpoints, or start server commands unless the user chose local self-managed.
+- Agents should not probe local ports, curl local health endpoints, or start server commands unless the user chose local custom setup.
 
 ## Before You Start
 
@@ -61,8 +61,8 @@ You need:
   - Node.js and npm for the standalone `@openviking/cli` package, or
   - Python tooling if you install the full `openviking` package.
 - A reachable OpenViking target:
-  - VolcEngine Cloud, or
-  - a self-managed OpenViking server.
+  - OpenViking Service (VolcEngine Cloud), or
+  - a custom OpenViking server.
 - An API key if your target requires authentication.
 
 API keys are sensitive. Prefer entering them through the interactive `ov config` prompt when you configure `ov` yourself. Only provide API keys to an agent through a channel you intentionally trust. The agent should pass the key through stdin and must not put it in shell commands, logs, long-term memory, or raw config output. Use an environment variable only when the key is already present in the shell environment.
@@ -133,7 +133,7 @@ ov config
 Then choose:
 
 1. `Add config`
-2. `VolcEngine Cloud` or `Self-Managed`
+2. `OpenViking Service (VolcEngine Cloud)` or `Custom`
 3. A config name, or leave it empty to generate one
 4. The required URL and API key values for the target you chose above
 5. Save the config after validation
@@ -154,7 +154,7 @@ Use this path when an agent is setting up `ov` for a user. The agent should read
 
 ### Agent Checklist
 
-1. Ask which target the user wants unless it has already been specified: VolcEngine Cloud, remote self-managed, or local self-managed.
+1. Ask which target the user wants unless it has already been specified: OpenViking Service (VolcEngine Cloud), remote custom, or local custom.
 2. Do not infer the intended setup from existing configs, active configs, local files, default ports, or running services.
 3. Ask before switching configs, replacing configs, probing local services, starting servers, or writing data.
 4. Run `ov --help`, `ov config --help`, and the relevant config subcommand help before choosing commands.
@@ -174,8 +174,8 @@ Run:
 ov --help
 ov config --help
 ov config add --help
-ov config add cloud --help
-ov config add self-managed --help
+ov config add ov-service --help
+ov config add custom --help
 ov config edit --help
 ```
 
@@ -227,7 +227,7 @@ ov config list -o json
 The list output shape is:
 
 ```json
-{"status":"ok","result":[{"name":"<CONFIG-NAME>","kind":"VolcEngine Cloud","url":"https://api.vikingdb.cn-beijing.volces.com/openviking","active":true}]}
+{"status":"ok","result":[{"name":"<CONFIG-NAME>","kind":"OpenViking Service","url":"https://api.vikingdb.cn-beijing.volces.com/openviking","active":true}]}
 ```
 
 For an existence check, inspect `result[].name`. To decide whether a config already needs switching, inspect the matching entry's `active` flag.
@@ -240,72 +240,72 @@ ov config switch <CONFIG-NAME> -o json
 
 Then run the verification commands.
 
-### Add VolcEngine Cloud
+### Add OpenViking Service
 
 If the agent already holds the API key through a trusted channel, run:
 
 ```bash
-ov config add cloud --name <CONFIG-NAME> --api-key-stdin --activate -o json
+ov config add ov-service --name <CONFIG-NAME> --api-key-stdin --activate -o json
 ```
 
 A shell pipe has this shape:
 
 ```bash
-printf '%s' "$API_KEY" | ov config add cloud --name <CONFIG-NAME> --api-key-stdin --activate -o json
+printf '%s' "$API_KEY" | ov config add ov-service --name <CONFIG-NAME> --api-key-stdin --activate -o json
 ```
 
 `$API_KEY` stands for a trusted runtime secret source, not the literal key. Use stdin when the agent can supply the key without putting it in the command text, shell history, logs, or a long-lived exported environment variable.
 
-Write only the API key bytes to stdin. Do not place the key in the shell command. This writes a VolcEngine Cloud config using the fixed endpoint `https://api.vikingdb.cn-beijing.volces.com/openviking`. The `cloud` target does not take a custom server URL.
+Write only the API key bytes to stdin. Do not place the key in the shell command. This writes an OpenViking Service config using the fixed endpoint `https://api.vikingdb.cn-beijing.volces.com/openviking`. The `ov-service` target does not take a custom server URL.
 
 Use an environment variable only if it already exists in the shell:
 
 ```bash
-ov config add cloud --name <CONFIG-NAME> --api-key-env <API-KEY-ENV-VAR> --activate -o json
+ov config add ov-service --name <CONFIG-NAME> --api-key-env <API-KEY-ENV-VAR> --activate -o json
 ```
 
-Do not pass `--account` or `--user` for standard VolcEngine Cloud setup. Use them only when the user or their OpenViking administrator provides identity override values.
+Do not pass `--account` or `--user` for standard OpenViking Service setup. Use them only when the user or their OpenViking administrator provides identity override values.
 
-### Add a Local Self-Managed Server
+### Add a Local Custom Server
 
-Use this path only after the user chooses local self-managed.
+Use this path only after the user chooses local custom setup.
 
 For a local unauthenticated server:
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url http://127.0.0.1:1933 --activate -o json
+ov config add custom --name <CONFIG-NAME> --url http://127.0.0.1:1933 --activate -o json
 ```
 
 If the local server is not running, guide the user to start it first. See the [Server Mode guide](03-quickstart-server.md).
 
-### Add a Remote Self-Managed Server
+### Add a Remote Custom Server
 
-For a hosted self-managed server with a normal API key:
+For a hosted custom server with a normal API key:
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
+ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
 ```
 
 The stdin pipe form is:
 
 ```bash
-printf '%s' "$API_KEY" | ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
+printf '%s' "$API_KEY" | ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
 ```
 
 Write the API key to stdin. If the key is already in the shell environment, use `--api-key-env <API-KEY-ENV-VAR>` instead.
 
-For a self-managed server where the user gives you only a root API key, include the target account and user:
+For a custom server where the user gives you only a root API key, include the target account and user:
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --root-api-key-stdin --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
+ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --root-api-key-stdin --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
 ```
 
 Write the root API key to stdin. Root keys require explicit `--account` and `--user` so normal CLI commands know which identity to use.
 
-For a self-managed server where the user has both a user key and a root key, store both in one config:
+For a custom server where the user has both a user key and a root key, store both in one config:
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --root-api-key-env <ROOT-API-KEY-ENV-VAR> --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
+ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --root-api-key-env <ROOT-API-KEY-ENV-VAR> --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
 ```
 
 This keeps normal commands on the user key and lets `--sudo` commands use the root key. Because one command has only one stdin stream, the second key must come from an existing environment variable. If neither key is already available in the environment, use `ov config` and guide the user through the interactive flow.
@@ -332,10 +332,10 @@ ov config edit <CONFIG-NAME> --api-key-stdin --activate -o json
 
 Write the replacement API key to stdin.
 
-Replace a self-managed URL:
+Replace a custom server URL:
 
 ```bash
-ov config edit <CONFIG-NAME> --url <SELF-MANAGED-URL> --activate -o json
+ov config edit <CONFIG-NAME> --url <CUSTOM-OPENVIKING-URL> --activate -o json
 ```
 
 Use `--force` only when you intentionally want to replace an existing saved config name.
@@ -417,7 +417,7 @@ If npm reports a permission error, use your normal Node.js setup policy. Avoid `
 
 ### Local Server Is Not Running
 
-Use this only when the user chose local self-managed setup. Then verify the server:
+Use this only when the user chose local custom setup. Then verify the server:
 
 ```bash
 curl http://127.0.0.1:1933/health
@@ -427,7 +427,7 @@ If it fails, start the server before configuring `ov`. See the [Server Mode guid
 
 ### API Key Validation Fails
 
-Run `ov config` again and edit the config. For VolcEngine Cloud, confirm the key came from the OpenViking console URL above. For self-managed servers, confirm whether the server requires authentication.
+Run `ov config` again and edit the config. For OpenViking Service, confirm the key came from the OpenViking console URL above. For custom servers, confirm whether the server requires authentication.
 
 Agents should not keep retrying unknown keys. Ask the user to confirm the target type, server URL, key type, account, and user.
 

--- a/docs/zh/agent-integrations/05-hermes.md
+++ b/docs/zh/agent-integrations/05-hermes.md
@@ -12,7 +12,7 @@ hermes memory setup
 
 向导会询问：
 
-- **OpenViking 服务 URL** — 自托管服务器（默认 `http://127.0.0.1:1933`）或火山引擎 OpenViking Cloud
+- **OpenViking 服务 URL** — 自托管服务器（默认 `http://127.0.0.1:1933`）或 OpenViking Service（火山引擎云）
 - **API Key** — 本地开发模式留空
 - **租户 account / user / agent ID** — 多租户部署时使用
 

--- a/docs/zh/getting-started/05-cli-setup.md
+++ b/docs/zh/getting-started/05-cli-setup.md
@@ -2,7 +2,7 @@
 
 本文介绍如何安装 OpenViking CLI、完成配置，并验证它可以连接到 OpenViking。
 
-`ov` 是客户端 CLI。它连接到已经存在的 OpenViking 服务端，或连接到 VolcEngine Cloud。它不是服务端安装命令。如果你还没有安装或启动自托管服务端，请先阅读[快速开始](02-quickstart.md)或[服务端模式](03-quickstart-server.md)。
+`ov` 是客户端 CLI。它连接到已经存在的 OpenViking 服务端，或连接到 OpenViking Service（火山引擎云）。它不是服务端安装命令。如果你还没有安装或启动自定义 OpenViking 服务端，请先阅读[快速开始](02-quickstart.md)或[服务端模式](03-quickstart-server.md)。
 
 你可以用两种方式阅读本文：
 
@@ -27,9 +27,9 @@ CLI 使用 `~/.openviking/ovcli.conf` 作为 active 客户端连接配置。
 
 除非用户已经明确说明，Agent 应先询问用户要连接哪种目标。已有配置、active 配置、本地文件、默认端口和正在运行的服务可以帮助 Agent 追问细节，但不代表用户同意 Agent 选择目标、切换或替换配置、探测本地服务、启动服务端，或写入数据。
 
-### VolcEngine Cloud
+### OpenViking Service（火山引擎云）
 
-如果你希望使用 VolcEngine Cloud 托管的 OpenViking，选择此项。
+如果你希望使用火山引擎云上的 OpenViking 托管服务，选择此项。
 
 - `ov` 使用的服务端端点：`https://api.vikingdb.cn-beijing.volces.com/openviking`
 - 管理 API Key 的控制台页面：https://console.volcengine.com/vikingdb/openviking/region:openviking+cn-beijing
@@ -37,21 +37,21 @@ CLI 使用 `~/.openviking/ovcli.conf` 作为 active 客户端连接配置。
 - API Key 必填。
 - 标准配置只需要 API Key。除非用户的管理员明确提供身份覆盖值，否则不要询问 `--account` 或 `--user`。
 
-### 远程自托管
+### 远程自定义
 
-如果你要连接不在当前机器上的自托管 OpenViking 服务端，选择此项。
+如果你要连接不在当前机器上的自定义 OpenViking 服务端，选择此项。
 
 - 服务端 URL 由用户或服务端管理员提供。
 - 可能需要 API Key。
 - 只有 root key 的配置需要 `--account` 和 `--user`。
 
-### 本地自托管
+### 本地自定义
 
-只有当用户要连接当前机器上的自托管 OpenViking 服务端时，才选择此项。
+只有当用户要连接当前机器上的自定义 OpenViking 服务端时，才选择此项。
 
 - 本地默认 URL：`http://127.0.0.1:1933`
 - 本地无鉴权服务通常不需要 API Key。
-- 除非用户选择本地自托管，否则 Agent 不应探测本地端口、curl 本地 health endpoint，或运行启动服务端的命令。
+- 除非用户选择本地自定义配置，否则 Agent 不应探测本地端口、curl 本地 health endpoint，或运行启动服务端的命令。
 
 ## 开始前
 
@@ -61,8 +61,8 @@ CLI 使用 `~/.openviking/ovcli.conf` 作为 active 客户端连接配置。
   - 使用 Node.js 和 npm 安装独立的 `@openviking/cli` 包，或
   - 使用 Python 工具安装完整的 `openviking` 包。
 - 一个可访问的 OpenViking 目标：
-  - VolcEngine Cloud，或
-  - 自托管 OpenViking 服务端。
+  - OpenViking Service（火山引擎云），或
+  - 自定义 OpenViking 服务端。
 - 如果目标需要鉴权，需要准备 API Key。
 
 API Key 是敏感凭证。手动配置时优先通过 `ov config` 的交互式输入框输入。只有当你明确相信当前渠道时，才把 API Key 提供给 Agent。Agent 应通过 stdin 传入 key，不能把 key 写进 shell 命令、日志、长期记忆或原始配置输出。只有当 key 已经存在于当前 shell 环境变量中时，才使用环境变量。
@@ -133,7 +133,7 @@ ov config
 然后选择：
 
 1. `Add config`
-2. `VolcEngine Cloud` 或 `Self-Managed`
+2. `OpenViking Service（火山引擎云）` 或 `自定义`
 3. 配置名称，或留空自动生成
 4. 上面选择的目标所需的 URL 和 API Key
 5. 校验成功后保存配置
@@ -154,7 +154,7 @@ ov config switch
 
 ### Agent 检查清单
 
-1. 除非用户已经明确说明，先询问用户要连接哪种目标：VolcEngine Cloud、远程自托管，还是本地自托管。
+1. 除非用户已经明确说明，先询问用户要连接哪种目标：OpenViking Service（火山引擎云）、远程自定义，还是本地自定义。
 2. 不要根据已有配置、active 配置、本地文件、默认端口或正在运行的服务推断用户想要的 setup。
 3. 切换配置、替换配置、探测本地服务、启动服务端或写入数据前，都要先询问用户。
 4. 在选择命令前，运行 `ov --help`、`ov config --help` 和相关 config 子命令的帮助。
@@ -174,8 +174,8 @@ ov config switch
 ov --help
 ov config --help
 ov config add --help
-ov config add cloud --help
-ov config add self-managed --help
+ov config add ov-service --help
+ov config add custom --help
 ov config edit --help
 ```
 
@@ -227,7 +227,7 @@ ov config list -o json
 列表输出形状如下：
 
 ```json
-{"status":"ok","result":[{"name":"<CONFIG-NAME>","kind":"VolcEngine Cloud","url":"https://api.vikingdb.cn-beijing.volces.com/openviking","active":true}]}
+{"status":"ok","result":[{"name":"<CONFIG-NAME>","kind":"OpenViking Service","url":"https://api.vikingdb.cn-beijing.volces.com/openviking","active":true}]}
 ```
 
 做存在性检查时，读取 `result[].name`。判断是否还需要切换 active config 时，读取匹配项的 `active` 标记。
@@ -240,56 +240,56 @@ ov config switch <CONFIG-NAME> -o json
 
 然后运行验证命令。
 
-### 添加 VolcEngine Cloud
+### 添加 OpenViking Service
 
 如果 Agent 已经通过可信渠道拿到 API Key，运行：
 
 ```bash
-ov config add cloud --name <CONFIG-NAME> --api-key-stdin --activate -o json
+ov config add ov-service --name <CONFIG-NAME> --api-key-stdin --activate -o json
 ```
 
 shell pipe 形式如下：
 
 ```bash
-printf '%s' "$API_KEY" | ov config add cloud --name <CONFIG-NAME> --api-key-stdin --activate -o json
+printf '%s' "$API_KEY" | ov config add ov-service --name <CONFIG-NAME> --api-key-stdin --activate -o json
 ```
 
 `$API_KEY` 表示可信的运行时密钥来源，不是字面量 key。Agent 能在不把 key 写进命令文本、shell history、日志或长期 export 的环境变量时提供 key，就应使用 stdin。
 
-只把 API Key 内容写入 stdin，不要把 key 放进 shell 命令本身。这会写入一个 VolcEngine Cloud 配置，并使用固定端点：`https://api.vikingdb.cn-beijing.volces.com/openviking`。`cloud` 目标不接受自定义服务端 URL。
+只把 API Key 内容写入 stdin，不要把 key 放进 shell 命令本身。这会写入一个 OpenViking Service 配置，并使用固定端点：`https://api.vikingdb.cn-beijing.volces.com/openviking`。`ov-service` 目标不接受自定义服务端 URL。
 
 只有当环境变量已经存在时，才使用环境变量：
 
 ```bash
-ov config add cloud --name <CONFIG-NAME> --api-key-env <API-KEY-ENV-VAR> --activate -o json
+ov config add ov-service --name <CONFIG-NAME> --api-key-env <API-KEY-ENV-VAR> --activate -o json
 ```
 
-标准 VolcEngine Cloud 配置不要传 `--account` 或 `--user`。只有当用户或 OpenViking 管理员提供身份覆盖值时，才使用它们。
+标准 OpenViking Service 配置不要传 `--account` 或 `--user`。只有当用户或 OpenViking 管理员提供身份覆盖值时，才使用它们。
 
-### 添加本地自托管服务
+### 添加本地自定义服务
 
-只有当用户选择本地自托管时，才使用这个路径。
+只有当用户选择本地自定义时，才使用这个路径。
 
 对于本地无鉴权服务：
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url http://127.0.0.1:1933 --activate -o json
+ov config add custom --name <CONFIG-NAME> --url http://127.0.0.1:1933 --activate -o json
 ```
 
 如果本地服务没有运行，请先引导用户启动服务端。参见[服务端模式](03-quickstart-server.md)。
 
-### 添加远程自托管服务
+### 添加远程自定义服务
 
-对于使用普通 API Key 的远程自托管服务：
+对于使用普通 API Key 的远程自定义服务：
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
+ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
 ```
 
 stdin pipe 形式如下：
 
 ```bash
-printf '%s' "$API_KEY" | ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
+printf '%s' "$API_KEY" | ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --activate -o json
 ```
 
 把 API Key 写入 stdin。如果 key 已经存在于当前 shell 环境变量中，可以改用 `--api-key-env <API-KEY-ENV-VAR>`。
@@ -297,7 +297,7 @@ printf '%s' "$API_KEY" | ov config add self-managed --name <CONFIG-NAME> --url <
 如果用户只提供 root API key，需要同时提供目标 account 和 user：
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --root-api-key-stdin --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
+ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --root-api-key-stdin --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
 ```
 
 把 root API key 写入 stdin。Root key 需要显式 `--account` 和 `--user`，这样普通 CLI 命令才知道以哪个身份执行。
@@ -305,7 +305,7 @@ ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --
 如果用户同时拥有 user key 和 root key，可以把两者放在同一个配置里：
 
 ```bash
-ov config add self-managed --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --root-api-key-env <ROOT-API-KEY-ENV-VAR> --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
+ov config add custom --name <CONFIG-NAME> --url <REMOTE-OPENVIKING-URL> --api-key-stdin --root-api-key-env <ROOT-API-KEY-ENV-VAR> --account <ACCOUNT-ID> --user <USER-ID> --activate -o json
 ```
 
 这样普通命令使用 user key，需要 `--sudo` 的命令使用 root key。因为一个命令只有一个 stdin 流，第二个 key 必须来自已经存在的环境变量。如果两个 key 都不在环境变量中，请使用 `ov config` 并引导用户完成交互式流程。
@@ -332,10 +332,10 @@ ov config edit <CONFIG-NAME> --api-key-stdin --activate -o json
 
 把新的 API Key 写入 stdin。
 
-替换自托管 URL：
+替换自定义服务 URL：
 
 ```bash
-ov config edit <CONFIG-NAME> --url <SELF-MANAGED-URL> --activate -o json
+ov config edit <CONFIG-NAME> --url <CUSTOM-OPENVIKING-URL> --activate -o json
 ```
 
 只有在你明确要覆盖已有 saved config 名称时，才使用 `--force`。
@@ -417,7 +417,7 @@ npm prefix -g
 
 ### 本地服务端没有运行
 
-只有当用户选择本地自托管时才使用此项。先验证服务端：
+只有当用户选择本地自定义时才使用此项。先验证服务端：
 
 ```bash
 curl http://127.0.0.1:1933/health
@@ -427,7 +427,7 @@ curl http://127.0.0.1:1933/health
 
 ### API Key 校验失败
 
-重新运行 `ov config` 并编辑配置。对于 VolcEngine Cloud，确认 API Key 来自上面的 OpenViking 控制台地址。对于自托管服务，确认服务端是否要求鉴权。
+重新运行 `ov config` 并编辑配置。对于 OpenViking Service，确认 API Key 来自上面的 OpenViking 控制台地址。对于自定义服务，确认服务端是否要求鉴权。
 
 Agent 不应该反复重试未知 key。请让用户确认目标类型、服务端 URL、key 类型、account 和 user。
 


### PR DESCRIPTION
## Description

Renames the `ov config` provider surface from the older cloud/self-managed wording to clearer user-facing terms:

- `OpenViking Service` for the managed OpenViking endpoint
- `Custom` for user-provided OpenViking servers

The managed endpoint and API-key console URL are unchanged. This updates the interactive config wizard, non-interactive agent commands, help output, config/status summaries, JSON kind strings, and setup docs so the CLI uses one consistent provider vocabulary.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- Rename config provider labels to `OpenViking Service` and `Custom`, while keeping the add wizard label explicit as `OpenViking Service (VolcEngine Cloud)`.
- Rename non-interactive config targets from `ov config add cloud` / `self-managed` to `ov config add ov-service` / `custom`.
- Update config list/status/show/switch rendering, JSON kind output, curated help, and EN/ZH setup and integration docs to the new provider names.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

- `cargo test -p ov_cli`
- `cargo build -p ov_cli`
- `npm --prefix docs run docs:build`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The OpenViking Service endpoint remains `https://api.vikingdb.cn-beijing.volces.com/openviking`; this PR only changes provider naming, command wording, and related documentation.