### PR TITLE
test(openclaw): restore tool placeholder capture contract

### DIFF
--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -223,7 +223,7 @@ describe("extractNewTurnTexts", () => {
 });
 
 describe("extractNewTurnMessages", () => {
-  it("keeps assistant toolCall messages that have no text block", () => {
+  it("drops assistant toolCall messages that have no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -237,15 +237,10 @@ describe("extractNewTurnMessages", () => {
     const { messages: extracted, newCount } = extractNewTurnMessages(messages, 0);
 
     expect(newCount).toBe(1);
-    expect(extracted).toEqual([
-      {
-        role: "assistant",
-        parts: [{ type: "text", text: "[tool: read_file]" }],
-      },
-    ]);
+    expect(extracted).toEqual([]);
   });
 
-  it("keeps assistant toolUse messages that have no text block", () => {
+  it("drops assistant toolUse messages that have no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -259,15 +254,10 @@ describe("extractNewTurnMessages", () => {
     const { messages: extracted, newCount } = extractNewTurnMessages(messages, 0);
 
     expect(newCount).toBe(1);
-    expect(extracted).toEqual([
-      {
-        role: "assistant",
-        parts: [{ type: "text", text: "[tool: grep]" }],
-      },
-    ]);
+    expect(extracted).toEqual([]);
   });
 
-  it("keeps multiple textless assistant tool calls in one placeholder", () => {
+  it("does not synthesize placeholders for multiple textless assistant tool calls", () => {
     const messages = [
       {
         role: "assistant",
@@ -280,12 +270,7 @@ describe("extractNewTurnMessages", () => {
 
     const { messages: extracted } = extractNewTurnMessages(messages, 0);
 
-    expect(extracted).toEqual([
-      {
-        role: "assistant",
-        parts: [{ type: "text", text: "[tool: read_file, grep]" }],
-      },
-    ]);
+    expect(extracted).toEqual([]);
   });
 
   it("does not create a placeholder for textless assistant messages without tool calls", () => {


### PR DESCRIPTION
## Summary
- Restore the #2534 text-utils test contract after the #2654 setup/routing refactor regressed the assertions.
- Keep textless assistant tool calls from being captured as synthetic `[tool: ...]` placeholders.
- Limit the change to tests; the implementation already matches the intended behavior.

## Root Cause
#2534 changed the capture path so textless assistant tool calls are dropped instead of synthesized into placeholder text. #2654 later brought the test assertions back to the old placeholder-preserving model, which made the current implementation look broken.

## Validation
- `npm run test -- tests/ut/text-utils.test.ts`
- `npm run typecheck`
- `npm run test -- tests/ut/text-utils.test.ts tests/ut/architecture-boundaries.test.ts` now only fails the pre-existing 4 architecture-boundaries cases, confirming the 3 tool-placeholder failures are gone.
