### PR TITLE
feat[codex] use session-aware search for recall

### DIFF
--- a/examples/codex-memory-plugin/DESIGN.md
+++ b/examples/codex-memory-plugin/DESIGN.md
@@ -146,11 +146,16 @@ State is updated:
 
 ## Injected context boundary
 
-`UserPromptSubmit` stdin `prompt` is the user's prompt only. Recalled
-memory is sent back through `hookSpecificOutput.additionalContext`, then
-Codex injects it into the model turn. Transcript capture may later see
-that injected context adjacent to the prompt, so plugin-generated recall
-and resume context are wrapped in a deterministic boundary:
+`UserPromptSubmit` stdin includes the user's `prompt` plus the Codex
+`session_id`. Recall derives the same OpenViking session id used by Stop
+capture (`cx-<safe-session-id>`, unless legacy state already has an
+`ovSessionId`) and calls `/api/v1/search/search` with that `session_id`,
+so OpenViking can use recent session messages and archive overview during
+query expansion. Recalled memory is sent back through
+`hookSpecificOutput.additionalContext`, then Codex injects it into the
+model turn. Transcript capture may later see that injected context
+adjacent to the prompt, so plugin-generated recall and resume context are
+wrapped in a deterministic boundary:
 
 ```text
 <openviking-context source="auto-recall" format="digest">
@@ -326,6 +331,16 @@ Configured `off` (`OPENVIKING_RECALL_COMPRESS=0`, model `off`, or thinking
   "permission_mode": "default" | "acceptEdits" | "plan" | "dontAsk" | "bypassPermissions",
   "transcript_path": "/path/to/rollout.jsonl" | null,
   "hook_event_name": "SessionStart"
+}
+
+// UserPromptSubmit input
+{
+  "session_id": "0193af...",
+  "prompt": "user prompt text",
+  "cwd": "/path/to/cwd",
+  "model": "gpt-5.5",
+  "permission_mode": "default",
+  "hook_event_name": "UserPromptSubmit"
 }
 
 // Stop input

--- a/examples/codex-memory-plugin/DESIGN.md
+++ b/examples/codex-memory-plugin/DESIGN.md
@@ -148,10 +148,11 @@ State is updated:
 
 `UserPromptSubmit` stdin includes the user's `prompt` plus the Codex
 `session_id`. Recall derives the same OpenViking session id used by Stop
-capture (`cx-<safe-session-id>`, unless legacy state already has an
-`ovSessionId`) and calls `/api/v1/search/search` with that `session_id`,
-so OpenViking can use recent session messages and archive overview during
-query expansion. Recalled memory is sent back through
+capture (`cx-<safe-session-id>`) directly from the Codex session id and
+calls `/api/v1/search/search` with that `session_id`, so OpenViking can
+use recent session messages and archive overview during query expansion.
+Recall does not read plugin state, so a corrupt or missing state file
+cannot crash the recall hook. Recalled memory is sent back through
 `hookSpecificOutput.additionalContext`, then Codex injects it into the
 model turn. Transcript capture may later see that injected context
 adjacent to the prompt, so plugin-generated recall and resume context are
@@ -216,8 +217,9 @@ OV session id, while commits create additional archives under that session.
 ```
 
 Legacy state files from earlier plugin versions may still contain a UUID
-`ovSessionId`; the hook preserves that value until the next commit so
-already-captured turns are not orphaned.
+`ovSessionId`; those are now overwritten with the derived `cx-*` id on the
+next resolve. The migration window for preserving old UUID sessions has
+closed.
 
 State files are atomic-write (tmpfile + rename) to survive crash mid-write.
 

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -114,7 +114,7 @@ Earlier plugin versions configured tuning fields under a `codex` block in `~/.op
       │                 │                │                   │
       │             ┌───▼────────────────▼───────────────────▼──┐
       └────────────►│        OpenViking REST API                │
-                    │ /api/v1/search/find                       │
+                    │ /api/v1/search/search                      │
                     │ /api/v1/sessions [+/{id}/{messages,commit}]│
                     │ /api/v1/content/read                      │
                     └─────────────────┬─────────────────────────┘
@@ -152,7 +152,7 @@ On `resume`, the script skips commit/sweep. If local state has no live `ovSessio
 
 ### Auto-recall (every UserPromptSubmit)
 
-`auto-recall.mjs` reads `prompt` from stdin, calls `/api/v1/search/find`, ranks results, reads full content for top-ranked leaves, and emits:
+`auto-recall.mjs` reads `prompt` and `session_id` from stdin, derives the long-lived OpenViking session id (`cx-<safe-session-id>` unless legacy state already has an `ovSessionId`), calls `/api/v1/search/search` with that `session_id`, ranks results, reads full content for top-ranked leaves, and emits:
 
 ```json
 { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "<openviking-context source=\"auto-recall\" format=\"digest\">\nOpenViking memory digest:\n- ...\n</openviking-context>" } }
@@ -204,7 +204,7 @@ Codex's hook output schema differs from Claude Code's. Notably:
 | Hook | Input field of interest | Output channel for context injection |
 |------|------------------------|--------------------------------------|
 | `SessionStart`   | `source` (`startup`/`resume`/`clear`), `session_id` | `hookSpecificOutput.additionalContext` |
-| `UserPromptSubmit` | `prompt`                                    | `hookSpecificOutput.additionalContext` |
+| `UserPromptSubmit` | `prompt`, `session_id`                     | `hookSpecificOutput.additionalContext` |
 | `Stop`           | `last_assistant_message`, `transcript_path`, `session_id` | `systemMessage` (only) |
 | `PreCompact`     | `trigger` (`manual`/`auto`), `transcript_path`, `session_id` | `systemMessage` (only) |
 
@@ -226,7 +226,7 @@ codex-memory-plugin/
 │   ├── debug-log.mjs            # Structured JSONL logger
 │   ├── recall-compressor-profile.mjs # Compressor profile detection/cache
 │   ├── session-state.mjs        # Per-codex-session OV session state
-│   ├── auto-recall.mjs          # UserPromptSubmit hook (REST /search/find)
+│   ├── auto-recall.mjs          # UserPromptSubmit hook (REST /search/search)
 │   ├── auto-capture.mjs         # Stop hook (REST /sessions/{id}/messages)
 │   ├── session-start-commit.mjs # SessionStart hook (active-window + idle TTL)
 │   └── pre-compact-capture.mjs  # PreCompact hook

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -152,7 +152,7 @@ On `resume`, the script skips commit/sweep. If local state has no live `ovSessio
 
 ### Auto-recall (every UserPromptSubmit)
 
-`auto-recall.mjs` reads `prompt` and `session_id` from stdin, derives the long-lived OpenViking session id (`cx-<safe-session-id>` unless legacy state already has an `ovSessionId`), calls `/api/v1/search/search` with that `session_id`, ranks results, reads full content for top-ranked leaves, and emits:
+`auto-recall.mjs` reads `prompt` and `session_id` from stdin, derives the long-lived OpenViking session id (`cx-<safe-session-id>`) directly from the Codex session id (no plugin state read, so a corrupt state file can't crash recall), calls `/api/v1/search/search` with that `session_id`, ranks results, reads full content for top-ranked leaves, and emits:
 
 ```json
 { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "<openviking-context source=\"auto-recall\" format=\"digest\">\nOpenViking memory digest:\n- ...\n</openviking-context>" } }

--- a/examples/codex-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.mjs
@@ -25,6 +25,7 @@ import {
   loadCachedRecallCompressorProfile,
   markRecallCompressorRuntimeFailed,
 } from "./recall-compressor-profile.mjs";
+import { loadState, resolveOvSessionId } from "./session-state.mjs";
 
 const cfg = loadConfig();
 const { log, logError } = createLogger("auto-recall");
@@ -212,21 +213,22 @@ function postProcess(items, limit, threshold) {
   return result;
 }
 
-async function searchScope(query, targetUri, limit, bucket = "memories") {
+async function searchScope(query, targetUri, limit, bucket = "memories", sessionId = null) {
   // Keep current-user shorthand here; the server canonicalizes it using the
   // authenticated/trusted request context.
   const body = { query, target_uri: targetUri, limit, score_threshold: 0 };
-  const result = await fetchJSON("/api/v1/search/find", {
+  if (sessionId) body.session_id = sessionId;
+  const result = await fetchJSON("/api/v1/search/search", {
     method: "POST",
     body: JSON.stringify(body),
   });
   return result?.[bucket] || [];
 }
 
-async function searchAll(query, limit) {
+async function searchAll(query, limit, sessionId = null) {
   const [userMems, userSkills] = await Promise.all([
-    searchScope(query, "viking://user/memories", limit),
-    searchScope(query, "viking://user/skills", limit, "skills"),
+    searchScope(query, "viking://user/memories", limit, "memories", sessionId),
+    searchScope(query, "viking://user/skills", limit, "skills", sessionId),
   ]);
   log("search_complete", { scope: "user", rawCount: userMems.length, topScores: userMems.slice(0, 3).map((m) => m.score) });
   log("search_complete", { scope: "skills", rawCount: userSkills.length, topScores: userSkills.slice(0, 3).map((m) => m.score) });
@@ -237,6 +239,12 @@ async function searchAll(query, limit) {
     seen.add(m.uri);
     return true;
   });
+}
+
+async function resolveRecallSessionId(codexSessionId) {
+  if (!codexSessionId) return null;
+  const state = await loadState(codexSessionId);
+  return resolveOvSessionId(state);
 }
 
 async function readMemoryContent(uri) {
@@ -447,7 +455,11 @@ async function main() {
   }
 
   const userPrompt = (input.prompt || "").trim();
+  const codexSessionId = typeof input.session_id === "string" ? input.session_id.trim() : "";
+  const recallSessionId = await resolveRecallSessionId(codexSessionId);
   log("start", {
+    codexSessionId: codexSessionId || null,
+    recallSessionId,
     query: userPrompt.slice(0, 200),
     queryLength: userPrompt.length,
     config: { recallLimit: cfg.recallLimit, scoreThreshold: cfg.scoreThreshold },
@@ -467,7 +479,7 @@ async function main() {
   }
 
   const candidateLimit = Math.max(cfg.recallLimit * 4, 20);
-  const allMemories = await searchAll(userPrompt, candidateLimit);
+  const allMemories = await searchAll(userPrompt, candidateLimit, recallSessionId);
   if (allMemories.length === 0) {
     log("skip", { stage: "search", reason: "no results" });
     emit();

--- a/examples/codex-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.mjs
@@ -25,7 +25,7 @@ import {
   loadCachedRecallCompressorProfile,
   markRecallCompressorRuntimeFailed,
 } from "./recall-compressor-profile.mjs";
-import { loadState, resolveOvSessionId } from "./session-state.mjs";
+import { deriveOvSessionId } from "./session-state.mjs";
 
 const cfg = loadConfig();
 const { log, logError } = createLogger("auto-recall");
@@ -241,10 +241,13 @@ async function searchAll(query, limit, sessionId = null) {
   });
 }
 
-async function resolveRecallSessionId(codexSessionId) {
+function resolveRecallSessionId(codexSessionId) {
   if (!codexSessionId) return null;
-  const state = await loadState(codexSessionId);
-  return resolveOvSessionId(state);
+  // Derive directly: the OV session id is deterministic (cx-<safe-id>), so
+  // recall does not need to read plugin state. This keeps the recall hook
+  // crash-free even if the state file is corrupt/missing, and stays in sync
+  // with capture, which now also derives cx-* unconditionally.
+  return deriveOvSessionId(codexSessionId);
 }
 
 async function readMemoryContent(uri) {
@@ -456,7 +459,7 @@ async function main() {
 
   const userPrompt = (input.prompt || "").trim();
   const codexSessionId = typeof input.session_id === "string" ? input.session_id.trim() : "";
-  const recallSessionId = await resolveRecallSessionId(codexSessionId);
+  const recallSessionId = resolveRecallSessionId(codexSessionId);
   log("start", {
     codexSessionId: codexSessionId || null,
     recallSessionId,

--- a/examples/codex-memory-plugin/scripts/auto-recall.test.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf-8");
+      try {
+        resolve(raw ? JSON.parse(raw) : null);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function writeJson(res, value) {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(value));
+}
+
+async function withMockOpenViking(handler, fn) {
+  const server = http.createServer((req, res) => {
+    handler(req, res).catch((err) => {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "error", error: String(err?.stack || err) }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function runAutoRecall(input, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(SCRIPT_DIR, "auto-recall.mjs")], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`auto-recall exited ${code}: ${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+test("auto-recall uses context-aware search with the derived OpenViking session id", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-auto-recall-state-"));
+  const requests = [];
+
+  try {
+    await withMockOpenViking(async (req, res) => {
+      const url = new URL(req.url, "http://127.0.0.1");
+      if (req.method === "GET" && url.pathname === "/health") {
+        writeJson(res, { status: "ok", result: { ok: true } });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/api/v1/search/search") {
+        const body = await readRequestBody(req);
+        requests.push({ path: url.pathname, body });
+        if (body.target_uri === "viking://user/memories") {
+          writeJson(res, {
+            status: "ok",
+            result: {
+              memories: [{
+                uri: "viking://user/zeus/memories/events/context-search.md",
+                level: 2,
+                score: 0.9,
+                category: "events",
+                abstract: "context search memory",
+              }],
+              skills: [],
+            },
+          });
+          return;
+        }
+        writeJson(res, { status: "ok", result: { memories: [], skills: [] } });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/v1/content/read") {
+        writeJson(res, { status: "ok", result: "context-aware recalled detail" });
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "error", error: "not found" }));
+    }, async (baseUrl) => {
+      const result = await runAutoRecall(
+        { prompt: "please use prior context", session_id: "codex:123" },
+        {
+          OPENVIKING_AUTO_RECALL: "1",
+          OPENVIKING_CODEX_STATE_DIR: stateDir,
+          OPENVIKING_CONFIG_FILE: join(stateDir, "missing-ov.conf"),
+          OPENVIKING_CLI_CONFIG_FILE: join(stateDir, "missing-ovcli.conf"),
+          OPENVIKING_CREDENTIAL_SOURCE: "env",
+          OPENVIKING_RECALL_COMPRESS: "0",
+          OPENVIKING_RECALL_LIMIT: "1",
+          OPENVIKING_RECALL_TIMEOUT_MS: "10000",
+          OPENVIKING_MIN_QUERY_LENGTH: "1",
+          OPENVIKING_SCORE_THRESHOLD: "0",
+          OPENVIKING_TIMEOUT_MS: "5000",
+          OPENVIKING_URL: baseUrl,
+        },
+      );
+
+      const output = JSON.parse(result.stdout.trim());
+      assert.match(
+        output.hookSpecificOutput.additionalContext,
+        /context-aware recalled detail/,
+      );
+    });
+
+    assert.equal(requests.length, 2);
+    assert.deepEqual(
+      requests.map((request) => request.body.target_uri).sort(),
+      ["viking://user/memories", "viking://user/skills"],
+    );
+    assert.ok(requests.every((request) => request.body.session_id === "cx-codex_123"));
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/examples/codex-memory-plugin/scripts/session-state.mjs
+++ b/examples/codex-memory-plugin/scripts/session-state.mjs
@@ -29,9 +29,10 @@ export function deriveOvSessionId(codexSessionId) {
 }
 
 export function resolveOvSessionId(state) {
-  // Keep legacy persisted UUIDs so already-captured turns are not orphaned
-  // before their next commit. Fresh or cleared state derives the cx-* id.
-  if (state.ovSessionId) return state.ovSessionId;
+  // Always derive the deterministic cx-* id. Legacy persisted UUIDs from
+  // before the cx-* scheme are no longer preserved: the migration window
+  // has closed and keeping them would desync recall (which derives cx-*)
+  // from capture (which used to echo back the legacy value).
   state.ovSessionId = deriveOvSessionId(state.codexSessionId);
   return state.ovSessionId;
 }


### PR DESCRIPTION
## Summary

- Switch Codex auto-recall from the query-only `/api/v1/search/find` endpoint to context-aware `/api/v1/search/search`.
- Derive the long-lived OpenViking session id (`cx-<safe-codex-session-id>`) **directly from the Codex session id**, without reading plugin state, so recall can use recent session messages and archive overview. Deriving directly (rather than `loadState` + `resolveOvSessionId`) keeps the UserPromptSubmit hook crash-free even if the state file is corrupt or missing.
- Drop legacy `ovSessionId` preservation in `resolveOvSessionId` (session-state.mjs): old UUID sessions from before the `cx-*` scheme are no longer kept. This closes a desync where recall (deriving `cx-*`) and capture (echoing a legacy UUID) would target different OV sessions. The migration window has closed; existing legacy state files are overwritten with `cx-*` on the next resolve.
- Add a Node regression test that runs the real hook against a mock OpenViking server and asserts the search payload includes the derived `session_id` (`cx-codex_123`).
- Update Codex plugin README/DESIGN docs to describe the session-aware recall path and the removed legacy preservation.

## Root Cause

The Codex plugin auto-recall path was using `/api/v1/search/find`, which only searched by the current query and target URI. That bypassed OpenViking's session-aware search context, so historical conversation context was not available during recall query expansion.

A follow-up issue (caught in review): recall was reading plugin state via `loadState` just to derive a deterministic id, which meant a corrupt state file could crash the hook and block the user from typing. Fixed by deriving directly.

## Validation

- `node --test examples/codex-memory-plugin/scripts/auto-recall.test.mjs examples/codex-memory-plugin/scripts/ov-credentials.test.mjs examples/codex-memory-plugin/scripts/recall-compressor-profile.test.mjs` — 23 pass, 0 fail
- `node --check` on all modified `.mjs` files
- `git diff --check`

## Changes

- `examples/codex-memory-plugin/scripts/auto-recall.mjs` — use `deriveOvSessionId` directly, drop `loadState` import, make `resolveRecallSessionId` sync
- `examples/codex-memory-plugin/scripts/session-state.mjs` — `resolveOvSessionId` always derives `cx-*`, no legacy UUID preservation
- `examples/codex-memory-plugin/DESIGN.md` / `README.md` — drop "unless legacy state has ovSessionId" wording, note recall no longer reads state