### PR TITLE
feat(sdk/go): expose tags search filter on Find and Search

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -123,6 +123,10 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		if !ok || len(levels) != 2 || levels[0] != float64(0) || levels[1] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		tags, ok := body["tags"].([]any)
+		if !ok || len(tags) != 2 || tags[0] != "project-x" || tags[1] != "draft" {
+			t.Fatalf("tags = %#v", body["tags"])
+		}
 		writeOK(t, w, map[string]any{
 			"resources": []map[string]any{
 				{"uri": "viking://resources/docs/api.md", "context_type": "resource", "score": 0.9},
@@ -139,6 +143,7 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		Until:       "2026-06-18",
 		TimeField:   "created_at",
 		Level:       []int{0, 2},
+		Tags:        []string{"project-x", "draft"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +159,7 @@ func TestFindOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "tags")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -195,6 +200,10 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		if !ok || len(levels) != 1 || levels[0] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		tags, ok := body["tags"].([]any)
+		if !ok || len(tags) != 1 || tags[0] != "project-x" {
+			t.Fatalf("tags = %#v", body["tags"])
+		}
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -206,6 +215,7 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		Until:     "2026-06-18",
 		TimeField: "updated_at",
 		Level:     []int{2},
+		Tags:      []string{"project-x"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +227,7 @@ func TestSearchOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "tags")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()

--- a/sdk/go/retrieval.go
+++ b/sdk/go/retrieval.go
@@ -32,6 +32,9 @@ func (c *Client) Find(ctx context.Context, queryText string, opts *FindOptions) 
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
 	}
+	if len(opts.Tags) > 0 {
+		payload["tags"] = opts.Tags
+	}
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult
 	err := c.doJSON(ctx, http.MethodPost, "/api/v1/search/find", nil, payload, &result)
@@ -65,6 +68,9 @@ func (c *Client) Search(ctx context.Context, queryText string, opts *SearchOptio
 	setString(payload, "time_field", opts.TimeField)
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
+	}
+	if len(opts.Tags) > 0 {
+		payload["tags"] = opts.Tags
 	}
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -161,6 +161,7 @@ type FindOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	Tags           []string
 }
 
 // SearchOptions controls Search.
@@ -177,6 +178,7 @@ type SearchOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	Tags           []string
 }
 
 // GrepOptions controls Grep.


### PR DESCRIPTION
## What

Adds a `Tags []string` option to the Go SDK `FindOptions` / `SearchOptions` and forwards it as `payload["tags"]` to `/api/v1/search/find` and `/api/v1/search/search`, closing a read/filter parity gap: the server and Python SDK accept a validated `tags` retrieval filter that the Go SDK currently cannot send.

## Why

The server already consumes `tags` end-to-end:

- `openviking/server/routers/search.py` — `FindRequest.tags` / `SearchRequest.tags` (`Optional[List[str]] = None`, under `model_config = ConfigDict(extra="forbid")`); the handlers pass `request.tags` into `normalize_search_tags(...)` → a `search_tags` must-filter.
- `openviking/storage/collection_schemas.py` — `search_tags` is a first-class `list<string>` collection field.
- Python SDK exposes it: `openviking/client/local.py` `find(tags=...)` / `search(tags=...)`.

The Go SDK had **no** way to send it — `sdk/go/types.go` `FindOptions` / `SearchOptions` carried `Since` / `Until` / `TimeField` / `Level` but no `Tags`, and `sdk/go/retrieval.go` never set `tags` in the payload. So tag-scoped retrieval was unreachable from Go.

This is strictly a **read/filter** parity fix. (Note: the Go SDK does not expose `set_tags` either; tags are populated server-side / via the Python `set_tags` path / #2706. This PR only lets Go callers *filter* by tags the server has validated.)

## Change

- `types.go`: append `Tags []string` to both option structs.
- `retrieval.go`: in `Find` and `Search`, add `if len(opts.Tags) > 0 { payload["tags"] = opts.Tags }` right after the `level` block — omitting the key when empty, exactly mirroring the existing filters.
- `client_test.go`: extend the existing filter tests to assert `tags` is forwarded when set and absent when unset.

Follow-up to #2703, which added `since`/`until`/`time_field`/`level` to the same `Find`/`Search` funcs in the same three files the same way.

## Compatibility

`Tags` is appended at the **end** of the option structs, so it does not reorder or change the type of any existing field. The SDK's option structs are used with keyed literals (e.g. `FindOptions{TargetURI: ..., Limit: ...}`), which are unaffected; the only theoretical impact is an unkeyed positional literal of these option structs (which `go vet`'s composite-literal check already flags for cross-package structs). This matches the additive convention accepted in #2703.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` (clean), and `go test ./...` all pass in `sdk/go`.
