### PR TITLE
fix: remove .value calls on Role (str, not Enum)

### DIFF
--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -239,7 +239,7 @@ class WatchScheduler:
                     account_id=task.account_id,
                     user_id=task.user_id,
                 )
-                role_value = getattr(task, "original_role", None) or Role.USER.value
+                role_value = getattr(task, "original_role", None) or Role.USER
                 try:
                     role = Role(role_value)
                 except Exception:
@@ -312,7 +312,7 @@ class WatchScheduler:
                                 task_id=task.task_id,
                                 account_id=task.account_id,
                                 user_id=task.user_id,
-                                role=getattr(task, "original_role", None) or Role.USER.value,
+                                role=getattr(task, "original_role", None) or Role.USER,
                                 is_active=False,
                             )
                         )

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -331,7 +331,7 @@ class FSService:
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
             peer_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=ctx.role,
             skip_vectorization=False,
             telemetry_id=telemetry_id,
             coalesce_key=build_semantic_coalesce_key(

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -565,7 +565,7 @@ class ReindexExecutor:
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
             peer_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=ctx.role,
             skip_vectorization=True,
         )
         await processor.on_dequeue({"data": msg.to_json()}, lock=lock.as_borrowed())

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -951,7 +951,7 @@ class ResourceService:
             to_uri=to_uri,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=ctx.role,
         )
         if existing_task:
             if existing_task.is_active:
@@ -964,7 +964,7 @@ class ResourceService:
                 task_id=existing_task.task_id,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
-                role=ctx.role.value,
+                role=ctx.role,
                 path=path,
                 to_uri=to_uri,
                 parent_uri=parent_uri,
@@ -985,7 +985,7 @@ class ResourceService:
                 path=path,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
-                original_role=ctx.role.value,
+                original_role=ctx.role,
                 to_uri=to_uri,
                 parent_uri=parent_uri,
                 reason=reason,
@@ -1013,14 +1013,14 @@ class ResourceService:
             to_uri=to_uri,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=ctx.role,
         )
         if existing_task:
             await watch_manager.update_task(
                 task_id=existing_task.task_id,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
-                role=ctx.role.value,
+                role=ctx.role,
                 is_active=False,
             )
             logger.info(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1326,7 +1326,7 @@ class Session:
                                 "session_uri": self._session_uri,
                                 "account_id": self.ctx.account_id,
                                 "user_id": self.ctx.user.user_id,
-                                "role": self.ctx.role.value,
+                                "role": self.ctx.role,
                             },
                         )
 

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -466,7 +466,7 @@ class ContentWriteCoordinator:
             recursive=recursive,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=ctx.role,
             skip_vectorization=False,
             telemetry_id=telemetry.telemetry_id,
             coalesce_key=(

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -171,7 +171,7 @@ class SemanticProcessor(DequeueHandlerBase):
 
     @staticmethod
     def _ctx_from_semantic_msg(msg: SemanticMsg) -> RequestContext:
-        role = Role(msg.role) if msg.role in {r.value for r in Role} else Role.ROOT
+        role = Role(msg.role) if msg.role in {Role.ROOT, Role.ADMIN, Role.USER} else Role.ROOT
         return RequestContext(
             user=UserIdentifier(msg.account_id, msg.user_id),
             role=role,

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -118,7 +118,7 @@ class Summarizer:
                     account_id=ctx.account_id,
                     user_id=ctx.user.user_id,
                     peer_id=ctx.user.user_id,
-                    role=ctx.role.value,
+                    role=ctx.role,
                     skip_vectorization=skip_vectorization,
                     telemetry_id=telemetry.telemetry_id,
                     target_uri=target_uri if target_uri != source_uri else None,

--- a/tests/integration/test_watch_e2e.py
+++ b/tests/integration/test_watch_e2e.py
@@ -23,7 +23,7 @@ async def get_watch_task(client: AsyncOpenViking, to_uri: str):
         to_uri=to_uri,
         account_id=client._service.user.account_id,
         user_id=client._service.user.user_id,
-        role=Role.USER.value,
+        role=Role.USER,
     )
 
 

--- a/tests/server/test_identity.py
+++ b/tests/server/test_identity.py
@@ -13,9 +13,9 @@ from openviking_cli.session.user_id import UserIdentifier
 
 def test_role_values():
     """Role enum should have correct string values."""
-    assert Role.ROOT.value == "root"
-    assert Role.ADMIN.value == "admin"
-    assert Role.USER.value == "user"
+    assert Role.ROOT == "root"
+    assert Role.ADMIN == "admin"
+    assert Role.USER == "user"
 
 
 def test_role_from_string():

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -22,7 +22,7 @@ async def get_task_by_uri(service: ResourceService, to_uri: str, ctx: RequestCon
         to_uri=to_uri,
         account_id=ctx.account_id,
         user_id=ctx.user.user_id,
-        role=ctx.role.value,
+        role=ctx.role,
     )
 
 
@@ -441,7 +441,7 @@ class TestWatchTaskConflict:
             task_id=task_id,
             account_id=request_context.account_id,
             user_id=request_context.user.user_id,
-            role=request_context.role.value,
+            role=request_context.role,
             is_active=False,
         )
 
@@ -590,7 +590,7 @@ class TestWatchTaskUpdate:
             task_id=task.task_id,
             account_id=request_context.account_id,
             user_id=request_context.user.user_id,
-            role=request_context.role.value,
+            role=request_context.role,
             is_active=False,
         )
 


### PR DESCRIPTION
## Description

`Role` was refactored from `class Role(str, Enum)` to `class Role(str)` in commit `ab656e24` (PR #2709), removing `Enum` inheritance. All `.value` calls on `Role` instances and class attributes now raise `AttributeError`, silently breaking memory extraction, summarization, resource watching, content writes, and reindex operations.

Replace all `.value` accesses with direct attribute access — `Role` is already a plain `str`.

## Related Issue

Fixes #2718

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `openviking/session/session.py` — `self.ctx.role.value` → `self.ctx.role`
- `openviking/utils/summarizer.py` — `role=ctx.role.value` → `role=ctx.role`
- `openviking/storage/content_write.py` — `role=ctx.role.value` → `role=ctx.role`
- `openviking/service/resource_service.py` — 5x replacements (including `original_role=ctx.role.value`)
- `openviking/service/fs_service.py` — `role=ctx.role.value` → `role=ctx.role`
- `openviking/service/reindex_executor.py` — `role=ctx.role.value` → `role=ctx.role`
- `openviking/resource/watch_scheduler.py` — 2x `Role.USER.value` → `Role.USER`
- `openviking/storage/queuefs/semantic_processor.py` — `{r.value for r in Role}` → `{Role.ROOT, Role.ADMIN, Role.USER}`
- `tests/service/test_resource_service_watch.py` — 3x `.value` removal
- `tests/server/test_identity.py` — updated assertions (no `.value`)
- `tests/integration/test_watch_e2e.py` — `Role.USER.value` → `Role.USER`

## Testing

- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [x] Linux

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published