### PR TITLE
fix(parse): tighten Feishu URL host matching

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -273,12 +273,11 @@ class FeishuAccessor(DataAccessor):
     def _is_feishu_url(url: str) -> bool:
         """Check if URL is a Feishu/Lark cloud document."""
         parsed = urlparse(url)
-        host = parsed.hostname or ""
+        host = (parsed.hostname or "").lower().rstrip(".")
         path = parsed.path
-        is_feishu_domain = (
-            host.endswith(".feishu.cn")
-            or host.endswith(".larksuite.com")
-            or host.endswith(".larkoffice.com")
+        is_feishu_domain = any(
+            host == allowed_host or host.endswith(f".{allowed_host}")
+            for allowed_host in ("feishu.cn", "larksuite.com", "larkoffice.com")
         )
         has_doc_path = any(
             path == f"/{t}" or path.startswith(f"/{t}/") for t in ("docx", "wiki", "sheets", "base")


### PR DESCRIPTION
## Description

Tightens Feishu/Lark URL host matching in `FeishuAccessor` so only the exact allowed domains or their subdomains are accepted.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Normalize Feishu/Lark URL hostnames by lowercasing and trimming trailing dots before matching.
- Require hosts to be exactly `feishu.cn`, `larksuite.com`, or `larkoffice.com`, or a subdomain of one of those hosts.
- Keep existing document path detection unchanged for `docx`, `wiki`, `sheets`, and `base` paths.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command run:

```bash
.venv/bin/python -m pytest tests/parse/test_feishu_parser.py::TestIsFeishuUrl -q
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Pre-commit hooks ran during commit and passed `ruff (legacy alias)` and `ruff format`.
