### PR TITLE
fix(openclaw): merge runtime query config updates

### DIFF
--- a/examples/openclaw-plugin/query-config.ts
+++ b/examples/openclaw-plugin/query-config.ts
@@ -231,7 +231,13 @@ export class RuntimeQueryConfigStore {
     const { params, warnings } = normalizeRuntimeQueryParams(patch);
     const key = this.keyForScope(scope, ctx);
     const bucket = scope === "claw" ? this.data.claws : this.data.sessions;
-    bucket[key] = { params, updatedAt: Date.now(), updatedBy: "command", peerId: ctx.peerId };
+    const previous = bucket[key];
+    bucket[key] = {
+      params: { ...(previous?.params ?? {}), ...params },
+      updatedAt: Date.now(),
+      updatedBy: "command",
+      peerId: ctx.peerId,
+    };
     this.data.updatedAt = Date.now();
     await this.persist();
     return { warnings };

--- a/examples/openclaw-plugin/tests/ut/query-config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/query-config.test.ts
@@ -175,4 +175,19 @@ describe("RuntimeQueryConfigStore", () => {
     expect(afterReset.recallLimit).toBe(6);
     expect(afterReset.scoreThreshold).toBe(0.15);
   });
+
+  it("merges incremental set calls within the same runtime scope", async () => {
+    const cfg = memoryOpenVikingConfigSchema.parse({ recallLimit: 6, recallScoreThreshold: 0.15 });
+    const store = RuntimeQueryConfigStore.createInMemory(cfg);
+    const ctx = { peerId: "assistant-a", sessionId: "s1" };
+
+    await store.set("session", ctx, { recallLimit: 2 });
+    await store.set("session", ctx, { scoreThreshold: 0.4 });
+
+    const effective = await store.getEffective(ctx);
+    expect(effective.recallLimit).toBe(2);
+    expect(effective.scoreThreshold).toBe(0.4);
+    expect(effective.sources.recallLimit).toBe("session");
+    expect(effective.sources.scoreThreshold).toBe("session");
+  });
 });


### PR DESCRIPTION
## Summary

- Preserve existing runtime query config fields when /ov-query-config set updates only part of a scope.
- Add a regression test covering incremental session-scope updates.

## Why

Runtime query config is applied field-by-field, and operators naturally tune it incrementally. Before this change, a second set command such as --scoreThreshold replaced the whole scoped record and silently dropped earlier fields like --recallLimit or --candidateLimit.

I checked the open modular-runtime refactor PRs (#2656/#2657); they still carry the same replacement behavior, so this is a narrow bug fix rather than a duplicate.

## Tests

- npm test -- tests/ut/query-config.test.ts
- npm test -- tests/ut/tools.test.ts
- npm test -- tests/ut/context-engine-assemble.test.ts
- npm run typecheck
