### PR TITLE
fix(openclaw): preserve heartbeat-looking user messages

### DIFF
--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -620,7 +620,7 @@ describe("context-engine afterTurn()", () => {
     expect(assistantParts.map(p => p.text).join(" ")).toContain("Here is context");
   });
 
-  it("skips heartbeat messages from being stored", async () => {
+  it("stores heartbeat-looking messages when host does not flag the turn", async () => {
     const { engine, client } = makeEngine();
 
     const messages = [
@@ -635,7 +635,35 @@ describe("context-engine afterTurn()", () => {
       prePromptMessageCount: 0,
     });
 
-    expect(client.addSessionMessage).not.toHaveBeenCalled();
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("user");
+    const userParts = client.addSessionMessage.mock.calls[0][2] as Array<{ text?: string }>;
+    expect(userParts.map(p => p.text).join(" ")).toContain("HEARTBEAT.md");
+  });
+
+  it("stores normal user messages that mention heartbeat artifacts", async () => {
+    const { engine, client } = makeEngine();
+
+    const messages = [
+      {
+        role: "user",
+        content:
+          "Please explain why HEARTBEAT.md appeared in the logs and whether HEARTBEAT_OK means success.",
+      },
+      { role: "assistant", content: "HEARTBEAT_OK is the heartbeat acknowledgement token." },
+    ];
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("user");
+    const userParts = client.addSessionMessage.mock.calls[0][2] as Array<{ text?: string }>;
+    expect(userParts.map(p => p.text).join(" ")).toContain("HEARTBEAT.md");
   });
 
   it("skips heartbeat via isHeartbeat flag", async () => {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -44,14 +44,9 @@ function looksLikeMetadataJsonBlock(content: string): boolean {
   return matchedKeys.size >= 3;
 }
 
-const HEARTBEAT_RE = /\bHEARTBEAT(?:\.md|_OK)\b/;
 const TOOL_PLACEHOLDER_RE = /^\s*\[tool(?::\s*|Use:\s*)[^\]]+\]\s*$/i;
 
 export function sanitizeUserTextForCapture(text: string): string {
-  // 过滤 HEARTBEAT 健康检查消息
-  if (HEARTBEAT_RE.test(text)) {
-    return "";
-  }
   // Drop legacy synthetic tool placeholders before they reach memory extraction.
   if (TOOL_PLACEHOLDER_RE.test(text)) {
     return "";


### PR DESCRIPTION
## Description

This PR follows up on an OpenClaw issue I reported, openclaw/openclaw#89302, which has now been fixed upstream: OpenClaw forwards heartbeat metadata to context-engine hooks.

With that host-provided signal available, OpenViking no longer needs to infer heartbeat turns from message content. The previous content-based fallback skipped user messages containing `HEARTBEAT.md` or `HEARTBEAT_OK`, which is too broad because users may legitimately discuss those heartbeat artifacts.

This PR removes that content-based filter and relies on `afterTurnParams.isHeartbeat` instead. Real heartbeat turns are still skipped, while normal user messages are captured correctly.

## Related Issue

Follow-up to openclaw/openclaw#89302, reported by me and fixed upstream in OpenClaw.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Removed broad content-based filtering for `HEARTBEAT.md` / `HEARTBEAT_OK` in user message capture.
- Kept real heartbeat suppression based on `afterTurnParams.isHeartbeat`.
- Added regression coverage for normal user messages that mention heartbeat artifacts.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Commands run:

```bash
npm run test -- tests/ut/context-engine-afterTurn.test.ts
npm run test -- tests/ut/text-utils.test.ts
npm run typecheck
npm run build
```

Also verified locally with OpenClaw `2026.6.6` + OpenViking plugin `2026.6.2`: a real agent turn containing `HEARTBEAT.md` and `HEARTBEAT_OK` was captured into the OpenViking session normally.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This change depends on the upstream OpenClaw fix for openclaw/openclaw#89302, where heartbeat metadata is now passed into context-engine hooks. With that contract available, filtering by message content is no longer necessary and can cause real user messages to disappear.