### PR TITLE
fix(session): skip vector seed for session directories

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -14,6 +14,7 @@ from openviking.core.context import Context, Vectorize
 from openviking.core.namespace import (
     canonical_user_root,
     context_type_for_uri,
+    is_session_uri,
     user_space_fragment,
 )
 from openviking.server.identity import RequestContext
@@ -258,7 +259,7 @@ class DirectoryInitializer:
 
         # 2. Seed directory L0/L1 vectors only during fresh initialization.
         owner_space = self._owner_space_for_scope(scope=scope, ctx=ctx)
-        if agfs_created:
+        if agfs_created and not is_session_uri(uri):
             await self._ensure_directory_l0_l1_vectors(
                 uri=uri,
                 parent_uri=parent_uri,

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -391,12 +391,6 @@ def _resolve_user_uri(
 ) -> ResolvedNamespace:
     normalized = "viking://" + "/".join(parts)
     if len(parts) == 1:
-        if ctx is not None:
-            return ResolvedNamespace(
-                uri=canonical_user_root(ctx),
-                scope="user",
-                owner_user_id=ctx.user.user_id,
-            )
         return ResolvedNamespace(uri="viking://user", scope="user", is_container=True)
 
     if _is_current_user_relative_uri(parts, ctx):

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -347,6 +347,12 @@ class VikingFS:
 
     def _ensure_supported_write_namespace(self, normalized_uri: str) -> None:
         parts = [p for p in normalized_uri[len("viking://") :].strip("/").split("/") if p]
+        if parts == ["user"]:
+            raise PermissionDeniedError(
+                "Writing viking://user is not supported; use an explicit user namespace "
+                "or current-user content path instead.",
+                resource=normalized_uri,
+            )
         if parts and parts[0] in {"agent", "session"}:
             raise PermissionDeniedError(
                 f"Writing {normalized_uri} is not supported; use user-owned namespaces instead.",

--- a/tests/unit/test_namespace_uri_classification.py
+++ b/tests/unit/test_namespace_uri_classification.py
@@ -147,11 +147,3 @@ def test_current_user_short_content_roots_are_canonicalized_from_content_segment
     assert is_content_root_uri("viking://resources", ctx, kind="resource")
     assert not is_content_namespace_root_uri("viking://user/resources/docs", ctx)
 
-
-def test_user_root_short_form_uses_current_identity():
-    ctx = RequestContext(
-        user=UserIdentifier(account_id="acct", user_id="alice"),
-        role=Role.ROOT,
-    )
-
-    assert canonicalize_uri("viking://user", ctx) == "viking://user/alice"


### PR DESCRIPTION
## Description

Prevent preset user session directories from seeding L0/L1 vector records during user directory initialization. Session directories are still created in VikingFS for discovery and migration, but they no longer enter the semantic vector index at creation time.

Also keep the short `viking://user` URI as the generic user namespace container instead of silently resolving it to the current user. Write operations now reject `viking://user` and require an explicit user namespace or current-user content path.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Skip preset L0/L1 vector seeding for URIs classified as session namespace paths.
- Keep existing session directory creation behavior unchanged.
- Reuse the existing `is_session_uri` namespace rule so initialization matches reindex/indexing exclusions.
- Preserve `viking://user` as a short user namespace container URI during canonicalization.
- Reject writes to `viking://user` with a clear permission error instead of resolving it through the current identity.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation run:
- `.venv/bin/ruff format openviking/core/directories.py --check`
- `.venv/bin/ruff check openviking/core/directories.py`

Not run per request:
- Unit tests

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Tests were not added or run per request.
