### PR TITLE
fix(semantic): limit concurrent DAG processing to prevent lock contention

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -117,6 +117,7 @@ class OpenVikingService:
             config.storage,
             config.embedding.max_concurrent,
             config.vlm.max_concurrent,
+            config.vlm.max_concurrent_dags,
             binding_config=binding_config,
         )
 
@@ -131,6 +132,7 @@ class OpenVikingService:
         config: StorageConfig,
         max_concurrent_embedding: int = 10,
         max_concurrent_semantic: int = 64,
+        max_concurrent_dags: Optional[int] = None,
         binding_config: Any = None,
     ) -> None:
         """Initialize storage resources."""
@@ -149,6 +151,7 @@ class OpenVikingService:
                 mount_point=queue_mount_point,
                 max_concurrent_embedding=max_concurrent_embedding,
                 max_concurrent_semantic=max_concurrent_semantic,
+                max_concurrent_dags=max_concurrent_dags,
             )
         else:
             logger.warning("RAGFS client not initialized, skipping queue manager")

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -30,7 +30,7 @@ def init_queue_manager(
     mount_point: str = "/queue",
     max_concurrent_embedding: int = 10,
     max_concurrent_semantic: int = 64,
-    max_concurrent_dags: int = 1,
+    max_concurrent_dags: Optional[int] = None,
 ) -> "QueueManager":
     """Initialize QueueManager singleton.
 
@@ -78,7 +78,7 @@ class QueueManager:
         mount_point: str = "/queue",
         max_concurrent_embedding: int = 10,
         max_concurrent_semantic: int = 64,
-    max_concurrent_dags: Optional[int] = None,
+        max_concurrent_dags: Optional[int] = None,
     ):
         """Initialize QueueManager."""
         self._agfs = agfs

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -30,6 +30,7 @@ def init_queue_manager(
     mount_point: str = "/queue",
     max_concurrent_embedding: int = 10,
     max_concurrent_semantic: int = 64,
+    max_concurrent_dags: int = 1,
 ) -> "QueueManager":
     """Initialize QueueManager singleton.
 
@@ -38,7 +39,8 @@ def init_queue_manager(
         timeout: Request timeout in seconds.
         mount_point: Path where QueueFS is mounted.
         max_concurrent_embedding: Max concurrent embedding tasks.
-        max_concurrent_semantic: Max concurrent semantic node work.
+        max_concurrent_semantic: Max concurrent semantic LLM calls.
+        max_concurrent_dags: Max concurrent DAG processing tasks.
     """
     global _instance
     _instance = QueueManager(
@@ -47,6 +49,7 @@ def init_queue_manager(
         mount_point=mount_point,
         max_concurrent_embedding=max_concurrent_embedding,
         max_concurrent_semantic=max_concurrent_semantic,
+        max_concurrent_dags=max_concurrent_dags,
     )
     return _instance
 
@@ -75,6 +78,7 @@ class QueueManager:
         mount_point: str = "/queue",
         max_concurrent_embedding: int = 10,
         max_concurrent_semantic: int = 64,
+    max_concurrent_dags: Optional[int] = None,
     ):
         """Initialize QueueManager."""
         self._agfs = agfs
@@ -82,6 +86,7 @@ class QueueManager:
         self.mount_point = mount_point
         self._max_concurrent_embedding = max_concurrent_embedding
         self._max_concurrent_semantic = max_concurrent_semantic
+        self._max_concurrent_dags = max_concurrent_dags
         self._queues: Dict[str, NamedQueue] = {}
         self._started = False
         self._queue_threads: Dict[str, threading.Thread] = {}
@@ -131,7 +136,10 @@ class QueueManager:
         logger.info("Embedding queue initialized with TextEmbeddingHandler")
 
         # Semantic Queue
-        semantic_processor = SemanticProcessor(max_concurrent_llm=self._max_concurrent_semantic)
+        semantic_processor = SemanticProcessor(
+            max_concurrent_llm=self._max_concurrent_semantic,
+            max_concurrent_dags=self._max_concurrent_dags,
+        )
         self.get_queue(
             self.SEMANTIC,
             dequeue_handler=semantic_processor,

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -101,14 +101,21 @@ class SemanticProcessor(DequeueHandlerBase):
     _request_stats_order: List[str] = []
     _max_cached_stats = 256
 
-    def __init__(self, max_concurrent_llm: int = 64):
+    def __init__(self, max_concurrent_llm: int = 64, max_concurrent_dags: Optional[int] = None):
         """
         Initialize SemanticProcessor.
 
         Args:
-            max_concurrent_llm: Maximum concurrent LLM calls
+            max_concurrent_llm: Maximum concurrent LLM calls.
+            max_concurrent_dags: Maximum concurrent DAG processing tasks.
+                None means unlimited.
         """
         self.max_concurrent_llm = max_concurrent_llm
+        self._processing_sem = (
+            asyncio.Semaphore(max_concurrent_dags)
+            if max_concurrent_dags is not None
+            else None
+        )
         self._default_ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
         self._circuit_breaker = CircuitBreaker()
 
@@ -357,108 +364,114 @@ class SemanticProcessor(DequeueHandlerBase):
                 root_attrs.account_id = msg.account_id
                 root_attrs.user_id = msg.user_id
                 root_context_token = bind_root_observability_context(root_attrs)
+                if self._processing_sem is not None:
+                    await self._processing_sem.acquire()
                 try:
-                    current_ctx = self._ctx_from_semantic_msg(msg)
-                    logger.info(
-                        f"Processing semantic generation for: {msg.uri} (recursive={msg.recursive})"
-                    )
-
-                    logger.info(f"Processing semantic generation for: {msg})")
-
-                    semantic_lock = await SemanticLockScope.resolve(
-                        msg.lock_handoff,
-                        caller_lock=lock,
-                    )
-                    lock_transferred = False
                     try:
-                        if msg.context_type == "memory":
-                            lock_transferred = True
-                            await self._process_memory_directory(
-                                msg,
-                                ctx=current_ctx,
-                                lock=semantic_lock.lock,
-                            )
-                        else:
-                            is_incremental = False
-                            target_uri = msg.target_uri
-                            run_uri = msg.uri
-                            changes = msg.changes
-                            viking_fs = get_viking_fs()
-                            if msg.target_uri:
-                                target_exists = await viking_fs.exists(
-                                    msg.target_uri, ctx=current_ctx
+                        current_ctx = self._ctx_from_semantic_msg(msg)
+                        logger.info(
+                            f"Processing semantic generation for: {msg.uri} (recursive={msg.recursive})"
+                        )
+
+                        logger.info(f"Processing semantic generation for: {msg})")
+
+                        semantic_lock = await SemanticLockScope.resolve(
+                            msg.lock_handoff,
+                            caller_lock=lock,
+                        )
+                        lock_transferred = False
+                        try:
+                            if msg.context_type == "memory":
+                                lock_transferred = True
+                                await self._process_memory_directory(
+                                    msg,
+                                    ctx=current_ctx,
+                                    lock=semantic_lock.lock,
                                 )
-                                if msg.uri != msg.target_uri:
-                                    logger.info(
-                                        "Syncing semantic source into target before processing: "
-                                        f"{msg.uri} -> {msg.target_uri}"
+                            else:
+                                is_incremental = False
+                                target_uri = msg.target_uri
+                                run_uri = msg.uri
+                                changes = msg.changes
+                                viking_fs = get_viking_fs()
+                                if msg.target_uri:
+                                    target_exists = await viking_fs.exists(
+                                        msg.target_uri, ctx=current_ctx
                                     )
-                                    diff = await self._sync_topdown_recursive(
-                                        msg.uri,
-                                        msg.target_uri,
-                                        ctx=current_ctx,
-                                        lock=semantic_lock.lock,
-                                    )
-                                    logger.info(
-                                        "[SyncDiff] Diff computed: "
-                                        f"added_files={len(diff.added_files)}, "
-                                        f"deleted_files={len(diff.deleted_files)}, "
-                                        f"updated_files={len(diff.updated_files)}, "
-                                        f"added_dirs={len(diff.added_dirs)}, "
-                                        f"deleted_dirs={len(diff.deleted_dirs)}"
-                                    )
-                                    changes = diff.to_changes()
+                                    if msg.uri != msg.target_uri:
+                                        logger.info(
+                                            "Syncing semantic source into target before processing: "
+                                            f"{msg.uri} -> {msg.target_uri}"
+                                        )
+                                        diff = await self._sync_topdown_recursive(
+                                            msg.uri,
+                                            msg.target_uri,
+                                            ctx=current_ctx,
+                                            lock=semantic_lock.lock,
+                                        )
+                                        logger.info(
+                                            "[SyncDiff] Diff computed: "
+                                            f"added_files={len(diff.added_files)}, "
+                                            f"deleted_files={len(diff.deleted_files)}, "
+                                            f"updated_files={len(diff.updated_files)}, "
+                                            f"added_dirs={len(diff.added_dirs)}, "
+                                            f"deleted_dirs={len(diff.deleted_dirs)}"
+                                        )
+                                        changes = diff.to_changes()
+                                        is_incremental = True
+                                        target_uri = msg.target_uri
+                                        run_uri = msg.target_uri
+                                    elif target_exists and msg.changes and msg.uri == msg.target_uri:
+                                        is_incremental = True
+                                        logger.info(
+                                            f"Using direct incremental semantic update for: {msg.uri}"
+                                        )
+                                elif msg.changes:
                                     is_incremental = True
-                                    target_uri = msg.target_uri
-                                    run_uri = msg.target_uri
-                                elif target_exists and msg.changes and msg.uri == msg.target_uri:
-                                    is_incremental = True
+                                    target_uri = msg.uri
                                     logger.info(
                                         f"Using direct incremental semantic update for: {msg.uri}"
                                     )
-                            elif msg.changes:
-                                is_incremental = True
-                                target_uri = msg.uri
-                                logger.info(
-                                    f"Using direct incremental semantic update for: {msg.uri}"
-                                )
 
-                            executor = SemanticDagExecutor(
-                                processor=self,
-                                context_type=msg.context_type,
-                                max_concurrent_llm=self.max_concurrent_llm,
-                                ctx=current_ctx,
-                                incremental_update=is_incremental,
-                                target_uri=target_uri,
-                                semantic_msg_id=msg.id,
-                                telemetry_id=msg.telemetry_id,
-                                recursive=msg.recursive,
-                                lock=semantic_lock.lock,
-                                is_code_repo=msg.is_code_repo,
-                                changes=changes,
-                                skip_vectorization=msg.skip_vectorization,
-                                coalesce_key=msg.coalesce_key,
-                                coalesce_version=msg.coalesce_version,
-                            )
-                            lock_transferred = True
-                            await executor.run(run_uri)
-                            self._cache_dag_stats(
-                                msg.telemetry_id,
-                                run_uri,
-                                executor.get_stats(),
-                            )
-                            if not executor.stale:
-                                await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
+                                executor = SemanticDagExecutor(
+                                    processor=self,
+                                    context_type=msg.context_type,
+                                    max_concurrent_llm=self.max_concurrent_llm,
+                                    ctx=current_ctx,
+                                    incremental_update=is_incremental,
+                                    target_uri=target_uri,
+                                    semantic_msg_id=msg.id,
+                                    telemetry_id=msg.telemetry_id,
+                                    recursive=msg.recursive,
+                                    lock=semantic_lock.lock,
+                                    is_code_repo=msg.is_code_repo,
+                                    changes=changes,
+                                    skip_vectorization=msg.skip_vectorization,
+                                    coalesce_key=msg.coalesce_key,
+                                    coalesce_version=msg.coalesce_version,
+                                )
+                                lock_transferred = True
+                                await executor.run(run_uri)
+                                self._cache_dag_stats(
+                                    msg.telemetry_id,
+                                    run_uri,
+                                    executor.get_stats(),
+                                )
+                                if not executor.stale:
+                                    await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
+                        finally:
+                            if not lock_transferred:
+                                await semantic_lock.close()
+                        self._merge_request_stats(msg.telemetry_id, processed=1)
+                        logger.info(f"Completed semantic generation for: {msg.uri}")
+                        self.report_success()
+                        self._circuit_breaker.record_success()
+                        return None
                     finally:
-                        if not lock_transferred:
-                            await semantic_lock.close()
-                    self._merge_request_stats(msg.telemetry_id, processed=1)
-                    logger.info(f"Completed semantic generation for: {msg.uri}")
-                    self.report_success()
-                    self._circuit_breaker.record_success()
-                    return None
+                        reset_root_observability_context(root_context_token)
                 finally:
-                    reset_root_observability_context(root_context_token)
+                    if self._processing_sem is not None:
+                        self._processing_sem.release()
 
         except Exception as e:
             if isinstance(e, LockAcquisitionError):

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -96,6 +96,13 @@ class VLMConfig(BaseModel):
         default=64, description="Maximum number of concurrent LLM calls for semantic processing"
     )
 
+    max_concurrent_dags: Optional[int] = Field(
+        default=None,
+        description="Maximum number of concurrent DAG processing tasks. "
+        "None (default) means unlimited (original behavior). "
+        "1 means sequential processing (no lock contention).",
+    )
+
     api_version: Optional[str] = Field(
         default=None,
         description="API version for Azure OpenAI (e.g., '2025-01-01-preview').",


### PR DESCRIPTION
## Description

`SemanticProcessor.on_dequeue()` spawns concurrent DAG processing tasks without any limit. Under high load (e.g., many simultaneous session commits), multiple DAGs run in parallel and contend on the same TREE locks in shared memory directories, causing lock contention and possible deadlocks.

This PR adds a configurable `max_concurrent_dags` option to limit concurrent DAG processing. Default is `None` (unlimited, preserving original behavior). Setting it to `1` provides sequential processing, eliminating lock contention entirely.

## Related Issue

Fixes #2699

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)

## Changes Made

- `openviking_cli/utils/config/vlm_config.py`: Added `max_concurrent_dags: Optional[int] = None` field to `VLMConfig`
- `openviking/service/core.py`: Plumb `max_concurrent_dags` from config through `_init_storage()` to `init_queue_manager()`
- `openviking/storage/queuefs/queue_manager.py`: Accept and pass `max_concurrent_dags` to `SemanticProcessor`
- `openviking/storage/queuefs/semantic_processor.py`:
  - Accept `max_concurrent_dags` parameter in `__init__`
  - Create `asyncio.Semaphore(max_concurrent_dags)` if value is not `None`
  - Acquire/release the semaphore around DAG processing in `on_dequeue()`

## Testing

- [ ] I have tested this on the following platforms:
  - [x] Linux

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes

Configuration example in `ov.conf`:
```json
{
  "vlm": {
    "max_concurrent_dags": 1
  }
}
```