### PR TITLE
fix(memory): truncate memory abstracts before vector writes

### DIFF
--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -44,6 +44,7 @@ from openviking_cli.utils import VikingURI, get_logger
 
 logger = get_logger(__name__)
 
+_MEMORY_ABSTRACT_MAX_BYTES = 50_000
 _EXTRACTION_CHUNK_MIN_CHARS = 100
 _EXTRACTION_CHUNK_BOUNDARY_RE = re.compile(r"(\n+|[。！？；!?;]+|(?<!\d)\.(?!\d))")
 _RESOURCE_ADDITION_FIELD_RE = re.compile(
@@ -1070,6 +1071,7 @@ class MemoryUpdater:
                 from openviking.session.memory.utils.link_renderer import LinkRenderer
 
                 abstract = LinkRenderer.strip_all_links(mf.content or "")
+                abstract = self._truncate_memory_abstract(abstract)
                 embedding_text = abstract
 
                 memory_type = uri_memory_type_map.get(uri)
@@ -1148,6 +1150,14 @@ class MemoryUpdater:
             except Exception as e:
                 tracer.error(f"Failed to vectorize memory {uri}: {e}")
         return attempted_count
+
+    @staticmethod
+    def _truncate_memory_abstract(abstract: str) -> str:
+        """Cap memory vector-store abstract fields below backend byte limits."""
+        encoded = (abstract or "").encode("utf-8")
+        if len(encoded) <= _MEMORY_ABSTRACT_MAX_BYTES:
+            return abstract or ""
+        return encoded[:_MEMORY_ABSTRACT_MAX_BYTES].decode("utf-8", errors="ignore")
 
     async def generate_overview(
         self,

--- a/tests/unit/session/memory/test_embedding_template.py
+++ b/tests/unit/session/memory/test_embedding_template.py
@@ -366,3 +366,52 @@ class TestEmbeddingTextConstruction:
 
         vector_text = mock_from_context.call_args[0][0].get_vectorization_text()
         assert vector_text == "Trip summary"
+
+    @pytest.mark.asyncio
+    async def test_memory_abstract_truncated_to_50000_bytes_before_vector_write(self):
+        registry = MemoryTypeRegistry(load_schemas=False)
+        registry._types["events"] = registry._parse_memory_type(
+            {
+                "memory_type": "events",
+                "directory": "viking://user/{{ user_space }}/memories/events",
+                "filename_template": "{{ event_name }}.md",
+                "fields": [
+                    {"name": "event_name", "type": "string"},
+                    {"name": "content", "type": "string"},
+                ],
+            }
+        )
+
+        long_content = "你" * 20_000  # 60,000 UTF-8 bytes
+        updater = MemoryUpdater(registry=registry, vikingdb=Mock())
+        updater._viking_fs = Mock()
+        updater._viking_fs.read_file = AsyncMock(
+            return_value=MemoryFileUtils.write(
+                MemoryFile(
+                    uri="viking://user/alice/memories/events/trip.md",
+                    memory_type="events",
+                    content=long_content,
+                    extra_fields={"event_name": "trip"},
+                )
+            )
+        )
+        updater._vikingdb.enqueue_embedding_msg = AsyncMock(return_value=True)
+
+        result = MemoryUpdateResult()
+        result.add_written("viking://user/alice/memories/events/trip.md")
+        ctx = SimpleNamespace(user=None, account_id="default")
+
+        with patch.object(EmbeddingMsgConverter, "from_context") as mock_from_context:
+            mock_from_context.side_effect = lambda context: SimpleNamespace(
+                telemetry_id=None, id="msg-1", message=context.get_vectorization_text()
+            )
+            await updater._vectorize_memories(
+                result,
+                ctx,
+                extract_context=None,
+                uri_memory_type_map={"viking://user/alice/memories/events/trip.md": "events"},
+            )
+
+        memory_context = mock_from_context.call_args[0][0]
+        assert len(memory_context.abstract.encode("utf-8")) <= 50_000
+        assert memory_context.abstract.encode("utf-8").decode("utf-8") == memory_context.abstract


### PR DESCRIPTION
## Summary\n- limit only memory updater vector-write abstracts to 50,000 UTF-8 bytes\n- keep the truncation local to the memory vectorization path; no generic converter/handler changes\n- add regression coverage for multibyte memory content before enqueue\n\n## Tests\n- uv run --extra dev ruff check openviking/session/memory/memory_updater.py tests/unit/session/memory/test_embedding_template.py\n- uv run --extra test pytest -q tests/unit/session/memory/test_embedding_template.py --no-cov