### PR TITLE
[codex] Simplify OpenClaw plugin text results

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -12,9 +12,15 @@ import { estimateTextTokens } from "./token-estimator.js";
 import type {
   RecallResourceType,
   RecallTraceEntry,
-  RecallTraceResult,
 } from "./recall-trace.js";
 import { resolveRecallSearchPlan } from "./recall-trace.js";
+import {
+  boundTraceQuery,
+  createTraceId,
+  inferRecallResourceType,
+  toTraceSelectedItem,
+  traceResultsFromFindResult,
+} from "./recall-trace-utils.js";
 
 const RECALL_QUERY_MAX_CHARS = 4_000;
 export const AUTO_RECALL_SOURCE_MARKER = "Source: openviking-auto-recall";
@@ -245,40 +251,8 @@ export function buildOpenVikingContextBlock(params: {
   ].join("\n");
 }
 
-function newTraceId(): string {
-  return `auto_recall_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function preview(value: string | undefined | null, maxChars: number): string | undefined {
-  const normalized = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
-  if (!normalized) {
-    return undefined;
-  }
-  return normalized.length > maxChars ? normalized.slice(0, maxChars) : normalized;
-}
-
 function traceResourceTypeForUri(uri: string | undefined): RecallResourceType {
-  if (uri?.startsWith("viking://resources")) return "resource";
-  if (uri?.startsWith("viking://session/") || uri?.includes("/sessions/")) return "session";
-  return "user";
-}
-
-function toTraceResults(items: FindResultItem[], resourceType: RecallResourceType): RecallTraceResult[] {
-  return items.map((item) => ({
-    uri: item.uri,
-    resourceType,
-    category: item.category,
-    score: item.score,
-    level: item.level,
-    abstractPreview: preview(item.abstract ?? item.overview, 240),
-    resultType: resourceType === "resource" ? "resource" : "memory",
-  }));
-}
-
-function boundTraceQuery(query: string, maxChars: number): { query: string; queryTruncated?: boolean } {
-  return query.length <= maxChars
-    ? { query }
-    : { query: query.slice(0, maxChars), queryTruncated: true };
+  return inferRecallResourceType(uri) ?? "user";
 }
 
 function runtimeFlag(runtimeContext: unknown, key: string): unknown {
@@ -578,8 +552,9 @@ export async function buildLongTermMemoryRecallContext(params: {
           const memories = result.memories ?? [];
           const resources = result.resources ?? [];
           allMemories.push(...memories, ...resources);
+          const resourceType = s.value.search.resourceType;
           traceSearches.push({
-            resourceType: s.value.search.resourceType,
+            resourceType,
             contextType: s.value.search.contextType,
             targetUriInput: s.value.search.targetUri,
             targetUriResolved: s.value.search.targetUri,
@@ -587,19 +562,10 @@ export async function buildLongTermMemoryRecallContext(params: {
             scoreThreshold: 0,
             durationMs: s.value.durationMs,
             total: result.total ?? memories.length + resources.length + (result.skills?.length ?? 0),
-            results: [
-              ...toTraceResults(memories, s.value.search.resourceType),
-              ...toTraceResults(resources, "resource"),
-              ...(result.skills ?? []).map((item): RecallTraceResult => ({
-                uri: item.uri,
-                resourceType: s.value.search.resourceType,
-                category: item.category,
-                score: item.score,
-                level: item.level,
-                abstractPreview: preview(item.abstract ?? item.overview, 240),
-                resultType: "skill",
-              })),
-            ].slice(0, cfg.traceRecallMaxResultsPerSearch),
+            results: traceResultsFromFindResult(result, 240, cfg.traceRecallMaxResultsPerSearch, {
+              memory: resourceType,
+              skill: resourceType,
+            }),
           });
         } else {
           logger.warn?.(`openviking: auto-recall search failed: ${String(s.reason)}`);
@@ -630,7 +596,7 @@ export async function buildLongTermMemoryRecallContext(params: {
       const recordTrace = (injectedMemories: FindResultItem[], injectedCount: number, estimatedTokens?: number) => {
         params.traceRecorder?.record({
           schemaVersion: "1.0",
-          traceId: newTraceId(),
+          traceId: createTraceId("auto_recall"),
           ts: Date.now(),
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
@@ -645,12 +611,8 @@ export async function buildLongTermMemoryRecallContext(params: {
             queryTruncated: params.queryTruncated || queryText.length > cfg.traceRecallQueryMaxChars,
           },
           searches: traceSearches,
-          selected: injectedMemories.map((memory) => ({
-            uri: memory.uri,
+          selected: injectedMemories.map((memory) => toTraceSelectedItem(memory, cfg.traceRecallPreviewChars, {
             resourceType: traceResourceTypeForUri(memory.uri),
-            category: memory.category,
-            score: memory.score,
-            abstractPreview: preview(memory.abstract ?? memory.overview, cfg.traceRecallPreviewChars),
             injected: true,
           })),
           stats: {

--- a/examples/openclaw-plugin/command-args.ts
+++ b/examples/openclaw-plugin/command-args.ts
@@ -1,0 +1,167 @@
+export type AddResourceToolInput = {
+  source?: string; to?: string; parent?: string; reason?: string;
+  instruction?: string; wait?: boolean; timeout?: number;
+};
+export type AddSkillToolInput = { source?: string; data?: unknown; wait?: boolean; timeout?: number };
+export type OVSearchInput = { query: string; uri?: string; limit?: number };
+type ParsedFlagArgs = { positionals: string[]; flags: Map<string, string | boolean> };
+
+export function tokenizeCommandArgs(args: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const ch = args[i]!;
+    const next = args[i + 1];
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\") {
+      const shouldEscape =
+        quote === '"'
+          ? next === '"' || next === "\\"
+          : !quote && Boolean(next && (/\s/.test(next) || next === '"' || next === "'"));
+      if (shouldEscape) {
+        escaping = true;
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+    if ((ch === '"' || ch === "'") && (!quote || quote === ch)) {
+      quote = quote ? null : ch;
+      continue;
+    }
+    if (!quote && /\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  if (quote) {
+    throw new Error("Unterminated quoted argument");
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+export function parseFlagArgs(args: string): ParsedFlagArgs {
+  const tokens = tokenizeCommandArgs(args);
+  const positionals: string[] = [];
+  const flags = new Map<string, string | boolean>();
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+    const raw = token.slice(2);
+    if (!raw) {
+      continue;
+    }
+    const eqIndex = raw.indexOf("=");
+    if (eqIndex >= 0) {
+      flags.set(raw.slice(0, eqIndex), raw.slice(eqIndex + 1));
+      continue;
+    }
+    const next = tokens[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags.set(raw, next);
+      i += 1;
+    } else {
+      flags.set(raw, true);
+    }
+  }
+
+  return { positionals, flags };
+}
+
+export function getStringFlag(flags: Map<string, string | boolean>, name: string): string | undefined {
+  const value = flags.get(name);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function getNumberFlag(flags: Map<string, string | boolean>, name: string): number | undefined {
+  const raw = getStringFlag(flags, name);
+  if (!raw) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`--${name} must be a number`);
+  }
+  return value;
+}
+
+export function getBoolFlag(flags: Map<string, string | boolean>, name: string): boolean {
+  return flags.get(name) === true;
+}
+
+export function parseAddResourceCommandArgs(args: string): AddResourceToolInput {
+  const parsed = parseFlagArgs(args);
+  const source = parsed.positionals.length <= 1
+    ? parsed.positionals[0]
+    : parsed.positionals.join(" ").trim();
+  if (!source) {
+    throw new Error("Usage: /add-resource <source> [--to URI] [--parent URI] [--reason TEXT] [--instruction TEXT] [--wait] [--timeout SEC]");
+  }
+  const to = getStringFlag(parsed.flags, "to");
+  const parent = getStringFlag(parsed.flags, "parent");
+  if (to && parent) {
+    throw new Error("Cannot specify both --to and --parent.");
+  }
+  return {
+    source,
+    to,
+    parent,
+    reason: getStringFlag(parsed.flags, "reason"),
+    instruction: getStringFlag(parsed.flags, "instruction"),
+    wait: getBoolFlag(parsed.flags, "wait"),
+    timeout: getNumberFlag(parsed.flags, "timeout"),
+  };
+}
+
+export function parseAddSkillCommandArgs(args: string): AddSkillToolInput {
+  const parsed = parseFlagArgs(args);
+  const source = parsed.positionals.length <= 1
+    ? parsed.positionals[0]
+    : parsed.positionals.join(" ").trim();
+  if (!source) {
+    throw new Error("Usage: /add-skill <source> [--wait] [--timeout SEC]");
+  }
+  if (parsed.flags.has("to") || parsed.flags.has("parent") || parsed.flags.has("reason") || parsed.flags.has("instruction")) {
+    throw new Error("--to, --parent, --reason, and --instruction are resource-only options.");
+  }
+  return {
+    source,
+    wait: getBoolFlag(parsed.flags, "wait"),
+    timeout: getNumberFlag(parsed.flags, "timeout"),
+  };
+}
+
+export function parseOVSearchCommandArgs(args: string): OVSearchInput {
+  const parsed = parseFlagArgs(args);
+  const query = parsed.positionals.join(" ").trim();
+  if (!query) {
+    throw new Error('Usage: /ov-search "<query>" [--uri URI] [--limit N]');
+  }
+  return {
+    query,
+    uri: getStringFlag(parsed.flags, "uri"),
+    limit: getNumberFlag(parsed.flags, "limit"),
+  };
+}

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -250,6 +250,11 @@ function getPositiveInteger(value: unknown, fallback: number): number {
   return Math.max(1, getOptionalInteger(value, fallback));
 }
 
+function textResult(text: string, details?: Record<string, unknown>) {
+  const content = [{ type: "text" as const, text }];
+  return details === undefined ? { content } : { content, details };
+}
+
 type OpenClawPluginApi = {
   pluginConfig?: unknown;
   logger: PluginLogger;
@@ -429,19 +434,15 @@ const contextEnginePlugin = {
       sessionKey?: string;
     }): boolean => shouldBypassSession(ctx ?? {}, bypassSessionPatterns);
 
-    const makeBypassedToolResult = (toolName: string) => ({
-      content: [
+    const makeBypassedToolResult = (toolName: string) =>
+      textResult(
+        `OpenViking is bypassed for this session by bypassSessionPatterns; ${toolName} was skipped.`,
         {
-          type: "text" as const,
-          text: `OpenViking is bypassed for this session by bypassSessionPatterns; ${toolName} was skipped.`,
+          action: "bypassed",
+          reason: "session_bypassed",
+          toolName,
         },
-      ],
-      details: {
-        action: "bypassed",
-        reason: "session_bypassed",
-        toolName,
-      },
-    });
+      );
 
     const resolvePluginSessionRouting = (ctx?: SessionAgentLookup): PluginSessionRouting => {
       const sessionId = typeof ctx?.sessionId === "string" ? ctx.sessionId.trim() : "";
@@ -612,25 +613,19 @@ const contextEnginePlugin = {
     const importResource = async (input: AddResourceInput, actorPeerId?: string) => {
       const client = await getClient();
       const result = await client.addResource(input, actorPeerId);
-      return {
-        content: [{ type: "text" as const, text: formatResourceImportText(result) }],
-        details: {
-          action: "resource_imported",
-          ...result,
-        },
-      };
+      return textResult(formatResourceImportText(result), {
+        action: "resource_imported",
+        ...result,
+      });
     };
 
     const importSkill = async (input: AddSkillInput, actorPeerId?: string) => {
       const client = await getClient();
       const result = await client.addSkill(input, actorPeerId);
-      return {
-        content: [{ type: "text" as const, text: formatSkillImportText(result) }],
-        details: {
-          action: "skill_imported",
-          ...result,
-        },
-      };
+      return textResult(formatSkillImportText(result), {
+        action: "skill_imported",
+        ...result,
+      });
     };
 
     const addResourceOpenViking = (input: AddResourceToolInput, actorPeerId?: string) =>
@@ -775,9 +770,7 @@ const contextEnginePlugin = {
           injectedCount: 0,
         },
       });
-      return {
-        content: [{ type: "text" as const, text: formatOVSearchText(query, input.uri, result) }],
-        details: {
+      return textResult(formatOVSearchText(query, input.uri, result), {
           action: "searched",
           query,
           uri: input.uri,
@@ -786,8 +779,7 @@ const contextEnginePlugin = {
           resources: result.resources ?? [],
           skills: result.skills ?? [],
           total: result.total ?? 0,
-        },
-      };
+      });
     };
 
     const readOpenViking = async (
@@ -800,14 +792,11 @@ const contextEnginePlugin = {
       }
       const client = await getClient();
       const content = await client.read(uri, actorPeerId);
-      return {
-        content: [{ type: "text" as const, text: formatOVReadText(uri, content) }],
-        details: {
+      return textResult(formatOVReadText(uri, content), {
           action: "read",
           uri,
           chars: content.length,
-        },
-      };
+      });
     };
 
     const multiReadOpenViking = async (
@@ -842,15 +831,12 @@ const contextEnginePlugin = {
           }
         }),
       );
-      return {
-        content: [{ type: "text" as const, text: formatOVMultiReadText(results) }],
-        details: {
+      return textResult(formatOVMultiReadText(results), {
           action: "multi_read",
           count: results.length,
           success_count: results.filter((result) => result.success).length,
           results,
-        },
-      };
+      });
     };
 
     const listOpenViking = async (
@@ -872,17 +858,14 @@ const contextEnginePlugin = {
           actorPeerId,
         },
       );
-      return {
-        content: [{ type: "text" as const, text: formatOVListText(uri, entries) }],
-        details: {
+      return textResult(formatOVListText(uri, entries), {
           action: "listed",
           uri,
           recursive: input.recursive ?? false,
           simple: input.simple ?? false,
           count: entries.length,
           entries,
-        },
-      };
+      });
     };
 
     if (cfg.enableAddResourceTool) {
@@ -1250,10 +1233,6 @@ const contextEnginePlugin = {
                   s.value,
                   cfg.traceRecallPreviewChars,
                   cfg.traceRecallMaxResultsPerSearch,
-                  {
-                    memory: search.resourceType,
-                    skill: search.resourceType,
-                  },
                 );
                 memoryRecallSearches.push({
                   resourceType: search.resourceType,
@@ -1343,10 +1322,7 @@ const contextEnginePlugin = {
           };
           if (memories.length === 0) {
             await recordMemoryRecallTrace(new Set());
-            return {
-              content: [{ type: "text", text: "No relevant OpenViking memories found." }],
-              details: { count: 0, total: result.total ?? 0, scoreThreshold },
-            };
+            return textResult("No relevant OpenViking memories found.", { count: 0, total: result.total ?? 0, scoreThreshold });
           }
           const { lines: memoryLines } = await buildMemoryLinesWithBudget(
             memories,
@@ -1358,40 +1334,24 @@ const contextEnginePlugin = {
           );
           if (memoryLines.length === 0) {
             await recordMemoryRecallTrace(new Set());
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `No complete OpenViking memories fit recallMaxInjectedChars=${cfg.recallMaxInjectedChars}.`,
-                },
-              ],
-              details: {
+            return textResult(`No complete OpenViking memories fit recallMaxInjectedChars=${cfg.recallMaxInjectedChars}.`, {
                 count: 0,
                 memories,
                 total: result.total ?? memories.length,
                 scoreThreshold,
                 requestLimit,
                 recallMaxInjectedChars: cfg.recallMaxInjectedChars,
-              },
-            };
+            });
           }
           await recordMemoryRecallTrace(new Set(memories.slice(0, memoryLines.length).map((item) => item.uri)));
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Found ${memoryLines.length} memories:\n\n${memoryLines.join("\n")}`,
-              },
-            ],
-            details: {
+          return textResult(`Found ${memoryLines.length} memories:\n\n${memoryLines.join("\n")}`, {
               count: memoryLines.length,
               memories,
               total: result.total ?? memories.length,
               scoreThreshold,
               requestLimit,
               recallMaxInjectedChars: cfg.recallMaxInjectedChars,
-            },
-          };
+          });
         },
       }),
       { name: "memory_recall" },
@@ -1425,16 +1385,13 @@ const contextEnginePlugin = {
             session,
             resolveToolSearchPeerId(ctx, session),
           );
-          return {
-            content: [{ type: "text" as const, text: formatRecallTraceText(result) }],
-            details: {
+          return textResult(formatRecallTraceText(result), {
               action: "queried",
               count: result.entries.length,
               lookupLayer: result.lookupLayer,
               warnings: result.warnings,
               entries: result.entries,
-            },
-          };
+          });
         },
       }),
       { name: "ov_recall_trace" },
@@ -1550,47 +1507,35 @@ const contextEnginePlugin = {
               api.logger.warn(
                 `openviking: memory_store commit failed (sessionId=${sessionId}): ${commitResult.error ?? "unknown"}`,
               );
-              return {
-                content: [{ type: "text", text: `Memory extraction failed for session ${sessionId}: ${commitResult.error ?? "unknown"}` }],
-                details: {
-                  action: "failed",
-                  sessionId,
-                  status: "failed",
-                  error: commitResult.error,
-                  usedTempSession,
-                },
-              };
+              return textResult(`Memory extraction failed for session ${sessionId}: ${commitResult.error ?? "unknown"}`, {
+                action: "failed",
+                sessionId,
+                status: "failed",
+                error: commitResult.error,
+                usedTempSession,
+              });
             }
             if (commitResult.status === "timeout") {
               api.logger.warn(
                 `openviking: memory_store commit timed out (sessionId=${sessionId}), task_id=${commitResult.task_id ?? "none"}. Memories may still be extracting in background.`,
               );
-              return {
-                content: [{ type: "text", text: `Memory extraction timed out for session ${sessionId}. It may still complete in the background (task_id=${commitResult.task_id ?? "none"}).` }],
-                details: {
-                  action: "timeout",
-                  sessionId,
-                  status: "timeout",
-                  taskId: commitResult.task_id,
-                  usedTempSession,
-                },
-              };
+              return textResult(`Memory extraction timed out for session ${sessionId}. It may still complete in the background (task_id=${commitResult.task_id ?? "none"}).`, {
+                action: "timeout",
+                sessionId,
+                status: "timeout",
+                taskId: commitResult.task_id,
+                usedTempSession,
+              });
             }
             if (memoriesCount === 0) {
               api.logger.warn(
                 `openviking: memory_store committed but 0 memories extracted (sessionId=${sessionId}). ` +
                   "No OpenViking-managed long-term memory was created. Check memory.extraction_enabled, VLM configuration/API keys, or whether the text was judged not durable.",
               );
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text:
-                      `Memory extraction completed for session ${sessionId}, but produced 0 memories. ` +
-                      "No OpenViking-managed long-term memory was stored. Check memory.extraction_enabled, VLM configuration/API keys, or whether the text is durable enough to remember.",
-                  },
-                ],
-                details: {
+              return textResult(
+                `Memory extraction completed for session ${sessionId}, but produced 0 memories. ` +
+                  "No OpenViking-managed long-term memory was stored. Check memory.extraction_enabled, VLM configuration/API keys, or whether the text is durable enough to remember.",
+                {
                   action: "failed",
                   sessionId,
                   status: commitResult.status,
@@ -1599,26 +1544,18 @@ const contextEnginePlugin = {
                   archived: commitResult.archived ?? false,
                   usedTempSession,
                 },
-              };
+              );
             } else {
               api.logger.info?.(`openviking: memory_store committed, memories=${memoriesCount}`);
             }
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Stored in OpenViking session ${sessionId} and committed ${memoriesCount} memories.`,
-                },
-              ],
-              details: {
+            return textResult(`Stored in OpenViking session ${sessionId} and committed ${memoriesCount} memories.`, {
                 action: "stored",
                 sessionId,
                 memoriesCount,
                 status: commitResult.status,
                 archived: commitResult.archived ?? false,
                 usedTempSession,
-              },
-            };
+            });
           } catch (err) {
             api.logger.warn(`openviking: memory_store failed: ${String(err)}`);
             throw err;
@@ -1655,24 +1592,15 @@ const contextEnginePlugin = {
           const uri = (params as { uri?: string }).uri;
           if (uri) {
             if (!isMemoryUri(uri)) {
-              return {
-                content: [{ type: "text", text: `Refusing to delete non-memory URI: ${uri}` }],
-                details: { action: "rejected", uri },
-              };
+              return textResult(`Refusing to delete non-memory URI: ${uri}`, { action: "rejected", uri });
             }
             await client.deleteUri(uri, peerId);
-            return {
-              content: [{ type: "text", text: `Forgotten: ${uri}` }],
-              details: { action: "deleted", uri },
-            };
+            return textResult(`Forgotten: ${uri}`, { action: "deleted", uri });
           }
 
           const query = (params as { query?: string }).query;
           if (!query) {
-            return {
-              content: [{ type: "text", text: "Provide uri or query." }],
-              details: { error: "missing_param" },
-            };
+            return textResult("Provide uri or query.", { error: "missing_param" });
           }
 
           const limit =
@@ -1704,38 +1632,19 @@ const contextEnginePlugin = {
             leafOnly: true,
           }).filter((item) => isMemoryUri(item.uri));
           if (candidates.length === 0) {
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: "No matching leaf memory candidates found. Try a more specific query.",
-                },
-              ],
-              details: { action: "none", scoreThreshold },
-            };
+            return textResult("No matching leaf memory candidates found. Try a more specific query.", { action: "none", scoreThreshold });
           }
           const top = candidates[0];
           if (candidates.length === 1 && clampScore(top.score) >= 0.85) {
             await client.deleteUri(top.uri, peerId);
-            return {
-              content: [{ type: "text", text: `Forgotten: ${top.uri}` }],
-              details: { action: "deleted", uri: top.uri, score: top.score ?? 0 },
-            };
+            return textResult(`Forgotten: ${top.uri}`, { action: "deleted", uri: top.uri, score: top.score ?? 0 });
           }
 
           const list = candidates
             .map((item) => `- ${item.uri} (${(clampScore(item.score) * 100).toFixed(0)}%)`)
             .join("\n");
 
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Found ${candidates.length} candidates. Specify uri:\n${list}`,
-              },
-            ],
-            details: { action: "candidates", candidates, scoreThreshold, requestLimit },
-          };
+          return textResult(`Found ${candidates.length} candidates. Specify uri:\n${list}`, { action: "candidates", candidates, scoreThreshold, requestLimit });
         },
       }),
       { name: "memory_forget" },
@@ -1771,20 +1680,14 @@ const contextEnginePlugin = {
           const sessionId = ctx.sessionId ?? "";
           const sessionKey = ctx.sessionKey ?? "";
           if (!sessionId && !sessionKey) {
-            return {
-              content: [{ type: "text", text: "Error: no active session." }],
-              details: { error: "no_session" },
-            };
+            return textResult("Error: no active session.", { error: "no_session" });
           }
           const ovSessionId = openClawSessionToOvStorageId(ctx.sessionId, ctx.sessionKey);
           const query = String((params as { query?: string }).query ?? "").trim();
           const archiveId = (params as { archiveId?: string }).archiveId;
 
           if (!query) {
-            return {
-              content: [{ type: "text", text: "Error: query is required." }],
-              details: { error: "missing_param", param: "query" },
-            };
+            return textResult("Error: query is required.", { error: "missing_param", param: "query" });
           }
 
           const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -1850,15 +1753,12 @@ const contextEnginePlugin = {
 
             if (!result.matches || result.matches.length === 0) {
               await recordArchiveTrace([]);
-              return {
-                content: [{
-                  type: "text",
-                  text: `No matches found for "${query}". Try a different keyword — ` +
-                    "the original conversation may use different wording than the question. " +
-                    "Try synonyms, related terms, or shorter fragments.",
-                }],
-                details: { query, matchCount: 0 },
-              };
+              return textResult(
+                `No matches found for "${query}". Try a different keyword — ` +
+                  "the original conversation may use different wording than the question. " +
+                  "Try synonyms, related terms, or shorter fragments.",
+                { query, matchCount: 0 },
+              );
             }
 
             const MAX_MATCHES = 12;
@@ -1876,17 +1776,11 @@ const contextEnginePlugin = {
             const header = `Found ${result.matches.length} match(es) for "${query}"` +
               (result.matches.length > MAX_MATCHES ? ` (showing first ${MAX_MATCHES})` : "") + ":";
 
-            return {
-              content: [{ type: "text", text: header + "\n\n" + blocks.join("\n\n") }],
-              details: { query, matchCount: result.matches.length },
-            };
+            return textResult(header + "\n\n" + blocks.join("\n\n"), { query, matchCount: result.matches.length });
           } catch (err: unknown) {
             const msg = err instanceof Error ? err.message : String(err);
             api.logger.error?.(`openviking: ov_archive_search error: ${msg}`);
-            return {
-              content: [{ type: "text", text: `Archive search failed: ${msg}` }],
-              details: { error: msg },
-            };
+            return textResult(`Archive search failed: ${msg}`, { error: msg });
           }
         },
       }),
@@ -1918,17 +1812,11 @@ const contextEnginePlugin = {
 
         if (!archiveId) {
           api.logger.warn?.(`openviking: ov_archive_expand missing archiveId`);
-          return {
-            content: [{ type: "text", text: "Error: archiveId is required." }],
-            details: { error: "missing_param", param: "archiveId" },
-          };
+          return textResult("Error: archiveId is required.", { error: "missing_param", param: "archiveId" });
         }
 
         if (!session.ovSessionId) {
-          return {
-            content: [{ type: "text", text: "Error: no active session." }],
-            details: { error: "no_session" },
-          };
+          return textResult("Error: no active session.", { error: "no_session" });
         }
 
         try {
@@ -1950,23 +1838,17 @@ const contextEnginePlugin = {
             .join("\n\n");
 
           api.logger.info?.(`openviking: ov_archive_expand expanded ${detail.archive_id}, messages=${detail.messages.length}, chars=${body.length}, sessionId=${sessionId}`);
-          return {
-            content: [{ type: "text", text: `${header}\n${body}` }],
-            details: {
+          return textResult(`${header}\n${body}`, {
               action: "expanded",
               archiveId: detail.archive_id,
               messageCount: detail.messages.length,
               sessionId,
               ovSessionId: session.ovSessionId,
-            },
-          };
+          });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           api.logger.warn?.(`openviking: ov_archive_expand failed (archiveId=${archiveId}, sessionId=${sessionId}): ${msg}`);
-          return {
-            content: [{ type: "text", text: `Failed to expand ${archiveId}: ${msg}` }],
-            details: { error: msg, archiveId, sessionId, ovSessionId: session.ovSessionId },
-          };
+          return textResult(`Failed to expand ${archiveId}: ${msg}`, { error: msg, archiveId, sessionId, ovSessionId: session.ovSessionId });
         }
       },
     }), { name: "ov_archive_expand" });
@@ -1996,37 +1878,25 @@ const contextEnginePlugin = {
           }
           const session = resolvePluginSessionRouting(ctx);
           if (!session.ovSessionId) {
-            return {
-              content: [{ type: "text", text: "Error: no active session." }],
-              details: { error: "no_session" },
-            };
+            return textResult("Error: no active session.", { error: "no_session" });
           }
 
           const parsed = parseToolResultRef(params.tool_output_ref ?? params.ref ?? params.uri);
           if (!parsed) {
-            return {
-              content: [{ type: "text", text: "Error: tool_output_ref must be a viking://user/sessions/.../tool-results/... URI." }],
-              details: { error: "invalid_tool_output_ref" },
-            };
+            return textResult("Error: tool_output_ref must be a viking://user/sessions/.../tool-results/... URI.", { error: "invalid_tool_output_ref" });
           }
           if (parsed.sessionId !== session.ovSessionId) {
-            return {
-              content: [{ type: "text", text: "Error: refusing to read a tool result from another session." }],
-              details: {
+            return textResult("Error: refusing to read a tool result from another session.", {
                 error: "session_mismatch",
                 requestedSessionId: parsed.sessionId,
                 currentSessionId: session.ovSessionId,
-              },
-            };
+            });
           }
 
           const offset = Math.max(0, getOptionalInteger(params.offset, 0));
           const limit = getOptionalInteger(params.limit, 20_000);
           if (limit < -1) {
-            return {
-              content: [{ type: "text", text: "Error: limit must be -1 or greater than or equal to 0." }],
-              details: { error: "invalid_limit", limit },
-            };
+            return textResult("Error: limit must be -1 or greater than or equal to 0.", { error: "invalid_limit", limit });
           }
 
           try {
@@ -2039,9 +1909,7 @@ const contextEnginePlugin = {
             const returnedChars = result.content.length;
             const nextOffset = result.offset + returnedChars;
             const text = result.content || "(empty tool result chunk)";
-            return {
-              content: [{ type: "text", text }],
-              details: {
+            return textResult(text, {
                 action: "read",
                 tool_output_ref: parsed.ref,
                 tool_result_id: result.tool_result_id,
@@ -2052,15 +1920,11 @@ const contextEnginePlugin = {
                 has_more: result.has_more,
                 next_offset: result.has_more ? nextOffset : null,
                 metadata: result.metadata ?? null,
-              },
-            };
+            });
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             api.logger.warn?.(`openviking: openviking_tool_result_read failed: ${msg}`);
-            return {
-              content: [{ type: "text", text: `Failed to read tool result: ${msg}` }],
-              details: { error: msg, tool_output_ref: parsed.ref },
-            };
+            return textResult(`Failed to read tool result: ${msg}`, { error: msg, tool_output_ref: parsed.ref });
           }
         },
       }),
@@ -2091,36 +1955,24 @@ const contextEnginePlugin = {
           }
           const session = resolvePluginSessionRouting(ctx);
           if (!session.ovSessionId) {
-            return {
-              content: [{ type: "text", text: "Error: no active session." }],
-              details: { error: "no_session" },
-            };
+            return textResult("Error: no active session.", { error: "no_session" });
           }
 
           const parsed = parseToolResultRef(params.tool_output_ref ?? params.ref ?? params.uri);
           if (!parsed) {
-            return {
-              content: [{ type: "text", text: "Error: tool_output_ref must be a viking://user/sessions/.../tool-results/... URI." }],
-              details: { error: "invalid_tool_output_ref" },
-            };
+            return textResult("Error: tool_output_ref must be a viking://user/sessions/.../tool-results/... URI.", { error: "invalid_tool_output_ref" });
           }
           if (parsed.sessionId !== session.ovSessionId) {
-            return {
-              content: [{ type: "text", text: "Error: refusing to search a tool result from another session." }],
-              details: {
+            return textResult("Error: refusing to search a tool result from another session.", {
                 error: "session_mismatch",
                 requestedSessionId: parsed.sessionId,
                 currentSessionId: session.ovSessionId,
-              },
-            };
+            });
           }
 
           const query = String(params.query ?? "").trim();
           if (!query) {
-            return {
-              content: [{ type: "text", text: "Error: query is required." }],
-              details: { error: "missing_param", param: "query" },
-            };
+            return textResult("Error: query is required.", { error: "missing_param", param: "query" });
           }
           const limit = getPositiveInteger(params.limit, 20);
           const contextChars = Math.max(
@@ -2146,24 +1998,18 @@ const contextEnginePlugin = {
                   ),
                 ].join("\n")
               : `No matches found for "${query}" in ${parsed.ref}.`;
-            return {
-              content: [{ type: "text", text }],
-              details: {
+            return textResult(text, {
                 action: "searched",
                 tool_output_ref: parsed.ref,
                 tool_result_id: result.tool_result_id,
                 query,
                 match_count: matches.length,
                 matches,
-              },
-            };
+            });
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             api.logger.warn?.(`openviking: openviking_tool_result_search failed: ${msg}`);
-            return {
-              content: [{ type: "text", text: `Failed to search tool result: ${msg}` }],
-              details: { error: msg, tool_output_ref: parsed.ref, query },
-            };
+            return textResult(`Failed to search tool result: ${msg}`, { error: msg, tool_output_ref: parsed.ref, query });
           }
         },
       }),
@@ -2188,10 +2034,7 @@ const contextEnginePlugin = {
           }
           const session = resolvePluginSessionRouting(ctx);
           if (!session.ovSessionId) {
-            return {
-              content: [{ type: "text", text: "Error: no active session." }],
-              details: { error: "no_session" },
-            };
+            return textResult("Error: no active session.", { error: "no_session" });
           }
 
           const toolName =
@@ -2224,23 +2067,17 @@ const contextEnginePlugin = {
               : toolName
                 ? `No externalized tool results found for tool "${toolName}" in current session.`
                 : "No externalized tool results found in current session.";
-            return {
-              content: [{ type: "text", text }],
-              details: {
+            return textResult(text, {
                 action: "listed",
                 session_id: session.ovSessionId,
                 tool_name: toolName ?? null,
                 count: items.length,
                 tool_results: items,
-              },
-            };
+            });
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             api.logger.warn?.(`openviking: openviking_tool_result_list failed: ${msg}`);
-            return {
-              content: [{ type: "text", text: `Failed to list tool results: ${msg}` }],
-              details: { error: msg, session_id: session.ovSessionId, tool_name: toolName ?? null },
-            };
+            return textResult(`Failed to list tool results: ${msg}`, { error: msg, session_id: session.ovSessionId, tool_name: toolName ?? null });
           }
         },
       }),

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -5,9 +5,7 @@ import { registerSetupCli } from "./commands/setup.js";
 import { OpenVikingClient, isMemoryUri } from "./client.js";
 import type {
   AddResourceInput,
-  AddResourceResult,
   AddSkillInput,
-  AddSkillResult,
   FindResult,
   FindResultItem,
   CommitSessionResult,
@@ -20,6 +18,18 @@ import {
   resolveSearchPeerId,
   toPeerId,
 } from "./context-engine.js";
+import {
+  getBoolFlag,
+  getNumberFlag,
+  getStringFlag,
+  parseAddResourceCommandArgs,
+  parseAddSkillCommandArgs,
+  parseFlagArgs,
+  parseOVSearchCommandArgs,
+  type AddResourceToolInput,
+  type AddSkillToolInput,
+  type OVSearchInput,
+} from "./command-args.js";
 import {
   compileSessionPatterns,
   shouldBypassSession,
@@ -44,6 +54,10 @@ import {
   prepareRecallQuery,
 } from "./auto-recall.js";
 import {
+  createSessionAgentResolver,
+  type SessionAgentLookup,
+} from "./session-agent.js";
+import {
   RecallTraceRecorder,
   normalizeResourceTypes,
   resolveRecallSearchPlan,
@@ -53,12 +67,43 @@ import {
   type RecallTraceResult,
   type RecallTraceSource,
 } from "./recall-trace.js";
+import {
+  boundTraceQuery,
+  createTraceId,
+  inferRecallResourceType,
+  previewText,
+  toTraceSelectedItem,
+  traceResultsFromFindResult,
+} from "./recall-trace-utils.js";
+import {
+  formatOVListText,
+  formatOVMultiReadText,
+  formatOVReadText,
+  formatOVSearchText,
+  formatRecallTraceText,
+  formatResourceImportText,
+  formatSkillImportText,
+  mergeFindResults,
+} from "./tool-formatters.js";
+export {
+  parseAddResourceCommandArgs,
+  parseAddSkillCommandArgs,
+  parseOVSearchCommandArgs,
+  tokenizeCommandArgs,
+} from "./command-args.js";
 export {
   buildMemoryLines,
   buildMemoryLinesWithBudget,
   estimateTokenCount,
   prepareRecallQuery,
 };
+export {
+  createSessionAgentResolver,
+  sanitizeRuntimeAgentId,
+} from "./session-agent.js";
+export type {
+  SessionAgentResolveResult,
+} from "./session-agent.js";
 export {
   estimateAgentMessageTokens,
   estimateAgentMessagesTokens,
@@ -84,32 +129,11 @@ type HookAgentContext = {
   sessionKey?: string;
 };
 
-type SessionAgentLookup = {
-  agentId?: string;
-  sessionId?: string;
-  sessionKey?: string;
-  ovSessionId?: string;
-};
-
 type PluginSessionRouting = {
   sessionId?: string;
   sessionKey?: string;
   ovSessionId?: string;
   agentId: string;
-};
-
-type SessionAgentResolveBranch =
-  | "session_resolved"
-  | "config_only_fallback"
-  | "default_no_session";
-
-export type SessionAgentResolveResult = {
-  resolved: string;
-  resolvedBeforeSanitize: string;
-  branch: SessionAgentResolveBranch;
-  mappedResolvedAgentId: string | null;
-  aliases: string[];
-  fromExplicitBinding: boolean;
 };
 
 type ToolDefinition = {
@@ -147,29 +171,6 @@ type CommandDefinition = {
   acceptsArgs?: boolean;
   requireAuth?: boolean;
   handler: (ctx: PluginCommandContext) => CommandResult | Promise<CommandResult>;
-};
-
-type AddResourceToolInput = {
-  source?: string;
-  to?: string;
-  parent?: string;
-  reason?: string;
-  instruction?: string;
-  wait?: boolean;
-  timeout?: number;
-};
-
-type AddSkillToolInput = {
-  source?: string;
-  data?: unknown;
-  wait?: boolean;
-  timeout?: number;
-};
-
-type OVSearchInput = {
-  query: string;
-  uri?: string;
-  limit?: number;
 };
 
 type OVListInput = {
@@ -289,168 +290,6 @@ type RecallTraceRouteAdapter = {
   }) => void;
 };
 
-const DEFAULT_OPENCLAW_AGENT_ID = "main";
-
-/**
- * OpenClaw ids may contain ":" (e.g. session keys), while OpenViking
- * peer/session metadata is path-friendly.
- */
-export function sanitizeRuntimeAgentId(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return "default";
-  }
-  const normalized = trimmed
-    .replace(/[^a-zA-Z0-9_-]/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^_|_$/g, "");
-  return normalized.length > 0 ? normalized : "ov_agent";
-}
-
-export function tokenizeCommandArgs(args: string): string[] {
-  const tokens: string[] = [];
-  let current = "";
-  let quote: "'" | '"' | null = null;
-  let escaping = false;
-
-  for (let i = 0; i < args.length; i += 1) {
-    const ch = args[i]!;
-    const next = args[i + 1];
-    if (escaping) {
-      current += ch;
-      escaping = false;
-      continue;
-    }
-    if (ch === "\\") {
-      const shouldEscape =
-        quote === '"'
-          ? next === '"' || next === "\\"
-          : !quote && Boolean(next && (/\s/.test(next) || next === '"' || next === "'"));
-      if (shouldEscape) {
-        escaping = true;
-        continue;
-      }
-      current += ch;
-      continue;
-    }
-    if ((ch === '"' || ch === "'") && (!quote || quote === ch)) {
-      quote = quote ? null : ch;
-      continue;
-    }
-    if (!quote && /\s/.test(ch)) {
-      if (current) {
-        tokens.push(current);
-        current = "";
-      }
-      continue;
-    }
-    current += ch;
-  }
-
-  if (escaping) {
-    current += "\\";
-  }
-  if (quote) {
-    throw new Error("Unterminated quoted argument");
-  }
-  if (current) {
-    tokens.push(current);
-  }
-  return tokens;
-}
-
-type ParsedFlagArgs = {
-  positionals: string[];
-  flags: Map<string, string | boolean>;
-};
-
-function parseFlagArgs(args: string): ParsedFlagArgs {
-  const tokens = tokenizeCommandArgs(args);
-  const positionals: string[] = [];
-  const flags = new Map<string, string | boolean>();
-
-  for (let i = 0; i < tokens.length; i += 1) {
-    const token = tokens[i]!;
-    if (!token.startsWith("--")) {
-      positionals.push(token);
-      continue;
-    }
-    const raw = token.slice(2);
-    if (!raw) {
-      continue;
-    }
-    const eqIndex = raw.indexOf("=");
-    if (eqIndex >= 0) {
-      flags.set(raw.slice(0, eqIndex), raw.slice(eqIndex + 1));
-      continue;
-    }
-    const next = tokens[i + 1];
-    if (next && !next.startsWith("--")) {
-      flags.set(raw, next);
-      i += 1;
-    } else {
-      flags.set(raw, true);
-    }
-  }
-
-  return { positionals, flags };
-}
-
-function getStringFlag(flags: Map<string, string | boolean>, name: string): string | undefined {
-  const value = flags.get(name);
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function getNumberFlag(flags: Map<string, string | boolean>, name: string): number | undefined {
-  const raw = getStringFlag(flags, name);
-  if (!raw) {
-    return undefined;
-  }
-  const value = Number(raw);
-  if (!Number.isFinite(value)) {
-    throw new Error(`--${name} must be a number`);
-  }
-  return value;
-}
-
-function getBoolFlag(flags: Map<string, string | boolean>, name: string): boolean {
-  return flags.get(name) === true;
-}
-
-function createTraceId(source: RecallTraceSource): string {
-  return `${source}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function previewText(value: string | undefined | null, maxChars: number): string | undefined {
-  const normalized = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
-  if (!normalized) {
-    return undefined;
-  }
-  return normalized.length > maxChars ? normalized.slice(0, maxChars) : normalized;
-}
-
-function boundTraceQuery(query: string, maxChars: number): { query: string; queryTruncated?: boolean } {
-  return query.length <= maxChars
-    ? { query }
-    : { query: query.slice(0, maxChars), queryTruncated: true };
-}
-
-function inferRecallResourceType(uri: string | undefined): RecallResourceType | undefined {
-  if (!uri) {
-    return undefined;
-  }
-  if (uri.startsWith("viking://resources")) {
-    return "resource";
-  }
-  if (uri.startsWith("viking://session/") || uri.includes("/sessions/")) {
-    return "session";
-  }
-  if (uri.startsWith("viking://user/")) {
-    return "user";
-  }
-  return undefined;
-}
-
 function extractToolSenderId(ctx: unknown): string | undefined {
   if (!ctx || typeof ctx !== "object") {
     return undefined;
@@ -469,183 +308,6 @@ function extractToolSenderId(ctx: unknown): string | undefined {
     }
   }
   return undefined;
-}
-
-export function parseAddResourceCommandArgs(args: string): AddResourceToolInput {
-  const parsed = parseFlagArgs(args);
-  const source =
-    parsed.positionals.length <= 1 ? parsed.positionals[0] : parsed.positionals.join(" ").trim();
-  if (!source) {
-    throw new Error("Usage: /add-resource <source> [--to URI] [--parent URI] [--reason TEXT] [--instruction TEXT] [--wait] [--timeout SEC]");
-  }
-  const to = getStringFlag(parsed.flags, "to");
-  const parent = getStringFlag(parsed.flags, "parent");
-  if (to && parent) {
-    throw new Error("Cannot specify both --to and --parent.");
-  }
-  return {
-    source,
-    to,
-    parent,
-    reason: getStringFlag(parsed.flags, "reason"),
-    instruction: getStringFlag(parsed.flags, "instruction"),
-    wait: getBoolFlag(parsed.flags, "wait"),
-    timeout: getNumberFlag(parsed.flags, "timeout"),
-  };
-}
-
-export function parseAddSkillCommandArgs(args: string): AddSkillToolInput {
-  const parsed = parseFlagArgs(args);
-  const source =
-    parsed.positionals.length <= 1 ? parsed.positionals[0] : parsed.positionals.join(" ").trim();
-  if (!source) {
-    throw new Error("Usage: /add-skill <source> [--wait] [--timeout SEC]");
-  }
-  if (parsed.flags.has("to") || parsed.flags.has("parent") || parsed.flags.has("reason") || parsed.flags.has("instruction")) {
-    throw new Error("--to, --parent, --reason, and --instruction are resource-only options.");
-  }
-  return {
-    source,
-    wait: getBoolFlag(parsed.flags, "wait"),
-    timeout: getNumberFlag(parsed.flags, "timeout"),
-  };
-}
-
-export function parseOVSearchCommandArgs(args: string): OVSearchInput {
-  const parsed = parseFlagArgs(args);
-  // `/ov-search` only accepts a single query string, so positional segments are
-  // always re-joined to preserve unquoted multi-word searches.
-  const query = parsed.positionals.join(" ").trim();
-  if (!query) {
-    throw new Error('Usage: /ov-search "<query>" [--uri URI] [--limit N]');
-  }
-  return {
-    query,
-    uri: getStringFlag(parsed.flags, "uri"),
-    limit: getNumberFlag(parsed.flags, "limit"),
-  };
-}
-
-function extractAgentIdFromSessionKey(sessionKey?: string): string | undefined {
-  const raw = typeof sessionKey === "string" ? sessionKey.trim() : "";
-  if (!raw) {
-    return undefined;
-  }
-
-  const match = raw.match(/^agent:([^:]+):/);
-  const agentId = match?.[1]?.trim();
-  return agentId || undefined;
-}
-
-function collectSessionAgentAliases(
-  sessionId?: string,
-  sessionKey?: string,
-  ovSessionId?: string,
-): string[] {
-  const aliases = new Set<string>();
-  const sid = typeof sessionId === "string" ? sessionId.trim() : "";
-  const sk = typeof sessionKey === "string" ? sessionKey.trim() : "";
-  const ovSid = typeof ovSessionId === "string" ? ovSessionId.trim() : "";
-
-  if (sid) {
-    aliases.add(sid);
-  }
-  if (sk) {
-    aliases.add(sk);
-  }
-  if (ovSid) {
-    aliases.add(ovSid);
-  }
-
-  if (!ovSid && (sid || sk)) {
-    try {
-      aliases.add(
-        openClawSessionToOvStorageId(
-          sid || undefined,
-          sk || undefined,
-        ),
-      );
-    } catch {
-      /* need a resolvable OpenClaw session identity */
-    }
-  }
-
-  return [...aliases];
-}
-
-export function createSessionAgentResolver(configAgentId: string) {
-  const configAgentPrefix = configAgentId.trim() === "default" ? "" : configAgentId.trim();
-  const sessionAgentIds = new Map<string, string>();
-
-  const remember = (ctx: SessionAgentLookup): void => {
-    const sessionScopedAgentId =
-      extractAgentIdFromSessionKey(ctx.sessionKey) ||
-      extractAgentIdFromSessionKey(ctx.sessionId);
-    const rawAgentId =
-      (typeof ctx.agentId === "string" ? ctx.agentId.trim() : "") ||
-      sessionScopedAgentId ||
-      "";
-    if (!rawAgentId) {
-      return;
-    }
-
-    const prefix = configAgentPrefix;
-    const resolvedBeforeSanitize = prefix ? `${prefix}_${rawAgentId}` : rawAgentId;
-    const resolved = sanitizeRuntimeAgentId(resolvedBeforeSanitize);
-    for (const alias of collectSessionAgentAliases(ctx.sessionId, ctx.sessionKey, ctx.ovSessionId)) {
-      sessionAgentIds.set(alias, resolved);
-    }
-  };
-
-  const resolve = (
-    sessionId?: string,
-    sessionKey?: string,
-    ovSessionId?: string,
-  ): SessionAgentResolveResult => {
-    const aliases = collectSessionAgentAliases(sessionId, sessionKey, ovSessionId);
-    const mappedAlias = aliases.find((alias) => sessionAgentIds.has(alias));
-    const mappedResolvedAgentId = mappedAlias ? sessionAgentIds.get(mappedAlias) : undefined;
-    const sessionScopedAgentId =
-      extractAgentIdFromSessionKey(sessionKey) ||
-      extractAgentIdFromSessionKey(sessionId);
-
-    let resolvedBeforeSanitize: string;
-    let resolved: string;
-    let branch: SessionAgentResolveBranch;
-    const prefix = configAgentPrefix;
-
-    if (mappedResolvedAgentId) {
-      resolvedBeforeSanitize = mappedResolvedAgentId;
-      resolved = mappedResolvedAgentId;
-      branch = "session_resolved";
-    } else if (sessionScopedAgentId) {
-      resolvedBeforeSanitize = prefix ? `${prefix}_${sessionScopedAgentId}` : sessionScopedAgentId;
-      resolved = sanitizeRuntimeAgentId(resolvedBeforeSanitize);
-      branch = "session_resolved";
-    } else if (!prefix) {
-      resolvedBeforeSanitize = DEFAULT_OPENCLAW_AGENT_ID;
-      resolved = DEFAULT_OPENCLAW_AGENT_ID;
-      branch = "default_no_session";
-    } else {
-      resolvedBeforeSanitize = `${prefix}_${DEFAULT_OPENCLAW_AGENT_ID}`;
-      resolved = sanitizeRuntimeAgentId(resolvedBeforeSanitize);
-      branch = "config_only_fallback";
-    }
-
-    return {
-      resolved,
-      resolvedBeforeSanitize,
-      branch,
-      mappedResolvedAgentId: mappedResolvedAgentId ?? null,
-      aliases,
-      fromExplicitBinding: !!(mappedResolvedAgentId || sessionScopedAgentId),
-    };
-  };
-
-  return {
-    remember,
-    resolve,
-  };
 }
 
 function totalCommitMemories(r: CommitSessionResult): number {
@@ -819,19 +481,6 @@ const contextEnginePlugin = {
         assistantPeerId: session.agentId,
       });
 
-    const toTraceResult = (
-      item: FindResultItem,
-      resultType: RecallTraceResult["resultType"],
-    ): RecallTraceResult => ({
-      uri: item.uri,
-      resourceType: inferRecallResourceType(item.uri),
-      category: item.category,
-      score: item.score,
-      level: item.level,
-      abstractPreview: previewText(item.abstract || item.overview, cfg.traceRecallPreviewChars),
-      resultType,
-    });
-
     const parseRecallTraceInput = (
       input: RecallTraceToolInput,
       ctx: { sessionId?: string; sessionKey?: string; ovSessionId?: string },
@@ -960,42 +609,6 @@ const contextEnginePlugin = {
       return true;
     };
 
-    const formatRecallTraceText = (result: { entries: RecallTraceEntry[]; lookupLayer: string; warnings: string[] }): string => {
-      if (result.entries.length === 0) {
-        return `No OpenViking recall traces found (lookupLayer=${result.lookupLayer}).`;
-      }
-      const blocks = result.entries.map((entry, index) => {
-        const selected = entry.selected.slice(0, 8)
-          .map((item) => `  - ${item.uri}${item.score !== undefined ? ` (${(clampScore(item.score) * 100).toFixed(0)}%)` : ""}`)
-          .join("\n");
-        return [
-          `## Trace ${index + 1}: ${entry.source}`,
-          `traceId: ${entry.traceId}`,
-          `query: ${entry.trigger.query}`,
-          `resourceTypes: ${entry.resourceTypes.join(", ")}`,
-          `searches: ${entry.searches.map((search) => search.contextType ?? search.resourceType).join(", ")}`,
-          `stats: candidates=${entry.stats.candidateCount}, selected=${entry.stats.selectedCount}, injected=${entry.stats.injectedCount}`,
-          selected ? `selected:\n${selected}` : "selected: (none)",
-        ].join("\n");
-      });
-      const warnings = result.warnings.length > 0
-        ? `\n\nWarnings:\n${result.warnings.map((warning) => `- ${warning}`).join("\n")}`
-        : "";
-      return `${blocks.join("\n\n")}${warnings}`;
-    };
-
-    const formatResourceImportText = (result: AddResourceResult): string => {
-      const root = result.root_uri ? ` ${result.root_uri}` : "";
-      const warnings = result.warnings?.length ? ` Warnings: ${result.warnings.join("; ")}` : "";
-      return `Imported OpenViking resource.${root}${warnings}`.trim();
-    };
-
-    const formatSkillImportText = (result: AddSkillResult): string => {
-      const uri = result.uri ? ` ${result.uri}` : "";
-      const name = result.name ? ` (${result.name})` : "";
-      return `Imported OpenViking skill${name}.${uri}`.trim();
-    };
-
     const importResource = async (input: AddResourceInput, actorPeerId?: string) => {
       const client = await getClient();
       const result = await client.addResource(input, actorPeerId);
@@ -1039,128 +652,6 @@ const contextEnginePlugin = {
         timeout: input.timeout,
       }, actorPeerId);
 
-    const mergeFindResults = (results: FindResult[]): FindResult => {
-      const deduplicate = (items: FindResultItem[]): FindResultItem[] => {
-        const seen = new Map<string, FindResultItem>();
-        for (const item of items) {
-          if (!seen.has(item.uri)) {
-            seen.set(item.uri, item);
-          }
-        }
-        return Array.from(seen.values());
-      };
-      const memories = deduplicate(results.flatMap((result) => result.memories ?? []));
-      const resources = deduplicate(results.flatMap((result) => result.resources ?? []));
-      const skills = deduplicate(results.flatMap((result) => result.skills ?? []));
-      return {
-        memories,
-        resources,
-        skills,
-        total: memories.length + resources.length + skills.length,
-      };
-    };
-
-    const formatOVSearchRows = (result: FindResult): string[] => {
-      const truncateSummary = (value: string, maxChars = 220): string => {
-        const collapsed = value.replace(/\s+/g, " ").trim();
-        if (collapsed.length <= maxChars) {
-          return collapsed;
-        }
-        return `${collapsed.slice(0, maxChars - 3)}...`;
-      };
-      const items = [
-        ...(result.memories ?? []).map((item) => ({ contextType: "memory", item })),
-        ...(result.resources ?? []).map((item) => ({ contextType: "resource", item })),
-        ...(result.skills ?? []).map((item) => ({ contextType: "skill", item })),
-      ];
-      if (items.length === 0) {
-        return [];
-      }
-      const numberHeader = "no";
-      const numberWidth = Math.max(numberHeader.length, String(items.length).length);
-      const typeWidth = Math.max("type".length, ...items.map(({ contextType }) => contextType.length));
-      const uriWidth = Math.max("uri".length, ...items.map(({ item }) => item.uri.length));
-      const levelWidth = Math.max("level".length, ...items.map(({ item }) => String(item.level ?? "").length));
-      const scoreWidth = Math.max(
-        "score".length,
-        ...items.map(({ item }) => (typeof item.score === "number" ? item.score.toFixed(2).length : 0)),
-      );
-      return [
-        `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}  abstract`,
-        ...items.map(({ contextType, item }, index) => {
-          const score = typeof item.score === "number" ? item.score.toFixed(2) : "";
-          const summary = truncateSummary(item.abstract || item.overview || "(no summary)");
-          return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}  ${summary}`;
-        }),
-      ];
-    };
-
-    const formatOVSearchText = (query: string, uri: string | undefined, result: FindResult): string => {
-      if ((result.total ?? 0) <= 0) {
-        const scope = uri ? ` under ${uri}` : "";
-        return `No OpenViking resource or skill results found for "${query}"${scope}.`;
-      }
-      const scope = uri ? ` under ${uri}` : "";
-      const lines = [
-        `Found ${result.total ?? 0} OpenViking results for "${query}"${scope}`,
-        "Tip: search results are ranked snippets. Use ov_read on exact hit URIs before answering precise questions. Use ov_list on a hit's parent URI to inspect sibling chunks or overview files before answering procedural or multi-step questions.",
-        "",
-        ...formatOVSearchRows(result),
-      ].filter((line, index, all) => line || (all[index - 1] && all[index + 1]));
-      return lines.join("\n");
-    };
-
-    const formatOVListEntry = (entry: unknown): string => {
-      if (typeof entry === "string") {
-        return entry;
-      }
-      if (!entry || typeof entry !== "object") {
-        return String(entry);
-      }
-      const item = entry as Record<string, unknown>;
-      const uri = typeof item.uri === "string" ? item.uri : "";
-      const name = typeof item.name === "string" ? item.name : "";
-      const isDir = item.isDir === true || item.type === "directory";
-      const marker = isDir ? "[dir]" : "[file]";
-      const summary =
-        typeof item.abstract === "string" && item.abstract.trim()
-          ? item.abstract.trim().replace(/\s+/g, " ")
-          : typeof item.overview === "string" && item.overview.trim()
-            ? item.overview.trim().replace(/\s+/g, " ")
-            : "";
-      const label = uri || name || JSON.stringify(item);
-      return summary ? `${marker} ${label} - ${summary}` : `${marker} ${label}`;
-    };
-
-    const formatOVListText = (uri: string, entries: unknown[]): string => {
-      if (entries.length === 0) {
-        return `No OpenViking entries found under ${uri}.`;
-      }
-      return [
-        `Listed ${entries.length} OpenViking entr${entries.length === 1 ? "y" : "ies"} under ${uri}`,
-        "",
-        ...entries.map((entry) => formatOVListEntry(entry)),
-      ].join("\n");
-    };
-
-    const formatOVReadText = (uri: string, content: string): string => {
-      const body = content || "(empty OpenViking content)";
-      return [`--- START OF ${uri} ---`, body, `--- END OF ${uri} ---`].join("\n");
-    };
-
-    const formatOVMultiReadText = (
-      results: Array<{ uri: string; content: string; success: boolean }>,
-    ): string => [
-      `Multi-read results for ${results.length} OpenViking resource${results.length === 1 ? "" : "s"}:`,
-      "",
-      ...results.flatMap((result) => [
-        `--- START OF ${result.uri} ---`,
-        result.success ? (result.content || "(empty OpenViking content)") : `ERROR: ${result.content}`,
-        `--- END OF ${result.uri} ---`,
-        "",
-      ]),
-    ].join("\n").trimEnd();
-
     const searchOpenViking = async (
       input: OVSearchInput,
       traceCtx?: PluginSessionRouting,
@@ -1177,11 +668,11 @@ const contextEnginePlugin = {
       if (input.uri) {
         const started = Date.now();
         result = await client.find(query, { targetUri: input.uri, limit, actorPeerId });
-        const items = [
-          ...(result.memories ?? []).map((item) => toTraceResult(item, "memory")),
-          ...(result.resources ?? []).map((item) => toTraceResult(item, "resource")),
-          ...(result.skills ?? []).map((item) => toTraceResult(item, "skill")),
-        ].slice(0, cfg.traceRecallMaxResultsPerSearch);
+        const items = traceResultsFromFindResult(
+          result,
+          cfg.traceRecallPreviewChars,
+          cfg.traceRecallMaxResultsPerSearch,
+        );
         searches.push({
           resourceType: inferRecallResourceType(input.uri) ?? "resource",
           targetUriInput: input.uri,
@@ -1200,11 +691,11 @@ const contextEnginePlugin = {
           const started = Date.now();
           try {
             const found = await client.find(query, { targetUri, limit, contextType, actorPeerId });
-            const items = [
-              ...(found.memories ?? []).map((item) => toTraceResult(item, "memory")),
-              ...(found.resources ?? []).map((item) => toTraceResult(item, "resource")),
-              ...(found.skills ?? []).map((item) => toTraceResult(item, "skill")),
-            ].slice(0, cfg.traceRecallMaxResultsPerSearch);
+            const items = traceResultsFromFindResult(
+              found,
+              cfg.traceRecallPreviewChars,
+              cfg.traceRecallMaxResultsPerSearch,
+            );
             searches.push({
               resourceType,
               contextType,
@@ -1258,31 +749,10 @@ const contextEnginePlugin = {
         result = mergeFindResults(successful);
       }
       const selected = [
-        ...(result.memories ?? []).map((item) => ({
-          uri: item.uri,
-          resourceType: inferRecallResourceType(item.uri),
-          category: item.category,
-          score: item.score,
-          abstractPreview: previewText(item.abstract || item.overview, cfg.traceRecallPreviewChars),
-          displayed: true,
-        })),
-        ...(result.resources ?? []).map((item) => ({
-          uri: item.uri,
-          resourceType: inferRecallResourceType(item.uri),
-          category: item.category,
-          score: item.score,
-          abstractPreview: previewText(item.abstract || item.overview, cfg.traceRecallPreviewChars),
-          displayed: true,
-        })),
-        ...(result.skills ?? []).map((item) => ({
-          uri: item.uri,
-          resourceType: inferRecallResourceType(item.uri),
-          category: item.category,
-          score: item.score,
-          abstractPreview: previewText(item.abstract || item.overview, cfg.traceRecallPreviewChars),
-          displayed: true,
-        })),
-      ];
+        ...(result.memories ?? []),
+        ...(result.resources ?? []),
+        ...(result.skills ?? []),
+      ].map((item) => toTraceSelectedItem(item, cfg.traceRecallPreviewChars, { displayed: true }));
       await traceRecorder?.recordAndFlush({
         schemaVersion: "1.0",
         traceId: createTraceId("ov_search"),
@@ -1727,11 +1197,11 @@ const contextEnginePlugin = {
                 actorPeerId: peerId,
               },
             );
-            const traceResults = [
-              ...(result.memories ?? []).map((item) => toTraceResult(item, "memory")),
-              ...(result.resources ?? []).map((item) => toTraceResult(item, "resource")),
-              ...(result.skills ?? []).map((item) => toTraceResult(item, "skill")),
-            ].slice(0, cfg.traceRecallMaxResultsPerSearch);
+            const traceResults = traceResultsFromFindResult(
+              result,
+              cfg.traceRecallPreviewChars,
+              cfg.traceRecallMaxResultsPerSearch,
+            );
             memoryRecallSearches = [{
               resourceType: inferRecallResourceType(targetUri) ?? "resource",
               targetUriInput: targetUri,
@@ -1776,11 +1246,15 @@ const contextEnginePlugin = {
               const search = searchPlan.searches[index]!;
               if (s.status === "fulfilled") {
                 allMemories.push(...(s.value.memories ?? []), ...(s.value.resources ?? []));
-                const traceResults = [
-                  ...(s.value.memories ?? []).map((item) => toTraceResult(item, "memory")),
-                  ...(s.value.resources ?? []).map((item) => toTraceResult(item, "resource")),
-                  ...(s.value.skills ?? []).map((item) => toTraceResult(item, "skill")),
-                ].slice(0, cfg.traceRecallMaxResultsPerSearch);
+                const traceResults = traceResultsFromFindResult(
+                  s.value,
+                  cfg.traceRecallPreviewChars,
+                  cfg.traceRecallMaxResultsPerSearch,
+                  {
+                    memory: search.resourceType,
+                    skill: search.resourceType,
+                  },
+                );
                 memoryRecallSearches.push({
                   resourceType: search.resourceType,
                   contextType: search.contextType,
@@ -1823,9 +1297,11 @@ const contextEnginePlugin = {
             scoreThreshold,
           });
           const memories = pickMemoriesForInjection(processed, limit, query);
-          const candidateTraceResults = leafOnly
-            .map((item) => toTraceResult(item, inferRecallResourceType(item.uri) === "resource" ? "resource" : "memory"))
-            .slice(0, cfg.traceRecallMaxResultsPerSearch);
+          const candidateTraceResults = traceResultsFromFindResult(
+            { memories: leafOnly },
+            cfg.traceRecallPreviewChars,
+            cfg.traceRecallMaxResultsPerSearch,
+          );
           const traceResourceTypes = [...new Set(
             (requestedTraceResourceTypes ?? (targetUri ? [inferRecallResourceType(targetUri)] : memoryRecallSearches.map((search) => search.resourceType)))
               .filter((resourceType): resourceType is RecallResourceType => Boolean(resourceType) && resourceType !== "archive"),
@@ -1854,12 +1330,7 @@ const contextEnginePlugin = {
                 total: result.total ?? leafOnly.length,
                 results: candidateTraceResults,
               }],
-              selected: memories.map((item) => ({
-                uri: item.uri,
-                resourceType: inferRecallResourceType(item.uri),
-                category: item.category,
-                score: item.score,
-                abstractPreview: previewText(item.abstract || item.overview, cfg.traceRecallPreviewChars),
+              selected: memories.map((item) => toTraceSelectedItem(item, cfg.traceRecallPreviewChars, {
                 injected: injectedUris.has(item.uri),
                 displayed: injectedUris.has(item.uri),
               })),

--- a/examples/openclaw-plugin/recall-trace-utils.ts
+++ b/examples/openclaw-plugin/recall-trace-utils.ts
@@ -1,0 +1,76 @@
+import type { FindResult, FindResultItem } from "./client.js";
+import type {
+  RecallResourceType,
+  RecallTraceEntry,
+  RecallTraceResult,
+  RecallTraceSource,
+} from "./recall-trace.js";
+
+export function createTraceId(source: RecallTraceSource): string {
+  return `${source}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function previewText(value: string | undefined | null, maxChars: number): string | undefined {
+  const normalized = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+  if (!normalized) return undefined;
+  return normalized.length > maxChars ? normalized.slice(0, maxChars) : normalized;
+}
+
+export function boundTraceQuery(query: string, maxChars: number): { query: string; queryTruncated?: boolean } {
+  return query.length <= maxChars
+    ? { query }
+    : { query: query.slice(0, maxChars), queryTruncated: true };
+}
+
+export function inferRecallResourceType(uri: string | undefined): RecallResourceType | undefined {
+  if (!uri) return undefined;
+  if (uri.startsWith("viking://resources")) return "resource";
+  if (uri.startsWith("viking://session/") || uri.includes("/sessions/")) return "session";
+  if (uri.startsWith("viking://user/")) return "user";
+  return undefined;
+}
+
+export function toRecallTraceResult(
+  item: FindResultItem,
+  resultType: RecallTraceResult["resultType"],
+  previewChars: number,
+  resourceType: RecallTraceResult["resourceType"] = inferRecallResourceType(item.uri),
+): RecallTraceResult {
+  return {
+    uri: item.uri,
+    resourceType,
+    category: item.category,
+    score: item.score,
+    level: item.level,
+    abstractPreview: previewText(item.abstract ?? item.overview, previewChars),
+    resultType,
+  };
+}
+
+export function traceResultsFromFindResult(
+  result: FindResult,
+  previewChars: number,
+  limit: number,
+  resourceTypes: Partial<Record<"memory" | "resource" | "skill", RecallTraceResult["resourceType"]>> = {},
+): RecallTraceResult[] {
+  return [
+    ...(result.memories ?? []).map((item) => toRecallTraceResult(item, "memory", previewChars, resourceTypes.memory)),
+    ...(result.resources ?? []).map((item) => toRecallTraceResult(item, "resource", previewChars, resourceTypes.resource ?? "resource")),
+    ...(result.skills ?? []).map((item) => toRecallTraceResult(item, "skill", previewChars, resourceTypes.skill)),
+  ].slice(0, limit);
+}
+
+export function toTraceSelectedItem(
+  item: FindResultItem,
+  previewChars: number,
+  extra: Partial<RecallTraceEntry["selected"][number]> = {},
+): RecallTraceEntry["selected"][number] {
+  return {
+    uri: item.uri,
+    resourceType: inferRecallResourceType(item.uri),
+    category: item.category,
+    score: item.score,
+    abstractPreview: previewText(item.abstract ?? item.overview, previewChars),
+    ...extra,
+  };
+}

--- a/examples/openclaw-plugin/session-agent.ts
+++ b/examples/openclaw-plugin/session-agent.ts
@@ -1,0 +1,148 @@
+import { openClawSessionToOvStorageId } from "./context-engine.js";
+
+const DEFAULT_OPENCLAW_AGENT_ID = "main";
+
+export type SessionAgentLookup = { agentId?: string; sessionId?: string; sessionKey?: string; ovSessionId?: string };
+
+type SessionAgentResolveBranch =
+  | "session_resolved"
+  | "config_only_fallback"
+  | "default_no_session";
+
+export type SessionAgentResolveResult = {
+  resolved: string; resolvedBeforeSanitize: string; branch: SessionAgentResolveBranch;
+  mappedResolvedAgentId: string | null; aliases: string[]; fromExplicitBinding: boolean;
+};
+
+/**
+ * OpenClaw ids may contain ":" (e.g. session keys), while OpenViking
+ * peer/session metadata is path-friendly.
+ */
+export function sanitizeRuntimeAgentId(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "default";
+  }
+  const normalized = trimmed
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+  return normalized.length > 0 ? normalized : "ov_agent";
+}
+
+function extractAgentIdFromSessionKey(sessionKey?: string): string | undefined {
+  const raw = typeof sessionKey === "string" ? sessionKey.trim() : "";
+  if (!raw) {
+    return undefined;
+  }
+
+  const match = raw.match(/^agent:([^:]+):/);
+  const agentId = match?.[1]?.trim();
+  return agentId || undefined;
+}
+
+function collectSessionAgentAliases(
+  sessionId?: string,
+  sessionKey?: string,
+  ovSessionId?: string,
+): string[] {
+  const aliases = new Set<string>();
+  const sid = typeof sessionId === "string" ? sessionId.trim() : "";
+  const sk = typeof sessionKey === "string" ? sessionKey.trim() : "";
+  const ovSid = typeof ovSessionId === "string" ? ovSessionId.trim() : "";
+
+  if (sid) {
+    aliases.add(sid);
+  }
+  if (sk) {
+    aliases.add(sk);
+  }
+  if (ovSid) {
+    aliases.add(ovSid);
+  }
+
+  if (!ovSid && (sid || sk)) {
+    try {
+      aliases.add(openClawSessionToOvStorageId(sid || undefined, sk || undefined));
+    } catch {
+      /* need a resolvable OpenClaw session identity */
+    }
+  }
+
+  return [...aliases];
+}
+
+export function createSessionAgentResolver(configAgentId: string) {
+  const configAgentPrefix = configAgentId.trim() === "default" ? "" : configAgentId.trim();
+  const sessionAgentIds = new Map<string, string>();
+
+  const remember = (ctx: SessionAgentLookup): void => {
+    const sessionScopedAgentId =
+      extractAgentIdFromSessionKey(ctx.sessionKey) ||
+      extractAgentIdFromSessionKey(ctx.sessionId);
+    const rawAgentId =
+      (typeof ctx.agentId === "string" ? ctx.agentId.trim() : "") ||
+      sessionScopedAgentId ||
+      "";
+    if (!rawAgentId) {
+      return;
+    }
+
+    const prefix = configAgentPrefix;
+    const resolvedBeforeSanitize = prefix ? `${prefix}_${rawAgentId}` : rawAgentId;
+    const resolved = sanitizeRuntimeAgentId(resolvedBeforeSanitize);
+    for (const alias of collectSessionAgentAliases(ctx.sessionId, ctx.sessionKey, ctx.ovSessionId)) {
+      sessionAgentIds.set(alias, resolved);
+    }
+  };
+
+  const resolve = (
+    sessionId?: string,
+    sessionKey?: string,
+    ovSessionId?: string,
+  ): SessionAgentResolveResult => {
+    const aliases = collectSessionAgentAliases(sessionId, sessionKey, ovSessionId);
+    const mappedAlias = aliases.find((alias) => sessionAgentIds.has(alias));
+    const mappedResolvedAgentId = mappedAlias ? sessionAgentIds.get(mappedAlias) : undefined;
+    const sessionScopedAgentId =
+      extractAgentIdFromSessionKey(sessionKey) ||
+      extractAgentIdFromSessionKey(sessionId);
+
+    let resolvedBeforeSanitize: string;
+    let resolved: string;
+    let branch: SessionAgentResolveBranch;
+    const prefix = configAgentPrefix;
+
+    if (mappedResolvedAgentId) {
+      resolvedBeforeSanitize = mappedResolvedAgentId;
+      resolved = mappedResolvedAgentId;
+      branch = "session_resolved";
+    } else if (sessionScopedAgentId) {
+      resolvedBeforeSanitize = prefix ? `${prefix}_${sessionScopedAgentId}` : sessionScopedAgentId;
+      resolved = sanitizeRuntimeAgentId(resolvedBeforeSanitize);
+      branch = "session_resolved";
+    } else if (!prefix) {
+      resolvedBeforeSanitize = DEFAULT_OPENCLAW_AGENT_ID;
+      resolved = DEFAULT_OPENCLAW_AGENT_ID;
+      branch = "default_no_session";
+    } else {
+      resolvedBeforeSanitize = `${prefix}_${DEFAULT_OPENCLAW_AGENT_ID}`;
+      resolved = sanitizeRuntimeAgentId(resolvedBeforeSanitize);
+      branch = "config_only_fallback";
+    }
+
+    return {
+      resolved,
+      resolvedBeforeSanitize,
+      branch,
+      mappedResolvedAgentId: mappedResolvedAgentId ?? null,
+      aliases,
+      fromExplicitBinding: !!(mappedResolvedAgentId || sessionScopedAgentId),
+    };
+  };
+
+  return {
+    remember,
+    resolve,
+  };
+}

--- a/examples/openclaw-plugin/tool-formatters.ts
+++ b/examples/openclaw-plugin/tool-formatters.ts
@@ -1,0 +1,160 @@
+import type { AddResourceResult, AddSkillResult, FindResult, FindResultItem } from "./client.js";
+import { clampScore } from "./memory-ranking.js";
+import type { RecallTraceEntry } from "./recall-trace.js";
+
+export function formatRecallTraceText(result: {
+  entries: RecallTraceEntry[];
+  lookupLayer: string;
+  warnings: string[];
+}): string {
+  if (result.entries.length === 0) {
+    return `No OpenViking recall traces found (lookupLayer=${result.lookupLayer}).`;
+  }
+  const blocks = result.entries.map((entry, index) => {
+    const selected = entry.selected.slice(0, 8)
+      .map((item) => `  - ${item.uri}${item.score !== undefined ? ` (${(clampScore(item.score) * 100).toFixed(0)}%)` : ""}`)
+      .join("\n");
+    return [
+      `## Trace ${index + 1}: ${entry.source}`,
+      `traceId: ${entry.traceId}`,
+      `query: ${entry.trigger.query}`,
+      `resourceTypes: ${entry.resourceTypes.join(", ")}`,
+      `searches: ${entry.searches.map((search) => search.contextType ?? search.resourceType).join(", ")}`,
+      `stats: candidates=${entry.stats.candidateCount}, selected=${entry.stats.selectedCount}, injected=${entry.stats.injectedCount}`,
+      selected ? `selected:\n${selected}` : "selected: (none)",
+    ].join("\n");
+  });
+  const warnings = result.warnings.length > 0
+    ? `\n\nWarnings:\n${result.warnings.map((warning) => `- ${warning}`).join("\n")}`
+    : "";
+  return `${blocks.join("\n\n")}${warnings}`;
+}
+
+export function formatResourceImportText(result: AddResourceResult): string {
+  const root = result.root_uri ? ` ${result.root_uri}` : "";
+  const warnings = result.warnings?.length ? ` Warnings: ${result.warnings.join("; ")}` : "";
+  return `Imported OpenViking resource.${root}${warnings}`.trim();
+}
+
+export function formatSkillImportText(result: AddSkillResult): string {
+  const uri = result.uri ? ` ${result.uri}` : "";
+  const name = result.name ? ` (${result.name})` : "";
+  return `Imported OpenViking skill${name}.${uri}`.trim();
+}
+
+export function mergeFindResults(results: FindResult[]): FindResult {
+  const deduplicate = (items: FindResultItem[]): FindResultItem[] => {
+    const seen = new Map<string, FindResultItem>();
+    for (const item of items) {
+      if (!seen.has(item.uri)) seen.set(item.uri, item);
+    }
+    return Array.from(seen.values());
+  };
+  const memories = deduplicate(results.flatMap((result) => result.memories ?? []));
+  const resources = deduplicate(results.flatMap((result) => result.resources ?? []));
+  const skills = deduplicate(results.flatMap((result) => result.skills ?? []));
+  return {
+    memories,
+    resources,
+    skills,
+    total: memories.length + resources.length + skills.length,
+  };
+}
+
+function truncateSummary(value: string, maxChars = 220): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= maxChars) return collapsed;
+  return `${collapsed.slice(0, maxChars - 3)}...`;
+}
+
+export function formatOVSearchRows(result: FindResult): string[] {
+  const items = [
+    ...(result.memories ?? []).map((item) => ({ contextType: "memory", item })),
+    ...(result.resources ?? []).map((item) => ({ contextType: "resource", item })),
+    ...(result.skills ?? []).map((item) => ({ contextType: "skill", item })),
+  ];
+  if (items.length === 0) {
+    return [];
+  }
+  const numberHeader = "no";
+  const numberWidth = Math.max(numberHeader.length, String(items.length).length);
+  const typeWidth = Math.max("type".length, ...items.map(({ contextType }) => contextType.length));
+  const uriWidth = Math.max("uri".length, ...items.map(({ item }) => item.uri.length));
+  const levelWidth = Math.max("level".length, ...items.map(({ item }) => String(item.level ?? "").length));
+  const scoreWidth = Math.max(
+    "score".length,
+    ...items.map(({ item }) => (typeof item.score === "number" ? item.score.toFixed(2).length : 0)),
+  );
+  return [
+    `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}  abstract`,
+    ...items.map(({ contextType, item }, index) => {
+      const score = typeof item.score === "number" ? item.score.toFixed(2) : "";
+      const summary = truncateSummary(item.abstract || item.overview || "(no summary)");
+      return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}  ${summary}`;
+    }),
+  ];
+}
+
+export function formatOVSearchText(query: string, uri: string | undefined, result: FindResult): string {
+  if ((result.total ?? 0) <= 0) {
+    const scope = uri ? ` under ${uri}` : "";
+    return `No OpenViking resource or skill results found for "${query}"${scope}.`;
+  }
+  const scope = uri ? ` under ${uri}` : "";
+  const lines = [
+    `Found ${result.total ?? 0} OpenViking results for "${query}"${scope}`,
+    "Tip: search results are ranked snippets. Use ov_read on exact hit URIs before answering precise questions. Use ov_list on a hit's parent URI to inspect sibling chunks or overview files before answering procedural or multi-step questions.",
+    "",
+    ...formatOVSearchRows(result),
+  ].filter((line, index, all) => line || (all[index - 1] && all[index + 1]));
+  return lines.join("\n");
+}
+
+export function formatOVListEntry(entry: unknown): string {
+  if (typeof entry === "string") return entry;
+  if (!entry || typeof entry !== "object") return String(entry);
+  const item = entry as Record<string, unknown>;
+  const uri = typeof item.uri === "string" ? item.uri : "";
+  const name = typeof item.name === "string" ? item.name : "";
+  const isDir = item.isDir === true || item.type === "directory";
+  const marker = isDir ? "[dir]" : "[file]";
+  const summary =
+    typeof item.abstract === "string" && item.abstract.trim()
+      ? item.abstract.trim().replace(/\s+/g, " ")
+      : typeof item.overview === "string" && item.overview.trim()
+        ? item.overview.trim().replace(/\s+/g, " ")
+        : "";
+  const label = uri || name || JSON.stringify(item);
+  return summary ? `${marker} ${label} - ${summary}` : `${marker} ${label}`;
+}
+
+export function formatOVListText(uri: string, entries: unknown[]): string {
+  if (entries.length === 0) {
+    return `No OpenViking entries found under ${uri}.`;
+  }
+  return [
+    `Listed ${entries.length} OpenViking entr${entries.length === 1 ? "y" : "ies"} under ${uri}`,
+    "",
+    ...entries.map((entry) => formatOVListEntry(entry)),
+  ].join("\n");
+}
+
+export function formatOVReadText(uri: string, content: string): string {
+  const body = content || "(empty OpenViking content)";
+  return [`--- START OF ${uri} ---`, body, `--- END OF ${uri} ---`].join("\n");
+}
+
+export function formatOVMultiReadText(
+  results: Array<{ uri: string; content: string; success: boolean }>,
+): string {
+  return [
+    `Multi-read results for ${results.length} OpenViking resource${results.length === 1 ? "" : "s"}:`,
+    "",
+    ...results.flatMap((result) => [
+      `--- START OF ${result.uri} ---`,
+      result.success ? (result.content || "(empty OpenViking content)") : `ERROR: ${result.content}`,
+      `--- END OF ${result.uri} ---`,
+      "",
+    ]),
+  ].join("\n").trimEnd();
+}


### PR DESCRIPTION
## Summary
- add a small textResult helper for standard OpenClaw text tool responses
- replace repeated single-text content/detail result boilerplate across OpenViking tools
- preserve memory_recall trace result typing by keeping per-result URI inference instead of search-level overrides

## Impact
This keeps tool names, command names, output text, details payloads, registration order, search behavior, and memory injection behavior unchanged while reducing boilerplate.

## Diff size
- Overall PR: 6 files changed, 741 insertions(+), 920 deletions(-), net -179 lines
- Additional simplify on top of helper split: index.ts net -163 lines

## Validation
- npm run typecheck
- npm test
- npm run build