### PR TITLE
docs(blog): update user peer model author

### DIFF
--- a/blog/src/posts/openviking-user-peer-model/index.jsx
+++ b/blog/src/posts/openviking-user-peer-model/index.jsx
@@ -409,6 +409,6 @@ export default {
     tags: ['openviking', 'memory', 'multi-tenant', 'agents'],
     languages: ['en', 'zh'],
     llmPath: LLM_PATH,
-    authors: [{ name: 'OpenViking Team', github: 'volcengine' }],
+    authors: [{ name: 'qin-ctx', github: 'qin-ctx' }],
   },
 };


### PR DESCRIPTION
## Summary
- Update the OpenViking User / Peer post author from OpenViking Team to qin-ctx.
- Scope is limited to blog/src/posts/openviking-user-peer-model/index.jsx metadata.

## Evidence
- GitHub contributors API shows qin-ctx as the largest contributor by contribution count: 181 contributions.
- GitHub user API confirms qin-ctx is the requested GitHub account.

## Verification
- git diff --check
- npm run build --prefix blog

No content, assets, secrets, or runtime code changed.