### PR TITLE
[codex] compress Codex auto-recall context before injection

### DIFF
--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -109,6 +109,7 @@ All plugin behavior is controlled by `OPENVIKING_*` environment variables — se
 ```sh
 # ~/.zshrc — examples
 export OPENVIKING_RECALL_LIMIT=6
+export OPENVIKING_RECALL_COMPRESS=1
 export OPENVIKING_CAPTURE_ASSISTANT_TURNS=1
 export OPENVIKING_AUTO_COMMIT_ON_COMPACT=1
 export OPENVIKING_DEBUG=1
@@ -179,10 +180,10 @@ On any /commit failure (OV unreachable, non-2xx, timeout) we **preserve state** 
 `auto-recall.mjs` reads `prompt` from stdin, calls `/api/v1/search/find`, ranks results, reads full content for top-ranked leaves, and emits:
 
 ```json
-{ "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "<relevant-memories>...</relevant-memories>" } }
+{ "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "OpenViking memory digest:\n- ..." } }
 ```
 
-Codex injects `additionalContext` into the model turn, so memories arrive without an extra tool call.
+Codex injects `additionalContext` into the model turn, so memories arrive without an extra tool call. By default the hook runs a low-reasoning Codex compression pass over recalled candidates before injection, dropping weakly-related memories and preserving only a short digest. Set `OPENVIKING_RECALL_COMPRESS=0` to fall back to deterministic short formatting.
 
 ### Stop (turn end → `add_message`, NOT `commit`)
 

--- a/examples/codex-memory-plugin/scripts/auto-capture.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-capture.mjs
@@ -137,7 +137,16 @@ async function readTranscriptTurns(transcriptPath) {
   }
 }
 
-async function appendTurns(ovSessionId, turns) {
+function selectStopTurns(state, turns) {
+  const limit = cfg.captureMaxTurnsPerStop;
+  if (turns.length <= limit) return turns;
+  const skipped = turns.length - limit;
+  state.capturedTurnCount += skipped;
+  log("backlog_trimmed", { newTurns: turns.length, skipped, selected: limit });
+  return turns.slice(-limit);
+}
+
+async function appendTurns(ovSessionId, turns, state) {
   let appended = 0;
   for (const turn of turns) {
     const body = { role: turn.role, content: turn.text };
@@ -148,6 +157,8 @@ async function appendTurns(ovSessionId, turns) {
     });
     if (!result) break;
     appended += 1;
+    state.capturedTurnCount += 1;
+    await saveState(state);
   }
   return appended;
 }
@@ -222,8 +233,9 @@ async function main() {
     if (!ovSessionId) {
       logError("resolve_ov_session", "failed to derive OV session id");
     } else {
-      added = await appendTurns(ovSessionId, newTurns);
-      state.capturedTurnCount += added;
+      const turnsToAppend = selectStopTurns(state, newTurns);
+      await saveState(state);
+      added = await appendTurns(ovSessionId, turnsToAppend, state);
       log("appended", { ovSessionId, added });
     }
   }

--- a/examples/codex-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.mjs
@@ -13,6 +13,10 @@
  * is just `{}`.
  */
 
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { loadConfig } from "./config.mjs";
 import { createLogger } from "./debug-log.mjs";
 
@@ -250,6 +254,148 @@ async function readMemoryContent(uri) {
   return null;
 }
 
+function truncateText(text, maxChars) {
+  const value = String(text || "").trim();
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 20)).trimEnd()}\n[truncated]`;
+}
+
+function sanitizeInjectedText(text) {
+  const legacyTag = ["relevant", "memories"].join("-");
+  return String(text || "").replace(new RegExp(`</?${legacyTag}>`, "gi"), "legacy memory wrapper");
+}
+
+function fallbackDigest(items) {
+  const lines = items.slice(0, cfg.recallCompressMaxBullets).map((item) => {
+    const text = sanitizeInjectedText(truncateText(item.text, 260)).replace(/\s+/g, " ");
+    return `- [${item.category || "memory"}] ${text} (${item.uri})`;
+  });
+  return lines.length > 0 ? `OpenViking memory digest:\n${lines.join("\n")}` : "";
+}
+
+function normalizeCompressedContext(text) {
+  let value = String(text || "").trim();
+  if (!value) return "";
+  value = value.replace(/^```(?:text|markdown)?\s*/i, "").replace(/\s*```$/i, "").trim();
+  value = sanitizeInjectedText(value);
+  if (!value || /^NO_RELEVANT_MEMORY\.?$/i.test(value)) return "";
+  if (!value.toLowerCase().startsWith("openviking memory digest:")) {
+    value = `OpenViking memory digest:\n${value}`;
+  }
+  return truncateText(value, 4000);
+}
+
+async function runCodexCompressor(prompt) {
+  const tmp = await mkdtemp(join(tmpdir(), "ov-recall-compress-"));
+  const outputPath = join(tmp, "last-message.txt");
+  const args = [
+    "-m",
+    cfg.recallCompressModel,
+    "-c",
+    'model_reasoning_effort="low"',
+    "--sandbox",
+    "read-only",
+    "--ask-for-approval",
+    "never",
+    "exec",
+    "--ephemeral",
+    "--ignore-user-config",
+    "--skip-git-repo-check",
+    "--output-last-message",
+    outputPath,
+    "-",
+  ];
+
+  try {
+    return await new Promise((resolve) => {
+      const env = {
+        ...process.env,
+        OPENVIKING_AUTO_RECALL: "0",
+        OPENVIKING_AUTO_CAPTURE: "0",
+        OPENVIKING_RECALL_COMPRESS: "0",
+      };
+      let done = false;
+      let timedOut = false;
+      let stderr = "";
+      const child = spawn("codex", args, { env, stdio: ["pipe", "ignore", "pipe"] });
+      const finish = (value) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve(value);
+      };
+      const timer = setTimeout(() => {
+        timedOut = true;
+        logError("compress_timeout", `timed out after ${cfg.recallCompressTimeoutMs}ms`);
+        child.kill("SIGKILL");
+      }, cfg.recallCompressTimeoutMs);
+
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+        if (stderr.length > 4000) stderr = stderr.slice(-4000);
+      });
+      child.on("error", (err) => {
+        logError("compress_spawn", err);
+        finish(null);
+      });
+      child.on("close", async (code) => {
+        if (timedOut) {
+          finish(null);
+          return;
+        }
+        if (code !== 0) {
+          logError("compress_exit", stderr.trim().slice(-1000) || `codex exited ${code}`);
+          finish(null);
+          return;
+        }
+        try {
+          finish(await readFile(outputPath, "utf-8"));
+        } catch (err) {
+          logError("compress_read", err);
+          finish(null);
+        }
+      });
+      child.stdin.end(prompt);
+    });
+  } finally {
+    await rm(tmp, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function compressMemoryContext(userPrompt, items) {
+  if (!cfg.recallCompress) return null;
+  const perItemChars = Math.max(500, Math.floor(cfg.recallCompressMaxInputChars / Math.max(1, items.length)));
+  const payload = {
+    user_prompt: userPrompt,
+    max_bullets: cfg.recallCompressMaxBullets,
+    memories: items.map((item) => ({
+      uri: item.uri,
+      category: item.category || "memory",
+      score: item.score,
+      text: truncateText(item.text, perItemChars),
+    })),
+  };
+  const prompt = `You are a memory relevance compressor for a Codex UserPromptSubmit hook.
+
+Task:
+- Keep only memories directly useful for answering the user's current prompt.
+- Drop stale, generic, duplicate, merely adjacent, or operationally unrelated memories.
+- Compress to at most ${cfg.recallCompressMaxBullets} short bullets.
+- Preserve concrete facts, dates, paths, repo names, commands, and user preferences.
+- Do not include XML/HTML wrappers.
+- Do not mention that you filtered memories.
+- If no memory is directly useful, output exactly: NO_RELEVANT_MEMORY
+
+Input JSON:
+${JSON.stringify(payload, null, 2)}
+`;
+  const raw = await runCodexCompressor(prompt);
+  if (raw === null) return null;
+  const compressed = normalizeCompressedContext(raw);
+  log("compressed", { inputCount: items.length, chars: compressed.length });
+  return compressed;
+}
+
 async function main() {
   if (!cfg.autoRecall) {
     log("skip", { stage: "init", reason: "autoRecall disabled" });
@@ -324,21 +470,24 @@ async function main() {
 
   log("picked", { pickedCount: memories.length, uris: memories.map((m) => m.uri) });
 
-  const lines = await Promise.all(
+  const memoryItems = await Promise.all(
     memories.map(async (item) => {
+      let text = (item.abstract || item.overview || item.uri).trim();
       if (item.level === 2) {
         const content = await readMemoryContent(item.uri);
-        if (content) return `- [${item.category || "memory"}] ${content}`;
+        if (content) text = content;
       }
-      return `- [${item.category || "memory"}] ${(item.abstract || item.overview || item.uri).trim()}`;
+      return {
+        uri: item.uri,
+        category: item.category || "memory",
+        score: clampScore(item.score),
+        text,
+      };
     }),
   );
 
-  const memoryContext =
-    "<relevant-memories>\n" +
-    "The following long-term memories from OpenViking may be relevant to this conversation:\n" +
-    lines.join("\n") + "\n" +
-    "</relevant-memories>";
+  const compressedContext = await compressMemoryContext(userPrompt, memoryItems);
+  const memoryContext = compressedContext === null ? fallbackDigest(memoryItems) : compressedContext;
 
   emit(memoryContext);
 }

--- a/examples/codex-memory-plugin/scripts/config.mjs
+++ b/examples/codex-memory-plugin/scripts/config.mjs
@@ -216,6 +216,23 @@ export function loadConfig() {
       num(cx.minQueryLength, 3),
     ))),
     logRankingDetails: envBool("OPENVIKING_LOG_RANKING_DETAILS") ?? (cx.logRankingDetails === true),
+    recallCompress: envBool("OPENVIKING_RECALL_COMPRESS") ?? (cx.recallCompress !== false),
+    recallCompressModel: str(
+      process.env.OPENVIKING_RECALL_COMPRESS_MODEL,
+      str(cx.recallCompressModel, "gpt-5.5"),
+    ),
+    recallCompressTimeoutMs: Math.max(1000, Math.floor(num(
+      process.env.OPENVIKING_RECALL_COMPRESS_TIMEOUT_MS,
+      num(cx.recallCompressTimeoutMs, 10000),
+    ))),
+    recallCompressMaxInputChars: Math.max(1000, Math.floor(num(
+      process.env.OPENVIKING_RECALL_COMPRESS_MAX_INPUT_CHARS,
+      num(cx.recallCompressMaxInputChars, 18000),
+    ))),
+    recallCompressMaxBullets: Math.max(1, Math.floor(num(
+      process.env.OPENVIKING_RECALL_COMPRESS_MAX_BULLETS,
+      num(cx.recallCompressMaxBullets, 6),
+    ))),
 
     autoCapture: envBool("OPENVIKING_AUTO_CAPTURE") ?? (cx.autoCapture !== false),
     captureMode: (str(process.env.OPENVIKING_CAPTURE_MODE, str(cx.captureMode, "semantic")) === "keyword")
@@ -224,6 +241,10 @@ export function loadConfig() {
     captureMaxLength: Math.max(200, Math.floor(num(
       process.env.OPENVIKING_CAPTURE_MAX_LENGTH,
       num(cx.captureMaxLength, 24000),
+    ))),
+    captureMaxTurnsPerStop: Math.max(1, Math.floor(num(
+      process.env.OPENVIKING_CAPTURE_MAX_TURNS_PER_STOP,
+      num(cx.captureMaxTurnsPerStop, 8),
     ))),
     captureTimeoutMs,
     // Default true: a "memory plugin" without assistant-side capture only sees half the


### PR DESCRIPTION
## What changed

- Add an optional Codex compression pass to the Codex memory plugin's `UserPromptSubmit` auto-recall hook.
- Inject a short `OpenViking memory digest` instead of the previous raw `<relevant-memories>` block.
- Add tuning knobs for compression model, timeout, input budget, and max bullets.
- Bound Stop-hook backlog capture with incremental state persistence so large pending transcripts do not keep timing out.

## Why

Raw auto-recall context can be noisy and overlong. The hook now retrieves candidates, asks a low-reasoning isolated Codex child process to keep only memories directly useful for the current user prompt, and falls back to a deterministic short digest if compression fails or times out.

The child process runs with `--ephemeral --ignore-user-config`, read-only sandboxing, no approval prompts, and auto-recall/capture disabled in its environment to avoid recursive hook activation.

## Validation

- `node --check examples/codex-memory-plugin/scripts/auto-recall.mjs`
- `node --check examples/codex-memory-plugin/scripts/auto-capture.mjs`
- `node --check examples/codex-memory-plugin/scripts/config.mjs`
- Synthetic `UserPromptSubmit` smoke with `OPENVIKING_AUTO_RECALL=0` returns `{}`
- Synthetic `Stop` smoke with `OPENVIKING_AUTO_CAPTURE=0` returns `{}`
- `git diff --check origin/main...HEAD`
