### PR TITLE
storage: add resource version retention policy to prune old numbered copies

### DIFF
--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -400,6 +400,8 @@ class ResourceProcessor:
         from openviking.storage.errors import ResourceBusyError
         from openviking.storage.transaction import get_lock_manager
 
+        from openviking_cli.utils.config import get_openviking_config
+
         viking_fs = get_viking_fs()
         lock_manager = get_lock_manager()
 
@@ -413,6 +415,17 @@ class ResourceProcessor:
                 resource_lock = await self.acquire_resource_lock(
                     lock_manager, dst_path, uri=root_uri, timeout=0.0
                 )
+
+                config = get_openviking_config()
+                retention = config.storage.retention
+                if retention.prune_on_import and retention.max_versions > 0:
+                    existing_versions = await self._find_numbered_versions(candidate_uri, ctx)
+                    await self._prune_old_versions(
+                        existing_versions,
+                        max_keep=retention.max_versions,
+                        ctx=ctx,
+                    )
+
                 return root_uri, resource_lock
             except ResourceBusyError:
                 continue
@@ -420,6 +433,68 @@ class ResourceProcessor:
         raise FileExistsError(
             f"Cannot resolve unique name for {candidate_uri} after {max_attempts} attempts"
         )
+
+    async def _find_numbered_versions(
+        self,
+        base_uri: str,
+        ctx: RequestContext,
+    ) -> list[tuple[str, int, float]]:
+        """Find all numbered versions of a resource.
+
+        Returns: List of (uri, version_number, mtime) sorted by version number.
+        """
+        from openviking_cli.utils.uri import VikingURI
+
+        viking_fs = get_viking_fs()
+        parent_uri = VikingURI(base_uri).parent.uri
+        base_name = base_uri.rsplit("/", 1)[-1]
+
+        versions: list[tuple[str, int, float]] = []
+        try:
+            entries = await viking_fs.ls(parent_uri, ctx=ctx)
+        except Exception:
+            return versions
+
+        for entry in entries:
+            name = entry.get("name", "")
+            entry_uri = entry.get("uri", "")
+            mtime = entry.get("mtime", 0.0)
+
+            if name == base_name:
+                versions.append((entry_uri, 0, mtime))
+            elif name.startswith(f"{base_name}_"):
+                suffix = name[len(base_name) + 1 :]
+                if suffix.isdigit():
+                    versions.append((entry_uri, int(suffix), mtime))
+
+        return sorted(versions, key=lambda x: x[1])
+
+    async def _prune_old_versions(
+        self,
+        versions: list[tuple[str, int, float]],
+        max_keep: int,
+        ctx: RequestContext,
+    ) -> int:
+        """Delete oldest versions beyond max_keep limit.
+
+        Returns: Number of versions deleted.
+        """
+        if len(versions) <= max_keep:
+            return 0
+
+        viking_fs = get_viking_fs()
+        to_delete = versions[:-max_keep]
+        deleted = 0
+
+        for uri, version_num, _ in to_delete:
+            try:
+                await viking_fs.rm(uri, recursive=True, ctx=ctx)
+                logger.info(f"[ResourceProcessor] Pruned old version: {uri}")
+                deleted += 1
+            except Exception as e:
+                logger.warning(f"[ResourceProcessor] Failed to prune {uri}: {e}")
+
+        return deleted
 
     @staticmethod
     async def acquire_resource_lock(

--- a/openviking_cli/utils/config/storage_config.py
+++ b/openviking_cli/utils/config/storage_config.py
@@ -14,6 +14,32 @@ from .vectordb_config import VectorDBBackendConfig
 logger = get_logger(__name__)
 
 
+class ResourceRetentionConfig(BaseModel):
+    """Configuration for resource version retention."""
+
+    max_versions: int = Field(
+        default=0,
+        description=(
+            "Maximum number of numbered version copies to keep per resource base name. "
+            "When exceeded, oldest versions are pruned after creating new version. "
+            "0 = no limit (current behavior)."
+        ),
+    )
+    max_age_days: int = Field(
+        default=0,
+        description=(
+            "Maximum age in days for numbered version copies. "
+            "Versions older than this may be pruned. 0 = no limit."
+        ),
+    )
+    prune_on_import: bool = Field(
+        default=True,
+        description="Automatically prune old versions when importing new resource.",
+    )
+
+    model_config = {"extra": "forbid"}
+
+
 class StorageConfig(BaseModel):
     """Configuration for storage backend.
 
@@ -41,6 +67,11 @@ class StorageConfig(BaseModel):
     vectordb: VectorDBBackendConfig = Field(
         default_factory=VectorDBBackendConfig,
         description="VectorDB backend configuration",
+    )
+
+    retention: ResourceRetentionConfig = Field(
+        default_factory=ResourceRetentionConfig,
+        description="Resource version retention configuration",
     )
 
     params: Dict[str, Any] = Field(

--- a/tests/misc/test_resource_retention.py
+++ b/tests/misc/test_resource_retention.py
@@ -1,0 +1,273 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from openviking.server.identity import RequestContext
+from openviking.utils.resource_processor import ResourceProcessor
+from openviking_cli.utils.config.storage_config import ResourceRetentionConfig
+
+
+class _DummyVikingDB:
+    def get_embedder(self):
+        return None
+
+
+@pytest.fixture
+def request_context():
+    ctx = MagicMock(spec=RequestContext)
+    ctx.account_id = "test_account"
+    ctx.user = MagicMock()
+    ctx.user.user_id = "test_user"
+    return ctx
+
+
+@pytest.fixture
+def resource_processor():
+    return ResourceProcessor(vikingdb=_DummyVikingDB(), media_storage=None)
+
+
+def _make_config(*, max_versions: int, prune_on_import: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        storage=SimpleNamespace(
+            retention=ResourceRetentionConfig(
+                max_versions=max_versions,
+                max_age_days=0,
+                prune_on_import=prune_on_import,
+            )
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_numbered_versions_finds_all_versions(monkeypatch, resource_processor, request_context):
+    fake_fs = AsyncMock()
+    fake_fs.ls.return_value = [
+        {"name": "foo", "uri": "viking://resources/foo", "mtime": 100.0},
+        {"name": "foo_2", "uri": "viking://resources/foo_2", "mtime": 300.0},
+        {"name": "other_dir", "uri": "viking://resources/other_dir", "mtime": 999.0},
+        {"name": "foo_1", "uri": "viking://resources/foo_1", "mtime": 200.0},
+        {"name": "foo_extra", "uri": "viking://resources/foo_extra", "mtime": 400.0},
+    ]
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+
+    versions = await resource_processor._find_numbered_versions(
+        "viking://resources/foo",
+        request_context,
+    )
+
+    assert versions == [
+        ("viking://resources/foo", 0, 100.0),
+        ("viking://resources/foo_1", 1, 200.0),
+        ("viking://resources/foo_2", 2, 300.0),
+    ]
+    fake_fs.ls.assert_awaited_once_with("viking://resources", ctx=request_context)
+
+
+@pytest.mark.asyncio
+async def test_find_numbered_versions_empty_when_no_matches(monkeypatch, resource_processor, request_context):
+    fake_fs = AsyncMock()
+    fake_fs.ls.return_value = [
+        {"name": "bar", "uri": "viking://resources/bar", "mtime": 100.0},
+        {"name": "foo_suffix", "uri": "viking://resources/foo_suffix", "mtime": 200.0},
+    ]
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+
+    versions = await resource_processor._find_numbered_versions(
+        "viking://resources/foo",
+        request_context,
+    )
+
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_find_numbered_versions_handles_ls_error(monkeypatch, resource_processor, request_context):
+    fake_fs = AsyncMock()
+    fake_fs.ls.side_effect = RuntimeError("boom")
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+
+    versions = await resource_processor._find_numbered_versions(
+        "viking://resources/foo",
+        request_context,
+    )
+
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_prune_old_versions_deletes_oldest(monkeypatch, resource_processor, request_context):
+    fake_fs = AsyncMock()
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    versions = [
+        ("viking://resources/foo", 0, 100.0),
+        ("viking://resources/foo_1", 1, 200.0),
+        ("viking://resources/foo_2", 2, 300.0),
+        ("viking://resources/foo_3", 3, 400.0),
+    ]
+
+    deleted = await resource_processor._prune_old_versions(versions, max_keep=2, ctx=request_context)
+
+    assert deleted == 2
+    fake_fs.rm.assert_has_awaits(
+        [
+            call("viking://resources/foo", recursive=True, ctx=request_context),
+            call("viking://resources/foo_1", recursive=True, ctx=request_context),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_prune_old_versions_skips_when_under_limit(monkeypatch, resource_processor, request_context):
+    fake_fs = AsyncMock()
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    versions = [
+        ("viking://resources/foo", 0, 100.0),
+        ("viking://resources/foo_1", 1, 200.0),
+    ]
+
+    deleted = await resource_processor._prune_old_versions(versions, max_keep=2, ctx=request_context)
+
+    assert deleted == 0
+    fake_fs.rm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prune_old_versions_handles_delete_error(
+    monkeypatch,
+    resource_processor,
+    request_context,
+    caplog,
+):
+    fake_fs = AsyncMock()
+
+    async def rm_side_effect(uri, recursive=True, ctx=None):
+        if uri == "viking://resources/foo":
+            raise RuntimeError("cannot delete")
+        return None
+
+    fake_fs.rm.side_effect = rm_side_effect
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    versions = [
+        ("viking://resources/foo", 0, 100.0),
+        ("viking://resources/foo_1", 1, 200.0),
+        ("viking://resources/foo_2", 2, 300.0),
+    ]
+
+    with caplog.at_level("WARNING"):
+        deleted = await resource_processor._prune_old_versions(versions, max_keep=1, ctx=request_context)
+
+    assert deleted == 1
+    assert "Failed to prune viking://resources/foo" in caplog.text
+    assert fake_fs.rm.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reserve_unique_candidate_prunes_when_enabled(
+    monkeypatch,
+    resource_processor,
+    request_context,
+): 
+    fake_fs = MagicMock()
+    fake_fs.exists = AsyncMock(return_value=False)
+    fake_fs._uri_to_path = MagicMock(return_value="/mock/resources/foo")
+    fake_lock = object()
+    versions = [("viking://resources/foo", 0, 100.0)]
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: MagicMock(name="lock_manager"),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _make_config(max_versions=2, prune_on_import=True),
+    )
+    resource_processor.acquire_resource_lock = AsyncMock(return_value=fake_lock)
+    resource_processor._find_numbered_versions = AsyncMock(return_value=versions)
+    resource_processor._prune_old_versions = AsyncMock()
+
+    root_uri, lock = await resource_processor.reserve_unique_candidate(
+        candidate_uri="viking://resources/foo",
+        ctx=request_context,
+    )
+
+    assert root_uri == "viking://resources/foo"
+    assert lock is fake_lock
+    resource_processor._find_numbered_versions.assert_awaited_once_with(
+        "viking://resources/foo",
+        request_context,
+    )
+    resource_processor._prune_old_versions.assert_awaited_once_with(
+        versions,
+        max_keep=2,
+        ctx=request_context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reserve_unique_candidate_skips_prune_when_disabled(
+    monkeypatch,
+    resource_processor,
+    request_context,
+): 
+    fake_fs = MagicMock()
+    fake_fs.exists = AsyncMock(return_value=False)
+    fake_fs._uri_to_path = MagicMock(return_value="/mock/resources/foo")
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: MagicMock(name="lock_manager"),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _make_config(max_versions=0, prune_on_import=True),
+    )
+    resource_processor.acquire_resource_lock = AsyncMock(return_value=object())
+    resource_processor._find_numbered_versions = AsyncMock()
+    resource_processor._prune_old_versions = AsyncMock()
+
+    await resource_processor.reserve_unique_candidate(
+        candidate_uri="viking://resources/foo",
+        ctx=request_context,
+    )
+
+    resource_processor._find_numbered_versions.assert_not_awaited()
+    resource_processor._prune_old_versions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reserve_unique_candidate_skips_prune_when_prune_on_import_false(
+    monkeypatch,
+    resource_processor,
+    request_context,
+): 
+    fake_fs = MagicMock()
+    fake_fs.exists = AsyncMock(return_value=False)
+    fake_fs._uri_to_path = MagicMock(return_value="/mock/resources/foo")
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: MagicMock(name="lock_manager"),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _make_config(max_versions=2, prune_on_import=False),
+    )
+    resource_processor.acquire_resource_lock = AsyncMock(return_value=object())
+    resource_processor._find_numbered_versions = AsyncMock()
+    resource_processor._prune_old_versions = AsyncMock()
+
+    await resource_processor.reserve_unique_candidate(
+        candidate_uri="viking://resources/foo",
+        ctx=request_context,
+    )
+
+    resource_processor._find_numbered_versions.assert_not_awaited()
+    resource_processor._prune_old_versions.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds a configurable retention policy for numbered resource version copies (e.g., `resource_1`, `resource_2`, etc.) that accumulate during re-imports.

Partially addresses #2707 - specifically the "numbered resource-version copies accumulate without retention policy" component.

## Changes

### Config (`storage_config.py`)
- Added `ResourceRetentionConfig` class with:
  - `max_versions: int` (default=0, meaning unlimited - backward compatible)
  - `max_age_days: int` (default=0, config only - logic not implemented)
  - `prune_on_import: bool` (default=True)
- Added `storage.retention` field to `StorageConfig`

### Core Logic (`resource_processor.py`)
- `_find_numbered_versions()`: Finds all `{base}` and `{base}_N` versions in parent directory
- `_prune_old_versions()`: Deletes oldest versions beyond `max_keep` limit
- Modified `reserve_unique_candidate()`: Calls pruning after acquiring lock when retention enabled

### Tests (`test_resource_retention.py`)
- 9 unit tests covering version finding, pruning logic, and config integration
- All tests mock VikingFS (no real filesystem operations)

## Config Example

```json
{
  "storage": {
    "workspace": "/data/openviking",
    "retention": {
      "max_versions": 3,
      "prune_on_import": true
    }
  }
}
```

## Testing

- Syntax validated via `py_compile`
- Unit tests added (require `pytest_asyncio` to run)

## Not Addressed (Future Work)

- `max_age_days` logic (config field added but not implemented)
- Disk-pressure awareness
- Existing queue.db migration (PR #2754 only fixes new DBs)
