### PR TITLE
fix(studio): stabilize account selection

### DIFF
--- a/web-studio/src/hooks/use-app-connection.test.ts
+++ b/web-studio/src/hooks/use-app-connection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveInitialApiKey } from './use-app-connection'
+
+describe('resolveInitialApiKey', () => {
+  it('keeps the stored connection key paired with the stored account and user', () => {
+    expect(
+      resolveInitialApiKey({
+        defaultApiKey: 'default-key',
+        envApiKey: '',
+        sessionApiKey: 'previous-session-user-key',
+        storedApiKey: 'stored-selected-user-key',
+      }),
+    ).toBe('stored-selected-user-key')
+  })
+
+  it('falls back to the session key when no connection key is stored', () => {
+    expect(
+      resolveInitialApiKey({
+        defaultApiKey: 'default-key',
+        envApiKey: '',
+        sessionApiKey: 'session-user-key',
+        storedApiKey: undefined,
+      }),
+    ).toBe('session-user-key')
+  })
+
+  it('honors an explicit environment key first', () => {
+    expect(
+      resolveInitialApiKey({
+        defaultApiKey: 'default-key',
+        envApiKey: 'env-key',
+        sessionApiKey: 'session-user-key',
+        storedApiKey: 'stored-selected-user-key',
+      }),
+    ).toBe('env-key')
+  })
+})

--- a/web-studio/src/hooks/use-app-connection.test.ts
+++ b/web-studio/src/hooks/use-app-connection.test.ts
@@ -8,21 +8,19 @@ describe('resolveInitialApiKey', () => {
       resolveInitialApiKey({
         defaultApiKey: 'default-key',
         envApiKey: '',
-        sessionApiKey: 'previous-session-user-key',
         storedApiKey: 'stored-selected-user-key',
       }),
     ).toBe('stored-selected-user-key')
   })
 
-  it('falls back to the session key when no connection key is stored', () => {
+  it('falls back to the default key when no connection key is stored', () => {
     expect(
       resolveInitialApiKey({
         defaultApiKey: 'default-key',
         envApiKey: '',
-        sessionApiKey: 'session-user-key',
         storedApiKey: undefined,
       }),
-    ).toBe('session-user-key')
+    ).toBe('default-key')
   })
 
   it('honors an explicit environment key first', () => {
@@ -30,7 +28,6 @@ describe('resolveInitialApiKey', () => {
       resolveInitialApiKey({
         defaultApiKey: 'default-key',
         envApiKey: 'env-key',
-        sessionApiKey: 'session-user-key',
         storedApiKey: 'stored-selected-user-key',
       }),
     ).toBe('env-key')

--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -138,6 +138,20 @@ function resolveIdentityField(
   return storedValue || defaultValue
 }
 
+export function resolveInitialApiKey({
+  defaultApiKey,
+  envApiKey,
+  sessionApiKey,
+  storedApiKey,
+}: {
+  defaultApiKey: string
+  envApiKey: string
+  sessionApiKey: string
+  storedApiKey: string | undefined
+}): string {
+  return envApiKey || storedApiKey || sessionApiKey || defaultApiKey
+}
+
 function applyConnection(
   connection: ConnectionDraft,
   serverMode: ServerMode,
@@ -176,15 +190,17 @@ async function detectConnectionRole(
 
 function readInitialConnection(): ConnectionDraft {
   const storedConnection = readStoredConnection()
+  const sessionApiKey = ovClient.getConnection().apiKey
   const adminApiKey =
     ENV_ADMIN_API_KEY ||
     storedConnection.adminApiKey ||
     DEFAULT_CONNECTION.adminApiKey
-  const apiKey =
-    ENV_API_KEY ||
-    ovClient.getConnection().apiKey ||
-    storedConnection.apiKey ||
-    DEFAULT_CONNECTION.apiKey
+  const apiKey = resolveInitialApiKey({
+    defaultApiKey: DEFAULT_CONNECTION.apiKey,
+    envApiKey: ENV_API_KEY,
+    sessionApiKey,
+    storedApiKey: storedConnection.apiKey,
+  })
   return normalizeConnectionDraft({
     ...DEFAULT_CONNECTION,
     ...storedConnection,
@@ -263,8 +279,8 @@ export function AppConnectionProvider({
     () =>
       Boolean(
         initialConnectionRef.current?.baseUrl &&
-          (initialConnectionRef.current.adminApiKey ||
-            initialConnectionRef.current.apiKey),
+        (initialConnectionRef.current.adminApiKey ||
+          initialConnectionRef.current.apiKey),
       ),
   )
   const [serverMode, setServerMode] = React.useState<ServerMode>('checking')

--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -141,15 +141,13 @@ function resolveIdentityField(
 export function resolveInitialApiKey({
   defaultApiKey,
   envApiKey,
-  sessionApiKey,
   storedApiKey,
 }: {
   defaultApiKey: string
   envApiKey: string
-  sessionApiKey: string
   storedApiKey: string | undefined
 }): string {
-  return envApiKey || storedApiKey || sessionApiKey || defaultApiKey
+  return envApiKey || storedApiKey || defaultApiKey
 }
 
 function applyConnection(
@@ -190,7 +188,6 @@ async function detectConnectionRole(
 
 function readInitialConnection(): ConnectionDraft {
   const storedConnection = readStoredConnection()
-  const sessionApiKey = ovClient.getConnection().apiKey
   const adminApiKey =
     ENV_ADMIN_API_KEY ||
     storedConnection.adminApiKey ||
@@ -198,7 +195,6 @@ function readInitialConnection(): ConnectionDraft {
   const apiKey = resolveInitialApiKey({
     defaultApiKey: DEFAULT_CONNECTION.apiKey,
     envApiKey: ENV_API_KEY,
-    sessionApiKey,
     storedApiKey: storedConnection.apiKey,
   })
   return normalizeConnectionDraft({

--- a/web-studio/src/lib/ov-client/client.ts
+++ b/web-studio/src/lib/ov-client/client.ts
@@ -39,7 +39,7 @@ function normalizeBaseUrl(baseUrl?: string): string {
 }
 
 function readSessionStorage(key: string): string {
-  if (!isBrowser()) {
+  if (!key || !isBrowser()) {
     return ''
   }
 
@@ -51,7 +51,7 @@ function readSessionStorage(key: string): string {
 }
 
 function writeSessionStorage(key: string, value: string): void {
-  if (!isBrowser()) {
+  if (!key || !isBrowser()) {
     return
   }
 
@@ -151,7 +151,7 @@ function isEnvelopeError(value: unknown): value is OvErrorEnvelope & {
 export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
   const bindSdkClient = options.bindSdkClient ?? false
   let runtimeOptions = {
-    apiKeyStorageKey: options.apiKeyStorageKey || DEFAULT_API_KEY_STORAGE_KEY,
+    apiKeyStorageKey: options.apiKeyStorageKey ?? DEFAULT_API_KEY_STORAGE_KEY,
     baseUrl: normalizeBaseUrl(options.baseUrl),
     defaultTelemetry: options.defaultTelemetry ?? true,
   }
@@ -316,6 +316,7 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
 }
 
 export const ovClient = createOvClient({
+  apiKeyStorageKey: '',
   baseUrl: ENV_BASE_URL,
   bindSdkClient: true,
 })

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -295,7 +295,7 @@ function AccountFilterChips({
   return (
     <div className="flex min-w-0 flex-col gap-2">
       <span className="text-xs font-medium text-muted-foreground">{label}</span>
-      <div className="flex max-w-full flex-wrap gap-2">
+      <div className="flex max-w-full min-w-0 flex-wrap gap-2">
         {options.map((accountId) => {
           const isSelected = selected.has(accountId)
 
@@ -306,8 +306,9 @@ function AccountFilterChips({
               aria-pressed={isSelected}
               disabled={disabled}
               onClick={() => toggle(accountId)}
+              title={accountId}
               className={cn(
-                'h-8 rounded-full border px-3 font-mono text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                'h-8 max-w-full truncate rounded-full border px-3 font-mono text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:max-w-72',
                 isSelected
                   ? 'border-primary bg-primary text-primary-foreground'
                   : 'border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground',
@@ -1161,48 +1162,54 @@ function SettingsRoute() {
       {hasAdminAccess ? (
         <Card className="overflow-hidden">
           <CardHeader className="gap-4 border-b bg-muted/20">
-            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
+            <div className="flex min-w-0 flex-col gap-4">
               <div className="min-w-0">
                 <CardTitle>{t('management.title')}</CardTitle>
-                <CardDescription>{t('management.description')}</CardDescription>
+                <CardDescription className="max-w-3xl">
+                  {t('management.description')}
+                </CardDescription>
               </div>
-              <div className="flex flex-wrap items-end gap-2 lg:justify-end">
-                <AccountFilterChips
-                  accounts={accountOptions}
-                  disabled={!canQueryAdmin || accountsQuery.isLoading}
-                  label={t('management.accountFilter')}
-                  selectedAccountIds={selectedManagedAccountIds}
-                  onChange={setManagedAccountIds}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => void refreshAdmin()}
-                  disabled={!canQueryAdmin || managedUsersQuery.isFetching}
-                >
-                  <RefreshCwIcon
-                    className={cn(
-                      managedUsersQuery.isFetching && 'animate-spin',
-                    )}
+              <div className="flex min-w-0 flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+                <div className="min-w-0 flex-1">
+                  <AccountFilterChips
+                    accounts={accountOptions}
+                    disabled={!canQueryAdmin || accountsQuery.isLoading}
+                    label={t('management.accountFilter')}
+                    selectedAccountIds={selectedManagedAccountIds}
+                    onChange={setManagedAccountIds}
                   />
-                  {t('actions.refresh')}
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => setAddAccountOpen(true)}
-                  disabled={!canQueryAdmin}
-                >
-                  <PlusIcon />
-                  {t('actions.addAccount')}
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => setAddUserOpen(true)}
-                  disabled={!canQueryAdmin}
-                >
-                  <PlusIcon />
-                  {t('actions.addUser')}
-                </Button>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2 xl:justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void refreshAdmin()}
+                    disabled={!canQueryAdmin || managedUsersQuery.isFetching}
+                  >
+                    <RefreshCwIcon
+                      className={cn(
+                        managedUsersQuery.isFetching && 'animate-spin',
+                      )}
+                    />
+                    {t('actions.refresh')}
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => setAddAccountOpen(true)}
+                    disabled={!canQueryAdmin}
+                  >
+                    <PlusIcon />
+                    {t('actions.addAccount')}
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => setAddUserOpen(true)}
+                    disabled={!canQueryAdmin}
+                  >
+                    <PlusIcon />
+                    {t('actions.addUser')}
+                  </Button>
+                </div>
               </div>
             </div>
           </CardHeader>

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -647,22 +647,6 @@ function SettingsRoute() {
     serverMode !== 'dev' && (hasAdminAccess || hasSavedAdminApiKey)
   const canQueryAdmin = Boolean(controlApiKey) && hasAdminAccess
   const showDevApiKeyPlaceholder = serverMode === 'dev'
-  const shouldPromoteApiKeyToAdmin =
-    hasAdminAccess && !draft.adminApiKey.trim() && Boolean(draft.apiKey.trim())
-
-  React.useEffect(() => {
-    if (!hasAdminAccess || draft.adminApiKey.trim() || !draft.apiKey.trim()) {
-      return
-    }
-
-    const next = {
-      ...draft,
-      adminApiKey: draft.apiKey,
-      apiKey: '',
-    }
-    setDraft(next)
-    saveConnection(next)
-  }, [draft, hasAdminAccess, saveConnection])
 
   const accountsQuery = useQuery({
     enabled: canQueryAdmin,
@@ -776,8 +760,7 @@ function SettingsRoute() {
         Boolean(current.userId) && userIds.includes(current.userId)
       const userId = hasCurrentUser ? current.userId : preferred
       const selectedUser = users.find((user) => user.userId === userId)
-      const apiKey =
-        selectedUser?.apiKey || (hasCurrentUser ? current.apiKey : '')
+      const apiKey = selectedUser?.apiKey || ''
       const next = { ...current, apiKey, userId }
 
       if (next.apiKey !== current.apiKey || next.userId !== current.userId) {
@@ -887,6 +870,25 @@ function SettingsRoute() {
   ).length
   const adminUnavailable = !canQueryAdmin || managedUsersQuery.isError
 
+  function findSelectedUser(
+    accountId: string,
+    preferredUserId: string,
+  ): AdminUser | undefined {
+    const normalizedAccountId = accountId || DEFAULT_ACCOUNT_ID
+    const candidates = [...users, ...managedUsers]
+      .filter((user) => user.accountId === normalizedAccountId)
+      .filter(
+        (user, index, list) =>
+          list.findIndex((item) => item.userId === user.userId) === index,
+      )
+
+    return (
+      candidates.find((user) => user.userId === preferredUserId) ||
+      candidates.find((user) => user.userId === DEFAULT_USER_ID) ||
+      candidates[0]
+    )
+  }
+
   function updateDraft(next: Partial<ConnectionDraft>): void {
     const updated = { ...draft, ...next }
     setDraft(updated)
@@ -894,15 +896,19 @@ function SettingsRoute() {
   }
 
   function updateConnectionAccount(accountId: string): void {
+    const selectedUser = findSelectedUser(accountId, draft.userId)
+    setManagedAccountIds((current) =>
+      sortedAccountIds([...current, accountId], ''),
+    )
     updateDraft({
       accountId,
-      apiKey: '',
-      userId: DEFAULT_USER_ID,
+      apiKey: selectedUser?.apiKey || '',
+      userId: selectedUser?.userId || DEFAULT_USER_ID,
     })
   }
 
   function updateConnectionUser(userId: string): void {
-    const selectedUser = users.find((user) => user.userId === userId)
+    const selectedUser = findSelectedUser(draft.accountId, userId)
     updateDraft({
       apiKey: selectedUser?.apiKey || '',
       userId,
@@ -1075,11 +1081,7 @@ function SettingsRoute() {
                     <Input
                       id="settings-admin-api-key"
                       type="password"
-                      value={
-                        shouldPromoteApiKeyToAdmin
-                          ? draft.apiKey
-                          : draft.adminApiKey
-                      }
+                      value={draft.adminApiKey}
                       onChange={(event) =>
                         updateDraft({ adminApiKey: event.target.value })
                       }
@@ -1096,7 +1098,7 @@ function SettingsRoute() {
                       accountId={draft.accountId || DEFAULT_ACCOUNT_ID}
                       id="settings-user-api-key"
                       userId={draft.userId || DEFAULT_USER_ID}
-                      value={shouldPromoteApiKeyToAdmin ? '' : draft.apiKey}
+                      value={draft.apiKey}
                       onChange={(apiKey) => updateDraft({ apiKey })}
                       placeholder={t('placeholders.userApiKey')}
                     />


### PR DESCRIPTION
## Summary
- keep Studio API key selection as a single localStorage-backed connection state; the global Studio client no longer reads/writes the legacy sessionStorage `ov_console_api_key`
- make account/user dropdown changes update `connection.apiKey` from the selected user key, and clear stale keys when the selected user has no key loaded
- make "Use as user key" update the same `connection.apiKey` without auto-promoting it into `adminApiKey`
- prevent the Settings user-management header from being squeezed by many account chips and truncate very long chips

## Tests
- npm run test -- src/hooks/use-app-connection.test.ts
- npm run lint (passes with existing warnings)
- npm run build