### PR TITLE
Fix blog index chat opener

### DIFF
--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -645,37 +645,6 @@ html {
   height: 15px;
 }
 
-.zouk-reader-launcher {
-  position: fixed;
-  z-index: 84;
-  right: 24px;
-  bottom: calc(24px + env(safe-area-inset-bottom, 0px));
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  padding: 0;
-  border: 1px solid color-mix(in oklab, var(--th-line) 82%, transparent);
-  border-radius: 999px;
-  background: color-mix(in oklab, var(--th-bg) 92%, var(--th-bg-2));
-  color: var(--th-ink);
-  box-shadow: 0 16px 42px color-mix(in oklab, #000 18%, transparent);
-  cursor: pointer;
-  transition: transform 0.15s, background 0.15s, border-color 0.15s, box-shadow 0.15s;
-}
-
-.zouk-reader-launcher:hover,
-.zouk-reader-launcher:focus-visible {
-  border-color: color-mix(in oklab, var(--th-accent) 42%, var(--th-line));
-  background: color-mix(in oklab, var(--th-bg) 78%, var(--th-bg-2));
-  box-shadow: 0 18px 48px color-mix(in oklab, #000 22%, transparent);
-}
-
-.zouk-reader-launcher:active {
-  transform: scale(0.97);
-}
-
 .zouk-reader-bottom-composer {
   --zouk-reader-field-radius: 22px;
   position: fixed;
@@ -1576,6 +1545,12 @@ html {
 
   .zouk-reader-edge-toggle {
     display: none;
+  }
+
+  .zouk-reader-edge-toggle--index {
+    top: 78px;
+    bottom: calc(28px + env(safe-area-inset-bottom, 0px));
+    display: flex;
   }
 
   .zouk-reader-close {

--- a/blog/src/zouk-embed.jsx
+++ b/blog/src/zouk-embed.jsx
@@ -747,7 +747,7 @@ export function ZoukInteractiveBlog({ route }) {
   const isPostRoute = route?.name === 'post';
   const panelVisible = open || closing;
   const showBottomComposer = isPostRoute && !panelVisible;
-  const showLauncher = !isPostRoute && !panelVisible;
+  const showEdgeToggle = !panelVisible;
   const composerPlaceholder = currentComposerPlaceholder();
   const referencedText = compactText(selectedText);
   const contextUrlChanged = Boolean(sourceUrl && sourceUrl !== lastContextUrl);
@@ -1217,21 +1217,10 @@ export function ZoukInteractiveBlog({ route }) {
         </button>
       ) : null}
 
-      {showLauncher ? (
+      {showEdgeToggle ? (
         <button
           type="button"
-          className="zouk-reader-launcher"
-          aria-label={launcherLabel}
-          onClick={() => openChat()}
-        >
-          <MessageIcon />
-        </button>
-      ) : null}
-
-      {showBottomComposer ? (
-        <button
-          type="button"
-          className="zouk-reader-edge-toggle"
+          className={`zouk-reader-edge-toggle${isPostRoute ? '' : ' zouk-reader-edge-toggle--index'}`}
           aria-label={launcherLabel}
           onClick={() => openChat()}
         />


### PR DESCRIPTION
## Summary
- replace the index-page circular Zouk launcher with the same right-edge line toggle used by post pages
- keep the post-page bottom composer behavior unchanged
- keep an index-page edge toggle visible on mobile where there is no bottom composer fallback

## Verification
- npm run build
- npx playwright screenshot --browser=chromium --viewport-size=1280,900 http://127.0.0.1:5175/?lang=en /tmp/ov-blog-index.png
- npx playwright screenshot --browser=chromium --viewport-size=1280,900 http://127.0.0.1:5175/post/openviking-context-database-architecture/?lang=en /tmp/ov-blog-post.png
- npx playwright screenshot --browser=chromium --viewport-size=390,844 http://127.0.0.1:5175/?lang=en /tmp/ov-blog-index-mobile.png
- npx playwright screenshot --browser=chromium --viewport-size=390,844 http://127.0.0.1:5175/post/openviking-context-database-architecture/?lang=en /tmp/ov-blog-post-mobile.png