### PR TITLE
feat(sdk/go): expose agent_id/agent_uri peer selector on Find and Search

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -123,6 +123,12 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		if !ok || len(levels) != 2 || levels[0] != float64(0) || levels[1] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		if got := body["agent_id"]; got != "agent-7" {
+			t.Fatalf("agent_id = %#v", got)
+		}
+		if got := body["agent_uri"]; got != "viking://peers/agent-7" {
+			t.Fatalf("agent_uri = %#v", got)
+		}
 		writeOK(t, w, map[string]any{
 			"resources": []map[string]any{
 				{"uri": "viking://resources/docs/api.md", "context_type": "resource", "score": 0.9},
@@ -139,6 +145,8 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		Until:       "2026-06-18",
 		TimeField:   "created_at",
 		Level:       []int{0, 2},
+		AgentID:     "agent-7",
+		AgentURI:    "viking://peers/agent-7",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +162,7 @@ func TestFindOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -195,6 +203,12 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		if !ok || len(levels) != 1 || levels[0] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		if got := body["agent_id"]; got != "agent-7" {
+			t.Fatalf("agent_id = %#v", got)
+		}
+		if got := body["agent_uri"]; got != "viking://peers/agent-7" {
+			t.Fatalf("agent_uri = %#v", got)
+		}
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -206,6 +220,8 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		Until:     "2026-06-18",
 		TimeField: "updated_at",
 		Level:     []int{2},
+		AgentID:   "agent-7",
+		AgentURI:  "viking://peers/agent-7",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +233,7 @@ func TestSearchOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()

--- a/sdk/go/retrieval.go
+++ b/sdk/go/retrieval.go
@@ -32,6 +32,8 @@ func (c *Client) Find(ctx context.Context, queryText string, opts *FindOptions) 
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
 	}
+	setString(payload, "agent_id", opts.AgentID)
+	setString(payload, "agent_uri", opts.AgentURI)
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult
 	err := c.doJSON(ctx, http.MethodPost, "/api/v1/search/find", nil, payload, &result)
@@ -66,6 +68,8 @@ func (c *Client) Search(ctx context.Context, queryText string, opts *SearchOptio
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
 	}
+	setString(payload, "agent_id", opts.AgentID)
+	setString(payload, "agent_uri", opts.AgentURI)
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult
 	err := c.doJSON(ctx, http.MethodPost, "/api/v1/search/search", nil, payload, &result)

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -161,6 +161,13 @@ type FindOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	// AgentID / AgentURI select the peer whose memories this call is
+	// scoped to (server FindRequest.agent_id / agent_uri). This is a
+	// per-call selector and is mutually exclusive with the client-global
+	// Config.ActorPeerID header: the server rejects a request that sets a
+	// different peer via both. Leave empty to use the client-global peer.
+	AgentID  string
+	AgentURI string
 }
 
 // SearchOptions controls Search.
@@ -177,6 +184,12 @@ type SearchOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	// AgentID / AgentURI select the peer whose memories this call is
+	// scoped to (server SearchRequest.agent_id / agent_uri). Per-call
+	// selector, mutually exclusive with the client-global
+	// Config.ActorPeerID header. Leave empty to use the client-global peer.
+	AgentID  string
+	AgentURI string
 }
 
 // GrepOptions controls Grep.


### PR DESCRIPTION
Follow-up in the Go SDK parity cluster (after merged #2703 date/level filters; siblings #2730 tags, #2731 include_provenance).

## Gap
The server `FindRequest` / `SearchRequest` accept and **actively use** `agent_id` / `agent_uri` (`openviking/server/routers/search.py`): `normalize_request_peer_id` normalizes them, and `find`/`search` call `_ctx_with_legacy_actor_peer(ctx, request.agent_id)` to scope retrieval to that peer (setting both `actor_peer_id` and `legacy_agent_id`).

The Go SDK had no way to send a per-call peer selector — `FindOptions`/`SearchOptions` lacked the fields and `Find()`/`Search()` never sent them. The only Go path was the **client-global** `X-OpenViking-Actor-Peer` header from `Config.ActorPeerID` (`transport.go`), and that header path does not set `legacy_agent_id`. So Go callers couldn't do per-call agent-scoped retrieval, unlike the Python SDK and the generated web-studio client.

## Change
- `types.go`: add `AgentID` / `AgentURI` to `FindOptions` and `SearchOptions`, appended after the existing fields (keeps unkeyed-composite-literal compatibility, same convention as #2703).
- `retrieval.go`: forward via `setString(payload, "agent_id", opts.AgentID)` / `"agent_uri"` in both `Find` and `Search` — `setString` omits empty values, so the keys are sent only when set.
- `client_test.go`: assert both keys are forwarded on each path, and add them to the `requireBodyKeysAbsent` checks so unset options omit them.

GoDoc notes the per-call selector is mutually exclusive with the client-global `Config.ActorPeerID` header (the server rejects a request that sets a *different* peer via both, `search.py` `_ctx_with_legacy_actor_peer`).

The Go SDK stays a thin HTTP client: it forwards these server-owned values rather than duplicating server-side peer validation.

## Test
`go vet ./...` clean; `go test ./...` passes. The two send-tests fail against the pre-change `retrieval.go` (`agent_id = <nil>`), confirming the forwarding is actually covered.
