### PR TITLE
fix(task): unify task tracker encryption binding

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -6,13 +6,10 @@ OpenViking Service Core.
 Main service class that composes all sub-services and manages infrastructure lifecycle.
 """
 
-import asyncio
 import os
-from threading import Thread
 from typing import TYPE_CHECKING, Any, Optional
 
 from openviking.core.directories import DirectoryInitializer
-from openviking.crypto.config import bootstrap_encryption
 from openviking.privacy import UserPrivacyConfigService
 from openviking.resource.watch_scheduler import WatchScheduler
 from openviking.server.identity import RequestContext, Role
@@ -32,7 +29,10 @@ from openviking.storage.index_consistency import check_index_consistency
 from openviking.storage.queuefs.queue_manager import QueueManager, init_queue_manager
 from openviking.storage.transaction import LockManager, init_lock_manager
 from openviking.storage.viking_fs import VikingFS, init_viking_fs
-from openviking.utils.agfs_utils import resolve_queuefs_mount_point
+from openviking.utils.agfs_utils import (
+    build_runtime_ragfs_binding_config,
+    resolve_queuefs_mount_point,
+)
 from openviking.utils.resource_processor import ResourceProcessor
 from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.exceptions import NotInitializedError
@@ -46,31 +46,6 @@ logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from openviking.session.compressor_v2 import SessionCompressorV2
-
-
-def _run_coro_blocking(coro: Any) -> Any:
-    """Run an async coroutine from sync startup code, even if an event loop is already running."""
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-
-    result: list[Any] = []
-    error: list[BaseException] = []
-
-    def _runner() -> None:
-        """Execute the coroutine in an isolated event loop on a helper thread."""
-        try:
-            result.append(asyncio.run(coro))
-        except BaseException as exc:
-            error.append(exc)
-
-    thread = Thread(target=_runner, daemon=True)
-    thread.start()
-    thread.join()
-    if error:
-        raise error[0]
-    return result[0] if result else None
 
 
 class OpenVikingService:
@@ -203,22 +178,8 @@ class OpenVikingService:
 
     def _build_ragfs_binding_config(self) -> Any:
         """Build the single runtime binding config from OpenViking storage + encryption settings."""
-        from openviking.utils.agfs_utils import RagfsBindingConfig
-
-        full_config = self._config.to_dict()
-        self._encryptor = _run_coro_blocking(bootstrap_encryption(full_config))
-        if self._encryptor is None:
-            return RagfsBindingConfig(agfs=self._config.storage.agfs)
-
-        root_key = _run_coro_blocking(self._encryptor.provider.get_root_key())
-        if not isinstance(root_key, (bytes, bytearray)) or len(root_key) != 32:
-            raise RuntimeError("encryption root_key must be exactly 32 bytes")
-
-        return RagfsBindingConfig(
-            agfs=self._config.storage.agfs,
-            root_key=bytes(root_key),
-            provider_type=self._encryptor.provider_type,
-        )
+        binding_config, self._encryptor = build_runtime_ragfs_binding_config(self._config)
+        return binding_config
 
     def _ensure_data_dir_lock_acquired(self) -> None:
         """Acquire the process-level data directory lock once for this service instance."""

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -523,9 +523,10 @@ class TaskTracker:
 
 def _build_default_task_tracker() -> TaskTracker:
     """Build the default persistent tracker from the active storage config."""
-    from openviking.utils.agfs_utils import RagfsBindingConfig, create_agfs_client
+    from openviking.utils.agfs_utils import build_runtime_ragfs_binding_config, create_agfs_client
     from openviking_cli.utils.config import get_openviking_config
 
     config = get_openviking_config()
-    agfs = create_agfs_client(RagfsBindingConfig(agfs=config.storage.agfs))
+    binding_config, _ = build_runtime_ragfs_binding_config(config)
+    agfs = create_agfs_client(binding_config)
     return config.storage.build_task_tracker(agfs)

--- a/openviking/utils/agfs_utils.py
+++ b/openviking/utils/agfs_utils.py
@@ -4,10 +4,12 @@
 RAGFS Client utilities for creating and configuring RAGFS clients.
 """
 
+import asyncio
 import multiprocessing
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Thread
 from typing import Any, Callable, Dict
 
 from openviking_cli.utils.config.config_loader import resolve_config_path
@@ -46,6 +48,72 @@ class RagfsBindingConfig:
             }
 
         return binding_config
+
+
+def _run_coro_blocking(coro: Any) -> Any:
+    """Run an async coroutine from sync startup code, even if an event loop is already running."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: list[Any] = []
+    error: list[BaseException] = []
+
+    def _runner() -> None:
+        try:
+            result.append(asyncio.run(coro))
+        except BaseException as exc:
+            error.append(exc)
+
+    thread = Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join()
+    if error:
+        raise error[0]
+    return result[0] if result else None
+
+
+def _dump_openviking_config(config: Any) -> Dict[str, Any]:
+    """Return a full OpenViking config dict for encryption bootstrap."""
+    if hasattr(config, "to_dict"):
+        dumped = config.to_dict()
+    elif hasattr(config, "model_dump"):
+        dumped = config.model_dump()
+    elif isinstance(config, dict):
+        dumped = config
+    else:
+        raise TypeError("OpenViking config must expose to_dict() or model_dump()")
+    if not isinstance(dumped, dict):
+        raise TypeError("OpenViking config dump must be a dictionary")
+    return dumped
+
+
+def build_runtime_ragfs_binding_config(config: Any) -> tuple[RagfsBindingConfig, Any | None]:
+    """Build the runtime AGFS binding config from storage and encryption settings."""
+    from openviking.crypto.config import bootstrap_encryption
+
+    storage = _get_config_value(config, "storage")
+    agfs_config = _get_config_value(storage, "agfs") if storage is not None else None
+    if agfs_config is None:
+        raise ValueError("OpenViking config storage.agfs is required")
+
+    encryptor = _run_coro_blocking(bootstrap_encryption(_dump_openviking_config(config)))
+    if encryptor is None:
+        return RagfsBindingConfig(agfs=agfs_config), None
+
+    root_key = _run_coro_blocking(encryptor.provider.get_root_key())
+    if not isinstance(root_key, (bytes, bytearray)) or len(root_key) != 32:
+        raise RuntimeError("encryption root_key must be exactly 32 bytes")
+
+    return (
+        RagfsBindingConfig(
+            agfs=agfs_config,
+            root_key=bytes(root_key),
+            provider_type=encryptor.provider_type,
+        ),
+        encryptor,
+    )
 
 
 def resolve_queuefs_mount_point(config: Any = None) -> str:

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -430,7 +430,7 @@ async def test_singleton_reset():
     assert t1 is not t2
 
 
-async def test_build_default_task_tracker_wraps_agfs_config_for_binding(monkeypatch):
+async def test_build_default_task_tracker_uses_runtime_encryption_binding(monkeypatch):
     captured = {}
     fake_agfs = object()
 
@@ -446,10 +446,28 @@ async def test_build_default_task_tracker_wraps_agfs_config_for_binding(monkeypa
         def __init__(self):
             self.storage = _FakeStorage()
 
+        def to_dict(self):
+            return {"encryption": {"enabled": True, "provider": "local"}}
+
+    class _FakeProvider:
+        async def get_root_key(self):
+            return b"t" * 32
+
+    class _FakeEncryptor:
+        provider_type = 9
+
+        def __init__(self):
+            self.provider = _FakeProvider()
+
+    async def _bootstrap(config):
+        assert config["encryption"]["enabled"] is True
+        return _FakeEncryptor()
+
     def _fake_create_agfs_client(config):
         captured["binding_config"] = config
         return fake_agfs
 
+    monkeypatch.setattr("openviking.crypto.config.bootstrap_encryption", _bootstrap)
     monkeypatch.setattr("openviking.utils.agfs_utils.create_agfs_client", _fake_create_agfs_client)
     monkeypatch.setattr(
         "openviking_cli.utils.config.get_openviking_config",
@@ -462,6 +480,10 @@ async def test_build_default_task_tracker_wraps_agfs_config_for_binding(monkeypa
     assert captured["build_arg"] is fake_agfs
     assert isinstance(captured["binding_config"], RagfsBindingConfig)
     assert isinstance(captured["binding_config"].agfs, AGFSConfig)
+    assert captured["binding_config"].to_binding_dict()["encryption"] == {
+        "root_key": b"t" * 32,
+        "provider_type": 9,
+    }
 
 
 async def test_persistent_store_cross_tracker_visibility():

--- a/tests/unit/service/test_core_encryption_startup.py
+++ b/tests/unit/service/test_core_encryption_startup.py
@@ -58,7 +58,7 @@ async def test_build_ragfs_binding_config_works_inside_running_event_loop(monkey
         assert config["encryption"]["enabled"] is True
         return _FakeEncryptor()
 
-    monkeypatch.setattr("openviking.service.core.bootstrap_encryption", _bootstrap)
+    monkeypatch.setattr("openviking.crypto.config.bootstrap_encryption", _bootstrap)
     service = OpenVikingService.__new__(OpenVikingService)
     service._config = _FakeConfig()
     service._encryptor = None
@@ -75,7 +75,7 @@ async def test_build_ragfs_binding_config_works_inside_running_event_loop(monkey
         "encryption": {
             "root_key": b"k" * 32,
             "provider_type": 1,
-        }
+        },
     }
     assert isinstance(service._encryptor, _FakeEncryptor)
 


### PR DESCRIPTION
## Description

修复 TaskTracker fallback 初始化路径的 AGFS 加密配置不一致问题。

此前正常服务启动路径会先根据完整 OpenViking 配置 bootstrap encryption，拿到 `root_key/provider_type` 后再创建带加密层的 AGFS client；但 `_build_default_task_tracker()` fallback 路径会直接用 `RagfsBindingConfig(agfs=config.storage.agfs)` 创建 AGFS client，没有携带加密信息。这样在开启加密的 workspace 中，task 持久化文件可能由不同路径以明文或密文写入，后续再用加密 AGFS 读写时就可能出现 `AES-GCM authentication failed`。

本 PR 将 runtime AGFS binding config 的构建收敛到同一个共享入口，确保 service 初始化和 task tracker fallback 都使用完整的 storage + encryption 配置。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 新增 `build_runtime_ragfs_binding_config(config)`，统一从完整 OpenViking 配置生成 `RagfsBindingConfig`，开启加密时会携带 `root_key/provider_type`。
- `OpenVikingService._build_ragfs_binding_config()` 改为复用共享入口，避免 service 和 fallback 各自维护一套 encryption bootstrap 逻辑。
- `_build_default_task_tracker()` 改为使用同一个 runtime binding config 创建 AGFS client，避免 task fallback 路径裸建未加密 client。
- 更新 task tracker 测试，覆盖加密开启时 fallback 会把 encryption config 传入 binding。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行过的命令：

```bash
.venv/bin/python -m ruff check openviking/utils/agfs_utils.py openviking/service/core.py openviking/service/task_tracker.py tests/test_task_tracker.py tests/unit/service/test_core_encryption_startup.py
.venv/bin/python -m pytest tests/test_task_tracker.py tests/unit/service/test_core_encryption_startup.py -q
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

这个修复会阻止后续 task 持久化继续出现明文/密文混写。对于已经由错误路径写出的历史 task 文件，如果运行时仍会扫描或读取到，可能需要单独清理 `_system/tasks` 下的旧记录。
