### PR TITLE
feat(docs): add OpenViking-powered search

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -133,9 +133,13 @@ const zhNav: DefaultTheme.NavItem[] = [
   { text: navLabels.zh.about, link: '/zh/about/01-about-us', activeMatch: '/zh/about/' }
 ]
 
-function collectAllMdFiles(srcDir: string): { relativePath: string; absPath: string }[] {
+function collectAllMdFiles(
+  srcDir: string,
+  options: { includeIndex?: boolean } = {}
+): { relativePath: string; absPath: string }[] {
   const results: { relativePath: string; absPath: string }[] = []
   const ignored = new Set(['node_modules', '.vitepress'])
+  const includeIndex = options.includeIndex ?? false
 
   function walk(dir: string) {
     for (const entry of fs.readdirSync(dir)) {
@@ -144,7 +148,7 @@ function collectAllMdFiles(srcDir: string): { relativePath: string; absPath: str
       const stat = fs.statSync(abs)
       if (stat.isDirectory()) {
         walk(abs)
-      } else if (entry.endsWith('.md') && entry !== 'index.md') {
+      } else if (entry.endsWith('.md') && (includeIndex || entry !== 'index.md')) {
         results.push({ relativePath: path.relative(srcDir, abs), absPath: abs })
       }
     }
@@ -161,7 +165,15 @@ function markdownToSearchText(content: string): string {
     .replace(/`([^`]+)`/g, '$1')
     .replace(/!\[[^\]]*\]\([^)]+\)/g, ' ')
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[#>*_~|:-]+/g, ' ')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, ' ')
+    .replace(/^\s{0,3}>\s?/gm, ' ')
+    .replace(/^\s*[-*+]\s+/gm, ' ')
+    .replace(/^\s*\|?[\s:-]+\|[\s|:-]*$/gm, ' ')
+    .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+    .replace(/__([^_\n]+)__/g, '$1')
+    .replace(/~~([^~\n]+)~~/g, '$1')
+    .replace(/(^|[\s([{"'（【])\*([^*\n]+)\*(?=$|[\s.,;:!?，。；：！？、）】\])}"'])/g, '$1$2')
+    .replace(/(^|[\s([{"'（【])_([^_\n]+)_(?=$|[\s.,;:!?，。；：！？、）】\])}"'])/g, '$1$2')
     .replace(/\s+/g, ' ')
     .trim()
 }
@@ -173,7 +185,7 @@ function docsSearchLocale(relativePath: string): 'en' | 'zh' | null {
 }
 
 function buildDocsSearchRecords(srcDir: string) {
-  return collectAllMdFiles(srcDir)
+  return collectAllMdFiles(srcDir, { includeIndex: true })
     .map(({ relativePath, absPath }) => {
       const normalizedPath = relativePath.replace(/\\/g, '/')
       const locale = docsSearchLocale(normalizedPath)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -154,6 +154,53 @@ function collectAllMdFiles(srcDir: string): { relativePath: string; absPath: str
   return results.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
 }
 
+function markdownToSearchText(content: string): string {
+  return content
+    .replace(/^---[\s\S]*?---\s*/m, '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#>*_~|:-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function docsSearchLocale(relativePath: string): 'en' | 'zh' | null {
+  if (relativePath.startsWith('en/')) return 'en'
+  if (relativePath.startsWith('zh/')) return 'zh'
+  return null
+}
+
+function buildDocsSearchRecords(srcDir: string) {
+  return collectAllMdFiles(srcDir)
+    .map(({ relativePath, absPath }) => {
+      const normalizedPath = relativePath.replace(/\\/g, '/')
+      const locale = docsSearchLocale(normalizedPath)
+      if (!locale) return null
+
+      const content = fs.readFileSync(absPath, 'utf-8')
+      const url = `/${normalizedPath.replace(/\.md$/, '')}`.replace(/\/index$/, '')
+      return {
+        locale,
+        path: normalizedPath,
+        text: markdownToSearchText(content),
+        title: titleFromMarkdown(absPath),
+        url
+      }
+    })
+    .filter((record): record is NonNullable<typeof record> => record !== null)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildDocsSearchIndex(siteConfig: any) {
+  fs.writeFileSync(
+    path.join(siteConfig.outDir, 'docs-search-index.json'),
+    JSON.stringify(buildDocsSearchRecords(siteConfig.srcDir)),
+    'utf-8'
+  )
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function buildLlmsTxt(siteConfig: any) {
   const siteUrl = (process.env.DOCS_SITE_URL || '').replace(/\/$/, '')
@@ -242,6 +289,7 @@ export default defineConfig({
   },
   buildEnd(siteConfig) {
     buildLlmsTxt(siteConfig)
+    buildDocsSearchIndex(siteConfig)
   },
   vite: {
     publicDir: 'images',
@@ -260,6 +308,13 @@ export default defineConfig({
               next()
             }
           })
+          server.middlewares.use((req, res, next) => {
+            const pathname = req.url?.split('?')[0]
+            if (pathname !== '/docs-search-index.json') return next()
+
+            res.setHeader('Content-Type', 'application/json; charset=utf-8')
+            res.end(JSON.stringify(buildDocsSearchRecords(docsRoot)))
+          })
         }
       }
     ]
@@ -267,9 +322,6 @@ export default defineConfig({
   themeConfig: {
     logo: '/ov-logo.png',
     logoLink: mainSiteBase,
-    search: {
-      provider: 'local'
-    },
     socialLinks: [
       { icon: 'github', link: `https://github.com/${repo}` }
     ],

--- a/docs/.vitepress/theme/OpenVikingSearch.vue
+++ b/docs/.vitepress/theme/OpenVikingSearch.vue
@@ -37,8 +37,8 @@ type RemoteSearchResponse =
 
 const PRODUCTION_SEARCH_URL = 'https://openviking.ai/studio/gateway/docs/search'
 const SEARCH_LIMIT = 8
-const REMOTE_SEARCH_DEBOUNCE_MS = 700
-const REMOTE_SEARCH_TIMEOUT_MS = 5000
+const REMOTE_SEARCH_DEBOUNCE_MS = 1000
+const REMOTE_SEARCH_TIMEOUT_MS = 10000
 
 const modes: { command: string; label: string; placeholder: string; value: SearchMode }[] = [
   {
@@ -76,6 +76,7 @@ const notice = ref('')
 let debounceTimer: ReturnType<typeof window.setTimeout> | null = null
 let searchSequence = 0
 let localIndexPromise: Promise<DocsIndexRecord[]> | null = null
+let activeSearchController: AbortController | null = null
 
 const trimmedQuery = computed(() => query.value.trim())
 const activeMode = computed(() => modes.find((item) => item.value === mode.value) ?? modes[0])
@@ -111,6 +112,8 @@ function closeSearch() {
   const shouldRestoreFocus = isOpen.value
   isOpen.value = false
   isModeMenuOpen.value = false
+  clearPendingSearch()
+  cancelActiveSearch()
   if (shouldRestoreFocus) {
     void nextTick(() => triggerRef.value?.focus())
   }
@@ -194,9 +197,7 @@ function dialogFocusableElements() {
 }
 
 function scheduleSearch() {
-  if (debounceTimer) {
-    window.clearTimeout(debounceTimer)
-  }
+  clearPendingSearch()
 
   debounceTimer = window.setTimeout(() => {
     void runSearch()
@@ -204,6 +205,7 @@ function scheduleSearch() {
 }
 
 async function runSearch() {
+  cancelActiveSearch()
   const currentQuery = trimmedQuery.value
   const currentSequence = ++searchSequence
   notice.value = ''
@@ -215,13 +217,16 @@ async function runSearch() {
   }
 
   isLoading.value = true
+  const controller = new AbortController()
+  activeSearchController = controller
 
   try {
     const remoteResponse = await fetchRemoteResults(
       PRODUCTION_SEARCH_URL,
       currentQuery,
       mode.value,
-      docsLocale()
+      docsLocale(),
+      controller
     )
 
     if (currentSequence !== searchSequence) return
@@ -239,6 +244,9 @@ async function runSearch() {
       notice.value = fallbackNotice(remoteResponse.reason, localResults.length)
     }
   } finally {
+    if (activeSearchController === controller) {
+      activeSearchController = null
+    }
     if (currentSequence === searchSequence) {
       isLoading.value = false
     }
@@ -249,10 +257,12 @@ async function fetchRemoteResults(
   endpoint: string,
   searchQuery: string,
   searchMode: SearchMode,
-  locale: SearchLocale
+  locale: SearchLocale,
+  controller: AbortController
 ) {
-  const controller = new AbortController()
-  const timeout = window.setTimeout(() => controller.abort(), REMOTE_SEARCH_TIMEOUT_MS)
+  const timeout = window.setTimeout(() => {
+    controller.abort('timeout')
+  }, REMOTE_SEARCH_TIMEOUT_MS)
 
   try {
     const response = await fetch(endpoint, {
@@ -283,13 +293,30 @@ async function fetchRemoteResults(
       results: Array.isArray(payload.results) ? payload.results : []
     } satisfies RemoteSearchResponse
   } catch (error) {
-    const isTimeout = error instanceof DOMException && error.name === 'AbortError'
+    const isTimeout =
+      controller.signal.reason === 'timeout' ||
+      (error instanceof DOMException && error.name === 'TimeoutError')
     return {
       ok: false,
       reason: isTimeout ? 'timeout' : 'unavailable'
     } satisfies RemoteSearchResponse
   } finally {
     window.clearTimeout(timeout)
+  }
+}
+
+function cancelActiveSearch() {
+  if (activeSearchController && !activeSearchController.signal.aborted) {
+    activeSearchController.abort('superseded')
+  }
+  activeSearchController = null
+  searchSequence += 1
+}
+
+function clearPendingSearch() {
+  if (debounceTimer) {
+    window.clearTimeout(debounceTimer)
+    debounceTimer = null
   }
 }
 
@@ -448,16 +475,22 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKeydown)
-  if (debounceTimer) {
-    window.clearTimeout(debounceTimer)
-  }
+  clearPendingSearch()
+  cancelActiveSearch()
 })
 </script>
 
 <template>
   <div class="ov-docs-search">
-    <button ref="triggerRef" class="ov-docs-search-trigger" type="button" @click="openSearch">
-      <span>Search docs</span>
+    <button
+      ref="triggerRef"
+      aria-label="Search docs"
+      class="ov-docs-search-trigger"
+      type="button"
+      @click="openSearch"
+    >
+      <span class="ov-docs-search-trigger-label">Search docs</span>
+      <span aria-hidden="true" class="ov-docs-search-trigger-compact">Search</span>
       <kbd>Ctrl K</kbd>
     </button>
 

--- a/docs/.vitepress/theme/OpenVikingSearch.vue
+++ b/docs/.vitepress/theme/OpenVikingSearch.vue
@@ -24,6 +24,10 @@ type DocsSearchResult = {
   url?: string
 }
 
+type ResolvedDocsSearchResult = DocsSearchResult & {
+  resolvedUrl: string
+}
+
 type RemoteSearchFailureReason = 'rate_limited' | 'timeout' | 'unavailable'
 
 type RemoteSearchResponse =
@@ -32,7 +36,6 @@ type RemoteSearchResponse =
 
 const PRODUCTION_SEARCH_URL = 'https://openviking.ai/studio/gateway/docs/search'
 const SEARCH_LIMIT = 8
-const LOCAL_SEARCH_DEBOUNCE_MS = 120
 const REMOTE_SEARCH_DEBOUNCE_MS = 700
 const REMOTE_SEARCH_TIMEOUT_MS = 5000
 
@@ -58,6 +61,8 @@ const modes: { command: string; label: string; placeholder: string; value: Searc
 ]
 
 const inputRef = ref<HTMLInputElement | null>(null)
+const triggerRef = ref<HTMLButtonElement | null>(null)
+const dialogRef = ref<HTMLElement | null>(null)
 const isOpen = ref(false)
 const isMounted = ref(false)
 const isLoading = ref(false)
@@ -73,13 +78,15 @@ let localIndexPromise: Promise<DocsIndexRecord[]> | null = null
 
 const trimmedQuery = computed(() => query.value.trim())
 const activeMode = computed(() => modes.find((item) => item.value === mode.value) ?? modes[0])
+const resolvedResults = computed<ResolvedDocsSearchResult[]>(() =>
+  results.value.flatMap((result) => {
+    const resolvedUrl = resultUrl(result)
+    return resolvedUrl ? [{ ...result, resolvedUrl }] : []
+  })
+)
 
 function docsLocale(): SearchLocale {
   return window.location.pathname.startsWith('/zh/') ? 'zh' : 'en'
-}
-
-function searchEndpoint(): string {
-  return PRODUCTION_SEARCH_URL
 }
 
 function openSearch() {
@@ -89,8 +96,12 @@ function openSearch() {
 }
 
 function closeSearch() {
+  const shouldRestoreFocus = isOpen.value
   isOpen.value = false
   isModeMenuOpen.value = false
+  if (shouldRestoreFocus) {
+    void nextTick(() => triggerRef.value?.focus())
+  }
 }
 
 function toggleModeMenu() {
@@ -130,15 +141,54 @@ function handleKeydown(event: KeyboardEvent) {
   openSearch()
 }
 
+function handleDialogKeydown(event: KeyboardEvent) {
+  if (event.key !== 'Tab') return
+
+  const focusable = dialogFocusableElements()
+  if (focusable.length === 0) {
+    event.preventDefault()
+    return
+  }
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const activeElement = document.activeElement
+
+  if (event.shiftKey && activeElement === first) {
+    event.preventDefault()
+    last.focus()
+    return
+  }
+
+  if (!event.shiftKey && activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+function dialogFocusableElements() {
+  const elements = dialogRef.value?.querySelectorAll<HTMLElement>(
+    [
+      'a[href]',
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(',')
+  )
+
+  return Array.from(elements ?? []).filter((element) => element.tabIndex >= 0)
+}
+
 function scheduleSearch() {
   if (debounceTimer) {
     window.clearTimeout(debounceTimer)
   }
 
-  const delay = searchEndpoint() ? REMOTE_SEARCH_DEBOUNCE_MS : LOCAL_SEARCH_DEBOUNCE_MS
   debounceTimer = window.setTimeout(() => {
     void runSearch()
-  }, delay)
+  }, REMOTE_SEARCH_DEBOUNCE_MS)
 }
 
 async function runSearch() {
@@ -155,10 +205,12 @@ async function runSearch() {
   isLoading.value = true
 
   try {
-    const endpoint = searchEndpoint()
-    const remoteResponse = endpoint
-      ? await fetchRemoteResults(endpoint, currentQuery, mode.value, docsLocale())
-      : null
+    const remoteResponse = await fetchRemoteResults(
+      PRODUCTION_SEARCH_URL,
+      currentQuery,
+      mode.value,
+      docsLocale()
+    )
 
     if (currentSequence !== searchSequence) return
 
@@ -246,7 +298,10 @@ async function loadLocalIndex() {
   localIndexPromise ??= fetch(withBase('/docs-search-index.json'))
     .then((response) => (response.ok ? response.json() : []))
     .then((payload) => (Array.isArray(payload) ? (payload as DocsIndexRecord[]) : []))
-    .catch(() => [])
+    .catch((error) => {
+      console.warn('Failed to load local docs search index.', error)
+      return []
+    })
 
   return localIndexPromise
 }
@@ -331,8 +386,9 @@ function resultUrl(result: DocsSearchResult) {
   const url =
     result.url ||
     routeFromRelativePath(result.relativePath, docsLocale()) ||
-    routeFromVikingUri(result.uri) ||
-    '/'
+    routeFromVikingUri(result.uri)
+
+  if (!url) return ''
 
   if (/^https?:\/\//.test(url)) return url
   return withBase(url)
@@ -380,7 +436,7 @@ onUnmounted(() => {
 
 <template>
   <div class="ov-docs-search">
-    <button class="ov-docs-search-trigger" type="button" @click="openSearch">
+    <button ref="triggerRef" class="ov-docs-search-trigger" type="button" @click="openSearch">
       <span>Search docs</span>
       <kbd>Ctrl K</kbd>
     </button>
@@ -388,9 +444,12 @@ onUnmounted(() => {
     <Teleport v-if="isMounted && isOpen" to="body">
       <div class="ov-docs-search-backdrop" @click.self="closeSearch">
         <section
+          ref="dialogRef"
           aria-label="OpenViking docs search"
+          aria-modal="true"
           class="ov-docs-search-dialog"
           role="dialog"
+          @keydown="handleDialogKeydown"
         >
           <div class="ov-docs-search-bar">
             <div class="ov-docs-search-mode-picker">
@@ -445,7 +504,7 @@ onUnmounted(() => {
 
           <div class="ov-docs-search-results">
             <p v-if="isLoading" class="ov-docs-search-empty">Searching...</p>
-            <p v-else-if="trimmedQuery && results.length === 0" class="ov-docs-search-empty">
+            <p v-else-if="trimmedQuery && resolvedResults.length === 0" class="ov-docs-search-empty">
               No results found.
             </p>
             <p v-else-if="!trimmedQuery" class="ov-docs-search-empty">
@@ -453,10 +512,10 @@ onUnmounted(() => {
             </p>
             <template v-else>
               <a
-                v-for="result in results"
-                :key="`${result.url}-${result.line ?? ''}`"
+                v-for="result in resolvedResults"
+                :key="`${result.resolvedUrl}-${result.line ?? ''}-${result.snippet ?? ''}`"
                 class="ov-docs-search-result"
-                :href="resultUrl(result)"
+                :href="result.resolvedUrl"
                 @click="closeSearch"
               >
                 <span class="ov-docs-search-result-title">{{ result.title }}</span>

--- a/docs/.vitepress/theme/OpenVikingSearch.vue
+++ b/docs/.vitepress/theme/OpenVikingSearch.vue
@@ -25,6 +25,7 @@ type DocsSearchResult = {
 }
 
 type ResolvedDocsSearchResult = DocsSearchResult & {
+  cleanedSnippet: string
   resolvedUrl: string
 }
 
@@ -81,12 +82,23 @@ const activeMode = computed(() => modes.find((item) => item.value === mode.value
 const resolvedResults = computed<ResolvedDocsSearchResult[]>(() =>
   results.value.flatMap((result) => {
     const resolvedUrl = resultUrl(result)
-    return resolvedUrl ? [{ ...result, resolvedUrl }] : []
+    return resolvedUrl ? [{ ...result, cleanedSnippet: cleanSearchSnippet(result.snippet), resolvedUrl }] : []
   })
 )
 
 function docsLocale(): SearchLocale {
-  return window.location.pathname.startsWith('/zh/') ? 'zh' : 'en'
+  const basePath = normalizeBasePath(import.meta.env.BASE_URL)
+  const pathname = window.location.pathname
+  const localizedPath = pathname.startsWith(basePath)
+    ? pathname.slice(basePath.length - 1)
+    : pathname
+
+  return localizedPath.startsWith('/zh/') ? 'zh' : 'en'
+}
+
+function normalizeBasePath(basePath: string) {
+  if (!basePath || basePath === '/') return '/'
+  return `/${basePath.replace(/^\/+|\/+$/g, '')}/`
 }
 
 function openSearch() {
@@ -296,9 +308,17 @@ function fallbackNotice(reason: RemoteSearchFailureReason, localResultCount: num
 
 async function loadLocalIndex() {
   localIndexPromise ??= fetch(withBase('/docs-search-index.json'))
-    .then((response) => (response.ok ? response.json() : []))
+    .then((response) => {
+      if (!response.ok) {
+        localIndexPromise = null
+        return []
+      }
+
+      return response.json()
+    })
     .then((payload) => (Array.isArray(payload) ? (payload as DocsIndexRecord[]) : []))
     .catch((error) => {
+      localIndexPromise = null
       console.warn('Failed to load local docs search index.', error)
       return []
     })
@@ -519,8 +539,8 @@ onUnmounted(() => {
                 @click="closeSearch"
               >
                 <span class="ov-docs-search-result-title">{{ result.title }}</span>
-                <span v-if="cleanSearchSnippet(result.snippet)" class="ov-docs-search-result-snippet">
-                  {{ cleanSearchSnippet(result.snippet) }}
+                <span v-if="result.cleanedSnippet" class="ov-docs-search-result-snippet">
+                  {{ result.cleanedSnippet }}
                 </span>
                 <span class="ov-docs-search-result-path">{{ result.relativePath }}</span>
               </a>

--- a/docs/.vitepress/theme/OpenVikingSearch.vue
+++ b/docs/.vitepress/theme/OpenVikingSearch.vue
@@ -1,0 +1,474 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { withBase } from 'vitepress'
+
+type SearchMode = 'semantic' | 'keyword' | 'file'
+type SearchLocale = 'en' | 'zh'
+
+type DocsIndexRecord = {
+  locale: SearchLocale
+  path: string
+  text: string
+  title: string
+  url: string
+}
+
+type DocsSearchResult = {
+  line?: number | null
+  mode?: SearchMode
+  relativePath?: string
+  score?: number | null
+  snippet?: string
+  title?: string
+  uri?: string
+  url?: string
+}
+
+type RemoteSearchFailureReason = 'rate_limited' | 'timeout' | 'unavailable'
+
+type RemoteSearchResponse =
+  | { ok: true; results: DocsSearchResult[] }
+  | { ok: false; reason: RemoteSearchFailureReason }
+
+const PRODUCTION_SEARCH_URL = 'https://openviking.ai/studio/gateway/docs/search'
+const SEARCH_LIMIT = 8
+const LOCAL_SEARCH_DEBOUNCE_MS = 120
+const REMOTE_SEARCH_DEBOUNCE_MS = 700
+const REMOTE_SEARCH_TIMEOUT_MS = 5000
+
+const modes: { command: string; label: string; placeholder: string; value: SearchMode }[] = [
+  {
+    command: '/find',
+    label: 'Semantic',
+    placeholder: 'Ask a question about the docs',
+    value: 'semantic'
+  },
+  {
+    command: '/grep',
+    label: 'Keyword',
+    placeholder: 'Search exact words in the docs',
+    value: 'keyword'
+  },
+  {
+    command: '/glob',
+    label: 'File',
+    placeholder: 'Find docs by path or filename',
+    value: 'file'
+  }
+]
+
+const inputRef = ref<HTMLInputElement | null>(null)
+const isOpen = ref(false)
+const isMounted = ref(false)
+const isLoading = ref(false)
+const isModeMenuOpen = ref(false)
+const mode = ref<SearchMode>('semantic')
+const query = ref('')
+const results = ref<DocsSearchResult[]>([])
+const notice = ref('')
+
+let debounceTimer: ReturnType<typeof window.setTimeout> | null = null
+let searchSequence = 0
+let localIndexPromise: Promise<DocsIndexRecord[]> | null = null
+
+const trimmedQuery = computed(() => query.value.trim())
+const activeMode = computed(() => modes.find((item) => item.value === mode.value) ?? modes[0])
+
+function docsLocale(): SearchLocale {
+  return window.location.pathname.startsWith('/zh/') ? 'zh' : 'en'
+}
+
+function searchEndpoint(): string {
+  return PRODUCTION_SEARCH_URL
+}
+
+function openSearch() {
+  isOpen.value = true
+  void nextTick(() => inputRef.value?.focus())
+  scheduleSearch()
+}
+
+function closeSearch() {
+  isOpen.value = false
+  isModeMenuOpen.value = false
+}
+
+function toggleModeMenu() {
+  isModeMenuOpen.value = !isModeMenuOpen.value
+}
+
+function selectMode(value: SearchMode) {
+  mode.value = value
+  isModeMenuOpen.value = false
+  void nextTick(() => inputRef.value?.focus())
+}
+
+function shouldIgnoreShortcut(event: KeyboardEvent) {
+  const target = event.target
+  if (!(target instanceof HTMLElement)) return false
+
+  const tagName = target.tagName.toLowerCase()
+  return target.isContentEditable || ['input', 'textarea', 'select'].includes(tagName)
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && isModeMenuOpen.value) {
+    isModeMenuOpen.value = false
+    return
+  }
+
+  if (event.key === 'Escape' && isOpen.value) {
+    closeSearch()
+    return
+  }
+
+  const opensWithSlash = event.key === '/' && !shouldIgnoreShortcut(event)
+  const opensWithK = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)
+  if (!opensWithSlash && !opensWithK) return
+
+  event.preventDefault()
+  openSearch()
+}
+
+function scheduleSearch() {
+  if (debounceTimer) {
+    window.clearTimeout(debounceTimer)
+  }
+
+  const delay = searchEndpoint() ? REMOTE_SEARCH_DEBOUNCE_MS : LOCAL_SEARCH_DEBOUNCE_MS
+  debounceTimer = window.setTimeout(() => {
+    void runSearch()
+  }, delay)
+}
+
+async function runSearch() {
+  const currentQuery = trimmedQuery.value
+  const currentSequence = ++searchSequence
+  notice.value = ''
+
+  if (!currentQuery) {
+    results.value = []
+    isLoading.value = false
+    return
+  }
+
+  isLoading.value = true
+
+  try {
+    const endpoint = searchEndpoint()
+    const remoteResponse = endpoint
+      ? await fetchRemoteResults(endpoint, currentQuery, mode.value, docsLocale())
+      : null
+
+    if (currentSequence !== searchSequence) return
+
+    if (remoteResponse?.ok) {
+      results.value = remoteResponse.results
+      return
+    }
+
+    const localResults = await searchLocalIndex(currentQuery, mode.value, docsLocale())
+    if (currentSequence !== searchSequence) return
+
+    results.value = localResults
+    if (remoteResponse && !remoteResponse.ok) {
+      notice.value = fallbackNotice(remoteResponse.reason, localResults.length)
+    }
+  } finally {
+    if (currentSequence === searchSequence) {
+      isLoading.value = false
+    }
+  }
+}
+
+async function fetchRemoteResults(
+  endpoint: string,
+  searchQuery: string,
+  searchMode: SearchMode,
+  locale: SearchLocale
+) {
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), REMOTE_SEARCH_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        limit: SEARCH_LIMIT,
+        locale,
+        mode: searchMode,
+        query: searchQuery
+      }),
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST',
+      signal: controller.signal
+    })
+
+    if (response.status === 429) {
+      return { ok: false, reason: 'rate_limited' } satisfies RemoteSearchResponse
+    }
+    if (!response.ok) {
+      return { ok: false, reason: 'unavailable' } satisfies RemoteSearchResponse
+    }
+
+    const payload = (await response.json()) as { results?: DocsSearchResult[] }
+    return {
+      ok: true,
+      results: Array.isArray(payload.results) ? payload.results : []
+    } satisfies RemoteSearchResponse
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && error.name === 'AbortError'
+    return {
+      ok: false,
+      reason: isTimeout ? 'timeout' : 'unavailable'
+    } satisfies RemoteSearchResponse
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}
+
+function fallbackNotice(reason: RemoteSearchFailureReason, localResultCount: number) {
+  const prefix =
+    reason === 'rate_limited'
+      ? 'OpenViking search is rate limited.'
+      : reason === 'timeout'
+        ? 'OpenViking search timed out.'
+        : 'OpenViking search is unavailable.'
+
+  return localResultCount > 0
+    ? `${prefix} Showing local docs results.`
+    : `${prefix} No local results found.`
+}
+
+async function loadLocalIndex() {
+  localIndexPromise ??= fetch(withBase('/docs-search-index.json'))
+    .then((response) => (response.ok ? response.json() : []))
+    .then((payload) => (Array.isArray(payload) ? (payload as DocsIndexRecord[]) : []))
+    .catch(() => [])
+
+  return localIndexPromise
+}
+
+async function searchLocalIndex(
+  searchQuery: string,
+  searchMode: SearchMode,
+  locale: SearchLocale
+) {
+  const index = await loadLocalIndex()
+  const normalizedQuery = searchQuery.toLowerCase()
+
+  return index
+    .filter((item) => item.locale === locale)
+    .map((item) => localScore(item, normalizedQuery, searchMode))
+    .filter((item): item is DocsSearchResult & { score: number } => item.score > 0)
+    .sort((a, b) => b.score - a.score || String(a.title).localeCompare(String(b.title)))
+    .slice(0, SEARCH_LIMIT)
+}
+
+function localScore(record: DocsIndexRecord, normalizedQuery: string, searchMode: SearchMode) {
+  const title = record.title.toLowerCase()
+  const path = record.path.toLowerCase()
+  const text = record.text.toLowerCase()
+  const fileMode = searchMode === 'file'
+  const titleMatch = title.includes(normalizedQuery)
+  const pathMatch = path.includes(normalizedQuery)
+  const textMatch = !fileMode && text.includes(normalizedQuery)
+  const score = (titleMatch ? 5 : 0) + (pathMatch ? 3 : 0) + (textMatch ? 1 : 0)
+
+  return {
+    mode: searchMode,
+    relativePath: record.path,
+    score,
+    snippet: fileMode
+      ? record.path
+      : localSnippet(record.text, normalizedQuery),
+    title: record.title,
+    url: record.url
+  }
+}
+
+function localSnippet(text: string, normalizedQuery: string) {
+  const normalizedText = text.toLowerCase()
+  const index = normalizedText.indexOf(normalizedQuery)
+  if (index < 0) return text.slice(0, 180)
+
+  const start = Math.max(0, index - 70)
+  const end = Math.min(text.length, index + normalizedQuery.length + 110)
+  const prefix = start > 0 ? '...' : ''
+  const suffix = end < text.length ? '...' : ''
+  return `${prefix}${text.slice(start, end)}${suffix}`
+}
+
+function cleanSearchSnippet(value: string | undefined) {
+  if (!value) return ''
+
+  return value
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/(^|[\s([{"'（【])\*([^*\n]+)\*(?=$|[\s.,;:!?，。；：！？、）】\])}"'])/g, '$1$2')
+    .replace(/(^|[\s([{"'（【])_([^_\n]+)_(?=$|[\s.,;:!?，。；：！？、）】\])}"'])/g, '$1$2')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/^\s*\|?[\s:-]+\|[\s|:-]*$/gm, '')
+    .split('\n')
+    .map((line) => line
+      .replace(/^\s*\|\s*/, '')
+      .replace(/\s*\|\s*$/, '')
+      .replace(/\s*\|\s*/g, ' - ')
+      .trim())
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function resultUrl(result: DocsSearchResult) {
+  const url =
+    result.url ||
+    routeFromRelativePath(result.relativePath, docsLocale()) ||
+    routeFromVikingUri(result.uri) ||
+    '/'
+
+  if (/^https?:\/\//.test(url)) return url
+  return withBase(url)
+}
+
+function routeFromRelativePath(path: string | undefined, locale: SearchLocale) {
+  if (!path) return ''
+
+  const normalizedPath = path.replace(/^\/+/, '').replace(/^docs\//, '')
+  const localeMatch = normalizedPath.match(/^(en|zh)\/(.+)$/)
+  if (localeMatch) {
+    return `/${localeMatch[1]}/${stripMarkdownExtension(localeMatch[2])}`
+  }
+
+  return `/${locale}/${stripMarkdownExtension(normalizedPath)}`
+}
+
+function routeFromVikingUri(uri: string | undefined) {
+  if (!uri) return ''
+
+  const match = uri.match(/\/docs\/(en|zh)\/(.+)$/)
+  if (!match) return ''
+
+  return `/${match[1]}/${stripMarkdownExtension(match[2])}`
+}
+
+function stripMarkdownExtension(path: string) {
+  return path.replace(/(?:\/index)?\.mdx?$/, '')
+}
+
+watch([query, mode], scheduleSearch)
+
+onMounted(() => {
+  isMounted.value = true
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+  if (debounceTimer) {
+    window.clearTimeout(debounceTimer)
+  }
+})
+</script>
+
+<template>
+  <div class="ov-docs-search">
+    <button class="ov-docs-search-trigger" type="button" @click="openSearch">
+      <span>Search docs</span>
+      <kbd>Ctrl K</kbd>
+    </button>
+
+    <Teleport v-if="isMounted && isOpen" to="body">
+      <div class="ov-docs-search-backdrop" @click.self="closeSearch">
+        <section
+          aria-label="OpenViking docs search"
+          class="ov-docs-search-dialog"
+          role="dialog"
+        >
+          <div class="ov-docs-search-bar">
+            <div class="ov-docs-search-mode-picker">
+              <button
+                aria-controls="ov-docs-search-mode-menu"
+                :aria-expanded="isModeMenuOpen"
+                aria-haspopup="listbox"
+                aria-label="Search mode"
+                class="ov-docs-search-mode-button"
+                type="button"
+                @click="toggleModeMenu"
+              >
+                <span>{{ activeMode.label }}</span>
+                <span aria-hidden="true" class="ov-docs-search-mode-caret"></span>
+              </button>
+
+              <div
+                v-if="isModeMenuOpen"
+                id="ov-docs-search-mode-menu"
+                aria-label="Search mode options"
+                class="ov-docs-search-mode-menu"
+                role="listbox"
+              >
+                <button
+                  v-for="item in modes"
+                  :key="item.value"
+                  :aria-selected="item.value === mode"
+                  class="ov-docs-search-mode-option"
+                  :class="{ 'is-selected': item.value === mode }"
+                  role="option"
+                  type="button"
+                  @click="selectMode(item.value)"
+                >
+                  <span>{{ item.label }}</span>
+                  <code>{{ item.command }}</code>
+                </button>
+              </div>
+            </div>
+
+            <input
+              ref="inputRef"
+              v-model="query"
+              aria-label="Search OpenViking docs"
+              class="ov-docs-search-input"
+              :placeholder="activeMode.placeholder"
+              type="search"
+              @focus="isModeMenuOpen = false"
+            >
+          </div>
+
+          <p v-if="notice" class="ov-docs-search-notice">{{ notice }}</p>
+
+          <div class="ov-docs-search-results">
+            <p v-if="isLoading" class="ov-docs-search-empty">Searching...</p>
+            <p v-else-if="trimmedQuery && results.length === 0" class="ov-docs-search-empty">
+              No results found.
+            </p>
+            <p v-else-if="!trimmedQuery" class="ov-docs-search-empty">
+              Type a query to search the current language docs.
+            </p>
+            <template v-else>
+              <a
+                v-for="result in results"
+                :key="`${result.url}-${result.line ?? ''}`"
+                class="ov-docs-search-result"
+                :href="resultUrl(result)"
+                @click="closeSearch"
+              >
+                <span class="ov-docs-search-result-title">{{ result.title }}</span>
+                <span v-if="cleanSearchSnippet(result.snippet)" class="ov-docs-search-result-snippet">
+                  {{ cleanSearchSnippet(result.snippet) }}
+                </span>
+                <span class="ov-docs-search-result-path">{{ result.relativePath }}</span>
+              </a>
+            </template>
+          </div>
+        </section>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -96,12 +96,16 @@
   color: var(--vp-c-text-1);
 }
 
-.ov-docs-search-trigger span {
+.ov-docs-search-trigger-label {
   flex: 1;
   overflow: hidden;
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.ov-docs-search-trigger-compact {
+  display: none;
 }
 
 .ov-docs-search-trigger kbd {
@@ -299,22 +303,22 @@
 
 @media (max-width: 767px) {
   .ov-docs-search-trigger {
-    min-width: 44px;
-    width: 44px;
-    padding: 0;
+    min-width: 72px;
+    width: 72px;
+    padding: 0 12px;
     justify-content: center;
   }
 
-  .ov-docs-search-trigger span {
+  .ov-docs-search-trigger-label,
+  .ov-docs-search-trigger kbd {
     display: none;
   }
 
-  .ov-docs-search-trigger kbd {
-    min-width: auto;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    font-size: 12px;
+  .ov-docs-search-trigger-compact {
+    display: inline;
+    color: var(--vp-c-text-2);
+    font-size: 13px;
+    font-weight: 600;
   }
 
   .ov-docs-search-backdrop {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -63,3 +63,265 @@
     display: none !important;
   }
 }
+
+.VPNavBarSearch {
+  display: none !important;
+}
+
+.ov-docs-search {
+  display: flex;
+  align-items: center;
+  margin-right: 12px;
+}
+
+.ov-docs-search-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 40px;
+  min-width: 190px;
+  max-width: 260px;
+  padding: 0 10px 0 14px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-alt);
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ov-docs-search-trigger:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-text-1);
+}
+
+.ov-docs-search-trigger span {
+  flex: 1;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ov-docs-search-trigger kbd {
+  flex: 0 0 auto;
+  min-width: 46px;
+  padding: 4px 6px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.ov-docs-search-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 84px 20px 24px;
+  background: rgba(0, 0, 0, 0.36);
+}
+
+.ov-docs-search-dialog {
+  width: min(720px, 100%);
+  max-height: min(720px, calc(100vh - 108px));
+  overflow: visible;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.28);
+}
+
+.ov-docs-search-bar {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr);
+  gap: 10px;
+  padding: 14px;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.ov-docs-search-mode-button,
+.ov-docs-search-input {
+  height: 42px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font: inherit;
+}
+
+.ov-docs-search-mode-picker {
+  position: relative;
+}
+
+.ov-docs-search-mode-button {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.ov-docs-search-mode-button span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ov-docs-search-mode-caret {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  opacity: 0.7;
+  transform: translateY(-2px) rotate(45deg);
+}
+
+.ov-docs-search-mode-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 2;
+  width: 210px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-elv);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+
+.ov-docs-search-mode-option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 11px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--vp-c-text-1);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.ov-docs-search-mode-option:hover,
+.ov-docs-search-mode-option.is-selected {
+  background: var(--vp-c-bg-soft);
+}
+
+.ov-docs-search-mode-option code {
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+}
+
+.ov-docs-search-input {
+  min-width: 0;
+  padding: 0 13px;
+}
+
+.ov-docs-search-input:focus,
+.ov-docs-search-mode-button:focus {
+  border-color: var(--vp-c-brand-1);
+  outline: 2px solid var(--vp-c-brand-soft);
+}
+
+.ov-docs-search-notice {
+  margin: 0;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+}
+
+.ov-docs-search-results {
+  max-height: min(560px, calc(100vh - 218px));
+  overflow: auto;
+  padding: 8px;
+}
+
+.ov-docs-search-empty {
+  margin: 0;
+  padding: 34px 18px;
+  color: var(--vp-c-text-2);
+  text-align: center;
+}
+
+.ov-docs-search-result {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border-radius: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.ov-docs-search-result:hover {
+  background: var(--vp-c-bg-soft);
+}
+
+.ov-docs-search-result-title {
+  color: var(--vp-c-text-1);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.ov-docs-search-result-snippet {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.ov-docs-search-result-path {
+  overflow: hidden;
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  .ov-docs-search-trigger {
+    min-width: 44px;
+    width: 44px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .ov-docs-search-trigger span {
+    display: none;
+  }
+
+  .ov-docs-search-trigger kbd {
+    min-width: auto;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    font-size: 12px;
+  }
+
+  .ov-docs-search-backdrop {
+    padding: 58px 12px 16px;
+  }
+
+  .ov-docs-search-bar {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import CopyMarkdownButton from './CopyMarkdownButton.vue'
 import LlmsTxtLink from './LlmsTxtLink.vue'
+import OpenVikingSearch from './OpenVikingSearch.vue'
 import './custom.css'
 
 type OpenVikingPreference = {
@@ -300,7 +301,8 @@ export default {
   Layout() {
     return h(DefaultTheme.Layout, null, {
       'doc-before': () => h(CopyMarkdownButton),
-      'doc-footer-before': () => h(LlmsTxtLink)
+      'doc-footer-before': () => h(LlmsTxtLink),
+      'nav-bar-content-before': () => h(OpenVikingSearch)
     })
   }
 }


### PR DESCRIPTION
## Description

Adds an OpenViking-powered search experience to the VitePress documentation site. The docs navbar search now opens a custom modal that can query the hosted OpenViking docs gateway for semantic, keyword, and file/path search, while keeping a generated local docs index fallback for gateway failures.

The gateway endpoint is a public, non-secret URL and is intentionally hardcoded for the official docs site:

```text
https://openviking.ai/studio/gateway/docs/search
```

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Replaces the default VitePress navbar search with an OpenViking docs search component.
- Adds three search modes: Semantic (`/find`), Keyword (`/grep`), and File (`/glob`).
- Calls the public docs gateway endpoint with the current docs locale and an 8-result limit.
- Adds a 1s remote-search debounce and 10s remote timeout to reduce unnecessary gateway traffic while avoiding premature semantic-search timeouts.
- Cancels pending debounced searches and superseded in-flight remote searches when the query changes, the modal closes, or the component unmounts.
- Falls back to the generated local docs search index when the gateway is unavailable, times out, or returns rate limit responses.
- Retries the local docs index on later searches if the first fallback index request fails or returns a non-OK response.
- Detects the current docs locale after stripping the configured VitePress base path, so `DOCS_BASE` deployments keep sending the correct locale.
- Generates `docs-search-index.json` during the VitePress build for local fallback search.
- Preserves useful punctuation in fallback-index text extraction while still removing Markdown formatting noise.
- Resolves result links from explicit URLs, relative paths, or OpenViking docs URIs, and skips unresolvable links instead of sending users to `/`.
- Precomputes cleaned result snippets before rendering each result.
- Adds modal accessibility improvements: `aria-modal`, focus restoration to the search trigger, and keyboard focus wrapping inside the dialog.
- Adds responsive styles for the custom search trigger, modal, mode dropdown, results, and fallback notices.
- Uses a compact `Search` trigger label on narrow screens instead of squeezing the full shortcut hint into a small button.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed locally:

- `git diff --check`
- `npm run docs:build` from `docs/`
- `DOCS_BASE=/docs/ npm run docs:build` from `docs/`
- Browser smoke test on `http://localhost:5178/`:
  - opened the docs homepage
  - opened the custom search modal by click and keyboard shortcut
  - searched `docker` in Semantic mode
  - confirmed the local fallback path renders usable results when the production gateway does not allow the localhost origin
  - confirmed rendered result links resolve to documentation paths rather than `/`
  - confirmed browser console reported no errors or warnings during the smoke test
- Latest polish verification:
  - `git diff --check`
  - `npm run docs:build` from `docs/`

Notes:

- VitePress currently emits existing syntax-highlight fallback warnings for `promql` and `caddyfile`; the build still completes successfully.
- No repository unit-test harness exists for this VitePress theme component, so this PR is verified through docs build plus rendered browser smoke testing.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The search endpoint is intentionally a public frontend URL, not a secret. Because the docs site is statically built, environment variables would still be baked into the generated JavaScript and would require a rebuild/redeploy for any URL change. Keeping the official endpoint in source keeps the deployed behavior explicit.
