### PR TITLE
fix(session): self-heal stale live messages from a lost commit clear / 自愈 commit 清空丢失导致的残留 live 消息

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -416,11 +416,13 @@ class Session:
             pass
 
         # Load .meta.json
+        meta_loaded = False
         try:
             meta_content = await self._viking_fs.read_file(
                 f"{self._session_uri}/.meta.json", ctx=self.ctx
             )
             self._meta = SessionMeta.from_dict(json.loads(meta_content))
+            meta_loaded = True
         except Exception:
             # Old session without meta — derive from existing data
             self._meta.message_count = len(self._messages)
@@ -431,6 +433,15 @@ class Session:
             self._meta.created_by_account_id = self.ctx.account_id
         if not self._meta.created_by_user_id:
             self._meta.created_by_user_id = self.ctx.user.user_id
+        # Self-heal a lost commit clear: if a commit persisted .meta.json (and the
+        # archive .done marker) but the live messages.jsonl clear never reached
+        # disk, load() would read the already-archived messages back as live and
+        # re-insert them as active context (#1487). Since add_message keeps
+        # .meta.json's message_count in lockstep with messages.jsonl, a loaded
+        # message count that exceeds the committed message_count means the clear
+        # was lost; trust the committed count and drop the stale leading prefix.
+        if meta_loaded:
+            await self._reconcile_stale_live_messages()
         # WM v2: always rebuild pending_tokens from current messages so the
         # counter stays consistent across restarts and is also backfilled for
         # legacy sessions whose .meta.json predates these fields. O(n) once,
@@ -438,6 +449,41 @@ class Session:
         self._rebuild_pending_tokens()
 
         self._loaded = True
+
+    async def _reconcile_stale_live_messages(self) -> None:
+        """Drop archived messages that a lost commit clear left in messages.jsonl.
+
+        ``commit_async`` clears the live ``messages.jsonl`` and persists the new
+        (lower) ``message_count`` to ``.meta.json``. If that clear is lost while
+        ``.meta.json`` lands, ``load()`` reads the archived tail back as live
+        messages. ``add_message`` keeps ``message_count`` equal to the
+        ``messages.jsonl`` line count, so ``len(self._messages) > message_count``
+        on load is the signature of that lost clear. Recover by keeping only the
+        most recent ``message_count`` messages (the retained tail) and rewriting
+        ``messages.jsonl`` so the heal survives the next restart.
+        """
+        committed_count = int(self._meta.message_count or 0)
+        if committed_count < 0 or len(self._messages) <= committed_count:
+            return
+
+        stale_count = len(self._messages) - committed_count
+        self._messages = self._messages[stale_count:] if committed_count else []
+        logger.warning(
+            "Session %s: dropped %d stale live message(s) from a lost commit clear "
+            "(messages.jsonl exceeded committed message_count=%d)",
+            self.session_id,
+            stale_count,
+            committed_count,
+        )
+        try:
+            await self._write_to_agfs_async(messages=self._messages)
+        except Exception as e:
+            logger.error(
+                "Session %s: failed to rewrite messages.jsonl during stale-message "
+                "reconciliation: %s",
+                self.session_id,
+                e,
+            )
 
     def _rebuild_pending_tokens(self) -> None:
         """Recompute ``pending_tokens`` from the current message list.

--- a/tests/session/test_session_stale_message_recovery.py
+++ b/tests/session/test_session_stale_message_recovery.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for #1487.
+
+``commit_async`` clears the live ``messages.jsonl`` and persists the new
+(lower) ``message_count`` to ``.meta.json``. If that clear is lost while
+``.meta.json`` and the archive ``.done`` marker land on disk, ``load()`` used
+to read the already-archived messages back as live messages and re-insert them
+as active context.
+
+``Session.load()`` now reconciles this on load: since ``add_message`` keeps
+``.meta.json``'s ``message_count`` in lockstep with the ``messages.jsonl`` line
+count, a loaded message count that exceeds the committed ``message_count`` is
+the signature of a lost clear, and the stale leading prefix is dropped.
+
+These tests drive a real ``Session`` against a minimal in-memory filesystem, so
+they exercise the actual ``load()`` path without the AGFS subprocess or an LLM.
+"""
+
+import json
+
+import pytest
+
+from openviking.message import TextPart
+from openviking.session import Session
+
+
+class FakeVikingFS:
+    """Minimal in-memory VikingFS covering the methods load()/reconcile use."""
+
+    def __init__(self):
+        self.files: dict[str, str] = {}
+
+    async def read_file(self, uri, offset=0, limit=-1, ctx=None):
+        if uri not in self.files:
+            raise FileNotFoundError(uri)
+        return self.files[uri]
+
+    async def write_file(self, uri, content, ctx=None):
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+        self.files[uri] = content
+
+    async def ls(self, uri, ctx=None):
+        base = uri.rstrip("/")
+        names = set()
+        for f in self.files:
+            if f.startswith(base + "/"):
+                names.add(f[len(base) + 1 :].split("/")[0])
+        return [{"name": n} for n in sorted(names)]
+
+
+def _msg_line(idx: int, role: str, text: str) -> str:
+    from openviking.message import Message
+
+    return Message(id=f"m{idx}", role=role, parts=[TextPart(text)]).to_jsonl()
+
+
+def _seed(fs: FakeVikingFS, session_uri: str, jsonl_messages, message_count):
+    """Persist a session state directly: messages.jsonl + .meta.json."""
+    content = "".join(_msg_line(i, r, t) + "\n" for i, (r, t) in enumerate(jsonl_messages))
+    fs.files[f"{session_uri}/messages.jsonl"] = content
+    fs.files[f"{session_uri}/.meta.json"] = json.dumps(
+        {"session_id": "s1487", "message_count": message_count, "last_commit_at": "t0"}
+    )
+
+
+class TestStaleLiveMessageReconciliation:
+    def _session(self, fs):
+        return Session(viking_fs=fs, session_id="s1487")
+
+    async def test_lost_clear_drops_all_stale_messages(self):
+        """keep=0 commit: message_count=0 but jsonl still holds archived rows."""
+        fs = FakeVikingFS()
+        uri = Session(viking_fs=fs, session_id="s1487")._session_uri
+        _seed(
+            fs,
+            uri,
+            [("user", "old A"), ("assistant", "old B")],
+            message_count=0,  # committed clear says zero live messages
+        )
+
+        s = self._session(fs)
+        await s.load()
+
+        assert len(s.messages) == 0
+        # messages.jsonl is rewritten so the heal survives a restart.
+        assert fs.files[f"{uri}/messages.jsonl"].strip() == ""
+
+    async def test_lost_clear_keeps_retained_tail(self):
+        """keep>0 commit: message_count=1 but jsonl holds archived prefix + tail."""
+        fs = FakeVikingFS()
+        uri = Session(viking_fs=fs, session_id="s1487")._session_uri
+        _seed(
+            fs,
+            uri,
+            [("user", "old A"), ("assistant", "old B"), ("user", "kept tail")],
+            message_count=1,  # only the last message should remain live
+        )
+
+        s = self._session(fs)
+        await s.load()
+
+        assert [m.content for m in s.messages] == ["kept tail"]
+        # Disk healed to exactly the retained tail.
+        reloaded = self._session(fs)
+        await reloaded.load()
+        assert [m.content for m in reloaded.messages] == ["kept tail"]
+
+    async def test_consistent_state_is_untouched(self):
+        """Normal case: message_count matches jsonl line count -> no change."""
+        fs = FakeVikingFS()
+        uri = Session(viking_fs=fs, session_id="s1487")._session_uri
+        _seed(
+            fs,
+            uri,
+            [("user", "live one"), ("assistant", "live two")],
+            message_count=2,
+        )
+        before = fs.files[f"{uri}/messages.jsonl"]
+
+        s = self._session(fs)
+        await s.load()
+
+        assert [m.content for m in s.messages] == ["live one", "live two"]
+        # No spurious rewrite of messages.jsonl.
+        assert fs.files[f"{uri}/messages.jsonl"] == before
+
+    async def test_legacy_session_without_meta_is_untouched(self):
+        """No .meta.json (legacy): reconciliation must not run."""
+        fs = FakeVikingFS()
+        uri = Session(viking_fs=fs, session_id="s1487")._session_uri
+        fs.files[f"{uri}/messages.jsonl"] = (
+            _msg_line(0, "user", "legacy one")
+            + "\n"
+            + _msg_line(1, "assistant", "legacy two")
+            + "\n"
+        )
+
+        s = self._session(fs)
+        await s.load()
+
+        assert [m.content for m in s.messages] == ["legacy one", "legacy two"]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary / 概述

Fixes #1487.

`commit_async` clears the live `messages.jsonl` and persists the new (lower) `message_count` to `.meta.json`. As the issue reports, the "live empty" write **sometimes does not actually reach disk**, while the archive `.done` marker and `.meta.json` do. On the next `load()` the already-archived messages are read back as **live** messages and re-inserted as active context. Archive completion was judged solely by `.done`, never cross-checking that the root `messages.jsonl` was actually cleared.

`commit_async` 会清空 live 的 `messages.jsonl` 并把新的（更小的）`message_count` 持久化到 `.meta.json`。如 issue 所述，"清空 live"的写**有时并未真正落盘**，而 archive 的 `.done` 与 `.meta.json` 却落了盘。于是下次 `load()` 把已归档的消息当作 **live** 重新读入并作为活跃上下文重复插入。此前 archive 完成仅以 `.done` 判定，从不交叉校验 root `messages.jsonl` 是否真的已清空。

## Root cause / 根因

- `openviking/session/session.py` `load()` reads active messages straight from `messages.jsonl` and trusts it. / `load()` 直接从 `messages.jsonl` 读活跃消息并完全信任它。
- `_get_completed_archive_refs()` judges completion by `.done` alone, with no consistency check against the live state. / `_get_completed_archive_refs()` 仅凭 `.done` 判完成，不校验 live 状态一致性。
- `_collect_session_context_components()` then merges these stale live messages into the active set returned to `/context`. / 随后 `_collect_session_context_components()` 把这些残留 live 消息合并进返回给 `/context` 的活跃集合。

## Fix / 修复

`add_message` keeps `.meta.json`'s `message_count` in lockstep with the `messages.jsonl` line count (`_append_messages` → `_save_meta_sync`). So on load, `len(messages) > committed message_count` is the **unambiguous signature** of a lost clear. `load()` now reconciles this in `_reconcile_stale_live_messages()`: it trusts the committed `message_count`, drops the stale leading prefix, keeps only the retained tail, and rewrites `messages.jsonl` so the heal survives the next restart.

由于 `add_message` 始终让 `.meta.json` 的 `message_count` 与 `messages.jsonl` 行数一致（`_append_messages` → `_save_meta_sync`），加载时 `len(messages) > 已提交的 message_count` 就是"清空丢失"的**明确信号**。`load()` 现在通过 `_reconcile_stale_live_messages()` 自愈：信任已提交的 `message_count`，丢弃残留前缀，仅保留应保留的尾部，并重写 `messages.jsonl` 使修复在下次重启后依然有效。

Safety / 安全性:
- Consistent states (`len == message_count`) are untouched — no spurious rewrite. / 一致状态不受影响，不会无谓重写。
- Legacy sessions without `.meta.json` skip reconciliation entirely. / 没有 `.meta.json` 的旧 session 完全跳过。
- Only ever trims a stale **prefix** when the live file has **more** messages than committed; never deletes legitimately-added post-commit messages. / 仅在 live 文件比已提交**多**时裁剪残留**前缀**，绝不删除 commit 后合法新增的消息。

## Tests / 测试

`tests/session/test_session_stale_message_recovery.py` drives a real `Session` against a minimal in-memory filesystem (no AGFS subprocess, no LLM), covering:
- lost clear with `keep=0` → all stale messages dropped, `messages.jsonl` healed;
- lost clear with `keep>0` → only the retained tail survives, heal persists across reload;
- consistent state → untouched;
- legacy session without `.meta.json` → untouched.

The bug-heal cases fail before the fix and pass after.

`tests/session/test_session_stale_message_recovery.py` 用真实 `Session` + 极简内存文件系统（无 AGFS 子进程、无 LLM）覆盖：keep=0 清空丢失→残留全清且 `messages.jsonl` 修复；keep>0 清空丢失→仅保留尾部且修复跨重载持久；一致状态→不变；无 `.meta.json` 的旧 session→不变。bug-heal 用例在修复前失败、修复后通过。

## Honest caveat / 诚实说明

The underlying lost write is a durability/timing condition (the reporter's MRE is empty, wording is "sometimes"). It **cannot be reproduced deterministically** in a unit test. This PR therefore lands a **defensive, idempotent consistency check + self-heal** that addresses the observable consequence (stale messages re-activated on load) rather than the unobservable physical write loss. The reconciliation is a no-op on healthy sessions, so the blast radius is minimal.

底层"写丢失"是持久化/时序条件（报告者的 MRE 为空、用词是"sometimes"），**无法在单测中稳定复现**。因此本 PR 落地的是**防御性、幂等的一致性校验 + 自愈**，针对可观测的后果（加载时残留消息被重新激活），而非不可观测的物理写丢失。该校验对健康 session 是 no-op，影响面最小。