### PR TITLE
test(api): harden user-key bootstrap for parallel CI

### DIFF
--- a/tests/api_test/conftest.py
+++ b/tests/api_test/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import psutil
 import pytest
@@ -306,6 +307,47 @@ def _extract_user_key(users, user_id):
     return None
 
 
+def _fallback_api_test_key(reason: str) -> str:
+    if (
+        Config.OPENVIKING_ROOT_API_KEY
+        and Config.OPENVIKING_API_KEY == Config.OPENVIKING_ROOT_API_KEY
+    ):
+        raise RuntimeError(
+            f"{reason}; refusing to fall back to the ROOT API key for tenant-scoped "
+            "API tests. Bootstrap a user/admin key first, or run in trusted mode "
+            "with explicit account/user identity headers."
+        )
+    print(f"{reason}, 使用配置的 API Key")
+    return Config.OPENVIKING_API_KEY
+
+
+def _extract_user_key_from_response(resp, user_id: str) -> str | None:
+    if resp.status_code != 200:
+        return None
+    users = resp.json().get("result", [])
+    return _extract_user_key(users, user_id)
+
+
+def _retry_existing_user_key(
+    root_client,
+    account_id: str,
+    user_id: str,
+    *,
+    reason: str,
+) -> str | None:
+    for attempt in range(3):
+        resp = root_client.admin_list_users(account_id)
+        user_key = _extract_user_key_from_response(resp, user_id)
+        if user_key:
+            print(f"{reason}; 复用测试用户 {account_id}/{user_id}")
+            return user_key
+        if resp.status_code not in (200, 404):
+            print(f"{reason}; 查询用户列表失败({resp.status_code}): {resp.text[:200]}")
+            return None
+        time.sleep(0.2 * (attempt + 1))
+    return None
+
+
 def _ensure_api_test_user_key(root_client, account_id: str, user_id: str) -> str:
     resp = root_client.admin_list_users(account_id)
     if resp.status_code == 404:
@@ -316,12 +358,22 @@ def _ensure_api_test_user_key(root_client, account_id: str, user_id: str) -> str
             if user_key:
                 print(f"已创建测试账户和用户 {account_id}/{user_id}")
                 return user_key
+        elif create_resp.status_code == 409:
+            user_key = _retry_existing_user_key(
+                root_client,
+                account_id,
+                user_id,
+                reason=f"测试账户/用户并发创建冲突({create_resp.status_code})",
+            )
+            if user_key:
+                return user_key
         print(f"创建测试账户失败({create_resp.status_code}): {create_resp.text[:200]}")
-        return Config.OPENVIKING_API_KEY
+        return _fallback_api_test_key("创建测试账户失败")
 
     if resp.status_code != 200:
-        print(f"无法查询用户列表({resp.status_code}), 使用配置的 API Key: {resp.text[:200]}")
-        return Config.OPENVIKING_API_KEY
+        return _fallback_api_test_key(
+            f"无法查询用户列表({resp.status_code}): {resp.text[:200]}"
+        )
 
     users = resp.json().get("result", [])
     user_key = _extract_user_key(users, user_id)
@@ -342,8 +394,17 @@ def _ensure_api_test_user_key(root_client, account_id: str, user_id: str) -> str
             if user_key:
                 print(f"已注册测试用户 {account_id}/{user_id}")
                 return user_key
+        elif reg_resp.status_code == 409:
+            user_key = _retry_existing_user_key(
+                root_client,
+                account_id,
+                user_id,
+                reason=f"测试用户并发注册冲突({reg_resp.status_code})",
+            )
+            if user_key:
+                return user_key
         print(f"注册测试用户失败({reg_resp.status_code}): {reg_resp.text[:200]}")
-        return Config.OPENVIKING_API_KEY
+        return _fallback_api_test_key("注册测试用户失败")
 
     role_resp = root_client.admin_set_role(account_id, user_id, "admin")
     if role_resp.status_code != 200:
@@ -357,7 +418,7 @@ def _ensure_api_test_user_key(root_client, account_id: str, user_id: str) -> str
             return user_key
 
     print(f"刷新测试用户 API Key 失败({key_resp.status_code}): {key_resp.text[:200]}")
-    return Config.OPENVIKING_API_KEY
+    return _fallback_api_test_key("刷新测试用户 API Key 失败")
 
 
 @pytest.fixture(scope="session")

--- a/tests/api_test/conftest.py
+++ b/tests/api_test/conftest.py
@@ -371,9 +371,7 @@ def _ensure_api_test_user_key(root_client, account_id: str, user_id: str) -> str
         return _fallback_api_test_key("创建测试账户失败")
 
     if resp.status_code != 200:
-        return _fallback_api_test_key(
-            f"无法查询用户列表({resp.status_code}): {resp.text[:200]}"
-        )
+        return _fallback_api_test_key(f"无法查询用户列表({resp.status_code}): {resp.text[:200]}")
 
     users = resp.json().get("result", [])
     user_key = _extract_user_key(users, user_id)

--- a/tests/api_test/test_user_key_bootstrap.py
+++ b/tests/api_test/test_user_key_bootstrap.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import conftest as api_conftest  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, body: dict | None = None):
+        self.status_code = status_code
+        self._body = body or {}
+        self.text = str(self._body)
+
+    def json(self):
+        return self._body
+
+
+class FakeRootClient:
+    def __init__(
+        self,
+        *,
+        list_responses: list[FakeResponse],
+        create_responses: list[FakeResponse] | None = None,
+        register_responses: list[FakeResponse] | None = None,
+    ):
+        self.list_responses = list(list_responses)
+        self.create_responses = list(create_responses or [])
+        self.register_responses = list(register_responses or [])
+
+    def admin_list_users(self, account_id: str):
+        return self.list_responses.pop(0)
+
+    def admin_create_account(self, account_id: str, user_id: str):
+        return self.create_responses.pop(0)
+
+    def admin_register_user(self, account_id: str, user_id: str, role: str):
+        return self.register_responses.pop(0)
+
+    def admin_set_role(self, account_id: str, user_id: str, role: str):
+        return FakeResponse(200, {"status": "ok"})
+
+    def admin_regenerate_key(self, account_id: str, user_id: str):
+        return FakeResponse(200, {"result": {"user_key": "regenerated-key"}})
+
+
+def _users_response(user_id: str = "default", api_key: str = "user-key") -> FakeResponse:
+    return FakeResponse(
+        200,
+        {"result": [{"user_id": user_id, "role": "admin", "api_key": api_key}]},
+    )
+
+
+def test_register_conflict_reuses_concurrently_created_user_key(monkeypatch):
+    monkeypatch.setattr(api_conftest.time, "sleep", lambda _seconds: None)
+    root_client = FakeRootClient(
+        list_responses=[
+            FakeResponse(200, {"result": []}),
+            _users_response(api_key="race-user-key"),
+        ],
+        register_responses=[FakeResponse(409, {"error": {"code": "ALREADY_EXISTS"}})],
+    )
+
+    assert (
+        api_conftest._ensure_api_test_user_key(root_client, "default", "default")
+        == "race-user-key"
+    )
+
+
+def test_create_account_conflict_reuses_concurrently_created_user_key(monkeypatch):
+    monkeypatch.setattr(api_conftest.time, "sleep", lambda _seconds: None)
+    root_client = FakeRootClient(
+        list_responses=[
+            FakeResponse(404, {"error": {"code": "NOT_FOUND"}}),
+            _users_response(api_key="created-by-peer-key"),
+        ],
+        create_responses=[FakeResponse(409, {"error": {"code": "ALREADY_EXISTS"}})],
+    )
+
+    assert (
+        api_conftest._ensure_api_test_user_key(root_client, "default", "default")
+        == "created-by-peer-key"
+    )
+
+
+def test_refuses_to_fall_back_to_root_key(monkeypatch):
+    monkeypatch.setattr(api_conftest.Config, "OPENVIKING_API_KEY", "root-key")
+    monkeypatch.setattr(api_conftest.Config, "OPENVIKING_ROOT_API_KEY", "root-key")
+    root_client = FakeRootClient(
+        list_responses=[FakeResponse(500, {"error": {"code": "SERVER_ERROR"}})]
+    )
+
+    with pytest.raises(RuntimeError, match="refusing to fall back to the ROOT API key"):
+        api_conftest._ensure_api_test_user_key(root_client, "default", "default")

--- a/tests/api_test/test_user_key_bootstrap.py
+++ b/tests/api_test/test_user_key_bootstrap.py
@@ -1,13 +1,30 @@
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+API_TEST_DIR = Path(__file__).resolve().parent
+if str(API_TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(API_TEST_DIR))
 
-import conftest as api_conftest  # noqa: E402
+
+def _load_api_test_conftest():
+    spec = importlib.util.spec_from_file_location(
+        "api_test_bootstrap_conftest",
+        API_TEST_DIR / "conftest.py",
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load tests/api_test/conftest.py")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+api_conftest = _load_api_test_conftest()
 
 
 class FakeResponse:
@@ -66,8 +83,7 @@ def test_register_conflict_reuses_concurrently_created_user_key(monkeypatch):
     )
 
     assert (
-        api_conftest._ensure_api_test_user_key(root_client, "default", "default")
-        == "race-user-key"
+        api_conftest._ensure_api_test_user_key(root_client, "default", "default") == "race-user-key"
     )
 
 


### PR DESCRIPTION
## Summary
- 409 bootstrap race -> re-read existing user key.
- ROOT fallback -> hard fail. Data API needs tenant user/admin key.
- Add UT for race reuse + ROOT fallback guard.

## Root Cause
`pytest-xdist` workers create `default/default` together. One wins. Others get `409 ALREADY_EXISTS`. Old helper fell back to `OPENVIKING_API_KEY` = ROOT key in CI. ROOT key + tenant data API in `api_key` mode -> 403 wave.

## Trusted Mode
Set `server.auth_mode = "trusted"`.

Non-localhost: also set `server.root_api_key`.

Tenant data req: send `X-OpenViking-Account` + `X-OpenViking-User`; if root key configured, also matching `Authorization: Bearer <root_api_key>`.

## Verify
- local: `ruff format --check tests/api_test/conftest.py tests/api_test/test_user_key_bootstrap.py`
- local: `ruff check tests/api_test/conftest.py tests/api_test/test_user_key_bootstrap.py`
- local: `python -m pytest tests/api_test/test_user_key_bootstrap.py -q`
- CI: lint pass; API & CLI pass