### PR TITLE
feat(storage): initialize user entry directories

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -183,25 +183,39 @@ class DirectoryInitializer:
         return count
 
     async def initialize_user_directories(self, ctx: RequestContext) -> int:
-        """Initialize only the user namespace root for the current user.
+        """Initialize the current user's root and first-level entry directories.
 
-        Child directories under ``viking://user/{user_space}`` are created lazily on
-        first write. This avoids materializing empty namespaces such as
-        ``memories/patterns`` or ``skills`` before any actual content exists.
+        Concrete leaf namespaces under entries such as ``memories`` or ``sessions``
+        are still created lazily when content is written. This keeps a new user
+        root discoverable without materializing the full empty taxonomy.
         """
         if "user" not in PRESET_DIRECTORIES:
             return 0
         user_space_root = canonical_user_root(ctx)
         user_tree = PRESET_DIRECTORIES["user"]
         parent_uri = "viking://user"
-        created = await self._ensure_directory(
+        count = 0
+        if await self._ensure_directory(
             uri=user_space_root,
             parent_uri=parent_uri,
             defn=user_tree,
             scope="user",
             ctx=ctx,
-        )
-        return 1 if created else 0
+        ):
+            count += 1
+
+        for child in user_tree.children:
+            child_uri = f"{user_space_root}/{child.path}"
+            if await self._ensure_directory(
+                uri=child_uri,
+                parent_uri=user_space_root,
+                defn=child,
+                scope="user",
+                ctx=ctx,
+            ):
+                count += 1
+
+        return count
 
     async def initialize_agent_directories(self, ctx: RequestContext) -> int:
         """Deprecated compatibility hook; agent directories are no longer initialized."""

--- a/tests/unit/test_directory_initializer.py
+++ b/tests/unit/test_directory_initializer.py
@@ -1,0 +1,58 @@
+import pytest
+
+from openviking.core.directories import PRESET_DIRECTORIES, DirectoryInitializer
+from openviking.core.namespace import canonical_user_root
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeVikingDB:
+    def __init__(self):
+        self.embedding_messages = []
+
+    async def get_context_by_uri(self, **_kwargs):
+        return []
+
+    async def enqueue_embedding_msg(self, message):
+        self.embedding_messages.append(message)
+
+
+class _FakeVikingFS:
+    def __init__(self):
+        self.contexts = {}
+
+    async def abstract(self, uri, ctx):
+        if uri not in self.contexts:
+            raise FileNotFoundError(uri)
+        return self.contexts[uri]["abstract"]
+
+    async def write_context(self, uri, abstract, overview, is_leaf, ctx):
+        self.contexts[uri] = {
+            "abstract": abstract,
+            "overview": overview,
+            "is_leaf": is_leaf,
+        }
+
+
+@pytest.mark.asyncio
+async def test_initialize_user_directories_creates_root_and_first_level_only():
+    vikingdb = _FakeVikingDB()
+    viking_fs = _FakeVikingFS()
+    initializer = DirectoryInitializer(vikingdb, viking_fs=viking_fs)
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.ADMIN)
+
+    count = await initializer.initialize_user_directories(ctx)
+
+    user_root = canonical_user_root(ctx)
+    expected_uris = {
+        user_root,
+        *(f"{user_root}/{child.path}" for child in PRESET_DIRECTORIES["user"].children),
+    }
+    assert count == len(expected_uris)
+    assert set(viking_fs.contexts) == expected_uris
+    assert f"{user_root}/memories/preferences" not in viking_fs.contexts
+
+    second_count = await initializer.initialize_user_directories(ctx)
+
+    assert second_count == 0
+    assert set(viking_fs.contexts) == expected_uris


### PR DESCRIPTION
## Description

Initialize first-level user namespace entry directories when an account or user is created, so a fresh `viking://user` root exposes the standard entry points instead of appearing empty.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Initialize the current user root plus its first-level preset entries during user directory setup.
- Keep deeper namespaces such as `memories/preferences` lazy-created to avoid materializing the full empty taxonomy.
- Add a unit test covering first-level initialization and idempotency.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
.venv/bin/python -m pytest tests/unit/test_directory_initializer.py -q
.venv/bin/python -m pytest tests/server/test_admin_api.py -q
.venv/bin/ruff check openviking/core/directories.py tests/unit/test_directory_initializer.py
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The pytest runs emit existing dependency/deprecation warnings unrelated to this change.
