### PR TITLE
fix(storage): tear down lock lease across event loops / 修复锁租约跨事件循环关闭 (#2515)

### DIFF
--- a/openviking/storage/transaction/lock_lease.py
+++ b/openviking/storage/transaction/lock_lease.py
@@ -221,9 +221,34 @@ class OwnedLockLease(LockLease):
                 logger.warning("Failed to refresh lock handle %s: %s", self.handle_id, exc)
 
     async def _stop_refresh(self) -> None:
-        if self._refresh_task is None:
+        task = self._refresh_task
+        if task is None:
             return
-        self._refresh_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await self._refresh_task
+        # Drop our reference first so a re-entrant close()/handoff() is a no-op
+        # and the owning loop is free to retire the task.
         self._refresh_task = None
+
+        try:
+            current_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        task_loop = task.get_loop()
+
+        if task_loop is current_loop:
+            # Same loop: cancel and await so the refresh coroutine is fully
+            # stopped before the caller proceeds to release the handle.
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+            return
+
+        if not task_loop.is_closed():
+            # Cross-loop: the refresh task is bound to another running loop.
+            # Marshal the cancellation back onto that loop instead of awaiting a
+            # future attached to a different loop (which raises RuntimeError).
+            # suppress(RuntimeError) guards the TOCTOU where the loop closes
+            # between the is_closed() check and call_soon_threadsafe().
+            with suppress(RuntimeError):
+                task_loop.call_soon_threadsafe(task.cancel)
+        # else: the owning loop is already closed; the task is dead. Drop it.

--- a/tests/transaction/test_lock_lease_cross_loop.py
+++ b/tests/transaction/test_lock_lease_cross_loop.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for cross-loop teardown of OwnedLockLease (issue #2515).
+
+The lease's refresh task is bound to the event loop that constructed the lease.
+When ``close()``/``handoff()`` runs from a *different* loop (e.g. an embedding
+completion callback that falls back to the current loop), tearing the task down
+must not ``await`` a future attached to another loop, which would raise
+``RuntimeError: ... got Future ... attached to a different loop``.
+"""
+
+import asyncio
+import threading
+from contextlib import suppress
+from unittest.mock import MagicMock
+
+from openviking.storage.transaction.lock_lease import OwnedLockLease
+from openviking.storage.transaction.lock_manager import LockManager
+
+
+class _LoopThread:
+    """Run an asyncio loop in a dedicated thread (acts as 'loop A')."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def run_coro(self, coro):
+        """Schedule a coroutine on loop A and block (from caller thread) for its result."""
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout=5)
+
+    def stop(self, *, close: bool = True) -> None:
+        # Cancel and drain any task still pending on loop A (e.g. a sleeping
+        # refresh loop) before closing it, so it is not later reported as
+        # "Task was destroyed but it is pending".
+        if self.loop.is_running():
+
+            async def _shutdown() -> None:
+                pending = [
+                    t for t in asyncio.all_tasks(self.loop) if t is not asyncio.current_task()
+                ]
+                for t in pending:
+                    t.cancel()
+                for t in pending:
+                    with suppress(asyncio.CancelledError):
+                        await t
+
+            with suppress(RuntimeError):
+                asyncio.run_coroutine_threadsafe(_shutdown(), self.loop).result(timeout=5)
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=5)
+        if close and not self.loop.is_closed():
+            self.loop.close()
+
+
+def _make_lease_on(loop_thread: _LoopThread) -> OwnedLockLease:
+    """Build an OwnedLockLease whose _refresh_task is bound to loop A.
+
+    A large ``lock_expire`` keeps the refresh loop sleeping (interval ≈ expire/2)
+    so it never performs real I/O against the mock agfs before we cancel it.
+    """
+    manager = LockManager(agfs=MagicMock(), lock_expire=10_000.0)
+    handle = manager.create_handle()
+    handle.add_lock("/local/default/x/.path.ovlock")  # non-empty locks -> __init__ starts refresh
+
+    async def _build() -> OwnedLockLease:
+        # Constructed inside loop A -> _refresh_task binds to loop A.
+        return OwnedLockLease(manager, handle)
+
+    return loop_thread.run_coro(_build())
+
+
+async def test_close_from_other_loop_does_not_raise_cross_loop_error():
+    """close() from loop B must tear down a loop-A-bound refresh task cleanly."""
+    loop_a = _LoopThread()
+    loop_a.start()
+    try:
+        lease = _make_lease_on(loop_a)
+        # Sanity: the refresh task really is bound to loop A, not the test loop.
+        assert lease._refresh_task is not None
+        assert lease._refresh_task.get_loop() is loop_a.loop
+        assert lease._refresh_task.get_loop() is not asyncio.get_running_loop()
+
+        # Regression assertion: must NOT raise cross-loop RuntimeError.
+        await lease.close()
+
+        assert lease._refresh_task is None
+        # Give loop A a tick to process the scheduled cancel.
+        await asyncio.sleep(0.05)
+    finally:
+        loop_a.stop()
+
+
+async def test_handoff_from_other_loop_does_not_raise_cross_loop_error():
+    """handoff() shares _stop_refresh() with close(); same cross-loop guarantee."""
+    loop_a = _LoopThread()
+    loop_a.start()
+    try:
+        lease = _make_lease_on(loop_a)
+        await lease.handoff()  # must not raise
+        assert lease._refresh_task is None
+    finally:
+        loop_a.stop()
+
+
+async def test_close_when_owner_loop_already_closed():
+    """If loop A is gone before close(), teardown still succeeds without raising
+    'Event loop is closed' from call_soon_threadsafe."""
+    loop_a = _LoopThread()
+    loop_a.start()
+    lease = _make_lease_on(loop_a)
+    loop_a.stop(close=True)  # owner loop closed -> task_loop.is_closed() is True
+    await lease.close()  # must hit the 'else: drop it' branch cleanly
+    assert lease._refresh_task is None
+
+
+async def test_close_same_loop_still_awaits_and_cancels():
+    """Same-loop close() keeps original behavior: task is cancelled and awaited."""
+    manager = LockManager(agfs=MagicMock(), lock_expire=10_000.0)
+    handle = manager.create_handle()
+    handle.add_lock("/local/default/y/.path.ovlock")
+    lease = OwnedLockLease(manager, handle)  # task bound to the test loop (loop B)
+    task = lease._refresh_task
+    assert task is not None
+    assert task.get_loop() is asyncio.get_running_loop()
+
+    await lease.close()
+
+    assert lease._refresh_task is None
+    assert task.cancelled() or task.done()


### PR DESCRIPTION
## Summary / 概述

Fixes #2515 — tearing down an `OwnedLockLease` from a *different* event loop than the one that created it raised `RuntimeError: ... got Future ... attached to a different loop`, failing lock cleanup in the embedding/semantic pipeline.

修复 #2515 —— 从与构造 lease 不同的事件循环关闭 `OwnedLockLease` 时，会抛出 `RuntimeError: got Future attached to a different loop`，导致 embedding/semantic 流水线的锁清理失败。

## Root cause / 根因

`OwnedLockLease._start_refresh()` creates `_refresh_task` via `asyncio.create_task()`, binding it to the constructing loop (loop A, the semantic worker thread's loop). `_stop_refresh()` then **unconditionally** `await`ed that task. When `close()`/`handoff()` runs from another loop (loop B) — e.g. `embedding_tracker._run_on_complete()` falling back to running the completion callback on the current loop when the owner loop is unavailable — awaiting the loop-A-bound future from loop B raises the cross-loop `RuntimeError`.

`_refresh_task` 绑定在构造时所在的循环（loop A）。原 `_stop_refresh()` 无条件 `await` 该 task；当 `close()`/`handoff()` 从另一个循环（loop B）调用时（如 embedding 完成回调在 owner loop 不可用时 fallback 到当前循环执行），从 loop B await 一个绑定在 loop A 的 future 即抛 cross-loop `RuntimeError`。

## Fix / 修复

Route teardown by the task's owning loop in `_stop_refresh()` (single convergence point shared by both `close()` and `handoff()`):

- **Same loop** → `cancel()` + `await` (preserves original behavior).
- **Cross-loop, owner still running** → `task_loop.call_soon_threadsafe(task.cancel)` instead of awaiting a foreign-loop future. `suppress(RuntimeError)` guards the TOCTOU between `is_closed()` and the call.
- **Owner loop already closed** → drop the dead task.

The reference is cleared up front so a re-entrant `close()`/`handoff()` is a no-op (close becomes idempotent). This mirrors the existing same-loop/cross-loop dispatch pattern in `observability/usage_audit/worker.py` and the `task.get_loop() is get_running_loop()` check in `lock_manager.py`.

在唯一收敛点 `_stop_refresh()`（`close()` 与 `handoff()` 共用）按 task 所属循环分流：同循环 cancel+await；跨循环用 `call_soon_threadsafe` 调度取消；owner 循环已关闭则丢弃。提前清引用使重入调用成为 no-op。复用了仓库既有惯例（`usage_audit/worker.py` 的同/跨循环分流、`lock_manager.py` 的 `get_loop()` 判定）。

## Tests / 测试

New `tests/transaction/test_lock_lease_cross_loop.py` (4 cases). On unmodified code, the cross-loop cases fail with the exact `RuntimeError` from #2515; with the fix they pass:

- `test_close_from_other_loop_does_not_raise_cross_loop_error` — primary regression.
- `test_handoff_from_other_loop_does_not_raise_cross_loop_error` — `handoff()` shares the same path.
- `test_close_when_owner_loop_already_closed` — exercises the `else` (drop) branch + `suppress(RuntimeError)` TOCTOU guard.
- `test_close_same_loop_still_awaits_and_cancels` — guards the same-loop path against regression.

新增 4 个回归测试：未改代码时跨循环用例以 #2515 的 `RuntimeError` 失败，应用修复后全绿。

## Verification / 验证

- `pytest tests/transaction/test_lock_lease_cross_loop.py -v` → 4 passed
- `pytest tests/transaction/` → 89 passed (the one pre-existing `FileNotFoundError` on `test_start_skips_redo_recovery_when_disabled` is environment-only — missing `ov.conf` — and reproduces on `main` without this change)
- `ruff format --check` / `ruff check` → clean
- `mypy` → no new errors in the changed range

## Follow-up (not in this PR) / 后续

`lock_manager.py` `stop()` unconditionally `await`s `_redo_task` with no loop guard, and `lock_manager.py:108`, while loop-guarded for `await`, still calls `cancel()` cross-loop directly. Neither is triggered by #2515; they can be hardened separately using this `_stop_refresh` as the reference pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)