### PR TITLE
docs(hermes): update OpenViking peer identity wording

### DIFF
--- a/docs/en/agent-integrations/05-hermes.md
+++ b/docs/en/agent-integrations/05-hermes.md
@@ -14,7 +14,7 @@ The wizard prompts for:
 
 - **OpenViking server URL** — your self-hosted server (default `http://127.0.0.1:1933`) or OpenViking Service (VolcEngine Cloud)
 - **API key** — leave blank for local dev mode
-- **Tenant account / user / agent IDs** — for multi-tenant deployments
+- **Tenant account / user / peer IDs** — for multi-tenant deployments. Legacy `agent_id` settings map to the request actor peer during migration.
 
 Configuration is saved to Hermes's `config.yaml` and `.env` files.
 

--- a/docs/zh/agent-integrations/05-hermes.md
+++ b/docs/zh/agent-integrations/05-hermes.md
@@ -14,7 +14,7 @@ hermes memory setup
 
 - **OpenViking 服务 URL** — 自托管服务器（默认 `http://127.0.0.1:1933`）或 OpenViking Service（火山引擎云）
 - **API Key** — 本地开发模式留空
-- **租户 account / user / agent ID** — 多租户部署时使用
+- **租户 account / user / peer ID** — 多租户部署时使用。迁移期的旧 `agent_id` 配置会映射为请求的 actor peer。
 
 配置保存在 Hermes 的 `config.yaml` 和 `.env` 文件中。
 


### PR DESCRIPTION
## Summary
- update Hermes integration docs from account/user/agent IDs to account/user/peer IDs
- note that legacy `agent_id` settings map to the request actor peer during migration
- keep the English and Chinese docs aligned

## Rationale
OpenViking's user/peer model makes `agent_id` legacy terminology. The Hermes integration page was still presenting account/user/agent IDs as the current multi-tenant identity shape, which can send new integrations toward deprecated fields.

## Tests
- `git diff --check`
