### PR TITLE
fix(ragfs): ignore path locks during shape probe

### DIFF
--- a/crates/ragfs/src/core/encryption_wrapper.rs
+++ b/crates/ragfs/src/core/encryption_wrapper.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
+use tracing::warn;
 
 use crate::crypto;
 use crate::shape::SHAPE_MANIFEST_PATH;
@@ -161,7 +162,20 @@ impl FileSystem for EncryptionWrappedFS {
         // the startup probe, so this layer always expects ciphertext.
         let data = self.inner.read(path, 0, 0).await?;
         let account_id = self.require_account_id()?;
-        let plaintext = self.decrypt_envelope(&account_id, &data)?;
+        let plaintext = match self.decrypt_envelope(&account_id, &data) {
+            Ok(plaintext) => plaintext,
+            Err(err) => {
+                warn!(
+                    path = %path,
+                    account_id = %account_id,
+                    ciphertext_len = data.len(),
+                    encrypted_magic = crypto::is_encrypted(&data),
+                    error = %err,
+                    "failed to decrypt encrypted RAGFS file"
+                );
+                return Err(err);
+            }
+        };
         Ok(slice_bytes(plaintext, offset, size))
     }
 

--- a/crates/ragfs/src/shape/probe.rs
+++ b/crates/ragfs/src/shape/probe.rs
@@ -9,6 +9,8 @@ use futures::stream::{self, StreamExt};
 use super::manifest::{StorageShape, SHAPE_MANIFEST_PATH};
 
 const SYSTEM_ACCOUNT_ID: &[u8] = b"_system";
+const PATH_LOCK_FILE: &str = ".path.ovlock";
+const EXACT_LOCK_FILE_PREFIX: &str = ".exact.ovlock.";
 
 fn normalize_shape_path(path: &str) -> String {
     let mut normalized = path.trim().to_string();
@@ -30,6 +32,11 @@ fn is_persistent_task_record_path(path: &str) -> bool {
         return !account_id.is_empty() && !user_id.is_empty();
     }
     false
+}
+
+fn is_path_lock_record_path(path: &str) -> bool {
+    let name = path.rsplit('/').next().unwrap_or("");
+    name == PATH_LOCK_FILE || name.starts_with(EXACT_LOCK_FILE_PREFIX)
 }
 
 /// Read the raw guard-file bytes from the backend root.
@@ -121,7 +128,10 @@ pub async fn detect_legacy_shape(raw_fs: &Arc<dyn FileSystem>) -> Result<Option<
         }
 
         let normalized = normalize_shape_path(&entry.path);
-        if normalized == SHAPE_MANIFEST_PATH || is_persistent_task_record_path(&normalized) {
+        if normalized == SHAPE_MANIFEST_PATH
+            || is_persistent_task_record_path(&normalized)
+            || is_path_lock_record_path(&normalized)
+        {
             continue;
         }
         candidates.push(normalized);


### PR DESCRIPTION
## Description

Skip legacy transaction path-lock marker files when probing existing backend files to infer storage shape.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Treat `.path.ovlock` as an internal path-lock marker during legacy backend shape probing.
- Treat `.exact.ovlock.*` as internal exact-path lock markers during legacy backend shape probing.
- Keep semantic sidecars and regular content files in the probe so real plaintext/encrypted content mismatches still fail fast.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Command run:

```bash
cargo fmt --manifest-path crates/ragfs/Cargo.toml
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This keeps the existing backend shape guard behavior intact for user content while avoiding false positives from stale path-lock markers left by older versions or interrupted transactions.
