### PR TITLE
test(openclaw): cover default memory auto recall search

### DIFF
--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -201,6 +201,64 @@ describe("context-engine assemble()", () => {
     expect(recorded.resourceTypes).toEqual(["user"]);
   });
 
+  it("uses one memory context-type search for default auto-recall targets", async () => {
+    const traces = new RecallTraceMemoryStore(10);
+    const { engine, client } = makeEngine(
+      {
+        latest_archive_overview: "unused",
+        pre_archive_abstracts: [],
+        messages: [],
+        estimatedTokens: 0,
+        stats: makeStats(),
+      },
+      {
+        traceRecorder: traces,
+        cfgOverrides: {
+          autoRecall: true,
+          recallPreferAbstract: true,
+        },
+      },
+    );
+    client.find.mockImplementation(async (_query: string, options: { contextType?: string; targetUri?: string }) => {
+      if (options.contextType === "memory" && options.targetUri === undefined) {
+        return {
+          memories: [
+            {
+              uri: "viking://user/default/memories/gateway-docs",
+              level: 2,
+              category: "memory",
+              abstract: "Gateway plugin docs live in the user memory store.",
+              score: 0.9,
+            },
+          ],
+          total: 1,
+        };
+      }
+      throw new Error(
+        `unexpected auto-recall target: ${options.targetUri ?? "none"} contextType=${options.contextType ?? "none"}`,
+      );
+    });
+
+    await engine.assemble({
+      sessionId: "session-transform-default-targets",
+      messages: [{ role: "user", content: "where are the gateway plugin docs?" }],
+    });
+
+    expect(client.find).toHaveBeenCalledTimes(1);
+    expect(client.find.mock.calls[0]![1]).toMatchObject({ contextType: "memory" });
+    expect(client.find.mock.calls[0]![1].targetUri).toBeUndefined();
+    expect(client.find.mock.calls[0]![1].actorPeerId).toBeUndefined();
+
+    const recorded = traces.query({
+      turn: "latest",
+      sessionId: "session-transform-default-targets",
+      limit: 10,
+    }).entries[0]!;
+    expect(recorded.searches).toHaveLength(1);
+    expect(recorded.searches[0]).toMatchObject({ contextType: "memory" });
+    expect(recorded.searches[0]!.targetUriResolved).toBeUndefined();
+  });
+
   it("passes sender peer_id to transformContext auto-recall when peer_role is person", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- Add a focused OpenClaw transformContext regression test for the default auto-recall search plan.
- Assert default auto-recall collapses to one `contextType=memory` search with no target URI.
- Assert the recall trace records one memory search instead of separate user/agent target URI searches.

This is handwritten against the current actor peer scope model; it does not cherry-pick #2581/#2593 or bring back body `peer_id` / `viking://agent/...` behavior.

## Validation
- npm test -- --run tests/ut/context-engine-assemble.test.ts
- npm run typecheck