### PR TITLE
[codex] fix install.sh validators: optional peer header + parenthesized plugin list state

### DIFF
--- a/examples/codex-memory-plugin/scripts/ov-credentials.mjs
+++ b/examples/codex-memory-plugin/scripts/ov-credentials.mjs
@@ -291,6 +291,10 @@ function main() {
     process.stdout.write(resolveOpenVikingCredentials().hasApiKey ? "1" : "0");
     return;
   }
+  if (cmd === "has-peer-id") {
+    process.stdout.write(resolveOpenVikingCredentials().peerId ? "1" : "0");
+    return;
+  }
   if (cmd === "sync-mcp") {
     const file = process.argv[3];
     if (!file) {
@@ -301,7 +305,7 @@ function main() {
     syncMcpConfig(file);
     return;
   }
-  process.stderr.write("usage: ov-credentials.mjs <shell-env|mcp-url|has-api-key|sync-mcp>\n");
+  process.stderr.write("usage: ov-credentials.mjs <shell-env|mcp-url|has-api-key|has-peer-id|sync-mcp>\n");
   process.exitCode = 2;
 }
 

--- a/examples/codex-memory-plugin/setup-helper/install.sh
+++ b/examples/codex-memory-plugin/setup-helper/install.sh
@@ -352,6 +352,15 @@ detect_api_key() {
 }
 HAS_API_KEY="$(detect_api_key)"
 
+# Detect whether an actor peer id is configured (ovcli.conf actor_peer_id /
+# peer_id, env, or legacy ov.conf codex.peerId). When no peer is configured
+# the syncMcpConfig call deliberately omits the X-OpenViking-Actor-Peer
+# env_http_headers mapping, so the validator must not require it.
+detect_peer_id() {
+  OPENVIKING_CLI_CONFIG_FILE="$OVCLI_CONF" node "$CREDS_SCRIPT" has-peer-id 2>/dev/null || echo "0"
+}
+HAS_PEER_ID="$(detect_peer_id)"
+
 render_plugin_cache() {
   mkdir -p "$(dirname "$CACHE_DIR")"
   rm -rf "$CACHE_DIR"
@@ -588,7 +597,9 @@ validate_plugin_install() {
   if [ ! -L "$marketplace_link" ] || [ "$(readlink "$marketplace_link" 2>/dev/null || true)" != "$PLUGIN_DIR" ]; then
     issues+=("marketplace symlink does not point at $PLUGIN_DIR")
   fi
-  if ! codex plugin list 2>/dev/null | grep -E -q "${PLUGIN_ID}[[:space:]]+installed, enabled"; then
+  # `codex plugin list` formats each row as `<plugin-id> (<state>)`, so accept
+  # either parenthesized or bare forms — codex CLI has historically shipped both.
+  if ! codex plugin list 2>/dev/null | grep -E -q "${PLUGIN_ID}[[:space:]]+\(?installed, enabled\)?"; then
     issues+=("codex plugin list does not show $PLUGIN_ID as installed, enabled")
   fi
   if [ ! -d "$CACHE_DIR" ]; then
@@ -610,7 +621,15 @@ validate_plugin_install() {
     if [ "$HAS_API_KEY" != "1" ] && grep -q "bearer_token_env_var" "$mcp_json"; then
       issues+=("cached .mcp.json keeps bearer_token_env_var without configured API key")
     fi
-    grep -q '"X-OpenViking-Actor-Peer"' "$mcp_json" || issues+=("cached .mcp.json is missing X-OpenViking-Actor-Peer header mapping")
+    # Actor-peer header is optional, mirrors bearer_token_env_var: only required
+    # when a peer id is actually configured (so codex MCP doesn't pass an empty
+    # X-OpenViking-Actor-Peer that the server has to disambiguate from no scope).
+    if [ "$HAS_PEER_ID" = "1" ] && ! grep -q '"X-OpenViking-Actor-Peer"' "$mcp_json"; then
+      issues+=("cached .mcp.json is missing X-OpenViking-Actor-Peer header mapping despite configured peer")
+    fi
+    if [ "$HAS_PEER_ID" != "1" ] && grep -q '"X-OpenViking-Actor-Peer"' "$mcp_json"; then
+      issues+=("cached .mcp.json keeps X-OpenViking-Actor-Peer without configured peer")
+    fi
   fi
 
   for script in \


### PR DESCRIPTION
## Problem

Re-running `setup-helper/install.sh` non-interactively after #2598 surfaces two false-positive validator warnings on a no-peer config (e.g. local unauth OV):

```
!! Install validation: codex plugin list does not show openviking-memory@openviking-plugins-local as installed, enabled
!! Install validation: cached .mcp.json is missing X-OpenViking-Actor-Peer header mapping
xx Plugin install validation failed in non-interactive mode.
```

Both are validator bugs, not actual install regressions — `codex plugin list` shows the plugin as installed, enabled and the cached `.mcp.json` is correct.

## Root cause

1. **Actor-peer validator unconditional.** #2598 commit 216dbb5e made `syncMcpConfig` omit the `X-OpenViking-Actor-Peer` header when no peer is configured (symmetric to `bearer_token_env_var` / `HAS_API_KEY`). The install validator at `install.sh:613` still required the header unconditionally, so every no-peer install gets flagged.

2. **`codex plugin list` regex too strict.** The validator grep at `install.sh:591` was `${PLUGIN_ID}[[:space:]]+installed, enabled`, but codex CLI prints `openviking-memory@openviking-plugins-local (installed, enabled)` with parens. The regex never matches the current CLI output. This is older brittleness (not a #2598 regression) and surfaces now because the actor-peer false-positive ran the validator long enough to notice.

## Fix

- **`ov-credentials.mjs`**: new `has-peer-id` CLI command, symmetric to `has-api-key`. Returns `1`/`0` based on `resolveOpenVikingCredentials().peerId`. Underlying resolution is already covered by existing tests 1–3 in `ov-credentials.test.mjs`.
- **`install.sh`**: new `HAS_PEER_ID="$(detect_peer_id)"` mirrors `HAS_API_KEY`. Validator becomes conditional both ways:
  - `HAS_PEER_ID=1` + header missing → flag (required header dropped)
  - `HAS_PEER_ID=0` + header present → flag (stale header, should be dropped)
  - Other two cases → ok
- **`install.sh` plugin list regex**: relaxed to `\(?installed, enabled\)?` to accept both the parenthesized and bare forms codex CLI has shipped at different points.

## Verification

```
$ bash examples/codex-memory-plugin/setup-helper/install.sh < /dev/null
…
6. Install validation
==> Plugin install looks valid.
```

Hand-traced both `HAS_PEER_ID` branches × both `X-OpenViking-Actor-Peer` presence states to confirm the four-case truth table.

```
$ node --test examples/codex-memory-plugin/scripts/ov-credentials.test.mjs \
              examples/codex-memory-plugin/scripts/recall-compressor-profile.test.mjs
# tests 20 # pass 20 # fail 0
$ find examples/codex-memory-plugin/scripts -name '*.mjs' | xargs node --check    # OK
$ bash -n / zsh -n examples/codex-memory-plugin/setup-helper/*.sh                  # OK
$ git diff --check                                                                  # OK
```

## Follow-up direction (out of scope)

@zaynjarvis suggested the longer-term home is `openviking@openai-curated` rather than the self-hosted `openviking-plugins-local` marketplace. That requires upstream coordination with codex's curated marketplace and is not part of this validator fix.