### PR TITLE
fix(ragfs): skip zero-byte files during legacy shape probe

### DIFF
--- a/crates/ragfs/src/shape/probe.rs
+++ b/crates/ragfs/src/shape/probe.rs
@@ -112,7 +112,10 @@ pub async fn detect_legacy_shape(raw_fs: &Arc<dyn FileSystem>) -> Result<Option<
     let mut detected: Option<StorageShape> = None;
 
     for entry in entries {
-        if entry.info.is_dir {
+        // Zero-byte files are a legacy plaintext artifact in the current implementation, but they
+        // do not carry enough signal to classify backend shape reliably. Skip them here instead of
+        // forcing a plaintext verdict during legacy shape inference.
+        if entry.info.is_dir || entry.info.size == 0 {
             continue;
         }
 


### PR DESCRIPTION
## Description

Skip zero-byte files during legacy backend shape probing so S3-backed mounts do not fail when the scanned prefix contains empty plaintext files such as newly created messages.jsonl
## Related Issue



## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Skip zero-byte entries in detect_legacy_shape() before attempting to read the first 6 bytes

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
