### PR TITLE
refactor(openclaw): add plugin runtime modules

### DIFF
--- a/examples/openclaw-plugin/adapters/http-transport.ts
+++ b/examples/openclaw-plugin/adapters/http-transport.ts
@@ -1,0 +1,3 @@
+export type HttpTransport = (url: string, init: RequestInit) => Promise<Response>;
+
+export const defaultHttpTransport: HttpTransport = (url, init) => fetch(url, init);

--- a/examples/openclaw-plugin/adapters/resource-packager.ts
+++ b/examples/openclaw-plugin/adapters/resource-packager.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { createWriteStream } from "node:fs";
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative } from "node:path";
+
+import { Zip, ZipDeflate } from "fflate";
+
+const REMOTE_RESOURCE_PREFIXES = ["http://", "https://", "git@", "ssh://", "git://"];
+
+export type PackagedResourceSource =
+  | { kind: "remote"; path: string }
+  | { kind: "upload"; uploadPath: string; sourceName?: string; cleanupPath?: string };
+
+export type ResourcePackager = {
+  prepareResourceSource(pathOrUrl: string): Promise<PackagedResourceSource>;
+  prepareLocalUploadSource(path: string): Promise<PackagedResourceSource>;
+  createTempUploadBody(uploadPath: string): Promise<BodyInit>;
+  cleanup(source?: PackagedResourceSource): Promise<void>;
+};
+
+function toBlobPart(value: Buffer): ArrayBuffer {
+  return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
+}
+
+export function isRemoteResourceSource(source: string): boolean {
+  return REMOTE_RESOURCE_PREFIXES.some((prefix) => source.startsWith(prefix));
+}
+
+export async function cleanupUploadTempPath(path?: string): Promise<void> {
+  if (!path) {
+    return;
+  }
+  await rm(path, { force: true }).catch(() => undefined);
+  await rm(dirname(path), { recursive: true, force: true }).catch(() => undefined);
+}
+
+export async function zipDirectoryForUpload(dirPath: string): Promise<string> {
+  const rootStats = await stat(dirPath);
+  if (!rootStats.isDirectory()) {
+    throw new Error(`Not a directory: ${dirPath}`);
+  }
+
+  const zipDir = await mkdtemp(join(tmpdir(), "openviking-openclaw-upload-"));
+  const zipPath = join(zipDir, `${basename(dirPath).replace(/[^a-zA-Z0-9._-]/g, "_")}-${randomUUID()}.zip`);
+  const output = createWriteStream(zipPath);
+  const outputClosed = once(output, "close");
+  const outputErrored = once(output, "error").then(([err]) => Promise.reject(err));
+  const zip = new Zip((err, chunk, final) => {
+    if (err) {
+      output.destroy(err);
+      return;
+    }
+    if (chunk?.length) {
+      output.write(Buffer.from(chunk));
+    }
+    if (final) {
+      output.end();
+    }
+  });
+
+  const walk = async (currentDir: string) => {
+    const entries = await readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const relPath = relative(dirPath, fullPath).split("\\").join("/");
+      if (!relPath || relPath.startsWith("../") || relPath.includes("/../")) {
+        throw new Error(`Unsafe relative path while zipping: ${relPath}`);
+      }
+      const file = new ZipDeflate(relPath);
+      zip.add(file);
+      file.push(new Uint8Array(await readFile(fullPath)), true);
+    }
+  };
+  try {
+    await walk(dirPath);
+    zip.end();
+    await Promise.race([outputClosed, outputErrored]);
+  } catch (err) {
+    zip.terminate();
+    output.destroy(err as Error);
+    await cleanupUploadTempPath(zipPath);
+    throw err;
+  }
+  return zipPath;
+}
+
+async function prepareLocalUploadSource(path: string, includeSourceName = false): Promise<PackagedResourceSource> {
+  const localStats = await stat(path);
+  if (localStats.isDirectory()) {
+    const uploadPath = await zipDirectoryForUpload(path);
+    return {
+      kind: "upload",
+      uploadPath,
+      cleanupPath: uploadPath,
+      ...(includeSourceName ? { sourceName: basename(path) } : {}),
+    };
+  }
+  if (!localStats.isFile()) {
+    throw new Error(`Path is not a file or directory: ${path}`);
+  }
+  return { kind: "upload", uploadPath: path };
+}
+
+export const defaultResourcePackager: ResourcePackager = {
+  async prepareResourceSource(pathOrUrl: string): Promise<PackagedResourceSource> {
+    if (isRemoteResourceSource(pathOrUrl)) {
+      return { kind: "remote", path: pathOrUrl };
+    }
+    return prepareLocalUploadSource(pathOrUrl, true);
+  },
+
+  async prepareLocalUploadSource(path: string): Promise<PackagedResourceSource> {
+    return prepareLocalUploadSource(path, false);
+  },
+
+  async createTempUploadBody(uploadPath: string): Promise<BodyInit> {
+    const fileBytes = await readFile(uploadPath);
+    const form = new FormData();
+    form.append(
+      "file",
+      new Blob([toBlobPart(fileBytes)], { type: "application/octet-stream" }),
+      basename(uploadPath),
+    );
+    return form;
+  },
+
+  async cleanup(source?: PackagedResourceSource): Promise<void> {
+    if (source?.kind === "upload") {
+      await cleanupUploadTempPath(source.cleanupPath);
+    }
+  },
+};

--- a/examples/openclaw-plugin/plugin/command-registration.ts
+++ b/examples/openclaw-plugin/plugin/command-registration.ts
@@ -1,0 +1,34 @@
+export type PluginCommandContext = {
+  args?: string;
+  commandBody?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  ovSessionId?: string;
+};
+
+export type CommandResult = {
+  text: string;
+  details?: Record<string, unknown>;
+};
+
+export type CommandDefinition = {
+  name: string;
+  description: string;
+  acceptsArgs?: boolean;
+  requireAuth?: boolean;
+  handler: (ctx: PluginCommandContext) => CommandResult | Promise<CommandResult>;
+};
+
+export type OpenVikingCommandRegistrationApi = {
+  registerCommand?: (command: CommandDefinition) => void;
+};
+
+export function registerOpenVikingCommands(
+  api: OpenVikingCommandRegistrationApi,
+  commands: CommandDefinition[],
+): void {
+  for (const command of commands) {
+    api.registerCommand?.(command);
+  }
+}

--- a/examples/openclaw-plugin/plugin/openviking-archive-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-archive-tools.ts
@@ -1,0 +1,301 @@
+import { Type } from "@sinclair/typebox";
+import type { OVMessage } from "../client.js";
+import type { RecallTraceEntry, RecallTraceResult } from "../recall-trace.js";
+
+export type OpenVikingArchiveToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+};
+
+export type OpenVikingArchiveSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+type OpenVikingArchiveMatch = {
+  uri: string;
+  line: number;
+  content: string;
+};
+
+export type OpenVikingArchiveClient = {
+  grepSessionArchives: (
+    sessionId: string,
+    pattern: string,
+    options: { archiveId?: string; caseInsensitive: boolean; agentId?: string },
+  ) => Promise<{
+    count?: number;
+    matches?: OpenVikingArchiveMatch[];
+  }>;
+  getSessionArchive: (
+    sessionId: string,
+    archiveId: string,
+    agentId?: string,
+  ) => Promise<{
+    archive_id: string;
+    abstract?: string;
+    messages: OVMessage[];
+  }>;
+};
+
+export type OpenVikingArchiveToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  getClient: () => Promise<OpenVikingArchiveClient>;
+  rememberSessionAgentId: (ctx: OpenVikingArchiveToolContext) => void;
+  toOvSessionId: (sessionId?: string, sessionKey?: string) => string;
+  resolveAgentId: (sessionId?: string, sessionKey?: string, ovSessionId?: string) => string;
+  resolvePluginSessionRouting: (ctx?: OpenVikingArchiveToolContext) => OpenVikingArchiveSession;
+  isBypassedSession: (ctx?: OpenVikingArchiveToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+  formatMessage: (message: OVMessage) => string;
+  traceRecorder?: { recordAndFlush: (trace: RecallTraceEntry) => Promise<unknown> | unknown };
+  traceRecallMaxResultsPerSearch: number;
+  traceRecallPreviewChars: number;
+  createTraceId: (source: string) => string;
+  logger?: {
+    info?: (message: string) => void;
+    warn?: (message: string) => void;
+    error?: (message: string) => void;
+  };
+};
+
+function previewText(value: unknown, maxChars: number): string | undefined {
+  const text = typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+  if (!text) {
+    return undefined;
+  }
+  return text.length <= maxChars ? text : `${text.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+export function registerOpenVikingArchiveTools(deps: OpenVikingArchiveToolsDeps): void {
+  deps.registerTool(
+    (ctx: OpenVikingArchiveToolContext) => ({
+      name: "ov_archive_search",
+      label: "Archive Search (OpenViking)",
+      description:
+        "Keyword-grep across all archived original conversation messages of the current session. " +
+        "Use this whenever the [Session History Summary] does not contain the specific detail " +
+        "the user is asking about. Extract 2-3 concrete entity words from the question " +
+        "(names, places, objects, dates) and search each separately. " +
+        "Only conclude information is unavailable after trying at least 2 different keyword variations.",
+      parameters: Type.Object({
+        query: Type.String({
+          description:
+            "A single keyword or short phrase to grep. Use concrete nouns, names, dates, " +
+            "or distinctive phrases. Case-insensitive. Prefer entity words over full sentences.",
+        }),
+        archiveId: Type.Optional(
+          Type.String({
+            description: 'Optional: limit search to one archive (e.g. "archive_005")',
+          }),
+        ),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("ov_archive_search");
+        }
+        deps.rememberSessionAgentId(ctx);
+        const sessionId = ctx.sessionId ?? "";
+        const sessionKey = ctx.sessionKey ?? "";
+        if (!sessionId && !sessionKey) {
+          return {
+            content: [{ type: "text", text: "Error: no active session." }],
+            details: { error: "no_session" },
+          };
+        }
+        const ovSessionId = deps.toOvSessionId(ctx.sessionId, ctx.sessionKey);
+        const query = String((params as { query?: string }).query ?? "").trim();
+        const archiveId = (params as { archiveId?: string }).archiveId;
+
+        if (!query) {
+          return {
+            content: [{ type: "text", text: "Error: query is required." }],
+            details: { error: "missing_param", param: "query" },
+          };
+        }
+
+        const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        deps.logger?.info?.(`openviking: ov_archive_search query="${query}" escaped="${escapedQuery}" archive=${archiveId ?? "all"} session=${ovSessionId}`);
+
+        try {
+          const client = await deps.getClient();
+          const agentId = deps.resolveAgentId(ctx.sessionId, ctx.sessionKey);
+          const started = Date.now();
+          const result = await client.grepSessionArchives(ovSessionId, escapedQuery, {
+            archiveId,
+            caseInsensitive: true,
+            agentId,
+          });
+          const traceResults: RecallTraceResult[] = (result.matches ?? []).slice(0, deps.traceRecallMaxResultsPerSearch).map((match) => ({
+            uri: match.uri,
+            resourceType: "archive",
+            abstractPreview: previewText(match.content, deps.traceRecallPreviewChars),
+            resultType: "archive_match",
+          }));
+
+          const recordArchiveTrace = async (displayed: OpenVikingArchiveMatch[]) => {
+            await deps.traceRecorder?.recordAndFlush({
+              schemaVersion: "1.0",
+              traceId: deps.createTraceId("ov_archive_search"),
+              ts: Date.now(),
+              sessionId: ctx.sessionId,
+              sessionKey: ctx.sessionKey,
+              ovSessionId,
+              agentId,
+              source: "ov_archive_search",
+              operationType: "archive_grep",
+              resourceTypes: ["session"],
+              trigger: { query, derivedKeywords: [query] },
+              searches: [{
+                resourceType: "archive",
+                targetUriResolved: archiveId ? `viking://session/${ovSessionId}/history/${archiveId}` : `viking://session/${ovSessionId}/history`,
+                limit: deps.traceRecallMaxResultsPerSearch,
+                durationMs: Date.now() - started,
+                total: result.matches?.length ?? result.count ?? 0,
+                results: traceResults,
+                archiveId,
+                caseInsensitive: true,
+              }],
+              selected: displayed.map((match) => ({
+                uri: match.uri,
+                resourceType: "archive",
+                line: match.line,
+                abstractPreview: previewText(match.content, deps.traceRecallPreviewChars),
+                displayed: true,
+              })),
+              stats: {
+                candidateCount: result.matches?.length ?? result.count ?? 0,
+                selectedCount: displayed.length,
+                injectedCount: 0,
+              },
+            });
+          };
+
+          if (!result.matches || result.matches.length === 0) {
+            await recordArchiveTrace([]);
+            return {
+              content: [{
+                type: "text",
+                text: `No matches found for "${query}". Try a different keyword — ` +
+                  "the original conversation may use different wording than the question. " +
+                  "Try synonyms, related terms, or shorter fragments.",
+              }],
+              details: { query, matchCount: 0 },
+            };
+          }
+
+          const MAX_MATCHES = 12;
+          const MAX_LINE_LEN = 1500;
+          const shown = result.matches.slice(0, MAX_MATCHES);
+          await recordArchiveTrace(shown);
+          const blocks = shown.map((m, i) => {
+            const archiveTag = m.uri.match(/archive_\d+/)?.[0] ?? "unknown";
+            const truncated = m.content.length > MAX_LINE_LEN
+              ? m.content.slice(0, MAX_LINE_LEN) + "…(truncated)"
+              : m.content;
+            return `## Match ${i + 1}: ${archiveTag} (line ${m.line})\n${truncated}`;
+          });
+
+          const header = `Found ${result.matches.length} match(es) for "${query}"` +
+            (result.matches.length > MAX_MATCHES ? ` (showing first ${MAX_MATCHES})` : "") + ":";
+
+          return {
+            content: [{ type: "text", text: header + "\n\n" + blocks.join("\n\n") }],
+            details: { query, matchCount: result.matches.length },
+          };
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          deps.logger?.error?.(`openviking: ov_archive_search error: ${msg}`);
+          return {
+            content: [{ type: "text", text: `Archive search failed: ${msg}` }],
+            details: { error: msg },
+          };
+        }
+      },
+    }),
+    { name: "ov_archive_search" },
+  );
+
+  deps.registerTool((ctx: OpenVikingArchiveToolContext) => ({
+    name: "ov_archive_expand",
+    label: "Archive Expand (OpenViking)",
+    description:
+      "Retrieve original messages from a compressed session archive. " +
+      "Use when a session summary lacks specific details " +
+      "such as exact commands, file paths, code snippets, or config values. " +
+      "Check [Archive Index] to find the right archive ID.",
+    parameters: Type.Object({
+      archiveId: Type.String({
+        description:
+          'Archive ID from [Archive Index] (e.g. "archive_002")',
+      }),
+    }),
+    async execute(_toolCallId: string, params: Record<string, unknown>) {
+      if (deps.isBypassedSession(ctx)) {
+        return deps.makeBypassedToolResult("ov_archive_expand");
+      }
+      const session = deps.resolvePluginSessionRouting(ctx);
+      const archiveId = String((params as { archiveId?: string }).archiveId ?? "").trim();
+      const sessionId = session.sessionId ?? "";
+      deps.logger?.info?.(`openviking: ov_archive_expand invoked (archiveId=${archiveId || "(empty)"}, sessionId=${sessionId || "(empty)"})`);
+
+      if (!archiveId) {
+        deps.logger?.warn?.("openviking: ov_archive_expand missing archiveId");
+        return {
+          content: [{ type: "text", text: "Error: archiveId is required." }],
+          details: { error: "missing_param", param: "archiveId" },
+        };
+      }
+
+      if (!session.ovSessionId) {
+        return {
+          content: [{ type: "text", text: "Error: no active session." }],
+          details: { error: "no_session" },
+        };
+      }
+
+      try {
+        const client = await deps.getClient();
+        const detail = await client.getSessionArchive(
+          session.ovSessionId,
+          archiveId,
+          session.agentId,
+        );
+
+        const header = [
+          `## ${detail.archive_id}`,
+          detail.abstract ? `**Summary**: ${detail.abstract}` : "",
+          `**Messages**: ${detail.messages.length}`,
+          "",
+        ].filter(Boolean).join("\n");
+
+        const body = detail.messages
+          .map((message) => deps.formatMessage(message))
+          .join("\n\n");
+
+        deps.logger?.info?.(`openviking: ov_archive_expand expanded ${detail.archive_id}, messages=${detail.messages.length}, chars=${body.length}, sessionId=${sessionId}`);
+        return {
+          content: [{ type: "text", text: `${header}\n${body}` }],
+          details: {
+            action: "expanded",
+            archiveId: detail.archive_id,
+            messageCount: detail.messages.length,
+            sessionId,
+            ovSessionId: session.ovSessionId,
+          },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        deps.logger?.warn?.(`openviking: ov_archive_expand failed (archiveId=${archiveId}, sessionId=${sessionId}): ${msg}`);
+        return {
+          content: [{ type: "text", text: `Failed to expand ${archiveId}: ${msg}` }],
+          details: { error: msg, archiveId, sessionId, ovSessionId: session.ovSessionId },
+        };
+      }
+    },
+  }), { name: "ov_archive_expand" });
+}

--- a/examples/openclaw-plugin/plugin/openviking-bypass-runtime.ts
+++ b/examples/openclaw-plugin/plugin/openviking-bypass-runtime.ts
@@ -1,0 +1,26 @@
+import {
+  compileSessionPatterns,
+  shouldBypassSession,
+} from "../text-utils.js";
+
+type BypassRuntimeConfig = {
+  bypassSessionPatterns: string[];
+};
+
+type SessionBypassContext = {
+  sessionId?: string;
+  sessionKey?: string;
+};
+
+export function createOpenVikingBypassRuntime<TConfig extends BypassRuntimeConfig>(options: {
+  cfg: TConfig;
+}) {
+  const bypassSessionPatterns = compileSessionPatterns(options.cfg.bypassSessionPatterns);
+
+  const isBypassedSession = (ctx?: SessionBypassContext): boolean =>
+    shouldBypassSession(ctx ?? {}, bypassSessionPatterns);
+
+  return {
+    isBypassedSession,
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-client-runtime.ts
+++ b/examples/openclaw-plugin/plugin/openviking-client-runtime.ts
@@ -1,0 +1,71 @@
+import { OpenVikingClient } from "../client.js";
+
+type Logger = {
+  info: (message: string) => void;
+};
+
+type ClientRuntimeConfig = {
+  baseUrl: string;
+  apiKey: string;
+  peer_role: "none" | "assistant" | "person";
+  peer_prefix: string;
+  timeoutMs: number;
+  accountId?: string;
+  userId?: string;
+  logFindRequests: boolean;
+};
+
+export function createOpenVikingClientRuntime(options: {
+  cfg: ClientRuntimeConfig;
+  rawPeerPrefix: unknown;
+  logger: Logger;
+}) {
+  const { cfg, logger } = options;
+
+  if (cfg.logFindRequests) {
+    logger.info(
+      "openviking: routing debug logging enabled (config logFindRequests, or env OPENVIKING_LOG_ROUTING=1 / OPENVIKING_DEBUG=1)",
+    );
+  }
+
+  const verboseRoutingInfo = (message: string) => {
+    if (cfg.logFindRequests) {
+      logger.info(message);
+    }
+  };
+
+  verboseRoutingInfo(
+    `openviking: loaded plugin config peer_role="${cfg.peer_role}" peer_prefix="${cfg.peer_prefix}" ` +
+      `(raw peer_prefix=${JSON.stringify(options.rawPeerPrefix ?? "(missing)")}; ` +
+      `${
+        cfg.peer_prefix
+          ? 'non-empty → assistant peer_id is <peer_prefix>_<ctx.agentId> when peer_role="assistant", or <peer_prefix>_main when ctx.agentId is unknown'
+          : 'empty → assistant peer_id follows OpenClaw ctx.agentId when peer_role="assistant", or "main" when ctx.agentId is unknown'
+      })`,
+  );
+
+  const routingDebugLog = cfg.logFindRequests
+    ? (msg: string) => {
+        logger.info(msg);
+      }
+    : undefined;
+
+  const clientPromise = Promise.resolve(
+    new OpenVikingClient(
+      cfg.baseUrl,
+      cfg.apiKey,
+      cfg.peer_prefix,
+      cfg.timeoutMs,
+      cfg.accountId,
+      cfg.userId,
+      routingDebugLog,
+    ),
+  );
+
+  const getClient = (): Promise<OpenVikingClient> => clientPromise;
+
+  return {
+    getClient,
+    verboseRoutingInfo,
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-command-args.ts
+++ b/examples/openclaw-plugin/plugin/openviking-command-args.ts
@@ -1,0 +1,187 @@
+export type AddResourceCommandArgs = {
+  source?: string;
+  to?: string;
+  parent?: string;
+  reason?: string;
+  instruction?: string;
+  wait?: boolean;
+  timeout?: number;
+};
+
+export type AddSkillCommandArgs = {
+  source?: string;
+  data?: unknown;
+  wait?: boolean;
+  timeout?: number;
+};
+
+export type OVSearchCommandArgs = {
+  query: string;
+  uri?: string;
+  limit?: number;
+};
+
+export function tokenizeCommandArgs(args: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const ch = args[i]!;
+    const next = args[i + 1];
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\") {
+      const shouldEscape =
+        quote === '"'
+          ? next === '"' || next === "\\"
+          : !quote && Boolean(next && (/\s/.test(next) || next === '"' || next === "'"));
+      if (shouldEscape) {
+        escaping = true;
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+    if ((ch === '"' || ch === "'") && (!quote || quote === ch)) {
+      quote = quote ? null : ch;
+      continue;
+    }
+    if (!quote && /\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  if (quote) {
+    throw new Error("Unterminated quoted argument");
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+type ParsedFlagArgs = {
+  positionals: string[];
+  flags: Map<string, string | boolean>;
+};
+
+function parseFlagArgs(args: string): ParsedFlagArgs {
+  const tokens = tokenizeCommandArgs(args);
+  const positionals: string[] = [];
+  const flags = new Map<string, string | boolean>();
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+    const raw = token.slice(2);
+    if (!raw) {
+      continue;
+    }
+    const eqIndex = raw.indexOf("=");
+    if (eqIndex >= 0) {
+      flags.set(raw.slice(0, eqIndex), raw.slice(eqIndex + 1));
+      continue;
+    }
+    const next = tokens[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags.set(raw, next);
+      i += 1;
+    } else {
+      flags.set(raw, true);
+    }
+  }
+
+  return { positionals, flags };
+}
+
+function getStringFlag(flags: Map<string, string | boolean>, name: string): string | undefined {
+  const value = flags.get(name);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function getNumberFlag(flags: Map<string, string | boolean>, name: string): number | undefined {
+  const raw = getStringFlag(flags, name);
+  if (!raw) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`--${name} must be a number`);
+  }
+  return value;
+}
+
+function getBoolFlag(flags: Map<string, string | boolean>, name: string): boolean {
+  return flags.get(name) === true;
+}
+
+export function parseAddResourceCommandArgs(args: string): AddResourceCommandArgs {
+  const parsed = parseFlagArgs(args);
+  const source =
+    parsed.positionals.length <= 1 ? parsed.positionals[0] : parsed.positionals.join(" ").trim();
+  if (!source) {
+    throw new Error("Usage: /add-resource <source> [--to URI] [--parent URI] [--reason TEXT] [--instruction TEXT] [--wait] [--timeout SEC]");
+  }
+  const to = getStringFlag(parsed.flags, "to");
+  const parent = getStringFlag(parsed.flags, "parent");
+  if (to && parent) {
+    throw new Error("Cannot specify both --to and --parent.");
+  }
+  return {
+    source,
+    to,
+    parent,
+    reason: getStringFlag(parsed.flags, "reason"),
+    instruction: getStringFlag(parsed.flags, "instruction"),
+    wait: getBoolFlag(parsed.flags, "wait"),
+    timeout: getNumberFlag(parsed.flags, "timeout"),
+  };
+}
+
+export function parseAddSkillCommandArgs(args: string): AddSkillCommandArgs {
+  const parsed = parseFlagArgs(args);
+  const source =
+    parsed.positionals.length <= 1 ? parsed.positionals[0] : parsed.positionals.join(" ").trim();
+  if (!source) {
+    throw new Error("Usage: /add-skill <source> [--wait] [--timeout SEC]");
+  }
+  if (parsed.flags.has("to") || parsed.flags.has("parent") || parsed.flags.has("reason") || parsed.flags.has("instruction")) {
+    throw new Error("--to, --parent, --reason, and --instruction are resource-only options.");
+  }
+  return {
+    source,
+    wait: getBoolFlag(parsed.flags, "wait"),
+    timeout: getNumberFlag(parsed.flags, "timeout"),
+  };
+}
+
+export function parseOVSearchCommandArgs(args: string): OVSearchCommandArgs {
+  const parsed = parseFlagArgs(args);
+  // `/ov-search` only accepts a single query string, so positional segments are
+  // always re-joined to preserve unquoted multi-word searches.
+  const query = parsed.positionals.join(" ").trim();
+  if (!query) {
+    throw new Error('Usage: /ov-search "<query>" [--uri URI] [--limit N]');
+  }
+  return {
+    query,
+    uri: getStringFlag(parsed.flags, "uri"),
+    limit: getNumberFlag(parsed.flags, "limit"),
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-command-definitions.ts
+++ b/examples/openclaw-plugin/plugin/openviking-command-definitions.ts
@@ -1,0 +1,294 @@
+import type { CommandDefinition, CommandResult, PluginCommandContext } from "./command-registration.js";
+import type { RecallTraceEntry, RecallTraceSource } from "../recall-trace.js";
+
+export type OpenVikingCommandSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OpenVikingCommandToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details?: Record<string, unknown>;
+};
+
+export type AddResourceCommandInput = {
+  source?: string;
+  to?: string;
+  parent?: string;
+  reason?: string;
+  instruction?: string;
+  wait?: boolean;
+  timeout?: number;
+};
+
+export type AddSkillCommandInput = {
+  source?: string;
+  data?: unknown;
+  wait?: boolean;
+  timeout?: number;
+};
+
+export type OVSearchCommandInput = {
+  query: string;
+  uri?: string;
+  limit?: number;
+};
+
+export type RecallTraceCommandInput = {
+  turn?: "latest" | "all";
+  traceId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  source?: RecallTraceSource;
+  resourceTypes?: string;
+  since?: number;
+  until?: number;
+  includeContent?: boolean;
+  limit?: number;
+};
+
+export type RecallTraceCommandResult = {
+  entries: RecallTraceEntry[];
+  lookupLayer: string;
+  warnings: string[];
+};
+
+export type OpenVikingCommandDefinitionsDeps = {
+  resolvePluginSessionRouting: (ctx?: PluginCommandContext) => OpenVikingCommandSession;
+  isBypassedSession: (ctx?: PluginCommandContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => OpenVikingCommandToolResult;
+  parseAddResourceCommandArgs: (args: string) => AddResourceCommandInput;
+  parseAddSkillCommandArgs: (args: string) => AddSkillCommandInput;
+  parseOVSearchCommandArgs: (args: string) => OVSearchCommandInput;
+  addResourceOpenViking: (input: AddResourceCommandInput, agentId?: string) => Promise<OpenVikingCommandToolResult>;
+  addSkillOpenViking: (input: AddSkillCommandInput, agentId?: string) => Promise<OpenVikingCommandToolResult>;
+  searchOpenViking: (
+    input: OVSearchCommandInput,
+    agentId?: string,
+    traceCtx?: OpenVikingCommandSession,
+  ) => Promise<OpenVikingCommandToolResult>;
+  handleQueryConfigCommand: (ctx: PluginCommandContext) => Promise<CommandResult>;
+  queryRecallTraces: (
+    input: RecallTraceCommandInput,
+    session: OpenVikingCommandSession,
+  ) => Promise<RecallTraceCommandResult>;
+  formatRecallTraceText: (result: RecallTraceCommandResult) => string;
+};
+
+function tokenizeCommandArgs(args: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const ch = args[i]!;
+    const next = args[i + 1];
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\") {
+      const shouldEscape =
+        quote === '"'
+          ? next === '"' || next === "\\"
+          : !quote && Boolean(next && (/\s/.test(next) || next === '"' || next === "'"));
+      if (shouldEscape) {
+        escaping = true;
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+    if ((ch === '"' || ch === "'") && (!quote || quote === ch)) {
+      quote = quote ? null : ch;
+      continue;
+    }
+    if (!quote && /\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  if (quote) {
+    throw new Error("Unterminated quoted argument");
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+function parseFlagArgs(args: string): { flags: Map<string, string | boolean> } {
+  const tokens = tokenizeCommandArgs(args);
+  const flags = new Map<string, string | boolean>();
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (!token.startsWith("--")) {
+      continue;
+    }
+    const raw = token.slice(2);
+    if (!raw) {
+      continue;
+    }
+    const eqIndex = raw.indexOf("=");
+    if (eqIndex >= 0) {
+      flags.set(raw.slice(0, eqIndex), raw.slice(eqIndex + 1));
+      continue;
+    }
+    const next = tokens[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags.set(raw, next);
+      i += 1;
+    } else {
+      flags.set(raw, true);
+    }
+  }
+
+  return { flags };
+}
+
+function getStringFlag(flags: Map<string, string | boolean>, name: string): string | undefined {
+  const value = flags.get(name);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function getNumberFlag(flags: Map<string, string | boolean>, name: string): number | undefined {
+  const raw = getStringFlag(flags, name);
+  if (!raw) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`--${name} must be a number`);
+  }
+  return value;
+}
+
+function getBoolFlag(flags: Map<string, string | boolean>, name: string): boolean {
+  return flags.get(name) === true;
+}
+
+function parseRecallTraceCommandArgs(args: string): RecallTraceCommandInput {
+  const flags = parseFlagArgs(args).flags;
+  return {
+    turn: getStringFlag(flags, "turn") as "latest" | "all" | undefined,
+    traceId: getStringFlag(flags, "trace-id"),
+    sessionId: getStringFlag(flags, "session-id"),
+    sessionKey: getStringFlag(flags, "session-key"),
+    ovSessionId: getStringFlag(flags, "ov-session-id"),
+    source: getStringFlag(flags, "source") as RecallTraceSource | undefined,
+    resourceTypes: getStringFlag(flags, "resource-types"),
+    since: getNumberFlag(flags, "since"),
+    until: getNumberFlag(flags, "until"),
+    includeContent: getBoolFlag(flags, "include-content"),
+    limit: getNumberFlag(flags, "limit"),
+  };
+}
+
+function toCommandResult(result: OpenVikingCommandToolResult): CommandResult {
+  return { text: result.content[0]!.text, details: result.details };
+}
+
+export function createOpenVikingCommandDefinitions(
+  deps: OpenVikingCommandDefinitionsDeps,
+): CommandDefinition[] {
+  return [
+    {
+      name: "add-resource",
+      description: "Add a resource into OpenViking.",
+      acceptsArgs: true,
+      handler: async (ctx: PluginCommandContext) => {
+        try {
+          if (deps.isBypassedSession(ctx)) {
+            return toCommandResult(deps.makeBypassedToolResult("add_resource"));
+          }
+          const session = deps.resolvePluginSessionRouting(ctx);
+          const input = deps.parseAddResourceCommandArgs(ctx.args ?? "");
+          return toCommandResult(await deps.addResourceOpenViking(input, session.agentId));
+        } catch (err) {
+          return { text: `OpenViking add resource failed: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      },
+    },
+    {
+      name: "add-skill",
+      description: "Add a skill into OpenViking.",
+      acceptsArgs: true,
+      handler: async (ctx: PluginCommandContext) => {
+        try {
+          if (deps.isBypassedSession(ctx)) {
+            return toCommandResult(deps.makeBypassedToolResult("add_skill"));
+          }
+          const session = deps.resolvePluginSessionRouting(ctx);
+          const input = deps.parseAddSkillCommandArgs(ctx.args ?? "");
+          return toCommandResult(await deps.addSkillOpenViking(input, session.agentId));
+        } catch (err) {
+          return { text: `OpenViking add skill failed: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      },
+    },
+    {
+      name: "ov-search",
+      description: "Search OpenViking resources and skills.",
+      acceptsArgs: true,
+      handler: async (ctx: PluginCommandContext) => {
+        try {
+          if (deps.isBypassedSession(ctx)) {
+            return toCommandResult(deps.makeBypassedToolResult("ov_search"));
+          }
+          const session = deps.resolvePluginSessionRouting(ctx);
+          const input = deps.parseOVSearchCommandArgs(ctx.args ?? "");
+          return toCommandResult(await deps.searchOpenViking(input, session.agentId, session));
+        } catch (err) {
+          return { text: `OpenViking search failed: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      },
+    },
+    {
+      name: "ov-query-config",
+      description: "Get or set runtime OpenViking query parameters for the current claw/session.",
+      acceptsArgs: true,
+      handler: async (ctx: PluginCommandContext) => {
+        try {
+          return await deps.handleQueryConfigCommand(ctx);
+        } catch (err) {
+          return { text: `OpenViking query config failed: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      },
+    },
+    {
+      name: "ov-recall-trace",
+      description: "Query OpenViking recall trace records.",
+      acceptsArgs: true,
+      handler: async (ctx: PluginCommandContext) => {
+        try {
+          if (deps.isBypassedSession(ctx)) {
+            return toCommandResult(deps.makeBypassedToolResult("ov_recall_trace"));
+          }
+          const session = deps.resolvePluginSessionRouting(ctx);
+          const input = parseRecallTraceCommandArgs(ctx.args ?? "");
+          const result = await deps.queryRecallTraces(input, session);
+          return {
+            text: deps.formatRecallTraceText(result),
+            details: { count: result.entries.length, lookupLayer: result.lookupLayer, warnings: result.warnings, entries: result.entries },
+          };
+        } catch (err) {
+          return { text: `OpenViking recall trace query failed: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      },
+    },
+  ];
+}

--- a/examples/openclaw-plugin/plugin/openviking-context-engine-ref.ts
+++ b/examples/openclaw-plugin/plugin/openviking-context-engine-ref.ts
@@ -1,0 +1,16 @@
+import type { ContextEngineWithCommit } from "../context-engine.js";
+
+export function createOpenVikingContextEngineRef() {
+  let contextEngineRef: ContextEngineWithCommit | null = null;
+
+  const getContextEngine = (): ContextEngineWithCommit | null => contextEngineRef;
+
+  const setContextEngineRef = (engine: ContextEngineWithCommit): void => {
+    contextEngineRef = engine;
+  };
+
+  return {
+    getContextEngine,
+    setContextEngineRef,
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-context-engine-registration.ts
+++ b/examples/openclaw-plugin/plugin/openviking-context-engine-registration.ts
@@ -1,0 +1,97 @@
+export type OpenVikingContextEngineRegistrationApi = {
+  registerContextEngine?: (id: string, factory: () => unknown) => void;
+};
+
+export type OpenVikingContextEngineLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+export type OpenVikingContextEnginePluginInfo = {
+  id: string;
+  name: string;
+};
+
+export type OpenVikingContextEngineCreateParams<
+  TCfg = unknown,
+  TClient = unknown,
+  TQueryConfigStore = unknown,
+  TTraceRecorder = unknown,
+  TLogger extends OpenVikingContextEngineLogger = OpenVikingContextEngineLogger,
+> = {
+  id: string;
+  name: string;
+  version: string;
+  cfg: TCfg;
+  logger: TLogger;
+  getClient: () => Promise<TClient>;
+  resolveAgentId: (sessionId: string, sessionKey?: string, ovSessionId?: string) => string;
+  rememberSessionAgentId: (ctx: {
+    agentId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+    ovSessionId?: string;
+  }) => void;
+  queryConfigStore: TQueryConfigStore;
+  traceRecorder: TTraceRecorder;
+};
+
+export type OpenVikingContextEngineRegistrationDeps<
+  TEngine,
+  TCfg = unknown,
+  TClient = unknown,
+  TQueryConfigStore = unknown,
+  TTraceRecorder = unknown,
+  TLogger extends OpenVikingContextEngineLogger = OpenVikingContextEngineLogger,
+> = {
+  api: OpenVikingContextEngineRegistrationApi;
+  plugin: OpenVikingContextEnginePluginInfo;
+  version: string;
+  cfg: TCfg;
+  logger: TLogger;
+  getClient: () => Promise<TClient>;
+  resolveAgentId: (sessionId: string, sessionKey?: string, ovSessionId?: string) => string;
+  rememberSessionAgentId: OpenVikingContextEngineCreateParams["rememberSessionAgentId"];
+  queryConfigStore: TQueryConfigStore;
+  traceRecorder: TTraceRecorder;
+  createContextEngine: (params: OpenVikingContextEngineCreateParams<TCfg, TClient, TQueryConfigStore, TTraceRecorder, TLogger>) => TEngine;
+  setContextEngineRef: (engine: TEngine) => void;
+};
+
+export function registerOpenVikingContextEngine<
+  TEngine,
+  TCfg,
+  TClient,
+  TQueryConfigStore,
+  TTraceRecorder,
+  TLogger extends OpenVikingContextEngineLogger,
+>(
+  deps: OpenVikingContextEngineRegistrationDeps<TEngine, TCfg, TClient, TQueryConfigStore, TTraceRecorder, TLogger>,
+): void {
+  if (typeof deps.api.registerContextEngine !== "function") {
+    deps.logger.warn(
+      "openviking: registerContextEngine is unavailable; context-engine behavior will not run",
+    );
+    return;
+  }
+
+  deps.api.registerContextEngine(deps.plugin.id, () => {
+    const contextEngine = deps.createContextEngine({
+      id: deps.plugin.id,
+      name: deps.plugin.name,
+      version: deps.version,
+      cfg: deps.cfg,
+      logger: deps.logger,
+      getClient: deps.getClient,
+      resolveAgentId: deps.resolveAgentId,
+      rememberSessionAgentId: deps.rememberSessionAgentId,
+      queryConfigStore: deps.queryConfigStore,
+      traceRecorder: deps.traceRecorder,
+    });
+    deps.setContextEngineRef(contextEngine);
+    return contextEngine;
+  });
+  deps.logger.info(
+    "openviking: registered context-engine (assemble=archive+active+auto-recall, afterTurn=auto-capture, session→OV id=uuid-or-sha256 + diag/Phase2 options)",
+  );
+}

--- a/examples/openclaw-plugin/plugin/openviking-feature-gates.ts
+++ b/examples/openclaw-plugin/plugin/openviking-feature-gates.ts
@@ -1,0 +1,335 @@
+import { existsSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Type, type Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+
+export const OPENVIKING_260610_FEATURE = "openviking.260610";
+export const OPENVIKING_FEATURE_GATES_RPC = "openviking.feature.gates";
+
+const versionPattern = String.raw`^\d+\.\d+\.\d+(?:-(?:\d+|beta(?:\.\d+)?))?$`;
+
+const FeatureGateSchema = Type.Object(
+  {
+    enable: Type.Boolean(),
+    minPluginVersion: Type.String({ pattern: versionPattern }),
+    minOpenclawVersion: Type.String({ minLength: 1 }),
+    editions: Type.Array(Type.String({ minLength: 1 }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
+  },
+  { additionalProperties: false },
+);
+
+const FeatureGatesConfigSchema = Type.Object(
+  {
+    features: Type.Record(Type.String({ minLength: 1 }), FeatureGateSchema),
+  },
+  { additionalProperties: false },
+);
+
+type FeatureGatesConfig = Static<typeof FeatureGatesConfigSchema>;
+
+interface ParsedVersion {
+  year: number;
+  month: number;
+  day: number;
+  channelRank: number;
+  sequence: number;
+}
+
+export interface OpenVikingFeatureGateServiceOptions {
+  configPath?: string;
+  getPluginVersion?: () => string;
+  getOpenClawVersion?: () => Promise<string>;
+  getOpenClawVersionSync?: () => string;
+}
+
+export interface OpenVikingFeatureGateService {
+  getEnabledFeatureGates(edition?: string): Promise<string[]>;
+  isFeatureGateEnabled(featureName: string, edition?: string): Promise<boolean>;
+  isFeatureGateEnabledSync(featureName: string, edition?: string): boolean;
+}
+
+export interface OpenVikingFeatureGatesGatewayApi {
+  registerGatewayMethod?: (
+    name: string,
+    handler: (input: {
+      params?: unknown;
+      respond: (success: boolean, data: unknown) => void;
+    }) => void | Promise<void>,
+  ) => void;
+}
+
+function parseVersion(version: string): ParsedVersion | null {
+  const stableMatch = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\d+))?$/);
+  if (stableMatch) {
+    return {
+      year: Number(stableMatch[1]),
+      month: Number(stableMatch[2]),
+      day: Number(stableMatch[3]),
+      channelRank: 1,
+      sequence: stableMatch[4] ? Number(stableMatch[4]) : 0,
+    };
+  }
+
+  const betaMatch = version.match(/^(\d+)\.(\d+)\.(\d+)-beta(?:\.(\d+))?$/);
+  if (betaMatch) {
+    return {
+      year: Number(betaMatch[1]),
+      month: Number(betaMatch[2]),
+      day: Number(betaMatch[3]),
+      channelRank: 0,
+      sequence: betaMatch[4] ? Number(betaMatch[4]) : 0,
+    };
+  }
+
+  return null;
+}
+
+export function isPluginVersionAtLeast(currentVersion: string, minVersion: string): boolean {
+  const current = parseVersion(currentVersion);
+  const minimum = parseVersion(minVersion);
+  if (!current || !minimum) {
+    return false;
+  }
+
+  if (current.year !== minimum.year) return current.year > minimum.year;
+  if (current.month !== minimum.month) return current.month > minimum.month;
+  if (current.day !== minimum.day) return current.day > minimum.day;
+  if (current.channelRank !== minimum.channelRank) {
+    return current.channelRank > minimum.channelRank;
+  }
+  return current.sequence >= minimum.sequence;
+}
+
+export function isOpenClawVersionAtLeast(currentVersion: string, minVersion: string): boolean {
+  return isPluginVersionAtLeast(currentVersion, minVersion);
+}
+
+function formatSchemaError(path: string, message: string): string {
+  const normalizedPath = path ? path.replace(/\//g, ".").replace(/^\./, "") : "$";
+  return `${normalizedPath}: ${message}`;
+}
+
+function parseFeatureGatesConfig(raw: string): FeatureGatesConfig {
+  const parsed = JSON.parse(raw) as unknown;
+  if (Value.Check(FeatureGatesConfigSchema, parsed)) {
+    return parsed;
+  }
+
+  const validationError = Value.Errors(FeatureGatesConfigSchema, parsed).First();
+  const errorMessage = validationError
+    ? formatSchemaError(validationError.path, validationError.message)
+    : "unknown validation error";
+  throw new Error(`Invalid feature-gates.json: ${errorMessage}`);
+}
+
+function normalizeFeatures(
+  features: FeatureGatesConfig["features"],
+  pluginVersion: string,
+  openclawVersion: string,
+  edition?: string,
+): string[] {
+  const requestedEdition = edition?.trim();
+  const businessCarriers = (process.env.BUSINESS_CARRIER ?? "")
+    .split(",")
+    .map((carrier) => carrier.trim())
+    .filter(Boolean);
+  const effectiveEditions = requestedEdition ? [requestedEdition] : businessCarriers;
+
+  return Object.entries(features).flatMap(([featureName, featureConfig]) => {
+    const editionOk =
+      effectiveEditions.length > 0 &&
+      effectiveEditions.some((carrier) => featureConfig.editions.includes(carrier));
+
+    if (
+      featureConfig.enable &&
+      editionOk &&
+      isPluginVersionAtLeast(pluginVersion, featureConfig.minPluginVersion) &&
+      isOpenClawVersionAtLeast(openclawVersion, featureConfig.minOpenclawVersion)
+    ) {
+      return [featureName];
+    }
+    return [];
+  });
+}
+
+let cachedPackageRoot: string | undefined;
+let cachedDefaultPluginVersion: string | undefined;
+
+function findPackageRoot(startDir: string): string {
+  let current = startDir;
+  for (;;) {
+    if (existsSync(join(current, "package.json"))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return startDir;
+    }
+    current = parent;
+  }
+}
+
+function getPackageRoot(): string {
+  cachedPackageRoot ??= findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+  return cachedPackageRoot;
+}
+
+function getDefaultFeatureGatesPath(): string {
+  return join(getPackageRoot(), "config", "feature-gates.json");
+}
+
+function getDefaultPluginVersion(): string {
+  if (cachedDefaultPluginVersion) {
+    return cachedDefaultPluginVersion;
+  }
+  try {
+    const raw = readFileSync(join(getPackageRoot(), "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    cachedDefaultPluginVersion = typeof parsed.version === "string" ? parsed.version : "0.0.0";
+  } catch {
+    cachedDefaultPluginVersion = "0.0.0";
+  }
+  return cachedDefaultPluginVersion;
+}
+
+function getDefaultOpenClawVersionSync(): string {
+  const envVersion = process.env.OPENCLAW_VERSION?.trim();
+  return envVersion || "2026.4.8";
+}
+
+export function createOpenVikingFeatureGateService(
+  options: OpenVikingFeatureGateServiceOptions = {},
+): OpenVikingFeatureGateService {
+  const configPath = options.configPath ?? getDefaultFeatureGatesPath();
+  const getPluginVersion = options.getPluginVersion ?? getDefaultPluginVersion;
+  const getOpenClawVersion = options.getOpenClawVersion ?? (async () => getDefaultOpenClawVersionSync());
+  const getOpenClawVersionSync = options.getOpenClawVersionSync ?? getDefaultOpenClawVersionSync;
+  let cachedConfig: FeatureGatesConfig | undefined;
+  let cachedConfigPromise: Promise<FeatureGatesConfig> | undefined;
+  let cachedOpenClawVersion: string | undefined;
+  let cachedOpenClawVersionPromise: Promise<string> | undefined;
+
+  async function loadFeatureGatesConfig(): Promise<FeatureGatesConfig> {
+    if (cachedConfig) {
+      return cachedConfig;
+    }
+    cachedConfigPromise ??= readFile(configPath, "utf8")
+      .then((raw) => {
+        cachedConfig = parseFeatureGatesConfig(raw);
+        return cachedConfig;
+      })
+      .catch((error: unknown) => {
+        cachedConfigPromise = undefined;
+        throw error;
+      });
+    return cachedConfigPromise;
+  }
+
+  function loadFeatureGatesConfigSync(): FeatureGatesConfig {
+    if (cachedConfig) {
+      return cachedConfig;
+    }
+    const raw = readFileSync(configPath, "utf8");
+    cachedConfig = parseFeatureGatesConfig(raw);
+    return cachedConfig;
+  }
+
+  async function loadOpenClawVersion(): Promise<string> {
+    if (cachedOpenClawVersion) {
+      return cachedOpenClawVersion;
+    }
+    cachedOpenClawVersionPromise ??= getOpenClawVersion()
+      .then((version) => {
+        cachedOpenClawVersion = version;
+        return version;
+      })
+      .catch((error: unknown) => {
+        cachedOpenClawVersionPromise = undefined;
+        throw error;
+      });
+    return cachedOpenClawVersionPromise;
+  }
+
+  function loadOpenClawVersionSync(): string {
+    cachedOpenClawVersion ??= getOpenClawVersionSync();
+    return cachedOpenClawVersion;
+  }
+
+  function loadAndNormalizeFeaturesSync(edition?: string): string[] {
+    const parsed = loadFeatureGatesConfigSync();
+    return normalizeFeatures(parsed.features, getPluginVersion(), loadOpenClawVersionSync(), edition);
+  }
+
+  async function loadAndNormalizeFeatures(edition?: string): Promise<string[]> {
+    const [parsed, openclawVersion] = await Promise.all([
+      loadFeatureGatesConfig(),
+      loadOpenClawVersion(),
+    ]);
+    return normalizeFeatures(parsed.features, getPluginVersion(), openclawVersion, edition);
+  }
+
+  return {
+    async getEnabledFeatureGates(edition?: string): Promise<string[]> {
+      return loadAndNormalizeFeatures(edition);
+    },
+
+    async isFeatureGateEnabled(featureName: string, edition?: string): Promise<boolean> {
+      try {
+        const features = await loadAndNormalizeFeatures(edition);
+        return features.includes(featureName);
+      } catch {
+        return false;
+      }
+    },
+
+    isFeatureGateEnabledSync(featureName: string, edition?: string): boolean {
+      try {
+        const features = loadAndNormalizeFeaturesSync(edition);
+        return features.includes(featureName);
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+function readEditionParam(params: unknown): string | undefined {
+  if (!params || typeof params !== "object") {
+    return undefined;
+  }
+  const value = (params as { edition?: unknown }).edition;
+  return typeof value === "string" ? value : undefined;
+}
+
+const defaultFeatureGateService = createOpenVikingFeatureGateService();
+
+export const getEnabledFeatureGates = (edition?: string): Promise<string[]> =>
+  defaultFeatureGateService.getEnabledFeatureGates(edition);
+export const isFeatureGateEnabled = (featureName: string, edition?: string): Promise<boolean> =>
+  defaultFeatureGateService.isFeatureGateEnabled(featureName, edition);
+export const isFeatureGateEnabledSync = (featureName: string, edition?: string): boolean =>
+  defaultFeatureGateService.isFeatureGateEnabledSync(featureName, edition);
+
+export function registerOpenVikingFeatureGatesMethod(
+  api: OpenVikingFeatureGatesGatewayApi,
+  service: OpenVikingFeatureGateService = defaultFeatureGateService,
+): void {
+  if (typeof api.registerGatewayMethod !== "function") {
+    return;
+  }
+
+  api.registerGatewayMethod(OPENVIKING_FEATURE_GATES_RPC, async ({ params, respond }) => {
+    try {
+      const edition = readEditionParam(params);
+      const features = await service.getEnabledFeatureGates(edition);
+      respond(true, { features });
+    } catch (error) {
+      respond(false, error instanceof Error ? error.message : String(error));
+    }
+  });
+}

--- a/examples/openclaw-plugin/plugin/openviking-import-runtime.ts
+++ b/examples/openclaw-plugin/plugin/openviking-import-runtime.ts
@@ -1,0 +1,105 @@
+import type {
+  AddResourceInput,
+  AddResourceResult,
+  AddSkillInput,
+  AddSkillResult,
+} from "../client.js";
+
+export type OpenVikingImportRuntimeResourceInput = {
+  source?: string;
+  to?: string;
+  parent?: string;
+  reason?: string;
+  instruction?: string;
+  wait?: boolean;
+  timeout?: number;
+};
+
+export type OpenVikingImportRuntimeSkillInput = {
+  source?: string;
+  data?: unknown;
+  wait?: boolean;
+  timeout?: number;
+};
+
+export type OpenVikingImportRuntimeToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details?: Record<string, unknown>;
+};
+
+export type OpenVikingImportRuntimeClient = {
+  addResource: (input: AddResourceInput, agentId?: string) => Promise<AddResourceResult>;
+  addSkill: (input: AddSkillInput, agentId?: string) => Promise<AddSkillResult>;
+};
+
+export type OpenVikingImportRuntimeDeps = {
+  getClient: () => Promise<OpenVikingImportRuntimeClient>;
+};
+
+function formatResourceImportText(result: AddResourceResult): string {
+  const root = result.root_uri ? ` ${result.root_uri}` : "";
+  const warnings = result.warnings?.length ? ` Warnings: ${result.warnings.join("; ")}` : "";
+  return `Imported OpenViking resource.${root}${warnings}`.trim();
+}
+
+function formatSkillImportText(result: AddSkillResult): string {
+  const uri = result.uri ? ` ${result.uri}` : "";
+  const name = result.name ? ` (${result.name})` : "";
+  return `Imported OpenViking skill${name}.${uri}`.trim();
+}
+
+export function createOpenVikingImportRuntime(deps: OpenVikingImportRuntimeDeps): {
+  addResourceOpenViking: (
+    input: OpenVikingImportRuntimeResourceInput,
+    agentId?: string,
+  ) => Promise<OpenVikingImportRuntimeToolResult>;
+  addSkillOpenViking: (
+    input: OpenVikingImportRuntimeSkillInput,
+    agentId?: string,
+  ) => Promise<OpenVikingImportRuntimeToolResult>;
+} {
+  const importResource = async (input: AddResourceInput, agentId?: string): Promise<OpenVikingImportRuntimeToolResult> => {
+    const client = await deps.getClient();
+    const result = await client.addResource(input, agentId);
+    return {
+      content: [{ type: "text", text: formatResourceImportText(result) }],
+      details: {
+        action: "resource_imported",
+        ...result,
+      },
+    };
+  };
+
+  const importSkill = async (input: AddSkillInput, agentId?: string): Promise<OpenVikingImportRuntimeToolResult> => {
+    const client = await deps.getClient();
+    const result = await client.addSkill(input, agentId);
+    return {
+      content: [{ type: "text", text: formatSkillImportText(result) }],
+      details: {
+        action: "skill_imported",
+        ...result,
+      },
+    };
+  };
+
+  const addResourceOpenViking = (input: OpenVikingImportRuntimeResourceInput, agentId?: string) =>
+    importResource({
+      pathOrUrl: input.source ?? "",
+      to: input.to,
+      parent: input.parent,
+      reason: input.reason,
+      instruction: input.instruction,
+      wait: input.wait,
+      timeout: input.timeout,
+    }, agentId);
+
+  const addSkillOpenViking = (input: OpenVikingImportRuntimeSkillInput, agentId?: string) =>
+    importSkill({
+      path: input.source,
+      data: input.data,
+      wait: input.wait,
+      timeout: input.timeout,
+    }, agentId);
+
+  return { addResourceOpenViking, addSkillOpenViking };
+}

--- a/examples/openclaw-plugin/plugin/openviking-import-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-import-tools.ts
@@ -1,0 +1,133 @@
+import { Type } from "@sinclair/typebox";
+
+import type {
+  AddResourceInput,
+  AddResourceResult,
+  AddSkillInput,
+  AddSkillResult,
+} from "../client.js";
+
+export type OpenVikingImportToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+};
+
+export type OpenVikingImportSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OpenVikingImportClient = {
+  addResource: (input: AddResourceInput, agentId?: string) => Promise<AddResourceResult>;
+  addSkill: (input: AddSkillInput, agentId?: string) => Promise<AddSkillResult>;
+};
+
+export type OpenVikingImportToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  getClient: () => Promise<OpenVikingImportClient>;
+  resolvePluginSessionRouting: (ctx?: OpenVikingImportToolContext) => OpenVikingImportSession;
+  isBypassedSession: (ctx?: OpenVikingImportToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+  enableAddResourceTool: boolean;
+};
+
+function formatResourceImportText(result: AddResourceResult): string {
+  const root = result.root_uri ? ` ${result.root_uri}` : "";
+  const warnings = result.warnings?.length ? ` Warnings: ${result.warnings.join("; ")}` : "";
+  return `Imported OpenViking resource.${root}${warnings}`.trim();
+}
+
+function formatSkillImportText(result: AddSkillResult): string {
+  const uri = result.uri ? ` ${result.uri}` : "";
+  const name = result.name ? ` (${result.name})` : "";
+  return `Imported OpenViking skill${name}.${uri}`.trim();
+}
+
+export function registerOpenVikingImportTools(deps: OpenVikingImportToolsDeps): void {
+  if (deps.enableAddResourceTool) {
+    deps.registerTool(
+      (ctx: OpenVikingImportToolContext) => ({
+        name: "add_resource",
+        label: "Add Resource (OpenViking)",
+        description:
+          "Use only when the user explicitly asks to import, add, upload, save, or index a document, directory, URL, Git repository, or OpenClaw media attachment into OpenViking resources. " +
+          "Never use this during search, retrieval, URI reading, or search-result optimization; use ov_search and ov_read for those flows. " +
+          "For a '[media attached: /path ...]' document, set source to that exact local media path. Do not invent OpenViking upload REST endpoints.",
+        parameters: Type.Object({
+          source: Type.String({ description: "Local path, OpenClaw media attachment path, directory path, public URL, or Git URL" }),
+          to: Type.Optional(Type.String({ description: "Exact target URI, e.g. viking://resources/project-docs" })),
+          parent: Type.Optional(Type.String({ description: "Parent URI under viking://resources" })),
+          reason: Type.Optional(Type.String({ description: "Reason or note for adding this resource" })),
+          instruction: Type.Optional(Type.String({ description: "Processing instruction for semantic extraction" })),
+          wait: Type.Optional(Type.Boolean({ description: "Wait for processing to complete" })),
+          timeout: Type.Optional(Type.Number({ description: "Timeout in seconds when wait is true" })),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          if (deps.isBypassedSession(ctx)) {
+            return deps.makeBypassedToolResult("add_resource");
+          }
+          const session = deps.resolvePluginSessionRouting(ctx);
+          const client = await deps.getClient();
+          const result = await client.addResource({
+            pathOrUrl: typeof params.source === "string" ? params.source : "",
+            to: typeof params.to === "string" ? params.to : undefined,
+            parent: typeof params.parent === "string" ? params.parent : undefined,
+            reason: typeof params.reason === "string" ? params.reason : undefined,
+            instruction: typeof params.instruction === "string" ? params.instruction : undefined,
+            wait: typeof params.wait === "boolean" ? params.wait : undefined,
+            timeout: typeof params.timeout === "number" ? params.timeout : undefined,
+          }, session.agentId);
+          return {
+            content: [{ type: "text" as const, text: formatResourceImportText(result) }],
+            details: {
+              action: "resource_imported",
+              ...result,
+            },
+          };
+        },
+      }),
+      { name: "add_resource" },
+    );
+  }
+
+  deps.registerTool(
+    (ctx: OpenVikingImportToolContext) => ({
+      name: "add_skill",
+      label: "Add Skill (OpenViking)",
+      description:
+        "Use only when the user explicitly asks to import, add, install, or register a skill into OpenViking. " +
+        "Set source to a local SKILL.md file or skill directory, or data to raw SKILL.md content or an MCP tool dict.",
+      parameters: Type.Object({
+        source: Type.Optional(Type.String({ description: "Local SKILL.md path or skill directory path" })),
+        data: Type.Optional(Type.Any({ description: "Raw SKILL.md content or MCP tool dict" })),
+        wait: Type.Optional(Type.Boolean({ description: "Wait for processing to complete" })),
+        timeout: Type.Optional(Type.Number({ description: "Timeout in seconds when wait is true" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("add_skill");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const client = await deps.getClient();
+        const result = await client.addSkill({
+          path: typeof params.source === "string" ? params.source : undefined,
+          data: params.data,
+          wait: typeof params.wait === "boolean" ? params.wait : undefined,
+          timeout: typeof params.timeout === "number" ? params.timeout : undefined,
+        }, session.agentId);
+        return {
+          content: [{ type: "text" as const, text: formatSkillImportText(result) }],
+          details: {
+            action: "skill_imported",
+            ...result,
+          },
+        };
+      },
+    }),
+    { name: "add_skill" },
+  );
+}

--- a/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
+++ b/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
@@ -1,0 +1,65 @@
+export type OpenVikingHookContext = {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+};
+
+export type ContextEngineCommitPort = {
+  commitOVSession: (ctx: { sessionId: string; sessionKey?: string }) => Promise<boolean>;
+};
+
+export type OpenVikingLifecycleHookApi = {
+  on: (
+    hookName: string,
+    handler: (event: unknown, ctx?: OpenVikingHookContext) => unknown,
+    opts?: { priority?: number },
+  ) => void;
+};
+
+export type OpenVikingLifecycleHooksDeps = {
+  api: OpenVikingLifecycleHookApi;
+  rememberSessionAgentId: (ctx: OpenVikingHookContext) => void;
+  isBypassedSession: (ctx?: OpenVikingHookContext) => boolean;
+  verboseRoutingInfo: (message: string) => void;
+  getContextEngine: () => ContextEngineCommitPort | null;
+  logger: {
+    info: (message: string) => void;
+    warn: (message: string) => void;
+  };
+};
+
+export function registerOpenVikingLifecycleHooks(deps: OpenVikingLifecycleHooksDeps): void {
+  deps.api.on("session_start", async (_event: unknown, ctx?: OpenVikingHookContext) => {
+    deps.rememberSessionAgentId(ctx ?? {});
+  });
+  deps.api.on("session_end", async (_event: unknown, ctx?: OpenVikingHookContext) => {
+    deps.rememberSessionAgentId(ctx ?? {});
+  });
+  deps.api.on("before_reset", async (_event: unknown, ctx?: OpenVikingHookContext) => {
+    if (deps.isBypassedSession(ctx)) {
+      deps.verboseRoutingInfo(
+        `openviking: bypassing before_reset due to session pattern match (sessionKey=${ctx?.sessionKey ?? "none"}, sessionId=${ctx?.sessionId ?? "none"})`,
+      );
+      return;
+    }
+    const sessionId = ctx?.sessionId;
+    const contextEngine = deps.getContextEngine();
+    if (sessionId && contextEngine) {
+      try {
+        const ok = await contextEngine.commitOVSession({
+          sessionId,
+          sessionKey: ctx?.sessionKey,
+        });
+        if (ok) {
+          deps.logger.info(`openviking: committed OV session on reset for session=${sessionId}`);
+        }
+      } catch (err) {
+        deps.logger.warn(`openviking: failed to commit OV session on reset: ${String(err)}`);
+      }
+    }
+  });
+  deps.api.on("after_compaction", async (_event: unknown, _ctx?: OpenVikingHookContext) => {
+    // Reserved hook registration for future post-compaction memory integration.
+  });
+}

--- a/examples/openclaw-plugin/plugin/openviking-memory-recall-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-memory-recall-tools.ts
@@ -1,0 +1,362 @@
+import { Type } from "@sinclair/typebox";
+
+import type { FindResult, FindResultItem } from "../client.js";
+import type { BuildMemoryLinesWithBudgetOptions } from "../auto-recall.js";
+import type { RankingOptions } from "../memory-ranking.js";
+import type { EffectiveQueryConfig, QueryConfigContext, RuntimeQueryParams } from "../query-config.js";
+import type { RecallResourceType } from "../registries/recall-resource-types.js";
+import type {
+  RecallTraceEntry,
+  RecallTraceResult,
+} from "../recall-trace.js";
+
+export type OpenVikingMemoryRecallToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+};
+
+export type OpenVikingMemoryRecallSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OpenVikingMemoryRecallClient = {
+  find: (
+    query: string,
+    options: { targetUri: string; limit: number; scoreThreshold: number },
+    agentId?: string,
+  ) => Promise<FindResult>;
+  read: (uri: string, agentId?: string) => Promise<string>;
+  getDefaultAgentId: () => string;
+};
+
+export type OpenVikingMemoryRecallToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  getClient: () => Promise<OpenVikingMemoryRecallClient>;
+  queryConfigStore: {
+    getEffective: (
+      ctx: QueryConfigContext,
+      request?: RuntimeQueryParams,
+    ) => Promise<EffectiveQueryConfig>;
+  };
+  toQueryConfigContext: (session: OpenVikingMemoryRecallSession) => QueryConfigContext;
+  resolvePluginSessionRouting: (
+    ctx?: OpenVikingMemoryRecallToolContext,
+  ) => OpenVikingMemoryRecallSession;
+  isBypassedSession: (ctx?: OpenVikingMemoryRecallToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+  resolveRecallSearchPlan: (
+    resourceTypes: unknown,
+    ctx: { ovSessionId?: string; agentId?: string },
+  ) => {
+    resourceTypes: RecallResourceType[];
+    searches: Array<{ resourceType: RecallResourceType; targetUri: string }>;
+    skipped: Array<{ resourceType: RecallResourceType; reason: "missing_session" }>;
+  };
+  postProcessMemories: (
+    items: FindResultItem[],
+    options: { limit: number; scoreThreshold: number },
+  ) => FindResultItem[];
+  pickMemoriesForInjection: (
+    items: FindResultItem[],
+    limit: number,
+    queryText: string,
+    scoreThreshold: number,
+    rankingOptions?: RankingOptions,
+  ) => FindResultItem[];
+  buildMemoryLinesWithBudget: (
+    memories: FindResultItem[],
+    readFn: (uri: string) => Promise<string>,
+    options: BuildMemoryLinesWithBudgetOptions,
+  ) => Promise<{ lines: string[]; estimatedTokens: number }>;
+  inferRecallResourceType: (uri: string) => RecallResourceType | undefined;
+  createTraceId: (source: string) => string;
+  boundTraceQuery: (query: string, maxChars: number) => { query: string; queryTruncated?: boolean };
+  previewText: (value: unknown, maxChars: number) => string | undefined;
+  traceRecorder?: { recordAndFlush?: (entry: RecallTraceEntry) => Promise<unknown> };
+  cfg: {
+    recallTargetTypes: RecallResourceType[];
+    traceRecallMaxResultsPerSearch: number;
+    traceRecallPreviewChars: number;
+    traceRecallQueryMaxChars: number;
+    logFindRequests: boolean;
+  };
+  logger: {
+    info?: (message: string) => void;
+  };
+};
+
+function toTraceResult(
+  item: FindResultItem,
+  resultType: RecallTraceResult["resultType"],
+  deps: OpenVikingMemoryRecallToolsDeps,
+): RecallTraceResult {
+  return {
+    uri: item.uri,
+    resourceType: deps.inferRecallResourceType(item.uri),
+    category: item.category,
+    score: item.score,
+    level: item.level,
+    abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
+    resultType,
+  };
+}
+
+export function registerOpenVikingMemoryRecallTools(
+  deps: OpenVikingMemoryRecallToolsDeps,
+): void {
+  deps.registerTool(
+    (ctx: OpenVikingMemoryRecallToolContext) => ({
+      name: "memory_recall",
+      label: "Memory Recall (OpenViking)",
+      description:
+        "Search long-term memories from OpenViking. Use when you need past user preferences, facts, or decisions.",
+      parameters: Type.Object({
+        query: Type.String({ description: "Search query" }),
+        limit: Type.Optional(
+          Type.Number({ description: "Max results (default: plugin config)" }),
+        ),
+        scoreThreshold: Type.Optional(
+          Type.Number({ description: "Minimum score (0-1, default: plugin config)" }),
+        ),
+        targetUri: Type.Optional(
+          Type.String({ description: "Search scope URI (default: plugin config)" }),
+        ),
+        resourceTypes: Type.Optional(
+          Type.Array(Type.String({ description: "resource, user, or agent; used when targetUri is omitted" })),
+        ),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("memory_recall");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const { query } = params as { query: string };
+        const queryConfig = await deps.queryConfigStore.getEffective(deps.toQueryConfigContext(session), {
+          recallLimit: typeof (params as { limit?: number }).limit === "number" ? (params as { limit: number }).limit : undefined,
+          scoreThreshold: typeof (params as { scoreThreshold?: number }).scoreThreshold === "number" ? (params as { scoreThreshold: number }).scoreThreshold : undefined,
+          targetUri: typeof (params as { targetUri?: string }).targetUri === "string" ? (params as { targetUri: string }).targetUri : undefined,
+          resourceTypes: Object.prototype.hasOwnProperty.call(params, "resourceTypes")
+            ? (params as { resourceTypes?: unknown }).resourceTypes as RuntimeQueryParams["resourceTypes"]
+            : undefined,
+        });
+        const limit = queryConfig.recallLimit;
+        const scoreThreshold = queryConfig.scoreThreshold;
+        const targetUri =
+          typeof (params as { targetUri?: string }).targetUri === "string"
+            ? (params as { targetUri: string }).targetUri
+            : queryConfig.targetUri;
+        const requestedResourceTypes = Object.prototype.hasOwnProperty.call(params, "resourceTypes")
+          ? (params as { resourceTypes?: unknown }).resourceTypes
+          : queryConfig.resourceTypes;
+        const requestLimit = queryConfig.candidateLimit;
+
+        const recallClient = await deps.getClient();
+        if (deps.cfg.logFindRequests) {
+          deps.logger.info?.(
+            `openviking: memory_recall X-OpenViking-Actor-Peer="${session.agentId}" ` +
+              `(plugin defaultAgentId="${recallClient.getDefaultAgentId()}" is unused when session context is present)`,
+          );
+        }
+
+        let result: FindResult;
+        let memoryRecallSearches: RecallTraceEntry["searches"] = [];
+        if (targetUri) {
+          result = await recallClient.find(
+            query,
+            {
+              targetUri,
+              limit: requestLimit,
+              scoreThreshold: 0,
+            },
+            session.agentId,
+          );
+          const traceResults = [
+            ...(result.memories ?? []).map((item) => toTraceResult(item, "memory", deps)),
+            ...(result.resources ?? []).map((item) => toTraceResult(item, "resource", deps)),
+          ].slice(0, deps.cfg.traceRecallMaxResultsPerSearch);
+          memoryRecallSearches = [{
+            resourceType: deps.inferRecallResourceType(targetUri) ?? "resource",
+            targetUriInput: targetUri,
+            targetUriResolved: targetUri,
+            limit: requestLimit,
+            scoreThreshold,
+            durationMs: 0,
+            total: result.total ?? traceResults.length,
+            results: traceResults,
+          }];
+        } else {
+          const searchPlan = deps.resolveRecallSearchPlan(requestedResourceTypes ?? deps.cfg.recallTargetTypes, {
+            ovSessionId: session.ovSessionId,
+            agentId: session.agentId,
+          });
+          const settled = await Promise.allSettled(searchPlan.searches.map((search) =>
+            recallClient.find(
+              query,
+              {
+                targetUri: search.targetUri,
+                limit: requestLimit,
+                scoreThreshold: 0,
+              },
+              session.agentId,
+            ),
+          ));
+          const allMemories: FindResultItem[] = [];
+          for (let index = 0; index < settled.length; index += 1) {
+            const s = settled[index]!;
+            const search = searchPlan.searches[index]!;
+            if (s.status === "fulfilled") {
+              allMemories.push(...(s.value.memories ?? []), ...(s.value.resources ?? []));
+              memoryRecallSearches.push({
+                resourceType: search.resourceType,
+                targetUriInput: search.targetUri,
+                targetUriResolved: search.targetUri,
+                limit: requestLimit,
+                scoreThreshold,
+                durationMs: 0,
+                total: s.value.total ?? ((s.value.memories ?? []).length + (s.value.resources ?? []).length),
+                results: [
+                  ...(s.value.memories ?? []).map((item) => toTraceResult(item, "memory", deps)),
+                  ...(s.value.resources ?? []).map((item) => toTraceResult(item, "resource", deps)),
+                ].slice(0, deps.cfg.traceRecallMaxResultsPerSearch),
+              });
+            } else {
+              memoryRecallSearches.push({
+                resourceType: search.resourceType,
+                targetUriInput: search.targetUri,
+                targetUriResolved: search.targetUri,
+                limit: requestLimit,
+                scoreThreshold,
+                durationMs: 0,
+                total: 0,
+                results: [],
+                error: s.reason instanceof Error ? s.reason.message : String(s.reason),
+              });
+            }
+          }
+          const uniqueMemories = allMemories.filter((memory, index, self) =>
+            index === self.findIndex((m) => m.uri === memory.uri)
+          );
+          const leafOnly = uniqueMemories.filter((m) => !m.level || m.level === 2);
+          result = {
+            memories: leafOnly,
+            total: leafOnly.length,
+          };
+        }
+
+        const leafOnly = (result.memories ?? []).filter((m) => !m.level || m.level === 2);
+        const processed = deps.postProcessMemories(leafOnly, {
+          limit: requestLimit,
+          scoreThreshold,
+        });
+        const memories = deps.pickMemoriesForInjection(processed, limit, query, scoreThreshold, {
+          weights: queryConfig.rankingWeights,
+          categoryWeights: queryConfig.categoryWeights,
+          resourceTypeWeights: queryConfig.resourceTypeWeights,
+        });
+        const candidateTraceResults = leafOnly
+          .map((item) => toTraceResult(item, deps.inferRecallResourceType(item.uri) === "resource" ? "resource" : "memory", deps))
+          .slice(0, deps.cfg.traceRecallMaxResultsPerSearch);
+        const traceResourceTypes = [...new Set(
+          (targetUri ? [deps.inferRecallResourceType(targetUri)] : memoryRecallSearches.map((search) => search.resourceType))
+            .filter((resourceType): resourceType is RecallResourceType => Boolean(resourceType)),
+        )];
+        const recordMemoryRecallTrace = async (injectedUris: Set<string>) => {
+          await deps.traceRecorder?.recordAndFlush?.({
+            schemaVersion: "1.0",
+            traceId: deps.createTraceId("memory_recall"),
+            ts: Date.now(),
+            sessionId: session.sessionId,
+            sessionKey: session.sessionKey,
+            ovSessionId: session.ovSessionId,
+            agentId: session.agentId,
+            source: "memory_recall",
+            operationType: "semantic_find",
+            resourceTypes: traceResourceTypes.length > 0 ? traceResourceTypes : ["resource"],
+            trigger: deps.boundTraceQuery(query, deps.cfg.traceRecallQueryMaxChars),
+            searches: memoryRecallSearches.length > 0 ? memoryRecallSearches : [{
+              resourceType: "resource",
+              targetUriInput: targetUri,
+              targetUriResolved: targetUri ?? "viking://resources",
+              limit: requestLimit,
+              scoreThreshold,
+              durationMs: 0,
+              total: result.total ?? leafOnly.length,
+              results: candidateTraceResults,
+            }],
+            selected: memories.map((item) => ({
+              uri: item.uri,
+              resourceType: deps.inferRecallResourceType(item.uri),
+              category: item.category,
+              score: item.score,
+              abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
+              injected: injectedUris.has(item.uri),
+              displayed: injectedUris.has(item.uri),
+            })),
+            stats: {
+              candidateCount: leafOnly.length,
+              selectedCount: memories.length,
+              injectedCount: injectedUris.size,
+            },
+          });
+        };
+        if (memories.length === 0) {
+          await recordMemoryRecallTrace(new Set());
+          return {
+            content: [{ type: "text", text: "No relevant OpenViking memories found." }],
+            details: { count: 0, total: result.total ?? 0, scoreThreshold },
+          };
+        }
+        const { lines: memoryLines } = await deps.buildMemoryLinesWithBudget(
+          memories,
+          (uri) => recallClient.read(uri, session.agentId),
+          {
+            recallPreferAbstract: false,
+            recallMaxInjectedChars: queryConfig.maxInjectedChars,
+          },
+        );
+        if (memoryLines.length === 0) {
+          await recordMemoryRecallTrace(new Set());
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No complete OpenViking memories fit recallMaxInjectedChars=${queryConfig.maxInjectedChars}.`,
+              },
+            ],
+            details: {
+              count: 0,
+              memories,
+              total: result.total ?? memories.length,
+              scoreThreshold,
+              requestLimit,
+              recallMaxInjectedChars: queryConfig.maxInjectedChars,
+            },
+          };
+        }
+        await recordMemoryRecallTrace(new Set(memories.slice(0, memoryLines.length).map((item) => item.uri)));
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Found ${memoryLines.length} memories:\n\n${memoryLines.join("\n")}`,
+            },
+          ],
+          details: {
+            count: memoryLines.length,
+            memories,
+            total: result.total ?? memories.length,
+            scoreThreshold,
+            requestLimit,
+            recallMaxInjectedChars: queryConfig.maxInjectedChars,
+          },
+        };
+      },
+    }),
+    { name: "memory_recall" },
+  );
+}

--- a/examples/openclaw-plugin/plugin/openviking-memory-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-memory-tools.ts
@@ -1,0 +1,299 @@
+import { Type } from "@sinclair/typebox";
+
+import type { CommitSessionResult, FindResultItem } from "../client.js";
+import { clampScore, postProcessMemories } from "../memory-ranking.js";
+import { isMemoryUri } from "../routing/memory-uri.js";
+
+export type OpenVikingMemoryToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+  requesterSenderId?: string;
+};
+
+export type OpenVikingMemorySession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OpenVikingMemoryClient = {
+  addSessionMessage: (
+    sessionId: string,
+    role: string,
+    parts: Array<{ type: "text"; text: string }>,
+    agentId?: string,
+    createdAt?: string,
+    roleId?: string,
+  ) => Promise<void>;
+  commitSession: (
+    sessionId: string,
+    options: { wait: true; agentId: string; keepRecentCount: number },
+  ) => Promise<CommitSessionResult>;
+  deleteUri: (uri: string, agentId?: string) => Promise<void>;
+  find: (
+    query: string,
+    options: { targetUri: string; limit: number; scoreThreshold: number },
+    agentId?: string,
+  ) => Promise<{ memories?: FindResultItem[] }>;
+};
+
+export type OpenVikingMemoryToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  getClient: () => Promise<OpenVikingMemoryClient>;
+  normalizeSessionId: (sessionId: string) => string;
+  createTempSessionId: () => string;
+  extractSenderId: (ctx?: OpenVikingMemoryToolContext) => string | undefined;
+  toRoleId: (senderId?: string) => string | undefined;
+  resolvePluginSessionRouting: (ctx?: OpenVikingMemoryToolContext) => OpenVikingMemorySession;
+  isBypassedSession: (ctx?: OpenVikingMemoryToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+  defaultTargetUri: string;
+  defaultRecallScoreThreshold: number;
+  logFindRequests: boolean;
+  logger: {
+    info?: (message: string) => void;
+    warn: (message: string) => void;
+  };
+};
+
+function totalCommitMemories(r: CommitSessionResult): number {
+  const m = r.memories_extracted;
+  if (!m || typeof m !== "object") return 0;
+  return Object.values(m).reduce((sum, n) => sum + (n ?? 0), 0);
+}
+
+export function registerOpenVikingMemoryTools(deps: OpenVikingMemoryToolsDeps): void {
+  deps.registerTool(
+    (ctx: OpenVikingMemoryToolContext) => ({
+      name: "memory_store",
+      label: "Memory Store (OpenViking)",
+      description:
+        "Store text in OpenViking memory pipeline by writing to a session and running memory extraction.",
+      parameters: Type.Object({
+        text: Type.String({ description: "Information to store as memory source text" }),
+        role: Type.Optional(Type.String({ description: "Session role, default user" })),
+        sessionId: Type.Optional(Type.String({ description: "Existing OpenViking session ID" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("memory_store");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const { text } = params as { text: string };
+        const role =
+          typeof (params as { role?: string }).role === "string"
+            ? (params as { role: string }).role
+            : "user";
+        const explicitSessionId =
+          typeof (params as { sessionId?: unknown }).sessionId === "string" &&
+          (params as { sessionId: string }).sessionId.trim()
+            ? deps.normalizeSessionId((params as { sessionId: string }).sessionId)
+            : undefined;
+
+        if (deps.logFindRequests) {
+          deps.logger.info?.(
+            `openviking: memory_store invoked (textLength=${text?.length ?? 0}, sessionId=${explicitSessionId ?? "auto"})`,
+          );
+        }
+
+        let sessionId = explicitSessionId;
+        let usedTempSession = false;
+        try {
+          const client = await deps.getClient();
+          if (!sessionId) {
+            sessionId = deps.createTempSessionId();
+            usedTempSession = true;
+          }
+          const roleId = role === "user" ? deps.toRoleId(deps.extractSenderId(ctx)) : undefined;
+          await client.addSessionMessage(
+            sessionId,
+            role,
+            [{ type: "text", text }],
+            session.agentId,
+            undefined,
+            roleId,
+          );
+          const commitResult = await client.commitSession(sessionId, {
+            wait: true,
+            agentId: session.agentId,
+            keepRecentCount: 0,
+          });
+          const memoriesCount = totalCommitMemories(commitResult);
+          if (commitResult.status === "failed") {
+            deps.logger.warn(
+              `openviking: memory_store commit failed (sessionId=${sessionId}): ${commitResult.error ?? "unknown"}`,
+            );
+            return {
+              content: [{ type: "text", text: `Memory extraction failed for session ${sessionId}: ${commitResult.error ?? "unknown"}` }],
+              details: {
+                action: "failed",
+                sessionId,
+                status: "failed",
+                error: commitResult.error,
+                usedTempSession,
+              },
+            };
+          }
+          if (commitResult.status === "timeout") {
+            deps.logger.warn(
+              `openviking: memory_store commit timed out (sessionId=${sessionId}), task_id=${commitResult.task_id ?? "none"}. Memories may still be extracting in background.`,
+            );
+            return {
+              content: [{ type: "text", text: `Memory extraction timed out for session ${sessionId}. It may still complete in the background (task_id=${commitResult.task_id ?? "none"}).` }],
+              details: {
+                action: "timeout",
+                sessionId,
+                status: "timeout",
+                taskId: commitResult.task_id,
+                usedTempSession,
+              },
+            };
+          }
+          if (memoriesCount === 0) {
+            deps.logger.warn(
+              `openviking: memory_store committed but 0 memories extracted (sessionId=${sessionId}). ` +
+                "Check OpenViking server logs for embedding/extract errors (e.g. 401 API key, or extraction pipeline).",
+            );
+          } else {
+            deps.logger.info?.(`openviking: memory_store committed, memories=${memoriesCount}`);
+          }
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Stored in OpenViking session ${sessionId} and committed ${memoriesCount} memories.`,
+              },
+            ],
+            details: {
+              action: "stored",
+              sessionId,
+              memoriesCount,
+              status: commitResult.status,
+              archived: commitResult.archived ?? false,
+              usedTempSession,
+            },
+          };
+        } catch (err) {
+          deps.logger.warn(`openviking: memory_store failed: ${String(err)}`);
+          throw err;
+        }
+      },
+    }),
+    { name: "memory_store" },
+  );
+
+  deps.registerTool(
+    (ctx: OpenVikingMemoryToolContext) => ({
+      name: "memory_forget",
+      label: "Memory Forget (OpenViking)",
+      description:
+        "Forget memory by URI, or search then delete when a strong single match is found.",
+      parameters: Type.Object({
+        uri: Type.Optional(Type.String({ description: "Exact memory URI to delete" })),
+        query: Type.Optional(Type.String({ description: "Search query to find memory URI" })),
+        targetUri: Type.Optional(
+          Type.String({ description: "Search scope URI (default: plugin config)" }),
+        ),
+        limit: Type.Optional(Type.Number({ description: "Search limit (default: 5)" })),
+        scoreThreshold: Type.Optional(
+          Type.Number({ description: "Minimum score (0-1, default: plugin config)" }),
+        ),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("memory_forget");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const client = await deps.getClient();
+        const uri = (params as { uri?: string }).uri;
+        if (uri) {
+          if (!isMemoryUri(uri)) {
+            return {
+              content: [{ type: "text", text: `Refusing to delete non-memory URI: ${uri}` }],
+              details: { action: "rejected", uri },
+            };
+          }
+          await client.deleteUri(uri, session.agentId);
+          return {
+            content: [{ type: "text", text: `Forgotten: ${uri}` }],
+            details: { action: "deleted", uri },
+          };
+        }
+
+        const query = (params as { query?: string }).query;
+        if (!query) {
+          return {
+            content: [{ type: "text", text: "Provide uri or query." }],
+            details: { error: "missing_param" },
+          };
+        }
+
+        const limit =
+          typeof (params as { limit?: number }).limit === "number"
+            ? Math.max(1, Math.floor((params as { limit: number }).limit))
+            : 5;
+        const scoreThreshold =
+          typeof (params as { scoreThreshold?: number }).scoreThreshold === "number"
+            ? Math.max(0, Math.min(1, (params as { scoreThreshold: number }).scoreThreshold))
+            : deps.defaultRecallScoreThreshold;
+        const targetUri =
+          typeof (params as { targetUri?: string }).targetUri === "string"
+            ? (params as { targetUri: string }).targetUri
+            : deps.defaultTargetUri;
+        const requestLimit = Math.max(limit * 4, 20);
+
+        const result = await client.find(
+          query,
+          {
+            targetUri,
+            limit: requestLimit,
+            scoreThreshold: 0,
+          },
+          session.agentId,
+        );
+        const candidates = postProcessMemories(result.memories ?? [], {
+          limit: requestLimit,
+          scoreThreshold,
+          leafOnly: true,
+        }).filter((item) => isMemoryUri(item.uri));
+        if (candidates.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No matching leaf memory candidates found. Try a more specific query.",
+              },
+            ],
+            details: { action: "none", scoreThreshold },
+          };
+        }
+        const top = candidates[0];
+        if (candidates.length === 1 && clampScore(top.score) >= 0.85) {
+          await client.deleteUri(top.uri, session.agentId);
+          return {
+            content: [{ type: "text", text: `Forgotten: ${top.uri}` }],
+            details: { action: "deleted", uri: top.uri, score: top.score ?? 0 },
+          };
+        }
+
+        const list = candidates
+          .map((item) => `- ${item.uri} (${(clampScore(item.score) * 100).toFixed(0)}%)`)
+          .join("\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Found ${candidates.length} candidates. Specify uri:\n${list}`,
+            },
+          ],
+          details: { action: "candidates", candidates, scoreThreshold, requestLimit },
+        };
+      },
+    }),
+    { name: "memory_forget" },
+  );
+}

--- a/examples/openclaw-plugin/plugin/openviking-query-config-command.ts
+++ b/examples/openclaw-plugin/plugin/openviking-query-config-command.ts
@@ -1,0 +1,230 @@
+import type { RuntimeQueryParams } from "../query-config.js";
+import type { CommandResult, PluginCommandContext } from "./command-registration.js";
+
+type RuntimeScope = "claw" | "session";
+
+type ParsedFlagArgs = {
+  positionals: string[];
+  flags: Map<string, string | boolean>;
+};
+
+export type OpenVikingQueryConfigCommandDeps<TSession, TQueryConfigContext, TEffectiveConfig> = {
+  resolvePluginSessionRouting: (ctx?: PluginCommandContext) => TSession;
+  toQueryConfigContext: (session: TSession) => TQueryConfigContext;
+  queryConfigStore: {
+    getEffective: (ctx: TQueryConfigContext) => Promise<TEffectiveConfig>;
+    set: (scope: RuntimeScope, ctx: TQueryConfigContext, params: RuntimeQueryParams) => Promise<unknown>;
+    unset: (scope: RuntimeScope, ctx: TQueryConfigContext, fields: string[]) => Promise<unknown>;
+    reset: (scope: RuntimeScope, ctx: TQueryConfigContext) => Promise<unknown>;
+  };
+  normalizeRuntimeQueryParams: (patch: RuntimeQueryParams & Record<string, unknown>) => {
+    params: RuntimeQueryParams;
+    warnings: string[];
+  };
+};
+
+function tokenizeCommandArgs(args: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const ch = args[i]!;
+    const next = args[i + 1];
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\") {
+      const shouldEscape =
+        quote === '"'
+          ? next === '"' || next === "\\"
+          : !quote && Boolean(next && (/\s/.test(next) || next === '"' || next === "'"));
+      if (shouldEscape) {
+        escaping = true;
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+    if ((ch === '"' || ch === "'") && (!quote || quote === ch)) {
+      quote = quote ? null : ch;
+      continue;
+    }
+    if (!quote && /\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  if (quote) {
+    throw new Error("Unterminated quoted argument");
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+function parseFlagArgs(args: string): ParsedFlagArgs {
+  const tokens = tokenizeCommandArgs(args);
+  const positionals: string[] = [];
+  const flags = new Map<string, string | boolean>();
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+    const raw = token.slice(2);
+    if (!raw) {
+      continue;
+    }
+    const eqIndex = raw.indexOf("=");
+    if (eqIndex >= 0) {
+      flags.set(raw.slice(0, eqIndex), raw.slice(eqIndex + 1));
+      continue;
+    }
+    const next = tokens[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags.set(raw, next);
+      i += 1;
+    } else {
+      flags.set(raw, true);
+    }
+  }
+
+  return { positionals, flags };
+}
+
+function getStringFlag(flags: Map<string, string | boolean>, name: string): string | undefined {
+  const value = flags.get(name);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function getNumberFlag(flags: Map<string, string | boolean>, name: string): number | undefined {
+  const raw = getStringFlag(flags, name);
+  if (!raw) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`--${name} must be a number`);
+  }
+  return value;
+}
+
+function getOptionalBoolFlag(flags: Map<string, string | boolean>, name: string): boolean | undefined {
+  const value = flags.get(name);
+  if (value === undefined) return undefined;
+  if (value === true) return true;
+  if (value === false) return false;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  throw new Error(`--${name} must be a boolean`);
+}
+
+function parseNumberMapFlag(flags: Map<string, string | boolean>, name: string): Record<string, number> | undefined {
+  const raw = getStringFlag(flags, name);
+  if (!raw) return undefined;
+  const result: Record<string, number> = {};
+  for (const item of raw.split(",")) {
+    const [key, rawValue, ...rest] = item.split("=");
+    const trimmedKey = key?.trim();
+    const trimmedValue = rawValue?.trim();
+    if (!trimmedKey || !trimmedValue || rest.length > 0) {
+      throw new Error(`--${name} must use key=value pairs separated by commas`);
+    }
+    const value = Number(trimmedValue);
+    if (!Number.isFinite(value)) {
+      throw new Error(`--${name} value for ${trimmedKey} must be a number`);
+    }
+    result[trimmedKey] = value;
+  }
+  return result;
+}
+
+function parseQueryConfigPatch(flags: Map<string, string | boolean>): RuntimeQueryParams {
+  const patch: RuntimeQueryParams = {};
+  const numberFields: Array<[string, keyof RuntimeQueryParams]> = [
+    ["recallLimit", "recallLimit"],
+    ["candidateLimit", "candidateLimit"],
+    ["candidateMultiplier", "candidateMultiplier"],
+    ["scoreThreshold", "scoreThreshold"],
+    ["maxInjectedChars", "maxInjectedChars"],
+    ["ovSearchLimit", "ovSearchLimit"],
+  ];
+  for (const [flag, field] of numberFields) {
+    if (flags.has(flag)) {
+      (patch as Record<string, unknown>)[field] = getNumberFlag(flags, flag);
+    }
+  }
+  const resourceTypes = getStringFlag(flags, "resourceTypes");
+  if (resourceTypes) patch.resourceTypes = resourceTypes;
+  const targetUri = getStringFlag(flags, "targetUri");
+  if (targetUri) patch.targetUri = targetUri;
+  const recallPreferAbstract = getOptionalBoolFlag(flags, "recallPreferAbstract");
+  if (recallPreferAbstract !== undefined) patch.recallPreferAbstract = recallPreferAbstract;
+
+  const rankingWeights = parseNumberMapFlag(flags, "weight") ?? parseNumberMapFlag(flags, "rankingWeights");
+  if (rankingWeights) patch.rankingWeights = rankingWeights;
+  const categoryWeights = parseNumberMapFlag(flags, "categoryWeight") ?? parseNumberMapFlag(flags, "categoryWeights");
+  if (categoryWeights) patch.categoryWeights = categoryWeights;
+  const resourceTypeWeights = parseNumberMapFlag(flags, "resourceTypeWeight") ?? parseNumberMapFlag(flags, "resourceTypeWeights");
+  if (resourceTypeWeights) patch.resourceTypeWeights = resourceTypeWeights as RuntimeQueryParams["resourceTypeWeights"];
+  return patch;
+}
+
+export function createOpenVikingQueryConfigCommandHandler<TSession, TQueryConfigContext, TEffectiveConfig>(
+  deps: OpenVikingQueryConfigCommandDeps<TSession, TQueryConfigContext, TEffectiveConfig>,
+): (ctx: PluginCommandContext) => Promise<CommandResult> {
+  return async (ctx: PluginCommandContext): Promise<CommandResult> => {
+    const parsed = parseFlagArgs(ctx.args ?? "");
+    const action = parsed.positionals[0] ?? "get";
+    const session = deps.resolvePluginSessionRouting(ctx);
+    const scope: RuntimeScope = getStringFlag(parsed.flags, "scope") === "claw" ? "claw" : "session";
+    const queryCtx = deps.toQueryConfigContext(session);
+
+    if (action === "get") {
+      const effective = await deps.queryConfigStore.getEffective(queryCtx);
+      return { text: JSON.stringify({ scope, effective }, null, 2), details: { scope, effective } };
+    }
+    if (action === "set") {
+      const patch = parseQueryConfigPatch(parsed.flags);
+      const { params, warnings } = deps.normalizeRuntimeQueryParams(patch as RuntimeQueryParams & Record<string, unknown>);
+      if (Object.keys(params).length === 0) {
+        throw new Error("No query config parameters provided for /ov-query-config set");
+      }
+      await deps.queryConfigStore.set(scope, queryCtx, params);
+      const effective = await deps.queryConfigStore.getEffective(queryCtx);
+      return {
+        text: `Updated OpenViking query config (${scope}).${warnings.length ? ` Warnings: ${warnings.join("; ")}` : ""}`,
+        details: { scope, params, warnings, effective },
+      };
+    }
+    if (action === "unset") {
+      const fields = parsed.positionals.slice(1);
+      if (fields.length === 0) throw new Error("Usage: /ov-query-config unset <field...> [--scope session|claw]");
+      await deps.queryConfigStore.unset(scope, queryCtx, fields);
+      const effective = await deps.queryConfigStore.getEffective(queryCtx);
+      return { text: `Unset OpenViking query config fields (${scope}): ${fields.join(", ")}`, details: { scope, fields, effective } };
+    }
+    if (action === "reset") {
+      await deps.queryConfigStore.reset(scope, queryCtx);
+      const effective = await deps.queryConfigStore.getEffective(queryCtx);
+      return { text: `Reset OpenViking query config (${scope}).`, details: { scope, effective } };
+    }
+    throw new Error("Usage: /ov-query-config get|set|unset|reset [--scope session|claw] [--recallLimit N] [--candidateLimit N] [--scoreThreshold N] [--resourceTypes user,agent]");
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-query-runtime.ts
+++ b/examples/openclaw-plugin/plugin/openviking-query-runtime.ts
@@ -1,0 +1,476 @@
+import type { FindResult, FindResultItem, FsListResult } from "../client.js";
+import type { RecallResourceType } from "../registries/recall-resource-types.js";
+import type { RecallTraceEntry, RecallTraceResult } from "../recall-trace.js";
+
+export type OpenVikingSearchInput = {
+  query: string;
+  uri?: string;
+  limit?: number;
+};
+
+export type OpenVikingReadInput = {
+  uri: string;
+};
+
+export type OpenVikingMultiReadInput = {
+  uris: string[];
+};
+
+export type OpenVikingListInput = {
+  uri: string;
+  recursive?: boolean;
+  simple?: boolean;
+  limit?: number;
+};
+
+export type OpenVikingQuerySession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OpenVikingQueryToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details?: Record<string, unknown>;
+};
+
+type OpenVikingQueryConfigOverrides = {
+  ovSearchLimit?: number;
+  targetUri?: string;
+};
+
+type OpenVikingQueryConfig = {
+  ovSearchLimit?: number;
+  targetUri?: string;
+};
+
+type OpenVikingQueryClient = {
+  find: (
+    query: string,
+    options: { targetUri: string; limit: number; scoreThreshold?: number },
+    agentId?: string,
+  ) => Promise<FindResult>;
+  read: (uri: string, agentId?: string) => Promise<unknown>;
+  list: (
+    uri: string,
+    options?: { recursive?: boolean; simple?: boolean; nodeLimit?: number },
+    agentId?: string,
+  ) => Promise<FsListResult>;
+};
+
+export type OpenVikingQueryRuntimeDeps<TQueryConfigContext> = {
+  getClient: () => Promise<OpenVikingQueryClient>;
+  queryConfigStore: {
+    getEffective: (ctx: TQueryConfigContext, overrides?: OpenVikingQueryConfigOverrides) => Promise<OpenVikingQueryConfig>;
+  };
+  toQueryConfigContext: (session: OpenVikingQuerySession) => TQueryConfigContext;
+  traceRecorder?: {
+    recordAndFlush?: (entry: RecallTraceEntry) => Promise<unknown>;
+  };
+  inferRecallResourceType: (uri: string) => RecallResourceType | undefined;
+  createTraceId: (source: string) => string;
+  boundTraceQuery: (query: string, maxChars: number) => { query: string; queryTruncated?: boolean };
+  previewText: (value: unknown, maxChars: number) => string | undefined;
+  logger: { warn?: (message: string) => void };
+  cfg: {
+    traceRecallMaxResultsPerSearch: number;
+    traceRecallPreviewChars: number;
+    traceRecallQueryMaxChars: number;
+  };
+};
+
+function mergeFindResults(results: FindResult[]): FindResult {
+  const deduplicate = (items: FindResultItem[]): FindResultItem[] => {
+    const seen = new Map<string, FindResultItem>();
+    for (const item of items) {
+      if (!seen.has(item.uri)) {
+        seen.set(item.uri, item);
+      }
+    }
+    return Array.from(seen.values());
+  };
+  const memories = deduplicate(results.flatMap((result) => result.memories ?? []));
+  const resources = deduplicate(results.flatMap((result) => result.resources ?? []));
+  const skills = deduplicate(results.flatMap((result) => result.skills ?? []));
+  return {
+    memories,
+    resources,
+    skills,
+    total: memories.length + resources.length + skills.length,
+  };
+}
+
+function formatOVSearchRows(result: FindResult): string[] {
+  const truncateSummary = (value: string, maxChars = 220): string => {
+    const collapsed = value.replace(/\s+/g, " ").trim();
+    if (collapsed.length <= maxChars) {
+      return collapsed;
+    }
+    return `${collapsed.slice(0, maxChars - 3)}...`;
+  };
+  const items = [
+    ...(result.memories ?? []).map((item) => ({ contextType: "memory", item })),
+    ...(result.resources ?? []).map((item) => ({ contextType: "resource", item })),
+    ...(result.skills ?? []).map((item) => ({ contextType: "skill", item })),
+  ];
+  if (items.length === 0) {
+    return [];
+  }
+  const numberHeader = "no";
+  const numberWidth = Math.max(numberHeader.length, String(items.length).length);
+  const typeWidth = Math.max("type".length, ...items.map(({ contextType }) => contextType.length));
+  const uriWidth = Math.max("uri".length, ...items.map(({ item }) => item.uri.length));
+  const levelWidth = Math.max("level".length, ...items.map(({ item }) => String(item.level ?? "").length));
+  const scoreWidth = Math.max(
+    "score".length,
+    ...items.map(({ item }) => (typeof item.score === "number" ? item.score.toFixed(2).length : 0)),
+  );
+  return [
+    `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}  abstract`,
+    ...items.map(({ contextType, item }, index) => {
+      const score = typeof item.score === "number" ? item.score.toFixed(2) : "";
+      const summary = truncateSummary(item.abstract || item.overview || "(no summary)");
+      return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}  ${summary}`;
+    }),
+  ];
+}
+
+function formatOVSearchText(query: string, uri: string | undefined, result: FindResult): string {
+  if ((result.total ?? 0) <= 0) {
+    const scope = uri ? ` under ${uri}` : "";
+    return `No OpenViking resource or skill results found for "${query}"${scope}.`;
+  }
+  const scope = uri ? ` under ${uri}` : "";
+  const lines = [
+    `Found ${result.total ?? 0} OpenViking results for "${query}"${scope}`,
+    "Tip: search results are ranked snippets. Use ov_read on exact hit URIs before answering precise questions. Use ov_list on a hit's parent URI to inspect sibling chunks or overview files before answering procedural or multi-step questions.",
+    "",
+    ...formatOVSearchRows(result),
+    "",
+    "Note: result URIs are OpenViking virtual URIs, not local file paths. Use the ov_read tool with the exact viking:// URI to read full content; do not use filesystem read tools for these URIs.",
+  ].filter((line, index, all) => line || (all[index - 1] && all[index + 1]));
+  return lines.join("\n");
+}
+
+function validateOpenVikingUri(toolName: string, uri: string): void {
+  if (!uri) {
+    throw new Error("uri is required");
+  }
+  if (!uri.startsWith("viking://")) {
+    throw new Error(`${toolName} only accepts OpenViking viking:// URIs, not local file paths or openviking:// display aliases`);
+  }
+  if (uri.endsWith("...") || uri.includes("…")) {
+    throw new Error(
+      `${toolName} received a truncated display URI. Use the exact full viking:// URI from ov_search details/results; do not shorten it with ... or ….`,
+    );
+  }
+}
+
+function formatOVListEntry(entry: unknown): string {
+  if (typeof entry === "string") {
+    return entry;
+  }
+  if (!entry || typeof entry !== "object") {
+    return String(entry);
+  }
+  const item = entry as Record<string, unknown>;
+  const uri = typeof item.uri === "string" ? item.uri : "";
+  const name = typeof item.name === "string" ? item.name : "";
+  const isDir = item.isDir === true || item.type === "directory";
+  const marker = isDir ? "[dir]" : "[file]";
+  const summary =
+    typeof item.abstract === "string" && item.abstract.trim()
+      ? item.abstract.trim().replace(/\s+/g, " ")
+      : typeof item.overview === "string" && item.overview.trim()
+        ? item.overview.trim().replace(/\s+/g, " ")
+        : "";
+  const label = uri || name || JSON.stringify(item);
+  return summary ? `${marker} ${label} - ${summary}` : `${marker} ${label}`;
+}
+
+function formatOVListText(uri: string, entries: FsListResult): string {
+  if (entries.length === 0) {
+    return `No OpenViking entries found under ${uri}.`;
+  }
+  return [
+    `Listed ${entries.length} OpenViking entr${entries.length === 1 ? "y" : "ies"} under ${uri}`,
+    "",
+    ...entries.map((entry) => formatOVListEntry(entry)),
+  ].join("\n");
+}
+
+function formatOVReadText(uri: string, content: string): string {
+  const body = content || "(empty OpenViking content)";
+  return [`--- START OF ${uri} ---`, body, `--- END OF ${uri} ---`].join("\n");
+}
+
+function formatOVMultiReadText(results: Array<{ uri: string; content: string; success: boolean }>): string {
+  return [
+    `Multi-read results for ${results.length} OpenViking resource${results.length === 1 ? "" : "s"}:`,
+    "",
+    ...results.flatMap((result) => [
+      `--- START OF ${result.uri} ---`,
+      result.success ? (result.content || "(empty OpenViking content)") : `ERROR: ${result.content}`,
+      `--- END OF ${result.uri} ---`,
+      "",
+    ]),
+  ].join("\n").trimEnd();
+}
+
+export function createOpenVikingQueryRuntime<TQueryConfigContext>(deps: OpenVikingQueryRuntimeDeps<TQueryConfigContext>): {
+  readOpenVikingContent: (input: OpenVikingReadInput, agentId?: string) => Promise<OpenVikingQueryToolResult>;
+  multiReadOpenVikingContent: (input: OpenVikingMultiReadInput, agentId?: string) => Promise<OpenVikingQueryToolResult>;
+  listOpenVikingDirectory: (input: OpenVikingListInput, agentId?: string) => Promise<OpenVikingQueryToolResult>;
+  searchOpenViking: (input: OpenVikingSearchInput, agentId?: string, traceCtx?: OpenVikingQuerySession) => Promise<OpenVikingQueryToolResult>;
+} {
+  const toTraceResult = (
+    item: FindResultItem,
+    resultType: RecallTraceResult["resultType"],
+  ): RecallTraceResult => ({
+    uri: item.uri,
+    resourceType: deps.inferRecallResourceType(item.uri),
+    category: item.category,
+    score: item.score,
+    level: item.level,
+    abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
+    resultType,
+  });
+
+  const readOpenVikingContent = async (input: OpenVikingReadInput, agentId?: string) => {
+    const uri = input.uri.trim();
+    validateOpenVikingUri("ov_read", uri);
+    const client = await deps.getClient();
+    const content = await client.read(uri, agentId);
+    const text = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+    return {
+      content: [{ type: "text" as const, text: formatOVReadText(uri, text) }],
+      details: {
+        action: "read",
+        uri,
+        chars: text.length,
+      },
+    };
+  };
+
+  const multiReadOpenVikingContent = async (input: OpenVikingMultiReadInput, agentId?: string) => {
+    const uris = input.uris
+      .map((uri) => (typeof uri === "string" ? uri.trim() : ""))
+      .filter((uri) => uri.length > 0);
+    if (uris.length === 0) {
+      throw new Error("uris is required");
+    }
+    for (const uri of uris) {
+      validateOpenVikingUri("ov_multi_read", uri);
+    }
+    const client = await deps.getClient();
+    const results = await Promise.all(
+      uris.map(async (uri) => {
+        try {
+          const content = await client.read(uri, agentId);
+          const text = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+          return {
+            uri,
+            content: text,
+            success: true,
+            chars: text.length,
+          };
+        } catch (err) {
+          return {
+            uri,
+            content: err instanceof Error ? err.message : String(err),
+            success: false,
+            chars: 0,
+          };
+        }
+      }),
+    );
+    return {
+      content: [{ type: "text" as const, text: formatOVMultiReadText(results) }],
+      details: {
+        action: "multi_read",
+        count: results.length,
+        success_count: results.filter((result) => result.success).length,
+        results,
+      },
+    };
+  };
+
+  const listOpenVikingDirectory = async (input: OpenVikingListInput, agentId?: string) => {
+    const uri = input.uri.trim();
+    validateOpenVikingUri("ov_list", uri);
+    const limit = Math.max(1, Math.floor(input.limit ?? 100));
+    const client = await deps.getClient();
+    const entries = await client.list(uri, {
+      recursive: input.recursive ?? false,
+      simple: input.simple ?? false,
+      nodeLimit: limit,
+    }, agentId);
+    return {
+      content: [{ type: "text" as const, text: formatOVListText(uri, entries) }],
+      details: {
+        action: "listed",
+        uri,
+        recursive: input.recursive ?? false,
+        simple: input.simple ?? false,
+        count: entries.length,
+        entries,
+      },
+    };
+  };
+
+  const searchOpenViking = async (input: OpenVikingSearchInput, agentId?: string, traceCtx?: OpenVikingQuerySession) => {
+    const query = input.query.trim();
+    if (!query) {
+      throw new Error("query is required");
+    }
+    const queryConfig = traceCtx
+      ? await deps.queryConfigStore.getEffective(deps.toQueryConfigContext(traceCtx), {
+          ovSearchLimit: typeof input.limit === "number" ? input.limit : undefined,
+          targetUri: input.uri,
+        })
+      : undefined;
+    const limit = Math.max(1, Math.floor(input.limit ?? queryConfig?.ovSearchLimit ?? 10));
+    const searchUri = input.uri ?? queryConfig?.targetUri;
+    const client = await deps.getClient();
+    let result: FindResult;
+    const searches: RecallTraceEntry["searches"] = [];
+    if (searchUri) {
+      const started = Date.now();
+      result = await client.find(query, { targetUri: searchUri, limit }, agentId);
+      const items = [
+        ...(result.memories ?? []).map((item) => toTraceResult(item, "memory")),
+        ...(result.resources ?? []).map((item) => toTraceResult(item, "resource")),
+        ...(result.skills ?? []).map((item) => toTraceResult(item, "skill")),
+      ].slice(0, deps.cfg.traceRecallMaxResultsPerSearch);
+      searches.push({
+        resourceType: deps.inferRecallResourceType(searchUri) ?? "resource",
+        targetUriInput: searchUri,
+        targetUriResolved: searchUri,
+        limit,
+        durationMs: Date.now() - started,
+        total: result.total ?? items.length,
+        results: items,
+      });
+    } else {
+      const runSearch = async (targetUri: string) => {
+        const started = Date.now();
+        try {
+          const found = await client.find(query, { targetUri, limit }, agentId);
+          const items = [
+            ...(found.memories ?? []).map((item) => toTraceResult(item, "memory")),
+            ...(found.resources ?? []).map((item) => toTraceResult(item, "resource")),
+            ...(found.skills ?? []).map((item) => toTraceResult(item, "skill")),
+          ].slice(0, deps.cfg.traceRecallMaxResultsPerSearch);
+          searches.push({
+            resourceType: deps.inferRecallResourceType(targetUri) ?? "resource",
+            targetUriResolved: targetUri,
+            limit,
+            durationMs: Date.now() - started,
+            total: found.total ?? items.length,
+            results: items,
+          });
+          return found;
+        } catch (err) {
+          searches.push({
+            resourceType: deps.inferRecallResourceType(targetUri) ?? "resource",
+            targetUriResolved: targetUri,
+            limit,
+            durationMs: Date.now() - started,
+            total: 0,
+            results: [],
+            error: err instanceof Error ? err.message : String(err),
+          });
+          throw err;
+        }
+      };
+      const [resourcesSettled, skillsSettled] = await Promise.allSettled([
+        runSearch("viking://resources"),
+        runSearch("viking://user/skills"),
+      ]);
+      const successful: FindResult[] = [];
+      if (resourcesSettled.status === "fulfilled") {
+        successful.push(resourcesSettled.value);
+      }
+      if (skillsSettled.status === "fulfilled") {
+        successful.push(skillsSettled.value);
+      }
+      if (successful.length === 0) {
+        const firstError =
+          resourcesSettled.status === "rejected"
+            ? resourcesSettled.reason
+            : skillsSettled.status === "rejected"
+              ? skillsSettled.reason
+              : "Both searches failed";
+        throw firstError instanceof Error ? firstError : new Error(String(firstError));
+      }
+      if (resourcesSettled.status === "rejected") {
+        deps.logger.warn?.(`openviking: resource search failed: ${String(resourcesSettled.reason)}`);
+      }
+      if (skillsSettled.status === "rejected") {
+        deps.logger.warn?.(`openviking: skill search failed: ${String(skillsSettled.reason)}`);
+      }
+      result = mergeFindResults(successful);
+    }
+    const selected = [
+      ...(result.memories ?? []).map((item) => ({
+        uri: item.uri,
+        resourceType: deps.inferRecallResourceType(item.uri),
+        category: item.category,
+        score: item.score,
+        abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
+        displayed: true,
+      })),
+      ...(result.resources ?? []).map((item) => ({
+        uri: item.uri,
+        resourceType: deps.inferRecallResourceType(item.uri),
+        category: item.category,
+        score: item.score,
+        abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
+        displayed: true,
+      })),
+      ...(result.skills ?? []).map((item) => ({
+        uri: item.uri,
+        resourceType: deps.inferRecallResourceType(item.uri),
+        category: item.category,
+        score: item.score,
+        abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
+        displayed: true,
+      })),
+    ];
+    await deps.traceRecorder?.recordAndFlush?.({
+      schemaVersion: "1.0",
+      traceId: deps.createTraceId("ov_search"),
+      ts: Date.now(),
+      sessionId: traceCtx?.sessionId,
+      sessionKey: traceCtx?.sessionKey,
+      ovSessionId: traceCtx?.ovSessionId,
+      agentId,
+      source: "ov_search",
+      operationType: "semantic_find",
+      resourceTypes: [...new Set(searches.map((search) => search.resourceType).filter((resourceType): resourceType is RecallResourceType => resourceType !== "archive"))],
+      trigger: deps.boundTraceQuery(query, deps.cfg.traceRecallQueryMaxChars),
+      searches,
+      selected,
+      stats: {
+        candidateCount: searches.reduce((sum, search) => sum + search.results.length, 0),
+        selectedCount: selected.length,
+        injectedCount: 0,
+      },
+    });
+    return {
+      content: [{ type: "text" as const, text: formatOVSearchText(query, searchUri, result) }],
+      details: {
+        action: "searched",
+        query,
+        uri: searchUri,
+        memories: result.memories ?? [],
+        resources: result.resources ?? [],
+        skills: result.skills ?? [],
+        total: result.total ?? 0,
+      },
+    };
+  };
+
+  return { readOpenVikingContent, multiReadOpenVikingContent, listOpenVikingDirectory, searchOpenViking };
+}

--- a/examples/openclaw-plugin/plugin/openviking-query-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-query-tools.ts
@@ -1,0 +1,161 @@
+import { Type } from "@sinclair/typebox";
+
+export type OpenVikingQueryToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+};
+
+export type OpenVikingQuerySession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OVSearchInput = {
+  query: string;
+  uri?: string;
+  limit?: number;
+};
+
+export type OVReadInput = {
+  uri: string;
+};
+
+export type OVMultiReadInput = {
+  uris: string[];
+};
+
+export type OVListInput = {
+  uri: string;
+  recursive?: boolean;
+  simple?: boolean;
+  limit?: number;
+};
+
+export type OpenVikingQueryToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  searchOpenViking: (
+    input: OVSearchInput,
+    agentId?: string,
+    traceCtx?: OpenVikingQuerySession,
+  ) => Promise<unknown>;
+  readOpenVikingContent: (input: OVReadInput, agentId?: string) => Promise<unknown>;
+  multiReadOpenVikingContent: (input: OVMultiReadInput, agentId?: string) => Promise<unknown>;
+  listOpenVikingDirectory: (input: OVListInput, agentId?: string) => Promise<unknown>;
+  resolvePluginSessionRouting: (ctx?: OpenVikingQueryToolContext) => OpenVikingQuerySession;
+  isBypassedSession: (ctx?: OpenVikingQueryToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+};
+
+export function registerOpenVikingQueryTools(deps: OpenVikingQueryToolsDeps): void {
+  deps.registerTool(
+    (ctx: OpenVikingQueryToolContext) => ({
+      name: "ov_search",
+      label: "Search (OpenViking)",
+      description:
+        "Search OpenViking resources and skills. Use after importing, or when the user asks to search OpenViking resources or skills. " +
+        "Search only returns ranked snippets; call ov_read on exact hit URIs before answering precise questions. " +
+        "When a result is part of a split document or a multi-step procedure, call ov_list on the parent URI to inspect sibling chunks and overview files before answering. " +
+        "Returned viking:// URIs are OpenViking virtual URIs, not local file paths.",
+      parameters: Type.Object({
+        query: Type.String({ description: "Search query" }),
+        uri: Type.Optional(Type.String({ description: "Optional search URI. Defaults to resources plus agent skills." })),
+        limit: Type.Optional(Type.Number({ description: "Max results per search scope. Default: 10" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("ov_search");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        return deps.searchOpenViking({
+          query: String((params as { query?: unknown }).query ?? ""),
+          uri: typeof params.uri === "string" ? params.uri : undefined,
+          limit: typeof params.limit === "number" ? params.limit : undefined,
+        }, session.agentId, session);
+      },
+    }),
+    { name: "ov_search" },
+  );
+
+  deps.registerTool(
+    (ctx: OpenVikingQueryToolContext) => ({
+      name: "ov_read",
+      label: "Read (OpenViking)",
+      description:
+        "Read the full original content of one exact OpenViking viking:// URI returned by ov_search, ov_list, or recall traces. " +
+        "Use after ov_search before answering precise documentation, codebase, configuration, or procedural questions. " +
+        "OpenViking URIs are virtual context-database identifiers, not local file paths; do not use filesystem read tools for them. " +
+        "Never pass shortened or display-truncated URIs ending with ... or containing …. Use the exact full URI.",
+      parameters: Type.Object({
+        uri: Type.String({ description: "Exact viking:// URI returned by ov_search; pass the full URI, e.g. viking://resources/project-docs/api.md#chunk-3; do not use shortened display text with ... or …." }),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("ov_read");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        return deps.readOpenVikingContent({
+          uri: String((params as { uri?: unknown }).uri ?? ""),
+        }, session.agentId);
+      },
+    }),
+    { name: "ov_read" },
+  );
+
+  deps.registerTool(
+    (ctx: OpenVikingQueryToolContext) => ({
+      name: "ov_multi_read",
+      label: "Multi Read (OpenViking)",
+      description:
+        "Read the full original content of multiple exact OpenViking URIs concurrently. " +
+        "Use after ov_search and ov_list to read an overview plus sibling chunks for split documents or multi-step procedures.",
+      parameters: Type.Object({
+        uris: Type.Array(Type.String({ description: "Exact OpenViking viking:// URI to read" }), {
+          description: "Exact OpenViking viking:// URIs to read",
+        }),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("ov_multi_read");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const uris = Array.isArray((params as { uris?: unknown }).uris)
+          ? (params as { uris: unknown[] }).uris.map((uri) => String(uri))
+          : [];
+        return deps.multiReadOpenVikingContent({ uris }, session.agentId);
+      },
+    }),
+    { name: "ov_multi_read" },
+  );
+
+  deps.registerTool(
+    (ctx: OpenVikingQueryToolContext) => ({
+      name: "ov_list",
+      label: "List (OpenViking)",
+      description:
+        "List files and directories under an OpenViking URI. Use after ov_search to inspect a hit's parent directory, sibling chunks, or .overview.md files when search only returns ranked snippets.",
+      parameters: Type.Object({
+        uri: Type.String({ description: "OpenViking directory URI to list, e.g. viking://resources/project/docs" }),
+        recursive: Type.Optional(Type.Boolean({ description: "List nested entries recursively. Default: false" })),
+        simple: Type.Optional(Type.Boolean({ description: "Return only URI entries from OpenViking. Default: false" })),
+        limit: Type.Optional(Type.Number({ description: "Maximum entries to list. Default: 100" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("ov_list");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        return deps.listOpenVikingDirectory({
+          uri: String((params as { uri?: unknown }).uri ?? ""),
+          recursive: typeof params.recursive === "boolean" ? params.recursive : undefined,
+          simple: typeof params.simple === "boolean" ? params.simple : undefined,
+          limit: typeof params.limit === "number" ? params.limit : undefined,
+        }, session.agentId);
+      },
+    }),
+    { name: "ov_list" },
+  );
+}

--- a/examples/openclaw-plugin/plugin/openviking-recall-trace-runtime.ts
+++ b/examples/openclaw-plugin/plugin/openviking-recall-trace-runtime.ts
@@ -1,0 +1,482 @@
+import type {
+  RecallTraceEntry,
+  RecallTraceQuery,
+  RecallTraceResult,
+  RecallTraceSource,
+} from "../recall-trace.js";
+import type { RecallResourceType } from "../registries/recall-resource-types.js";
+import type { RecallTraceRouteHandlers, RecallTraceRouteRequest } from "./recall-trace-routes.js";
+
+export type OpenVikingRecallTraceInput = {
+  turn?: "latest" | "all";
+  traceId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  source?: RecallTraceSource;
+  resourceTypes?: RecallResourceType[] | string;
+  since?: number;
+  until?: number;
+  includeContent?: boolean;
+  limit?: number;
+};
+
+export type OpenVikingRecallTraceSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OpenVikingRecallTraceQueryResult = {
+  entries: RecallTraceEntry[];
+  lookupLayer: "memory" | "persistent";
+  warnings: string[];
+};
+
+export type OpenVikingRecallTraceRuntimeDeps = {
+  getClient: () => Promise<{ read: (uri: string, agentId?: string) => Promise<unknown> }>;
+  resolvePluginSessionRouting: (ctx?: {
+    agentId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+    ovSessionId?: string;
+  }) => OpenVikingRecallTraceSession;
+  traceRecorder?: {
+    queryWithFallback: (query: RecallTraceQuery) => Promise<OpenVikingRecallTraceQueryResult>;
+  };
+  registerRecallTraceRoutes: (ctx: unknown, handlers: RecallTraceRouteHandlers) => boolean;
+  normalizeResourceTypes: (value: unknown) => RecallResourceType[];
+  clampScore: (score: number) => number;
+  previewText: (value: unknown, maxChars: number) => string | undefined;
+  cfg: {
+    traceRecallIncludeContentByDefault: boolean;
+    traceRecallPreviewChars: number;
+    recallMaxContentChars: number;
+  };
+};
+
+function getOptionalInteger(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function getPositiveInteger(value: unknown, fallback: number): number {
+  return Math.max(1, getOptionalInteger(value, fallback));
+}
+
+function toQueryObject(request?: RecallTraceRouteRequest): Record<string, unknown> {
+  const query: Record<string, unknown> = { ...(request?.query ?? {}) };
+  if (request?.url) {
+    const parsed = new URL(request.url, "http://openclaw.local");
+    for (const [key, value] of parsed.searchParams.entries()) {
+      query[key] = value;
+    }
+  }
+  return { ...query, ...(request?.params ?? {}) };
+}
+
+function toBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+  return ["1", "true", "yes"].includes(value.trim().toLowerCase());
+}
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function toString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function queryValue(query: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    if (query[key] !== undefined) {
+      return query[key];
+    }
+  }
+  return undefined;
+}
+
+function toSessionKey(query: Record<string, unknown>): string | undefined {
+  return toString(queryValue(query, "sessionKey", "sessionkey", "session_key", "session-key"));
+}
+
+function toLimitedInteger(value: unknown, fallback: number, min: number, max: number): number | undefined {
+  const parsed = toNumber(value);
+  const raw = parsed === undefined ? fallback : Math.floor(parsed);
+  return Number.isFinite(raw) && raw >= min && raw <= max ? raw : undefined;
+}
+
+function inferUriType(uri: string): string {
+  if (uri.startsWith("viking://resources") || uri.startsWith("viking://resource")) return "resource";
+  if (uri.startsWith("viking://session/")) return "session";
+  if (uri.startsWith("viking://user/skills") || uri.startsWith("viking://skills")) return "skill";
+  if (uri.startsWith("viking://user/")) return "user_memory";
+  if (uri.includes("/archive") || uri.includes("/history/")) return "archive";
+  return "unknown";
+}
+
+function hasExplicitRecallTraceIdentityFilter(input: OpenVikingRecallTraceInput): boolean {
+  const traceId = typeof input.traceId === "string" && input.traceId.trim();
+  const sessionId = typeof input.sessionId === "string" && input.sessionId.trim();
+  const sessionKey = typeof input.sessionKey === "string" && input.sessionKey.trim();
+  const ovSessionId = typeof input.ovSessionId === "string" && input.ovSessionId.trim();
+  return !!(traceId || sessionId || sessionKey || ovSessionId);
+}
+
+function findTraceItem(entry: RecallTraceEntry, uri: string): {
+  category?: string;
+  score?: number;
+  level?: number;
+  abstractPreview?: string;
+  resultType?: RecallTraceResult["resultType"];
+  sourceTraceId?: string;
+  source?: RecallTraceSource;
+} | undefined {
+  const selected = entry.selected.find((item) => item.uri === uri);
+  const searchResult = entry.searches.flatMap((search) => search.results).find((item) => item.uri === uri);
+  if (!selected && !searchResult) {
+    return undefined;
+  }
+  return {
+    category: selected?.category ?? searchResult?.category,
+    score: selected?.score ?? searchResult?.score,
+    level: searchResult?.level,
+    abstractPreview: selected?.abstractPreview ?? searchResult?.abstractPreview,
+    resultType: searchResult?.resultType,
+    sourceTraceId: entry.traceId,
+    source: entry.source,
+  };
+}
+
+export function createOpenVikingRecallTraceRuntime(deps: OpenVikingRecallTraceRuntimeDeps): {
+  queryRecallTraces: (input: OpenVikingRecallTraceInput, session: OpenVikingRecallTraceSession) => Promise<OpenVikingRecallTraceQueryResult>;
+  formatRecallTraceText: (result: { entries: RecallTraceEntry[]; lookupLayer: string; warnings: string[] }) => string;
+  routeHandlers: RecallTraceRouteHandlers;
+  registerRecallTraceRoutes: (ctx?: unknown) => boolean;
+} {
+  const parseRecallTraceInput = (
+    input: OpenVikingRecallTraceInput,
+    ctx: { sessionId?: string; sessionKey?: string; ovSessionId?: string },
+  ): RecallTraceQuery => {
+    const traceId = typeof input.traceId === "string" && input.traceId.trim() ? input.traceId.trim() : undefined;
+    const explicitSessionId = typeof input.sessionId === "string" && input.sessionId.trim() ? input.sessionId.trim() : undefined;
+    const explicitSessionKey = typeof input.sessionKey === "string" && input.sessionKey.trim() ? input.sessionKey.trim() : undefined;
+    const explicitOvSessionId = typeof input.ovSessionId === "string" && input.ovSessionId.trim() ? input.ovSessionId.trim() : undefined;
+    const hasExplicitIdentityFilter = !!(traceId || explicitSessionId || explicitSessionKey || explicitOvSessionId);
+    const defaultSessionKey = !hasExplicitIdentityFilter ? ctx.sessionKey : undefined;
+    const defaultSessionId = !hasExplicitIdentityFilter && !defaultSessionKey ? ctx.sessionId : undefined;
+    const defaultOvSessionId = !hasExplicitIdentityFilter && !defaultSessionKey && !defaultSessionId ? ctx.ovSessionId : undefined;
+    return {
+      turn: input.turn === "all" ? "all" : "latest",
+      traceId,
+      sessionId: explicitSessionId ?? defaultSessionId,
+      sessionKey: explicitSessionKey ?? defaultSessionKey,
+      ovSessionId: explicitOvSessionId ?? defaultOvSessionId,
+      source: typeof input.source === "string" && input.source.trim() ? input.source as RecallTraceSource : undefined,
+      resourceTypes: input.resourceTypes ? deps.normalizeResourceTypes(input.resourceTypes) : undefined,
+      since: typeof input.since === "number" ? input.since : undefined,
+      until: typeof input.until === "number" ? input.until : undefined,
+      limit: getPositiveInteger(input.limit, 20),
+    };
+  };
+
+  const shouldIncludeTraceContent = (input?: { includeContent?: boolean }): boolean =>
+    typeof input?.includeContent === "boolean" ? input.includeContent : deps.cfg.traceRecallIncludeContentByDefault;
+
+  const enrichTraceEntriesWithContent = async (
+    result: OpenVikingRecallTraceQueryResult,
+    includeContent: boolean,
+    agentId?: string,
+  ): Promise<OpenVikingRecallTraceQueryResult> => {
+    if (!includeContent || result.entries.length === 0) {
+      return result;
+    }
+    const client = await deps.getClient();
+    const warnings = [...result.warnings];
+    const entries = await Promise.all(result.entries.map(async (entry) => {
+      const selected = await Promise.all(entry.selected.map(async (item) => {
+        try {
+          const content = await client.read(item.uri, agentId);
+          const text = typeof content === "string" ? content : JSON.stringify(content);
+          return { ...item, contentPreview: deps.previewText(text, deps.cfg.recallMaxContentChars) };
+        } catch (err) {
+          const readError = err instanceof Error ? err.message : String(err);
+          warnings.push(`Failed to read recall trace content ${item.uri}: ${readError}`);
+          return { ...item, readError };
+        }
+      }));
+      return { ...entry, selected };
+    }));
+    return { ...result, entries, warnings };
+  };
+
+  const queryTraceForRoute = async (query: OpenVikingRecallTraceInput, session: OpenVikingRecallTraceSession) => deps.traceRecorder
+    ? deps.traceRecorder.queryWithFallback(parseRecallTraceInput(query, session))
+    : Promise.resolve({ entries: [], lookupLayer: "memory" as const, warnings: ["traceRecall is disabled"] });
+
+  const queryRecallTraces = async (
+    input: OpenVikingRecallTraceInput,
+    session: OpenVikingRecallTraceSession,
+  ): Promise<OpenVikingRecallTraceQueryResult> => {
+    const query = parseRecallTraceInput(input, session);
+    const base = deps.traceRecorder
+      ? await deps.traceRecorder.queryWithFallback(query)
+      : { entries: [], lookupLayer: "memory" as const, warnings: ["traceRecall is disabled"] };
+    if (
+      deps.traceRecorder &&
+      base.entries.length === 0 &&
+      !hasExplicitRecallTraceIdentityFilter(input) &&
+      query.sessionKey
+    ) {
+      const fallbackIdentities: RecallTraceQuery[] = [];
+      if (session.sessionId) {
+        fallbackIdentities.push({ ...query, sessionKey: undefined, sessionId: session.sessionId, ovSessionId: undefined });
+      }
+      if (session.ovSessionId) {
+        fallbackIdentities.push({ ...query, sessionKey: undefined, sessionId: undefined, ovSessionId: session.ovSessionId });
+      }
+      for (const fallbackQuery of fallbackIdentities) {
+        const fallback = await deps.traceRecorder.queryWithFallback(fallbackQuery);
+        if (fallback.entries.length > 0) {
+          return enrichTraceEntriesWithContent(fallback, shouldIncludeTraceContent(input), session.agentId);
+        }
+      }
+    }
+    return enrichTraceEntriesWithContent(base, shouldIncludeTraceContent(input), session.agentId);
+  };
+
+  const handleUriDetail = async (request?: RecallTraceRouteRequest) => {
+    const query = toQueryObject(request);
+    const uri = toString(query.uri);
+    if (!uri || !uri.startsWith("viking://") || uri.endsWith("...") || uri.includes("…")) {
+      return { status: 400, body: { ok: false, uri: uri ?? "", readStatus: "not_requested", warnings: [], error: { code: "invalid_uri", message: "uri must be a complete viking:// URI" } } };
+    }
+    const offset = toLimitedInteger(query.offset, 0, 0, 1_000_000_000);
+    const contentLimit = toLimitedInteger(queryValue(query, "contentLimit", "content-limit", "content_limit"), 20_000, 1, 100_000);
+    if (offset === undefined || contentLimit === undefined) {
+      return { status: 400, body: { ok: false, uri, readStatus: "not_requested", warnings: [], error: { code: "invalid_param", message: "offset or contentLimit is invalid" } } };
+    }
+    const includeContent = toBoolean(queryValue(query, "includeContent", "include-content", "include_content")) ?? true;
+    const preferTracePreview = toBoolean(queryValue(query, "preferTracePreview", "prefer-trace-preview", "prefer_trace_preview")) ?? true;
+    const session = deps.resolvePluginSessionRouting(query);
+    const traceId = toString(queryValue(query, "traceId", "trace-id", "trace_id"));
+    let traceMetadata: ReturnType<typeof findTraceItem> | undefined;
+    const warnings: string[] = [];
+    if (preferTracePreview && traceId && deps.traceRecorder) {
+      const traceResult = await queryTraceForRoute({ traceId, turn: "latest", limit: 1 }, session);
+      warnings.push(...traceResult.warnings);
+      traceMetadata = traceResult.entries[0] ? findTraceItem(traceResult.entries[0], uri) : undefined;
+    }
+    const baseBody = {
+      ok: true,
+      uri,
+      uriType: inferUriType(uri),
+      abstractPreview: traceMetadata?.abstractPreview,
+      metadata: {
+        category: traceMetadata?.category,
+        score: traceMetadata?.score,
+        level: traceMetadata?.level,
+        resultType: traceMetadata?.resultType,
+        sourceTraceId: traceMetadata?.sourceTraceId,
+        source: traceMetadata?.source,
+      },
+      readStatus: "not_requested" as const,
+      warnings,
+    };
+    if (!includeContent) {
+      return { status: 200, body: baseBody };
+    }
+    try {
+      const client = await deps.getClient();
+      const content = await client.read(uri, toString(query.agentId) ?? session.agentId);
+      const text = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+      const chars = Array.from(text);
+      const slice = chars.slice(offset, offset + contentLimit).join("");
+      return {
+        status: 200,
+        body: {
+          ...baseBody,
+          content: {
+            text: slice,
+            offset,
+            limit: contentLimit,
+            returnedChars: Array.from(slice).length,
+            totalChars: chars.length,
+            hasMore: offset + contentLimit < chars.length,
+          },
+          readStatus: "ok" as const,
+        },
+      };
+    } catch (err) {
+      return {
+        status: 502,
+        body: {
+          ...baseBody,
+          ok: false,
+          readStatus: "read_failed" as const,
+          error: { code: "read_failed", message: err instanceof Error ? err.message : String(err) },
+        },
+      };
+    }
+  };
+
+  const handleLatestOvSearchList = async (request?: RecallTraceRouteRequest) => {
+    const query = toQueryObject(request);
+    const session = deps.resolvePluginSessionRouting(query);
+    const limit = toLimitedInteger(query.limit, 20, 1, 100);
+    if (limit === undefined) {
+      return { status: 400, body: { ok: false, items: [], totalItems: 0, warnings: [], error: { code: "invalid_param", message: "limit is invalid" } } };
+    }
+    const includeSelected = toBoolean(query.includeSelected) ?? true;
+    const dedupe = toBoolean(query.dedupe) ?? true;
+    const includeSkills = toBoolean(query.includeSkills) ?? true;
+    const strict = toBoolean(query.strict) ?? false;
+    const result = await queryTraceForRoute({
+      turn: "latest",
+      source: "ov_search",
+      sessionId: toString(query.sessionId),
+      sessionKey: toSessionKey(query),
+      ovSessionId: toString(query.ovSessionId),
+      limit: 1,
+    }, session);
+    const agentId = toString(query.agentId);
+    const entry = agentId ? result.entries.find((candidate) => candidate.agentId === agentId) : result.entries[0];
+    if (!entry) {
+      const body = {
+        ok: !strict,
+        lookupLayer: "none" as const,
+        fallbackUsed: false,
+        query: { sessionId: toString(query.sessionId), sessionKey: toString(query.sessionKey), ovSessionId: toString(query.ovSessionId), agentId, limit, lookup: toString(query.lookup) ?? "auto" },
+        items: [],
+        totalItems: 0,
+        warnings: [...result.warnings, "no ov_search trace found for latest interaction"],
+        ...(strict ? { error: { code: "not_found", message: "no ov_search trace found for latest interaction" } } : {}),
+      };
+      return { status: strict ? 404 : 200, body };
+    }
+    const searchResultByUri = new Map<string, RecallTraceResult & { targetUri?: string }>();
+    for (const search of entry.searches) {
+      for (const item of search.results) {
+        searchResultByUri.set(item.uri, { ...item, targetUri: search.targetUriResolved ?? search.targetUriInput });
+      }
+    }
+    const items: Array<Record<string, unknown>> = [];
+    const addItem = (item: { uri: string; resourceType?: unknown; category?: string; score?: number; abstractPreview?: string }, source: "search_result" | "selected") => {
+      const matched = searchResultByUri.get(item.uri);
+      const resultType = matched?.resultType ?? (inferUriType(item.uri) === "skill" ? "skill" : inferUriType(item.uri).includes("memory") ? "memory" : "resource");
+      if (!includeSkills && resultType === "skill") {
+        return;
+      }
+      const row = {
+        uri: item.uri,
+        abstractPreview: item.abstractPreview ?? matched?.abstractPreview,
+        resourceType: item.resourceType ?? matched?.resourceType,
+        resultType,
+        category: item.category ?? matched?.category,
+        score: item.score ?? matched?.score,
+        source,
+        targetUri: matched?.targetUri,
+        detailUrl: `/api/openviking/uri-detail?uri=${encodeURIComponent(item.uri)}&traceId=${encodeURIComponent(entry.traceId)}`,
+      };
+      if (dedupe) {
+        const existing = items.findIndex((candidate) => candidate.uri === item.uri);
+        if (existing >= 0) {
+          if (source === "selected") items[existing] = row;
+          return;
+        }
+      }
+      items.push(row);
+    };
+    if (includeSelected) {
+      entry.selected.forEach((item) => addItem(item, "selected"));
+    }
+    for (const search of entry.searches) {
+      search.results.forEach((item) => addItem(item, "search_result"));
+    }
+    const limited = items.slice(0, limit);
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        lookupLayer: result.lookupLayer,
+        fallbackUsed: result.lookupLayer === "persistent",
+        query: { sessionId: toString(query.sessionId), sessionKey: toString(query.sessionKey), ovSessionId: toString(query.ovSessionId), agentId, limit, lookup: toString(query.lookup) ?? "auto" },
+        trace: {
+          traceId: entry.traceId,
+          ts: entry.ts,
+          isoTime: new Date(entry.ts).toISOString(),
+          triggerQuery: entry.trigger.query,
+          totalSearches: entry.searches.length,
+        },
+        items: limited,
+        totalItems: limited.length,
+        warnings: result.warnings,
+      },
+    };
+  };
+
+  const handleRecallTraces = async (request?: RecallTraceRouteRequest) => {
+    const query = toQueryObject(request);
+    const session = deps.resolvePluginSessionRouting(query);
+    const result = await queryRecallTraces({
+      turn: query.turn === "all" ? "all" : "latest",
+      traceId: toString(queryValue(query, "traceId", "trace-id", "trace_id")),
+      sessionId: typeof query.sessionId === "string" ? query.sessionId : undefined,
+      sessionKey: toSessionKey(query),
+      ovSessionId: typeof query.ovSessionId === "string" ? query.ovSessionId : undefined,
+      source: typeof query.source === "string" ? query.source as RecallTraceSource : undefined,
+      resourceTypes: typeof query.resourceTypes === "string" ? query.resourceTypes : undefined,
+      since: toNumber(query.since),
+      until: toNumber(query.until),
+      includeContent: toBoolean(queryValue(query, "includeContent", "include-content", "include_content")),
+      limit: toNumber(query.limit),
+    }, session);
+    return { status: 200, body: { ok: true, ...result } };
+  };
+
+  const formatRecallTraceText = (result: { entries: RecallTraceEntry[]; lookupLayer: string; warnings: string[] }): string => {
+    if (result.entries.length === 0) {
+      return `No OpenViking recall traces found (lookupLayer=${result.lookupLayer}).`;
+    }
+    const blocks = result.entries.map((entry, index) => {
+      const selected = entry.selected.slice(0, 8)
+        .map((item) => `  - ${item.uri}${item.score !== undefined ? ` (${(deps.clampScore(item.score) * 100).toFixed(0)}%)` : ""}`)
+        .join("\n");
+      return [
+        `## Trace ${index + 1}: ${entry.source}`,
+        `traceId: ${entry.traceId}`,
+        `query: ${entry.trigger.query}`,
+        `resourceTypes: ${entry.resourceTypes.join(", ")}`,
+        `stats: candidates=${entry.stats.candidateCount}, selected=${entry.stats.selectedCount}, injected=${entry.stats.injectedCount}`,
+        selected ? `selected:\n${selected}` : "selected: (none)",
+      ].join("\n");
+    });
+    const warnings = result.warnings.length > 0
+      ? `\n\nWarnings:\n${result.warnings.map((w) => `- ${w}`).join("\n")}`
+      : "";
+    return `${blocks.join("\n\n")}${warnings}`;
+  };
+
+  const routeHandlers = {
+    handleRecallTraces,
+    handleUriDetail,
+    handleLatestOvSearchList,
+  };
+
+  return {
+    queryRecallTraces,
+    formatRecallTraceText,
+    routeHandlers,
+    registerRecallTraceRoutes: (ctx?: unknown) => deps.registerRecallTraceRoutes(ctx, routeHandlers),
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-recall-trace-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-recall-trace-tools.ts
@@ -1,0 +1,99 @@
+import { Type } from "@sinclair/typebox";
+
+import type { RecallResourceType } from "../registries/recall-resource-types.js";
+import type {
+  RecallTraceEntry,
+  RecallTraceSource,
+} from "../recall-trace.js";
+
+export type OpenVikingRecallTraceToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+};
+
+export type OpenVikingRecallTraceSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type RecallTraceToolInput = {
+  turn?: "latest" | "all";
+  traceId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  source?: RecallTraceSource;
+  resourceTypes?: RecallResourceType[] | string;
+  since?: number;
+  until?: number;
+  includeContent?: boolean;
+  limit?: number;
+};
+
+export type RecallTraceToolResult = {
+  entries: RecallTraceEntry[];
+  lookupLayer: string;
+  warnings: string[];
+};
+
+export type OpenVikingRecallTraceToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  queryRecallTraces: (
+    input: RecallTraceToolInput,
+    session: OpenVikingRecallTraceSession,
+  ) => Promise<RecallTraceToolResult>;
+  formatRecallTraceText: (result: RecallTraceToolResult) => string;
+  resolvePluginSessionRouting: (
+    ctx?: OpenVikingRecallTraceToolContext,
+  ) => OpenVikingRecallTraceSession;
+  isBypassedSession: (ctx?: OpenVikingRecallTraceToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+};
+
+export function registerOpenVikingRecallTraceTools(
+  deps: OpenVikingRecallTraceToolsDeps,
+): void {
+  deps.registerTool(
+    (ctx: OpenVikingRecallTraceToolContext) => ({
+      name: "ov_recall_trace",
+      label: "Recall Trace (OpenViking)",
+      description:
+        "Query OpenViking recall trace records captured by auto-recall and explicit recall/search tools.",
+      parameters: Type.Object({
+        turn: Type.Optional(Type.String({ description: "latest or all (default: latest)" })),
+        traceId: Type.Optional(Type.String({ description: "Exact trace id" })),
+        sessionId: Type.Optional(Type.String({ description: "OpenClaw session id" })),
+        sessionKey: Type.Optional(Type.String({ description: "OpenClaw session key" })),
+        ovSessionId: Type.Optional(Type.String({ description: "OpenViking session id" })),
+        source: Type.Optional(Type.String({ description: "auto_recall, memory_recall, ov_search, or ov_archive_search" })),
+        resourceTypes: Type.Optional(Type.Array(Type.String({ description: "resource, user, or agent" }))),
+        since: Type.Optional(Type.Number({ description: "Unix timestamp lower bound in milliseconds" })),
+        until: Type.Optional(Type.Number({ description: "Unix timestamp upper bound in milliseconds" })),
+        includeContent: Type.Optional(Type.Boolean({ description: "Read selected/displayed URI content previews on demand" })),
+        limit: Type.Optional(Type.Number({ description: "Maximum traces to return (default: 20)" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("ov_recall_trace");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const result = await deps.queryRecallTraces(params as RecallTraceToolInput, session);
+        return {
+          content: [{ type: "text" as const, text: deps.formatRecallTraceText(result) }],
+          details: {
+            action: "queried",
+            count: result.entries.length,
+            lookupLayer: result.lookupLayer,
+            warnings: result.warnings,
+            entries: result.entries,
+          },
+        };
+      },
+    }),
+    { name: "ov_recall_trace" },
+  );
+}

--- a/examples/openclaw-plugin/plugin/openviking-runtime-state.ts
+++ b/examples/openclaw-plugin/plugin/openviking-runtime-state.ts
@@ -1,0 +1,52 @@
+import type { MemoryOpenVikingConfig } from "../config.js";
+import { RuntimeQueryConfigStore } from "../query-config.js";
+import { RecallTraceRecorder } from "../recall-trace.js";
+
+type Logger = {
+  warn?: (message: string) => void;
+};
+
+type RuntimeStateConfig = Required<
+  Pick<
+    MemoryOpenVikingConfig,
+    | "runtimeQueryConfigPath"
+    | "traceRecall"
+    | "traceRecallMaxEntries"
+    | "traceRecallPersist"
+    | "traceRecallDir"
+    | "traceRecallIncludeRawUserPreview"
+    | "traceRecallRetentionDays"
+    | "traceRecallQueryMaxDays"
+  >
+>;
+
+export function createOpenVikingRuntimeState(options: {
+  cfg: Required<MemoryOpenVikingConfig> & RuntimeStateConfig;
+  logger: Logger;
+}) {
+  const { cfg, logger } = options;
+
+  const queryConfigStore = new RuntimeQueryConfigStore({
+    staticConfig: cfg,
+    path: cfg.runtimeQueryConfigPath || undefined,
+  });
+  void queryConfigStore.load().catch((err) => {
+    logger.warn?.(`openviking: failed to load runtime query config: ${String(err)}`);
+  });
+
+  const traceRecorder = cfg.traceRecall
+    ? new RecallTraceRecorder({
+        memoryMaxEntries: cfg.traceRecallMaxEntries,
+        persist: cfg.traceRecallPersist,
+        traceDir: cfg.traceRecallDir,
+        includeRawUserPreview: cfg.traceRecallIncludeRawUserPreview,
+        retentionDays: cfg.traceRecallRetentionDays,
+        queryMaxDays: cfg.traceRecallQueryMaxDays,
+      })
+    : undefined;
+
+  return {
+    queryConfigStore,
+    traceRecorder,
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-runtime-utils.ts
+++ b/examples/openclaw-plugin/plugin/openviking-runtime-utils.ts
@@ -1,0 +1,67 @@
+import type { RecallResourceType } from "../registries/recall-resource-types.js";
+
+export function previewText(value: unknown, maxChars: number): string | undefined {
+  const text = typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+  if (!text) {
+    return undefined;
+  }
+  return text.length <= maxChars ? text : `${text.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+export function inferRecallResourceType(uri: string): RecallResourceType | undefined {
+  if (uri.startsWith("viking://resources")) return "resource";
+  if (uri.startsWith("viking://user/skills") || uri.startsWith("viking://skills")) return "agent";
+  if (uri.startsWith("viking://user/")) return "user";
+  return undefined;
+}
+
+export function createTraceId(source: string): string {
+  return `${source}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function createMemoryStoreTempSessionId(): string {
+  return `memory-store-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function boundTraceQuery(query: string, maxChars: number): { query: string; queryTruncated?: boolean } {
+  if (query.length <= maxChars) {
+    return { query };
+  }
+  return { query: query.slice(0, maxChars), queryTruncated: true };
+}
+
+export function extractToolSenderId(ctx: unknown): string | undefined {
+  if (!ctx || typeof ctx !== "object") {
+    return undefined;
+  }
+  const toolCtx = ctx as Record<string, unknown>;
+  if (typeof toolCtx.requesterSenderId === "string") {
+    const trimmed = toolCtx.requesterSenderId.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  if (typeof toolCtx.senderId === "string") {
+    const trimmed = toolCtx.senderId.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+export function makeBypassedToolResult(toolName: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `OpenViking is bypassed for this session by bypassSessionPatterns; ${toolName} was skipped.`,
+      },
+    ],
+    details: {
+      action: "bypassed",
+      reason: "session_bypassed",
+      toolName,
+    },
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-services.ts
+++ b/examples/openclaw-plugin/plugin/openviking-services.ts
@@ -1,0 +1,49 @@
+export type OpenVikingServiceLogger = {
+  info: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+export type OpenVikingServiceConfig = {
+  baseUrl: string;
+  targetUri: string;
+};
+
+export type OpenVikingServiceClient = {
+  healthCheck: () => Promise<unknown>;
+};
+
+export type OpenVikingServiceOptions = {
+  cfg: OpenVikingServiceConfig;
+  getClient: () => Promise<OpenVikingServiceClient>;
+  logger: OpenVikingServiceLogger;
+  recallTraceHttpRoutesRegistered: boolean;
+  registerRecallTraceRoutes: (ctx?: unknown) => boolean;
+};
+
+export function createOpenVikingService({
+  cfg,
+  getClient,
+  logger,
+  recallTraceHttpRoutesRegistered,
+  registerRecallTraceRoutes,
+}: OpenVikingServiceOptions) {
+  return {
+    id: "openviking",
+    start: async (ctx?: unknown) => {
+      const runtimeRouteRegistered = registerRecallTraceRoutes(ctx);
+      const routeRegistered = recallTraceHttpRoutesRegistered || runtimeRouteRegistered;
+      await (await getClient()).healthCheck().catch(() => {});
+      logger.info(
+        `openviking: initialized (url: ${cfg.baseUrl}, targetUri: ${cfg.targetUri}, search: hybrid endpoint)`,
+      );
+      if (routeRegistered) {
+        logger.info("openviking: registered recall trace Gateway routes");
+      } else {
+        logger.warn?.("openviking: recall trace Gateway route adapter unavailable; use ov_recall_trace tool or /ov-recall-trace command");
+      }
+    },
+    stop: () => {
+      logger.info("openviking: stopped");
+    },
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-session-routing-runtime.ts
+++ b/examples/openclaw-plugin/plugin/openviking-session-routing-runtime.ts
@@ -1,0 +1,105 @@
+import type { QueryConfigContext } from "../query-config.js";
+import {
+  createSessionAgentResolver,
+  openClawSessionToOvStorageId,
+} from "../routing/identity-routing.js";
+
+type Logger = {
+  info: (message: string) => void;
+};
+
+export type SessionAgentLookup = {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+};
+
+export type PluginSessionRouting = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export function createOpenVikingSessionRoutingRuntime(options: {
+  peerPrefix: string;
+  logFindRequests: boolean;
+  logger: Logger;
+}) {
+  const sessionAgentResolver = createSessionAgentResolver(options.peerPrefix);
+
+  const rememberSessionAgentId = (ctx: SessionAgentLookup) => {
+    sessionAgentResolver.remember(ctx);
+  };
+
+  const resolveAgentId = (
+    sessionId?: string,
+    sessionKey?: string,
+    ovSessionId?: string,
+  ): string => {
+    const sid = typeof sessionId === "string" ? sessionId.trim() : "";
+    const sk = typeof sessionKey === "string" ? sessionKey.trim() : "";
+    const ovSid = typeof ovSessionId === "string" ? ovSessionId.trim() : "";
+    const result = sessionAgentResolver.resolve(sid, sk, ovSid);
+    if (options.logFindRequests) {
+      options.logger.info(
+        `openviking: resolveAgentId ${JSON.stringify({
+          sessionId: sid || "(empty)",
+          sessionKey: sk || "(empty)",
+          ovSessionId: ovSid || "(empty)",
+          parsedConfigPeerPrefix: options.peerPrefix,
+          mappedResolvedAgentId: result.mappedResolvedAgentId,
+          resolvedBeforeSanitize: result.resolvedBeforeSanitize,
+          resolved: result.resolved,
+          branch: result.branch,
+          aliases: result.aliases,
+          fromExplicitBinding: result.fromExplicitBinding,
+        })}`,
+      );
+    }
+    return result.resolved;
+  };
+
+  const resolvePluginSessionRouting = (ctx?: SessionAgentLookup): PluginSessionRouting => {
+    const sessionId = typeof ctx?.sessionId === "string" ? ctx.sessionId.trim() : "";
+    const sessionKey = typeof ctx?.sessionKey === "string" ? ctx.sessionKey.trim() : "";
+    let ovSessionId = typeof ctx?.ovSessionId === "string" ? ctx.ovSessionId.trim() : "";
+
+    if (!ovSessionId && (sessionId || sessionKey)) {
+      ovSessionId = openClawSessionToOvStorageId(
+        sessionId || undefined,
+        sessionKey || undefined,
+      );
+    }
+
+    const session = {
+      agentId: ctx?.agentId,
+      sessionId: sessionId || undefined,
+      sessionKey: sessionKey || undefined,
+      ovSessionId: ovSessionId || undefined,
+    };
+    rememberSessionAgentId(session);
+
+    return {
+      sessionId: session.sessionId,
+      sessionKey: session.sessionKey,
+      ovSessionId: session.ovSessionId,
+      agentId: resolveAgentId(session.sessionId, session.sessionKey, session.ovSessionId),
+    };
+  };
+
+  const toQueryConfigContext = (session: PluginSessionRouting): QueryConfigContext => ({
+    agentId: session.agentId,
+    sessionId: session.sessionId,
+    sessionKey: session.sessionKey,
+    ovSessionId: session.ovSessionId,
+  });
+
+  return {
+    rememberSessionAgentId,
+    resolveAgentId,
+    resolvePluginSessionRouting,
+    toQueryConfigContext,
+  };
+}

--- a/examples/openclaw-plugin/plugin/openviking-tool-result-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-tool-result-tools.ts
@@ -1,0 +1,397 @@
+import { Type } from "@sinclair/typebox";
+
+export type OpenVikingToolResultToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+};
+
+export type OpenVikingToolResultSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+};
+
+export type OpenVikingToolResultToolDefinition = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  execute: (_toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+export type OpenVikingToolResultClient = {
+  readToolResult: (
+    sessionId: string,
+    toolResultId: string,
+    options: { offset: number; limit: number; includeMetadata: boolean },
+    agentId?: string,
+  ) => Promise<{
+    content: string;
+    offset: number;
+    limit: number;
+    total_chars: number;
+    has_more: boolean;
+    tool_result_id: string;
+    metadata?: unknown;
+  }>;
+  searchToolResult: (
+    sessionId: string,
+    toolResultId: string,
+    query: string,
+    options: { limit: number; contextChars: number },
+    agentId?: string,
+  ) => Promise<{
+    tool_result_id: string;
+    matches?: Array<{ offset: number; snippet: string }>;
+  }>;
+  listToolResults: (
+    sessionId: string,
+    options: { toolName?: string; limit: number },
+    agentId?: string,
+  ) => Promise<{
+    tool_results?: Array<{
+      storage_uri?: string;
+      tool_name?: string;
+      original_chars?: number;
+      created_at?: string;
+    }>;
+  }>;
+};
+
+export type OpenVikingToolResultToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  getClient: () => Promise<OpenVikingToolResultClient>;
+  resolvePluginSessionRouting: (ctx?: OpenVikingToolResultToolContext) => OpenVikingToolResultSession;
+  isBypassedSession: (ctx?: OpenVikingToolResultToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+  logger?: { warn?: (message: string) => void };
+};
+
+type ToolResultRef = {
+  sessionId: string;
+  toolResultId: string;
+  ref: string;
+};
+
+export function parseToolResultRef(value: unknown): ToolResultRef | null {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) {
+    return null;
+  }
+  const match = raw.match(/^viking:\/\/session\/([^/]+)\/tool-results\/([^/?#]+)(?:[?#].*)?$/);
+  if (!match) {
+    return null;
+  }
+  const sessionId = decodeURIComponent(match[1]!);
+  const toolResultId = decodeURIComponent(match[2]!);
+  if (!sessionId || !toolResultId) {
+    return null;
+  }
+  return {
+    sessionId,
+    toolResultId,
+    ref: `viking://session/${encodeURIComponent(sessionId)}/tool-results/${encodeURIComponent(toolResultId)}`,
+  };
+}
+
+function getOptionalInteger(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function getPositiveInteger(value: unknown, fallback: number): number {
+  return Math.max(1, getOptionalInteger(value, fallback));
+}
+
+export function registerOpenVikingToolResultTools({
+  registerTool,
+  getClient,
+  resolvePluginSessionRouting,
+  isBypassedSession,
+  makeBypassedToolResult,
+  logger,
+}: OpenVikingToolResultToolsDeps): void {
+  registerTool(
+    (ctx: OpenVikingToolResultToolContext): OpenVikingToolResultToolDefinition => ({
+      name: "openviking_tool_result_read",
+      label: "Tool Result Read (OpenViking)",
+      description:
+        "Restore the full original content of a tool result that was externalized by OpenViking. " +
+        "Use when a previous tool result was externalized and only a preview is visible — " +
+        "the preview contains a [tool-result-ref] or viking://session/.../tool-results/... URI. " +
+        "\"Read\" tool returns the same truncated preview; this tool returns the complete content. " +
+        "To read all content: pass offset=0 and a limit large enough to cover the whole result " +
+        "(e.g. limit=100000). Use offset/limit for paging only when you need a specific section.",
+      parameters: Type.Object({
+        tool_output_ref: Type.String({
+          description:
+            "Exact OV URI from the preview, e.g. viking://session/<session_id>/tool-results/<tool_result_id>",
+        }),
+        offset: Type.Optional(Type.Number({ description: "Unicode character offset. Default: 0" })),
+        limit: Type.Optional(Type.Number({ description: "Maximum Unicode characters to read. Default: 20000" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (isBypassedSession(ctx)) {
+          return makeBypassedToolResult("openviking_tool_result_read");
+        }
+        const session = resolvePluginSessionRouting(ctx);
+        if (!session.ovSessionId) {
+          return {
+            content: [{ type: "text", text: "Error: no active session." }],
+            details: { error: "no_session" },
+          };
+        }
+
+        const parsed = parseToolResultRef(params.tool_output_ref ?? params.ref ?? params.uri);
+        if (!parsed) {
+          return {
+            content: [{ type: "text", text: "Error: tool_output_ref must be a viking://session/.../tool-results/... URI." }],
+            details: { error: "invalid_tool_output_ref" },
+          };
+        }
+        if (parsed.sessionId !== session.ovSessionId) {
+          return {
+            content: [{ type: "text", text: "Error: refusing to read a tool result from another session." }],
+            details: {
+              error: "session_mismatch",
+              requestedSessionId: parsed.sessionId,
+              currentSessionId: session.ovSessionId,
+            },
+          };
+        }
+
+        const offset = Math.max(0, getOptionalInteger(params.offset, 0));
+        const limit = getOptionalInteger(params.limit, 20_000);
+        if (limit < -1) {
+          return {
+            content: [{ type: "text", text: "Error: limit must be -1 or greater than or equal to 0." }],
+            details: { error: "invalid_limit", limit },
+          };
+        }
+
+        try {
+          const client = await getClient();
+          const result = await client.readToolResult(
+            session.ovSessionId,
+            parsed.toolResultId,
+            { offset, limit, includeMetadata: true },
+            session.agentId,
+          );
+          const returnedChars = result.content.length;
+          const nextOffset = result.offset + returnedChars;
+          const text = result.content || "(empty tool result chunk)";
+          return {
+            content: [{ type: "text", text }],
+            details: {
+              action: "read",
+              tool_output_ref: parsed.ref,
+              tool_result_id: result.tool_result_id,
+              offset: result.offset,
+              limit: result.limit,
+              returned_chars: returnedChars,
+              total_chars: result.total_chars,
+              has_more: result.has_more,
+              next_offset: result.has_more ? nextOffset : null,
+              metadata: result.metadata ?? null,
+            },
+          };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger?.warn?.(`openviking: openviking_tool_result_read failed: ${msg}`);
+          return {
+            content: [{ type: "text", text: `Failed to read tool result: ${msg}` }],
+            details: { error: msg, tool_output_ref: parsed.ref },
+          };
+        }
+      },
+    }),
+    { name: "openviking_tool_result_read" },
+  );
+
+  registerTool(
+    (ctx: OpenVikingToolResultToolContext): OpenVikingToolResultToolDefinition => ({
+      name: "openviking_tool_result_search",
+      label: "Tool Result Search (OpenViking)",
+      description:
+        "Search inside an externalized tool result for a keyword. " +
+        "Use when you need to find specific content in a large externalized result, " +
+        "before reading it with openviking_tool_result_read. " +
+        "Returns matching snippets with their character offsets.",
+      parameters: Type.Object({
+        tool_output_ref: Type.String({
+          description:
+            "Exact OV URI from the preview, e.g. viking://session/<session_id>/tool-results/<tool_result_id>",
+        }),
+        query: Type.String({ description: "Keyword or exact text to search for" }),
+        limit: Type.Optional(Type.Number({ description: "Maximum matches. Default: 20" })),
+        context_chars: Type.Optional(Type.Number({ description: "Characters around each match. Default: 300" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (isBypassedSession(ctx)) {
+          return makeBypassedToolResult("openviking_tool_result_search");
+        }
+        const session = resolvePluginSessionRouting(ctx);
+        if (!session.ovSessionId) {
+          return {
+            content: [{ type: "text", text: "Error: no active session." }],
+            details: { error: "no_session" },
+          };
+        }
+
+        const parsed = parseToolResultRef(params.tool_output_ref ?? params.ref ?? params.uri);
+        if (!parsed) {
+          return {
+            content: [{ type: "text", text: "Error: tool_output_ref must be a viking://session/.../tool-results/... URI." }],
+            details: { error: "invalid_tool_output_ref" },
+          };
+        }
+        if (parsed.sessionId !== session.ovSessionId) {
+          return {
+            content: [{ type: "text", text: "Error: refusing to search a tool result from another session." }],
+            details: {
+              error: "session_mismatch",
+              requestedSessionId: parsed.sessionId,
+              currentSessionId: session.ovSessionId,
+            },
+          };
+        }
+
+        const query = String(params.query ?? "").trim();
+        if (!query) {
+          return {
+            content: [{ type: "text", text: "Error: query is required." }],
+            details: { error: "missing_param", param: "query" },
+          };
+        }
+        const limit = getPositiveInteger(params.limit, 20);
+        const contextChars = Math.max(
+          0,
+          getOptionalInteger(params.context_chars ?? params.contextChars, 300),
+        );
+
+        try {
+          const client = await getClient();
+          const result = await client.searchToolResult(
+            session.ovSessionId,
+            parsed.toolResultId,
+            query,
+            { limit, contextChars },
+            session.agentId,
+          );
+          const matches = result.matches ?? [];
+          const text = matches.length
+            ? [
+                `Found ${matches.length} match(es) for "${query}" in ${parsed.ref}:`,
+                "",
+                ...matches.map((match, index) =>
+                  `## Match ${index + 1} (offset ${match.offset})\n${match.snippet}`,
+                ),
+              ].join("\n")
+            : `No matches found for "${query}" in ${parsed.ref}.`;
+          return {
+            content: [{ type: "text", text }],
+            details: {
+              action: "searched",
+              tool_output_ref: parsed.ref,
+              tool_result_id: result.tool_result_id,
+              query,
+              match_count: matches.length,
+              matches,
+            },
+          };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger?.warn?.(`openviking: openviking_tool_result_search failed: ${msg}`);
+          return {
+            content: [{ type: "text", text: `Failed to search tool result: ${msg}` }],
+            details: { error: msg, tool_output_ref: parsed.ref, query },
+          };
+        }
+      },
+    }),
+    { name: "openviking_tool_result_search" },
+  );
+
+  registerTool(
+    (ctx: OpenVikingToolResultToolContext): OpenVikingToolResultToolDefinition => ({
+      name: "openviking_tool_result_list",
+      label: "Tool Result List (OpenViking)",
+      description:
+        "List externalized tool results for the current session. " +
+        "Use to discover available refs before calling openviking_tool_result_read. " +
+        "Optionally filter by tool_name to narrow down results.",
+      parameters: Type.Object({
+        tool_name: Type.Optional(Type.String({ description: "Optional exact tool name filter" })),
+        limit: Type.Optional(Type.Number({ description: "Maximum results. Default: 50" })),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (isBypassedSession(ctx)) {
+          return makeBypassedToolResult("openviking_tool_result_list");
+        }
+        const session = resolvePluginSessionRouting(ctx);
+        if (!session.ovSessionId) {
+          return {
+            content: [{ type: "text", text: "Error: no active session." }],
+            details: { error: "no_session" },
+          };
+        }
+
+        const toolName =
+          typeof params.tool_name === "string" && params.tool_name.trim()
+            ? params.tool_name.trim()
+            : typeof params.toolName === "string" && params.toolName.trim()
+              ? params.toolName.trim()
+              : undefined;
+        const limit = getPositiveInteger(params.limit, 50);
+
+        try {
+          const client = await getClient();
+          const result = await client.listToolResults(
+            session.ovSessionId,
+            { toolName, limit },
+            session.agentId,
+          );
+          const items = result.tool_results ?? [];
+          const text = items.length
+            ? [
+                `Found ${items.length} externalized tool result(s) in current session:`,
+                "",
+                ...items.map((item, index) => {
+                  const ref = typeof item.storage_uri === "string" ? item.storage_uri : "(missing ref)";
+                  const name = typeof item.tool_name === "string" ? item.tool_name : "tool";
+                  const chars = typeof item.original_chars === "number" ? item.original_chars : "unknown";
+                  const created = typeof item.created_at === "string" ? ` created_at=${item.created_at}` : "";
+                  return `${index + 1}. ${name} original_chars=${chars}${created}\nref: ${ref}`;
+                }),
+              ].join("\n")
+            : toolName
+              ? `No externalized tool results found for tool "${toolName}" in current session.`
+              : "No externalized tool results found in current session.";
+          return {
+            content: [{ type: "text", text }],
+            details: {
+              action: "listed",
+              session_id: session.ovSessionId,
+              tool_name: toolName ?? null,
+              count: items.length,
+              tool_results: items,
+            },
+          };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger?.warn?.(`openviking: openviking_tool_result_list failed: ${msg}`);
+          return {
+            content: [{ type: "text", text: `Failed to list tool results: ${msg}` }],
+            details: { error: msg, session_id: session.ovSessionId, tool_name: toolName ?? null },
+          };
+        }
+      },
+    }),
+    { name: "openviking_tool_result_list" },
+  );
+}

--- a/examples/openclaw-plugin/plugin/recall-trace-routes.ts
+++ b/examples/openclaw-plugin/plugin/recall-trace-routes.ts
@@ -1,0 +1,133 @@
+export type RecallTraceRouteRequest = {
+  query?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+  url?: string;
+};
+
+export type RecallTraceRouteResult = {
+  status?: number;
+  body?: unknown;
+};
+
+export type RecallTraceRouteHandler = (request?: RecallTraceRouteRequest) => Promise<RecallTraceRouteResult | unknown>;
+
+export type RecallTraceRoute = {
+  method: "GET";
+  path: string;
+  handler: RecallTraceRouteHandler;
+};
+
+export type RecallTraceRouteAdapter = {
+  registerRoute?: (route: RecallTraceRoute) => void;
+  registerHttpRoute?: (route: {
+    path: string;
+    auth: "plugin";
+    match: "exact" | "prefix";
+    handler: (req: { method?: string; url?: string }, res: {
+      statusCode?: number;
+      setHeader?: (name: string, value: string) => void;
+      end?: (body?: string) => void;
+    }) => Promise<boolean>;
+  }) => void;
+};
+
+export type RecallTraceRouteHandlers = {
+  handleRecallTraces: RecallTraceRouteHandler;
+  handleUriDetail: RecallTraceRouteHandler;
+  handleLatestOvSearchList: RecallTraceRouteHandler;
+};
+
+export const RECALL_TRACE_ROUTE_PATHS = [
+  "/api/openviking/recall-traces",
+  "/api/openviking/uri-detail",
+  "/api/openviking/recall-traces/latest-ov-search-list",
+  "/api/openviking/recall-traces/:traceId",
+] as const;
+
+export function registerRecallTraceRoutes(
+  ctx: unknown,
+  handlers: RecallTraceRouteHandlers,
+): boolean {
+  const routeAdapter = ctx as RecallTraceRouteAdapter | undefined;
+  const canRegisterLegacyRoute = typeof routeAdapter?.registerRoute === "function";
+  const canRegisterHttpRoute = typeof routeAdapter?.registerHttpRoute === "function";
+  if (!canRegisterLegacyRoute && !canRegisterHttpRoute) {
+    return false;
+  }
+
+  const handle = handlers.handleRecallTraces;
+  const routes: RecallTraceRoute[] = [
+    { method: "GET", path: RECALL_TRACE_ROUTE_PATHS[0], handler: handle },
+    { method: "GET", path: RECALL_TRACE_ROUTE_PATHS[1], handler: handlers.handleUriDetail },
+    { method: "GET", path: RECALL_TRACE_ROUTE_PATHS[2], handler: handlers.handleLatestOvSearchList },
+    {
+      method: "GET",
+      path: RECALL_TRACE_ROUTE_PATHS[3],
+      handler: (request?: RecallTraceRouteRequest) => handle({
+        ...request,
+        query: {
+          ...(request?.query ?? {}),
+          traceId: typeof request?.params?.traceId === "string" ? request.params.traceId : undefined,
+        },
+      }),
+    },
+  ];
+
+  for (const route of routes) {
+    routeAdapter?.registerRoute?.(route);
+  }
+
+  if (canRegisterHttpRoute) {
+    const sendJson = (
+      res: { statusCode?: number; setHeader?: (name: string, value: string) => void; end?: (body?: string) => void },
+      status: number,
+      body: unknown,
+    ) => {
+      res.statusCode = status;
+      res.setHeader?.("Cache-Control", "no-store");
+      res.setHeader?.("Content-Type", "application/json; charset=utf-8");
+      res.end?.(JSON.stringify(body));
+    };
+    const makeHttpHandler = (
+      route: RecallTraceRoute,
+      getParams?: (url: string) => Record<string, unknown>,
+    ) => async (
+      req: { method?: string; url?: string },
+      res: { statusCode?: number; setHeader?: (name: string, value: string) => void; end?: (body?: string) => void },
+    ) => {
+      if ((req.method ?? "GET").toUpperCase() !== route.method) {
+        sendJson(res, 405, { ok: false, error: { code: "method_not_allowed", message: `${route.method} is required` } });
+        return true;
+      }
+      const url = req.url ?? route.path;
+      const result = await route.handler({ url, params: getParams?.(url) });
+      const response = result as { status?: number; body?: unknown };
+      sendJson(res, typeof response.status === "number" ? response.status : 200, response.body ?? response);
+      return true;
+    };
+    for (const route of routes) {
+      if (route.path === RECALL_TRACE_ROUTE_PATHS[3]) {
+        const prefix = "/api/openviking/recall-traces/";
+        routeAdapter?.registerHttpRoute?.({
+          path: "/api/openviking/recall-traces",
+          auth: "plugin",
+          match: "prefix",
+          handler: makeHttpHandler(route, (url) => {
+            const pathname = new URL(url, "http://openclaw.local").pathname;
+            const traceId = pathname.startsWith(prefix) ? decodeURIComponent(pathname.slice(prefix.length)) : "";
+            return traceId ? { traceId } : {};
+          }),
+        });
+      } else {
+        routeAdapter?.registerHttpRoute?.({
+          path: route.path,
+          auth: "plugin",
+          match: "exact",
+          handler: makeHttpHandler(route),
+        });
+      }
+    }
+  }
+
+  return true;
+}

--- a/examples/openclaw-plugin/plugin/tool-registration.ts
+++ b/examples/openclaw-plugin/plugin/tool-registration.ts
@@ -1,0 +1,51 @@
+export type OpenVikingToolRegistrationApi = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+};
+
+export type OpenVikingToolRegistrationLogger = {
+  debug?: (message: string) => void;
+};
+
+export type OpenVikingToolRegistrarOptions = {
+  api: OpenVikingToolRegistrationApi;
+  enabledToolNames: ReadonlySet<string>;
+  logger?: OpenVikingToolRegistrationLogger;
+};
+
+export type OpenVikingToolRegistrationRuntimeConfig = {
+  enabledTools: string[] | string;
+};
+
+export function createOpenVikingToolRegistrar({
+  api,
+  enabledToolNames,
+  logger,
+}: OpenVikingToolRegistrarOptions) {
+  return (toolOrFactory: unknown, opts: { name: string }): void => {
+    if (!enabledToolNames.has(opts.name)) {
+      logger?.debug?.(`openviking: tool ${opts.name} disabled by config`);
+      return;
+    }
+    api.registerTool(toolOrFactory, opts);
+  };
+}
+
+export function createOpenVikingToolRegistrationRuntime<TConfig extends OpenVikingToolRegistrationRuntimeConfig>(options: {
+  api: OpenVikingToolRegistrationApi;
+  cfg: TConfig;
+  logger?: OpenVikingToolRegistrationLogger;
+}) {
+  const enabledTools = Array.isArray(options.cfg.enabledTools)
+    ? options.cfg.enabledTools
+    : [options.cfg.enabledTools];
+  const enabledToolNames = new Set<string>(enabledTools);
+  const registerOpenVikingTool = createOpenVikingToolRegistrar({
+    api: options.api,
+    enabledToolNames,
+    logger: options.logger,
+  });
+
+  return {
+    registerOpenVikingTool,
+  };
+}

--- a/examples/openclaw-plugin/query-config.ts
+++ b/examples/openclaw-plugin/query-config.ts
@@ -1,0 +1,400 @@
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { MemoryOpenVikingConfig } from "./config.js";
+import { normalizeResourceTypes, type RecallResourceType } from "./recall-trace.js";
+
+export type RuntimeQueryParams = {
+  recallLimit?: number;
+  candidateLimit?: number;
+  candidateMultiplier?: number;
+  scoreThreshold?: number;
+  maxInjectedChars?: number;
+  recallPreferAbstract?: boolean;
+  resourceTypes?: RecallResourceType[] | string;
+  targetUri?: string;
+  ovSearchLimit?: number;
+  rankingWeights?: {
+    baseScore?: number;
+    leaf?: number;
+    event?: number;
+    preference?: number;
+    lexicalOverlapMax?: number;
+  };
+  resourceTypeWeights?: Partial<Record<RecallResourceType, number>>;
+  categoryWeights?: Record<string, number>;
+};
+
+type RuntimeQueryParamsPatch = RuntimeQueryParams & Record<string, unknown>;
+type ConfigSource = "request" | "session" | "claw" | "static" | "default";
+type RuntimeScope = "claw" | "session";
+
+export type QueryConfigContext = {
+  peerId: string;
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+};
+
+export type EffectiveQueryConfig = {
+  recallLimit: number;
+  candidateLimit: number;
+  candidateMultiplier: number;
+  scoreThreshold: number;
+  maxInjectedChars: number;
+  recallPreferAbstract: boolean;
+  resourceTypes: RecallResourceType[];
+  targetUri?: string;
+  ovSearchLimit: number;
+  rankingWeights: {
+    baseScore: number;
+    leaf: number;
+    event: number;
+    preference: number;
+    lexicalOverlapMax: number;
+  };
+  resourceTypeWeights: Record<string, number>;
+  categoryWeights: Record<string, number>;
+  sources: Record<string, ConfigSource>;
+  warnings: string[];
+};
+
+type RuntimeRecord = {
+  params: RuntimeQueryParams;
+  updatedAt: number;
+  updatedBy?: string;
+  peerId?: string;
+  expiresAt?: number;
+};
+
+type RuntimeFile = {
+  schemaVersion: "1.0";
+  updatedAt: number;
+  claws: Record<string, RuntimeRecord>;
+  sessions: Record<string, RuntimeRecord>;
+};
+
+const DEFAULT_CANDIDATE_MULTIPLIER = 4;
+const DEFAULT_OV_SEARCH_LIMIT = 10;
+const DEFAULT_RANKING_WEIGHTS = {
+  baseScore: 1,
+  leaf: 0.12,
+  event: 0.1,
+  preference: 0.08,
+  lexicalOverlapMax: 0.2,
+};
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function clampInteger(value: unknown, min: number, max: number): number | undefined {
+  const n = toNumber(value);
+  if (n === undefined) return undefined;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+function clampNumber(value: unknown, min: number, max: number): number | undefined {
+  const n = toNumber(value);
+  if (n === undefined) return undefined;
+  return Math.max(min, Math.min(max, n));
+}
+
+function shallowNumberRecord(value: unknown, min: number, max: number): Record<string, number> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const result: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const n = clampNumber(raw, min, max);
+    if (n !== undefined) result[key] = n;
+  }
+  return result;
+}
+
+export function normalizeRuntimeQueryParams(value: RuntimeQueryParamsPatch): { params: RuntimeQueryParams; warnings: string[] } {
+  const warnings: string[] = [];
+  const params: RuntimeQueryParams = {};
+
+  const recallLimit = clampInteger(value.recallLimit, 1, 50);
+  if (recallLimit !== undefined) params.recallLimit = recallLimit;
+  const candidateMultiplier = clampInteger(value.candidateMultiplier, 1, 20);
+  if (candidateMultiplier !== undefined) params.candidateMultiplier = candidateMultiplier;
+  const candidateLimit = clampInteger(value.candidateLimit, 1, 200);
+  if (candidateLimit !== undefined) params.candidateLimit = candidateLimit;
+  const scoreThreshold = clampNumber(value.scoreThreshold, 0, 1);
+  if (scoreThreshold !== undefined) params.scoreThreshold = scoreThreshold;
+  const maxInjectedChars = clampInteger(value.maxInjectedChars, 100, 50_000);
+  if (maxInjectedChars !== undefined) params.maxInjectedChars = maxInjectedChars;
+  const ovSearchLimit = clampInteger(value.ovSearchLimit, 1, 100);
+  if (ovSearchLimit !== undefined) params.ovSearchLimit = ovSearchLimit;
+
+  if (typeof value.recallPreferAbstract === "boolean") params.recallPreferAbstract = value.recallPreferAbstract;
+  if (value.resourceTypes !== undefined) params.resourceTypes = normalizeResourceTypes(value.resourceTypes);
+  if (typeof value.targetUri === "string" && value.targetUri.trim()) {
+    const targetUri = value.targetUri.trim();
+    if (!targetUri.startsWith("viking://")) throw new Error("targetUri must start with viking://");
+    params.targetUri = targetUri;
+  }
+
+  const rankingWeights = shallowNumberRecord(value.rankingWeights, 0, 2);
+  if (rankingWeights) params.rankingWeights = rankingWeights;
+  const resourceTypeWeights = shallowNumberRecord(value.resourceTypeWeights, -1, 2);
+  if (resourceTypeWeights) params.resourceTypeWeights = resourceTypeWeights as Partial<Record<RecallResourceType, number>>;
+  const categoryWeights = shallowNumberRecord(value.categoryWeights, -1, 2);
+  if (categoryWeights) params.categoryWeights = categoryWeights;
+
+  if (params.candidateLimit !== undefined && params.recallLimit !== undefined && params.candidateLimit < params.recallLimit) {
+    params.candidateLimit = params.recallLimit;
+    warnings.push("candidateLimit was raised to recallLimit");
+  }
+
+  return { params, warnings };
+}
+
+export function resolveSessionQueryConfigKey(ctx: Partial<QueryConfigContext>): string | undefined {
+  if (ctx.ovSessionId) return `ov:${ctx.ovSessionId}`;
+  if (ctx.sessionId) return `session:${ctx.sessionId}`;
+  if (ctx.sessionKey) return `key:${ctx.sessionKey}`;
+  return undefined;
+}
+
+function emptyRuntimeFile(): RuntimeFile {
+  return { schemaVersion: "1.0", updatedAt: Date.now(), claws: {}, sessions: {} };
+}
+
+function isRuntimeFile(value: unknown): value is RuntimeFile {
+  return !!value && typeof value === "object" && !Array.isArray(value) && (value as RuntimeFile).schemaVersion === "1.0";
+}
+
+export class RuntimeQueryConfigStore {
+  private data: RuntimeFile = emptyRuntimeFile();
+  private lastMtimeMs = 0;
+  private loadPromise: Promise<void> | undefined;
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  static createInMemory(staticConfig: Required<MemoryOpenVikingConfig>): RuntimeQueryConfigStore {
+    return new RuntimeQueryConfigStore({ staticConfig });
+  }
+
+  constructor(private readonly options: { staticConfig: Required<MemoryOpenVikingConfig>; path?: string }) {}
+
+  async load(): Promise<void> {
+    if (!this.options.path) return;
+    const loadPromise = this.loadFromDisk({ resetOnFailure: true });
+    this.loadPromise = loadPromise;
+    try {
+      await loadPromise;
+    } finally {
+      if (this.loadPromise === loadPromise) this.loadPromise = undefined;
+    }
+  }
+
+  private async loadFromDisk(options?: { resetOnFailure?: boolean }): Promise<void> {
+    try {
+      const raw = await readFile(this.options.path!, "utf8");
+      const parsed = JSON.parse(raw);
+      if (isRuntimeFile(parsed)) this.data = parsed;
+      const s = await stat(this.options.path!);
+      this.lastMtimeMs = s.mtimeMs;
+    } catch {
+      if (options?.resetOnFailure) this.data = emptyRuntimeFile();
+    }
+  }
+
+  private async waitForInitialLoad(): Promise<void> {
+    if (this.loadPromise) await this.loadPromise;
+  }
+
+  async reloadIfChanged(options?: { force?: boolean }): Promise<void> {
+    if (!this.options.path) return;
+    await this.waitForInitialLoad();
+    try {
+      const s = await stat(this.options.path);
+      if (!options?.force && s.mtimeMs === this.lastMtimeMs) return;
+      const raw = await readFile(this.options.path, "utf8");
+      const parsed = JSON.parse(raw);
+      if (isRuntimeFile(parsed)) {
+        this.data = parsed;
+        this.lastMtimeMs = s.mtimeMs;
+      }
+    } catch {
+      // Keep the last known-good in-memory config.
+    }
+  }
+
+  async set(scope: RuntimeScope, ctx: QueryConfigContext, patch: RuntimeQueryParamsPatch): Promise<{ warnings: string[] }> {
+    await this.waitForInitialLoad();
+    const { params, warnings } = normalizeRuntimeQueryParams(patch);
+    const key = this.keyForScope(scope, ctx);
+    const bucket = scope === "claw" ? this.data.claws : this.data.sessions;
+    bucket[key] = { params, updatedAt: Date.now(), updatedBy: "command", peerId: ctx.peerId };
+    this.data.updatedAt = Date.now();
+    await this.persist();
+    return { warnings };
+  }
+
+  async unset(scope: RuntimeScope, ctx: QueryConfigContext, fields: string[]): Promise<void> {
+    await this.waitForInitialLoad();
+    const key = this.keyForScope(scope, ctx);
+    const bucket = scope === "claw" ? this.data.claws : this.data.sessions;
+    const record = bucket[key];
+    if (!record) return;
+    for (const field of fields) {
+      delete (record.params as Record<string, unknown>)[field];
+    }
+    record.updatedAt = Date.now();
+    this.data.updatedAt = Date.now();
+    await this.persist();
+  }
+
+  async reset(scope: RuntimeScope, ctx: QueryConfigContext): Promise<void> {
+    await this.waitForInitialLoad();
+    const key = this.keyForScope(scope, ctx);
+    const bucket = scope === "claw" ? this.data.claws : this.data.sessions;
+    delete bucket[key];
+    this.data.updatedAt = Date.now();
+    await this.persist();
+  }
+
+  async getEffective(ctx: QueryConfigContext, requestOverrides?: RuntimeQueryParamsPatch): Promise<EffectiveQueryConfig> {
+    await this.reloadIfChanged();
+    const cfg = this.options.staticConfig;
+    const warnings: string[] = [];
+    const effective: EffectiveQueryConfig = {
+      recallLimit: cfg.recallLimit,
+      candidateMultiplier: DEFAULT_CANDIDATE_MULTIPLIER,
+      candidateLimit: Math.max(cfg.recallLimit * DEFAULT_CANDIDATE_MULTIPLIER, 20),
+      scoreThreshold: cfg.recallScoreThreshold,
+      maxInjectedChars: cfg.recallMaxInjectedChars,
+      recallPreferAbstract: cfg.recallPreferAbstract,
+      resourceTypes: normalizeResourceTypes(cfg.recallTargetTypes),
+      ovSearchLimit: DEFAULT_OV_SEARCH_LIMIT,
+      rankingWeights: { ...DEFAULT_RANKING_WEIGHTS },
+      resourceTypeWeights: {},
+      categoryWeights: {},
+      sources: {
+        recallLimit: "static",
+        candidateMultiplier: "default",
+        candidateLimit: "default",
+        scoreThreshold: "static",
+        maxInjectedChars: "static",
+        recallPreferAbstract: "static",
+        resourceTypes: "static",
+        ovSearchLimit: "default",
+        rankingWeights: "default",
+      },
+      warnings,
+    };
+
+    let candidateLimitExplicit = false;
+    candidateLimitExplicit = this.applyLayer(effective, this.data.claws[ctx.peerId]?.params, "claw", candidateLimitExplicit);
+    const sessionRecord = this.findSessionRecord(ctx);
+    if (sessionRecord) candidateLimitExplicit = this.applyLayer(effective, sessionRecord.params, "session", candidateLimitExplicit);
+    if (requestOverrides) {
+      const normalized = normalizeRuntimeQueryParams(requestOverrides);
+      warnings.push(...normalized.warnings);
+      this.applyLayer(effective, normalized.params, "request", candidateLimitExplicit);
+    }
+    effective.candidateLimit = Math.max(effective.candidateLimit, effective.recallLimit);
+    return effective;
+  }
+
+  private applyLayer(
+    effective: EffectiveQueryConfig,
+    params: RuntimeQueryParams | undefined,
+    source: ConfigSource,
+    candidateLimitExplicit: boolean,
+  ): boolean {
+    if (!params) return candidateLimitExplicit;
+    if (params.recallLimit !== undefined) {
+      effective.recallLimit = params.recallLimit;
+      effective.sources.recallLimit = source;
+      if (!candidateLimitExplicit) {
+        effective.candidateLimit = Math.max(effective.recallLimit * effective.candidateMultiplier, 20);
+        effective.sources.candidateLimit = source;
+      }
+    }
+    if (params.candidateMultiplier !== undefined) {
+      effective.candidateMultiplier = params.candidateMultiplier;
+      effective.sources.candidateMultiplier = source;
+      if (!candidateLimitExplicit) {
+        effective.candidateLimit = Math.max(effective.recallLimit * params.candidateMultiplier, 20);
+        effective.sources.candidateLimit = source;
+      }
+    }
+    if (params.candidateLimit !== undefined) {
+      effective.candidateLimit = params.candidateLimit;
+      effective.sources.candidateLimit = source;
+      candidateLimitExplicit = true;
+    }
+    if (params.scoreThreshold !== undefined) {
+      effective.scoreThreshold = params.scoreThreshold;
+      effective.sources.scoreThreshold = source;
+    }
+    if (params.maxInjectedChars !== undefined) {
+      effective.maxInjectedChars = params.maxInjectedChars;
+      effective.sources.maxInjectedChars = source;
+    }
+    if (params.recallPreferAbstract !== undefined) {
+      effective.recallPreferAbstract = params.recallPreferAbstract;
+      effective.sources.recallPreferAbstract = source;
+    }
+    if (params.resourceTypes !== undefined) {
+      effective.resourceTypes = Array.isArray(params.resourceTypes) ? [...params.resourceTypes] : normalizeResourceTypes(params.resourceTypes);
+      effective.sources.resourceTypes = source;
+    }
+    if (params.targetUri !== undefined) {
+      effective.targetUri = params.targetUri;
+      effective.sources.targetUri = source;
+    }
+    if (params.ovSearchLimit !== undefined) {
+      effective.ovSearchLimit = params.ovSearchLimit;
+      effective.sources.ovSearchLimit = source;
+    }
+    if (params.rankingWeights) {
+      effective.rankingWeights = { ...effective.rankingWeights, ...params.rankingWeights };
+      effective.sources.rankingWeights = source;
+    }
+    if (params.resourceTypeWeights) effective.resourceTypeWeights = { ...effective.resourceTypeWeights, ...params.resourceTypeWeights };
+    if (params.categoryWeights) effective.categoryWeights = { ...effective.categoryWeights, ...params.categoryWeights };
+    return candidateLimitExplicit;
+  }
+
+  private keyForScope(scope: RuntimeScope, ctx: QueryConfigContext): string {
+    if (scope === "claw") return ctx.peerId;
+    const key = resolveSessionQueryConfigKey(ctx);
+    if (!key) throw new Error("session scope requires ovSessionId, sessionId, or sessionKey");
+    return key;
+  }
+
+  private findSessionRecord(ctx: QueryConfigContext): RuntimeRecord | undefined {
+    const keys = [
+      ctx.ovSessionId ? `ov:${ctx.ovSessionId}` : undefined,
+      ctx.sessionId ? `session:${ctx.sessionId}` : undefined,
+      ctx.sessionKey ? `key:${ctx.sessionKey}` : undefined,
+    ].filter((key): key is string => Boolean(key));
+    for (const key of keys) {
+      const record = this.data.sessions[key];
+      if (record) return record;
+    }
+    return undefined;
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.options.path) return;
+    const operation = this.writeQueue.catch(() => undefined).then(async () => {
+      await mkdir(dirname(this.options.path!), { recursive: true });
+      const temp = `${this.options.path}.${process.pid}.${Date.now()}.tmp`;
+      await writeFile(temp, JSON.stringify(this.data, null, 2), "utf8");
+      await rename(temp, this.options.path!);
+      const s = await stat(this.options.path!);
+      this.lastMtimeMs = s.mtimeMs;
+    });
+    this.writeQueue = operation.catch(() => undefined);
+    await operation;
+  }
+}

--- a/examples/openclaw-plugin/registries/openviking-tools.ts
+++ b/examples/openclaw-plugin/registries/openviking-tools.ts
@@ -1,0 +1,84 @@
+export type OpenVikingToolGroup =
+  | "memory"
+  | "resource_query"
+  | "import"
+  | "recall_trace"
+  | "archive"
+  | "tool_result";
+
+export type OpenVikingToolName =
+  | "add_resource"
+  | "add_skill"
+  | "ov_search"
+  | "ov_read"
+  | "ov_multi_read"
+  | "ov_list"
+  | "memory_recall"
+  | "ov_recall_trace"
+  | "memory_store"
+  | "memory_forget"
+  | "ov_archive_search"
+  | "ov_archive_expand"
+  | "openviking_tool_result_read"
+  | "openviking_tool_result_search"
+  | "openviking_tool_result_list";
+
+export type OpenVikingToolSpec = {
+  name: OpenVikingToolName;
+  group: OpenVikingToolGroup;
+  defaultEnabled: boolean;
+  requiresLegacyFlag?: "enableAddResourceTool";
+};
+
+export const OPENVIKING_ADD_RESOURCE_TOOL_NAME = "add_resource" as const;
+
+export const OPENVIKING_TOOL_SPECS = [
+  {
+    name: OPENVIKING_ADD_RESOURCE_TOOL_NAME,
+    group: "import",
+    defaultEnabled: false,
+    requiresLegacyFlag: "enableAddResourceTool",
+  },
+  { name: "add_skill", group: "import", defaultEnabled: true },
+  { name: "ov_search", group: "resource_query", defaultEnabled: true },
+  { name: "ov_read", group: "resource_query", defaultEnabled: true },
+  { name: "ov_multi_read", group: "resource_query", defaultEnabled: true },
+  { name: "ov_list", group: "resource_query", defaultEnabled: true },
+  { name: "memory_recall", group: "memory", defaultEnabled: true },
+  { name: "ov_recall_trace", group: "recall_trace", defaultEnabled: true },
+  { name: "memory_store", group: "memory", defaultEnabled: true },
+  { name: "memory_forget", group: "memory", defaultEnabled: true },
+  { name: "ov_archive_search", group: "archive", defaultEnabled: true },
+  { name: "ov_archive_expand", group: "archive", defaultEnabled: true },
+  { name: "openviking_tool_result_read", group: "tool_result", defaultEnabled: true },
+  { name: "openviking_tool_result_search", group: "tool_result", defaultEnabled: true },
+  { name: "openviking_tool_result_list", group: "tool_result", defaultEnabled: true },
+] as const satisfies readonly OpenVikingToolSpec[];
+
+export const OPENVIKING_ALL_TOOL_NAMES = OPENVIKING_TOOL_SPECS.map((spec) => spec.name) as OpenVikingToolName[];
+
+export const OPENVIKING_DEFAULT_ENABLED_TOOL_NAMES = OPENVIKING_TOOL_SPECS
+  .filter((spec) => spec.defaultEnabled)
+  .map((spec) => spec.name) as OpenVikingToolName[];
+
+const OPENVIKING_TOOL_GROUP_ORDER: readonly OpenVikingToolGroup[] = [
+  "memory",
+  "resource_query",
+  "import",
+  "recall_trace",
+  "archive",
+  "tool_result",
+];
+
+export const OPENVIKING_TOOL_GROUPS: Record<string, readonly OpenVikingToolName[]> = {
+  all: OPENVIKING_ALL_TOOL_NAMES,
+  default: OPENVIKING_DEFAULT_ENABLED_TOOL_NAMES,
+  ...Object.fromEntries(
+    OPENVIKING_TOOL_GROUP_ORDER.map((group) => [
+      group,
+      OPENVIKING_TOOL_SPECS
+        .filter((spec) => spec.group === group)
+        .map((spec) => spec.name),
+    ]),
+  ),
+};

--- a/examples/openclaw-plugin/registries/recall-resource-types.ts
+++ b/examples/openclaw-plugin/registries/recall-resource-types.ts
@@ -1,0 +1,74 @@
+export const ALLOWED_RECALL_RESOURCE_TYPES = ["resource", "user", "agent"] as const;
+export type RecallResourceType = typeof ALLOWED_RECALL_RESOURCE_TYPES[number];
+export const DEFAULT_RECALL_RESOURCE_TYPES: readonly RecallResourceType[] = ["user", "agent"];
+
+export type RecallSearchPlan = {
+  resourceTypes: RecallResourceType[];
+  searches: Array<{ resourceType: RecallResourceType; contextType: "memory" | "resource"; targetUri?: string }>;
+  skipped: Array<{ resourceType: RecallResourceType; reason: "missing_session" }>;
+};
+
+function toResourceTypeEntries(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/[,\n]/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export function normalizeRecallResourceTypes(value: unknown): RecallResourceType[] {
+  const entries = toResourceTypeEntries(value);
+  if (entries.length === 0) {
+    return [...DEFAULT_RECALL_RESOURCE_TYPES];
+  }
+
+  const seen = new Set<RecallResourceType>();
+  const normalized: RecallResourceType[] = [];
+  const invalid: string[] = [];
+  for (const entry of entries) {
+    if ((ALLOWED_RECALL_RESOURCE_TYPES as readonly string[]).includes(entry)) {
+      const typed = entry as RecallResourceType;
+      if (!seen.has(typed)) {
+        seen.add(typed);
+        normalized.push(typed);
+      }
+    } else {
+      invalid.push(entry);
+    }
+  }
+
+  if (invalid.length > 0) {
+    throw new Error(`invalid resourceTypes: ${invalid.join(", ")}`);
+  }
+
+  return normalized.length > 0 ? normalized : [...DEFAULT_RECALL_RESOURCE_TYPES];
+}
+
+export function resolveRecallSearchPlan(
+  resourceTypes: unknown,
+  _ctx: { ovSessionId?: string; agentId?: string },
+): RecallSearchPlan {
+  const normalized = normalizeRecallResourceTypes(resourceTypes);
+  const searches: RecallSearchPlan["searches"] = [];
+  const skipped: RecallSearchPlan["skipped"] = [];
+  let addedMemorySearch = false;
+
+  for (const resourceType of normalized) {
+    if (resourceType === "resource") {
+      searches.push({ resourceType, contextType: "resource" });
+    } else if ((resourceType === "user" || resourceType === "agent") && !addedMemorySearch) {
+      searches.push({ resourceType: "user", contextType: "memory" });
+      addedMemorySearch = true;
+    }
+  }
+
+  return { resourceTypes: normalized, searches, skipped };
+}

--- a/examples/openclaw-plugin/routing/identity-routing.ts
+++ b/examples/openclaw-plugin/routing/identity-routing.ts
@@ -1,0 +1,210 @@
+import { createHash } from "node:crypto";
+
+const DEFAULT_OPENCLAW_AGENT_ID = "main";
+
+/** OpenClaw session UUID (path-safe on Windows). */
+const OPENVIKING_OV_SESSION_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const WINDOWS_BAD_SESSION_SEGMENT = /[:<>"\\/|?\u0000-\u001f]/;
+
+export type SessionAgentLookup = {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+};
+
+export type SessionAgentResolveBranch =
+  | "session_resolved"
+  | "config_only_fallback"
+  | "default_no_session";
+
+export type SessionAgentResolveResult = {
+  resolved: string;
+  resolvedBeforeSanitize: string;
+  branch: SessionAgentResolveBranch;
+  mappedResolvedAgentId: string | null;
+  aliases: string[];
+  fromExplicitBinding: boolean;
+};
+
+/**
+ * Map OpenClaw session identity to an OpenViking session_id that is safe as a single
+ * AGFS path segment on Windows (no `:` etc.). Prefer UUID sessionId when present;
+ * otherwise derive a stable sha256 from sessionKey.
+ */
+export function openClawSessionToOvStorageId(
+  sessionId: string | undefined,
+  sessionKey: string | undefined,
+): string {
+  const sid = typeof sessionId === "string" ? sessionId.trim() : "";
+  const key = typeof sessionKey === "string" ? sessionKey.trim() : "";
+
+  if (sid && OPENVIKING_OV_SESSION_UUID.test(sid)) {
+    return sid.toLowerCase();
+  }
+  if (key) {
+    return createHash("sha256").update(key, "utf8").digest("hex");
+  }
+  if (sid) {
+    if (WINDOWS_BAD_SESSION_SEGMENT.test(sid)) {
+      return createHash("sha256").update(`openclaw-session:${sid}`, "utf8").digest("hex");
+    }
+    return sid;
+  }
+  throw new Error("openviking: need sessionId or sessionKey for OV session path");
+}
+
+/** Normalize a hook/tool session ref (uuid, sessionKey, or already-safe id) for OV storage. */
+export function openClawSessionRefToOvStorageId(ref: string): string {
+  const t = ref.trim();
+  if (!t) {
+    throw new Error("openviking: empty session ref");
+  }
+  if (OPENVIKING_OV_SESSION_UUID.test(t)) {
+    return t.toLowerCase();
+  }
+  if (WINDOWS_BAD_SESSION_SEGMENT.test(t)) {
+    return createHash("sha256").update(t, "utf8").digest("hex");
+  }
+  return t;
+}
+
+/**
+ * OpenViking peer identifiers allow only [a-zA-Z0-9_-].
+ * OpenClaw ids may contain ":"; never send raw colons in X-OpenViking-Actor-Peer.
+ */
+export function sanitizeOpenVikingAgentIdHeader(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "default";
+  }
+  const normalized = trimmed
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+  return normalized.length > 0 ? normalized : "ov_agent";
+}
+
+function extractAgentIdFromSessionKey(sessionKey?: string): string | undefined {
+  const raw = typeof sessionKey === "string" ? sessionKey.trim() : "";
+  if (!raw) {
+    return undefined;
+  }
+
+  const match = raw.match(/^agent:([^:]+):/);
+  const agentId = match?.[1]?.trim();
+  return agentId || undefined;
+}
+
+function collectSessionAgentAliases(
+  sessionId?: string,
+  sessionKey?: string,
+  ovSessionId?: string,
+): string[] {
+  const aliases = new Set<string>();
+  const sid = typeof sessionId === "string" ? sessionId.trim() : "";
+  const sk = typeof sessionKey === "string" ? sessionKey.trim() : "";
+  const ovSid = typeof ovSessionId === "string" ? ovSessionId.trim() : "";
+
+  if (sid) {
+    aliases.add(sid);
+  }
+  if (sk) {
+    aliases.add(sk);
+  }
+  if (ovSid) {
+    aliases.add(ovSid);
+  }
+
+  if (!ovSid && (sid || sk)) {
+    try {
+      aliases.add(
+        openClawSessionToOvStorageId(
+          sid || undefined,
+          sk || undefined,
+        ),
+      );
+    } catch {
+      /* need a resolvable OpenClaw session identity */
+    }
+  }
+
+  return [...aliases];
+}
+
+export function createSessionAgentResolver(configAgentId: string) {
+  const configAgentPrefix = configAgentId.trim() === "default" ? "" : configAgentId.trim();
+  const sessionAgentIds = new Map<string, string>();
+
+  const remember = (ctx: SessionAgentLookup): void => {
+    const sessionScopedAgentId =
+      extractAgentIdFromSessionKey(ctx.sessionKey) ||
+      extractAgentIdFromSessionKey(ctx.sessionId);
+    const rawAgentId =
+      (typeof ctx.agentId === "string" ? ctx.agentId.trim() : "") ||
+      sessionScopedAgentId ||
+      "";
+    if (!rawAgentId) {
+      return;
+    }
+
+    const prefix = configAgentPrefix;
+    const resolvedBeforeSanitize = prefix ? `${prefix}_${rawAgentId}` : rawAgentId;
+    const resolved = sanitizeOpenVikingAgentIdHeader(resolvedBeforeSanitize);
+    for (const alias of collectSessionAgentAliases(ctx.sessionId, ctx.sessionKey, ctx.ovSessionId)) {
+      sessionAgentIds.set(alias, resolved);
+    }
+  };
+
+  const resolve = (
+    sessionId?: string,
+    sessionKey?: string,
+    ovSessionId?: string,
+  ): SessionAgentResolveResult => {
+    const aliases = collectSessionAgentAliases(sessionId, sessionKey, ovSessionId);
+    const mappedAlias = aliases.find((alias) => sessionAgentIds.has(alias));
+    const mappedResolvedAgentId = mappedAlias ? sessionAgentIds.get(mappedAlias) : undefined;
+    const sessionScopedAgentId =
+      extractAgentIdFromSessionKey(sessionKey) ||
+      extractAgentIdFromSessionKey(sessionId);
+
+    let resolvedBeforeSanitize: string;
+    let resolved: string;
+    let branch: SessionAgentResolveBranch;
+    const prefix = configAgentPrefix;
+
+    if (mappedResolvedAgentId) {
+      resolvedBeforeSanitize = mappedResolvedAgentId;
+      resolved = mappedResolvedAgentId;
+      branch = "session_resolved";
+    } else if (sessionScopedAgentId) {
+      resolvedBeforeSanitize = prefix ? `${prefix}_${sessionScopedAgentId}` : sessionScopedAgentId;
+      resolved = sanitizeOpenVikingAgentIdHeader(resolvedBeforeSanitize);
+      branch = "session_resolved";
+    } else if (!prefix) {
+      resolvedBeforeSanitize = DEFAULT_OPENCLAW_AGENT_ID;
+      resolved = DEFAULT_OPENCLAW_AGENT_ID;
+      branch = "default_no_session";
+    } else {
+      resolvedBeforeSanitize = `${prefix}_${DEFAULT_OPENCLAW_AGENT_ID}`;
+      resolved = sanitizeOpenVikingAgentIdHeader(resolvedBeforeSanitize);
+      branch = "config_only_fallback";
+    }
+
+    return {
+      resolved,
+      resolvedBeforeSanitize,
+      branch,
+      mappedResolvedAgentId: mappedResolvedAgentId ?? null,
+      aliases,
+      fromExplicitBinding: !!(mappedResolvedAgentId || sessionScopedAgentId),
+    };
+  };
+
+  return {
+    remember,
+    resolve,
+  };
+}

--- a/examples/openclaw-plugin/routing/memory-uri.ts
+++ b/examples/openclaw-plugin/routing/memory-uri.ts
@@ -1,0 +1,8 @@
+const MEMORY_URI_PATTERNS = [
+  /^viking:\/\/user\/(?:[^/]+(?:\/agent\/[^/]+)?\/)?memories(?:\/|$)/,
+  /^viking:\/\/agent\/(?:[^/]+(?:\/user\/[^/]+)?\/)?memories(?:\/|$)/,
+];
+
+export function isMemoryUri(uri: string): boolean {
+  return MEMORY_URI_PATTERNS.some((pattern) => pattern.test(uri));
+}

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -1,0 +1,1007 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createOpenVikingCommandDefinitions,
+} from "../../plugin/openviking-command-definitions.js";
+import { registerOpenVikingContextEngine } from "../../plugin/openviking-context-engine-registration.js";
+import { createOpenVikingQueryConfigCommandHandler } from "../../plugin/openviking-query-config-command.js";
+import { createOpenVikingQueryRuntime } from "../../plugin/openviking-query-runtime.js";
+import { createOpenVikingRecallTraceRuntime } from "../../plugin/openviking-recall-trace-runtime.js";
+import {
+  createOpenVikingToolRegistrar,
+} from "../../plugin/tool-registration.js";
+import {
+  registerOpenVikingCommands,
+} from "../../plugin/command-registration.js";
+import {
+  RECALL_TRACE_ROUTE_PATHS,
+  registerRecallTraceRoutes,
+} from "../../plugin/recall-trace-routes.js";
+import { createOpenVikingService } from "../../plugin/openviking-services.js";
+import { registerOpenVikingArchiveTools } from "../../plugin/openviking-archive-tools.js";
+import { registerOpenVikingImportTools } from "../../plugin/openviking-import-tools.js";
+import { createOpenVikingImportRuntime } from "../../plugin/openviking-import-runtime.js";
+import { registerOpenVikingLifecycleHooks } from "../../plugin/openviking-lifecycle-hooks.js";
+import { registerOpenVikingMemoryTools } from "../../plugin/openviking-memory-tools.js";
+import { registerOpenVikingMemoryRecallTools } from "../../plugin/openviking-memory-recall-tools.js";
+import { registerOpenVikingQueryTools } from "../../plugin/openviking-query-tools.js";
+import { registerOpenVikingRecallTraceTools } from "../../plugin/openviking-recall-trace-tools.js";
+import { registerOpenVikingToolResultTools } from "../../plugin/openviking-tool-result-tools.js";
+
+describe("plugin module seams", () => {
+  it("registers only enabled OpenViking tools through the tool-registration seam", () => {
+    const api = { registerTool: vi.fn() };
+    const logger = { debug: vi.fn() };
+    const registrar = createOpenVikingToolRegistrar({
+      api,
+      enabledToolNames: new Set(["ov_search"]),
+      logger,
+    });
+    const toolFactory = () => ({ name: "ov_search" });
+    const disabledFactory = () => ({ name: "memory_store" });
+
+    registrar(toolFactory, { name: "ov_search" });
+    registrar(disabledFactory, { name: "memory_store" });
+
+    expect(api.registerTool).toHaveBeenCalledTimes(1);
+    expect(api.registerTool).toHaveBeenCalledWith(toolFactory, { name: "ov_search" });
+    expect(logger.debug).toHaveBeenCalledWith("openviking: tool memory_store disabled by config");
+  });
+
+  it("registers command definitions without changing names or handlers", async () => {
+    const command = {
+      name: "ov-search",
+      description: "Search OpenViking resources and skills.",
+      acceptsArgs: true,
+      handler: vi.fn().mockResolvedValue({ text: "ok" }),
+    };
+    const api = { registerCommand: vi.fn() };
+
+    registerOpenVikingCommands(api, [command]);
+
+    expect(api.registerCommand).toHaveBeenCalledWith(command);
+    const registered = api.registerCommand.mock.calls[0]?.[0];
+    await expect(registered.handler({ args: "query" })).resolves.toEqual({ text: "ok" });
+    expect(command.handler).toHaveBeenCalledWith({ args: "query" });
+  });
+
+  it("builds OpenViking command definitions through a dedicated plugin module", async () => {
+    const addResourceOpenViking = vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: "resource imported" }],
+      details: { action: "resource_imported" },
+    });
+    const addSkillOpenViking = vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: "skill imported" }],
+      details: { action: "skill_imported" },
+    });
+    const searchOpenViking = vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: "search result" }],
+      details: { action: "searched" },
+    });
+    const handleQueryConfigCommand = vi.fn().mockResolvedValue({ text: "query config", details: { action: "query_config" } });
+    const queryRecallTraces = vi.fn().mockResolvedValue({ entries: [{ traceId: "trace-1" }], lookupLayer: "memory", warnings: [] });
+    const formatRecallTraceText = vi.fn().mockReturnValue("trace text");
+    const deps = {
+      resolvePluginSessionRouting: () => ({ agentId: "agent-main", sessionId: "session-1", ovSessionId: "ov-session-1" }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      parseAddResourceCommandArgs: vi.fn().mockReturnValue({ source: "https://example.com/doc", wait: true }),
+      parseAddSkillCommandArgs: vi.fn().mockReturnValue({ source: "skill.md" }),
+      parseOVSearchCommandArgs: vi.fn().mockReturnValue({ query: "docs", uri: "viking://resources", limit: 3 }),
+      addResourceOpenViking,
+      addSkillOpenViking,
+      searchOpenViking,
+      handleQueryConfigCommand,
+      queryRecallTraces,
+      formatRecallTraceText,
+    };
+
+    const commands = createOpenVikingCommandDefinitions(deps);
+
+    expect(commands.map((command) => command.name)).toEqual([
+      "add-resource",
+      "add-skill",
+      "ov-search",
+      "ov-query-config",
+      "ov-recall-trace",
+    ]);
+
+    await expect(commands[0]!.handler({ args: "https://example.com/doc", sessionId: "session-1" })).resolves.toEqual({
+      text: "resource imported",
+      details: { action: "resource_imported" },
+    });
+    expect(addResourceOpenViking).toHaveBeenCalledWith({ source: "https://example.com/doc", wait: true }, "agent-main");
+
+    await commands[1]!.handler({ args: "skill.md" });
+    expect(addSkillOpenViking).toHaveBeenCalledWith({ source: "skill.md" }, "agent-main");
+
+    await commands[2]!.handler({ args: "docs --uri viking://resources --limit 3" });
+    expect(searchOpenViking).toHaveBeenCalledWith({ query: "docs", uri: "viking://resources", limit: 3 }, "agent-main", {
+      agentId: "agent-main",
+      sessionId: "session-1",
+      ovSessionId: "ov-session-1",
+    });
+
+    await expect(commands[3]!.handler({ args: "get" })).resolves.toEqual({ text: "query config", details: { action: "query_config" } });
+    expect(handleQueryConfigCommand).toHaveBeenCalledWith({ args: "get" });
+
+    await expect(commands[4]!.handler({ args: "--source ov_search --limit 5" })).resolves.toEqual({
+      text: "trace text",
+      details: { count: 1, lookupLayer: "memory", warnings: [], entries: [{ traceId: "trace-1" }] },
+    });
+    expect(queryRecallTraces).toHaveBeenCalledWith(expect.objectContaining({ source: "ov_search", limit: 5, includeContent: false }), {
+      agentId: "agent-main",
+      sessionId: "session-1",
+      ovSessionId: "ov-session-1",
+    });
+    expect(formatRecallTraceText).toHaveBeenCalledWith({ entries: [{ traceId: "trace-1" }], lookupLayer: "memory", warnings: [] });
+  });
+
+  it("keeps recall trace route paths stable across legacy and HTTP adapters", () => {
+    expect(RECALL_TRACE_ROUTE_PATHS).toEqual([
+      "/api/openviking/recall-traces",
+      "/api/openviking/uri-detail",
+      "/api/openviking/recall-traces/latest-ov-search-list",
+      "/api/openviking/recall-traces/:traceId",
+    ]);
+
+    const adapter = {
+      registerRoute: vi.fn(),
+      registerHttpRoute: vi.fn(),
+    };
+    const handlers = {
+      handleRecallTraces: vi.fn().mockResolvedValue({ status: 200, body: { ok: true } }),
+      handleUriDetail: vi.fn().mockResolvedValue({ status: 200, body: { ok: true } }),
+      handleLatestOvSearchList: vi.fn().mockResolvedValue({ status: 200, body: { ok: true } }),
+    };
+
+    const registered = registerRecallTraceRoutes(adapter, handlers);
+
+    expect(registered).toBe(true);
+    expect(adapter.registerRoute.mock.calls.map(([route]) => route.path)).toEqual(RECALL_TRACE_ROUTE_PATHS);
+    expect(adapter.registerHttpRoute.mock.calls.map(([route]) => route.path)).toEqual([
+      "/api/openviking/recall-traces",
+      "/api/openviking/uri-detail",
+      "/api/openviking/recall-traces/latest-ov-search-list",
+      "/api/openviking/recall-traces",
+    ]);
+  });
+
+  it("creates recall trace route handlers through a dedicated runtime module", async () => {
+    const entry = {
+      schemaVersion: "1.0" as const,
+      traceId: "trace-1",
+      ts: Date.UTC(2026, 0, 1),
+      sessionId: "session-1",
+      sessionKey: "session-key-1",
+      ovSessionId: "ov-session-1",
+      agentId: "agent-main",
+      source: "ov_search" as const,
+      operationType: "semantic_find" as const,
+      resourceTypes: ["resource" as const],
+      trigger: { query: "project spec" },
+      searches: [{
+        resourceType: "resource" as const,
+        targetUriResolved: "viking://resources",
+        limit: 5,
+        durationMs: 1,
+        total: 2,
+        results: [
+          { uri: "viking://resources/project/spec.md", resourceType: "resource" as const, category: "doc", score: 0.91, abstractPreview: "Search abstract", resultType: "resource" as const },
+          { uri: "viking://user/skills/debugger", resourceType: "agent" as const, category: "skill", score: 0.8, abstractPreview: "Skill abstract", resultType: "skill" as const },
+        ],
+      }],
+      selected: [{ uri: "viking://resources/project/spec.md", resourceType: "resource" as const, category: "selected-doc", score: 0.95, abstractPreview: "Selected abstract" }],
+      stats: { candidateCount: 2, selectedCount: 1, injectedCount: 0 },
+    };
+    const traceRecorder = {
+      queryWithFallback: vi.fn().mockResolvedValue({ entries: [entry], lookupLayer: "memory", warnings: [] }),
+    };
+    const read = vi.fn().mockResolvedValue("0123456789abcdefghijklmnopqrstuvwxyz");
+    const runtime = createOpenVikingRecallTraceRuntime({
+      getClient: async () => ({ read }),
+      resolvePluginSessionRouting: () => ({ agentId: "agent-main", sessionId: "session-1", sessionKey: "session-key-1", ovSessionId: "ov-session-1" }),
+      traceRecorder,
+      registerRecallTraceRoutes: vi.fn().mockReturnValue(true),
+      normalizeResourceTypes: (value) => Array.isArray(value) ? value : [String(value)],
+      clampScore: (value) => value,
+      previewText: (value, maxChars) => typeof value === "string" ? value.slice(0, maxChars) : undefined,
+      cfg: { traceRecallIncludeContentByDefault: true, traceRecallPreviewChars: 80, recallMaxContentChars: 100 },
+    });
+
+    const list = await runtime.routeHandlers.handleLatestOvSearchList({ query: { sessionkey: "session-key-1", includeSkills: "false", limit: "5" } }) as { status: number; body: any };
+    expect(list.status).toBe(200);
+    expect(list.body.items).toHaveLength(1);
+    expect(list.body.items[0]).toMatchObject({
+      uri: "viking://resources/project/spec.md",
+      abstractPreview: "Selected abstract",
+      source: "selected",
+      targetUri: "viking://resources",
+    });
+
+    const detail = await runtime.routeHandlers.handleUriDetail({ query: { uri: "viking://resources/project/spec.md", traceId: "trace-1", offset: "10", contentLimit: "5" } }) as { status: number; body: any };
+    expect(detail.status).toBe(200);
+    expect(detail.body.uriType).toBe("resource");
+    expect(detail.body.metadata).toMatchObject({ category: "selected-doc", sourceTraceId: "trace-1", source: "ov_search" });
+    expect(detail.body.content).toMatchObject({ text: "abcde", offset: 10, limit: 5, hasMore: true });
+
+    read.mockClear();
+    const kebabDetail = await runtime.routeHandlers.handleUriDetail({ query: { uri: "viking://resources/project/spec.md", "trace-id": "trace-1", offset: "10", "content-limit": "5", "include-content": "false" } }) as { status: number; body: any };
+    expect(kebabDetail.status).toBe(200);
+    expect(kebabDetail.body.metadata).toMatchObject({ category: "selected-doc", sourceTraceId: "trace-1", source: "ov_search" });
+    expect(kebabDetail.body).not.toHaveProperty("content");
+    expect(read).not.toHaveBeenCalled();
+
+    traceRecorder.queryWithFallback.mockClear();
+    read.mockClear();
+    const traces = await runtime.routeHandlers.handleRecallTraces({ query: { "trace-id": "trace-1", "session-key": "session-key-1", "include-content": "false", limit: "1" } }) as { status: number; body: any };
+    expect(traces.status).toBe(200);
+    expect(traceRecorder.queryWithFallback).toHaveBeenCalledWith(expect.objectContaining({
+      traceId: "trace-1",
+      sessionKey: "session-key-1",
+      limit: 1,
+    }));
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("creates OpenViking query runtime for search/read behavior", async () => {
+    const find = vi.fn(async (_query: string, options: { targetUri?: string }) => {
+      if (options.targetUri === "viking://resources") {
+        return {
+          memories: [],
+          resources: [{ uri: "viking://resources/spec.md", abstract: "Spec abstract", score: 0.91, category: "doc" }],
+          skills: [],
+          total: 1,
+        };
+      }
+      return {
+        memories: [],
+        resources: [],
+        skills: [{ uri: "viking://user/skills/debugger", overview: "Debugger overview", score: 0.8, category: "skill" }],
+        total: 1,
+      };
+    });
+    const read = vi.fn().mockResolvedValue({ text: "full content" });
+    const recordAndFlush = vi.fn();
+    const runtime = createOpenVikingQueryRuntime({
+      getClient: async () => ({ find, read, list: vi.fn().mockResolvedValue([]) }),
+      queryConfigStore: { getEffective: vi.fn().mockResolvedValue({ ovSearchLimit: 2 }) },
+      toQueryConfigContext: (session) => session,
+      traceRecorder: { recordAndFlush },
+      inferRecallResourceType: (uri) => uri.includes("skills") ? "agent" : "resource",
+      createTraceId: () => "trace-query-1",
+      boundTraceQuery: (query) => ({ query }),
+      previewText: (value) => typeof value === "string" ? value : undefined,
+      logger: { warn: vi.fn() },
+      cfg: { traceRecallMaxResultsPerSearch: 5, traceRecallPreviewChars: 80, traceRecallQueryMaxChars: 120 },
+    });
+
+    const search = await runtime.searchOpenViking({ query: "spec" }, "agent-main", { agentId: "agent-main", sessionId: "session-1" }) as any;
+    expect(find.mock.calls.map(([, options]) => options.targetUri)).toEqual(["viking://resources", "viking://user/skills"]);
+    expect(search.content[0].text).toContain("Found 2 OpenViking results for \"spec\"");
+    expect(search.details).toMatchObject({ action: "searched", total: 2 });
+    expect(recordAndFlush).toHaveBeenCalledWith(expect.objectContaining({
+      traceId: "trace-query-1",
+      source: "ov_search",
+      agentId: "agent-main",
+      stats: { candidateCount: 2, selectedCount: 2, injectedCount: 0 },
+    }));
+
+    const readResult = await runtime.readOpenVikingContent({ uri: "viking://resources/spec.md" }, "agent-main") as any;
+    expect(read).toHaveBeenCalledWith("viking://resources/spec.md", "agent-main");
+    expect(readResult.content[0].text).toContain("--- START OF viking://resources/spec.md ---");
+  });
+
+  it("handles OpenViking query config commands through a dedicated module", async () => {
+    const session = { agentId: "agent-main", sessionId: "session-1", sessionKey: "key-1", ovSessionId: "ov-session-1" };
+    const queryCtx = { agentId: "agent-main", sessionId: "session-1", sessionKey: "key-1", ovSessionId: "ov-session-1" };
+    const effective = { ovSearchLimit: 7, targetUri: "viking://resources", warnings: [] };
+    const queryConfigStore = {
+      getEffective: vi.fn().mockResolvedValue(effective),
+      set: vi.fn().mockResolvedValue(undefined),
+      unset: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn().mockResolvedValue(undefined),
+    };
+    const normalizeRuntimeQueryParams = vi.fn().mockReturnValue({ params: { ovSearchLimit: 3 }, warnings: ["normalized"] });
+    const handler = createOpenVikingQueryConfigCommandHandler({
+      resolvePluginSessionRouting: vi.fn().mockReturnValue(session),
+      toQueryConfigContext: vi.fn().mockReturnValue(queryCtx),
+      queryConfigStore,
+      normalizeRuntimeQueryParams,
+    });
+
+    await expect(handler({ args: "get --scope claw" })).resolves.toEqual({
+      text: JSON.stringify({ scope: "claw", effective }, null, 2),
+      details: { scope: "claw", effective },
+    });
+
+    await expect(handler({ args: "set --ovSearchLimit 3 --scope session" })).resolves.toMatchObject({
+      text: "Updated OpenViking query config (session). Warnings: normalized",
+      details: { scope: "session", params: { ovSearchLimit: 3 }, warnings: ["normalized"], effective },
+    });
+    expect(normalizeRuntimeQueryParams).toHaveBeenCalledWith({ ovSearchLimit: 3 });
+    expect(queryConfigStore.set).toHaveBeenCalledWith("session", queryCtx, { ovSearchLimit: 3 });
+
+    await expect(handler({ args: "unset ovSearchLimit targetUri --scope claw" })).resolves.toMatchObject({
+      text: "Unset OpenViking query config fields (claw): ovSearchLimit, targetUri",
+      details: { scope: "claw", fields: ["ovSearchLimit", "targetUri"], effective },
+    });
+    expect(queryConfigStore.unset).toHaveBeenCalledWith("claw", queryCtx, ["ovSearchLimit", "targetUri"]);
+
+    await expect(handler({ args: "reset" })).resolves.toMatchObject({
+      text: "Reset OpenViking query config (session).",
+      details: { scope: "session", effective },
+    });
+    expect(queryConfigStore.reset).toHaveBeenCalledWith("session", queryCtx);
+  });
+
+  it("creates OpenViking import runtime for command import behavior", async () => {
+    const addResource = vi.fn().mockResolvedValue({
+      root_uri: "viking://resources/project-docs",
+      warnings: ["kept existing metadata"],
+      task_id: "task-resource-1",
+    });
+    const addSkill = vi.fn().mockResolvedValue({
+      uri: "viking://user/skills/debugger",
+      name: "debugger",
+      task_id: "task-skill-1",
+    });
+    const runtime = createOpenVikingImportRuntime({
+      getClient: async () => ({ addResource, addSkill }),
+    });
+
+    await expect(runtime.addResourceOpenViking({
+      source: "./docs",
+      to: "viking://resources/project-docs",
+      parent: "viking://resources",
+      reason: "project docs",
+      instruction: "extract API notes",
+      wait: true,
+      timeout: 30,
+    }, "agent-main")).resolves.toEqual({
+      content: [{ type: "text", text: "Imported OpenViking resource. viking://resources/project-docs Warnings: kept existing metadata" }],
+      details: {
+        action: "resource_imported",
+        root_uri: "viking://resources/project-docs",
+        warnings: ["kept existing metadata"],
+        task_id: "task-resource-1",
+      },
+    });
+    expect(addResource).toHaveBeenCalledWith({
+      pathOrUrl: "./docs",
+      to: "viking://resources/project-docs",
+      parent: "viking://resources",
+      reason: "project docs",
+      instruction: "extract API notes",
+      wait: true,
+      timeout: 30,
+    }, "agent-main");
+
+    await expect(runtime.addSkillOpenViking({
+      source: "./skills/debugger/SKILL.md",
+      data: "skill body",
+      wait: false,
+      timeout: 5,
+    }, "agent-main")).resolves.toEqual({
+      content: [{ type: "text", text: "Imported OpenViking skill (debugger). viking://user/skills/debugger" }],
+      details: {
+        action: "skill_imported",
+        uri: "viking://user/skills/debugger",
+        name: "debugger",
+        task_id: "task-skill-1",
+      },
+    });
+    expect(addSkill).toHaveBeenCalledWith({
+      path: "./skills/debugger/SKILL.md",
+      data: "skill body",
+      wait: false,
+      timeout: 5,
+    }, "agent-main");
+  });
+
+  it("creates the OpenViking lifecycle service without changing start/stop behavior", async () => {
+    const healthCheck = vi.fn().mockResolvedValue({ ok: true });
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const registerRecallTraceRoutes = vi.fn().mockReturnValue(true);
+    const service = createOpenVikingService({
+      cfg: { baseUrl: "http://127.0.0.1:1933", targetUri: "viking://resources" },
+      getClient: async () => ({ healthCheck }),
+      logger,
+      recallTraceHttpRoutesRegistered: false,
+      registerRecallTraceRoutes,
+    });
+
+    expect(service.id).toBe("openviking");
+    await service.start({ registerRoute: vi.fn() });
+    service.stop();
+
+    expect(registerRecallTraceRoutes).toHaveBeenCalled();
+    expect(healthCheck).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("openviking: initialized"));
+    expect(logger.info).toHaveBeenCalledWith("openviking: registered recall trace Gateway routes");
+    expect(logger.info).toHaveBeenCalledWith("openviking: stopped");
+  });
+
+  it("registers lifecycle hooks through a dedicated plugin module", async () => {
+    const handlers = new Map<string, Function>();
+    const api = {
+      on: vi.fn((hookName: string, handler: Function) => {
+        handlers.set(hookName, handler);
+      }),
+    };
+    const rememberSessionAgentId = vi.fn();
+    const verboseRoutingInfo = vi.fn();
+    const commitOVSession = vi.fn().mockResolvedValue(true);
+    const logger = { info: vi.fn(), warn: vi.fn() };
+
+    registerOpenVikingLifecycleHooks({
+      api,
+      rememberSessionAgentId,
+      isBypassedSession: (ctx) => ctx?.sessionKey === "bypass",
+      verboseRoutingInfo,
+      getContextEngine: () => ({ commitOVSession }),
+      logger,
+    });
+
+    expect(api.on.mock.calls.map(([hookName]) => hookName)).toEqual([
+      "session_start",
+      "session_end",
+      "before_reset",
+      "after_compaction",
+    ]);
+
+    await handlers.get("session_start")?.({}, { sessionId: "session-1", agentId: "agent-main" });
+    await handlers.get("session_end")?.({}, { sessionId: "session-2", agentId: "agent-main" });
+    expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-1", agentId: "agent-main" });
+    expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-2", agentId: "agent-main" });
+
+    await handlers.get("before_reset")?.({}, { sessionId: "session-3", sessionKey: "key-3" });
+    expect(commitOVSession).toHaveBeenCalledWith({ sessionId: "session-3", sessionKey: "key-3" });
+    expect(logger.info).toHaveBeenCalledWith("openviking: committed OV session on reset for session=session-3");
+
+    await handlers.get("before_reset")?.({}, { sessionId: "session-4", sessionKey: "bypass" });
+    expect(verboseRoutingInfo).toHaveBeenCalledWith(expect.stringContaining("bypassing before_reset"));
+    expect(commitOVSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers the context engine through a dedicated plugin module", () => {
+    const engine = { id: "openviking", commitOVSession: vi.fn() };
+    const api = { registerContextEngine: vi.fn() };
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const getClient = vi.fn();
+    const resolveAgentId = vi.fn();
+    const rememberSessionAgentId = vi.fn();
+    const queryConfigStore = { get: vi.fn() };
+    const traceRecorder = { record: vi.fn() };
+    const createContextEngine = vi.fn().mockReturnValue(engine);
+    const setContextEngineRef = vi.fn();
+
+    registerOpenVikingContextEngine({
+      api,
+      plugin: { id: "openviking", name: "OpenViking" },
+      version: "0.1.0",
+      cfg: { baseUrl: "http://127.0.0.1:1933" },
+      logger,
+      getClient,
+      resolveAgentId,
+      rememberSessionAgentId,
+      queryConfigStore,
+      traceRecorder,
+      createContextEngine,
+      setContextEngineRef,
+    });
+
+    expect(api.registerContextEngine).toHaveBeenCalledWith("openviking", expect.any(Function));
+    expect(createContextEngine).not.toHaveBeenCalled();
+    const registeredFactory = api.registerContextEngine.mock.calls[0]?.[1];
+
+    expect(registeredFactory()).toBe(engine);
+    expect(createContextEngine).toHaveBeenCalledWith({
+      id: "openviking",
+      name: "OpenViking",
+      version: "0.1.0",
+      cfg: { baseUrl: "http://127.0.0.1:1933" },
+      logger,
+      getClient,
+      resolveAgentId,
+      rememberSessionAgentId,
+      queryConfigStore,
+      traceRecorder,
+    });
+    expect(setContextEngineRef).toHaveBeenCalledWith(engine);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("registered context-engine"));
+  });
+
+  it("warns when the context-engine registration API is unavailable", () => {
+    const logger = { info: vi.fn(), warn: vi.fn() };
+
+    registerOpenVikingContextEngine({
+      api: {},
+      plugin: { id: "openviking", name: "OpenViking" },
+      version: "0.1.0",
+      cfg: {},
+      logger,
+      getClient: vi.fn(),
+      resolveAgentId: vi.fn(),
+      rememberSessionAgentId: vi.fn(),
+      queryConfigStore: {},
+      traceRecorder: {},
+      createContextEngine: vi.fn(),
+      setContextEngineRef: vi.fn(),
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("registerContextEngine is unavailable"));
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("registers externalized tool-result tools through a dedicated plugin module", async () => {
+    const registerTool = vi.fn();
+    const readToolResult = vi.fn().mockResolvedValue({
+      content: "full tool result",
+      offset: 0,
+      limit: 20_000,
+      total_chars: 16,
+      has_more: false,
+      tool_result_id: "tr_1",
+      metadata: { tool_name: "ov_search" },
+    });
+    const deps = {
+      registerTool,
+      getClient: async () => ({ readToolResult }),
+      resolvePluginSessionRouting: () => ({ agentId: "agent-main", ovSessionId: "ov-session-1" }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      logger: { warn: vi.fn() },
+    };
+
+    registerOpenVikingToolResultTools(deps);
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual([
+      "openviking_tool_result_read",
+      "openviking_tool_result_search",
+      "openviking_tool_result_list",
+    ]);
+    const readFactory = registerTool.mock.calls[0]?.[0];
+    const readTool = readFactory({ sessionId: "session-1" });
+    const result = await readTool.execute("call-1", {
+      tool_output_ref: "viking://session/ov-session-1/tool-results/tr_1",
+    });
+
+    expect(readToolResult).toHaveBeenCalledWith(
+      "ov-session-1",
+      "tr_1",
+      { offset: 0, limit: 20_000, includeMetadata: true },
+      "agent-main",
+    );
+    expect(result.content[0].text).toBe("full tool result");
+    expect(result.details).toMatchObject({ action: "read", tool_result_id: "tr_1" });
+  });
+
+  it("registers archive search and expansion through a dedicated plugin module", async () => {
+    const registerTool = vi.fn();
+    const recordAndFlush = vi.fn().mockResolvedValue(undefined);
+    const grepSessionArchives = vi.fn().mockResolvedValue({
+      count: 1,
+      matches: [{
+        uri: "viking://session/ov-session-1/history/archive_001#L12",
+        line: 12,
+        content: "important command output",
+      }],
+    });
+    const getSessionArchive = vi.fn().mockResolvedValue({
+      archive_id: "archive_001",
+      abstract: "Compressed summary",
+      messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "hello" }], created_at: "2026-06-10T00:00:00Z" }],
+    });
+    const deps = {
+      registerTool,
+      getClient: async () => ({ grepSessionArchives, getSessionArchive }),
+      rememberSessionAgentId: vi.fn(),
+      toOvSessionId: () => "ov-session-1",
+      resolveAgentId: () => "agent-main",
+      resolvePluginSessionRouting: () => ({
+        agentId: "agent-main",
+        sessionId: "session-1",
+        ovSessionId: "ov-session-1",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      formatMessage: (message: { role: string; parts: Array<{ text?: string }> }) => `${message.role}: ${message.parts[0]?.text ?? ""}`,
+      traceRecorder: { recordAndFlush },
+      traceRecallMaxResultsPerSearch: 10,
+      traceRecallPreviewChars: 20,
+      createTraceId: () => "trace-archive-search",
+      logger: { info: vi.fn(), warn: vi.fn() },
+    };
+
+    registerOpenVikingArchiveTools(deps);
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual([
+      "ov_archive_search",
+      "ov_archive_expand",
+    ]);
+    const searchFactory = registerTool.mock.calls[0]?.[0];
+    const searchTool = searchFactory({ sessionId: "session-1", sessionKey: "session-key" });
+    const searchResult = await searchTool.execute("call-1", { query: "command" });
+
+    expect(grepSessionArchives).toHaveBeenCalledWith("ov-session-1", "command", {
+      archiveId: undefined,
+      caseInsensitive: true,
+      agentId: "agent-main",
+    });
+    expect(searchResult.content[0].text).toContain("Found 1 match(es)");
+    expect(searchResult.content[0].text).toContain("important command output");
+    expect(searchResult.details).toMatchObject({ query: "command", matchCount: 1 });
+    expect(recordAndFlush).toHaveBeenCalledWith(expect.objectContaining({
+      traceId: "trace-archive-search",
+      source: "ov_archive_search",
+      operationType: "archive_grep",
+    }));
+
+    const expandFactory = registerTool.mock.calls[1]?.[0];
+    const expandTool = expandFactory({ sessionId: "session-1" });
+    const result = await expandTool.execute("call-2", { archiveId: "archive_001" });
+
+    expect(getSessionArchive).toHaveBeenCalledWith("ov-session-1", "archive_001", "agent-main");
+    expect(result.content[0].text).toContain("## archive_001");
+    expect(result.content[0].text).toContain("user: hello");
+    expect(result.details).toMatchObject({
+      action: "expanded",
+      archiveId: "archive_001",
+      messageCount: 1,
+      sessionId: "session-1",
+      ovSessionId: "ov-session-1",
+    });
+  });
+
+  it("registers import tools through a dedicated plugin module", async () => {
+    const registerTool = vi.fn();
+    const addResource = vi.fn().mockResolvedValue({ root_uri: "viking://resources/docs", warnings: ["warn"] });
+    const addSkill = vi.fn().mockResolvedValue({ uri: "viking://user/skills/demo", name: "demo" });
+    const deps = {
+      registerTool,
+      getClient: async () => ({ addResource, addSkill }),
+      resolvePluginSessionRouting: () => ({ agentId: "agent-main" }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      enableAddResourceTool: true,
+    };
+
+    registerOpenVikingImportTools(deps);
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual(["add_resource", "add_skill"]);
+    const addResourceFactory = registerTool.mock.calls[0]?.[0];
+    const addResourceTool = addResourceFactory({ sessionId: "session-1" });
+    const resourceResult = await addResourceTool.execute("call-1", {
+      source: "https://example.com/docs",
+      to: "viking://resources/docs",
+      wait: true,
+      timeout: 30,
+    });
+    expect(addResource).toHaveBeenCalledWith({
+      pathOrUrl: "https://example.com/docs",
+      to: "viking://resources/docs",
+      parent: undefined,
+      reason: undefined,
+      instruction: undefined,
+      wait: true,
+      timeout: 30,
+    }, "agent-main");
+    expect(resourceResult.content[0].text).toBe("Imported OpenViking resource. viking://resources/docs Warnings: warn");
+    expect(resourceResult.details).toMatchObject({ action: "resource_imported", root_uri: "viking://resources/docs" });
+
+    const addSkillFactory = registerTool.mock.calls[1]?.[0];
+    const addSkillTool = addSkillFactory({ sessionId: "session-1" });
+    const skillResult = await addSkillTool.execute("call-2", { data: "name: demo\n" });
+    expect(addSkill).toHaveBeenCalledWith({
+      path: undefined,
+      data: "name: demo\n",
+      wait: undefined,
+      timeout: undefined,
+    }, "agent-main");
+    expect(skillResult.content[0].text).toBe("Imported OpenViking skill (demo). viking://user/skills/demo");
+    expect(skillResult.details).toMatchObject({ action: "skill_imported", uri: "viking://user/skills/demo" });
+  });
+
+  it("keeps add_resource import tool behind explicit opt-in", () => {
+    const registerTool = vi.fn();
+    registerOpenVikingImportTools({
+      registerTool,
+      getClient: async () => ({ addResource: vi.fn(), addSkill: vi.fn() }),
+      resolvePluginSessionRouting: () => ({ agentId: "agent-main" }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      enableAddResourceTool: false,
+    });
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual(["add_skill"]);
+  });
+
+  it("registers query tools through a dedicated plugin module", async () => {
+    const registerTool = vi.fn();
+    const searchOpenViking = vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: "search result" }],
+      details: { action: "searched", total: 1 },
+    });
+    const readOpenVikingContent = vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: "read result" }],
+      details: { action: "read", uri: "viking://resources/doc" },
+    });
+    const multiReadOpenVikingContent = vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: "multi read result" }],
+      details: { action: "multi_read", count: 2 },
+    });
+    const listOpenVikingDirectory = vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: "list result" }],
+      details: { action: "listed", count: 2 },
+    });
+    const deps = {
+      registerTool,
+      searchOpenViking,
+      readOpenVikingContent,
+      multiReadOpenVikingContent,
+      listOpenVikingDirectory,
+      resolvePluginSessionRouting: () => ({
+        agentId: "agent-main",
+        sessionId: "session-1",
+        ovSessionId: "ov-session-1",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+    };
+
+    registerOpenVikingQueryTools(deps);
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual(["ov_search", "ov_read", "ov_multi_read", "ov_list"]);
+    const searchFactory = registerTool.mock.calls[0]?.[0];
+    const searchTool = searchFactory({ sessionId: "session-1" });
+    const searched = await searchTool.execute("call-1", { query: "docs", uri: "viking://resources", limit: 3 });
+    expect(searchOpenViking).toHaveBeenCalledWith({
+      query: "docs",
+      uri: "viking://resources",
+      limit: 3,
+    }, "agent-main", {
+      agentId: "agent-main",
+      sessionId: "session-1",
+      ovSessionId: "ov-session-1",
+    });
+    expect(searched.details).toMatchObject({ action: "searched", total: 1 });
+
+    const readFactory = registerTool.mock.calls[1]?.[0];
+    const readTool = readFactory({ sessionId: "session-1" });
+    const read = await readTool.execute("call-2", { uri: "viking://resources/doc" });
+    expect(readOpenVikingContent).toHaveBeenCalledWith({ uri: "viking://resources/doc" }, "agent-main");
+    expect(read.content[0].text).toBe("read result");
+
+    const multiReadFactory = registerTool.mock.calls[2]?.[0];
+    const multiReadTool = multiReadFactory({ sessionId: "session-1" });
+    const multiRead = await multiReadTool.execute("call-3", { uris: ["viking://resources/a.md", "viking://resources/b.md"] });
+    expect(multiReadOpenVikingContent).toHaveBeenCalledWith({
+      uris: ["viking://resources/a.md", "viking://resources/b.md"],
+    }, "agent-main");
+    expect(multiRead.content[0].text).toBe("multi read result");
+
+    const listFactory = registerTool.mock.calls[3]?.[0];
+    const listTool = listFactory({ sessionId: "session-1" });
+    const list = await listTool.execute("call-4", {
+      uri: "viking://resources/doc",
+      recursive: true,
+      simple: true,
+      limit: 5,
+    });
+    expect(listOpenVikingDirectory).toHaveBeenCalledWith({
+      uri: "viking://resources/doc",
+      recursive: true,
+      simple: true,
+      limit: 5,
+    }, "agent-main");
+    expect(list.content[0].text).toBe("list result");
+  });
+
+  it("registers memory store and forget through a dedicated plugin module", async () => {
+    const registerTool = vi.fn();
+    const addSessionMessage = vi.fn().mockResolvedValue(undefined);
+    const commitSession = vi.fn().mockResolvedValue({
+      session_id: "memory-store-temp",
+      status: "completed",
+      archived: false,
+      memories_extracted: { core: 2 },
+    });
+    const deleteUri = vi.fn().mockResolvedValue(undefined);
+    const find = vi.fn().mockResolvedValue({ memories: [], total: 0 });
+    const deps = {
+      registerTool,
+      getClient: async () => ({ addSessionMessage, commitSession, deleteUri, find }),
+      normalizeSessionId: (sessionId: string) => `normalized:${sessionId}`,
+      createTempSessionId: () => "memory-store-temp",
+      extractSenderId: () => "ou_01@abc",
+      toRoleId: (senderId?: string) => senderId?.replace(/[^a-zA-Z0-9_-]/g, "_"),
+      resolvePluginSessionRouting: () => ({ agentId: "agent-main" }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      defaultTargetUri: "viking://user/default",
+      defaultRecallScoreThreshold: 0.25,
+      logFindRequests: true,
+      logger: { info: vi.fn(), warn: vi.fn() },
+    };
+
+    registerOpenVikingMemoryTools(deps);
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual(["memory_store", "memory_forget"]);
+    const storeFactory = registerTool.mock.calls[0]?.[0];
+    const storeTool = storeFactory({ sessionId: "session-1", requesterSenderId: "ou_01@abc" });
+    const stored = await storeTool.execute("call-1", { text: "remember this" });
+    expect(addSessionMessage).toHaveBeenCalledWith(
+      "memory-store-temp",
+      "user",
+      [{ type: "text", text: "remember this" }],
+      "agent-main",
+      undefined,
+      "ou_01_abc",
+    );
+    expect(commitSession).toHaveBeenCalledWith("memory-store-temp", {
+      wait: true,
+      agentId: "agent-main",
+      keepRecentCount: 0,
+    });
+    expect(stored.details).toMatchObject({ action: "stored", memoriesCount: 2, usedTempSession: true });
+
+    const forgetFactory = registerTool.mock.calls[1]?.[0];
+    const forgetTool = forgetFactory({ sessionId: "session-1" });
+    const rejected = await forgetTool.execute("call-2", { uri: "viking://resources/r1" });
+    expect(rejected.details).toMatchObject({ action: "rejected", uri: "viking://resources/r1" });
+    expect(deleteUri).not.toHaveBeenCalled();
+
+    const deleted = await forgetTool.execute("call-3", { uri: "viking://user/default/memories/m1" });
+    expect(deleteUri).toHaveBeenCalledWith("viking://user/default/memories/m1", "agent-main");
+    expect(deleted.content[0].text).toBe("Forgotten: viking://user/default/memories/m1");
+    expect(deleted.details).toMatchObject({ action: "deleted", uri: "viking://user/default/memories/m1" });
+  });
+
+  it("registers recall trace tool through a dedicated plugin module", async () => {
+    const registerTool = vi.fn();
+    const traceResult = {
+      entries: [{ traceId: "trace-1", source: "ov_search" }],
+      lookupLayer: "memory",
+      warnings: ["warn"],
+    };
+    const queryRecallTraces = vi.fn().mockResolvedValue(traceResult);
+    const formatRecallTraceText = vi.fn().mockReturnValue("formatted trace");
+    const deps = {
+      registerTool,
+      queryRecallTraces,
+      formatRecallTraceText,
+      resolvePluginSessionRouting: () => ({
+        agentId: "agent-main",
+        sessionId: "session-1",
+        ovSessionId: "ov-session-1",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+    };
+
+    registerOpenVikingRecallTraceTools(deps);
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual(["ov_recall_trace"]);
+    const traceFactory = registerTool.mock.calls[0]?.[0];
+    const traceTool = traceFactory({ sessionId: "session-1" });
+    const result = await traceTool.execute("call-1", { source: "ov_search", limit: 5 });
+
+    expect(queryRecallTraces).toHaveBeenCalledWith({ source: "ov_search", limit: 5 }, {
+      agentId: "agent-main",
+      sessionId: "session-1",
+      ovSessionId: "ov-session-1",
+    });
+    expect(formatRecallTraceText).toHaveBeenCalledWith(traceResult);
+    expect(result.content[0].text).toBe("formatted trace");
+    expect(result.details).toMatchObject({
+      action: "queried",
+      count: 1,
+      lookupLayer: "memory",
+      warnings: ["warn"],
+      entries: traceResult.entries,
+    });
+  });
+
+  it("registers memory recall tool through a dedicated plugin module", async () => {
+    const registerTool = vi.fn();
+    const memory = {
+      uri: "viking://user/default/memories/m1",
+      category: "preferences",
+      abstract: "User prefers TDD.",
+      score: 0.93,
+      level: 2,
+    };
+    const find = vi.fn().mockResolvedValue({ memories: [memory], total: 1 });
+    const read = vi.fn().mockResolvedValue("User prefers TDD.");
+    const getDefaultAgentId = vi.fn().mockReturnValue("default-agent");
+    const recordAndFlush = vi.fn().mockResolvedValue(undefined);
+    const getEffective = vi.fn().mockResolvedValue({
+      recallLimit: 1,
+      scoreThreshold: 0.5,
+      targetUri: "viking://user/default",
+      resourceTypes: ["user"],
+      candidateLimit: 4,
+      maxInjectedChars: 500,
+      rankingWeights: {},
+      categoryWeights: {},
+      resourceTypeWeights: {},
+    });
+
+    registerOpenVikingMemoryRecallTools({
+      registerTool,
+      getClient: async () => ({ find, read, getDefaultAgentId }),
+      queryConfigStore: { getEffective },
+      toQueryConfigContext: (session) => ({ agentId: session.agentId, sessionId: session.sessionId, sessionKey: session.sessionKey, ovSessionId: session.ovSessionId }),
+      resolvePluginSessionRouting: () => ({
+        agentId: "agent-main",
+        sessionId: "session-1",
+        sessionKey: "agent:agent-main:session-1",
+        ovSessionId: "ov-session-1",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      resolveRecallSearchPlan: vi.fn(),
+      postProcessMemories: (items) => items,
+      pickMemoriesForInjection: (items) => items.slice(0, 1),
+      buildMemoryLinesWithBudget: vi.fn(async (items, readFn) => {
+        await readFn(items[0].uri);
+        return { lines: ["1. [preferences] User prefers TDD. (93%)"], estimatedTokens: 8 };
+      }),
+      inferRecallResourceType: (uri) => uri.startsWith("viking://user/") ? "user" : "resource",
+      createTraceId: () => "memory_recall-trace-1",
+      boundTraceQuery: (query) => ({ query }),
+      previewText: (value) => typeof value === "string" ? value : undefined,
+      traceRecorder: { recordAndFlush },
+      cfg: {
+        recallTargetTypes: ["user"],
+        traceRecallMaxResultsPerSearch: 5,
+        traceRecallPreviewChars: 120,
+        traceRecallQueryMaxChars: 200,
+        logFindRequests: true,
+      },
+      logger: { info: vi.fn() },
+    });
+
+    expect(registerTool.mock.calls.map(([, opts]) => opts.name)).toEqual(["memory_recall"]);
+    const recallFactory = registerTool.mock.calls[0]?.[0];
+    const recallTool = recallFactory({ sessionId: "session-1" });
+    const result = await recallTool.execute("call-1", { query: "TDD preference", limit: 2, scoreThreshold: 0.5 });
+
+    expect(getEffective).toHaveBeenCalledWith({
+      agentId: "agent-main",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-main:session-1",
+      ovSessionId: "ov-session-1",
+    }, {
+      recallLimit: 2,
+      scoreThreshold: 0.5,
+      targetUri: undefined,
+      resourceTypes: undefined,
+    });
+    expect(find).toHaveBeenCalledWith("TDD preference", {
+      targetUri: "viking://user/default",
+      limit: 4,
+      scoreThreshold: 0,
+    }, "agent-main");
+    expect(read).toHaveBeenCalledWith("viking://user/default/memories/m1", "agent-main");
+    expect(recordAndFlush).toHaveBeenCalledWith(expect.objectContaining({
+      traceId: "memory_recall-trace-1",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-main:session-1",
+      ovSessionId: "ov-session-1",
+      agentId: "agent-main",
+      source: "memory_recall",
+      resourceTypes: ["user"],
+      stats: { candidateCount: 1, selectedCount: 1, injectedCount: 1 },
+    }));
+    expect(result.content[0].text).toContain("Found 1 memories");
+    expect(result.details).toMatchObject({
+      count: 1,
+      total: 1,
+      scoreThreshold: 0.5,
+      requestLimit: 4,
+      recallMaxInjectedChars: 500,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Port #2613 OpenClaw plugin runtime helper modules and module-level tests
- Include the minimum helper dependency closure needed for these modules to run on current main
- Adapt restored code to the current peer model: peer_prefix / X-OpenViking-Actor-Peer / viking://user/skills, without reintroducing legacy agent URI routing

## Validation
- npm test -- tests/ut/plugin-modules.test.ts
- npm run typecheck
- npm run build
- git diff --check