### PR TITLE
fix(embedding): sidecar .embedding_cache.json so re-add of unchanged dirs is truly idempotent (#2383)

### DIFF
--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -1339,9 +1339,7 @@ def test_tool_context_syncs_legacy_memory_user_alias():
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(monkeypatch, tmp_path):
     calls = []
 
     class _FakeClient:
@@ -1379,9 +1377,7 @@ async def test_viking_memory_context_keeps_legacy_users_separate_from_peers(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(monkeypatch, tmp_path):
     clients = []
     base_uri = "viking://user/default/peers/sender-1/memories"
 
@@ -1393,8 +1389,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
                 f"{base_uri}/events/e2.md": (
                     "Summary: long event summary\n"
                     "2023-01-01 (Sunday) ChatLog:\n"
-                    "full long event details "
-                    + ("x" * 800)
+                    "full long event details " + ("x" * 800)
                 ),
                 f"{base_uri}/events/e3.md": "legacy event without summary",
                 f"{base_uri}/entities/en1.md": "short entity",
@@ -1497,9 +1492,7 @@ async def test_viking_memory_type_quota_groups_with_event_summaries_and_uris(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_continues_after_oversized_entity(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_continues_after_oversized_entity(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1541,17 +1534,15 @@ async def test_viking_memory_type_quota_continues_after_oversized_entity(
     )
 
     assert '<memory index="1" type="uri">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/long.md</uri>" in result
     assert '<memory index="2" type="full">' in result
-    assert '<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>' in result
+    assert "<uri>viking://user/default/peers/sender-1/memories/entities/short.md</uri>" in result
     assert "<content>short fact</content>" in result
     assert "long fact " not in result
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_type_quota_does_not_overflow_preference_budget(monkeypatch, tmp_path):
     base_uri = "viking://user/default/peers/sender-1/memories"
 
     class _FakeClient:
@@ -1599,9 +1590,7 @@ async def test_viking_memory_type_quota_does_not_overflow_preference_budget(
 
 
 @pytest.mark.asyncio
-async def test_viking_memory_context_returns_empty_after_profile_filter(
-    monkeypatch, tmp_path
-):
+async def test_viking_memory_context_returns_empty_after_profile_filter(monkeypatch, tmp_path):
     class _FakeClient:
         async def search_memory(self, **_kwargs):
             return [
@@ -1704,7 +1693,9 @@ async def test_openviking_grep_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def grep(self, uri, pattern, case_insensitive=False, user_id=None):
@@ -1739,7 +1730,9 @@ async def test_openviking_list_default_memory_expands_current_peer(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def list_resources(self, path=None, recursive=False):
@@ -1773,7 +1766,9 @@ async def test_openviking_glob_root_adds_current_peer_memory(monkeypatch):
 
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/memories/"] if include_self else []
-            uris.extend(f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or [])
+            uris.extend(
+                f"viking://user/default/peers/{peer_id}/memories/" for peer_id in peer_ids or []
+            )
             return uris
 
         async def glob(self, pattern, uri="viking://"):
@@ -1810,8 +1805,7 @@ async def test_openviking_glob_root_uses_namespaced_self_targets_for_root_key(mo
         def build_current_memory_target_uris(self, *, peer_ids=None, include_self=True):
             uris = ["viking://user/admin/memories/"] if include_self else []
             uris.extend(
-                f"viking://user/admin/peers/{peer_id}/memories/"
-                for peer_id in peer_ids or []
+                f"viking://user/admin/peers/{peer_id}/memories/" for peer_id in peer_ids or []
             )
             return uris
 

--- a/bot/vikingbot/agent/memory.py
+++ b/bot/vikingbot/agent/memory.py
@@ -18,9 +18,7 @@ _TYPE_QUOTA_MEMORY_TYPES = ("events", "entities", "preferences")
 _TYPE_QUOTA_EVENT_CHAR_RATIO = 0.75
 _TYPE_QUOTA_PREFERENCE_FULL_LIMIT = 1
 _MEMORY_TYPE_DESCRIPTIONS = {
-    "events": (
-        "Event memories. The URI path includes the event date."
-    ),
+    "events": ("Event memories. The URI path includes the event date."),
     "entities": (
         "Entity and topic memories. Use them for stable facts, attributes, "
         "relationships, and background about people, hobbies, places, or concepts."
@@ -289,9 +287,7 @@ class MemoryStore:
             memory_type = self._infer_memory_type(memory) or "other"
             should_try_full = idx <= full_limit
             if use_type_budgets:
-                should_try_full = (
-                    memory_type in type_char_budgets
-                ) or (
+                should_try_full = (memory_type in type_char_budgets) or (
                     memory_type == "preferences"
                     and preference_full_count < max(0, preference_full_limit)
                 )
@@ -488,9 +484,7 @@ class MemoryStore:
                 type_char_budgets=(
                     self._type_quota_char_budgets(recall_max_chars) if use_type_quota else None
                 ),
-                preference_full_limit=(
-                    _TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0
-                ),
+                preference_full_limit=(_TYPE_QUOTA_PREFERENCE_FULL_LIMIT if use_type_quota else 0),
                 include_uri_entries=True,
             )
             return f"### user memories:\n{user_memory}"

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -164,7 +164,11 @@ class VikingListTool(OVFileTool):
         }
 
     async def execute(
-        self, tool_context: "ToolContext", uri: str = "viking://", recursive: bool = False, **kwargs: Any
+        self,
+        tool_context: "ToolContext",
+        uri: str = "viking://",
+        recursive: bool = False,
+        **kwargs: Any,
     ) -> str:
         client = None
         try:
@@ -434,8 +438,7 @@ class VikingSearchTool(OVFileTool):
                         ]
                     )
                     search_requests = [
-                        {"target_uri": memory_uri, "peer_id": None}
-                        for memory_uri in memory_uris
+                        {"target_uri": memory_uri, "peer_id": None} for memory_uri in memory_uris
                     ]
                 else:
                     search_requests = [{"target_uri": target_uri, "peer_id": None}]
@@ -795,7 +798,9 @@ class VikingMemoryCommitTool(OVFileTool):
             timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
             session_id = f"{source_session_id}__memory_commit__{timestamp}__{commit_seq:04d}"
             result = await client.commit(session_id, messages, peer_id=tool_context.sender_id)
-            session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            session_id = (
+                result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            )
             commit_result = result.get("commit", {}) if isinstance(result, dict) else {}
             archive_uri = commit_result.get("archive_uri")
             memory_diff_uri = f"{archive_uri}/memory_diff.json" if archive_uri else None

--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -341,11 +341,7 @@ class VikingClient:
             uris.append(self._memory_target_uri(None))
 
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         for peer_id in normalized_peer_ids:
             try:
@@ -378,11 +374,7 @@ class VikingClient:
             [str(user_id).strip() for user_id in (user_ids or []) if str(user_id).strip()]
         )
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or []))
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_id) for peer_id in (peer_ids or [])) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
@@ -703,18 +695,14 @@ class VikingClient:
         if peer_id:
             peer_values.append(peer_id)
         normalized_peer_ids = self._dedupe_strings(
-            [
-                pid
-                for pid in (self._peer_id(peer_value) for peer_value in peer_values)
-                if pid
-            ]
+            [pid for pid in (self._peer_id(peer_value) for peer_value in peer_values) if pid]
         )
         effective_owner_user_id = self._effective_user_id(owner_user_id) if owner_user_id else None
 
         user_ids_to_check = self._dedupe_strings(
             [
                 *normalized_user_ids,
-                *( [effective_owner_user_id] if effective_owner_user_id else [] ),
+                *([effective_owner_user_id] if effective_owner_user_id else []),
             ]
         )
 

--- a/openviking/parse/parsers/code/ast/code_tools.py
+++ b/openviking/parse/parsers/code/ast/code_tools.py
@@ -127,9 +127,7 @@ def search_symbols(query: str, files: List[Tuple[str, str]]) -> str:
     return "\n".join(out)
 
 
-def _resolve_symbol(
-    skeleton: CodeSkeleton, symbol: str
-) -> Optional[Tuple[str, int, int]]:
+def _resolve_symbol(skeleton: CodeSkeleton, symbol: str) -> Optional[Tuple[str, int, int]]:
     """Find a symbol by 'foo' (bare) or 'Foo.bar' (qualified). Case sensitive.
 
     Search priority for bare names (no dot):

--- a/openviking/parse/parsers/code/ast/extractor.py
+++ b/openviking/parse/parsers/code/ast/extractor.py
@@ -107,9 +107,7 @@ class ASTExtractor:
         try:
             return extractor.extract(file_name, content)
         except Exception as e:
-            logger.warning(
-                "AST extraction failed for '%s' (language: %s): %s", file_name, lang, e
-            )
+            logger.warning("AST extraction failed for '%s' (language: %s): %s", file_name, lang, e)
             return None
 
     def extract_skeleton(

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -340,9 +340,7 @@ class MarkdownParser(BaseParser):
             content, frontmatter = self._extract_frontmatter(content)
             if frontmatter:
                 meta["frontmatter"] = frontmatter
-                logger.debug(
-                    f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}"
-                )
+                logger.debug(f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}")
 
         explicit_name = kwargs.get("resource_name")
         if not explicit_name and kwargs.get("source_name"):
@@ -593,7 +591,6 @@ class MarkdownParser(BaseParser):
             seen_paths = set()
 
             for path_str in image_refs:
-
                 # Skip remote URIs
                 if self._is_remote_uri(path_str):
                     continue
@@ -629,7 +626,9 @@ class MarkdownParser(BaseParser):
                     image_bytes = await asyncio.to_thread(resolved_path.read_bytes)
 
                     # Validate pixel size and file size; skip non-compliant images
-                    if not await asyncio.to_thread(self._is_valid_image, image_bytes, resolved_path):
+                    if not await asyncio.to_thread(
+                        self._is_valid_image, image_bytes, resolved_path
+                    ):
                         continue
 
                     # Get filename and deduplicate
@@ -649,7 +648,9 @@ class MarkdownParser(BaseParser):
                     logger.warning(f"[MarkdownParser] Failed to ingest image {resolved_path}: {e}")
 
             if file_mappings:
-                rel_md_path = md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                rel_md_path = (
+                    md_uri[len(root_prefix) + 1 :] if md_uri.startswith(root_prefix) else md_uri
+                )
                 mappings[rel_md_path] = file_mappings
 
         # Write a single mapping file at the root directory for rewrite_image_uris
@@ -688,9 +689,7 @@ class MarkdownParser(BaseParser):
 
             # Reject absolute paths: they can point anywhere on the host
             if path.is_absolute():
-                logger.warning(
-                    f"[MarkdownParser] Rejected absolute image path: {path_str}"
-                )
+                logger.warning(f"[MarkdownParser] Rejected absolute image path: {path_str}")
                 return None
 
             # Build the list of allowed roots to confine resolution to.
@@ -760,9 +759,7 @@ class MarkdownParser(BaseParser):
         """
         # File size check (local file path limit: 10 MB)
         if len(image_bytes) > self.IMAGE_MAX_FILE_BYTES:
-            logger.warning(
-                f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}"
-            )
+            logger.warning(f"[MarkdownParser] Image exceeds 10MB, skipping: {source_path}")
             return False
 
         # Pixel size check
@@ -932,20 +929,15 @@ class MarkdownParser(BaseParser):
                     rel
                     for rel, text in layout.items()
                     if any(
-                        _gh_slug(h) == anchor
-                        for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
+                        _gh_slug(h) == anchor for h in re.findall(r"^#{1,6}\s+(.+)$", text, re.M)
                     )
                 ]
                 if len(hits) == 1:
-                    return _to_rel(
-                        os.path.join(target_parent, hits[0]), keep_suffix=True
-                    )
+                    return _to_rel(os.path.join(target_parent, hits[0]), keep_suffix=True)
             # B) Single-file document (a bare file, or a directory holding exactly one
             #    file) → the anchor/query lives in that one file; keep the suffix.
             if len(layout) == 1:
-                return _to_rel(
-                    os.path.join(target_parent, next(iter(layout))), keep_suffix=True
-                )
+                return _to_rel(os.path.join(target_parent, next(iter(layout))), keep_suffix=True)
 
         # C) Single bare file with no suffix to place (e.g. a future small .md kept as
         #    a file) → point at the file itself (empty suffix ⇒ no trailing slash).
@@ -971,9 +963,7 @@ class MarkdownParser(BaseParser):
             if resolved is not None:
                 try:
                     image_bytes = await asyncio.to_thread(resolved.read_bytes)
-                    handled = await asyncio.to_thread(
-                        self._is_valid_image, image_bytes, resolved
-                    )
+                    handled = await asyncio.to_thread(self._is_valid_image, image_bytes, resolved)
                 except Exception:
                     handled = False
             cache[link] = handled

--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -53,29 +53,67 @@ _LATIN_ACCENT_BONUSES = {
 _LATIN_HINT_LANGUAGES = {"it", "fr", "es", "de", "pt"}
 
 _LOCALE_LANGUAGE_PREFIXES = dict(
-    zh="zh-CN", ja="ja", ko="ko", ru="ru", ar="ar",
-    it="it", fr="fr", es="es", de="de", pt="pt", en="en",
-    chinese="zh-CN", japanese="ja", korean="ko", russian="ru", arabic="ar",
-    italian="it", french="fr", spanish="es", german="de", portuguese="pt", english="en",
+    zh="zh-CN",
+    ja="ja",
+    ko="ko",
+    ru="ru",
+    ar="ar",
+    it="it",
+    fr="fr",
+    es="es",
+    de="de",
+    pt="pt",
+    en="en",
+    chinese="zh-CN",
+    japanese="ja",
+    korean="ko",
+    russian="ru",
+    arabic="ar",
+    italian="it",
+    french="fr",
+    spanish="es",
+    german="de",
+    portuguese="pt",
+    english="en",
 )
 
 # Use Timezone as a weak fallback signal.
 _TIMEZONE_LANGUAGE_GROUPS = {
     "zh-CN": (
-        "asia/shanghai", "asia/chongqing", "asia/harbin", "asia/urumqi",
-        "asia/hong_kong", "asia/macau", "asia/taipei", "prc", "roc", "hongkong",
-        "china standard time", "taipei standard time",
+        "asia/shanghai",
+        "asia/chongqing",
+        "asia/harbin",
+        "asia/urumqi",
+        "asia/hong_kong",
+        "asia/macau",
+        "asia/taipei",
+        "prc",
+        "roc",
+        "hongkong",
+        "china standard time",
+        "taipei standard time",
     ),
     "ja": ("asia/tokyo", "japan", "tokyo standard time"),
     "ko": ("asia/seoul", "rok", "korea standard time"),
     "ru": (
-        "europe/moscow", "europe/kaliningrad", "asia/yekaterinburg", "asia/vladivostok",
+        "europe/moscow",
+        "europe/kaliningrad",
+        "asia/yekaterinburg",
+        "asia/vladivostok",
         "russian standard time",
     ),
     "ar": (
-        "asia/riyadh", "asia/dubai", "asia/qatar", "asia/kuwait",
-        "asia/baghdad", "africa/cairo", "africa/algiers", "africa/tunis",
-        "arab standard time", "arabian standard time", "egypt standard time",
+        "asia/riyadh",
+        "asia/dubai",
+        "asia/qatar",
+        "asia/kuwait",
+        "asia/baghdad",
+        "africa/cairo",
+        "africa/algiers",
+        "africa/tunis",
+        "arab standard time",
+        "arabian standard time",
+        "egypt standard time",
     ),
     "it": ("europe/rome",),
     "fr": ("europe/paris",),
@@ -83,13 +121,34 @@ _TIMEZONE_LANGUAGE_GROUPS = {
     "de": ("europe/berlin",),
     "pt": ("europe/lisbon", "america/sao_paulo"),
     "en": (
-        "america/new_york", "america/chicago", "america/denver", "america/los_angeles",
-        "america/phoenix", "america/anchorage", "pacific/honolulu", "us/eastern",
-        "us/central", "us/mountain", "us/pacific", "europe/london", "europe/dublin",
-        "gb", "gb-eire", "america/toronto", "america/vancouver", "canada/eastern",
-        "canada/pacific", "australia/sydney", "australia/melbourne",
-        "australia/brisbane", "australia/perth", "pacific/auckland", "nz",
-        "eastern standard time", "pacific standard time", "gmt standard time",
+        "america/new_york",
+        "america/chicago",
+        "america/denver",
+        "america/los_angeles",
+        "america/phoenix",
+        "america/anchorage",
+        "pacific/honolulu",
+        "us/eastern",
+        "us/central",
+        "us/mountain",
+        "us/pacific",
+        "europe/london",
+        "europe/dublin",
+        "gb",
+        "gb-eire",
+        "america/toronto",
+        "america/vancouver",
+        "canada/eastern",
+        "canada/pacific",
+        "australia/sydney",
+        "australia/melbourne",
+        "australia/brisbane",
+        "australia/perth",
+        "pacific/auckland",
+        "nz",
+        "eastern standard time",
+        "pacific standard time",
+        "gmt standard time",
     ),
 }
 
@@ -109,7 +168,11 @@ def _language_allowed_by_fallback(language: str, fallback_language: str) -> bool
 
 
 def _is_strong_dominant(count: int, total: int) -> bool:
-    return count >= _STRONG_DOMINANT_MIN_CHARS and total > 0 and count / total >= _STRONG_DOMINANT_RATIO
+    return (
+        count >= _STRONG_DOMINANT_MIN_CHARS
+        and total > 0
+        and count / total >= _STRONG_DOMINANT_RATIO
+    )
 
 
 def _language_from_locale_value(value: str) -> str:

--- a/openviking/storage/internal_names.py
+++ b/openviking/storage/internal_names.py
@@ -28,6 +28,7 @@ WEBDAV_RESERVED_FILENAMES = frozenset(
         ".abstract.md",
         ".overview.md",
         ".relations.json",
+        ".embedding_cache.json",
         *MULTIWRITE_INTERNAL_FILE_NAMES,
     }
 )

--- a/openviking/storage/queuefs/embedding_cache.py
+++ b/openviking/storage/queuefs/embedding_cache.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Sidecar embedding-skip cache for queuefs.
+
+Persisted alongside ``.overview.md`` as ``.embedding_cache.json``. Decouples
+the "did we already embed this file?" decision from parsing per-file headers
+out of the LLM-written overview, which silently produced false-misses when
+the LLM wrote free-text or non-English overviews (issue #2383).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+from openviking.server.identity import RequestContext
+from openviking_cli.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+EMBEDDING_CACHE_FILENAME = ".embedding_cache.json"
+_CACHE_VERSION = 1
+_HASH_BYTE_LIMIT = 4 * 1024 * 1024  # cap sha256 fallback at 4 MB
+
+
+async def compute_embedding_cache_key(
+    viking_fs: Any,
+    file_uri: str,
+    ctx: Optional[RequestContext],
+) -> Optional[str]:
+    """Return a stable per-file cache key, or None if neither stat nor read works.
+
+    Prefers ``{size}:{modTime}`` from ``viking_fs.stat()`` because it is cheap
+    and consistent with how other parts of the codebase (e.g.
+    ``_resolve_context_timestamps``) treat file identity. Falls back to
+    sha256 over the first ``_HASH_BYTE_LIMIT`` bytes when stat omits either
+    field, so backends without reliable mtime still benefit.
+    """
+    try:
+        stat = await viking_fs.stat(file_uri, ctx=ctx)
+    except Exception:
+        stat = None
+
+    if isinstance(stat, dict):
+        size = stat.get("size")
+        mod_time = stat.get("modTime")
+        if size is not None and mod_time:
+            return f"size+mtime:{size}:{mod_time}"
+
+    try:
+        content = await viking_fs.read_file(file_uri, ctx=ctx)
+        if isinstance(content, str):
+            content = content.encode("utf-8", errors="replace")
+        if not isinstance(content, (bytes, bytearray)):
+            return None
+        digest = hashlib.sha256(bytes(content)[:_HASH_BYTE_LIMIT]).hexdigest()
+        return f"sha256:{digest}"
+    except Exception:
+        return None
+
+
+async def load_embedding_cache(
+    viking_fs: Any,
+    dir_uri: str,
+    ctx: Optional[RequestContext],
+) -> Dict[str, Dict[str, str]]:
+    """Load the directory's ``.embedding_cache.json``; return entries map (filename -> entry)."""
+    path = f"{dir_uri}/{EMBEDDING_CACHE_FILENAME}"
+    try:
+        raw = await viking_fs.read_file(path, ctx=ctx)
+    except Exception:
+        return {}
+    if not raw:
+        return {}
+    if isinstance(raw, bytes):
+        try:
+            raw = raw.decode("utf-8")
+        except Exception:
+            return {}
+    try:
+        data = json.loads(raw)
+    except Exception:
+        logger.debug("embedding cache at %s is not valid JSON; ignoring", path)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    if data.get("version") != _CACHE_VERSION:
+        return {}
+    entries = data.get("entries")
+    if not isinstance(entries, dict):
+        return {}
+    out: Dict[str, Dict[str, str]] = {}
+    for name, entry in entries.items():
+        if isinstance(name, str) and isinstance(entry, dict):
+            key = entry.get("content_hash")
+            if isinstance(key, str) and key:
+                out[name] = {
+                    "content_hash": key,
+                    "embedded_at": entry.get("embedded_at") or "",
+                }
+    return out
+
+
+async def write_embedding_cache(
+    viking_fs: Any,
+    dir_uri: str,
+    entries: Dict[str, Dict[str, str]],
+    ctx: Optional[RequestContext],
+) -> None:
+    """Persist the cache atomically: write to a tmp file, then ``viking_fs.mv()``."""
+    if not entries:
+        return
+    payload = {
+        "version": _CACHE_VERSION,
+        "entries": {
+            name: {
+                "content_hash": str(entry.get("content_hash", "")),
+                "embedded_at": str(entry.get("embedded_at", "")),
+            }
+            for name, entry in entries.items()
+            if isinstance(name, str) and isinstance(entry, dict)
+        },
+    }
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    final_path = f"{dir_uri}/{EMBEDDING_CACHE_FILENAME}"
+    tmp_path = f"{dir_uri}/{EMBEDDING_CACHE_FILENAME}.{uuid.uuid4().hex}.tmp"
+    try:
+        await viking_fs.write_file(tmp_path, serialized, ctx=ctx)
+    except Exception as e:
+        logger.warning("failed to write embedding cache tmp for %s: %s", dir_uri, e)
+        return
+    try:
+        await viking_fs.mv(tmp_path, final_path, ctx=ctx)
+    except Exception as e:
+        logger.warning(
+            "failed to atomically rename embedding cache for %s: %s",
+            dir_uri,
+            e,
+        )
+        try:
+            # Best-effort fallback: write directly. Race window is small and
+            # the cache is advisory — losing it just means a future re-embed.
+            await viking_fs.write_file(final_path, serialized, ctx=ctx)
+        except Exception as e2:
+            logger.warning("fallback write of embedding cache failed for %s: %s", dir_uri, e2)
+
+
+def make_cache_entry(content_hash: str) -> Dict[str, str]:
+    return {
+        "content_hash": content_hash,
+        "embedded_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def probe_vectors_present(
+    file_uris: Iterable[str],
+    ctx: Optional[RequestContext],
+) -> Dict[str, bool]:
+    """Cheap per-URI probe of the vector backend.
+
+    Returns a map URI -> bool. Missing service/backend yields all-False so the
+    caller falls back to re-embedding (safe default). Failures on individual
+    URIs are also treated as "not present" rather than raising.
+    """
+    uris = [u for u in file_uris if u]
+    if not uris or ctx is None:
+        return {u: False for u in uris}
+    try:
+        from openviking.server.dependencies import get_service
+
+        service = get_service()
+    except Exception:
+        return {u: False for u in uris}
+    if not service or not getattr(service, "vikingdb_manager", None):
+        return {u: False for u in uris}
+
+    results: Dict[str, bool] = {}
+    for uri in uris:
+        try:
+            record = await service.vikingdb_manager.fetch_by_uri(uri, ctx=ctx)
+            results[uri] = bool(record)
+        except Exception:
+            results[uri] = False
+    return results

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -625,9 +625,7 @@ class SemanticDagExecutor:
                         self._viking_fs, parent_uri, self._ctx
                     )
                 except Exception as e:
-                    logger.debug(
-                        "failed to load embedding cache for %s: %s", parent_uri, e
-                    )
+                    logger.debug("failed to load embedding cache for %s: %s", parent_uri, e)
                     self._embedding_cache[parent_uri] = {}
         return self._embedding_cache[parent_uri]
 
@@ -644,15 +642,11 @@ class SemanticDagExecutor:
                         file_uris, self._ctx
                     )
                 except Exception as e:
-                    logger.debug(
-                        "failed to probe vector backend for %s: %s", parent_uri, e
-                    )
+                    logger.debug("failed to probe vector backend for %s: %s", parent_uri, e)
                     self._embedding_vectors_present[parent_uri] = {u: False for u in file_uris}
         return self._embedding_vectors_present[parent_uri]
 
-    async def _check_embedding_cache_hit(
-        self, parent_uri: str, file_path: str
-    ) -> Optional[str]:
+    async def _check_embedding_cache_hit(self, parent_uri: str, file_path: str) -> Optional[str]:
         """Return the cached content hash if it still matches and vectors exist.
 
         ``None`` means: cache miss, stale, or vectors absent — caller must embed.
@@ -665,9 +659,7 @@ class SemanticDagExecutor:
         cached_key = entry.get("content_hash")
         if not cached_key:
             return None
-        current_key = await compute_embedding_cache_key(
-            self._viking_fs, file_path, self._ctx
-        )
+        current_key = await compute_embedding_cache_key(self._viking_fs, file_path, self._ctx)
         if not current_key or current_key != cached_key:
             return None
         presence = await self._vectors_present_for_dir(parent_uri)
@@ -790,9 +782,7 @@ class SemanticDagExecutor:
                         # or "overview not generated" fallback). Consult the
                         # .embedding_cache.json sidecar so we don't pointlessly
                         # re-embed identical content (issue #2383).
-                        cache_hit = await self._check_embedding_cache_hit(
-                            parent_uri, file_path
-                        )
+                        cache_hit = await self._check_embedding_cache_hit(parent_uri, file_path)
                         if cache_hit is not None:
                             need_vectorize = False
                         else:
@@ -825,13 +815,9 @@ class SemanticDagExecutor:
                     use_summary=use_summary,
                 )
                 await self._add_vectorize_task(task)
-                await self._record_embedding_cache_entry(
-                    parent_uri, file_path, skipped=False
-                )
+                await self._record_embedding_cache_entry(parent_uri, file_path, skipped=False)
             else:
-                await self._record_embedding_cache_entry(
-                    parent_uri, file_path, skipped=True
-                )
+                await self._record_embedding_cache_entry(parent_uri, file_path, skipped=True)
         except Exception as e:
             logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
         await self._on_file_done(parent_uri, file_path, summary_dict)

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -9,6 +9,13 @@ from dataclasses import dataclass, field
 from typing import ClassVar, Dict, List, Optional, Set
 
 from openviking.server.identity import RequestContext
+from openviking.storage.queuefs.embedding_cache import (
+    compute_embedding_cache_key,
+    load_embedding_cache,
+    make_cache_entry,
+    probe_vectors_present,
+    write_embedding_cache,
+)
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
 from openviking.storage.transaction import NO_LOCK, LockLease
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
@@ -212,6 +219,17 @@ class SemanticDagExecutor:
         self._dir_change_status: Dict[str, bool] = {}
         self._overview_cache: Dict[str, Dict[str, str]] = {}
         self._overview_cache_lock = asyncio.Lock()
+        # Per-directory embedding-skip sidecar state. Indexed by parent dir URI.
+        # _embedding_cache holds the loaded entries (filename -> {content_hash, embedded_at}).
+        # _embedding_vectors_present holds a per-file presence map from a single
+        # batched probe of the vector backend.
+        # _embedding_cache_updates accumulates entries for files we (re-)embedded
+        # in this run; flushed when the directory's overview is written.
+        self._embedding_cache: Dict[str, Dict[str, Dict[str, str]]] = {}
+        self._embedding_vectors_present: Dict[str, Dict[str, bool]] = {}
+        self._embedding_cache_updates: Dict[str, Dict[str, Dict[str, str]]] = {}
+        self._embedding_cache_lock = asyncio.Lock()
+        self._embedding_skip_counts: Dict[str, int] = {}
 
     async def run(self, root_uri: str) -> None:
         """Run DAG execution starting from root_uri."""
@@ -596,6 +614,110 @@ class SemanticDagExecutor:
 
         return None
 
+    async def _load_embedding_cache_for_dir(self, parent_uri: str) -> Dict[str, Dict[str, str]]:
+        """Load (and memoize) the .embedding_cache.json for ``parent_uri``."""
+        if parent_uri in self._embedding_cache:
+            return self._embedding_cache[parent_uri]
+        async with self._embedding_cache_lock:
+            if parent_uri not in self._embedding_cache:
+                try:
+                    self._embedding_cache[parent_uri] = await load_embedding_cache(
+                        self._viking_fs, parent_uri, self._ctx
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "failed to load embedding cache for %s: %s", parent_uri, e
+                    )
+                    self._embedding_cache[parent_uri] = {}
+        return self._embedding_cache[parent_uri]
+
+    async def _vectors_present_for_dir(self, parent_uri: str) -> Dict[str, bool]:
+        """Batch-probe the vector backend once per directory."""
+        if parent_uri in self._embedding_vectors_present:
+            return self._embedding_vectors_present[parent_uri]
+        async with self._embedding_cache_lock:
+            if parent_uri not in self._embedding_vectors_present:
+                node = self._nodes.get(parent_uri)
+                file_uris = list(node.file_paths) if node else []
+                try:
+                    self._embedding_vectors_present[parent_uri] = await probe_vectors_present(
+                        file_uris, self._ctx
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "failed to probe vector backend for %s: %s", parent_uri, e
+                    )
+                    self._embedding_vectors_present[parent_uri] = {u: False for u in file_uris}
+        return self._embedding_vectors_present[parent_uri]
+
+    async def _check_embedding_cache_hit(
+        self, parent_uri: str, file_path: str
+    ) -> Optional[str]:
+        """Return the cached content hash if it still matches and vectors exist.
+
+        ``None`` means: cache miss, stale, or vectors absent — caller must embed.
+        """
+        file_name = file_path.split("/")[-1]
+        cache = await self._load_embedding_cache_for_dir(parent_uri)
+        entry = cache.get(file_name)
+        if not entry:
+            return None
+        cached_key = entry.get("content_hash")
+        if not cached_key:
+            return None
+        current_key = await compute_embedding_cache_key(
+            self._viking_fs, file_path, self._ctx
+        )
+        if not current_key or current_key != cached_key:
+            return None
+        presence = await self._vectors_present_for_dir(parent_uri)
+        if not presence.get(file_path, False):
+            return None
+        return cached_key
+
+    async def _record_embedding_cache_entry(
+        self, parent_uri: str, file_path: str, *, skipped: bool
+    ) -> None:
+        """Record that ``file_path`` is embedded; track skip count for logging."""
+        file_name = file_path.split("/")[-1]
+        key = await compute_embedding_cache_key(self._viking_fs, file_path, self._ctx)
+        if not key:
+            return
+        async with self._embedding_cache_lock:
+            updates = self._embedding_cache_updates.setdefault(parent_uri, {})
+            updates[file_name] = make_cache_entry(key)
+            if skipped:
+                self._embedding_skip_counts[parent_uri] = (
+                    self._embedding_skip_counts.get(parent_uri, 0) + 1
+                )
+
+    async def _flush_embedding_cache(self, parent_uri: str) -> None:
+        """Persist the merged cache for ``parent_uri`` (called after overview write)."""
+        async with self._embedding_cache_lock:
+            updates = self._embedding_cache_updates.pop(parent_uri, None)
+            existing = dict(self._embedding_cache.get(parent_uri, {}))
+            skipped = self._embedding_skip_counts.pop(parent_uri, 0)
+        if not updates:
+            return
+        existing.update(updates)
+        # Drop entries for files no longer in the directory.
+        node = self._nodes.get(parent_uri)
+        if node is not None:
+            current_names = {fp.split("/")[-1] for fp in node.file_paths}
+            existing = {n: e for n, e in existing.items() if n in current_names}
+        try:
+            await write_embedding_cache(self._viking_fs, parent_uri, existing, self._ctx)
+        except Exception as e:
+            logger.debug("failed to persist embedding cache for %s: %s", parent_uri, e)
+            return
+        self._embedding_cache[parent_uri] = existing
+        if skipped:
+            logger.info(
+                "embedding cache hit: skipped %d files for directory %s",
+                skipped,
+                parent_uri,
+            )
+
     async def _check_dir_children_changed(
         self, dir_uri: str, current_files: List[str], current_dirs: List[str]
     ) -> bool:
@@ -664,7 +786,17 @@ class SemanticDagExecutor:
                     if summary_dict is not None:
                         need_vectorize = False
                     else:
-                        self._file_change_status[file_path] = True
+                        # Overview parsing returned nothing (free-text, non-English,
+                        # or "overview not generated" fallback). Consult the
+                        # .embedding_cache.json sidecar so we don't pointlessly
+                        # re-embed identical content (issue #2383).
+                        cache_hit = await self._check_embedding_cache_hit(
+                            parent_uri, file_path
+                        )
+                        if cache_hit is not None:
+                            need_vectorize = False
+                        else:
+                            self._file_change_status[file_path] = True
             else:
                 self._file_change_status[file_path] = True
             if summary_dict is None:
@@ -693,6 +825,13 @@ class SemanticDagExecutor:
                     use_summary=use_summary,
                 )
                 await self._add_vectorize_task(task)
+                await self._record_embedding_cache_entry(
+                    parent_uri, file_path, skipped=False
+                )
+            else:
+                await self._record_embedding_cache_entry(
+                    parent_uri, file_path, skipped=True
+                )
         except Exception as e:
             logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
         await self._on_file_done(parent_uri, file_path, summary_dict)
@@ -820,6 +959,8 @@ class SemanticDagExecutor:
                 wrote = await self._write_directory_semantics(dir_uri, overview, abstract)
                 if not wrote:
                     need_vectorize = False
+                else:
+                    await self._flush_embedding_cache(dir_uri)
             except Exception:
                 logger.info(f"[SemanticDag] {dir_uri} write failed, skipping")
 

--- a/tests/parse/test_code_tools.py
+++ b/tests/parse/test_code_tools.py
@@ -281,14 +281,14 @@ class TestOutlineFile:
 # ---------------------------------------------------------------------------
 
 
-SECOND_FILE = '''def greet():
+SECOND_FILE = """def greet():
     pass
 
 
 class Other:
     def helper(self):
         pass
-'''
+"""
 
 
 class TestSearchSymbols:

--- a/tests/storage/test_embedding_cache.py
+++ b/tests/storage/test_embedding_cache.py
@@ -42,9 +42,7 @@ class _FakeVikingFS:
 
     def __init__(self, tree: Dict[str, List[Dict[str, Any]]], file_contents: Dict[str, str]):
         self._tree = {self._norm(k): v for k, v in tree.items()}
-        self._file_contents: Dict[str, str] = {
-            self._norm(k): v for k, v in file_contents.items()
-        }
+        self._file_contents: Dict[str, str] = {self._norm(k): v for k, v in file_contents.items()}
         self._mod_times: Dict[str, str] = {}
         self.writes: List[tuple] = []
 

--- a/tests/storage/test_embedding_cache.py
+++ b/tests/storage/test_embedding_cache.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the .embedding_cache.json sidecar (issue #2383)."""
+
+import json
+import re
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs import embedding_cache as embedding_cache_module
+from openviking.storage.queuefs.embedding_cache import (
+    EMBEDDING_CACHE_FILENAME,
+    compute_embedding_cache_key,
+    load_embedding_cache,
+    write_embedding_cache,
+)
+from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _mock_transaction_layer(monkeypatch):
+    mock_handle = MagicMock()
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aenter__",
+        AsyncMock(return_value=mock_handle),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aexit__",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: MagicMock(),
+    )
+
+
+class _FakeVikingFS:
+    """Minimal in-memory VikingFS supporting stat/read/write/mv/ls."""
+
+    def __init__(self, tree: Dict[str, List[Dict[str, Any]]], file_contents: Dict[str, str]):
+        self._tree = {self._norm(k): v for k, v in tree.items()}
+        self._file_contents: Dict[str, str] = {
+            self._norm(k): v for k, v in file_contents.items()
+        }
+        self._mod_times: Dict[str, str] = {}
+        self.writes: List[tuple] = []
+
+    @staticmethod
+    def _norm(path: str) -> str:
+        if "://" not in path:
+            return path
+        scheme, rest = path.split("://", 1)
+        rest = re.sub(r"/{2,}", "/", rest)
+        return f"{scheme}://{rest}"
+
+    async def ls(self, uri, node_limit=None, ctx=None):
+        return self._tree.get(self._norm(uri), [])
+
+    async def stat(self, uri, ctx=None):
+        norm = self._norm(uri)
+        if norm not in self._file_contents:
+            raise FileNotFoundError(uri)
+        content = self._file_contents[norm]
+        return {
+            "size": len(content),
+            "modTime": self._mod_times.get(norm, "2026-01-01T00:00:00Z"),
+        }
+
+    async def read_file(self, path, ctx=None):
+        return self._file_contents.get(self._norm(path), "")
+
+    async def write_file(self, path, content, ctx=None):
+        norm = self._norm(path)
+        self._file_contents[norm] = content
+        self.writes.append((norm, content))
+
+    async def mv(self, old_uri, new_uri, ctx=None, lock_handle=None):
+        old_norm = self._norm(old_uri)
+        new_norm = self._norm(new_uri)
+        if old_norm in self._file_contents:
+            self._file_contents[new_norm] = self._file_contents.pop(old_norm)
+        return {"name": new_norm.rsplit("/", 1)[-1]}
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri.replace("viking://", "/local/acc1/")
+
+    def touch(self, uri: str, mod_time: str) -> None:
+        self._mod_times[self._norm(uri)] = mod_time
+
+
+# ---------- direct unit tests for the cache helpers ----------
+
+
+@pytest.mark.asyncio
+async def test_write_and_load_roundtrip():
+    fs = _FakeVikingFS(tree={}, file_contents={})
+    dir_uri = "viking://resources/d"
+    entries = {"a.txt": {"content_hash": "size+mtime:11:T1", "embedded_at": "T1"}}
+    await write_embedding_cache(fs, dir_uri, entries, ctx=None)
+
+    final_path = f"{dir_uri}/{EMBEDDING_CACHE_FILENAME}"
+    assert final_path in fs._file_contents
+    payload = json.loads(fs._file_contents[final_path])
+    assert payload["version"] == 1
+    assert payload["entries"]["a.txt"]["content_hash"] == "size+mtime:11:T1"
+
+    loaded = await load_embedding_cache(fs, dir_uri, ctx=None)
+    assert loaded["a.txt"]["content_hash"] == "size+mtime:11:T1"
+
+
+@pytest.mark.asyncio
+async def test_load_returns_empty_for_missing_or_garbage():
+    fs = _FakeVikingFS(tree={}, file_contents={})
+    assert await load_embedding_cache(fs, "viking://resources/d", ctx=None) == {}
+
+    fs._file_contents[f"viking://resources/d/{EMBEDDING_CACHE_FILENAME}"] = "{not json"
+    assert await load_embedding_cache(fs, "viking://resources/d", ctx=None) == {}
+
+    fs._file_contents[f"viking://resources/d/{EMBEDDING_CACHE_FILENAME}"] = json.dumps(
+        {"version": 999, "entries": {"a.txt": {"content_hash": "x"}}}
+    )
+    assert await load_embedding_cache(fs, "viking://resources/d", ctx=None) == {}
+
+
+@pytest.mark.asyncio
+async def test_compute_cache_key_uses_size_and_modtime():
+    fs = _FakeVikingFS(
+        tree={},
+        file_contents={"viking://resources/d/a.txt": "hello"},
+    )
+    fs.touch("viking://resources/d/a.txt", "2026-06-01T00:00:00Z")
+    key = await compute_embedding_cache_key(fs, "viking://resources/d/a.txt", ctx=None)
+    assert key == "size+mtime:5:2026-06-01T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_compute_cache_key_falls_back_to_sha256_when_stat_lacks_modtime():
+    class _StatlessFS(_FakeVikingFS):
+        async def stat(self, uri, ctx=None):
+            return {"size": 5}  # no modTime
+
+    fs = _StatlessFS(tree={}, file_contents={"viking://resources/d/a.txt": "hello"})
+    key = await compute_embedding_cache_key(fs, "viking://resources/d/a.txt", ctx=None)
+    assert key is not None and key.startswith("sha256:")
+
+
+# ---------- integration test through SemanticDagExecutor ----------
+
+
+class _FakeProcessor:
+    def __init__(self, fs: _FakeVikingFS):
+        self._fs = fs
+        self.summarized_files: List[str] = []
+
+    def _parse_overview_md(self, overview_content):
+        # Mimic the buggy real-world case: free-text overview that yields no entries.
+        if "FILES:" not in overview_content:
+            return {}
+        results = {}
+        for line in overview_content.splitlines():
+            m = re.match(r"^-\s*(?P<name>[^:]+):\s*(?P<summary>.*)$", line.strip())
+            if not m:
+                continue
+            results[m.group("name").strip()] = m.group("summary").strip()
+        return results
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.summarized_files.append(file_path)
+        return {"name": file_path.split("/")[-1], "summary": "summary"}
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        # Return a free-text overview that the parser will reject. This is
+        # exactly the production failure mode for issue #2383.
+        return "This directory has stuff in it."
+
+    def _extract_abstract_from_overview(self, overview):
+        return "abstract"
+
+    def _enforce_size_limits(self, overview, abstract):
+        return overview, abstract
+
+
+def _make_executor(monkeypatch, fake_fs, processor, *, target_uri, changes=None):
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    # Vector backend probes default to "all absent" — tests that need a hit
+    # patch this per-test.
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.probe_vectors_present",
+        AsyncMock(return_value={}),
+    )
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=target_uri,
+        changes=changes or {},
+    )
+    return executor
+
+
+@pytest.mark.asyncio
+async def test_no_op_refresh_with_unparseable_overview_skips_embedding(monkeypatch):
+    """Issue #2383: free-text overview must NOT trigger spurious embeds when sidecar exists."""
+    _mock_transaction_layer(monkeypatch)
+    root_uri = "viking://resources/root"
+    tree = {root_uri: [{"name": "a.txt", "isDir": False}, {"name": "b.txt", "isDir": False}]}
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "AAA",
+            f"{root_uri}/b.txt": "BBB",
+            f"{root_uri}/.overview.md": "This directory has stuff in it.",  # unparseable
+            f"{root_uri}/.abstract.md": "old-abstract",
+        },
+    )
+    fake_fs.touch(f"{root_uri}/a.txt", "T-A")
+    fake_fs.touch(f"{root_uri}/b.txt", "T-B")
+    # Pre-seed the embedding-cache sidecar (simulating a previous successful run).
+    sidecar = {
+        "version": 1,
+        "entries": {
+            "a.txt": {"content_hash": "size+mtime:3:T-A", "embedded_at": "prev"},
+            "b.txt": {"content_hash": "size+mtime:3:T-B", "embedded_at": "prev"},
+        },
+    }
+    fake_fs._file_contents[f"{root_uri}/{EMBEDDING_CACHE_FILENAME}"] = json.dumps(sidecar)
+
+    processor = _FakeProcessor(fake_fs)
+    executor = _make_executor(monkeypatch, fake_fs, processor, target_uri=root_uri)
+    # All vectors present — cache hits are valid.
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.probe_vectors_present",
+        AsyncMock(return_value={f"{root_uri}/a.txt": True, f"{root_uri}/b.txt": True}),
+    )
+    add_vec = AsyncMock()
+    monkeypatch.setattr(executor, "_add_vectorize_task", add_vec)
+
+    await executor.run(root_uri)
+
+    # No file was vectorized (the bug would have re-embedded both).
+    file_calls = [c for c in add_vec.await_args_list if c.args[0].task_type == "file"]
+    assert len(file_calls) == 0, "embedding cache should have suppressed file re-embeds"
+
+
+@pytest.mark.asyncio
+async def test_modified_file_is_reembedded_others_skipped(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+    root_uri = "viking://resources/root"
+    tree = {root_uri: [{"name": "a.txt", "isDir": False}, {"name": "b.txt", "isDir": False}]}
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "AAA-NEW",  # changed since last embed
+            f"{root_uri}/b.txt": "BBB",
+            f"{root_uri}/.overview.md": "free text",
+            f"{root_uri}/.abstract.md": "old",
+        },
+    )
+    fake_fs.touch(f"{root_uri}/a.txt", "T-A2")
+    fake_fs.touch(f"{root_uri}/b.txt", "T-B")
+    sidecar = {
+        "version": 1,
+        "entries": {
+            "a.txt": {"content_hash": "size+mtime:3:T-A", "embedded_at": "prev"},
+            "b.txt": {"content_hash": "size+mtime:3:T-B", "embedded_at": "prev"},
+        },
+    }
+    fake_fs._file_contents[f"{root_uri}/{EMBEDDING_CACHE_FILENAME}"] = json.dumps(sidecar)
+
+    processor = _FakeProcessor(fake_fs)
+    executor = _make_executor(
+        monkeypatch,
+        fake_fs,
+        processor,
+        target_uri=root_uri,
+        changes={"modified": [f"{root_uri}/a.txt"]},
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.probe_vectors_present",
+        AsyncMock(return_value={f"{root_uri}/a.txt": True, f"{root_uri}/b.txt": True}),
+    )
+    add_vec = AsyncMock()
+    monkeypatch.setattr(executor, "_add_vectorize_task", add_vec)
+
+    await executor.run(root_uri)
+
+    file_calls = [c for c in add_vec.await_args_list if c.args[0].task_type == "file"]
+    assert len(file_calls) == 1
+    assert file_calls[0].args[0].file_path == f"{root_uri}/a.txt"
+
+
+@pytest.mark.asyncio
+async def test_missing_vectors_force_reembed_even_with_sidecar_hit(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+    root_uri = "viking://resources/root"
+    tree = {root_uri: [{"name": "a.txt", "isDir": False}]}
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "AAA",
+            f"{root_uri}/.overview.md": "free text",
+            f"{root_uri}/.abstract.md": "old",
+        },
+    )
+    fake_fs.touch(f"{root_uri}/a.txt", "T-A")
+    sidecar = {
+        "version": 1,
+        "entries": {"a.txt": {"content_hash": "size+mtime:3:T-A", "embedded_at": "prev"}},
+    }
+    fake_fs._file_contents[f"{root_uri}/{EMBEDDING_CACHE_FILENAME}"] = json.dumps(sidecar)
+
+    processor = _FakeProcessor(fake_fs)
+    executor = _make_executor(monkeypatch, fake_fs, processor, target_uri=root_uri)
+    # Vector backend reports the URI is gone — sidecar must NOT lie.
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.probe_vectors_present",
+        AsyncMock(return_value={f"{root_uri}/a.txt": False}),
+    )
+    add_vec = AsyncMock()
+    monkeypatch.setattr(executor, "_add_vectorize_task", add_vec)
+
+    await executor.run(root_uri)
+
+    file_calls = [c for c in add_vec.await_args_list if c.args[0].task_type == "file"]
+    assert len(file_calls) == 1
+    assert file_calls[0].args[0].file_path == f"{root_uri}/a.txt"
+
+
+@pytest.mark.asyncio
+async def test_backward_compat_parseable_overview_still_skips(monkeypatch):
+    """Pre-existing parseable .overview.md without a sidecar still benefits from the legacy skip."""
+    _mock_transaction_layer(monkeypatch)
+    root_uri = "viking://resources/root"
+    tree = {root_uri: [{"name": "a.txt", "isDir": False}]}
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "AAA",
+            f"{root_uri}/.overview.md": "FILES:\n- a.txt: prior summary",
+            f"{root_uri}/.abstract.md": "old",
+        },
+    )
+    fake_fs.touch(f"{root_uri}/a.txt", "T-A")
+    # NO .embedding_cache.json on disk.
+
+    processor = _FakeProcessor(fake_fs)
+    executor = _make_executor(monkeypatch, fake_fs, processor, target_uri=root_uri)
+    add_vec = AsyncMock()
+    monkeypatch.setattr(executor, "_add_vectorize_task", add_vec)
+
+    await executor.run(root_uri)
+
+    file_calls = [c for c in add_vec.await_args_list if c.args[0].task_type == "file"]
+    assert len(file_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_first_run_writes_sidecar(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+    root_uri = "viking://resources/root"
+    tree = {root_uri: [{"name": "a.txt", "isDir": False}]}
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={f"{root_uri}/a.txt": "AAA"},
+    )
+    fake_fs.touch(f"{root_uri}/a.txt", "T-A")
+
+    processor = _FakeProcessor(fake_fs)
+    executor = _make_executor(monkeypatch, fake_fs, processor, target_uri=root_uri)
+    add_vec = AsyncMock()
+    monkeypatch.setattr(executor, "_add_vectorize_task", add_vec)
+
+    await executor.run(root_uri)
+
+    sidecar_path = f"{root_uri}/{EMBEDDING_CACHE_FILENAME}"
+    assert sidecar_path in fake_fs._file_contents
+    payload = json.loads(fake_fs._file_contents[sidecar_path])
+    assert "a.txt" in payload["entries"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary
Closes #2383. The incremental skip in `add_resource` was honest — the embed work it reported was real — but it shouldn't have been doing the work. The skip relied on parsing per-file headers out of the LLM-written `.overview.md`, and silently re-embedded every file whenever that parse came back empty (free-text overview, non-English output, or the "overview not generated" fallback). `fancyboi999` reproduced 13 spurious embed calls on a 17-file no-op refresh.

This PR mirrors the fix already shipped for the semantic-summary path in [#2636](https://github.com/volcengine/OpenViking/pull/2636): a `.embedding_cache.json` sidecar persisted alongside `.overview.md`, mapping `filename → {content_hash, embedded_at}`. Skip decisions consult the sidecar first; the existing `.overview.md` parsing remains as a fallback so legacy directories still benefit from the previous best-effort cache.

To avoid a deleted-vectordb foot-gun, the cache also probes the vector backend cheaply before declaring a hit — files re-embed if their vectors are no longer present.

## Test plan
- [ ] `pytest tests/storage/test_embedding_cache.py -x -q` passes.
- [ ] Manual: ingest a directory once, then re-`add_resource` on the same dir → `Embedding.processed` is 0 (verified against fancyboi999's repro shape).
- [ ] Modify one file, re-add → only that file is re-embedded.
- [ ] Delete the vector store, re-add the same directory → all files are re-embedded (cache doesn't lie).

Closes #2383