### PR TITLE
docs(config): document embedding.image_vectorization (summary_only/image_only/image_and_summary) from #2460

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -213,6 +213,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 | `max_concurrent` | int | Maximum concurrent embedding requests (`embedding.max_concurrent`, default: `10`) |
 | `max_retries` | int | Maximum retry attempts for transient embedding provider errors (`embedding.max_retries`, default: `3`; `0` disables retry) |
 | `text_source` | str | Text used for vectorizing text files. `content_only` reads raw content, `summary_first` uses summary when available and falls back to content, `summary_only` uses only summary. Default: `content_only` |
+| `image_vectorization` | str | How image files are vectorized. `summary_only` embeds only the generated text summary; `image_only` sends the image itself to a multimodal embedder; `image_and_summary` sends both the image and its text summary. `image_only`/`image_and_summary` require a multimodal-capable embedder. Default: `summary_only` |
 | `max_input_tokens` | int | Maximum estimated raw text tokens sent to the embedding model when content is used. Default: `4096` |
 | `provider` | str | `"openai"`, `"azure"`, `"volcengine"`, `"vikingdb"`, `"jina"`, `"ollama"`, `"gemini"`, `"voyage"`, `"dashscope"`, `"minimax"`, `"cohere"`, `"litellm"`, or `"local"` |
 | `api_key` | str | API key |

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -215,6 +215,7 @@ openviking-server doctor
 | `max_concurrent` | int | 最大并发 Embedding 请求数（`embedding.max_concurrent`，默认：`10`） |
 | `max_retries` | int | Embedding provider 瞬时错误的最大重试次数（`embedding.max_retries`，默认：`3`；`0` 表示禁用重试） |
 | `text_source` | str | 文本文件向量化时使用的文本来源。`content_only` 读取原文内容；`summary_first` 优先使用摘要，没有摘要时回退到原文；`summary_only` 只使用摘要。默认：`content_only` |
+| `image_vectorization` | str | 图片文件的向量化方式。`summary_only` 仅对生成的文本摘要做向量化；`image_only` 将图片本身发送给多模态 embedder；`image_and_summary` 同时发送图片及其文本摘要。`image_only`/`image_and_summary` 需要支持多模态的 embedder。默认：`summary_only` |
 | `max_input_tokens` | int | 使用原文内容向量化时，发送给 embedding 模型的最大估算 token 数。默认：`4096` |
 | `provider` | str | `"openai"`、`"azure"`、`"volcengine"`、`"vikingdb"`、`"jina"`、`"ollama"`、`"gemini"`、`"voyage"`、`"dashscope"`、`"minimax"`、`"cohere"`、`"litellm"` 或 `"local"` |
 | `api_key` | str | API Key |


### PR DESCRIPTION
### Drift

`embedding.image_vectorization` (shipped in #2460) is defined and validated in `openviking_cli/utils/config/embedding_config.py` (default `summary_only`, enum `summary_only` / `image_only` / `image_and_summary`), but it is **absent from the canonical embedding config table** in `docs/en/guides/01-configuration.md` and `docs/zh/guides/01-configuration.md` — even though its sibling `text_source` is documented. Users currently can't discover the `image_only` / `image_and_summary` multimodal image-embedding modes from the docs.

### Change

Adds the `image_vectorization` row to the embedding config table (EN + ZH), placed after `text_source` (matching the field order in the source), describing the three modes and their multimodal-embedder requirement. Pure docs, dual-doc mirror.