### PR TITLE
fix(cli): filter non-Press key events to prevent double-registration

### DIFF
--- a/crates/ov_cli/src/commands/skills.rs
+++ b/crates/ov_cli/src/commands/skills.rs
@@ -1422,49 +1422,60 @@ fn prompt_multi_select_skills(
     let _raw_guard = RawGuard::enter()?;
     let mut current = 0usize;
     let mut checked = vec![false; skills.len()];
-    let mut rendered_region = RenderedSkillSelectRegion::default();
+
+    // Initial render
+    let lines = skill_multi_select_lines(prompt, skills, current, &checked);
+    let mut rendered_region =
+        RenderedSkillSelectRegion::from_lines(&lines, live_skill_select_columns());
+    print!("{}", live_select_block(&lines));
+    io::stdout().flush()?;
 
     loop {
-        clear_rendered_region(&rendered_region)?;
-        let lines = skill_multi_select_lines(prompt, skills, current, &checked);
-        rendered_region =
-            RenderedSkillSelectRegion::from_lines(&lines, live_skill_select_columns());
-        print!("{}", live_select_block(&lines));
-        io::stdout().flush()?;
-
         match event::read()? {
-            Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                KeyCode::Up => {
-                    current = if current == 0 {
-                        skills.len().saturating_sub(1)
-                    } else {
-                        current - 1
-                    };
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                match key.code {
+                    KeyCode::Up => {
+                        current = if current == 0 {
+                            skills.len().saturating_sub(1)
+                        } else {
+                            current - 1
+                        };
+                    }
+                    KeyCode::Down => current = (current + 1) % skills.len(),
+                    KeyCode::Char(' ') => checked[current] = !checked[current],
+                    KeyCode::Char('a') | KeyCode::Char('A') => {
+                        let select_all = checked.iter().any(|value| !*value);
+                        checked.fill(select_all);
+                    }
+                    KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r') => {
+                        clear_rendered_region(&rendered_region)?;
+                        let selected = selected_skill_names(skills, current, &checked);
+                        return Ok(Some(selected));
+                    }
+                    KeyCode::Esc => {
+                        clear_rendered_region(&rendered_region)?;
+                        return Ok(None);
+                    }
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        clear_rendered_region(&rendered_region)?;
+                        return Err(Error::Client("Aborted.".to_string()));
+                    }
+                    _ => continue,
                 }
-                KeyCode::Down => current = (current + 1) % skills.len(),
-                KeyCode::Char(' ') => checked[current] = !checked[current],
-                KeyCode::Char('a') | KeyCode::Char('A') => {
-                    let select_all = checked.iter().any(|value| !*value);
-                    checked.fill(select_all);
-                }
-                KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r') => {
-                    clear_rendered_region(&rendered_region)?;
-                    let selected = selected_skill_names(skills, current, &checked);
-                    return Ok(Some(selected));
-                }
-                KeyCode::Esc => {
-                    clear_rendered_region(&rendered_region)?;
-                    return Ok(None);
-                }
-                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    clear_rendered_region(&rendered_region)?;
-                    return Err(Error::Client("Aborted.".to_string()));
-                }
-                _ => {}
-            },
-            Event::Key(_) => {}
+                clear_rendered_region(&rendered_region)?;
+                let lines = skill_multi_select_lines(prompt, skills, current, &checked);
+                rendered_region =
+                    RenderedSkillSelectRegion::from_lines(&lines, live_skill_select_columns());
+                print!("{}", live_select_block(&lines));
+                io::stdout().flush()?;
+            }
             Event::Resize(_, _) => {
-                // Redraw on the next loop using the new terminal width.
+                clear_rendered_region(&rendered_region)?;
+                let lines = skill_multi_select_lines(prompt, skills, current, &checked);
+                rendered_region =
+                    RenderedSkillSelectRegion::from_lines(&lines, live_skill_select_columns());
+                print!("{}", live_select_block(&lines));
+                io::stdout().flush()?;
             }
             _ => {}
         }

--- a/crates/ov_cli/src/commands/skills.rs
+++ b/crates/ov_cli/src/commands/skills.rs
@@ -1386,7 +1386,7 @@ fn prompt_multi_select_skills(
 ) -> Result<Option<Vec<String>>> {
     use crossterm::{
         cursor,
-        event::{self, Event, KeyCode, KeyModifiers},
+        event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
         execute, terminal,
     };
 
@@ -1433,7 +1433,7 @@ fn prompt_multi_select_skills(
         io::stdout().flush()?;
 
         match event::read()? {
-            Event::Key(key) => match key.code {
+            Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 KeyCode::Up => {
                     current = if current == 0 {
                         skills.len().saturating_sub(1)
@@ -1462,6 +1462,7 @@ fn prompt_multi_select_skills(
                 }
                 _ => {}
             },
+            Event::Key(_) => {}
             Event::Resize(_, _) => {
                 // Redraw on the next loop using the new terminal width.
             }

--- a/crates/ov_cli/src/config_wizard/wizard.rs
+++ b/crates/ov_cli/src/config_wizard/wizard.rs
@@ -8,7 +8,7 @@ use colored::Colorize;
 use crossterm::{
     ExecutableCommand,
     cursor::{Hide, MoveToColumn, MoveUp, Show},
-    event::{self, Event, KeyCode, KeyModifiers},
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     terminal::{self, Clear, ClearType, disable_raw_mode, enable_raw_mode},
 };
 use unicode_width::UnicodeWidthChar;
@@ -5648,7 +5648,7 @@ fn prompt_select<T: ToString>(
         ))?;
 
         match event::read()? {
-            Event::Key(key) => match key.code {
+            Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 KeyCode::Up => {
                     selected = if selected == 0 {
                         items.len().saturating_sub(1)
@@ -5674,6 +5674,7 @@ fn prompt_select<T: ToString>(
                 }
                 _ => {}
             },
+            Event::Key(_) => {}
             Event::Resize(_, _) => {
                 // Redraw on the next loop using the new terminal width.
             }
@@ -5713,7 +5714,7 @@ fn prompt_text(
         let raw = RawPrompt::enter(false)?;
         loop {
             match event::read()? {
-                Event::Key(key) => match key.code {
+                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                     KeyCode::Enter => {
                         let chosen = if value.trim().is_empty() {
                             default_copy.trim().to_string()
@@ -5767,6 +5768,7 @@ fn prompt_text(
                     }
                     _ => {}
                 },
+                Event::Key(_) => {}
                 Event::Resize(_, _) => {
                     render_text_prompt(
                         ui,

--- a/crates/ov_cli/src/config_wizard/wizard.rs
+++ b/crates/ov_cli/src/config_wizard/wizard.rs
@@ -5638,45 +5638,59 @@ fn prompt_select<T: ToString>(
     let mut selected = default.min(items.len().saturating_sub(1));
     let raw = RawPrompt::enter(true)?;
 
-    loop {
-        ui.render(&select_live_lines(
-            section,
-            prompt,
-            &items,
-            selected,
-            helper_lines,
-        ))?;
+    ui.render(&select_live_lines(
+        section,
+        prompt,
+        &items,
+        selected,
+        helper_lines,
+    ))?;
 
+    loop {
         match event::read()? {
-            Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                KeyCode::Up => {
-                    selected = if selected == 0 {
-                        items.len().saturating_sub(1)
-                    } else {
-                        selected - 1
-                    };
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                match key.code {
+                    KeyCode::Up => {
+                        selected = if selected == 0 {
+                            items.len().saturating_sub(1)
+                        } else {
+                            selected - 1
+                        };
+                    }
+                    KeyCode::Down => selected = (selected + 1) % items.len().max(1),
+                    KeyCode::Enter => {
+                        drop(raw);
+                        ui.clear()?;
+                        return Ok(PromptResult::Value(selected));
+                    }
+                    KeyCode::Esc => {
+                        drop(raw);
+                        ui.clear()?;
+                        return Ok(PromptResult::Back);
+                    }
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        drop(raw);
+                        ui.clear()?;
+                        return Ok(PromptResult::Quit);
+                    }
+                    _ => continue,
                 }
-                KeyCode::Down => selected = (selected + 1) % items.len().max(1),
-                KeyCode::Enter => {
-                    drop(raw);
-                    ui.clear()?;
-                    return Ok(PromptResult::Value(selected));
-                }
-                KeyCode::Esc => {
-                    drop(raw);
-                    ui.clear()?;
-                    return Ok(PromptResult::Back);
-                }
-                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    drop(raw);
-                    ui.clear()?;
-                    return Ok(PromptResult::Quit);
-                }
-                _ => {}
-            },
-            Event::Key(_) => {}
+                ui.render(&select_live_lines(
+                    section,
+                    prompt,
+                    &items,
+                    selected,
+                    helper_lines,
+                ))?;
+            }
             Event::Resize(_, _) => {
-                // Redraw on the next loop using the new terminal width.
+                ui.render(&select_live_lines(
+                    section,
+                    prompt,
+                    &items,
+                    selected,
+                    helper_lines,
+                ))?;
             }
             _ => {}
         }

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -970,7 +970,7 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
 
     use crossterm::{
         cursor,
-        event::{self, Event, KeyCode, KeyModifiers},
+        event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
         execute, terminal,
     };
 
@@ -1013,7 +1013,7 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
         io::stdout().flush()?;
 
         match event::read()? {
-            Event::Key(key) => match key.code {
+            Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 KeyCode::Up => {
                     selected = if selected == 0 {
                         items.len().saturating_sub(1)
@@ -1036,6 +1036,7 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
                 }
                 _ => {}
             },
+            Event::Key(_) => {}
             Event::Resize(_, _) => {
                 // Redraw on the next loop using the new terminal width.
             }

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -1002,43 +1002,52 @@ fn prompt_select(prompt: &str, items: &[String], default: usize) -> Result<Selec
     }
 
     let mut selected = default.min(items.len().saturating_sub(1));
-    let mut rendered_region = RenderedSelectRegion::default();
     let _raw_guard = RawGuard::enter()?;
 
-    loop {
-        clear_rendered_region(&rendered_region)?;
-        let lines = select_lines(prompt, items, selected);
-        rendered_region = RenderedSelectRegion::from_lines(&lines, live_select_columns());
-        print!("{}", live_select_block(&lines));
-        io::stdout().flush()?;
+    // Initial render
+    let lines = select_lines(prompt, items, selected);
+    let mut rendered_region = RenderedSelectRegion::from_lines(&lines, live_select_columns());
+    print!("{}", live_select_block(&lines));
+    io::stdout().flush()?;
 
+    loop {
         match event::read()? {
-            Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                KeyCode::Up => {
-                    selected = if selected == 0 {
-                        items.len().saturating_sub(1)
-                    } else {
-                        selected - 1
-                    };
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                match key.code {
+                    KeyCode::Up => {
+                        selected = if selected == 0 {
+                            items.len().saturating_sub(1)
+                        } else {
+                            selected - 1
+                        };
+                    }
+                    KeyCode::Down => selected = (selected + 1) % items.len(),
+                    KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r') => {
+                        clear_rendered_region(&rendered_region)?;
+                        return Ok(SelectOutcome::Selected(selected));
+                    }
+                    KeyCode::Esc => {
+                        clear_rendered_region(&rendered_region)?;
+                        return Ok(SelectOutcome::Back);
+                    }
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        clear_rendered_region(&rendered_region)?;
+                        return Ok(SelectOutcome::Quit);
+                    }
+                    _ => continue,
                 }
-                KeyCode::Down => selected = (selected + 1) % items.len(),
-                KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r') => {
-                    clear_rendered_region(&rendered_region)?;
-                    return Ok(SelectOutcome::Selected(selected));
-                }
-                KeyCode::Esc => {
-                    clear_rendered_region(&rendered_region)?;
-                    return Ok(SelectOutcome::Back);
-                }
-                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    clear_rendered_region(&rendered_region)?;
-                    return Ok(SelectOutcome::Quit);
-                }
-                _ => {}
-            },
-            Event::Key(_) => {}
+                clear_rendered_region(&rendered_region)?;
+                let lines = select_lines(prompt, items, selected);
+                rendered_region = RenderedSelectRegion::from_lines(&lines, live_select_columns());
+                print!("{}", live_select_block(&lines));
+                io::stdout().flush()?;
+            }
             Event::Resize(_, _) => {
-                // Redraw on the next loop using the new terminal width.
+                clear_rendered_region(&rendered_region)?;
+                let lines = select_lines(prompt, items, selected);
+                rendered_region = RenderedSelectRegion::from_lines(&lines, live_select_columns());
+                print!("{}", live_select_block(&lines));
+                io::stdout().flush()?;
             }
             _ => {}
         }


### PR DESCRIPTION
## Description

### Double-key registration
On Windows with ENABLE_VIRTUAL_TERMINAL_INPUT enabled (crossterm 0.28.1), the console can generate both Press and Release key events for a single physical key press. The TUI runner (tui/mod.rs) already filters for KeyEventKind::Press, but the config wizard, config switch selector, and skill multi-select did not, causing double-processing of every key press.

### Flickering
Previously ui.render() was called at the top of every event loop iteration, causing a full clear-and-redraw for every ignored event (Release, Resize, and other non-Press events). On Windows with ENABLE_VIRTUAL_TERMINAL_INPUT enabled, crossterm can emit multiple events per physical key press, leading to excessive flickering.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

Add key.kind == KeyEventKind::Press guard to all three interactive event-reading loops:
- config_wizard/wizard.rs: prompt_select and prompt_text
- handlers.rs: config switch prompt_select
- commands/skills.rs: skill multi-select prompt

Also add explicit Event::Key(_) => {} arms to discard non-Press key events cleanly.

Restructure all three interactive event loops to:
- Render once initially before the loop
- Re-render only when selection/state actually changes (Up/Down/Space)
- Re-render on terminal resize
- Skip render entirely for Release, unhandled Press, and other events

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

