### PR TITLE
docs(api): list code navigation endpoints

### DIFF
--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -455,6 +455,14 @@ Below are all HTTP API endpoints provided by OpenViking, grouped by functional m
 | POST | `/api/v1/search/grep` | Content pattern search |
 | POST | `/api/v1/search/glob` | File pattern matching |
 
+### Code Navigation
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/code/outline` | Outline symbols in a source file |
+| POST | `/api/v1/code/search` | Search symbols under a `viking://` code URI |
+| POST | `/api/v1/code/expand` | Expand a symbol definition from a source file |
+
 ### Relations (Experimental, may change in future versions)
 
 | Method | Path | Description |

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -451,6 +451,14 @@ JSON 输出 - 错误：
 | POST | `/api/v1/search/grep` | 内容模式搜索 |
 | POST | `/api/v1/search/glob` | 文件模式匹配 |
 
+### 代码导航端点
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `/api/v1/code/outline` | 提取源文件符号大纲 |
+| POST | `/api/v1/code/search` | 在 `viking://` 代码 URI 下搜索符号 |
+| POST | `/api/v1/code/expand` | 展开源文件中的符号定义 |
+
 ### 关系端点（实验特性，可能在后续版本中改变）
 
 | 方法 | 路径 | 说明 |


### PR DESCRIPTION
## Summary
- add the `/api/v1/code/outline`, `/api/v1/code/search`, and `/api/v1/code/expand` endpoints to the English API overview
- mirror the same endpoint table in the Chinese API overview

## Testing
- `git diff --check`
- verified against `openviking/server/routers/code.py` (`prefix="/api/v1/code"` and `outline` / `search` / `expand` handlers)
