### PR TITLE
feat(session): add clear-failed-archive endpoint + ov session fix-archive CLI (#2294)

### DIFF
--- a/crates/ov_cli/src/commands/session.rs
+++ b/crates/ov_cli/src/commands/session.rs
@@ -364,6 +364,51 @@ pub async fn commit_session(
     Ok(())
 }
 
+pub async fn fix_session_archive(
+    client: &HttpClient,
+    session_id: &str,
+    archive_id: &str,
+    force: bool,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let path = format!(
+        "/api/v1/sessions/{}/archives/{}/clear-failed",
+        url_encode(session_id),
+        url_encode(archive_id)
+    );
+    let params: Vec<(String, String)> = if force {
+        vec![("force".to_string(), "true".to_string())]
+    } else {
+        Vec::new()
+    };
+    let result: std::result::Result<serde_json::Value, _> =
+        client.post_with_query(&path, &json!({}), &params).await;
+    match result {
+        Ok(response) => {
+            output_success(&response, output_format, compact);
+            Ok(())
+        }
+        Err(err) => {
+            if !force && is_archive_data_present_conflict(&err) {
+                eprintln!(
+                    "{}",
+                    theme::muted(
+                        "archive data is still present on disk. Inspect the archive directory \
+                         and re-run with --force once you have decided the residue can be \
+                         discarded (the data directory itself is NOT removed by this command)."
+                    )
+                );
+            }
+            Err(err)
+        }
+    }
+}
+
+fn is_archive_data_present_conflict(err: &Error) -> bool {
+    matches!(err, Error::Api { status: Some(409), .. })
+}
+
 /// Add memory in one shot: creates a session, adds messages, and commits.
 ///
 /// Input can be:

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -493,6 +493,21 @@ pub async fn handle_session(cmd: SessionCommands, ctx: CliContext) -> Result<()>
             commands::session::commit_session(&client, &session_id, ctx.output_format, ctx.compact)
                 .await
         }
+        SessionCommands::FixArchive {
+            session_id,
+            archive_id,
+            force,
+        } => {
+            commands::session::fix_session_archive(
+                &client,
+                &session_id,
+                &archive_id,
+                force,
+                ctx.output_format,
+                ctx.compact,
+            )
+            .await
+        }
     }
 }
 

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1123,6 +1123,20 @@ enum SessionCommands {
         #[arg(value_name = "session-id")]
         session_id: String,
     },
+    /// Resolve a wedged session by clearing a stale .failed.json archive marker
+    FixArchive {
+        /// Session ID
+        #[arg(value_name = "session-id")]
+        session_id: String,
+        /// Archive ID
+        #[arg(value_name = "archive-id")]
+        archive_id: String,
+        /// Clear the marker even when the archive data directory still has
+        /// contents. By default the command refuses with a 409 to give the
+        /// operator a chance to inspect the residue first.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -346,6 +346,57 @@ async def get_session_archive(
     return Response(status="ok", result=_to_jsonable(result))
 
 
+@router.post("/{session_id}/archives/{archive_id}/clear-failed")
+async def clear_failed_archive(
+    session_id: str = Path(..., description="Session ID"),
+    archive_id: str = Path(..., description="Archive ID"),
+    force: bool = Query(
+        False,
+        description=(
+            "If true, clear the marker even when the archive data directory "
+            "is still present. By default the endpoint refuses with 409."
+        ),
+    ),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Clear a stale ``.failed.json`` marker that is wedging session commits.
+
+    A session can become permanently wedged when an archive operation fails
+    mid-flight: a ``.failed.json`` marker is persisted but the archive
+    directory itself is missing (disk full, crash, network mount loss). The
+    server correctly preserves that marker across restarts, so the only safe
+    way to recover is to explicitly resolve it.
+
+    Behavior:
+
+    - 200 — the marker existed and the archive data directory was missing
+      (or ``force=true`` was passed); the marker is removed and subsequent
+      commits will succeed.
+    - 404 — there is no marker for ``archive_id`` on this session.
+    - 409 — the marker exists but the archive data directory still has
+      contents; the operator should investigate before clearing. Pass
+      ``?force=true`` to override.
+
+    Audit: a WARNING log line is emitted on success including
+    ``session_id``, ``archive_id``, the calling user, and the ``force`` flag.
+    """
+    service = get_service()
+    result = await service.sessions.clear_failed_archive(
+        session_id,
+        archive_id,
+        _ctx,
+        force=force,
+    )
+    logger.warning(
+        "cleared failed-archive marker session=%s archive=%s by_user=%s force=%s",
+        session_id,
+        archive_id,
+        _ctx.user.user_id,
+        force,
+    )
+    return Response(status="ok", result=result)
+
+
 @router.delete("/{session_id}")
 async def delete_session(
     session_id: str = Path(..., description="Session ID"),

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -294,6 +294,24 @@ class SessionService:
         self._record_archive_metric("ok" if result.get("archived") else "skip")
         return result
 
+    async def clear_failed_archive(
+        self,
+        session_id: str,
+        archive_id: str,
+        ctx: RequestContext,
+        *,
+        force: bool = False,
+    ) -> Dict[str, Any]:
+        """Resolve a wedged session by removing a stale ``.failed.json`` marker.
+
+        See :meth:`openviking.session.session.Session.clear_failed_archive`
+        for the contract. This wrapper just resolves the session and
+        delegates.
+        """
+        self._ensure_initialized()
+        session = await self.get(session_id, ctx)
+        return await session.clear_failed_archive(archive_id, force=force)
+
     async def get_commit_task(self, task_id: str, ctx: RequestContext) -> Optional[Dict[str, Any]]:
         """Query background commit task status by task_id for the calling owner."""
         task = await get_task_tracker().get(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1917,6 +1917,95 @@ class Session:
             return archive
         return None
 
+    async def clear_failed_archive(
+        self,
+        archive_id: str,
+        *,
+        force: bool = False,
+    ) -> Dict[str, Any]:
+        """Clear a ``.failed.json`` marker that is wedging this session.
+
+        A session commit can leave the on-disk pair (``.failed.json`` marker +
+        archive directory) in an inconsistent state if a write was interrupted
+        (crash, disk full, network mount loss). Once that happens every
+        subsequent commit raises ``FailedPreconditionError`` and there is no
+        way to recover without reaching into the storage layer manually.
+
+        This method removes the ``.failed.json`` marker for ``archive_id`` so
+        the session can be committed again. It is intentionally narrow:
+
+        - If no marker exists for ``archive_id``: raises ``NotFoundError``.
+        - If the archive data directory still exists and ``force`` is False:
+          raises ``FailedPreconditionError``. The caller is expected to look
+          at the data first (or pass ``force=True`` once they've decided the
+          residue can be ignored).
+        - Otherwise: removes the marker and returns a small status dict.
+
+        The actual archive data directory is **never** removed by this
+        method — only the marker — so a force-clear of a still-present
+        archive only suppresses the failure flag.
+        """
+        from openviking.storage.transaction import LockContext, get_lock_manager
+        from openviking_cli.exceptions import ConflictError, NotFoundError
+
+        if not self._viking_fs:
+            raise NotFoundError(archive_id, "session archive")
+
+        archive_uri = f"{self._session_uri}/history/{archive_id}"
+        marker_uri = f"{archive_uri}/.failed.json"
+
+        # Use the same path-lock the commit path uses so this can't race
+        # with an in-flight commit on the same session.
+        session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
+        async with LockContext(get_lock_manager(), [session_path], lock_mode="exact"):
+            try:
+                await self._viking_fs.read_file(marker_uri, ctx=self.ctx)
+            except Exception as exc:
+                raise NotFoundError(
+                    f"no failed archive marker for archive_id={archive_id}",
+                    "failed archive marker",
+                ) from exc
+
+            data_present = await self._archive_data_present(archive_uri)
+            if data_present and not force:
+                raise ConflictError(
+                    f"archive data still present at {archive_uri}; "
+                    f"delete data manually first or pass force=true",
+                    resource=archive_id,
+                )
+
+            await self._viking_fs.rm(marker_uri, ctx=self.ctx)
+
+        return {
+            "session_id": self.session_id,
+            "archive_id": archive_id,
+            "archive_uri": archive_uri,
+            "data_present": data_present,
+            "force": force,
+            "cleared": True,
+        }
+
+    async def _archive_data_present(self, archive_uri: str) -> bool:
+        """Return True when the archive directory has on-disk data beyond the marker.
+
+        We treat the archive as "data present" if the directory listing
+        contains any entry other than the ``.failed.json`` marker itself.
+        Anything else (``messages.jsonl``, ``.done``, ``.overview.md``, ...)
+        means the operator should look at the residue before clearing.
+        """
+        if not self._viking_fs:
+            return False
+        try:
+            entries = await self._viking_fs.ls(archive_uri, ctx=self.ctx)
+        except Exception:
+            return False
+        for entry in entries:
+            name = entry.get("name") if isinstance(entry, dict) else entry
+            if not name or name in (".", "..", ".failed.json"):
+                continue
+            return True
+        return False
+
     async def _read_archive_overview(self, archive_uri: str) -> str:
         """Read archive overview text."""
         try:

--- a/tests/server/test_session_clear_failed_archive.py
+++ b/tests/server/test_session_clear_failed_archive.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for the clear-failed-archive session resolve endpoint (#2294)."""
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+# These tests exercise the real session storage layer, which requires both the
+# RAGFS native binding and the local vectordb native engine. CI builds those
+# from source; pure-Python dev sandboxes don't have them. Match the failure
+# mode of the rest of the server suite by skipping (rather than erroring) when
+# the natives can't be loaded.
+ragfs_python = pytest.importorskip("ragfs_python")
+from openviking.storage.vectordb import engine as _vectordb_engine  # noqa: E402
+
+if getattr(_vectordb_engine, "ENGINE_VARIANT", "unavailable") == "unavailable":
+    pytest.skip(
+        "vectordb native engine unavailable in this dev sandbox",
+        allow_module_level=True,
+    )
+
+from openviking.server.app import create_app  # noqa: E402
+from openviking.server.config import ServerConfig  # noqa: E402
+from openviking.server.dependencies import set_service  # noqa: E402
+from openviking.server.identity import RequestContext, Role  # noqa: E402
+from openviking_cli.session.user_id import UserIdentifier  # noqa: E402
+
+ROOT_KEY = "test-root-secret-for-clear-failed"
+
+
+async def _make_session(client: httpx.AsyncClient) -> str:
+    resp = await client.post("/api/v1/sessions", json={})
+    assert resp.status_code == 200
+    return resp.json()["result"]["session_id"]
+
+
+async def _write_failed_marker(
+    service,
+    session_id: str,
+    archive_id: str,
+    *,
+    extra_files: dict[str, str] | None = None,
+) -> str:
+    """Write a fake .failed.json marker (and optionally other archive files).
+
+    Uses the same default identity that the dev-mode HTTP client uses, so the
+    on-disk session URI here matches the one the route resolves.
+    """
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    session = service.sessions.session(ctx, session_id)
+    await session.load()
+    archive_uri = f"{session.uri}/history/{archive_id}"
+
+    payload = {
+        "stage": "memory_extraction",
+        "error": "synthetic failure for tests",
+        "failed_at": "2026-06-15T00:00:00Z",
+    }
+    await session._viking_fs.write_file(
+        uri=f"{archive_uri}/.failed.json",
+        content=json.dumps(payload),
+        ctx=session.ctx,
+    )
+    for name, content in (extra_files or {}).items():
+        await session._viking_fs.write_file(
+            uri=f"{archive_uri}/{name}",
+            content=content,
+            ctx=session.ctx,
+        )
+    return archive_uri
+
+
+async def test_clears_marker_when_data_missing(client: httpx.AsyncClient, service):
+    """Marker exists and the archive directory has nothing else → clear succeeds."""
+    session_id = await _make_session(client)
+    archive_id = "archive_001"
+    await _write_failed_marker(service, session_id, archive_id)
+
+    resp = await client.post(f"/api/v1/sessions/{session_id}/archives/{archive_id}/clear-failed")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["cleared"] is True
+    assert body["result"]["session_id"] == session_id
+    assert body["result"]["archive_id"] == archive_id
+    assert body["result"]["data_present"] is False
+    assert body["result"]["force"] is False
+
+    # And the marker is now gone, so a follow-up commit no longer trips the
+    # FAILED_PRECONDITION guard. We add a message first so the commit path
+    # actually exercises the blocking-archive check.
+    await client.post(
+        f"/api/v1/sessions/{session_id}/messages",
+        json={"role": "user", "content": "after fix-archive"},
+    )
+    commit_resp = await client.post(f"/api/v1/sessions/{session_id}/commit")
+    assert commit_resp.status_code == 200, commit_resp.text
+    commit_body = commit_resp.json()
+    assert commit_body["status"] == "ok"
+
+
+async def test_409_when_data_still_present(client: httpx.AsyncClient, service):
+    """If the archive dir still has real content, default behavior refuses with 409."""
+    session_id = await _make_session(client)
+    archive_id = "archive_001"
+    await _write_failed_marker(
+        service,
+        session_id,
+        archive_id,
+        extra_files={"messages.jsonl": '{"role":"user"}\n'},
+    )
+
+    resp = await client.post(f"/api/v1/sessions/{session_id}/archives/{archive_id}/clear-failed")
+    assert resp.status_code == 409, resp.text
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "CONFLICT"
+
+    # Marker still present.
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    session = service.sessions.session(ctx, session_id)
+    await session.load()
+    marker = await session._viking_fs.read_file(
+        f"{session.uri}/history/{archive_id}/.failed.json", ctx=session.ctx
+    )
+    assert marker  # still there
+
+
+async def test_force_clears_with_data_present(client: httpx.AsyncClient, service):
+    """force=true clears the marker even when archive data is present.
+
+    The archive data directory contents are NOT touched — only the marker is
+    removed, so the operator's data residue is preserved for inspection.
+    """
+    session_id = await _make_session(client)
+    archive_id = "archive_001"
+    await _write_failed_marker(
+        service,
+        session_id,
+        archive_id,
+        extra_files={"messages.jsonl": '{"role":"user"}\n'},
+    )
+
+    resp = await client.post(
+        f"/api/v1/sessions/{session_id}/archives/{archive_id}/clear-failed?force=true"
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["result"]["cleared"] is True
+    assert body["result"]["force"] is True
+    assert body["result"]["data_present"] is True
+
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    session = service.sessions.session(ctx, session_id)
+    await session.load()
+
+    # Marker is gone — read_file raises NotFoundError.
+    from openviking_cli.exceptions import NotFoundError as _NotFoundError
+
+    with pytest.raises(_NotFoundError):
+        await session._viking_fs.read_file(
+            f"{session.uri}/history/{archive_id}/.failed.json", ctx=session.ctx
+        )
+
+    # Data file is still there.
+    surviving = await session._viking_fs.read_file(
+        f"{session.uri}/history/{archive_id}/messages.jsonl", ctx=session.ctx
+    )
+    assert "user" in surviving
+
+
+async def test_404_when_no_marker(client: httpx.AsyncClient):
+    """If there is no .failed.json marker for archive_id, return 404."""
+    session_id = await _make_session(client)
+
+    resp = await client.post(f"/api/v1/sessions/{session_id}/archives/archive_999/clear-failed")
+    assert resp.status_code == 404, resp.text
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "NOT_FOUND"
+
+
+@pytest_asyncio.fixture(scope="function")
+async def auth_app(service):
+    """App with root_api_key configured so the auth layer is active."""
+    from openviking.server.api_keys import APIKeyManager
+
+    config = ServerConfig(root_api_key=ROOT_KEY)
+    app = create_app(config=config, service=service)
+    set_service(service)
+    manager = APIKeyManager(root_key=ROOT_KEY, viking_fs=service.viking_fs)
+    await manager.load()
+    app.state.api_key_manager = manager
+    return app
+
+
+@pytest_asyncio.fixture(scope="function")
+async def auth_client(auth_app):
+    transport = httpx.ASGITransport(app=auth_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+
+
+async def test_auth_required(auth_client: httpx.AsyncClient):
+    """Anonymous request must be rejected by the auth layer."""
+    resp = await auth_client.post("/api/v1/sessions/some-session/archives/archive_001/clear-failed")
+    assert resp.status_code in (401, 403), resp.text
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] in ("UNAUTHENTICATED", "PERMISSION_DENIED")


### PR DESCRIPTION
## Summary
Closes #2294. Sessions wedged by an inconsistent failed-archive state (`.failed.json` marker present, archive directory missing) had no resolution path — every subsequent commit kept failing with `FAILED_PRECONDITION` and a server restart didn't help.

This PR adds:

- **`POST /api/v1/sessions/{session_id}/archives/{archive_id}/clear-failed`** — removes the `.failed.json` marker when the archive directory is also missing. Returns 409 if the data directory is still present (the operator should investigate before clearing); `?force=true` opts into clearing anyway.
- **`ov session fix-archive <session_id> <archive_id>`** — CLI wrapper that calls the endpoint, with a `--force` flag for the 409 path.

Audit-friendly: each clear emits a WARNING log line including `session_id`, `archive_id`, caller identity, and `force` flag.

### Relation to #2476
[#2476](https://github.com/volcengine/OpenViking/pull/2476) adds a commit-time `force` flag that *bypasses* a wedged failed archive. This PR is *complementary* — it lets operators explicitly **resolve** the marker and keep using the session normally.

## Test plan
- [ ] `pytest tests/server/test_session_clear_failed_archive.py -x -q` passes (5 cases).
- [ ] Manual: reproduce the wedge by writing `.failed.json` + deleting the archive dir; clear via the CLI; subsequent `ov session commit` succeeds.
- [ ] Existing session tests still pass.

Closes #2294