### PR TITLE
fix(path_lock): fall back to lock_expire when timeout is None (#2698)

### DIFF
--- a/openviking/storage/transaction/path_lock.py
+++ b/openviking/storage/transaction/path_lock.py
@@ -488,9 +488,8 @@ class PathLockEngine:
             logger.debug(f"[EXACT] Reusing owned ancestor TREE lock on: {path}")
             return True
         if timeout is None:
-            deadline = float("inf")
-        else:
-            deadline = asyncio.get_running_loop().time() + timeout
+            timeout = self._lock_expire
+        deadline = asyncio.get_running_loop().time() + timeout
         wait_start = asyncio.get_running_loop().time()
         next_wait_log_at = wait_start + _WAIT_LOG_INTERVAL
 
@@ -642,11 +641,8 @@ class PathLockEngine:
             logger.debug(f"[TREE] Reusing owned ancestor TREE lock on: {path}")
             return True
         if timeout is None:
-            # 无限等待
-            deadline = float("inf")
-        else:
-            # 有限超时
-            deadline = asyncio.get_running_loop().time() + timeout
+            timeout = self._lock_expire
+        deadline = asyncio.get_running_loop().time() + timeout
         wait_start = asyncio.get_running_loop().time()
         next_wait_log_at = wait_start + _WAIT_LOG_INTERVAL
 


### PR DESCRIPTION
## Description

When `lock_timeout` is not configured in `ov.conf`, `PathLock._lock_path()` receives `timeout=None`, which is passed to `asyncio.wait_for()` as `float("inf")`. This causes lock acquisition to hang forever if the lock is held by a crashed or stuck process.

This PR changes the behavior so that when `timeout` is `None`, it falls back to `self._lock_expire` (default 300s), ensuring stale locks eventually time out and the system can recover.

## Related Issue

Fixes #2698

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `openviking/storage/transaction/path_lock.py`:
  - In `_lock_exact_path()`: when `timeout is None`, set `timeout = self._lock_expire` instead of `deadline = float("inf")`
  - In `_lock_tree_path()`: same change

## Testing

- [ ] I have tested this on the following platforms:
  - [x] Linux

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes

Before: `timeout=None` -> `deadline = float("inf")` -> infinite wait, no recovery without restart.
After: `timeout=None` -> `timeout = lock_expire` (300s) -> bounded wait, automatic recovery.
