### PR TITLE
fix(vectordb): auto-rebuild default index when _recover finds records but no index (#2118)

### DIFF
--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -1339,9 +1339,7 @@ def test_tool_context_syncs_legacy_memory_user_alias():
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(monkeypatch, tmp_path):
     calls = []
 
     class _FakeClient:
@@ -1379,9 +1377,7 @@ async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(monkeypatch, tmp_path):
     clients = []
     base_uri = "viking://user/default/peers/sender-1/memories"
 
@@ -1393,8 +1389,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
                 f"{base_uri}/events/e2.md": (
                     "Summary: long event summary\n"
                     "2023-01-01 (Sunday) ChatLog:\n"
-                    "full long event details "
-                    + ("x" * 800)
+                    "full long event details " + ("x" * 800)
                 ),
                 f"{base_uri}/events/e3.md": "legacy event without summary",
                 f"{base_uri}/entities/en1.md": "short entity",
@@ -1497,9 +1492,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_continues_after_oversized_entity(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_continues_after_oversized_entity(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1541,17 +1534,15 @@ async def test_viking_memory_type_quota_continues_after_oversized_entity(
     )
 
     assert '<memory index="1" type="uri">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>" in result
     assert '<memory index="2" type="full">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>" in result
     assert "<content>short fact</content>" in result
     assert "long fact " not in result
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_does_not_overflow_preference_budget(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1599,9 +1590,7 @@ async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_returns_empty_after_profile_filter(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_returns_empty_after_profile_filter(monkeypatch, tmp_path):
     class _FakeClient:
         async def search_memory(self, **_kwargs):
             return [
@@ -1704,7 +1693,9 @@ async def test_openviking_grep_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def grep(self, uri, pattern, case_insensitive=False, user_id=None):
@@ -1739,7 +1730,9 @@ async def test_openviking_list_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def list_resources(self, path=None, recursive=False):
@@ -1773,7 +1766,9 @@ async def test_openviking_glob_root_adds_current_peer_memory(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def glob(self, pattern, uri="viking://"):
@@ -1810,8 +1805,7 @@ async def test_openviking_glob_root_uses_namespaced_self_targets_for_root_key(mo
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/admin/memories/"] if include_self else []
             uris.extend(
-                f"viking://user/admin/peers/{peer_id}/memories/"
-                for peer_id in peer_ids or []
+                f"viking://user/admin/peers/{peer_id}/memories/" for peer_id in peer_ids or []
             )
             return uris
 

--- a/bot/vikingbot/agent/memory.py
+++ b/bot/vikingbot/agent/memory.py
@@ -18,9 +18,7 @@ _TYPE_QUOTA_MEMORY_TYPES = ("events", "entities", "preferences")
 _TYPE_QUOTA_EVENT_CHAR_RATIO = 0.75
 _TYPE_QUOTA_PREFERENCE_FULL_LIMIT = 1
 _MEMORY_TYPE_DESCRIPTIONS = {
-    "events": (
-        "Event memories. The URI path includes the event date."
-    ),
+    "events": ("Event memories. The URI path includes the event date."),
     "entities": (
         "Entity and topic memories. Use them for stable facts, attributes, "
         "relationships, and background about people, hobbies, places, or concepts."
@@ -289,9 +287,7 @@ class MemoryStore:
             memory_type = self._infer_memory_type(memory) or "other"
             should_try_full = idx <= full_limit
             if use_type_budgets:
-                should_try_full = (
-                    memory_type in type_char_budgets
-                ) or (
+                should_try_full = (memory_type in type_char_budgets) or (
                     memory_type == "preferences"
                     and preference_full_count < max(0, preference_full_limit)
                 )
@@ -488,9 +484,7 @@ class MemoryStore:
                 type_char_budgets=(
                     self._type_quota_char_budgets(recall_max_chars) if use_type_quota else None
                 ),
-                preference_full_limit=(
-                    _TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0
-                ),
+                preference_full_limit=(_TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0),
                 include_uri_entries=True,
             )
             return f"### user memories:\n{user_memory}"

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -164,7 +164,11 @@ class VikingListTool(OVFileTool):
         }
 
     async def execute(
-        self, tool_context: "ToolContext", uri: str = "viking://", recursive: bool = False, **kwargs: Any
+        self,
+        tool_context: "ToolContext",
+        uri: str = "viking://",
+        recursive: bool = False,
+        **kwargs: Any,
     ) -> str:
         client = None
         try:
@@ -434,8 +438,7 @@ class VikingSearchTool(OVFileTool):
                         ]
                     )
                     search_requests = [
-                        {"target_uri": memory_uri, "peer_id": None}
-                        for memory_uri in memory_uris
+                        {"target_uri": memory_uri, "peer_id": None} for memory_uri in memory_uris
                     ]
                 else:
                     search_requests = [{"target_uri": target_uri, "peer_id": None}]
@@ -795,7 +798,9 @@ class VikingMemoryCommitTool(OVFileTool):
             timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
             session_id = f"{source_session_id}__memory_commit__{timestamp}__{commit_seq:04d}"
             result = await client.commit(session_id, messages, peer_id=tool_context.sender_id)
-            session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            session_id = (
+                result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            )
             commit_result = result.get("commit", {}) if isinstance(result, dict) else {}
             archive_uri = commit_result.get("archive_uri")
             memory_diff_uri = f"{archive_uri}/memory_diff.json" if archive_uri else None

--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -341,11 +341,7 @@ class VikingClient:
             uris.append(self._memory_target_uri(None))
 
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         for peer_id in normalized_peer_ids:
             try:
@@ -378,11 +374,7 @@ class VikingClient:
             [str(user_id).strip() for user_id in (user_ids or []) if str(user_id).strip()]
         )
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
@@ -703,18 +695,14 @@ class VikingClient:
         if peer_id:
             peer_values.append(peer_id)
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_value) for peer_value in peer_values)
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_value) for peer_value in peer_values) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
         user_ids_to_check = self._dedupe_strings(
             [
                 *normalized_user_ids,
-                *( [effective_owner_user_id] if effective_owner_user_id else [] ),
+                *([effective_owner_user_id] if effective_owner_user_id else []),
             ]
         )
 

--- a/openviking/parse/parsers/code/ast/code_tools.py
+++ b/openviking/parse/parsers/code/ast/code_tools.py
@@ -127,9 +127,7 @@ def search_symbols(query: str, files: List[Tuple[str, str]]) -> str:
     return "\n".join(out)
 
 
-def _resolve_symbol(
-    skeleton: CodeSkeleton, symbol: str
-) -> Optional[Tuple[str, int, int]]:
+def _resolve_symbol(skeleton: CodeSkeleton, symbol: str) -> Optional[Tuple[str, int, int]]:
     """Find a symbol by 'foo' (bare) or 'Foo.bar' (qualified). Case sensitive.
 
     Search priority for bare names (no dot):

--- a/openviking/parse/parsers/code/ast/extractor.py
+++ b/openviking/parse/parsers/code/ast/extractor.py
@@ -107,9 +107,7 @@ class ASTExtractor:
         try:
             return extractor.extract(file_name, content)
         except Exception as e:
-            logger.warning(
-                "AST extraction failed for '%s' (language: %s): %s", file_name, lang, e
-            )
+            logger.warning("AST extraction failed for '%s' (language: %s): %s", file_name, lang, e)
             return None
 
     def extract_skeleton(

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -340,9 +340,7 @@ class MarkdownParser(BaseParser):
             content, frontmatter = self._extract_frontmatter(content)
             if frontmatter:
                 meta["frontmatter"] = frontmatter
-                logger.debug(
-                    f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}"
-                )
+                logger.debug(f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}")
 
         explicit_name = kwargs.get("resource_name")
         if not explicit_name and kwargs.get("source_name"):
@@ -593,7 +591,6 @@ class MarkdownParser(BaseParser):
             seen_paths = set()
 
             for path_str in image_refs:
-
                 # Skip remote URIs
                 if self._is_remote_uri(path_str):
                     continue
@@ -629,7 +626,9 @@ class MarkdownParser(BaseParser):
                     image_bytes = await asyncio.to_thread(resolved_path.read_bytes)
 
                     # Validate pixel size and file size; skip non-compliant images
-                    if not await asyncio.to_thread(self._is_valid_image, image_bytes, resolved_path):
+                    if not await asyncio.to_thread(
+                        self._is_valid_image, image_bytes, resolved_path
+                    ):
                         continue
 
                     # Get filename and deduplicate
@@ -649,7 +648,9 @@ class MarkdownParser(BaseParser):
                     logger.warning(f"[MarkdownParser] Failed to ingest image {resolved_path}: {e}")
 
             if file_mappings:
-                rel_md_path = md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                rel_md_path = (
+                    md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                )
                 mappings[rel_md_path] = file_mappings
 
         # Write a single mapping file at the root directory for rewrite_image_uris
@@ -688,9 +689,7 @@ class MarkdownParser(BaseParser):
 
             # Reject absolute paths: they can point anywhere on the host
             if path.is_absolute():
-                logger.warning(
-                    f"[MarkdownParser] Rejected absolute image path: {path_str}"
-                )
+                logger.warning(f"[MarkdownParser] Rejected absolute image path: {path_str}")
                 return None
 
             # Build the list of allowed roots to confine resolution to.
@@ -760,9 +759,7 @@ class MarkdownParser(BaseParser):
         """
         # File size check (local file path limit: 10 MB)
         if len(image_bytes) > self.IMAGE_MAX_FILE_BYTES:
-            logger.warning(
-                f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}"
-            )
+            logger.warning(f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}")
             return False
 
         # Pixel size check
@@ -932,20 +929,15 @@ class MarkdownParser(BaseParser):
                     rel
                     for rel, text in layout.items()
                     if any(
-                        _gh_slug(h) == anchor
-                        for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
+                        _gh_slug(h) == anchor for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
                     )
                 ]
                 if len(hits) == 1:
-                    return _to_rel(
-                        os.path.join(target_parent, hits[0]), keep_suffix=True
-                    )
+                    return _to_rel(os.path.join(target_parent, hits[0]), keep_suffix=True)
             # B) Single-file document (a bare file, or a directory holding exactly one
             #    file) → the anchor/query lives in that one file; keep the suffix.
             if len(layout) == 1:
-                return _to_rel(
-                    os.path.join(target_parent, next(iter(layout))), keep_suffix=True
-                )
+                return _to_rel(os.path.join(target_parent, next(iter(layout))), keep_suffix=True)
 
         # C) Single bare file with no suffix to place (e.g. a future small .md kept as
         #    a file) → point at the file itself (empty suffix ⇒ no trailing slash).
@@ -971,9 +963,7 @@ class MarkdownParser(BaseParser):
             if resolved is not None:
                 try:
                     image_bytes = await asyncio.to_thread(resolved.read_bytes)
-                    handled = await asyncio.to_thread(
-                        self._is_valid_image, image_bytes, resolved
-                    )
+                    handled = await asyncio.to_thread(self._is_valid_image, image_bytes, resolved)
                 except Exception:
                     handled = False
             cache[link] = handled

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -53,29 +53,67 @@ _LATIN_ACCENT_BONUSES = {
 _LATIN_HINT_LANGUAGES = {"it", "fr", "es", "de", "pt"}
 
 _LOCALE_LANGUAGE_PREFIXES = dict(
-    zh="zh-CN", ja="ja", ko="ko", ru="ru", ar="ar",
-    it="it", fr="fr", es="es", de="de", pt="pt", en="en",
-    chinese="zh-CN", japanese="ja", korean="ko", russian="ru", arabic="ar",
-    italian="it", french="fr", spanish="es", german="de", portuguese="pt", english="en",
+    zh="zh-CN",
+    ja="ja",
+    ko="ko",
+    ru="ru",
+    ar="ar",
+    it="it",
+    fr="fr",
+    es="es",
+    de="de",
+    pt="pt",
+    en="en",
+    chinese="zh-CN",
+    japanese="ja",
+    korean="ko",
+    russian="ru",
+    arabic="ar",
+    italian="it",
+    french="fr",
+    spanish="es",
+    german="de",
+    portuguese="pt",
+    english="en",
 )
 
 # Use Timezone as a weak fallback signal.
 _TIMEZONE_LANGUAGE_GROUPS = {
     "zh-CN": (
-        "asia/shanghai", "asia/chongqing", "asia/harbin", "asia/urumqi",
-        "asia/hong_kong", "asia/macau", "asia/taipei", "prc", "roc", "hongkong",
-        "china standard time", "taipei standard time",
+        "asia/shanghai",
+        "asia/chongqing",
+        "asia/harbin",
+        "asia/urumqi",
+        "asia/hong_kong",
+        "asia/macau",
+        "asia/taipei",
+        "prc",
+        "roc",
+        "hongkong",
+        "china standard time",
+        "taipei standard time",
     ),
     "ja": ("asia/tokyo", "japan", "tokyo standard time"),
     "ko": ("asia/seoul", "rok", "korea standard time"),
     "ru": (
-        "europe/moscow", "europe/kaliningrad", "asia/yekaterinburg", "asia/vladivostok",
+        "europe/moscow",
+        "europe/kaliningrad",
+        "asia/yekaterinburg",
+        "asia/vladivostok",
         "russian standard time",
     ),
     "ar": (
-        "asia/riyadh", "asia/dubai", "asia/qatar", "asia/kuwait",
-        "asia/baghdad", "africa/cairo", "africa/algiers", "africa/tunis",
-        "arab standard time", "arabian standard time", "egypt standard time",
+        "asia/riyadh",
+        "asia/dubai",
+        "asia/qatar",
+        "asia/kuwait",
+        "asia/baghdad",
+        "africa/cairo",
+        "africa/algiers",
+        "africa/tunis",
+        "arab standard time",
+        "arabian standard time",
+        "egypt standard time",
     ),
     "it": ("europe/rome",),
     "fr": ("europe/paris",),
@@ -83,13 +121,34 @@ _TIMEZONE_LANGUAGE_GROUPS = {
     "de": ("europe/berlin",),
     "pt": ("europe/lisbon", "america/sao_paulo"),
     "en": (
-        "america/new_york", "america/chicago", "america/denver", "america/los_angeles",
-        "america/phoenix", "america/anchorage", "pacific/honolulu", "us/eastern",
-        "us/central", "us/mountain", "us/pacific", "europe/london", "europe/dublin",
-        "gb", "gb-eire", "america/toronto", "america/vancouver", "canada/eastern",
-        "canada/pacific", "australia/sydney", "australia/melbourne",
-        "australia/brisbane", "australia/perth", "pacific/auckland", "nz",
-        "eastern standard time", "pacific standard time", "gmt standard time",
+        "america/new_york",
+        "america/chicago",
+        "america/denver",
+        "america/los_angeles",
+        "america/phoenix",
+        "america/anchorage",
+        "pacific/honolulu",
+        "us/eastern",
+        "us/central",
+        "us/mountain",
+        "us/pacific",
+        "europe/london",
+        "europe/dublin",
+        "gb",
+        "gb-eire",
+        "america/toronto",
+        "america/vancouver",
+        "canada/eastern",
+        "canada/pacific",
+        "australia/sydney",
+        "australia/melbourne",
+        "australia/brisbane",
+        "australia/perth",
+        "pacific/auckland",
+        "nz",
+        "eastern standard time",
+        "pacific standard time",
+        "gmt standard time",
     ),
 }
 
@@ -109,7 +168,11 @@ def _language_allowed_by_fallback(language: str, fallback_language: str) -> bool
 
 
 def _is_strong_dominant(count: int, total: int) -> bool:
-    return count >= _STRONG_DOMINANT_MIN_CHARS and total > 0 and count / total >= _STRONG_DOMINANT_RATIO
+    return (
+        count >= _STRONG_DOMINANT_MIN_CHARS
+        and total > 0
+        and count / total >= _STRONG_DOMINANT_RATIO
+    )
 
 
 def _language_from_locale_value(value: str) -> str:

--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -1069,6 +1069,54 @@ class PersistCollection(LocalCollection):
             logger.info("Index '%s': replay complete (%d records)", index_name, _processed)
             self.indexes.set(index_name, index)
 
+        # Self-heal: if no indexes were recovered but the store still holds
+        # candidate records, the previous shutdown lost the index before the
+        # background persist could flush. Synchronously rebuild a default
+        # index from the store so the collection is searchable again.
+        if self.indexes.list_names():
+            return
+        if not self.store_mgr:
+            return
+        try:
+            cands_list = self.store_mgr.get_all_cands_data()
+        except Exception as exc:
+            logger.warning("Failed to inspect store during recovery rebuild: %s", exc)
+            return
+        if not cands_list:
+            return
+        logger.warning(
+            "auto-rebuilding default index: found %d records with no index in %s",
+            len(cands_list),
+            self.index_dir,
+        )
+        try:
+            self._rebuild_default_index_from_store(cands_list)
+        except Exception as exc:
+            self._index_rebuild_failed = True
+            logger.error(
+                "Failed to auto-rebuild default index from %d store records: %s",
+                len(cands_list),
+                exc,
+            )
+
+    def _rebuild_default_index_from_store(self, cands_list: List[CandidateData]) -> None:
+        """Build a default index in-place from store candidate records and persist it."""
+        default_name = "default"
+        default_meta_data: Dict[str, Any] = {
+            "VectorIndex": {"IndexType": "flat", "Distance": "l2"},
+        }
+        index = self._new_index(default_name, default_meta_data, cands_list)
+        self.indexes.set(default_name, index)
+        # Persist synchronously so the rebuilt index survives the next restart
+        # without depending on the background maintenance job.
+        if hasattr(index, "persist") and callable(index.persist):
+            try:
+                index.persist()
+            except Exception as exc:
+                logger.warning(
+                    "Default index rebuilt in memory but persist() failed: %s", exc
+                )
+
     def _replay_recovery_records(
         self,
         *,

--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -1113,9 +1113,7 @@ class PersistCollection(LocalCollection):
             try:
                 index.persist()
             except Exception as exc:
-                logger.warning(
-                    "Default index rebuilt in memory but persist() failed: %s", exc
-                )
+                logger.warning("Default index rebuilt in memory but persist() failed: %s", exc)
 
     def _replay_recovery_records(
         self,

--- a/tests/parse/test_code_tools.py
+++ b/tests/parse/test_code_tools.py
@@ -281,14 +281,14 @@ class TestOutlineFile:
 # ---------------------------------------------------------------------------
 
 
-SECOND_FILE = '''def greet():
+SECOND_FILE = """def greet():
     pass
 
 
 class Other:
     def helper(self):
         pass
-'''
+"""
 
 
 class TestSearchSymbols:

--- a/tests/vectordb/test_local_collection_recover.py
+++ b/tests/vectordb/test_local_collection_recover.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for local_collection._recover() self-healing.
+
+Covers issue #2118: when the index directory is empty but the store still
+holds candidate records, _recover() must rebuild a default index instead of
+returning silently.
+"""
+import os
+import shutil
+import unittest
+
+from openviking.storage.vectordb.collection.local_collection import get_or_create_local_collection
+from openviking.storage.vectordb.engine import ENGINE_VARIANT
+
+DB_PATH = "./test_data/test_local_collection_recover"
+
+
+def _meta():
+    return {
+        "CollectionName": "recover_test_col",
+        "Fields": [
+            {"FieldName": "id", "FieldType": "int64", "IsPrimaryKey": True},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": 4},
+            {"FieldName": "data", "FieldType": "string"},
+        ],
+    }
+
+
+def _wipe_index_dir(path: str) -> None:
+    """Simulate the bug from #2118: store survives, index directory does not."""
+    index_dir = os.path.join(path, "index")
+    if os.path.isdir(index_dir):
+        shutil.rmtree(index_dir)
+
+
+@unittest.skipIf(
+    ENGINE_VARIANT == "unavailable",
+    "vectordb native engine not built in this environment",
+)
+class TestLocalCollectionRecover(unittest.TestCase):
+    def setUp(self):
+        if os.path.exists(DB_PATH):
+            shutil.rmtree(DB_PATH)
+
+    def tearDown(self):
+        if os.path.exists(DB_PATH):
+            shutil.rmtree(DB_PATH)
+
+    def test_recover_rebuilds_index_when_store_has_records_and_index_dir_is_empty(self):
+        col = get_or_create_local_collection(meta_data=_meta(), path=DB_PATH)
+        col.create_index(
+            "idx_main",
+            {"IndexName": "idx_main", "VectorIndex": {"IndexType": "flat", "Distance": "l2"}},
+        )
+        records = [
+            {"id": i, "vector": [0.1] * 4, "data": f"row_{i}"} for i in range(10)
+        ]
+        col.upsert_data(records)
+        col.close()
+
+        # Reproduce the bug: the store survives, the index directory does not.
+        _wipe_index_dir(DB_PATH)
+
+        col2 = get_or_create_local_collection(meta_data=_meta(), path=DB_PATH)
+        try:
+            self.assertEqual(
+                len(col2.fetch_data(list(range(10))).items),
+                10,
+                "store records should still be intact after wiping only the index dir",
+            )
+
+            indexes = col2.list_indexes()
+            self.assertTrue(
+                indexes,
+                "a default index must be auto-rebuilt when the store has records but no index",
+            )
+
+            search_res = col2.search_by_vector(indexes[0], dense_vector=[0.1] * 4, limit=10)
+            self.assertGreater(
+                len(search_res.data),
+                0,
+                "rebuilt default index must return results from the recovered store",
+            )
+        finally:
+            col2.close()
+
+    def test_recover_no_op_when_both_store_and_index_are_empty(self):
+        col = get_or_create_local_collection(meta_data=_meta(), path=DB_PATH)
+        col.close()
+        _wipe_index_dir(DB_PATH)
+
+        col2 = get_or_create_local_collection(meta_data=_meta(), path=DB_PATH)
+        try:
+            self.assertEqual(
+                col2.list_indexes(),
+                [],
+                "no default index should be created when the store is empty",
+            )
+        finally:
+            col2.close()
+
+    def test_recover_does_not_double_rebuild_when_index_already_exists(self):
+        col = get_or_create_local_collection(meta_data=_meta(), path=DB_PATH)
+        col.create_index(
+            "idx_main",
+            {"IndexName": "idx_main", "VectorIndex": {"IndexType": "flat", "Distance": "l2"}},
+        )
+        col.upsert_data(
+            [{"id": i, "vector": [0.1] * 4, "data": f"row_{i}"} for i in range(5)]
+        )
+        col.close()
+
+        # Reopen without wiping anything: the healthy "idx_main" must come back
+        # alone, and the rebuild path must NOT add a phantom "default" index.
+        col2 = get_or_create_local_collection(meta_data=_meta(), path=DB_PATH)
+        try:
+            indexes = col2.list_indexes()
+            self.assertIn("idx_main", indexes)
+            self.assertNotIn(
+                "default",
+                indexes,
+                "auto-rebuild must not run when a healthy index already recovered",
+            )
+        finally:
+            col2.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vectordb/test_local_collection_recover.py
+++ b/tests/vectordb/test_local_collection_recover.py
@@ -6,6 +6,7 @@ Covers issue #2118: when the index directory is empty but the store still
 holds candidate records, _recover() must rebuild a default index instead of
 returning silently.
 """
+
 import os
 import shutil
 import unittest
@@ -53,9 +54,7 @@ class TestLocalCollectionRecover(unittest.TestCase):
             "idx_main",
             {"IndexName": "idx_main", "VectorIndex": {"IndexType": "flat", "Distance": "l2"}},
         )
-        records = [
-            {"id": i, "vector": [0.1] * 4, "data": f"row_{i}"} for i in range(10)
-        ]
+        records = [{"id": i, "vector": [0.1] * 4, "data": f"row_{i}"} for i in range(10)]
         col.upsert_data(records)
         col.close()
 
@@ -106,9 +105,7 @@ class TestLocalCollectionRecover(unittest.TestCase):
             "idx_main",
             {"IndexName": "idx_main", "VectorIndex": {"IndexType": "flat", "Distance": "l2"}},
         )
-        col.upsert_data(
-            [{"id": i, "vector": [0.1] * 4, "data": f"row_{i}"} for i in range(5)]
-        )
+        col.upsert_data([{"id": i, "vector": [0.1] * 4, "data": f"row_{i}"} for i in range(5)])
         col.close()
 
         # Reopen without wiping anything: the healthy "idx_main" must come back


### PR DESCRIPTION
## Summary
Closes #2118.

When the OpenViking server is killed or crashes after `create_index()` returned but before the background index-persist task flushed, the next start finds an empty index directory and a non-empty store. `_recover()` previously bailed out silently — the collection stayed unsearchable, and the only fix was to delete the whole vectordb directory and re-ingest everything.

This PR makes `_recover()` self-heal that case: when records exist but no index files do, it synchronously rebuilds the default index from the store's candidate records and persists it before returning. If the rebuild itself fails it's logged loudly, but the collection is left exactly as it was — never worse than before.

## Test plan
- [ ] `pytest tests/storage/vectordb/test_local_collection_recover.py -x -q` passes.
- [ ] Manual: ingest data into a fresh collection, kill the server, delete only `<collection>/index/`, restart server → search returns results without manual intervention.
- [ ] Truly empty collection still recovers as empty (no spurious rebuild).
- [ ] Healthy collection on restart does not double-rebuild.

Closes #2118