### PR TITLE
docs: redirect docs root to introduction

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -14,6 +14,7 @@ const PREFERENCE_COOKIE_KEY = 'openviking-preferences'
 const PREFERENCE_TRANSFER_PREFIX = 'openviking-preferences:'
 const VITEPRESS_THEME_KEY = 'vitepress-theme-appearance'
 const LOCAL_PLAYGROUND_URL = 'http://localhost:8080/'
+const ROOT_DOCS_REDIRECT_PATH = '/en/getting-started/01-introduction'
 const MAIN_SITE_HOSTS = new Set([
   'www.openviking.ai',
   'openviking.ai',
@@ -277,12 +278,21 @@ function syncPreferenceToMainSiteLinks() {
 }
 
 function startPreferenceSync() {
+  redirectDocsRoot()
   syncPreferenceFromPeerSite()
   syncCurrentDocsPreference()
   patchHistoryForPreferenceSync()
   watchThemePreference()
   syncPreferenceToMainSiteLinks()
   window.addEventListener('pageshow', syncPreferenceFromPeerSite)
+}
+
+function redirectDocsRoot() {
+  if (window.location.pathname !== '/') return
+
+  window.location.replace(
+    `${ROOT_DOCS_REDIRECT_PATH}${window.location.search}${window.location.hash}`
+  )
 }
 
 syncPreferenceFromPeerSite()

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,8 @@
 ---
-layout: home
-
-hero:
-  name: OpenViking Docs
-  text: Context database documentation
-  tagline: A focused reference for building agent memory, resources, skills, and retrieval flows with OpenViking.
-  image:
-    src: /ov-logo.png
-    alt: OpenViking
-  actions:
-    - theme: brand
-      text: Read English Docs
-      link: /en/getting-started/01-introduction
-    - theme: alt
-      text: 查看中文文档
-      link: /zh/getting-started/01-introduction
-
-features:
-  - title: Agent Context
-    details: Learn how OpenViking organizes memory, resources, and skills through a file-system paradigm.
-  - title: Retrieval Architecture
-    details: Explore hierarchical context loading, recursive retrieval, sessions, metrics, and observability.
-  - title: Operations Ready
-    details: Find deployment, authentication, encryption, telemetry, and API references in one place.
+layout: false
 ---
+
+# Redirecting to OpenViking docs
+
+Continue to the [English introduction](/en/getting-started/01-introduction)
+or [Chinese introduction](/zh/getting-started/01-introduction).


### PR DESCRIPTION
## Summary

- Replace the VitePress docs root landing page with a minimal fallback page.
- Redirect visitors from `/` to `/en/getting-started/01-introduction`.
- Preserve any query string or hash on the root URL during the redirect.

## Why

The docs site should take visitors directly to the primary introduction page instead of showing an intermediate landing page. This keeps `https://docs.openviking.ai/` focused on the canonical getting-started entry point while still leaving a small fallback page for static hosting or no-JavaScript cases.

## Implementation

- `docs/index.md` no longer uses the VitePress `home` layout, hero, CTA actions, or feature cards.
- `docs/.vitepress/theme/index.ts` adds a root-only redirect that runs during the existing theme startup flow.
- The fallback page keeps direct links to both the English and Chinese introduction pages.

## Validation

- `git diff --check`
- `npm run docs:build` from `docs/`

The docs build completes successfully. Existing VitePress warnings about unloaded `promql`/`caddyfile` highlighters and large chunks are unrelated to this change.