### PR TITLE
refactor(openclaw): extract query result formatters

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -53,6 +53,12 @@ import {
   type RecallTraceResult,
   type RecallTraceSource,
 } from "./recall-trace.js";
+import {
+  formatOVListText,
+  formatOVMultiReadText,
+  formatOVReadText,
+  formatOVSearchText,
+} from "./plugin/openviking-query-formatters.js";
 export {
   buildMemoryLines,
   buildMemoryLinesWithBudget,
@@ -1059,107 +1065,6 @@ const contextEnginePlugin = {
         total: memories.length + resources.length + skills.length,
       };
     };
-
-    const formatOVSearchRows = (result: FindResult): string[] => {
-      const truncateSummary = (value: string, maxChars = 220): string => {
-        const collapsed = value.replace(/\s+/g, " ").trim();
-        if (collapsed.length <= maxChars) {
-          return collapsed;
-        }
-        return `${collapsed.slice(0, maxChars - 3)}...`;
-      };
-      const items = [
-        ...(result.memories ?? []).map((item) => ({ contextType: "memory", item })),
-        ...(result.resources ?? []).map((item) => ({ contextType: "resource", item })),
-        ...(result.skills ?? []).map((item) => ({ contextType: "skill", item })),
-      ];
-      if (items.length === 0) {
-        return [];
-      }
-      const numberHeader = "no";
-      const numberWidth = Math.max(numberHeader.length, String(items.length).length);
-      const typeWidth = Math.max("type".length, ...items.map(({ contextType }) => contextType.length));
-      const uriWidth = Math.max("uri".length, ...items.map(({ item }) => item.uri.length));
-      const levelWidth = Math.max("level".length, ...items.map(({ item }) => String(item.level ?? "").length));
-      const scoreWidth = Math.max(
-        "score".length,
-        ...items.map(({ item }) => (typeof item.score === "number" ? item.score.toFixed(2).length : 0)),
-      );
-      return [
-        `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}  abstract`,
-        ...items.map(({ contextType, item }, index) => {
-          const score = typeof item.score === "number" ? item.score.toFixed(2) : "";
-          const summary = truncateSummary(item.abstract || item.overview || "(no summary)");
-          return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}  ${summary}`;
-        }),
-      ];
-    };
-
-    const formatOVSearchText = (query: string, uri: string | undefined, result: FindResult): string => {
-      if ((result.total ?? 0) <= 0) {
-        const scope = uri ? ` under ${uri}` : "";
-        return `No OpenViking resource or skill results found for "${query}"${scope}.`;
-      }
-      const scope = uri ? ` under ${uri}` : "";
-      const lines = [
-        `Found ${result.total ?? 0} OpenViking results for "${query}"${scope}`,
-        "Tip: search results are ranked snippets. Use ov_read on exact hit URIs before answering precise questions. Use ov_list on a hit's parent URI to inspect sibling chunks or overview files before answering procedural or multi-step questions.",
-        "",
-        ...formatOVSearchRows(result),
-      ].filter((line, index, all) => line || (all[index - 1] && all[index + 1]));
-      return lines.join("\n");
-    };
-
-    const formatOVListEntry = (entry: unknown): string => {
-      if (typeof entry === "string") {
-        return entry;
-      }
-      if (!entry || typeof entry !== "object") {
-        return String(entry);
-      }
-      const item = entry as Record<string, unknown>;
-      const uri = typeof item.uri === "string" ? item.uri : "";
-      const name = typeof item.name === "string" ? item.name : "";
-      const isDir = item.isDir === true || item.type === "directory";
-      const marker = isDir ? "[dir]" : "[file]";
-      const summary =
-        typeof item.abstract === "string" && item.abstract.trim()
-          ? item.abstract.trim().replace(/\s+/g, " ")
-          : typeof item.overview === "string" && item.overview.trim()
-            ? item.overview.trim().replace(/\s+/g, " ")
-            : "";
-      const label = uri || name || JSON.stringify(item);
-      return summary ? `${marker} ${label} - ${summary}` : `${marker} ${label}`;
-    };
-
-    const formatOVListText = (uri: string, entries: unknown[]): string => {
-      if (entries.length === 0) {
-        return `No OpenViking entries found under ${uri}.`;
-      }
-      return [
-        `Listed ${entries.length} OpenViking entr${entries.length === 1 ? "y" : "ies"} under ${uri}`,
-        "",
-        ...entries.map((entry) => formatOVListEntry(entry)),
-      ].join("\n");
-    };
-
-    const formatOVReadText = (uri: string, content: string): string => {
-      const body = content || "(empty OpenViking content)";
-      return [`--- START OF ${uri} ---`, body, `--- END OF ${uri} ---`].join("\n");
-    };
-
-    const formatOVMultiReadText = (
-      results: Array<{ uri: string; content: string; success: boolean }>,
-    ): string => [
-      `Multi-read results for ${results.length} OpenViking resource${results.length === 1 ? "" : "s"}:`,
-      "",
-      ...results.flatMap((result) => [
-        `--- START OF ${result.uri} ---`,
-        result.success ? (result.content || "(empty OpenViking content)") : `ERROR: ${result.content}`,
-        `--- END OF ${result.uri} ---`,
-        "",
-      ]),
-    ].join("\n").trimEnd();
 
     const searchOpenViking = async (
       input: OVSearchInput,

--- a/examples/openclaw-plugin/install-manifest.json
+++ b/examples/openclaw-plugin/install-manifest.json
@@ -21,6 +21,7 @@
       "session-transcript-repair.ts",
       "runtime-utils.ts",
       "recall-trace.ts",
+      "plugin/openviking-query-formatters.ts",
       "commands/setup.ts",
       "tsconfig.json",
       "tsconfig.build.json",

--- a/examples/openclaw-plugin/package.json
+++ b/examples/openclaw-plugin/package.json
@@ -22,6 +22,7 @@
     "dist/",
     "*.ts",
     "commands/setup.ts",
+    "plugin/openviking-query-formatters.ts",
     "!vitest.config.ts",
     "install-manifest.json",
     "openclaw.plugin.json",

--- a/examples/openclaw-plugin/plugin/openviking-query-formatters.ts
+++ b/examples/openclaw-plugin/plugin/openviking-query-formatters.ts
@@ -1,0 +1,108 @@
+import type { FindResult } from "../client.js";
+
+export type OVMultiReadTextResult = {
+  uri: string;
+  content: string;
+  success: boolean;
+};
+
+export function formatOVSearchRows(result: FindResult): string[] {
+  const truncateSummary = (value: string, maxChars = 220): string => {
+    const collapsed = value.replace(/\s+/g, " ").trim();
+    if (collapsed.length <= maxChars) {
+      return collapsed;
+    }
+    return `${collapsed.slice(0, maxChars - 3)}...`;
+  };
+  const items = [
+    ...(result.memories ?? []).map((item) => ({ contextType: "memory", item })),
+    ...(result.resources ?? []).map((item) => ({ contextType: "resource", item })),
+    ...(result.skills ?? []).map((item) => ({ contextType: "skill", item })),
+  ];
+  if (items.length === 0) {
+    return [];
+  }
+  const numberHeader = "no";
+  const numberWidth = Math.max(numberHeader.length, String(items.length).length);
+  const typeWidth = Math.max("type".length, ...items.map(({ contextType }) => contextType.length));
+  const uriWidth = Math.max("uri".length, ...items.map(({ item }) => item.uri.length));
+  const levelWidth = Math.max("level".length, ...items.map(({ item }) => String(item.level ?? "").length));
+  const scoreWidth = Math.max(
+    "score".length,
+    ...items.map(({ item }) => (typeof item.score === "number" ? item.score.toFixed(2).length : 0)),
+  );
+  return [
+    `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}  abstract`,
+    ...items.map(({ contextType, item }, index) => {
+      const score = typeof item.score === "number" ? item.score.toFixed(2) : "";
+      const summary = truncateSummary(item.abstract || item.overview || "(no summary)");
+      return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}  ${summary}`;
+    }),
+  ];
+}
+
+export function formatOVSearchText(query: string, uri: string | undefined, result: FindResult): string {
+  if ((result.total ?? 0) <= 0) {
+    const scope = uri ? ` under ${uri}` : "";
+    return `No OpenViking resource or skill results found for "${query}"${scope}.`;
+  }
+  const scope = uri ? ` under ${uri}` : "";
+  const lines = [
+    `Found ${result.total ?? 0} OpenViking results for "${query}"${scope}`,
+    "Tip: search results are ranked snippets. Use ov_read on exact hit URIs before answering precise questions. Use ov_list on a hit's parent URI to inspect sibling chunks or overview files before answering procedural or multi-step questions.",
+    "",
+    ...formatOVSearchRows(result),
+  ].filter((line, index, all) => line || (all[index - 1] && all[index + 1]));
+  return lines.join("\n");
+}
+
+export function formatOVListEntry(entry: unknown): string {
+  if (typeof entry === "string") {
+    return entry;
+  }
+  if (!entry || typeof entry !== "object") {
+    return String(entry);
+  }
+  const item = entry as Record<string, unknown>;
+  const uri = typeof item.uri === "string" ? item.uri : "";
+  const name = typeof item.name === "string" ? item.name : "";
+  const isDir = item.isDir === true || item.type === "directory";
+  const marker = isDir ? "[dir]" : "[file]";
+  const summary =
+    typeof item.abstract === "string" && item.abstract.trim()
+      ? item.abstract.trim().replace(/\s+/g, " ")
+      : typeof item.overview === "string" && item.overview.trim()
+        ? item.overview.trim().replace(/\s+/g, " ")
+        : "";
+  const label = uri || name || JSON.stringify(item);
+  return summary ? `${marker} ${label} - ${summary}` : `${marker} ${label}`;
+}
+
+export function formatOVListText(uri: string, entries: unknown[]): string {
+  if (entries.length === 0) {
+    return `No OpenViking entries found under ${uri}.`;
+  }
+  return [
+    `Listed ${entries.length} OpenViking entr${entries.length === 1 ? "y" : "ies"} under ${uri}`,
+    "",
+    ...entries.map((entry) => formatOVListEntry(entry)),
+  ].join("\n");
+}
+
+export function formatOVReadText(uri: string, content: string): string {
+  const body = content || "(empty OpenViking content)";
+  return [`--- START OF ${uri} ---`, body, `--- END OF ${uri} ---`].join("\n");
+}
+
+export function formatOVMultiReadText(results: OVMultiReadTextResult[]): string {
+  return [
+    `Multi-read results for ${results.length} OpenViking resource${results.length === 1 ? "" : "s"}:`,
+    "",
+    ...results.flatMap((result) => [
+      `--- START OF ${result.uri} ---`,
+      result.success ? (result.content || "(empty OpenViking content)") : `ERROR: ${result.content}`,
+      `--- END OF ${result.uri} ---`,
+      "",
+    ]),
+  ].join("\n").trimEnd();
+}

--- a/examples/openclaw-plugin/tests/ut/plugin-query-formatters.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-query-formatters.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatOVListEntry,
+  formatOVListText,
+  formatOVMultiReadText,
+  formatOVReadText,
+  formatOVSearchRows,
+  formatOVSearchText,
+} from "../../plugin/openviking-query-formatters.js";
+
+describe("openviking query formatters", () => {
+  it("formats ranked search rows across memories, resources, and skills", () => {
+    const rows = formatOVSearchRows({
+      memories: [
+        { uri: "viking://user/memory/1", level: 2, score: 0.987, abstract: "remember this" },
+      ],
+      resources: [
+        { uri: "viking://resources/doc", score: 0.7, overview: "resource overview" },
+      ],
+      skills: [
+        { uri: "skill://openviking-context-database", abstract: "skill overview" },
+      ],
+      total: 3,
+    });
+
+    expect(rows[0]).toContain("no  type");
+    expect(rows[1]).toContain("memory");
+    expect(rows[1]).toContain("viking://user/memory/1");
+    expect(rows[1]).toContain("0.99");
+    expect(rows[1]).toContain("remember this");
+    expect(rows.join("\n")).toContain("resource overview");
+    expect(rows.join("\n")).toContain("skill overview");
+  });
+
+  it("formats search text and empty search text", () => {
+    expect(formatOVSearchText("query", "viking://resources", { total: 0 })).toBe(
+      'No OpenViking resource or skill results found for "query" under viking://resources.',
+    );
+
+    const text = formatOVSearchText("query", undefined, {
+      resources: [{ uri: "viking://resources/doc", abstract: "result" }],
+      total: 1,
+    });
+
+    expect(text).toContain('Found 1 OpenViking results for "query"');
+    expect(text).toContain("Use ov_read on exact hit URIs");
+    expect(text).toContain("viking://resources/doc");
+  });
+
+  it("formats list entries with directory markers and summaries", () => {
+    expect(formatOVListEntry("viking://resources/raw")).toBe("viking://resources/raw");
+    expect(formatOVListEntry({ uri: "viking://resources/folder", type: "directory" })).toBe(
+      "[dir] viking://resources/folder",
+    );
+    expect(formatOVListText("viking://resources", [
+      { uri: "viking://resources/doc", isDir: false, abstract: "  short\nsummary  " },
+    ])).toBe("Listed 1 OpenViking entry under viking://resources\n\n[file] viking://resources/doc - short summary");
+  });
+
+  it("formats read and multi-read output", () => {
+    expect(formatOVReadText("viking://resources/doc", "")).toBe(
+      "--- START OF viking://resources/doc ---\n(empty OpenViking content)\n--- END OF viking://resources/doc ---",
+    );
+
+    expect(formatOVMultiReadText([
+      { uri: "viking://resources/a", content: "content", success: true },
+      { uri: "viking://resources/b", content: "boom", success: false },
+    ])).toBe(
+      "Multi-read results for 2 OpenViking resources:\n\n--- START OF viking://resources/a ---\ncontent\n--- END OF viking://resources/a ---\n\n--- START OF viking://resources/b ---\nERROR: boom\n--- END OF viking://resources/b ---",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extract OpenViking query/list/read response formatting helpers from the plugin entrypoint into a focused helper module
- add direct unit coverage for the formatter behavior
- include the helper module in the plugin package files and install manifest

## Notes
- This ports the low-risk helper modularization part of #2613 only.
- It does not bring over the old user/agent routing model, agent-prefixed URIs, or agent headers.

## Tests
- npm test -- tests/ut/plugin-query-formatters.test.ts
- npm test -- tests/ut/tools.test.ts
- npm run typecheck
- npm run build
- git diff --check