### PR TITLE
docs(openclaw): document autoRecallTimeoutMs config in integration guide (#2391)

### DIFF
--- a/docs/en/agent-integrations/03-openclaw.md
+++ b/docs/en/agent-integrations/03-openclaw.md
@@ -97,6 +97,7 @@ Plugin config lives under `plugins.entries.openviking.config`. Setup usually wri
 | `baseUrl` | `http://127.0.0.1:1933` | OpenViking server endpoint |
 | `apiKey` | empty | OpenViking API key |
 | `peer_prefix` | empty | Optional prefix for assistant peer identity when `peer_role=assistant` |
+| `autoRecallTimeoutMs` | `5000` | Outer timeout (ms) for the whole auto-recall flow; increase for slow local embedding hardware (clamped 1000–300000) |
 
 ```bash
 openclaw config set plugins.entries.openviking.config.baseUrl http://your-server:1933

--- a/docs/zh/agent-integrations/03-openclaw.md
+++ b/docs/zh/agent-integrations/03-openclaw.md
@@ -97,6 +97,7 @@ python examples/openclaw-plugin/health_check_tools/ov-healthcheck.py
 | `baseUrl` | `http://127.0.0.1:1933` | OpenViking 服务端点 |
 | `apiKey` | 空 | OpenViking API Key |
 | `peer_prefix` | 空 | `peer_role=assistant` 时 assistant peer 身份的可选前缀 |
+| `autoRecallTimeoutMs` | `5000` | 整个 auto-recall 流程的外层超时（毫秒）；本地嵌入硬件较慢时可调大（取值范围 1000–300000） |
 
 ```bash
 openclaw config set plugins.entries.openviking.config.baseUrl http://your-server:1933


### PR DESCRIPTION
The OpenClaw integration guide 's Configuration table (docs/{en,zh}/agent-integrations/03-openclaw.md) lists `baseUrl`/`apiKey`/`peer_prefix` but not the `autoRecallTimeoutMs` knob added in #2448 (issue #2391).

#2448 made the auto-recall timeout configurable via `plugins.entries.openviking.config.autoRecallTimeoutMs` (config.ts: default `5000`, clamped to 1000–300000; wired into the `withTimeout()` call in auto-recall.ts). It is currently discoverable only in the plugin SKILL.md, not in the canonical guide. Issue #2391 reports the old fixed timeout being too short on slow local embedding hardware, so users need this knob from the main docs.

Adds one row to the Configuration table in both EN and ZH. Docs only.