### PR TITLE
fix(openclaw-plugin): tolerate missing OV session during assemble

### DIFF
--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -406,6 +406,11 @@ function assemblePassthrough(
   return { messages: liveMessages, estimatedTokens: originalTokens };
 }
 
+function isSessionNotFoundError(err: unknown): boolean {
+  const errorMessage = String(err);
+  return errorMessage.includes("[NOT_FOUND]") && errorMessage.includes("Session not found");
+}
+
 export async function assembleOpenVikingSession({
   sessionId,
   sessionKey,
@@ -627,6 +632,27 @@ export async function assembleOpenVikingSession({
       ...(instruction.text ? { systemPromptAddition: instruction.text } : {}),
     };
   } catch (err) {
+    if (isSessionNotFoundError(err)) {
+      const errorMessage = String(err);
+      logger.info(
+        `openviking: assemble skipped because OV session does not exist ` +
+          `(session=${ovSessionId}, tokenBudget=${tokenBudget}, agentId=${resolveAgentId(ovSessionId)})`,
+      );
+      return assemblePassthrough({
+        diag,
+        ovSessionId,
+        reason: "session_not_found",
+        liveMessages: messages,
+        originalTokens,
+        extra: {
+          error: errorMessage,
+          tokenBudget,
+          agentId: resolveAgentId(ovSessionId),
+          senderIdFound: sender.found,
+          senderId: sender.senderId ?? null,
+        },
+      });
+    }
     logger.warn?.(
       `openviking: assemble failed for session=${ovSessionId}, ` +
         `tokenBudget=${tokenBudget}, agentId=${resolveAgentId(ovSessionId)}: ${String(err)}`,
@@ -1192,7 +1218,7 @@ export async function compactOpenVikingSession({
     };
   } catch (err) {
     const errorMessage = String(err);
-    if (errorMessage.includes("[NOT_FOUND]") && errorMessage.includes("Session not found")) {
+    if (isSessionNotFoundError(err)) {
       logger.info(
         `openviking: compact skipped because OV session does not exist ` +
           `(session=${ovSessionId}, agentId=${agentId})`,


### PR DESCRIPTION
## Summary
- Treat OpenViking `Session not found` during OpenClaw context assemble as an empty/new session passthrough instead of a warning-level assemble failure.
- Reuse the same NOT_FOUND predicate for compact's existing missing-session skip path.

## Why
For a brand-new OpenClaw session, assemble can run before afterTurn has captured any messages into OpenViking. The `/context` endpoint returns `[NOT_FOUND]: Session not found` in that lifecycle window. This is expected for a first turn and should not be logged as an assemble failure.

## Verification
- `node --check /root/work-openviking-api-fix/files/context-lifecycle-service.ts`
- Targeted local runtime check against installed OpenViking plugin: fake `getSessionContext()` throws `[NOT_FOUND]: Session not found`; verified passthrough result, `reason=session_not_found`, and no warn log.