### PR TITLE
fix(parse): use safe_extract_zip for UnderstandingAPI zip download to close Zip Slip

### DIFF
--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -26,6 +26,7 @@ import httpx
 from openviking.parse.base import NodeType, ParseResult, ResourceNode
 from openviking.parse.parsers.base_parser import BaseParser
 from openviking.storage.viking_fs import get_viking_fs
+from openviking.utils.zip_safe import safe_extract_zip
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -460,7 +461,7 @@ class UnderstandingAPI(BaseParser):
 
         with tempfile.TemporaryDirectory() as extract_dir:
             with zipfile.ZipFile(zip_path, "r") as zf:
-                zf.extractall(extract_dir)
+                safe_extract_zip(zf, extract_dir)
             extract_path = Path(extract_dir)
             items = [p for p in extract_path.iterdir() if p.name not in {".", ".."}]
             if len(items) == 1 and items[0].is_dir():


### PR DESCRIPTION
## What

`UnderstandingAPI` (added in #2614) extracts the third-party-downloaded result zip with a raw `zipfile.ZipFile(...).extractall()`, bypassing the project's canonical `safe_extract_zip` Zip-Slip guard.

```python
with tempfile.TemporaryDirectory() as extract_dir:
    with zipfile.ZipFile(zip_path, "r") as zf:
        zf.extractall(extract_dir)   # <- no Zip-Slip protection
```

## Why

#2615's same-day hardening sweep routed every other production extractor through `safe_extract_zip` (`utils/zip_safe.py`, `utils/skill_processor.py`, upload paths), but its file list didn't include `understanding_api.py`, so this one download path still calls `extractall()`. A malicious or MITM'd Understanding-API result zip whose members use `../../…` would currently escape the temp dir and write onto the user's filesystem. The `safe_extract_zip` invariant is deliberately source-agnostic, so even a configured-endpoint source should go through it.

## Change

One-line swap to the same helper `parse/parsers/zip_parser.py` already uses:

```python
safe_extract_zip(zf, extract_dir)
```

No behavior change for benign archives: `safe_extract_zip` validates each member stays inside `extract_dir` and recreates the same tree the downstream `extract_path.iterdir()` / single-root-dir detection expects (`safe_extract_zip` `Path()`-coerces the `str` temp dir and calls `normalize_zip_filenames` internally). Zip-Slip behavior is already covered centrally by `tests/misc/test_zip_safe.py`.
