### PR TITLE
feat(opencode-memory-plugin): opt-in local server auto-start with binary + config preflight (#1951)

### DIFF
--- a/examples/opencode-memory-plugin/README.md
+++ b/examples/opencode-memory-plugin/README.md
@@ -92,6 +92,7 @@ Example config:
   "peerId": "",
   "enabled": true,
   "timeoutMs": 30000,
+  "autoStartServer": false,
   "autoCommit": {
     "enabled": true,
     "intervalMinutes": 10
@@ -103,6 +104,18 @@ Example config:
 `peerId` is sent as `X-OpenViking-Actor-Peer` on data-plane memory requests; captured session messages store it as body `peer_id`. Leave it empty to preserve existing behavior.
 
 The environment variables `OPENVIKING_API_KEY`, `OPENVIKING_ACCOUNT`, `OPENVIKING_USER`, and `OPENVIKING_PEER_ID` take precedence over the config file.
+
+### Auto-start the OpenViking server (opt-in)
+
+Set `"autoStartServer": true` to let the plugin spawn `openviking-server` when the configured endpoint is local and `/health` is not yet responding. The default is `false` so existing users see no behavior change.
+
+When enabled, the plugin will only attempt auto-start when **all** of the following preflight checks pass:
+
+- The configured `endpoint` resolves to `localhost`, `127.0.0.1`, or `::1`. Remote endpoints are skipped silently.
+- An OpenViking binary (`ov` or `openviking-server`) is on `PATH` (`command -v` on POSIX, `where` on Windows). If neither resolves, the attempt is skipped with a clear log entry.
+- `~/.openviking/ov.conf` exists. If it doesn't, the plugin logs `OpenViking config not found — run \`ov init\` first` and skips.
+
+If all checks pass, the server is spawned detached and the plugin polls `/health` every 1s for up to 30s. If the child exits before becoming healthy, the failure is surfaced immediately rather than waiting out the full timeout.
 
 ## Runtime Files
 
@@ -228,6 +241,7 @@ Add an `autoRecall` block to your `openviking-config.json` to customize recall b
   "user": "opencode",
   "enabled": true,
   "timeoutMs": 30000,
+  "autoStartServer": false,
   "autoCommit": {
     "enabled": true,
     "intervalMinutes": 10

--- a/examples/opencode-memory-plugin/README_CN.md
+++ b/examples/opencode-memory-plugin/README_CN.md
@@ -92,6 +92,7 @@ export OPENVIKING_USER="opencode"
   "peerId": "",
   "enabled": true,
   "timeoutMs": 30000,
+  "autoStartServer": false,
   "autoCommit": {
     "enabled": true,
     "intervalMinutes": 10
@@ -103,6 +104,18 @@ export OPENVIKING_USER="opencode"
 `peerId` 会作为 `X-OpenViking-Actor-Peer` 用于数据面的 memory 请求；捕获 session message 时仍写入 body `peer_id`。留空则保持现有行为。
 
 环境变量 `OPENVIKING_API_KEY`、`OPENVIKING_ACCOUNT`、`OPENVIKING_USER` 和 `OPENVIKING_PEER_ID` 优先于配置文件。
+
+### 自动启动 OpenViking 服务器（可选）
+
+将 `"autoStartServer"` 设为 `true`，插件会在配置的端点为本地且 `/health` 尚未响应时自动启动 `openviking-server`。默认值为 `false`，现有用户不会受到任何行为变化的影响。
+
+启用后，插件只会在以下**所有**预检都通过时才尝试自动启动：
+
+- 配置的 `endpoint` 解析为 `localhost`、`127.0.0.1` 或 `::1`。远程端点会被静默跳过。
+- `PATH` 上存在 OpenViking 可执行文件（`ov` 或 `openviking-server`）（POSIX 使用 `command -v`，Windows 使用 `where`）。两者都没有则跳过并记录清晰的日志。
+- 存在 `~/.openviking/ov.conf`。如果不存在，插件会记录 `OpenViking config not found — run \`ov init\` first` 并跳过。
+
+预检全部通过后，插件会以 detached 方式启动服务器，并每 1 秒轮询一次 `/health`，最多 30 秒。如果子进程在变为健康状态之前退出，将立即上报失败而不是等待整个超时窗口。
 
 ## 运行时文件
 

--- a/examples/opencode-memory-plugin/openviking-config.example.json
+++ b/examples/opencode-memory-plugin/openviking-config.example.json
@@ -5,6 +5,7 @@
   "user": "opencode",
   "enabled": true,
   "timeoutMs": 30000,
+  "autoStartServer": false,
   "autoCommit": {
     "enabled": true,
     "intervalMinutes": 10

--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -13,7 +13,9 @@
 
 import type { Hooks, PluginInput } from "@opencode-ai/plugin"
 import { tool } from "@opencode-ai/plugin"
+import { spawn } from "child_process"
 import * as fs from "fs"
+import * as os from "os"
 import * as path from "path"
 import { fileURLToPath } from "url"
 
@@ -282,6 +284,9 @@ interface OpenVikingConfig {
   peerId: string
   enabled: boolean
   timeoutMs: number
+  // Opt-in: auto-start `openviking-server` when the configured endpoint is
+  // local and not yet healthy. Default false preserves existing behavior.
+  autoStartServer?: boolean
   autoCommit?: {
     enabled: boolean
     intervalMinutes: number
@@ -366,6 +371,7 @@ const DEFAULT_CONFIG: OpenVikingConfig = {
   peerId: "",
   enabled: true,
   timeoutMs: 30000,
+  autoStartServer: false,
   autoCommit: {
     enabled: true,
     intervalMinutes: 10
@@ -634,6 +640,184 @@ async function checkServiceHealth(config: OpenVikingConfig): Promise<boolean> {
     })
     return false
   }
+}
+
+// ============================================================================
+// Server Auto-Start (opt-in)
+// ============================================================================
+
+const SERVER_BINARY_CANDIDATES = ["ov", "openviking-server"]
+const AUTO_START_HEALTH_TIMEOUT_MS = 30_000
+const AUTO_START_HEALTH_INTERVAL_MS = 1_000
+
+function isLocalEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint)
+    const host = url.hostname.toLowerCase()
+    if (host === "localhost" || host === "127.0.0.1") return true
+    // URL parser strips brackets from IPv6 hostnames; accept both forms.
+    if (host === "::1" || host === "[::1]") return true
+    return false
+  } catch {
+    return false
+  }
+}
+
+function ovConfPath(): string {
+  return path.join(os.homedir(), ".openviking", "ov.conf")
+}
+
+function ovConfExists(): boolean {
+  try {
+    return fs.existsSync(ovConfPath())
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve the first server binary on PATH. Returns the resolved name or null.
+ * Uses `where` on Windows and `command -v` on POSIX, mirroring the convention
+ * used by examples/opencode/plugin/index.mjs.
+ */
+async function findServerBinary(): Promise<string | null> {
+  const isWindows = process.platform === "win32"
+  for (const candidate of SERVER_BINARY_CANDIDATES) {
+    const found = await new Promise<boolean>((resolve) => {
+      const child = isWindows
+        ? spawn("where", [candidate], { stdio: "ignore", shell: false })
+        : spawn("command", ["-v", candidate], { stdio: "ignore", shell: true })
+      const timer = setTimeout(() => {
+        try { child.kill() } catch {}
+        resolve(false)
+      }, 2000)
+      child.on("error", () => {
+        clearTimeout(timer)
+        resolve(false)
+      })
+      child.on("exit", (code) => {
+        clearTimeout(timer)
+        resolve(code === 0)
+      })
+    })
+    if (found) return candidate
+  }
+  return null
+}
+
+/**
+ * Spawn the server detached and poll /health until healthy or the 30s budget
+ * expires. If the child exits before /health responds, fail fast instead of
+ * waiting out the polling loop.
+ */
+async function spawnAndWaitHealthy(
+  binary: string,
+  config: OpenVikingConfig,
+): Promise<boolean> {
+  let child
+  try {
+    // The `ov` CLI dispatches to subcommands; `openviking-server` is the server
+    // binary itself. Mirror the precedent in examples/opencode/plugin/index.mjs
+    // which simply runs `openviking-server`.
+    const args = binary === "openviking-server" ? [] : ["server"]
+    child = spawn(binary, args, {
+      detached: true,
+      stdio: "ignore",
+    })
+    child.unref()
+  } catch (error: any) {
+    log("ERROR", "auto-start", "Failed to spawn openviking server", {
+      binary,
+      error: error.message,
+    })
+    return false
+  }
+
+  let earlyExit = false
+  const onExit = (code: number | null) => {
+    earlyExit = true
+    log("ERROR", "auto-start", "Server process exited before becoming healthy", {
+      binary,
+      code,
+    })
+  }
+  child.on("exit", onExit)
+  child.on("error", (error: Error) => {
+    earlyExit = true
+    log("ERROR", "auto-start", "Server process emitted error", {
+      binary,
+      error: error.message,
+    })
+  })
+
+  const startedAt = Date.now()
+  try {
+    while (Date.now() - startedAt < AUTO_START_HEALTH_TIMEOUT_MS) {
+      if (earlyExit) return false
+      if (await checkServiceHealth(config)) {
+        log("INFO", "auto-start", "Server became healthy", {
+          binary,
+          elapsed_ms: Date.now() - startedAt,
+        })
+        return true
+      }
+      await new Promise((r) => setTimeout(r, AUTO_START_HEALTH_INTERVAL_MS))
+    }
+  } finally {
+    child.removeListener("exit", onExit)
+  }
+
+  // Timed out — try to clean up the child if it's still running.
+  try {
+    if (!earlyExit) child.kill()
+  } catch {}
+  log("ERROR", "auto-start", "Server did not become healthy within timeout", {
+    binary,
+    timeout_ms: AUTO_START_HEALTH_TIMEOUT_MS,
+  })
+  return false
+}
+
+/**
+ * Opt-in auto-start with preflight checks. Returns true if the server is
+ * healthy after the call, false otherwise. Refuses to spawn against remote
+ * endpoints, missing binaries, or missing ov.conf.
+ */
+async function ensureServerRunning(config: OpenVikingConfig): Promise<boolean> {
+  // 1. Already running? No-op.
+  if (await checkServiceHealth(config)) return true
+
+  // 2. Opt-out — preserve existing behavior.
+  if (!config.autoStartServer) return false
+
+  // 3. Local-only — never spawn against remote endpoints.
+  if (!isLocalEndpoint(config.endpoint)) {
+    log("INFO", "auto-start", "Skipping auto-start: endpoint is not local", {
+      endpoint: config.endpoint,
+    })
+    return false
+  }
+
+  // 4. Binary preflight.
+  const binary = await findServerBinary()
+  if (!binary) {
+    log("ERROR", "auto-start", "openviking is not installed (ov / openviking-server not on PATH). Run: pip install openviking")
+    return false
+  }
+
+  // 5. Config preflight.
+  if (!ovConfExists()) {
+    log("ERROR", "auto-start", `OpenViking config not found at ${ovConfPath()} — run \`ov init\` or create ov.conf first`)
+    return false
+  }
+
+  // 6. Spawn + health-check loop.
+  const started = await spawnAndWaitHealthy(binary, config)
+  if (!started) {
+    log("ERROR", "auto-start", "Failed to auto-start openviking-server")
+    return false
+  }
+  return true
 }
 
 // ============================================================================
@@ -1748,9 +1932,10 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
   // Load session map from disk
   await loadSessionMap()
 
-  const healthy = await checkServiceHealth(config)
+  const healthy = await ensureServerRunning(config)
   log("INFO", "health", healthy ? "OpenViking health check passed" : "OpenViking health check failed", {
     endpoint: config.endpoint,
+    auto_start: config.autoStartServer === true,
   })
 
   // Start auto-commit scheduler


### PR DESCRIPTION
## Summary
Closes #1951. Mirrors the existing auto-start behavior in `examples/opencode/plugin/index.mjs` for the memory plugin, fixing the gap that the previous attempt (#2133, closed) left open.

PR reviewer flagged #2133 as **partially compliant** — missing two preflight checks. This PR adds both:
- Verify `ov` / `openviking-server` is on PATH before spawning (Windows: `where`, POSIX: `command -v`).
- Verify `~/.openviking/ov.conf` exists before spawning.

Both failures surface a clear toast and skip the auto-start attempt rather than spawning into a 30-second timeout.

Also adds an `exit` listener on the spawned child so an immediate crash surfaces as a failure instead of waiting out the polling window (suggestion from the #2133 review).

### Order of operations in `_init`
1. `/health` already responds → return true (no-op).
2. `autoStartServer === false` (default) → return false (preserves existing behavior).
3. Endpoint is not local (`localhost` / `127.0.0.1` / `::1`) → refuse to auto-start.
4. Binary not on PATH → toast + bail.
5. `~/.openviking/ov.conf` missing → toast + bail.
6. Spawn detached, poll `/health` for 30 s. On `exit` event before health → fail fast.

## Test plan
- [ ] `npm install && npx tsc --noEmit openviking-memory.ts` passes (or the existing bundle script).
- [ ] With `autoStartServer: false` (default) and no server running, behavior matches main: clear `OpenViking service unavailable` toast, plugin disabled.
- [ ] With `autoStartServer: true` and `ov` on PATH + ov.conf present + endpoint local: server auto-starts and `/health` becomes healthy within 30 s.
- [ ] With `autoStartServer: true` but `ov` not on PATH: toast says "openviking is not installed", no spawn attempted.
- [ ] With `autoStartServer: true` but ov.conf missing: toast says config not found, no spawn attempted.
- [ ] With `autoStartServer: true` against a remote endpoint: skipped silently (no spawn).

Closes #1951