### PR TITLE
fix(rerank): filter empty docs before rerank API; concurrent read_batch

### DIFF
--- a/openviking/models/rerank/openai_rerank.py
+++ b/openviking/models/rerank/openai_rerank.py
@@ -63,10 +63,28 @@ class OpenAIRerankClient(RerankBase):
         if not documents:
             return []
 
+        # Filter out empty/blank documents that providers like SiliconFlow silently drop.
+        # Track original indices so we can reconstruct a full scores array.
+        non_empty_docs: List[str] = []
+        non_empty_indices: List[int] = []
+        for i, doc in enumerate(documents):
+            text = (doc or "").strip()
+            if text:
+                non_empty_docs.append(text)
+                non_empty_indices.append(i)
+            else:
+                logger.debug(
+                    "[OpenAIRerankClient] Skipping empty document at index %s", i
+                )
+
+        if not non_empty_docs:
+            return [0.0] * len(documents)
+
         req_body = {
             "model": self.model_name,
             "query": query,
-            "documents": documents,
+            "documents": non_empty_docs,
+            "top_n": len(non_empty_docs),
         }
 
         try:
@@ -87,7 +105,7 @@ class OpenAIRerankClient(RerankBase):
             result = response.json()
 
             # Update token usage tracking (estimate, OpenAI rerank doesn't provide token info)
-            self._extract_and_update_token_usage(result, query, documents)
+            self._extract_and_update_token_usage(result, query, non_empty_docs)
 
             # Standard OpenAI/Cohere rerank format: results[].{index, relevance_score}
             results = result.get("results")
@@ -95,26 +113,27 @@ class OpenAIRerankClient(RerankBase):
                 logger.warning(f"[OpenAIRerankClient] Unexpected response format: {result}")
                 return None
 
-            if len(results) != len(documents):
+            if len(results) != len(non_empty_docs):
                 logger.warning(
                     "[OpenAIRerankClient] Unexpected rerank result length: expected=%s actual=%s",
-                    len(documents),
+                    len(non_empty_docs),
                     len(results),
                 )
                 return None
 
-            # Results may not be in original order — sort by index
+            # Map API results (indexed against non_empty_docs) back to original indices
             scores = [0.0] * len(documents)
             for item in results:
-                idx = item.get("index")
-                if idx is None or not (0 <= idx < len(documents)):
+                api_idx = item.get("index")
+                if api_idx is None or not (0 <= api_idx < len(non_empty_docs)):
                     logger.warning(
                         "[OpenAIRerankClient] Out-of-bounds or missing index in result: %s", item
                     )
                     return None
-                scores[idx] = item.get("relevance_score", 0.0)
+                original_idx = non_empty_indices[api_idx]
+                scores[original_idx] = item.get("relevance_score", 0.0)
 
-            logger.debug(f"[OpenAIRerankClient] Reranked {len(documents)} documents")
+            logger.debug(f"[OpenAIRerankClient] Reranked {len(non_empty_docs)} documents")
             return scores
 
         except Exception as e:

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import PurePath
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from openviking.core.namespace import (
     canonicalize_uri,
@@ -2381,19 +2381,22 @@ class VikingFS:
     async def read_batch(
         self, uris: List[str], level: str = "l0", ctx: Optional[RequestContext] = None
     ) -> Dict[str, str]:
-        """Batch read content from multiple URIs."""
-        results = {}
-        for uri in uris:
+        """Batch read content from multiple URIs concurrently."""
+        async def _read_one(uri: str) -> Tuple[str, str]:
             try:
-                content = ""
                 if level == "l0":
                     content = await self.abstract(uri, ctx=ctx)
                 elif level == "l1":
                     content = await self.overview(uri, ctx=ctx)
-                results[uri] = content
+                else:
+                    content = ""
+                return uri, content
             except Exception:
-                pass
-        return results
+                return uri, ""
+
+        tasks = [_read_one(uri) for uri in uris]
+        gathered = await asyncio.gather(*tasks)
+        return {uri: content for uri, content in gathered}
 
     # ========== Other Preserved Methods ==========
 


### PR DESCRIPTION
## Problem

Two issues causing slow search (up to 8.3s worst-case):

### 1. Reranker fails when documents contain empty strings
SiliconFlow API silently drops empty documents from results. When one of N documents has an empty string, the API returns N-1 results. The client detects the count mismatch and falls back to vector scores, wasting the API call entirely (approximately 180ms per call, plus worse result quality).

Log evidence:
```
[OpenAIRerankClient] Unexpected rerank result length: expected=24 actual=23
[HierarchicalRetriever] Invalid rerank result, fallback to vector scores
```

### 2. read_batch reads files sequentially
VikingFS.read_batch() loops through URIs sequentially with await self.abstract() for each file. For 24 candidates each with up to 5 relations, that is up to 120 serial file reads.

## Fix

### openai_rerank.py
- Filter out empty/blank documents before sending to the rerank API
- Track original indices with non_empty_indices list
- Map API results back to original document indices, with 0.0 for empty docs
- Also add top_n parameter to prevent SiliconFlow default top_n=12 truncation

### viking_fs.py
- Rewrite read_batch() to use asyncio.gather() for concurrent I/O
- Add Tuple to typing imports

## Test Results

Before:
```
[OV-TIMING] global_search: 4632ms
[OV-TIMING] recursive_search: 334ms
[OV-TIMING] convert: 3385ms
Total worst: approximately 8.3s
```

After:
```
[OV-TIMING] global_search: 212ms
[OV-TIMING] recursive_search: 220ms
[OV-TIMING] convert: 4ms
Total: approximately 436ms
```

Reranker now works correctly - no more "Invalid rerank result" warnings.