### PR TITLE
feat(auth): add readonly role that blocks shared-workspace writes (#1668)

### DIFF
--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1427,7 +1427,7 @@ enum AdminCommands {
         /// User ID to register
         #[arg(value_name = "user-id")]
         user_id: String,
-        /// Role: admin or user
+        /// Role: admin, user, or readonly
         #[arg(long, default_value = "user", value_name = "role")]
         role: String,
     },
@@ -1463,7 +1463,7 @@ enum AdminCommands {
         /// User ID
         #[arg(value_name = "user-id")]
         user_id: String,
-        /// New role: admin or user
+        /// New role: admin, user, or readonly
         #[arg(value_name = "role")]
         role: String,
     },

--- a/openviking/server/auth.py
+++ b/openviking/server/auth.py
@@ -26,7 +26,7 @@ from openviking_cli.session.user_id import UserIdentifier
 # rank ⇒ more privilege. Used to compare an OAuth token's embedded role
 # against the user's current role: a token whose role outranks the current
 # role is a stale token from before a `set_role` demotion and must be rejected.
-_ROLE_RANK = {Role.USER: 0, Role.ADMIN: 1, Role.ROOT: 2}
+_ROLE_RANK = {Role.READONLY: -1, Role.USER: 0, Role.ADMIN: 1, Role.ROOT: 2}
 
 
 _TRUSTED_RELAXED_IDENTITY_PREFIXES = ("/api/v1/admin",)
@@ -420,6 +420,19 @@ def require_role(*allowed_roles: Role):
 require_root = require_role(Role.ROOT)
 require_admin = require_role(Role.ADMIN)
 require_user = require_role(Role.USER)
+
+
+def require_write_access(ctx: RequestContext = Depends(get_request_context)) -> RequestContext:
+    """Block readonly callers from mutating shared/public workspace resources.
+
+    Routes that touch the caller's own session/memory namespace MUST NOT use
+    this guard — readonly users are still allowed to write there.
+    """
+    if ctx.role == Role.READONLY:
+        raise PermissionDeniedError(
+            "readonly role cannot perform write operations on shared workspace resources"
+        )
+    return ctx
 
 
 _DEV_MODE_ADMIN_API_MESSAGE = (

--- a/openviking/server/identity.py
+++ b/openviking/server/identity.py
@@ -18,6 +18,10 @@ class Role(str, Enum):
     ROOT = "root"
     ADMIN = "admin"
     USER = "user"
+    # Strictly weaker than USER: read/search only on shared/public workspace
+    # resources. Still allowed to write within the caller's own session and
+    # memory namespace. See server.auth.require_write_access.
+    READONLY = "readonly"
 
 
 class AuthMode(str, Enum):

--- a/openviking/server/oauth/provider.py
+++ b/openviking/server/oauth/provider.py
@@ -35,7 +35,7 @@ from openviking_cli.utils import get_logger
 
 # Mirrors auth.py:_ROLE_RANK; duplicated here to avoid the import cycle
 # (auth.py already depends on this module via the Provider Protocol).
-_ROLE_RANK = {Role.USER: 0, Role.ADMIN: 1, Role.ROOT: 2}
+_ROLE_RANK = {Role.READONLY: -1, Role.USER: 0, Role.ADMIN: 1, Role.ROOT: 2}
 
 logger = get_logger(__name__)
 

--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -14,6 +14,7 @@ from openviking.pyagfs.exceptions import AGFSClientError, AGFSNotFoundError
 from openviking.server.auth import (
     get_request_context,
     require_role,
+    require_write_access,
 )
 from openviking.server.dependencies import get_service
 from openviking.server.error_mapping import map_exception
@@ -174,7 +175,7 @@ async def download(
 @router.post("/write")
 async def write(
     request: WriteContentRequest = Body(...),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Write text content to a file (replace, append, or create) and refresh semantics/vectors."""
     service = get_service()

--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from openviking.core.path_variables import resolve_path_variables
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSNotFoundError
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_request_context, require_write_access
 from openviking.server.dependencies import get_service
 from openviking.server.error_mapping import map_exception
 from openviking.server.identity import RequestContext
@@ -129,7 +129,7 @@ class MkdirRequest(BaseModel):
 @router.post("/mkdir")
 async def mkdir(
     request: MkdirRequest,
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Create directory."""
     service = get_service()
@@ -151,7 +151,7 @@ async def rm(
     recursive: bool = Query(False, description="Remove recursively"),
     wait: bool = Query(False, description="Wait for semantic refresh to complete"),
     timeout: Optional[float] = Query(None, description="Wait timeout in seconds"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Remove resource."""
     service = get_service()
@@ -196,7 +196,7 @@ class MvRequest(BaseModel):
 @router.post("/mv")
 async def mv(
     request: MvRequest,
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Move resource."""
     service = get_service()

--- a/openviking/server/routers/privacy_configs.py
+++ b/openviking/server/routers/privacy_configs.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Depends, Path
 from pydantic import BaseModel, ConfigDict
 
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_request_context, require_write_access
 from openviking_cli.exceptions import NotFoundError
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
@@ -115,7 +115,7 @@ async def upsert_privacy_config(
     request: UpsertPrivacyConfigRequest,
     category: str = Path(..., description="Privacy config category"),
     target_key: str = Path(..., description="Privacy config target key"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     service = get_service()
     privacy = service.privacy_configs
@@ -138,7 +138,7 @@ async def activate_privacy_version(
     request: ActivatePrivacyConfigVersionRequest,
     category: str = Path(..., description="Privacy config category"),
     target_key: str = Path(..., description="Privacy config target key"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     service = get_service()
     privacy = service.privacy_configs

--- a/openviking/server/routers/relations.py
+++ b/openviking/server/routers/relations.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from openviking.core.path_variables import resolve_path_variables
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_request_context, require_write_access
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
@@ -54,7 +54,7 @@ async def relations(
 @router.post("/link")
 async def link(
     request: LinkRequest,
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Create link between resources."""
     service = get_service()
@@ -67,7 +67,7 @@ async def link(
 @router.delete("/link")
 async def unlink(
     request: UnlinkRequest,
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Remove link between resources."""
     service = get_service()
@@ -87,7 +87,7 @@ class BuildGraphRequest(BaseModel):
 @router.post("/build_graph")
 async def build_graph(
     request: BuildGraphRequest,
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Generate a self-contained HTML graph from multiple memory roots into one output file."""
     from openviking.session.memory.graph_view import MemoryGraph

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_request_context, require_write_access
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext, Role
 from openviking.server.local_input_guard import require_remote_resource_source
@@ -127,7 +127,7 @@ async def temp_upload(
     file: UploadFile = File(...),
     telemetry: bool = Form(False),
     upload_mode: str = Form("local"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Upload a temporary file for add_resource or import_ovpack."""
 
@@ -192,7 +192,7 @@ async def temp_upload_signed(
 async def add_resource(
     http_request: Request,
     request: AddResourceRequest,
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Add resource to OpenViking."""
     service = get_service()
@@ -273,7 +273,7 @@ async def add_resource(
 async def add_skill(
     http_request: Request,
     request: AddSkillRequest,
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Add skill to OpenViking."""
     service = get_service()

--- a/openviking/server/routers/skills.py
+++ b/openviking/server/routers/skills.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict, model_validator
 from openviking.core.namespace import canonical_user_root
 from openviking.core.skill_loader import SkillLoader
 from openviking.privacy.service import UserPrivacyConfigVersion
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_request_context, require_write_access
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
@@ -536,7 +536,7 @@ async def update_skill(
     http_request: Request,
     request: UpdateSkillRequest,
     skill_name: str = ApiPath(..., description="Skill name"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Replace an existing agent skill with new content."""
     service = get_service()
@@ -660,7 +660,7 @@ async def update_skill(
 @router.delete("/{skill_name}")
 async def delete_skill(
     skill_name: str = ApiPath(..., description="Skill name"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Remove one installed agent skill."""
     service = get_service()

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 from openviking.resource import watch_manager as wm_mod
 from openviking.resource.watch_manager import WatchManager, WatchTask
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_request_context, require_write_access
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
@@ -235,7 +235,7 @@ async def patch_watch_by_id(
         ),
     ),
     body: UpdateWatchRequest = Body(...),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Partial update by task_id. Fields left null are preserved."""
     task = await _resolve_task(task_id, to_uri, _ctx)
@@ -246,7 +246,7 @@ async def patch_watch_by_id(
 async def patch_watch_by_uri(
     to_uri: str = Query(..., description="Target URI of the watch task"),
     body: UpdateWatchRequest = Body(...),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Partial update by to_uri (query parameter)."""
     task = await _resolve_task(None, to_uri, _ctx)
@@ -282,7 +282,7 @@ async def delete_watch_by_id(
             "task, so omit it unless the cross-check is desired."
         ),
     ),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Delete a watch task by ID."""
     task = await _resolve_task(task_id, to_uri, _ctx)
@@ -292,7 +292,7 @@ async def delete_watch_by_id(
 @router.delete("/watches")
 async def delete_watch_by_uri(
     to_uri: str = Query(..., description="Target URI of the watch task"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Delete a watch task by to_uri."""
     task = await _resolve_task(None, to_uri, _ctx)
@@ -333,7 +333,7 @@ async def trigger_watch_by_id(
             "task, so omit it unless the cross-check is desired."
         ),
     ),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Immediately schedule the watch task for execution (fire-and-forget).
 
@@ -348,7 +348,7 @@ async def trigger_watch_by_id(
 @router.post("/watches/trigger")
 async def trigger_watch_by_uri(
     to_uri: str = Query(..., description="Target URI of the watch task"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(require_write_access),
 ):
     """Trigger by to_uri (fire-and-forget; see by-id variant for semantics)."""
     task = await _resolve_task(None, to_uri, _ctx)

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1342,3 +1342,101 @@ async def test_trusted_mode_admin_api_http_route_without_identity():
     assert response.json()["result"]["role"] == "root"
     assert response.json()["result"]["account_id"] == "trusted"
     assert response.json()["result"]["user_id"] == "trusted"
+
+
+# ---- Role.READONLY tests (issue #1668) ----
+
+
+def _build_readonly_test_app(identity: ResolvedIdentity) -> FastAPI:
+    """Test app exposing one mutating route guarded by require_write_access
+    and one route under /api/v1/sessions which must remain open to readonly.
+    """
+    from openviking.server.auth import require_write_access
+
+    app = _build_auth_http_test_app(identity=identity, auth_enabled=True)
+
+    @app.post("/api/v1/resources")
+    async def add_resource(ctx=Depends(require_write_access)):
+        return {"status": "ok", "result": {"role": ctx.role.value}}
+
+    @app.delete("/api/v1/fs")
+    async def fs_rm(ctx=Depends(require_write_access)):
+        return {"status": "ok"}
+
+    @app.post("/api/v1/sessions")
+    async def create_session(ctx=Depends(get_request_context)):
+        # Sessions/memories are the user's own namespace — no write gate.
+        return {"status": "ok", "result": {"role": ctx.role.value}}
+
+    @app.post("/api/v1/search/find")
+    async def search_find(ctx=Depends(get_request_context)):
+        return {"status": "ok", "result": {"role": ctx.role.value}}
+
+    return app
+
+
+async def test_readonly_role_blocks_post_resources():
+    """POST /api/v1/resources must 403 for readonly users."""
+    identity = ResolvedIdentity(role=Role.READONLY, account_id="acme", user_id="ro")
+    app = _build_readonly_test_app(identity)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post("/api/v1/resources", json={})
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "PERMISSION_DENIED"
+    assert "readonly" in body["error"]["message"].lower()
+
+
+async def test_readonly_role_blocks_delete_resource():
+    """DELETE under /api/v1/fs (used for resource removal) must 403 for readonly."""
+    identity = ResolvedIdentity(role=Role.READONLY, account_id="acme", user_id="ro")
+    app = _build_readonly_test_app(identity)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.delete("/api/v1/fs?uri=viking://resources/x")
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "PERMISSION_DENIED"
+
+
+async def test_readonly_role_allows_read_endpoints():
+    """Read-style endpoints must remain accessible for readonly users."""
+    identity = ResolvedIdentity(role=Role.READONLY, account_id="acme", user_id="ro")
+    app = _build_readonly_test_app(identity)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        ls_resp = await client.get("/api/v1/fs/ls")
+        find_resp = await client.post("/api/v1/search/find", json={"query": "x"})
+    assert ls_resp.status_code == 200
+    assert ls_resp.json()["result"]["account_id"] == "acme"
+    assert find_resp.status_code == 200
+    assert find_resp.json()["result"]["role"] == "readonly"
+
+
+async def test_readonly_role_allows_session_writes():
+    """Sessions/memories are the user's own namespace — readonly must still write there."""
+    identity = ResolvedIdentity(role=Role.READONLY, account_id="acme", user_id="ro")
+    app = _build_readonly_test_app(identity)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post("/api/v1/sessions", json={})
+    assert resp.status_code == 200
+    assert resp.json()["result"]["role"] == "readonly"
+
+
+async def test_readonly_role_round_trips_through_role_enum():
+    """The string 'readonly' must round-trip through Role(...) for persistence."""
+    assert Role("readonly") is Role.READONLY
+    assert Role.READONLY.value == "readonly"
+
+
+async def test_require_write_access_allows_user_role():
+    """USER role must still be able to write — guard is readonly-specific."""
+    identity = ResolvedIdentity(role=Role.USER, account_id="acme", user_id="alice")
+    app = _build_readonly_test_app(identity)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post("/api/v1/resources", json={})
+    assert resp.status_code == 200
+    assert resp.json()["result"]["role"] == "user"


### PR DESCRIPTION
## Summary
Adds `Role.READONLY` — strictly weaker than `Role.USER`. Maintainer `@qin-ctx` flagged this as a `good idea` in the issue, so the design here favors a minimal, conservative cut that's easy to review.

### What gets blocked
Mutating routes that touch shared/public workspace state (via a single `Depends(require_write_access)` gate that reuses the existing role enum):
- `POST /api/v1/resources`, `POST /api/v1/resources/temp_upload`, `POST /api/v1/skills`
- `POST /api/v1/content/write`
- mutating `/api/v1/fs/*` routes (`mkdir`, `rm`, `mv`)
- `POST/DELETE /api/v1/relations/link`, `POST /api/v1/relations/build_graph`
- `PUT/DELETE /api/v1/skills/{name}`
- mutating `/api/v1/watches/*` (PATCH/DELETE/trigger)
- mutating `/api/v1/privacy-configs/*`

### What stays allowed
- All read endpoints (`GET`, `POST /api/v1/search/find`, etc.)
- The user's own session & memory namespace (`/api/v1/sessions/*`) — the issue explicitly asks `不影响用户自身记忆`. Sessions/memories are scoped to the caller's `(account_id, user_id)`, so leaving the whole namespace open is safe.
- Maintenance endpoints already gated to ROOT/ADMIN (e.g. `/api/v1/content/reindex`) keep their stricter gate; READONLY can't reach them through ADMIN gating either.

### Out of scope (deliberately, to keep this PR reviewable)
- vikingBot chat-side tool gating — downstream of the role; lands in a follow-up.
- New admin UI for assigning roles — admins use the existing API-key management endpoints, which already accept the new role string (`Role(role)` round-trips).

## Test plan
- [x] `pytest tests/server/test_auth.py -k readonly --no-cov` — 6 new tests pass (4 required + 2 sanity tests for enum round-trip and USER not affected).
- [ ] Manual: create a readonly key, confirm `POST /api/v1/resources` 403s and `POST /api/v1/search/find` works.
- [ ] Existing role tests still pass (verified the touched routers all import cleanly; the missing-binary errors in this dev sandbox are pre-existing and unrelated).

Closes #1668