### PR TITLE
fix(openclaw-plugin): stop capturing tool placeholders

### DIFF
--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -48,6 +48,16 @@ describe("sanitizeUserTextForCapture", () => {
     expect(sanitizeUserTextForCapture("   ")).toBe("");
   });
 
+  it("drops legacy synthetic tool placeholders", () => {
+    expect(sanitizeUserTextForCapture("[tool: exec]")).toBe("");
+    expect(sanitizeUserTextForCapture(" [toolUse: grep] ")).toBe("");
+  });
+
+  it("preserves ordinary text that mentions a tool placeholder", () => {
+    const input = "The model echoed [tool: exec] in a previous answer.";
+    expect(sanitizeUserTextForCapture(input)).toBe(input);
+  });
+
   it("strips leading timestamp prefix", () => {
     const input = "[2026-03-29T10:00:00Z] actual content here";
     const result = sanitizeUserTextForCapture(input);
@@ -223,7 +233,7 @@ describe("extractNewTurnTexts", () => {
 });
 
 describe("extractNewTurnMessages", () => {
-  it("keeps assistant toolCall messages that have no text block", () => {
+  it("drops assistant toolCall messages that have no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -237,15 +247,10 @@ describe("extractNewTurnMessages", () => {
     const { messages: extracted, newCount } = extractNewTurnMessages(messages, 0);
 
     expect(newCount).toBe(1);
-    expect(extracted).toEqual([
-      {
-        role: "assistant",
-        parts: [{ type: "text", text: "[tool: read_file]" }],
-      },
-    ]);
+    expect(extracted).toEqual([]);
   });
 
-  it("keeps assistant toolUse messages that have no text block", () => {
+  it("drops assistant toolUse messages that have no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -259,15 +264,10 @@ describe("extractNewTurnMessages", () => {
     const { messages: extracted, newCount } = extractNewTurnMessages(messages, 0);
 
     expect(newCount).toBe(1);
-    expect(extracted).toEqual([
-      {
-        role: "assistant",
-        parts: [{ type: "text", text: "[tool: grep]" }],
-      },
-    ]);
+    expect(extracted).toEqual([]);
   });
 
-  it("keeps multiple textless assistant tool calls in one placeholder", () => {
+  it("does not synthesize placeholders for multiple textless assistant tool calls", () => {
     const messages = [
       {
         role: "assistant",
@@ -280,12 +280,7 @@ describe("extractNewTurnMessages", () => {
 
     const { messages: extracted } = extractNewTurnMessages(messages, 0);
 
-    expect(extracted).toEqual([
-      {
-        role: "assistant",
-        parts: [{ type: "text", text: "[tool: read_file, grep]" }],
-      },
-    ]);
+    expect(extracted).toEqual([]);
   });
 
   it("does not create a placeholder for textless assistant messages without tool calls", () => {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -44,10 +44,15 @@ function looksLikeMetadataJsonBlock(content: string): boolean {
 }
 
 const HEARTBEAT_RE = /\bHEARTBEAT(?:\.md|_OK)\b/;
+const TOOL_PLACEHOLDER_RE = /^\s*\[tool(?::\s*|Use:\s*)[^\]]+\]\s*$/i;
 
 export function sanitizeUserTextForCapture(text: string): string {
   // 过滤 HEARTBEAT 健康检查消息
   if (HEARTBEAT_RE.test(text)) {
+    return "";
+  }
+  // Drop legacy synthetic tool placeholders before they reach memory extraction.
+  if (TOOL_PLACEHOLDER_RE.test(text)) {
     return "";
   }
   // 处理 Compactor 系统消息，提取实际用户输入
@@ -425,40 +430,6 @@ export function extractNewTurnMessages(
             text: cleanedText,
           }],
         });
-      }
-    } else {
-      /// 如果原始消息有 toolCall，提取所有工具名并生成占位符
-      if (role === "assistant" && Array.isArray(content)) {
-        const toolNames: string[] = [];
-        
-        // 收集所有 toolCall 的 tool_name
-        for (const block of content) {
-          const b = block as Record<string, unknown>;
-          const blockType = b?.type as string;
-          if (
-            blockType === "toolCall" ||
-            blockType === "toolUse" ||
-            blockType === "tool_use" ||
-            blockType === "tool_call"
-          ) {
-            const name = b?.name as string || b?.toolName as string;
-            if (name && typeof name === "string" && name.trim()) {
-              toolNames.push(name.trim());
-            }
-          }
-        }
-        
-        // 只有找到 toolCall 时才添加占位符
-        if (toolNames.length > 0) {
-          const toolNamesStr = toolNames.join(", ");
-          result.push({
-            role: "assistant",
-            parts: [{
-              type: "text",
-              text: `[tool: ${toolNamesStr}]`,
-            }],
-          });
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #2480.

This keeps the fix scoped to the OpenClaw plugin capture path:

- stop synthesizing assistant text like `[tool: exec]` for textless assistant tool-call messages
- keep structured tool results flowing through the existing `type: "tool"` path
- add a defensive sanitizer for legacy whole-message `[tool: ...]` / `[toolUse: ...]` placeholders
- update text-utils tests to lock in the non-capturing behavior

Unlike #2481, this does not introduce a new `toolCall` message part type, because the current server message model only supports `text`, `context`, and `tool` parts.

## Tests

- `npm run typecheck` in `examples/openclaw-plugin`
- `npx vitest run tests/ut/text-utils.test.ts` in `examples/openclaw-plugin`
- `npm run build` in `examples/openclaw-plugin`

Note: full `npm test` currently has 4 failures in `tests/ut/context-engine-assemble.test.ts` on unmodified `origin/main` as well; they expect two auto-recall `find` calls while main now makes one.