### PR TITLE
fix(logger): harden queued stream logging

### DIFF
--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -8,6 +8,7 @@ import atexit
 import logging
 import queue
 import sys
+import threading
 from contextlib import contextmanager
 from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
@@ -66,9 +67,11 @@ _MANAGED_LOGGER_ROOTS = ("openviking", "openviking_cli", "uvicorn")
 _shared_log_handler: Optional[logging.Handler] = None
 _shared_log_handler_key: Optional[tuple[Any, ...]] = None
 
-# QueueListener for thread-safe stdout/stderr logging (avoids StreamHandler deadlocks)
-_std_queue_listener: Optional[QueueListener] = None
-_std_queue_real_handler: Optional[logging.Handler] = None
+# QueueListeners for thread-safe stdout/stderr logging (avoids StreamHandler stalls
+# on application threads when process managers redirect streams).
+_std_stream_handlers: dict[str, Tuple[QueueListener, logging.Handler]] = {}
+_std_stream_handlers_lock = threading.RLock()
+_std_stream_atexit_registered = False
 
 
 def _get_log_context() -> dict[str, Any]:
@@ -628,6 +631,7 @@ def _load_log_config() -> Tuple[str, str, str, Optional[Any]]:
             log_dir.mkdir(parents=True, exist_ok=True)
             log_output = str(log_dir / "openviking.log")
     except Exception:
+        config = None
         log_level_str = "INFO"
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         log_output = "stdout"
@@ -642,34 +646,64 @@ def _managed_root_name(name: str) -> Optional[str]:
     return None
 
 
+def _stop_std_stream_listeners() -> None:
+    """Stop queue listeners created for stdout/stderr logging."""
+    with _std_stream_handlers_lock:
+        listeners = list(_std_stream_handlers.values())
+        _std_stream_handlers.clear()
+
+    for listener, real_handler in listeners:
+        try:
+            listener.stop()
+        except Exception:
+            pass
+        try:
+            real_handler.close()
+        except Exception:
+            pass
+
+
+def _create_queued_stream_handler(log_output: str) -> QueueHandler:
+    """Create a QueueHandler backed by a per-stream QueueListener."""
+    global _std_stream_atexit_registered
+
+    if log_output not in ("stdout", "stderr"):
+        raise ValueError(f"unsupported stream log output: {log_output}")
+
+    with _std_stream_handlers_lock:
+        entry = _std_stream_handlers.get(log_output)
+        if entry is None:
+            stream = sys.stdout if log_output == "stdout" else sys.stderr
+            real_handler = logging.StreamHandler(stream)
+            log_queue: queue.Queue = queue.Queue(-1)
+            listener = QueueListener(log_queue, real_handler, respect_handler_level=True)
+            listener.start()
+            _std_stream_handlers[log_output] = (listener, real_handler)
+            entry = (listener, real_handler)
+            if not _std_stream_atexit_registered:
+                atexit.register(_stop_std_stream_listeners)
+                _std_stream_atexit_registered = True
+
+        listener, real_handler = entry
+        handler = QueueHandler(listener.queue)
+        handler._ov_real_handler = real_handler  # type: ignore[attr-defined]
+        return handler
+
+
+def _add_trace_id_filter(handler: logging.Handler) -> None:
+    from openviking.telemetry.tracer import TraceIdLoggingFilter
+
+    if not any(isinstance(filter_, TraceIdLoggingFilter) for filter_ in handler.filters):
+        handler.addFilter(TraceIdLoggingFilter())
+
+
 def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handler:
     # Prevent creating a file literally named "file"
     if log_output == "file":
         log_output = "stdout"
 
     if log_output in ("stdout", "stderr"):
-        # QueueHandler + QueueListener prevents StreamHandler thread deadlocks
-        # when stdout/stderr is redirected to a file by systemd/journald.
-        # The listener thread is the ONLY thread that touches the real stream,
-        # so the handler lock can never be held across threads.
-        global _std_queue_listener, _std_queue_real_handler
-
-        if _std_queue_listener is not None:
-            return QueueHandler(_std_queue_listener.queue)
-
-        stream = sys.stdout if log_output == "stdout" else sys.stderr
-        _std_queue_real_handler = logging.StreamHandler(stream)
-
-        log_queue: queue.Queue = queue.Queue(-1)
-        _std_queue_listener = QueueListener(
-            log_queue, _std_queue_real_handler, respect_handler_level=True
-        )
-        _std_queue_listener.start()
-        atexit.register(_std_queue_listener.stop)
-
-        qh = QueueHandler(log_queue)
-        qh._ov_real_handler = _std_queue_real_handler  # type: ignore[attr-defined]
-        return qh
+        return _create_queued_stream_handler(log_output)
     else:
         if config is not None:
             try:
@@ -707,23 +741,19 @@ def _build_standard_handler(
 ) -> logging.Handler:
     handler = _create_log_handler(log_output, config)
 
-    # QueueHandler delegates formatting to the real handler in the listener thread.
-    # Set formatter + filters on the real handler so emitted LogRecords get
-    # formatted by the listener (single-threaded, no deadlock risk).
+    # QueueHandler must enrich and format records on the caller thread so
+    # context-local trace data and per-logger format strings are captured before
+    # the shared listener-side stream handler writes the prepared message.
     if isinstance(handler, QueueHandler):
-        real = getattr(handler, '_ov_real_handler', None)
+        real = getattr(handler, "_ov_real_handler", None)
         if real is not None:
-            real.setFormatter(logging.Formatter(format_string))
-            from openviking.telemetry.tracer import TraceIdLoggingFilter
-            real.addFilter(TraceIdLoggingFilter())
+            real.setFormatter(logging.Formatter("%(message)s"))
+        handler.setFormatter(logging.Formatter(format_string))
+        _add_trace_id_filter(handler)
         return handler
 
     handler.setFormatter(logging.Formatter(format_string))
-
-    # Add trace id filter
-    from openviking.telemetry.tracer import TraceIdLoggingFilter
-
-    handler.addFilter(TraceIdLoggingFilter())
+    _add_trace_id_filter(handler)
     return handler
 
 

--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -4,10 +4,12 @@
 Logging utilities for OpenViking.
 """
 
+import atexit
 import logging
+import queue
 import sys
 from contextlib import contextmanager
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
 from typing import Any, Optional, Tuple
 from uuid import uuid4
@@ -63,6 +65,10 @@ _otel_log_handler: Any = None
 _MANAGED_LOGGER_ROOTS = ("openviking", "openviking_cli", "uvicorn")
 _shared_log_handler: Optional[logging.Handler] = None
 _shared_log_handler_key: Optional[tuple[Any, ...]] = None
+
+# QueueListener for thread-safe stdout/stderr logging (avoids StreamHandler deadlocks)
+_std_queue_listener: Optional[QueueListener] = None
+_std_queue_real_handler: Optional[logging.Handler] = None
 
 
 def _get_log_context() -> dict[str, Any]:
@@ -641,10 +647,29 @@ def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handl
     if log_output == "file":
         log_output = "stdout"
 
-    if log_output == "stdout":
-        return logging.StreamHandler(sys.stdout)
-    elif log_output == "stderr":
-        return logging.StreamHandler(sys.stderr)
+    if log_output in ("stdout", "stderr"):
+        # QueueHandler + QueueListener prevents StreamHandler thread deadlocks
+        # when stdout/stderr is redirected to a file by systemd/journald.
+        # The listener thread is the ONLY thread that touches the real stream,
+        # so the handler lock can never be held across threads.
+        global _std_queue_listener, _std_queue_real_handler
+
+        if _std_queue_listener is not None:
+            return QueueHandler(_std_queue_listener.queue)
+
+        stream = sys.stdout if log_output == "stdout" else sys.stderr
+        _std_queue_real_handler = logging.StreamHandler(stream)
+
+        log_queue: queue.Queue = queue.Queue(-1)
+        _std_queue_listener = QueueListener(
+            log_queue, _std_queue_real_handler, respect_handler_level=True
+        )
+        _std_queue_listener.start()
+        atexit.register(_std_queue_listener.stop)
+
+        qh = QueueHandler(log_queue)
+        qh._ov_real_handler = _std_queue_real_handler  # type: ignore[attr-defined]
+        return qh
     else:
         if config is not None:
             try:
@@ -681,6 +706,18 @@ def _build_standard_handler(
     format_string: str,
 ) -> logging.Handler:
     handler = _create_log_handler(log_output, config)
+
+    # QueueHandler delegates formatting to the real handler in the listener thread.
+    # Set formatter + filters on the real handler so emitted LogRecords get
+    # formatted by the listener (single-threaded, no deadlock risk).
+    if isinstance(handler, QueueHandler):
+        real = getattr(handler, '_ov_real_handler', None)
+        if real is not None:
+            real.setFormatter(logging.Formatter(format_string))
+            from openviking.telemetry.tracer import TraceIdLoggingFilter
+            real.addFilter(TraceIdLoggingFilter())
+        return handler
+
     handler.setFormatter(logging.Formatter(format_string))
 
     # Add trace id filter

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -3,6 +3,7 @@
 """Tests for config_loader utilities."""
 
 import logging
+from logging.handlers import QueueHandler
 
 import pytest
 
@@ -389,6 +390,7 @@ def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, mo
         logger.propagate = True
     logger_module._shared_log_handler = None
     logger_module._shared_log_handler_key = None
+    logger_module._stop_std_stream_listeners()
 
     OpenVikingConfigSingleton.reset_instance()
     monkeypatch.setenv("OPENVIKING_CONFIG_FILE", "/tmp/codex-no-config.json")
@@ -396,7 +398,7 @@ def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, mo
     early_logger = logger_module.get_logger(logger_name)
     openviking_root = logging.getLogger("openviking")
     assert early_logger.handlers == []
-    assert any(isinstance(h, logging.StreamHandler) for h in openviking_root.handlers)
+    assert any(isinstance(h, QueueHandler) for h in openviking_root.handlers)
 
     config_path = tmp_path / "ov.conf"
     config_path.write_text(
@@ -442,4 +444,5 @@ def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, mo
             logger.propagate = True
         logger_module._shared_log_handler = None
         logger_module._shared_log_handler_key = None
+        logger_module._stop_std_stream_listeners()
         OpenVikingConfigSingleton.reset_instance()


### PR DESCRIPTION
## Summary

Based on #2753, this keeps the stdlib `QueueHandler` / `QueueListener` direction but tightens the implementation before merge:

- use separate queue listeners for `stdout` and `stderr`, so mixed stream configurations do not accidentally share the first initialized stream
- preserve formatter reconfiguration by keeping a reference from each `QueueHandler` to its real listener-side handler
- run trace-id enrichment on the caller-side `QueueHandler`, not in the listener thread, so context-local trace data is captured before the record is queued
- keep test changes minimal: only adapt the existing early logger reconfiguration test for the QueueHandler path and listener cleanup

## Context

The original contributor PR #2753 is closed and comes from a fork with `maintainerCanModify=false`, so this branch carries the maintainer cleanup version in `volcengine/OpenViking`.

Fixes #2752.

## Tests

- `pytest tests/test_config_loader.py -q`
- `ruff check openviking_cli/utils/logger.py tests/test_config_loader.py`
- `ruff format openviking_cli/utils/logger.py tests/test_config_loader.py`
- `python -m compileall -q openviking_cli/utils/logger.py tests/test_config_loader.py`