### PR TITLE
fix(openclaw): honor auto-recall timeout config

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -19,7 +19,6 @@ import {
 import { sanitizeUserTextForCapture } from "./text-utils.js";
 import { estimateTextTokens } from "./token-estimator.js";
 
-const AUTO_RECALL_TIMEOUT_MS = 5_000;
 const RECALL_QUERY_MAX_CHARS = 4_000;
 export const AUTO_RECALL_SOURCE_MARKER = "Source: openviking-auto-recall";
 
@@ -512,7 +511,7 @@ export async function buildAutoRecallContext(params: {
       await recordTrace(memories.slice(0, memoryLines.length), memoryLines.length, estimatedTokens);
       return { block, memoryCount: memoryLines.length, estimatedTokens };
     })(),
-    AUTO_RECALL_TIMEOUT_MS,
+    cfg.autoRecallTimeoutMs,
     "openviking: auto-recall search timeout",
   );
 }

--- a/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
+++ b/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
@@ -370,6 +370,46 @@ describe("buildAutoRecallContext trace", () => {
     expect(recorded.searches.map((search) => search.resourceType)).toEqual(["user"]);
   });
 
+  it("uses configured autoRecallTimeoutMs as the outer timeout budget", async () => {
+    vi.useFakeTimers();
+    try {
+      const cfg = makeCfg({ autoRecallTimeoutMs: 30000, recallTargetTypes: ["user"] });
+      const client = {
+        healthCheck: vi.fn().mockResolvedValue(undefined),
+        find: vi.fn().mockImplementation(() =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve({
+              memories: [makeMemory({
+                uri: "viking://user/memories/slow-backend",
+                abstract: "Slow local backend recall still completes within the configured budget.",
+                score: 0.9,
+              })],
+              total: 1,
+            }), 10000);
+          })
+        ),
+        read: vi.fn().mockResolvedValue("unused"),
+      };
+
+      const resultPromise = buildAutoRecallContext({
+        cfg,
+        client: client as any,
+        agentId: "agent-1",
+        queryText: "which slow backend memory should be recalled?",
+        logger: { info: vi.fn(), warn: vi.fn() },
+      });
+
+      await vi.advanceTimersByTimeAsync(10000);
+      await expect(resultPromise).resolves.toMatchObject({
+        memoryCount: 1,
+      });
+      const result = await resultPromise;
+      expect(result.block).toContain("Slow local backend recall still completes within the configured budget.");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("records search errors while still injecting successful recall hits", async () => {
     const cfg = makeCfg({ recallTargetTypes: ["resource", "user"] });
     const client = {


### PR DESCRIPTION
## Summary

Fixes #2723.

`autoRecallTimeoutMs` was parsed and clamped correctly, but the auto-recall path regressed to using the hardcoded `AUTO_RECALL_TIMEOUT_MS = 5_000` value after the #2654 setup/routing refactor. This restores `cfg.autoRecallTimeoutMs` as the outer `withTimeout()` budget.

## Changes

- Removed the hardcoded 5s auto-recall timeout constant from `auto-recall.ts`.
- Threaded `cfg.autoRecallTimeoutMs` back into the auto-recall `withTimeout()` wrapper.
- Added a fake-timer regression test where recall completes after 10s under a configured 30s budget.

## Validation

Passed:

- `npm test -- tests/ut/build-memory-lines.test.ts`
- `npm test -- tests/ut/config.test.ts tests/ut/build-memory-lines.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Also ran `npm test`; it currently fails on existing unrelated tests in `tests/ut/text-utils.test.ts` and `tests/ut/architecture-boundaries.test.ts`, outside this PR's touched files.