### PR TITLE
[codex] Add minimal blog chat composer

### DIFF
--- a/blog/src/shell-ui.jsx
+++ b/blog/src/shell-ui.jsx
@@ -53,7 +53,6 @@ function Topbar({ lang, theme, onLang, onToggleTheme, onHome, S }) {
               </svg>
             )}
           </button>
-          <div id="zouk-reader-header-slot" className="zouk-reader-header-slot" />
         </div>
       </div>
     </header>

--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -607,6 +607,7 @@ html {
 }
 
 .zouk-reader-bottom-composer {
+  --zouk-reader-field-radius: 18px;
   position: fixed;
   z-index: 84;
   left: 50%;
@@ -1121,7 +1122,7 @@ html {
   gap: 6px;
   min-height: var(--zouk-reader-input-min-height);
   border: 1px solid var(--th-line);
-  border-radius: var(--zouk-reader-field-radius);
+  border-radius: var(--zouk-reader-field-radius, 12px);
   background: var(--th-bg-2);
   padding-right: 5px;
   transition: border-color 0.15s, box-shadow 0.15s;

--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -293,9 +293,6 @@ a.b-tag:hover { color: var(--th-ink); border-color: var(--th-ink); }
 /* light/dark toggle */
 .b-mode-toggle { display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; background: var(--th-bg-2); border: 1px solid var(--th-line); border-radius: 999px; cursor: pointer; color: var(--th-ink); transition: border-color 0.12s; }
 .b-mode-toggle:hover { border-color: var(--th-ink); }
-.zouk-reader-header-slot { display: inline-flex; align-items: center; flex: 0 0 auto; }
-.zouk-reader-header-slot:empty { display: none; }
-
 @media (max-width: 720px) {
   .b-topbar__inner { padding: 10px 16px; gap: 10px; flex-wrap: nowrap; justify-content: space-between; }
   .b-brand { min-width: 0; max-width: calc(100% - 168px); flex: 0 1 auto; }
@@ -564,8 +561,8 @@ html[lang="zh"] :is(.b-hero__title, .b-post__title, .b-card__title, .b-post__nav
 /* ===========================================================
    ZOUK INTERACTIVE BLOG
    =========================================================== */
-.zouk-reader-launcher,
 .zouk-selection-action,
+.zouk-reader-bottom-composer button,
 .zouk-reader-panel button {
   font-family: var(--th-font-mono);
 }
@@ -574,64 +571,8 @@ html {
   --zouk-reader-rail: min(33.333vw, 460px);
 }
 
-.zouk-reader-launcher {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  min-width: 36px;
-  padding: 0;
-  border: 1px solid var(--th-line);
-  border-radius: 999px;
-  background: var(--th-bg-2);
-  color: var(--th-ink);
-  box-shadow: none;
-  cursor: pointer;
-  transition: border-color 0.12s, background 0.12s, color 0.12s;
-}
-
-.zouk-reader-launcher:hover,
-.zouk-reader-launcher.is-active {
-  border-color: var(--th-ink);
-}
-
-.zouk-reader-launcher.is-active {
-  background: color-mix(in oklab, var(--th-ink) 10%, var(--th-bg-2));
-}
-
-.zouk-reader-launcher.has-live::after {
-  content: "";
-  position: absolute;
-  right: 3px;
-  bottom: 3px;
-  width: 6px;
-  height: 6px;
-  border: 2px solid var(--th-bg-2);
-  border-radius: 999px;
-  background: var(--zouk-status-online);
-  box-sizing: content-box;
-}
-
-.zouk-reader-launcher.has-live.is-working::after {
-  background: var(--zouk-status-working);
-}
-
-.zouk-reader-launcher.has-live.is-thinking::after {
-  background: var(--zouk-status-thinking);
-}
-
-.zouk-reader-launcher.has-live.is-offline::after {
-  background: var(--zouk-status-offline);
-}
-
-.zouk-reader-launcher.has-live.is-error::after {
-  background: var(--zouk-status-error);
-}
-
-.zouk-reader-launcher svg,
 .zouk-selection-action svg,
+.zouk-reader-send svg,
 .zouk-reader-panel svg {
   width: 18px;
   height: 18px;
@@ -663,6 +604,18 @@ html {
 .zouk-selection-action svg {
   width: 15px;
   height: 15px;
+}
+
+.zouk-reader-bottom-composer {
+  position: fixed;
+  z-index: 84;
+  left: 50%;
+  bottom: calc(18px + env(safe-area-inset-bottom, 0px));
+  width: min(620px, calc(100vw - 32px));
+  transform: translateX(-50%);
+  padding: 0;
+  border: 0;
+  background: transparent;
 }
 
 .zouk-reader-panel {
@@ -1165,10 +1118,12 @@ html {
   position: relative;
   display: flex;
   align-items: flex-end;
+  gap: 6px;
   min-height: var(--zouk-reader-input-min-height);
   border: 1px solid var(--th-line);
   border-radius: var(--zouk-reader-field-radius);
   background: var(--th-bg-2);
+  padding-right: 5px;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
@@ -1178,7 +1133,9 @@ html {
 }
 
 .zouk-reader-input-shell textarea {
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
   min-height: 42px;
   max-height: 132px;
   border: 0;
@@ -1196,6 +1153,44 @@ html {
   color: var(--th-mute);
 }
 
+.zouk-reader-send {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 5px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: var(--th-ink);
+  color: var(--th-bg);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, opacity 0.15s, transform 0.15s;
+}
+
+.zouk-reader-send:hover,
+.zouk-reader-send:focus-visible {
+  background: color-mix(in oklab, var(--th-ink) 88%, var(--th-accent));
+}
+
+.zouk-reader-send:active {
+  transform: scale(0.96);
+}
+
+.zouk-reader-send:disabled {
+  cursor: default;
+  opacity: 0.34;
+  transform: none;
+}
+
+.zouk-reader-bottom-composer .zouk-reader-input-shell {
+  border-color: color-mix(in oklab, var(--th-line) 78%, transparent);
+  background: color-mix(in oklab, var(--th-bg) 92%, var(--th-bg-2));
+  box-shadow: 0 14px 42px color-mix(in oklab, #000 16%, transparent);
+}
+
 .zouk-reader-error {
   display: flex;
   align-items: center;
@@ -1210,7 +1205,11 @@ html {
 @media (min-width: 900px) {
   .b-shell__main,
   .b-footer {
-    transition: padding-right 220ms ease;
+    transition: padding-right 220ms ease, padding-bottom 220ms ease;
+  }
+
+  html.zouk-reader-bottom-composer-visible .b-shell__main {
+    padding-bottom: 96px;
   }
 
   html.zouk-reader-open-desktop .b-shell__main {
@@ -1312,22 +1311,23 @@ html {
     border-color: color-mix(in oklab, var(--th-line) 68%, transparent);
     background: color-mix(in oklab, var(--th-bg-2) 60%, transparent);
   }
-}
 
-@media (max-width: 720px) {
-  .zouk-reader-launcher {
-    width: 34px;
-    height: 34px;
-    min-width: 34px;
-  }
-
-  .zouk-reader-launcher svg {
-    width: 17px;
-    height: 17px;
+  .zouk-reader-bottom-composer .zouk-reader-input-shell {
+    border-color: color-mix(in oklab, var(--th-line) 72%, transparent);
+    background: color-mix(in oklab, var(--th-bg) 88%, var(--th-bg-2));
   }
 }
 
 @media (max-width: 899px) {
+  html.zouk-reader-bottom-composer-visible .b-shell__main {
+    padding-bottom: calc(86px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .zouk-reader-bottom-composer {
+    bottom: calc(10px + env(safe-area-inset-bottom, 0px));
+    width: calc(100vw - 20px);
+  }
+
   .zouk-reader-panel {
     --zouk-blog-drag: 0px;
     --zouk-blog-sheet-top: calc(var(--zouk-blog-vv-top, 0px) + var(--zouk-blog-vv-height, 100svh) - var(--zouk-blog-sheet-height, 50svh));

--- a/blog/src/zouk-embed.jsx
+++ b/blog/src/zouk-embed.jsx
@@ -600,7 +600,9 @@ export function ZoukInteractiveBlog({ route }) {
   const sheetHeightRef = useRef(0);
   const thinkingMessageKeyRef = useRef('');
   const target = `#${CONFIG.channel}`;
+  const isPostRoute = route?.name === 'post';
   const panelVisible = open || closing;
+  const showBottomComposer = isPostRoute && !panelVisible;
   const composerPlaceholder = `Ask OpenViking about this post...`;
   const referencedText = compactText(selectedText);
   const contextUrlChanged = Boolean(sourceUrl && sourceUrl !== lastContextUrl);
@@ -805,9 +807,9 @@ export function ZoukInteractiveBlog({ route }) {
   useEffect(() => {
     if (!browserAvailable()) return undefined;
     const root = document.documentElement;
-    root.classList.toggle('zouk-reader-bottom-composer-visible', !panelVisible);
+    root.classList.toggle('zouk-reader-bottom-composer-visible', showBottomComposer);
     return () => root.classList.remove('zouk-reader-bottom-composer-visible');
-  }, [panelVisible]);
+  }, [showBottomComposer]);
 
   useEffect(() => {
     const node = scrollRef.current;
@@ -1068,7 +1070,7 @@ export function ZoukInteractiveBlog({ route }) {
         </button>
       ) : null}
 
-      {!panelVisible ? (
+      {showBottomComposer ? (
         <form className="zouk-reader-bottom-composer" onSubmit={onSubmit} aria-label="Ask OpenViking">
           <div className="zouk-reader-input-shell">
             <textarea

--- a/blog/src/zouk-embed.jsx
+++ b/blog/src/zouk-embed.jsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 
 const CONFIG = {
   serverUrl: (import.meta.env.VITE_ZOUK_SERVER_URL || 'https://zouk.zaynjarvis.com').replace(/\/+$/, ''),
@@ -411,11 +410,11 @@ function MessageIcon() {
   );
 }
 
-function MessagesIcon() {
+function SendIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M17 12a4 4 0 0 1-4 4H7l-4 3V8a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4Z" />
-      <path d="M9 16v1a3 3 0 0 0 3 3h5l4 2V11a3 3 0 0 0-3-3h-1" />
+      <path d="M22 2 11 13" />
+      <path d="m22 2-7 20-4-9-9-4Z" />
     </svg>
   );
 }
@@ -591,8 +590,8 @@ export function ZoukInteractiveBlog({ route }) {
   const [sourceUrl, setSourceUrl] = useState(currentSourceUrl);
   const [lastContextUrl, setLastContextUrl] = useState('');
   const [selectionAction, setSelectionAction] = useState(null);
-  const [headerSlot, setHeaderSlot] = useState(null);
   const [dismissedThinkingKey, setDismissedThinkingKey] = useState('');
+  const [sendWhenReady, setSendWhenReady] = useState(false);
   const scrollRef = useRef(null);
   const textareaRef = useRef(null);
   const wsRef = useRef(null);
@@ -602,10 +601,13 @@ export function ZoukInteractiveBlog({ route }) {
   const thinkingMessageKeyRef = useRef('');
   const target = `#${CONFIG.channel}`;
   const panelVisible = open || closing;
+  const composerPlaceholder = `Ask OpenViking about this post...`;
   const referencedText = compactText(selectedText);
   const contextUrlChanged = Boolean(sourceUrl && sourceUrl !== lastContextUrl);
   const includeContextUrl = contextUrlChanged || Boolean(referencedText);
   const shouldInjectContext = includeContextUrl || Boolean(referencedText);
+  const composerTrimmed = composer.trim();
+  const submitDisabled = !composerTrimmed || status === 'sending' || sendWhenReady;
 
   const authHeaders = useMemo(() => ({
     'Content-Type': 'application/json',
@@ -641,15 +643,6 @@ export function ZoukInteractiveBlog({ route }) {
   );
   const thinkingMessageKey = thinkingAgent ? thinkingAgent.id : '';
   const showThinkingMessage = Boolean(thinkingAgent && thinkingMessageKey !== dismissedThinkingKey);
-  const launcherStatus = useMemo(() => {
-    const statuses = liveAgents.map(agentDotStatus);
-    if (statuses.includes('error')) return 'error';
-    if (statuses.includes('working')) return 'working';
-    if (statuses.includes('thinking')) return 'thinking';
-    if (statuses.includes('online')) return 'online';
-    return liveAgents.length ? 'offline' : '';
-  }, [liveAgents]);
-
   const rememberSource = useCallback(() => {
     const next = currentSourceUrl();
     setSourceUrl(next);
@@ -685,11 +678,6 @@ export function ZoukInteractiveBlog({ route }) {
       closeTimerRef.current = null;
     }, CLOSE_ANIMATION_MS);
   }, []);
-
-  const toggleChat = useCallback(() => {
-    if (panelVisible) closeChat();
-    else openChat();
-  }, [closeChat, openChat, panelVisible]);
 
   const loadHistory = useCallback(async (nextToken = token) => {
     if (!nextToken) return;
@@ -800,12 +788,6 @@ export function ZoukInteractiveBlog({ route }) {
 
   useEffect(() => {
     if (!browserAvailable()) return undefined;
-    setHeaderSlot(document.getElementById('zouk-reader-header-slot'));
-    return undefined;
-  }, []);
-
-  useEffect(() => {
-    if (!browserAvailable()) return undefined;
     const media = window.matchMedia('(min-width: 900px)');
     const update = () => setIsDesktop(media.matches);
     update();
@@ -819,6 +801,13 @@ export function ZoukInteractiveBlog({ route }) {
     root.classList.toggle('zouk-reader-open-desktop', open && !closing && isDesktop);
     return () => root.classList.remove('zouk-reader-open-desktop');
   }, [closing, isDesktop, open]);
+
+  useEffect(() => {
+    if (!browserAvailable()) return undefined;
+    const root = document.documentElement;
+    root.classList.toggle('zouk-reader-bottom-composer-visible', !panelVisible);
+    return () => root.classList.remove('zouk-reader-bottom-composer-visible');
+  }, [panelVisible]);
 
   useEffect(() => {
     const node = scrollRef.current;
@@ -953,9 +942,15 @@ export function ZoukInteractiveBlog({ route }) {
     else setDragY(0);
   }, [closeChat]);
 
-  const sendMessage = useCallback(async () => {
+  const sendMessage = useCallback(async ({ openPanel = false } = {}) => {
     const trimmed = composer.trim();
-    if (!trimmed || !token || status === 'sending') return;
+    if (!trimmed || status === 'sending') return;
+    if (openPanel && !panelVisible) openChat();
+    if (!token) {
+      setSendWhenReady(true);
+      if (status === 'error') connect();
+      return;
+    }
     const nextSourceUrl = rememberSource();
     const nextReferencedText = compactText(selectedText);
     const nextIncludeUrl = Boolean(nextSourceUrl && (nextSourceUrl !== lastContextUrl || nextReferencedText));
@@ -986,7 +981,13 @@ export function ZoukInteractiveBlog({ route }) {
       setStatus('error');
       setError(err instanceof Error ? err.message : 'Send failed');
     }
-  }, [authHeaders, composer, dismissThinkingMessage, lastContextUrl, rememberSource, selectedText, status, target, token]);
+  }, [authHeaders, composer, connect, dismissThinkingMessage, lastContextUrl, openChat, panelVisible, rememberSource, selectedText, status, target, token]);
+
+  useEffect(() => {
+    if (!sendWhenReady || !token || status !== 'connected') return;
+    setSendWhenReady(false);
+    sendMessage();
+  }, [sendMessage, sendWhenReady, status, token]);
 
   const loadThreadMessages = useCallback(async (parentMessage) => {
     const parentId = parentMessage?.id;
@@ -1050,20 +1051,8 @@ export function ZoukInteractiveBlog({ route }) {
 
   const onSubmit = (event) => {
     event.preventDefault();
-    sendMessage();
+    sendMessage({ openPanel: true });
   };
-
-  const launcher = (
-    <button
-      type="button"
-      className={`zouk-reader-launcher${panelVisible ? ' is-active' : ''}${launcherStatus ? ` has-live is-${launcherStatus}` : ''}`}
-      aria-label={panelVisible ? 'Close blog chat' : 'Open blog chat'}
-      aria-pressed={panelVisible}
-      onClick={toggleChat}
-    >
-      <MessagesIcon />
-    </button>
-  );
 
   return (
     <>
@@ -1079,7 +1068,34 @@ export function ZoukInteractiveBlog({ route }) {
         </button>
       ) : null}
 
-      {headerSlot ? createPortal(launcher, headerSlot) : null}
+      {!panelVisible ? (
+        <form className="zouk-reader-bottom-composer" onSubmit={onSubmit} aria-label="Ask OpenViking">
+          <div className="zouk-reader-input-shell">
+            <textarea
+              ref={textareaRef}
+              value={composer}
+              rows={1}
+              enterKeyHint="send"
+              placeholder={composerPlaceholder}
+              onChange={(event) => setComposer(event.target.value)}
+              onKeyDown={(event) => {
+                if (shouldSubmitOnEnter(event)) {
+                  event.preventDefault();
+                  sendMessage({ openPanel: true });
+                }
+              }}
+            />
+            <button
+              type="submit"
+              className="zouk-reader-send"
+              aria-label="Send message"
+              disabled={submitDisabled}
+            >
+              <SendIcon />
+            </button>
+          </div>
+        </form>
+      ) : null}
 
       {panelVisible ? (
         <aside
@@ -1177,10 +1193,18 @@ export function ZoukInteractiveBlog({ route }) {
                 onKeyDown={(event) => {
                   if (shouldSubmitOnEnter(event)) {
                     event.preventDefault();
-                    sendMessage();
+                    sendMessage({ openPanel: true });
                   }
                 }}
               />
+              <button
+                type="submit"
+                className="zouk-reader-send"
+                aria-label="Send message"
+                disabled={submitDisabled}
+              >
+                <SendIcon />
+              </button>
             </div>
             {error && visibleMessages.length ? (
               <div className="zouk-reader-error">


### PR DESCRIPTION
## Summary

- Replace the blog header chat icon entry with a fixed minimal bottom composer on post pages.
- Keep the homepage clean by not rendering the bottom composer there.
- Soften the composer border with a dedicated rounded field radius.
- Add an icon-only send control to both the bottom composer and the open chat composer.
- When a reader sends from the bottom composer, open the Zouk chat rail/sheet and send after the embed guest session is ready.
- Hide the bottom composer while the chat rail/sheet is open.

## Screenshots

Follow-up: homepage without composer:

![Homepage without composer](https://raw.githubusercontent.com/ZaynJarvis/OpenViking/codex/minimal-blog-composer-screens/screenshots/desktop-home-no-composer.png)

Follow-up: post page rounded composer:

![Post rounded composer](https://raw.githubusercontent.com/ZaynJarvis/OpenViking/codex/minimal-blog-composer-screens/screenshots/desktop-post-rounded-composer.png)

Desktop closed composer:

![Desktop closed composer](https://raw.githubusercontent.com/ZaynJarvis/OpenViking/codex/minimal-blog-composer-screens/screenshots/desktop-closed-composer.png)

Desktop after send / rail open:

![Desktop after send rail](https://raw.githubusercontent.com/ZaynJarvis/OpenViking/codex/minimal-blog-composer-screens/screenshots/desktop-after-send-rail.png)

Mobile closed composer:

![Mobile closed composer](https://raw.githubusercontent.com/ZaynJarvis/OpenViking/codex/minimal-blog-composer-screens/screenshots/mobile-closed-composer.png)

Mobile after send / sheet open:

![Mobile after send sheet](https://raw.githubusercontent.com/ZaynJarvis/OpenViking/codex/minimal-blog-composer-screens/screenshots/mobile-after-send-sheet.png)

## Validation

- `npm run build`
- `git diff --check`
- Playwright screenshot smoke: homepage composer count `0`, post composer count `1`, computed radius `18px`
- Playwright screenshot smoke with mocked Zouk auth/message endpoints
