### PR TITLE
Package OpenClaw plugin dist entrypoints

### DIFF
--- a/examples/openclaw-plugin/.gitignore
+++ b/examples/openclaw-plugin/.gitignore
@@ -1,1 +1,16 @@
-node_modules/
+.idea
+.vscode
+.git
+output
+node_modules
+dist
+*.tar.gz
+no-use-file
+.DS_Store
+.trae
+dashboard-ui/dist
+dashboard-ui/node_modules
+log
+artifacts/
+.env.openclaw-compat
+.tmp-home

--- a/examples/openclaw-plugin/package-lock.json
+++ b/examples/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openviking/openclaw-plugin",
-  "version": "2026.5.8",
+  "version": "2026.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openviking/openclaw-plugin",
-      "version": "2026.5.8",
+      "version": "2026.6.2",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",

--- a/examples/openclaw-plugin/package.json
+++ b/examples/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openviking/openclaw-plugin",
-  "version": "2026.5.8",
+  "version": "2026.6.2",
   "displayName": "OpenViking",
   "description": "OpenClaw context-engine plugin — OpenViking AI memory, long-term memory, knowledge base, semantic search, RAG, context engine. 长期记忆 · 知识库 · 语义检索 · 上下文引擎",
   "type": "module",
@@ -51,14 +51,17 @@
     "type": "git",
     "url": "https://github.com/volcengine/OpenViking"
   },
+  "overrides": {
+    "axios": "^1.16.1"
+  },
   "homepage": "https://github.com/volcengine/OpenViking/tree/main/examples/openclaw-plugin",
   "license": "MIT",
   "author": "OpenViking Contributors",
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
-    "setupEntry": "./commands/setup.ts",
+    "setupEntry": "./dist/commands/setup.js",
     "compat": {
       "pluginApi": ">=2026.4.8",
       "minGatewayVersion": "2026.4.8"


### PR DESCRIPTION
## Summary

- Bump `@openviking/openclaw-plugin` package metadata to `2026.6.2`.
- Point OpenClaw plugin entrypoints at built JavaScript under `dist/` instead of TypeScript source files.
- Add the axios override carried by the original OpenViking plugin packaging update.
- Sync the plugin `.gitignore` rules from the original packaging update.

## Why

The published/packed plugin should load the compiled runtime entrypoints (`dist/index.js` and `dist/commands/setup.js`) rather than relying on TypeScript source execution in installed packages. The ignore rules also need to match the original packaging update so local build, IDE, dashboard, log, artifact, and compatibility temp outputs stay out of the working tree.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm pack --dry-run --json` confirms the tarball includes `dist/index.js` and `dist/commands/setup.js`
