### PR TITLE
fix(storage): rebuild missing default index on local collection load / 本地 collection 加载时重建缺失的默认索引

### DIFF
--- a/openviking/storage/vectordb_adapters/local_adapter.py
+++ b/openviking/storage/vectordb_adapters/local_adapter.py
@@ -10,8 +10,11 @@ from typing import Any, Dict
 
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb.collection.local_collection import get_or_create_local_collection
+from openviking_cli.utils import get_logger
 
 from .base import CollectionAdapter
+
+logger = get_logger(__name__)
 
 
 class LocalCollectionAdapter(CollectionAdapter):
@@ -19,10 +22,19 @@ class LocalCollectionAdapter(CollectionAdapter):
 
     DEFAULT_LOCAL_PROJECT_NAME = "vectordb"
 
-    def __init__(self, collection_name: str, project_path: str, index_name: str):
+    def __init__(
+        self,
+        collection_name: str,
+        project_path: str,
+        index_name: str,
+        distance: str = "cosine",
+        sparse_weight: float = 0.0,
+    ):
         super().__init__(collection_name=collection_name, index_name=index_name)
         self.mode = "local"
         self._project_path = project_path
+        self._distance = distance
+        self._sparse_weight = sparse_weight
 
     @classmethod
     def from_config(cls, config: Any):
@@ -33,6 +45,8 @@ class LocalCollectionAdapter(CollectionAdapter):
             collection_name=config.name or "context",
             project_path=project_path,
             index_name=config.index_name or "default",
+            distance=getattr(config, "distance_metric", None) or "cosine",
+            sparse_weight=getattr(config, "sparse_weight", 0.0) or 0.0,
         )
 
     def _collection_path(self) -> str:
@@ -49,6 +63,35 @@ class LocalCollectionAdapter(CollectionAdapter):
         meta_path = os.path.join(collection_path, "collection_meta.json")
         if os.path.exists(meta_path):
             self._collection = get_or_create_local_collection(path=collection_path)
+            self._recover_missing_default_index()
+
+    def _recover_missing_default_index(self) -> None:
+        """Rebuild the default index from the store when it is missing on load.
+
+        A collection can end up persisted with store content but no usable index
+        (e.g. the ``index/`` directory was emptied, or an index subdir survived
+        but its ``index_meta.json`` was lost/corrupted). ``_recover()`` only
+        restores indexes that still have valid on-disk metadata, so such dirty
+        states leave the collection with no searchable index and ``search``
+        silently returns nothing. Rebuilding from the store (a full scan of the
+        candidate table) makes the data searchable again.
+        """
+        coll = self._collection
+        if coll is None or coll.has_index(self._index_name):
+            return
+        index_meta = self.build_default_index_meta(
+            index_name=self._index_name,
+            distance=self._distance,
+            use_sparse=self._sparse_weight > 0.0,
+            sparse_weight=self._sparse_weight,
+            scalar_index_fields=[],
+        )
+        coll.create_index(self._index_name, index_meta)
+        logger.warning(
+            "Rebuilt missing index '%s' from store for local collection '%s'",
+            self._index_name,
+            self._collection_name,
+        )
 
     def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
         collection_path = self._collection_path()

--- a/tests/storage/test_local_adapter_index_recovery.py
+++ b/tests/storage/test_local_adapter_index_recovery.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for #1381.
+
+A local vectordb collection can be persisted with store content but no usable
+index (the ``index/`` directory emptied, or an index subdir whose
+``index_meta.json`` was lost/corrupted). ``PersistCollection._recover()`` only
+restores indexes that still carry valid on-disk metadata, so such dirty states
+used to leave the collection with no searchable index: ``add_resource`` and
+``reindex`` reported success, yet ``search``/``find`` silently returned 0.
+
+``LocalCollectionAdapter`` now rebuilds the missing default index from the store
+on load, restoring searchability.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from openviking.storage.vectordb_adapters.local_adapter import LocalCollectionAdapter
+
+COLLECTION_NAME = "context"
+INDEX_NAME = "default"
+SCHEMA = {
+    "CollectionName": COLLECTION_NAME,
+    "Fields": [
+        {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+        {"FieldName": "uri", "FieldType": "string"},
+        {"FieldName": "vector", "FieldType": "vector", "Dim": 4},
+    ],
+}
+VECTOR = [0.1, 0.2, 0.3, 0.4]
+
+
+def _new_adapter(project_path: str) -> LocalCollectionAdapter:
+    return LocalCollectionAdapter(
+        collection_name=COLLECTION_NAME,
+        project_path=project_path,
+        index_name=INDEX_NAME,
+    )
+
+
+class TestLocalAdapterIndexRecovery(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="ov1381-")
+        self.project_path = os.path.join(self.tmp, "vectordb")
+        self.collection_path = os.path.join(self.project_path, COLLECTION_NAME)
+        self.index_dir = os.path.join(self.collection_path, "index")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _seed_collection(self):
+        adapter = _new_adapter(self.project_path)
+        adapter.create_collection(
+            COLLECTION_NAME,
+            SCHEMA,
+            distance="cosine",
+            sparse_weight=0.0,
+            index_name=INDEX_NAME,
+        )
+        adapter.upsert({"id": "a", "uri": "viking://resources/demo", "vector": VECTOR})
+        # Sanity: data is searchable before we corrupt anything.
+        results = adapter.query(query_vector=VECTOR, limit=10)
+        self.assertEqual(len(results), 1)
+        adapter.close()
+
+    def _query_after_reload(self) -> int:
+        adapter = _new_adapter(self.project_path)
+        try:
+            return len(adapter.query(query_vector=VECTOR, limit=10))
+        finally:
+            adapter.close()
+
+    def test_recovers_when_index_dir_emptied(self):
+        """index/ wiped entirely -> rebuilt from store on load."""
+        self._seed_collection()
+        for entry in os.listdir(self.index_dir):
+            path = os.path.join(self.index_dir, entry)
+            shutil.rmtree(path) if os.path.isdir(path) else os.remove(path)
+        self.assertEqual(os.listdir(self.index_dir), [])
+
+        self.assertEqual(self._query_after_reload(), 1)
+
+    def test_recovers_when_index_meta_missing(self):
+        """index/<name>/ survives but index_meta.json lost -> rebuilt from store."""
+        self._seed_collection()
+        meta_path = os.path.join(self.index_dir, INDEX_NAME, "index_meta.json")
+        self.assertTrue(os.path.exists(meta_path))
+        os.remove(meta_path)
+
+        self.assertEqual(self._query_after_reload(), 1)
+
+    def test_healthy_collection_still_loads(self):
+        """A clean persisted collection keeps working across reloads."""
+        self._seed_collection()
+        self.assertEqual(self._query_after_reload(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary / 概述

Fixes #1381.

A local `vectordb` collection can be persisted with store content but **no usable index** — the `index/` directory was emptied, or an index subdir survived while its `index_meta.json` was lost/corrupted. `PersistCollection._recover()` only restores indexes that still carry valid on-disk metadata, so it silently skips these dirty states. The collection then loads with no searchable index, and because `search_by_vector` returns an empty result for a missing index name, `add_resource`/`reindex` report success while `search`/`find` return `total=0`.

本地 `vectordb` collection 可能已持久化 store 数据但**没有可用索引**——`index/` 目录被清空，或索引子目录尚在但其 `index_meta.json` 丢失/损坏。`PersistCollection._recover()` 只恢复仍带有效磁盘元数据的索引，因此会静默跳过这类脏状态。collection 加载后没有任何可搜索索引，而 `search_by_vector` 对缺失的索引名直接返回空结果，于是 `add_resource`/`reindex` 报告成功，`search`/`find` 却返回 `total=0`。

## Root cause / 根因

- `openviking/storage/vectordb/collection/local_collection.py` — `_recover()` iterates only existing `index/<name>/` subdirs and skips any whose `index_meta.json` is missing; it never rebuilds from the store. / `_recover()` 仅遍历已存在的 `index/<name>/` 子目录，对缺失 `index_meta.json` 的索引跳过，从不从 store 重建。
- `search_by_vector` returns an empty `SearchResult` when the index name is absent — hence the silent `total=0`. / 索引名不存在时 `search_by_vector` 返回空结果——这就是静默的 `total=0`。
- Data written while no index exists never enters the delta log (`upsert_data` sets `need_record_delta=False` when there are zero indexes), so only a full candidate-table scan (`create_index` → `get_all_cands_data`) can recover it; delta replay cannot. / 在无索引期间写入的数据从不进入 delta log（无索引时 `upsert_data` 将 `need_record_delta=False`），因此只有全量扫描候选表（`create_index` → `get_all_cands_data`）能恢复，delta 回放无效。

## Fix / 修复

`LocalCollectionAdapter._recover_missing_default_index()` rebuilds the missing default index from the store on load. It acts only when the configured index is absent, reuses the same default index meta as collection creation, and threads `distance`/`sparse_weight` from config so the rebuilt metric matches the original. Healthy collections are untouched.

`LocalCollectionAdapter._recover_missing_default_index()` 在加载时从 store 重建缺失的默认索引。仅当配置的索引不存在时才动作，复用与创建 collection 一致的默认索引 meta，并从 config 透传 `distance`/`sparse_weight` 以保证重建后的度量一致。健康的 collection 不受影响。

## Tests / 测试

`tests/storage/test_local_adapter_index_recovery.py` reproduces both dirty states (emptied `index/`, and a surviving subdir with missing `index_meta.json`) plus a healthy-reload control. All three fail before the fix (search returns 0) and pass after. / 覆盖两种脏状态（清空 `index/`；子目录尚在但 `index_meta.json` 缺失）及健康重载对照。修复前三者中的两个脏状态用例失败（search 返回 0），修复后全部通过。

```
pytest tests/storage/test_local_adapter_index_recovery.py -v
```

> Note: this repo currently has unrelated pre-existing test failures (e.g. `tests/storage/test_collection_schemas.py` embedding-handler tests fail on a clean `origin/main` due to a `_DummyEmbedder` mock missing `prepare_embedding_input`). They are not touched by this change. / 注：本仓库当前在干净 `origin/main` 上即存在与本改动无关的预存测试失败（如 `test_collection_schemas.py` 的 embedding-handler 用例因 `_DummyEmbedder` mock 缺 `prepare_embedding_input` 而失败），本 PR 不涉及。