### PR TITLE
fix(openclaw-plugin): drop duplicate viking://user/memories find in auto-recall (regression from #2236)

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -215,12 +215,6 @@ export async function buildAutoRecallContext(params: {
           scoreThreshold: 0,
           peerId,
         }, agentId),
-        client.find(queryText, {
-          targetUri: "viking://user/memories",
-          limit: candidateLimit,
-          scoreThreshold: 0,
-          peerId,
-        }, agentId),
       ];
       if (cfg.recallResources) {
         autoRecallPromises.push(


### PR DESCRIPTION
`buildAutoRecallContext` fires the `viking://user/memories` find **twice, byte-for-byte** on every auto-recall (same query, targetUri, limit, scoreThreshold, peerId, agentId). This is an accidental regression from #2236 (commit `ff258768`): the User/Peer refactor changed the second call's target from `viking://agent/memories` to `viking://user/memories` and added `peerId` to both, collapsing it into a duplicate of the first. The sibling plugins (`claude-code-memory-plugin`, `codex-memory-plugin`) instead *removed* the `agent/memories` search in the same refactor — peer isolation is carried by the `peerId` param on the same `viking://user/memories` namespace, not a separate URI (a search for `viking://peer` returns 0 hits).

Results from all promises are merged then deduped by URI, so the second call adds backend search load + recall latency on every auto-recall for **zero** added results. Fix: drop the redundant second find. `viking://resources` (the optional `cfg.recallResources` find) is untouched.