### PR TITLE
fix(memory): force JSON output when extract loop disables tools / 抽取循环禁用工具时强制 JSON 输出 (#1541)

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -263,6 +263,7 @@ class LiteLLMVLMProvider(VLMBase):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[str] = None,
         thinking: bool = False,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
         """Build kwargs for LiteLLM call."""
         kwargs: dict[str, Any] = {
@@ -285,6 +286,8 @@ class LiteLLMVLMProvider(VLMBase):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+        if response_format:
+            kwargs["response_format"] = response_format
         if self.extra_request_body:
             kwargs["extra_body"] = dict(self.extra_request_body)
 
@@ -355,10 +358,18 @@ class LiteLLMVLMProvider(VLMBase):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
         model = self._resolve_model(self.model or "gpt-4o-mini")
         kwargs_messages = messages or [{"role": "user", "content": prompt}]
-        return self._build_kwargs(model, kwargs_messages, tools, tool_choice, thinking=thinking)
+        return self._build_kwargs(
+            model,
+            kwargs_messages,
+            tools,
+            tool_choice,
+            thinking=thinking,
+            response_format=response_format,
+        )
 
     def _build_vision_kwargs(
         self,
@@ -417,9 +428,12 @@ class LiteLLMVLMProvider(VLMBase):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Union[str, VLMResponse]:
         """Get text completion asynchronously."""
-        kwargs = self._build_text_kwargs(prompt, thinking, tools, tool_choice, messages)
+        kwargs = self._build_text_kwargs(
+            prompt, thinking, tools, tool_choice, messages, response_format
+        )
         # 用 tracer.info 打印请求
         tracer.info(f"request: {json.dumps(kwargs, ensure_ascii=False, indent=2)}")
 

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -219,6 +219,7 @@ class OpenAIVLM(VLMBase):
         tool_choice: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
         thinking: Optional[bool] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         effective_thinking = self.thinking if thinking is None else thinking
         kwargs_messages = messages or [{"role": "user", "content": prompt}]
@@ -238,6 +239,8 @@ class OpenAIVLM(VLMBase):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+        if response_format:
+            kwargs["response_format"] = response_format
         return kwargs
 
     def _build_vision_kwargs(
@@ -325,11 +328,14 @@ class OpenAIVLM(VLMBase):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Union[str, VLMResponse]:
         """Get text completion asynchronously"""
         effective_thinking = self.thinking if thinking is None else thinking
         client = self.get_async_client()
-        kwargs = self._build_text_kwargs(prompt, tools, tool_choice, messages, effective_thinking)
+        kwargs = self._build_text_kwargs(
+            prompt, tools, tool_choice, messages, effective_thinking, response_format
+        )
 
         async def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -138,6 +138,7 @@ class VolcEngineVLM(OpenAIVLM):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Union[str, VLMResponse]:
         """Get text completion asynchronously via Chat Completions API."""
         effective_thinking = self.thinking if thinking is None else thinking
@@ -153,6 +154,8 @@ class VolcEngineVLM(OpenAIVLM):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+        if response_format:
+            kwargs["response_format"] = response_format
 
         # 用 tracer.info 打印请求
         tracer.info(f"request: {json.dumps(kwargs_messages, ensure_ascii=False, indent=2)}")

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -105,6 +105,7 @@ class VLMBase(ABC):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Union[str, VLMResponse]:
         """Get text completion asynchronously
 
@@ -114,6 +115,9 @@ class VLMBase(ABC):
             tools: Optional list of tool definitions in OpenAI function format
             tool_choice: Optional tool choice mode ("auto", "none", or specific tool name)
             messages: Optional list of message dicts (takes precedence over prompt)
+            response_format: Optional OpenAI-style response_format, e.g.
+                ``{"type": "json_object"}`` to force valid JSON output. Ignored
+                when the backend or model does not support it.
 
         Returns:
             str if no tools provided, VLMResponse if tools provided
@@ -478,6 +482,7 @@ class FailoverVLM(VLMBase):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Union[str, VLMResponse]:
         """Get text completion asynchronously with failover support."""
         return await self._get_completion_with_failover_async(
@@ -487,6 +492,7 @@ class FailoverVLM(VLMBase):
             tools=tools,
             tool_choice=tool_choice,
             messages=messages,
+            response_format=response_format,
         )
 
     def get_vision_completion(

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -610,11 +610,19 @@ The final output of the model must strictly follow the JSON Schema format shown 
         if not self._disable_tools_for_iteration and self._tool_schemas:
             tools = self._tool_schemas
             tool_choice = "auto"
+
+        # When tools are disabled the model must emit the final operations as a
+        # JSON object in `content` (there is no tool call to carry structure).
+        # Weak models otherwise reply with plain prose here, which fails parsing
+        # and yields "Extracted 0 memories" (issue #1541). Force JSON output via
+        # response_format on this path; backends that don't support it ignore it.
+        response_format = None if tools else {"type": "json_object"}
         with bind_telemetry_stage("memory_extract"):
             response = await self.vlm.get_completion_async(
                 messages=messages,
                 tools=tools,
                 tool_choice=tool_choice,
+                response_format=response_format,
             )
         tracer.info(f"llm_response={response}")
         # print(f'response={response}')

--- a/tests/unit/session/memory/test_extract_loop_response_format.py
+++ b/tests/unit/session/memory/test_extract_loop_response_format.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""`_call_llm` forces JSON output on the tool-less path (issue #1541).
+
+When tools are disabled the model must emit final operations as a JSON object
+in message content. Weak models otherwise return plain prose, parsing fails,
+and extraction stores zero memories. The fix passes
+``response_format={"type": "json_object"}`` to the VLM only on that path.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from openviking.models.vlm.base import VLMResponse
+from openviking.session.memory.extract_loop import ExtractLoop
+
+
+def _make_loop(captured: dict) -> ExtractLoop:
+    """Build a minimally-wired ExtractLoop whose VLM records its call kwargs."""
+
+    async def fake_completion(**kwargs):
+        captured.clear()
+        captured.update(kwargs)
+        # Valid empty-operations JSON so the tool-less path parses cleanly.
+        return VLMResponse(content="{}")
+
+    vlm = Mock(model="test-model")
+    vlm.get_completion_async = AsyncMock(side_effect=fake_completion)
+
+    loop = ExtractLoop(vlm=vlm, viking_fs=Mock(), context_provider=Mock())
+    loop._mark_cache_breakpoint = AsyncMock()
+    loop._tool_schemas = [{"type": "function", "function": {"name": "read"}}]
+    loop._expected_fields = ["delete_uris"]
+    # parse path: any content maps to a truthy operations object
+    loop._operations_model = SimpleNamespace(model_json_schema=lambda: {})
+    return loop
+
+
+class TestCallLlmResponseFormat:
+    @pytest.mark.asyncio
+    async def test_tool_less_path_forces_json_object(self, monkeypatch):
+        captured: dict = {}
+        loop = _make_loop(captured)
+        # Tools disabled -> final-operations path.
+        loop._disable_tools_for_iteration = True
+
+        # Make parsing deterministic and independent of schema internals.
+        monkeypatch.setattr(
+            "openviking.session.memory.extract_loop.parse_json_with_stability",
+            lambda content, model_class, expected_fields: ({}, None),
+        )
+
+        await loop._call_llm(messages=[{"role": "user", "content": "hi"}])
+
+        assert captured["response_format"] == {"type": "json_object"}
+        assert captured["tools"] is None
+
+    @pytest.mark.asyncio
+    async def test_tool_path_omits_response_format(self):
+        captured: dict = {}
+        loop = _make_loop(captured)
+        # Tools enabled -> structured tool-call path, no response_format.
+        loop._disable_tools_for_iteration = False
+
+        await loop._call_llm(messages=[{"role": "user", "content": "hi"}])
+
+        assert captured["response_format"] is None
+        assert captured["tools"] == loop._tool_schemas

--- a/tests/unit/test_vlm_response_format_kwargs.py
+++ b/tests/unit/test_vlm_response_format_kwargs.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for `response_format` passthrough in VLM backends (issue #1541).
+
+Memory extraction relies on the model returning a JSON object as message
+content when tools are disabled. Weak models otherwise return plain prose,
+which fails parsing and stores zero memories. The fix lets callers pass an
+OpenAI-style ``response_format`` (e.g. ``{"type": "json_object"}``) that the
+backends forward to the provider. These tests pin that passthrough and verify
+that omitting it keeps the request body unchanged (no regression).
+"""
+
+from openviking.models.vlm.backends.litellm_vlm import LiteLLMVLMProvider
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+
+_JSON_OBJECT = {"type": "json_object"}
+
+
+class TestOpenAIResponseFormat:
+    def _vlm(self, **overrides):
+        config = {
+            "api_key": "sk-test",
+            "model": "gpt-4o-mini",
+            "api_base": "https://api.openai.com/v1",
+            "max_tokens": 256,
+        }
+        config.update(overrides)
+        return OpenAIVLM(config)
+
+    def test_omitted_by_default(self):
+        kwargs = self._vlm()._build_text_kwargs(prompt="hi")
+        assert "response_format" not in kwargs
+
+    def test_injected_when_provided(self):
+        kwargs = self._vlm()._build_text_kwargs(prompt="hi", response_format=_JSON_OBJECT)
+        assert kwargs["response_format"] == _JSON_OBJECT
+
+    def test_injected_for_reasoning_model(self):
+        kwargs = self._vlm(model="gpt-5-mini")._build_text_kwargs(
+            prompt="hi", response_format=_JSON_OBJECT
+        )
+        assert kwargs["response_format"] == _JSON_OBJECT
+        # reasoning-model translation still applies alongside response_format
+        assert kwargs["max_completion_tokens"] == 256
+
+
+class TestLiteLLMResponseFormat:
+    def _vlm(self, **overrides):
+        config = {
+            "api_key": "sk-test",
+            "model": "gpt-4o-mini",
+            "api_base": "https://api.openai.com/v1",
+            "max_tokens": 256,
+        }
+        config.update(overrides)
+        return LiteLLMVLMProvider(config)
+
+    def test_omitted_by_default(self):
+        kwargs = self._vlm()._build_text_kwargs(prompt="hi")
+        assert "response_format" not in kwargs
+
+    def test_injected_when_provided(self):
+        kwargs = self._vlm()._build_text_kwargs(prompt="hi", response_format=_JSON_OBJECT)
+        assert kwargs["response_format"] == _JSON_OBJECT


### PR DESCRIPTION
## Summary / 概述

Fixes #1541 — memory extraction stores **0 memories** when a weak model returns plain conversational text instead of the required JSON object.

修复 #1541 —— 当弱模型返回纯对话文本而非所需 JSON 对象时，记忆抽取存入 **0 条记忆**。

## Root cause / 根因

`ExtractLoop` expects the model's *final* answer to be a JSON object parsed from message `content` (the final operations are **not** a tool call). With `tool_choice="auto"`, a weak model is free to reply with prose, which `parse_json_with_stability()` cannot parse → `Failed to parse memory operations: Expected dict ... got <class 'str'>` → "Extracted 0 memories".

As the issue notes, the VLM backends never implemented `response_format`, so there was no way to *enforce* JSON output — only prompt-level hints (already present) and a retry, which a weak model can still ignore.

`ExtractLoop` 期望模型的*最终*回答是从 `content` 解析出的 JSON 对象（最终操作**不是** tool call）。在 `tool_choice="auto"` 下，弱模型可自由返回散文，`parse_json_with_stability()` 无法解析，最终"存入 0 条记忆"。如 issue 所述，VLM 后端从未实现 `response_format`，因此无法*强制* JSON 输出。

## Fix / 修复 (issue 方案 1)

1. **Thread an optional `response_format`** through `get_completion_async` on the base interface, `FailoverVLM`, and the OpenAI / VolcEngine / LiteLLM backends (Codex / Kimi / GLM inherit it). Default `None` keeps every existing request body **byte-for-byte unchanged**.
2. **In `ExtractLoop._call_llm`**, pass `response_format={"type": "json_object"}` **only when tools are disabled** — the recovery / final-operations path where the model must emit JSON in `content`. The tool-call path is untouched.

This targets exactly the failing path: iteration 1 returns prose → parse fails → tools disabled for the retry → the retry now forces JSON.

1. 在基类、`FailoverVLM` 及 OpenAI/VolcEngine/LiteLLM 后端的 `get_completion_async` 增加可选 `response_format`（Codex/Kimi/GLM 继承）。默认 `None`，现有请求体**逐字节不变**。
2. 在 `ExtractLoop._call_llm` 中，**仅在禁用工具时**（恢复/最终输出路径，模型必须在 `content` 输出 JSON）传入 `response_format={"type": "json_object"}`；工具调用路径不变。

## Why this is safe / 为何安全

- The normal extraction flow (tools enabled, model behaves) sends **no** `response_format` and is completely unchanged → **zero regression**.
- Backends that don't support `response_format` simply ignore the field; LiteLLM has `drop_params = True`.
- `response_format` is never combined with `tools`, avoiding provider incompatibilities.

- 正常抽取流程（启用工具、模型正常）**不**发送 `response_format`，完全不变 → **零回归**。
- 不支持 `response_format` 的后端会忽略该字段；LiteLLM 已设 `drop_params = True`。
- `response_format` 不与 `tools` 同时出现，规避 provider 兼容性问题。

## Tests / 测试

- `tests/unit/test_vlm_response_format_kwargs.py` — OpenAI & LiteLLM backends inject `response_format` only when provided (omitted by default; coexists with reasoning-model translation).
- `tests/unit/session/memory/test_extract_loop_response_format.py` — `_call_llm` forces `{"type": "json_object"}` on the tool-less path and omits it on the tool-call path.

All VLM-backend and `extract_loop` suites pass; the few unrelated failures on this tree (`test_volcengine_cache`, a reasoning `max_tokens` case, `test_embedding_template`) are **pre-existing on `origin/main`** and untouched by this change.

VLM 后端与 `extract_loop` 相关测试全部通过；本仓库中少数无关失败（`test_volcengine_cache`、某 reasoning `max_tokens` 用例、`test_embedding_template`）在 `origin/main` 上**已预先存在**，与本次改动无关。