### PR TITLE
fix(cli): derive help scanner values from clap

### DIFF
--- a/crates/ov_cli/src/cli_arg_scan.rs
+++ b/crates/ov_cli/src/cli_arg_scan.rs
@@ -1,0 +1,136 @@
+use std::collections::BTreeSet;
+
+use clap::{Arg, ArgAction, Command};
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ValueOptions {
+    tokens: BTreeSet<String>,
+}
+
+impl ValueOptions {
+    pub(crate) fn from_command(command: &Command) -> Self {
+        let mut options = Self::default();
+        options.collect_from_command(command);
+        options
+    }
+
+    pub(crate) fn from_command_arguments(command: &Command) -> Self {
+        let mut options = Self::default();
+        options.collect_from_arguments(command);
+        options
+    }
+
+    pub(crate) fn consumes_value(&self, token: &str) -> bool {
+        let option_token = token.split_once('=').map(|(name, _)| name).unwrap_or(token);
+        self.tokens.contains(option_token)
+    }
+
+    fn collect_from_command(&mut self, command: &Command) {
+        self.collect_from_arguments(command);
+        for subcommand in command.get_subcommands() {
+            self.collect_from_command(subcommand);
+        }
+    }
+
+    fn collect_from_arguments(&mut self, command: &Command) {
+        for arg in command
+            .get_arguments()
+            .filter(|arg| arg_consumes_value(arg))
+        {
+            self.insert_arg(arg);
+        }
+    }
+
+    fn insert_arg(&mut self, arg: &Arg) {
+        if let Some(short) = arg.get_short() {
+            self.tokens.insert(format!("-{short}"));
+        }
+        if let Some(short_aliases) = arg.get_all_short_aliases() {
+            for short_alias in short_aliases {
+                self.tokens.insert(format!("-{short_alias}"));
+            }
+        }
+        if let Some(long) = arg.get_long() {
+            self.tokens.insert(format!("--{long}"));
+        }
+        if let Some(aliases) = arg.get_all_aliases() {
+            for alias in aliases {
+                self.tokens.insert(format!("--{alias}"));
+            }
+        }
+    }
+}
+
+fn arg_consumes_value(arg: &Arg) -> bool {
+    arg.get_num_args().unwrap_or_default().takes_values()
+        && !matches!(
+            arg.get_action(),
+            ArgAction::SetTrue
+                | ArgAction::SetFalse
+                | ArgAction::Help
+                | ArgAction::HelpShort
+                | ArgAction::HelpLong
+                | ArgAction::Version
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Arg, ArgAction, Command};
+
+    use super::ValueOptions;
+
+    #[test]
+    fn value_options_are_discovered_from_clap_metadata() {
+        let mut command = Command::new("ov")
+            .arg(
+                Arg::new("owner")
+                    .long("owner")
+                    .short('O')
+                    .short_alias('P')
+                    .alias("assignee")
+                    .num_args(1),
+            )
+            .arg(Arg::new("flag").long("flag").action(ArgAction::SetTrue))
+            .subcommand(
+                Command::new("task")
+                    .arg(Arg::new("status").long("status").num_args(1))
+                    .arg(
+                        Arg::new("active-only")
+                            .long("active-only")
+                            .action(ArgAction::SetTrue),
+                    ),
+            );
+        command.build();
+
+        let value_options = ValueOptions::from_command(&command);
+
+        assert!(value_options.consumes_value("--owner"));
+        assert!(value_options.consumes_value("--owner=help"));
+        assert!(value_options.consumes_value("-O"));
+        assert!(value_options.consumes_value("-P"));
+        assert!(value_options.consumes_value("--assignee"));
+        assert!(value_options.consumes_value("--assignee=help"));
+        assert!(value_options.consumes_value("--status"));
+        assert!(value_options.consumes_value("--status=help"));
+
+        assert!(!value_options.consumes_value("--flag"));
+        assert!(!value_options.consumes_value("--active-only"));
+        assert!(!value_options.consumes_value("--help"));
+    }
+
+    #[test]
+    fn root_value_options_ignore_subcommand_options() {
+        let mut command = Command::new("ov")
+            .arg(Arg::new("output").long("output").short('o').num_args(1))
+            .subcommand(Command::new("task").arg(Arg::new("status").long("status").num_args(1)));
+        command.build();
+
+        let value_options = ValueOptions::from_command_arguments(&command);
+
+        assert!(value_options.consumes_value("--output"));
+        assert!(value_options.consumes_value("--output=json"));
+        assert!(value_options.consumes_value("-o"));
+        assert!(!value_options.consumes_value("--status"));
+    }
+}

--- a/crates/ov_cli/src/help_ui.rs
+++ b/crates/ov_cli/src/help_ui.rs
@@ -6,6 +6,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     Cli,
+    cli_arg_scan::ValueOptions,
     i18n::{Language, copy},
     theme,
 };
@@ -2002,12 +2003,13 @@ fn command_help_path(args: &[OsString]) -> Option<Vec<String>> {
         return None;
     }
 
+    let value_options = cli_value_options();
     let has_help_flag = tokens.iter().skip(1).any(|token| is_help_flag(token));
     if has_help_flag {
-        if has_invalid_config_add_provider(&tokens) {
+        if has_invalid_config_add_provider(&tokens, &value_options) {
             return None;
         }
-        if let Some(path) = config_help_path(&tokens) {
+        if let Some(path) = config_help_path(&tokens, &value_options) {
             return Some(path);
         }
     }
@@ -2019,16 +2021,8 @@ fn command_help_path(args: &[OsString]) -> Option<Vec<String>> {
         if is_help_flag(token) {
             break;
         }
-        if token == "--sudo" || token == "--progress" || token == "--no-progress" || token == "-v" {
-            i += 1;
-            continue;
-        }
-        if consumes_value(token) {
-            i += if token.contains('=') { 1 } else { 2 };
-            continue;
-        }
-        if token.starts_with('-') {
-            i += 1;
+        if let Some(width) = option_token_width(&tokens, i, &value_options) {
+            i += width;
             continue;
         }
 
@@ -2038,7 +2032,8 @@ fn command_help_path(args: &[OsString]) -> Option<Vec<String>> {
                 // Explicit help for this top-level command.
             } else if !next.starts_with('-') {
                 if has_help_flag && path.len() == 1 && is_bare_group_help_command(&path[0]) {
-                    let nested_path = command_path_until_help_flag(&tokens, i + 1, path);
+                    let nested_path =
+                        command_path_until_help_flag(&tokens, i + 1, path, &value_options);
                     return if command_spec(&nested_path).is_some() {
                         Some(nested_path)
                     } else {
@@ -2068,22 +2063,15 @@ fn command_path_until_help_flag(
     tokens: &[String],
     mut i: usize,
     mut path: Vec<String>,
+    value_options: &ValueOptions,
 ) -> Vec<String> {
     while i < tokens.len() {
         let token = &tokens[i];
         if is_help_flag(token) {
             break;
         }
-        if token == "--sudo" || token == "--progress" || token == "--no-progress" || token == "-v" {
-            i += 1;
-            continue;
-        }
-        if consumes_value(token) {
-            i += if token.contains('=') { 1 } else { 2 };
-            continue;
-        }
-        if token.starts_with('-') {
-            i += 1;
+        if let Some(width) = option_token_width(tokens, i, value_options) {
+            i += width;
             continue;
         }
 
@@ -2093,23 +2081,15 @@ fn command_path_until_help_flag(
     path
 }
 
-fn config_help_path(tokens: &[String]) -> Option<Vec<String>> {
+fn config_help_path(tokens: &[String], value_options: &ValueOptions) -> Option<Vec<String>> {
     let mut i = 1;
     while i < tokens.len() {
         let token = &tokens[i];
         if is_help_flag(token) {
             return None;
         }
-        if token == "--sudo" || token == "--progress" || token == "--no-progress" || token == "-v" {
-            i += 1;
-            continue;
-        }
-        if consumes_value(token) {
-            i += if token.contains('=') { 1 } else { 2 };
-            continue;
-        }
-        if token.starts_with('-') {
-            i += 1;
+        if let Some(width) = option_token_width(tokens, i, value_options) {
+            i += width;
             continue;
         }
 
@@ -2124,24 +2104,8 @@ fn config_help_path(tokens: &[String]) -> Option<Vec<String>> {
             if is_help_flag(token) {
                 return Some(path);
             }
-            if consumes_value(token)
-                || matches!(
-                    token.as_str(),
-                    "--name"
-                        | "--new-name"
-                        | "--url"
-                        | "--api-key-env"
-                        | "--root-api-key-env"
-                        | "--account"
-                        | "--user"
-                        | "--actor-peer-id"
-                )
-            {
-                i += if token.contains('=') { 1 } else { 2 };
-                continue;
-            }
-            if token.starts_with('-') {
-                i += 1;
+            if let Some(width) = option_token_width(tokens, i, value_options) {
+                i += width;
                 continue;
             }
 
@@ -2166,7 +2130,7 @@ fn config_help_path(tokens: &[String]) -> Option<Vec<String>> {
     None
 }
 
-fn has_invalid_config_add_provider(tokens: &[String]) -> bool {
+fn has_invalid_config_add_provider(tokens: &[String], value_options: &ValueOptions) -> bool {
     let mut i = 1;
     let mut saw_config = false;
     let mut saw_add = false;
@@ -2176,28 +2140,8 @@ fn has_invalid_config_add_provider(tokens: &[String]) -> bool {
         if is_help_flag(token) {
             return false;
         }
-        if token == "--sudo" || token == "--progress" || token == "--no-progress" || token == "-v" {
-            i += 1;
-            continue;
-        }
-        if consumes_value(token)
-            || matches!(
-                token.as_str(),
-                "--name"
-                    | "--new-name"
-                    | "--url"
-                    | "--api-key-env"
-                    | "--root-api-key-env"
-                    | "--account"
-                    | "--user"
-                    | "--actor-peer-id"
-            )
-        {
-            i += if token.contains('=') { 1 } else { 2 };
-            continue;
-        }
-        if token.starts_with('-') {
-            i += 1;
+        if let Some(width) = option_token_width(tokens, i, value_options) {
+            i += width;
             continue;
         }
 
@@ -2262,15 +2206,49 @@ fn is_help_flag(token: &str) -> bool {
     matches!(token, "--help" | "-h" | "-help")
 }
 
-fn consumes_value(token: &str) -> bool {
+fn option_token_width(
+    tokens: &[String],
+    index: usize,
+    value_options: &ValueOptions,
+) -> Option<usize> {
+    let token = &tokens[index];
+    if matches!(
+        token.as_str(),
+        "--sudo" | "--progress" | "--no-progress" | "--verbose" | "-v"
+    ) {
+        return Some(1);
+    }
+    if token == "--compact" || token == "-c" {
+        return Some(compact_option_width(tokens, index));
+    }
+    if value_options.consumes_value(token) {
+        return Some(if token.contains('=') { 1 } else { 2 });
+    }
+    token.starts_with('-').then_some(1)
+}
+
+fn compact_option_width(tokens: &[String], index: usize) -> usize {
+    if tokens
+        .get(index + 1)
+        .is_some_and(|value| is_bool_arg(value))
+    {
+        2
+    } else {
+        1
+    }
+}
+
+fn is_bool_arg(value: &str) -> bool {
     matches!(
-        token,
-        "-o" | "--output" | "-c" | "--compact" | "--account" | "--user" | "--actor-peer-id"
-    ) || token.starts_with("--output=")
-        || token.starts_with("--compact=")
-        || token.starts_with("--account=")
-        || token.starts_with("--user=")
-        || token.starts_with("--actor-peer-id=")
+        value,
+        "true" | "false" | "True" | "False" | "TRUE" | "FALSE"
+    )
+}
+
+fn cli_value_options() -> ValueOptions {
+    let mut root = Cli::command();
+    root.build();
+    ValueOptions::from_command(&root)
 }
 
 #[cfg(test)]
@@ -2807,6 +2785,18 @@ mod tests {
                 "{args:?} should fall back to clap help"
             );
         }
+        assert!(
+            render_command_help_request(&os_args(&[
+                "ov",
+                "--compact",
+                "privacy",
+                "get",
+                "sample-policy",
+                "--help",
+            ]))
+            .is_none(),
+            "--compact without a value should not hide the privacy command from help detection"
+        );
     }
 
     #[test]

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1,4 +1,5 @@
 mod base_client;
+mod cli_arg_scan;
 mod client;
 mod commands;
 mod config;
@@ -18,7 +19,7 @@ mod theme;
 mod tui;
 mod utils;
 
-use clap::{ArgAction, Args, Parser, Subcommand};
+use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand};
 use colored::Colorize;
 use config::Config;
 use error::{Error, Result};
@@ -128,7 +129,10 @@ struct Cli {
         long,
         global = true,
         default_value = "true",
+        default_missing_value = "true",
         hide = true,
+        num_args = 0..=1,
+        require_equals = true,
         action = ArgAction::Set,
         value_name = "bool"
     )]
@@ -1687,21 +1691,26 @@ struct ConfigDeleteArgs {
 }
 
 fn find_command_index(args: &[OsString]) -> Option<usize> {
+    let root_value_options = cli_root_value_options();
     let mut i = 1;
     while i < args.len() {
         let token = args[i].to_string_lossy();
-        match token.as_ref() {
-            "--output" | "-o" | "--compact" | "--account" | "--user" | "--actor-peer-id" => {
-                i += 2;
-            }
-            "--sudo" | "--progress" | "--no-progress" | "--verbose" | "-v" => {
-                i += 1;
-            }
-            _ if token.starts_with('-') => {
-                i += 1;
-            }
-            _ => return Some(i),
+        let token_ref = token.as_ref();
+
+        if token_ref == "--compact" || token_ref == "-c" {
+            i += compact_option_width(args, i);
+            continue;
         }
+        if token_ref.starts_with('-') {
+            i += if root_value_options.consumes_value(token_ref) && !token_ref.contains('=') {
+                2
+            } else {
+                1
+            };
+            continue;
+        }
+
+        return Some(i);
     }
     None
 }
@@ -1764,12 +1773,14 @@ fn plain_help_misuse(args: &[OsString]) -> Option<PlainHelpMisuse> {
 }
 
 fn command_tokens_for_plain_help(args: &[OsString]) -> Vec<String> {
+    let value_options = cli_value_options();
+
     let mut tokens = Vec::new();
     let mut i = 1;
     while i < args.len() {
         let token = args[i].to_string_lossy();
         let token_ref = token.as_ref();
-        if consumes_plain_help_value(token_ref) {
+        if value_options.consumes_value(token_ref) {
             i += if token_ref.contains('=') { 1 } else { 2 };
             continue;
         }
@@ -1783,135 +1794,16 @@ fn command_tokens_for_plain_help(args: &[OsString]) -> Vec<String> {
     tokens
 }
 
-fn consumes_plain_help_value(token: &str) -> bool {
-    matches!(
-        token,
-        "-o" | "--output"
-            | "-c"
-            | "--compact"
-            | "--account"
-            | "--user"
-            | "--actor-peer-id"
-            | "-u"
-            | "--uri"
-            | "-x"
-            | "--exclude-uri"
-            | "--to"
-            | "--parent"
-            | "-p"
-            | "--parent-auto-create"
-            | "--reason"
-            | "--instruction"
-            | "--timeout"
-            | "--watch-interval"
-            | "--ignore-dirs"
-            | "--include"
-            | "--exclude"
-            | "--description"
-            | "-n"
-            | "--node-limit"
-            | "--limit"
-            | "-l"
-            | "--abs-limit"
-            | "-L"
-            | "--level"
-            | "--level-limit"
-            | "-t"
-            | "--threshold"
-            | "--after"
-            | "--before"
-            | "--context-type"
-            | "--peer-id"
-            | "-s"
-            | "--skill"
-            | "--session"
-            | "--session-id"
-            | "-m"
-            | "--sender"
-            | "--message"
-            | "--role"
-            | "--content"
-            | "--from-file"
-            | "--mode"
-            | "--stream"
-            | "--on-conflict"
-            | "--vector-mode"
-            | "--task-type"
-            | "--status"
-            | "--token-budget"
-            | "--interval"
-            | "--active"
-            | "--values-json"
-            | "--values-file"
-            | "--key"
-            | "--change-reason"
-            | "--labels-json"
-            | "--admin"
-            | "--name"
-            | "--new-name"
-            | "--url"
-            | "--api-key-env"
-            | "--root-api-key-env"
-            | "--output-file"
-            | "--format"
-    ) || token.starts_with("--output=")
-        || token.starts_with("--compact=")
-        || token.starts_with("--account=")
-        || token.starts_with("--user=")
-        || token.starts_with("--actor-peer-id=")
-        || token.starts_with("--uri=")
-        || token.starts_with("--exclude-uri=")
-        || token.starts_with("--to=")
-        || token.starts_with("--parent=")
-        || token.starts_with("--parent-auto-create=")
-        || token.starts_with("--reason=")
-        || token.starts_with("--instruction=")
-        || token.starts_with("--timeout=")
-        || token.starts_with("--watch-interval=")
-        || token.starts_with("--ignore-dirs=")
-        || token.starts_with("--include=")
-        || token.starts_with("--exclude=")
-        || token.starts_with("--description=")
-        || token.starts_with("--node-limit=")
-        || token.starts_with("--limit=")
-        || token.starts_with("--abs-limit=")
-        || token.starts_with("--level=")
-        || token.starts_with("--level-limit=")
-        || token.starts_with("--threshold=")
-        || token.starts_with("--after=")
-        || token.starts_with("--before=")
-        || token.starts_with("--context-type=")
-        || token.starts_with("--peer-id=")
-        || token.starts_with("--skill=")
-        || token.starts_with("--session=")
-        || token.starts_with("--session-id=")
-        || token.starts_with("--sender=")
-        || token.starts_with("--message=")
-        || token.starts_with("--role=")
-        || token.starts_with("--content=")
-        || token.starts_with("--from-file=")
-        || token.starts_with("--mode=")
-        || token.starts_with("--stream=")
-        || token.starts_with("--on-conflict=")
-        || token.starts_with("--vector-mode=")
-        || token.starts_with("--task-type=")
-        || token.starts_with("--status=")
-        || token.starts_with("--token-budget=")
-        || token.starts_with("--interval=")
-        || token.starts_with("--active=")
-        || token.starts_with("--values-json=")
-        || token.starts_with("--values-file=")
-        || token.starts_with("--key=")
-        || token.starts_with("--change-reason=")
-        || token.starts_with("--labels-json=")
-        || token.starts_with("--admin=")
-        || token.starts_with("--name=")
-        || token.starts_with("--new-name=")
-        || token.starts_with("--url=")
-        || token.starts_with("--api-key-env=")
-        || token.starts_with("--root-api-key-env=")
-        || token.starts_with("--output-file=")
-        || token.starts_with("--format=")
+fn cli_value_options() -> cli_arg_scan::ValueOptions {
+    let mut command = Cli::command();
+    command.build();
+    cli_arg_scan::ValueOptions::from_command(&command)
+}
+
+fn cli_root_value_options() -> cli_arg_scan::ValueOptions {
+    let mut command = Cli::command();
+    command.build();
+    cli_arg_scan::ValueOptions::from_command_arguments(&command)
 }
 
 fn canonical_plain_help_token(token: &str) -> &str {
@@ -2002,6 +1894,8 @@ fn is_config_agent_command_request(args: &[OsString]) -> bool {
 }
 
 fn command_tokens_for_config_gate(args: &[OsString]) -> Vec<String> {
+    let value_options = cli_value_options();
+    let root_value_options = cli_root_value_options();
     let mut tokens = Vec::new();
     let mut seen_command = false;
     let mut i = 1;
@@ -2021,18 +1915,11 @@ fn command_tokens_for_config_gate(args: &[OsString]) -> Vec<String> {
 
         if !seen_command {
             if token_ref == "--compact" || token_ref == "-c" {
-                i += if args
-                    .get(i + 1)
-                    .is_some_and(|value| is_bool_arg(&value.to_string_lossy()))
-                {
-                    2
-                } else {
-                    1
-                };
+                i += compact_option_width(args, i);
                 continue;
             }
             if token_ref.starts_with("--") {
-                i += if global_option_takes_value(token_ref) && !token_ref.contains('=') {
+                i += if root_value_options.consumes_value(token_ref) && !token_ref.contains('=') {
                     2
                 } else {
                     1
@@ -2040,7 +1927,7 @@ fn command_tokens_for_config_gate(args: &[OsString]) -> Vec<String> {
                 continue;
             }
             if token_ref.starts_with('-') {
-                i += if global_short_option_takes_value(token_ref) {
+                i += if root_value_options.consumes_value(token_ref) && !token_ref.contains('=') {
                     2
                 } else {
                     1
@@ -2054,17 +1941,10 @@ fn command_tokens_for_config_gate(args: &[OsString]) -> Vec<String> {
         }
 
         if token_ref == "--compact" || token_ref == "-c" {
-            i += if args
-                .get(i + 1)
-                .is_some_and(|value| is_bool_arg(&value.to_string_lossy()))
-            {
-                2
-            } else {
-                1
-            };
+            i += compact_option_width(args, i);
             continue;
         }
-        if consumes_plain_help_value(token_ref) {
+        if value_options.consumes_value(token_ref) {
             i += if token_ref.contains('=') { 1 } else { 2 };
             continue;
         }
@@ -2279,6 +2159,43 @@ fn preprocess_privacy_upsert_key_flags(args: Vec<OsString>) -> Vec<OsString> {
     converted
 }
 
+fn preprocess_compact_args(args: Vec<OsString>) -> Vec<OsString> {
+    if args.is_empty() {
+        return args;
+    }
+
+    let mut converted = Vec::with_capacity(args.len());
+    converted.push(args[0].clone());
+    let mut i = 1;
+
+    while i < args.len() {
+        let token = args[i].to_string_lossy();
+        if token == "--compact" || token == "-c" {
+            if let Some(next) = args.get(i + 1) {
+                let next_value = next.to_string_lossy();
+                if is_bool_arg(&next_value) {
+                    converted.push(OsString::from(format!("--compact={next_value}")));
+                    i += 2;
+                    continue;
+                }
+            }
+            converted.push(OsString::from("--compact=true"));
+            i += 1;
+            continue;
+        }
+
+        converted.push(args[i].clone());
+        i += 1;
+    }
+
+    converted
+}
+
+fn preprocess_cli_args(args: Vec<OsString>) -> Vec<OsString> {
+    let args = preprocess_compact_args(args);
+    preprocess_privacy_args(args)
+}
+
 fn preprocess_privacy_args(args: Vec<OsString>) -> Vec<OsString> {
     let args = preprocess_privacy_get_shortcut(args);
     preprocess_privacy_upsert_key_flags(args)
@@ -2334,6 +2251,7 @@ fn is_language_command_request(args: &[OsString]) -> bool {
 }
 
 fn first_command_token(args: &[OsString]) -> Option<String> {
+    let root_value_options = cli_root_value_options();
     let mut index = 1usize;
 
     while index < args.len() {
@@ -2344,18 +2262,11 @@ fn first_command_token(args: &[OsString]) -> Option<String> {
                 .map(|value| value.to_string_lossy().to_string());
         }
         if token == "--compact" || token == "-c" {
-            index += if args
-                .get(index + 1)
-                .is_some_and(|value| is_bool_arg(&value.to_string_lossy()))
-            {
-                2
-            } else {
-                1
-            };
+            index += compact_option_width(args, index);
             continue;
         }
         if token.starts_with("--") {
-            index += if global_option_takes_value(&token) && !token.contains('=') {
+            index += if root_value_options.consumes_value(&token) && !token.contains('=') {
                 2
             } else {
                 1
@@ -2363,7 +2274,7 @@ fn first_command_token(args: &[OsString]) -> Option<String> {
             continue;
         }
         if token.starts_with('-') {
-            index += if global_short_option_takes_value(&token) {
+            index += if root_value_options.consumes_value(&token) && !token.contains('=') {
                 2
             } else {
                 1
@@ -2376,15 +2287,15 @@ fn first_command_token(args: &[OsString]) -> Option<String> {
     None
 }
 
-fn global_option_takes_value(option: &str) -> bool {
-    matches!(
-        option,
-        "--output" | "--account" | "--user" | "--actor-peer-id"
-    )
-}
-
-fn global_short_option_takes_value(option: &str) -> bool {
-    matches!(option, "-o")
+fn compact_option_width(args: &[OsString], index: usize) -> usize {
+    if args
+        .get(index + 1)
+        .is_some_and(|value| is_bool_arg(&value.to_string_lossy()))
+    {
+        2
+    } else {
+        1
+    }
 }
 
 fn is_bool_arg(value: &str) -> bool {
@@ -2411,7 +2322,7 @@ fn language_command_can_run_picker(has_language_value: bool, is_interactive: boo
 
 #[tokio::main]
 async fn main() {
-    let args = preprocess_privacy_args(std::env::args_os().collect());
+    let args = preprocess_cli_args(std::env::args_os().collect());
     let command_display = error_ui::display_command(&args);
     match ensure_language_selected_before_command(&args).await {
         Ok(true) => {}
@@ -3025,10 +2936,10 @@ async fn main() {
 mod tests {
     use super::{
         Cli, CliContext, Commands, ConfigAddTarget, ConfigCommands, LanguageGateAction,
-        PrivacyCommands, SkillCommands, UploadCliOptions, first_command_token,
+        PrivacyCommands, SkillCommands, UploadCliOptions, find_command_index, first_command_token,
         is_language_command_request, language_command_can_run_picker, language_gate_action,
         language_required_message, legacy_upload_option_error, plain_help_misuse,
-        pre_parse_requires_cli_config_file, preprocess_privacy_args,
+        pre_parse_requires_cli_config_file, preprocess_cli_args, preprocess_privacy_args,
     };
     use crate::config::{Config, DEFAULT_CUSTOM_URL};
     use crate::output::OutputFormat;
@@ -3892,6 +3803,31 @@ mod tests {
     }
 
     #[test]
+    fn find_command_index_skips_root_value_options() {
+        assert_eq!(
+            find_command_index(&os_args(&[
+                "ov",
+                "--output",
+                "json",
+                "--account=acme",
+                "--actor-peer-id",
+                "peer-a",
+                "privacy",
+                "sample-policy",
+            ])),
+            Some(6)
+        );
+        assert_eq!(
+            find_command_index(&os_args(&["ov", "--compact", "privacy", "sample-policy"])),
+            Some(2)
+        );
+        assert_eq!(
+            find_command_index(&os_args(&["ov", "-c", "false", "privacy", "sample-policy"])),
+            Some(3)
+        );
+    }
+
+    #[test]
     fn cli_status_parses_verbose_flag() {
         let cli =
             Cli::try_parse_from(["ov", "status", "--verbose"]).expect("status verbose parses");
@@ -4258,5 +4194,43 @@ mod tests {
             },
             _ => panic!("expected privacy command"),
         }
+    }
+
+    #[test]
+    fn cli_parses_privacy_shortcut_after_compact_without_value() {
+        let cli = Cli::try_parse_from(preprocess_cli_args(vec![
+            OsString::from("ov"),
+            OsString::from("--compact"),
+            OsString::from("privacy"),
+            OsString::from("skill"),
+            OsString::from("demo"),
+        ]))
+        .expect("--compact without a value should not consume the privacy command");
+
+        assert!(cli.compact);
+        match cli.command {
+            Commands::Privacy { action } => match action {
+                PrivacyCommands::Get {
+                    category,
+                    target_key,
+                } => {
+                    assert_eq!(category, "skill");
+                    assert_eq!(target_key, "demo");
+                }
+                _ => panic!("expected privacy get"),
+            },
+            _ => panic!("expected privacy command"),
+        }
+
+        let explicit_false = Cli::try_parse_from(preprocess_cli_args(vec![
+            OsString::from("ov"),
+            OsString::from("-c"),
+            OsString::from("false"),
+            OsString::from("privacy"),
+            OsString::from("skill"),
+            OsString::from("demo"),
+        ]))
+        .expect("-c false should keep its explicit bool value");
+        assert!(!explicit_false.compact);
     }
 }


### PR DESCRIPTION
## Description

Follow-up to #2574. This moves the CLI pre-help/config-gate scanner off its manual lists of value-taking flags and derives those tokens from the clap command tree instead.

Root cause: #2574 made the styled help content derive command facts from clap, but the earlier scanner still had hand-maintained lists for flags that consume a following value. If a future command added something like `--owner <user>` and the scanner list was not updated, `ov ... --owner help` could be misread as a request for help instead of treating `help` as the option value.

## Related Issue

Follow-up to review discussion on #2574.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Added a small `cli_arg_scan::ValueOptions` helper that walks the built clap `Command` tree and records short flags, short aliases, long flags, and long aliases that consume values.
- Added a root-only clap argument scan for pre-command global option handling, so `command_tokens_for_config_gate` and `first_command_token` no longer keep manual `--output` / `--account` / `--user` / `-o` value lists.
- Replaced the manual value-consuming flag lists in plain-help detection, config-gate scanning, language-gate command detection, and styled help path detection with clap-derived scanners.
- Added regression coverage for future long flags, short flags, short aliases, long aliases, nested command flags, `--flag=value` forms, root-only scans, and boolean/help flags that should not consume values.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
cargo test -p ov_cli cli_arg_scan::tests::value_options_are_discovered_from_clap_metadata
cargo test -p ov_cli cli_arg_scan::tests::root_value_options_ignore_subcommand_options
cargo test -p ov_cli tests::first_command_token_skips_global_flags
cargo test -p ov_cli tests::pre_parse_config_gate_respects_aliases_and_valid_help_values
cargo test -p ov_cli
cargo build -p ov_cli
git diff --check -- crates/ov_cli/src/help_ui.rs crates/ov_cli/src/main.rs crates/ov_cli/src/cli_arg_scan.rs
rustfmt --edition 2024 --check --config skip_children=true crates/ov_cli/src/cli_arg_scan.rs crates/ov_cli/src/help_ui.rs crates/ov_cli/src/main.rs
NO_COLOR=1 target/debug/ov -o json --user alice config add custom --url help --help
NO_COLOR=1 target/debug/ov --output json --compact false language --help
NO_COLOR=1 target/debug/ov write viking://x --from-file help
```

Additional isolated smoke for the config gate:

```bash
tmp_home=$(mktemp -d)
mkdir -p "$tmp_home/.openviking"
printf '{"language":"en"}' > "$tmp_home/.openviking/ovcli.settings.conf"
HOME="$tmp_home" NO_COLOR=1 target/debug/ov --account help status
```

The scanner regression test was first run red against a synthetic clap short alias, then green after collecting `get_all_short_aliases()`. The root-only scanner test was first run red against the missing `from_command_arguments` API, then green after adding it. The smoke checks cover both sides of scanner behavior: explicit `--help` still renders curated help, root/global values before commands are skipped correctly, and `--from-file help` treats `help` as the option value.

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

`cargo fmt -p ov_cli -- --check` currently reports formatting drift in existing untouched files (`crates/ov_cli/src/commands/skills.rs` and `crates/ov_cli/src/config_agent.rs`). I left those files out of this PR to keep the change scoped; the focused rustfmt check above passes for the changed files.