### PR TITLE
docs(changelog): add v0.4.3 and v0.4.4 notes (EN + ZH)

### DIFF
--- a/docs/en/about/02-changelog.md
+++ b/docs/en/about/02-changelog.md
@@ -3,6 +3,29 @@
 All notable changes to OpenViking will be documented in this file.
 This changelog is automatically generated from [GitHub Releases](https://github.com/volcengine/OpenViking/releases).
 
+## v0.4.4 (2026-06-18)
+
+### Highlights
+
+- **Plugin-based authentication architecture**: authentication was refactored into a plugin-based design so auth backends can be swapped and extended.
+- **Go SDK search filters**: the Go SDK now exposes the search `date` and `level` filters.
+- **RAGFS encryption fix**: fixed a root-directory acquire failure caused by a missing encryption `account_id`.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.4.3...v0.4.4)
+
+## v0.4.3 (2026-06-18)
+
+### Highlights
+
+- **RAGFS caching and storage reliability**: a `CachedFileSystem` with Redis / Mooncake / Yuanrong cache providers was added, alongside a plaintext fallback for the encrypted-read migration path and a faster, more defensive legacy shape probe (parallelized, skipping zero-byte files and path locks).
+- **Go HTTP SDK**: a Go HTTP SDK landed, with accompanying Go filesystem usage examples.
+- **Code navigation endpoints**: new code-navigation endpoints were added for the opencode plugin.
+- **Security hardening**: the `python-multipart` (GHSA-5rvq-cxj2-64vf) and `cryptography` (GHSA-537c-gmf6-5ccf) dependency floors were bumped for HIGH advisories, and UnderstandingAPI zip downloads now use `safe_extract_zip` to close a Zip Slip.
+- **Feishu parsing and task encryption**: Feishu URL host matching was tightened and task-tracker encryption binding was unified.
+- **Docs search**: documentation gained OpenViking-powered, localized search.
+
+[Full Changelog](https://github.com/volcengine/OpenViking/compare/v0.4.2...v0.4.3)
+
 ## v0.4.2 (2026-06-17)
 
 ### Highlights

--- a/docs/zh/about/02-changelog.md
+++ b/docs/zh/about/02-changelog.md
@@ -3,6 +3,29 @@
 OpenViking 的所有重要变更都将记录在此文件中。
 此更新日志从 [GitHub Releases](https://github.com/volcengine/OpenViking/releases) 自动生成。
 
+## v0.4.4 (2026-06-18)
+
+### 重点更新
+
+- **插件化认证架构**：认证重构为插件化设计，认证后端可替换、可扩展。
+- **Go SDK 检索过滤**：Go SDK 新增暴露检索 `date` 与 `level` 过滤参数。
+- **RAGFS 加密修复**：修复根目录 acquire 因缺少加密 `account_id` 导致的异常。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.4.3...v0.4.4)
+
+## v0.4.3 (2026-06-18)
+
+### 重点更新
+
+- **RAGFS 缓存与存储可靠性**：新增 `CachedFileSystem` 及 Redis / Mooncake / Yuanrong 缓存 provider，补充加密读迁移路径的明文回退，并让 legacy shape probe 更快更稳健（并行化，跳过零字节文件与 path lock）。
+- **Go HTTP SDK**：新增 Go HTTP SDK，并补充 Go filesystem 使用示例。
+- **代码导航端点**：为 opencode 插件新增代码导航端点。
+- **安全加固**：将 `python-multipart`（GHSA-5rvq-cxj2-64vf）与 `cryptography`（GHSA-537c-gmf6-5ccf）依赖下限提升以修复 HIGH 级公告，UnderstandingAPI 的 zip 下载改用 `safe_extract_zip` 关闭 Zip Slip。
+- **飞书解析与任务加密**：收紧飞书 URL host 匹配，统一 task tracker 加密绑定。
+- **文档检索**：文档新增 OpenViking 驱动的本地化检索。
+
+[完整变更记录](https://github.com/volcengine/OpenViking/compare/v0.4.2...v0.4.3)
+
 ## v0.4.2 (2026-06-17)
 
 ### 重点更新


### PR DESCRIPTION
The changelog currently tops out at `v0.4.2 (2026-06-17)`, but two non-draft releases have since shipped:

- **v0.4.3** (2026-06-18) — RAGFS `CachedFileSystem` + Redis/Mooncake/Yuanrong cache providers, Go HTTP SDK, opencode code-navigation endpoints, `python-multipart`/`cryptography` security floor bumps + UnderstandingAPI Zip Slip fix, tightened Feishu host matching.
- **v0.4.4** (2026-06-18) — plugin-based authentication architecture, Go SDK search `date`/`level` filters, RAGFS root-directory encryption `account_id` fix.

This adds curated Highlights for both to `docs/en/about/02-changelog.md` and `docs/zh/about/02-changelog.md`, newest-first above v0.4.2, matching the existing curated format. Keeps the canonical changelog in sync with the published releases.

Docs-only.