### PR TITLE
fix zip root detection with macOS metadata

### DIFF
--- a/openviking/parse/parsers/zip_parser.py
+++ b/openviking/parse/parsers/zip_parser.py
@@ -22,6 +22,12 @@ from openviking_cli.utils.logger import get_logger
 logger = get_logger(__name__)
 
 
+def _is_zip_metadata_entry(path: Path) -> bool:
+    """Return true for archive metadata that should not define a resource root."""
+    name = path.name
+    return name == "__MACOSX" or name == ".DS_Store" or name.startswith("._")
+
+
 class ZipParser(BaseParser):
     """
     ZIP archive parser for OpenViking.
@@ -75,7 +81,11 @@ class ZipParser(BaseParser):
 
             # Check if extracted content has a single root directory (non-blocking)
             def _list_entries():
-                return [p for p in temp_dir.iterdir() if p.name not in {".", ".."}]
+                return [
+                    p
+                    for p in temp_dir.iterdir()
+                    if p.name not in {".", ".."} and not _is_zip_metadata_entry(p)
+                ]
 
             extracted_entries = await asyncio.to_thread(_list_entries)
 

--- a/tests/misc/test_media_processor_zip_root.py
+++ b/tests/misc/test_media_processor_zip_root.py
@@ -9,6 +9,7 @@ Verifies that ZipParser correctly handles:
 """
 
 import zipfile
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, patch
@@ -47,6 +48,20 @@ class _FakeVikingFS:
 
     async def read(self, uri: str, offset: int = 0, size: int = -1) -> bytes:
         return self.files.get(uri, b"")
+
+    async def read_file(self, uri: str, **_: Any) -> str:
+        return self.files.get(uri, b"").decode("utf-8")
+
+    async def glob(self, pattern: str, uri: str = "viking://", **_: Any) -> Dict[str, Any]:
+        prefix = uri.rstrip("/") + "/"
+        matches = []
+        for key in self.files:
+            if not key.startswith(prefix):
+                continue
+            relative = key[len(prefix) :]
+            if fnmatch(relative, pattern) or fnmatch(Path(relative).name, pattern):
+                matches.append(key)
+        return {"matches": sorted(matches), "count": len(matches)}
 
     async def ls(self, uri: str, **_: Any) -> List[Dict[str, Any]]:
         prefix = uri.rstrip("/") + "/"
@@ -140,6 +155,29 @@ async def test_zip_single_top_level_dir_ignores_zip_source_name(tmp_path: Path):
         called_path = Path(mock_dir_parse.await_args.args[0])
         assert called_path.name == "tt_b"
         # source_name should NOT be passed to DirectoryParser in this case
+        assert "source_name" not in mock_dir_parse.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_zip_single_top_level_dir_ignores_macos_metadata(tmp_path: Path):
+    zip_path = tmp_path / "knowledge.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("knowledge/guide.md", "# hello\n")
+        zf.writestr("knowledge/.DS_Store", "")
+        zf.writestr("__MACOSX/._knowledge", "")
+        zf.writestr("__MACOSX/knowledge/._guide.md", "")
+
+    parser = ZipParser()
+
+    with patch("openviking.parse.parsers.directory.DirectoryParser.parse") as mock_dir_parse:
+        mock_result = AsyncMock()
+        mock_result.temp_dir_path = None
+        mock_dir_parse.return_value = mock_result
+
+        await parser.parse(zip_path, instruction="", source_name="knowledge.zip")
+
+        called_path = Path(mock_dir_parse.await_args.args[0])
+        assert called_path.name == "knowledge"
         assert "source_name" not in mock_dir_parse.await_args.kwargs
 
 


### PR DESCRIPTION
## Summary
- ignore macOS archive metadata when ZipParser decides whether a zip has a single effective root directory
- add regression coverage for zip files containing `__MACOSX`, AppleDouble `._*`, and `.DS_Store` entries
- update the zip parser test fake FS with the minimal `glob`/`read_file` methods needed by current MarkdownParser image ingestion

## Root cause
ZipParser counted metadata directories such as `__MACOSX` as real root entries. A zip that effectively contained one folder was treated as a multi-root archive, so DirectoryParser wrapped the imported content under the zip filename and produced paths like `<target>/知识汇总.zip/知识汇总/...`.

## Validation
- `pytest tests/misc/test_media_processor_zip_root.py`
