### PR TITLE
feat(plugins): GitHub-free TOS install path for memory plugins

### DIFF
--- a/.github/workflows/release-tos.yml
+++ b/.github/workflows/release-tos.yml
@@ -1,0 +1,155 @@
+name: 20. Release TOS Upload
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to upload (e.g. v0.3.24)'
+        required: true
+        type: string
+      update_latest:
+        description: 'Also overwrite the stable/latest paths'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    name: Upload Release Artifacts to TOS
+    # Skip CLI releases (cli@* / cli-* tags); main releases use v* tags
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.release.tag_name, 'cli')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Resolve release tag
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [ -z "${TAG}" ]; then
+            echo "::error::Unable to resolve release tag"
+            exit 1
+          fi
+          echo "RELEASE_TAG=${TAG}" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Check TOS configuration
+        id: tos_config
+        env:
+          TOS_ACCESS_KEY: ${{ secrets.TOS_ACCESS_KEY }}
+          TOS_SECRET_KEY: ${{ secrets.TOS_SECRET_KEY }}
+          TOS_REGION: ${{ secrets.TOS_REGION }}
+          TOS_RELEASE_BUCKET: ${{ secrets.TOS_RELEASE_BUCKET }}
+          TOS_ENDPOINT: ${{ secrets.TOS_ENDPOINT }}
+        run: |
+          if [ -n "${TOS_ACCESS_KEY}" ] && [ -n "${TOS_SECRET_KEY}" ] && [ -n "${TOS_REGION}" ] && [ -n "${TOS_RELEASE_BUCKET}" ] && [ -n "${TOS_ENDPOINT}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.tos_config.outputs.configured == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install AWS CLI
+        if: steps.tos_config.outputs.configured == 'true'
+        run: |
+          python -m pip install --upgrade awscli
+          aws configure set default.s3.addressing_style virtual
+
+      - name: Build source archive
+        if: steps.tos_config.outputs.configured == 'true'
+        run: |
+          git archive --format=zip --prefix="OpenViking-${RELEASE_TAG}/" \
+            -o "/tmp/openviking-${RELEASE_TAG}-source.zip" HEAD
+
+      - name: Upload release artifacts to TOS
+        if: steps.tos_config.outputs.configured == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TOS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOS_SECRET_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.TOS_REGION }}
+          TOS_BUCKET: ${{ secrets.TOS_RELEASE_BUCKET }}
+          TOS_ENDPOINT: ${{ secrets.TOS_ENDPOINT }}
+          UPDATE_LATEST: ${{ github.event_name == 'release' || inputs.update_latest }}
+        run: |
+          set -euo pipefail
+
+          TOS_ENDPOINT="${TOS_ENDPOINT#https://}"
+          TOS_ENDPOINT="${TOS_ENDPOINT#http://}"
+          case "${TOS_ENDPOINT}" in
+            tos-s3-*) TOS_S3_ENDPOINT="${TOS_ENDPOINT}" ;;
+            tos-*) TOS_S3_ENDPOINT="tos-s3-${TOS_ENDPOINT#tos-}" ;;
+            *) TOS_S3_ENDPOINT="${TOS_ENDPOINT}" ;;
+          esac
+
+          IMMUTABLE_CACHE_CONTROL="public, max-age=31536000, immutable"
+          NO_CACHE_CONTROL="no-store, no-cache, must-revalidate, max-age=0"
+          SHELL_CONTENT_TYPE="text/plain; charset=utf-8"
+          ZIP_CONTENT_TYPE="application/zip"
+
+          UPLOADED_KEYS=""
+
+          upload() {
+            src="$1"
+            key="$2"
+            content_type="$3"
+            cache_control="$4"
+
+            extra_args=()
+            case "${content_type}" in
+              text/*) extra_args+=(--content-disposition "inline") ;;
+            esac
+
+            aws s3 cp "${src}" "s3://${TOS_BUCKET}/${key}" \
+              --endpoint-url "https://${TOS_S3_ENDPOINT}" \
+              --content-type "${content_type}" \
+              --cache-control "${cache_control}" \
+              ${extra_args[@]+"${extra_args[@]}"} \
+              --only-show-errors
+            echo "Uploaded ${key}"
+            UPLOADED_KEYS="${UPLOADED_KEYS}- \`${key}\`"$'\n'
+          }
+
+          SOURCE_ZIP="/tmp/openviking-${RELEASE_TAG}-source.zip"
+          CLAUDE_INSTALL="examples/claude-code-memory-plugin/setup-helper/install.sh"
+          CODEX_INSTALL="examples/codex-memory-plugin/setup-helper/install.sh"
+
+          # Versioned, immutable copies
+          upload "${SOURCE_ZIP}" "releases/${RELEASE_TAG}/openviking-${RELEASE_TAG}-source.zip" "${ZIP_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
+          upload "${CLAUDE_INSTALL}" "releases/${RELEASE_TAG}/claude-code-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
+          upload "${CODEX_INSTALL}" "releases/${RELEASE_TAG}/codex-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
+
+          # Stable paths, overwritten on every release
+          if [ "${UPDATE_LATEST}" = "true" ]; then
+            upload "${SOURCE_ZIP}" "releases/latest/openviking-source.zip" "${ZIP_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
+            upload "${CLAUDE_INSTALL}" "claude-code-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
+            upload "${CODEX_INSTALL}" "codex-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
+          else
+            echo "Skipping stable/latest paths (update_latest=false)"
+          fi
+
+          {
+            echo "## Uploaded to TOS (${RELEASE_TAG})"
+            echo ""
+            printf '%s' "${UPLOADED_KEYS}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report skipped TOS upload
+        if: steps.tos_config.outputs.configured != 'true'
+        run: |
+          {
+            echo "## TOS upload skipped"
+            echo ""
+            echo "TOS secrets are not fully configured for this repository (TOS_ACCESS_KEY / TOS_SECRET_KEY / TOS_REGION / TOS_RELEASE_BUCKET / TOS_ENDPOINT). Upload was skipped without failing the workflow."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tos.yml
+++ b/.github/workflows/release-tos.yml
@@ -128,11 +128,15 @@ jobs:
           SOURCE_ZIP="/tmp/openviking-${RELEASE_TAG}-source.zip"
           CLAUDE_INSTALL="examples/claude-code-memory-plugin/setup-helper/install.sh"
           CODEX_INSTALL="examples/codex-memory-plugin/setup-helper/install.sh"
+          CLAUDE_TOS_INSTALL="examples/claude-code-memory-plugin/setup-helper/tos-install.sh"
+          CODEX_TOS_INSTALL="examples/codex-memory-plugin/setup-helper/tos-install.sh"
 
           # Versioned, immutable copies
           upload "${SOURCE_ZIP}" "releases/${RELEASE_TAG}/openviking-${RELEASE_TAG}-source.zip" "${ZIP_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
           upload "${CLAUDE_INSTALL}" "releases/${RELEASE_TAG}/claude-code-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
           upload "${CODEX_INSTALL}" "releases/${RELEASE_TAG}/codex-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
+          upload "${CLAUDE_TOS_INSTALL}" "releases/${RELEASE_TAG}/claude-code-memory-plugin/tos-install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
+          upload "${CODEX_TOS_INSTALL}" "releases/${RELEASE_TAG}/codex-memory-plugin/tos-install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
 
           # Stable paths, overwritten on every release. The zip is copied
           # server-side from the versioned key instead of re-transferring it.
@@ -140,6 +144,8 @@ jobs:
             upload "s3://${TOS_BUCKET}/releases/${RELEASE_TAG}/openviking-${RELEASE_TAG}-source.zip" "releases/latest/openviking-source.zip" "${ZIP_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
             upload "${CLAUDE_INSTALL}" "claude-code-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
             upload "${CODEX_INSTALL}" "codex-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
+            upload "${CLAUDE_TOS_INSTALL}" "claude-code-memory-plugin/tos-install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
+            upload "${CODEX_TOS_INSTALL}" "codex-memory-plugin/tos-install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
           else
             echo "Skipping stable/latest paths (update_latest=false)"
           fi

--- a/.github/workflows/release-tos.yml
+++ b/.github/workflows/release-tos.yml
@@ -110,6 +110,10 @@ jobs:
             case "${content_type}" in
               text/*) extra_args+=(--content-disposition "inline") ;;
             esac
+            # s3:// source = server-side CopyObject; REPLACE re-applies metadata
+            case "${src}" in
+              s3://*) extra_args+=(--metadata-directive REPLACE) ;;
+            esac
 
             aws s3 cp "${src}" "s3://${TOS_BUCKET}/${key}" \
               --endpoint-url "https://${TOS_S3_ENDPOINT}" \
@@ -130,9 +134,10 @@ jobs:
           upload "${CLAUDE_INSTALL}" "releases/${RELEASE_TAG}/claude-code-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
           upload "${CODEX_INSTALL}" "releases/${RELEASE_TAG}/codex-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${IMMUTABLE_CACHE_CONTROL}"
 
-          # Stable paths, overwritten on every release
+          # Stable paths, overwritten on every release. The zip is copied
+          # server-side from the versioned key instead of re-transferring it.
           if [ "${UPDATE_LATEST}" = "true" ]; then
-            upload "${SOURCE_ZIP}" "releases/latest/openviking-source.zip" "${ZIP_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
+            upload "s3://${TOS_BUCKET}/releases/${RELEASE_TAG}/openviking-${RELEASE_TAG}-source.zip" "releases/latest/openviking-source.zip" "${ZIP_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
             upload "${CLAUDE_INSTALL}" "claude-code-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
             upload "${CODEX_INSTALL}" "codex-memory-plugin/install.sh" "${SHELL_CONTENT_TYPE}" "${NO_CACHE_CONTROL}"
           else

--- a/examples/claude-code-memory-plugin/setup-helper/install.sh
+++ b/examples/claude-code-memory-plugin/setup-helper/install.sh
@@ -16,10 +16,13 @@
 #      ~/.claude/settings.json.
 #
 # Env overrides:
-#   OPENVIKING_HOME        default: $HOME/.openviking
-#   OPENVIKING_REPO_DIR    default: $OPENVIKING_HOME/openviking-repo
-#   OPENVIKING_REPO_URL    default: https://github.com/volcengine/OpenViking.git
-#   OPENVIKING_REPO_BRANCH default: main
+#   OPENVIKING_HOME            default: $HOME/.openviking
+#   OPENVIKING_REPO_DIR        default: $OPENVIKING_HOME/openviking-repo
+#   OPENVIKING_REPO_URL        default: https://github.com/volcengine/OpenViking.git
+#   OPENVIKING_REPO_BRANCH     default: main
+#   OPENVIKING_REPO_ARCHIVE_URL  when set, fetch the source from this zip instead
+#                                of git clone (used by the TOS bootstrap for users
+#                                who can't reach GitHub). Requires `unzip`.
 #
 # Targets bash 3.2+ (macOS /bin/bash) and Linux.
 
@@ -29,6 +32,10 @@ OV_HOME="${OPENVIKING_HOME:-$HOME/.openviking}"
 REPO_DIR="${OPENVIKING_REPO_DIR:-$OV_HOME/openviking-repo}"
 REPO_URL="${OPENVIKING_REPO_URL:-https://github.com/volcengine/OpenViking.git}"
 REPO_BRANCH="${OPENVIKING_REPO_BRANCH:-main}"
+REPO_ARCHIVE_URL="${OPENVIKING_REPO_ARCHIVE_URL:-}"
+# Marks a $REPO_DIR populated from an archive (no .git). Lets re-runs refresh it
+# safely while refusing to clobber a git checkout or unrelated user data.
+ARCHIVE_MARKER='.openviking-archive-source'
 # Honor OPENVIKING_CLI_CONFIG_FILE (the env var the `ov` CLI itself reads —
 # crates/ov_cli/src/config.rs:6) so this installer matches CLI behavior.
 OVCLI_CONF="${OPENVIKING_CLI_CONFIG_FILE:-$OV_HOME/ovcli.conf}"
@@ -46,6 +53,31 @@ warn()    { printf '%s!!%s  %s\n' "$YELLOW" "$RESET" "$*"; }
 err()     { printf '%sxx%s  %s\n' "$RED" "$RESET" "$*" >&2; }
 ask()     { printf '%s??%s  %s' "$CYAN" "$RESET" "$*"; }
 heading() { printf '\n%s%s%s\n' "$BOLD" "$*" "$RESET"; }
+
+# Download a source zip and lay it out at $REPO_DIR (used for the GitHub-free
+# TOS install path). The archive is `git archive` output: a single top-level
+# OpenViking-<ref>/ dir, identical to a checkout minus .git.
+fetch_archive() {
+  local url="$1" dest="$2" tmp_zip tmp_dir top
+  command -v unzip >/dev/null 2>&1 || { err 'unzip not found; required to install from an archive.'; exit 1; }
+  tmp_zip=$(mktemp "${TMPDIR:-/tmp}/ov-src.XXXXXX") || { err 'mktemp failed'; exit 1; }
+  tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/ov-src.XXXXXX") || { err 'mktemp failed'; rm -f "$tmp_zip"; exit 1; }
+  info "Downloading source archive"
+  info "  $url"
+  curl -fsSL -o "$tmp_zip" "$url" || { err "download failed: $url"; rm -rf "$tmp_zip" "$tmp_dir"; exit 1; }
+  unzip -q "$tmp_zip" -d "$tmp_dir" || { err 'unzip failed (corrupt download?)'; rm -rf "$tmp_zip" "$tmp_dir"; exit 1; }
+  top=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+  if [ -z "$top" ] || [ ! -d "$top/examples" ]; then
+    err 'unexpected archive layout (no top-level dir containing examples/)'
+    rm -rf "$tmp_zip" "$tmp_dir"; exit 1
+  fi
+  rm -rf "$dest"
+  mkdir -p "$(dirname "$dest")"
+  mv "$top" "$dest"
+  : > "$dest/$ARCHIVE_MARKER"
+  rm -rf "$tmp_zip" "$tmp_dir"
+  info "Source ready at $dest"
+}
 
 # ----- 1. Environment check -----
 
@@ -144,7 +176,14 @@ fi
 
 heading "3. OpenViking source repository ($REPO_DIR)"
 
-if [ -d "$REPO_DIR/.git" ]; then
+if [ -n "$REPO_ARCHIVE_URL" ]; then
+  # Archive mode (GitHub-free): refuse to overwrite anything we didn't create.
+  if [ -e "$REPO_DIR" ] && [ ! -f "$REPO_DIR/$ARCHIVE_MARKER" ]; then
+    err "$REPO_DIR exists and was not created from an archive. Move it aside or set OPENVIKING_REPO_DIR."
+    exit 1
+  fi
+  fetch_archive "$REPO_ARCHIVE_URL" "$REPO_DIR"
+elif [ -d "$REPO_DIR/.git" ]; then
   info "Updating existing checkout"
   git -C "$REPO_DIR" fetch --depth 1 origin "$REPO_BRANCH"
   git -C "$REPO_DIR" reset --hard "FETCH_HEAD"

--- a/examples/claude-code-memory-plugin/setup-helper/tos-install.sh
+++ b/examples/claude-code-memory-plugin/setup-helper/tos-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# OpenViking Memory Plugin for Claude Code — TOS bootstrap (China-friendly).
+#
+# For users who can't reach github.com / raw.githubusercontent.com. Pulls both
+# the installer and the source archive from Volcengine TOS instead of GitHub,
+# then hands off to the standard interactive installer.
+#
+# One-liner:
+#   bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/claude-code-memory-plugin/tos-install.sh)
+#
+# Env overrides:
+#   OPENVIKING_TOS_BASE          default: https://ovrelease.tos-cn-beijing.volces.com
+#   OPENVIKING_REPO_ARCHIVE_URL  default: $OPENVIKING_TOS_BASE/releases/latest/openviking-source.zip
+#   (every install.sh env override applies too.)
+
+set -euo pipefail
+
+TOS_BASE="${OPENVIKING_TOS_BASE:-https://ovrelease.tos-cn-beijing.volces.com}"
+TOS_BASE="${TOS_BASE%/}"
+export OPENVIKING_REPO_ARCHIVE_URL="${OPENVIKING_REPO_ARCHIVE_URL:-$TOS_BASE/releases/latest/openviking-source.zip}"
+
+# Fetch the real installer to a file (not a pipe) so it keeps the terminal on
+# stdin for its interactive prompts. It then sources the repo from the archive
+# URL above instead of git clone.
+installer=$(mktemp "${TMPDIR:-/tmp}/ov-cc-install.XXXXXX") || { echo "mktemp failed" >&2; exit 1; }
+trap 'rm -f "$installer"' EXIT
+curl -fsSL -o "$installer" "$TOS_BASE/claude-code-memory-plugin/install.sh"
+bash "$installer"

--- a/examples/codex-memory-plugin/setup-helper/install.sh
+++ b/examples/codex-memory-plugin/setup-helper/install.sh
@@ -13,6 +13,9 @@
 #   OPENVIKING_HOME, OPENVIKING_REPO_DIR, OPENVIKING_REPO_URL,
 #   OPENVIKING_REPO_REF / OPENVIKING_REPO_BRANCH, OPENVIKING_CLI_CONFIG_FILE,
 #   OPENVIKING_CODEX_WRAP_EXTRA (extra launch commands to wrap).
+#   OPENVIKING_REPO_ARCHIVE_URL  when set, fetch the source from this zip instead
+#                                of git clone (used by the TOS bootstrap for users
+#                                who can't reach GitHub). Requires `unzip`.
 
 set -euo pipefail
 
@@ -22,6 +25,10 @@ REPO_DIR="${OPENVIKING_REPO_DIR:-$OV_HOME/openviking-repo}"
 # Accept both OPENVIKING_REPO_REF and OPENVIKING_REPO_BRANCH so users can
 # reuse the same env var across the claude-code and codex installers.
 REPO_REF="${OPENVIKING_REPO_REF:-${OPENVIKING_REPO_BRANCH:-main}}"
+REPO_ARCHIVE_URL="${OPENVIKING_REPO_ARCHIVE_URL:-}"
+# Marks a $REPO_DIR populated from an archive (no .git). Lets re-runs refresh it
+# safely while refusing to clobber a git checkout or unrelated user data.
+ARCHIVE_MARKER='.openviking-archive-source'
 MARKETPLACE_NAME="${OPENVIKING_CODEX_MARKETPLACE_NAME:-openviking-plugins-local}"
 MARKETPLACE_ROOT="${OPENVIKING_CODEX_MARKETPLACE_ROOT:-$HOME/.codex/${MARKETPLACE_NAME}-marketplace}"
 PLUGIN_NAME="openviking-memory"
@@ -42,6 +49,31 @@ warn()    { printf '%s!!%s  %s\n' "$YELLOW" "$RESET" "$*"; }
 err()     { printf '%sxx%s  %s\n' "$RED" "$RESET" "$*" >&2; }
 ask()     { printf '%s??%s  %s' "$CYAN" "$RESET" "$*"; }
 heading() { printf '\n%s%s%s\n' "$BOLD" "$*" "$RESET"; }
+
+# Download a source zip and lay it out at $REPO_DIR (used for the GitHub-free
+# TOS install path). The archive is `git archive` output: a single top-level
+# OpenViking-<ref>/ dir, identical to a checkout minus .git.
+fetch_archive() {
+  local url="$1" dest="$2" tmp_zip tmp_dir top
+  command -v unzip >/dev/null 2>&1 || { err 'unzip not found; required to install from an archive.'; exit 1; }
+  tmp_zip=$(mktemp "${TMPDIR:-/tmp}/ov-src.XXXXXX") || { err 'mktemp failed'; exit 1; }
+  tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/ov-src.XXXXXX") || { err 'mktemp failed'; rm -f "$tmp_zip"; exit 1; }
+  info "Downloading source archive"
+  info "  $url"
+  curl -fsSL -o "$tmp_zip" "$url" || { err "download failed: $url"; rm -rf "$tmp_zip" "$tmp_dir"; exit 1; }
+  unzip -q "$tmp_zip" -d "$tmp_dir" || { err 'unzip failed (corrupt download?)'; rm -rf "$tmp_zip" "$tmp_dir"; exit 1; }
+  top=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+  if [ -z "$top" ] || [ ! -d "$top/examples" ]; then
+    err 'unexpected archive layout (no top-level dir containing examples/)'
+    rm -rf "$tmp_zip" "$tmp_dir"; exit 1
+  fi
+  rm -rf "$dest"
+  mkdir -p "$(dirname "$dest")"
+  mv "$top" "$dest"
+  : > "$dest/$ARCHIVE_MARKER"
+  rm -rf "$tmp_zip" "$tmp_dir"
+  info "Source ready at $dest"
+}
 
 # ----- 1. Environment check -----
 
@@ -169,7 +201,14 @@ heading "3. OpenViking source repository ($REPO_DIR)"
 
 mkdir -p "$(dirname "$REPO_DIR")" "$HOME/.codex"
 
-if [ ! -e "$REPO_DIR/.git" ]; then
+if [ -n "$REPO_ARCHIVE_URL" ]; then
+  # Archive mode (GitHub-free): refuse to overwrite anything we didn't create.
+  if [ -e "$REPO_DIR" ] && [ ! -f "$REPO_DIR/$ARCHIVE_MARKER" ]; then
+    err "$REPO_DIR exists and was not created from an archive. Move it aside or set OPENVIKING_REPO_DIR."
+    exit 1
+  fi
+  fetch_archive "$REPO_ARCHIVE_URL" "$REPO_DIR"
+elif [ ! -e "$REPO_DIR/.git" ]; then
   if [ -e "$REPO_DIR" ]; then
     err "$REPO_DIR exists but is not a git checkout."
     exit 1

--- a/examples/codex-memory-plugin/setup-helper/tos-install.sh
+++ b/examples/codex-memory-plugin/setup-helper/tos-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# OpenViking Memory Plugin for Codex — TOS bootstrap (China-friendly).
+#
+# For users who can't reach github.com / raw.githubusercontent.com. Pulls both
+# the installer and the source archive from Volcengine TOS instead of GitHub,
+# then hands off to the standard interactive installer.
+#
+# One-liner:
+#   bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/codex-memory-plugin/tos-install.sh)
+#
+# Env overrides:
+#   OPENVIKING_TOS_BASE          default: https://ovrelease.tos-cn-beijing.volces.com
+#   OPENVIKING_REPO_ARCHIVE_URL  default: $OPENVIKING_TOS_BASE/releases/latest/openviking-source.zip
+#   (every install.sh env override applies too.)
+
+set -euo pipefail
+
+TOS_BASE="${OPENVIKING_TOS_BASE:-https://ovrelease.tos-cn-beijing.volces.com}"
+TOS_BASE="${TOS_BASE%/}"
+export OPENVIKING_REPO_ARCHIVE_URL="${OPENVIKING_REPO_ARCHIVE_URL:-$TOS_BASE/releases/latest/openviking-source.zip}"
+
+# Fetch the real installer to a file (not a pipe) so it keeps the terminal on
+# stdin for its interactive prompts. It then sources the repo from the archive
+# URL above instead of git clone.
+installer=$(mktemp "${TMPDIR:-/tmp}/ov-codex-install.XXXXXX") || { echo "mktemp failed" >&2; exit 1; }
+trap 'rm -f "$installer"' EXIT
+curl -fsSL -o "$installer" "$TOS_BASE/codex-memory-plugin/install.sh"
+bash "$installer"


### PR DESCRIPTION
## Description

Adds a GitHub-free install path for the Claude Code and Codex memory plugins, for users behind the GFW who can't reach `github.com` / `raw.githubusercontent.com`. Today's one-liner installers download fine from anywhere, but stall at their step-3 `git clone https://github.com/volcengine/OpenViking.git`. This wires the source archive (already published to Volcengine TOS by the release workflow) into the installers, so the whole flow can run from TOS.

China-friendly one-liner:

```
bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/claude-code-memory-plugin/tos-install.sh)
bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/codex-memory-plugin/tos-install.sh)
```

> [!NOTE]
> Stacked on #2575 (which adds `release-tos.yml`). Please merge after #2575; this branch will be rebased onto `main` to drop those commits once it lands. The only file shared with #2575 is `release-tos.yml`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Both `setup-helper/install.sh` learn `OPENVIKING_REPO_ARCHIVE_URL`: when set, step 3 fetches the source from a zip (`curl` + `unzip`) instead of `git clone`. A `.openviking-archive-source` marker keeps re-runs idempotent and refuses to clobber a git checkout or unrelated data already at `REPO_DIR`. The GitHub default path is unchanged — archive mode only activates when the env var is set.
- New `setup-helper/tos-install.sh` bootstrap per plugin: defaults the archive URL to the TOS `latest` zip, downloads the real `install.sh` from TOS to a temp file (kept off the stdin pipe so the installer's interactive prompts still work), and delegates. `OPENVIKING_TOS_BASE` overrides the mirror.
- `release-tos.yml` uploads both `tos-install.sh` next to `install.sh` (versioned + stable paths).

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated locally end-to-end against the real TOS zip, in a sandboxed `env -i` + temp `HOME` with no `claude`/`codex` on PATH (GitHub never contacted):

- `bash -n` on all four scripts; `actionlint` on the workflow.
- claude `install.sh` archive mode: source laid out from the zip, sentinel written, `.git` absent, rc source-hook added, existing `ovcli.conf` preserved. Re-run is idempotent (re-extracts, no duplicate rc block).
- Safety guard: a pre-existing non-sentinel `REPO_DIR` is refused and its contents left intact.
- codex `install.sh` archive mode (stubbed `codex`, real Node): archive laid out, marketplace + plugin cache built, `config.toml` gets `enabled = true` + `plugin_hooks = true`, `.mcp.json` URL rendered, bearer kept when an api_key is present.
- `tos-install.sh` end-to-end: downloads the installer from a stand-in mirror and pulls the source zip from real TOS, completing the chain with zero GitHub access.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Updating the README / docs one-liners to point at the TOS bootstrap is intentionally a follow-up, once the path has run through a real release. `wrapper.sh` and friends are not uploaded separately — they ship inside the source zip.
