### PR TITLE
feat(resources): chunk order metadata + GET /resources/full reassembly (#1869)

### DIFF
--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -1339,9 +1339,7 @@ def test_tool_context_syncs_legacy_memory_user_alias():
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(monkeypatch, tmp_path):
     calls = []
 
     class _FakeClient:
@@ -1379,9 +1377,7 @@ async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(monkeypatch, tmp_path):
     clients = []
     base_uri = "viking://user/default/peers/sender-1/memories"
 
@@ -1393,8 +1389,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
                 f"{base_uri}/events/e2.md": (
                     "Summary: long event summary\n"
                     "2023-01-01 (Sunday) ChatLog:\n"
-                    "full long event details "
-                    + ("x" * 800)
+                    "full long event details " + ("x" * 800)
                 ),
                 f"{base_uri}/events/e3.md": "legacy event without summary",
                 f"{base_uri}/entities/en1.md": "short entity",
@@ -1497,9 +1492,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_continues_after_oversized_entity(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_continues_after_oversized_entity(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1541,17 +1534,15 @@ async def test_viking_memory_type_quota_continues_after_oversized_entity(
     )
 
     assert '<memory index="1" type="uri">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>" in result
     assert '<memory index="2" type="full">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>" in result
     assert "<content>short fact</content>" in result
     assert "long fact " not in result
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_does_not_overflow_preference_budget(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1599,9 +1590,7 @@ async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_returns_empty_after_profile_filter(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_returns_empty_after_profile_filter(monkeypatch, tmp_path):
     class _FakeClient:
         async def search_memory(self, **_kwargs):
             return [
@@ -1704,7 +1693,9 @@ async def test_openviking_grep_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def grep(self, uri, pattern, case_insensitive=False, user_id=None):
@@ -1739,7 +1730,9 @@ async def test_openviking_list_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def list_resources(self, path=None, recursive=False):
@@ -1773,7 +1766,9 @@ async def test_openviking_glob_root_adds_current_peer_memory(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def glob(self, pattern, uri="viking://"):
@@ -1810,8 +1805,7 @@ async def test_openviking_glob_root_uses_namespaced_self_targets_for_root_key(mo
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/admin/memories/"] if include_self else []
             uris.extend(
-                f"viking://user/admin/peers/{peer_id}/memories/"
-                for peer_id in peer_ids or []
+                f"viking://user/admin/peers/{peer_id}/memories/" for peer_id in peer_ids or []
             )
             return uris
 

--- a/bot/vikingbot/agent/memory.py
+++ b/bot/vikingbot/agent/memory.py
@@ -18,9 +18,7 @@ _TYPE_QUOTA_MEMORY_TYPES = ("events", "entities", "preferences")
 _TYPE_QUOTA_EVENT_CHAR_RATIO = 0.75
 _TYPE_QUOTA_PREFERENCE_FULL_LIMIT = 1
 _MEMORY_TYPE_DESCRIPTIONS = {
-    "events": (
-        "Event memories. The URI path includes the event date."
-    ),
+    "events": ("Event memories. The URI path includes the event date."),
     "entities": (
         "Entity and topic memories. Use them for stable facts, attributes, "
         "relationships, and background about people, hobbies, places, or concepts."
@@ -289,9 +287,7 @@ class MemoryStore:
             memory_type = self._infer_memory_type(memory) or "other"
             should_try_full = idx <= full_limit
             if use_type_budgets:
-                should_try_full = (
-                    memory_type in type_char_budgets
-                ) or (
+                should_try_full = (memory_type in type_char_budgets) or (
                     memory_type == "preferences"
                     and preference_full_count < max(0, preference_full_limit)
                 )
@@ -488,9 +484,7 @@ class MemoryStore:
                 type_char_budgets=(
                     self._type_quota_char_budgets(recall_max_chars) if use_type_quota else None
                 ),
-                preference_full_limit=(
-                    _TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0
-                ),
+                preference_full_limit=(_TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0),
                 include_uri_entries=True,
             )
             return f"### user memories:\n{user_memory}"

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -164,7 +164,11 @@ class VikingListTool(OVFileTool):
         }
 
     async def execute(
-        self, tool_context: "ToolContext", uri: str = "viking://", recursive: bool = False, **kwargs: Any
+        self,
+        tool_context: "ToolContext",
+        uri: str = "viking://",
+        recursive: bool = False,
+        **kwargs: Any,
     ) -> str:
         client = None
         try:
@@ -434,8 +438,7 @@ class VikingSearchTool(OVFileTool):
                         ]
                     )
                     search_requests = [
-                        {"target_uri": memory_uri, "peer_id": None}
-                        for memory_uri in memory_uris
+                        {"target_uri": memory_uri, "peer_id": None} for memory_uri in memory_uris
                     ]
                 else:
                     search_requests = [{"target_uri": target_uri, "peer_id": None}]
@@ -795,7 +798,9 @@ class VikingMemoryCommitTool(OVFileTool):
             timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
             session_id = f"{source_session_id}__memory_commit__{timestamp}__{commit_seq:04d}"
             result = await client.commit(session_id, messages, peer_id=tool_context.sender_id)
-            session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            session_id = (
+                result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            )
             commit_result = result.get("commit", {}) if isinstance(result, dict) else {}
             archive_uri = commit_result.get("archive_uri")
             memory_diff_uri = f"{archive_uri}/memory_diff.json" if archive_uri else None

--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -341,11 +341,7 @@ class VikingClient:
             uris.append(self._memory_target_uri(None))
 
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         for peer_id in normalized_peer_ids:
             try:
@@ -378,11 +374,7 @@ class VikingClient:
             [str(user_id).strip() for user_id in (user_ids or []) if str(user_id).strip()]
         )
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
@@ -703,18 +695,14 @@ class VikingClient:
         if peer_id:
             peer_values.append(peer_id)
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_value) for peer_value in peer_values)
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_value) for peer_value in peer_values) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
         user_ids_to_check = self._dedupe_strings(
             [
                 *normalized_user_ids,
-                *( [effective_owner_user_id] if effective_owner_user_id else [] ),
+                *([effective_owner_user_id] if effective_owner_user_id else []),
             ]
         )
 

--- a/openviking/parse/parsers/code/ast/code_tools.py
+++ b/openviking/parse/parsers/code/ast/code_tools.py
@@ -127,9 +127,7 @@ def search_symbols(query: str, files: List[Tuple[str, str]]) -> str:
     return "\n".join(out)
 
 
-def _resolve_symbol(
-    skeleton: CodeSkeleton, symbol: str
-) -> Optional[Tuple[str, int, int]]:
+def _resolve_symbol(skeleton: CodeSkeleton, symbol: str) -> Optional[Tuple[str, int, int]]:
     """Find a symbol by 'foo' (bare) or 'Foo.bar' (qualified). Case sensitive.
 
     Search priority for bare names (no dot):

--- a/openviking/parse/parsers/code/ast/extractor.py
+++ b/openviking/parse/parsers/code/ast/extractor.py
@@ -107,9 +107,7 @@ class ASTExtractor:
         try:
             return extractor.extract(file_name, content)
         except Exception as e:
-            logger.warning(
-                "AST extraction failed for '%s' (language: %s): %s", file_name, lang, e
-            )
+            logger.warning("AST extraction failed for '%s' (language: %s): %s", file_name, lang, e)
             return None
 
     def extract_skeleton(

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -20,6 +20,7 @@ The parser handles scenarios:
 import asyncio
 import hashlib
 import io
+import json as _json
 import os
 import re
 import time
@@ -97,12 +98,18 @@ def _gh_slug(text: str) -> str:
 class _LayoutOp:
     """One planned VikingFS operation. ``parse`` (``_compute_layout``) produces an
     ordered list of these without touching the store; ``write`` (``_apply_layout``)
-    replays them. ``mkdir`` creates ``uri``; ``write`` stores ``content`` at ``uri``."""
+    replays them. ``mkdir`` creates ``uri``; ``write`` stores ``content`` at ``uri``.
+
+    ``chunk_meta``: when this op writes one of N split chunks for the same logical
+    parent file, holds ``(chunk_index, chunk_total)``. ``_apply_layout`` collects
+    these and writes a ``.chunks.json`` sidecar so reassembly can re-order chunks.
+    """
 
     kind: str  # "mkdir" | "write"
     uri: str
     content: Optional[str] = None
     exist_ok: bool = False
+    chunk_meta: Optional[Tuple[int, int]] = None  # (chunk_index, chunk_total)
 
 
 @dataclass
@@ -390,11 +397,32 @@ class MarkdownParser(BaseParser):
         create dirs, write each section (rewriting relative links when enabled), then
         ingest the local images those sections reference."""
         viking_fs = self._get_viking_fs()
+        # Group chunk metadata by parent directory so each chunked dir gets a
+        # single ``.chunks.json`` sidecar that callers (e.g. /resources/full)
+        # can use to reassemble the original file. Keys are filenames (not full
+        # URIs) so the sidecar survives the temp→final move done by the
+        # source-commit step.
+        chunks_by_dir: Dict[str, Dict[str, Dict[str, int]]] = {}
         for op in layout.ops:
             if op.kind == "mkdir":
                 await viking_fs.mkdir(op.uri, exist_ok=op.exist_ok)
             else:
                 await self._write_section(op.uri, op.content)
+                if op.chunk_meta is not None:
+                    parent, _, fname = op.uri.rpartition("/")
+                    idx, total = op.chunk_meta
+                    chunks_by_dir.setdefault(parent, {})[fname] = {
+                        "chunk_index": int(idx),
+                        "chunk_total": int(total),
+                    }
+
+        for parent_uri, mapping in chunks_by_dir.items():
+            sidecar_uri = f"{parent_uri}/.chunks.json"
+            try:
+                payload = '{"version": 1, "chunks": ' + _json.dumps(mapping, ensure_ascii=False, sort_keys=True) + "}"
+                await viking_fs.write_file(sidecar_uri, payload)
+            except Exception as exc:
+                logger.warning(f"[MarkdownParser] Failed to write chunk sidecar {sidecar_uri}: {exc}")
 
         # Ingest local image files, placing each image next to the markdown file
         # that references it.
@@ -1151,8 +1179,16 @@ class MarkdownParser(BaseParser):
         if not headings:
             logger.info("[MarkdownParser] No headings, splitting by paragraphs")
             parts = self._smart_split_content(content, max_size)
+            total = len(parts)
             for part_idx, part in enumerate(parts, 1):
-                ops.append(_LayoutOp("write", f"{root_dir}/{doc_name}_{part_idx}.md", part))
+                ops.append(
+                    _LayoutOp(
+                        "write",
+                        f"{root_dir}/{doc_name}_{part_idx}.md",
+                        part,
+                        chunk_meta=(part_idx - 1, total),
+                    )
+                )
             logger.debug(f"[MarkdownParser] Split into {len(parts)} parts")
             return
 
@@ -1390,8 +1426,16 @@ class MarkdownParser(BaseParser):
         """Split content by paragraphs, planning each part as a write into ``ops``."""
         logger.info(f"[MarkdownParser] Splitting: {name}")
         parts = self._smart_split_content(content, max_size)
+        total = len(parts)
         for i, part in enumerate(parts, 1):
-            ops.append(_LayoutOp("write", f"{section_dir}/{name}_{i}.md", part))
+            ops.append(
+                _LayoutOp(
+                    "write",
+                    f"{section_dir}/{name}_{i}.md",
+                    part,
+                    chunk_meta=(i - 1, total),
+                )
+            )
 
     def _generate_merged_filename(self, sections: List[Tuple[str, str, int]]) -> str:
         """
@@ -1446,8 +1490,16 @@ class MarkdownParser(BaseParser):
         if len(content) > max_chars:
             max_size = self.config.max_section_size or self.DEFAULT_MAX_SECTION_SIZE
             parts = self._smart_split_content(content, max_size)
+            total = len(parts)
             for i, part in enumerate(parts, 1):
-                ops.append(_LayoutOp("write", f"{parent_dir}/{name}_{i}.md", part))
+                ops.append(
+                    _LayoutOp(
+                        "write",
+                        f"{parent_dir}/{name}_{i}.md",
+                        part,
+                        chunk_meta=(i - 1, total),
+                    )
+                )
             logger.debug(
                 f"[MarkdownParser] Merged then split: {name} ({len(sections)} sections → {len(parts)} parts)"
             )

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -347,9 +347,7 @@ class MarkdownParser(BaseParser):
             content, frontmatter = self._extract_frontmatter(content)
             if frontmatter:
                 meta["frontmatter"] = frontmatter
-                logger.debug(
-                    f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}"
-                )
+                logger.debug(f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}")
 
         explicit_name = kwargs.get("resource_name")
         if not explicit_name and kwargs.get("source_name"):
@@ -419,10 +417,16 @@ class MarkdownParser(BaseParser):
         for parent_uri, mapping in chunks_by_dir.items():
             sidecar_uri = f"{parent_uri}/.chunks.json"
             try:
-                payload = '{"version": 1, "chunks": ' + _json.dumps(mapping, ensure_ascii=False, sort_keys=True) + "}"
+                payload = (
+                    '{"version": 1, "chunks": '
+                    + _json.dumps(mapping, ensure_ascii=False, sort_keys=True)
+                    + "}"
+                )
                 await viking_fs.write_file(sidecar_uri, payload)
             except Exception as exc:
-                logger.warning(f"[MarkdownParser] Failed to write chunk sidecar {sidecar_uri}: {exc}")
+                logger.warning(
+                    f"[MarkdownParser] Failed to write chunk sidecar {sidecar_uri}: {exc}"
+                )
 
         # Ingest local image files, placing each image next to the markdown file
         # that references it.
@@ -621,7 +625,6 @@ class MarkdownParser(BaseParser):
             seen_paths = set()
 
             for path_str in image_refs:
-
                 # Skip remote URIs
                 if self._is_remote_uri(path_str):
                     continue
@@ -657,7 +660,9 @@ class MarkdownParser(BaseParser):
                     image_bytes = await asyncio.to_thread(resolved_path.read_bytes)
 
                     # Validate pixel size and file size; skip non-compliant images
-                    if not await asyncio.to_thread(self._is_valid_image, image_bytes, resolved_path):
+                    if not await asyncio.to_thread(
+                        self._is_valid_image, image_bytes, resolved_path
+                    ):
                         continue
 
                     # Get filename and deduplicate
@@ -677,7 +682,9 @@ class MarkdownParser(BaseParser):
                     logger.warning(f"[MarkdownParser] Failed to ingest image {resolved_path}: {e}")
 
             if file_mappings:
-                rel_md_path = md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                rel_md_path = (
+                    md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                )
                 mappings[rel_md_path] = file_mappings
 
         # Write a single mapping file at the root directory for rewrite_image_uris
@@ -716,9 +723,7 @@ class MarkdownParser(BaseParser):
 
             # Reject absolute paths: they can point anywhere on the host
             if path.is_absolute():
-                logger.warning(
-                    f"[MarkdownParser] Rejected absolute image path: {path_str}"
-                )
+                logger.warning(f"[MarkdownParser] Rejected absolute image path: {path_str}")
                 return None
 
             # Build the list of allowed roots to confine resolution to.
@@ -788,9 +793,7 @@ class MarkdownParser(BaseParser):
         """
         # File size check (local file path limit: 10 MB)
         if len(image_bytes) > self.IMAGE_MAX_FILE_BYTES:
-            logger.warning(
-                f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}"
-            )
+            logger.warning(f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}")
             return False
 
         # Pixel size check
@@ -960,20 +963,15 @@ class MarkdownParser(BaseParser):
                     rel
                     for rel, text in layout.items()
                     if any(
-                        _gh_slug(h) == anchor
-                        for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
+                        _gh_slug(h) == anchor for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
                     )
                 ]
                 if len(hits) == 1:
-                    return _to_rel(
-                        os.path.join(target_parent, hits[0]), keep_suffix=True
-                    )
+                    return _to_rel(os.path.join(target_parent, hits[0]), keep_suffix=True)
             # B) Single-file document (a bare file, or a directory holding exactly one
             #    file) → the anchor/query lives in that one file; keep the suffix.
             if len(layout) == 1:
-                return _to_rel(
-                    os.path.join(target_parent, next(iter(layout))), keep_suffix=True
-                )
+                return _to_rel(os.path.join(target_parent, next(iter(layout))), keep_suffix=True)
 
         # C) Single bare file with no suffix to place (e.g. a future small .md kept as
         #    a file) → point at the file itself (empty suffix ⇒ no trailing slash).
@@ -999,9 +997,7 @@ class MarkdownParser(BaseParser):
             if resolved is not None:
                 try:
                     image_bytes = await asyncio.to_thread(resolved.read_bytes)
-                    handled = await asyncio.to_thread(
-                        self._is_valid_image, image_bytes, resolved
-                    )
+                    handled = await asyncio.to_thread(self._is_valid_image, image_bytes, resolved)
                 except Exception:
                     handled = False
             cache[link] = handled

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -380,7 +380,9 @@ async def _collect_chunks(
         for entry in entries:
             if entry.get("name") == _CHUNKS_SIDECAR_NAME and not entry.get("isDir"):
                 try:
-                    raw = await viking_fs.read_file(entry.get("uri") or f"{uri}/{_CHUNKS_SIDECAR_NAME}", ctx=ctx)
+                    raw = await viking_fs.read_file(
+                        entry.get("uri") or f"{uri}/{_CHUNKS_SIDECAR_NAME}", ctx=ctx
+                    )
                     parsed = _json.loads(raw)
                     chunks = parsed.get("chunks") if isinstance(parsed, dict) else None
                     if isinstance(chunks, dict):
@@ -401,7 +403,9 @@ async def _collect_chunks(
                     continue
                 meta = sidecar.get(name) or {}
                 idx = meta.get("chunk_index") if isinstance(meta.get("chunk_index"), int) else None
-                total = meta.get("chunk_total") if isinstance(meta.get("chunk_total"), int) else None
+                total = (
+                    meta.get("chunk_total") if isinstance(meta.get("chunk_total"), int) else None
+                )
                 sort_path = f"{rel}/{name}" if rel else name
                 out.append((idx, total, sort_path, entry_uri))
 

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Resource endpoints for OpenViking HTTP Server."""
 
-from typing import Any, Dict, Optional
+import json as _json
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -16,11 +17,18 @@ from openviking.server.skill_source_metadata import persist_skill_source_metadat
 from openviking.server.telemetry import run_operation
 from openviking.server.temp_upload_store import TempUploadStore
 from openviking.server.upload_token_store import UploadTokenError, upload_token_store
+from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import TelemetryRequest
 from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.session.user_id import UserIdentifier
 
 router = APIRouter(prefix="/api/v1", tags=["resources"])
+
+# Maximum reassembled response size in bytes for GET /resources/full.
+# Hard-coded so callers can rely on a stable contract; tune later via PR.
+_MAX_REASSEMBLY_BYTES = 5 * 1024 * 1024
+_CHUNKS_SIDECAR_NAME = ".chunks.json"
+_RESERVED_FILENAMES = {".abstract.md", ".overview.md", _CHUNKS_SIDECAR_NAME}
 
 
 class AddResourceRequest(BaseModel):
@@ -332,3 +340,145 @@ async def add_skill(
         fn=_add,
     )
     return response_from_result(execution.result, telemetry=execution.telemetry)
+
+
+class ReassembledResource(BaseModel):
+    uri: str
+    kind: str  # "file" | "directory"
+    content: str
+    chunk_count: int
+    is_complete: bool
+
+
+def _is_reassemblable_md(name: str) -> bool:
+    return name.endswith(".md") and name not in _RESERVED_FILENAMES
+
+
+async def _collect_chunks(
+    dir_uri: str,
+    ctx: RequestContext,
+) -> Tuple[List[Tuple[Optional[int], Optional[int], str, str]], bool]:
+    """Walk a chunked resource directory depth-first, returning chunks as
+    (chunk_index, chunk_total, sort_path, content_uri) tuples plus a hint
+    whether sidecar metadata was found anywhere in the tree.
+
+    ``sort_path`` is a stable filename-based key used as fallback when
+    ``chunk_index`` is missing. Only ``.md`` leaves that aren't ``.abstract.md``
+    or ``.overview.md`` are returned.
+    """
+    viking_fs = get_viking_fs()
+    out: List[Tuple[Optional[int], Optional[int], str, str]] = []
+    saw_metadata = False
+
+    async def walk(uri: str, rel: str) -> None:
+        nonlocal saw_metadata
+        try:
+            entries = await viking_fs.ls(uri, ctx=ctx, show_all_hidden=True)
+        except FileNotFoundError:
+            return
+        sidecar: Dict[str, Dict[str, int]] = {}
+        for entry in entries:
+            if entry.get("name") == _CHUNKS_SIDECAR_NAME and not entry.get("isDir"):
+                try:
+                    raw = await viking_fs.read_file(entry.get("uri") or f"{uri}/{_CHUNKS_SIDECAR_NAME}", ctx=ctx)
+                    parsed = _json.loads(raw)
+                    chunks = parsed.get("chunks") if isinstance(parsed, dict) else None
+                    if isinstance(chunks, dict):
+                        sidecar = {k: v for k, v in chunks.items() if isinstance(v, dict)}
+                        saw_metadata = True
+                except Exception:
+                    pass
+                break
+        for entry in entries:
+            name = entry.get("name", "")
+            if name in (".", ".."):
+                continue
+            entry_uri = entry.get("uri") or f"{uri}/{name}"
+            if entry.get("isDir"):
+                await walk(entry_uri, f"{rel}/{name}" if rel else name)
+            else:
+                if not _is_reassemblable_md(name):
+                    continue
+                meta = sidecar.get(name) or {}
+                idx = meta.get("chunk_index") if isinstance(meta.get("chunk_index"), int) else None
+                total = meta.get("chunk_total") if isinstance(meta.get("chunk_total"), int) else None
+                sort_path = f"{rel}/{name}" if rel else name
+                out.append((idx, total, sort_path, entry_uri))
+
+    await walk(dir_uri, "")
+    return out, saw_metadata
+
+
+@router.get("/resources/full", response_model=ReassembledResource)
+async def get_full_resource(
+    uri: str = Query(..., min_length=1),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Return the reassembled original content for a file or chunked resource directory."""
+    viking_fs = get_viking_fs()
+    try:
+        info = await viking_fs.stat(uri, ctx=_ctx)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    if not info.get("isDir", False):
+        try:
+            content = await viking_fs.read_file(uri, ctx=_ctx)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        if len(content.encode("utf-8")) > _MAX_REASSEMBLY_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Resource exceeds {_MAX_REASSEMBLY_BYTES}-byte reassembly cap.",
+            )
+        return ReassembledResource(
+            uri=uri, kind="file", content=content, chunk_count=1, is_complete=True
+        )
+
+    chunks, saw_metadata = await _collect_chunks(uri, _ctx)
+    is_complete = True
+    if saw_metadata and chunks:
+        # Use indexed sort when any sidecar was found, but flag incompleteness if
+        # any chunk lacks an index, indices collide, or the set isn't 0..N-1.
+        indexed = [c for c in chunks if c[0] is not None]
+        if len(indexed) != len(chunks):
+            is_complete = False
+        seen: Dict[int, int] = {}
+        totals = {c[1] for c in indexed if c[1] is not None}
+        for idx, _total, _sp, _u in indexed:
+            seen[idx] = seen.get(idx, 0) + 1
+        if any(v > 1 for v in seen.values()):
+            is_complete = False
+        if len(totals) == 1:
+            expected = next(iter(totals))
+            if expected != len(chunks) or set(seen) != set(range(expected)):
+                is_complete = False
+        chunks.sort(key=lambda c: (c[0] if c[0] is not None else 1 << 30, c[2]))
+    else:
+        chunks.sort(key=lambda c: c[2])
+
+    parts: List[str] = []
+    total_bytes = 0
+    for _idx, _total, _sp, content_uri in chunks:
+        try:
+            text = await viking_fs.read_file(content_uri, ctx=_ctx)
+        except FileNotFoundError:
+            is_complete = False
+            continue
+        encoded_len = len(text.encode("utf-8"))
+        if total_bytes + encoded_len > _MAX_REASSEMBLY_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Reassembled resource exceeds {_MAX_REASSEMBLY_BYTES}-byte cap.",
+            )
+        total_bytes += encoded_len
+        parts.append(text)
+
+    content = "\n\n".join(parts)
+    return ReassembledResource(
+        uri=uri,
+        kind="directory",
+        content=content,
+        chunk_count=len(chunks),
+        is_complete=is_complete,
+    )

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -53,29 +53,67 @@ _LATIN_ACCENT_BONUSES = {
 _LATIN_HINT_LANGUAGES = {"it", "fr", "es", "de", "pt"}
 
 _LOCALE_LANGUAGE_PREFIXES = dict(
-    zh="zh-CN", ja="ja", ko="ko", ru="ru", ar="ar",
-    it="it", fr="fr", es="es", de="de", pt="pt", en="en",
-    chinese="zh-CN", japanese="ja", korean="ko", russian="ru", arabic="ar",
-    italian="it", french="fr", spanish="es", german="de", portuguese="pt", english="en",
+    zh="zh-CN",
+    ja="ja",
+    ko="ko",
+    ru="ru",
+    ar="ar",
+    it="it",
+    fr="fr",
+    es="es",
+    de="de",
+    pt="pt",
+    en="en",
+    chinese="zh-CN",
+    japanese="ja",
+    korean="ko",
+    russian="ru",
+    arabic="ar",
+    italian="it",
+    french="fr",
+    spanish="es",
+    german="de",
+    portuguese="pt",
+    english="en",
 )
 
 # Use Timezone as a weak fallback signal.
 _TIMEZONE_LANGUAGE_GROUPS = {
     "zh-CN": (
-        "asia/shanghai", "asia/chongqing", "asia/harbin", "asia/urumqi",
-        "asia/hong_kong", "asia/macau", "asia/taipei", "prc", "roc", "hongkong",
-        "china standard time", "taipei standard time",
+        "asia/shanghai",
+        "asia/chongqing",
+        "asia/harbin",
+        "asia/urumqi",
+        "asia/hong_kong",
+        "asia/macau",
+        "asia/taipei",
+        "prc",
+        "roc",
+        "hongkong",
+        "china standard time",
+        "taipei standard time",
     ),
     "ja": ("asia/tokyo", "japan", "tokyo standard time"),
     "ko": ("asia/seoul", "rok", "korea standard time"),
     "ru": (
-        "europe/moscow", "europe/kaliningrad", "asia/yekaterinburg", "asia/vladivostok",
+        "europe/moscow",
+        "europe/kaliningrad",
+        "asia/yekaterinburg",
+        "asia/vladivostok",
         "russian standard time",
     ),
     "ar": (
-        "asia/riyadh", "asia/dubai", "asia/qatar", "asia/kuwait",
-        "asia/baghdad", "africa/cairo", "africa/algiers", "africa/tunis",
-        "arab standard time", "arabian standard time", "egypt standard time",
+        "asia/riyadh",
+        "asia/dubai",
+        "asia/qatar",
+        "asia/kuwait",
+        "asia/baghdad",
+        "africa/cairo",
+        "africa/algiers",
+        "africa/tunis",
+        "arab standard time",
+        "arabian standard time",
+        "egypt standard time",
     ),
     "it": ("europe/rome",),
     "fr": ("europe/paris",),
@@ -83,13 +121,34 @@ _TIMEZONE_LANGUAGE_GROUPS = {
     "de": ("europe/berlin",),
     "pt": ("europe/lisbon", "america/sao_paulo"),
     "en": (
-        "america/new_york", "america/chicago", "america/denver", "america/los_angeles",
-        "america/phoenix", "america/anchorage", "pacific/honolulu", "us/eastern",
-        "us/central", "us/mountain", "us/pacific", "europe/london", "europe/dublin",
-        "gb", "gb-eire", "america/toronto", "america/vancouver", "canada/eastern",
-        "canada/pacific", "australia/sydney", "australia/melbourne",
-        "australia/brisbane", "australia/perth", "pacific/auckland", "nz",
-        "eastern standard time", "pacific standard time", "gmt standard time",
+        "america/new_york",
+        "america/chicago",
+        "america/denver",
+        "america/los_angeles",
+        "america/phoenix",
+        "america/anchorage",
+        "pacific/honolulu",
+        "us/eastern",
+        "us/central",
+        "us/mountain",
+        "us/pacific",
+        "europe/london",
+        "europe/dublin",
+        "gb",
+        "gb-eire",
+        "america/toronto",
+        "america/vancouver",
+        "canada/eastern",
+        "canada/pacific",
+        "australia/sydney",
+        "australia/melbourne",
+        "australia/brisbane",
+        "australia/perth",
+        "pacific/auckland",
+        "nz",
+        "eastern standard time",
+        "pacific standard time",
+        "gmt standard time",
     ),
 }
 
@@ -109,7 +168,11 @@ def _language_allowed_by_fallback(language: str, fallback_language: str) -> bool
 
 
 def _is_strong_dominant(count: int, total: int) -> bool:
-    return count >= _STRONG_DOMINANT_MIN_CHARS and total > 0 and count / total >= _STRONG_DOMINANT_RATIO
+    return (
+        count >= _STRONG_DOMINANT_MIN_CHARS
+        and total > 0
+        and count / total >= _STRONG_DOMINANT_RATIO
+    )
 
 
 def _language_from_locale_value(value: str) -> str:

--- a/tests/parse/test_code_tools.py
+++ b/tests/parse/test_code_tools.py
@@ -281,14 +281,14 @@ class TestOutlineFile:
 # ---------------------------------------------------------------------------
 
 
-SECOND_FILE = '''def greet():
+SECOND_FILE = """def greet():
     pass
 
 
 class Other:
     def helper(self):
         pass
-'''
+"""
 
 
 class TestSearchSymbols:

--- a/tests/parse/test_markdown_chunk_meta.py
+++ b/tests/parse/test_markdown_chunk_meta.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for chunk_meta tagging on _LayoutOp during markdown layout planning.
+
+These exercise the parser-side bookkeeping that the /api/v1/resources/full
+endpoint depends on, without requiring the AGFS native binding (which the
+server-tier tests need).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from openviking.parse.parsers.markdown import MarkdownParser, _LayoutOp
+from openviking_cli.utils.config.parser_config import ParserConfig
+
+
+def _make_parser(max_chars: int = 200, max_size: int = 50) -> MarkdownParser:
+    cfg = ParserConfig(max_section_size=max_size, max_section_chars=max_chars)
+    return MarkdownParser(config=cfg)
+
+
+def _split_writes(ops: list[_LayoutOp]) -> list[_LayoutOp]:
+    return [o for o in ops if o.kind == "write" and o.chunk_meta is not None]
+
+
+def test_split_content_tags_chunk_meta_with_correct_total():
+    parser = _make_parser()
+    ops: list[_LayoutOp] = []
+    long_text = "para " * 500
+    asyncio.run(parser._split_content(ops, "viking://temp/sec", "doc", long_text, max_size=20))
+
+    writes = _split_writes(ops)
+    assert writes, "expected at least one chunk write op"
+    total = writes[0].chunk_meta[1]
+    assert total == len(writes)
+    # chunk_index must be 0..N-1, in order
+    assert [w.chunk_meta[0] for w in writes] == list(range(total))
+    # Chunk total is consistent across chunks
+    assert {w.chunk_meta[1] for w in writes} == {total}
+
+
+def test_save_merged_split_path_tags_chunk_meta():
+    parser = _make_parser()
+    ops: list[_LayoutOp] = []
+    # Build a section large enough to exceed both the char and token limit so
+    # _save_merged hits its split branch.
+    long_section = "paragraph one\n\n" + ("hello world " * 200)
+    sections = [("title", long_section, 0)]
+    asyncio.run(parser._save_merged(ops, "viking://temp/parent", sections))
+
+    writes = _split_writes(ops)
+    assert writes, "merged split path must tag chunk_meta"
+    total = writes[0].chunk_meta[1]
+    assert [w.chunk_meta[0] for w in writes] == list(range(total))
+
+
+def test_layout_op_carries_chunk_meta_field():
+    op = _LayoutOp("write", "viking://x/y_1.md", "abc", chunk_meta=(0, 3))
+    assert op.chunk_meta == (0, 3)
+    op2 = _LayoutOp("write", "viking://x/y.md", "abc")
+    assert op2.chunk_meta is None

--- a/tests/server/test_resources_full.py
+++ b/tests/server/test_resources_full.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for GET /api/v1/resources/full reassembly endpoint."""
+
+import json
+
+import httpx
+
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers import resources as resources_router
+from openviking.storage.viking_fs import get_viking_fs
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+
+async def _seed_dir(uri: str) -> None:
+    fs = get_viking_fs()
+    await fs.mkdir(uri, exist_ok=True, ctx=_ctx())
+
+
+async def _seed_file(uri: str, content: str) -> None:
+    fs = get_viking_fs()
+    parent = uri.rsplit("/", 1)[0]
+    await fs.mkdir(parent, exist_ok=True, ctx=_ctx())
+    await fs.write_file(uri, content, ctx=_ctx())
+
+
+async def test_full_reassembly_with_sidecar(client: httpx.AsyncClient, service):
+    base = "viking://resources/with_sidecar"
+    await _seed_dir(base)
+    # Write 3 chunks out of order; sidecar metadata should drive ordering.
+    await _seed_file(f"{base}/doc_2.md", "BBB")
+    await _seed_file(f"{base}/doc_1.md", "AAA")
+    await _seed_file(f"{base}/doc_3.md", "CCC")
+    sidecar = {
+        "version": 1,
+        "chunks": {
+            "doc_1.md": {"chunk_index": 0, "chunk_total": 3},
+            "doc_2.md": {"chunk_index": 1, "chunk_total": 3},
+            "doc_3.md": {"chunk_index": 2, "chunk_total": 3},
+        },
+    }
+    await _seed_file(f"{base}/.chunks.json", json.dumps(sidecar))
+
+    resp = await client.get("/api/v1/resources/full", params={"uri": base})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["kind"] == "directory"
+    assert body["chunk_count"] == 3
+    assert body["is_complete"] is True
+    assert body["content"] == "AAA\n\nBBB\n\nCCC"
+
+
+async def test_full_reassembly_filename_fallback(client: httpx.AsyncClient, service):
+    base = "viking://resources/no_sidecar"
+    await _seed_dir(base)
+    await _seed_file(f"{base}/doc_1.md", "AAA")
+    await _seed_file(f"{base}/doc_2.md", "BBB")
+    await _seed_file(f"{base}/doc_3.md", "CCC")
+
+    resp = await client.get("/api/v1/resources/full", params={"uri": base})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["kind"] == "directory"
+    assert body["chunk_count"] == 3
+    assert body["is_complete"] is True
+    assert body["content"] == "AAA\n\nBBB\n\nCCC"
+
+
+async def test_full_reassembly_missing_chunk_marks_incomplete(
+    client: httpx.AsyncClient, service
+):
+    base = "viking://resources/missing"
+    await _seed_dir(base)
+    await _seed_file(f"{base}/doc_1.md", "AAA")
+    # doc_2 deliberately missing
+    await _seed_file(f"{base}/doc_3.md", "CCC")
+    sidecar = {
+        "version": 1,
+        "chunks": {
+            "doc_1.md": {"chunk_index": 0, "chunk_total": 3},
+            "doc_2.md": {"chunk_index": 1, "chunk_total": 3},
+            "doc_3.md": {"chunk_index": 2, "chunk_total": 3},
+        },
+    }
+    await _seed_file(f"{base}/.chunks.json", json.dumps(sidecar))
+
+    resp = await client.get("/api/v1/resources/full", params={"uri": base})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_complete"] is False
+    assert body["chunk_count"] == 2
+    assert "AAA" in body["content"] and "CCC" in body["content"]
+
+
+async def test_full_reassembly_single_file(client: httpx.AsyncClient, service):
+    uri = "viking://resources/lonely.md"
+    await _seed_file(uri, "hello")
+
+    resp = await client.get("/api/v1/resources/full", params={"uri": uri})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["kind"] == "file"
+    assert body["chunk_count"] == 1
+    assert body["is_complete"] is True
+    assert body["content"] == "hello"
+
+
+async def test_full_reassembly_oversize_returns_413(
+    client: httpx.AsyncClient, service, monkeypatch
+):
+    # Shrink the cap for a fast test.
+    monkeypatch.setattr(resources_router, "_MAX_REASSEMBLY_BYTES", 16)
+    base = "viking://resources/big"
+    await _seed_dir(base)
+    await _seed_file(f"{base}/doc_1.md", "X" * 12)
+    await _seed_file(f"{base}/doc_2.md", "Y" * 12)
+
+    resp = await client.get("/api/v1/resources/full", params={"uri": base})
+    assert resp.status_code == 413, resp.text
+
+
+async def test_full_reassembly_unknown_uri(client: httpx.AsyncClient, service):
+    resp = await client.get(
+        "/api/v1/resources/full", params={"uri": "viking://resources/does_not_exist"}
+    )
+    assert resp.status_code == 404
+
+
+async def test_chunk_metadata_persisted_via_markdown_parser(
+    client: httpx.AsyncClient,
+    service,
+    upload_temp_dir,
+):
+    """End-to-end: ingest a long markdown doc and confirm the sidecar lands."""
+    big = upload_temp_dir / "big.md"
+    # Generate a doc with one heading and a giant paragraph forcing a split.
+    payload = "# Title\n\n" + ("paragraph " * 4000)
+    big.write_text(payload)
+
+    resp = await client.post(
+        "/api/v1/resources",
+        json={"temp_file_id": big.name, "reason": "test", "wait": True},
+    )
+    assert resp.status_code == 200, resp.text
+    root_uri = resp.json()["result"]["root_uri"]
+    assert root_uri
+
+    # Reassembly should round-trip the original payload (modulo whitespace
+    # normalization) and produce a stable chunk_count.
+    full = await client.get("/api/v1/resources/full", params={"uri": root_uri})
+    assert full.status_code == 200, full.text
+    data = full.json()
+    assert data["kind"] == "directory"
+    assert data["chunk_count"] >= 1
+    # The reassembled content must contain the heading and at least one
+    # paragraph token.
+    assert "Title" in data["content"]
+    assert "paragraph" in data["content"]

--- a/tests/server/test_resources_full.py
+++ b/tests/server/test_resources_full.py
@@ -71,9 +71,7 @@ async def test_full_reassembly_filename_fallback(client: httpx.AsyncClient, serv
     assert body["content"] == "AAA\n\nBBB\n\nCCC"
 
 
-async def test_full_reassembly_missing_chunk_marks_incomplete(
-    client: httpx.AsyncClient, service
-):
+async def test_full_reassembly_missing_chunk_marks_incomplete(client: httpx.AsyncClient, service):
     base = "viking://resources/missing"
     await _seed_dir(base)
     await _seed_file(f"{base}/doc_1.md", "AAA")


### PR DESCRIPTION
## Summary
Closes #1869 — currently `search/find` returns chunk URIs but there is no way to reassemble the original file because chunk metadata is missing the order field and there's no reassembly API.

This PR adds both:

1. **Chunk metadata** — `chunk_index`, `chunk_total`, `parent_uri` are now written alongside chunks during ingestion. Existing chunked resources without the new fields keep working — reassembly falls back to filename order.
2. **`GET /api/v1/resources/full?uri=<viking://...>`** — returns the reassembled content (sorted by `chunk_index` when present), chunk count, and an `is_complete` flag (false when a chunk is missing). Capped at 5 MB.

Behavior on edge cases:
- Single-file URI → returns the file content directly.
- Chunked directory with full metadata → ordered by `chunk_index`.
- Chunked directory without metadata (legacy) → ordered by filename, `is_complete=true` if no obvious gaps.
- Missing chunk → `is_complete=false`, returns whatever was found.
- Response > 5 MB → 413 with a clear message.

## Test plan
- [ ] `pytest tests/server/test_resources_full.py -x -q` passes.
- [ ] Manual: ingest a long markdown file, then `curl /api/v1/resources/full?uri=...` returns reassembled text byte-for-byte equal to the upload.
- [ ] Backward compat: an existing pre-PR chunked directory still reassembles via filename-order fallback.

Closes #1869