### PR TITLE
fix(vlm): send MiMo thinking parameter as object format

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -141,11 +141,23 @@ class OpenAIVLM(VLMBase):
 
         return host.lower() in _DASHSCOPE_HOSTS
 
+    def _is_mimo_endpoint(self) -> bool:
+        """Return True for Xiaomi MiMo API endpoints."""
+        if not self.api_base:
+            return False
+        try:
+            host = urlparse(self.api_base).hostname or ""
+        except ValueError:
+            return False
+        return "xiaomimimo.com" in host.lower()
+
     def _apply_provider_specific_extra_body(self, kwargs: Dict[str, Any], thinking: bool) -> None:
         """Attach provider-specific raw body parameters understood by compatible APIs."""
         extra_body = dict(self.extra_request_body)
         if self._supports_enable_thinking():
             extra_body["enable_thinking"] = bool(thinking)
+        if self._is_mimo_endpoint():
+            extra_body["thinking"] = {"type": "enabled" if thinking else "disabled"}
         if extra_body:
             kwargs["extra_body"] = extra_body
 


### PR DESCRIPTION
## Problem

Xiaomi MiMo API (mimo-v2.5 / mimo-v2.5-pro) requires the `thinking` parameter as an object:

```json
{thinking: {type: disabled}}
```

The current `_apply_provider_specific_extra_body()` only handles DashScope's `enable_thinking` boolean parameter. For MiMo endpoints, no thinking-related parameter is sent, causing MiMo to default to `thinking: enabled`. When thinking is enabled, MiMo returns the actual response in `reasoning_content` while `content` is empty — breaking VLM memory extraction silently.

## Fix

- Add `_is_mimo_endpoint()` method to detect `xiaomimimo.com` hosts (consistent with existing `_supports_enable_thinking()` pattern)
- In `_apply_provider_specific_extra_body()`, send `{thinking: {type: disabled}}` for MiMo endpoints when thinking is disabled

## Testing

Verified with mimo-v2.5 API:

```
thinking: {type: disabled} → content: 1+1等于2。 ✅ reasoning_content: (empty) ✅
thinking: {type: enabled}  → content:            reasoning_content: ... ✅
```

Without this patch, no thinking parameter is sent and MiMo defaults to enabled, causing empty `content` for all VLM extractions.