### PR TITLE
fix(openclaw): Restrict auto recall to transformContext assemble

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -364,26 +364,6 @@ function prependRecallToLatestUserMessage(messages: AgentMessage[], recallBlock:
   return prependRecallAtIndex(messages, messages.length - 1, recallBlock);
 }
 
-function injectRecallIntoContext(messages: AgentMessage[], recallBlock: string): AgentMessage[] {
-  const latest = messages.at(-1);
-  if (latest?.role === "user" && !hasAutoRecallBlock(latest)) {
-    return prependRecallToLatestUserMessage(messages, recallBlock);
-  }
-
-  const firstUserIndex = messages.findIndex((msg) => msg.role === "user" && !hasAutoRecallBlock(msg));
-  if (firstUserIndex >= 0) {
-    return prependRecallAtIndex(messages, firstUserIndex, recallBlock);
-  }
-
-  return [
-    {
-      role: "user",
-      content: recallBlock,
-    },
-    ...messages,
-  ];
-}
-
 function emitDiag(log: Logger, stage: string, sessionId: string, data: Record<string, unknown>, enabled = true): void {
   if (!enabled) return;
   log.info(`openviking: diag ${JSON.stringify({ ts: Date.now(), stage, sessionId, data })}`);
@@ -1296,43 +1276,6 @@ export function createMemoryOpenVikingContextEngine(params: {
     return { sanitized, archive, session, budgets, instruction };
   }
 
-  async function buildRecallForAssemble(params: {
-    ovSessionId: string;
-    agentId: string;
-    peerId?: string;
-    queryInput: RecallQueryInput;
-    client?: OpenVikingClient;
-  }): Promise<AssembleRecall> {
-    const query = prepareRecallQuery(params.queryInput.text);
-    if (!query.query || query.query.length < 5) {
-      diag("assemble_recall_skip", params.ovSessionId, {
-        reason: "empty_or_short_query",
-        querySource: params.queryInput.source,
-        queryChars: query.finalChars,
-        peerId: params.peerId ?? null,
-      });
-      return { memoryCount: 0, estimatedTokens: 0, queryChars: query.finalChars };
-    }
-
-    if (query.truncated) {
-      logger.info(
-        `openviking: recall query truncated (` +
-          `chars=${query.originalChars}->${query.finalChars})`,
-      );
-    }
-
-    const recall = await buildLongTermMemoryRecallContext({
-      cfg,
-      client: params.client ?? await getClient(),
-      agentId: params.agentId,
-      peerId: params.peerId,
-      queryText: query.query,
-      logger,
-      verbose: (message) => logger.info(message),
-    });
-    return { ...recall, queryChars: query.finalChars };
-  }
-
   function recallDiagFields(params: {
     recall: AssembleRecall;
     queryInput: RecallQueryInput;
@@ -1361,42 +1304,6 @@ export function createMemoryOpenVikingContextEngine(params: {
       personPeerId: toPeerId(sender.senderId),
       assistantPeerId: agentId,
     });
-  }
-
-  function emptyAssembleRecall(): AssembleRecall {
-    return { memoryCount: 0, estimatedTokens: 0, queryChars: 0 };
-  }
-
-  function assembleRecallOnlyResult(params: {
-    ovSessionId: string;
-    reason: string;
-    baseMessages: AgentMessage[];
-    originalTokens: number;
-    recall: AssembleRecall;
-    recallBlock: string;
-    queryInput: RecallQueryInput;
-    peerId?: string;
-    sender: ResolvedSender;
-    extra?: Record<string, unknown>;
-  }): AssembleResult {
-    const withRecall = injectRecallIntoContext(params.baseMessages, params.recallBlock);
-    const estimatedTokens = roughEstimate(withRecall);
-    diag("assemble_result", params.ovSessionId, {
-      passthrough: false,
-      reason: params.reason,
-      ...(params.extra ?? {}),
-      outputMessagesCount: withRecall.length,
-      inputTokenEstimate: params.originalTokens,
-      estimatedTokens,
-      ...recallDiagFields({
-        recall: params.recall,
-        queryInput: params.queryInput,
-        peerId: params.peerId,
-        sender: params.sender,
-      }),
-      messages: messageDigest(withRecall),
-    });
-    return { messages: withRecall, estimatedTokens };
   }
 
   return {
@@ -1563,77 +1470,13 @@ export function createMemoryOpenVikingContextEngine(params: {
         const client = await getClient();
         const routingRef = assembleParams.sessionId ?? sessionKey ?? OVSessionId;
         const agentId = resolveAgentId(routingRef, sessionKey, OVSessionId);
-        const peerId = resolveAssembleRecallPeerId(agentId, sender);
-        const recallQueryInput = resolveRecallQueryInput({
-          latestMessage,
-          prompt: assembleParams.prompt,
-          senderName: sender.senderName,
-          preferPrompt: true,
-        });
-        const hasInjectedRecall = messages.some((message) => hasAutoRecallBlock(message));
-        let recall = emptyAssembleRecall();
-        if (cfg.autoRecall && !hasInjectedRecall) {
-          try {
-            recall = await buildRecallForAssemble({
-              ovSessionId: OVSessionId,
-              agentId,
-              peerId,
-              queryInput: recallQueryInput,
-              client,
-            });
-          } catch (recallErr) {
-            logger.warn?.(`openviking: auto-recall failed: ${String(recallErr)}`);
-            diag("assemble_recall_failed", OVSessionId, {
-              error: String(recallErr),
-              querySource: recallQueryInput.source,
-              peerId: peerId ?? null,
-              senderSource: sender.source,
-            });
-          }
-        }
-        const recallContextBlock = recall.section
-          ? buildOpenVikingContextBlock({ sections: [recall.section] })
-          : "";
-        let ctx;
-        try {
-          ctx = await client.getSessionContext(OVSessionId, tokenBudget, agentId);
-        } catch (ctxErr) {
-          if (recallContextBlock) {
-            return assembleRecallOnlyResult({
-              ovSessionId: OVSessionId,
-              reason: "recall_only_context_unavailable",
-              baseMessages: messages,
-              originalTokens,
-              recall,
-              recallBlock: recallContextBlock,
-              queryInput: recallQueryInput,
-              peerId,
-              sender,
-              extra: { contextError: String(ctxErr) },
-            });
-          }
-          throw ctxErr;
-        }
+        const ctx = await client.getSessionContext(OVSessionId, tokenBudget, agentId);
 
         const preAbstracts = ctx?.pre_archive_abstracts ?? [];
         const hasArchives = !!ctx?.latest_archive_overview || preAbstracts.length > 0;
         const activeCount = ctx?.messages?.length ?? 0;
 
         if (!ctx || (!hasArchives && activeCount === 0)) {
-          if (recallContextBlock) {
-            return assembleRecallOnlyResult({
-              ovSessionId: OVSessionId,
-              reason: "recall_only_no_ov_data",
-              baseMessages: messages,
-              originalTokens,
-              recall,
-              recallBlock: recallContextBlock,
-              queryInput: recallQueryInput,
-              peerId,
-              sender,
-              extra: { archiveCount: 0, activeCount: 0 },
-            });
-          }
           return assemblePassthrough(OVSessionId, "no_ov_data", messages, originalTokens, {
             archiveCount: 0, activeCount: 0,
           });
@@ -1658,9 +1501,7 @@ export function createMemoryOpenVikingContextEngine(params: {
           });
         }
 
-        const outputMessages = recallContextBlock
-          ? injectRecallIntoContext(sanitized, recallContextBlock)
-          : sanitized;
+        const outputMessages = sanitized;
         const assembledTokens = roughEstimate(outputMessages) + instruction.tokens;
         const tokensSaved = originalTokens - assembledTokens;
         const savingPct = originalTokens > 0 ? Math.round((tokensSaved / originalTokens) * 100) : 0;
@@ -1679,7 +1520,9 @@ export function createMemoryOpenVikingContextEngine(params: {
           sessionTokens: session.tokens,
           sessionBudget: budgets.sessionContext,
           reservedBudget: budgets.reserved,
-          ...recallDiagFields({ recall, queryInput: recallQueryInput, peerId, sender }),
+          senderIdFound: sender.found,
+          senderId: sender.senderId ?? null,
+          senderSource: sender.source,
           messages: messageDigest(outputMessages),
         });
 

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -173,6 +173,7 @@ describe("context-engine assemble()", () => {
           cfgOverrides: {
             autoRecall: true,
             peer_role: "person",
+            recallResources: true,
           },
         },
       );
@@ -188,7 +189,7 @@ describe("context-engine assemble()", () => {
         messages: sourceMessages,
       });
 
-      expect(client.find).toHaveBeenCalledTimes(1);
+      expect(client.find).toHaveBeenCalledTimes(2);
       for (const call of client.find.mock.calls) {
         expect(call[1]).toMatchObject({ peerId: "wx_user-01_abc" });
       }
@@ -197,7 +198,7 @@ describe("context-engine assemble()", () => {
     }
   });
 
-  it("uses prompt metadata sender_id for main assemble peer auto-recall when runtimeContext is missing", async () => {
+  it("does not auto-recall during main assemble from prompt metadata", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -219,20 +220,6 @@ describe("context-engine assemble()", () => {
       client.getSessionContext.mockRejectedValueOnce(
         new Error("OpenViking request failed [NOT_FOUND]: Session not found"),
       );
-      client.find
-        .mockResolvedValueOnce({
-          memories: [
-            {
-              uri: "viking://user/acme/peers/ou_bcc/memories/profile.md",
-              level: 2,
-              category: "profile",
-              abstract: "# 秦浩杰\n- 正在维护的项目：openviking",
-              score: 0.92,
-            },
-          ],
-          total: 1,
-        })
-        .mockResolvedValueOnce({ memories: [], total: 0 });
 
       const prompt = [
         "Conversation info (untrusted metadata):",
@@ -258,30 +245,27 @@ describe("context-engine assemble()", () => {
         "",
         "[System: mention metadata]",
       ].join("\n");
+      const liveMessages = [{ role: "user", content: "live main assemble prompt" }];
 
       const result = await engine.assemble({
         sessionId: "session-main-prompt-peer",
         sessionKey: "agent:main:feishu:group:oc_123",
-        messages: [],
+        messages: liveMessages,
         prompt,
       });
 
-      expect(client.find).toHaveBeenCalledTimes(1);
-      for (const call of client.find.mock.calls) {
-        expect(call[1]).toMatchObject({ peerId: "ou_bcc" });
-      }
-      expect(result.messages[0]?.role).toBe("user");
-      expect(result.messages[0]?.content).toContain("Source: openviking-auto-recall");
-      expect(result.messages[0]?.content).toContain("<openviking-context>");
-      expect(result.messages[0]?.content).toContain("## Long-term Memories");
-      expect(result.messages[0]?.content).not.toContain("<relevant-memories>");
-      expect(result.messages[0]?.content).toContain("正在维护的项目：openviking");
+      expect(client.getSessionContext).toHaveBeenCalled();
+      expect(client.find).not.toHaveBeenCalled();
+      expect(result.messages).toEqual(liveMessages);
+      expect(result.messages[0]?.content).not.toContain("Source: openviking-auto-recall");
+      expect(result.messages[0]?.content).not.toContain("<openviking-context>");
+      expect(result.messages[0]?.content).not.toContain("## Long-term Memories");
     } finally {
       vi.unstubAllGlobals();
     }
   });
 
-  it("prefers runtimeContext senderId over prompt metadata for main assemble recall", async () => {
+  it("does not inject auto-recall into main assemble OV context", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -294,9 +278,19 @@ describe("context-engine assemble()", () => {
         {
           latest_archive_overview: "",
           pre_archive_abstracts: [],
-          messages: [],
-          estimatedTokens: 0,
-          stats: makeStats(),
+          messages: [
+            {
+              id: "stored-main-user",
+              role: "user",
+              created_at: "2026-04-30T00:00:00Z",
+              parts: [{ type: "text", text: "Stored OpenViking prompt." }],
+            },
+          ],
+          estimatedTokens: 12,
+          stats: {
+            ...makeStats(),
+            activeTokens: 12,
+          },
         },
         {
           cfgOverrides: {
@@ -306,10 +300,11 @@ describe("context-engine assemble()", () => {
         },
       );
 
-      await engine.assemble({
+      const liveMessages = [{ role: "user", content: "live prompt" }];
+      const result = await engine.assemble({
         sessionId: "session-main-runtime-peer",
         runtimeContext: { senderId: "trusted/runtime-user" },
-        messages: [],
+        messages: liveMessages,
         prompt: [
           "Conversation info (untrusted metadata):",
           "```json",
@@ -321,10 +316,15 @@ describe("context-engine assemble()", () => {
         ].join("\n"),
       });
 
-      expect(client.find).toHaveBeenCalledTimes(1);
-      for (const call of client.find.mock.calls) {
-        expect(call[1]).toMatchObject({ peerId: "trusted_runtime-user" });
-      }
+      expect(client.getSessionContext).toHaveBeenCalled();
+      expect(client.find).not.toHaveBeenCalled();
+      expect(result.messages[0]).toEqual({
+        role: "user",
+        content: "Stored OpenViking prompt.",
+      });
+      expect(result.messages[0]?.content).not.toContain("Source: openviking-auto-recall");
+      expect(result.messages[0]?.content).not.toContain("<openviking-context>");
+      expect(result.messages[0]?.content).not.toContain("## Long-term Memories");
     } finally {
       vi.unstubAllGlobals();
     }
@@ -351,6 +351,7 @@ describe("context-engine assemble()", () => {
           cfgOverrides: {
             autoRecall: true,
             peer_role: "assistant",
+            recallResources: true,
           },
         },
       );
@@ -365,7 +366,7 @@ describe("context-engine assemble()", () => {
         messages: sourceMessages,
       });
 
-      expect(client.find).toHaveBeenCalledTimes(1);
+      expect(client.find).toHaveBeenCalledTimes(2);
       for (const call of client.find.mock.calls) {
         expect(call[1]).toMatchObject({ peerId: "agent:session-assistant-peer" });
       }

--- a/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
@@ -234,8 +234,8 @@ describe("plugin normal flow with healthy backend", () => {
 
     expect(assembled.messages[0]?.role).toBe("user");
     const firstAssembledMessage = String(assembled.messages[0]?.content);
-    expect(firstAssembledMessage).toContain("Source: openviking-auto-recall");
-    expect(firstAssembledMessage).toContain("User prefers Rust for backend tasks.");
+    expect(firstAssembledMessage).not.toContain("Source: openviking-auto-recall");
+    expect(firstAssembledMessage).not.toContain("User prefers Rust for backend tasks.");
     expect(firstAssembledMessage).toContain(
       "[Session History Summary]\nEarlier work focused on backend stack choices.",
     );
@@ -243,6 +243,9 @@ describe("plugin normal flow with healthy backend", () => {
       role: "assistant",
       content: [{ type: "text", text: "Stored answer from OpenViking." }],
     });
+    expect(
+      requests.some((entry) => entry.method === "POST" && entry.path === "/api/v1/search/find"),
+    ).toBe(false);
 
     const transformed = await contextEngine.assemble({
       sessionId: "session-normal",


### PR DESCRIPTION
## Background

OpenClaw calls this context engine through two different assemble paths:

1. **main / preflight assemble**: builds the model input from OpenViking session context. In this path the plugin fetches archived summaries and active session messages via `getSessionContext`, then returns the reconstructed history plus any session guide system prompt.
2. **transformContext assemble**: runs after the current user message is present in the message list. This path is the right place for query-based long-term memory recall, because it can use the latest real `user` message as the recall query and prepend recalled memories directly to that same message.

Long-term auto-recall is different from OpenViking session context assembly. It is semantic retrieval based on the user's current intent, so the injection target should be the latest real user message, not a reconstructed historical message from session assembly.

## Problem

Before this change, main / preflight assemble could also run long-term auto-recall when `autoRecall` was enabled.

That created two functional issues:

- **Duplicate recall injection**: main / preflight assemble could inject recalled memories into the reconstructed OpenViking history, and transformContext could later recall again and inject another recall block into the latest real user message.
- **Wrong injection target**: when main / preflight assemble performed recall, the recall block could be attached to the assembled history, the first user message, or a recall-only fallback message. That is not necessarily the user's latest real request.

There was also a recall-only fallback path: if `getSessionContext` failed or returned no OpenViking data, main / preflight assemble could still return a response containing only auto-recalled long-term memories. That made session assembly do semantic memory retrieval even when no session context was available, which blurred the responsibility between session history assembly and latest-user-message recall.

## What Changed

This PR removes long-term auto-recall from main / preflight assemble:

- main / preflight assemble no longer builds an auto-recall query
- main / preflight assemble no longer calls `find` for long-term memories
- main / preflight assemble no longer injects recall blocks into reconstructed OpenViking history
- recall-only fallback results for unavailable / empty OpenViking context are removed

TransformContext auto-recall is kept intact:

- it only runs when the latest message is a real `user` message
- it still respects `autoRecall`
- it still skips if a recall block is already present
- it still prepends recalled memories to the latest user message only

## Behavior After This Change

- If main / preflight assemble gets valid OpenViking session context, it returns only the assembled session history and system prompt addition.
- If main / preflight assemble gets no OpenViking data, it falls back to the live input messages without adding long-term memories.
- If main / preflight assemble hits a `getSessionContext` error, it uses the existing assemble error fallback without adding long-term memories.
- Long-term memory recall happens only in transformContext, based on the latest real user message.
- This prevents the same long-term memory from being injected once during main / preflight assembly and again during transformContext.

## Tests

- `npm test`
- `npm run typecheck`