### PR TITLE
docs(changelog): add v0.3.24 entry (EN+ZH)

### DIFF
--- a/docs/en/about/02-changelog.md
+++ b/docs/en/about/02-changelog.md
@@ -3,6 +3,23 @@
 All notable changes to OpenViking will be documented in this file.
 This changelog is automatically generated from [GitHub Releases](https://github.com/volcengine/OpenViking/releases).
 
+## v0.3.24 (2026-06-05)
+
+### Highlights
+
+- **CLI configuration UX and non-interactive setup**: `ov config` ships a refreshed wizard and clearer result output, and new non-interactive config commands let configuration be scripted in automation without interactive prompts.
+- **Durable async resource imports**: asynchronous `add_resource` tasks are now persisted, so an in-progress import survives a server restart instead of being dropped.
+- **Storage internals**: the snapshot tree function is optimized, and the deprecated agfs HTTP-mode client has been removed.
+- **MiniMax default model upgraded to M3**: the default MiniMax model is now M3.
+- **More precise embedding error classification**: `classify_api_error` uses word-boundary matching for numeric error patterns, reducing misclassification of provider error codes.
+
+### Upgrade Notes
+
+- The agfs HTTP-mode client has been removed; switch to the supported agfs access path if you relied on HTTP mode.
+- The default MiniMax model is now M3 — pin an explicit model in your config if you need the previous default.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.3.23...v0.3.24)
+
 ## v0.3.23 (2026-06-03)
 
 ### Highlights

--- a/docs/zh/about/02-changelog.md
+++ b/docs/zh/about/02-changelog.md
@@ -3,6 +3,23 @@
 OpenViking 的所有重要变更都将记录在此文件中。
 此更新日志从 [GitHub Releases](https://github.com/volcengine/OpenViking/releases) 自动生成。
 
+## v0.3.24 (2026-06-05)
+
+### 重点更新
+
+- **CLI 配置体验与非交互式配置**：`ov config` 重构配置向导并优化结果输出，同时新增非交互式配置命令，可在自动化场景中无需交互提示即可脚本化完成配置。
+- **异步资源导入持久化**：异步执行的 `add_resource` 任务现在会被持久化，进行中的导入在服务重启后不再丢失。
+- **存储内部优化**：优化快照 tree 函数，并移除已废弃的 agfs HTTP 模式客户端。
+- **MiniMax 默认模型升级为 M3**：MiniMax 默认模型现为 M3。
+- **更精确的 embedding 错误分类**：`classify_api_error` 对数字错误码采用词边界匹配，减少对服务商错误码的误判。
+
+### 升级说明
+
+- agfs HTTP 模式客户端已移除；如果你依赖 HTTP 模式，请改用受支持的 agfs 接入方式。
+- MiniMax 默认模型现为 M3；如需此前的默认模型，请在配置中显式指定模型。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.3.23...v0.3.24)
+
 ## v0.3.23 (2026-06-03)
 
 ### 重点更新


### PR DESCRIPTION
Adds the `v0.3.24` (2026-06-05) entry to the changelog in both EN and ZH. The
changelog top was still `v0.3.23` while `v0.3.24` is the latest release.

Curated **Highlights** + **Upgrade Notes** from the release, matching the format
of #2316 (v0.3.20–v0.3.23) and #2088 (v0.3.17):

- CLI config wizard/result UX refresh + new non-interactive config commands (#2408, #2426)
- Persisted async `add_resource` tasks (#2433)
- Storage tree-function optimization + removal of the deprecated agfs HTTP-mode client (#2372, #2425)
- MiniMax default model upgraded to M3 (#2368)
- Word-boundary matching for numeric error patterns in `classify_api_error` (#2370)

Upgrade Notes flag the two behavior changes (agfs HTTP-mode client removed; MiniMax
default now M3). EN and ZH kept in sync.
