### PR TITLE
fix(reindex): stop embedding "Directory ... is not ready" placeholders as L0/L1 vectors (#2434)

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -48,6 +48,30 @@ logger = get_logger(__name__)
 
 REINDEX_TASK_TYPE = "admin_reindex"
 
+
+# Trailing markers VikingFS appends when a directory has no generated .abstract.md/.overview.md
+# (see openviking/storage/viking_fs.py). The rendered value is a placeholder, not semantic
+# content, and must never be embedded as an ABSTRACT (L0) / OVERVIEW (L1) vector (issue #2434).
+_ABSTRACT_NOT_READY_SUFFIX = "[Directory abstract is not ready]"
+_OVERVIEW_NOT_READY_SUFFIX = "[Directory overview is not ready]"
+
+
+def _is_not_ready_sentinel(text: str, suffix: str) -> bool:
+    """Return True if *text* is a VikingFS not-ready directory placeholder.
+
+    VikingFS renders these as a single ``# <uri>`` header followed only by the not-ready marker.
+    Match that exact shape (a ``#`` header with no substantive body before the trailing marker)
+    so the check is uri-agnostic yet never drops real directory content that merely ends with,
+    or mentions, the user-facing marker phrase.
+    """
+    if not text:
+        return False
+    head = text.rstrip()
+    if not head.endswith(suffix):
+        return False
+    head = head[: -len(suffix)].strip()
+    return head.startswith("#") and "\n" not in head
+
 _reindex_executor: "ReindexExecutor | None" = None
 
 
@@ -1150,15 +1174,17 @@ class ReindexExecutor:
 
     async def _read_directory_abstract(self, uri: str, *, ctx: RequestContext) -> str:
         try:
-            return await get_viking_fs().abstract(uri, ctx=ctx)
+            value = await get_viking_fs().abstract(uri, ctx=ctx)
         except Exception:
             return ""
+        return "" if _is_not_ready_sentinel(value, _ABSTRACT_NOT_READY_SUFFIX) else value
 
     async def _read_directory_overview(self, uri: str, *, ctx: RequestContext) -> str:
         try:
-            return await get_viking_fs().overview(uri, ctx=ctx)
+            value = await get_viking_fs().overview(uri, ctx=ctx)
         except Exception:
             return ""
+        return "" if _is_not_ready_sentinel(value, _OVERVIEW_NOT_READY_SUFFIX) else value
 
     async def _best_file_summary(self, uri: str, *, ctx: RequestContext) -> str:
         parent_uri = VikingURI(uri).parent.uri

--- a/tests/service/test_reindex_placeholder.py
+++ b/tests/service/test_reindex_placeholder.py
@@ -1,0 +1,49 @@
+"""Regression tests for directory-meta placeholder filtering in reindex (issue #2434).
+
+VikingFS.abstract()/overview() render a ``# <uri>`` header followed only by a
+``[Directory ... is not ready]`` marker for directories without a generated
+``.abstract.md``/``.overview.md``. Before this fix the reindex executor embedded those
+placeholders as real ABSTRACT (L0) / OVERVIEW (L1) vectors, so they surfaced in
+search/memory-prefetch and displaced genuine memories. Detection is uri-agnostic and
+shape-anchored so legitimate directory content is never dropped.
+"""
+
+from openviking.service.reindex_executor import (
+    _ABSTRACT_NOT_READY_SUFFIX,
+    _OVERVIEW_NOT_READY_SUFFIX,
+    _is_not_ready_sentinel,
+)
+
+
+def test_real_abstract_sentinel_is_detected():
+    rendered = "# viking://memory/projects/foo [Directory abstract is not ready]"
+    assert _is_not_ready_sentinel(rendered, _ABSTRACT_NOT_READY_SUFFIX)
+
+
+def test_real_overview_sentinel_is_detected():
+    rendered = "# viking://memory/projects/foo\n\n[Directory overview is not ready]"
+    assert _is_not_ready_sentinel(rendered, _OVERVIEW_NOT_READY_SUFFIX)
+
+
+def test_sentinel_detection_is_uri_agnostic():
+    for uri in ("viking://a/b/", "viking://x%20y/z", "viking://"):
+        assert _is_not_ready_sentinel(f"# {uri} [Directory abstract is not ready]", _ABSTRACT_NOT_READY_SUFFIX)
+
+
+def test_content_mentioning_phrase_mid_body_is_preserved():
+    real = "# Notes\n\nWe used to show '[Directory abstract is not ready]' here, but now it has content."
+    assert not _is_not_ready_sentinel(real, _ABSTRACT_NOT_READY_SUFFIX)
+
+
+def test_authored_content_ending_with_marker_is_preserved():
+    # multi-line authored body that ends with the exact user-facing marker must survive
+    real = "# Project notes\n\nCurrent CLI output: [Directory abstract is not ready]"
+    assert not _is_not_ready_sentinel(real, _ABSTRACT_NOT_READY_SUFFIX)
+
+
+def test_real_content_preserved():
+    assert not _is_not_ready_sentinel("# Project\n\nReal abstract body.", _ABSTRACT_NOT_READY_SUFFIX)
+
+
+def test_empty_is_not_a_sentinel():
+    assert not _is_not_ready_sentinel("", _ABSTRACT_NOT_READY_SUFFIX)


### PR DESCRIPTION
Fixes #2434.

`VikingFS.abstract()`/`overview()` return a `# <uri> [Directory abstract is not ready]` / `# <uri>\n\n[Directory overview is not ready]` placeholder for a directory without a generated `.abstract.md`/`.overview.md`. The reindex executor read these verbatim, so the rebuild-loop empty-guards (`if not abstract and not overview` / `if abstract` / `if overview`) saw truthy placeholder text and upserted it as a real ABSTRACT (L0) / OVERVIEW (L1) vector. The sentinels then surfaced in search / memory-prefetch (~0.4-0.5 similarity) and displaced genuine memories.

Fix at the single read chokepoint: `_read_directory_abstract` / `_read_directory_overview` coerce the not-ready sentinel to `""`, so the existing empty-guards skip the directory. This covers all four reindex flows (L611/612, L850/851, L930/931, L1079/1080) — they all route through these two helpers.

Detection (`_is_not_ready_sentinel`) is **uri-agnostic** (matches the trailing marker, robust to however the uri header is rendered) and **shape-anchored** (only fires on a `#` header with no substantive body before the marker), so legitimate directory content that merely mentions or ends with the phrase is never dropped.

Scope: index-layer filter (issue Option B); rewiring `MemoryUpdater` -> `SemanticQueue` (Option A) is intentionally out of scope. Mirrors the existing Rust display-layer guard `is_directory_abstract_placeholder`.

Adds `tests/service/test_reindex_placeholder.py` covering detection, uri-agnosticism, and authored-content preservation.