### PR TITLE
fix(opencode-plugin): fall back to session mapping when memcommit gets an empty session_id (#2412)

### DIFF
--- a/examples/opencode-plugin/lib/memory-tools.mjs
+++ b/examples/opencode-plugin/lib/memory-tools.mjs
@@ -125,7 +125,10 @@ export function createMemoryTools({ config, sessionManager, projectDirectory }) 
         session_id: z.string().optional().describe("Optional explicit OpenViking session ID. Omit to use the current OpenCode session mapping."),
       },
       async execute(args, context) {
-        const sessionId = args.session_id ?? (context.sessionID ? sessionManager.getMappedSessionId(context.sessionID) : undefined)
+        let sessionId = args.session_id
+        if (!sessionId && context.sessionID) {
+          sessionId = sessionManager.getMappedSessionId(context.sessionID)
+        }
         if (!sessionId) {
           return "Error: No OpenViking session is associated with the current OpenCode session. Start or resume a normal OpenCode session first, or pass session_id."
         }


### PR DESCRIPTION
Fixes #2412.

`memcommit` resolves its session id with `??`, so an explicit empty string (`session_id: ""`) is passed through instead of falling back to the current OpenCode->OpenViking mapping. The next line (`if (!sessionId)`) then treats `""` as falsy and returns *"No OpenViking session is associated..."* even when a valid mapping exists.

Sibling `memsearch` in the same file already uses the correct truthiness fallback. This change aligns `memcommit` with it, so `""` (like a missing arg) falls back to the mapped session. A real `session_id` is always a non-empty UUID, so treating `""` as "not provided" matches `memsearch`'s existing semantics and is regression-free.