### PR TITLE
fix(langchain): resolve local resource paths before ingestion

### DIFF
--- a/openviking/integrations/langchain/tools.py
+++ b/openviking/integrations/langchain/tools.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 import logging
 import re
+from pathlib import Path
 from typing import Annotated, Any, Iterable, Literal
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from pydantic import BeforeValidator, Field
 
@@ -417,17 +420,35 @@ def create_openviking_tools(
         is not for ordinary chat facts or ad hoc memory notes.
         """
 
-        result = call_openviking(
-            get_client(),
-            "add_resource",
-            path=path,
-            to=to,
-            parent=parent,
-            reason=reason,
-            instruction=instruction,
-            wait=wait,
-            timeout=timeout,
-        )
+        resolved_path = _resolve_resource_source(path)
+        if isinstance(resolved_path, dict):
+            return compact_json(resolved_path)
+
+        try:
+            result = call_openviking(
+                get_client(),
+                "add_resource",
+                path=str(resolved_path),
+                to=to,
+                parent=parent,
+                reason=reason,
+                instruction=instruction,
+                wait=wait,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            if _is_probably_local_path(path) and "direct host filesystem paths" in str(exc):
+                return compact_json(
+                    {
+                        "error": "local_paths_not_supported_for_http_server",
+                        "path": path,
+                        "message": (
+                            "The OpenViking HTTP client could not upload this local path. "
+                            "Provide an existing local file/directory or a remote URL/repository."
+                        ),
+                    }
+                )
+            raise
         return stringify(result, max_chars=8_000)
 
     def viking_add_skill(
@@ -544,6 +565,60 @@ def _is_directory_read_error(exc: Exception) -> bool:
         and details.get("expected") == "file"
         and details.get("actual") == "directory"
     )
+
+
+def _is_probably_local_path(value: str) -> bool:
+    text = str(value or "").strip()
+    if not text or "\n" in text or "\r" in text:
+        return False
+    if _is_remote_resource_source(text):
+        return False
+    if text.startswith(("/", "./", "../", "~/", ".\\", "..\\", "~\\")):
+        return True
+    if re.match(r"^[A-Za-z]:[\\/]", text) or "\\" in text:
+        return True
+    if "/" in text:
+        first_segment = text.split("/", 1)[0]
+        return "." not in first_segment
+    return False
+
+
+def _is_remote_resource_source(value: str) -> bool:
+    text = str(value or "").strip()
+    return text.startswith(("http://", "https://", "git@", "ssh://", "git://"))
+
+
+def _resolve_resource_source(value: str) -> str | dict[str, str]:
+    text = str(value or "").strip()
+    if not text:
+        return {"error": "missing_path", "message": "path is required"}
+
+    parsed = urlparse(text)
+    if parsed.scheme == "file":
+        if parsed.netloc not in ("", "localhost"):
+            return {
+                "error": "unsupported_file_uri",
+                "path": text,
+                "message": f"Unsupported non-local file URI: {text}",
+            }
+        path = Path(url2pathname(parsed.path)).expanduser()
+    elif parsed.scheme and not re.match(r"^[A-Za-z]$", parsed.scheme):
+        return text
+    else:
+        path = Path(text).expanduser()
+
+    if path.exists():
+        return str(path)
+    if _is_probably_local_path(text):
+        return {
+            "error": "local_path_not_found",
+            "path": text,
+            "message": (
+                f"Local resource path does not exist: {text}. "
+                "Existing local files/directories can be uploaded as resources."
+            ),
+        }
+    return text
 
 
 def _format_openviking_health(status: Any) -> dict[str, Any]:

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -35,7 +35,7 @@ from openviking.integrations.langchain.history import (
     openviking_message_to_langchain,
 )
 from openviking.integrations.langchain.middleware import _message_signature
-from openviking.integrations.langchain.tools import _archive_grep_pattern
+from openviking.integrations.langchain.tools import _archive_grep_pattern, _resolve_resource_source
 from openviking_cli.exceptions import InvalidArgumentError
 
 
@@ -177,6 +177,74 @@ def test_create_openviking_tools_passes_peer_id_without_exposing_tool_arg():
         messages and messages[0].get("peer_id") == "peer-tools"
         for messages in client.sessions.values()
     )
+
+
+def test_add_resource_resolves_existing_local_file_for_client_upload(tmp_path):
+    class RecordingClient:
+        def __init__(self):
+            self.paths = []
+
+        def add_resource(self, path, **_kwargs):
+            self.paths.append(path)
+            return {"uri": "viking://resources/report.md"}
+
+    client = RecordingClient()
+    resource_file = tmp_path / "report.md"
+    resource_file.write_text("deployment notes", encoding="utf-8")
+    tools = {
+        tool.name: tool
+        for tool in create_openviking_tools(
+            client=client,
+            tool_names=["viking_add_resource"],
+        )
+    }
+
+    result = tools["viking_add_resource"].invoke({"path": str(resource_file)})
+
+    assert client.paths == [str(resource_file)]
+    assert "viking://resources/report.md" in result
+
+
+def test_resolve_resource_source_handles_local_and_remote_sources(tmp_path):
+    local_file = tmp_path / "resource with spaces.md"
+    local_file.write_text("notes", encoding="utf-8")
+
+    assert (
+        _resolve_resource_source("https://example.com/repo.git") == "https://example.com/repo.git"
+    )
+    assert _resolve_resource_source("git@github.com:org/repo.git") == "git@github.com:org/repo.git"
+    assert (
+        _resolve_resource_source("ssh://git@github.com/org/repo.git")
+        == "ssh://git@github.com/org/repo.git"
+    )
+    assert _resolve_resource_source("github.com/org/repo") == "github.com/org/repo"
+    assert _resolve_resource_source(f"file://{local_file}") == str(local_file)
+    assert (
+        _resolve_resource_source("file://remote-host/tmp/report.md")["error"]
+        == "unsupported_file_uri"
+    )
+
+    missing = _resolve_resource_source(str(tmp_path / "missing.md"))
+    assert missing["error"] == "local_path_not_found"
+    assert _resolve_resource_source("docs/missing.md")["error"] == "local_path_not_found"
+
+
+def test_add_resource_keeps_explicit_local_clients_supported(tmp_path):
+    client = InMemoryOpenVikingClient()
+    resource_file = tmp_path / "report.md"
+    resource_file.write_text("report", encoding="utf-8")
+    tools = {
+        tool.name: tool
+        for tool in create_openviking_tools(
+            client=client,
+            tool_names=["viking_add_resource"],
+        )
+    }
+
+    result = tools["viking_add_resource"].invoke({"path": str(resource_file)})
+
+    assert "viking://resources/report.md" in result
+    assert "viking://resources/report.md" in client.records
 
 
 def test_create_openviking_tools_profiles_control_destructive_tools():


### PR DESCRIPTION
## Summary
- Resolve existing local file and directory paths before the LangChain `viking_add_resource` tool calls the OpenViking client.
- Support local `file://` URIs while returning structured errors for missing local paths or unsupported non-local file URIs.
- Preserve remote URLs and Git-style resource sources by passing them through unchanged.

## Why
LangChain hosts can expose uploaded files or local resource paths to the model. If those paths are forwarded directly to a remote OpenViking server, ingestion can fail because the server cannot read the host machine filesystem path.

The SDK already knows how to upload existing local files and directories from the client side. This change normalizes model-provided local sources into that client-side ingestion flow before calling `add_resource`, while leaving non-local sources unchanged.

## Validation
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" uv run ruff format --check openviking/integrations/langchain/tools.py tests/unit/test_langchain_integration.py`
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" uv run ruff check openviking/integrations/langchain/tools.py tests/unit/test_langchain_integration.py`
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" uv run python -m pytest tests/unit/test_langchain_integration.py -q`
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" uv run python -m pytest tests/server/test_http_client_sdk.py::test_sdk_add_resource -q`
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" UV_NATIVE_TLS=true OV_SKIP_STUDIO_BUILD=1 make PYTHON="$PWD/.venv/bin/python" build`
- `git diff --check`
