### PR TITLE
fix(parse): normalize legacy text encodings

### DIFF
--- a/openviking/parse/parsers/base_parser.py
+++ b/openviking/parse/parsers/base_parser.py
@@ -80,16 +80,30 @@ class BaseParser(ABC):
             File content as string
         """
         path = Path(path)
-        encodings = ["utf-8", "utf-8-sig", "latin-1", "cp1252"]
+        from openviking.parse.parsers.upload_utils import (
+            detect_and_convert_encoding,
+            is_text_file,
+        )
 
-        for encoding in encodings:
+        raw = path.read_bytes()
+        normalized = detect_and_convert_encoding(raw, path)
+        decode_error: Optional[UnicodeDecodeError] = None
+        try:
+            return normalized.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            decode_error = exc
+            if is_text_file(path):
+                raise ValueError(f"Unable to decode text file: {path}") from exc
+
+        # Preserve the previous permissive fallback for parser subclasses that
+        # read custom extensions not covered by the shared text-file detector.
+        for encoding in ("utf-8-sig", "cp1252", "latin-1"):
             try:
-                with open(path, "r", encoding=encoding) as f:
-                    return f.read()
+                return raw.decode(encoding)
             except UnicodeDecodeError:
                 continue
 
-        raise ValueError(f"Unable to decode file: {path}")
+        raise ValueError(f"Unable to decode file: {path}") from decode_error
 
     def _get_viking_fs(self):
         """

--- a/openviking/parse/parsers/base_parser.py
+++ b/openviking/parse/parsers/base_parser.py
@@ -80,30 +80,24 @@ class BaseParser(ABC):
             File content as string
         """
         path = Path(path)
-        from openviking.parse.parsers.upload_utils import (
-            detect_and_convert_encoding,
-            is_text_file,
-        )
+        from openviking.parse.parsers.upload_utils import detect_and_convert_encoding
 
         raw = path.read_bytes()
         normalized = detect_and_convert_encoding(raw, path)
-        decode_error: Optional[UnicodeDecodeError] = None
         try:
             return normalized.decode("utf-8")
-        except UnicodeDecodeError as exc:
-            decode_error = exc
-            if is_text_file(path):
-                raise ValueError(f"Unable to decode text file: {path}") from exc
+        except UnicodeDecodeError:
+            pass
 
-        # Preserve the previous permissive fallback for parser subclasses that
-        # read custom extensions not covered by the shared text-file detector.
-        for encoding in ("utf-8-sig", "cp1252", "latin-1"):
+        # Preserve the previous permissive fallback for files whose encoding is
+        # unknown or rejected by text detection as likely binary/control-heavy.
+        for encoding in ("utf-8-sig", "cp1252"):
             try:
                 return raw.decode(encoding)
             except UnicodeDecodeError:
                 continue
 
-        raise ValueError(f"Unable to decode file: {path}") from decode_error
+        return raw.decode("latin-1")
 
     def _get_viking_fs(self):
         """

--- a/openviking/parse/parsers/constants.py
+++ b/openviking/parse/parsers/constants.py
@@ -237,6 +237,7 @@ ADDITIONAL_TEXT_EXTENSIONS = {
 TEXT_ENCODINGS = [
     "utf-8",  # Most common modern encoding
     "utf-8-sig",  # UTF-8 with BOM
+    "gb18030",  # Chinese GB18030 (superset of GBK)
     "gbk",  # Chinese GBK (simplified Chinese)
     "gb2312",  # Chinese GB2312 (simplified Chinese)
     "big5",  # Traditional Chinese

--- a/openviking/parse/parsers/constants.py
+++ b/openviking/parse/parsers/constants.py
@@ -232,21 +232,3 @@ ADDITIONAL_TEXT_EXTENSIONS = {
     ".lock",
     ".in",
 }
-
-# Common text encodings to try for encoding detection (in order of likelihood)
-TEXT_ENCODINGS = [
-    "utf-8",  # Most common modern encoding
-    "utf-8-sig",  # UTF-8 with BOM
-    "gb18030",  # Chinese GB18030 (superset of GBK)
-    "gbk",  # Chinese GBK (simplified Chinese)
-    "gb2312",  # Chinese GB2312 (simplified Chinese)
-    "big5",  # Traditional Chinese
-    "shift_jis",  # Japanese
-    "euc-kr",  # Korean
-    "iso-8859-1",  # Latin-1 (Western European)
-    "cp1252",  # Windows Latin-1
-    "latin-1",  # Latin-1 alias
-]
-
-# UTF-8 variants that don't need conversion
-UTF8_VARIANTS = {"utf-8", "utf-8-sig"}

--- a/openviking/parse/parsers/text_encoding.py
+++ b/openviking/parse/parsers/text_encoding.py
@@ -63,6 +63,7 @@ class _EncodingCandidate:
     encoding: str
     decoded: str
     rank: int
+    from_detector: bool
 
 
 def normalize_text_bytes(content: bytes, file_path: Union[str, Path] = "") -> bytes:
@@ -126,7 +127,7 @@ def _iter_candidates(content: bytes) -> Iterable[_EncodingCandidate]:
     rank = 0
 
     for match in from_bytes(content, cp_isolation=_DETECTION_ENCODINGS):
-        candidate = _decode_candidate(content, match.encoding, rank)
+        candidate = _decode_candidate(content, match.encoding, rank, from_detector=True)
         if candidate is None or candidate.encoding in seen:
             continue
         seen.add(candidate.encoding)
@@ -134,7 +135,7 @@ def _iter_candidates(content: bytes) -> Iterable[_EncodingCandidate]:
         yield candidate
 
     for encoding in _DETECTION_ENCODINGS:
-        candidate = _decode_candidate(content, encoding, rank)
+        candidate = _decode_candidate(content, encoding, rank, from_detector=False)
         if candidate is None or candidate.encoding in seen:
             continue
         seen.add(candidate.encoding)
@@ -143,7 +144,7 @@ def _iter_candidates(content: bytes) -> Iterable[_EncodingCandidate]:
 
 
 def _decode_candidate(
-    content: bytes, encoding: Optional[str], rank: int
+    content: bytes, encoding: Optional[str], rank: int, *, from_detector: bool
 ) -> Optional[_EncodingCandidate]:
     if not encoding:
         return None
@@ -157,7 +158,12 @@ def _decode_candidate(
     if not _is_valid_text(decoded):
         return None
 
-    return _EncodingCandidate(encoding=canonical, decoded=decoded, rank=rank)
+    return _EncodingCandidate(
+        encoding=canonical,
+        decoded=decoded,
+        rank=rank,
+        from_detector=from_detector,
+    )
 
 
 def _is_valid_text(decoded: str) -> bool:
@@ -198,6 +204,7 @@ def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_Enc
         return first
 
     preferred_chinese = _preferred_chinese_candidate(consistent)
+    detected_chinese = _preferred_chinese_candidate(consistent, from_detector_only=True)
     for candidate in consistent:
         profile = _script_profile(candidate.decoded)
         if (
@@ -208,13 +215,17 @@ def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_Enc
             return candidate
 
     first_profile = _script_profile(first.decoded)
+    # Short Simplified Chinese can be misranked as mixed Hangul/CJK under CP949.
+    # Only rescue to Chinese when charset-normalizer also emitted a Chinese
+    # candidate and the Korean-looking decode is not Hanja-dominant.
     if (
         first.encoding in _KOREAN_ENCODINGS
-        and preferred_chinese is not None
+        and detected_chinese is not None
         and first_profile.hangul_syllables > 0
         and first_profile.cjk > 0
+        and first_profile.hangul_syllables >= first_profile.cjk
     ):
-        return preferred_chinese
+        return detected_chinese
 
     if first.encoding in _CHINESE_ENCODINGS and preferred_chinese is not None:
         return preferred_chinese
@@ -224,10 +235,14 @@ def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_Enc
 
 def _preferred_chinese_candidate(
     candidates: Iterable[_EncodingCandidate],
+    *,
+    from_detector_only: bool = False,
 ) -> Optional[_EncodingCandidate]:
     for encoding in _CHINESE_ENCODING_PREFERENCE:
         for candidate in candidates:
-            if candidate.encoding == encoding:
+            if candidate.encoding == encoding and (
+                not from_detector_only or candidate.from_detector
+            ):
                 return candidate
     return None
 

--- a/openviking/parse/parsers/text_encoding.py
+++ b/openviking/parse/parsers/text_encoding.py
@@ -197,6 +197,7 @@ def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_Enc
     if first.encoding in _JAPANESE_ENCODINGS:
         return first
 
+    preferred_chinese = _preferred_chinese_candidate(consistent)
     for candidate in consistent:
         profile = _script_profile(candidate.decoded)
         if (
@@ -206,13 +207,29 @@ def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_Enc
         ):
             return candidate
 
-    if first.encoding in _CHINESE_ENCODINGS:
-        for encoding in _CHINESE_ENCODING_PREFERENCE:
-            for candidate in consistent:
-                if candidate.encoding == encoding:
-                    return candidate
+    first_profile = _script_profile(first.decoded)
+    if (
+        first.encoding in _KOREAN_ENCODINGS
+        and preferred_chinese is not None
+        and first_profile.hangul_syllables > 0
+        and first_profile.cjk > 0
+    ):
+        return preferred_chinese
+
+    if first.encoding in _CHINESE_ENCODINGS and preferred_chinese is not None:
+        return preferred_chinese
 
     return first
+
+
+def _preferred_chinese_candidate(
+    candidates: Iterable[_EncodingCandidate],
+) -> Optional[_EncodingCandidate]:
+    for encoding in _CHINESE_ENCODING_PREFERENCE:
+        for candidate in candidates:
+            if candidate.encoding == encoding:
+                return candidate
+    return None
 
 
 def _is_script_consistent(candidate: _EncodingCandidate) -> bool:

--- a/openviking/parse/parsers/text_encoding.py
+++ b/openviking/parse/parsers/text_encoding.py
@@ -37,10 +37,13 @@ _DETECTION_ENCODINGS = (
     "latin_1",
 )
 
+# These values use codecs.lookup(...).name canonical forms because candidates
+# are canonicalized before set membership checks.
 _CHINESE_ENCODINGS = {"gb18030", "gbk", "gb2312", "big5", "cp950"}
 _CHINESE_ENCODING_PREFERENCE = ("gb18030", "gbk", "gb2312", "big5", "cp950")
 _JAPANESE_ENCODINGS = {"cp932", "shift_jis", "euc_jp"}
 _KOREAN_ENCODINGS = {"euc_kr", "cp949"}
+_CJK_ENCODINGS = _CHINESE_ENCODINGS | _JAPANESE_ENCODINGS | _KOREAN_ENCODINGS
 # Very short CJK samples can decode into plausible text under several legacy
 # code pages. Require a few script-specific characters before overriding the
 # detector's rank with Korean script evidence.
@@ -103,7 +106,10 @@ def _normalize_text_bytes(content: bytes, file_path: Union[str, Path] = "") -> b
 def _decode_known_bom(content: bytes) -> Optional[bytes]:
     for bom, encoding in _BOM_ENCODINGS:
         if content.startswith(bom):
-            return content.decode(encoding).encode("utf-8")
+            try:
+                return content.decode(encoding).encode("utf-8")
+            except UnicodeDecodeError:
+                return None
     return None
 
 
@@ -183,6 +189,11 @@ def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_Enc
     # Preserve detector rank for Japanese: short kanji-only Shift-JIS has no
     # kana signal, but charset-normalizer still ranks CP932 first.
     first = min(consistent, key=lambda candidate: candidate.rank)
+    if first.encoding not in _CJK_ENCODINGS:
+        return first
+
+    # Short CJK-only samples can remain ambiguous across Chinese, Japanese, and
+    # Korean encodings without source charset or language metadata.
     if first.encoding in _JAPANESE_ENCODINGS:
         return first
 
@@ -195,10 +206,11 @@ def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_Enc
         ):
             return candidate
 
-    for encoding in _CHINESE_ENCODING_PREFERENCE:
-        for candidate in consistent:
-            if candidate.encoding == encoding:
-                return candidate
+    if first.encoding in _CHINESE_ENCODINGS:
+        for encoding in _CHINESE_ENCODING_PREFERENCE:
+            for candidate in consistent:
+                if candidate.encoding == encoding:
+                    return candidate
 
     return first
 

--- a/openviking/parse/parsers/text_encoding.py
+++ b/openviking/parse/parsers/text_encoding.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Text encoding normalization helpers for uploaded text files."""
+
+import codecs
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Union
+
+from charset_normalizer import from_bytes
+
+from openviking_cli.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+_BOM_ENCODINGS = (
+    (codecs.BOM_UTF32_LE, "utf-32"),
+    (codecs.BOM_UTF32_BE, "utf-32"),
+    (codecs.BOM_UTF16_LE, "utf-16"),
+    (codecs.BOM_UTF16_BE, "utf-16"),
+    (codecs.BOM_UTF8, "utf-8-sig"),
+)
+
+_DETECTION_ENCODINGS = (
+    "gb18030",
+    "gbk",
+    "gb2312",
+    "big5",
+    "cp950",
+    "cp932",
+    "shift_jis",
+    "euc_jp",
+    "euc_kr",
+    "cp949",
+    "cp1252",
+    "latin_1",
+)
+
+_CHINESE_ENCODINGS = {"gb18030", "gbk", "gb2312", "big5", "cp950"}
+_CHINESE_ENCODING_PREFERENCE = ("gb18030", "gbk", "gb2312", "big5", "cp950")
+_JAPANESE_ENCODINGS = {"cp932", "shift_jis", "euc_jp"}
+_KOREAN_ENCODINGS = {"euc_kr", "cp949"}
+# Very short CJK samples can decode into plausible text under several legacy
+# code pages. Require a few script-specific characters before overriding the
+# detector's rank with Korean script evidence.
+_MIN_STRONG_SCRIPT_CHARS = 4
+
+
+@dataclass(frozen=True)
+class _ScriptProfile:
+    cjk: int
+    kana: int
+    hangul_syllables: int
+    hangul_jamo: int
+
+
+@dataclass(frozen=True)
+class _EncodingCandidate:
+    encoding: str
+    decoded: str
+    rank: int
+
+
+def normalize_text_bytes(content: bytes, file_path: Union[str, Path] = "") -> bytes:
+    """Normalize legacy text bytes to UTF-8 while leaving unknown bytes untouched."""
+    try:
+        return _normalize_text_bytes(content, file_path)
+    except Exception as exc:
+        logger.warning(f"Encoding detection failed for {file_path}: {exc}")
+        return content
+
+
+def _normalize_text_bytes(content: bytes, file_path: Union[str, Path] = "") -> bytes:
+    if not content:
+        return content
+
+    bom_normalized = _decode_known_bom(content)
+    if bom_normalized is not None:
+        return bom_normalized
+
+    try:
+        content.decode("utf-8")
+        return content
+    except UnicodeDecodeError:
+        pass
+
+    if _looks_binary(content):
+        logger.debug(f"Detected binary-like text file {file_path}, skipping encoding detection")
+        return content
+
+    candidate = _choose_candidate(_iter_candidates(content))
+    if candidate is None:
+        logger.warning(f"Encoding detection failed for {file_path}: no matching encoding found")
+        return content
+
+    decoded = candidate.decoded.replace("\x00", "")
+    normalized = decoded.encode("utf-8")
+    logger.debug(f"Converted {file_path} from {candidate.encoding} to UTF-8")
+    return normalized
+
+
+def _decode_known_bom(content: bytes) -> Optional[bytes]:
+    for bom, encoding in _BOM_ENCODINGS:
+        if content.startswith(bom):
+            return content.decode(encoding).encode("utf-8")
+    return None
+
+
+def _looks_binary(content: bytes) -> bool:
+    sample = content[: min(8192, len(content))]
+    if not sample:
+        return False
+
+    return sample.count(b"\x00") / len(sample) > 0.05
+
+
+def _iter_candidates(content: bytes) -> Iterable[_EncodingCandidate]:
+    seen: set[str] = set()
+    rank = 0
+
+    for match in from_bytes(content, cp_isolation=_DETECTION_ENCODINGS):
+        candidate = _decode_candidate(content, match.encoding, rank)
+        if candidate is None or candidate.encoding in seen:
+            continue
+        seen.add(candidate.encoding)
+        rank += 1
+        yield candidate
+
+    for encoding in _DETECTION_ENCODINGS:
+        candidate = _decode_candidate(content, encoding, rank)
+        if candidate is None or candidate.encoding in seen:
+            continue
+        seen.add(candidate.encoding)
+        rank += 1
+        yield candidate
+
+
+def _decode_candidate(
+    content: bytes, encoding: Optional[str], rank: int
+) -> Optional[_EncodingCandidate]:
+    if not encoding:
+        return None
+
+    try:
+        canonical = codecs.lookup(encoding).name
+        decoded = content.decode(canonical)
+    except (LookupError, UnicodeDecodeError):
+        return None
+
+    if not _is_valid_text(decoded):
+        return None
+
+    return _EncodingCandidate(encoding=canonical, decoded=decoded, rank=rank)
+
+
+def _is_valid_text(decoded: str) -> bool:
+    sample = decoded[:1000]
+    if not sample:
+        return True
+
+    if "\ufffd" in sample:
+        return False
+
+    disallowed_controls = sum(1 for char in sample if _is_disallowed_control(char))
+    return disallowed_controls / len(sample) <= 0.05
+
+
+def _is_disallowed_control(char: str) -> bool:
+    codepoint = ord(char)
+    return (codepoint < 32 and char not in "\t\n\r") or 0x7F <= codepoint <= 0x9F
+
+
+def _choose_candidate(candidates: Iterable[_EncodingCandidate]) -> Optional[_EncodingCandidate]:
+    candidates = list(candidates)
+    if not candidates:
+        return None
+
+    consistent = [candidate for candidate in candidates if _is_script_consistent(candidate)]
+    if not consistent:
+        consistent = candidates
+
+    # Preserve detector rank for Japanese: short kanji-only Shift-JIS has no
+    # kana signal, but charset-normalizer still ranks CP932 first.
+    first = min(consistent, key=lambda candidate: candidate.rank)
+    if first.encoding in _JAPANESE_ENCODINGS:
+        return first
+
+    for candidate in consistent:
+        profile = _script_profile(candidate.decoded)
+        if (
+            candidate.encoding in _KOREAN_ENCODINGS
+            and profile.hangul_syllables >= _MIN_STRONG_SCRIPT_CHARS
+            and profile.cjk == 0
+        ):
+            return candidate
+
+    for encoding in _CHINESE_ENCODING_PREFERENCE:
+        for candidate in consistent:
+            if candidate.encoding == encoding:
+                return candidate
+
+    return first
+
+
+def _is_script_consistent(candidate: _EncodingCandidate) -> bool:
+    profile = _script_profile(candidate.decoded)
+
+    if candidate.encoding in _CHINESE_ENCODINGS:
+        return profile.kana == 0 and profile.hangul_syllables == 0 and profile.hangul_jamo == 0
+
+    if candidate.encoding in _JAPANESE_ENCODINGS:
+        return profile.hangul_syllables == 0 and profile.hangul_jamo == 0
+
+    if candidate.encoding in _KOREAN_ENCODINGS:
+        return profile.kana == 0 and profile.hangul_jamo == 0
+
+    return True
+
+
+def _script_profile(decoded: str) -> _ScriptProfile:
+    sample = decoded[:1000]
+    return _ScriptProfile(
+        cjk=sum(1 for char in sample if _is_cjk(char)),
+        kana=sum(1 for char in sample if _is_kana(char)),
+        hangul_syllables=sum(1 for char in sample if "\uac00" <= char <= "\ud7af"),
+        hangul_jamo=sum(1 for char in sample if _is_hangul_jamo(char)),
+    )
+
+
+def _is_cjk(char: str) -> bool:
+    return "\u3400" <= char <= "\u4dbf" or "\u4e00" <= char <= "\u9fff"
+
+
+def _is_kana(char: str) -> bool:
+    return "\u3040" <= char <= "\u30ff" or "\uff66" <= char <= "\uff9f"
+
+
+def _is_hangul_jamo(char: str) -> bool:
+    return (
+        "\u1100" <= char <= "\u11ff"
+        or "\u3130" <= char <= "\u318f"
+        or "\ua960" <= char <= "\ua97f"
+        or "\ud7b0" <= char <= "\ud7ff"
+    )

--- a/openviking/parse/parsers/upload_utils.py
+++ b/openviking/parse/parsers/upload_utils.py
@@ -45,6 +45,92 @@ _EXTENSIONLESS_TEXT_NAMES: Set[str] = {
 }
 
 
+_CP1252_PUNCTUATION_CODEPOINTS = {
+    0x20AC,  # euro sign
+    0x2018,
+    0x2019,
+    0x201C,
+    0x201D,
+    0x2013,
+    0x2014,
+}
+_CP1252_MOJIBAKE_CODEPOINTS = {
+    0x0192,
+    0x201A,
+    0x201E,
+    0x2020,
+    0x2021,
+    0x02C6,
+    0x2030,
+    0x0160,
+    0x2039,
+    0x0152,
+    0x017D,
+    0x2022,
+    0x02DC,
+    0x2122,
+    0x0161,
+    0x203A,
+    0x0153,
+    0x017E,
+    0x0178,
+}
+_LATIN_FALLBACK_ENCODINGS = {"cp1252", "iso-8859-1", "latin-1"}
+
+
+def _is_control_heavy(decoded: str) -> bool:
+    sample = decoded[:1000]
+    if not sample:
+        return False
+
+    control_chars = sum(1 for char in sample if ord(char) < 32 and char not in "\t\n\r")
+    return control_chars / len(sample) > 0.05
+
+
+def _encoding_score(decoded: str, encoding: str) -> int:
+    """Lower score means the decoded text looks more plausible for this codec."""
+    sample = decoded[:1000]
+    sample_length = max(1, len(sample))
+
+    c1_controls = sum(1 for char in sample if 0x80 <= ord(char) <= 0x9F)
+    cjk = sum(1 for char in sample if "\u4e00" <= char <= "\u9fff")
+    hiragana = sum(1 for char in sample if "\u3040" <= char <= "\u309f")
+    katakana = sum(1 for char in sample if "\u30a0" <= char <= "\u30ff")
+    halfwidth_katakana = sum(1 for char in sample if "\uff66" <= char <= "\uff9f")
+    kana = hiragana + katakana + halfwidth_katakana
+    hangul = sum(1 for char in sample if "\uac00" <= char <= "\ud7af")
+    extended_latin = sum(1 for char in sample if "\u00a0" <= char <= "\u024f")
+    cp1252_punctuation = sum(1 for char in sample if ord(char) in _CP1252_PUNCTUATION_CODEPOINTS)
+    cp1252_mojibake = sum(1 for char in sample if ord(char) in _CP1252_MOJIBAKE_CODEPOINTS)
+
+    score = c1_controls * 30
+
+    if encoding in _LATIN_FALLBACK_ENCODINGS:
+        score += (cjk + kana + hangul) * 40
+        if extended_latin / sample_length > 0.20:
+            score += extended_latin * 8
+        score += cp1252_mojibake * 15
+
+    if encoding in {"iso-8859-1", "latin-1"}:
+        score += cp1252_punctuation * 30
+    elif encoding == "cp1252":
+        score -= cp1252_punctuation * 3
+
+    if encoding == "shift_jis":
+        score -= (hiragana + katakana) * 10
+        score += halfwidth_katakana * 8 + hangul * 30
+    elif encoding == "euc-kr":
+        score += 25
+        score -= hangul * 10
+        score += kana * 30 + cjk * 35
+    elif encoding == "big5":
+        score += kana * 30 + hangul * 30
+    elif encoding.startswith("gb"):
+        score += kana * 30 + hangul * 30
+
+    return score
+
+
 def is_text_file(file_path: Union[str, Path]) -> bool:
     """Return True when the file extension is treated as text content."""
     p = Path(file_path)
@@ -63,6 +149,8 @@ def detect_and_convert_encoding(content: bytes, file_path: Union[str, Path] = ""
     """Detect text encoding and normalize content to UTF-8 when needed."""
     if not is_text_file(file_path):
         return content
+    if not content:
+        return content
 
     try:
         # Check for potential binary content (null bytes in first 8KB)
@@ -77,31 +165,41 @@ def detect_and_convert_encoding(content: bytes, file_path: Union[str, Path] = ""
                 )
                 return content
 
-        detected_encoding: Optional[str] = None
-        for encoding in TEXT_ENCODINGS:
+        if content.startswith(b"\xef\xbb\xbf"):
+            decoded_content = content.decode("utf-8-sig")
+            return decoded_content.encode("utf-8")
+
+        try:
+            content.decode("utf-8")
+            return content
+        except UnicodeDecodeError:
+            pass
+
+        candidates: List[Tuple[int, int, str, str]] = []
+        for encoding_index, encoding in enumerate(TEXT_ENCODINGS):
+            if encoding in UTF8_VARIANTS:
+                continue
             try:
                 decoded = content.decode(encoding)
-                # Additional validation: check for control characters that suggest binary
-                control_chars = sum(1 for c in decoded[:1000] if ord(c) < 32 and c not in "\t\n\r")
-                if control_chars / min(1000, len(decoded)) > 0.05:  # More than 5% control chars
+                if _is_control_heavy(decoded):
                     continue
-                detected_encoding = encoding
-                break
+                candidates.append(
+                    (_encoding_score(decoded, encoding), encoding_index, encoding, decoded)
+                )
             except UnicodeDecodeError:
                 continue
 
-        if detected_encoding is None:
+        if not candidates:
             logger.warning(f"Encoding detection failed for {file_path}: no matching encoding found")
             return content
 
-        if detected_encoding not in UTF8_VARIANTS:
-            decoded_content = content.decode(detected_encoding, errors="replace")
-            # Remove null bytes from decoded content as they can cause issues downstream
-            if "\x00" in decoded_content:
-                decoded_content = decoded_content.replace("\x00", "")
-                logger.debug(f"Removed null bytes from decoded content in {file_path}")
-            content = decoded_content.encode("utf-8")
-            logger.debug(f"Converted {file_path} from {detected_encoding} to UTF-8")
+        _, _, detected_encoding, decoded_content = min(candidates)
+        # Remove null bytes from decoded content as they can cause issues downstream
+        if "\x00" in decoded_content:
+            decoded_content = decoded_content.replace("\x00", "")
+            logger.debug(f"Removed null bytes from decoded content in {file_path}")
+        content = decoded_content.encode("utf-8")
+        logger.debug(f"Converted {file_path} from {detected_encoding} to UTF-8")
 
         return content
     except Exception as exc:

--- a/openviking/parse/parsers/upload_utils.py
+++ b/openviking/parse/parsers/upload_utils.py
@@ -14,9 +14,8 @@ from openviking.parse.parsers.constants import (
     DOCUMENTATION_EXTENSIONS,
     IGNORE_DIRS,
     IGNORE_EXTENSIONS,
-    TEXT_ENCODINGS,
-    UTF8_VARIANTS,
 )
+from openviking.parse.parsers.text_encoding import normalize_text_bytes
 from openviking.utils.path_safety import safe_join_viking_uri, sanitize_relative_viking_path
 from openviking_cli.utils.logger import get_logger
 
@@ -45,92 +44,6 @@ _EXTENSIONLESS_TEXT_NAMES: Set[str] = {
 }
 
 
-_CP1252_PUNCTUATION_CODEPOINTS = {
-    0x20AC,  # euro sign
-    0x2018,
-    0x2019,
-    0x201C,
-    0x201D,
-    0x2013,
-    0x2014,
-}
-_CP1252_MOJIBAKE_CODEPOINTS = {
-    0x0192,
-    0x201A,
-    0x201E,
-    0x2020,
-    0x2021,
-    0x02C6,
-    0x2030,
-    0x0160,
-    0x2039,
-    0x0152,
-    0x017D,
-    0x2022,
-    0x02DC,
-    0x2122,
-    0x0161,
-    0x203A,
-    0x0153,
-    0x017E,
-    0x0178,
-}
-_LATIN_FALLBACK_ENCODINGS = {"cp1252", "iso-8859-1", "latin-1"}
-
-
-def _is_control_heavy(decoded: str) -> bool:
-    sample = decoded[:1000]
-    if not sample:
-        return False
-
-    control_chars = sum(1 for char in sample if ord(char) < 32 and char not in "\t\n\r")
-    return control_chars / len(sample) > 0.05
-
-
-def _encoding_score(decoded: str, encoding: str) -> int:
-    """Lower score means the decoded text looks more plausible for this codec."""
-    sample = decoded[:1000]
-    sample_length = max(1, len(sample))
-
-    c1_controls = sum(1 for char in sample if 0x80 <= ord(char) <= 0x9F)
-    cjk = sum(1 for char in sample if "\u4e00" <= char <= "\u9fff")
-    hiragana = sum(1 for char in sample if "\u3040" <= char <= "\u309f")
-    katakana = sum(1 for char in sample if "\u30a0" <= char <= "\u30ff")
-    halfwidth_katakana = sum(1 for char in sample if "\uff66" <= char <= "\uff9f")
-    kana = hiragana + katakana + halfwidth_katakana
-    hangul = sum(1 for char in sample if "\uac00" <= char <= "\ud7af")
-    extended_latin = sum(1 for char in sample if "\u00a0" <= char <= "\u024f")
-    cp1252_punctuation = sum(1 for char in sample if ord(char) in _CP1252_PUNCTUATION_CODEPOINTS)
-    cp1252_mojibake = sum(1 for char in sample if ord(char) in _CP1252_MOJIBAKE_CODEPOINTS)
-
-    score = c1_controls * 30
-
-    if encoding in _LATIN_FALLBACK_ENCODINGS:
-        score += (cjk + kana + hangul) * 40
-        if extended_latin / sample_length > 0.20:
-            score += extended_latin * 8
-        score += cp1252_mojibake * 15
-
-    if encoding in {"iso-8859-1", "latin-1"}:
-        score += cp1252_punctuation * 30
-    elif encoding == "cp1252":
-        score -= cp1252_punctuation * 3
-
-    if encoding == "shift_jis":
-        score -= (hiragana + katakana) * 10
-        score += halfwidth_katakana * 8 + hangul * 30
-    elif encoding == "euc-kr":
-        score += 25
-        score -= hangul * 10
-        score += kana * 30 + cjk * 35
-    elif encoding == "big5":
-        score += kana * 30 + hangul * 30
-    elif encoding.startswith("gb"):
-        score += kana * 30 + hangul * 30
-
-    return score
-
-
 def is_text_file(file_path: Union[str, Path]) -> bool:
     """Return True when the file extension is treated as text content."""
     p = Path(file_path)
@@ -149,62 +62,7 @@ def detect_and_convert_encoding(content: bytes, file_path: Union[str, Path] = ""
     """Detect text encoding and normalize content to UTF-8 when needed."""
     if not is_text_file(file_path):
         return content
-    if not content:
-        return content
-
-    try:
-        # Check for potential binary content (null bytes in first 8KB)
-        # Binary files often contain null bytes which can cause issues
-        sample_size = min(8192, len(content))
-        if b"\x00" in content[:sample_size]:
-            null_count = content[:sample_size].count(b"\x00")
-            # If more than 5% null bytes in sample, likely binary - don't process
-            if null_count / sample_size > 0.05:
-                logger.debug(
-                    f"Detected binary content in {file_path} (null bytes: {null_count}), skipping encoding detection"
-                )
-                return content
-
-        if content.startswith(b"\xef\xbb\xbf"):
-            decoded_content = content.decode("utf-8-sig")
-            return decoded_content.encode("utf-8")
-
-        try:
-            content.decode("utf-8")
-            return content
-        except UnicodeDecodeError:
-            pass
-
-        candidates: List[Tuple[int, int, str, str]] = []
-        for encoding_index, encoding in enumerate(TEXT_ENCODINGS):
-            if encoding in UTF8_VARIANTS:
-                continue
-            try:
-                decoded = content.decode(encoding)
-                if _is_control_heavy(decoded):
-                    continue
-                candidates.append(
-                    (_encoding_score(decoded, encoding), encoding_index, encoding, decoded)
-                )
-            except UnicodeDecodeError:
-                continue
-
-        if not candidates:
-            logger.warning(f"Encoding detection failed for {file_path}: no matching encoding found")
-            return content
-
-        _, _, detected_encoding, decoded_content = min(candidates)
-        # Remove null bytes from decoded content as they can cause issues downstream
-        if "\x00" in decoded_content:
-            decoded_content = decoded_content.replace("\x00", "")
-            logger.debug(f"Removed null bytes from decoded content in {file_path}")
-        content = decoded_content.encode("utf-8")
-        logger.debug(f"Converted {file_path} from {detected_encoding} to UTF-8")
-
-        return content
-    except Exception as exc:
-        logger.warning(f"Encoding detection failed for {file_path}: {exc}")
-        return content
+    return normalize_text_bytes(content, file_path)
 
 
 def should_skip_file(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "markdownify>=0.11.0",
     "openai>=1.0.0",
     "requests>=2.31.0",
+    "charset-normalizer>=3.4,<4",
     "python-docx>=1.0.0",
     "olefile>=0.47",
     "xlrd>=2.0.1",

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -46,6 +46,20 @@ def test_markdown_file_read_preserves_detector_first_non_cjk_text(tmp_path):
     assert MarkdownParser()._read_file(path) == content
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        "한국어 漢字 混用 문장 입니다\n",
+        "大韓民國 서울特別市 政府\n",
+    ],
+)
+def test_markdown_file_read_preserves_korean_hanja_text(tmp_path, content):
+    path = tmp_path / "korean-hanja.md"
+    path.write_bytes(content.encode("euc-kr"))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
 def test_markdown_file_read_strips_utf8_bom(tmp_path):
     content = "# Heading\n\nBody\n"
     path = tmp_path / "utf8-bom.md"

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -29,13 +29,30 @@ def test_markdown_file_read_strips_utf8_bom(tmp_path):
     assert MarkdownParser()._read_file(path) == content
 
 
+@pytest.mark.parametrize("encoding", ["utf-16", "utf-16-be", "utf-32", "utf-32-be"])
+def test_markdown_file_read_normalizes_unicode_bom_text(tmp_path, encoding):
+    content = "# Heading\n\nBody\n"
+    path = tmp_path / f"unicode-bom-{encoding}.md"
+    encoded = content.encode(encoding)
+    if encoding == "utf-16-be":
+        encoded = b"\xfe\xff" + encoded
+    elif encoding == "utf-32-be":
+        encoded = b"\x00\x00\xfe\xff" + encoded
+    path.write_bytes(encoded)
+
+    assert MarkdownParser()._read_file(path) == content
+
+
 @pytest.mark.parametrize(
     ("encoding", "content"),
     [
+        ("shift_jis", "漢字\n"),
         ("shift_jis", "# タイトル\n本文です\n"),
         ("big5", "# 標題\n繁體中文內容\n"),
         ("euc-kr", "# 제목\n본문 내용\n"),
         ("cp1252", "Price: €10 – café\n"),
+        ("cp1252", "Smart “quotes” and — dash\n"),
+        ("cp1252", "œ Œ ž Ž š Š Ÿ ™\n"),
         ("latin-1", "café naïve\n"),
     ],
 )
@@ -62,3 +79,10 @@ def test_encoding_detection_handles_empty_text_without_warning(tmp_path, monkeyp
 
     assert detect_and_convert_encoding(b"", path) == b""
     assert warnings == []
+
+
+def test_encoding_detection_preserves_malformed_bom_bytes(tmp_path):
+    raw = b"\xff\xfe\x00"
+    path = tmp_path / "malformed-utf16.md"
+
+    assert detect_and_convert_encoding(raw, path) == raw

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -1,0 +1,9 @@
+from openviking.parse.parsers.markdown import MarkdownParser
+
+
+def test_markdown_file_read_normalizes_gb18030_text(tmp_path):
+    content = "# 大奉打更人校对版\n\n这是一段中文正文，用于验证旧编码文本不会被解析成乱码。\n"
+    path = tmp_path / "legacy-chinese.md"
+    path.write_bytes(content.encode("gb18030"))
+
+    assert MarkdownParser()._read_file(path) == content

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -21,6 +21,14 @@ def test_markdown_file_read_normalizes_gb18030_four_byte_text(tmp_path):
     assert MarkdownParser()._read_file(path) == content
 
 
+def test_markdown_file_read_preserves_detector_first_non_cjk_text(tmp_path):
+    content = "# Müller straße Zürich Köln Größe\n"
+    path = tmp_path / "legacy-german.md"
+    path.write_bytes(content.encode("cp1252"))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
 def test_markdown_file_read_strips_utf8_bom(tmp_path):
     content = "# Heading\n\nBody\n"
     path = tmp_path / "utf8-bom.md"

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -1,4 +1,8 @@
+import pytest
+
+from openviking.parse.parsers import upload_utils
 from openviking.parse.parsers.markdown import MarkdownParser
+from openviking.parse.parsers.upload_utils import detect_and_convert_encoding
 
 
 def test_markdown_file_read_normalizes_gb18030_text(tmp_path):
@@ -7,3 +11,54 @@ def test_markdown_file_read_normalizes_gb18030_text(tmp_path):
     path.write_bytes(content.encode("gb18030"))
 
     assert MarkdownParser()._read_file(path) == content
+
+
+def test_markdown_file_read_normalizes_gb18030_four_byte_text(tmp_path):
+    content = "# 标题 😀 emoji\n\n正文内容\n"
+    path = tmp_path / "legacy-chinese-emoji.md"
+    path.write_bytes(content.encode("gb18030"))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
+def test_markdown_file_read_strips_utf8_bom(tmp_path):
+    content = "# Heading\n\nBody\n"
+    path = tmp_path / "utf8-bom.md"
+    path.write_bytes(b"\xef\xbb\xbf" + content.encode("utf-8"))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
+@pytest.mark.parametrize(
+    ("encoding", "content"),
+    [
+        ("shift_jis", "# タイトル\n本文です\n"),
+        ("big5", "# 標題\n繁體中文內容\n"),
+        ("euc-kr", "# 제목\n본문 내용\n"),
+        ("cp1252", "Price: €10 – café\n"),
+        ("latin-1", "café naïve\n"),
+    ],
+)
+def test_markdown_file_read_normalizes_representative_legacy_encodings(tmp_path, encoding, content):
+    path = tmp_path / f"legacy-{encoding}.md"
+    path.write_bytes(content.encode(encoding))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
+def test_text_file_read_preserves_legacy_latin1_fallback_for_unrecognized_bytes(tmp_path):
+    raw = bytes([1, 2, 3, 4, 5, 0xFF, 0xFE, 0xFD])
+    path = tmp_path / "control-heavy.txt"
+    path.write_bytes(raw)
+
+    assert MarkdownParser()._read_file(path) == raw.decode("latin-1")
+
+
+def test_encoding_detection_handles_empty_text_without_warning(tmp_path, monkeypatch):
+    path = tmp_path / "empty.md"
+    warnings = []
+
+    monkeypatch.setattr(upload_utils.logger, "warning", lambda message: warnings.append(message))
+
+    assert detect_and_convert_encoding(b"", path) == b""
+    assert warnings == []

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -6,7 +6,7 @@ from openviking.parse.parsers.upload_utils import detect_and_convert_encoding
 
 
 def test_markdown_file_read_normalizes_gb18030_text(tmp_path):
-    content = "# 大奉打更人校对版\n\n这是一段中文正文，用于验证旧编码文本不会被解析成乱码。\n"
+    content = "# 编码兼容测试文档\n\n这是一段中文正文，用于验证旧编码文本不会被解析成乱码。\n"
     path = tmp_path / "legacy-chinese.md"
     path.write_bytes(content.encode("gb18030"))
 

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -29,9 +29,7 @@ def test_markdown_file_read_normalizes_gb18030_four_byte_text(tmp_path):
         ("gbk", "简体中文测试内容\n"),
     ],
 )
-def test_markdown_file_read_normalizes_short_simplified_chinese_text(
-    tmp_path, encoding, content
-):
+def test_markdown_file_read_normalizes_short_simplified_chinese_text(tmp_path, encoding, content):
     path = tmp_path / "short-simplified-chinese.md"
     path.write_bytes(content.encode(encoding))
 

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -21,6 +21,23 @@ def test_markdown_file_read_normalizes_gb18030_four_byte_text(tmp_path):
     assert MarkdownParser()._read_file(path) == content
 
 
+@pytest.mark.parametrize(
+    ("encoding", "content"),
+    [
+        ("gb18030", "简体中文测试内容\n"),
+        ("gb18030", "简体中文测试内容123 abc\n"),
+        ("gbk", "简体中文测试内容\n"),
+    ],
+)
+def test_markdown_file_read_normalizes_short_simplified_chinese_text(
+    tmp_path, encoding, content
+):
+    path = tmp_path / "short-simplified-chinese.md"
+    path.write_bytes(content.encode(encoding))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
 def test_markdown_file_read_preserves_detector_first_non_cjk_text(tmp_path):
     content = "# Müller straße Zürich Köln Größe\n"
     path = tmp_path / "legacy-german.md"

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -423,9 +423,8 @@ class TestDetectAndConvertEncodingEdgeCases:
         assert result.decode("utf-8") == text
 
     def test_undecodable_content(self) -> None:
-        # Note: TEXT_ENCODINGS includes iso-8859-1 which can decode any byte sequence,
-        # so the "no matching encoding" branch is effectively unreachable.
-        # This test verifies that arbitrary bytes are handled gracefully regardless.
+        # Arbitrary bytes should be handled gracefully even when no text
+        # encoding can be selected with confidence.
         content = bytes(range(128, 256)) * 10
         result = detect_and_convert_encoding(content, "test.py")
         assert isinstance(result, bytes)

--- a/uv.lock
+++ b/uv.lock
@@ -3509,6 +3509,7 @@ source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
     { name = "argon2-cffi" },
+    { name = "charset-normalizer" },
     { name = "cryptography" },
     { name = "ebooklib" },
     { name = "fastapi" },
@@ -3733,6 +3734,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'bot'", specifier = ">=4.12.0" },
     { name = "boto3", marker = "extra == 'test'", specifier = ">=1.42.44" },
     { name = "build", marker = "extra == 'build'" },
+    { name = "charset-normalizer", specifier = ">=3.4,<4" },
     { name = "cmake", marker = "extra == 'build'", specifier = ">=3.15" },
     { name = "croniter", marker = "extra == 'bot'", specifier = ">=2.0.0" },
     { name = "cryptography", specifier = ">=42.0.0" },


### PR DESCRIPTION
## Description

Fix parser/upload handling for non-UTF-8 text resources by normalizing recognized text files to UTF-8 before downstream parsing.

The previous implementation relied on a hand-rolled encoding scorer, which was hard to review and still had ambiguous CJK failure modes. This update replaces that scorer with a focused text encoding module built around `charset-normalizer`, strict decoding, deterministic BOM handling, and small Unicode script-family sanity checks for legacy CJK encodings.

The behavior remains conservative:

- UTF-8 and known Unicode BOM inputs use a fast path.
- Non-text files are unchanged.
- Binary-like, malformed, or low-confidence text bytes are left untouched so the existing permissive fallback behavior remains available.
- No `errors="replace"` decoding is used, so replacement-character corruption is avoided.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added `openviking/parse/parsers/text_encoding.py` for shared text-byte normalization.
- Replaced the ad hoc encoding scoring logic in `upload_utils` with the new normalization helper.
- Added `charset-normalizer` as a direct dependency; it was already present transitively in the lockfile.
- Preserved UTF-8 passthrough, non-text passthrough, binary-like passthrough, and fallback behavior for unknown/control-heavy bytes.
- Added BOM support for UTF-8, UTF-16, and UTF-32 text.
- Added regression coverage for GB18030 4-byte text, GBK, Shift-JIS including kanji-only text, Big5, EUC-KR, CP1252, Latin-1, empty files, malformed BOM bytes, and arbitrary byte fallback.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run locally on macOS:

```bash
UV_NATIVE_TLS=true uv run --frozen ruff check \
  openviking/parse/parsers/text_encoding.py \
  openviking/parse/parsers/upload_utils.py \
  tests/parse/test_text_file_encoding.py \
  tests/test_upload_utils.py
```

Result: passed.

```bash
UV_NATIVE_TLS=true uv run --frozen ruff format --check \
  openviking/parse/parsers/text_encoding.py \
  openviking/parse/parsers/upload_utils.py \
  tests/parse/test_text_file_encoding.py \
  tests/test_upload_utils.py
```

Result: passed.

```bash
UV_NATIVE_TLS=true uv run --frozen pytest \
  tests/parse/test_text_file_encoding.py \
  tests/test_upload_utils.py -q
```

Result: `73 passed, 4 warnings`.

Broader parser smoke:

```bash
UV_NATIVE_TLS=true uv run --frozen pytest tests/parse tests/test_upload_utils.py -q
```

Result: `473 passed, 13 failed, 7 warnings`.

The 13 broader failures appear unrelated to this encoding change:

- `tests/parse/test_add_directory.py`: fake filesystem fixture lacks `glob`, causing Markdown parser image-ingestion failures.
- `tests/parse/test_html_parser_utils.py`: tests expect `HTMLParser._convert_to_raw_url`, while the current implementation exposes that helper on `HTTPAccessor`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings in the focused verification
- [x] Any dependent changes have been merged and published (N/A: no dependent changes)
- [ ] I have made corresponding changes to the documentation (N/A: internal parser bug fix, no user-facing API or documented workflow change)

## Screenshots (if applicable)

N/A

## Additional Notes

Legacy encoding detection is inherently ambiguous for very short CJK samples. The implementation keeps those cases conservative by using detector rank plus minimal script-family sanity checks instead of broad language-model-style heuristics.
