### PR TITLE
fix(auth,cli): honor root_api_key in trusted mode and wire --sudo flag (#1722)

### DIFF
--- a/openviking/server/auth.py
+++ b/openviking/server/auth.py
@@ -276,13 +276,7 @@ async def resolve_identity(
                     "X-OpenViking-Account or explicit account_id in the URL and "
                     "X-OpenViking-User or explicit user_id in the URL."
                 )
-            if configured_root_api_key:
-                return ResolvedIdentity(
-                    role=Role.ROOT,
-                    account_id=effective_account_id or "trusted",
-                    user_id=effective_user_id or "trusted",
-                )
-            if not effective_account_id and not effective_user_id:
+            if not configured_root_api_key and not effective_account_id and not effective_user_id:
                 return ResolvedIdentity(
                     role=Role.ROOT,
                     account_id="trusted",
@@ -299,6 +293,19 @@ async def resolve_identity(
                 raise InvalidArgumentError(
                     "Trusted mode requests must include " + " and ".join(missing_fields) + "."
                 )
+
+        # When the request authenticated with the configured root_api_key
+        # (already verified above), grant Role.ROOT for ALL paths, not only
+        # /api/v1/admin/*. This is what allows ROOT-only operations such as
+        # `ov reindex --sudo` (POST /api/v1/content/reindex) to succeed in
+        # trusted mode. Non-root keys never reach this branch because the
+        # hmac.compare_digest check above rejects them with UNAUTHENTICATED.
+        if configured_root_api_key:
+            return ResolvedIdentity(
+                role=Role.ROOT,
+                account_id=effective_account_id or "trusted",
+                user_id=effective_user_id or "trusted",
+            )
 
         trusted_role = Role.USER
         if api_key_manager and effective_account_id and effective_user_id:

--- a/openviking_cli/client/http.py
+++ b/openviking_cli/client/http.py
@@ -150,6 +150,8 @@ class AsyncHTTPClient(BaseClient):
         timeout: float = 60.0,
         extra_headers: Optional[Dict[str, str]] = None,
         profile_enabled: Optional[bool] = None,
+        sudo: bool = False,
+        root_api_key: Optional[str] = None,
     ):
         """Initialize AsyncHTTPClient.
 
@@ -163,6 +165,12 @@ class AsyncHTTPClient(BaseClient):
             agent_id: Legacy alias for actor_peer_id.
             timeout: HTTP request timeout in seconds. Default 60.0.
             extra_headers: Additional HTTP headers to send with requests. If not provided, reads from ovcli.conf.
+            sudo: When True, send ``root_api_key`` (from arg or ovcli.conf) as
+                ``X-API-Key`` instead of ``api_key``. Mirrors the ``ov --sudo``
+                flag for ROOT-only operations such as ``reindex`` in trusted
+                mode. Falls back to ``api_key`` if ``root_api_key`` is unset.
+            root_api_key: Optional explicit root API key. If not provided and
+                ``sudo`` is True, reads from ``ovcli.conf``.
         """
         effective_user = user if user is not None else user_id
         profile_load_requested = profile_enabled is None
@@ -174,6 +182,7 @@ class AsyncHTTPClient(BaseClient):
             or (actor_peer_id is None and agent_id is None)
             or timeout == 60.0
             or extra_headers is None
+            or (sudo and root_api_key is None)
         )
         cli_config = None
         if should_load_cli_config:
@@ -190,6 +199,8 @@ class AsyncHTTPClient(BaseClient):
                     timeout = cli_config.timeout
                 if extra_headers is None:
                     extra_headers = cli_config.extra_headers
+                if sudo and root_api_key is None:
+                    root_api_key = cli_config.root_api_key
         if profile_load_requested:
             if cli_config is None:
                 cli_config = load_ovcli_config()
@@ -201,7 +212,12 @@ class AsyncHTTPClient(BaseClient):
                 '~/.openviking/ovcli.conf (key: "url").'
             )
         self._url = url.rstrip("/")
-        self._api_key = api_key
+        # In sudo mode, prefer root_api_key when present; otherwise fall back
+        # to api_key so the existing key-only flows keep working unchanged.
+        if sudo and root_api_key:
+            self._api_key = root_api_key
+        else:
+            self._api_key = api_key
         self._account = account
         self._user_id = effective_user
         if actor_peer_id and agent_id:

--- a/openviking_cli/utils/config/ovcli_config.py
+++ b/openviking_cli/utils/config/ovcli_config.py
@@ -28,6 +28,7 @@ class OVCLIConfig(BaseModel):
 
     url: Optional[str] = None
     api_key: Optional[str] = None
+    root_api_key: Optional[str] = None
     account: Optional[str] = None
     user: Optional[str] = None
     actor_peer_id: Optional[str] = None

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1042,7 +1042,12 @@ async def test_trusted_mode_with_root_api_key_requires_matching_api_key():
 
 
 async def test_trusted_mode_with_root_api_key_accepts_matching_api_key():
-    """Trusted mode should accept explicit identity headers plus the configured server API key."""
+    """Trusted mode with the configured root_api_key should grant ROOT for any path.
+
+    Regression test for #1722: previously the matching root key only granted ROOT
+    on /api/v1/admin/* paths, which broke `ov reindex --sudo` and other ROOT-only
+    operations in trusted mode.
+    """
     request = _make_request(
         "/api/v1/resources",
         headers={
@@ -1062,7 +1067,33 @@ async def test_trusted_mode_with_root_api_key_accepts_matching_api_key():
         x_openviking_user="alice",
     )
 
-    assert identity.role == Role.USER
+    assert identity.role == Role.ROOT
+    assert identity.account_id == "acme"
+    assert identity.user_id == "alice"
+
+
+async def test_trusted_mode_with_root_api_key_grants_root_on_non_admin_paths():
+    """Trusted mode with matching root_api_key should grant ROOT on tenant data paths too."""
+    request = _make_request(
+        "/api/v1/content/reindex",
+        headers={
+            "X-API-Key": ROOT_KEY,
+            "X-OpenViking-Account": "acme",
+            "X-OpenViking-User": "alice",
+        },
+        auth_enabled=False,
+        auth_mode="trusted",
+        root_api_key=ROOT_KEY,
+    )
+
+    identity = await resolve_identity(
+        request,
+        x_api_key=ROOT_KEY,
+        x_openviking_account="acme",
+        x_openviking_user="alice",
+    )
+
+    assert identity.role == Role.ROOT
     assert identity.account_id == "acme"
     assert identity.user_id == "alice"
 


### PR DESCRIPTION
## Summary
- **Server (`openviking/server/auth.py`)**: in TRUSTED mode, an `X-API-Key` matching the configured `root_api_key` now grants `Role.ROOT` for all paths, not only `/api/v1/admin/*`. Non-root keys against admin paths still 403 as before.
- **CLI (`openviking_cli/client/http.py`)**: the `--sudo` flag now sends `root_api_key` from `ovcli.conf` as the `X-API-Key` header, falling back to `api_key` if `root_api_key` is unset.

## Test plan
- [ ] In TRUSTED mode with `root_api_key` configured, `ov reindex viking://... --sudo` succeeds.
- [ ] Same setup, `ov reindex` (no `--sudo`) still uses regular `api_key` and is subject to normal role checks.
- [ ] Server: regular user key against `/api/v1/admin/*` still returns PERMISSION_DENIED.

Closes #1722