### PR TITLE
docs(observability): document server.observability.usage_audit in config hierarchy

### DIFF
--- a/docs/en/guides/05-observability.md
+++ b/docs/en/guides/05-observability.md
@@ -261,6 +261,7 @@ OpenViking groups signal-level observability configuration under `server.observa
 - `server.observability.traces`: trace export configuration
 - `server.observability.logs`: log export configuration
 - `server.observability.dump_body`: attaches HTTP request/response bodies (filtered by content-type, truncated by bytes) as attributes on the active trace span so they can be inspected in trace UIs. Off by default — bodies may contain secrets and high-cardinality content
+- `server.observability.usage_audit`: per-request usage/cost audit log, stored in SQLite. `sqlite_path` overrides the database location (use a per-instance local path for multi-instance deployments); `timezone` controls timestamp localization. Enabled by default
 
 Example:
 
@@ -310,6 +311,11 @@ Example:
       "dump_body": {
         "enabled": false,
         "max_bytes": 4096
+      },
+      "usage_audit": {
+        "enabled": true,
+        "sqlite_path": null,
+        "timezone": "local"
       }
     }
   }

--- a/docs/zh/guides/05-observability.md
+++ b/docs/zh/guides/05-observability.md
@@ -260,6 +260,7 @@ OpenViking 将信号级别的可观测性配置统一放在 `server.observabilit
 - `server.observability.traces`：trace 导出配置
 - `server.observability.logs`：log 导出配置
 - `server.observability.dump_body`：把 HTTP 请求/响应 body（按 content-type 过滤、按字节截断）作为属性挂到当前 trace span 上，便于在 trace UI 中调试。默认关闭，因为 body 可能含密钥/高基数内容
+- `server.observability.usage_audit`：按请求记录用量/成本审计日志，使用 SQLite 存储。`sqlite_path` 可覆盖数据库位置（多实例部署时设为每实例独立的本地路径）；`timezone` 控制时间戳的时区本地化。默认开启
 
 示例：
 
@@ -309,6 +310,11 @@ OpenViking 将信号级别的可观测性配置统一放在 `server.observabilit
       "dump_body": {
         "enabled": false,
         "max_bytes": 4096
+      },
+      "usage_audit": {
+        "enabled": true,
+        "sqlite_path": null,
+        "timezone": "local"
       }
     }
   }


### PR DESCRIPTION
The **Observability config hierarchy** section lists `server.observability.{metrics,traces,logs,dump_body}` but omits `server.observability.usage_audit`, even though it is a real wired subkey of `ObservabilityConfig`.

Source-grounded in `openviking/server/config.py`:
- `class UsageAuditConfig` (L89): `enabled: bool = True` (L92), `backend: Literal["sqlite"] = "sqlite"` (L93), `sqlite_path: Optional[str] = None` (L94), `timezone: str = "local"` (L102)
- wired via `class ObservabilityConfig` → `usage_audit: UsageAuditConfig = Field(default_factory=UsageAuditConfig)` (L126)

This gap became conspicuous after #2442: the multi-instance deployment notes (`03-deployment.md`) now direct operators to set `server.observability.usage_audit.sqlite_path` for per-instance paths, but the observability config hierarchy — the canonical place that enumerates the `server.observability.*` subkeys — does not list `usage_audit` at all, so an operator cannot discover `enabled`/`sqlite_path`/`timezone` from the hierarchy.

Adds the missing `usage_audit` bullet + an entry in the config example, matching the existing `dump_body` documentation style (#2063). EN + ZH mirrored.