### PR TITLE
feat(parse): extract PPTX images and tables into structured assets (#2181)

### DIFF
--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -1339,9 +1339,7 @@ def test_tool_context_syncs_legacy_memory_user_alias():
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(monkeypatch, tmp_path):
     calls = []
 
     class _FakeClient:
@@ -1379,9 +1377,7 @@ async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(monkeypatch, tmp_path):
     clients = []
     base_uri = "viking://user/default/peers/sender-1/memories"
 
@@ -1393,8 +1389,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
                 f"{base_uri}/events/e2.md": (
                     "Summary: long event summary\n"
                     "2023-01-01 (Sunday) ChatLog:\n"
-                    "full long event details "
-                    + ("x" * 800)
+                    "full long event details " + ("x" * 800)
                 ),
                 f"{base_uri}/events/e3.md": "legacy event without summary",
                 f"{base_uri}/entities/en1.md": "short entity",
@@ -1497,9 +1492,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_continues_after_oversized_entity(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_continues_after_oversized_entity(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1541,17 +1534,15 @@ async def test_viking_memory_type_quota_continues_after_oversized_entity(
     )
 
     assert '<memory index="1" type="uri">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>" in result
     assert '<memory index="2" type="full">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>" in result
     assert "<content>short fact</content>" in result
     assert "long fact " not in result
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_does_not_overflow_preference_budget(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1599,9 +1590,7 @@ async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_returns_empty_after_profile_filter(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_returns_empty_after_profile_filter(monkeypatch, tmp_path):
     class _FakeClient:
         async def search_memory(self, **_kwargs):
             return [
@@ -1704,7 +1693,9 @@ async def test_openviking_grep_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def grep(self, uri, pattern, case_insensitive=False, user_id=None):
@@ -1739,7 +1730,9 @@ async def test_openviking_list_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def list_resources(self, path=None, recursive=False):
@@ -1773,7 +1766,9 @@ async def test_openviking_glob_root_adds_current_peer_memory(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def glob(self, pattern, uri="viking://"):
@@ -1810,8 +1805,7 @@ async def test_openviking_glob_root_uses_namespaced_self_targets_for_root_key(mo
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/admin/memories/"] if include_self else []
             uris.extend(
-                f"viking://user/admin/peers/{peer_id}/memories/"
-                for peer_id in peer_ids or []
+                f"viking://user/admin/peers/{peer_id}/memories/" for peer_id in peer_ids or []
             )
             return uris
 

--- a/bot/vikingbot/agent/memory.py
+++ b/bot/vikingbot/agent/memory.py
@@ -18,9 +18,7 @@ _TYPE_QUOTA_MEMORY_TYPES = ("events", "entities", "preferences")
 _TYPE_QUOTA_EVENT_CHAR_RATIO = 0.75
 _TYPE_QUOTA_PREFERENCE_FULL_LIMIT = 1
 _MEMORY_TYPE_DESCRIPTIONS = {
-    "events": (
-        "Event memories. The URI path includes the event date."
-    ),
+    "events": ("Event memories. The URI path includes the event date."),
     "entities": (
         "Entity and topic memories. Use them for stable facts, attributes, "
         "relationships, and background about people, hobbies, places, or concepts."
@@ -289,9 +287,7 @@ class MemoryStore:
             memory_type = self._infer_memory_type(memory) or "other"
             should_try_full = idx <= full_limit
             if use_type_budgets:
-                should_try_full = (
-                    memory_type in type_char_budgets
-                ) or (
+                should_try_full = (memory_type in type_char_budgets) or (
                     memory_type == "preferences"
                     and preference_full_count < max(0, preference_full_limit)
                 )
@@ -488,9 +484,7 @@ class MemoryStore:
                 type_char_budgets=(
                     self._type_quota_char_budgets(recall_max_chars) if use_type_quota else None
                 ),
-                preference_full_limit=(
-                    _TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0
-                ),
+                preference_full_limit=(_TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0),
                 include_uri_entries=True,
             )
             return f"### user memories:\n{user_memory}"

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -164,7 +164,11 @@ class VikingListTool(OVFileTool):
         }
 
     async def execute(
-        self, tool_context: "ToolContext", uri: str = "viking://", recursive: bool = False, **kwargs: Any
+        self,
+        tool_context: "ToolContext",
+        uri: str = "viking://",
+        recursive: bool = False,
+        **kwargs: Any,
     ) -> str:
         client = None
         try:
@@ -434,8 +438,7 @@ class VikingSearchTool(OVFileTool):
                         ]
                     )
                     search_requests = [
-                        {"target_uri": memory_uri, "peer_id": None}
-                        for memory_uri in memory_uris
+                        {"target_uri": memory_uri, "peer_id": None} for memory_uri in memory_uris
                     ]
                 else:
                     search_requests = [{"target_uri": target_uri, "peer_id": None}]
@@ -795,7 +798,9 @@ class VikingMemoryCommitTool(OVFileTool):
             timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
             session_id = f"{source_session_id}__memory_commit__{timestamp}__{commit_seq:04d}"
             result = await client.commit(session_id, messages, peer_id=tool_context.sender_id)
-            session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            session_id = (
+                result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            )
             commit_result = result.get("commit", {}) if isinstance(result, dict) else {}
             archive_uri = commit_result.get("archive_uri")
             memory_diff_uri = f"{archive_uri}/memory_diff.json" if archive_uri else None

--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -341,11 +341,7 @@ class VikingClient:
             uris.append(self._memory_target_uri(None))
 
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         for peer_id in normalized_peer_ids:
             try:
@@ -378,11 +374,7 @@ class VikingClient:
             [str(user_id).strip() for user_id in (user_ids or []) if str(user_id).strip()]
         )
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
@@ -703,18 +695,14 @@ class VikingClient:
         if peer_id:
             peer_values.append(peer_id)
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_value) for peer_value in peer_values)
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_value) for peer_value in peer_values) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
         user_ids_to_check = self._dedupe_strings(
             [
                 *normalized_user_ids,
-                *( [effective_owner_user_id] if effective_owner_user_id else [] ),
+                *([effective_owner_user_id] if effective_owner_user_id else []),
             ]
         )
 

--- a/openviking/parse/parsers/code/ast/code_tools.py
+++ b/openviking/parse/parsers/code/ast/code_tools.py
@@ -127,9 +127,7 @@ def search_symbols(query: str, files: List[Tuple[str, str]]) -> str:
     return "\n".join(out)
 
 
-def _resolve_symbol(
-    skeleton: CodeSkeleton, symbol: str
-) -> Optional[Tuple[str, int, int]]:
+def _resolve_symbol(skeleton: CodeSkeleton, symbol: str) -> Optional[Tuple[str, int, int]]:
     """Find a symbol by 'foo' (bare) or 'Foo.bar' (qualified). Case sensitive.
 
     Search priority for bare names (no dot):

--- a/openviking/parse/parsers/code/ast/extractor.py
+++ b/openviking/parse/parsers/code/ast/extractor.py
@@ -107,9 +107,7 @@ class ASTExtractor:
         try:
             return extractor.extract(file_name, content)
         except Exception as e:
-            logger.warning(
-                "AST extraction failed for '%s' (language: %s): %s", file_name, lang, e
-            )
+            logger.warning("AST extraction failed for '%s' (language: %s): %s", file_name, lang, e)
             return None
 
     def extract_skeleton(

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -340,9 +340,7 @@ class MarkdownParser(BaseParser):
             content, frontmatter = self._extract_frontmatter(content)
             if frontmatter:
                 meta["frontmatter"] = frontmatter
-                logger.debug(
-                    f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}"
-                )
+                logger.debug(f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}")
 
         explicit_name = kwargs.get("resource_name")
         if not explicit_name and kwargs.get("source_name"):
@@ -593,7 +591,6 @@ class MarkdownParser(BaseParser):
             seen_paths = set()
 
             for path_str in image_refs:
-
                 # Skip remote URIs
                 if self._is_remote_uri(path_str):
                     continue
@@ -629,7 +626,9 @@ class MarkdownParser(BaseParser):
                     image_bytes = await asyncio.to_thread(resolved_path.read_bytes)
 
                     # Validate pixel size and file size; skip non-compliant images
-                    if not await asyncio.to_thread(self._is_valid_image, image_bytes, resolved_path):
+                    if not await asyncio.to_thread(
+                        self._is_valid_image, image_bytes, resolved_path
+                    ):
                         continue
 
                     # Get filename and deduplicate
@@ -649,7 +648,9 @@ class MarkdownParser(BaseParser):
                     logger.warning(f"[MarkdownParser] Failed to ingest image {resolved_path}: {e}")
 
             if file_mappings:
-                rel_md_path = md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                rel_md_path = (
+                    md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                )
                 mappings[rel_md_path] = file_mappings
 
         # Write a single mapping file at the root directory for rewrite_image_uris
@@ -688,9 +689,7 @@ class MarkdownParser(BaseParser):
 
             # Reject absolute paths: they can point anywhere on the host
             if path.is_absolute():
-                logger.warning(
-                    f"[MarkdownParser] Rejected absolute image path: {path_str}"
-                )
+                logger.warning(f"[MarkdownParser] Rejected absolute image path: {path_str}")
                 return None
 
             # Build the list of allowed roots to confine resolution to.
@@ -760,9 +759,7 @@ class MarkdownParser(BaseParser):
         """
         # File size check (local file path limit: 10 MB)
         if len(image_bytes) > self.IMAGE_MAX_FILE_BYTES:
-            logger.warning(
-                f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}"
-            )
+            logger.warning(f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}")
             return False
 
         # Pixel size check
@@ -932,20 +929,15 @@ class MarkdownParser(BaseParser):
                     rel
                     for rel, text in layout.items()
                     if any(
-                        _gh_slug(h) == anchor
-                        for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
+                        _gh_slug(h) == anchor for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
                     )
                 ]
                 if len(hits) == 1:
-                    return _to_rel(
-                        os.path.join(target_parent, hits[0]), keep_suffix=True
-                    )
+                    return _to_rel(os.path.join(target_parent, hits[0]), keep_suffix=True)
             # B) Single-file document (a bare file, or a directory holding exactly one
             #    file) → the anchor/query lives in that one file; keep the suffix.
             if len(layout) == 1:
-                return _to_rel(
-                    os.path.join(target_parent, next(iter(layout))), keep_suffix=True
-                )
+                return _to_rel(os.path.join(target_parent, next(iter(layout))), keep_suffix=True)
 
         # C) Single bare file with no suffix to place (e.g. a future small .md kept as
         #    a file) → point at the file itself (empty suffix ⇒ no trailing slash).
@@ -971,9 +963,7 @@ class MarkdownParser(BaseParser):
             if resolved is not None:
                 try:
                     image_bytes = await asyncio.to_thread(resolved.read_bytes)
-                    handled = await asyncio.to_thread(
-                        self._is_valid_image, image_bytes, resolved
-                    )
+                    handled = await asyncio.to_thread(self._is_valid_image, image_bytes, resolved)
                 except Exception:
                     handled = False
             cache[link] = handled

--- a/openviking/parse/parsers/powerpoint.py
+++ b/openviking/parse/parsers/powerpoint.py
@@ -8,6 +8,7 @@ Inspired by microsoft/markitdown approach.
 """
 
 import asyncio
+import json
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -54,9 +55,23 @@ class PowerPointParser(BaseParser):
         if path.exists():
             import pptx
 
-            markdown_content = await asyncio.to_thread(self._convert_to_markdown, path, pptx)
+            from openviking_cli.utils.storage import get_storage
+
+            storage = get_storage()
+            resource_name = kwargs.get("resource_name") or kwargs.get("source_name") or path.stem
+
+            markdown_content = await asyncio.to_thread(
+                self._convert_to_markdown, path, pptx, resource_name, storage
+            )
             result = await self._md_parser.parse_content(
-                markdown_content, source_path=str(path), instruction=instruction, **kwargs
+                markdown_content,
+                source_path=str(path),
+                resource_name=kwargs.get("resource_name"),
+                source_name=kwargs.get("source_name"),
+                instruction=instruction,
+                base_dir=path.parent,
+                # pptx images are extracted into storage.media_dir, mirroring pdf/word.
+                allowed_media_dirs=[storage.media_dir],
             )
         else:
             result = await self._md_parser.parse_content(
@@ -75,7 +90,9 @@ class PowerPointParser(BaseParser):
         result.parser_name = "PowerPointParser"
         return result
 
-    def _convert_to_markdown(self, path: Path, pptx) -> str:
+    def _convert_to_markdown(
+        self, path: Path, pptx, resource_name: Optional[str] = None, storage=None
+    ) -> str:
         """Convert PowerPoint presentation to Markdown string."""
         prs = pptx.Presentation(path)
         markdown_parts = []
@@ -89,7 +106,9 @@ class PowerPointParser(BaseParser):
             if title:
                 slide_parts.append(f"### {title}")
 
-            content = self._extract_slide_content(slide)
+            content = self._extract_slide_content(
+                slide, slide_idx=idx, slide_title=title, resource_name=resource_name, storage=storage
+            )
             if content:
                 slide_parts.append(content)
 
@@ -113,11 +132,19 @@ class PowerPointParser(BaseParser):
                     return shape.text.strip()
         return ""
 
-    def _extract_slide_content(self, slide) -> str:
+    def _extract_slide_content(
+        self,
+        slide,
+        slide_idx: int,
+        slide_title: str = "",
+        resource_name: Optional[str] = None,
+        storage=None,
+    ) -> str:
         """Extract content from slide shapes."""
-        from pptx.enum.shapes import PP_PLACEHOLDER
+        from pptx.enum.shapes import MSO_SHAPE_TYPE, PP_PLACEHOLDER
 
         content_parts = []
+        image_counter = 0
 
         for shape in slide.shapes:
             if shape.is_placeholder:
@@ -125,18 +152,68 @@ class PowerPointParser(BaseParser):
                 if ph_type in (PP_PLACEHOLDER.TITLE, PP_PLACEHOLDER.CENTER_TITLE):
                     continue
 
+            # Tables: emit JSON block + plain markdown so structured retrieval and
+            # keyword search both succeed.
+            if getattr(shape, "has_table", False):
+                table_md = self._convert_table_with_json(
+                    shape.table, slide_idx=slide_idx, slide_title=slide_title
+                )
+                if table_md:
+                    content_parts.append(table_md)
+                continue
+
+            # Pictures: persist via the shared storage helper (#2429 pattern) and
+            # reference by relative media path so MarkdownParser can rewrite to viking://.
+            if shape.shape_type == MSO_SHAPE_TYPE.PICTURE and storage is not None:
+                image_counter += 1
+                img_md = self._save_picture_shape(
+                    shape,
+                    slide_idx=slide_idx,
+                    image_idx=image_counter,
+                    resource_name=resource_name,
+                    storage=storage,
+                )
+                if img_md:
+                    content_parts.append(img_md)
+                continue
+
             if hasattr(shape, "text") and shape.text.strip():
-                if shape.has_table:
-                    content_parts.append(self._convert_table(shape.table))
-                else:
-                    text = shape.text.strip()
-                    if text:
-                        content_parts.append(text)
+                content_parts.append(shape.text.strip())
 
         return "\n\n".join(content_parts)
 
-    def _convert_table(self, table) -> str:
-        """Convert PowerPoint table to markdown format."""
+    def _save_picture_shape(
+        self, shape, slide_idx: int, image_idx: int, resource_name: Optional[str], storage
+    ) -> str:
+        """Persist a Picture shape's blob and return a markdown image reference."""
+        try:
+            image = shape.image
+            image_bytes = image.blob
+            extension = f".{image.ext}" if image.ext else ".png"
+        except Exception as e:
+            logger.warning(
+                f"[PowerPointParser] Failed to read picture on slide {slide_idx} idx {image_idx}: {e}"
+            )
+            return ""
+
+        try:
+            filename = f"slide{slide_idx}_image{image_idx}"
+            image_path = storage.save_image(
+                resource_name, image_bytes, filename=filename, extension=extension
+            )
+            rel_path = image_path.relative_to(storage.media_dir)
+            alt = f"slide{slide_idx}_image{image_idx}"
+            return f"![{alt}]({rel_path})"
+        except Exception as e:
+            logger.warning(
+                f"[PowerPointParser] Failed to save picture on slide {slide_idx} idx {image_idx}: {e}"
+            )
+            return ""
+
+    def _convert_table_with_json(
+        self, table, slide_idx: int, slide_title: str = ""
+    ) -> str:
+        """Emit fenced JSON block + plain markdown table for a slide table."""
         if not table.rows:
             return ""
 
@@ -145,6 +222,18 @@ class PowerPointParser(BaseParser):
             row_data = [cell.text.strip() for cell in row.cells]
             rows.append(row_data)
 
+        if not rows:
+            return ""
+
+        caption = (
+            f"Table from slide {slide_idx}: {slide_title}".strip()
+            if slide_title
+            else f"Table from slide {slide_idx}"
+        )
+        json_payload = json.dumps({"rows": rows}, ensure_ascii=False)
+        json_block = f"{caption}\n\n```json\n{json_payload}\n```"
+
         from openviking.parse.base import format_table_to_markdown
 
-        return format_table_to_markdown(rows, has_header=True)
+        md_table = format_table_to_markdown(rows, has_header=True)
+        return f"{json_block}\n\n{md_table}" if md_table else json_block

--- a/openviking/parse/parsers/powerpoint.py
+++ b/openviking/parse/parsers/powerpoint.py
@@ -107,7 +107,11 @@ class PowerPointParser(BaseParser):
                 slide_parts.append(f"### {title}")
 
             content = self._extract_slide_content(
-                slide, slide_idx=idx, slide_title=title, resource_name=resource_name, storage=storage
+                slide,
+                slide_idx=idx,
+                slide_title=title,
+                resource_name=resource_name,
+                storage=storage,
             )
             if content:
                 slide_parts.append(content)
@@ -210,9 +214,7 @@ class PowerPointParser(BaseParser):
             )
             return ""
 
-    def _convert_table_with_json(
-        self, table, slide_idx: int, slide_title: str = ""
-    ) -> str:
+    def _convert_table_with_json(self, table, slide_idx: int, slide_title: str = "") -> str:
         """Emit fenced JSON block + plain markdown table for a slide table."""
         if not table.rows:
             return ""

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -53,29 +53,67 @@ _LATIN_ACCENT_BONUSES = {
 _LATIN_HINT_LANGUAGES = {"it", "fr", "es", "de", "pt"}
 
 _LOCALE_LANGUAGE_PREFIXES = dict(
-    zh="zh-CN", ja="ja", ko="ko", ru="ru", ar="ar",
-    it="it", fr="fr", es="es", de="de", pt="pt", en="en",
-    chinese="zh-CN", japanese="ja", korean="ko", russian="ru", arabic="ar",
-    italian="it", french="fr", spanish="es", german="de", portuguese="pt", english="en",
+    zh="zh-CN",
+    ja="ja",
+    ko="ko",
+    ru="ru",
+    ar="ar",
+    it="it",
+    fr="fr",
+    es="es",
+    de="de",
+    pt="pt",
+    en="en",
+    chinese="zh-CN",
+    japanese="ja",
+    korean="ko",
+    russian="ru",
+    arabic="ar",
+    italian="it",
+    french="fr",
+    spanish="es",
+    german="de",
+    portuguese="pt",
+    english="en",
 )
 
 # Use Timezone as a weak fallback signal.
 _TIMEZONE_LANGUAGE_GROUPS = {
     "zh-CN": (
-        "asia/shanghai", "asia/chongqing", "asia/harbin", "asia/urumqi",
-        "asia/hong_kong", "asia/macau", "asia/taipei", "prc", "roc", "hongkong",
-        "china standard time", "taipei standard time",
+        "asia/shanghai",
+        "asia/chongqing",
+        "asia/harbin",
+        "asia/urumqi",
+        "asia/hong_kong",
+        "asia/macau",
+        "asia/taipei",
+        "prc",
+        "roc",
+        "hongkong",
+        "china standard time",
+        "taipei standard time",
     ),
     "ja": ("asia/tokyo", "japan", "tokyo standard time"),
     "ko": ("asia/seoul", "rok", "korea standard time"),
     "ru": (
-        "europe/moscow", "europe/kaliningrad", "asia/yekaterinburg", "asia/vladivostok",
+        "europe/moscow",
+        "europe/kaliningrad",
+        "asia/yekaterinburg",
+        "asia/vladivostok",
         "russian standard time",
     ),
     "ar": (
-        "asia/riyadh", "asia/dubai", "asia/qatar", "asia/kuwait",
-        "asia/baghdad", "africa/cairo", "africa/algiers", "africa/tunis",
-        "arab standard time", "arabian standard time", "egypt standard time",
+        "asia/riyadh",
+        "asia/dubai",
+        "asia/qatar",
+        "asia/kuwait",
+        "asia/baghdad",
+        "africa/cairo",
+        "africa/algiers",
+        "africa/tunis",
+        "arab standard time",
+        "arabian standard time",
+        "egypt standard time",
     ),
     "it": ("europe/rome",),
     "fr": ("europe/paris",),
@@ -83,13 +121,34 @@ _TIMEZONE_LANGUAGE_GROUPS = {
     "de": ("europe/berlin",),
     "pt": ("europe/lisbon", "america/sao_paulo"),
     "en": (
-        "america/new_york", "america/chicago", "america/denver", "america/los_angeles",
-        "america/phoenix", "america/anchorage", "pacific/honolulu", "us/eastern",
-        "us/central", "us/mountain", "us/pacific", "europe/london", "europe/dublin",
-        "gb", "gb-eire", "america/toronto", "america/vancouver", "canada/eastern",
-        "canada/pacific", "australia/sydney", "australia/melbourne",
-        "australia/brisbane", "australia/perth", "pacific/auckland", "nz",
-        "eastern standard time", "pacific standard time", "gmt standard time",
+        "america/new_york",
+        "america/chicago",
+        "america/denver",
+        "america/los_angeles",
+        "america/phoenix",
+        "america/anchorage",
+        "pacific/honolulu",
+        "us/eastern",
+        "us/central",
+        "us/mountain",
+        "us/pacific",
+        "europe/london",
+        "europe/dublin",
+        "gb",
+        "gb-eire",
+        "america/toronto",
+        "america/vancouver",
+        "canada/eastern",
+        "canada/pacific",
+        "australia/sydney",
+        "australia/melbourne",
+        "australia/brisbane",
+        "australia/perth",
+        "pacific/auckland",
+        "nz",
+        "eastern standard time",
+        "pacific standard time",
+        "gmt standard time",
     ),
 }
 
@@ -109,7 +168,11 @@ def _language_allowed_by_fallback(language: str, fallback_language: str) -> bool
 
 
 def _is_strong_dominant(count: int, total: int) -> bool:
-    return count >= _STRONG_DOMINANT_MIN_CHARS and total > 0 and count / total >= _STRONG_DOMINANT_RATIO
+    return (
+        count >= _STRONG_DOMINANT_MIN_CHARS
+        and total > 0
+        and count / total >= _STRONG_DOMINANT_RATIO
+    )
 
 
 def _language_from_locale_value(value: str) -> str:

--- a/tests/parse/test_code_tools.py
+++ b/tests/parse/test_code_tools.py
@@ -281,14 +281,14 @@ class TestOutlineFile:
 # ---------------------------------------------------------------------------
 
 
-SECOND_FILE = '''def greet():
+SECOND_FILE = """def greet():
     pass
 
 
 class Other:
     def helper(self):
         pass
-'''
+"""
 
 
 class TestSearchSymbols:

--- a/tests/parse/test_document_parser_threading.py
+++ b/tests/parse/test_document_parser_threading.py
@@ -80,9 +80,7 @@ async def test_word_parser_offloads_docx_conversion(monkeypatch, tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_word_parser_forwards_original_name_to_markdown(
-    monkeypatch, tmp_path: Path
-):
+async def test_word_parser_forwards_original_name_to_markdown(monkeypatch, tmp_path: Path):
     # On single-file upload the on-disk path is a temp name (upload_<uuid>.docx)
     # and the user's original filename arrives via source_name. WordParser must
     # forward that name to MarkdownParser explicitly; otherwise parse_content can
@@ -91,9 +89,7 @@ async def test_word_parser_forwards_original_name_to_markdown(
     seen = _stub_markdown_parse(parser)
     _patch_to_thread(monkeypatch, word)
     monkeypatch.setitem(sys.modules, "docx", SimpleNamespace())
-    monkeypatch.setattr(
-        parser, "_convert_to_markdown", lambda *args, **kwargs: "# converted docx"
-    )
+    monkeypatch.setattr(parser, "_convert_to_markdown", lambda *args, **kwargs: "# converted docx")
 
     upload = tmp_path / "upload_abc123.docx"
     upload.write_bytes(b"placeholder")

--- a/tests/parse/test_document_parser_threading.py
+++ b/tests/parse/test_document_parser_threading.py
@@ -157,7 +157,7 @@ async def test_powerpoint_parser_offloads_pptx_conversion(monkeypatch, tmp_path:
     fake_pptx = SimpleNamespace()
     monkeypatch.setitem(sys.modules, "pptx", fake_pptx)
 
-    def convert(path: Path, pptx_module) -> str:
+    def convert(path: Path, pptx_module, resource_name=None, storage=None) -> str:
         assert pptx_module is fake_pptx
         return "# converted pptx"
 
@@ -167,7 +167,12 @@ async def test_powerpoint_parser_offloads_pptx_conversion(monkeypatch, tmp_path:
 
     result = await parser.parse(source)
 
-    assert calls == [(convert, (source, fake_pptx), {})]
+    assert len(calls) == 1
+    called_func, called_args, called_kwargs = calls[0]
+    assert called_func is convert
+    assert called_args[0] == source
+    assert called_args[1] is fake_pptx
+    assert called_kwargs == {}
     assert seen["content"] == "# converted pptx"
     assert result.source_format == "pptx"
     assert result.parser_name == "PowerPointParser"

--- a/tests/parse/test_powerpoint_assets.py
+++ b/tests/parse/test_powerpoint_assets.py
@@ -114,7 +114,7 @@ async def test_pptx_image_and_table_extraction(sample_pptx: Path, isolated_stora
     }
 
     # Plain markdown table emitted after the JSON block (additive).
-    after_json = md[json_match.end():]
+    after_json = md[json_match.end() :]
     assert re.search(r"\|\s*Region\s*\|\s*Revenue\s*\|", after_json)
     assert re.search(r"\|\s*-+\s*\|\s*-+\s*\|", after_json)
     assert re.search(r"\|\s*EMEA\s*\|\s*100\s*\|", after_json)
@@ -126,12 +126,8 @@ async def test_pptx_image_filenames_are_deterministic(sample_pptx: Path, isolate
     parser = PowerPointParser()
     pptx = pytest.importorskip("pptx")
 
-    parser._convert_to_markdown(
-        sample_pptx, pptx, resource_name="sample", storage=isolated_storage
-    )
-    parser._convert_to_markdown(
-        sample_pptx, pptx, resource_name="sample", storage=isolated_storage
-    )
+    parser._convert_to_markdown(sample_pptx, pptx, resource_name="sample", storage=isolated_storage)
+    parser._convert_to_markdown(sample_pptx, pptx, resource_name="sample", storage=isolated_storage)
 
     images_dir = isolated_storage.get_resource_media_dir("sample", "images")
     saved = sorted(images_dir.glob("slide1_image*.*"))

--- a/tests/parse/test_powerpoint_assets.py
+++ b/tests/parse/test_powerpoint_assets.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for PowerPointParser image and table extraction."""
+
+import io
+import json
+import re
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+from openviking.parse.parsers.powerpoint import PowerPointParser
+
+
+def _make_png_bytes(width: int = 4, height: int = 4) -> bytes:
+    """Build a tiny valid PNG without depending on Pillow."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+    raw = b"".join(b"\x00" + b"\xff\x00\x00" * width for _ in range(height))
+    idat = chunk(b"IDAT", zlib.compress(raw))
+    iend = chunk(b"IEND", b"")
+    return sig + ihdr + idat + iend
+
+
+@pytest.fixture
+def sample_pptx(tmp_path: Path) -> Path:
+    """Build a tiny pptx with one slide containing a title, a table, and a picture."""
+    pptx = pytest.importorskip("pptx")
+    from pptx.util import Inches
+
+    prs = pptx.Presentation()
+    slide_layout = prs.slide_layouts[5]  # Title only
+    slide = prs.slides.add_slide(slide_layout)
+    slide.shapes.title.text = "Quarterly Results"
+
+    # Table: 3 rows x 2 cols
+    rows, cols = 3, 2
+    left = top = Inches(1)
+    width = Inches(4)
+    height = Inches(2)
+    table_shape = slide.shapes.add_table(rows, cols, left, top, width, height)
+    table = table_shape.table
+    table.cell(0, 0).text = "Region"
+    table.cell(0, 1).text = "Revenue"
+    table.cell(1, 0).text = "EMEA"
+    table.cell(1, 1).text = "100"
+    table.cell(2, 0).text = "APAC"
+    table.cell(2, 1).text = "200"
+
+    # Picture
+    image_stream = io.BytesIO(_make_png_bytes())
+    slide.shapes.add_picture(image_stream, Inches(5), Inches(1), Inches(2), Inches(2))
+
+    out = tmp_path / "sample.pptx"
+    prs.save(str(out))
+    return out
+
+
+@pytest.fixture
+def isolated_storage(tmp_path: Path, monkeypatch):
+    """Pin the global StoragePath at a per-test temp dir to keep cwd clean."""
+    from openviking_cli.utils import storage as storage_mod
+
+    storage = storage_mod.StoragePath(base_path=tmp_path)
+    storage.ensure_dirs()
+    monkeypatch.setattr(storage_mod, "get_storage", lambda base_path=None: storage)
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_pptx_image_and_table_extraction(sample_pptx: Path, isolated_storage):
+    parser = PowerPointParser()
+    pptx = pytest.importorskip("pptx")
+
+    # Pull the intermediate markdown by calling the sync helper directly.
+    md = parser._convert_to_markdown(
+        sample_pptx, pptx, resource_name="sample", storage=isolated_storage
+    )
+
+    # Slide heading preserved.
+    assert "## Slide 1/1" in md
+    assert "### Quarterly Results" in md
+
+    # Picture saved to media dir under deterministic name.
+    images_dir = isolated_storage.get_resource_media_dir("sample", "images")
+    saved = list(images_dir.glob("slide1_image1.*"))
+    assert saved, f"expected slide1_image1.* under {images_dir}, got {list(images_dir.iterdir())}"
+
+    # Markdown contains a relative reference to that saved image.
+    rel = saved[0].relative_to(isolated_storage.media_dir)
+    assert f"]({rel})" in md
+
+    # Fenced JSON block with the table rows (order preserved).
+    json_match = re.search(r"```json\n(.*?)\n```", md, re.DOTALL)
+    assert json_match, f"expected fenced json block in markdown:\n{md}"
+    payload = json.loads(json_match.group(1))
+    assert payload == {
+        "rows": [
+            ["Region", "Revenue"],
+            ["EMEA", "100"],
+            ["APAC", "200"],
+        ]
+    }
+
+    # Plain markdown table emitted after the JSON block (additive).
+    after_json = md[json_match.end():]
+    assert re.search(r"\|\s*Region\s*\|\s*Revenue\s*\|", after_json)
+    assert re.search(r"\|\s*-+\s*\|\s*-+\s*\|", after_json)
+    assert re.search(r"\|\s*EMEA\s*\|\s*100\s*\|", after_json)
+
+
+@pytest.mark.asyncio
+async def test_pptx_image_filenames_are_deterministic(sample_pptx: Path, isolated_storage):
+    """Re-parsing the same pptx must overwrite, not pile up duplicates."""
+    parser = PowerPointParser()
+    pptx = pytest.importorskip("pptx")
+
+    parser._convert_to_markdown(
+        sample_pptx, pptx, resource_name="sample", storage=isolated_storage
+    )
+    parser._convert_to_markdown(
+        sample_pptx, pptx, resource_name="sample", storage=isolated_storage
+    )
+
+    images_dir = isolated_storage.get_resource_media_dir("sample", "images")
+    saved = sorted(images_dir.glob("slide1_image*.*"))
+    # Same deterministic name reused; second pass must not produce slide1_image2.
+    assert len(saved) == 1, f"expected one image, got {[p.name for p in saved]}"


### PR DESCRIPTION
## Summary
Closes the **PPTX image** and **PPTX table** halves of #2181 (PDF image extraction was already shipped in #2199 / #2429).

- **Picture shapes** are saved through the same vikingfs asset helper #2429 introduced for PDF/Word, and the slide markdown now references the saved file via a `viking://...` URI (matching the rewriting convention from #2557).
- **Table shapes** are emitted twice: once as a fenced JSON block (`{"rows": [...]}`) for structured retrieval, then as a plain markdown table so existing keyword search still works.
- Slide heading structure is preserved; images and tables nest under the slide they came from.

Formulas / equations and PDF/Word table-as-JSON are deliberately out of scope for this PR — they require larger refactors and benefit from being reviewed separately.

## Test plan
- [ ] `pytest tests/parse/test_powerpoint*.py -x -q` passes.
- [ ] Manual: `ov add-resource tests/parse/fixtures/<sample>.pptx` shows image references in the resulting markdown and a table JSON block.
- [ ] Re-importing the same PPTX produces deterministic image filenames (no duplicates).

Refs #2181