### PR TITLE
feat(rerank): add TEI provider

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -809,7 +809,7 @@ The `PermissionDeniedError` message names the exact key to add for the blocked h
 
 ### rerank
 
-Reranking model for search result refinement. Supports VikingDB (Volcengine), Cohere, and OpenAI-compatible APIs.
+Reranking model for search result refinement. Supports VikingDB (Volcengine), Cohere, OpenAI-compatible APIs, LiteLLM, and Hugging Face Text Embeddings Inference (TEI).
 
 **Volcengine (VikingDB):**
 
@@ -839,24 +839,42 @@ Reranking model for search result refinement. Supports VikingDB (Volcengine), Co
 }
 ```
 
+**Hugging Face Text Embeddings Inference (TEI):**
+
+```json
+{
+  "rerank": {
+    "provider": "tei",
+    "api_base": "http://localhost:8080",
+    "api_key": "optional-tei-api-key",
+    "model": "BAAI/bge-reranker-v2-m3",
+    "threshold": 0.05
+  }
+}
+```
+
+For TEI, `api_base` may be either the server base URL (`http://localhost:8080`) or the full rerank endpoint (`http://localhost:8080/rerank`). `api_key` is optional and is sent as a Bearer token when configured. TEI is auto-detected when only `api_base` is set; if your TEI deployment also uses `api_key`, set `"provider": "tei"` explicitly so it is not treated as an OpenAI-compatible rerank endpoint.
+
 **Parameters**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `provider` | str | `"vikingdb"`, `"cohere"`, or `"openai"`. Auto-detected if omitted. |
+| `provider` | str | `"vikingdb"`, `"cohere"`, `"openai"`, `"litellm"`, or `"tei"`. Auto-detected if omitted. |
 | `ak` | str | VikingDB Access Key (vikingdb provider only) |
 | `sk` | str | VikingDB Secret Key (vikingdb provider only) |
 | `model_name` | str | Model name (vikingdb provider only, default: `doubao-seed-rerank`) |
-| `api_key` | str | API key (for `openai` or `cohere` providers) |
-| `api_base` | str | Endpoint URL (for `openai` provider) |
-| `model` | str | Model name (for `openai` providers) |
+| `api_key` | str | API key (for `openai` or `cohere` providers, optional for `tei`) |
+| `api_base` | str | Endpoint URL (for `openai` provider) or TEI base/rerank URL (for `tei`) |
+| `model` | str | Model name (for `openai` and `litellm`; optional label for TEI usage tracking) |
 | `threshold` | float | Score threshold between `0.0` and `1.0`; results below this are filtered out. Default: `0.1` |
-| `extra_headers` | object | Custom HTTP headers (for OpenAI-compatible providers, optional) |
+| `extra_headers` | object | Custom HTTP headers (for OpenAI-compatible or TEI providers, optional) |
 
 **Supported providers:**
 - `vikingdb`: Volcengine VikingDB Rerank API (uses AK/SK)
 - `cohere`: Cohere Rerank API
 - `openai`: OpenAI-compatible Rerank API
+- `litellm`: LiteLLM rerank API
+- `tei`: Hugging Face Text Embeddings Inference rerank API
 
 If rerank is not configured, search uses vector similarity only.
 

--- a/openviking/models/rerank/__init__.py
+++ b/openviking/models/rerank/__init__.py
@@ -8,12 +8,14 @@ Provides rerank functionality for hierarchical retrieval with multiple provider 
 - cohere: Cohere Rerank v3.5 API
 - litellm: LiteLLM rerank (supports multiple providers)
 - openai: OpenAI-compatible rerank API
+- tei: Hugging Face Text Embeddings Inference rerank API
 """
 
 from openviking.models.rerank.base import RerankBase
 from openviking.models.rerank.cohere_rerank import CohereRerankClient
 from openviking.models.rerank.litellm_rerank import LiteLLMRerankClient
 from openviking.models.rerank.openai_rerank import OpenAIRerankClient
+from openviking.models.rerank.tei_rerank import TEIRerankClient
 from openviking.models.rerank.volcengine_rerank import RerankClient
 
 __all__ = [
@@ -22,4 +24,5 @@ __all__ = [
     "CohereRerankClient",
     "LiteLLMRerankClient",
     "OpenAIRerankClient",
+    "TEIRerankClient",
 ]

--- a/openviking/models/rerank/tei_rerank.py
+++ b/openviking/models/rerank/tei_rerank.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Text Embeddings Inference rerank API client.
+
+Hugging Face Text Embeddings Inference (TEI) exposes rerank models through a
+provider-specific `/rerank` endpoint. Its request/response shape differs from
+OpenAI-compatible rerank APIs, so it needs a dedicated adapter.
+"""
+
+import time
+from typing import Dict, List, Optional
+
+import requests
+
+from openviking.models.rerank.base import RerankBase
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class TEIRerankClient(RerankBase):
+    """
+    TEI rerank API client.
+
+    TEI accepts `texts` and returns a list of `{index, score}` items:
+    https://huggingface.co/docs/text-embeddings-inference
+    """
+
+    def __init__(
+        self,
+        api_base: str,
+        api_key: Optional[str] = None,
+        model_name: Optional[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Initialize TEI rerank client.
+
+        Args:
+            api_base: TEI base URL (`http://host:port`) or full rerank endpoint.
+            api_key: Optional Bearer token for TEI deployments that enforce auth.
+            model_name: Optional model name used for usage tracking.
+            extra_headers: Optional extra headers for API requests.
+        """
+        super().__init__()
+        self.api_base = api_base
+        self.api_key = api_key
+        self.model_name = model_name
+        self.extra_headers = extra_headers or {}
+        self.provider = "tei"
+
+    @property
+    def rerank_url(self) -> str:
+        """Return the full TEI rerank URL while accepting base or endpoint config."""
+        base = self.api_base.rstrip("/")
+        if base.endswith("/rerank"):
+            return base
+        return f"{base}/rerank"
+
+    def rerank_batch(self, query: str, documents: List[str]) -> Optional[List[float]]:
+        """
+        Batch rerank documents against a query.
+
+        Args:
+            query: Query text
+            documents: List of document texts to rank
+
+        Returns:
+            List of rerank scores in the same order as input documents, or None
+            when rerank fails and the caller should fall back.
+        """
+        if not documents:
+            return []
+
+        req_body = {
+            "query": query,
+            "texts": documents,
+            "raw_scores": False,
+        }
+
+        try:
+            headers = {"Content-Type": "application/json"}
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            if self.extra_headers:
+                headers.update(self.extra_headers)
+
+            started = time.monotonic()
+            response = requests.post(
+                url=self.rerank_url,
+                headers=headers,
+                json=req_body,
+                timeout=30,
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            self._extract_and_update_token_usage(
+                {"results": result} if isinstance(result, list) else result,
+                query,
+                documents,
+                duration_seconds=time.monotonic() - started,
+            )
+
+            results = self._extract_results(result)
+            if not results:
+                logger.warning(f"[TEIRerankClient] Unexpected response format: {result}")
+                return None
+
+            scores = [0.0] * len(documents)
+            for item in results:
+                idx = item.get("index")
+                if idx is None or not (0 <= idx < len(documents)):
+                    logger.warning(
+                        "[TEIRerankClient] Out-of-bounds or missing index in result: %s", item
+                    )
+                    return None
+                scores[idx] = float(item.get("score", item.get("relevance_score", 0.0)))
+
+            logger.debug(f"[TEIRerankClient] Reranked {len(documents)} documents")
+            return scores
+
+        except Exception as e:
+            logger.error(f"[TEIRerankClient] Rerank failed: {e}")
+            return None
+
+    @staticmethod
+    def _extract_results(result) -> Optional[List[dict]]:
+        """Extract TEI rerank rows from supported response shapes."""
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            rows = result.get("results")
+            if isinstance(rows, list):
+                return rows
+        return None
+
+    @classmethod
+    def from_config(cls, config) -> Optional["TEIRerankClient"]:
+        """
+        Create TEIRerankClient from RerankConfig.
+
+        Args:
+            config: RerankConfig instance with provider='tei'
+
+        Returns:
+            TEIRerankClient instance or None if config is not available
+        """
+        if not config or not config.is_available():
+            return None
+        return cls(
+            api_base=config.api_base,
+            api_key=config.api_key,
+            model_name=config.model,
+            extra_headers=config.extra_headers,
+        )

--- a/openviking/models/rerank/volcengine_rerank.py
+++ b/openviking/models/rerank/volcengine_rerank.py
@@ -219,6 +219,11 @@ class RerankClient(RerankBase):
 
             return OpenAIRerankClient.from_config(config)
 
+        if provider == "tei":
+            from openviking.models.rerank.tei_rerank import TEIRerankClient
+
+            return TEIRerankClient.from_config(config)
+
         return cls(
             ak=config.ak,
             sk=config.sk,

--- a/openviking_cli/utils/config/rerank_config.py
+++ b/openviking_cli/utils/config/rerank_config.py
@@ -6,11 +6,11 @@ from pydantic import BaseModel, Field, model_validator
 
 
 class RerankConfig(BaseModel):
-    """Configuration for rerank API. Supports VikingDB, Cohere, OpenAI-compatible, and LiteLLM providers."""
+    """Configuration for rerank API. Supports VikingDB, Cohere, OpenAI-compatible, LiteLLM, and TEI providers."""
 
     provider: Optional[str] = Field(
         default=None,
-        description="Rerank provider: 'vikingdb', 'cohere', 'openai', or 'litellm'. Auto-detected from config if omitted.",
+        description="Rerank provider: 'vikingdb', 'cohere', 'openai', 'litellm', or 'tei'. Auto-detected from config if omitted.",
     )
 
     # VikingDB fields
@@ -22,18 +22,18 @@ class RerankConfig(BaseModel):
     model_name: str = Field(default="doubao-seed-rerank", description="Rerank model name")
     model_version: str = Field(default="251028", description="Rerank model version")
 
-    # Shared / OpenAI-compatible / Cohere fields
+    # Shared / OpenAI-compatible / Cohere / TEI fields
     api_key: Optional[str] = Field(
-        default=None, description="API key (Cohere Bearer token or OpenAI-compatible providers)"
+        default=None,
+        description="API key (Cohere Bearer token, OpenAI-compatible providers, or optional TEI auth)",
     )
     api_base: Optional[str] = Field(default=None, description="Custom endpoint URL")
     model: Optional[str] = Field(
-        default=None, description="Model name for OpenAI-compatible or LiteLLM providers"
+        default=None, description="Model name for OpenAI-compatible, LiteLLM, or TEI providers"
     )
 
     extra_headers: Optional[Dict[str, str]] = Field(
-        default=None,
-        description="Extra HTTP headers for OpenAI-compatible providers"
+        default=None, description="Extra HTTP headers for OpenAI-compatible or TEI providers"
     )
 
     threshold: float = Field(
@@ -52,14 +52,16 @@ class RerankConfig(BaseModel):
             return "cohere"
         if self.ak and self.sk:
             return "vikingdb"
+        if self.api_base:
+            return "tei"
         return None
 
     @model_validator(mode="after")
     def validate_provider_fields(self) -> "RerankConfig":
         provider = self._effective_provider()
-        if provider and provider not in ["vikingdb", "cohere", "openai", "litellm"]:
+        if provider and provider not in ["vikingdb", "cohere", "openai", "litellm", "tei"]:
             raise ValueError(
-                f"Rerank provider must be one of ['vikingdb', 'cohere', 'openai', 'litellm'], got '{provider}'"
+                f"Rerank provider must be one of ['vikingdb', 'cohere', 'openai', 'litellm', 'tei'], got '{provider}'"
             )
         if provider == "openai":
             if not self.api_key or not self.api_base:
@@ -69,6 +71,9 @@ class RerankConfig(BaseModel):
         if provider == "litellm":
             if not self.model:
                 raise ValueError("LiteLLM rerank provider requires 'model'")
+        if provider == "tei":
+            if not self.api_base:
+                raise ValueError("TEI rerank provider requires 'api_base'")
         return self
 
     def is_available(self) -> bool:
@@ -80,6 +85,8 @@ class RerankConfig(BaseModel):
             return self.api_key is not None and self.api_base is not None
         if p == "litellm":
             return self.model is not None
+        if p == "tei":
+            return self.api_base is not None
         if p == "vikingdb":
             return self.ak is not None and self.sk is not None
         return False

--- a/tests/misc/test_rerank_openai.py
+++ b/tests/misc/test_rerank_openai.py
@@ -251,10 +251,11 @@ class TestRerankConfig:
         with pytest.raises(ValidationError):
             RerankConfig(provider="openai", api_base="https://example.com/rerank")
 
-    def test_default_provider_is_vikingdb(self):
+    def test_default_provider_is_auto_detected(self):
         config = RerankConfig()
-        assert config.provider == "vikingdb"
+        assert config.provider is None
+        assert config._effective_provider() is None
 
     def test_unknown_provider_raises_value_error(self):
-        with pytest.raises(ValueError, match="provider"):
-            RerankConfig(provider="cohere", ak="ak", sk="sk")
+        with pytest.raises(ValidationError, match="provider"):
+            RerankConfig(provider="unknown")

--- a/tests/unit/test_tei_rerank.py
+++ b/tests/unit/test_tei_rerank.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for Hugging Face Text Embeddings Inference rerank client."""
+
+from unittest.mock import MagicMock, patch
+
+from openviking.models.rerank import RerankClient, TEIRerankClient
+from openviking_cli.utils.config.rerank_config import RerankConfig
+
+
+class TestTEIRerankClient:
+    """Test cases for TEIRerankClient."""
+
+    @patch("openviking.models.rerank.tei_rerank.requests.post")
+    def test_rerank_batch_basic(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {"index": 1, "score": 0.95},
+            {"index": 0, "score": 0.42},
+            {"index": 2, "score": 0.10},
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = TEIRerankClient(
+            api_base="http://tei.local:8080",
+            api_key="test-key",
+            model_name="BAAI/bge-reranker-v2-m3",
+        )
+        scores = client.rerank_batch("What is UCW?", ["doc A", "doc B", "doc C"])
+
+        assert scores == [0.42, 0.95, 0.10]
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["url"] == "http://tei.local:8080/rerank"
+        assert kwargs["headers"]["Authorization"] == "Bearer test-key"
+        assert kwargs["json"] == {
+            "query": "What is UCW?",
+            "texts": ["doc A", "doc B", "doc C"],
+            "raw_scores": False,
+        }
+
+    @patch("openviking.models.rerank.tei_rerank.requests.post")
+    def test_rerank_batch_accepts_full_endpoint(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = [{"index": 0, "score": 0.9}]
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = TEIRerankClient(api_base="http://tei.local:8080/rerank")
+        assert client.rerank_batch("q", ["doc"]) == [0.9]
+        assert mock_post.call_args.kwargs["url"] == "http://tei.local:8080/rerank"
+        assert "Authorization" not in mock_post.call_args.kwargs["headers"]
+
+    @patch("openviking.models.rerank.tei_rerank.requests.post")
+    def test_rerank_batch_fills_missing_top_n_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = [{"index": 2, "score": 0.99}]
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = TEIRerankClient(api_base="http://tei.local:8080")
+        assert client.rerank_batch("q", ["first", "second", "third"]) == [0.0, 0.0, 0.99]
+
+    @patch("openviking.models.rerank.tei_rerank.requests.post")
+    def test_rerank_batch_supports_results_wrapper(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"index": 0, "relevance_score": 0.7},
+                {"index": 1, "relevance_score": 0.2},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = TEIRerankClient(api_base="http://tei.local:8080")
+        assert client.rerank_batch("q", ["first", "second"]) == [0.7, 0.2]
+
+    @patch("openviking.models.rerank.tei_rerank.requests.post")
+    def test_rerank_batch_invalid_index_returns_none(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = [{"index": 10, "score": 0.99}]
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = TEIRerankClient(api_base="http://tei.local:8080")
+        assert client.rerank_batch("q", ["doc"]) is None
+
+    @patch("openviking.models.rerank.tei_rerank.requests.post")
+    def test_rerank_batch_api_error_returns_none(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = RuntimeError("boom")
+        mock_post.return_value = mock_response
+
+        client = TEIRerankClient(api_base="http://tei.local:8080")
+        assert client.rerank_batch("q", ["doc"]) is None
+
+    def test_rerank_batch_empty(self):
+        client = TEIRerankClient(api_base="http://tei.local:8080")
+        assert client.rerank_batch("query", []) == []
+
+
+class TestTEIRerankConfig:
+    """Test TEI rerank config parsing and dispatch."""
+
+    def test_config_requires_api_base(self):
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RerankConfig(provider="tei")
+
+    def test_config_available_without_api_key(self):
+        config = RerankConfig(provider="tei", api_base="http://tei.local:8080")
+
+        assert config._effective_provider() == "tei"
+        assert config.is_available() is True
+
+    def test_config_auto_detects_tei_without_api_key(self):
+        config = RerankConfig(api_base="http://tei.local:8080")
+
+        assert config._effective_provider() == "tei"
+        assert config.is_available() is True
+
+    def test_config_api_key_and_api_base_auto_detects_openai(self):
+        config = RerankConfig(api_key="key", api_base="https://example.com/rerank")
+
+        assert config._effective_provider() == "openai"
+        assert config.is_available() is True
+
+    def test_from_config_creates_tei_client(self):
+        config = RerankConfig(
+            provider="tei",
+            api_base="http://tei.local:8080",
+            api_key="key",
+            model="BAAI/bge-reranker-v2-m3",
+            extra_headers={"X-Test": "1"},
+        )
+
+        client = RerankClient.from_config(config)
+
+        assert isinstance(client, TEIRerankClient)
+        assert client.api_base == "http://tei.local:8080"
+        assert client.api_key == "key"
+        assert client.model_name == "BAAI/bge-reranker-v2-m3"
+        assert client.extra_headers == {"X-Test": "1"}


### PR DESCRIPTION
## Summary
- add a dedicated Hugging Face Text Embeddings Inference (TEI) rerank provider
- support TEI base URLs and full /rerank endpoint URLs, optional Bearer auth, extra headers, and optional model names
- document TEI rerank configuration and refresh stale rerank config tests for current auto-detect behavior

## Tests
- PYTHONPATH=. .venv/bin/python -m pytest -o addopts='' --confcutdir=tests/unit tests/unit/test_tei_rerank.py tests/unit/test_cohere_rerank.py tests/unit/models/rerank/test_openai_rerank_extra_headers.py tests/unit/config/test_rerank_extra_headers_config.py -q
- PYTHONPATH=. .venv/bin/python -m pytest -o addopts='' --confcutdir=tests/misc tests/misc/test_rerank_openai.py -q
- .venv/bin/python -m ruff check openviking/models/rerank/tei_rerank.py openviking/models/rerank/__init__.py openviking/models/rerank/volcengine_rerank.py openviking_cli/utils/config/rerank_config.py tests/unit/test_tei_rerank.py tests/misc/test_rerank_openai.py
- .venv/bin/python -m ruff format --check openviking/models/rerank/tei_rerank.py openviking/models/rerank/__init__.py openviking/models/rerank/volcengine_rerank.py openviking_cli/utils/config/rerank_config.py tests/unit/test_tei_rerank.py tests/misc/test_rerank_openai.py
- python3 -m compileall openviking/models/rerank openviking_cli/utils/config/rerank_config.py

## Smoke test
- Verified against a live TEI reranker using BAAI/bge-reranker-v2-m3: POST /rerank returns ordered scores through TEIRerankClient.