### PR TITLE
fix(opencode-memory-plugin): repair autoRecall (drop mode:auto, read output.parts, pass config) (#2757)

### DIFF
--- a/examples/opencode-memory-plugin/openviking-memory.ts
+++ b/examples/opencode-memory-plugin/openviking-memory.ts
@@ -1664,10 +1664,9 @@ function extractMessageText(parts: { type: string; text?: string }[]): string | 
 /** Perform search against OpenViking with a timeout guard. Returns empty on any failure. */
 async function performRecallSearch(config: OpenVikingConfig, query: string): Promise<RecallSearchItem[]> {
   try {
-    const body: { query: string; limit: number; mode: string } = {
+    const body: { query: string; limit: number } = {
       query: query.slice(0, 4000),
       limit: 20,
-      mode: "auto",
     }
     const response = await makeRequest<OpenVikingResponse<{ memories?: RecallSearchItem[]; results?: RecallSearchItem[] }>>(
       config,
@@ -1688,10 +1687,11 @@ async function performRecallSearch(config: OpenVikingConfig, query: string): Pro
 
 /** Run auto recall using chat.message hook — injects persistent synthetic part. */
 async function runAutoRecall(
-  input: { sessionID: string; messageID: string; parts: { type: string; text?: string }[] },
+  config: OpenVikingConfig,
+  input: { sessionID: string; messageID?: string },
   output: { parts: any[] },
 ): Promise<void> {
-  const query = extractMessageText(input.parts ?? [])
+  const query = extractMessageText(output.parts ?? [])
   if (!query) return
 
   const rawResults = await performRecallSearch(config, query)
@@ -2375,7 +2375,7 @@ export const OpenVikingMemoryPlugin = async (input: PluginInput): Promise<Hooks>
     "chat.message": async (input, output) => {
       try {
         if (!config.autoRecall?.enabled) return
-        await runAutoRecall(input, output)
+        await runAutoRecall(config, input, output)
       } catch (error: any) {
         log("WARN", "recall", "Auto recall failed, skipping silently", {
           error: error?.message ?? String(error),


### PR DESCRIPTION
## Summary

`autoRecall` — the opencode-memory plugin's headline persistent-memory injection (it auto-prepends a `<relevant-memories>` block to the prompt) — is silently dead on current OpenViking: three independent runtime bugs in `examples/opencode-memory-plugin/openviking-memory.ts` each make it no-op, and every failure is swallowed so the user only sees memories never being injected. This restores it with a minimal, focused fix. Fixes #2757.

## Root causes

1. **Server rejects `mode: "auto"`.** `performRecallSearch` POSTs `{ query, limit, mode: "auto" }` to `/api/v1/search/find`, but the server's `FindRequest` is declared `model_config = ConfigDict(extra="forbid")` (`openviking/server/routers/search.py`) and has no `mode` field — so every recall request fails with `body.mode: Extra inputs are not permitted` (the exact error reported in #2757). `mode` is a client-side tool argument only, never a request-body field. → drop `mode` from the body.

2. **Query read from the wrong object.** `runAutoRecall` extracts the query from `input.parts`, but the OpenCode `chat.message` hook delivers the user message parts on **`output.parts`** — `input` carries no `parts`. So the query was always empty and recall returned early on every message. → read `output.parts`. (`extractMessageText` already skips parts containing `<relevant-memories>`, so reading the output array won't re-ingest an injected block.)

3. **`config` is undefined at call time.** `runAutoRecall` is a module-level function that references the free variable `config`, whose only binding is the factory-scope `const config = loadConfig()`. The hook called `runAutoRecall(input, output)` without it, so `config` was `undefined` → `ReferenceError`, caught by the hook's `try/catch` and logged as "Auto recall failed, skipping silently". → thread `config` in as the first parameter.

## Notes

- ~5 lines, one file. Behavior of every other code path is unchanged.
- The example has no test/build harness in CI; the fix was source-verified against the server `FindRequest` schema and the OpenCode `chat.message` hook signature rather than guessed.
- Coexists cleanly with the other open opencode-memory-plugin PRs (disjoint regions).
