### PR TITLE
chore(cli): show detailed validation error messages, extract zh-CN to…

### DIFF
--- a/crates/ov_cli/src/config_wizard/store.rs
+++ b/crates/ov_cli/src/config_wizard/store.rs
@@ -651,14 +651,75 @@ fn should_run_authenticated_probe(
     }
 }
 
-pub(crate) fn validation_error_copy(kind: ConfigKind, _error: &Error) -> String {
-    match kind {
-        ConfigKind::OpenVikingService => {
-            "Validation failed. Check your API key and try again.".to_string()
+pub(crate) fn validation_error_copy(kind: ConfigKind, error: &Error) -> String {
+    match error {
+        Error::Network(msg) if msg.contains("unhealthy") => {
+            "Server is reachable but reported unhealthy status. Check the server logs.".to_string()
         }
-        ConfigKind::Custom => {
-            "Validation failed. Check the server URL and API key if required.".to_string()
+        Error::Network(_) => match kind {
+            ConfigKind::OpenVikingService => {
+                "Cannot reach OpenViking Service. Check your network connection.".to_string()
+            }
+            ConfigKind::Custom => {
+                "Cannot reach the server. Check the URL and your network connection.".to_string()
+            }
+        },
+        Error::Api {
+            status: Some(401 | 403),
+            ..
+        } => "API key was rejected. Check your API key.".to_string(),
+        Error::Api { status: Some(404), .. } => {
+            "Server responded but the API endpoint was not found. Check the server URL.".to_string()
         }
+        Error::Api { status: Some(status), .. } => {
+            format!("Server returned HTTP {status}. Check the server configuration.")
+        }
+        Error::Api { .. } => {
+            "Server returned an error during validation. Check the server logs.".to_string()
+        }
+        Error::Config(msg) => msg.clone(),
+        _ => match kind {
+            ConfigKind::OpenVikingService => {
+                "Validation failed. Check your API key and try again.".to_string()
+            }
+            ConfigKind::Custom => {
+                "Validation failed. Check the server URL and API key if required.".to_string()
+            }
+        },
+    }
+}
+
+pub(crate) fn validation_error_copy_zh(kind: ConfigKind, error: &Error) -> String {
+    match error {
+        Error::Network(msg) if msg.contains("unhealthy") => {
+            "服务器可连接，但健康状态异常。请检查服务器日志。".to_string()
+        }
+        Error::Network(_) => match kind {
+            ConfigKind::OpenVikingService => {
+                "无法连接 OpenViking 服务。请检查网络连接。".to_string()
+            }
+            ConfigKind::Custom => {
+                "无法连接服务器。请检查 URL 和网络连接。".to_string()
+            }
+        },
+        Error::Api {
+            status: Some(401 | 403),
+            ..
+        } => "API Key 被拒绝。请检查 API Key。".to_string(),
+        Error::Api { status: Some(404), .. } => {
+            "服务器响应了，但 API 端点未找到。请检查服务器 URL。".to_string()
+        }
+        Error::Api { status: Some(status), .. } => {
+            format!("服务器返回 HTTP {status}。请检查服务器配置。")
+        }
+        Error::Api { .. } => {
+            "服务器验证时返回错误。请检查服务器日志。".to_string()
+        }
+        Error::Config(msg) => msg.clone(),
+        _ => match kind {
+            ConfigKind::OpenVikingService => "验证失败。请检查 API Key 后重试。".to_string(),
+            ConfigKind::Custom => "验证失败。请检查服务器 URL，以及是否需要 API Key。".to_string(),
+        },
     }
 }
 
@@ -1081,11 +1142,11 @@ mod tests {
 
         assert_eq!(
             cloud,
-            "Validation failed. Check your API key and try again."
+            "Server returned an error during validation. Check the server logs."
         );
         assert_eq!(
             custom,
-            "Validation failed. Check the server URL and API key if required."
+            "Server returned an error during validation. Check the server logs."
         );
         assert!(!cloud.contains("Request ID"));
         assert!(!custom.contains("AuthenticationError"));

--- a/crates/ov_cli/src/config_wizard/wizard.rs
+++ b/crates/ov_cli/src/config_wizard/wizard.rs
@@ -29,6 +29,7 @@ use super::store::{
     OPENVIKING_SERVICE_URL, build_config, custom_allows_empty_api_key, normalize_custom_url,
     validate_candidate_config, validate_candidate_config_with_role, validate_config,
     validate_config_name, validate_identity_value, validation_error_copy,
+    validation_error_copy_zh,
 };
 
 const OPENVIKING_SERVICE_API_KEY_URL: &str =
@@ -5502,11 +5503,8 @@ fn switch_confirm_prompt(name: &str) -> String {
 
 fn localized_validation_error(kind: ConfigKind, error: &Error) -> String {
     match Language::current() {
-        Language::En => validation_error_copy(kind, error),
-        Language::ZhCn => match kind {
-            ConfigKind::OpenVikingService => "验证失败。请检查 API Key 后重试。".to_string(),
-            ConfigKind::Custom => "验证失败。请检查服务器 URL，以及是否需要 API Key。".to_string(),
-        },
+        Language::ZhCn => validation_error_copy_zh(kind, error),
+        _ => validation_error_copy(kind, error),
     }
 }
 
@@ -6309,12 +6307,12 @@ mod tests {
         let lines = switch_validation_error_lines(
             "cloud",
             ConfigKind::OpenVikingService,
-            &Error::Config("invalid".to_string()),
+            &Error::api_with_status("invalid key", 401),
         );
         let plain = strip_ansi(&lines.join("\n"));
 
         assert!(plain.contains("Target config 'cloud' failed validation."));
-        assert!(plain.contains("Check your API key"));
+        assert!(plain.contains("API key"));
         assert!(!plain.contains("server URL"));
     }
 


### PR DESCRIPTION
… store

## Description

validation_error_copy() took _error: &Error but completely ignored it, always returning the same generic message regardless of the actual failure. Users saw 'Validation failed. Check the server URL and API key if required.' for every kind of error — network unreachable, unhealthy server, rejected API key, or HTTP errors.

Now inspects the error to provide actionable messages.
- Network errors → 'Cannot reach the server. Check the URL.'
- Unhealthy server → 'Server reported unhealthy status.'
- Auth rejected (401/403) → 'API key was rejected.'
- HTTP errors → 'Server returned HTTP {status}.'
- Config errors → passes through the original message
- Other → original generic fallback

Both English (validation_error_copy) and Chinese
(validation_error_copy_zh) paths updated.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

In crates/ov_cli/src/config_wizard/store.rs and crates/ov_cli/src/config_wizard/wizard.rs 
- added detailed information in validation_error_copy
- added validation_error_copy_zh for localization
- updated test case for changed validation_error_copy

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
