### PR TITLE
fix(memory): treat bare empty-list LLM response as no-operations instead of crashing extraction (#2487)

### DIFF
--- a/openviking/session/memory/schema_model_generator.py
+++ b/openviking/session/memory/schema_model_generator.py
@@ -350,6 +350,9 @@ class SchemaModelGenerator:
         StructuredMemoryOperations.is_empty = is_empty
         StructuredMemoryOperations.to_legacy_operations = to_legacy_operations
         StructuredMemoryOperations._memory_type_fields = memory_type_fields  # type: ignore
+        # Opt this model into treating a bare `[]` LLM response as an empty-ops result
+        # (every field is default_factory=list); see parse_json_with_stability Layer 3.
+        StructuredMemoryOperations._allow_empty_list_response = True  # type: ignore
 
         self._operations_model = StructuredMemoryOperations
         return self._operations_model

--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -429,6 +429,15 @@ def parse_json_with_stability(
     if isinstance(parsed_data, list) and len(parsed_data) > 0:
         parsed_data = parsed_data[0]
         tracer.info("Extracted first item from list response")
+    elif isinstance(parsed_data, list) and len(parsed_data) == 0 and getattr(
+        model_class, "_allow_empty_list_response", False
+    ):
+        # The operations model opts in (via _allow_empty_list_response) to treating a
+        # bare `[]` as a valid "no operations" outcome: every field is default_factory=list,
+        # so map [] to {} and let it validate to an empty-ops object instead of raising
+        # downstream. Every other model keeps the fail-loud "Expected dict" path below.
+        parsed_data = {}
+        tracer.info("Empty list response treated as empty object (no operations)")
 
     if not isinstance(parsed_data, dict):
         return None, f"Expected dict after parsing, got {type(parsed_data)}"

--- a/tests/session/memory/test_json_stability.py
+++ b/tests/session/memory/test_json_stability.py
@@ -180,6 +180,35 @@ class TestParseJsonWithStability:
         assert error is None
         assert data.reasonning == "test"
 
+    def test_handles_empty_list_for_operations_model(self):
+        """A bare [] from the operations model (opted in via _allow_empty_list_response)
+        is a valid 'no operations' outcome: mapped to an empty object, not an error."""
+
+        class OperationsLike(BaseModel):
+            reasonning: str = ""
+            tags: List[str] = Field(default_factory=list)
+
+        OperationsLike._allow_empty_list_response = True
+
+        data, error = parse_json_with_stability('[]', model_class=OperationsLike)
+        assert error is None
+        assert data.tags == []
+
+    def test_empty_list_fails_loud_without_opt_in(self):
+        """A bare [] for any model that has NOT opted in stays fail-loud, even if it
+        happens to expose an is_empty() convenience method."""
+
+        class HasIsEmptyButNotOptedIn(BaseModel):
+            tags: List[str] = Field(default_factory=list)
+
+            def is_empty(self) -> bool:
+                return not self.tags
+
+        for model in (self.TestModel, HasIsEmptyButNotOptedIn):
+            data, error = parse_json_with_stability('[]', model_class=model)
+            assert data is None
+            assert error is not None
+
     def test_filters_extra_fields(self):
         """Test extra fields are filtered when expected_fields is provided."""
         content = '{"reasonning": "test", "extra_field": "should be filtered", "count": 42}'


### PR DESCRIPTION
Fixes #2487.

When the extraction LLM emits a bare `[]` to mean "no memory operations", `parse_json_with_stability` fell through Layer-3 structure tolerance (which only handles non-empty lists) and returned `Expected dict after parsing, got <class 'list'>`. `_call_llm` then logged `Failed to parse memory operations` and the ReAct loop ultimately raised `RuntimeError("Memory extraction final response could not be parsed as JSON operations")` — crashing memcommit/auto-capture on a *legitimate* no-ops outcome (reporter hit it with MiniMax-M2.5 via LiteLLM).

`[]` is unambiguous valid JSON for "empty", and the operations model is explicitly designed to represent emptiness (every field is `default_factory=list`, plus an `is_empty()` method). This maps a bare `[]` to an empty-ops object **only for the operations model**, which now opts in via a `_allow_empty_list_response` marker set in `create_structured_operations_model`. Every other model (and `model_class=None`) keeps the existing fail-loud `Expected dict` behaviour, so genuinely malformed output is still surfaced (the deliberate fail-don't-mask stance at `extract_loop.py` is preserved). Non-empty/garbage lists are unaffected.

- `openviking/session/memory/utils/json_parser.py`: Layer-3 empty-list → `{}` gated on the opt-in marker.
- `openviking/session/memory/schema_model_generator.py`: set `_allow_empty_list_response = True` on the operations model.
- `tests/session/memory/test_json_stability.py`: regression tests for the no-ops mapping **and** for fail-loud preservation on non-opted-in models (incl. a model that defines `is_empty` but does not opt in).
