### PR TITLE
fix(ragfs): ignore legacy task records during shape probe

### DIFF
--- a/crates/ragfs/src/core/builder.rs
+++ b/crates/ragfs/src/core/builder.rs
@@ -230,4 +230,31 @@ mod tests {
             other => panic!("unexpected error: {other:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn encrypted_mount_ignores_legacy_plaintext_task_records() {
+        let dir = TempDir::new().unwrap();
+        let account_task_dir = dir.path().join("default/_system/tasks/default");
+        let system_task_dir = dir.path().join("_system/tasks/root");
+        fs::create_dir_all(&account_task_dir).unwrap();
+        fs::create_dir_all(&system_task_dir).unwrap();
+        fs::write(
+            account_task_dir.join("00f676a8-b8cf-4b1a-a0a9-fe46ca3324d3.json"),
+            br#"{"task_id":"account-task"}"#,
+        )
+        .unwrap();
+        fs::write(
+            system_task_dir.join("00f676a8-b8cf-4b1a-a0a9-fe46ca3324d4.json"),
+            br#"{"task_id":"system-task"}"#,
+        )
+        .unwrap();
+
+        let stack = build_default_stack(enc_config()).await;
+        mount_local(&stack, "/local", dir.path().to_str().unwrap())
+            .await
+            .unwrap();
+
+        let manifest = fs::read(dir.path().join("backend_meta.json")).unwrap();
+        assert!(crypto::is_encrypted(&manifest));
+    }
 }

--- a/crates/ragfs/src/shape/probe.rs
+++ b/crates/ragfs/src/shape/probe.rs
@@ -20,6 +20,17 @@ fn normalize_shape_path(path: &str) -> String {
     normalized
 }
 
+fn is_persistent_task_record_path(path: &str) -> bool {
+    let parts: Vec<&str> = path.trim_matches('/').split('/').collect();
+    if let ["_system", "tasks", user_id, _record, ..] = parts.as_slice() {
+        return !user_id.is_empty();
+    }
+    if let [account_id, "_system", "tasks", user_id, _record, ..] = parts.as_slice() {
+        return !account_id.is_empty() && !user_id.is_empty();
+    }
+    false
+}
+
 /// Read the raw guard-file bytes from the backend root.
 async fn read_shape_guard_raw(raw_fs: &Arc<dyn FileSystem>) -> Result<Option<Vec<u8>>> {
     match raw_fs.read(SHAPE_MANIFEST_PATH, 0, 0).await {
@@ -106,7 +117,7 @@ pub async fn detect_legacy_shape(raw_fs: &Arc<dyn FileSystem>) -> Result<Option<
         }
 
         let normalized = normalize_shape_path(&entry.path);
-        if normalized == SHAPE_MANIFEST_PATH {
+        if normalized == SHAPE_MANIFEST_PATH || is_persistent_task_record_path(&normalized) {
             continue;
         }
 


### PR DESCRIPTION
## Description

Allow encrypted RAGFS backends to mount when legacy plaintext task tracker records are present under `_system/tasks`, while keeping mixed-shape validation for normal backend data.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Skip persisted task record paths during legacy backend shape detection.
- Keep shape validation active for regular plaintext files so mixed encrypted/plaintext backend data is still rejected.
- Add a regression test covering account-scoped and system task record paths during encrypted localfs mount.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command:

```bash
cargo test -p ragfs encrypted_mount
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This is intentionally scoped to startup storage-shape probing. It does not bypass normal AGFS reads or writes, so newly written task records still go through the configured encryption layer.
