### PR TITLE
test(cli): extend pack add-resource timeout & minor refactoring on tests

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -467,7 +467,18 @@ def test_pack_uri(test_dir_uri):
         r = None
         for _attempt in range(10):
             r = ov(
-                ["add-resource", temp_path, "--to", pack_uri, "--wait", "-o", "json"], timeout=120
+                [
+                    "add-resource",
+                    temp_path,
+                    "--to",
+                    pack_uri,
+                    "--wait",
+                    "--timeout",
+                    "300",
+                    "-o",
+                    "json",
+                ],
+                timeout=360,
             )
             if r["exit_code"] == 0:
                 break

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -287,6 +287,8 @@ def _write_cli_config():
 CLI_CONFIG_PATH = _write_cli_config()
 ADD_RESOURCE_WAIT_TIMEOUT = "300"
 ADD_RESOURCE_COMMAND_TIMEOUT = 360
+WRITE_WAIT_TIMEOUT = "300"
+WRITE_COMMAND_TIMEOUT = 360
 
 
 def _env():
@@ -413,6 +415,62 @@ def ov_add_resource(path, to_uri, *extra_args):
     )
 
 
+def ov_retry(args, *, attempts=5, interval=5, timeout=120, retry_if=None):
+    r = None
+    for attempt in range(attempts):
+        r = ov(args, timeout=timeout)
+        if r["exit_code"] == 0:
+            return r
+        if retry_if is not None and not retry_if(r):
+            return r
+        if attempt < attempts - 1:
+            time.sleep(interval)
+    return r
+
+
+def ov_rm(uri, *, recursive=True, attempts=5, interval=3):
+    args = ["rm", uri, "-o", "json"]
+    if recursive:
+        args.insert(2, "-r")
+    return ov_retry(args, attempts=attempts, interval=interval)
+
+
+def ov_mv(src_uri, dst_uri):
+    return ov_retry(["mv", src_uri, dst_uri, "-o", "json"], attempts=20, interval=15)
+
+
+def ov_write(uri, content, *extra_args):
+    return ov_retry(
+        [
+            "write",
+            uri,
+            "--content",
+            content,
+            *extra_args,
+            "--wait",
+            "--timeout",
+            WRITE_WAIT_TIMEOUT,
+            "-o",
+            "json",
+        ],
+        attempts=15,
+        interval=20,
+        timeout=WRITE_COMMAND_TIMEOUT,
+    )
+
+
+def ov_reindex(uri):
+    return ov_retry(["reindex", uri, "--wait", "true", "-o", "json"], attempts=15, interval=15)
+
+
+def ov_session_new():
+    return ov_retry(["session", "new", "-o", "json"], attempts=5, interval=5)
+
+
+def ov_session_delete(session_id):
+    return ov(["session", "delete", session_id, "-o", "json"])
+
+
 def _wait_for_resource_ready(uri, retries=20, interval=10):
     for _attempt in range(retries):
         r = ov(["read", uri, "-o", "json"], timeout=30)
@@ -470,11 +528,7 @@ def test_dir_uri(ensure_resources_dir):
         time.sleep(5)
     assert r["exit_code"] == 0, f"mkdir failed after retries: {r['stderr']}"
     yield uri
-    for _attempt in range(10):
-        r = ov(["rm", uri, "-r", "-o", "json"], timeout=120)
-        if r["exit_code"] == 0:
-            break
-        time.sleep(5)
+    ov_rm(uri, attempts=10, interval=5)
 
 
 @pytest.fixture(scope="session")
@@ -515,13 +569,8 @@ def test_file_uri(test_pack_uri):
 
 @pytest.fixture(scope="session")
 def test_session_id():
-    r = None
-    for _attempt in range(5):
-        r = ov(["session", "new", "-o", "json"], timeout=120)
-        if r["exit_code"] == 0:
-            break
-        time.sleep(5)
+    r = ov_session_new()
     assert r["exit_code"] == 0, f"session new failed: {r['stderr']}"
     session_id = r["json"]["result"]["session_id"]
     yield session_id
-    ov(["session", "delete", session_id, "-o", "json"])
+    ov_session_delete(session_id)

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -285,6 +285,8 @@ def _write_cli_config():
 
 
 CLI_CONFIG_PATH = _write_cli_config()
+ADD_RESOURCE_WAIT_TIMEOUT = "300"
+ADD_RESOURCE_COMMAND_TIMEOUT = 360
 
 
 def _env():
@@ -393,6 +395,24 @@ def ov(args, timeout=120):
     }
 
 
+def ov_add_resource(path, to_uri, *extra_args):
+    return ov(
+        [
+            "add-resource",
+            path,
+            "--to",
+            to_uri,
+            *extra_args,
+            "--wait",
+            "--timeout",
+            ADD_RESOURCE_WAIT_TIMEOUT,
+            "-o",
+            "json",
+        ],
+        timeout=ADD_RESOURCE_COMMAND_TIMEOUT,
+    )
+
+
 def _wait_for_resource_ready(uri, retries=20, interval=10):
     for _attempt in range(retries):
         r = ov(["read", uri, "-o", "json"], timeout=30)
@@ -466,20 +486,7 @@ def test_pack_uri(test_dir_uri):
         pack_uri = f"{test_dir_uri}/test_pack"
         r = None
         for _attempt in range(10):
-            r = ov(
-                [
-                    "add-resource",
-                    temp_path,
-                    "--to",
-                    pack_uri,
-                    "--wait",
-                    "--timeout",
-                    "300",
-                    "-o",
-                    "json",
-                ],
-                timeout=360,
-            )
+            r = ov_add_resource(temp_path, pack_uri)
             if r["exit_code"] == 0:
                 break
             if "CONFLICT" in (r.get("stderr") or "") or "busy" in (r.get("stderr") or "").lower():

--- a/tests/cli/test_cli_content.py
+++ b/tests/cli/test_cli_content.py
@@ -8,7 +8,7 @@ import time
 import uuid
 
 import pytest
-from conftest import ov, ov_add_resource
+from conftest import ov, ov_add_resource, ov_reindex, ov_write
 
 pytestmark = pytest.mark.cli_remote
 
@@ -56,29 +56,7 @@ class TestContentDownload:
 
 class TestContentWrite:
     def test_write_replace(self, test_file_uri):
-        time.sleep(15)
-        r = None
-        for _attempt in range(15):
-            r = ov(
-                [
-                    "write",
-                    test_file_uri,
-                    "--content",
-                    "Updated via CLI write.",
-                    "--mode",
-                    "replace",
-                    "--wait",
-                    "-o",
-                    "json",
-                ],
-                timeout=120,
-            )
-            if r["exit_code"] == 0:
-                break
-            if "busy" in r["stderr"].lower() or "internal" in r["stderr"].lower():
-                time.sleep(20)
-                continue
-            time.sleep(10)
+        r = ov_write(test_file_uri, "Updated via CLI write.", "--mode", "replace")
         assert r["exit_code"] == 0, (
             f"ov write replace should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )
@@ -86,28 +64,7 @@ class TestContentWrite:
         assert data is not None and data.get("ok") is True, "Expected ok=true"
 
     def test_write_append(self, test_file_uri):
-        time.sleep(15)
-        r = None
-        for _attempt in range(15):
-            r = ov(
-                [
-                    "write",
-                    test_file_uri,
-                    "--content",
-                    "\nAppended via CLI.",
-                    "--append",
-                    "--wait",
-                    "-o",
-                    "json",
-                ],
-                timeout=120,
-            )
-            if r["exit_code"] == 0:
-                break
-            if "busy" in r["stderr"].lower() or "internal" in r["stderr"].lower():
-                time.sleep(20)
-                continue
-            time.sleep(10)
+        r = ov_write(test_file_uri, "\nAppended via CLI.", "--append")
         assert r["exit_code"] == 0, (
             f"ov write append should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )
@@ -138,16 +95,7 @@ class TestContentReindex:
         finally:
             os.unlink(temp_path)
 
-        time.sleep(15)
-        r = None
-        for _attempt in range(15):
-            r = ov(["reindex", reindex_pack, "--wait", "true", "-o", "json"], timeout=120)
-            if r["exit_code"] == 0:
-                break
-            if "INTERNAL" in r["stderr"]:
-                time.sleep(20)
-                continue
-            time.sleep(15)
+        r = ov_reindex(reindex_pack)
         assert r["exit_code"] == 0, (
             f"ov reindex should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )

--- a/tests/cli/test_cli_content.py
+++ b/tests/cli/test_cli_content.py
@@ -8,7 +8,7 @@ import time
 import uuid
 
 import pytest
-from conftest import ov
+from conftest import ov, ov_add_resource
 
 pytestmark = pytest.mark.cli_remote
 
@@ -124,10 +124,7 @@ class TestContentReindex:
         try:
             r = None
             for _attempt in range(10):
-                r = ov(
-                    ["add-resource", temp_path, "--to", reindex_pack, "--wait", "-o", "json"],
-                    timeout=120,
-                )
+                r = ov_add_resource(temp_path, reindex_pack)
                 if r["exit_code"] == 0:
                     break
                 if (

--- a/tests/cli/test_cli_filesystem.py
+++ b/tests/cli/test_cli_filesystem.py
@@ -8,7 +8,7 @@ import time
 import uuid
 
 import pytest
-from conftest import ov
+from conftest import ov, ov_add_resource
 
 pytestmark = pytest.mark.cli_remote
 
@@ -134,7 +134,7 @@ class TestFsMv:
             f.write("move me")
             temp_path = f.name
         try:
-            ov(["add-resource", temp_path, "--to", src_uri, "--wait", "-o", "json"], timeout=120)
+            ov_add_resource(temp_path, src_uri)
         finally:
             os.unlink(temp_path)
         time.sleep(15)

--- a/tests/cli/test_cli_filesystem.py
+++ b/tests/cli/test_cli_filesystem.py
@@ -4,11 +4,10 @@
 
 import os
 import tempfile
-import time
 import uuid
 
 import pytest
-from conftest import ov, ov_add_resource
+from conftest import ov, ov_add_resource, ov_mv, ov_rm
 
 pytestmark = pytest.mark.cli_remote
 
@@ -96,7 +95,7 @@ class TestFsMkdir:
         assert "Directory created" in r["stdout"] or (r["json"] and r["json"].get("ok")), (
             f"mkdir should confirm creation, got: {r['stdout'][:200]}"
         )
-        ov(["rm", sub_dir, "-r", "-o", "json"])
+        ov_rm(sub_dir)
 
     def test_mkdir_with_description(self, test_dir_uri):
         sub_dir = f"{test_dir_uri}/mkdir_desc"
@@ -104,20 +103,14 @@ class TestFsMkdir:
         assert r["exit_code"] == 0, (
             f"ov mkdir with description should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )
-        ov(["rm", sub_dir, "-r", "-o", "json"])
+        ov_rm(sub_dir)
 
 
 class TestFsRm:
     def test_rm_directory(self, test_dir_uri):
         sub_dir = f"{test_dir_uri}/rm_test"
         ov(["mkdir", sub_dir, "-o", "json"])
-        time.sleep(2)
-        r = None
-        for _attempt in range(5):
-            r = ov(["rm", sub_dir, "-r", "-o", "json"])
-            if r["exit_code"] == 0:
-                break
-            time.sleep(3)
+        r = ov_rm(sub_dir)
         assert r["exit_code"] == 0, (
             f"ov rm should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )
@@ -137,14 +130,8 @@ class TestFsMv:
             ov_add_resource(temp_path, src_uri)
         finally:
             os.unlink(temp_path)
-        time.sleep(15)
-        r = None
-        for _attempt in range(20):
-            r = ov(["mv", src_uri, dst_uri, "-o", "json"])
-            if r["exit_code"] == 0:
-                break
-            time.sleep(15)
+        r = ov_mv(src_uri, dst_uri)
         assert r["exit_code"] == 0, (
             f"ov mv should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )
-        ov(["rm", dst_uri, "-r", "-o", "json"])
+        ov_rm(dst_uri)

--- a/tests/cli/test_cli_relations.py
+++ b/tests/cli/test_cli_relations.py
@@ -7,7 +7,7 @@ import tempfile
 import uuid
 
 import pytest
-from conftest import ov
+from conftest import ov, ov_add_resource
 
 pytestmark = pytest.mark.cli_remote
 
@@ -30,10 +30,7 @@ class TestLinkUnlink:
             f.write("# Link Target\n\nThis is a link target file.")
             temp_path = f.name
         try:
-            ov(
-                ["add-resource", temp_path, "--to", second_pack_uri, "--wait", "-o", "json"],
-                timeout=120,
-            )
+            ov_add_resource(temp_path, second_pack_uri)
         finally:
             os.unlink(temp_path)
 

--- a/tests/cli/test_cli_relations.py
+++ b/tests/cli/test_cli_relations.py
@@ -7,7 +7,7 @@ import tempfile
 import uuid
 
 import pytest
-from conftest import ov, ov_add_resource
+from conftest import ov, ov_add_resource, ov_rm
 
 pytestmark = pytest.mark.cli_remote
 
@@ -50,4 +50,4 @@ class TestLinkUnlink:
         unlink_data = unlink_r["json"]
         assert unlink_data.get("ok") is True, f"Expected ok=true, got {unlink_data.get('ok')}"
 
-        ov(["rm", second_pack_uri, "-r", "-o", "json"])
+        ov_rm(second_pack_uri)

--- a/tests/cli/test_cli_resources.py
+++ b/tests/cli/test_cli_resources.py
@@ -8,7 +8,7 @@ import time
 import uuid
 
 import pytest
-from conftest import ov
+from conftest import ov, ov_add_resource
 
 pytestmark = pytest.mark.cli_remote
 
@@ -22,9 +22,7 @@ class TestAddResource:
             to_uri = f"{test_dir_uri}/res_{uuid.uuid4().hex[:6]}"
             r = None
             for _attempt in range(5):
-                r = ov(
-                    ["add-resource", temp_path, "--to", to_uri, "--wait", "-o", "json"], timeout=120
-                )
+                r = ov_add_resource(temp_path, to_uri)
                 if r["exit_code"] == 0:
                     break
                 if "CONFLICT" in (r.get("stderr") or "") or "Network error" in (
@@ -93,20 +91,7 @@ class TestAddSkill:
             to_uri = f"{test_dir_uri}/reason_{uuid.uuid4().hex[:6]}"
             r = None
             for _attempt in range(5):
-                r = ov(
-                    [
-                        "add-resource",
-                        temp_path,
-                        "--to",
-                        to_uri,
-                        "--reason",
-                        "CLI test reason",
-                        "--wait",
-                        "-o",
-                        "json",
-                    ],
-                    timeout=120,
-                )
+                r = ov_add_resource(temp_path, to_uri, "--reason", "CLI test reason")
                 if r["exit_code"] == 0:
                     break
                 if "CONFLICT" in (r.get("stderr") or "") or "Network error" in (

--- a/tests/cli/test_cli_sessions.py
+++ b/tests/cli/test_cli_sessions.py
@@ -3,14 +3,14 @@
 """CLI session operation tests (new, list, get, get-context, delete, add-message, commit)."""
 
 import pytest
-from conftest import ov
+from conftest import ov, ov_session_delete, ov_session_new
 
 pytestmark = pytest.mark.cli_remote
 
 
 class TestSessionNew:
     def test_session_new(self):
-        r = ov(["session", "new", "-o", "json"])
+        r = ov_session_new()
         assert r["exit_code"] == 0, (
             f"ov session new should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )
@@ -22,7 +22,7 @@ class TestSessionNew:
         )
         assert isinstance(result["session_id"], str), "session_id should be a string"
         assert len(result["session_id"]) > 0, "session_id should not be empty"
-        ov(["session", "delete", result["session_id"], "-o", "json"])
+        ov_session_delete(result["session_id"])
 
 
 class TestSessionList:
@@ -63,13 +63,13 @@ class TestSessionGetContext:
 
 class TestSessionDelete:
     def test_session_delete(self):
-        create_r = ov(["session", "new", "-o", "json"])
+        create_r = ov_session_new()
         assert create_r["exit_code"] == 0, f"session new failed: {create_r['stderr'][:300]}"
         assert create_r["json"] is not None, (
             f"session new should return JSON, got: {create_r['stdout'][:200]}"
         )
         session_id = create_r["json"]["result"]["session_id"]
-        r = ov(["session", "delete", session_id, "-o", "json"])
+        r = ov_session_delete(session_id)
         assert r["exit_code"] == 0, (
             f"ov session delete should exit 0, got {r['exit_code']}: {r['stderr'][:300]}"
         )


### PR DESCRIPTION
## Why
CLI mutation tests hand-roll retry/sleep. Real OV can stay busy after wait. Same failure class.

## Change
- add shared helpers: ov_retry, ov_rm, ov_mv, ov_write, ov_reindex, session helpers
- add write wait timeout: 300s
- keep add-resource wait timeout: 300s
- simplify rm/mv/write/reindex/session delete tests

## Test
- python3 -m py_compile tests/cli/conftest.py tests/cli/test_cli_filesystem.py tests/cli/test_cli_content.py tests/cli/test_cli_relations.py tests/cli/test_cli_sessions.py
- uv run ruff check same files
- git diff --check