### PR TITLE
fix: auth role string serialization [the Enum issue]

### DIFF
--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -239,7 +239,7 @@ class WatchScheduler:
                     account_id=task.account_id,
                     user_id=task.user_id,
                 )
-                role_value = getattr(task, "original_role", None) or Role.USER.value
+                role_value = getattr(task, "original_role", None) or str(Role.USER)
                 try:
                     role = Role(role_value)
                 except Exception:
@@ -312,7 +312,7 @@ class WatchScheduler:
                                 task_id=task.task_id,
                                 account_id=task.account_id,
                                 user_id=task.user_id,
-                                role=getattr(task, "original_role", None) or Role.USER.value,
+                                role=getattr(task, "original_role", None) or str(Role.USER),
                                 is_active=False,
                             )
                         )

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -331,7 +331,7 @@ class FSService:
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
             peer_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=str(ctx.role),
             skip_vectorization=False,
             telemetry_id=telemetry_id,
             coalesce_key=build_semantic_coalesce_key(

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -565,7 +565,7 @@ class ReindexExecutor:
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
             peer_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=str(ctx.role),
             skip_vectorization=True,
         )
         await processor.on_dequeue({"data": msg.to_json()}, lock=lock.as_borrowed())

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -951,7 +951,7 @@ class ResourceService:
             to_uri=to_uri,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=str(ctx.role),
         )
         if existing_task:
             if existing_task.is_active:
@@ -964,7 +964,7 @@ class ResourceService:
                 task_id=existing_task.task_id,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
-                role=ctx.role.value,
+                role=str(ctx.role),
                 path=path,
                 to_uri=to_uri,
                 parent_uri=parent_uri,
@@ -985,7 +985,7 @@ class ResourceService:
                 path=path,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
-                original_role=ctx.role.value,
+                original_role=str(ctx.role),
                 to_uri=to_uri,
                 parent_uri=parent_uri,
                 reason=reason,
@@ -1013,14 +1013,14 @@ class ResourceService:
             to_uri=to_uri,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=str(ctx.role),
         )
         if existing_task:
             await watch_manager.update_task(
                 task_id=existing_task.task_id,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
-                role=ctx.role.value,
+                role=str(ctx.role),
                 is_active=False,
             )
             logger.info(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1326,7 +1326,7 @@ class Session:
                                 "session_uri": self._session_uri,
                                 "account_id": self.ctx.account_id,
                                 "user_id": self.ctx.user.user_id,
-                                "role": self.ctx.role.value,
+                                "role": str(self.ctx.role),
                             },
                         )
 

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -466,7 +466,7 @@ class ContentWriteCoordinator:
             recursive=recursive,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
-            role=ctx.role.value,
+            role=str(ctx.role),
             skip_vectorization=False,
             telemetry_id=telemetry.telemetry_id,
             coalesce_key=(

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -3,7 +3,6 @@
 """SemanticProcessor: Processes messages from SemanticQueue, generates .abstract.md and .overview.md."""
 
 import asyncio
-import json
 import threading
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -13,16 +12,16 @@ from openviking.observability.context import (
     bind_root_observability_context,
     reset_root_observability_context,
 )
+from openviking.parse.image_rewrite import (
+    IMAGE_MAPPINGS_FILENAME,
+    rewrite_image_uris,
+)
 from openviking.parse.parsers.constants import (
     CODE_EXTENSIONS,
     DOCUMENTATION_EXTENSIONS,
     FILE_TYPE_CODE,
     FILE_TYPE_DOCUMENTATION,
     FILE_TYPE_OTHER,
-)
-from openviking.parse.image_rewrite import (
-    IMAGE_MAPPINGS_FILENAME,
-    rewrite_image_uris,
 )
 from openviking.parse.parsers.media.utils import (
     generate_audio_summary,
@@ -171,7 +170,7 @@ class SemanticProcessor(DequeueHandlerBase):
 
     @staticmethod
     def _ctx_from_semantic_msg(msg: SemanticMsg) -> RequestContext:
-        role = Role(msg.role) if msg.role in {r.value for r in Role} else Role.ROOT
+        role = Role(msg.role or Role.ROOT)
         return RequestContext(
             user=UserIdentifier(msg.account_id, msg.user_id),
             role=role,

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -118,7 +118,7 @@ class Summarizer:
                     account_id=ctx.account_id,
                     user_id=ctx.user.user_id,
                     peer_id=ctx.user.user_id,
-                    role=ctx.role.value,
+                    role=str(ctx.role),
                     skip_vectorization=skip_vectorization,
                     telemetry_id=telemetry.telemetry_id,
                     target_uri=target_uri if target_uri != source_uri else None,

--- a/tests/integration/test_watch_e2e.py
+++ b/tests/integration/test_watch_e2e.py
@@ -23,7 +23,7 @@ async def get_watch_task(client: AsyncOpenViking, to_uri: str):
         to_uri=to_uri,
         account_id=client._service.user.account_id,
         user_id=client._service.user.user_id,
-        role=Role.USER.value,
+        role=str(Role.USER),
     )
 
 

--- a/tests/server/test_identity.py
+++ b/tests/server/test_identity.py
@@ -12,10 +12,10 @@ from openviking_cli.session.user_id import UserIdentifier
 
 
 def test_role_values():
-    """Role enum should have correct string values."""
-    assert Role.ROOT.value == "root"
-    assert Role.ADMIN.value == "admin"
-    assert Role.USER.value == "user"
+    """Built-in roles should expose stable string values."""
+    assert str(Role.ROOT) == "root"
+    assert str(Role.ADMIN) == "admin"
+    assert str(Role.USER) == "user"
 
 
 def test_role_from_string():
@@ -23,6 +23,19 @@ def test_role_from_string():
     assert Role("root") == Role.ROOT
     assert Role("admin") == Role.ADMIN
     assert Role("user") == Role.USER
+
+
+def test_custom_role_value():
+    """Custom roles should behave like strings and support registered ranks."""
+    role = Role("reviewer")
+    assert str(role) == "reviewer"
+    assert role == "reviewer"
+
+    try:
+        Role.register("reviewer", 1)
+        assert Role("reviewer").rank == 1
+    finally:
+        Role._CUSTOM_RANK.pop("reviewer", None)
 
 
 def test_resolved_identity_defaults():

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -22,7 +22,7 @@ async def get_task_by_uri(service: ResourceService, to_uri: str, ctx: RequestCon
         to_uri=to_uri,
         account_id=ctx.account_id,
         user_id=ctx.user.user_id,
-        role=ctx.role.value,
+        role=str(ctx.role),
     )
 
 
@@ -441,7 +441,7 @@ class TestWatchTaskConflict:
             task_id=task_id,
             account_id=request_context.account_id,
             user_id=request_context.user.user_id,
-            role=request_context.role.value,
+            role=str(request_context.role),
             is_active=False,
         )
 
@@ -590,7 +590,7 @@ class TestWatchTaskUpdate:
             task_id=task.task_id,
             account_id=request_context.account_id,
             user_id=request_context.user.user_id,
-            role=request_context.role.value,
+            role=str(request_context.role),
             is_active=False,
         )
 

--- a/tests/storage/test_semantic_processor_identity.py
+++ b/tests/storage/test_semantic_processor_identity.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SemanticProcessor identity reconstruction."""
+
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+
+def test_ctx_from_semantic_msg_preserves_custom_role():
+    msg = SemanticMsg(
+        uri="viking://resources/doc",
+        context_type="resource",
+        account_id="acme",
+        user_id="alice",
+        role="reviewer",
+    )
+
+    ctx = SemanticProcessor._ctx_from_semantic_msg(msg)
+
+    assert ctx.account_id == "acme"
+    assert ctx.user.user_id == "alice"
+    assert str(ctx.role) == "reviewer"
+
+
+def test_ctx_from_semantic_msg_defaults_empty_role_to_root():
+    msg = SemanticMsg(
+        uri="viking://resources/doc",
+        context_type="resource",
+        role="",
+    )
+
+    ctx = SemanticProcessor._ctx_from_semantic_msg(msg)
+
+    assert str(ctx.role) == "root"


### PR DESCRIPTION
## Summary

Follow-up for the auth refactor from #2709. `Role` is now an open string value object so auth plugins can define custom roles, but several downstream queue, watch, session, and service paths still treated it like an enum and accessed `.value`.

This PR aligns those boundaries to the new model:

- serialize request roles with `str(ctx.role)` when writing semantic queue messages, watch tasks, redo-log payloads, and related metadata
- reconstruct semantic queue request context with `Role(msg.role or Role.ROOT)` so custom plugin roles are preserved instead of collapsed to root
- update tests to assert string role behavior rather than enum `.value` behavior
- add coverage for semantic processor custom role reconstruction

## Validation

- `uv run --frozen --extra test pytest tests/server/test_identity.py tests/storage/test_semantic_processor_identity.py tests/server/test_content_write_service.py::test_resource_write_semantic_refresh_uses_coalesce_key tests/service/test_fs_service.py::test_resource_rm_without_wait_only_queues_refresh`
- `uv run --frozen --extra dev ruff check openviking/resource/watch_scheduler.py openviking/service/fs_service.py openviking/service/reindex_executor.py openviking/service/resource_service.py openviking/session/session.py openviking/storage/content_write.py openviking/storage/queuefs/semantic_processor.py openviking/utils/summarizer.py tests/integration/test_watch_e2e.py tests/server/test_identity.py tests/service/test_resource_service_watch.py tests/storage/test_semantic_processor_identity.py`
- `git diff --check`
