### PR TITLE
fix(memory): give v2_lock_max_retries a finite default (#1581)

### DIFF
--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -25,11 +25,13 @@ class MemoryConfig(BaseModel):
         ),
     )
     v2_lock_max_retries: int = Field(
-        default=0,
+        default=300,
         ge=0,
         description=(
             "Maximum retries for SessionCompressorV2 memory lock acquisition. "
-            "0 means unlimited retries."
+            "Default 300 (~60s at the default 0.2s v2_lock_retry_interval_seconds) so a stuck "
+            "lock fails fast instead of spinning forever. Set to 0 to explicitly opt into "
+            "unlimited retries."
         ),
     )
     agent_memory_enabled: bool = Field(


### PR DESCRIPTION
Fixes #1581.

`memory.v2_lock_max_retries` defaults to `0`, and both `SessionCompressorV2` retry loops treat `0` as unlimited (`if max_retries > 0 and retry_count >= max_retries: raise TimeoutError(...)`). So a default deployment that hits a stuck/held memory-tree lock spins forever in `while True` (`acquire_exact_tree_batch(timeout=None)` returns `False` without raising) instead of failing fast — a silent ops footgun.

This changes only the **default** to `300` (~60s at the default `0.2s` `v2_lock_retry_interval_seconds`) so a stuck lock fails fast by default. `compressor_v2.py` is untouched — positive values are already treated as finite caps. Backward compatible: explicit `0` still opts into unlimited retries (the `> 0` guard and the `max_retries or "unlimited"` log label are unchanged).

Note: the issue prefers an explicit sentinel (`None`/`-1`) for unlimited rather than overloading `0`. This PR keeps `0 = unlimited` for backward compatibility and changes only the default; happy to switch to a sentinel design if you'd prefer that direction.