### PR TITLE
fix(storage): roll back only own locks on acquire_mv failure / acquire_mv 失败时仅回滚自身锁 (#1047)

### DIFF
--- a/openviking/storage/transaction/path_lock.py
+++ b/openviking/storage/transaction/path_lock.py
@@ -800,22 +800,37 @@ class PathLockEngine:
             timeout: Maximum seconds to wait for each lock.
             src_is_dir: Whether the source is a directory (TREE lock)
                 or a file (ExactPathLock on source and destination path).
+
+        On partial failure only the locks acquired *by this call* are rolled
+        back; locks the owner already held (e.g. an outer subtree lock borrowed
+        from a transaction handle) are preserved. Releasing the whole owner here
+        would tear down that borrowed lock and cascade into "Failed to acquire
+        mv lock" for every sibling move sharing the handle (issue #1047).
         """
+        locks_before = set(owner.locks)
+
+        async def _rollback() -> None:
+            newly_acquired = [lp for lp in owner.locks if lp not in locks_before]
+            if newly_acquired:
+                await self.release_selected(owner, newly_acquired)
+
         if src_is_dir:
             if not await self.acquire_tree(src_path, owner, timeout=timeout):
                 logger.warning(f"[MV] Failed to acquire TREE lock on source: {src_path}")
+                await _rollback()
                 return False
             if not await self.acquire_exact_path(dst_path, owner, timeout=timeout):
                 logger.warning(f"[MV] Failed to acquire exact lock on destination: {dst_path}")
-                await self.release(owner)
+                await _rollback()
                 return False
         else:
             if not await self.acquire_exact_path(src_path, owner, timeout=timeout):
                 logger.warning(f"[MV] Failed to acquire exact lock on source: {src_path}")
+                await _rollback()
                 return False
             if not await self.acquire_exact_path(dst_path, owner, timeout=timeout):
                 logger.warning(f"[MV] Failed to acquire exact lock on destination: {dst_path}")
-                await self.release(owner)
+                await _rollback()
                 return False
 
         logger.debug(f"[MV] Locks acquired: {src_path} -> {dst_path}")

--- a/tests/transaction/test_acquire_mv_rollback.py
+++ b/tests/transaction/test_acquire_mv_rollback.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for `PathLockEngine.acquire_mv` lock rollback (issue #1047).
+
+When a move runs under a borrowed transaction handle (e.g. the outer subtree
+TREE lock held by ``SemanticLockScope`` and shared by every move in
+``_sync_topdown_recursive``), a *partial* mv lock failure must NOT tear down the
+owner's pre-existing locks. The original code called ``self.release(owner)`` on
+destination failure, which dropped the borrowed outer lock and cascaded into
+"Failed to acquire mv lock" for every sibling move — leaving L0/L1 files stuck
+in temp.
+
+The fix rolls back only the locks acquired by the failing ``acquire_mv`` call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openviking.storage.transaction.lock_manager import LockManager
+from openviking.storage.transaction.path_lock import LOCK_FILE_NAME, PathLockEngine
+from tests.transaction.test_lock_reentrancy_unit import _FakeAGFS
+
+
+@pytest.mark.asyncio
+async def test_acquire_mv_dir_dst_conflict_preserves_borrowed_outer_lock():
+    """src_is_dir=True: dst taken by another owner must not drop the outer lock."""
+    agfs = _FakeAGFS()
+    agfs.mkdir("/root")
+    agfs.mkdir("/root/src")
+    agfs.mkdir("/dest")
+    agfs.mkdir("/dest/taken")
+    lock = PathLockEngine(agfs)
+    lm = LockManager(agfs)
+    owner = lm.create_handle()
+    other = lm.create_handle()
+
+    # Owner holds the outer TREE lock on /root (its semantic subtree).
+    assert await lock.acquire_tree("/root", owner, timeout=0.1) is True
+    outer_lock_path = f"/root/{LOCK_FILE_NAME}"
+    assert outer_lock_path in owner.locks
+
+    # A concurrent task holds the mv destination, so the dst step will fail.
+    assert await lock.acquire_exact_path("/dest/taken", other, timeout=0.1) is True
+
+    # The move fails, but the borrowed outer lock must survive.
+    acquired = await lock.acquire_mv(
+        "/root/src", "/dest/taken", owner, timeout=0.0, src_is_dir=True
+    )
+    assert acquired is False
+    assert outer_lock_path in owner.locks, "borrowed outer TREE lock was released"
+    assert outer_lock_path in agfs._files, "outer TREE lock file was deleted from disk"
+
+
+@pytest.mark.asyncio
+async def test_acquire_mv_file_dst_conflict_preserves_borrowed_outer_lock():
+    """src_is_dir=False: same guarantee on the file (exact/exact) path."""
+    agfs = _FakeAGFS()
+    agfs.mkdir("/root")
+    agfs.write("/root/src.md", b"x")
+    agfs.mkdir("/dest")
+    agfs.write("/dest/taken.md", b"y")
+    lock = PathLockEngine(agfs)
+    lm = LockManager(agfs)
+    owner = lm.create_handle()
+    other = lm.create_handle()
+
+    assert await lock.acquire_tree("/root", owner, timeout=0.1) is True
+    outer_lock_path = f"/root/{LOCK_FILE_NAME}"
+
+    # Hold the destination so the second exact-lock step fails.
+    assert await lock.acquire_exact_path("/dest/taken.md", other, timeout=0.1) is True
+
+    acquired = await lock.acquire_mv(
+        "/root/src.md", "/dest/taken.md", owner, timeout=0.0, src_is_dir=False
+    )
+    assert acquired is False
+    assert outer_lock_path in owner.locks, "borrowed outer TREE lock was released"
+    assert outer_lock_path in agfs._files, "outer TREE lock file was deleted from disk"
+
+
+@pytest.mark.asyncio
+async def test_acquire_mv_success_still_locks_src_and_dst():
+    """Happy path is unchanged: a clean mv acquires both src and dst locks."""
+    agfs = _FakeAGFS()
+    agfs.mkdir("/root")
+    agfs.mkdir("/root/src")
+    agfs.mkdir("/dest")
+    lock = PathLockEngine(agfs)
+    lm = LockManager(agfs)
+    owner = lm.create_handle()
+
+    acquired = await lock.acquire_mv(
+        "/root/src", "/dest/moved", owner, timeout=0.1, src_is_dir=True
+    )
+    assert acquired is True
+    # src gets a TREE lock; dst gets an exact-path lock (distinct file naming).
+    assert f"/root/src/{LOCK_FILE_NAME}" in owner.locks
+    assert any("moved" in lock_path for lock_path in owner.locks), owner.locks
+
+
+@pytest.mark.asyncio
+async def test_acquire_mv_dst_conflict_rolls_back_its_own_src_lock():
+    """The failing call must not leak the src lock it acquired this round."""
+    agfs = _FakeAGFS()
+    agfs.mkdir("/area")
+    agfs.mkdir("/area/src")
+    agfs.mkdir("/area/dest")
+    agfs.mkdir("/area/dest/taken")
+    lock = PathLockEngine(agfs)
+    lm = LockManager(agfs)
+    owner = lm.create_handle()
+    other = lm.create_handle()
+
+    # No outer lock this time; owner starts empty.
+    assert await lock.acquire_exact_path("/area/dest/taken", other, timeout=0.1) is True
+
+    acquired = await lock.acquire_mv(
+        "/area/src", "/area/dest/taken", owner, timeout=0.0, src_is_dir=True
+    )
+    assert acquired is False
+    # The src TREE lock grabbed during this call must be rolled back.
+    assert owner.locks == [], f"acquire_mv leaked locks: {owner.locks}"
+    assert f"/area/src/{LOCK_FILE_NAME}" not in agfs._files


### PR DESCRIPTION
## Summary / 概述

Fixes #1047 — `SemanticProcessor` fails to move generated **L0 (`.abstract.md`)** and **L1 (`.overview.md`)** files from temp to the target directory, logging `[SyncDiff] Failed to acquire mv lock`. The target ends up with only the L2 content file; L0/L1 stay in temp and are later cleaned up.

修复 #1047 —— `SemanticProcessor` 无法把生成的 **L0 (`.abstract.md`)** 与 **L1 (`.overview.md`)** 从 temp 移动到目标目录，日志报 `[SyncDiff] Failed to acquire mv lock`；目标目录只剩 L2 内容文件，L0/L1 滞留 temp 并最终被清理。

## Root cause / 根因

`_sync_topdown_recursive` moves files into the target using `viking_fs.mv(..., lock_handle=lock_handle)`, where `lock_handle` is a **single borrowed handle** that already holds the outer subtree **TREE lock** (acquired by `SemanticLockScope`) and is **shared by every move** in the sync.

`PathLockEngine.acquire_mv` released locks incorrectly on partial failure:

```python
if not await self.acquire_exact_path(dst_path, owner, timeout=timeout):
    await self.release(owner)   # <-- releases ALL of owner's locks
    return False
```

`release(owner)` drops **every** lock the owner holds — including the borrowed outer TREE lock. So the moment the **first** move hits contention on its destination, the shared transaction lock is torn down, and **every subsequent move** in the same `_sync_topdown_recursive` fails with "Failed to acquire mv lock". L0/L1 never reach the target.

This is more precise than the timeout theory in the issue: bumping `lock_timeout` from `0.0` only widens the race window; the lock teardown is the actual defect. `lock_timeout=0.0` is an intentional default (see `TransactionConfig`), so this fix leaves it untouched.

`_sync_topdown_recursive` 通过 `viking_fs.mv(..., lock_handle=lock_handle)` 移动文件，该 `lock_handle` 是**单个借用 handle**，已持有外层子树 **TREE 锁**（由 `SemanticLockScope` 获取）且被本次同步的**所有 move 共享**。`PathLockEngine.acquire_mv` 在部分失败时调用 `release(owner)`，会释放 owner 的**全部**锁（含借用的外层 TREE 锁）。于是**第一个**发生目标争用的 move 一旦失败，就把共享事务锁拆掉，导致同一次同步中**后续所有 move** 全部 "Failed to acquire mv lock"，L0/L1 无法到达目标。

这比 issue 中的 timeout 推测更精确：把 `lock_timeout` 从 `0.0` 调大只是缩小竞态窗口，真正缺陷是锁被错误拆除。`lock_timeout=0.0` 是有意的默认值（见 `TransactionConfig`），本修复不改动它。

## Fix / 修复

On partial failure, roll back **only the locks acquired by this `acquire_mv` call**, mirroring the `acquired_lock_paths` + `release_selected` pattern already used by `LockManager.acquire_tree_batch` / `acquire_exact_path_batch`. Locks the owner held before the call are preserved.

部分失败时，仅回滚**本次 `acquire_mv` 调用新获取的锁**，沿用 `LockManager.acquire_tree_batch` / `acquire_exact_path_batch` 已有的 `acquired_lock_paths` + `release_selected` 模式；调用前已持有的锁予以保留。

## Verification / 验证

Reproduced first (diagnose-style): an owner holding an outer TREE lock on `/root`, then a dir `mv` whose destination is held by another owner — on `main`, `owner.locks` becomes `[]` and the outer lock file is deleted. With the fix, the outer lock survives.

先复现（diagnose 方式）：owner 持有 `/root` 外层 TREE 锁，再对一个目标被他人占用的目录做 `mv` —— 在 `main` 上 `owner.locks` 变为 `[]`、外层锁文件被删除；修复后外层锁保留。

`tests/transaction/test_acquire_mv_rollback.py` covers:
- dir mv (`src_is_dir=True`) dst conflict preserves the borrowed outer lock
- file mv (`src_is_dir=False`) dst conflict preserves the borrowed outer lock
- a failing call rolls back the src lock it grabbed this round (no leak)
- happy-path mv still locks src and dst

Full `tests/transaction/` + storage lock suites pass (104 passed). The one unrelated setup error (`test_start_skips_redo_recovery_when_disabled`, missing config file) is **pre-existing on `origin/main`**.

完整 `tests/transaction/` 与 storage 锁套件通过（104 passed）。唯一无关的 setup error（`test_start_skips_redo_recovery_when_disabled`，缺配置文件）在 `origin/main` 上**已预先存在**。