### PR TITLE
docs(api): document memory_policy (self/peer memory isolation) on create_session & commit (#2236)

### DIFF
--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -32,6 +32,7 @@ Create a new session. Sessions are containers for conversations, storing message
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | session_id | str | No | None | Session ID. Creates new session with auto-generated ID if None |
+| memory_policy | object | No | None | Default self/peer memory-extraction policy for the session. An object with optional `self` and `peer` keys, each `{"enabled": <bool>}` (defaults: `self.enabled=true`, `peer.enabled=false`). Overridable per commit; a non-object value is rejected with `InvalidArgumentError`. |
 
 #### 3. Usage Examples
 
@@ -909,6 +910,7 @@ Commit a session. Message archiving (Phase 1) completes immediately. Summary gen
 |-----------|------|----------|---------|-------------|
 | session_id | str | Yes | - | Session ID to commit |
 | keep_recent_count | int | No | 0 | Number of recent live messages to retain (kept live, not archived) after commit. `0` (default) archives all messages. |
+| memory_policy | object | No | None | Controls whether self-memory and peer-memory extraction run on this commit. An object with optional `self` and `peer` keys, each `{"enabled": <bool>}` (defaults: `self.enabled=true`, `peer.enabled=false`). A commit-level value overrides the session-level policy; a non-object value is rejected with `InvalidArgumentError`. |
 
 #### 3. Usage Examples
 
@@ -923,6 +925,12 @@ POST /api/v1/sessions/{session_id}/commit
 curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/commit \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key"
+
+# Commit and additionally run peer-memory extraction (off by default)
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/commit \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"memory_policy": {"peer": {"enabled": true}}}'
 
 # Poll task status
 curl -X GET http://localhost:1933/api/v1/tasks/{task_id} \

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -32,6 +32,7 @@
 | 参数 | 类型 | 必填 | 默认值 | 说明 |
 |------|------|------|--------|------|
 | session_id | str | 否 | None | 会话 ID。如果为 None，则创建一个自动生成 ID 的新会话 |
+| memory_policy | object | 否 | None | 会话默认的自我/对方记忆抽取策略。对象，包含可选的 `self` 和 `peer` 键，每个为 `{"enabled": <bool>}`（默认：`self.enabled=true`、`peer.enabled=false`）。可在 commit 时覆盖；非对象值会以 `InvalidArgumentError` 拒绝。 |
 
 #### 3. 使用示例
 
@@ -909,6 +910,7 @@ await client.session_used(
 |------|------|------|--------|------|
 | session_id | str | 是 | - | 要提交的会话 ID |
 | keep_recent_count | int | 否 | 0 | 提交后保留为 live 状态的最近消息数 (保持 live, 不归档)。`0` (默认) 归档全部消息。 |
+| memory_policy | object | 否 | None | 控制本次 commit 是否运行自我记忆与对方记忆抽取。对象，包含可选的 `self` 和 `peer` 键，每个为 `{"enabled": <bool>}`（默认：`self.enabled=true`、`peer.enabled=false`）。commit 级的值会覆盖会话级策略；非对象值会以 `InvalidArgumentError` 拒绝。 |
 
 #### 3. 使用示例
 
@@ -923,6 +925,12 @@ POST /api/v1/sessions/{session_id}/commit
 curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/commit \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key"
+
+# 提交并额外运行对方记忆抽取（默认关闭）
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/commit \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"memory_policy": {"peer": {"enabled": true}}}'
 
 # 查询任务状态
 curl -X GET http://localhost:1933/api/v1/tasks/{task_id} \


### PR DESCRIPTION
`#2236` shipped a wired `memory_policy` request-body field on `POST /api/v1/sessions` (create) and `POST /api/v1/sessions/{id}/commit`, gating whether self-memory and peer-memory extraction run. `api/05-sessions.md` (EN + ZH) documents neither — yet OV's own openclaw plugin already sends it.

**Source (main):**
- `server/routers/sessions.py`: `CreateSessionRequest.memory_policy` (L119) → `create(memory_policy=…)` (L177); `CommitRequest.memory_policy` (L355) → `commit(memory_policy=…)` (L379)
- `session/memory_policy.py`: `MemoryPolicy.from_dict` parses `{"self":{"enabled":bool},"peer":{"enabled":bool}}` (L59-60), defaults `self.enabled=true` / `peer.enabled=false` (L43-44), `merge` lets commit-level override session-level (L64), non-object → `InvalidArgumentError` (L57)

**Change (docs-only, EN + ZH):** add a `memory_policy` row to the `create_session()` and `commit()` Parameters tables + a commit request-body example. Field semantics quoted verbatim from `memory_policy.py`.