### PR TITLE
fix(semantic): add per-URI retry limits and file existence check

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -57,6 +57,10 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Default max consecutive retries per URI before marking as permanently failed.
+# Prevents token-burn loops (see #1595: 35.96M tokens from a single import).
+DEFAULT_MAX_RETRIES_PER_URI = 3
+
 
 @dataclass
 class DiffResult:
@@ -101,16 +105,22 @@ class SemanticProcessor(DequeueHandlerBase):
     _request_stats_order: List[str] = []
     _max_cached_stats = 256
 
-    def __init__(self, max_concurrent_llm: int = 64):
+    def __init__(self, max_concurrent_llm: int = 64, max_retries_per_uri: int = DEFAULT_MAX_RETRIES_PER_URI):
         """
         Initialize SemanticProcessor.
 
         Args:
             max_concurrent_llm: Maximum concurrent LLM calls
+            max_retries_per_uri: Max consecutive failures per URI before dropping
         """
         self.max_concurrent_llm = max_concurrent_llm
+        self.max_retries_per_uri = max_retries_per_uri
         self._default_ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
         self._circuit_breaker = CircuitBreaker()
+
+        # Track consecutive retry counts per URI to prevent infinite retry loops.
+        # Maps URI -> number of consecutive failures since last success.
+        self._retry_counts: Dict[str, int] = {}
 
     @classmethod
     def _cache_dag_stats(cls, telemetry_id: str, uri: str, stats: DagStats) -> None:
@@ -249,6 +259,29 @@ class SemanticProcessor(DequeueHandlerBase):
         data: Optional[Dict[str, Any]],
         error: Exception,
     ) -> None:
+        uri = msg.uri
+        current_count = self._retry_counts.get(uri, 0) + 1
+        self._retry_counts[uri] = current_count
+
+        if current_count >= self.max_retries_per_uri:
+            logger.warning(
+                "Max retries (%d) reached for %s, dropping to prevent token burn. "
+                "Last error: %s",
+                self.max_retries_per_uri,
+                uri,
+                error,
+            )
+            self._retry_counts.pop(uri, None)
+            self._merge_request_stats(msg.telemetry_id, error_count=1)
+            get_request_wait_tracker().mark_semantic_failed(
+                msg.telemetry_id, msg.id, f"Max retries ({self.max_retries_per_uri}) exceeded: {error}"
+            )
+            self.report_error(
+                f"Max retries ({self.max_retries_per_uri}) exceeded for {uri}: {error}",
+                data,
+            )
+            return
+
         try:
             await self._reenqueue_semantic_msg(msg)
             self._merge_request_stats(msg.telemetry_id, requeue_count=1)
@@ -328,6 +361,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     msg.uri,
                     msg.coalesce_version,
                 )
+                self._retry_counts.pop(msg.uri, None)
                 if msg.telemetry_id and msg.id:
                     get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
                 self.report_success()
@@ -345,6 +379,29 @@ class SemanticProcessor(DequeueHandlerBase):
                 self.report_requeue()
                 self.report_success()
                 return None
+            # File existence check: skip processing if the source file is gone.
+            # Prevents infinite retry loops on deleted files (see #1595).
+            try:
+                viking_fs = get_viking_fs()
+                file_exists = await viking_fs.exists(msg.uri, ctx=None)
+                if not file_exists:
+                    logger.warning(
+                        "Source URI does not exist, dropping from queue: %s",
+                        msg.uri,
+                    )
+                    self._retry_counts.pop(msg.uri, None)
+                    if msg.telemetry_id and msg.id:
+                        get_request_wait_tracker().mark_semantic_failed(
+                            msg.telemetry_id, msg.id, "Source URI does not exist"
+                        )
+                    self.report_error(f"Source URI does not exist: {msg.uri}", data)
+                    return None
+            except Exception as check_err:
+                logger.debug(
+                    "Could not check existence for %s, proceeding anyway: %s",
+                    msg.uri,
+                    check_err,
+                )
             collector = resolve_telemetry(msg.telemetry_id)
             telemetry_ctx = bind_telemetry(collector) if collector is not None else nullcontext()
             with telemetry_ctx:
@@ -459,6 +516,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     logger.info(f"Completed semantic generation for: {msg.uri}")
                     self.report_success()
                     self._circuit_breaker.record_success()
+                    self._retry_counts.pop(msg.uri, None)
                     return None
                 finally:
                     reset_root_observability_context(root_context_token)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -259,19 +259,19 @@ class SemanticProcessor(DequeueHandlerBase):
         data: Optional[Dict[str, Any]],
         error: Exception,
     ) -> None:
-        uri = msg.uri
-        current_count = self._retry_counts.get(uri, 0) + 1
-        self._retry_counts[uri] = current_count
+        retry_key = msg.coalesce_key or msg.uri
+        current_count = self._retry_counts.get(retry_key, 0) + 1
+        self._retry_counts[retry_key] = current_count
 
         if current_count >= self.max_retries_per_uri:
             logger.warning(
                 "Max retries (%d) reached for %s, dropping to prevent token burn. "
                 "Last error: %s",
                 self.max_retries_per_uri,
-                uri,
+                retry_key,
                 error,
             )
-            self._retry_counts.pop(uri, None)
+            self._retry_counts.pop(retry_key, None)
             self._merge_request_stats(msg.telemetry_id, error_count=1)
             get_request_wait_tracker().mark_semantic_failed(
                 msg.telemetry_id, msg.id, f"Max retries ({self.max_retries_per_uri}) exceeded: {error}"
@@ -361,7 +361,8 @@ class SemanticProcessor(DequeueHandlerBase):
                     msg.uri,
                     msg.coalesce_version,
                 )
-                self._retry_counts.pop(msg.uri, None)
+                retry_key = msg.coalesce_key or msg.uri
+                self._retry_counts.pop(retry_key, None)
                 if msg.telemetry_id and msg.id:
                     get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
                 self.report_success()
@@ -380,10 +381,11 @@ class SemanticProcessor(DequeueHandlerBase):
                 self.report_success()
                 return None
             # File existence check: skip processing if the source file is gone.
-            # Prevents infinite retry loops on deleted files (see #1595).
+            # Prevents infinite retry loops on deleted files.
             try:
                 viking_fs = get_viking_fs()
-                file_exists = await viking_fs.exists(msg.uri, ctx=None)
+                check_ctx = self._ctx_from_semantic_msg(msg)
+                file_exists = await viking_fs.exists(msg.uri, ctx=check_ctx)
                 if not file_exists:
                     logger.warning(
                         "Source URI does not exist, dropping from queue: %s",
@@ -516,7 +518,8 @@ class SemanticProcessor(DequeueHandlerBase):
                     logger.info(f"Completed semantic generation for: {msg.uri}")
                     self.report_success()
                     self._circuit_breaker.record_success()
-                    self._retry_counts.pop(msg.uri, None)
+                    retry_key = msg.coalesce_key or msg.uri
+                    self._retry_counts.pop(retry_key, None)
                     return None
                 finally:
                     reset_root_observability_context(root_context_token)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -105,7 +105,9 @@ class SemanticProcessor(DequeueHandlerBase):
     _request_stats_order: List[str] = []
     _max_cached_stats = 256
 
-    def __init__(self, max_concurrent_llm: int = 64, max_retries_per_uri: int = DEFAULT_MAX_RETRIES_PER_URI):
+    def __init__(
+        self, max_concurrent_llm: int = 64, max_retries_per_uri: int = DEFAULT_MAX_RETRIES_PER_URI
+    ):
         """
         Initialize SemanticProcessor.
 
@@ -119,8 +121,22 @@ class SemanticProcessor(DequeueHandlerBase):
         self._circuit_breaker = CircuitBreaker()
 
         # Track consecutive retry counts per URI to prevent infinite retry loops.
-        # Maps URI -> number of consecutive failures since last success.
+        # Maps coalesce_key -> number of consecutive failures since last success.
         self._retry_counts: Dict[str, int] = {}
+
+    @staticmethod
+    def _retry_key(msg: SemanticMsg) -> str:
+        """Build a tenant-aware retry key. Uses coalesce_key if present,
+        otherwise constructs from msg fields to avoid cross-tenant collisions."""
+        if msg.coalesce_key:
+            return msg.coalesce_key
+        return build_semantic_coalesce_key(
+            context_type=msg.context_type,
+            uri=msg.uri,
+            account_id=msg.account_id or "default",
+            user_id=msg.user_id or "default",
+            peer_id=getattr(msg, "peer_id", None) or "default",
+        )
 
     @classmethod
     def _cache_dag_stats(cls, telemetry_id: str, uri: str, stats: DagStats) -> None:
@@ -259,14 +275,13 @@ class SemanticProcessor(DequeueHandlerBase):
         data: Optional[Dict[str, Any]],
         error: Exception,
     ) -> None:
-        retry_key = msg.coalesce_key or msg.uri
+        retry_key = self._retry_key(msg)
         current_count = self._retry_counts.get(retry_key, 0) + 1
         self._retry_counts[retry_key] = current_count
 
         if current_count >= self.max_retries_per_uri:
             logger.warning(
-                "Max retries (%d) reached for %s, dropping to prevent token burn. "
-                "Last error: %s",
+                "Max retries (%d) reached for %s, dropping to prevent token burn. Last error: %s",
                 self.max_retries_per_uri,
                 retry_key,
                 error,
@@ -274,10 +289,12 @@ class SemanticProcessor(DequeueHandlerBase):
             self._retry_counts.pop(retry_key, None)
             self._merge_request_stats(msg.telemetry_id, error_count=1)
             get_request_wait_tracker().mark_semantic_failed(
-                msg.telemetry_id, msg.id, f"Max retries ({self.max_retries_per_uri}) exceeded: {error}"
+                msg.telemetry_id,
+                msg.id,
+                f"Max retries ({self.max_retries_per_uri}) exceeded: {error}",
             )
             self.report_error(
-                f"Max retries ({self.max_retries_per_uri}) exceeded for {uri}: {error}",
+                f"Max retries ({self.max_retries_per_uri}) exceeded for {retry_key}: {error}",
                 data,
             )
             return
@@ -361,7 +378,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     msg.uri,
                     msg.coalesce_version,
                 )
-                retry_key = msg.coalesce_key or msg.uri
+                retry_key = self._retry_key(msg)
                 self._retry_counts.pop(retry_key, None)
                 if msg.telemetry_id and msg.id:
                     get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
@@ -391,7 +408,7 @@ class SemanticProcessor(DequeueHandlerBase):
                         "Source URI does not exist, dropping from queue: %s",
                         msg.uri,
                     )
-                    self._retry_counts.pop(msg.uri, None)
+                    self._retry_counts.pop(self._retry_key(msg), None)
                     if msg.telemetry_id and msg.id:
                         get_request_wait_tracker().mark_semantic_failed(
                             msg.telemetry_id, msg.id, "Source URI does not exist"
@@ -518,7 +535,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     logger.info(f"Completed semantic generation for: {msg.uri}")
                     self.report_success()
                     self._circuit_breaker.record_success()
-                    retry_key = msg.coalesce_key or msg.uri
+                    retry_key = self._retry_key(msg)
                     self._retry_counts.pop(retry_key, None)
                     return None
                 finally:

--- a/tests/storage/test_semantic_processor_lock_ownership.py
+++ b/tests/storage/test_semantic_processor_lock_ownership.py
@@ -76,7 +76,7 @@ class _RecoveringLockManager:
 class _FakeVikingFS:
     async def exists(self, uri, ctx=None):
         del uri, ctx
-        return False
+        return True
 
     def _uri_to_path(self, uri, ctx=None):
         del ctx

--- a/tests/storage/test_semantic_processor_retry_limits.py
+++ b/tests/storage/test_semantic_processor_retry_limits.py
@@ -26,7 +26,9 @@ def _make_msg(
     account_id: str = "default",
     user_id: str = "default",
 ) -> SemanticMsg:
-    msg = SemanticMsg(uri=uri, context_type="resource", account_id=account_id, user_id=user_id)
+    msg = SemanticMsg(
+        uri=uri, context_type="resource", account_id=account_id, user_id=user_id
+    )
     return msg
 
 
@@ -157,8 +159,11 @@ class TestFileExistenceCheck:
         assert call_args[0][0] == "viking://user/deleted_file.txt"
         ctx = call_args[1].get("ctx") or call_args[0][1]
         assert ctx is not None, "exists() must receive a RequestContext"
-        # ctx should carry the non-default tenant IDs
-        assert hasattr(ctx, "account_id") or hasattr(ctx, "user")
+        # ctx must carry the non-default tenant IDs (not just have the attributes)
+        assert ctx.account_id == "acct-custom-42"
+        assert ctx.user.user_id == "user-7-zeta"
+
+
 # ---------------------------------------------------------------------------
 # 3. Config support for circuit breaker and semantic processor settings
 # ---------------------------------------------------------------------------

--- a/tests/storage/test_semantic_processor_retry_limits.py
+++ b/tests/storage/test_semantic_processor_retry_limits.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for semantic processor retry limits, file existence checks, and circuit breaker config.
+
+Addresses issue #1595: 35.96M tokens burned from a single import due to
+infinite retry loops on failed VLM summarization.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.queuefs.semantic_processor import (
+    DEFAULT_MAX_RETRIES_PER_URI,
+    SemanticProcessor,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_msg(uri: str = "viking://user/default/file.txt") -> SemanticMsg:
+    return SemanticMsg(uri=uri, context_type="resource")
+
+# ---------------------------------------------------------------------------
+# 1. Max retries per URI
+# ---------------------------------------------------------------------------
+
+class TestMaxRetriesPerUri:
+    """Tests for the max-retries-per-URI safeguard."""
+
+    def test_default_max_retries(self):
+        processor = SemanticProcessor()
+        assert processor.max_retries_per_uri == DEFAULT_MAX_RETRIES_PER_URI
+
+    def test_custom_max_retries(self):
+        processor = SemanticProcessor(max_retries_per_uri=5)
+        assert processor.max_retries_per_uri == 5
+
+    @pytest.mark.asyncio
+    async def test_requeue_increments_retry_count(self):
+        processor = SemanticProcessor(max_retries_per_uri=3)
+        msg = _make_msg()
+
+        # Mock the re-enqueue to avoid needing a real queue manager
+        with patch.object(processor, "_reenqueue_semantic_msg", new_callable=AsyncMock):
+            with patch.object(processor, "report_requeue"):
+                with patch.object(processor, "report_success"):
+                    with patch(
+                        "openviking.storage.queuefs.semantic_processor.get_request_wait_tracker"
+                    ) as mock_tracker:
+                        mock_tracker.return_value = MagicMock()
+                        await processor._requeue_semantic_msg_after_error(
+                            msg, {}, RuntimeError("test error")
+                        )
+
+        assert processor._retry_counts[msg.uri] == 1
+
+    @pytest.mark.asyncio
+    async def test_drops_after_max_retries(self):
+        processor = SemanticProcessor(max_retries_per_uri=2)
+        msg = _make_msg()
+
+        # Pre-set retry count to max-1
+        processor._retry_counts[msg.uri] = 1
+
+        with patch.object(processor, "report_error") as mock_err:
+            with patch(
+                "openviking.storage.queuefs.semantic_processor.get_request_wait_tracker"
+            ) as mock_tracker:
+                mock_tracker.return_value = MagicMock()
+                await processor._requeue_semantic_msg_after_error(
+                    msg, {}, RuntimeError("test error")
+                )
+
+        # Should have reported error, not re-enqueued
+        mock_err.assert_called_once()
+        # URI should be cleaned up from retry counts
+        assert msg.uri not in processor._retry_counts
+
+    @pytest.mark.asyncio
+    async def test_success_resets_retry_count(self):
+        """Stale-message early-exit must clean up _retry_counts."""
+        processor = SemanticProcessor(max_retries_per_uri=3)
+        msg = _make_msg("viking://test")
+        processor._retry_counts[msg.uri] = 2
+
+        with patch(
+            "openviking.storage.queuefs.semantic_processor.is_semantic_msg_stale",
+            return_value=True,
+        ):
+            with patch(
+                "openviking.storage.queuefs.semantic_processor.get_request_wait_tracker"
+            ) as mock_tracker:
+                mock_tracker.return_value = MagicMock()
+                with patch.object(processor, "report_success"):
+                    result = await processor.on_dequeue(msg.to_dict())
+
+        assert result is None
+        assert msg.uri not in processor._retry_counts
+
+# ---------------------------------------------------------------------------
+# 2. File existence check
+# ---------------------------------------------------------------------------
+
+class TestFileExistenceCheck:
+    """Tests for the file-existence-before-processing safeguard."""
+
+    @pytest.mark.asyncio
+    async def test_missing_file_drops_from_queue(self):
+        processor = SemanticProcessor()
+        msg = _make_msg("viking://user/default/deleted_file.txt")
+
+        mock_fs = MagicMock()
+        mock_fs.exists = AsyncMock(return_value=False)
+
+        with patch(
+            "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+            return_value=mock_fs,
+        ):
+            with patch(
+                "openviking.storage.queuefs.semantic_processor.resolve_telemetry",
+                return_value=None,
+            ):
+                with patch.object(processor, "report_error") as mock_err:
+                    with patch(
+                        "openviking.storage.queuefs.semantic_processor.is_semantic_msg_stale",
+                        return_value=False,
+                    ):
+                        # The on_dequeue will check existence and report error
+                        data = msg.to_dict()
+                        result = await processor.on_dequeue(data)
+
+        assert result is None
+        mock_err.assert_called_once()
+        # Check the error message mentions the non-existent file
+        error_msg = mock_err.call_args[0][0]
+        assert "does not exist" in error_msg
+
+# ---------------------------------------------------------------------------
+# 3. Config support for circuit breaker and semantic processor settings
+# ---------------------------------------------------------------------------
+

--- a/tests/storage/test_semantic_processor_retry_limits.py
+++ b/tests/storage/test_semantic_processor_retry_limits.py
@@ -20,8 +20,14 @@ from openviking.storage.queuefs.semantic_processor import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_msg(uri: str = "viking://user/default/file.txt") -> SemanticMsg:
-    return SemanticMsg(uri=uri, context_type="resource")
+def _make_msg(
+    uri: str = "viking://user/default/file.txt",
+    account_id: str = "default",
+    user_id: str = "default",
+) -> SemanticMsg:
+    msg = SemanticMsg(uri=uri, context_type="resource", account_id=account_id, user_id=user_id)
+    msg.coalesce_key = f"{msg.context_type}:{account_id}:{user_id}::{uri}"
+    return msg
 
 # ---------------------------------------------------------------------------
 # 1. Max retries per URI
@@ -55,7 +61,7 @@ class TestMaxRetriesPerUri:
                             msg, {}, RuntimeError("test error")
                         )
 
-        assert processor._retry_counts[msg.uri] == 1
+        assert processor._retry_counts[msg.coalesce_key] == 1
 
     @pytest.mark.asyncio
     async def test_drops_after_max_retries(self):
@@ -63,7 +69,7 @@ class TestMaxRetriesPerUri:
         msg = _make_msg()
 
         # Pre-set retry count to max-1
-        processor._retry_counts[msg.uri] = 1
+        processor._retry_counts[msg.coalesce_key] = 1
 
         with patch.object(processor, "report_error") as mock_err:
             with patch(
@@ -76,15 +82,15 @@ class TestMaxRetriesPerUri:
 
         # Should have reported error, not re-enqueued
         mock_err.assert_called_once()
-        # URI should be cleaned up from retry counts
-        assert msg.uri not in processor._retry_counts
+        # Coalesce key should be cleaned up from retry counts
+        assert msg.coalesce_key not in processor._retry_counts
 
     @pytest.mark.asyncio
     async def test_success_resets_retry_count(self):
         """Stale-message early-exit must clean up _retry_counts."""
         processor = SemanticProcessor(max_retries_per_uri=3)
         msg = _make_msg("viking://test")
-        processor._retry_counts[msg.uri] = 2
+        processor._retry_counts[msg.coalesce_key] = 2
 
         with patch(
             "openviking.storage.queuefs.semantic_processor.is_semantic_msg_stale",
@@ -98,7 +104,7 @@ class TestMaxRetriesPerUri:
                     result = await processor.on_dequeue(msg.to_dict())
 
         assert result is None
-        assert msg.uri not in processor._retry_counts
+        assert msg.coalesce_key not in processor._retry_counts
 
 # ---------------------------------------------------------------------------
 # 2. File existence check
@@ -134,7 +140,6 @@ class TestFileExistenceCheck:
 
         assert result is None
         mock_err.assert_called_once()
-        # Check the error message mentions the non-existent file
         error_msg = mock_err.call_args[0][0]
         assert "does not exist" in error_msg
 
@@ -142,3 +147,19 @@ class TestFileExistenceCheck:
 # 3. Config support for circuit breaker and semantic processor settings
 # ---------------------------------------------------------------------------
 
+
+class TestMultiTenantIsolation:
+    """Retry counts must be isolated per tenant/peer, not shared by URI alone."""
+
+    @pytest.mark.asyncio
+    async def test_different_tenants_have_separate_retry_budgets(self):
+        processor = SemanticProcessor(max_retries_per_uri=2)
+        msg_a = _make_msg("viking://shared/file.txt", account_id="tenant-a")
+        msg_b = _make_msg("viking://shared/file.txt", account_id="tenant-b")
+
+        # Exhaust retries for tenant-a
+        processor._retry_counts[msg_a.coalesce_key] = 1
+
+        # tenant-b should still have a fresh budget
+        assert msg_b.coalesce_key not in processor._retry_counts
+        assert processor._retry_counts.get(msg_b.coalesce_key, 0) == 0

--- a/tests/storage/test_semantic_processor_retry_limits.py
+++ b/tests/storage/test_semantic_processor_retry_limits.py
@@ -120,7 +120,11 @@ class TestFileExistenceCheck:
     @pytest.mark.asyncio
     async def test_missing_file_drops_from_queue(self):
         processor = SemanticProcessor()
-        msg = _make_msg("viking://user/default/deleted_file.txt")
+        msg = _make_msg(
+            "viking://user/deleted_file.txt",
+            account_id="acct-custom-42",
+            user_id="user-7-zeta",
+        )
 
         mock_fs = MagicMock()
         mock_fs.exists = AsyncMock(return_value=False)
@@ -147,7 +151,14 @@ class TestFileExistenceCheck:
         error_msg = mock_err.call_args[0][0]
         assert "does not exist" in error_msg
 
-
+        # Verify the existence check received a ctx that preserves tenant identity
+        mock_fs.exists.assert_called_once()
+        call_args = mock_fs.exists.call_args
+        assert call_args[0][0] == "viking://user/deleted_file.txt"
+        ctx = call_args[1].get("ctx") or call_args[0][1]
+        assert ctx is not None, "exists() must receive a RequestContext"
+        # ctx should carry the non-default tenant IDs
+        assert hasattr(ctx, "account_id") or hasattr(ctx, "user")
 # ---------------------------------------------------------------------------
 # 3. Config support for circuit breaker and semantic processor settings
 # ---------------------------------------------------------------------------

--- a/tests/storage/test_semantic_processor_retry_limits.py
+++ b/tests/storage/test_semantic_processor_retry_limits.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Tests for semantic processor retry limits, file existence checks, and circuit breaker config.
+"""Tests for per-URI retry limits and file existence check.
 
-Addresses issue #1595: 35.96M tokens burned from a single import due to
-infinite retry loops on failed VLM summarization.
+Transient retry + file-existence safeguard to prevent runaway token
+consumption from infinite retry loops on failed VLM summarization.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,18 +20,20 @@ from openviking.storage.queuefs.semantic_processor import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_msg(
     uri: str = "viking://user/default/file.txt",
     account_id: str = "default",
     user_id: str = "default",
 ) -> SemanticMsg:
     msg = SemanticMsg(uri=uri, context_type="resource", account_id=account_id, user_id=user_id)
-    msg.coalesce_key = f"{msg.context_type}:{account_id}:{user_id}::{uri}"
     return msg
+
 
 # ---------------------------------------------------------------------------
 # 1. Max retries per URI
 # ---------------------------------------------------------------------------
+
 
 class TestMaxRetriesPerUri:
     """Tests for the max-retries-per-URI safeguard."""
@@ -61,7 +63,7 @@ class TestMaxRetriesPerUri:
                             msg, {}, RuntimeError("test error")
                         )
 
-        assert processor._retry_counts[msg.coalesce_key] == 1
+        assert processor._retry_counts[SemanticProcessor._retry_key(msg)] == 1
 
     @pytest.mark.asyncio
     async def test_drops_after_max_retries(self):
@@ -69,7 +71,7 @@ class TestMaxRetriesPerUri:
         msg = _make_msg()
 
         # Pre-set retry count to max-1
-        processor._retry_counts[msg.coalesce_key] = 1
+        processor._retry_counts[SemanticProcessor._retry_key(msg)] = 1
 
         with patch.object(processor, "report_error") as mock_err:
             with patch(
@@ -83,14 +85,14 @@ class TestMaxRetriesPerUri:
         # Should have reported error, not re-enqueued
         mock_err.assert_called_once()
         # Coalesce key should be cleaned up from retry counts
-        assert msg.coalesce_key not in processor._retry_counts
+        assert SemanticProcessor._retry_key(msg) not in processor._retry_counts
 
     @pytest.mark.asyncio
     async def test_success_resets_retry_count(self):
         """Stale-message early-exit must clean up _retry_counts."""
         processor = SemanticProcessor(max_retries_per_uri=3)
         msg = _make_msg("viking://test")
-        processor._retry_counts[msg.coalesce_key] = 2
+        processor._retry_counts[SemanticProcessor._retry_key(msg)] = 2
 
         with patch(
             "openviking.storage.queuefs.semantic_processor.is_semantic_msg_stale",
@@ -104,11 +106,13 @@ class TestMaxRetriesPerUri:
                     result = await processor.on_dequeue(msg.to_dict())
 
         assert result is None
-        assert msg.coalesce_key not in processor._retry_counts
+        assert SemanticProcessor._retry_key(msg) not in processor._retry_counts
+
 
 # ---------------------------------------------------------------------------
 # 2. File existence check
 # ---------------------------------------------------------------------------
+
 
 class TestFileExistenceCheck:
     """Tests for the file-existence-before-processing safeguard."""
@@ -143,6 +147,7 @@ class TestFileExistenceCheck:
         error_msg = mock_err.call_args[0][0]
         assert "does not exist" in error_msg
 
+
 # ---------------------------------------------------------------------------
 # 3. Config support for circuit breaker and semantic processor settings
 # ---------------------------------------------------------------------------
@@ -157,9 +162,22 @@ class TestMultiTenantIsolation:
         msg_a = _make_msg("viking://shared/file.txt", account_id="tenant-a")
         msg_b = _make_msg("viking://shared/file.txt", account_id="tenant-b")
 
+        key_a = SemanticProcessor._retry_key(msg_a)
+        key_b = SemanticProcessor._retry_key(msg_b)
+        assert key_a != key_b
+
         # Exhaust retries for tenant-a
-        processor._retry_counts[msg_a.coalesce_key] = 1
+        processor._retry_counts[key_a] = 1
 
         # tenant-b should still have a fresh budget
-        assert msg_b.coalesce_key not in processor._retry_counts
-        assert processor._retry_counts.get(msg_b.coalesce_key, 0) == 0
+        assert key_b not in processor._retry_counts
+
+    def test_retry_key_with_empty_coalesce_key(self):
+        """When coalesce_key is empty, _retry_key builds from msg fields."""
+        msg = _make_msg("viking://test/file.txt", account_id="acct-x", user_id="user-y")
+        msg.coalesce_key = ""  # simulate old message without coalesce_key
+        key = SemanticProcessor._retry_key(msg)
+        assert "acct-x" in key
+        assert "user-y" in key
+        assert "viking://test/file.txt" in key
+        assert key == "resource|acct-x|user-y|default|viking://test/file.txt"


### PR DESCRIPTION
## Summary

Prevents runaway token consumption from infinite retry loops on failed VLM summarization (observed: 35.96M tokens from a single import).

Scoped as **transient retry + file-existence safeguard** only. Import-wide token/file-size/fan-out budget (#1595) is a separate effort.

### Changes

- **Per-URI retry limit** — Track consecutive failure count per URI (keyed by coalesce_key for multi-tenant isolation); drop after max_retries (default: 3)
- **File existence check** — Check file existence with proper account context before processing; drop deleted URIs immediately
- **Retry-state cleanup** — Clean up retry state on stale-message early-exit and on success

### Files changed

| File | Change |
|------|--------|
| `openviking/storage/queuefs/semantic_processor.py` | Retry tracking, file existence check, stale-message cleanup |
| `tests/storage/test_semantic_processor_retry_limits.py` | Tests for retry counting, max-retry drop, file-existence check, multi-tenant isolation |