### PR TITLE
fix(storage): fix empty chunk overwrite during multiwrite copy

### DIFF
--- a/crates/ragfs/src/core/multibackend_wrapper.rs
+++ b/crates/ragfs/src/core/multibackend_wrapper.rs
@@ -307,6 +307,16 @@ async fn copy_file_state(
             while offset < size {
                 let chunk_len = (size - offset).min(DEFAULT_COPY_CHUNK_SIZE as u64);
                 let chunk = source.read(source_path, offset, chunk_len).await?;
+                if chunk.is_empty() {
+                    if offset == 0 {
+                        if destination.exists(destination_path).await {
+                            destination.truncate(destination_path, 0).await?;
+                        } else {
+                            destination.create(destination_path).await?;
+                        }
+                    }
+                    break;
+                }
                 let flag = if offset == 0 {
                     WriteFlag::Create
                 } else {
@@ -316,12 +326,6 @@ async fn copy_file_state(
                     .write(destination_path, &chunk, offset, flag)
                     .await?;
                 offset = offset.saturating_add(chunk.len() as u64);
-                if chunk.is_empty() {
-                    return Err(Error::internal(format!(
-                        "source returned empty chunk while copying '{}' -> '{}'",
-                        source_path, destination_path
-                    )));
-                }
             }
             Ok(())
         })


### PR DESCRIPTION
## Description

Fix a multi-write copy issue where copying from an encrypted primary backend to a plaintext S3 backup could overwrite the S3 object with an empty payload.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Updated multi-write copy logic to stop before writing an empty chunk to the destination backend.
- Prevented plaintext S3 backups from being overwritten with zero-byte objects after logical EOF.
- Preserved existing behavior for empty source files by creating or truncating the destination to an empty file when the first read returns empty.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

```bash
cargo test -p ragfs core::multibackend_wrapper::tests -- --nocapture
```

Result: 18 passed, 0 failed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->

This issue occurs when the primary backend is encrypted and the backup backend is configured as plaintext. The primary `stat` size may reflect encrypted envelope bytes, while `read` returns plaintext bytes. The copy loop could then read an empty chunk after plaintext EOF. Since S3 writes replace the full object, writing that empty chunk could clear the object content.