### PR TITLE
fix(reindex): surface indexed/skipped file counts in maintenance reindex response (#1706)

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -90,6 +90,8 @@ class _ReindexCounters:
     rebuilt_records: int = 0
     unsupported_records: int = 0
     failed_records: int = 0
+    indexed_files: int = 0
+    skipped_files: int = 0
     warnings: list[str] = field(default_factory=list)
 
 
@@ -460,6 +462,8 @@ class ReindexExecutor:
             "rebuilt_records": counters.rebuilt_records,
             "unsupported_records": counters.unsupported_records,
             "failed_records": counters.failed_records,
+            "indexed_files": counters.indexed_files,
+            "skipped_files": counters.skipped_files,
             "duration_ms": int((time.perf_counter() - started_at) * 1000),
             "warnings": counters.warnings,
         }
@@ -599,7 +603,9 @@ class ReindexExecutor:
                     continue
                 if entry.get("isDir"):
                     directories.append(entry_uri)
-                elif not self._is_hidden_meta_file(entry_uri):
+                elif self._is_hidden_meta_file(entry_uri):
+                    counters.skipped_files += 1
+                else:
                     files.append(entry_uri)
         else:
             directories = []
@@ -688,6 +694,7 @@ class ReindexExecutor:
             vector_text = await self._best_resource_file_vector_text(file_uri, summary, ctx=ctx)
             if not vector_text:
                 counters.unsupported_records += 1
+                counters.skipped_files += 1
                 counters.warnings.append(f"No vector source found for {file_uri}")
                 continue
             abstract = self._prefer_non_empty(summary, vector_text)
@@ -703,6 +710,7 @@ class ReindexExecutor:
                     ctx=ctx,
                 )
                 counters.rebuilt_records += 1
+                counters.indexed_files += 1
             except Exception as exc:
                 counters.failed_records += 1
                 counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
@@ -763,7 +771,9 @@ class ReindexExecutor:
                 continue
             if entry.get("isDir"):
                 resource_directories.append(entry_uri)
-            elif not self._is_hidden_meta_file(entry_uri):
+            elif self._is_hidden_meta_file(entry_uri):
+                counters.skipped_files += 1
+            else:
                 resource_files.append(entry_uri)
 
         for memory_root in sorted(set(memory_roots)):
@@ -842,7 +852,9 @@ class ReindexExecutor:
                 continue
             if entry.get("isDir"):
                 resource_directories.append(entry_uri)
-            elif not self._is_hidden_meta_file(entry_uri):
+            elif self._is_hidden_meta_file(entry_uri):
+                counters.skipped_files += 1
+            else:
                 resource_files.append(entry_uri)
 
         for user_root in sorted(set(user_roots)):

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -1412,3 +1412,93 @@ async def test_openviking_service_reindex_uses_default_root_context(monkeypatch)
     assert seen["ctx"].role == Role.ROOT
     assert seen["ctx"].user.account_id == "acct"
     assert seen["ctx"].user.user_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_reindex_resource_vectors_directory_with_only_overview_md_reports_skipped(
+    monkeypatch,
+):
+    """Issue #1706: a dir whose only file is .overview.md must report skipped_files>=1."""
+    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return True
+
+        async def stat(self, uri, ctx=None):
+            return {"isDir": True}
+
+        async def tree(
+            self,
+            uri,
+            output="original",
+            show_all_hidden=True,
+            node_limit=None,
+            level_limit=None,
+            ctx=None,
+        ):
+            return [
+                {"uri": "viking://resources/demo/.overview.md", "isDir": False},
+            ]
+
+    async def fake_read_directory_abstract(self, uri, *, ctx):
+        return ""
+
+    async def fake_read_directory_overview(self, uri, *, ctx):
+        return ""
+
+    monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
+    monkeypatch.setattr(ReindexExecutor, "_read_directory_abstract", fake_read_directory_abstract)
+    monkeypatch.setattr(ReindexExecutor, "_read_directory_overview", fake_read_directory_overview)
+
+    service = ReindexExecutor()
+    counters = _ReindexCounters()
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    await service._reindex_resource_vectors(
+        uri="viking://resources/demo",
+        counters=counters,
+        ctx=ctx,
+    )
+
+    assert counters.indexed_files == 0
+    assert counters.skipped_files == 1
+    assert counters.rebuilt_records == 0
+
+
+@pytest.mark.asyncio
+async def test_reindex_response_includes_indexed_and_skipped_file_counts(monkeypatch):
+    """Issue #1706: top-level reindex response surfaces indexed_files / skipped_files."""
+    from openviking.server.routers.content import ReindexRequest, reindex
+
+    class FakeService:
+        async def reindex(self, *, uri, mode, wait, ctx):
+            return {
+                "status": "completed",
+                "uri": uri,
+                "object_type": "resource",
+                "mode": mode,
+                "rebuilt_records": 0,
+                "scanned_records": 1,
+                "unsupported_records": 0,
+                "failed_records": 0,
+                "indexed_files": 0,
+                "skipped_files": 1,
+                "duration_ms": 7,
+                "warnings": [],
+            }
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+    request = ReindexRequest(uri="viking://resources/demo", mode="vectors_only", wait=True)
+
+    monkeypatch.setattr("openviking.server.routers.content.get_service", lambda: FakeService())
+    response = await reindex(body=request, ctx=ctx)
+
+    assert response.result["indexed_files"] == 0
+    assert response.result["skipped_files"] == 1


### PR DESCRIPTION
## Summary
- Surfaces indexed-file and skipped-file counts in the maintenance reindex API response so callers can detect no-op reindexes (e.g. a directory that only contains a skipped `.overview.md`).
- Previously the endpoint returned a generic success regardless of actual work performed.

## Test plan
- [ ] Reindex a URI with only `.overview.md` -> response shows `indexed_files: 0`, `skipped_files: 1`.
- [ ] Reindex a URI with real content files -> response shows non-zero `indexed_files`.
- [ ] Existing reindex callers continue to work (added fields are additive).

Closes #1706