### PR TITLE
feat: chunk long messages for memory extraction

### DIFF
--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -19,7 +19,6 @@ from openviking.session.memory import ExtractLoop, MemoryUpdater
 from openviking.session.memory.dataclass import ResolvedOperations, StoredLink
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import (
-    ExtractContext,
     MemoryUpdateResult,
     write_stored_links,
 )
@@ -139,6 +138,7 @@ class SessionCompressorV2:
         latest_archive_overview: str = "",
         isolation_handler: Optional[MemoryIsolationHandler] = None,
         transaction_handle=None,
+        context_provider: Optional[Any] = None,
     ) -> ExtractLoop:
         """Create new ExtractLoop instance with current ctx.
 
@@ -149,19 +149,20 @@ class SessionCompressorV2:
         vlm = config.vlm.get_vlm_instance()
         viking_fs = get_viking_fs()
 
-        # Create context provider with messages (provider 负责加载 schema)
-        from openviking.session.memory.session_extract_context_provider import (
-            SessionExtractContextProvider,
-        )
+        if context_provider is None:
+            # Create context provider with messages (provider 负责加载 schema)
+            from openviking.session.memory.session_extract_context_provider import (
+                SessionExtractContextProvider,
+            )
 
-        context_provider = SessionExtractContextProvider(
-            messages=messages,
-            latest_archive_overview=latest_archive_overview,
-            isolation_handler=isolation_handler,
-            ctx=ctx,
-            viking_fs=viking_fs,
-            transaction_handle=transaction_handle,
-        )
+            context_provider = SessionExtractContextProvider(
+                messages=messages,
+                latest_archive_overview=latest_archive_overview,
+                isolation_handler=isolation_handler,
+                ctx=ctx,
+                viking_fs=viking_fs,
+                transaction_handle=transaction_handle,
+            )
 
         return ExtractLoop(
             vlm=vlm,
@@ -292,12 +293,19 @@ class SessionCompressorV2:
             logger.debug("AGFS unavailable, running memory extraction without locks")
 
         try:
-            # Create extract context from messages
-            from openviking.session.memory.memory_updater import ExtractContext
+            from openviking.session.memory.session_extract_context_provider import (
+                SessionExtractContextProvider,
+            )
 
-            extract_context = ExtractContext(messages)
-
-            # Create MemoryIsolationHandler
+            context_provider = SessionExtractContextProvider(
+                messages=messages,
+                latest_archive_overview=latest_archive_overview,
+                isolation_handler=None,
+                ctx=ctx,
+                viking_fs=viking_fs,
+                transaction_handle=transaction_handle,
+            )
+            extract_context = context_provider.get_extract_context()
             isolation_handler = MemoryIsolationHandler(
                 ctx,
                 extract_context,
@@ -306,6 +314,8 @@ class SessionCompressorV2:
                 allowed_peer_ids=allowed_peer_ids,
             )
             isolation_handler.prepare_messages()
+            context_provider._isolation_handler = isolation_handler
+
             # 获取所有记忆 schema 目录并加锁（仅在有锁管理器时）
             orchestrator = self._get_or_create_react(
                 ctx=ctx,
@@ -313,6 +323,7 @@ class SessionCompressorV2:
                 latest_archive_overview=latest_archive_overview,
                 isolation_handler=isolation_handler,
                 transaction_handle=transaction_handle,
+                context_provider=context_provider,
             )
             read_scope = isolation_handler.get_read_scope()
             if lock_manager:
@@ -701,9 +712,9 @@ class SessionCompressorV2:
         vlm = config.vlm.get_vlm_instance()
         viking_fs = get_viking_fs()
 
-        # Build isolation_handler BEFORE creating the orchestrator so that
-        # ExtractLoop.resolve_operations() can fill identity fields correctly.
-        extract_context = ExtractContext(messages)
+        # Use the provider's extraction context so prompt ranges and memory
+        # rendering resolve against the same message list.
+        extract_context = provider.get_extract_context()
         isolation_handler = MemoryIsolationHandler(
             ctx,
             extract_context,

--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -19,6 +19,7 @@ from openviking.session.memory import ExtractLoop, MemoryUpdater
 from openviking.session.memory.dataclass import ResolvedOperations, StoredLink
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import (
+    ExtractContext,
     MemoryUpdateResult,
     write_stored_links,
 )
@@ -712,9 +713,13 @@ class SessionCompressorV2:
         vlm = config.vlm.get_vlm_instance()
         viking_fs = get_viking_fs()
 
-        # Use the provider's extraction context so prompt ranges and memory
-        # rendering resolve against the same message list.
-        extract_context = provider.get_extract_context()
+        # Use the provider's extraction context when available so prompt
+        # ranges and memory rendering resolve against the same message list.
+        # Fallback providers still get ExtractContext-level message chunking.
+        get_extract_context = getattr(provider, "get_extract_context", None)
+        extract_context = (
+            get_extract_context() if callable(get_extract_context) else ExtractContext(messages)
+        )
         isolation_handler = MemoryIsolationHandler(
             ctx,
             extract_context,

--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -19,7 +19,6 @@ from openviking.session.memory import ExtractLoop, MemoryUpdater
 from openviking.session.memory.dataclass import ResolvedOperations, StoredLink
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import (
-    ExtractContext,
     MemoryUpdateResult,
     write_stored_links,
 )
@@ -713,13 +712,9 @@ class SessionCompressorV2:
         vlm = config.vlm.get_vlm_instance()
         viking_fs = get_viking_fs()
 
-        # Use the provider's extraction context when available so prompt
-        # ranges and memory rendering resolve against the same message list.
-        # Fallback providers still get ExtractContext-level message chunking.
-        get_extract_context = getattr(provider, "get_extract_context", None)
-        extract_context = (
-            get_extract_context() if callable(get_extract_context) else ExtractContext(messages)
-        )
+        # Use the provider's extraction context so prompt ranges and memory
+        # rendering resolve against the same message list.
+        extract_context = provider.get_extract_context()
         isolation_handler = MemoryIsolationHandler(
             ctx,
             extract_context,

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -9,6 +9,7 @@ to the storage system.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
     from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 
 from openviking.message import Message
+from openviking.message.part import TextPart
 from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import (
     MemoryFile,
@@ -37,6 +39,9 @@ from openviking_cli.exceptions import NotFoundError
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
+
+_EXTRACTION_CHUNK_MIN_CHARS = 100
+_EXTRACTION_CHUNK_BOUNDARY_RE = re.compile(r"(\n+|[。！？；!?;]+|(?<!\d)\.(?!\d))")
 
 
 @dataclass(frozen=True)
@@ -93,9 +98,103 @@ class ExtractContext:
     """Extract context for template rendering."""
 
     def __init__(self, messages: List[Message], chunk_meta: Optional[Dict[int, ChunkMeta]] = None):
-        self.messages = messages
-        self.chunk_meta = chunk_meta or {}
+        if chunk_meta is None:
+            self.messages, self.chunk_meta = self._build_extraction_messages(messages)
+        else:
+            self.messages = messages
+            self.chunk_meta = chunk_meta
         self.page_id_map = PageIdMap()
+
+    @classmethod
+    def _build_extraction_messages(
+        cls, messages: List[Message]
+    ) -> Tuple[List[Message], Dict[int, ChunkMeta]]:
+        """Build messages used by memory extraction.
+
+        Long text-only messages are split into derived chunks so event `ranges`
+        can point to a narrower source span without relying on brittle text
+        matching. The original session messages are not modified.
+        """
+        extraction_messages: List[Message] = []
+        chunk_meta: Dict[int, ChunkMeta] = {}
+        for message in messages:
+            for extraction_message, meta in cls._split_message_for_extraction(message):
+                extraction_messages.append(extraction_message)
+                if meta is not None:
+                    chunk_meta[id(extraction_message)] = meta
+        return extraction_messages, chunk_meta
+
+    @classmethod
+    def _split_message_for_extraction(
+        cls, message: Message
+    ) -> List[Tuple[Message, Optional[ChunkMeta]]]:
+        parts = getattr(message, "parts", [])
+        if not parts or not all(isinstance(part, TextPart) for part in parts):
+            return [(message, None)]
+
+        text = "".join(part.text for part in parts)
+        chunks = cls._split_text_for_extraction(text)
+        if len(chunks) <= 1:
+            return [(message, None)]
+
+        chunk_messages = []
+        for idx, chunk in enumerate(chunks):
+            chunk_message = Message(
+                id=f"{message.id}#chunk_{idx}",
+                role=message.role,
+                peer_id=getattr(message, "peer_id", None),
+                parts=[TextPart(chunk)],
+                created_at=message.created_at,
+            )
+            chunk_messages.append(
+                (
+                    chunk_message,
+                    ChunkMeta(
+                        source_message_id=message.id,
+                        chunk_index=idx,
+                        chunk_count=len(chunks),
+                    ),
+                )
+            )
+        return chunk_messages
+
+    @classmethod
+    def _split_text_for_extraction(cls, text: str) -> List[str]:
+        return cls._pack_text_units(cls._split_text_units(text)) or [text]
+
+    @staticmethod
+    def _pack_text_units(units: List[str]) -> List[str]:
+        chunks: List[str] = []
+        current = ""
+        for unit in units:
+            current += unit
+            if len(current) < _EXTRACTION_CHUNK_MIN_CHARS:
+                continue
+            chunks.append(current)
+            current = ""
+
+        if current:
+            if chunks:
+                chunks[-1] += current
+            else:
+                chunks.append(current)
+        return chunks
+
+    @staticmethod
+    def _split_text_units(text: str) -> List[str]:
+        pieces = _EXTRACTION_CHUNK_BOUNDARY_RE.split(text)
+        units: List[str] = []
+        current = ""
+        for piece in pieces:
+            if not piece:
+                continue
+            current += piece
+            if _EXTRACTION_CHUNK_BOUNDARY_RE.fullmatch(piece):
+                units.append(current)
+                current = ""
+        if current:
+            units.append(current)
+        return units or [text]
 
     def get_first_message_time_from_ranges(self, ranges_str: str) -> str | None:
         """根据 ranges 字符串获取第一条消息的时间（YAML 日期格式）"""

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -9,6 +9,7 @@ to the storage system.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
@@ -36,6 +37,15 @@ from openviking_cli.exceptions import NotFoundError
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ChunkMeta:
+    """Metadata for a derived extraction chunk message."""
+
+    source_message_id: str
+    chunk_index: int
+    chunk_count: int
 
 
 async def write_stored_links(
@@ -82,8 +92,9 @@ async def write_stored_links(
 class ExtractContext:
     """Extract context for template rendering."""
 
-    def __init__(self, messages: List[Message]):
+    def __init__(self, messages: List[Message], chunk_meta: Optional[Dict[int, ChunkMeta]] = None):
         self.messages = messages
+        self.chunk_meta = chunk_meta or {}
         self.page_id_map = PageIdMap()
 
     def get_first_message_time_from_ranges(self, ranges_str: str) -> str | None:
@@ -226,26 +237,86 @@ class ExtractContext:
             range_msgs = self.messages[start : end + 1]
             elements.append(range_msgs)
 
-        return MessageRange(elements)
+        return MessageRange(elements, chunk_meta=self.chunk_meta)
 
 
 class MessageRange:
     """Represents a range of messages for formatting."""
 
-    def __init__(self, elements: List[List[Message]]):
+    def __init__(
+        self,
+        elements: List[List[Message]],
+        chunk_meta: Optional[Dict[int, ChunkMeta]] = None,
+    ):
         self.elements = elements
+        self.chunk_meta = chunk_meta or {}
 
     def pretty_print(self) -> str:
         """Pretty print the message range with '...' separator between non-contiguous ranges."""
         result = []
         for i, msg_group in enumerate(self.elements):
-            for msg in msg_group:
-                speaker = msg.peer_id or msg.role
-                result.append(f"[{speaker}]: {msg.content}")
+            result.extend(self._format_contiguous_group(msg_group))
             # Add "..." separator between non-contiguous message groups
             if i < len(self.elements) - 1:
                 result.append("...")
         return "\n".join(result)
+
+    def _format_contiguous_group(self, msg_group: List[Message]) -> List[str]:
+        formatted = []
+        current_messages: List[Message] = []
+
+        def flush_current() -> None:
+            nonlocal current_messages
+            if not current_messages:
+                return
+            content = self._format_merged_content(current_messages)
+            formatted.append(f"[{self._speaker_for(current_messages[0])}]: {content}")
+            current_messages = []
+
+        for msg in msg_group:
+            if current_messages and not self._can_merge_messages(current_messages[-1], msg):
+                flush_current()
+            current_messages.append(msg)
+
+        flush_current()
+        return formatted
+
+    @staticmethod
+    def _speaker_for(message: Message) -> str:
+        return (
+            getattr(message, "peer_id", None) or getattr(message, "role_id", None) or message.role
+        )
+
+    def _can_merge_messages(self, previous: Message, current: Message) -> bool:
+        previous_meta = self._chunk_meta_for(previous)
+        current_meta = self._chunk_meta_for(current)
+        if previous_meta is None or current_meta is None:
+            return False
+        if self._speaker_for(previous) != self._speaker_for(current):
+            return False
+        return (
+            previous_meta.source_message_id == current_meta.source_message_id
+            and current_meta.chunk_index == previous_meta.chunk_index + 1
+        )
+
+    def _format_merged_content(self, messages: List[Message]) -> str:
+        content = "".join((msg.content or "") for msg in messages)
+        if not messages or not self._contains_chunk_message(messages):
+            return content
+
+        first_chunk = self._chunk_meta_for(messages[0])
+        if first_chunk is not None and first_chunk.chunk_index > 0:
+            content = "..." + content.lstrip()
+        last_chunk = self._chunk_meta_for(messages[-1])
+        if last_chunk is not None and last_chunk.chunk_index < last_chunk.chunk_count - 1:
+            content = content.rstrip() + "..."
+        return content
+
+    def _contains_chunk_message(self, messages: List[Message]) -> bool:
+        return any(self._chunk_meta_for(msg) is not None for msg in messages)
+
+    def _chunk_meta_for(self, message: Message) -> Optional[ChunkMeta]:
+        return self.chunk_meta.get(id(message))
 
     def _first_message_time(self) -> str | None:
         """获取第一条消息的时间（内部方法）"""

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -8,11 +8,9 @@ Session Extract Context Provider - 会话提取 Provider 实现
 
 import json
 import os
-import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from openviking.message import Message
-from openviking.message.part import TextPart, ToolPart
+from openviking.message.part import ToolPart
 from openviking.prompts.manager import PromptManager
 from openviking.server.identity import RequestContext, ToolContext
 from openviking.session.memory.core import ExtractContextProvider
@@ -46,8 +44,6 @@ _PREFETCH_SEARCH_QUERY_MAX_CHARS = 5000
 _PREFETCH_SEARCH_TEXT_PART_MAX_CHARS = 1000
 _PREFETCH_SEARCH_ASSISTANT_TEXT_PART_MAX_CHARS = 500
 _PREFETCH_SEARCH_TOOL_FIELD_MAX_CHARS = 500
-_EXTRACTION_CHUNK_MIN_CHARS = 100
-_EXTRACTION_CHUNK_BOUNDARY_RE = re.compile(r"(\n+|[。！？；!?;]+|(?<!\d)\.(?!\d))")
 
 
 class SessionExtractContextProvider(ExtractContextProvider):
@@ -68,8 +64,6 @@ class SessionExtractContextProvider(ExtractContextProvider):
         self._registry = None  # 延迟加载
         self._schema_directories = None
         self._extract_context = None  # 缓存 ExtractContext 实例
-        self._extraction_messages = None  # 缓存用于提取的派生消息列表
-        self._extraction_chunk_meta: Dict[int, Any] = {}
         self._isolation_handler = isolation_handler
         self._read_file_contents: Dict[str, MemoryFile] = {}
         # 读取 eager_prefetch 配置
@@ -106,95 +100,9 @@ class SessionExtractContextProvider(ExtractContextProvider):
 
         if self._extract_context is None:
             self._extract_context = ExtractContext(
-                self._get_extraction_messages(),
-                chunk_meta=self._extraction_chunk_meta,
+                self.messages if isinstance(self.messages, list) else []
             )
         return self._extract_context
-
-    def _get_extraction_messages(self) -> List[Message]:
-        """Return messages used by memory extraction.
-
-        Long text-only messages are split into derived chunks so event `ranges`
-        can point to a narrower source span without relying on brittle text
-        matching. The original session messages are not modified.
-        """
-        if self._extraction_messages is not None:
-            return self._extraction_messages
-        if not isinstance(self.messages, list):
-            self._extraction_messages = []
-            self._extraction_chunk_meta = {}
-            return self._extraction_messages
-
-        extraction_messages: List[Message] = []
-        self._extraction_chunk_meta = {}
-        for message in self.messages:
-            extraction_messages.extend(self._split_message_for_extraction(message))
-        self._extraction_messages = extraction_messages
-        return self._extraction_messages
-
-    def _split_message_for_extraction(self, message: Message) -> List[Message]:
-        parts = getattr(message, "parts", [])
-        if not parts or not all(isinstance(part, TextPart) for part in parts):
-            return [message]
-
-        text = "".join(part.text for part in parts)
-        chunks = self._split_text_for_extraction(text)
-        if len(chunks) <= 1:
-            return [message]
-
-        from openviking.session.memory.memory_updater import ChunkMeta
-
-        chunk_messages = []
-        for idx, chunk in enumerate(chunks):
-            chunk_message = Message(
-                id=f"{message.id}#chunk_{idx}",
-                role=message.role,
-                peer_id=getattr(message, "peer_id", None),
-                parts=[TextPart(chunk)],
-                created_at=message.created_at,
-            )
-            chunk_messages.append(chunk_message)
-            self._extraction_chunk_meta[id(chunk_message)] = ChunkMeta(
-                source_message_id=message.id,
-                chunk_index=idx,
-                chunk_count=len(chunks),
-            )
-        return chunk_messages
-
-    def _split_text_for_extraction(self, text: str) -> List[str]:
-        return self._pack_text_units(self._split_text_units(text)) or [text]
-
-    def _pack_text_units(self, units: List[str]) -> List[str]:
-        chunks: List[str] = []
-        current = ""
-        for unit in units:
-            current += unit
-            if len(current) < _EXTRACTION_CHUNK_MIN_CHARS:
-                continue
-            chunks.append(current)
-            current = ""
-
-        if current:
-            if chunks:
-                chunks[-1] += current
-            else:
-                chunks.append(current)
-        return chunks
-
-    def _split_text_units(self, text: str) -> List[str]:
-        pieces = _EXTRACTION_CHUNK_BOUNDARY_RE.split(text)
-        units: List[str] = []
-        current = ""
-        for piece in pieces:
-            if not piece:
-                continue
-            current += piece
-            if _EXTRACTION_CHUNK_BOUNDARY_RE.fullmatch(piece):
-                units.append(current)
-                current = ""
-        if current:
-            units.append(current)
-        return units or [text]
 
     def _detect_language(self) -> str:
         """检测输出语言"""
@@ -274,8 +182,8 @@ from neighboring messages.
         else:
             time_display = session_time_str
 
-        extraction_messages = self._get_extraction_messages()
-        conversation = self._assemble_conversation(extraction_messages)
+        extract_context = self.get_extract_context()
+        conversation = self._assemble_conversation(extract_context.messages)
 
         return {
             "role": "user",

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -8,9 +8,11 @@ Session Extract Context Provider - 会话提取 Provider 实现
 
 import json
 import os
+import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from openviking.message.part import ToolPart
+from openviking.message import Message
+from openviking.message.part import TextPart, ToolPart
 from openviking.prompts.manager import PromptManager
 from openviking.server.identity import RequestContext, ToolContext
 from openviking.session.memory.core import ExtractContextProvider
@@ -44,6 +46,8 @@ _PREFETCH_SEARCH_QUERY_MAX_CHARS = 5000
 _PREFETCH_SEARCH_TEXT_PART_MAX_CHARS = 1000
 _PREFETCH_SEARCH_ASSISTANT_TEXT_PART_MAX_CHARS = 500
 _PREFETCH_SEARCH_TOOL_FIELD_MAX_CHARS = 500
+_EXTRACTION_CHUNK_MIN_CHARS = 100
+_EXTRACTION_CHUNK_BOUNDARY_RE = re.compile(r"(\n+|[。！？；!?;]+|(?<!\d)\.(?!\d))")
 
 
 class SessionExtractContextProvider(ExtractContextProvider):
@@ -64,6 +68,8 @@ class SessionExtractContextProvider(ExtractContextProvider):
         self._registry = None  # 延迟加载
         self._schema_directories = None
         self._extract_context = None  # 缓存 ExtractContext 实例
+        self._extraction_messages = None  # 缓存用于提取的派生消息列表
+        self._extraction_chunk_meta: Dict[int, Any] = {}
         self._isolation_handler = isolation_handler
         self._read_file_contents: Dict[str, MemoryFile] = {}
         # 读取 eager_prefetch 配置
@@ -99,8 +105,96 @@ class SessionExtractContextProvider(ExtractContextProvider):
         from openviking.session.memory.memory_updater import ExtractContext
 
         if self._extract_context is None:
-            self._extract_context = ExtractContext(self.messages or [])
+            self._extract_context = ExtractContext(
+                self._get_extraction_messages(),
+                chunk_meta=self._extraction_chunk_meta,
+            )
         return self._extract_context
+
+    def _get_extraction_messages(self) -> List[Message]:
+        """Return messages used by memory extraction.
+
+        Long text-only messages are split into derived chunks so event `ranges`
+        can point to a narrower source span without relying on brittle text
+        matching. The original session messages are not modified.
+        """
+        if self._extraction_messages is not None:
+            return self._extraction_messages
+        if not isinstance(self.messages, list):
+            self._extraction_messages = []
+            self._extraction_chunk_meta = {}
+            return self._extraction_messages
+
+        extraction_messages: List[Message] = []
+        self._extraction_chunk_meta = {}
+        for message in self.messages:
+            extraction_messages.extend(self._split_message_for_extraction(message))
+        self._extraction_messages = extraction_messages
+        return self._extraction_messages
+
+    def _split_message_for_extraction(self, message: Message) -> List[Message]:
+        parts = getattr(message, "parts", [])
+        if not parts or not all(isinstance(part, TextPart) for part in parts):
+            return [message]
+
+        text = "".join(part.text for part in parts)
+        chunks = self._split_text_for_extraction(text)
+        if len(chunks) <= 1:
+            return [message]
+
+        from openviking.session.memory.memory_updater import ChunkMeta
+
+        chunk_messages = []
+        for idx, chunk in enumerate(chunks):
+            chunk_message = Message(
+                id=f"{message.id}#chunk_{idx}",
+                role=message.role,
+                peer_id=getattr(message, "peer_id", None),
+                parts=[TextPart(chunk)],
+                created_at=message.created_at,
+            )
+            chunk_messages.append(chunk_message)
+            self._extraction_chunk_meta[id(chunk_message)] = ChunkMeta(
+                source_message_id=message.id,
+                chunk_index=idx,
+                chunk_count=len(chunks),
+            )
+        return chunk_messages
+
+    def _split_text_for_extraction(self, text: str) -> List[str]:
+        return self._pack_text_units(self._split_text_units(text)) or [text]
+
+    def _pack_text_units(self, units: List[str]) -> List[str]:
+        chunks: List[str] = []
+        current = ""
+        for unit in units:
+            current += unit
+            if len(current) < _EXTRACTION_CHUNK_MIN_CHARS:
+                continue
+            chunks.append(current)
+            current = ""
+
+        if current:
+            if chunks:
+                chunks[-1] += current
+            else:
+                chunks.append(current)
+        return chunks
+
+    def _split_text_units(self, text: str) -> List[str]:
+        pieces = _EXTRACTION_CHUNK_BOUNDARY_RE.split(text)
+        units: List[str] = []
+        current = ""
+        for piece in pieces:
+            if not piece:
+                continue
+            current += piece
+            if _EXTRACTION_CHUNK_BOUNDARY_RE.fullmatch(piece):
+                units.append(current)
+                current = ""
+        if current:
+            units.append(current)
+        return units or [text]
 
     def _detect_language(self) -> str:
         """检测输出语言"""
@@ -180,7 +274,8 @@ from neighboring messages.
         else:
             time_display = session_time_str
 
-        conversation = self._assemble_conversation(self.messages)
+        extraction_messages = self._get_extraction_messages()
+        conversation = self._assemble_conversation(extraction_messages)
 
         return {
             "role": "user",

--- a/tests/session/memory/test_compressor_v2.py
+++ b/tests/session/memory/test_compressor_v2.py
@@ -328,6 +328,9 @@ class TestCompressorV2:
                     def get_memory_schemas(self, ctx):
                         return []
 
+                    def get_extract_context(self):
+                        return ExtractContext(messages)
+
                 return DummyProvider()
 
             async def run(self):
@@ -552,6 +555,9 @@ class TestCompressorV2:
             def get_memory_schemas(self, _ctx):
                 return [FixedSchema(), VariableSchema()]
 
+            def get_extract_context(self):
+                return ExtractContext(messages)
+
             def _get_registry(self):
                 return object()
 
@@ -618,6 +624,9 @@ class TestCompressorV2:
         class DummyProvider:
             def get_memory_schemas(self, _ctx):
                 return []
+
+            def get_extract_context(self):
+                return ExtractContext(messages)
 
             def _get_registry(self):
                 return object()

--- a/tests/session/memory/test_memory_timestamp_parsing.py
+++ b/tests/session/memory/test_memory_timestamp_parsing.py
@@ -101,8 +101,8 @@ def test_extraction_context_chunks_long_text_and_preserves_decimal_numbers(stub_
         + "金然优势是Agent架构全栈，缺点是缺乏CPU服务器底层调优经验 "
         + "周三 query-builder的输出直接进行判断会触发错误，原因不明。"
     )
-    provider = SessionExtractContextProvider(
-        messages=[
+    extract_context = ExtractContext(
+        [
             Message(
                 id="msg-long",
                 role="user",
@@ -112,12 +112,13 @@ def test_extraction_context_chunks_long_text_and_preserves_decimal_numbers(stub_
         ]
     )
 
-    extraction_messages = provider._get_extraction_messages()
+    extraction_messages = extract_context.messages
     merged = "".join(message.content for message in extraction_messages)
 
     assert len(extraction_messages) > 1
     assert merged == text
     assert all(message.id.startswith("msg-long#chunk_") for message in extraction_messages)
+    assert all(id(message) in extract_context.chunk_meta for message in extraction_messages)
     assert "21.9K" in merged
     assert "110.2k" in merged
     assert "501.0k" in merged

--- a/tests/session/memory/test_memory_timestamp_parsing.py
+++ b/tests/session/memory/test_memory_timestamp_parsing.py
@@ -92,6 +92,169 @@ def test_message_range_uses_peer_id_when_present():
     assert "[default]: invoice follow-up" not in msg_range.pretty_print()
 
 
+def test_extraction_context_chunks_long_text_and_preserves_decimal_numbers(stub_provider_config):
+    text = (
+        "周一 "
+        + "需求沟通。" * 20
+        + "上下文用量out：21.9K、in：110.2k、缓存读取501.0k，先简单记录下来。 "
+        + "周二 面试三个新员工：王军优势是agent算法，田伟优势是分布式后端架构，"
+        + "金然优势是Agent架构全栈，缺点是缺乏CPU服务器底层调优经验 "
+        + "周三 query-builder的输出直接进行判断会触发错误，原因不明。"
+    )
+    provider = SessionExtractContextProvider(
+        messages=[
+            Message(
+                id="msg-long",
+                role="user",
+                parts=[TextPart(text=text)],
+                created_at="2026-06-01T08:56:37.382Z",
+            )
+        ]
+    )
+
+    extraction_messages = provider._get_extraction_messages()
+    merged = "".join(message.content for message in extraction_messages)
+
+    assert len(extraction_messages) > 1
+    assert merged == text
+    assert all(message.id.startswith("msg-long#chunk_") for message in extraction_messages)
+    assert "21.9K" in merged
+    assert "110.2k" in merged
+    assert "501.0k" in merged
+    assert not any(message.content.startswith(("9K", "2k")) for message in extraction_messages)
+
+
+def test_message_range_merges_adjacent_chunks_for_same_speaker():
+    first = Message(
+        id="msg-long#chunk_0",
+        role="user",
+        parts=[TextPart(text="first chunk. ")],
+        peer_id="web:visitor:alice",
+    )
+    second = Message(
+        id="msg-long#chunk_1",
+        role="user",
+        parts=[TextPart(text="second chunk.")],
+        peer_id="web:visitor:alice",
+    )
+    msg_range = MessageRange(
+        [[first, second]],
+        chunk_meta={
+            id(first): SimpleNamespace(
+                source_message_id="msg-long",
+                chunk_index=0,
+                chunk_count=2,
+            ),
+            id(second): SimpleNamespace(
+                source_message_id="msg-long",
+                chunk_index=1,
+                chunk_count=2,
+            ),
+        },
+    )
+
+    assert msg_range.pretty_print() == "[web:visitor:alice]: first chunk. second chunk."
+
+
+def test_message_range_keeps_regular_same_speaker_messages_separate():
+    msg_range = MessageRange(
+        [
+            [
+                Message(
+                    id="msg-a",
+                    role="user",
+                    parts=[TextPart(text="first message")],
+                    peer_id="web:visitor:alice",
+                ),
+                Message(
+                    id="msg-b",
+                    role="user",
+                    parts=[TextPart(text="second message")],
+                    peer_id="web:visitor:alice",
+                ),
+            ]
+        ]
+    )
+
+    assert msg_range.pretty_print() == (
+        "[web:visitor:alice]: first message\n[web:visitor:alice]: second message"
+    )
+
+
+def test_message_range_keeps_different_source_chunks_separate():
+    first = Message(
+        id="msg-a#chunk_0",
+        role="user",
+        parts=[TextPart(text="first source chunk")],
+        peer_id="web:visitor:alice",
+    )
+    second = Message(
+        id="msg-b#chunk_0",
+        role="user",
+        parts=[TextPart(text="second source chunk")],
+        peer_id="web:visitor:alice",
+    )
+    msg_range = MessageRange(
+        [[first, second]],
+        chunk_meta={
+            id(first): SimpleNamespace(
+                source_message_id="msg-a",
+                chunk_index=0,
+                chunk_count=2,
+            ),
+            id(second): SimpleNamespace(
+                source_message_id="msg-b",
+                chunk_index=0,
+                chunk_count=2,
+            ),
+        },
+    )
+
+    assert msg_range.pretty_print() == (
+        "[web:visitor:alice]: first source chunk...\n[web:visitor:alice]: second source chunk..."
+    )
+
+
+def test_message_range_does_not_treat_original_chunk_like_id_as_chunk():
+    msg_range = MessageRange(
+        [
+            [
+                Message(
+                    id="msg-long#chunk_0",
+                    role="user",
+                    parts=[TextPart(text="original message id contains chunk marker")],
+                    peer_id="web:visitor:alice",
+                ),
+            ]
+        ]
+    )
+
+    assert msg_range.pretty_print() == (
+        "[web:visitor:alice]: original message id contains chunk marker"
+    )
+
+
+def test_message_range_marks_middle_chunk_as_abbreviated():
+    message = Message(
+        id="msg-long#chunk_1",
+        role="user",
+        parts=[TextPart(text="middle chunk")],
+        peer_id="web:visitor:alice",
+    )
+    msg_range = MessageRange(
+        [[message]],
+        chunk_meta={
+            id(message): SimpleNamespace(
+                source_message_id="msg-long",
+                chunk_index=1,
+                chunk_count=3,
+            )
+        },
+    )
+
+    assert msg_range.pretty_print() == "[web:visitor:alice]: ...middle chunk..."
+
+
 def test_peer_id_routes_peer_memory_for_all_role_selected_types(stub_provider_config):
     messages = [
         Message(


### PR DESCRIPTION
## Description

Adds chunk-aware memory extraction for long session messages so extraction prompts, model-produced ranges, and rendered ChatLog evidence all refer to the same message list. This keeps long multi-topic messages from forcing unrelated content into a single extracted memory while preserving readable evidence snippets.

## Related Issue

None.

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Test update

## Changes Made

- Split long text messages into extraction-only chunks before building the memory extraction conversation history.
- Carry chunk metadata through `ExtractContext` and `MessageRange` so rendered ranges can add ellipses based on chunk position without relying on message id string parsing.
- Reuse the same extraction context provider through the compressor/extract loop path so extraction prompts and range rendering operate on the same chunked message list.
- Restrict ChatLog line merging to consecutive chunks from the same original source message; regular same-speaker messages remain separate lines.
- Added regression coverage for timestamp parsing, chunk range rendering, id safety, and same-speaker merge behavior.

## Testing

- [x] `python -m pytest tests/session/memory/test_memory_timestamp_parsing.py -q`
- [x] `python -m ruff check openviking/session/compressor_v2.py openviking/session/memory/memory_updater.py openviking/session/memory/session_extract_context_provider.py tests/session/memory/test_memory_timestamp_parsing.py`
- [x] `python -m ruff format --check openviking/session/compressor_v2.py openviking/session/memory/memory_updater.py openviking/session/memory/session_extract_context_provider.py tests/session/memory/test_memory_timestamp_parsing.py`

## Checklist

- [x] Code follows project style
- [x] Tests added or updated
- [x] Relevant local verification was run
- [ ] Documentation updated
