### PR TITLE
fix(openclaw-plugin): gate low-score resource recall

### DIFF
--- a/docs/plans/2026-06-10-openclaw-resource-recall-gating-design.md
+++ b/docs/plans/2026-06-10-openclaw-resource-recall-gating-design.md
@@ -1,0 +1,61 @@
+# OpenClaw Resource Recall Gating Design
+
+Date: 2026-06-10
+
+## Problem
+
+When `recallResources` is enabled, the OpenClaw plugin searches both user memories and `viking://resources`, then applies the same recall score threshold to all returned items. The default threshold is low enough that shared resource entries such as transcripts or logs can be injected even when their semantic match is weak.
+
+The ranking code also tokenizes recall queries with an ASCII-only expression, so Cyrillic query terms do not contribute lexical overlap ranking.
+
+## Goals
+
+- Keep the fix small and local to OpenClaw recall ranking.
+- Require a stronger minimum score for `viking://resources` results than for user memories.
+- Preserve existing behavior for user and agent memories.
+- Support Unicode letters and numbers in recall query tokenization.
+- Cover the behavior with focused unit tests.
+
+## Non-Goals
+
+- Do not change server-side retrieval or search scoring.
+- Do not change the default `recallResources` setting.
+- Do not add broad vague-query suppression in this patch, because it can reject useful short prompts.
+
+## Design
+
+Add resource-aware threshold helpers in `examples/openclaw-plugin/memory-ranking.ts`:
+
+- `isResourceMemory(item)` returns true for URIs under `viking://resources/`.
+- `RESOURCE_RECALL_SCORE_FLOOR` defines a minimum score for shared resources. The initial value is `0.56`, which blocks the observed `~0.53` noisy resource matches while keeping the change conservative.
+- `recallScoreThresholdForItem(item, baseThreshold)` returns the max of the configured threshold and resource floor for shared resources, and the configured threshold for other memories.
+- `passesRecallScoreThreshold(item, baseThreshold)` centralizes the threshold check.
+
+Update recall flows to call `passesRecallScoreThreshold` before post-processing:
+
+- Auto recall in `auto-recall.ts`.
+- Explicit `memory_recall` in `index.ts`.
+
+After the resource-aware filter, call `postProcessMemories` with `scoreThreshold: 0` so the threshold logic has a single owner.
+
+Update query tokenization from ASCII-only tokens to Unicode-aware tokens:
+
+```ts
+/[\p{L}\p{N}][\p{L}\p{N}_-]+/giu
+```
+
+This lets Cyrillic query terms participate in lexical overlap ranking without changing the overall ranking model.
+
+## Tests
+
+Add or update unit tests to verify:
+
+- `viking://resources/...` is detected as a resource memory.
+- A resource item below `RESOURCE_RECALL_SCORE_FLOOR` fails the threshold even if it passes the base threshold.
+- A user memory at the same score still passes the base threshold.
+- Cyrillic query terms can move a matching item ahead of a higher-scored generic item.
+- Auto recall skips a low-score resource result when resource recall is enabled.
+
+## Risk
+
+The main behavior change is that shared resources need a slightly stronger score to inject. This can reduce noisy context injection, but it may also suppress marginally relevant resources with scores between the base threshold and `0.56`. User and agent memories keep their existing threshold behavior.

--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -1,6 +1,7 @@
 import type { FindResult, FindResultItem, OpenVikingClient } from "./client.js";
 import type { ParsedMemoryOpenVikingConfig } from "./config.js";
 import {
+  passesRecallScoreThreshold,
   pickMemoriesForInjection,
   postProcessMemories,
   summarizeInjectionMemories,
@@ -520,9 +521,12 @@ export async function buildLongTermMemoryRecallContext(params: {
         index === self.findIndex((m) => m.uri === memory.uri)
       );
       const leafOnly = uniqueMemories.filter((m) => (!m.level || m.level === 2) && !isExperienceMemory(m));
-      const processed = postProcessMemories(leafOnly, {
+      const thresholded = leafOnly.filter((memory) =>
+        passesRecallScoreThreshold(memory, cfg.recallScoreThreshold)
+      );
+      const processed = postProcessMemories(thresholded, {
         limit: candidateLimit,
-        scoreThreshold: cfg.recallScoreThreshold,
+        scoreThreshold: 0,
       });
       const memories = pickMemoriesForInjection(processed, cfg.recallLimit, queryText);
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./text-utils.js";
 import {
   clampScore,
+  passesRecallScoreThreshold,
   postProcessMemories,
   pickMemoriesForInjection,
 } from "./memory-ranking.js";
@@ -1154,9 +1155,10 @@ const contextEnginePlugin = {
           }
 
           const leafOnly = (result.memories ?? []).filter((m) => !m.level || m.level === 2);
-          const processed = postProcessMemories(leafOnly, {
+          const thresholded = leafOnly.filter((m) => passesRecallScoreThreshold(m, scoreThreshold));
+          const processed = postProcessMemories(thresholded, {
             limit: requestLimit,
-            scoreThreshold,
+            scoreThreshold: 0,
           });
           const memories = pickMemoriesForInjection(processed, limit, query);
           if (memories.length === 0) {

--- a/examples/openclaw-plugin/memory-ranking.ts
+++ b/examples/openclaw-plugin/memory-ranking.ts
@@ -145,10 +145,24 @@ function isLeafLikeMemory(item: FindResultItem): boolean {
   return item.level === 2;
 }
 
+export function isResourceMemory(item: FindResultItem): boolean {
+  return item.uri.startsWith("viking://resources/");
+}
+
+export const RESOURCE_RECALL_SCORE_FLOOR = 0.56;
+
+export function recallScoreThresholdForItem(item: FindResultItem, baseThreshold: number): number {
+  return isResourceMemory(item) ? Math.max(baseThreshold, RESOURCE_RECALL_SCORE_FLOOR) : baseThreshold;
+}
+
+export function passesRecallScoreThreshold(item: FindResultItem, baseThreshold: number): boolean {
+  return clampScore(item.score) >= recallScoreThresholdForItem(item, baseThreshold);
+}
+
 const PREFERENCE_QUERY_RE = /prefer|preference|favorite|favourite|like|偏好|喜欢|爱好|更倾向/i;
 const TEMPORAL_QUERY_RE =
   /when|what time|date|day|month|year|yesterday|today|tomorrow|last|next|什么时候|何时|哪天|几月|几年|昨天|今天|明天|上周|下周|上个月|下个月|去年|明年/i;
-const QUERY_TOKEN_RE = /[a-z0-9]{2,}/gi;
+const QUERY_TOKEN_RE = /[\p{L}\p{N}][\p{L}\p{N}_-]+/giu;
 const QUERY_TOKEN_STOPWORDS = new Set([
   "what",
   "when",

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -152,6 +152,53 @@ describe("context-engine assemble()", () => {
     expect(result.systemPromptAddition).toBeUndefined();
   });
 
+  it("skips low-score resources during transformContext auto-recall", async () => {
+    const { engine, client } = makeEngine(
+      {
+        latest_archive_overview: "unused",
+        pre_archive_abstracts: [],
+        messages: [],
+        estimatedTokens: 0,
+        stats: makeStats(),
+      },
+      {
+        cfgOverrides: {
+          autoRecall: true,
+          recallResources: true,
+          recallScoreThreshold: 0.5,
+          recallPreferAbstract: true,
+        },
+      },
+    );
+    client.find
+      .mockResolvedValueOnce({ memories: [], total: 0 })
+      .mockResolvedValueOnce({
+        resources: [
+          {
+            uri: "viking://resources/second-brain/noisy-transcript.md",
+            level: 2,
+            category: "",
+            abstract: "A loose raw transcript with unrelated meeting chatter.",
+            score: 0.55,
+          },
+        ],
+        total: 1,
+      });
+
+    const sourceMessages = [
+      { role: "assistant", content: [{ type: "text", text: "Previous answer." }] },
+      { role: "user", content: "Посмотри что там было и подскажи" },
+    ];
+
+    const result = await engine.assemble({
+      sessionId: "session-low-score-resource",
+      messages: sourceMessages,
+    });
+
+    expect(result.messages).toBe(sourceMessages);
+    expect(client.find).toHaveBeenCalledTimes(2);
+  });
+
   it("passes sender peer_id to transformContext auto-recall when peer_role is person", async () => {
     vi.stubGlobal(
       "fetch",

--- a/examples/openclaw-plugin/tests/ut/memory-ranking.test.ts
+++ b/examples/openclaw-plugin/tests/ut/memory-ranking.test.ts
@@ -9,6 +9,8 @@ import {
   summarizeInjectionMemories,
   summarizeExtractedMemories,
   pickMemoriesForInjection,
+  isResourceMemory,
+  passesRecallScoreThreshold,
 } from "../../memory-ranking.js";
 import type { FindResultItem } from "../../client.js";
 
@@ -254,5 +256,41 @@ describe("pickMemoriesForInjection", () => {
     ];
     const result = pickMemoriesForInjection(items, 1, "When did the user deploy?");
     expect(result[0]!.uri).toBe("event");
+  });
+
+  it("uses Cyrillic query terms for lexical overlap", () => {
+    const items = [
+      mem({ uri: "generic", category: "facts", score: 0.76, abstract: "OpenViking diagnostics" }),
+      mem({
+        uri: "badminton",
+        category: "facts",
+        score: 0.7,
+        abstract: "Решил играть в бадминтон по календарю",
+      }),
+    ];
+    const result = pickMemoriesForInjection(items, 1, "что я решил про бадминтон и календарь");
+    expect(result[0]!.uri).toBe("badminton");
+  });
+});
+
+describe("recall score thresholds", () => {
+  it("detects shared resource memories by URI", () => {
+    expect(isResourceMemory(mem({ uri: "viking://resources/second-brain/note.md" }))).toBe(true);
+    expect(isResourceMemory(mem({ uri: "viking://user/default/memories/note.md" }))).toBe(false);
+  });
+
+  it("requires a stronger score for shared resource memories", () => {
+    expect(
+      passesRecallScoreThreshold(
+        mem({ uri: "viking://resources/second-brain/noisy.md", score: 0.55 }),
+        0.5,
+      ),
+    ).toBe(false);
+    expect(
+      passesRecallScoreThreshold(
+        mem({ uri: "viking://user/default/memories/useful.md", score: 0.55 }),
+        0.5,
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Replaces #2084 with a smaller, current-main-based fix for noisy OpenClaw resource recall.

- add resource-aware recall score gating for `viking://resources/` results
- keep user/agent memory threshold behavior unchanged
- make recall query tokenization Unicode-aware so Cyrillic query terms can contribute lexical overlap
- document the focused design in `docs/plans/2026-06-10-openclaw-resource-recall-gating-design.md`

## Verification

- `npm test -- tests/ut/memory-ranking.test.ts tests/ut/context-engine-assemble.test.ts`
- `npm run build`
- `git diff --check`