### PR TITLE
fix(server): share log file handler for rotation

### DIFF
--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -60,6 +60,10 @@ except ImportError:
 _otel_log_handler_initialized = False
 _otel_log_handler: Any = None
 
+_MANAGED_LOGGER_ROOTS = ("openviking", "openviking_cli", "uvicorn")
+_shared_log_handler: Optional[logging.Handler] = None
+_shared_log_handler_key: Optional[tuple[Any, ...]] = None
+
 
 def _get_log_context() -> dict[str, Any]:
     """
@@ -382,6 +386,9 @@ def add_otel_log_handler_to_logger(logger: logging.Logger) -> None:
         logger: The logger instance to add the handler to.
     """
     if _otel_log_handler is not None:
+        root_name = _managed_root_name(logger.name)
+        if root_name and logger.name != root_name:
+            logger = logging.getLogger(root_name)
         # Check if the handler has already been added
         if not any(isinstance(h, type(_otel_log_handler)) for h in logger.handlers):
             logger.addHandler(_otel_log_handler)
@@ -622,6 +629,13 @@ def _load_log_config() -> Tuple[str, str, str, Optional[Any]]:
     return log_level_str, log_format, log_output, config
 
 
+def _managed_root_name(name: str) -> Optional[str]:
+    for root_name in _MANAGED_LOGGER_ROOTS:
+        if name == root_name or name.startswith(f"{root_name}."):
+            return root_name
+    return None
+
+
 def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handler:
     # Prevent creating a file literally named "file"
     if log_output == "file":
@@ -661,20 +675,6 @@ def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handl
             return logging.FileHandler(log_output, encoding="utf-8")
 
 
-def _configure_logger_instance(
-    logger: logging.Logger,
-    *,
-    level: int,
-    formatter: logging.Formatter,
-    handler: logging.Handler,
-) -> None:
-    """Apply a fully configured handler to a logger."""
-    logger.handlers.clear()
-    logger.addHandler(handler)
-    logger.propagate = False
-    logger.setLevel(level)
-
-
 def _build_standard_handler(
     log_output: str,
     config: Optional[Any],
@@ -688,6 +688,58 @@ def _build_standard_handler(
 
     handler.addFilter(TraceIdLoggingFilter())
     return handler
+
+
+def _get_shared_handler(
+    log_output: str,
+    config: Optional[Any],
+    format_string: str,
+    *,
+    force: bool = False,
+) -> logging.Handler:
+    global _shared_log_handler, _shared_log_handler_key
+
+    if config is None:
+        handler_key = (log_output, format_string, None)
+    else:
+        handler_key = (
+            log_output,
+            format_string,
+            bool(config.log.rotation),
+            config.log.rotation_interval,
+            config.log.rotation_days,
+        )
+    if not force and _shared_log_handler is not None and _shared_log_handler_key == handler_key:
+        return _shared_log_handler
+
+    _shared_log_handler = _build_standard_handler(log_output, config, format_string)
+    _shared_log_handler_key = handler_key
+    return _shared_log_handler
+
+
+def _configure_logger_instance(
+    logger: logging.Logger,
+    *,
+    level: int,
+    handler: Optional[logging.Handler],
+    propagate: bool,
+) -> None:
+    old_handlers = list(logger.handlers)
+    logger.handlers.clear()
+    if handler is not None:
+        logger.addHandler(handler)
+        if _otel_log_handler is not None and isinstance(_otel_log_handler, logging.Handler):
+            logger.addHandler(_otel_log_handler)
+    logger.propagate = propagate
+    logger.setLevel(level)
+    current_handlers = set(logger.handlers)
+    for old_handler in old_handlers:
+        if old_handler in current_handlers or old_handler is _otel_log_handler:
+            continue
+        try:
+            old_handler.close()
+        except Exception:
+            pass
 
 
 def get_logger(
@@ -712,10 +764,26 @@ def get_logger(
         level = getattr(logging, log_level_str, logging.INFO)
         if format_string is None:
             format_string = log_format
-        handler = _build_standard_handler(log_output, config, format_string)
-        _configure_logger_instance(
-            logger, level=level, formatter=logging.Formatter(format_string), handler=handler
-        )
+        root_name = _managed_root_name(name)
+        if root_name:
+            handler = _get_shared_handler(log_output, config, format_string)
+            root_logger = logging.getLogger(root_name)
+            _configure_logger_instance(
+                root_logger,
+                level=level,
+                handler=handler,
+                propagate=False,
+            )
+            if name != root_name:
+                _configure_logger_instance(logger, level=level, handler=None, propagate=True)
+        else:
+            handler = _build_standard_handler(log_output, config, format_string)
+            _configure_logger_instance(
+                logger,
+                level=level,
+                handler=handler,
+                propagate=False,
+            )
 
     # If OTel log export is globally initialized, attach the handler automatically.
     if add_otel_handler or _otel_log_handler_initialized:
@@ -741,31 +809,24 @@ def reconfigure_logging() -> None:
     """Re-apply logging configuration to already-created OpenViking loggers."""
     log_level_str, log_format, log_output, config = _load_log_config()
     level = getattr(logging, log_level_str, logging.INFO)
+    handler = _get_shared_handler(log_output, config, log_format, force=True)
 
     logger_dict = logging.Logger.manager.loggerDict
     target_names = [
         name
         for name, candidate in logger_dict.items()
-        if isinstance(candidate, logging.Logger)
-        and (name == "openviking" or name.startswith("openviking.") or name.startswith("uvicorn"))
+        if isinstance(candidate, logging.Logger) and _managed_root_name(name)
     ]
-    if "openviking" not in target_names:
-        target_names.append("openviking")
+    target_names.extend(_MANAGED_LOGGER_ROOTS)
 
     for logger_name in sorted(set(target_names)):
         logger = logging.getLogger(logger_name)
-        format_string = log_format
-        if logger_name.startswith("uvicorn"):
-            handler = _create_log_handler(log_output, config)
-            handler.setFormatter(logging.Formatter(log_format))
-            handler.addFilter(TraceContextFilter())
-        else:
-            handler = _build_standard_handler(log_output, config, format_string)
+        root_name = _managed_root_name(logger_name)
         _configure_logger_instance(
             logger,
             level=level,
-            formatter=logging.Formatter(format_string),
-            handler=handler,
+            handler=handler if root_name == logger_name else None,
+            propagate=root_name != logger_name,
         )
 
 
@@ -777,17 +838,15 @@ def configure_uvicorn_logging() -> None:
     """
     log_level_str, log_format, log_output, config = _load_log_config()
     level = getattr(logging, log_level_str, logging.INFO)
+    handler = _get_shared_handler(log_output, config, log_format)
 
     # Configure all Uvicorn loggers
     uvicorn_logger_names = ["uvicorn", "uvicorn.error", "uvicorn.access"]
     for logger_name in uvicorn_logger_names:
         logger = logging.getLogger(logger_name)
-        handler = _create_log_handler(log_output, config)
-        handler.setFormatter(logging.Formatter(log_format))
-        handler.addFilter(TraceContextFilter())
         _configure_logger_instance(
             logger,
             level=level,
-            formatter=logging.Formatter(log_format),
-            handler=handler,
+            handler=handler if logger_name == "uvicorn" else None,
+            propagate=logger_name != "uvicorn",
         )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -380,18 +380,26 @@ def test_openviking_config_singleton_initialize_missing_message_uses_openviking_
 
 
 def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, monkeypatch):
+    from openviking_cli.utils import logger as logger_module
     from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
-    from openviking_cli.utils.logger import get_logger
 
     logger_name = "openviking.test.early_init"
-    logger = logging.getLogger(logger_name)
-    logger.handlers.clear()
+    for name in ("openviking", "uvicorn", "uvicorn.error", "uvicorn.access", logger_name):
+        logger = logging.getLogger(name)
+        for handler in logger.handlers:
+            handler.close()
+        logger.handlers.clear()
+        logger.propagate = True
+    logger_module._shared_log_handler = None
+    logger_module._shared_log_handler_key = None
 
     OpenVikingConfigSingleton.reset_instance()
     monkeypatch.setenv("OPENVIKING_CONFIG_FILE", "/tmp/codex-no-config.json")
 
-    early_logger = get_logger(logger_name)
-    assert any(isinstance(h, logging.StreamHandler) for h in early_logger.handlers)
+    early_logger = logger_module.get_logger(logger_name)
+    openviking_root = logging.getLogger("openviking")
+    assert early_logger.handlers == []
+    assert any(isinstance(h, logging.StreamHandler) for h in openviking_root.handlers)
 
     config_path = tmp_path / "ov.conf"
     config_path.write_text(
@@ -409,9 +417,32 @@ def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, mo
 
     try:
         OpenVikingConfigSingleton.initialize(config_path=str(config_path))
-        refreshed_logger = get_logger(logger_name)
-        assert any(isinstance(h, logging.FileHandler) for h in refreshed_logger.handlers)
-        assert not any(type(h) is logging.StreamHandler for h in refreshed_logger.handlers)
+        refreshed_logger = logger_module.get_logger(logger_name)
+        logger_module.configure_uvicorn_logging()
+        openviking_root = logging.getLogger("openviking")
+        uvicorn_root = logging.getLogger("uvicorn")
+        uvicorn_access = logging.getLogger("uvicorn.access")
+        assert refreshed_logger.handlers == []
+        assert uvicorn_access.handlers == []
+        assert any(isinstance(h, logging.FileHandler) for h in openviking_root.handlers)
+        assert not any(type(h) is logging.StreamHandler for h in openviking_root.handlers)
+        assert openviking_root.handlers == uvicorn_root.handlers
+
+        refreshed_logger.info("child-line")
+        uvicorn_access.info("access-line")
+        for handler in openviking_root.handlers:
+            handler.flush()
+
+        content = (tmp_path / "log" / "openviking.log").read_text(encoding="utf-8")
+        assert content.count("child-line") == 1
+        assert content.count("access-line") == 1
     finally:
-        refreshed_logger.handlers.clear()
+        for name in ("openviking", "uvicorn", "uvicorn.error", "uvicorn.access", logger_name):
+            logger = logging.getLogger(name)
+            for handler in logger.handlers:
+                handler.close()
+            logger.handlers.clear()
+            logger.propagate = True
+        logger_module._shared_log_handler = None
+        logger_module._shared_log_handler_key = None
         OpenVikingConfigSingleton.reset_instance()


### PR DESCRIPTION
## Description

Fix server file logging so OpenViking-managed Python loggers share one process-level file handler instead of opening separate handlers to the same log file. This prevents Python child loggers and Uvicorn loggers from keeping independent file descriptors that can continue writing to an archived file after timed rotation.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Configure `openviking`, `openviking_cli`, and `uvicorn` logger trees to share one standard handler while child loggers propagate to their managed root logger.
- Reconfigure existing OpenViking and Uvicorn loggers through the same shared handler path so file rotation has a single Python file-handler owner per process.
- Keep non-managed loggers on the existing per-logger handler path to avoid broad behavior changes.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
.venv/bin/python -m ruff check openviking_cli/utils/logger.py tests/test_config_loader.py
.venv/bin/python -m pytest tests/test_config_loader.py::test_early_logger_initialization_is_reconfigured_to_file_output -q
git diff origin/main --check
```

Manual verification:

- Loaded an `ov.conf`-derived temporary config with `log.output=file` and second-level rotation.
- Verified `openviking.*` and `uvicorn.access` logs share one `TimedRotatingFileHandler`, child loggers have no independent handlers, and post-rollover Python logs continue in active `openviking.log`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally keeps the scope to the observed Python logger rotation issue. It does not change shell redirection examples or native C++ logging ownership.
