### PR TITLE
ci(cli): initialize language before version check

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -502,6 +502,7 @@ jobs:
             openviking version
             echo "OPENVIKING_CLI_BIN=$(which openviking)" >> $GITHUB_ENV
           elif command -v ov &> /dev/null; then
+            ov language en
             ov version
             echo "OPENVIKING_CLI_BIN=$(which ov)" >> $GITHUB_ENV
           else


### PR DESCRIPTION
## Description

Initializes the released `ov` CLI display language before the API/CLI integration workflow runs `ov version`. The released installer currently provides `ov 0.4.4`, whose commands require `ov language en` or `ov language zh-CN` on a fresh runner.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Run `ov language en` in the Unix CLI install verification path before `ov version`.
- Keep the existing `OPENVIKING_CLI_BIN` export behavior unchanged.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run locally:

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/api_test.yml"); puts ".github/workflows/api_test.yml: valid YAML"'
git diff --check
tmp_home=$(mktemp -d); HOME="$tmp_home" ov language en && HOME="$tmp_home" ov version; exit_code=$?; rm -rf "$tmp_home"; exit $exit_code
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This is intentionally separated from the text encoding PR so the CI workflow fix can be reviewed independently.
