### PR TITLE
fix(storage): avoid invalid vector migration output field

### DIFF
--- a/openviking/storage/vector_migration.py
+++ b/openviking/storage/vector_migration.py
@@ -32,7 +32,6 @@ VECTOR_MIGRATION_OUTPUT_FIELDS = [
     "abstract",
     "account_id",
     "owner_user_id",
-    "owner_space",
 ]
 
 _VECTOR_PAYLOAD_FIELDS = ("vector", "sparse_vector")
@@ -112,9 +111,15 @@ async def _records_in_scope(
     uri: str,
     recursive: bool,
 ) -> list[dict[str, Any]]:
-    filters = [Eq("uri", uri), Contains("uri", uri + "#")]
+    filters = [Eq("uri", uri)]
     if recursive:
         filters.append(PathScope("uri", uri, depth=-1))
+    if getattr(vector_store, "mode", None) == "volcengine":
+        parent = VikingURI(uri).parent
+        if parent is not None and parent.uri != "viking://":
+            filters.append(PathScope("uri", parent.uri, depth=1))
+    else:
+        filters.append(Contains("uri", uri + "#"))
 
     ctx = _root_ctx(account_id)
     records = await vector_store.filter(


### PR DESCRIPTION
## Description

Fix vector migration reads against the VolcEngine backend by avoiding an invalid legacy output field and covering VolcEngine path-scope lookup behavior for chunk records.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Removed `owner_space` from vector migration output fields because it is not part of the current context collection schema.
- Kept vector copy/delete reads using `owner_user_id`, which is the current owner field used by the schema.
- Added a VolcEngine-specific parent path-scope lookup so migration can still find in-file chunk vectors that are validated by local URI scope filtering.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

` .venv/bin/python -m pytest tests/storage/test_vector_migration.py -q `

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The default `pytest` command in the user-level Python environment failed before collection due to an incompatible `pydantic` / `pydantic-core` install, so validation was run through the repository virtualenv.
