### PR TITLE
fix(path_lock): restore 'Still waiting for lock' progress logs disabled by #2700

### DIFF
--- a/openviking/storage/transaction/path_lock.py
+++ b/openviking/storage/transaction/path_lock.py
@@ -487,7 +487,8 @@ class PathLockEngine:
         if await self._has_owned_ancestor_tree(path, owner):
             logger.debug(f"[EXACT] Reusing owned ancestor TREE lock on: {path}")
             return True
-        if timeout is None:
+        had_no_timeout = timeout is None
+        if had_no_timeout:
             timeout = self._lock_expire
         deadline = asyncio.get_running_loop().time() + timeout
         wait_start = asyncio.get_running_loop().time()
@@ -504,7 +505,7 @@ class PathLockEngine:
                     _log_timeout_waiting(f"[EXACT] Timeout waiting for exact lock on: {path}")
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[EXACT] Still waiting for lock on: {path} "
                         f"(waited={now - wait_start:.1f}s)"
@@ -543,7 +544,7 @@ class PathLockEngine:
                     )
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[EXACT] Still waiting for ancestor TREE lock: {ancestor_conflict} "
                         f"(path={path}, waited={now - wait_start:.1f}s)"
@@ -596,7 +597,7 @@ class PathLockEngine:
                         await self._remove_lock_file(lock_path)
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[EXACT] Still waiting after conflict check on: {path} "
                         f"(waited={now - wait_start:.1f}s)"
@@ -610,7 +611,7 @@ class PathLockEngine:
                 if asyncio.get_running_loop().time() >= deadline:
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[EXACT] Still waiting for lock ownership verification: {path} "
                         f"(waited={now - wait_start:.1f}s)"
@@ -640,7 +641,8 @@ class PathLockEngine:
         if await self._has_owned_ancestor_tree(path, owner):
             logger.debug(f"[TREE] Reusing owned ancestor TREE lock on: {path}")
             return True
-        if timeout is None:
+        had_no_timeout = timeout is None
+        if had_no_timeout:
             timeout = self._lock_expire
         deadline = asyncio.get_running_loop().time() + timeout
         wait_start = asyncio.get_running_loop().time()
@@ -656,7 +658,7 @@ class PathLockEngine:
                     _log_timeout_waiting(f"[TREE] Timeout waiting for lock on: {path}")
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[TREE] Still waiting for lock on: {path} (waited={now - wait_start:.1f}s)"
                     )
@@ -677,7 +679,7 @@ class PathLockEngine:
                     )
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[TREE] Still waiting for ancestor TREE lock: {ancestor_conflict} "
                         f"(path={path}, waited={now - wait_start:.1f}s)"
@@ -710,7 +712,7 @@ class PathLockEngine:
                     )
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[TREE] Still waiting for descendant lock: {desc_conflict} "
                         f"(path={path}, waited={now - wait_start:.1f}s)"
@@ -752,7 +754,7 @@ class PathLockEngine:
                         await self._remove_lock_file(lock_path)
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[TREE] Still waiting after conflict check on: {path} "
                         f"(waited={now - wait_start:.1f}s)"
@@ -766,7 +768,7 @@ class PathLockEngine:
                 if asyncio.get_running_loop().time() >= deadline:
                     return False
                 now = asyncio.get_running_loop().time()
-                if timeout is None and now >= next_wait_log_at:
+                if had_no_timeout and now >= next_wait_log_at:
                     logger.info(
                         f"[TREE] Still waiting for lock ownership verification: {path} "
                         f"(waited={now - wait_start:.1f}s)"


### PR DESCRIPTION
## Problem

`acquire_exact_path` / `acquire_tree` in `openviking/storage/transaction/path_lock.py` emit a periodic `[EXACT]/[TREE] Still waiting for lock on: <path> (waited=Ns)` progress log (every `_WAIT_LOG_INTERVAL` = 10s) while blocked on lock contention, so an operator can see a stuck lock instead of a silent hang.

Merged #2700 ("fall back to lock_expire when timeout is None", closes #2698) added a bounded wait by reassigning the sentinel **before** the wait loop, in both `acquire_exact_path` (~L491) and `acquire_tree` (~L644):

```python
if timeout is None:
    timeout = self._lock_expire   # 300.0
deadline = asyncio.get_running_loop().time() + timeout
```

That bounded-wait fix is correct, but it leaves `timeout` non-`None` for the whole loop, so all **9** in-loop progress-log guards `if timeout is None and now >= next_wait_log_at:` (L507/546/599/613 EXACT + L659/680/713/755/769 TREE) are now permanently `False` — dead code. Parent commit `7ee1481e1` (pre-#2700) set `deadline=float("inf")` and **left `timeout=None`**, so the guards stayed live and logged every 10s.

Net regression: the **default** deployment (no `lock_timeout` → `timeout=None` → reassigned to 300s) now waits **silently for up to 300s** on lock contention with zero "Still waiting" diagnostics — exactly the stuck-lock scenario #2698/#2700 set out to make recoverable. #2700's description only covered the deadline/bounded-wait change; it didn't declare the logging change intentional.

## Fix

Capture the original `None`-ness into `had_no_timeout` **before** the `_lock_expire` reassignment, and gate the 9 progress logs on that flag:

```python
had_no_timeout = timeout is None
if had_no_timeout:
    timeout = self._lock_expire
...
if had_no_timeout and now >= next_wait_log_at:
    ...
```

This restores the exact pre-#2700 logging semantics (progress logs fire only when the caller passed no explicit timeout) **without** touching #2700's bounded wait — `deadline` still uses `_lock_expire`, so no infinite wait is reintroduced. Logging-only; no lock-acquisition semantics change. The dead branch is verifiable by inspection: `timeout` is reassigned non-`None` immediately before each guard.

Follow-up to merged #2700.
