### PR TITLE
feat(cli): improve config TUI

### DIFF
--- a/crates/ov_cli/src/commands/skills.rs
+++ b/crates/ov_cli/src/commands/skills.rs
@@ -48,6 +48,26 @@ struct InstalledSkillSummary {
     description: String,
 }
 
+#[derive(Default)]
+struct RenderedSkillSelectRegion {
+    lines: Vec<String>,
+    rows_drawn: usize,
+}
+
+impl RenderedSkillSelectRegion {
+    fn from_lines(lines: &[String], columns: usize) -> Self {
+        Self {
+            lines: lines.to_vec(),
+            rows_drawn: rendered_skill_select_rows(lines, columns),
+        }
+    }
+
+    fn rows_to_clear(&self, columns: usize) -> usize {
+        self.rows_drawn
+            .max(rendered_skill_select_rows(&self.lines, columns))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 struct SkillSourceRecord {
@@ -1141,10 +1161,8 @@ async fn resolve_update_target(
         return update_target_from_record(&record, name, allow_prompt);
     }
 
-    if allow_prompt {
-        if let Some(target) = prompt_update_source(name)? {
-            return Ok(target);
-        }
+    if allow_prompt && let Some(target) = prompt_update_source(name)? {
+        return Ok(target);
     }
 
     Err(Error::Client(format!(
@@ -1422,17 +1440,18 @@ fn prompt_multi_select_skills(
     let _raw_guard = RawGuard::enter()?;
     let mut current = 0usize;
     let mut checked = vec![false; skills.len()];
-    let mut rendered_lines = 0usize;
+    let mut rendered_region = RenderedSkillSelectRegion::default();
 
     loop {
-        clear_rendered_lines(rendered_lines)?;
+        clear_rendered_region(&rendered_region)?;
         let lines = skill_multi_select_lines(prompt, skills, current, &checked);
-        rendered_lines = lines.len();
+        rendered_region =
+            RenderedSkillSelectRegion::from_lines(&lines, live_skill_select_columns());
         print!("{}", live_select_block(&lines));
         io::stdout().flush()?;
 
-        if let Event::Key(key) = event::read()? {
-            match key.code {
+        match event::read()? {
+            Event::Key(key) => match key.code {
                 KeyCode::Up => {
                     current = if current == 0 {
                         skills.len().saturating_sub(1)
@@ -1447,21 +1466,29 @@ fn prompt_multi_select_skills(
                     checked.fill(select_all);
                 }
                 KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r') => {
-                    clear_rendered_lines(rendered_lines)?;
+                    clear_rendered_region(&rendered_region)?;
                     let selected = selected_skill_names(skills, current, &checked);
                     return Ok(Some(selected));
                 }
                 KeyCode::Esc => {
-                    clear_rendered_lines(rendered_lines)?;
+                    clear_rendered_region(&rendered_region)?;
                     return Ok(None);
                 }
                 KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    clear_rendered_lines(rendered_lines)?;
+                    clear_rendered_region(&rendered_region)?;
                     return Err(Error::Client("Aborted.".to_string()));
                 }
                 _ => {}
+            },
+            Event::Resize(_, _) => {
+                // Redraw on the next loop using the new terminal width.
             }
+            _ => {}
         }
+    }
+
+    fn clear_rendered_region(region: &RenderedSkillSelectRegion) -> Result<()> {
+        clear_rendered_lines(region.rows_to_clear(live_skill_select_columns()))
     }
 
     fn clear_rendered_lines(lines: usize) -> Result<()> {
@@ -1501,7 +1528,8 @@ fn selected_skill_names(
     let mut selected = skills
         .iter()
         .zip(checked)
-        .filter_map(|(skill, checked)| checked.then(|| skill.name.clone()))
+        .filter(|(_, checked)| **checked)
+        .map(|(skill, _)| skill.name.clone())
         .collect::<Vec<_>>();
     if selected.is_empty()
         && let Some(skill) = skills.get(current)
@@ -1590,6 +1618,47 @@ fn live_select_block(lines: &[String]) -> String {
     let mut rendered = lines.join("\r\n");
     rendered.push_str("\r\n");
     rendered
+}
+
+fn live_skill_select_columns() -> usize {
+    crossterm::terminal::size()
+        .map(|(columns, _)| columns as usize)
+        .unwrap_or(100)
+        .max(1)
+}
+
+fn rendered_skill_select_rows(lines: &[String], columns: usize) -> usize {
+    lines
+        .iter()
+        .map(|line| rendered_skill_select_row_count(line, columns))
+        .sum()
+}
+
+fn rendered_skill_select_row_count(line: &str, columns: usize) -> usize {
+    let columns = columns.max(1);
+    let width = ansi_stripped_display_width(line);
+
+    (width / columns) + usize::from(width == 0 || !width.is_multiple_of(columns))
+}
+
+fn ansi_stripped_display_width(line: &str) -> usize {
+    let mut width = 0usize;
+    let mut chars = line.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for next in chars.by_ref() {
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            width += UnicodeWidthChar::width(ch).unwrap_or(0);
+        }
+    }
+
+    width
 }
 
 fn confirm_action(action: &str, names: &[String]) -> Result<bool> {
@@ -1783,9 +1852,10 @@ fn output_message_result(
 #[cfg(test)]
 mod tests {
     use super::{
-        PreparedSource, SkillSourceRecord, SourceOrigin, filter_skill_show_level,
-        parse_github_tree_source, parse_skill_md, prepare_source_from_git_record,
-        render_skill_show_for_table, resolve_add_targets, update_target_from_record,
+        PreparedSource, RenderedSkillSelectRegion, SkillSourceRecord, SourceOrigin,
+        filter_skill_show_level, parse_github_tree_source, parse_skill_md,
+        prepare_source_from_git_record, render_skill_show_for_table, rendered_skill_select_rows,
+        resolve_add_targets, update_target_from_record,
     };
     use serde_json::json;
     use std::path::Path;
@@ -2024,5 +2094,25 @@ mod tests {
                 .iter()
                 .any(|target| target.data.ends_with("skill-b"))
         );
+    }
+
+    #[test]
+    fn skill_remove_selector_counts_wrapped_ansi_rows() {
+        let lines = vec![
+            "\u{1b}[32m12345678901\u{1b}[0m".to_string(),
+            "short".to_string(),
+        ];
+
+        assert_eq!(rendered_skill_select_rows(&lines, 10), 3);
+    }
+
+    #[test]
+    fn skill_remove_selector_recomputes_clear_rows_after_resize() {
+        let lines = vec!["x".repeat(90)];
+        let region = RenderedSkillSelectRegion::from_lines(&lines, 90);
+
+        assert_eq!(rendered_skill_select_rows(&lines, 90), 1);
+        assert_eq!(rendered_skill_select_rows(&lines, 30), 3);
+        assert_eq!(region.rows_to_clear(30), 3);
     }
 }

--- a/crates/ov_cli/src/commands/skills.rs
+++ b/crates/ov_cli/src/commands/skills.rs
@@ -1,6 +1,10 @@
 use crate::client::HttpClient;
 use crate::error::{Error, Result};
 use crate::output::{OutputFormat, output_success};
+use crate::terminal_ui::{
+    RenderedRegion as RenderedSkillSelectRegion, clear_rendered_lines, live_select_block,
+    truncate_to_display_width,
+};
 use crate::theme;
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -10,7 +14,6 @@ use std::io::{self, IsTerminal, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use url::Url;
 
 enum PreparedSource {
@@ -46,26 +49,6 @@ struct AddTarget {
 struct InstalledSkillSummary {
     name: String,
     description: String,
-}
-
-#[derive(Default)]
-struct RenderedSkillSelectRegion {
-    lines: Vec<String>,
-    rows_drawn: usize,
-}
-
-impl RenderedSkillSelectRegion {
-    fn from_lines(lines: &[String], columns: usize) -> Self {
-        Self {
-            lines: lines.to_vec(),
-            rows_drawn: rendered_skill_select_rows(lines, columns),
-        }
-    }
-
-    fn rows_to_clear(&self, columns: usize) -> usize {
-        self.rows_drawn
-            .max(rendered_skill_select_rows(&self.lines, columns))
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1404,8 +1387,7 @@ fn prompt_multi_select_skills(
     use crossterm::{
         cursor,
         event::{self, Event, KeyCode, KeyModifiers},
-        execute,
-        terminal::{self, Clear, ClearType},
+        execute, terminal,
     };
 
     if skills.is_empty() {
@@ -1490,34 +1472,6 @@ fn prompt_multi_select_skills(
     fn clear_rendered_region(region: &RenderedSkillSelectRegion) -> Result<()> {
         clear_rendered_lines(region.rows_to_clear(live_skill_select_columns()))
     }
-
-    fn clear_rendered_lines(lines: usize) -> Result<()> {
-        if lines == 0 {
-            return Ok(());
-        }
-        let mut stdout = io::stdout();
-        execute!(
-            stdout,
-            cursor::MoveUp(lines as u16),
-            cursor::MoveToColumn(0)
-        )?;
-        for line in 0..lines {
-            execute!(
-                stdout,
-                cursor::MoveToColumn(0),
-                Clear(ClearType::CurrentLine)
-            )?;
-            if line + 1 < lines {
-                execute!(stdout, cursor::MoveDown(1))?;
-            }
-        }
-        execute!(
-            stdout,
-            cursor::MoveUp(lines.saturating_sub(1) as u16),
-            cursor::MoveToColumn(0)
-        )?;
-        Ok(())
-    }
 }
 
 fn selected_skill_names(
@@ -1586,38 +1540,7 @@ fn skill_selection_label(skill: &InstalledSkillSummary, width: usize) -> String 
     } else {
         format!("{} - {}", skill.name, skill.description)
     };
-    truncate_display_width(&label, width)
-}
-
-fn truncate_display_width(text: &str, max_width: usize) -> String {
-    if UnicodeWidthStr::width(text) <= max_width {
-        return text.to_string();
-    }
-
-    let ellipsis = "...";
-    let target_width = max_width.saturating_sub(ellipsis.len());
-    let mut width = 0usize;
-    let mut out = String::new();
-    for ch in text.chars() {
-        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if width + ch_width > target_width {
-            break;
-        }
-        out.push(ch);
-        width += ch_width;
-    }
-    out.push_str(ellipsis);
-    out
-}
-
-fn live_select_block(lines: &[String]) -> String {
-    if lines.is_empty() {
-        return String::new();
-    }
-
-    let mut rendered = lines.join("\r\n");
-    rendered.push_str("\r\n");
-    rendered
+    truncate_to_display_width(&label, width)
 }
 
 fn live_skill_select_columns() -> usize {
@@ -1627,38 +1550,9 @@ fn live_skill_select_columns() -> usize {
         .max(1)
 }
 
+#[cfg(test)]
 fn rendered_skill_select_rows(lines: &[String], columns: usize) -> usize {
-    lines
-        .iter()
-        .map(|line| rendered_skill_select_row_count(line, columns))
-        .sum()
-}
-
-fn rendered_skill_select_row_count(line: &str, columns: usize) -> usize {
-    let columns = columns.max(1);
-    let width = ansi_stripped_display_width(line);
-
-    (width / columns) + usize::from(width == 0 || !width.is_multiple_of(columns))
-}
-
-fn ansi_stripped_display_width(line: &str) -> usize {
-    let mut width = 0usize;
-    let mut chars = line.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
-            chars.next();
-            for next in chars.by_ref() {
-                if next.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-        } else {
-            width += UnicodeWidthChar::width(ch).unwrap_or(0);
-        }
-    }
-
-    width
+    crate::terminal_ui::rendered_row_count(lines, columns)
 }
 
 fn confirm_action(action: &str, names: &[String]) -> Result<bool> {

--- a/crates/ov_cli/src/config_wizard/wizard.rs
+++ b/crates/ov_cli/src/config_wizard/wizard.rs
@@ -11,7 +11,7 @@ use crossterm::{
     event::{self, Event, KeyCode, KeyModifiers},
     terminal::{self, Clear, ClearType, disable_raw_mode, enable_raw_mode},
 };
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthChar;
 use uuid::Uuid;
 
 use crate::{
@@ -19,6 +19,7 @@ use crate::{
     config::{Config, DEFAULT_CUSTOM_URL},
     error::{Error, Result},
     i18n::{self, Language, copy},
+    terminal_ui::{RenderedRegion, display_width, rendered_line_rows, rendered_row_count},
     theme::{self, Rgb},
 };
 use serde_json::Value;
@@ -35,6 +36,7 @@ const OPENVIKING_SERVICE_API_KEY_URL: &str =
 const HEADER_TAGLINE: &str = "Context Database for AI Agents";
 const HEADER_TAGLINE_ZH: &str = "AI Agent 上下文数据库";
 const STATUS_BOX_PROBE_TIMEOUT_SECS: f64 = 3.0;
+const TEXT_INPUT_PROMPT: &str = "  > ";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum IdentityMode {
@@ -76,6 +78,8 @@ const OV_LOGO_LINES: [&str; 14] = [
     "            ⠈⠉⠉⠉⠁",
 ];
 
+// Full mode needs enough height for the standalone wordmark, logo art,
+// status box, and prompts without wrapping into each other.
 const FULL_STATUS_BOX_MIN_ROWS: u16 = 30;
 
 pub async fn run_config_wizard() -> Result<()> {
@@ -88,7 +92,7 @@ async fn run_config_wizard_with_store(store: ConfigStore) -> Result<()> {
     if !ensure_language_selected(&mut ui)? {
         return Ok(());
     }
-    print_header(live_status_box_frame().mode);
+    print_full_header(live_status_box_frame().mode);
     print_status_box(&store).await?;
 
     loop {
@@ -595,7 +599,7 @@ pub(crate) fn should_prompt_root_identity(
         && (api_key_was_entered || is_blank(account) || is_blank(user))
 }
 
-fn print_header(mode: StatusBoxMode) {
+fn print_full_header(mode: StatusBoxMode) {
     if mode != StatusBoxMode::Full {
         return;
     }
@@ -773,25 +777,6 @@ fn print_status_box_with_runtime(
     }
     io::stdout().flush()?;
     Ok(RenderedRegion::from_lines(&lines, render_columns))
-}
-
-struct RenderedRegion {
-    lines: Vec<String>,
-    rows_drawn: usize,
-}
-
-impl RenderedRegion {
-    fn from_lines(lines: &[String], columns: usize) -> Self {
-        Self {
-            lines: lines.to_vec(),
-            rows_drawn: rendered_row_count(lines, columns),
-        }
-    }
-
-    fn rows_to_clear(&self, columns: usize) -> usize {
-        self.rows_drawn
-            .max(rendered_row_count(&self.lines, columns))
-    }
 }
 
 fn clear_rendered_region(region: &RenderedRegion, cursor_on_last_line: bool) -> io::Result<()> {
@@ -1690,31 +1675,6 @@ fn truncate_to_width(text: &str, width: usize) -> String {
     }
     truncated.push('…');
     truncated
-}
-
-fn display_width(text: &str) -> usize {
-    UnicodeWidthStr::width(text)
-}
-
-fn visible_display_width(text: &str) -> usize {
-    let mut width = 0usize;
-    let mut chars = text.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
-            chars.next();
-            for next in chars.by_ref() {
-                if next.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-            continue;
-        }
-
-        width += UnicodeWidthChar::width(ch).unwrap_or(0);
-    }
-
-    width
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3115,7 +3075,11 @@ async fn run_switch_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<b
                         ))?;
                         if let Err(error) = validate_config(&selected_config.config).await {
                             ui.clear()?;
-                            print_switch_validation_error(&selected_config.name, &error);
+                            print_switch_validation_error(
+                                &selected_config.name,
+                                selected_config.kind,
+                                &error,
+                            );
                             return Ok(true);
                         }
 
@@ -3729,29 +3693,37 @@ fn config_already_active_message(name: &str) -> String {
     }
 }
 
-fn print_switch_validation_error(name: &str, error: &Error) {
-    println!();
-    println!(
-        "{} {}",
-        theme::error("✗"),
-        theme::error(match Language::current() {
-            Language::En => format!("Target config '{name}' failed validation."),
-            Language::ZhCn => format!("目标配置 '{name}' 验证失败。"),
-        })
-    );
-    println!(
-        "  {}",
-        theme::muted(localized_validation_error(ConfigKind::Custom, error))
-    );
-    println!(
-        "{} {}",
-        theme::muted(copy(Language::current(), "Next:", "下一步：")),
-        theme::body(copy(
-            Language::current(),
-            "Run ov config and edit this config before switching.",
-            "请运行 ov config 编辑该配置后再切换。",
-        ))
-    );
+fn switch_validation_error_lines(name: &str, kind: ConfigKind, error: &Error) -> Vec<String> {
+    vec![
+        String::new(),
+        format!(
+            "{} {}",
+            theme::error("✗"),
+            theme::error(match Language::current() {
+                Language::En => format!("Target config '{name}' failed validation."),
+                Language::ZhCn => format!("目标配置 '{name}' 验证失败。"),
+            })
+        ),
+        format!(
+            "  {}",
+            theme::muted(localized_validation_error(kind, error))
+        ),
+        format!(
+            "{} {}",
+            theme::muted(copy(Language::current(), "Next:", "下一步：")),
+            theme::body(copy(
+                Language::current(),
+                "Run ov config and edit this config before switching.",
+                "请运行 ov config 编辑该配置后再切换。",
+            ))
+        ),
+    ]
+}
+
+fn print_switch_validation_error(name: &str, kind: ConfigKind, error: &Error) {
+    for line in switch_validation_error_lines(name, kind, error) {
+        println!("{line}");
+    }
 }
 
 pub(crate) fn add_save_action_labels() -> Vec<&'static str> {
@@ -3837,8 +3809,8 @@ fn prompt_select<T: ToString>(
             helper_lines,
         ))?;
 
-        if let Event::Key(key) = event::read()? {
-            match key.code {
+        match event::read()? {
+            Event::Key(key) => match key.code {
                 KeyCode::Up => {
                     selected = if selected == 0 {
                         items.len().saturating_sub(1)
@@ -3863,7 +3835,11 @@ fn prompt_select<T: ToString>(
                     return Ok(PromptResult::Quit);
                 }
                 _ => {}
+            },
+            Event::Resize(_, _) => {
+                // Redraw on the next loop using the new terminal width.
             }
+            _ => {}
         }
     }
 }
@@ -3882,23 +3858,24 @@ fn prompt_text(
     'attempt: loop {
         let mut value = String::new();
         let default_copy = default.unwrap_or_default();
-        ui.render_input(
-            &input_live_lines(
+        render_text_prompt(
+            ui,
+            TextPromptView {
                 section,
                 prompt,
                 default,
                 value_label,
                 secret,
                 helper_lines,
-                error.as_deref(),
-            ),
-            "  > ",
+                error: error.as_deref(),
+                value: &value,
+            },
         )?;
 
         let raw = RawPrompt::enter(false)?;
         loop {
-            if let Event::Key(key) = event::read()? {
-                match key.code {
+            match event::read()? {
+                Event::Key(key) => match key.code {
                     KeyCode::Enter => {
                         let chosen = if value.trim().is_empty() {
                             default_copy.trim().to_string()
@@ -3934,6 +3911,7 @@ fn prompt_text(
                     KeyCode::Backspace => {
                         if let Some(ch) = value.pop() {
                             raw_write(erase_sequence_for_char(ch, secret))?;
+                            ui.set_input_prompt(input_prompt_with_value(&value, secret));
                             io::stdout().flush()?;
                         }
                     }
@@ -3945,14 +3923,80 @@ fn prompt_text(
                             } else {
                                 raw_write(ch.to_string())?;
                             }
+                            ui.set_input_prompt(input_prompt_with_value(&value, secret));
                             io::stdout().flush()?;
                         }
                     }
                     _ => {}
+                },
+                Event::Resize(_, _) => {
+                    render_text_prompt(
+                        ui,
+                        TextPromptView {
+                            section,
+                            prompt,
+                            default,
+                            value_label,
+                            secret,
+                            helper_lines,
+                            error: error.as_deref(),
+                            value: &value,
+                        },
+                    )?;
                 }
+                _ => {}
             }
         }
     }
+}
+
+struct TextPromptView<'a> {
+    section: &'a str,
+    prompt: &'a str,
+    default: Option<&'a str>,
+    value_label: Option<InputValueLabel>,
+    secret: bool,
+    helper_lines: &'a [String],
+    error: Option<&'a str>,
+    value: &'a str,
+}
+
+fn render_text_prompt(ui: &mut LiveRegion, view: TextPromptView<'_>) -> Result<()> {
+    ui.render_input(
+        &input_live_lines(
+            view.section,
+            view.prompt,
+            view.default,
+            view.value_label,
+            view.secret,
+            view.helper_lines,
+            view.error,
+        ),
+        TEXT_INPUT_PROMPT,
+    )?;
+    let input_prompt = input_prompt_with_value(view.value, view.secret);
+    if input_prompt.len() > TEXT_INPUT_PROMPT.len() {
+        if view.secret {
+            raw_write("*".repeat(view.value.chars().count()))?;
+        } else {
+            raw_write(view.value)?;
+        }
+    }
+    ui.set_input_prompt(input_prompt);
+    io::stdout().flush()?;
+    Ok(())
+}
+
+fn input_prompt_with_value(value: &str, secret: bool) -> String {
+    if value.is_empty() {
+        return TEXT_INPUT_PROMPT.to_string();
+    }
+    let rendered_value = if secret {
+        "*".repeat(value.chars().count())
+    } else {
+        value.to_string()
+    };
+    format!("{TEXT_INPUT_PROMPT}{rendered_value}")
 }
 
 fn erase_sequence_for_char(ch: char, secret: bool) -> String {
@@ -4056,6 +4100,15 @@ impl LiveRegion {
         Ok(())
     }
 
+    fn set_input_prompt(&mut self, prompt: String) {
+        self.input_prompt = Some(prompt);
+        self.rows_drawn = self.rows_drawn.max(rendered_live_region_rows(
+            &self.lines,
+            self.input_prompt.as_deref(),
+            live_region_columns(),
+        ));
+    }
+
     fn rows_to_clear(&self, columns: usize) -> usize {
         self.rows_drawn.max(rendered_live_region_rows(
             &self.lines,
@@ -4071,13 +4124,6 @@ fn live_region_columns() -> usize {
         .unwrap_or_else(|_| status_box_width())
 }
 
-fn rendered_row_count(lines: &[String], columns: usize) -> usize {
-    lines
-        .iter()
-        .map(|line| rendered_rows_for_columns(line, columns))
-        .sum()
-}
-
 fn rendered_live_region_rows(
     lines: &[String],
     input_prompt: Option<&str>,
@@ -4085,14 +4131,8 @@ fn rendered_live_region_rows(
 ) -> usize {
     rendered_row_count(lines, columns)
         + input_prompt
-            .map(|prompt| rendered_rows_for_columns(prompt, columns))
+            .map(|prompt| rendered_line_rows(prompt, columns))
             .unwrap_or(0)
-}
-
-fn rendered_rows_for_columns(text: &str, columns: usize) -> usize {
-    let columns = columns.max(1);
-    let width = visible_display_width(text);
-    width.max(1).div_ceil(columns)
 }
 
 pub(crate) fn select_live_lines<T: ToString>(
@@ -4290,23 +4330,25 @@ impl Drop for RawPrompt {
 #[cfg(test)]
 mod tests {
     use super::{
-        CustomKeyMode, FULL_STATUS_BOX_MIN_ROWS, IdentityMode, InputValueLabel, LiveRegion,
-        OV_LOGO_LINES, RenderedRegion, Rgb, StatusBoxFrame, StatusBoxMode, StatusBoxRuntime,
-        active_delete_block_helper_lines, active_summary_lines, active_summary_render_parts,
-        add_config_name_label, add_save_action_labels, allocate_config_name, box_content_line,
-        box_footer_line, box_title_line, compact_status_box_width, config_select_label,
-        custom_api_key_helper_lines, custom_api_key_input_helper_lines, custom_key_mode_labels,
+        COMPACT_STATUS_DETAIL_WIDTH, CustomKeyMode, FULL_STATUS_BOX_MIN_ROWS, IdentityMode,
+        InputValueLabel, LiveRegion, OV_LOGO_LINES, RenderedRegion, Rgb, StatusBoxFrame,
+        StatusBoxMode, StatusBoxRuntime, active_delete_block_helper_lines, active_summary_lines,
+        active_summary_render_parts, add_config_name_label, add_save_action_labels,
+        allocate_config_name, box_content_line, box_footer_line, box_title_line,
+        compact_status_box_width, config_select_label, custom_api_key_helper_lines,
+        custom_api_key_input_helper_lines, custom_key_mode_labels,
         custom_validation_failure_choices, display_config_home, display_width,
         edit_api_key_choice_labels, edit_custom_key_action_labels, edit_save_action_labels,
         erase_sequence_for_char, extract_models_from_status_payload, identity_prompt_parts,
-        input_live_lines, logo_glass_color_for_theme, main_action_labels, next_step_copy,
-        openviking_service_api_key_helper_lines, openviking_service_validation_failure_choices,
-        ov_logo_width, provider_labels, rendered_live_region_rows, rendered_row_count,
-        root_key_normal_command_notice_lines, root_key_redirect_labels, saved_summary_render_parts,
-        select_live_lines, should_confirm_detected_user_key, should_prompt_root_identity,
-        status_box_frame_for_size, status_box_lines, status_box_lines_with_runtime,
-        status_box_lines_with_runtime_width, status_box_width, status_payload_is_healthy,
-        styled_logo_to_width_for_color_level, styled_wordmark_line_for_color_level,
+        input_live_lines, input_prompt_with_value, logo_glass_color_for_theme, main_action_labels,
+        next_step_copy, openviking_service_api_key_helper_lines,
+        openviking_service_validation_failure_choices, ov_logo_width, provider_labels,
+        rendered_live_region_rows, rendered_row_count, root_key_normal_command_notice_lines,
+        root_key_redirect_labels, saved_summary_render_parts, select_live_lines,
+        should_confirm_detected_user_key, should_prompt_root_identity, status_box_frame_for_size,
+        status_box_lines, status_box_lines_with_runtime, status_box_lines_with_runtime_width,
+        status_box_width, status_payload_is_healthy, styled_logo_to_width_for_color_level,
+        styled_wordmark_line_for_color_level, switch_validation_error_lines,
         tagline_ice_color_for_theme, user_key_redirect_labels, validate_config_name,
         validate_draft, wizard_header_lines, wordmark_gradient_color_for_theme, wordmark_lines,
         wordmark_width,
@@ -4316,6 +4358,7 @@ mod tests {
         ApiKeyRole, ConfigDraft, ConfigEntry, ConfigKind, ConfigStore, OPENVIKING_SERVICE_URL,
         validate_account_id_value, validate_user_id_value,
     };
+    use crate::error::Error;
     use crate::i18n::Language;
     use crate::theme::{self, ThemeColor};
     use colored::Colorize;
@@ -4372,6 +4415,27 @@ mod tests {
         assert_eq!(erase_sequence_for_char('a', false), "\x08 \x08");
         assert_eq!(erase_sequence_for_char('中', false), "\x08 \x08\x08 \x08");
         assert_eq!(erase_sequence_for_char('中', true), "\x08 \x08");
+    }
+
+    #[test]
+    fn input_prompt_tracks_visible_or_secret_value() {
+        assert_eq!(input_prompt_with_value("", false), "  > ");
+        assert_eq!(input_prompt_with_value("abc", false), "  > abc");
+        assert_eq!(input_prompt_with_value("secret", true), "  > ******");
+    }
+
+    #[test]
+    fn switch_validation_error_uses_selected_config_kind() {
+        let lines = switch_validation_error_lines(
+            "cloud",
+            ConfigKind::OpenVikingService,
+            &Error::Config("invalid".to_string()),
+        );
+        let plain = strip_ansi(&lines.join("\n"));
+
+        assert!(plain.contains("Target config 'cloud' failed validation."));
+        assert!(plain.contains("Check your API key"));
+        assert!(!plain.contains("server URL"));
     }
 
     #[test]
@@ -4473,7 +4537,8 @@ mod tests {
         );
         let text = lines.join("\n");
 
-        assert_eq!(width, 56);
+        assert!(width >= COMPACT_STATUS_DETAIL_WIDTH + 4);
+        assert!(width <= status_box_width());
         assert!(lines[0].contains("OpenViking | Context Database for AI Agents"));
         assert!(text.contains("Active:"));
         assert!(!text.contains('⣿'));
@@ -4529,6 +4594,20 @@ mod tests {
         };
 
         assert_eq!(ui.rows_to_clear(30), 3);
+    }
+
+    #[test]
+    fn live_region_keeps_largest_input_rows_until_clear() {
+        let mut ui = LiveRegion {
+            lines: vec!["Prompt".to_string()],
+            input_prompt: Some(format!("  > {}", "x".repeat(90))),
+            rows_drawn: 10,
+            cursor_on_last_line: true,
+        };
+
+        ui.set_input_prompt("  > x".to_string());
+
+        assert_eq!(ui.rows_to_clear(120), 10);
     }
 
     #[test]

--- a/crates/ov_cli/src/config_wizard/wizard.rs
+++ b/crates/ov_cli/src/config_wizard/wizard.rs
@@ -9,7 +9,7 @@ use crossterm::{
     ExecutableCommand,
     cursor::{Hide, MoveToColumn, MoveUp, Show},
     event::{self, Event, KeyCode, KeyModifiers},
-    terminal::{Clear, ClearType, disable_raw_mode, enable_raw_mode},
+    terminal::{self, Clear, ClearType, disable_raw_mode, enable_raw_mode},
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use uuid::Uuid;
@@ -26,8 +26,8 @@ use serde_json::Value;
 use super::store::{
     ApiKeyRole, ConfigDraft, ConfigEntry, ConfigKind, ConfigStore, IdentityField,
     OPENVIKING_SERVICE_URL, build_config, custom_allows_empty_api_key, validate_candidate_config,
-    validate_candidate_config_with_role, validate_config_name, validate_identity_value,
-    validation_error_copy,
+    validate_candidate_config_with_role, validate_config, validate_config_name,
+    validate_identity_value, validation_error_copy,
 };
 
 const OPENVIKING_SERVICE_API_KEY_URL: &str =
@@ -76,6 +76,8 @@ const OV_LOGO_LINES: [&str; 14] = [
     "            ⠈⠉⠉⠉⠁",
 ];
 
+const FULL_STATUS_BOX_MIN_ROWS: u16 = 30;
+
 pub async fn run_config_wizard() -> Result<()> {
     let store = ConfigStore::new()?;
     run_config_wizard_with_store(store).await
@@ -86,7 +88,7 @@ async fn run_config_wizard_with_store(store: ConfigStore) -> Result<()> {
     if !ensure_language_selected(&mut ui)? {
         return Ok(());
     }
-    print_header();
+    print_header(live_status_box_frame().mode);
     print_status_box(&store).await?;
 
     loop {
@@ -109,11 +111,16 @@ async fn run_config_wizard_with_store(store: ConfigStore) -> Result<()> {
                 }
             }
             PromptResult::Value(1) => {
-                if run_edit_config(&store, &mut ui).await? {
+                if run_switch_config(&store, &mut ui).await? {
                     return Ok(());
                 }
             }
             PromptResult::Value(2) => {
+                if run_edit_config(&store, &mut ui).await? {
+                    return Ok(());
+                }
+            }
+            PromptResult::Value(3) => {
                 if run_delete_config(&store, &mut ui)? {
                     return Ok(());
                 }
@@ -159,12 +166,11 @@ fn ensure_language_selected(ui: &mut LiveRegion) -> Result<bool> {
 }
 
 pub(crate) fn wizard_header_lines() -> Vec<String> {
-    let mut lines: Vec<String> = wordmark_lines()
-        .iter()
-        .map(|line| (*line).to_string())
-        .collect();
-    lines.push(String::new());
-    lines
+    wordmark_lines()
+        .into_iter()
+        .map(str::to_string)
+        .chain(std::iter::once(String::new()))
+        .collect()
 }
 
 pub(crate) fn wordmark_width() -> usize {
@@ -191,7 +197,71 @@ fn header_version_text() -> String {
 }
 
 fn status_box_width() -> usize {
-    wordmark_width()
+    preferred_status_box_width()
+}
+
+const COMPACT_STATUS_DETAIL_WIDTH: usize = 52;
+
+fn preferred_status_box_width() -> usize {
+    let title_width = 4 + display_width(status_box_title(StatusBoxMode::Full));
+
+    wordmark_width().max(title_width)
+}
+
+fn compact_status_box_width() -> usize {
+    let content_width = 4 + COMPACT_STATUS_DETAIL_WIDTH;
+    let title_width = 4 + display_width(status_box_title(StatusBoxMode::Compact));
+
+    content_width.max(title_width)
+}
+
+fn status_box_title(mode: StatusBoxMode) -> &'static str {
+    match mode {
+        StatusBoxMode::Full => copy(Language::current(), HEADER_TAGLINE, HEADER_TAGLINE_ZH),
+        StatusBoxMode::Compact => copy(
+            Language::current(),
+            "OpenViking | Context Database for AI Agents",
+            "OpenViking | AI Agent 上下文数据库",
+        ),
+    }
+}
+
+fn live_status_box_frame() -> StatusBoxFrame {
+    match terminal::size() {
+        Ok((columns, rows)) if columns > 4 => status_box_frame_for_size(columns, rows),
+        _ => StatusBoxFrame {
+            width: preferred_status_box_width(),
+            mode: StatusBoxMode::Full,
+        },
+    }
+}
+
+fn status_box_frame_for_size(columns: u16, rows: u16) -> StatusBoxFrame {
+    let available = usize::from(columns).saturating_sub(1);
+    let preferred = preferred_status_box_width();
+    if rows >= FULL_STATUS_BOX_MIN_ROWS && available >= preferred {
+        return StatusBoxFrame {
+            width: preferred.min(available),
+            mode: StatusBoxMode::Full,
+        };
+    }
+
+    StatusBoxFrame {
+        width: compact_status_box_width().min(available),
+        mode: StatusBoxMode::Compact,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StatusBoxFrame {
+    width: usize,
+    mode: StatusBoxMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StatusBoxMode {
+    Full,
+    Compact,
 }
 
 fn nav_hint() -> &'static str {
@@ -223,6 +293,14 @@ fn section_edit() -> &'static str {
         Language::current(),
         "Update a saved config.",
         "更新已保存的配置。",
+    )
+}
+
+fn section_switch() -> &'static str {
+    copy(
+        Language::current(),
+        "Switch to a saved config.",
+        "切换到已保存的配置。",
     )
 }
 
@@ -432,14 +510,19 @@ fn has_normal_user_key(api_key: Option<&str>, root_api_key: Option<&str>) -> boo
         .is_none_or(|root_api_key| root_api_key != api_key)
 }
 
-pub(crate) fn main_action_labels() -> [&'static str; 3] {
-    ["Add config", "Edit config", "Delete config"]
+pub(crate) fn main_action_labels() -> [&'static str; 4] {
+    [
+        "Add Config",
+        "Switch Config",
+        "Edit Config",
+        "Delete Config",
+    ]
 }
 
-fn main_action_labels_for_language(language: Language) -> [&'static str; 3] {
+fn main_action_labels_for_language(language: Language) -> [&'static str; 4] {
     match language {
         Language::En => main_action_labels(),
-        Language::ZhCn => ["添加配置", "编辑配置", "删除配置"],
+        Language::ZhCn => ["添加配置", "切换配置", "编辑配置", "删除配置"],
     }
 }
 
@@ -512,12 +595,17 @@ pub(crate) fn should_prompt_root_identity(
         && (api_key_was_entered || is_blank(account) || is_blank(user))
 }
 
-fn print_header() {
+fn print_header(mode: StatusBoxMode) {
+    if mode != StatusBoxMode::Full {
+        return;
+    }
+
     let lines = wizard_header_lines();
     println!();
     for (index, line) in lines.iter().take(wordmark_lines().len()).enumerate() {
         println!("{}", styled_wordmark_line(index, line));
     }
+    println!();
 }
 
 fn styled_wordmark_line(_index: usize, line: &str) -> String {
@@ -657,14 +745,14 @@ async fn print_status_box(store: &ConfigStore) -> Result<()> {
         return Ok(());
     };
 
-    let rendered_lines = print_status_box_with_runtime(
+    let rendered_region = print_status_box_with_runtime(
         active.as_ref(),
         &configs,
         &config_home,
         &StatusBoxRuntime::checking(),
     )?;
     let runtime = status_box_runtime(Some(active_config)).await;
-    clear_live_region(rendered_lines, false)?;
+    clear_rendered_region(&rendered_region, false)?;
     print_status_box_with_runtime(active.as_ref(), &configs, &config_home, &runtime)?;
 
     Ok(())
@@ -675,29 +763,42 @@ fn print_status_box_with_runtime(
     configs: &[ConfigEntry],
     config_home: &str,
     runtime: &StatusBoxRuntime,
-) -> Result<usize> {
-    let width = status_box_width();
+) -> Result<RenderedRegion> {
+    let frame = live_status_box_frame();
+    let lines = styled_status_box_lines_with_runtime(active, configs, config_home, runtime, frame);
+    let render_columns = live_region_columns();
 
-    println!();
-    println!(
-        "{}",
-        styled_box_title_line(
-            copy(Language::current(), HEADER_TAGLINE, HEADER_TAGLINE_ZH),
-            width
-        )
-    );
-    let details = status_box_details(active, configs, config_home, runtime);
-    let rows = OV_LOGO_LINES.len().max(details.len());
-    let details = center_status_box_details(details, rows);
-    for index in 0..rows {
-        let logo = OV_LOGO_LINES.get(index).copied().unwrap_or("");
-        let detail = details.get(index).unwrap_or(&StatusBoxDetail::Empty);
-        println!("{}", styled_box_content_line(logo, detail, width, index));
+    for line in &lines {
+        println!("{line}");
     }
-    println!("{}", styled_box_footer_line(&header_version_text(), width));
-    println!();
     io::stdout().flush()?;
-    Ok(rows + 4)
+    Ok(RenderedRegion::from_lines(&lines, render_columns))
+}
+
+struct RenderedRegion {
+    lines: Vec<String>,
+    rows_drawn: usize,
+}
+
+impl RenderedRegion {
+    fn from_lines(lines: &[String], columns: usize) -> Self {
+        Self {
+            lines: lines.to_vec(),
+            rows_drawn: rendered_row_count(lines, columns),
+        }
+    }
+
+    fn rows_to_clear(&self, columns: usize) -> usize {
+        self.rows_drawn
+            .max(rendered_row_count(&self.lines, columns))
+    }
+}
+
+fn clear_rendered_region(region: &RenderedRegion, cursor_on_last_line: bool) -> io::Result<()> {
+    clear_live_region(
+        region.rows_to_clear(live_region_columns()),
+        cursor_on_last_line,
+    )
 }
 
 #[cfg(test)]
@@ -716,26 +817,98 @@ fn status_box_lines_with_runtime(
     config_home: &str,
     runtime: &StatusBoxRuntime,
 ) -> Vec<String> {
-    let width = status_box_width();
+    status_box_lines_with_runtime_width(
+        active,
+        configs,
+        config_home,
+        runtime,
+        StatusBoxFrame {
+            width: status_box_width(),
+            mode: StatusBoxMode::Full,
+        },
+    )
+}
+
+#[cfg(test)]
+fn status_box_lines_with_runtime_width(
+    active: Option<&Config>,
+    configs: &[ConfigEntry],
+    config_home: &str,
+    runtime: &StatusBoxRuntime,
+    frame: StatusBoxFrame,
+) -> Vec<String> {
     let details = status_box_details(active, configs, config_home, runtime);
-    let rows = OV_LOGO_LINES.len().max(details.len());
-    let details = center_status_box_details(details, rows);
+    let right_rows = status_box_right_rows(details, frame.mode);
+    let rows = status_box_row_count(right_rows.len(), frame.mode);
     let mut lines = Vec::with_capacity(rows + 2);
 
-    lines.push(box_title_line(HEADER_TAGLINE, width));
+    lines.push(box_title_line(status_box_title(frame.mode), frame.width));
     for index in 0..rows {
         lines.push(box_content_line(
-            OV_LOGO_LINES.get(index).copied().unwrap_or(""),
-            details
+            status_box_logo_line(index, frame.mode),
+            right_rows
                 .get(index)
-                .map(StatusBoxDetail::plain)
+                .map(|row| row.plain(frame.width, frame.mode))
                 .unwrap_or_default()
                 .as_str(),
-            width,
+            frame.width,
+            frame.mode,
         ));
     }
-    lines.push(box_footer_line(&header_version_text(), width));
+    lines.push(box_footer_line(&header_version_text(), frame.width));
     lines
+}
+
+fn styled_status_box_lines_with_runtime(
+    active: Option<&Config>,
+    configs: &[ConfigEntry],
+    config_home: &str,
+    runtime: &StatusBoxRuntime,
+    frame: StatusBoxFrame,
+) -> Vec<String> {
+    let details = status_box_details(active, configs, config_home, runtime);
+    let right_rows = status_box_right_rows(details, frame.mode);
+    let rows = status_box_row_count(right_rows.len(), frame.mode);
+    let mut lines = Vec::with_capacity(rows + 4);
+
+    lines.push(String::new());
+    lines.push(styled_box_title_line(
+        status_box_title(frame.mode),
+        frame.width,
+    ));
+    for index in 0..rows {
+        lines.push(styled_box_content_line(
+            status_box_logo_line(index, frame.mode),
+            right_rows.get(index).unwrap_or(&StatusBoxRightRow::Empty),
+            frame.width,
+            index,
+            frame.mode,
+        ));
+    }
+    lines.push(styled_box_footer_line(&header_version_text(), frame.width));
+    lines.push(String::new());
+    lines
+}
+
+fn status_box_row_count(right_rows: usize, mode: StatusBoxMode) -> usize {
+    match mode {
+        StatusBoxMode::Full => OV_LOGO_LINES.len().max(right_rows),
+        StatusBoxMode::Compact => right_rows,
+    }
+}
+
+fn status_box_logo_line(index: usize, mode: StatusBoxMode) -> &'static str {
+    status_box_logo_lines(mode)
+        .get(index)
+        .copied()
+        .unwrap_or("")
+}
+
+fn status_box_logo_lines(mode: StatusBoxMode) -> &'static [&'static str] {
+    match mode {
+        StatusBoxMode::Full => &OV_LOGO_LINES,
+        StatusBoxMode::Compact => &[],
+    }
 }
 
 async fn status_box_runtime(active: Option<&Config>) -> StatusBoxRuntime {
@@ -794,9 +967,7 @@ fn status_payload_health(value: &Value) -> Option<bool> {
         return Some(healthy);
     }
 
-    let Some(components) = value.get("components").and_then(Value::as_object) else {
-        return None;
-    };
+    let components = value.get("components").and_then(Value::as_object)?;
 
     if components.is_empty() {
         return None;
@@ -945,6 +1116,22 @@ impl StatusBoxRuntime {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StatusBoxRightRow {
+    Detail(StatusBoxDetail),
+    Empty,
+}
+
+#[cfg(test)]
+impl StatusBoxRightRow {
+    fn plain(&self, _width: usize, _mode: StatusBoxMode) -> String {
+        match self {
+            Self::Detail(detail) => detail.plain(),
+            Self::Empty => String::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RuntimeConnectionStatus {
     Checking,
@@ -1015,7 +1202,6 @@ enum StatusBoxDetail {
     Model { label: &'static str, value: String },
     Saved { count: String },
     Home { path: String },
-    Empty,
 }
 
 impl StatusBoxDetail {
@@ -1031,7 +1217,6 @@ impl StatusBoxDetail {
             Self::Model { label, value } => format!("{label}: {value}"),
             Self::Saved { count } => format!("{} {count}", status_label("Saved configs:")),
             Self::Home { path } => format!("{} {path}", status_label("Config home:")),
-            Self::Empty => String::new(),
         }
     }
 
@@ -1078,7 +1263,6 @@ impl StatusBoxDetail {
                     theme::sky_value(path).bold()
                 )
             }
-            Self::Empty => String::new(),
         }
     }
 }
@@ -1157,18 +1341,46 @@ fn unknown_copy() -> &'static str {
     copy(Language::current(), "Unknown", "未知")
 }
 
-fn center_status_box_details(details: Vec<StatusBoxDetail>, rows: usize) -> Vec<StatusBoxDetail> {
-    let top_padding = rows.saturating_sub(details.len()) / 2;
-    let mut centered = Vec::with_capacity(rows);
-    centered.extend(std::iter::repeat_n(StatusBoxDetail::Empty, top_padding));
-    centered.extend(details);
-    centered.resize(rows, StatusBoxDetail::Empty);
+fn status_box_right_rows(
+    details: Vec<StatusBoxDetail>,
+    mode: StatusBoxMode,
+) -> Vec<StatusBoxRightRow> {
+    let rows = details
+        .into_iter()
+        .map(StatusBoxRightRow::Detail)
+        .collect::<Vec<_>>();
+
+    match mode {
+        StatusBoxMode::Full => center_status_box_rows(rows, OV_LOGO_LINES.len()),
+        StatusBoxMode::Compact => rows,
+    }
+}
+
+fn center_status_box_rows(
+    rows: Vec<StatusBoxRightRow>,
+    target_rows: usize,
+) -> Vec<StatusBoxRightRow> {
+    if rows.len() >= target_rows {
+        return rows;
+    }
+
+    let empty_rows = target_rows - rows.len();
+    let top = empty_rows / 2;
+    let bottom = empty_rows - top;
+    let mut centered = Vec::with_capacity(target_rows);
+    centered.extend(std::iter::repeat_n(StatusBoxRightRow::Empty, top));
+    centered.extend(rows);
+    centered.extend(std::iter::repeat_n(StatusBoxRightRow::Empty, bottom));
     centered
 }
 
 #[cfg(test)]
 fn box_title_line(title: &str, width: usize) -> String {
     let inner_width = width.saturating_sub(2);
+    if title.trim().is_empty() {
+        return format!("╭{}╮", "─".repeat(inner_width));
+    }
+
     let title = format!(" {title} ");
     let visible_title = truncate_to_width(&title, inner_width);
     let title_width = display_width(&visible_title);
@@ -1201,26 +1413,34 @@ fn box_footer_line(title: &str, width: usize) -> String {
 }
 
 #[cfg(test)]
-fn box_content_line(left: &str, right: &str, width: usize) -> String {
-    let logo_width = ov_logo_width();
-    let gutter = 3usize;
-    let right_width = width.saturating_sub(4 + logo_width + gutter);
+fn box_content_line(left: &str, right: &str, width: usize, mode: StatusBoxMode) -> String {
+    let layout = status_box_content_layout(width, mode);
     format!(
         "│ {}{}{} │",
-        pad_to_width(left, logo_width),
-        " ".repeat(gutter),
-        pad_to_width(right, right_width)
+        pad_to_width(left, layout.logo_width),
+        " ".repeat(layout.gutter),
+        pad_to_width(right, layout.right_width)
     )
 }
 
 fn styled_box_title_line(title: &str, width: usize) -> String {
     let inner_width = width.saturating_sub(2);
+    let border = theme::active_theme().border.rgb_fallback();
+
+    if title.trim().is_empty() {
+        return format!(
+            "{}{}{}",
+            theme::style_rgb("╭", border, false),
+            theme::style_rgb("─".repeat(inner_width), border, false),
+            theme::style_rgb("╮", border, false)
+        );
+    }
+
     let title = format!(" {title} ");
     let visible_title = truncate_to_width(&title, inner_width);
     let title_width = display_width(&visible_title);
     let left = inner_width.saturating_sub(title_width) / 2;
     let right = inner_width.saturating_sub(title_width + left);
-    let border = theme::active_theme().border.rgb_fallback();
 
     format!(
         "{}{}{}{}{}",
@@ -1254,32 +1474,86 @@ fn styled_box_footer_line(title: &str, width: usize) -> String {
 
 fn styled_box_content_line(
     left: &str,
-    detail: &StatusBoxDetail,
+    right: &StatusBoxRightRow,
     width: usize,
     logo_row: usize,
+    mode: StatusBoxMode,
 ) -> String {
-    let logo_width = ov_logo_width();
-    let gutter = 3usize;
-    let right_width = width.saturating_sub(4 + logo_width + gutter);
+    let layout = status_box_content_layout(width, mode);
     let border = theme::active_theme().border.rgb_fallback();
+    let logo_height = status_box_logo_lines(mode).len();
     format!(
         "{} {}{}{} {}",
         theme::style_rgb("│", border, false),
-        styled_logo_to_width(left, logo_width, logo_row),
-        " ".repeat(gutter),
-        styled_detail_to_width(detail, right_width),
+        styled_logo_to_width(left, layout.logo_width, logo_row, logo_height),
+        " ".repeat(layout.gutter),
+        styled_status_right_row_to_width(right, layout.right_width),
         theme::style_rgb("│", border, false)
     )
 }
 
-fn styled_logo_to_width(line: &str, width: usize, row: usize) -> String {
-    styled_logo_to_width_for_color_level(line, width, row, theme::terminal_color_level())
+#[derive(Debug, Clone, Copy)]
+struct StatusBoxContentLayout {
+    logo_width: usize,
+    gutter: usize,
+    right_width: usize,
 }
 
+fn status_box_content_layout(width: usize, mode: StatusBoxMode) -> StatusBoxContentLayout {
+    let inner_width = width.saturating_sub(4);
+    if mode == StatusBoxMode::Compact {
+        return StatusBoxContentLayout {
+            logo_width: 0,
+            gutter: 0,
+            right_width: inner_width,
+        };
+    }
+
+    let preferred_logo_width = match mode {
+        StatusBoxMode::Full => ov_logo_width(),
+        StatusBoxMode::Compact => 0,
+    };
+    let preferred_gutter = 3usize;
+
+    if inner_width <= preferred_logo_width {
+        return StatusBoxContentLayout {
+            logo_width: inner_width,
+            gutter: 0,
+            right_width: 0,
+        };
+    }
+
+    let room_after_logo = inner_width.saturating_sub(preferred_logo_width);
+    let gutter = preferred_gutter.min(room_after_logo.saturating_sub(1));
+    let logo_width = preferred_logo_width.min(inner_width.saturating_sub(gutter));
+    let right_width = inner_width.saturating_sub(logo_width + gutter);
+
+    StatusBoxContentLayout {
+        logo_width,
+        gutter,
+        right_width,
+    }
+}
+
+fn styled_logo_to_width(line: &str, width: usize, row: usize, logo_height: usize) -> String {
+    styled_logo_to_width_with_height(line, width, row, logo_height, theme::terminal_color_level())
+}
+
+#[cfg(test)]
 fn styled_logo_to_width_for_color_level(
     line: &str,
     width: usize,
     row: usize,
+    color_level: theme::ColorLevel,
+) -> String {
+    styled_logo_to_width_with_height(line, width, row, OV_LOGO_LINES.len(), color_level)
+}
+
+fn styled_logo_to_width_with_height(
+    line: &str,
+    width: usize,
+    row: usize,
+    logo_height: usize,
     color_level: theme::ColorLevel,
 ) -> String {
     let mut rendered = String::new();
@@ -1289,8 +1563,10 @@ fn styled_logo_to_width_for_color_level(
         if ch.is_whitespace() {
             rendered.push(ch);
         } else {
-            let rgb =
-                header_display_rgb(logo_glass_color(ch, column, row, width.max(1)), color_level);
+            let rgb = header_display_rgb(
+                logo_glass_color(ch, column, row, width.max(1), logo_height),
+                color_level,
+            );
             rendered.push_str(&theme::style_rgb_for_level(
                 ch.to_string(),
                 rgb,
@@ -1311,22 +1587,33 @@ fn header_display_rgb(rgb: Rgb, color_level: theme::ColorLevel) -> Rgb {
     }
 }
 
-fn logo_glass_color(_ch: char, column: usize, row: usize, width: usize) -> Rgb {
-    logo_glass_color_for_theme(theme::active_theme(), column, row, width)
+fn logo_glass_color(_ch: char, column: usize, row: usize, width: usize, logo_height: usize) -> Rgb {
+    logo_glass_color_for_theme_with_height(theme::active_theme(), column, row, width, logo_height)
 }
 
+#[cfg(test)]
 fn logo_glass_color_for_theme(
     palette: theme::CliTheme,
     column: usize,
     row: usize,
     width: usize,
 ) -> Rgb {
+    logo_glass_color_for_theme_with_height(palette, column, row, width, OV_LOGO_LINES.len())
+}
+
+fn logo_glass_color_for_theme_with_height(
+    palette: theme::CliTheme,
+    column: usize,
+    row: usize,
+    width: usize,
+    logo_height: usize,
+) -> Rgb {
     if width <= 1 {
         return palette.wordmark_start;
     }
 
     let column_ratio = column as f32 / (width - 1) as f32;
-    let row_height = OV_LOGO_LINES.len().saturating_sub(1).max(1);
+    let row_height = logo_height.saturating_sub(1).max(1);
     let row_ratio = row as f32 / row_height as f32;
     let ratio = (column_ratio * 0.4 + row_ratio * 0.6).clamp(0.0, 1.0);
 
@@ -1353,6 +1640,13 @@ fn styled_detail_to_width(detail: &StatusBoxDetail, width: usize) -> String {
         styled,
         " ".repeat(width.saturating_sub(display_width(&plain)))
     )
+}
+
+fn styled_status_right_row_to_width(row: &StatusBoxRightRow, width: usize) -> String {
+    match row {
+        StatusBoxRightRow::Detail(detail) => styled_detail_to_width(detail, width),
+        StatusBoxRightRow::Empty => " ".repeat(width),
+    }
 }
 
 fn ov_logo_width() -> usize {
@@ -1400,6 +1694,27 @@ fn truncate_to_width(text: &str, width: usize) -> String {
 
 fn display_width(text: &str) -> usize {
     UnicodeWidthStr::width(text)
+}
+
+fn visible_display_width(text: &str) -> usize {
+    let mut width = 0usize;
+    let mut chars = text.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for next in chars.by_ref() {
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        width += UnicodeWidthChar::width(ch).unwrap_or(0);
+    }
+
+    width
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2714,6 +3029,127 @@ fn run_delete_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool> {
     }
 }
 
+async fn run_switch_config(store: &ConfigStore, ui: &mut LiveRegion) -> Result<bool> {
+    enum Stage {
+        Select,
+        Confirm,
+    }
+
+    let configs = store.list_configs()?;
+    if configs.is_empty() {
+        let helper_lines = vec![
+            theme::warning(copy(
+                Language::current(),
+                "No saved configs to switch.",
+                "没有可切换的配置。",
+            ))
+            .to_string(),
+        ];
+        let _ = prompt_select(
+            ui,
+            section_switch(),
+            copy(Language::current(), "Nothing to switch.", "没有可切换项。"),
+            &[copy(Language::current(), "Back", "返回")],
+            0,
+            &helper_lines,
+        )?;
+        return Ok(false);
+    }
+
+    let mut stage = Stage::Select;
+    let mut selected = 0usize;
+
+    loop {
+        match stage {
+            Stage::Select => match prompt_config_select(
+                ui,
+                section_switch(),
+                copy(Language::current(), "Config to switch to", "要切换到的配置"),
+                &configs,
+            )? {
+                PromptResult::Value(index) => {
+                    selected = index;
+                    if configs[index].is_active {
+                        let helper_lines = vec![
+                            theme::muted(config_already_active_message(&configs[index].name))
+                                .to_string(),
+                        ];
+                        let _ = prompt_select(
+                            ui,
+                            section_switch(),
+                            copy(
+                                Language::current(),
+                                "Config already active.",
+                                "配置已是当前配置。",
+                            ),
+                            &[copy(Language::current(), "Back", "返回")],
+                            0,
+                            &helper_lines,
+                        )?;
+                        return Ok(false);
+                    }
+                    stage = Stage::Confirm;
+                }
+                PromptResult::Back => return Ok(false),
+                PromptResult::Quit => {
+                    print_cancelled(ui)?;
+                    return Ok(true);
+                }
+            },
+            Stage::Confirm => {
+                let selected_config = &configs[selected];
+                match confirm(
+                    ui,
+                    section_switch(),
+                    &switch_confirm_prompt(&selected_config.name),
+                    true,
+                )? {
+                    PromptResult::Value(true) => {
+                        ui.render(&status_live_lines(
+                            section_switch(),
+                            copy(
+                                Language::current(),
+                                "Validating target config...",
+                                "正在验证目标配置...",
+                            ),
+                        ))?;
+                        if let Err(error) = validate_config(&selected_config.config).await {
+                            ui.clear()?;
+                            print_switch_validation_error(&selected_config.name, &error);
+                            return Ok(true);
+                        }
+
+                        ui.clear()?;
+                        store.activate_config(&selected_config.name)?;
+                        println!();
+                        println!(
+                            "{} {}",
+                            theme::success("✓"),
+                            theme::success(switched_config_message(&selected_config.name))
+                        );
+                        println!(
+                            "{} {}",
+                            theme::muted(copy(Language::current(), "Next:", "下一步：")),
+                            theme::body(copy(
+                                Language::current(),
+                                "Run ov status to inspect it.",
+                                "运行 ov status 查看状态。",
+                            ))
+                        );
+                        return Ok(true);
+                    }
+                    PromptResult::Value(false) => stage = Stage::Select,
+                    PromptResult::Back => stage = Stage::Select,
+                    PromptResult::Quit => {
+                        print_cancelled(ui)?;
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+    }
+}
+
 struct ValidatedConfig {
     config: Config,
     api_key_role: Option<ApiKeyRole>,
@@ -2933,7 +3369,7 @@ fn least_privilege_user_key_notice() -> String {
             theme::body(", run "),
             theme::command("ov config").bold(),
             theme::body(" -> "),
-            theme::strong("Edit config"),
+            theme::strong("Edit Config"),
             theme::body(" -> "),
             theme::strong("Set normal user API key"),
             theme::body("."),
@@ -2943,7 +3379,7 @@ fn least_privilege_user_key_notice() -> String {
             theme::body("为遵循最小权限原则，请运行 "),
             theme::command("ov config").bold(),
             theme::body(" -> "),
-            theme::strong("Edit config"),
+            theme::strong("Edit Config"),
             theme::body(" -> "),
             theme::strong("Set normal user API key"),
             theme::body("。"),
@@ -3255,6 +3691,13 @@ fn delete_confirm_prompt(name: &str) -> String {
     }
 }
 
+fn switch_confirm_prompt(name: &str) -> String {
+    match Language::current() {
+        Language::En => format!("Switch active config to '{name}'?"),
+        Language::ZhCn => format!("切换当前配置为 '{name}'？"),
+    }
+}
+
 fn localized_validation_error(kind: ConfigKind, error: &Error) -> String {
     match Language::current() {
         Language::En => validation_error_copy(kind, error),
@@ -3270,6 +3713,45 @@ fn deleted_config_message(name: &str) -> String {
         Language::En => format!("Deleted config '{name}'."),
         Language::ZhCn => format!("已删除配置 '{name}'。"),
     }
+}
+
+fn switched_config_message(name: &str) -> String {
+    match Language::current() {
+        Language::En => format!("Switched active config to '{name}'."),
+        Language::ZhCn => format!("已切换当前配置为 '{name}'。"),
+    }
+}
+
+fn config_already_active_message(name: &str) -> String {
+    match Language::current() {
+        Language::En => format!("Config '{name}' is already active."),
+        Language::ZhCn => format!("配置 '{name}' 已是当前配置。"),
+    }
+}
+
+fn print_switch_validation_error(name: &str, error: &Error) {
+    println!();
+    println!(
+        "{} {}",
+        theme::error("✗"),
+        theme::error(match Language::current() {
+            Language::En => format!("Target config '{name}' failed validation."),
+            Language::ZhCn => format!("目标配置 '{name}' 验证失败。"),
+        })
+    );
+    println!(
+        "  {}",
+        theme::muted(localized_validation_error(ConfigKind::Custom, error))
+    );
+    println!(
+        "{} {}",
+        theme::muted(copy(Language::current(), "Next:", "下一步：")),
+        theme::body(copy(
+            Language::current(),
+            "Run ov config and edit this config before switching.",
+            "请运行 ov config 编辑该配置后再切换。",
+        ))
+    );
 }
 
 pub(crate) fn add_save_action_labels() -> Vec<&'static str> {
@@ -3520,7 +4002,9 @@ fn confirm(
 
 #[derive(Default)]
 struct LiveRegion {
-    lines_drawn: usize,
+    lines: Vec<String>,
+    input_prompt: Option<String>,
+    rows_drawn: usize,
     cursor_on_last_line: bool,
 }
 
@@ -3531,7 +4015,13 @@ impl LiveRegion {
             raw_line(line)?;
         }
         io::stdout().flush()?;
-        self.lines_drawn = lines.len();
+        self.lines = lines.to_vec();
+        self.input_prompt = None;
+        self.rows_drawn = rendered_live_region_rows(
+            &self.lines,
+            self.input_prompt.as_deref(),
+            live_region_columns(),
+        );
         self.cursor_on_last_line = false;
         Ok(())
     }
@@ -3543,17 +4033,66 @@ impl LiveRegion {
         }
         raw_write(prompt)?;
         io::stdout().flush()?;
-        self.lines_drawn = lines.len() + 1;
+        self.lines = lines.to_vec();
+        self.input_prompt = Some(prompt.to_string());
+        self.rows_drawn = rendered_live_region_rows(
+            &self.lines,
+            self.input_prompt.as_deref(),
+            live_region_columns(),
+        );
         self.cursor_on_last_line = true;
         Ok(())
     }
 
     fn clear(&mut self) -> Result<()> {
-        clear_live_region(self.lines_drawn, self.cursor_on_last_line)?;
-        self.lines_drawn = 0;
+        clear_live_region(
+            self.rows_to_clear(live_region_columns()),
+            self.cursor_on_last_line,
+        )?;
+        self.lines.clear();
+        self.input_prompt = None;
+        self.rows_drawn = 0;
         self.cursor_on_last_line = false;
         Ok(())
     }
+
+    fn rows_to_clear(&self, columns: usize) -> usize {
+        self.rows_drawn.max(rendered_live_region_rows(
+            &self.lines,
+            self.input_prompt.as_deref(),
+            columns,
+        ))
+    }
+}
+
+fn live_region_columns() -> usize {
+    terminal::size()
+        .map(|(columns, _)| usize::from(columns).saturating_sub(1).max(1))
+        .unwrap_or_else(|_| status_box_width())
+}
+
+fn rendered_row_count(lines: &[String], columns: usize) -> usize {
+    lines
+        .iter()
+        .map(|line| rendered_rows_for_columns(line, columns))
+        .sum()
+}
+
+fn rendered_live_region_rows(
+    lines: &[String],
+    input_prompt: Option<&str>,
+    columns: usize,
+) -> usize {
+    rendered_row_count(lines, columns)
+        + input_prompt
+            .map(|prompt| rendered_rows_for_columns(prompt, columns))
+            .unwrap_or(0)
+}
+
+fn rendered_rows_for_columns(text: &str, columns: usize) -> usize {
+    let columns = columns.max(1);
+    let width = visible_display_width(text);
+    width.max(1).div_ceil(columns)
 }
 
 pub(crate) fn select_live_lines<T: ToString>(
@@ -3751,20 +4290,22 @@ impl Drop for RawPrompt {
 #[cfg(test)]
 mod tests {
     use super::{
-        CustomKeyMode, IdentityMode, InputValueLabel, OV_LOGO_LINES, Rgb, StatusBoxRuntime,
+        CustomKeyMode, FULL_STATUS_BOX_MIN_ROWS, IdentityMode, InputValueLabel, LiveRegion,
+        OV_LOGO_LINES, RenderedRegion, Rgb, StatusBoxFrame, StatusBoxMode, StatusBoxRuntime,
         active_delete_block_helper_lines, active_summary_lines, active_summary_render_parts,
         add_config_name_label, add_save_action_labels, allocate_config_name, box_content_line,
-        box_footer_line, box_title_line, config_select_label, custom_api_key_helper_lines,
-        custom_api_key_input_helper_lines, custom_key_mode_labels,
+        box_footer_line, box_title_line, compact_status_box_width, config_select_label,
+        custom_api_key_helper_lines, custom_api_key_input_helper_lines, custom_key_mode_labels,
         custom_validation_failure_choices, display_config_home, display_width,
         edit_api_key_choice_labels, edit_custom_key_action_labels, edit_save_action_labels,
         erase_sequence_for_char, extract_models_from_status_payload, identity_prompt_parts,
         input_live_lines, logo_glass_color_for_theme, main_action_labels, next_step_copy,
         openviking_service_api_key_helper_lines, openviking_service_validation_failure_choices,
-        ov_logo_width, provider_labels, root_key_normal_command_notice_lines,
-        root_key_redirect_labels, saved_summary_render_parts, select_live_lines,
-        should_confirm_detected_user_key, should_prompt_root_identity, status_box_lines,
-        status_box_lines_with_runtime, status_box_width, status_payload_is_healthy,
+        ov_logo_width, provider_labels, rendered_live_region_rows, rendered_row_count,
+        root_key_normal_command_notice_lines, root_key_redirect_labels, saved_summary_render_parts,
+        select_live_lines, should_confirm_detected_user_key, should_prompt_root_identity,
+        status_box_frame_for_size, status_box_lines, status_box_lines_with_runtime,
+        status_box_lines_with_runtime_width, status_box_width, status_payload_is_healthy,
         styled_logo_to_width_for_color_level, styled_wordmark_line_for_color_level,
         tagline_ice_color_for_theme, user_key_redirect_labels, validate_config_name,
         validate_draft, wizard_header_lines, wordmark_gradient_color_for_theme, wordmark_lines,
@@ -3814,10 +4355,10 @@ mod tests {
     }
 
     #[test]
-    fn wizard_header_is_scrollback_branded() {
+    fn wizard_header_contains_standalone_wordmark() {
         let header = wizard_header_lines().join("\n");
 
-        assert!(header.contains("█████"));
+        assert!(header.contains("██████╗"));
         assert!(!header.contains("Context Database for AI Agents"));
         assert!(!header.contains(".openviking ~ ov config"));
         assert!(!header.contains("CLI config"));
@@ -3834,11 +4375,11 @@ mod tests {
     }
 
     #[test]
-    fn wizard_header_has_spaced_bands() {
+    fn wizard_header_has_no_standalone_spaced_bands() {
         let lines = wizard_header_lines();
 
-        assert_eq!(lines[wordmark_lines().len()], "");
         assert_eq!(lines.len(), wordmark_lines().len() + 1);
+        assert_eq!(lines.last().map(String::as_str), Some(""));
     }
 
     #[test]
@@ -3851,7 +4392,7 @@ mod tests {
     }
 
     #[test]
-    fn status_box_lines_align_to_wordmark_width_with_tagline_title_and_version_footer() {
+    fn full_status_box_puts_motto_in_border_without_wordmark() {
         let config = Config {
             url: "http://127.0.0.1:1933".to_string(),
             ..Config::default()
@@ -3870,6 +4411,8 @@ mod tests {
 
         assert!(lines.len() >= 6);
         assert!(lines[0].contains("Context Database for AI Agents"));
+        assert!(!lines.iter().any(|line| line.contains("██████╗")));
+        assert!(lines.iter().any(|line| line.contains('⣿')));
         assert!(!lines[0].contains(&version));
         assert!(
             lines
@@ -3898,15 +4441,124 @@ mod tests {
     }
 
     #[test]
+    fn status_box_empty_title_uses_continuous_top_border() {
+        let width = 48;
+        let title = box_title_line("", width);
+
+        assert_eq!(title, format!("╭{}╮", "─".repeat(width - 2)));
+        assert_eq!(display_width(&title), width);
+    }
+
+    #[test]
+    fn compact_status_box_omits_logo_art_and_fits_status_details() {
+        let config = Config {
+            url: "http://127.0.0.1:1933".to_string(),
+            ..Config::default()
+        };
+        let width = compact_status_box_width();
+        let lines = status_box_lines_with_runtime_width(
+            Some(&config),
+            &[ConfigEntry {
+                name: "compact".to_string(),
+                config: config.clone(),
+                is_active: true,
+                kind: ConfigKind::Custom,
+            }],
+            "~/.openviking",
+            &StatusBoxRuntime::unknown(),
+            StatusBoxFrame {
+                width,
+                mode: StatusBoxMode::Compact,
+            },
+        );
+        let text = lines.join("\n");
+
+        assert_eq!(width, 56);
+        assert!(lines[0].contains("OpenViking | Context Database for AI Agents"));
+        assert!(text.contains("Active:"));
+        assert!(!text.contains('⣿'));
+        assert!(!text.contains('⣶'));
+        assert!(!text.contains("██████╗"));
+        assert!(!text.contains("╚═════╝"));
+        assert!(!text.contains("OPENVIKING"));
+        assert!(!text.contains("⠠⣶⣾⣿⣿⣿⣶⣤⣀ ⠾⠟⠛⠉⠉   ⣀⣤⣾⡿⠃"));
+        for line in &lines {
+            assert_eq!(display_width(line), width, "{line:?}");
+        }
+    }
+
+    #[test]
+    fn status_box_frame_uses_compact_mode_when_full_art_would_not_fit() {
+        let compact_width = compact_status_box_width();
+
+        assert_eq!(
+            status_box_frame_for_size(compact_width as u16 + 1, FULL_STATUS_BOX_MIN_ROWS - 1),
+            StatusBoxFrame {
+                width: compact_width,
+                mode: StatusBoxMode::Compact,
+            }
+        );
+        assert_eq!(
+            status_box_frame_for_size(status_box_width() as u16 - 1, FULL_STATUS_BOX_MIN_ROWS).mode,
+            StatusBoxMode::Compact
+        );
+        assert_eq!(
+            status_box_frame_for_size(status_box_width() as u16 + 1, FULL_STATUS_BOX_MIN_ROWS).mode,
+            StatusBoxMode::Full
+        );
+    }
+
+    #[test]
+    fn rendered_region_clears_render_time_rows_after_width_changes() {
+        let lines = vec!["x".repeat(90)];
+        let region = RenderedRegion::from_lines(&lines, 30);
+
+        assert_eq!(rendered_row_count(&lines, 30), 3);
+        assert_eq!(rendered_row_count(&lines, 90), 1);
+        assert_eq!(region.rows_to_clear(90), 3);
+    }
+
+    #[test]
+    fn live_region_recomputes_clear_rows_after_resize() {
+        let lines = vec!["x".repeat(90)];
+        let ui = LiveRegion {
+            lines: lines.clone(),
+            input_prompt: None,
+            rows_drawn: rendered_live_region_rows(&lines, None, 90),
+            cursor_on_last_line: false,
+        };
+
+        assert_eq!(ui.rows_to_clear(30), 3);
+    }
+
+    #[test]
     fn status_box_cjk_lines_align_to_display_width() {
         let width = status_box_width();
         let title = box_title_line("AI Agent 上下文数据库", width);
-        let content = box_content_line("", "当前配置： VPS_ROOT (自定义)", width);
+        let content = box_content_line(
+            "",
+            "当前配置： VPS_ROOT (自定义)",
+            width,
+            StatusBoxMode::Full,
+        );
         let footer = box_footer_line("v0.0.0", width);
 
         for line in [title, content, footer] {
             assert_eq!(display_width(&line), width, "{line:?}");
         }
+    }
+
+    #[test]
+    fn status_box_content_line_respects_narrow_terminal_width() {
+        let width = 40;
+        let content = box_content_line(
+            OV_LOGO_LINES[8],
+            "Context Database for AI Agents",
+            width,
+            StatusBoxMode::Full,
+        );
+
+        assert_eq!(display_width(&content), width, "{content:?}");
     }
 
     #[test]
@@ -4133,16 +4785,16 @@ mod tests {
     }
 
     #[test]
-    fn wordmark_is_subtly_wider_for_viking_readability() {
+    fn wordmark_preserves_original_standalone_block_art() {
         let width = wordmark_width();
 
-        assert!(
-            (79..=83).contains(&width),
-            "wordmark should widen only enough to make VIKING readable; got {width}"
+        assert_eq!(
+            width, 81,
+            "wordmark should preserve the original standalone width"
         );
         assert!(
-            wordmark_lines()[0].contains("██╗   ██╗ ██╗ ██╗  ██╗ ██╗"),
-            "VIKING should have subtle breathing room without obvious gaps"
+            wordmark_lines().iter().any(|line| line.contains("████")),
+            "wordmark should preserve block-art styling"
         );
     }
 
@@ -4169,8 +4821,7 @@ mod tests {
 
     #[test]
     fn wordmark_does_not_use_protruding_corner_glyphs() {
-        let lines = wizard_header_lines();
-        let wordmark = &lines[0..wordmark_lines().len()];
+        let wordmark = wordmark_lines();
 
         assert!(!wordmark[0].starts_with('◢'));
         assert!(!wordmark[0].ends_with('◣'));
@@ -4305,8 +4956,10 @@ mod tests {
 
     #[test]
     fn active_summary_hides_url_and_shows_kind() {
-        let mut config = Config::default();
-        config.url = "http://127.0.0.1:1933".to_string();
+        let config = Config {
+            url: "http://127.0.0.1:1933".to_string(),
+            ..Config::default()
+        };
         let lines = active_summary_lines(
             Some(&config),
             &[ConfigEntry {
@@ -4326,8 +4979,10 @@ mod tests {
 
     #[test]
     fn active_summary_uses_compact_openviking_service_kind() {
-        let mut config = Config::default();
-        config.url = OPENVIKING_SERVICE_URL.to_string();
+        let config = Config {
+            url: OPENVIKING_SERVICE_URL.to_string(),
+            ..Config::default()
+        };
         let lines = active_summary_lines(
             Some(&config),
             &[ConfigEntry {
@@ -4623,7 +5278,7 @@ mod tests {
 
         assert!(text.contains("Root key configured."));
         assert!(text.contains("Normal commands will use this key"));
-        assert!(text.contains("ov config -> Edit config -> Set normal user API key"));
+        assert!(text.contains("ov config -> Edit Config -> Set normal user API key"));
     }
 
     #[test]
@@ -4654,7 +5309,7 @@ mod tests {
                 theme::body(", run "),
                 theme::command("ov config").bold(),
                 theme::body(" -> "),
-                theme::strong("Edit config"),
+                theme::strong("Edit Config"),
                 theme::body(" -> "),
                 theme::strong("Set normal user API key"),
                 theme::body(".")
@@ -5088,23 +5743,34 @@ mod tests {
         let lines = select_live_lines(
             "What would you like to configure?",
             "Choose action",
-            &["Add config", "Edit config", "Delete config"],
+            &[
+                "Add Config",
+                "Switch Config",
+                "Edit Config",
+                "Delete Config",
+            ],
             1,
             &[],
         );
 
         assert!(lines[0].contains("What would you like to configure?"));
-        assert!(lines.iter().any(|line| line.contains("› Edit config")));
+        assert!(lines.iter().any(|line| line.contains("› Switch Config")));
         assert!(!lines.iter().any(|line| line.contains("✓ Choose action")));
         assert!(!lines.iter().any(|line| line.contains("Back")));
-        assert_eq!(lines.len(), 8);
+        assert_eq!(lines.len(), 9);
     }
 
     #[test]
-    fn wizard_main_actions_stay_focused() {
+    fn wizard_main_actions_include_switch_config() {
         assert_eq!(
-            main_action_labels(),
-            ["Add config", "Edit config", "Delete config"]
+            main_action_labels().as_slice(),
+            [
+                "Add Config",
+                "Switch Config",
+                "Edit Config",
+                "Delete Config"
+            ]
+            .as_slice()
         );
     }
 }

--- a/crates/ov_cli/src/error_ui.rs
+++ b/crates/ov_cli/src/error_ui.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 
 use colored::Colorize;
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{
     error::Error,
@@ -582,27 +582,56 @@ fn ensure_sentence(value: &str) -> String {
 }
 
 pub(crate) fn render_report(report: &ErrorReport, verbose: bool) -> String {
+    render_report_with_width(report, verbose, error_output_width())
+}
+
+fn render_report_with_width(report: &ErrorReport, verbose: bool, width: usize) -> String {
     let mut output = String::new();
     let language = Language::current();
     let try_command = try_command_for_report(report);
 
     if let Some(command) = report.command.as_deref() {
-        output.push_str(&format!("{}\n\n", theme::strong(command)));
+        if width >= CARD_WIDTH {
+            output.push_str(&format!("{}\n\n", theme::strong(command)));
+        } else {
+            output.push_str(&format!(
+                "{}\n\n",
+                theme::strong(truncate_to_display_width(command, width))
+            ));
+        }
     }
     if let Some(usage) = report.usage.as_deref() {
-        output.push_str(&format!(
-            "{} {}\n",
-            theme::warning(copy(language, "Usage:", "用法：")).bold(),
-            theme::strong(usage)
-        ));
-        output.push_str(&format!(
-            "{} {}\n\n",
-            theme::muted(copy(language, "Try:", "可尝试：")),
-            theme::command(&try_command)
-        ));
+        if width >= CARD_WIDTH {
+            output.push_str(&format!(
+                "{} {}\n",
+                theme::warning(copy(language, "Usage:", "用法：")).bold(),
+                theme::strong(usage)
+            ));
+            output.push_str(&format!(
+                "{} {}\n\n",
+                theme::muted(copy(language, "Try:", "可尝试：")),
+                theme::command(&try_command)
+            ));
+        } else {
+            output.push_str(&format!(
+                "{}\n",
+                theme::warning(truncate_to_display_width(
+                    &format!("{} {usage}", copy(language, "Usage:", "用法：")),
+                    width
+                ))
+                .bold()
+            ));
+            output.push_str(&format!(
+                "{}\n\n",
+                theme::muted(truncate_to_display_width(
+                    &format!("{} {try_command}", copy(language, "Try:", "可尝试：")),
+                    width
+                ))
+            ));
+        }
     }
 
-    output.push_str(&render_card(report, verbose));
+    output.push_str(&render_card(report, verbose, width));
 
     if !report.actions.is_empty() {
         output.push_str("\n\n");
@@ -610,19 +639,10 @@ pub(crate) fn render_report(report: &ErrorReport, verbose: bool) -> String {
             "{}\n",
             theme::strong(copy(language, "Next:", "下一步："))
         ));
-        let command_width = report
-            .actions
-            .iter()
-            .map(|action| action.command.width())
-            .max()
-            .unwrap_or_default();
+        let command_width = action_command_width(&report.actions, width);
         for action in &report.actions {
-            output.push_str(&format!(
-                "  {}{}  {}\n",
-                theme::command(action.command.clone()).bold(),
-                " ".repeat(command_width.saturating_sub(action.command.width())),
-                theme::muted(&action.description)
-            ));
+            output.push_str(&render_action_line(action, command_width, width));
+            output.push('\n');
         }
     } else {
         output.push('\n');
@@ -645,11 +665,12 @@ impl OptionalUsage for ErrorReport {
     }
 }
 
-fn render_card(report: &ErrorReport, verbose: bool) -> String {
+fn render_card(report: &ErrorReport, verbose: bool, width: usize) -> String {
     let language = Language::current();
-    let inner_width = CARD_WIDTH.saturating_sub(4);
+    let inner_width = width.saturating_sub(4).max(1);
     let title = format!("─ {} ", report.title);
-    let fill = CARD_WIDTH.saturating_sub(2 + title.width());
+    let title = truncate_to_display_width(&title, width.saturating_sub(2));
+    let fill = width.saturating_sub(2 + title.width());
     let mut lines = Vec::new();
 
     lines.extend(wrap_text(&report.message, inner_width));
@@ -657,11 +678,9 @@ fn render_card(report: &ErrorReport, verbose: bool) -> String {
         lines.push(String::new());
         lines.extend(wrap_text(&did_you_mean(language, suggestion), inner_width));
     }
-    if verbose {
-        if let Some(detail) = report.detail.as_deref() {
-            lines.push(String::new());
-            lines.extend(wrap_text(&detail_line(language, detail), inner_width));
-        }
+    if verbose && let Some(detail) = report.detail.as_deref() {
+        lines.push(String::new());
+        lines.extend(wrap_text(&detail_line(language, detail), inner_width));
     }
 
     let mut rendered = String::new();
@@ -679,10 +698,55 @@ fn render_card(report: &ErrorReport, verbose: bool) -> String {
     rendered.push_str(&format!(
         "{}{}{}",
         theme::error("╰"),
-        theme::error("─".repeat(CARD_WIDTH.saturating_sub(2))),
+        theme::error("─".repeat(width.saturating_sub(2))),
         theme::error("╯")
     ));
     rendered
+}
+
+#[cfg(not(test))]
+fn error_output_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(columns, _)| terminal_width(columns as usize, CARD_WIDTH))
+        .unwrap_or(CARD_WIDTH)
+}
+
+#[cfg(test)]
+fn error_output_width() -> usize {
+    CARD_WIDTH
+}
+
+#[cfg(not(test))]
+fn terminal_width(columns: usize, default_width: usize) -> usize {
+    let available = columns.saturating_sub(1).max(4);
+    available.min(default_width)
+}
+
+fn action_command_width(actions: &[ErrorAction], width: usize) -> usize {
+    let available = width.saturating_sub(4);
+    let preferred = actions
+        .iter()
+        .map(|action| action.command.width())
+        .max()
+        .unwrap_or_default();
+
+    preferred.min(available / 2).max(1)
+}
+
+fn render_action_line(action: &ErrorAction, command_width: usize, width: usize) -> String {
+    if width <= 4 {
+        return truncate_to_display_width(&action.command, width);
+    }
+
+    let description_width = width.saturating_sub(command_width + 4);
+    let command = fit_to_display_width(&action.command, command_width);
+    let description = truncate_to_display_width(&action.description, description_width);
+
+    format!(
+        "  {}  {}",
+        theme::command(command).bold(),
+        theme::muted(description)
+    )
 }
 
 fn did_you_mean(language: Language, suggestion: &str) -> String {
@@ -700,12 +764,13 @@ fn detail_line(language: Language, detail: &str) -> String {
 }
 
 fn render_card_line(line: &str, inner_width: usize) -> String {
+    let line = truncate_to_display_width(line, inner_width);
     let width = line.width();
     let padding = inner_width.saturating_sub(width);
     format!(
         "{} {}{} {}",
         theme::error("│"),
-        theme::body(line),
+        theme::body(&line),
         " ".repeat(padding),
         theme::error("│")
     )
@@ -720,6 +785,11 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
     let mut current = String::new();
 
     for word in text.split_whitespace() {
+        if current.is_empty() && word.width() > width {
+            lines.push(truncate_to_display_width(word, width));
+            continue;
+        }
+
         let separator = if current.is_empty() { 0 } else { 1 };
         if !current.is_empty() && current.width() + separator + word.width() > width {
             lines.push(current);
@@ -735,6 +805,41 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
         lines.push(current);
     }
     lines
+}
+
+fn truncate_to_display_width(value: &str, width: usize) -> String {
+    if value.width() <= width {
+        return value.to_string();
+    }
+
+    if width <= 3 {
+        return ".".repeat(width);
+    }
+
+    let target = width - 3;
+    let mut truncated = String::new();
+    let mut used = 0;
+
+    for ch in value.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_width > target {
+            break;
+        }
+        truncated.push(ch);
+        used += ch_width;
+    }
+
+    truncated.push_str("...");
+    truncated
+}
+
+fn fit_to_display_width(value: &str, width: usize) -> String {
+    let value = truncate_to_display_width(value, width);
+    format!(
+        "{}{}",
+        value,
+        " ".repeat(width.saturating_sub(value.width()))
+    )
 }
 
 pub(crate) fn display_command(args: &[OsString]) -> String {
@@ -898,9 +1003,7 @@ fn help_command_from_usage(usage: &str) -> Option<String> {
         }
         parts.push(token);
     }
-    let Some(program) = parts.first() else {
-        return None;
-    };
+    let program = parts.first()?;
     if !program.starts_with("ov") {
         return None;
     }
@@ -914,7 +1017,8 @@ fn help_command_from_usage(usage: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        CARD_WIDTH, ErrorReport, render_report, report_for_clap_error, report_for_runtime_error,
+        CARD_WIDTH, ErrorAction, ErrorReport, render_report, render_report_with_width,
+        report_for_clap_error, report_for_runtime_error,
     };
     use crate::error::Error;
     use std::ffi::OsString;
@@ -1199,6 +1303,30 @@ Usage: ov config [OPTIONS] [COMMAND]
             .filter(|line| line.starts_with('╭') || line.starts_with('│') || line.starts_with('╰'))
         {
             assert_eq!(line.width(), CARD_WIDTH, "{line}");
+        }
+    }
+
+    #[test]
+    fn error_report_respects_narrow_terminal_width() {
+        let report = ErrorReport::new(
+            "Command Error",
+            "Plain help is not supported for this command. Use prefixed help instead.",
+        )
+        .with_command("ov very-long-command-name with many extra positional values")
+        .with_usage("ov very-long-command-name --with-a-long-option <long-value>")
+        .with_suggestion("ov --help")
+        .with_actions(vec![ErrorAction::new(
+            "ov --help",
+            "Show this command's help",
+        )]);
+        let width = 32;
+        let rendered = strip_ansi(&render_report_with_width(&report, false, width));
+
+        for line in rendered.lines() {
+            assert!(
+                line.width() <= width,
+                "line exceeded narrow width: {line:?}"
+            );
         }
     }
 }

--- a/crates/ov_cli/src/error_ui.rs
+++ b/crates/ov_cli/src/error_ui.rs
@@ -1,12 +1,13 @@
 use std::ffi::OsString;
 
 use colored::Colorize;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 use crate::{
     error::Error,
     error_classifier::looks_like_auth_error,
     i18n::{Language, copy},
+    terminal_ui::{fit_to_display_width, truncate_to_display_width},
     theme,
 };
 
@@ -707,19 +708,13 @@ fn render_card(report: &ErrorReport, verbose: bool, width: usize) -> String {
 #[cfg(not(test))]
 fn error_output_width() -> usize {
     crossterm::terminal::size()
-        .map(|(columns, _)| terminal_width(columns as usize, CARD_WIDTH))
+        .map(|(columns, _)| crate::terminal_ui::terminal_width(columns as usize, CARD_WIDTH))
         .unwrap_or(CARD_WIDTH)
 }
 
 #[cfg(test)]
 fn error_output_width() -> usize {
     CARD_WIDTH
-}
-
-#[cfg(not(test))]
-fn terminal_width(columns: usize, default_width: usize) -> usize {
-    let available = columns.saturating_sub(1).max(4);
-    available.min(default_width)
 }
 
 fn action_command_width(actions: &[ErrorAction], width: usize) -> usize {
@@ -805,41 +800,6 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
         lines.push(current);
     }
     lines
-}
-
-fn truncate_to_display_width(value: &str, width: usize) -> String {
-    if value.width() <= width {
-        return value.to_string();
-    }
-
-    if width <= 3 {
-        return ".".repeat(width);
-    }
-
-    let target = width - 3;
-    let mut truncated = String::new();
-    let mut used = 0;
-
-    for ch in value.chars() {
-        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if used + ch_width > target {
-            break;
-        }
-        truncated.push(ch);
-        used += ch_width;
-    }
-
-    truncated.push_str("...");
-    truncated
-}
-
-fn fit_to_display_width(value: &str, width: usize) -> String {
-    let value = truncate_to_display_width(value, width);
-    format!(
-        "{}{}",
-        value,
-        " ".repeat(width.saturating_sub(value.width()))
-    )
 }
 
 pub(crate) fn display_command(args: &[OsString]) -> String {

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -5,11 +5,13 @@ use crate::commands;
 use crate::config::merge_csv_options;
 use crate::config_agent;
 use crate::error::{Error, Result};
+use crate::terminal_ui::{
+    RenderedRegion as RenderedSelectRegion, clear_rendered_lines, live_select_block,
+};
 use crate::theme;
 use crate::tui;
 use colored::Colorize;
 use serde_json::{Map, Value};
-use unicode_width::UnicodeWidthChar;
 
 pub async fn handle_add_resource(
     mut path: String,
@@ -963,34 +965,13 @@ enum SelectOutcome {
     Quit,
 }
 
-#[derive(Default)]
-struct RenderedSelectRegion {
-    lines: Vec<String>,
-    rows_drawn: usize,
-}
-
-impl RenderedSelectRegion {
-    fn from_lines(lines: &[String], columns: usize) -> Self {
-        Self {
-            lines: lines.to_vec(),
-            rows_drawn: rendered_select_rows(lines, columns),
-        }
-    }
-
-    fn rows_to_clear(&self, columns: usize) -> usize {
-        self.rows_drawn
-            .max(rendered_select_rows(&self.lines, columns))
-    }
-}
-
 fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<SelectOutcome> {
     use std::io::{self, Write};
 
     use crossterm::{
         cursor,
         event::{self, Event, KeyCode, KeyModifiers},
-        execute,
-        terminal::{self, Clear, ClearType},
+        execute, terminal,
     };
 
     if items.is_empty() {
@@ -1065,34 +1046,6 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
     fn clear_rendered_region(region: &RenderedSelectRegion) -> Result<()> {
         clear_rendered_lines(region.rows_to_clear(live_select_columns()))
     }
-
-    fn clear_rendered_lines(lines: usize) -> Result<()> {
-        if lines == 0 {
-            return Ok(());
-        }
-        let mut stdout = io::stdout();
-        execute!(
-            stdout,
-            cursor::MoveUp(lines as u16),
-            cursor::MoveToColumn(0)
-        )?;
-        for line in 0..lines {
-            execute!(
-                stdout,
-                cursor::MoveToColumn(0),
-                Clear(ClearType::CurrentLine)
-            )?;
-            if line + 1 < lines {
-                execute!(stdout, cursor::MoveDown(1))?;
-            }
-        }
-        execute!(
-            stdout,
-            cursor::MoveUp(lines.saturating_sub(1) as u16),
-            cursor::MoveToColumn(0)
-        )?;
-        Ok(())
-    }
 }
 
 fn live_select_columns() -> usize {
@@ -1101,48 +1054,9 @@ fn live_select_columns() -> usize {
         .unwrap_or(80)
 }
 
+#[cfg(test)]
 fn rendered_select_rows(lines: &[String], columns: usize) -> usize {
-    lines
-        .iter()
-        .map(|line| rendered_select_line_rows(line, columns))
-        .sum()
-}
-
-fn rendered_select_line_rows(line: &str, columns: usize) -> usize {
-    let columns = columns.max(1);
-    let width = visible_display_width(line);
-    width.max(1).div_ceil(columns)
-}
-
-fn visible_display_width(value: &str) -> usize {
-    let mut width = 0usize;
-    let mut chars = value.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
-            chars.next();
-            for next in chars.by_ref() {
-                if next.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-            continue;
-        }
-
-        width += UnicodeWidthChar::width(ch).unwrap_or(0);
-    }
-
-    width
-}
-
-fn live_select_block(lines: &[String]) -> String {
-    if lines.is_empty() {
-        return String::new();
-    }
-
-    let mut rendered = lines.join("\r\n");
-    rendered.push_str("\r\n");
-    rendered
+    crate::terminal_ui::rendered_row_count(lines, columns)
 }
 
 fn switch_confirmation_labels() -> Vec<String> {

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -9,6 +9,7 @@ use crate::theme;
 use crate::tui;
 use colored::Colorize;
 use serde_json::{Map, Value};
+use unicode_width::UnicodeWidthChar;
 
 pub async fn handle_add_resource(
     mut path: String,
@@ -962,6 +963,26 @@ enum SelectOutcome {
     Quit,
 }
 
+#[derive(Default)]
+struct RenderedSelectRegion {
+    lines: Vec<String>,
+    rows_drawn: usize,
+}
+
+impl RenderedSelectRegion {
+    fn from_lines(lines: &[String], columns: usize) -> Self {
+        Self {
+            lines: lines.to_vec(),
+            rows_drawn: rendered_select_rows(lines, columns),
+        }
+    }
+
+    fn rows_to_clear(&self, columns: usize) -> usize {
+        self.rows_drawn
+            .max(rendered_select_rows(&self.lines, columns))
+    }
+}
+
 fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<SelectOutcome> {
     use std::io::{self, Write};
 
@@ -1000,18 +1021,18 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
     }
 
     let mut selected = default.min(items.len().saturating_sub(1));
-    let mut rendered_lines = 0usize;
+    let mut rendered_region = RenderedSelectRegion::default();
     let _raw_guard = RawGuard::enter()?;
 
     loop {
-        clear_rendered_lines(rendered_lines)?;
+        clear_rendered_region(&rendered_region)?;
         let lines = select_lines(prompt, items, selected);
-        rendered_lines = lines.len();
+        rendered_region = RenderedSelectRegion::from_lines(&lines, live_select_columns());
         print!("{}", live_select_block(&lines));
         io::stdout().flush()?;
 
-        if let Event::Key(key) = event::read()? {
-            match key.code {
+        match event::read()? {
+            Event::Key(key) => match key.code {
                 KeyCode::Up => {
                     selected = if selected == 0 {
                         items.len().saturating_sub(1)
@@ -1021,20 +1042,28 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
                 }
                 KeyCode::Down => selected = (selected + 1) % items.len(),
                 KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r') => {
-                    clear_rendered_lines(rendered_lines)?;
+                    clear_rendered_region(&rendered_region)?;
                     return Ok(SelectOutcome::Selected(selected));
                 }
                 KeyCode::Esc => {
-                    clear_rendered_lines(rendered_lines)?;
+                    clear_rendered_region(&rendered_region)?;
                     return Ok(SelectOutcome::Back);
                 }
                 KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    clear_rendered_lines(rendered_lines)?;
+                    clear_rendered_region(&rendered_region)?;
                     return Ok(SelectOutcome::Quit);
                 }
                 _ => {}
+            },
+            Event::Resize(_, _) => {
+                // Redraw on the next loop using the new terminal width.
             }
+            _ => {}
         }
+    }
+
+    fn clear_rendered_region(region: &RenderedSelectRegion) -> Result<()> {
+        clear_rendered_lines(region.rows_to_clear(live_select_columns()))
     }
 
     fn clear_rendered_lines(lines: usize) -> Result<()> {
@@ -1064,6 +1093,46 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
         )?;
         Ok(())
     }
+}
+
+fn live_select_columns() -> usize {
+    crossterm::terminal::size()
+        .map(|(columns, _)| usize::from(columns).saturating_sub(1).max(1))
+        .unwrap_or(80)
+}
+
+fn rendered_select_rows(lines: &[String], columns: usize) -> usize {
+    lines
+        .iter()
+        .map(|line| rendered_select_line_rows(line, columns))
+        .sum()
+}
+
+fn rendered_select_line_rows(line: &str, columns: usize) -> usize {
+    let columns = columns.max(1);
+    let width = visible_display_width(line);
+    width.max(1).div_ceil(columns)
+}
+
+fn visible_display_width(value: &str) -> usize {
+    let mut width = 0usize;
+    let mut chars = value.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for next in chars.by_ref() {
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        width += UnicodeWidthChar::width(ch).unwrap_or(0);
+    }
+
+    width
 }
 
 fn live_select_block(lines: &[String]) -> String {
@@ -1570,6 +1639,26 @@ mod config_switch_prompt_tests {
 
         assert_eq!(rendered, "Choose config\r\n  › local\r\n");
         assert!(!rendered.contains("config\n"));
+    }
+
+    #[test]
+    fn switch_selector_counts_physical_rows_after_wrapping_and_ansi_styles() {
+        let lines = vec![
+            "\u{1b}[31m12345678901\u{1b}[0m".to_string(),
+            "short".to_string(),
+        ];
+
+        assert_eq!(rendered_select_rows(&lines, 10), 3);
+    }
+
+    #[test]
+    fn switch_selector_recomputes_clear_rows_after_resize() {
+        let lines = vec!["x".repeat(90)];
+        let region = RenderedSelectRegion::from_lines(&lines, 90);
+
+        assert_eq!(rendered_select_rows(&lines, 90), 1);
+        assert_eq!(rendered_select_rows(&lines, 30), 3);
+        assert_eq!(region.rows_to_clear(30), 3);
     }
 
     #[test]

--- a/crates/ov_cli/src/help_ui.rs
+++ b/crates/ov_cli/src/help_ui.rs
@@ -2,12 +2,14 @@ use std::ffi::OsString;
 
 use clap::{Arg, ArgAction, Command, CommandFactory};
 use colored::Colorize;
-use unicode_width::UnicodeWidthStr;
 
 use crate::{
     Cli,
     cli_arg_scan::ValueOptions,
     i18n::{Language, copy},
+    terminal_ui::{
+        display_width, fit_to_display_width, pad_to_display_width, truncate_to_display_width,
+    },
     theme,
 };
 
@@ -1938,19 +1940,13 @@ fn localized_global_option_description<'a>(
 #[cfg(not(test))]
 fn help_output_width() -> usize {
     crossterm::terminal::size()
-        .map(|(columns, _)| terminal_width(columns as usize, BOX_WIDTH))
+        .map(|(columns, _)| crate::terminal_ui::terminal_width(columns as usize, BOX_WIDTH))
         .unwrap_or(BOX_WIDTH)
 }
 
 #[cfg(test)]
 fn help_output_width() -> usize {
     BOX_WIDTH
-}
-
-#[cfg(not(test))]
-fn terminal_width(columns: usize, default_width: usize) -> usize {
-    let available = columns.saturating_sub(1).max(4);
-    available.min(default_width)
 }
 
 fn boxed_command_width(width: usize) -> usize {
@@ -2041,48 +2037,6 @@ fn two_column_line_with_style(
     let description = truncate_to_display_width(description, description_width);
 
     format!("  {} {}", label, theme::body(description))
-}
-
-fn display_width(value: &str) -> usize {
-    UnicodeWidthStr::width(value)
-}
-
-fn truncate_to_display_width(value: &str, width: usize) -> String {
-    if display_width(value) <= width {
-        return value.to_string();
-    }
-
-    if width <= 3 {
-        return ".".repeat(width);
-    }
-
-    let target = width - 3;
-    let mut truncated = String::new();
-    let mut used = 0;
-
-    for ch in value.chars() {
-        let ch_width = display_width(&ch.to_string());
-        if used + ch_width > target {
-            break;
-        }
-        truncated.push(ch);
-        used += ch_width;
-    }
-
-    truncated.push_str("...");
-    truncated
-}
-
-fn pad_to_display_width(value: &str, width: usize) -> String {
-    format!(
-        "{}{}",
-        value,
-        " ".repeat(width.saturating_sub(display_width(value)))
-    )
-}
-
-fn fit_to_display_width(value: &str, width: usize) -> String {
-    pad_to_display_width(&truncate_to_display_width(value, width), width)
 }
 
 fn localized_section_title(title: &str, language: Language) -> &str {

--- a/crates/ov_cli/src/help_ui.rs
+++ b/crates/ov_cli/src/help_ui.rs
@@ -13,9 +13,7 @@ use crate::{
 
 const BOX_WIDTH: usize = 74;
 const COMMAND_WIDTH: usize = 16;
-const DESCRIPTION_WIDTH: usize = BOX_WIDTH - COMMAND_WIDTH - 5;
 const COMMAND_HELP_LEFT_WIDTH: usize = 34;
-const START_HERE_DESCRIPTION_WIDTH: usize = 56;
 
 #[derive(Debug, Clone, Copy)]
 struct HelpCommand {
@@ -1145,114 +1143,155 @@ pub(crate) fn render_top_level_help() -> String {
 }
 
 pub(crate) fn render_top_level_help_with_language(language: Language) -> String {
+    render_top_level_help_with_language_and_width(language, help_output_width())
+}
+
+fn render_top_level_help_with_language_and_width(language: Language, width: usize) -> String {
     let mut lines = Vec::new();
     let mut root = Cli::command();
     root.build();
 
-    lines.push(format!(
-        "{} {}",
-        theme::brand_title("OpenViking").bold(),
-        theme::version(version())
-    ));
-    lines.push(
-        theme::heading(copy(
-            language,
-            "Context Database for AI Agents",
-            "AI Agent 上下文数据库",
-        ))
-        .bold()
-        .to_string(),
+    let title = format!("OpenViking {}", version());
+    if width >= BOX_WIDTH || display_width(&title) <= width {
+        lines.push(format!(
+            "{} {}",
+            theme::brand_title("OpenViking").bold(),
+            theme::version(version())
+        ));
+    } else {
+        lines.push(
+            theme::brand_title(truncate_to_display_width(&title, width))
+                .bold()
+                .to_string(),
+        );
+    }
+    let motto = copy(
+        language,
+        "Context Database for AI Agents",
+        "AI Agent 上下文数据库",
     );
+    let motto = if width >= BOX_WIDTH {
+        motto.to_string()
+    } else {
+        truncate_to_display_width(motto, width)
+    };
+    lines.push(theme::heading(motto).bold().to_string());
     lines.push(String::new());
-    lines.push(format!(
-        "{}",
-        theme::warning(copy(language, "Usage:", "用法：")).bold()
-    ));
-    lines.push(format!("  {}", theme::strong("ov <command> [options]")));
+    lines.push(warning_line(copy(language, "Usage:", "用法："), width));
+    let usage = if width >= BOX_WIDTH {
+        "ov <command> [options]".to_string()
+    } else {
+        truncate_to_display_width("ov <command> [options]", width.saturating_sub(2))
+    };
+    lines.push(format!("  {}", theme::strong(usage)));
     lines.push(String::new());
-    lines.push(format!(
-        "{}",
-        theme::strong(copy(language, "Start here:", "从这里开始："))
+    lines.push(strong_line(
+        copy(language, "Start here:", "从这里开始："),
+        width,
     ));
     for command in ["config", "health", "status", "tui"] {
-        if let Some(line) = top_level_start_here_line(&root, command, language) {
+        if let Some(line) = top_level_start_here_line(&root, command, language, width) {
             lines.push(line);
         }
     }
     lines.push(String::new());
 
     for section in HELP_SECTIONS {
-        lines.extend(section_lines(section, &root, language));
+        lines.extend(section_lines(section, &root, language, width));
         lines.push(String::new());
     }
 
-    lines.push(format!(
-        "{}",
-        theme::strong(copy(language, "Global options:", "全局选项："))
+    lines.push(strong_line(
+        copy(language, "Global options:", "全局选项："),
+        width,
     ));
     for item in top_level_global_options(&root, language) {
-        lines.push(option_line(&item.label, &item.description));
+        lines.push(option_line(&item.label, &item.description, width));
     }
     lines.push(String::new());
-    lines.push(format!(
-        "{}",
-        theme::strong(copy(language, "More:", "更多："))
-    ));
+    lines.push(strong_line(copy(language, "More:", "更多："), width));
     lines.push(start_here_line(
         "ov <command> --help",
         copy(language, "Show command details", "查看命令详情"),
+        width,
     ));
     lines.push(start_here_line(
         "ov config",
         copy(language, "Configure the CLI", "配置 CLI"),
+        width,
     ));
 
     format!("{}\n", lines.join("\n"))
 }
 
 fn render_command_help(spec: &CommandHelpSpec) -> String {
+    render_command_help_with_width(spec, help_output_width())
+}
+
+fn render_command_help_with_width(spec: &CommandHelpSpec, width: usize) -> String {
     let mut lines = Vec::new();
     let language = Language::current();
     let command = command_display(spec.path);
     let clap_command = clap_command_for_path(spec.path)
         .unwrap_or_else(|| panic!("curated help path missing from clap: {command}"));
 
-    lines.push(format!(
-        "{} {} {}",
-        theme::brand_title("OpenViking").bold(),
-        theme::version(version()),
-        theme::muted(format!("· {command}"))
-    ));
-    lines.push(theme::body(localized_command_purpose(spec, language)).to_string());
+    let plain_title_line = format!("OpenViking {} · {command}", version());
+    if width >= BOX_WIDTH || display_width(&plain_title_line) <= width {
+        lines.push(format!(
+            "{} {} {}",
+            theme::brand_title("OpenViking").bold(),
+            theme::version(version()),
+            theme::muted(format!("· {command}"))
+        ));
+    } else {
+        lines.push(
+            theme::brand_title(truncate_to_display_width(&plain_title_line, width))
+                .bold()
+                .to_string(),
+        );
+    }
+    let purpose = localized_command_purpose(spec, language);
+    let purpose = if width >= BOX_WIDTH {
+        purpose.to_string()
+    } else {
+        truncate_to_display_width(purpose, width)
+    };
+    lines.push(theme::body(purpose).to_string());
     lines.push(String::new());
-    lines.push(format!(
-        "{}",
-        theme::warning(copy(language, "Usage:", "用法：")).bold()
-    ));
+    lines.push(warning_line(copy(language, "Usage:", "用法："), width));
     let usage = usage_for_command(clap_command.clone(), spec.path);
+    let usage = if width >= BOX_WIDTH {
+        usage
+    } else {
+        truncate_to_display_width(&usage, width.saturating_sub(2))
+    };
     lines.push(format!("  {}", theme::strong(usage)));
     push_section(
         &mut lines,
         copy(language, "Examples", "示例"),
         spec.examples,
+        width,
     );
     let argument_items = arguments_from_command(&clap_command);
     push_dynamic_section(
         &mut lines,
         copy(language, "Arguments", "参数"),
         &argument_items,
+        width,
     );
     let subcommand_items = subcommands_from_command(&clap_command);
     push_dynamic_section(
         &mut lines,
         copy(language, "Subcommands", "子命令"),
         &subcommand_items,
+        width,
     );
     for section in option_sections_from_command(&clap_command) {
         push_dynamic_section(
             &mut lines,
             localized_option_section_title(&section.title, language),
             &section.items,
+            width,
         );
     }
     let global_items = global_options_for(spec);
@@ -1260,11 +1299,13 @@ fn render_command_help(spec: &CommandHelpSpec) -> String {
         &mut lines,
         copy(language, "Global options", "全局选项"),
         &global_items,
+        width,
     );
     push_section(
         &mut lines,
         copy(language, "Next", "下一步"),
         spec.next_steps,
+        width,
     );
 
     format!("{}\n", lines.join("\n"))
@@ -1529,50 +1570,59 @@ fn localized_option_section_title(title: &str, language: Language) -> &str {
     }
 }
 
-fn push_section(lines: &mut Vec<String>, title: &str, items: &[HelpItem]) {
+fn push_section(lines: &mut Vec<String>, title: &str, items: &[HelpItem], width: usize) {
     if items.is_empty() {
         return;
     }
 
     lines.push(String::new());
-    lines.push(format!("{}", theme::heading(title).bold()));
+    lines.push(heading_line(title, width));
     for item in items {
-        lines.push(help_item_line(item));
+        lines.push(help_item_line(item, width));
     }
 }
 
-fn push_dynamic_section(lines: &mut Vec<String>, title: &str, items: &[RenderedHelpItem]) {
+fn push_dynamic_section(
+    lines: &mut Vec<String>,
+    title: &str,
+    items: &[RenderedHelpItem],
+    width: usize,
+) {
     if items.is_empty() {
         return;
     }
 
     lines.push(String::new());
-    lines.push(format!("{}", theme::heading(title).bold()));
+    lines.push(heading_line(title, width));
     for item in items {
-        lines.push(help_item_line_parts(&item.label, &item.description));
+        lines.push(help_item_line_parts(&item.label, &item.description, width));
     }
 }
 
-fn help_item_line(item: &HelpItem) -> String {
+fn help_item_line(item: &HelpItem, width: usize) -> String {
     let language = Language::current();
     let description = localized_help_item_description(item.label, item.description, language);
-    help_item_line_parts(item.label, description)
+    help_item_line_parts(item.label, description, width)
 }
 
-fn help_item_line_parts(label: &str, description: &str) -> String {
-    if display_width(label) > COMMAND_HELP_LEFT_WIDTH {
+fn help_item_line_parts(label: &str, description: &str, width: usize) -> String {
+    if width >= BOX_WIDTH {
+        if display_width(label) > COMMAND_HELP_LEFT_WIDTH {
+            return format!(
+                "  {}\n      {}",
+                theme::command(label),
+                theme::body(description)
+            );
+        }
+
         return format!(
-            "  {}\n      {}",
-            theme::command(label),
+            "  {} {}",
+            theme::command(pad_to_display_width(label, COMMAND_HELP_LEFT_WIDTH)),
             theme::body(description)
         );
     }
 
-    format!(
-        "  {} {}",
-        theme::command(pad_to_display_width(label, COMMAND_HELP_LEFT_WIDTH)),
-        theme::body(description)
-    )
+    two_column_line(label, description, COMMAND_HELP_LEFT_WIDTH, width)
 }
 
 fn localized_command_purpose(spec: &CommandHelpSpec, language: Language) -> &str {
@@ -1659,32 +1709,25 @@ fn localized_help_item_description<'a>(
     }
 }
 
-fn start_here_line(command: &str, description: &str) -> String {
-    let description = truncate_to_display_width(description, START_HERE_DESCRIPTION_WIDTH);
-    format!(
-        "  {} {}",
-        theme::command(pad_to_display_width(command, 22)).bold(),
-        theme::body(description)
-    )
+fn start_here_line(command: &str, description: &str, width: usize) -> String {
+    two_column_line_with_bold_label(command, description, 22, width)
 }
 
-fn option_line(option: &str, description: &str) -> String {
-    format!(
-        "  {} {}",
-        theme::command(pad_to_display_width(option, 26)),
-        theme::body(description)
-    )
+fn option_line(option: &str, description: &str, width: usize) -> String {
+    two_column_line(option, description, 26, width)
 }
 
 fn top_level_start_here_line(
     root: &Command,
     command_name: &str,
     language: Language,
+    width: usize,
 ) -> Option<String> {
     let command = root.find_subcommand(command_name)?;
     Some(start_here_line(
         &format!("ov {command_name}"),
         &top_level_command_description(command, language),
+        width,
     ))
 }
 
@@ -1735,11 +1778,17 @@ fn rendered_global_options(
         .collect()
 }
 
-fn section_lines(section: &HelpSection, root: &Command, language: Language) -> Vec<String> {
+fn section_lines(
+    section: &HelpSection,
+    root: &Command,
+    language: Language,
+    width: usize,
+) -> Vec<String> {
     let mut lines = Vec::new();
     let title_text = localized_section_title(section.title, language);
     let title = format!("─ {title_text} ");
-    let fill = BOX_WIDTH.saturating_sub(2 + display_width(&title));
+    let title = truncate_to_display_width(&title, width.saturating_sub(2));
+    let fill = width.saturating_sub(2 + display_width(&title));
     lines.push(format!(
         "{}{}{}{}",
         theme::border("╭"),
@@ -1750,44 +1799,48 @@ fn section_lines(section: &HelpSection, root: &Command, language: Language) -> V
 
     for command in section.commands {
         if let Some(clap_command) = root.find_subcommand(command.name) {
-            lines.push(command_line(command.name, clap_command, language));
+            lines.push(command_line(command.name, clap_command, language, width));
         }
     }
 
     lines.push(format!(
         "{}{}{}",
         theme::border("╰"),
-        theme::border("─".repeat(BOX_WIDTH.saturating_sub(2))),
+        theme::border("─".repeat(width.saturating_sub(2))),
         theme::border("╯")
     ));
     lines
 }
 
-fn command_line(command_name: &str, command: &Command, language: Language) -> String {
+fn command_line(command_name: &str, command: &Command, language: Language, width: usize) -> String {
     let command_description = top_level_command_description(command, language);
     let badge = top_level_command_badge(command);
+    let command_width = boxed_command_width(width);
+    let description_width = boxed_description_width(width, command_width);
     let description = match badge.as_deref() {
         Some(badge) => {
             let badge = localized_badge(badge, language);
-            let description_width = DESCRIPTION_WIDTH.saturating_sub(display_width(badge) + 1);
+            let badge = truncate_to_display_width(badge, description_width);
+            let badge_width = display_width(&badge);
+            let description_text_width = description_width.saturating_sub(badge_width + 1);
             let command_description =
-                truncate_to_display_width(&command_description, description_width);
-            let used = display_width(&command_description) + display_width(badge);
-            let spacer = DESCRIPTION_WIDTH.saturating_sub(used).max(1);
+                truncate_to_display_width(&command_description, description_text_width);
+            let used = display_width(&command_description) + badge_width;
+            let spacer = description_width.saturating_sub(used);
             format!(
                 "{}{}{}",
                 command_description,
                 " ".repeat(spacer),
-                theme::muted(badge)
+                theme::muted(&badge)
             )
         }
         None => {
             let command_description =
-                truncate_to_display_width(&command_description, DESCRIPTION_WIDTH);
+                truncate_to_display_width(&command_description, description_width);
             format!(
                 "{}{}",
                 command_description,
-                " ".repeat(DESCRIPTION_WIDTH.saturating_sub(display_width(&command_description)))
+                " ".repeat(description_width.saturating_sub(display_width(&command_description)))
             )
         }
     };
@@ -1795,7 +1848,7 @@ fn command_line(command_name: &str, command: &Command, language: Language) -> St
     format!(
         "{} {} {} {}",
         theme::border("│"),
-        theme::command(pad_to_display_width(command_name, COMMAND_WIDTH)).bold(),
+        theme::command(fit_to_display_width(command_name, command_width)).bold(),
         theme::body(description),
         theme::border("│")
     )
@@ -1882,6 +1935,114 @@ fn localized_global_option_description<'a>(
     }
 }
 
+#[cfg(not(test))]
+fn help_output_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(columns, _)| terminal_width(columns as usize, BOX_WIDTH))
+        .unwrap_or(BOX_WIDTH)
+}
+
+#[cfg(test)]
+fn help_output_width() -> usize {
+    BOX_WIDTH
+}
+
+#[cfg(not(test))]
+fn terminal_width(columns: usize, default_width: usize) -> usize {
+    let available = columns.saturating_sub(1).max(4);
+    available.min(default_width)
+}
+
+fn boxed_command_width(width: usize) -> usize {
+    let content_width = width.saturating_sub(5);
+    COMMAND_WIDTH.min(content_width / 2).max(1)
+}
+
+fn boxed_description_width(width: usize, command_width: usize) -> usize {
+    width.saturating_sub(command_width + 5)
+}
+
+fn two_column_line(
+    label: &str,
+    description: &str,
+    preferred_label_width: usize,
+    width: usize,
+) -> String {
+    two_column_line_with_style(label, description, preferred_label_width, width, false)
+}
+
+fn two_column_line_with_bold_label(
+    label: &str,
+    description: &str,
+    preferred_label_width: usize,
+    width: usize,
+) -> String {
+    two_column_line_with_style(label, description, preferred_label_width, width, true)
+}
+
+fn strong_line(text: &str, width: usize) -> String {
+    let text = if width >= BOX_WIDTH {
+        text.to_string()
+    } else {
+        truncate_to_display_width(text, width)
+    };
+    theme::strong(text).to_string()
+}
+
+fn warning_line(text: &str, width: usize) -> String {
+    let text = if width >= BOX_WIDTH {
+        text.to_string()
+    } else {
+        truncate_to_display_width(text, width)
+    };
+    theme::warning(text).bold().to_string()
+}
+
+fn heading_line(text: &str, width: usize) -> String {
+    let text = if width >= BOX_WIDTH {
+        text.to_string()
+    } else {
+        truncate_to_display_width(text, width)
+    };
+    theme::heading(text).bold().to_string()
+}
+
+fn two_column_line_with_style(
+    label: &str,
+    description: &str,
+    preferred_label_width: usize,
+    width: usize,
+    bold_label: bool,
+) -> String {
+    if width >= BOX_WIDTH {
+        let label = pad_to_display_width(label, preferred_label_width);
+        let label = if bold_label {
+            theme::command(label).bold().to_string()
+        } else {
+            theme::command(label).to_string()
+        };
+
+        return format!("  {} {}", label, theme::body(description));
+    }
+
+    if width <= 3 {
+        return truncate_to_display_width(label, width);
+    }
+
+    let content_width = width.saturating_sub(3);
+    let label_width = preferred_label_width.min(content_width / 2).max(1);
+    let description_width = width.saturating_sub(label_width + 3);
+    let label = fit_to_display_width(label, label_width);
+    let label = if bold_label {
+        theme::command(label).bold().to_string()
+    } else {
+        theme::command(label).to_string()
+    };
+    let description = truncate_to_display_width(description, description_width);
+
+    format!("  {} {}", label, theme::body(description))
+}
+
 fn display_width(value: &str) -> usize {
     UnicodeWidthStr::width(value)
 }
@@ -1918,6 +2079,10 @@ fn pad_to_display_width(value: &str, width: usize) -> String {
         value,
         " ".repeat(width.saturating_sub(display_width(value)))
     )
+}
+
+fn fit_to_display_width(value: &str, width: usize) -> String {
+    pad_to_display_width(&truncate_to_display_width(value, width), width)
 }
 
 fn localized_section_title(title: &str, language: Language) -> &str {
@@ -2263,10 +2428,12 @@ fn cli_value_options() -> ValueOptions {
 mod tests {
     use super::{
         COMMAND_HELP_SPECS, HELP_SECTIONS, command_help_path, display_width,
-        render_command_help_request, render_top_level_help,
+        render_command_help_request, render_command_help_with_width, render_top_level_help,
+        render_top_level_help_with_language_and_width,
     };
     use super::{command_spec, is_top_level_help_request};
     use crate::Cli;
+    use crate::i18n::Language;
     use clap::CommandFactory;
     use std::ffi::OsString;
 
@@ -2391,6 +2558,37 @@ mod tests {
     }
 
     #[test]
+    fn top_level_help_respects_narrow_terminal_width() {
+        let width = 24;
+        let rendered = strip_ansi(&render_top_level_help_with_language_and_width(
+            Language::En,
+            width,
+        ));
+
+        for line in rendered.lines() {
+            assert!(
+                display_width(line) <= width,
+                "line exceeded narrow width: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn command_help_respects_narrow_terminal_width() {
+        let width = 24;
+        let path = vec!["config".to_string()];
+        let spec = command_spec(&path).expect("config command spec");
+        let rendered = strip_ansi(&render_command_help_with_width(spec, width));
+
+        for line in rendered.lines() {
+            assert!(
+                display_width(line) <= width,
+                "line exceeded narrow width: {line:?}"
+            );
+        }
+    }
+
+    #[test]
     fn every_curated_top_level_command_in_help_map_has_command_help() {
         for command in HELP_SECTIONS
             .iter()
@@ -2465,7 +2663,7 @@ mod tests {
             &["ov", "config", "add", "custom", "--help"][..],
         ] {
             let rendered = strip_ansi(
-                &render_command_help_request(&os_args(&args)).expect("help should render"),
+                &render_command_help_request(&os_args(args)).expect("help should render"),
             );
             assert!(
                 rendered.contains("Common options"),

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -15,6 +15,7 @@ mod help_ui;
 mod i18n;
 mod output;
 mod status_ui;
+mod terminal_ui;
 mod theme;
 mod tui;
 mod utils;

--- a/crates/ov_cli/src/terminal_ui.rs
+++ b/crates/ov_cli/src/terminal_ui.rs
@@ -1,0 +1,202 @@
+use std::io;
+
+use crossterm::{
+    cursor, execute,
+    terminal::{Clear, ClearType},
+};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::error::Result;
+
+pub(crate) fn display_width(value: &str) -> usize {
+    UnicodeWidthStr::width(value)
+}
+
+pub(crate) fn visible_display_width(value: &str) -> usize {
+    let mut width = 0usize;
+    let mut chars = value.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for next in chars.by_ref() {
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        width += UnicodeWidthChar::width(ch).unwrap_or(0);
+    }
+
+    width
+}
+
+pub(crate) fn truncate_to_display_width(value: &str, width: usize) -> String {
+    if display_width(value) <= width {
+        return value.to_string();
+    }
+
+    if width <= 3 {
+        return ".".repeat(width);
+    }
+
+    let target = width - 3;
+    let mut truncated = String::new();
+    let mut used = 0usize;
+
+    for ch in value.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_width > target {
+            break;
+        }
+        truncated.push(ch);
+        used += ch_width;
+    }
+
+    truncated.push_str("...");
+    truncated
+}
+
+pub(crate) fn pad_to_display_width(value: &str, width: usize) -> String {
+    format!(
+        "{}{}",
+        value,
+        " ".repeat(width.saturating_sub(display_width(value)))
+    )
+}
+
+pub(crate) fn fit_to_display_width(value: &str, width: usize) -> String {
+    pad_to_display_width(&truncate_to_display_width(value, width), width)
+}
+
+pub(crate) fn terminal_width(columns: usize, default_width: usize) -> usize {
+    let available = columns.saturating_sub(1).max(4);
+    available.min(default_width)
+}
+
+pub(crate) fn rendered_line_rows(text: &str, columns: usize) -> usize {
+    let columns = columns.max(1);
+    let width = visible_display_width(text);
+    width.max(1).div_ceil(columns)
+}
+
+pub(crate) fn rendered_row_count(lines: &[String], columns: usize) -> usize {
+    lines
+        .iter()
+        .map(|line| rendered_line_rows(line, columns))
+        .sum()
+}
+
+pub(crate) fn live_select_block(lines: &[String]) -> String {
+    if lines.is_empty() {
+        return String::new();
+    }
+
+    let mut rendered = lines.join("\r\n");
+    rendered.push_str("\r\n");
+    rendered
+}
+
+pub(crate) fn clear_rendered_lines(lines: usize) -> Result<()> {
+    if lines == 0 {
+        return Ok(());
+    }
+    let mut stdout = io::stdout();
+    execute!(
+        stdout,
+        cursor::MoveUp(lines as u16),
+        cursor::MoveToColumn(0)
+    )?;
+    for line in 0..lines {
+        execute!(
+            stdout,
+            cursor::MoveToColumn(0),
+            Clear(ClearType::CurrentLine)
+        )?;
+        if line + 1 < lines {
+            execute!(stdout, cursor::MoveDown(1))?;
+        }
+    }
+    execute!(
+        stdout,
+        cursor::MoveUp(lines.saturating_sub(1) as u16),
+        cursor::MoveToColumn(0)
+    )?;
+    Ok(())
+}
+
+#[derive(Default)]
+pub(crate) struct RenderedRegion {
+    lines: Vec<String>,
+    rows_drawn: usize,
+}
+
+impl RenderedRegion {
+    pub(crate) fn from_lines(lines: &[String], columns: usize) -> Self {
+        Self {
+            lines: lines.to_vec(),
+            rows_drawn: rendered_row_count(lines, columns),
+        }
+    }
+
+    pub(crate) fn rows_to_clear(&self, columns: usize) -> usize {
+        self.rows_drawn
+            .max(rendered_row_count(&self.lines, columns))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RenderedRegion, display_width, fit_to_display_width, live_select_block, rendered_row_count,
+        terminal_width, truncate_to_display_width, visible_display_width,
+    };
+
+    #[test]
+    fn visible_display_width_ignores_ansi_and_counts_cjk_columns() {
+        assert_eq!(visible_display_width("\u{1b}[32mOpen\u{1b}[0m"), 4);
+        assert_eq!(visible_display_width("配置"), 4);
+    }
+
+    #[test]
+    fn truncate_and_fit_respect_display_width() {
+        assert_eq!(truncate_to_display_width("abcdef", 4), "a...");
+        assert_eq!(truncate_to_display_width("abcdef", 2), "..");
+        let fitted = fit_to_display_width("配置abc", 6);
+
+        assert_eq!(display_width(&fitted), 6);
+        assert_eq!(fitted, "配... ");
+    }
+
+    #[test]
+    fn rendered_row_count_accounts_for_wrapping_and_empty_lines() {
+        let lines = vec!["\u{1b}[31m12345678901\u{1b}[0m".to_string(), String::new()];
+
+        assert_eq!(rendered_row_count(&lines, 10), 3);
+    }
+
+    #[test]
+    fn terminal_width_leaves_room_for_prompt_edge() {
+        assert_eq!(terminal_width(3, 72), 4);
+        assert_eq!(terminal_width(80, 72), 72);
+        assert_eq!(terminal_width(40, 72), 39);
+    }
+
+    #[test]
+    fn rendered_region_clears_original_or_current_wrapped_rows() {
+        let lines = vec!["x".repeat(90)];
+        let region = RenderedRegion::from_lines(&lines, 90);
+
+        assert_eq!(region.rows_to_clear(30), 3);
+        assert_eq!(region.rows_to_clear(120), 1);
+    }
+
+    #[test]
+    fn live_select_block_uses_crlf_for_raw_mode_rows() {
+        let lines = vec!["Choose config".to_string(), "  > local".to_string()];
+
+        assert_eq!(live_select_block(&lines), "Choose config\r\n  > local\r\n");
+    }
+}


### PR DESCRIPTION
## Description

Improve the `ov config` interactive TUI so configuration management is easier to navigate and more robust when terminal dimensions change.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Added `Switch Config` to the main `ov config` interactive menu and route it through the existing `ov config switch` flow.
- Added back/exit behavior for config switching prompts so `Esc` returns and `Ctrl+C` aborts cleanly.
- Reworked the `ov config` status header into two responsive modes:
  - full mode keeps the standalone OpenViking wordmark and full boat status art when the terminal has enough room;
  - compact mode removes the heavy art and uses `OpenViking | Context Database for AI Agents` in the status border.
- Fixed rendered-row accounting for wrapped ANSI output so resized terminals clear stale rows correctly in config, config switch, skill removal, help, and error surfaces.
- Updated the main action labels to consistent title case: `Add Config`, `Switch Config`, `Edit Config`, `Delete Config`.
- Added focused tests for the menu entry, compact/full status box behavior, terminal-width wrapping, resize clearing, and switch prompt controls.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run locally after rebasing onto latest `upstream/main`:

```bash
git diff --check
rustfmt --edition 2024 --check crates/ov_cli/src/commands/skills.rs crates/ov_cli/src/config_wizard/wizard.rs crates/ov_cli/src/error_ui.rs crates/ov_cli/src/handlers.rs crates/ov_cli/src/help_ui.rs
RUSTFLAGS="-D warnings" cargo build -p ov_cli
RUSTFLAGS="-D warnings" cargo test -p ov_cli -- --test-threads=1
```

Result: `343 passed` for `ov_cli` tests.

Manual smoke checks:

- Ran `./target/debug/ov config` in full and compact terminal sizes.
- Confirmed full mode keeps the wordmark and boat art without squeezing.
- Confirmed compact mode removes the wordmark/logo and uses the combined status title.
- Confirmed the main menu renders `Add Config`, `Switch Config`, `Edit Config`, and `Delete Config`.
- Checked help and command error output in narrow terminals to verify borders and text wrap within the terminal width.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Documentation note: this changes CLI interactive behavior only and does not require documentation updates.

## Screenshots (if applicable)

N/A

## Additional Notes

This PR is scoped to the Rust CLI TUI path under `crates/ov_cli`.
