### PR TITLE
feat: add force parameter to commit to skip blocking failed archives (fixes #2475)

### DIFF
--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -352,6 +352,14 @@ class CommitRequest(BaseModel):
             "(default 10); compact path passes 0 to archive everything."
         ),
     )
+    force: bool = Field(
+        default=False,
+        description=(
+            "If true, skip the blocking-failed-archive check and commit anyway. "
+            "Useful for recovering from transient failures (e.g. VLM timeouts) "
+            "that left a stale .failed.json marker."
+        ),
+    )
     memory_policy: Optional[Dict[str, Any]] = None
     telemetry: TelemetryRequest = False
 
@@ -377,6 +385,7 @@ async def commit_session(
             _ctx,
             keep_recent_count=body.keep_recent_count,
             memory_policy=body.memory_policy,
+            force=body.force,
         ),
     )
     return Response(

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -316,6 +316,7 @@ class SessionService:
         ctx: RequestContext,
         keep_recent_count: int = 0,
         memory_policy: Optional[Dict[str, Any]] = None,
+        force: bool = False,
     ) -> Dict[str, Any]:
         """Async commit a session.
 
@@ -326,6 +327,7 @@ class SessionService:
             session_id: Session ID to commit
             keep_recent_count: Number of most-recent messages to keep in the
                 live session after commit. ``0`` archives everything.
+            force: If ``True``, skip blocking-failed-archive check.
 
         Returns:
             Commit result with keys: session_id, status, task_id,
@@ -336,6 +338,7 @@ class SessionService:
         result = await session.commit_async(
             keep_recent_count=keep_recent_count,
             memory_policy=memory_policy,
+            force=force,
         )
         self._record_lifecycle_metric("commit", "ok" if result.get("status") else "error")
         self._record_archive_metric("ok" if result.get("archived") else "skip")

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1052,6 +1052,7 @@ class Session:
         self,
         keep_recent_count: int = 0,
         memory_policy: Optional[Dict[str, Any]] = None,
+        force: bool = False,
     ) -> Dict[str, Any]:
         """Async commit session: archive immediately, extract memories in background.
 
@@ -1070,6 +1071,9 @@ class Session:
                 path passes ``0``.
             memory_policy: Optional per-commit extraction policy. When omitted,
                 the session default policy is used.
+            force: If ``True``, skip the blocking-failed-archive check and
+                commit anyway. Useful for recovering from transient failures
+                (e.g. VLM timeouts) that left a stale ``.failed.json`` marker.
 
         Returns a task_id for tracking Phase 2 progress.
         """
@@ -1108,11 +1112,17 @@ class Session:
 
         blocking_archive = await self._get_blocking_failed_archive_ref()
         if blocking_archive:
-            raise FailedPreconditionError(
-                f"Session {self.session_id} has unresolved failed archive "
-                f"{blocking_archive['archive_id']}; fix it before committing again.",
-                details={"archive_id": blocking_archive["archive_id"]},
-            )
+            if force:
+                logger.warning(
+                    f"Session {self.session_id} has unresolved failed archive "
+                    f"{blocking_archive['archive_id']}; force=True, skipping block"
+                )
+            else:
+                raise FailedPreconditionError(
+                    f"Session {self.session_id} has unresolved failed archive "
+                    f"{blocking_archive['archive_id']}; fix it before committing again.",
+                    details={"archive_id": blocking_archive["archive_id"]},
+                )
 
         # Use filesystem-based distributed lock so this works across workers/processes.
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
@@ -1227,6 +1237,7 @@ class Session:
                 first_message_id=messages_to_archive[0].id if messages_to_archive else "",
                 last_message_id=messages_to_archive[-1].id if messages_to_archive else "",
                 memory_policy=effective_memory_policy,
+                force=force,
             )
         )
 
@@ -1249,6 +1260,7 @@ class Session:
         first_message_id: str,
         last_message_id: str,
         memory_policy: Optional[Dict[str, Any]],
+        force: bool = False,
     ) -> None:
         """Phase 2: Extract memories, write relations, enqueue — runs in background."""
         import uuid
@@ -1273,23 +1285,29 @@ class Session:
 
         try:
             if not await self._wait_for_previous_archive_done(archive_index):
-                await self._write_failed_marker(
-                    archive_uri,
-                    stage="waiting_previous_done",
-                    error=(
+                if force:
+                    logger.warning(
+                        f"Previous archive archive_{archive_index - 1:03d} has unresolved failure; "
+                        f"force=True, skipping block and continuing Phase 2"
+                    )
+                else:
+                    await self._write_failed_marker(
+                        archive_uri,
+                        stage="waiting_previous_done",
+                        error=(
+                            f"Previous archive archive_{archive_index - 1:03d} failed; "
+                            "this archive cannot proceed"
+                        ),
+                        blocked_by=f"archive_{archive_index - 1:03d}",
+                    )
+                    await tracker.fail(
+                        task_id,
                         f"Previous archive archive_{archive_index - 1:03d} failed; "
-                        "this archive cannot proceed"
-                    ),
-                    blocked_by=f"archive_{archive_index - 1:03d}",
-                )
-                await tracker.fail(
-                    task_id,
-                    f"Previous archive archive_{archive_index - 1:03d} failed; "
-                    "cannot continue session commit",
-                    account_id=self.ctx.account_id,
-                    user_id=self.ctx.user.user_id,
-                )
-                return
+                        "cannot continue session commit",
+                        account_id=self.ctx.account_id,
+                        user_id=self.ctx.user.user_id,
+                    )
+                    return
 
             await tracker.start(
                 task_id,


### PR DESCRIPTION
## Problem

Closes #2475

A single transient failure (VLM timeout, SSL error, LLM parse error, etc.) during Phase 2 (memory extraction) writes a `.failed.json` marker that **permanently blocks all future commits** on that session. There is no auto-recovery, no retry mechanism, and no admin API to clear it.

### Real-world impact

When OpenViking is used as an OpenClaw context engine plugin, the `afterTurn` hook auto-commits on token threshold. A single VLM 180s timeout locks the entire session forever — the user has no way to recover without manually deleting `.failed.json` files from the filesystem.

### Failure chain

1. Session commits → Phase 1 (archive) succeeds
2. Phase 2 (memory extraction) fails (VLM timeout, SSL error, etc.)
3. `.failed.json` is written to the archive directory
4. All subsequent `POST /sessions/{id}/commit` return `FAILED_PRECONDITION`
5. Session is permanently locked

Additionally, the failure cascades: archive_002 fails → archive_003's `_wait_for_previous_archive_done()` sees 002's `.failed.json` → 003 also writes `.failed.json` → archive_004 blocked → entire session dead.

## Solution

Add a `force: bool = False` parameter throughout the commit flow. When `force=True`, both the Phase 1 and Phase 2 blocking checks are skipped with a warning log.

### Changes

| File | Change |
|------|--------|
| `session.py` | `commit_async(force=False)`: skip `_get_blocking_failed_archive_ref()` when force=True |
| `session.py` | `_run_memory_extraction(force=False)`: skip `_wait_for_previous_archive_done()` when force=True |
| `session.py` | `create_task` call: pass `force=force` to `_run_memory_extraction` |
| `session_service.py` | `commit_async(force=False)`: pass through to session |
| `sessions.py` router | `CommitRequest`: add `force: bool = False` field, pass through |

### Design decisions

- **Default `force=False`** preserves existing behavior — no breaking changes
- **`force=True`** only logs a warning, does not delete `.failed.json` — the marker stays for debugging
- Phase 1 and Phase 2 both need independent `force` handling because Phase 2 runs in a background `asyncio.create_task()` with its own `_wait_for_previous_archive_done()` check

### Testing

Verified in production:
- VLM timeout → `.failed.json` written → session locked
- With `force=True`: commit proceeds, Phase 2 runs, new memories extracted
- Without `force`: existing `FAILED_PRECONDITION` behavior unchanged