### PR TITLE
storage: add disk pressure awareness to prevent server failures on disk exhaustion

### DIFF
--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -194,6 +194,24 @@ async def readiness_check(request: Request):
     except Exception as e:
         checks["ollama"] = f"error: {e}"
 
+    # 6. Disk pressure check
+    try:
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.get_instance()
+        if monitor is not None:
+            disk_status = monitor.get_status()
+            if disk_status["state"] == "critical":
+                checks["disk"] = f"critical: {disk_status['usage_percent']}% used"
+            elif disk_status["state"] == "warning":
+                checks["disk"] = f"warning: {disk_status['usage_percent']}% used"
+            else:
+                checks["disk"] = "ok"
+        else:
+            checks["disk"] = "not_configured"
+    except Exception as e:
+        checks["disk"] = f"error: {e}"
+
     all_ok = all(_is_ready_check_ok(v) for v in checks.values())
     status_code = 200 if all_ok else 503
     return JSONResponse(
@@ -312,3 +330,27 @@ async def admin_sync_retry(
     uri = validate_viking_uri(resolve_path_variables(sync_path))
     result = await service.fs.system_sync_retry(uri, ctx=ctx)
     return Response(status="ok", result=result)
+
+
+@router.get("/api/v1/system/disk", tags=["system"])
+async def disk_status():
+    """Disk pressure status endpoint.
+
+    Returns disk usage stats and pressure state.
+    Returns 503 if disk pressure is CRITICAL.
+    """
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor.get_instance()
+    if monitor is None:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "not_configured",
+                "reason": "Disk pressure monitor not initialized",
+            },
+        )
+
+    status = monitor.get_status()
+    status_code = 200 if status["state"] != "critical" else 503
+    return JSONResponse(status_code=status_code, content=status)

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -33,6 +33,7 @@ from openviking.utils.agfs_utils import (
     build_runtime_ragfs_binding_config,
     resolve_queuefs_mount_point,
 )
+from openviking.utils.disk_pressure import DiskPressureMonitor
 from openviking.utils.resource_processor import ResourceProcessor
 from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.exceptions import NotInitializedError
@@ -374,6 +375,19 @@ class OpenVikingService:
         await self._watch_scheduler.start()
         logger.info("WatchScheduler started")
 
+        # Start disk pressure monitor if enabled
+        dp_config = config.storage.disk_pressure
+        if dp_config.enabled:
+            monitor = DiskPressureMonitor.initialize(
+                workspace_path=config.storage.workspace,
+                check_interval_seconds=dp_config.check_interval_seconds,
+                warning_threshold_percent=dp_config.warning_threshold_percent,
+                critical_threshold_percent=dp_config.critical_threshold_percent,
+                min_free_bytes=dp_config.min_free_bytes,
+            )
+            await monitor.start()
+            logger.info("DiskPressureMonitor started")
+
         # Wire up sub-services
         self._fs_service.set_dependencies(
             viking_fs=self._viking_fs,
@@ -416,6 +430,11 @@ class OpenVikingService:
 
     async def close(self) -> None:
         """Close OpenViking and release resources."""
+        monitor = DiskPressureMonitor.get_instance()
+        if monitor is not None:
+            await monitor.stop()
+            logger.info("DiskPressureMonitor stopped")
+
         await self._resource_service.close_background_tasks()
 
         if self._watch_scheduler:

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -202,6 +202,16 @@ class NamedQueue:
 
     async def enqueue(self, data: Union[str, Dict[str, Any]]) -> str:
         """Send message to queue (enqueue)."""
+        from openviking.utils.disk_pressure import DiskPressureError, DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.get_instance()
+        if monitor is not None:
+            try:
+                monitor.check_write_allowed()
+            except DiskPressureError as e:
+                logger.error(f"Queue enqueue blocked by disk pressure: {e}")
+                raise
+
         await self._ensure_initialized()
         enqueue_file = f"{self.path}/enqueue"
 

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -407,6 +407,17 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
     ) -> str:
         """Write file"""
+        from openviking.utils.disk_pressure import DiskPressureError, DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.get_instance()
+        if monitor is not None:
+            try:
+                monitor.check_write_allowed()
+            except DiskPressureError as e:
+                from openviking.pyagfs.exceptions import AGFSIOError
+
+                raise AGFSIOError(str(e)) from e
+
         self._ensure_mutable_access(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         if isinstance(data, str):

--- a/openviking/utils/disk_pressure.py
+++ b/openviking/utils/disk_pressure.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Disk pressure monitoring for proactive space protection."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import threading
+import time
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from openviking_cli.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class DiskPressureState(str, Enum):
+    NORMAL = "normal"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+class DiskPressureError(Exception):
+    """Raised when disk pressure is CRITICAL and operation is blocked."""
+
+
+class DiskPressureMonitor:
+    """Monitor disk usage and block operations when critically low.
+
+    Thread-safe singleton that periodically checks disk usage and
+    maintains a pressure state (NORMAL, WARNING, CRITICAL).
+    """
+
+    _instance: Optional[DiskPressureMonitor] = None
+    _lock = threading.Lock()
+
+    def __init__(
+        self,
+        workspace_path: str,
+        *,
+        check_interval_seconds: float = 30.0,
+        warning_threshold_percent: float = 85.0,
+        critical_threshold_percent: float = 95.0,
+        min_free_bytes: int = 1073741824,  # 1 GB
+    ):
+        self._workspace = Path(workspace_path)
+        self._check_interval = check_interval_seconds
+        self._warning_threshold = warning_threshold_percent
+        self._critical_threshold = critical_threshold_percent
+        self._min_free_bytes = min_free_bytes
+
+        self._state = DiskPressureState.NORMAL
+        self._state_lock = threading.Lock()
+        self._last_check: float = 0
+        self._last_usage_percent: float = 0
+        self._last_free_bytes: int = 0
+
+        self._monitor_task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+
+    @classmethod
+    def get_instance(cls) -> Optional[DiskPressureMonitor]:
+        """Get the singleton instance if initialized."""
+        return cls._instance
+
+    @classmethod
+    def initialize(cls, workspace_path: str, **kwargs) -> DiskPressureMonitor:
+        """Initialize the singleton monitor."""
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = cls(workspace_path, **kwargs)
+            return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton instance (for testing)."""
+        with cls._lock:
+            cls._instance = None
+
+    @property
+    def state(self) -> DiskPressureState:
+        """Current disk pressure state."""
+        with self._state_lock:
+            return self._state
+
+    @property
+    def usage_percent(self) -> float:
+        """Last recorded disk usage percentage."""
+        with self._state_lock:
+            return self._last_usage_percent
+
+    @property
+    def free_bytes(self) -> int:
+        """Last recorded free bytes."""
+        with self._state_lock:
+            return self._last_free_bytes
+
+    def check(self) -> DiskPressureState:
+        """Check disk usage and update state. Returns new state."""
+        try:
+            usage = shutil.disk_usage(self._workspace)
+            usage_percent = (usage.used / usage.total) * 100
+            free_bytes = usage.free
+        except OSError as e:
+            logger.error(f"Failed to check disk usage: {e}")
+            with self._state_lock:
+                self._state = DiskPressureState.CRITICAL
+                return self._state
+
+        with self._state_lock:
+            self._last_check = time.monotonic()
+            self._last_usage_percent = usage_percent
+            self._last_free_bytes = free_bytes
+
+            old_state = self._state
+
+            if usage_percent >= self._critical_threshold or free_bytes < self._min_free_bytes:
+                self._state = DiskPressureState.CRITICAL
+            elif usage_percent >= self._warning_threshold:
+                self._state = DiskPressureState.WARNING
+            else:
+                self._state = DiskPressureState.NORMAL
+
+            if self._state != old_state:
+                logger.warning(
+                    f"Disk pressure state changed: {old_state.value} -> {self._state.value} "
+                    f"(usage={usage_percent:.1f}%, free={free_bytes / 1073741824:.2f}GB)"
+                )
+            elif self._state == DiskPressureState.WARNING:
+                logger.warning(
+                    f"Disk pressure WARNING: {usage_percent:.1f}% used, "
+                    f"{free_bytes / 1073741824:.2f}GB free"
+                )
+            elif self._state == DiskPressureState.CRITICAL:
+                logger.error(
+                    f"Disk pressure CRITICAL: {usage_percent:.1f}% used, "
+                    f"{free_bytes / 1073741824:.2f}GB free - blocking writes"
+                )
+
+            return self._state
+
+    def check_write_allowed(self) -> None:
+        """Raise DiskPressureError if writes are blocked.
+
+        Call this before write operations to ensure disk has space.
+        """
+        if self.state == DiskPressureState.CRITICAL:
+            raise DiskPressureError(
+                f"Disk pressure is CRITICAL: {self._last_usage_percent:.1f}% used, "
+                f"{self._last_free_bytes / 1073741824:.2f}GB free. "
+                "Write operations are blocked until disk space is freed."
+            )
+
+    async def start(self) -> None:
+        """Start the background monitoring loop."""
+        if self._monitor_task is not None:
+            return
+
+        self._stop_event.clear()
+        self._monitor_task = asyncio.create_task(self._monitor_loop())
+        logger.info(
+            f"Disk pressure monitor started (interval={self._check_interval}s, "
+            f"warning={self._warning_threshold}%, critical={self._critical_threshold}%)"
+        )
+
+    async def stop(self) -> None:
+        """Stop the background monitoring loop."""
+        if self._monitor_task is None:
+            return
+
+        self._stop_event.set()
+        self._monitor_task.cancel()
+        try:
+            await self._monitor_task
+        except asyncio.CancelledError:
+            pass
+        self._monitor_task = None
+        logger.info("Disk pressure monitor stopped")
+
+    async def _monitor_loop(self) -> None:
+        """Background loop that periodically checks disk usage."""
+        while not self._stop_event.is_set():
+            self.check()
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self._check_interval,
+                )
+            except asyncio.TimeoutError:
+                pass
+
+    def get_status(self) -> dict:
+        """Get current disk status for health endpoint."""
+        with self._state_lock:
+            return {
+                "state": self._state.value,
+                "usage_percent": round(self._last_usage_percent, 2),
+                "free_bytes": self._last_free_bytes,
+                "free_gb": round(self._last_free_bytes / 1073741824, 2),
+                "warning_threshold_percent": self._warning_threshold,
+                "critical_threshold_percent": self._critical_threshold,
+                "min_free_bytes": self._min_free_bytes,
+            }

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -129,6 +129,15 @@ class ResourceProcessor:
         4. (Optional) Build vector index
         5. (Optional) Summarize
         """
+        from openviking.utils.disk_pressure import DiskPressureError, DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.get_instance()
+        if monitor is not None:
+            try:
+                monitor.check_write_allowed()
+            except DiskPressureError as e:
+                raise OpenVikingError(f"Resource import blocked by disk pressure: {e}") from e
+
         result = {
             "status": "success",
             "errors": [],

--- a/openviking_cli/utils/config/storage_config.py
+++ b/openviking_cli/utils/config/storage_config.py
@@ -14,6 +14,83 @@ from .vectordb_config import VectorDBBackendConfig
 logger = get_logger(__name__)
 
 
+class ResourceRetentionConfig(BaseModel):
+    """Configuration for resource version retention."""
+
+    max_versions: int = Field(
+        default=0,
+        description=(
+            "Maximum number of numbered version copies to keep per resource base name. "
+            "When exceeded, oldest versions are pruned after creating new version. "
+            "0 = no limit (current behavior)."
+        ),
+    )
+    max_age_days: int = Field(
+        default=0,
+        description=(
+            "Maximum age in days for numbered version copies. "
+            "Versions older than this may be pruned. 0 = no limit."
+        ),
+    )
+    prune_on_import: bool = Field(
+        default=True,
+        description="Automatically prune old versions when importing new resource.",
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+class DiskPressureConfig(BaseModel):
+    """Configuration for disk pressure monitoring."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable disk pressure monitoring.",
+    )
+    check_interval_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        description="Interval between disk usage checks in seconds.",
+    )
+    warning_threshold_percent: float = Field(
+        default=85.0,
+        ge=0,
+        le=100,
+        description=(
+            "Disk usage percentage that triggers WARNING state. "
+            "Operations continue but warnings are logged."
+        ),
+    )
+    critical_threshold_percent: float = Field(
+        default=95.0,
+        ge=0,
+        le=100,
+        description=(
+            "Disk usage percentage that triggers CRITICAL state. "
+            "Write operations are blocked until disk usage decreases."
+        ),
+    )
+    min_free_bytes: int = Field(
+        default=1073741824,  # 1 GB
+        ge=0,
+        description=(
+            "Minimum free bytes required. Triggers CRITICAL if free space "
+            "falls below this value, regardless of percentage."
+        ),
+    )
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def validate_thresholds(self):
+        if self.critical_threshold_percent <= self.warning_threshold_percent:
+            raise ValueError(
+                "storage.disk_pressure.critical_threshold_percent must be > warning_threshold_percent"
+            )
+        return self
+
+
+
 class StorageConfig(BaseModel):
     """Configuration for storage backend.
 
@@ -42,6 +119,17 @@ class StorageConfig(BaseModel):
         default_factory=VectorDBBackendConfig,
         description="VectorDB backend configuration",
     )
+
+    retention: ResourceRetentionConfig = Field(
+        default_factory=ResourceRetentionConfig,
+        description="Resource version retention configuration",
+    )
+
+    disk_pressure: DiskPressureConfig = Field(
+        default_factory=DiskPressureConfig,
+        description="Disk pressure monitoring configuration",
+    )
+
 
     params: Dict[str, Any] = Field(
         default_factory=dict, description="Additional storage-specific parameters"

--- a/tests/server/test_disk_pressure_endpoints.py
+++ b/tests/server/test_disk_pressure_endpoints.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestDiskStatusEndpoint:
+
+    @pytest.mark.asyncio
+    async def test_disk_status_not_configured(self, client):
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=None,
+        ):
+            response = await client.get("/api/v1/system/disk")
+            assert response.status_code == 200
+            assert response.json()["status"] == "not_configured"
+
+    @pytest.mark.asyncio
+    async def test_disk_status_normal(self, client):
+        mock_monitor = MagicMock()
+        mock_monitor.get_status.return_value = {
+            "state": "normal",
+            "usage_percent": 45.0,
+            "free_bytes": 107374182400,
+            "free_gb": 100.0,
+        }
+
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=mock_monitor,
+        ):
+            response = await client.get("/api/v1/system/disk")
+            assert response.status_code == 200
+            assert response.json()["state"] == "normal"
+
+    @pytest.mark.asyncio
+    async def test_disk_status_warning(self, client):
+        mock_monitor = MagicMock()
+        mock_monitor.get_status.return_value = {
+            "state": "warning",
+            "usage_percent": 88.5,
+            "free_bytes": 21474836480,
+            "free_gb": 20.0,
+        }
+
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=mock_monitor,
+        ):
+            response = await client.get("/api/v1/system/disk")
+            assert response.status_code == 200
+            assert response.json()["state"] == "warning"
+
+    @pytest.mark.asyncio
+    async def test_disk_status_critical_returns_503(self, client):
+        mock_monitor = MagicMock()
+        mock_monitor.get_status.return_value = {
+            "state": "critical",
+            "usage_percent": 96.5,
+            "free_bytes": 536870912,
+            "free_gb": 0.5,
+        }
+
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=mock_monitor,
+        ):
+            response = await client.get("/api/v1/system/disk")
+            assert response.status_code == 503
+            assert response.json()["state"] == "critical"
+
+
+class TestReadyEndpointDiskCheck:
+
+    @pytest.mark.asyncio
+    async def test_ready_includes_disk_check_ok(self, client):
+        mock_monitor = MagicMock()
+        mock_monitor.get_status.return_value = {
+            "state": "normal",
+            "usage_percent": 45.0,
+        }
+
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=mock_monitor,
+        ):
+            response = await client.get("/ready")
+            data = response.json()
+            assert "checks" in data
+            assert data["checks"].get("disk") == "ok"
+
+    @pytest.mark.asyncio
+    async def test_ready_includes_disk_check_warning(self, client):
+        mock_monitor = MagicMock()
+        mock_monitor.get_status.return_value = {
+            "state": "warning",
+            "usage_percent": 88.5,
+        }
+
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=mock_monitor,
+        ):
+            response = await client.get("/ready")
+            data = response.json()
+            assert "checks" in data
+            assert "warning: 88.5% used" in data["checks"].get("disk", "")
+
+    @pytest.mark.asyncio
+    async def test_ready_includes_disk_check_critical(self, client):
+        mock_monitor = MagicMock()
+        mock_monitor.get_status.return_value = {
+            "state": "critical",
+            "usage_percent": 96.5,
+        }
+
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=mock_monitor,
+        ):
+            response = await client.get("/ready")
+            data = response.json()
+            assert "checks" in data
+            assert "critical: 96.5% used" in data["checks"].get("disk", "")
+
+    @pytest.mark.asyncio
+    async def test_ready_includes_disk_not_configured(self, client):
+        with patch(
+            "openviking.server.routers.system.DiskPressureMonitor.get_instance",
+            return_value=None,
+        ):
+            response = await client.get("/ready")
+            data = response.json()
+            assert "checks" in data
+            assert data["checks"].get("disk") == "not_configured"

--- a/tests/storage/test_disk_pressure_protection.py
+++ b/tests/storage/test_disk_pressure_protection.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openviking.utils.disk_pressure import DiskPressureError, DiskPressureState
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    DiskPressureMonitor.reset_instance()
+    yield
+    DiskPressureMonitor.reset_instance()
+
+
+class TestVikingFSWriteProtection:
+    @pytest.mark.asyncio
+    async def test_write_proceeds_when_monitor_not_initialized(self):
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        assert DiskPressureMonitor.get_instance() is None
+
+        mock_agfs = MagicMock()
+        mock_async_agfs = AsyncMock()
+        mock_async_agfs.write = AsyncMock(return_value="mock_result")
+
+        with (
+            patch("openviking.storage.viking_fs.AsyncAGFSClient", return_value=mock_async_agfs),
+            patch("openviking.storage.viking_fs._instance") as mock_instance,
+        ):
+            from openviking.storage.viking_fs import VikingFS
+
+            fs = VikingFS(agfs=mock_agfs)
+            fs._async_agfs = mock_async_agfs
+            fs._ensure_mutable_access = MagicMock()
+            fs._uri_to_path = MagicMock(return_value="/test/path")
+
+            result = await fs.write("viking://test/file.txt", b"data")
+            assert result == "mock_result"
+            mock_async_agfs.write.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_write_proceeds_when_disk_normal(self):
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.initialize("/tmp")
+        monitor._state = DiskPressureState.NORMAL
+
+        mock_agfs = MagicMock()
+        mock_async_agfs = AsyncMock()
+        mock_async_agfs.write = AsyncMock(return_value="mock_result")
+
+        with patch("openviking.storage.viking_fs.AsyncAGFSClient", return_value=mock_async_agfs):
+            from openviking.storage.viking_fs import VikingFS
+
+            fs = VikingFS(agfs=mock_agfs)
+            fs._async_agfs = mock_async_agfs
+            fs._ensure_mutable_access = MagicMock()
+            fs._uri_to_path = MagicMock(return_value="/test/path")
+
+            result = await fs.write("viking://test/file.txt", b"data")
+            assert result == "mock_result"
+
+    @pytest.mark.asyncio
+    async def test_write_blocked_when_critical(self):
+        from openviking.pyagfs.exceptions import AGFSIOError
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.initialize("/tmp")
+        monitor._state = DiskPressureState.CRITICAL
+        monitor._last_usage_percent = 96.0
+        monitor._last_free_bytes = 500_000_000
+
+        mock_agfs = MagicMock()
+        mock_async_agfs = AsyncMock()
+
+        with patch("openviking.storage.viking_fs.AsyncAGFSClient", return_value=mock_async_agfs):
+            from openviking.storage.viking_fs import VikingFS
+
+            fs = VikingFS(agfs=mock_agfs)
+            fs._async_agfs = mock_async_agfs
+            fs._ensure_mutable_access = MagicMock()
+            fs._uri_to_path = MagicMock(return_value="/test/path")
+
+            with pytest.raises(AGFSIOError) as exc_info:
+                await fs.write("viking://test/file.txt", b"data")
+
+            assert "CRITICAL" in str(exc_info.value)
+            mock_async_agfs.write.assert_not_called()
+
+
+class TestQueueEnqueueProtection:
+    @pytest.mark.asyncio
+    async def test_enqueue_proceeds_when_monitor_not_initialized(self):
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        assert DiskPressureMonitor.get_instance() is None
+
+        mock_agfs = MagicMock()
+        mock_async_agfs = AsyncMock()
+        mock_async_agfs.mkdir = AsyncMock()
+        mock_async_agfs.write = AsyncMock(return_value="msg_123")
+
+        with patch(
+            "openviking.storage.queuefs.named_queue.AsyncAGFSClient",
+            return_value=mock_async_agfs,
+        ):
+            from openviking.storage.queuefs.named_queue import NamedQueue
+
+            queue = NamedQueue(mock_agfs, "/mount", "test_queue")
+            queue._async_agfs = mock_async_agfs
+
+            result = await queue.enqueue({"test": "data"})
+            assert result == "msg_123"
+            mock_async_agfs.write.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_enqueue_proceeds_when_disk_normal(self):
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.initialize("/tmp")
+        monitor._state = DiskPressureState.NORMAL
+
+        mock_agfs = MagicMock()
+        mock_async_agfs = AsyncMock()
+        mock_async_agfs.mkdir = AsyncMock()
+        mock_async_agfs.write = AsyncMock(return_value="msg_123")
+
+        with patch(
+            "openviking.storage.queuefs.named_queue.AsyncAGFSClient",
+            return_value=mock_async_agfs,
+        ):
+            from openviking.storage.queuefs.named_queue import NamedQueue
+
+            queue = NamedQueue(mock_agfs, "/mount", "test_queue")
+            queue._async_agfs = mock_async_agfs
+
+            result = await queue.enqueue({"test": "data"})
+            assert result == "msg_123"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_blocked_when_critical(self):
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        monitor = DiskPressureMonitor.initialize("/tmp")
+        monitor._state = DiskPressureState.CRITICAL
+        monitor._last_usage_percent = 96.0
+        monitor._last_free_bytes = 500_000_000
+
+        mock_agfs = MagicMock()
+        mock_async_agfs = AsyncMock()
+
+        with patch(
+            "openviking.storage.queuefs.named_queue.AsyncAGFSClient",
+            return_value=mock_async_agfs,
+        ):
+            from openviking.storage.queuefs.named_queue import NamedQueue
+
+            queue = NamedQueue(mock_agfs, "/mount", "test_queue")
+            queue._async_agfs = mock_async_agfs
+
+            with pytest.raises(DiskPressureError) as exc_info:
+                await queue.enqueue({"test": "data"})
+
+            assert "CRITICAL" in str(exc_info.value)
+            mock_async_agfs.write.assert_not_called()
+
+
+class TestResourceProcessorProtection:
+    @pytest.mark.asyncio
+    async def test_process_resource_blocked_when_critical(self):
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+        from openviking_cli.exceptions import OpenVikingError
+
+        monitor = DiskPressureMonitor.initialize("/tmp")
+        monitor._state = DiskPressureState.CRITICAL
+        monitor._last_usage_percent = 96.0
+        monitor._last_free_bytes = 500_000_000
+
+        mock_vikingdb = MagicMock()
+        mock_vikingdb.get_embedder = MagicMock(return_value=MagicMock())
+        mock_ctx = MagicMock()
+
+        from openviking.utils.resource_processor import ResourceProcessor
+
+        processor = ResourceProcessor(vikingdb=mock_vikingdb)
+
+        with pytest.raises(OpenVikingError) as exc_info:
+            await processor.process_resource("/some/path", ctx=mock_ctx)
+
+        assert "disk pressure" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_process_resource_proceeds_when_monitor_not_initialized(self):
+        from openviking.utils.disk_pressure import DiskPressureMonitor
+
+        assert DiskPressureMonitor.get_instance() is None
+
+        mock_vikingdb = MagicMock()
+        mock_vikingdb.get_embedder = MagicMock(return_value=MagicMock())
+        mock_ctx = MagicMock()
+
+        from openviking.utils.resource_processor import ResourceProcessor
+
+        processor = ResourceProcessor(vikingdb=mock_vikingdb)
+
+        with patch.object(processor, "_get_media_processor") as mock_media:
+            mock_media_processor = MagicMock()
+            mock_parse_result = MagicMock()
+            mock_parse_result.temp_dir_path = None
+            mock_parse_result.warnings = ["test warning"]
+            mock_media_processor.process = AsyncMock(return_value=mock_parse_result)
+            mock_media.return_value = mock_media_processor
+
+            with patch("openviking.utils.resource_processor.get_viking_fs") as mock_fs:
+                mock_fs_instance = MagicMock()
+                mock_fs_instance.bind_request_context = MagicMock(return_value=MagicMock(__enter__=MagicMock(), __exit__=MagicMock()))
+                mock_fs.return_value = mock_fs_instance
+
+                result = await processor.process_resource("/some/path", ctx=mock_ctx)
+                assert result["status"] == "error"

--- a/tests/utils/test_disk_pressure.py
+++ b/tests/utils/test_disk_pressure.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset the singleton before and after each test."""
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    DiskPressureMonitor.reset_instance()
+    yield
+    DiskPressureMonitor.reset_instance()
+
+
+def make_disk_usage(total: int, used: int, free: int):
+    mock = MagicMock()
+    mock.total = total
+    mock.used = used
+    mock.free = free
+    return mock
+
+
+def test_initial_state_is_normal():
+    from openviking.utils.disk_pressure import DiskPressureMonitor, DiskPressureState
+
+    monitor = DiskPressureMonitor("/tmp")
+    assert monitor.state == DiskPressureState.NORMAL
+
+
+def test_state_transition_to_warning():
+    from openviking.utils.disk_pressure import DiskPressureMonitor, DiskPressureState
+
+    monitor = DiskPressureMonitor(
+        "/tmp",
+        warning_threshold_percent=80.0,
+        critical_threshold_percent=95.0,
+    )
+
+    # 85% used -> WARNING
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 85, 15)):
+        state = monitor.check()
+
+    assert state == DiskPressureState.WARNING
+    assert monitor.state == DiskPressureState.WARNING
+
+
+def test_state_transition_to_critical():
+    from openviking.utils.disk_pressure import DiskPressureMonitor, DiskPressureState
+
+    monitor = DiskPressureMonitor(
+        "/tmp",
+        warning_threshold_percent=80.0,
+        critical_threshold_percent=95.0,
+    )
+
+    # 96% used -> CRITICAL
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 96, 4)):
+        state = monitor.check()
+
+    assert state == DiskPressureState.CRITICAL
+    assert monitor.state == DiskPressureState.CRITICAL
+
+
+def test_state_transition_to_critical_by_min_free():
+    from openviking.utils.disk_pressure import DiskPressureMonitor, DiskPressureState
+
+    monitor = DiskPressureMonitor(
+        "/tmp",
+        warning_threshold_percent=80.0,
+        critical_threshold_percent=95.0,
+        min_free_bytes=1000,
+    )
+
+    # 50% used but only 500 bytes free (< 1000 min) -> CRITICAL
+    with patch("shutil.disk_usage", return_value=make_disk_usage(1000, 500, 500)):
+        state = monitor.check()
+
+    assert state == DiskPressureState.CRITICAL
+
+
+def test_check_write_allowed_normal():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor("/tmp")
+
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 50, 50)):
+        monitor.check()
+
+    monitor.check_write_allowed()  # Should not raise
+
+
+def test_check_write_allowed_warning():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor(
+        "/tmp",
+        warning_threshold_percent=80.0,
+        critical_threshold_percent=95.0,
+    )
+
+    # 85% used -> WARNING
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 85, 15)):
+        monitor.check()
+
+    monitor.check_write_allowed()  # Should not raise in WARNING state
+
+
+def test_check_write_allowed_critical():
+    from openviking.utils.disk_pressure import DiskPressureError, DiskPressureMonitor
+
+    monitor = DiskPressureMonitor(
+        "/tmp",
+        warning_threshold_percent=80.0,
+        critical_threshold_percent=95.0,
+    )
+
+    # 96% used -> CRITICAL
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 96, 4)):
+        monitor.check()
+
+    with pytest.raises(DiskPressureError):
+        monitor.check_write_allowed()
+
+
+def test_state_recovery():
+    from openviking.utils.disk_pressure import DiskPressureMonitor, DiskPressureState
+
+    monitor = DiskPressureMonitor(
+        "/tmp",
+        warning_threshold_percent=80.0,
+        critical_threshold_percent=95.0,
+    )
+
+    # Go to CRITICAL
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 96, 4)):
+        monitor.check()
+    assert monitor.state == DiskPressureState.CRITICAL
+
+    # Recover to NORMAL
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 50, 50)):
+        monitor.check()
+    assert monitor.state == DiskPressureState.NORMAL
+
+
+def test_get_status_format():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor(
+        "/tmp",
+        warning_threshold_percent=85.0,
+        critical_threshold_percent=95.0,
+        min_free_bytes=1073741824,
+    )
+
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100_000_000_000, 45_000_000_000, 55_000_000_000)):
+        monitor.check()
+
+    status = monitor.get_status()
+
+    assert status["state"] == "normal"
+    assert "usage_percent" in status
+    assert "free_bytes" in status
+    assert "free_gb" in status
+    assert status["warning_threshold_percent"] == 85.0
+    assert status["critical_threshold_percent"] == 95.0
+    assert status["min_free_bytes"] == 1073741824
+
+
+def test_singleton_pattern():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor1 = DiskPressureMonitor.initialize("/tmp")
+    monitor2 = DiskPressureMonitor.initialize("/other/path")
+    monitor3 = DiskPressureMonitor.get_instance()
+
+    assert monitor1 is monitor2
+    assert monitor1 is monitor3
+
+
+def test_get_instance_returns_none_before_init():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    assert DiskPressureMonitor.get_instance() is None
+
+
+def test_oserror_triggers_critical():
+    from openviking.utils.disk_pressure import DiskPressureMonitor, DiskPressureState
+
+    monitor = DiskPressureMonitor("/tmp")
+
+    with patch("shutil.disk_usage", side_effect=OSError("disk error")):
+        state = monitor.check()
+
+    assert state == DiskPressureState.CRITICAL
+
+
+def test_thread_safety():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor("/tmp")
+    errors = []
+
+    def check_repeatedly():
+        try:
+            for _ in range(50):
+                with patch("shutil.disk_usage", return_value=make_disk_usage(100, 50, 50)):
+                    monitor.check()
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=check_repeatedly) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+
+
+@pytest.mark.asyncio
+async def test_monitor_start_stop_lifecycle():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor("/tmp", check_interval_seconds=0.1)
+
+    assert monitor._monitor_task is None
+
+    await monitor.start()
+    assert monitor._monitor_task is not None
+    assert not monitor._monitor_task.done()
+
+    await monitor.stop()
+    assert monitor._monitor_task is None
+
+
+@pytest.mark.asyncio
+async def test_monitor_start_is_idempotent():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor("/tmp", check_interval_seconds=0.1)
+
+    await monitor.start()
+    task1 = monitor._monitor_task
+
+    await monitor.start()
+    task2 = monitor._monitor_task
+
+    assert task1 is task2
+
+    await monitor.stop()
+
+
+@pytest.mark.asyncio
+async def test_monitor_stop_is_idempotent():
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor("/tmp", check_interval_seconds=0.1)
+
+    await monitor.stop()
+    await monitor.stop()
+
+
+@pytest.mark.asyncio
+async def test_monitor_performs_check_on_interval():
+    import asyncio
+
+    from openviking.utils.disk_pressure import DiskPressureMonitor
+
+    monitor = DiskPressureMonitor("/tmp", check_interval_seconds=0.05)
+
+    with patch("shutil.disk_usage", return_value=make_disk_usage(100, 50, 50)) as mock_usage:
+        await monitor.start()
+        await asyncio.sleep(0.15)
+        await monitor.stop()
+
+    assert mock_usage.call_count >= 2


### PR DESCRIPTION
## Summary

Adds proactive disk pressure monitoring to prevent server failures when disk space is low. This is the third and final part of addressing Issue #2707.

## Related

- Fixes #2707 (partial - disk pressure awareness)
- Related: PR #2754 (queue.db auto-vacuum - MERGED)
- Related: PR #2777 (resource version retention - SUBMITTED)

## Problem

When disk fills up, OpenViking currently has no self-protection mechanism:
- QueueFS fails with "sqlite enqueue error: database or disk is full"
- Embedding circuit breaker trips after consecutive SQLite failures
- Server logs `OSError: [Errno 28] No space left on device`
- Server can enter an unrecoverable state requiring manual intervention

## Solution

### Proactive Disk Monitoring

New `DiskPressureMonitor` singleton that:
- Periodically checks disk usage using `shutil.disk_usage()`
- Maintains state: NORMAL, WARNING, or CRITICAL
- Logs warnings when approaching thresholds
- Blocks write operations when CRITICAL

### Health Endpoint

New `GET /api/v1/system/disk` endpoint returns:
```json
{
  "state": "normal",
  "usage_percent": 45.32,
  "free_bytes": 107374182400,
  "free_gb": 100.0,
  "warning_threshold_percent": 85.0,
  "critical_threshold_percent": 95.0,
  "min_free_bytes": 1073741824
}
```

Returns 503 when state is "critical".

### Readiness Integration

`/ready` endpoint now includes disk status as check #6.

### Write Protection

When disk pressure is CRITICAL, the following operations are blocked:
- `VikingFS.write()` - raises `AGFSIOError`
- `NamedQueue.enqueue()` - raises `DiskPressureError`
- `ResourceProcessor.process_resource()` - raises `OpenVikingError`

## Configuration

```json
{
  "storage": {
    "disk_pressure": {
      "enabled": true,
      "check_interval_seconds": 30,
      "warning_threshold_percent": 85,
      "critical_threshold_percent": 95,
      "min_free_bytes": 1073741824
    }
  }
}
```

All fields are optional with sensible defaults. Set `enabled: false` to disable.

## Testing

- Unit tests for `DiskPressureMonitor` state transitions
- Integration tests for health endpoints
- Write protection tests using mocked disk states

## Backwards Compatibility

- New feature, no breaking changes
- Default `enabled: true` for proactive protection
- Set `enabled: false` to maintain previous behavior
