### PR TITLE
docs(openclaw): document runtime RPC and install contracts

### DIFF
--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -75,6 +75,9 @@ openclaw config get plugins.slots.contextEngine  # should output: openviking
 | [INSTALL-ZH.md](./INSTALL-ZH.md) | Chinese install guide |
 | [INSTALL-AGENT.md](./INSTALL-AGENT.md) | Agent-oriented operator guide |
 | [docs/openviking-openclaw-plugin-guide.md](./docs/openviking-openclaw-plugin-guide.md) | Comprehensive Chinese guide for usage, configuration, debugging, testing, build, release, deployment, and rollback |
+| [docs/openviking-websocket-rpc-api.md](./docs/openviking-websocket-rpc-api.md) | Gateway WebSocket RPC usage for OpenViking tools |
+| [docs/openviking-runtime-query-config.md](./docs/openviking-runtime-query-config.md) | Runtime query config scopes, fields, and commands |
+| [docs/openviking-install-package-contract.md](./docs/openviking-install-package-contract.md) | Package and install contract verification notes |
 
 > **Plugin vs Skill**: This page is for `@openviking/openclaw-plugin` (the context-engine plugin). Do **not** use `clawhub install openviking` — that installs a different AgentSkill.
 
@@ -144,7 +147,7 @@ In this setup:
 
 ### User namespace
 
-The plugin writes and searches user-scoped memory through `viking://user/...`; OpenViking resolves that alias from the request tenant and actor-peer context. `viking://agent/...` is deprecated by OpenViking and is not used by the plugin.
+The plugin writes and searches user-scoped memory through `viking://user/...`; OpenViking resolves that alias from the request tenant and actor-peer context. Deprecated agent URI paths are not used by the plugin.
 
 ## assemble Recall Flow
 

--- a/examples/openclaw-plugin/docs/openviking-install-package-contract.md
+++ b/examples/openclaw-plugin/docs/openviking-install-package-contract.md
@@ -1,0 +1,85 @@
+# OpenViking Install And Package Contract
+
+This document records the install/package contract that the OpenViking OpenClaw plugin must keep stable.
+
+It intentionally documents the current package contract instead of the unpublished TOS shell-script flow from #2613. Current main does not contain those TOS publishing scripts, so the safe contract is the npm/openclaw package shape that is actually built and installed by this repository.
+
+## Required Package Entries
+
+The plugin package must include:
+
+| Entry | Why it is required |
+| --- | --- |
+| `dist/` | Compiled runtime loaded by OpenClaw. |
+| `dist/index.js` | Main extension entry. |
+| `dist/commands/setup.js` | Setup entry used by OpenClaw. |
+| `package.json` | OpenClaw package metadata and runtime dependencies. |
+| `openclaw.plugin.json` | Plugin manifest. |
+| `install-manifest.json` | Install-time file contract. |
+| `README.md`, `INSTALL.md`, `INSTALL-ZH.md` | User-facing install and usage docs. |
+| `skills/` | Packaged OpenViking skills. |
+
+Helper modules added under `plugin/` must be listed in the package `files` contract or included by a package-level directory rule.
+
+## OpenClaw Metadata
+
+`package.json` must keep these OpenClaw fields valid:
+
+```json
+{
+  "openclaw": {
+    "extensions": ["./dist/index.js"],
+    "setupEntry": "./dist/commands/setup.js"
+  }
+}
+```
+
+The `setupEntry` must point at compiled JavaScript, not source TypeScript.
+
+## Runtime Dependencies
+
+Runtime dependencies must include everything the compiled plugin imports at runtime. Development-only test/build packages belong in `devDependencies`.
+
+The package currently keeps an `axios` override to avoid installing vulnerable or incompatible transitive versions through OpenClaw packaging.
+
+## Install Manifest
+
+`install-manifest.json` defines the source files and metadata required by the OpenClaw install flow. When a new runtime source module is imported by `index.ts` or setup code, add it to `files.required`.
+
+Required entries should include core runtime modules such as:
+
+- `index.ts`
+- `config.ts`
+- `context-engine.ts`
+- `client.ts`
+- `auto-recall.ts`
+- `recall-trace.ts`
+- `commands/setup.ts`
+- `package.json`
+- `openclaw.plugin.json`
+
+Optional entries are for files that improve the installed plugin but are not needed to load the runtime, such as lockfiles or extra docs.
+
+## Verification Checklist
+
+Before publishing or merging package-contract changes, run:
+
+```bash
+npm test -- tests/ut/package-install-contract.test.ts
+npm run typecheck
+npm run build
+git diff --check
+```
+
+The package contract test should verify:
+
+- compiled extension entry exists after build,
+- compiled setup entry exists after build,
+- `openclaw.extensions` and `openclaw.setupEntry` point to `dist/*.js`,
+- package `files` include runtime assets and docs,
+- install manifest required files exist,
+- runtime dependencies and overrides are present.
+
+## Out Of Scope
+
+The #2613 branch also contained draft TOS publishing/install notes. Those notes depend on release scripts and object-storage upload flow that are not present in current main. They should be added only with the corresponding scripts and CI/release process, not as standalone documentation.

--- a/examples/openclaw-plugin/docs/openviking-runtime-query-config.md
+++ b/examples/openclaw-plugin/docs/openviking-runtime-query-config.md
@@ -1,0 +1,139 @@
+# OpenViking Runtime Query Config
+
+Runtime query config lets operators tune recall and search behavior without restarting OpenClaw. It is intended for live debugging and rollout control around recall limit, candidate count, score threshold, target resource types, and ranking weights.
+
+This document describes the runtime query config capability ported from the broader #2613 work into the split OpenViking plugin PR series.
+
+## Configuration Layers
+
+Effective query config is resolved per request with this priority:
+
+```text
+explicit tool request arguments
+  > session runtime config
+  > peer runtime config
+  > static plugin config
+  > code defaults
+```
+
+The higher layer wins field by field. Object fields such as ranking weights are shallow-merged. Array fields such as `resourceTypes` replace the lower layer.
+
+## Scopes
+
+Runtime config has two persistent scopes:
+
+| Scope | Meaning |
+| --- | --- |
+| `peer` | Applies to the current OpenClaw peer/assistant identity across sessions. |
+| `session` | Applies only to the current session identity. |
+
+For command compatibility, `--scope claw` is accepted as an alias for `peer`.
+
+## Supported Fields
+
+| Field | Purpose |
+| --- | --- |
+| `recallLimit` | Number of final recall results to inject or display. |
+| `candidateLimit` | Number of candidates requested before local ranking/filtering. |
+| `candidateMultiplier` | Multiplier used to derive candidate count from recall limit when `candidateLimit` is not explicit. |
+| `scoreThreshold` | Client-side minimum score after semantic search. |
+| `maxInjectedChars` | Character budget for automatic recall injection. |
+| `recallPreferAbstract` | Prefer abstracts over full content when injecting recalled context. |
+| `resourceTypes` | Default semantic recall target types: `user`, `agent`, `resource`. |
+| `targetUri` | Force a single `viking://` target URI for search. |
+| `ovSearchLimit` | Default result count for `ov_search`. |
+| `rankingWeights` | Local ranking weights, such as base score and lexical overlap. |
+| `categoryWeights` | Optional category-specific ranking adjustments. |
+| `resourceTypeWeights` | Optional resource type ranking adjustments. |
+
+Session history is not a semantic recall target. Use `ov_archive_search` and `ov_archive_expand` for session archive recovery.
+
+## Slash Command
+
+### Get
+
+```text
+/ov-query-config get --scope session
+/ov-query-config get --scope peer
+```
+
+The response includes the effective config and per-field sources, which are useful for understanding why a value is active.
+
+### Set
+
+```text
+/ov-query-config set --scope peer \
+  --recallLimit 6 \
+  --candidateLimit 40 \
+  --scoreThreshold 0.15 \
+  --resourceTypes user,agent,resource
+```
+
+```text
+/ov-query-config set --scope session \
+  --ovSearchLimit 8 \
+  --recallPreferAbstract true
+```
+
+### Weights
+
+```text
+/ov-query-config set --scope peer \
+  --weight baseScore=1,leaf=0.12,lexicalOverlapMax=0.2 \
+  --categoryWeight preference=0.2,event=0.1 \
+  --resourceTypeWeight user=0.15,resource=0.1
+```
+
+### Unset
+
+```text
+/ov-query-config unset recallLimit scoreThreshold rankingWeights --scope session
+```
+
+### Reset
+
+```text
+/ov-query-config reset --scope session
+/ov-query-config reset --scope peer
+```
+
+## Persistence
+
+Runtime query config can be persisted by configuring `runtimeQueryConfigPath`.
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openviking": {
+        "config": {
+          "runtimeQueryConfigPath": "/path/to/runtime-query-config.json"
+        }
+      }
+    }
+  }
+}
+```
+
+If the file is missing, the store starts empty. If the file is malformed, the plugin keeps the last known-good in-memory config and reports a warning instead of breaking recall.
+
+## Interaction With Tools
+
+`memory_recall` and `ov_search` use runtime config as defaults. Explicit arguments on the current tool call still win.
+
+Examples:
+
+- If peer scope sets `ovSearchLimit=8`, `ov_search` defaults to 8 results.
+- If a specific `ov_search` call passes `limit=3`, that request returns 3 results and does not mutate runtime config.
+- If session scope sets `scoreThreshold`, it overrides peer/static threshold only for that session.
+
+## Verification
+
+The split implementation is covered by unit tests for:
+
+- normalization and persistence,
+- layer precedence,
+- empty patch rejection,
+- `peer` and `claw` scope compatibility,
+- `memory_recall` and `ov_search` runtime defaulting,
+- explicit request arguments overriding runtime defaults.

--- a/examples/openclaw-plugin/docs/openviking-websocket-rpc-api.md
+++ b/examples/openclaw-plugin/docs/openviking-websocket-rpc-api.md
@@ -1,0 +1,226 @@
+# OpenViking WebSocket RPC Guide
+
+This document explains how to call the OpenViking OpenClaw plugin through the OpenClaw Gateway WebSocket RPC surface.
+
+The plugin does not start its own WebSocket server. OpenViking tools are registered through the OpenClaw plugin API, and the Gateway exposes them through standard tool RPC methods.
+
+## Supported Flow
+
+1. Connect to the OpenClaw Gateway WebSocket endpoint.
+2. Call `tools.effective` for a real `sessionKey` to inspect tools available in the current session.
+3. Call `tools.invoke` with an OpenViking tool name and JSON arguments.
+
+Typical endpoint:
+
+```text
+ws://127.0.0.1:<gateway-port>
+```
+
+If TLS is enabled, use `wss://`.
+
+## Connect
+
+The first message is a `connect` request. Exact auth fields depend on the Gateway deployment.
+
+```json
+{
+  "type": "req",
+  "id": "connect-1",
+  "method": "connect",
+  "params": {
+    "minProtocol": 3,
+    "maxProtocol": 4,
+    "client": {
+      "id": "openviking-rpc-client",
+      "version": "1.0.0",
+      "platform": "macos",
+      "mode": "operator"
+    },
+    "role": "operator",
+    "scopes": ["operator.read", "operator.write"],
+    "auth": {
+      "token": "<OPENCLAW_GATEWAY_TOKEN>"
+    },
+    "locale": "zh-CN",
+    "userAgent": "openviking-rpc-client/1.0.0"
+  }
+}
+```
+
+The Gateway returns `hello-ok` when the connection is accepted.
+
+## Discover Tools
+
+Use the current OpenClaw session key. Do not invent a synthetic session key for production debugging.
+
+```json
+{
+  "type": "req",
+  "id": "tools-1",
+  "method": "tools.effective",
+  "params": {
+    "sessionKey": "main"
+  }
+}
+```
+
+OpenViking plugin tools are entries with `source="plugin"` and `pluginId="openviking"`.
+
+## Invoke Tools
+
+All OpenViking tools use `tools.invoke`.
+
+```json
+{
+  "type": "req",
+  "id": "invoke-1",
+  "method": "tools.invoke",
+  "params": {
+    "name": "ov_search",
+    "sessionKey": "main",
+    "args": {
+      "query": "OpenViking installation",
+      "limit": 5
+    }
+  }
+}
+```
+
+`params.sessionKey` is the Gateway/session routing field. It tells OpenClaw which session context the tool call belongs to.
+
+`params.args.sessionKey` is a tool argument only when a specific OpenViking tool defines it. For example, `ov_recall_trace` can use it as an explicit trace filter. For the current session's trace, pass only the outer `params.sessionKey` unless you intentionally want a different filter.
+
+## Common Tools
+
+### `ov_search`
+
+Search OpenViking resources, skills, and memories.
+
+```json
+{
+  "name": "ov_search",
+  "sessionKey": "main",
+  "args": {
+    "query": "runtime query config",
+    "limit": 5,
+    "uri": "viking://resources"
+  }
+}
+```
+
+### `ov_read`
+
+Read an exact `viking://` URI.
+
+```json
+{
+  "name": "ov_read",
+  "sessionKey": "main",
+  "args": {
+    "uri": "viking://resources/project/spec.md"
+  }
+}
+```
+
+### `ov_multi_read`
+
+Read multiple exact URIs in one tool call.
+
+```json
+{
+  "name": "ov_multi_read",
+  "sessionKey": "main",
+  "args": {
+    "uris": [
+      "viking://resources/project/spec.md",
+      "viking://resources/project/faq.md"
+    ]
+  }
+}
+```
+
+### `memory_recall`
+
+Recall semantic memories and resources. Current semantic recall target types are `user`, `agent`, and `resource`. Session history is not a vector recall target; use `ov_archive_search` and `ov_archive_expand` for archived session history.
+
+```json
+{
+  "name": "memory_recall",
+  "sessionKey": "main",
+  "args": {
+    "query": "what did we decide about install verification",
+    "limit": 5,
+    "resourceTypes": ["user", "agent", "resource"]
+  }
+}
+```
+
+### `ov_recall_trace`
+
+Inspect recall traces when `traceRecall` is enabled.
+
+```json
+{
+  "name": "ov_recall_trace",
+  "sessionKey": "main",
+  "args": {
+    "turn": "latest",
+    "limit": 5,
+    "includeContent": false
+  }
+}
+```
+
+## Response Shape
+
+Successful tool invocation usually returns a Gateway response whose payload contains the plugin tool output.
+
+```json
+{
+  "type": "res",
+  "id": "invoke-1",
+  "ok": true,
+  "payload": {
+    "ok": true,
+    "toolName": "ov_search",
+    "source": "plugin",
+    "output": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Found 2 OpenViking results ..."
+        }
+      ],
+      "details": {
+        "action": "searched",
+        "total": 2
+      }
+    }
+  }
+}
+```
+
+If the Gateway accepted the RPC request but the tool failed, the outer `ok` can still be `true` while `payload.ok` is `false`.
+
+```json
+{
+  "type": "res",
+  "id": "invoke-1",
+  "ok": true,
+  "payload": {
+    "ok": false,
+    "toolName": "ov_search",
+    "error": {
+      "code": "not_found",
+      "message": "Tool not available: ov_search"
+    }
+  }
+}
+```
+
+## Notes
+
+- Use `tools.effective` before invoking a tool in a live session.
+- Use exact `viking://` URIs with `ov_read` and `ov_multi_read`.
+- Do not use deprecated agent URI paths for memory routing. Current routing is based on OpenViking context type and actor peer identity.
+- For recall trace HTTP routes, see `openviking-recall-trace-api.md`.


### PR DESCRIPTION
## Summary
- add WebSocket RPC usage documentation for calling OpenViking tools through OpenClaw Gateway
- add runtime query config documentation for scopes, fields, commands, and precedence
- add package/install contract verification documentation for the current plugin packaging flow
- link the new docs from the OpenViking OpenClaw plugin README

## Notes
- This ports the documentation/verification part of #2613 that matches the split PR series.
- It intentionally does not claim the #2613 TOS publishing scripts are supported, because those scripts are not present on current main.
- Deprecated agent URI paths and old OpenViking agent headers are not reintroduced.

## Tests
- git diff --check
- rg -n "agent_prefix|X-OpenViking-Agent|viking://agent|isolateAgentScopeByUser" examples/openclaw-plugin/README.md examples/openclaw-plugin/docs/openviking-websocket-rpc-api.md examples/openclaw-plugin/docs/openviking-runtime-query-config.md examples/openclaw-plugin/docs/openviking-install-package-contract.md