### PR TITLE
fix(logger): replace StreamHandler with QueueHandler+QueueListener to prevent thread deadlock

### DIFF
--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -4,10 +4,12 @@
 Logging utilities for OpenViking.
 """
 
+import atexit
 import logging
+import queue
 import sys
 from contextlib import contextmanager
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
 from typing import Any, Optional, Tuple
 from uuid import uuid4
@@ -63,6 +65,10 @@ _otel_log_handler: Any = None
 _MANAGED_LOGGER_ROOTS = ("openviking", "openviking_cli", "uvicorn")
 _shared_log_handler: Optional[logging.Handler] = None
 _shared_log_handler_key: Optional[tuple[Any, ...]] = None
+
+# QueueListener for thread-safe stdout/stderr logging (avoids StreamHandler deadlocks)
+_std_queue_listener: Optional[QueueListener] = None
+_std_queue_real_handler: Optional[logging.Handler] = None
 
 
 def _get_log_context() -> dict[str, Any]:
@@ -641,10 +647,29 @@ def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handl
     if log_output == "file":
         log_output = "stdout"
 
-    if log_output == "stdout":
-        return logging.StreamHandler(sys.stdout)
-    elif log_output == "stderr":
-        return logging.StreamHandler(sys.stderr)
+    if log_output in ("stdout", "stderr"):
+        # QueueHandler + QueueListener prevents StreamHandler thread deadlocks
+        # when stdout/stderr is redirected to a file by systemd/journald.
+        # The listener thread is the ONLY thread that touches the real stream,
+        # so the handler lock can never be held across threads.
+        global _std_queue_listener, _std_queue_real_handler
+
+        if _std_queue_listener is not None:
+            return QueueHandler(_std_queue_listener.queue)
+
+        stream = sys.stdout if log_output == "stdout" else sys.stderr
+        _std_queue_real_handler = logging.StreamHandler(stream)
+
+        log_queue: queue.Queue = queue.Queue(-1)
+        _std_queue_listener = QueueListener(
+            log_queue, _std_queue_real_handler, respect_handler_level=True
+        )
+        _std_queue_listener.start()
+        atexit.register(_std_queue_listener.stop)
+
+        qh = QueueHandler(log_queue)
+        qh._ov_real_handler = _std_queue_real_handler  # type: ignore[attr-defined]
+        return qh
     else:
         if config is not None:
             try:
@@ -681,6 +706,18 @@ def _build_standard_handler(
     format_string: str,
 ) -> logging.Handler:
     handler = _create_log_handler(log_output, config)
+
+    # QueueHandler delegates formatting to the real handler in the listener thread.
+    # Set formatter + filters on the real handler so emitted LogRecords get
+    # formatted by the listener (single-threaded, no deadlock risk).
+    if isinstance(handler, QueueHandler):
+        real = getattr(handler, '_ov_real_handler', None)
+        if real is not None:
+            real.setFormatter(logging.Formatter(format_string))
+            from openviking.telemetry.tracer import TraceIdLoggingFilter
+            real.addFilter(TraceIdLoggingFilter())
+        return handler
+
     handler.setFormatter(logging.Formatter(format_string))
 
     # Add trace id filter


### PR DESCRIPTION
## Summary

Fixes #2752: `logging.StreamHandler` multi-thread deadlock in `session.commit()` phase 2.

## Problem

When `log.output='stdout'` (default) and OV runs under systemd (which redirects stdout to a file), Python's `logging.StreamHandler.emit()` holds a thread lock across `stream.flush()`, which can block on systemd-piped file I/O.

During `session.commit()` phase 2, multiple async coroutines concurrently call `logger.info()` / `logger.warning()` with large payloads (memory extraction, WM update). The deadlock chain:

1. Thread-A: `logger.warning(large_payload)` → `handler.acquire()` → `stream.flush()` blocks on systemd pipe
2. Thread-B: `logger.info(...)` → `handler.acquire()` → **blocks forever**
3. All subsequent `logger.*()` calls block → server log goes **completely silent**
4. Phase 2's `_write_done_file()` needs `logger.info()` → deadlock → **`.done` never written**

## Root Cause

`_create_log_handler()` in `openviking_cli/utils/logger.py` returns raw `StreamHandler` for stdout/stderr, which uses blocking I/O inside a thread lock.

## Fix

Replace `StreamHandler` with `QueueHandler` + `QueueListener` (Python stdlib, available since 3.2):

| Before | After |
|--------|-------|
| `StreamHandler(sys.stdout)` — lock-acquire → flush → lock-release | `QueueHandler(queue)` — `queue.put(record)` returns immediately |
| Multiple threads contend on handler lock | Single listener thread exclusively touches real stream |
| File I/O inside lock → deadlock possible | File I/O outside worker threads → deadlock impossible |

## Changes

- File: `openviking_cli/utils/logger.py`
- +42 / −5 lines, 4 blocks touched:
  1. Imports: add `atexit`, `queue`, `QueueHandler`, `QueueListener`
  2. Module globals: `_std_queue_listener`, `_std_queue_real_handler`
  3. `_create_log_handler()`: stdout/stderr → QueueHandler+QueueListener+atexit
  4. `_build_standard_handler()`: delegate formatter+filter to real handler

## Verification

Tested on OpenViking 0.4.4 (356 Qdrant points, 30 sessions, Python 3.12, systemd-managed):

- **Before fix**: archive_004 deadlocked at 12:47:53 — all 5 files written except `.done`, server.log silent thereafter for 40+ minutes
- **After fix**: archive_012 completed in ~2min — 6/6 files ✅, 8 long_term + 5 execution memories extracted ✅, `.done` with complete `message_id` boundaries ✅, server.log continuous output ✅

Full reproduction steps and evidence chain in #2752.

## Risk Assessment

- **Low risk**: uses Python stdlib only (`logging.handlers` since 3.2)
- **Backward compatible**: same log format, same output destination, same atexit flush behavior
- **No performance regression**: `queue.put()` is O(1) amortized; listener thread consumes sequentially
- **Graceful degradation**: atexit cleanup drains remaining queue entries; SIGKILL loses entries same as before

## Note

The file handler branch (`TimedRotatingFileHandler` / `FileHandler`) also inherits `StreamHandler`'s locking pattern and could theoretically deadlock. This PR focuses on the stdout/stderr path (default config, most common trigger).