### PR TITLE
feat(openclaw): add feature gates RPC

### DIFF
--- a/examples/openclaw-plugin/config/feature-gates.json
+++ b/examples/openclaw-plugin/config/feature-gates.json
@@ -1,0 +1,10 @@
+{
+  "features": {
+    "openviking.260610": {
+      "enable": true,
+      "minPluginVersion": "2026.6.10",
+      "minOpenclawVersion": "2026.4.8",
+      "editions": ["arkclaw_enterprise", "arkclaw"]
+    }
+  }
+}

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -1,6 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import { memoryOpenVikingConfigSchema } from "./config.js";
 import { registerSetupCli } from "./commands/setup.js";
+import { registerOpenVikingFeatureGatesMethod } from "./plugin/openviking-feature-gates.js";
 
 import { OpenVikingClient, isMemoryUri } from "./client.js";
 import type {
@@ -266,6 +267,13 @@ type OpenClawPluginApi = {
     stop?: (ctx?: unknown) => void | Promise<void>;
   }) => void;
   registerContextEngine?: (id: string, factory: () => unknown) => void;
+  registerGatewayMethod?: (
+    name: string,
+    handler: (input: {
+      params?: unknown;
+      respond: (success: boolean, data: unknown) => void;
+    }) => void | Promise<void>,
+  ) => void;
   registerCli?: (
     factory: (ctx: { program: unknown; workspaceDir?: string }) => void,
     opts?: { commands?: string[] },
@@ -662,6 +670,8 @@ const contextEnginePlugin = {
   configSchema: memoryOpenVikingConfigSchema,
 
   register(api: OpenClawPluginApi) {
+    registerOpenVikingFeatureGatesMethod(api);
+
     const rawCfg =
       api.pluginConfig && typeof api.pluginConfig === "object" && !Array.isArray(api.pluginConfig)
         ? (api.pluginConfig as Record<string, unknown>)

--- a/examples/openclaw-plugin/install-manifest.json
+++ b/examples/openclaw-plugin/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": "1.0",
-  "pluginVersion": "2026.5.8",
+  "pluginVersion": "2026.6.11",
   "plugin": {
     "id": "openviking",
     "kind": "context-engine",
@@ -22,6 +22,8 @@
       "runtime-utils.ts",
       "recall-trace.ts",
       "commands/setup.ts",
+      "plugin/openviking-feature-gates.ts",
+      "config/feature-gates.json",
       "tsconfig.json",
       "tsconfig.build.json",
       "package.json",

--- a/examples/openclaw-plugin/package.json
+++ b/examples/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openviking/openclaw-plugin",
-  "version": "2026.6.2",
+  "version": "2026.6.11",
   "displayName": "OpenViking",
   "description": "OpenClaw context-engine plugin — OpenViking AI memory, long-term memory, knowledge base, semantic search, RAG, context engine. 长期记忆 · 知识库 · 语义检索 · 上下文引擎",
   "type": "module",
@@ -22,6 +22,8 @@
     "dist/",
     "*.ts",
     "commands/setup.ts",
+    "plugin/openviking-feature-gates.ts",
+    "config/feature-gates.json",
     "!vitest.config.ts",
     "install-manifest.json",
     "openclaw.plugin.json",

--- a/examples/openclaw-plugin/plugin/openviking-feature-gates.ts
+++ b/examples/openclaw-plugin/plugin/openviking-feature-gates.ts
@@ -1,0 +1,335 @@
+import { existsSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Type, type Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+
+export const OPENVIKING_260610_FEATURE = "openviking.260610";
+export const OPENVIKING_FEATURE_GATES_RPC = "openviking.feature.gates";
+
+const versionPattern = String.raw`^\d+\.\d+\.\d+(?:-(?:\d+|beta(?:\.\d+)?))?$`;
+
+const FeatureGateSchema = Type.Object(
+  {
+    enable: Type.Boolean(),
+    minPluginVersion: Type.String({ pattern: versionPattern }),
+    minOpenclawVersion: Type.String({ minLength: 1 }),
+    editions: Type.Array(Type.String({ minLength: 1 }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
+  },
+  { additionalProperties: false },
+);
+
+const FeatureGatesConfigSchema = Type.Object(
+  {
+    features: Type.Record(Type.String({ minLength: 1 }), FeatureGateSchema),
+  },
+  { additionalProperties: false },
+);
+
+type FeatureGatesConfig = Static<typeof FeatureGatesConfigSchema>;
+
+interface ParsedVersion {
+  year: number;
+  month: number;
+  day: number;
+  channelRank: number;
+  sequence: number;
+}
+
+export interface OpenVikingFeatureGateServiceOptions {
+  configPath?: string;
+  getPluginVersion?: () => string;
+  getOpenClawVersion?: () => Promise<string>;
+  getOpenClawVersionSync?: () => string;
+}
+
+export interface OpenVikingFeatureGateService {
+  getEnabledFeatureGates(edition?: string): Promise<string[]>;
+  isFeatureGateEnabled(featureName: string, edition?: string): Promise<boolean>;
+  isFeatureGateEnabledSync(featureName: string, edition?: string): boolean;
+}
+
+export interface OpenVikingFeatureGatesGatewayApi {
+  registerGatewayMethod?: (
+    name: string,
+    handler: (input: {
+      params?: unknown;
+      respond: (success: boolean, data: unknown) => void;
+    }) => void | Promise<void>,
+  ) => void;
+}
+
+function parseVersion(version: string): ParsedVersion | null {
+  const stableMatch = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\d+))?$/);
+  if (stableMatch) {
+    return {
+      year: Number(stableMatch[1]),
+      month: Number(stableMatch[2]),
+      day: Number(stableMatch[3]),
+      channelRank: 1,
+      sequence: stableMatch[4] ? Number(stableMatch[4]) : 0,
+    };
+  }
+
+  const betaMatch = version.match(/^(\d+)\.(\d+)\.(\d+)-beta(?:\.(\d+))?$/);
+  if (betaMatch) {
+    return {
+      year: Number(betaMatch[1]),
+      month: Number(betaMatch[2]),
+      day: Number(betaMatch[3]),
+      channelRank: 0,
+      sequence: betaMatch[4] ? Number(betaMatch[4]) : 0,
+    };
+  }
+
+  return null;
+}
+
+export function isPluginVersionAtLeast(currentVersion: string, minVersion: string): boolean {
+  const current = parseVersion(currentVersion);
+  const minimum = parseVersion(minVersion);
+  if (!current || !minimum) {
+    return false;
+  }
+
+  if (current.year !== minimum.year) return current.year > minimum.year;
+  if (current.month !== minimum.month) return current.month > minimum.month;
+  if (current.day !== minimum.day) return current.day > minimum.day;
+  if (current.channelRank !== minimum.channelRank) {
+    return current.channelRank > minimum.channelRank;
+  }
+  return current.sequence >= minimum.sequence;
+}
+
+export function isOpenClawVersionAtLeast(currentVersion: string, minVersion: string): boolean {
+  return isPluginVersionAtLeast(currentVersion, minVersion);
+}
+
+function formatSchemaError(path: string, message: string): string {
+  const normalizedPath = path ? path.replace(/\//g, ".").replace(/^\./, "") : "$";
+  return `${normalizedPath}: ${message}`;
+}
+
+function parseFeatureGatesConfig(raw: string): FeatureGatesConfig {
+  const parsed = JSON.parse(raw) as unknown;
+  if (Value.Check(FeatureGatesConfigSchema, parsed)) {
+    return parsed;
+  }
+
+  const validationError = Value.Errors(FeatureGatesConfigSchema, parsed).First();
+  const errorMessage = validationError
+    ? formatSchemaError(validationError.path, validationError.message)
+    : "unknown validation error";
+  throw new Error(`Invalid feature-gates.json: ${errorMessage}`);
+}
+
+function normalizeFeatures(
+  features: FeatureGatesConfig["features"],
+  pluginVersion: string,
+  openclawVersion: string,
+  edition?: string,
+): string[] {
+  const requestedEdition = edition?.trim();
+  const businessCarriers = (process.env.BUSINESS_CARRIER ?? "")
+    .split(",")
+    .map((carrier) => carrier.trim())
+    .filter(Boolean);
+  const effectiveEditions = requestedEdition ? [requestedEdition] : businessCarriers;
+
+  return Object.entries(features).flatMap(([featureName, featureConfig]) => {
+    const editionOk =
+      effectiveEditions.length > 0 &&
+      effectiveEditions.some((carrier) => featureConfig.editions.includes(carrier));
+
+    if (
+      featureConfig.enable &&
+      editionOk &&
+      isPluginVersionAtLeast(pluginVersion, featureConfig.minPluginVersion) &&
+      isOpenClawVersionAtLeast(openclawVersion, featureConfig.minOpenclawVersion)
+    ) {
+      return [featureName];
+    }
+    return [];
+  });
+}
+
+let cachedPackageRoot: string | undefined;
+let cachedDefaultPluginVersion: string | undefined;
+
+function findPackageRoot(startDir: string): string {
+  let current = startDir;
+  for (;;) {
+    if (existsSync(join(current, "package.json"))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return startDir;
+    }
+    current = parent;
+  }
+}
+
+function getPackageRoot(): string {
+  cachedPackageRoot ??= findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+  return cachedPackageRoot;
+}
+
+function getDefaultFeatureGatesPath(): string {
+  return join(getPackageRoot(), "config", "feature-gates.json");
+}
+
+function getDefaultPluginVersion(): string {
+  if (cachedDefaultPluginVersion) {
+    return cachedDefaultPluginVersion;
+  }
+  try {
+    const raw = readFileSync(join(getPackageRoot(), "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    cachedDefaultPluginVersion = typeof parsed.version === "string" ? parsed.version : "0.0.0";
+  } catch {
+    cachedDefaultPluginVersion = "0.0.0";
+  }
+  return cachedDefaultPluginVersion;
+}
+
+function getDefaultOpenClawVersionSync(): string {
+  const envVersion = process.env.OPENCLAW_VERSION?.trim();
+  return envVersion || "2026.4.8";
+}
+
+export function createOpenVikingFeatureGateService(
+  options: OpenVikingFeatureGateServiceOptions = {},
+): OpenVikingFeatureGateService {
+  const configPath = options.configPath ?? getDefaultFeatureGatesPath();
+  const getPluginVersion = options.getPluginVersion ?? getDefaultPluginVersion;
+  const getOpenClawVersion = options.getOpenClawVersion ?? (async () => getDefaultOpenClawVersionSync());
+  const getOpenClawVersionSync = options.getOpenClawVersionSync ?? getDefaultOpenClawVersionSync;
+  let cachedConfig: FeatureGatesConfig | undefined;
+  let cachedConfigPromise: Promise<FeatureGatesConfig> | undefined;
+  let cachedOpenClawVersion: string | undefined;
+  let cachedOpenClawVersionPromise: Promise<string> | undefined;
+
+  async function loadFeatureGatesConfig(): Promise<FeatureGatesConfig> {
+    if (cachedConfig) {
+      return cachedConfig;
+    }
+    cachedConfigPromise ??= readFile(configPath, "utf8")
+      .then((raw) => {
+        cachedConfig = parseFeatureGatesConfig(raw);
+        return cachedConfig;
+      })
+      .catch((error: unknown) => {
+        cachedConfigPromise = undefined;
+        throw error;
+      });
+    return cachedConfigPromise;
+  }
+
+  function loadFeatureGatesConfigSync(): FeatureGatesConfig {
+    if (cachedConfig) {
+      return cachedConfig;
+    }
+    const raw = readFileSync(configPath, "utf8");
+    cachedConfig = parseFeatureGatesConfig(raw);
+    return cachedConfig;
+  }
+
+  async function loadOpenClawVersion(): Promise<string> {
+    if (cachedOpenClawVersion) {
+      return cachedOpenClawVersion;
+    }
+    cachedOpenClawVersionPromise ??= getOpenClawVersion()
+      .then((version) => {
+        cachedOpenClawVersion = version;
+        return version;
+      })
+      .catch((error: unknown) => {
+        cachedOpenClawVersionPromise = undefined;
+        throw error;
+      });
+    return cachedOpenClawVersionPromise;
+  }
+
+  function loadOpenClawVersionSync(): string {
+    cachedOpenClawVersion ??= getOpenClawVersionSync();
+    return cachedOpenClawVersion;
+  }
+
+  function loadAndNormalizeFeaturesSync(edition?: string): string[] {
+    const parsed = loadFeatureGatesConfigSync();
+    return normalizeFeatures(parsed.features, getPluginVersion(), loadOpenClawVersionSync(), edition);
+  }
+
+  async function loadAndNormalizeFeatures(edition?: string): Promise<string[]> {
+    const [parsed, openclawVersion] = await Promise.all([
+      loadFeatureGatesConfig(),
+      loadOpenClawVersion(),
+    ]);
+    return normalizeFeatures(parsed.features, getPluginVersion(), openclawVersion, edition);
+  }
+
+  return {
+    async getEnabledFeatureGates(edition?: string): Promise<string[]> {
+      return loadAndNormalizeFeatures(edition);
+    },
+
+    async isFeatureGateEnabled(featureName: string, edition?: string): Promise<boolean> {
+      try {
+        const features = await loadAndNormalizeFeatures(edition);
+        return features.includes(featureName);
+      } catch {
+        return false;
+      }
+    },
+
+    isFeatureGateEnabledSync(featureName: string, edition?: string): boolean {
+      try {
+        const features = loadAndNormalizeFeaturesSync(edition);
+        return features.includes(featureName);
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+function readEditionParam(params: unknown): string | undefined {
+  if (!params || typeof params !== "object") {
+    return undefined;
+  }
+  const value = (params as { edition?: unknown }).edition;
+  return typeof value === "string" ? value : undefined;
+}
+
+const defaultFeatureGateService = createOpenVikingFeatureGateService();
+
+export const getEnabledFeatureGates = (edition?: string): Promise<string[]> =>
+  defaultFeatureGateService.getEnabledFeatureGates(edition);
+export const isFeatureGateEnabled = (featureName: string, edition?: string): Promise<boolean> =>
+  defaultFeatureGateService.isFeatureGateEnabled(featureName, edition);
+export const isFeatureGateEnabledSync = (featureName: string, edition?: string): boolean =>
+  defaultFeatureGateService.isFeatureGateEnabledSync(featureName, edition);
+
+export function registerOpenVikingFeatureGatesMethod(
+  api: OpenVikingFeatureGatesGatewayApi,
+  service: OpenVikingFeatureGateService = defaultFeatureGateService,
+): void {
+  if (typeof api.registerGatewayMethod !== "function") {
+    return;
+  }
+
+  api.registerGatewayMethod(OPENVIKING_FEATURE_GATES_RPC, async ({ params, respond }) => {
+    try {
+      const edition = readEditionParam(params);
+      const features = await service.getEnabledFeatureGates(edition);
+      respond(true, { features });
+    } catch (error) {
+      respond(false, error instanceof Error ? error.message : String(error));
+    }
+  });
+}

--- a/examples/openclaw-plugin/tests/ut/feature-gates.test.ts
+++ b/examples/openclaw-plugin/tests/ut/feature-gates.test.ts
@@ -1,0 +1,223 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  OPENVIKING_260610_FEATURE,
+  OPENVIKING_FEATURE_GATES_RPC,
+  createOpenVikingFeatureGateService,
+  isPluginVersionAtLeast,
+  registerOpenVikingFeatureGatesMethod,
+} from "../../plugin/openviking-feature-gates.js";
+
+const tempDirs: string[] = [];
+
+function writeFeatureGatesConfig(content: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "openviking-feature-gates-"));
+  tempDirs.push(dir);
+  const configPath = join(dir, "feature-gates.json");
+  writeFileSync(configPath, JSON.stringify(content), "utf8");
+  return configPath;
+}
+
+describe("openviking feature gates", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("compares date-style plugin versions with beta and revision ordering", () => {
+    expect(isPluginVersionAtLeast("2026.6.10", "2026.6.10")).toBe(true);
+    expect(isPluginVersionAtLeast("2026.6.10-1", "2026.6.10")).toBe(true);
+    expect(isPluginVersionAtLeast("2026.6.10", "2026.6.10-beta.1")).toBe(true);
+    expect(isPluginVersionAtLeast("2026.6.10-beta.1", "2026.6.10")).toBe(false);
+    expect(isPluginVersionAtLeast("2026.6.9", "2026.6.10")).toBe(false);
+    expect(isPluginVersionAtLeast("not-a-version", "2026.6.10")).toBe(false);
+  });
+
+  it("returns the 2026.6.10 gate when version and edition match", async () => {
+    const configPath = writeFeatureGatesConfig({
+      features: {
+        [OPENVIKING_260610_FEATURE]: {
+          enable: true,
+          minPluginVersion: "2026.6.10",
+          minOpenclawVersion: "2026.4.8",
+          editions: ["arkclaw_enterprise", "arkclaw"],
+        },
+      },
+    });
+    const service = createOpenVikingFeatureGateService({
+      configPath,
+      getPluginVersion: () => "2026.6.10",
+      getOpenClawVersion: async () => "2026.4.8",
+      getOpenClawVersionSync: () => "2026.4.8",
+    });
+
+    await expect(service.getEnabledFeatureGates("arkclaw")).resolves.toEqual([
+      OPENVIKING_260610_FEATURE,
+    ]);
+  });
+
+  it("filters gates by plugin version, OpenClaw version and edition", async () => {
+    const configPath = writeFeatureGatesConfig({
+      features: {
+        [OPENVIKING_260610_FEATURE]: {
+          enable: true,
+          minPluginVersion: "2026.6.10",
+          minOpenclawVersion: "2026.4.8",
+          editions: ["arkclaw_enterprise", "arkclaw"],
+        },
+      },
+    });
+
+    await expect(
+      createOpenVikingFeatureGateService({
+        configPath,
+        getPluginVersion: () => "2026.6.9",
+        getOpenClawVersion: async () => "2026.4.8",
+        getOpenClawVersionSync: () => "2026.4.8",
+      }).getEnabledFeatureGates("arkclaw"),
+    ).resolves.toEqual([]);
+
+    await expect(
+      createOpenVikingFeatureGateService({
+        configPath,
+        getPluginVersion: () => "2026.6.10",
+        getOpenClawVersion: async () => "2026.4.7",
+        getOpenClawVersionSync: () => "2026.4.7",
+      }).getEnabledFeatureGates("arkclaw"),
+    ).resolves.toEqual([]);
+
+    await expect(
+      createOpenVikingFeatureGateService({
+        configPath,
+        getPluginVersion: () => "2026.6.10",
+        getOpenClawVersion: async () => "2026.4.8",
+        getOpenClawVersionSync: () => "2026.4.8",
+      }).getEnabledFeatureGates("other"),
+    ).resolves.toEqual([]);
+  });
+
+  it("prefers RPC edition over BUSINESS_CARRIER and falls back to carrier list", async () => {
+    const previousCarrier = process.env.BUSINESS_CARRIER;
+    const configPath = writeFeatureGatesConfig({
+      features: {
+        [OPENVIKING_260610_FEATURE]: {
+          enable: true,
+          minPluginVersion: "2026.6.10",
+          minOpenclawVersion: "2026.4.8",
+          editions: ["arkclaw_enterprise", "arkclaw"],
+        },
+      },
+    });
+    const service = createOpenVikingFeatureGateService({
+      configPath,
+      getPluginVersion: () => "2026.6.10",
+      getOpenClawVersion: async () => "2026.4.8",
+      getOpenClawVersionSync: () => "2026.4.8",
+    });
+
+    try {
+      process.env.BUSINESS_CARRIER = "other, arkclaw_enterprise";
+      await expect(service.getEnabledFeatureGates()).resolves.toEqual([
+        OPENVIKING_260610_FEATURE,
+      ]);
+
+      process.env.BUSINESS_CARRIER = "other";
+      await expect(service.getEnabledFeatureGates("arkclaw")).resolves.toEqual([
+        OPENVIKING_260610_FEATURE,
+      ]);
+    } finally {
+      if (previousCarrier === undefined) {
+        delete process.env.BUSINESS_CARRIER;
+      } else {
+        process.env.BUSINESS_CARRIER = previousCarrier;
+      }
+    }
+  });
+
+  it("returns false for sync gate checks when config loading fails", () => {
+    const service = createOpenVikingFeatureGateService({
+      configPath: "/path/that/does/not/exist/feature-gates.json",
+      getPluginVersion: () => "2026.6.10",
+      getOpenClawVersion: async () => "2026.4.8",
+      getOpenClawVersionSync: () => "2026.4.8",
+    });
+
+    expect(service.isFeatureGateEnabledSync(OPENVIKING_260610_FEATURE, "arkclaw")).toBe(false);
+  });
+
+  it("registers the Gateway RPC and returns enabled feature names", async () => {
+    const configPath = writeFeatureGatesConfig({
+      features: {
+        [OPENVIKING_260610_FEATURE]: {
+          enable: true,
+          minPluginVersion: "2026.6.10",
+          minOpenclawVersion: "2026.4.8",
+          editions: ["arkclaw"],
+        },
+      },
+    });
+    const service = createOpenVikingFeatureGateService({
+      configPath,
+      getPluginVersion: () => "2026.6.10",
+      getOpenClawVersion: async () => "2026.4.8",
+      getOpenClawVersionSync: () => "2026.4.8",
+    });
+    const registered: Array<{
+      name: string;
+      handler: (input: {
+        params?: unknown;
+        respond: (success: boolean, data: unknown) => void;
+      }) => Promise<void>;
+    }> = [];
+    const api = {
+      registerGatewayMethod: vi.fn((name, handler) => {
+        registered.push({ name, handler });
+      }),
+    };
+
+    registerOpenVikingFeatureGatesMethod(api, service);
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0]?.name).toBe(OPENVIKING_FEATURE_GATES_RPC);
+
+    const respond = vi.fn();
+    await registered[0]?.handler({ params: { edition: "arkclaw" }, respond });
+
+    expect(respond).toHaveBeenCalledWith(true, {
+      features: [OPENVIKING_260610_FEATURE],
+    });
+  });
+
+  it("returns RPC failure when the feature gate config cannot be loaded", async () => {
+    const service = createOpenVikingFeatureGateService({
+      configPath: "/path/that/does/not/exist/feature-gates.json",
+      getPluginVersion: () => "2026.6.10",
+      getOpenClawVersion: async () => "2026.4.8",
+      getOpenClawVersionSync: () => "2026.4.8",
+    });
+    const registered: Array<{
+      handler: (input: {
+        params?: unknown;
+        respond: (success: boolean, data: unknown) => void;
+      }) => Promise<void>;
+    }> = [];
+
+    registerOpenVikingFeatureGatesMethod(
+      {
+        registerGatewayMethod: vi.fn((_name, handler) => {
+          registered.push({ handler });
+        }),
+      },
+      service,
+    );
+
+    const respond = vi.fn();
+    await registered[0]?.handler({ params: { edition: "arkclaw" }, respond });
+
+    expect(respond).toHaveBeenCalledWith(false, expect.stringContaining("feature-gates.json"));
+  });
+});

--- a/examples/openclaw-plugin/tests/ut/plugin-registration.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-registration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import contextEnginePlugin from "../../index.js";
+import { OPENVIKING_FEATURE_GATES_RPC } from "../../plugin/openviking-feature-gates.js";
 
 function withOpenVikingEnv<T>(
   values: Partial<Record<"OPENVIKING_API_KEY" | "OPENVIKING_BASE_URL", string | undefined>>,
@@ -43,6 +44,7 @@ function createPluginApi(pluginConfig: Record<string, unknown>) {
     registerCommand: vi.fn(),
     registerService: vi.fn(),
     registerContextEngine: vi.fn(),
+    registerGatewayMethod: vi.fn(),
     on: vi.fn(),
   };
 }
@@ -83,6 +85,17 @@ describe("plugin registration", () => {
         expect(api.registerTool).toHaveBeenCalled();
         expect(api.registerContextEngine).toHaveBeenCalledWith("openviking", expect.any(Function));
       },
+    );
+  });
+
+  it("registers the feature-gates Gateway RPC when Gateway methods are available", () => {
+    const api = createPluginApi({});
+
+    contextEnginePlugin.register(api as any);
+
+    expect(api.registerGatewayMethod).toHaveBeenCalledWith(
+      OPENVIKING_FEATURE_GATES_RPC,
+      expect.any(Function),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add the OpenViking feature gate service and `openviking.feature.gates` Gateway RPC.
- Ship the default `config/feature-gates.json` and include it in package/install manifests.
- Cover version ordering, edition filtering, RPC success/failure, and plugin registration.

## Notes
- This ports the feature-gates slice from #2613 only.
- It does not bring in the #2613 runtime/module refactor or old user/agent routing paths.
- No `agent_prefix`, `X-OpenViking-Agent`, or `viking://agent/*` behavior is introduced.

## Checks
- `npm test -- tests/ut/feature-gates.test.ts tests/ut/plugin-registration.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
