### PR TITLE
fix(utils): normalize trailing-dot/case in code-hosting host matching

### DIFF
--- a/openviking/utils/code_hosting_utils.py
+++ b/openviking/utils/code_hosting_utils.py
@@ -7,10 +7,25 @@ This module provides shared functionality for parsing URLs from code hosting
 platforms like GitHub and GitLab.
 """
 
+from collections.abc import Iterable
 from typing import Optional
 from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
 from openviking_cli.utils.config import get_openviking_config
+
+
+def _normalize_host(host: str) -> str:
+    """Normalize a host for case- and trailing-dot-insensitive matching.
+
+    Mirrors :func:`openviking.utils.network_guard._normalize_host` so code-hosting
+    URL matching agrees with the egress allowlist: a fully-qualified trailing-dot
+    host (``github.com.``) and any letter casing resolve to the same canonical form.
+    """
+    return host.rstrip(".").lower()
+
+
+def _normalize_domains(domains: Iterable[str]) -> set[str]:
+    return {_normalize_host(domain) for domain in domains}
 
 
 def _domain_matches(parsed: ParseResult, domains: list[str]) -> bool:
@@ -25,8 +40,8 @@ def _domain_matches(parsed: ParseResult, domains: list[str]) -> bool:
     if not hostname:
         return False
 
-    normalized_domains = {domain.lower() for domain in domains}
-    host = hostname.lower()
+    normalized_domains = _normalize_domains(domains)
+    host = _normalize_host(hostname)
     candidates = {host}
 
     try:
@@ -45,10 +60,10 @@ def _extract_host(url: str) -> str:
         rest = url[4:]
         if ":" not in rest:
             return ""
-        return rest.split(":", 1)[0].strip().lower()
+        return _normalize_host(rest.split(":", 1)[0].strip())
 
     parsed = urlparse(url)
-    return (parsed.hostname or parsed.netloc or "").strip().lower()
+    return _normalize_host((parsed.hostname or parsed.netloc or "").strip())
 
 
 def _get_all_domains() -> list[str]:
@@ -122,10 +137,11 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
         if ":" not in url[4:]:
             return None
         host_part, path_part = url[4:].split(":", 1)
-        if host_part not in all_domains:
+        host_part = _normalize_host(host_part)
+        if host_part not in _normalize_domains(all_domains):
             return None
         path_parts = [p for p in path_part.split("/") if p]
-        if host_part in _get_azure_devops_domains():
+        if host_part in _normalize_domains(_get_azure_devops_domains()):
             azure_repo_parts = _extract_azure_devops_ssh_repo_parts(path_parts)
             if azure_repo_parts:
                 return "/".join(
@@ -183,7 +199,7 @@ def is_github_url(url: str) -> bool:
         True if the URL is a GitHub URL
     """
     config = get_openviking_config()
-    return _extract_host(url) in config.code.github_domains
+    return _extract_host(url) in _normalize_domains(config.code.github_domains)
 
 
 def is_gitlab_url(url: str) -> bool:
@@ -196,7 +212,7 @@ def is_gitlab_url(url: str) -> bool:
         True if the URL is a GitLab URL
     """
     config = get_openviking_config()
-    return _extract_host(url) in config.code.gitlab_domains
+    return _extract_host(url) in _normalize_domains(config.code.gitlab_domains)
 
 
 def is_code_hosting_url(url: str) -> bool:
@@ -215,7 +231,7 @@ def is_code_hosting_url(url: str) -> bool:
         if ":" not in url[4:]:
             return False
         host_part = url[4:].split(":", 1)[0]
-        return host_part in all_domains
+        return _normalize_host(host_part) in _normalize_domains(all_domains)
 
     return _domain_matches(urlparse(url), all_domains)
 
@@ -264,7 +280,7 @@ def is_git_repo_url(url: str) -> bool:
         if path_parts and path_parts[-1].endswith(".git"):
             path_parts[-1] = path_parts[-1][:-4]
 
-        if _extract_host(url) in _get_azure_devops_domains():
+        if _extract_host(url) in _normalize_domains(_get_azure_devops_domains()):
             azure_repo_parts = _extract_azure_devops_repo_parts(path_parts)
             if azure_repo_parts:
                 if _is_azure_devops_browse_url(parsed.query):
@@ -284,7 +300,8 @@ def is_git_repo_url(url: str) -> bool:
             "wiki",
         }
         if (
-            _extract_host(url) in config.code.github_domains + config.code.gitlab_domains
+            _extract_host(url)
+            in _normalize_domains(config.code.github_domains + config.code.gitlab_domains)
             and len(path_parts) >= 3
             and path_parts[2] in non_repo_paths
         ):

--- a/openviking/utils/code_hosting_utils.py
+++ b/openviking/utils/code_hosting_utils.py
@@ -116,6 +116,18 @@ _NESTED_REPOSITORY_DOMAIN_CONFIG_FIELDS = (
 )
 
 
+def _normalize_host(host: str) -> str:
+    """Normalize casing and a DNS trailing dot, retaining an explicit port."""
+    hostname, separator, port = host.rpartition(":")
+    if separator and port.isdigit():
+        return f"{hostname.rstrip('.').lower()}:{port}"
+    return host.rstrip(".").lower()
+
+
+def _normalize_domains(domains: Iterable[str]) -> set[str]:
+    return {_normalize_host(domain) for domain in domains}
+
+
 def _get_code_config():
     return get_openviking_config().code
 
@@ -134,7 +146,7 @@ def get_configured_code_hosting_domains(code_config=None) -> set[str]:
 
     domains: set[str] = set()
     for field_name in _CODE_HOSTING_DOMAIN_CONFIG_FIELDS:
-        domains.update(domain.lower() for domain in _get_domains_for_field(field_name, code_config))
+        domains.update(_normalize_domains(_get_domains_for_field(field_name, code_config)))
     return domains
 
 
@@ -150,7 +162,7 @@ def _get_reserved_top_level_segments(parsed: ParseResult) -> frozenset[str]:
             reserved.update(segments)
     reserved.update(
         _KNOWN_PLATFORM_RESERVED_TOP_LEVEL_SEGMENTS.get(
-            (parsed.hostname or "").lower(), frozenset()
+            _normalize_host(parsed.hostname or ""), frozenset()
         )
     )
     return frozenset(reserved)
@@ -158,7 +170,9 @@ def _get_reserved_top_level_segments(parsed: ParseResult) -> frozenset[str]:
 
 def _get_known_platform_non_repo_segments(parsed: ParseResult) -> frozenset[str]:
     """Return browse-route markers for a configured public platform."""
-    return _KNOWN_PLATFORM_NON_REPO_PATH_SEGMENTS.get((parsed.hostname or "").lower(), frozenset())
+    return _KNOWN_PLATFORM_NON_REPO_PATH_SEGMENTS.get(
+        _normalize_host(parsed.hostname or ""), frozenset()
+    )
 
 
 def _find_known_platform_non_repo_segment(
@@ -213,8 +227,8 @@ def _domain_matches(parsed: ParseResult, domains: Iterable[str]) -> bool:
     if not hostname:
         return False
 
-    normalized_domains = {domain.lower() for domain in domains}
-    host = hostname.lower()
+    normalized_domains = _normalize_domains(domains)
+    host = _normalize_host(hostname)
     candidates = {host}
 
     try:
@@ -233,10 +247,10 @@ def _extract_host(url: str) -> str:
         rest = url[4:]
         if ":" not in rest:
             return ""
-        return rest.split(":", 1)[0].strip().lower()
+        return _normalize_host(rest.split(":", 1)[0].strip())
 
     parsed = urlparse(url)
-    return (parsed.hostname or parsed.netloc or "").strip().lower()
+    return _normalize_host((parsed.hostname or parsed.netloc or "").strip())
 
 
 def _get_all_domains() -> list[str]:
@@ -244,7 +258,7 @@ def _get_all_domains() -> list[str]:
 
 
 def _get_azure_devops_domains() -> set[str]:
-    return set(_get_domains_for_field("azure_devops_domains"))
+    return _normalize_domains(_get_domains_for_field("azure_devops_domains"))
 
 
 def _sanitize_segment(segment: str) -> str:
@@ -360,7 +374,7 @@ def _parse_scp_git_repo_url(url: str) -> Optional[ParsedGitRepoURL]:
         return None
 
     host, path = rest.split(":", 1)
-    host = host.strip().lower()
+    host = _normalize_host(host.strip())
     if not host or host not in get_configured_code_hosting_domains():
         return None
 
@@ -386,7 +400,7 @@ def _parse_scp_git_repo_url(url: str) -> Optional[ParsedGitRepoURL]:
 def _is_known_platform_tree_route(parsed: ParseResult, path_parts: list[str]) -> bool:
     """Return whether the URL uses a known platform's owner/repo tree route."""
     return (
-        (parsed.hostname or "").lower() in _KNOWN_PLATFORM_TREE_ROUTE_HOSTS
+        _normalize_host(parsed.hostname or "") in _KNOWN_PLATFORM_TREE_ROUTE_HOSTS
         and len(path_parts) >= 3
         and path_parts[2] == "tree"
     )
@@ -590,6 +604,7 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
         if ":" not in url[4:]:
             return None
         host_part, path_part = url[4:].split(":", 1)
+        host_part = _normalize_host(host_part)
         if host_part not in all_domains:
             return None
         path_parts = [p for p in path_part.split("/") if p]
@@ -670,7 +685,7 @@ def is_github_url(url: str) -> bool:
         True if the URL is a GitHub URL
     """
     config = get_openviking_config()
-    return _extract_host(url) in config.code.github_domains
+    return _extract_host(url) in _normalize_domains(config.code.github_domains)
 
 
 def is_gitlab_url(url: str) -> bool:
@@ -683,7 +698,7 @@ def is_gitlab_url(url: str) -> bool:
         True if the URL is a GitLab URL
     """
     config = get_openviking_config()
-    return _extract_host(url) in config.code.gitlab_domains
+    return _extract_host(url) in _normalize_domains(config.code.gitlab_domains)
 
 
 def is_code_hosting_url(url: str) -> bool:
@@ -701,7 +716,7 @@ def is_code_hosting_url(url: str) -> bool:
     if url.startswith("git@"):
         if ":" not in url[4:]:
             return False
-        host_part = url[4:].split(":", 1)[0]
+        host_part = _normalize_host(url[4:].split(":", 1)[0])
         return host_part in all_domains
 
     return _domain_matches(urlparse(url), all_domains)
@@ -721,7 +736,7 @@ def is_code_hosting_blob_url(url: str) -> bool:
 
     config = get_openviking_config()
     parsed = urlparse(url)
-    host = (parsed.hostname or "").lower()
+    host = _normalize_host(parsed.hostname or "")
     if not host:
         return False
 
@@ -729,7 +744,7 @@ def is_code_hosting_blob_url(url: str) -> bool:
     if host in raw_hosts:
         return True
 
-    code_hosts = set(config.code.github_domains) | set(config.code.gitlab_domains)
+    code_hosts = _normalize_domains(config.code.github_domains + config.code.gitlab_domains)
     if host not in code_hosts:
         return False
 

--- a/tests/test_code_hosting_utils.py
+++ b/tests/test_code_hosting_utils.py
@@ -290,3 +290,37 @@ def test_is_git_repo_url_unknown_domain():
 
 def test_is_git_repo_url_single_segment():
     assert is_git_repo_url("https://github.com/org") is False
+
+
+# --- host normalization (trailing dot / case), consistency with #2689 + network_guard ---
+
+
+def test_parse_code_hosting_url_https_trailing_dot():
+    assert parse_code_hosting_url("https://github.com./org/repo") == "org/repo"
+
+
+def test_parse_code_hosting_url_git_ssh_uppercase_host():
+    assert parse_code_hosting_url("git@GitHub.com:org/repo.git") == "org/repo"
+
+
+def test_is_github_url_trailing_dot():
+    assert is_github_url("https://github.com./org/repo") is True
+
+
+def test_is_code_hosting_url_trailing_dot():
+    assert is_code_hosting_url("https://github.com./org/repo") is True
+
+
+def test_is_github_url_uppercase_config_domain():
+    def upper_cfg():
+        return SimpleNamespace(
+            code=SimpleNamespace(
+                github_domains=["GITHUB.COM"],
+                gitlab_domains=[],
+                azure_devops_domains=[],
+                code_hosting_domains=["GITHUB.COM"],
+            )
+        )
+
+    with patch.object(_module, "get_openviking_config", side_effect=upper_cfg):
+        assert is_github_url("https://github.com/org/repo") is True

--- a/tests/test_code_hosting_utils.py
+++ b/tests/test_code_hosting_utils.py
@@ -784,3 +784,85 @@ def test_parse_git_repo_url_returns_consistent_clone_metadata(
     assert parsed.branch == branch
     assert parsed.commit == commit
     assert is_git_repo_url(url) is True
+
+
+# --- host normalization (trailing dot / case), consistency with #2689 + network_guard ---
+
+
+def test_parse_code_hosting_url_https_trailing_dot():
+    assert parse_code_hosting_url("https://github.com./org/repo") == "org/repo"
+
+
+def test_parse_code_hosting_url_git_ssh_uppercase_host():
+    assert parse_code_hosting_url("git@GitHub.com:org/repo.git") == "org/repo"
+
+
+def test_is_github_url_trailing_dot():
+    assert is_github_url("https://github.com./org/repo") is True
+
+
+def test_is_code_hosting_url_trailing_dot():
+    assert is_code_hosting_url("https://github.com./org/repo") is True
+
+
+def test_is_github_url_uppercase_config_domain():
+    def upper_cfg():
+        return SimpleNamespace(
+            code=SimpleNamespace(
+                github_domains=["GITHUB.COM"],
+                gitlab_domains=[],
+                azure_devops_domains=[],
+                code_hosting_domains=["GITHUB.COM"],
+            )
+        )
+
+    with patch.object(_module, "get_openviking_config", side_effect=upper_cfg):
+        assert is_github_url("https://github.com/org/repo") is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com./org/repo/issues/123",
+        "https://github.com./org/repo/blob/main/README.md",
+        "https://gitcode.com./org/repo/issues/123",
+        "https://github.com./settings/profile",
+    ],
+)
+def test_trailing_dot_preserves_non_repository_routes(url):
+    assert parse_git_repo_url(url) is None
+
+
+@pytest.mark.parametrize(
+    "url, repo_path, branch",
+    [
+        ("https://github.com./org/repo/tree/main", "org/repo", "main"),
+        ("https://gitlab.com./org/subgroup/repo/-/tree/main", "org/subgroup/repo", "main"),
+        ("git@SSH.DEV.AZURE.COM.:v3/org/project/repo", "org/project/repo", None),
+    ],
+)
+def test_trailing_dot_preserves_repository_identity(url, repo_path, branch):
+    parsed = parse_git_repo_url(url)
+    assert parsed is not None
+    assert parsed.repo_path == repo_path
+    assert parsed.branch == branch
+
+
+def test_configured_trailing_dot_with_port():
+    config = _mock_config()
+    config.code.code_hosting_domains = ["GIT.EXAMPLE.COM.:8443"]
+    with patch.object(_module, "get_openviking_config", return_value=config):
+        assert is_code_hosting_url("https://git.example.com.:8443/org/repo")
+        assert not is_code_hosting_url("https://git.example.com:9443/org/repo")
+        assert not is_code_hosting_url("https://git.example.com.evil:8443/org/repo")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com./org/repo/blob/main/README.md",
+        "https://RAW.GITHUBUSERCONTENT.COM./org/repo/main/README.md",
+    ],
+)
+def test_trailing_dot_blob_urls_keep_file_routing(url):
+    assert _module.is_code_hosting_blob_url(url)


### PR DESCRIPTION
`code_hosting_utils` host matching lowercased hosts but did not strip the trailing root dot, and the `git@` branches compared the raw host against un-normalized config domains. So a valid trailing-dot FQDN (`github.com.`) or an uppercase entry in `github_domains` was silently not recognized as a code-hosting URL, mis-routing the accessor.

`network_guard._normalize_host` already canonicalizes hosts with `rstrip(".").lower()` (applied to both the host and the allowlist), and #2689 just hardened the same host-match class for Feishu. This applies the same normalization symmetrically across every host↔domain comparison in `code_hosting_utils` (`_domain_matches`, `_extract_host`, both `git@` branches, and the `is_github_url` / `is_gitlab_url` / `is_git_repo_url` config-domain checks).

Normalization only widens matching to the correct canonical host; valid matches are unaffected. Adds regression tests.