### PR TITLE
fix(resource): clean up orphaned viking://temp tree when Phase 3.5 commit/lock fails (#2478)

### DIFF
--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -309,6 +309,15 @@ class ResourceProcessor:
                         source_committed = True
                 except Exception:
                     stage_status = "error"
+                    # Mirror the Phase 3 (finalize) on-error cleanup: a lock or
+                    # persist failure here would otherwise orphan the
+                    # viking://temp tree with no GC (#2478). Skip when the temp
+                    # tree was already persisted + deleted on the success path.
+                    if not source_committed and parse_result.temp_dir_path:
+                        try:
+                            await get_viking_fs().delete_temp(parse_result.temp_dir_path, ctx=ctx)
+                        except Exception:
+                            pass
                     raise
                 finally:
                     try:


### PR DESCRIPTION
Fixes #2478 (smallest root-cause fix — option 1 in the issue).

The Phase 3.5 (source commit + resource lock) error path re-raises without deleting the temp tree, unlike the sibling **Phase 3 (finalize)** error path which already calls `delete_temp(parse_result.temp_dir_path)`. So any lock conflict / persist failure permanently orphans a `viking://temp` dir with no GC — long-running deployments accumulate stale temp dirs.

**Fix:** mirror the Phase 3 on-error cleanup — best-effort `delete_temp`, guarded by `source_committed` to avoid a double-delete on the success path; the inner `try/except: pass` keeps cleanup from masking the original exception (still re-raised). The deleted `parse_result.temp_dir_path` lives under `viking://temp/`, structurally disjoint from the committed `root_uri` (resources/user scope), so cleanup can't touch a persisted resource. The startup-sweep / scheduled-GC options (2/3) are intentionally out of scope.
