### PR TITLE
fix(observability): dashboard summary skills counter returns actual count

### DIFF
--- a/openviking/observability/usage_audit/inventory.py
+++ b/openviking/observability/usage_audit/inventory.py
@@ -47,7 +47,7 @@ class ContextInventoryProvider:
 
         files, skills, memories = await asyncio.gather(
             self._stat_count("viking://resources", ctx=ctx),
-            self._stat_count(f"{user_root}/skills", ctx=ctx),
+            self._stat_count("viking://resources/skills", ctx=ctx),
             self._stat_count(f"{user_root}/memories", ctx=ctx),
         )
         return {

--- a/tests/observability/test_inventory_skills_counter.py
+++ b/tests/observability/test_inventory_skills_counter.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression test for the dashboard summary skills counter.
+
+Skills live under ``viking://resources/skills/`` (not under the per-user
+namespace), so the inventory must stat that URI to surface a non-zero
+``context_counts.skills`` on ``GET /api/v1/console/dashboard/summary``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.observability.usage_audit.inventory import ContextInventoryProvider
+from openviking.pyagfs.exceptions import AGFSNotFoundError
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier(account_id="acct-1", user_id="user-1"),
+        role=Role.ADMIN,
+    )
+
+
+class _SkillsFSService:
+    """fs_service stub: skills exist at viking://resources/skills, user_root is empty."""
+
+    def __init__(self, skill_count: int) -> None:
+        self.skill_count = skill_count
+        self.calls: list[str] = []
+
+    async def stat(self, uri, *, ctx):
+        self.calls.append(uri)
+        if uri == "viking://resources":
+            return {"count": 7}
+        if uri == "viking://resources/skills":
+            return {"count": self.skill_count}
+        if uri == "viking://user/user-1/memories":
+            return {"count": 4}
+        if uri == "viking://user/user-1/skills":
+            # Old (pre-fix) location — empty in this deployment.
+            raise AGFSNotFoundError(uri)
+        raise AssertionError(f"unexpected stat uri: {uri}")
+
+
+@pytest.mark.asyncio
+async def test_skills_counter_reads_resources_skills_root():
+    fs = _SkillsFSService(skill_count=112)
+    provider = ContextInventoryProvider(SimpleNamespace(fs=fs), ttl_seconds=0)
+
+    counts = await provider.get_counts(_ctx())
+
+    assert counts["skills"] == 112
+    assert "viking://resources/skills" in fs.calls
+    # Sanity: no regression in other counters or in the total.
+    assert counts["files"] == 7
+    assert counts["memories"] == 4
+    assert counts["total"] == 7 + 112 + 4
+
+
+@pytest.mark.asyncio
+async def test_skills_counter_zero_when_no_skills_present():
+    fs = _SkillsFSService(skill_count=0)
+    provider = ContextInventoryProvider(SimpleNamespace(fs=fs), ttl_seconds=0)
+
+    counts = await provider.get_counts(_ctx())
+
+    assert counts["skills"] == 0
+    assert counts["total"] == 7 + 0 + 4

--- a/tests/observability/test_usage_audit_inventory.py
+++ b/tests/observability/test_usage_audit_inventory.py
@@ -29,7 +29,7 @@ class FakeFSService:
         self.calls.append((uri, ctx))
         return {
             "viking://resources": {"count": 2},
-            "viking://user/user-1/skills": {"count": 3},
+            "viking://resources/skills": {"count": 3},
             "viking://user/user-1/memories": {"count": 5},
         }[uri]
 
@@ -59,7 +59,7 @@ async def test_context_inventory_counts_from_stat():
     assert len(fs.calls) == 3
     assert {uri for uri, call_ctx in fs.calls if call_ctx is ctx} == {
         "viking://resources",
-        "viking://user/user-1/skills",
+        "viking://resources/skills",
         "viking://user/user-1/memories",
     }
 


### PR DESCRIPTION
## Summary
`GET /api/v1/console/dashboard/summary` returned `context_counts.skills: 0` regardless of how many skills existed under `viking://resources/skills/`. The Studio home page consequently showed "Skills = 0".

Root cause: `ContextInventoryProvider._read_counts()` in `openviking/observability/usage_audit/inventory.py` was statting `f"{user_root}/skills"` (i.e. `viking://user/<user_id>/skills`), which is empty in deployments that keep their skill library under the shared `viking://resources/skills/` tree. Switched the URI to `viking://resources/skills`, matching the location reported by `GET /api/v1/fs/ls?uri=viking://resources/skills` and the same `viking://resources` scheme already used one line above for the `files` counter.

This bug is independent of the memory-counter bug discussed in #1257 / #1425 — those PRs target `stats_aggregator._query_all_memories()`; this one targets `inventory.py`. Identified by `@LegendaryLionMan` in a comment on #1255.

## Test plan
- [ ] `pytest tests/observability/test_inventory_skills_counter.py -x -q` passes.
- [ ] Manual: with N skills present under `viking://resources/skills/`, `GET /api/v1/console/dashboard/summary` returns `context_counts.skills == N` (and `total == files + skills + memories`).
- [ ] No change in the `files` or `memories` fields.

Refs #1255