### PR TITLE
fix(storage): fix incremental semantic refresh for unchanged files

### DIFF
--- a/docs/openviking/2026-06-04-issue-2383-insights.md
+++ b/docs/openviking/2026-06-04-issue-2383-insights.md
@@ -1,0 +1,121 @@
+# Issue 2383 洞察记录
+
+这份文档记录围绕 `#2383` 重复 `add_resource` 仍产生较多 embedding 工作量时讨论出的系统洞察。它不是最终修复方案，而是用于沉淀判断依据。
+
+## 1. `.overview.md` 同时承担了人读文档和机器缓存的角色
+
+当前增量导入时，如果文件内容没有变化，系统会尝试复用旧的文件 summary。
+
+具体做法是：
+
+- 读取父目录下已有的 `.overview.md`
+- 用 `_parse_overview_md()` 从 Markdown 文本里反解析出 `filename -> summary`
+- 如果能解析出当前文件名对应的 summary，就复用旧 summary，并跳过文件级 vectorization
+- 如果解析不出来，就重新生成 summary，并重新 vectorize
+
+这说明 `.overview.md` 在当前设计里有双重角色：
+
+- 对用户/模型可读的目录概览
+- 对系统可反解析的 summary cache
+
+这个设计有风险，因为 `.overview.md` 是 Markdown 文本，不是严格机器结构。
+
+## 2. overview 生成不是完全无格式，但也不是强结构化数据
+
+overview 生成 prompt 确实要求模型输出固定 Markdown 结构：
+
+- H1 标题
+- 简短描述
+- Quick Navigation
+- Detailed Description
+- 每个文件或子目录一个 H3 subsection
+
+所以问题不是“没有指定格式”。
+
+更准确的问题是：
+
+`系统要求 LLM 输出强 Markdown 格式，但后续代码又把这份 Markdown 当作稳定可解析的结构化缓存。`
+
+Markdown 结构对人类阅读友好，但对机器反解析不够稳：
+
+- LLM 可能不严格输出 H3
+- H3 标题可能不是纯文件名
+- 标题可能包含编号、解释、路径或重复词
+- parser 只识别有限格式，比如 `### filename` 或 `[1] filename: summary`
+- 一旦格式偏离，旧 summary 就无法复用
+
+## 3. 这个点对 `#2383` 的意义
+
+`#2383` 的核心问题是重复导入没有达到预期的增量效果。
+
+其中一个关键原因可能是：
+
+`文件内容虽然没变，但旧 summary 不能稳定从 .overview.md 中恢复，于是系统重新 summary + 重新 embedding。`
+
+这不是单纯返回值显示错误，而是可能真实触发额外模型调用。
+
+## 4. 初步产品/系统判断
+
+如果希望持续导入真的低成本，文件级 summary 应该有更稳定的缓存来源。
+
+更合理的方向可能是：
+
+- 不把 `.overview.md` 同时当做人读文档和机器缓存
+- 单独维护结构化 summary cache
+- 或在派生语义文件中加入可验证的结构化 metadata block
+- 或让目录 overview 继续面向阅读，而把增量判断依赖放到更稳定的内部状态上
+
+当前最重要的判断是：
+
+`overview 可以继续是知识页，但不应该是唯一的机器可恢复 summary source。`
+
+## 5. 文件变化检测不应该依赖 summary 恢复结果
+
+进一步讨论后，一个更底层的判断是：
+
+`文件是否变化，应该只由文件本身决定，而不是由 summary 是否能恢复决定。`
+
+当前代码里已经有文件层面的内容对比：
+
+- 先比较源文件和目标文件的 size
+- size 相同后再读取完整 content 比较
+
+这说明系统本来就具备文件级变化检测。
+
+但当前增量链路里，文件未变化后还会继续尝试从 `.overview.md` 中恢复旧 summary。如果旧 summary 恢复失败，代码会重新生成 summary，并把该文件重新标记为 changed。
+
+这里的问题是：
+
+`summary cache miss` 不等于 `file content changed`。
+
+更合理的状态应该拆开：
+
+- `file_content_changed`
+- `summary_cache_miss`
+- `summary_regenerated`
+- `embedding_needs_rebuild`
+- `directory_semantics_changed`
+
+文件没有变化时，一般不应该因为 summary 取不回来就把文件当成内容变化。summary 丢失或恢复失败，最多说明需要修复或补齐 summary 缓存，不应该直接触发文件级 changed 状态向上游目录传播。
+
+## 6. 目录语义更新应该由真实子内容变化驱动
+
+目录的 summary / overview / abstract 自底向上生成是合理的，因为父目录需要依赖当前目录文件 summary 和子目录 abstract。
+
+但触发条件应该是：
+
+`当前目录下的文件或子目录语义真的发生变化。`
+
+不是：
+
+`因为旧 summary 没恢复出来，所以把未变化文件当成变化文件。`
+
+也就是说，理想链路应该是：
+
+- 文件内容没变：文件 summary 和 embedding 默认不需要重建
+- 文件新增、删除、修改：当前目录 summary / overview / abstract 需要更新
+- 子目录 abstract 真的变化：父目录 summary / overview / abstract 才需要更新
+
+这个洞察可以概括为：
+
+`增量导入应该由真实内容 diff 驱动，而不是由派生语义缓存恢复是否成功来驱动。`

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -540,62 +540,6 @@ class SemanticDagExecutor:
         except Exception:
             return True
 
-    async def _read_existing_summary(self, file_path: str) -> Optional[Dict[str, str]]:
-        """Read existing summary from parent directory's .overview.md.
-
-        Args:
-            file_path: Current file path
-
-        Returns:
-            Summary dict with 'name' and 'summary' keys, or None if not found
-        """
-        target_path = self._get_target_file_path(file_path)
-        if not target_path:
-            return None
-
-        try:
-            parent_uri = "/".join(target_path.rsplit("/", 1)[:-1])
-            if not parent_uri:
-                return None
-
-            if parent_uri not in self._overview_cache:
-                try:
-                    from openviking.metrics.datasources.cache import CacheEventDataSource
-
-                    CacheEventDataSource.record_miss("L1")
-                except Exception:
-                    pass
-                async with self._overview_cache_lock:
-                    if parent_uri not in self._overview_cache:
-                        overview_path = f"{parent_uri}/.overview.md"
-                        overview_content = await self._viking_fs.read_file(
-                            overview_path, ctx=self._ctx
-                        )
-                        if overview_content:
-                            self._overview_cache[parent_uri] = self._processor._parse_overview_md(
-                                overview_content
-                            )
-                        else:
-                            self._overview_cache[parent_uri] = {}
-            else:
-                try:
-                    from openviking.metrics.datasources.cache import CacheEventDataSource
-
-                    CacheEventDataSource.record_hit("L1")
-                except Exception:
-                    pass
-
-            existing_summaries = self._overview_cache.get(parent_uri, {})
-            file_name = file_path.split("/")[-1]
-
-            if file_name in existing_summaries:
-                return {"name": file_name, "summary": existing_summaries[file_name]}
-
-        except Exception as e:
-            logger.debug(f"Failed to read existing summary from overview.md for {file_path}: {e}")
-
-        return None
-
     async def _check_dir_children_changed(
         self, dir_uri: str, current_files: List[str], current_dirs: List[str]
     ) -> bool:
@@ -654,26 +598,24 @@ class SemanticDagExecutor:
         file_name = file_path.split("/")[-1]
         need_vectorize = True
         try:
-            summary_dict = None
+            summary_dict: Optional[Dict[str, str]] = None
             if self._incremental_update:
                 content_changed = await self._check_file_content_changed(file_path)
                 self._file_change_status[file_path] = content_changed
 
                 if not content_changed:
-                    summary_dict = await self._read_existing_summary(file_path)
-                    if summary_dict is not None:
-                        need_vectorize = False
-                    else:
-                        self._file_change_status[file_path] = True
+                    need_vectorize = False
             else:
                 self._file_change_status[file_path] = True
-            if summary_dict is None:
+            if summary_dict is None and need_vectorize:
                 summary_dict = await self._processor._generate_single_file_summary(
                     file_path, llm_sem=self._llm_sem, ctx=self._ctx
                 )
         except Exception as e:
             logger.warning(f"Failed to generate summary for {file_path}: {e}")
             summary_dict = {"name": file_name, "summary": ""}
+            self._file_change_status[file_path] = True
+            need_vectorize = True
         finally:
             self._stats.done_nodes += 1
             self._stats.in_progress_nodes = max(0, self._stats.in_progress_nodes - 1)
@@ -698,7 +640,7 @@ class SemanticDagExecutor:
         await self._on_file_done(parent_uri, file_path, summary_dict)
 
     async def _on_file_done(
-        self, parent_uri: str, file_path: str, summary_dict: Dict[str, str]
+        self, parent_uri: str, file_path: str, summary_dict: Optional[Dict[str, str]]
     ) -> None:
         node = self._nodes.get(parent_uri)
         if not node:
@@ -733,12 +675,61 @@ class SemanticDagExecutor:
         node.overview_scheduled = True
         self._schedule_work(DagWork(kind="overview", dir_uri=dir_uri))
 
-    def _finalize_file_summaries(self, node: DirNode) -> List[Dict[str, str]]:
+    async def _read_existing_summaries_for_dir(self, dir_uri: str) -> Dict[str, str]:
+        target_path = self._get_target_file_path(dir_uri)
+        if not target_path:
+            return {}
+
+        if target_path in self._overview_cache:
+            try:
+                from openviking.metrics.datasources.cache import CacheEventDataSource
+
+                CacheEventDataSource.record_hit("L1")
+            except Exception:
+                pass
+            return self._overview_cache.get(target_path, {})
+
+        try:
+            from openviking.metrics.datasources.cache import CacheEventDataSource
+
+            CacheEventDataSource.record_miss("L1")
+        except Exception:
+            pass
+
+        async with self._overview_cache_lock:
+            if target_path not in self._overview_cache:
+                try:
+                    overview_content = await self._viking_fs.read_file(
+                        f"{target_path}/.overview.md", ctx=self._ctx
+                    )
+                    if overview_content:
+                        self._overview_cache[target_path] = self._processor._parse_overview_md(
+                            overview_content
+                        )
+                    else:
+                        self._overview_cache[target_path] = {}
+                except Exception as e:
+                    logger.debug(
+                        "Failed to read existing overview summaries for %s: %s",
+                        dir_uri,
+                        e,
+                    )
+                    self._overview_cache[target_path] = {}
+
+        return self._overview_cache.get(target_path, {})
+
+    async def _finalize_file_summaries(self, node: DirNode) -> List[Dict[str, str]]:
+        existing_summaries: Optional[Dict[str, str]] = None
         summaries: List[Dict[str, str]] = []
         for idx, file_path in enumerate(node.file_paths):
             item = node.file_summaries[idx]
             if item is None:
-                summaries.append({"name": file_path.split("/")[-1], "summary": ""})
+                file_name = file_path.split("/")[-1]
+                if existing_summaries is None:
+                    existing_summaries = await self._read_existing_summaries_for_dir(node.uri)
+                summaries.append(
+                    {"name": file_name, "summary": existing_summaries.get(file_name, "")}
+                )
             else:
                 summaries.append(item)
         return summaries
@@ -746,6 +737,12 @@ class SemanticDagExecutor:
     @property
     def stale(self) -> bool:
         return self._stale
+
+    @property
+    def has_effective_changes(self) -> bool:
+        if not self._incremental_update:
+            return True
+        return any(self._file_change_status.values()) or any(self._dir_change_status.values())
 
     async def _finalize_children_abstracts(self, node: DirNode) -> List[Dict[str, str]]:
         results: List[Dict[str, str]] = []
@@ -804,9 +801,9 @@ class SemanticDagExecutor:
                 if not children_changed:
                     need_vectorize = False
                     overview, abstract = await self._read_existing_overview_abstract(dir_uri)
-            if overview is None or abstract is None:
+            if children_changed and (overview is None or abstract is None):
                 async with node.lock:
-                    file_summaries = self._finalize_file_summaries(node)
+                    file_summaries = await self._finalize_file_summaries(node)
                     children_abstracts = await self._finalize_children_abstracts(node)
                 async with self._llm_sem:
                     overview = await self._processor._generate_overview(
@@ -816,12 +813,15 @@ class SemanticDagExecutor:
                 overview, abstract = self._processor._enforce_size_limits(overview, abstract)
 
             # Write directly, protected by the outer semantic lock.
-            try:
-                wrote = await self._write_directory_semantics(dir_uri, overview, abstract)
-                if not wrote:
-                    need_vectorize = False
-            except Exception:
-                logger.info(f"[SemanticDag] {dir_uri} write failed, skipping")
+            if overview is not None and abstract is not None:
+                try:
+                    wrote = await self._write_directory_semantics(dir_uri, overview, abstract)
+                    if not wrote:
+                        need_vectorize = False
+                except Exception:
+                    logger.info(f"[SemanticDag] {dir_uri} write failed, skipping")
+            else:
+                need_vectorize = False
 
             try:
                 if need_vectorize:

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -446,7 +446,7 @@ class SemanticProcessor(DequeueHandlerBase):
                                 run_uri,
                                 executor.get_stats(),
                             )
-                            if not executor.stale:
+                            if not executor.stale and executor.has_effective_changes:
                                 await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
                     finally:
                         if not lock_transferred:

--- a/tests/storage/test_issue_2383_incremental_behavior.py
+++ b/tests/storage/test_issue_2383_incremental_behavior.py
@@ -1,0 +1,391 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _mock_transaction_layer(monkeypatch):
+    mock_handle = MagicMock()
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aenter__",
+        AsyncMock(return_value=mock_handle),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aexit__",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: MagicMock(),
+    )
+
+
+class _FakeVikingFS:
+    def __init__(self, tree, contents):
+        self._tree = tree
+        self._contents = contents
+        self.writes = []
+
+    async def ls(self, uri, ctx=None, show_all_hidden=False):
+        return list(self._tree.get(uri, []))
+
+    async def write_file(self, path, content, ctx=None):
+        self.writes.append((path, content))
+        self._contents[path] = content
+
+    async def stat(self, uri, ctx=None):
+        if uri not in self._contents:
+            raise FileNotFoundError(uri)
+        content = self._contents[uri]
+        if isinstance(content, bytes):
+            size = len(content)
+        else:
+            size = len(str(content))
+        return {"size": size}
+
+    async def read_file(self, uri, ctx=None):
+        if uri not in self._contents:
+            raise FileNotFoundError(uri)
+        return self._contents[uri]
+
+    async def exists(self, uri, ctx=None):
+        return uri in self._tree or uri in self._contents
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri.replace("viking://", "/local/acc1/")
+
+
+class _FakeProcessor:
+    def __init__(self):
+        self.summarized_files = []
+        self.overview_inputs = []
+        self.vectorized_files = []
+        self.vectorized_dirs = []
+
+    def _parse_overview_md(self, overview_content):
+        results = {}
+        for line in overview_content.splitlines():
+            line = line.strip()
+            if not line.startswith("- ") or ":" not in line:
+                continue
+            name, summary = line[2:].split(":", 1)
+            results[name.strip()] = summary.strip()
+        return results
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.summarized_files.append(file_path)
+        return {"name": file_path.split("/")[-1], "summary": "fresh summary"}
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        self.overview_inputs.append((dir_uri, list(file_summaries), list(children_abstracts)))
+        lines = ["FILES:"]
+        for item in file_summaries:
+            lines.append(f"- {item['name']}: {item['summary']}")
+        return "\n".join(lines)
+
+    def _extract_abstract_from_overview(self, overview):
+        return "abstract"
+
+    def _enforce_size_limits(self, overview, abstract):
+        return overview, abstract
+
+    async def _vectorize_directory(
+        self, uri, context_type, abstract, overview, ctx=None, semantic_msg_id=None
+    ):
+        self.vectorized_dirs.append(uri)
+
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+    ):
+        self.vectorized_files.append(file_path)
+
+    async def _sync_topdown_recursive(
+        self,
+        root_uri,
+        target_uri,
+        ctx=None,
+        file_change_status=None,
+        lock=None,
+    ):
+        return SimpleNamespace(
+            added_files=[],
+            deleted_files=[],
+            updated_files=[],
+            added_dirs=[],
+            deleted_dirs=[],
+        )
+
+
+class _DummyEmbeddingTracker:
+    async def register(self, **_kwargs):
+        return None
+
+
+class _CapturedSemanticQueue:
+    def __init__(self):
+        self.messages = []
+
+    async def enqueue(self, msg):
+        self.messages.append(msg)
+        return "queued"
+
+
+class _FakeQueueManager:
+    SEMANTIC = "semantic"
+
+    def __init__(self, queue):
+        self._queue = queue
+
+    def get_queue(self, name, allow_create=False):
+        assert name == self.SEMANTIC
+        return self._queue
+
+
+def _patch_dag_deps(monkeypatch, fake_fs):
+    _mock_transaction_layer(monkeypatch)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.get_viking_fs",
+        lambda: fake_fs,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _DummyEmbeddingTracker(),
+    )
+
+
+def _ctx():
+    return RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+
+
+@pytest.mark.asyncio
+async def test_incremental_unchanged_file_does_not_read_summary_or_vectorize(monkeypatch):
+    temp_root = "viking://resources/_tmp/repeat-add"
+    target_root = "viking://resources/repeat-add"
+    temp_file = f"{temp_root}/alpha.md"
+    target_file = f"{target_root}/alpha.md"
+
+    fake_fs = _FakeVikingFS(
+        tree={
+            temp_root: [{"name": "alpha.md", "isDir": False}],
+            target_root: [{"name": "alpha.md", "isDir": False}],
+        },
+        contents={
+            temp_file: "# Alpha\n\nsame content\n",
+            target_file: "# Alpha\n\nsame content\n",
+            f"{target_root}/.overview.md": "This old prose is intentionally unparsable.",
+            f"{target_root}/.abstract.md": "old abstract",
+        },
+    )
+    _patch_dag_deps(monkeypatch, fake_fs)
+
+    processor = _FakeProcessor()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=_ctx(),
+        incremental_update=True,
+        target_uri=target_root,
+    )
+
+    await executor.run(temp_root)
+    await asyncio.sleep(0)
+
+    assert processor.summarized_files == []
+    assert processor.overview_inputs == []
+    assert processor.vectorized_files == []
+    assert processor.vectorized_dirs == []
+    assert executor.has_effective_changes is False
+
+
+@pytest.mark.asyncio
+async def test_incremental_changed_file_summarizes_and_vectorizes(monkeypatch):
+    temp_root = "viking://resources/_tmp/repeat-add"
+    target_root = "viking://resources/repeat-add"
+    temp_file = f"{temp_root}/alpha.md"
+    target_file = f"{target_root}/alpha.md"
+
+    fake_fs = _FakeVikingFS(
+        tree={
+            temp_root: [{"name": "alpha.md", "isDir": False}],
+            target_root: [{"name": "alpha.md", "isDir": False}],
+        },
+        contents={
+            temp_file: "# Alpha\n\nchanged content\n",
+            target_file: "# Alpha\n\nold content\n",
+            f"{target_root}/.overview.md": "FILES:\n- alpha.md: old summary",
+            f"{target_root}/.abstract.md": "old abstract",
+        },
+    )
+    _patch_dag_deps(monkeypatch, fake_fs)
+
+    processor = _FakeProcessor()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=_ctx(),
+        incremental_update=True,
+        target_uri=target_root,
+    )
+
+    await executor.run(temp_root)
+    await asyncio.sleep(0)
+
+    assert processor.summarized_files == [temp_file]
+    assert processor.vectorized_files == [temp_file]
+    assert processor.vectorized_dirs == [temp_root]
+    assert executor.has_effective_changes is True
+
+
+@pytest.mark.asyncio
+async def test_incremental_directory_change_reuses_unchanged_file_summary_at_directory_level(
+    monkeypatch,
+):
+    root_uri = "viking://resources/root"
+    changed_file = f"{root_uri}/a.txt"
+    unchanged_file = f"{root_uri}/b.txt"
+
+    fake_fs = _FakeVikingFS(
+        tree={
+            root_uri: [
+                {"name": "a.txt", "isDir": False},
+                {"name": "b.txt", "isDir": False},
+            ],
+        },
+        contents={
+            changed_file: "new content",
+            unchanged_file: "unchanged",
+            f"{root_uri}/.overview.md": "FILES:\n- a.txt: old-a\n- b.txt: old-b",
+            f"{root_uri}/.abstract.md": "old abstract",
+        },
+    )
+    _patch_dag_deps(monkeypatch, fake_fs)
+
+    processor = _FakeProcessor()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=_ctx(),
+        incremental_update=True,
+        target_uri=root_uri,
+        changes={"modified": [changed_file]},
+    )
+
+    await executor.run(root_uri)
+    await asyncio.sleep(0)
+
+    assert processor.summarized_files == [changed_file]
+    assert len(processor.overview_inputs) == 1
+    _dir_uri, file_summaries, _child_abstracts = processor.overview_inputs[0]
+    assert file_summaries == [
+        {"name": "a.txt", "summary": "fresh summary"},
+        {"name": "b.txt", "summary": "old-b"},
+    ]
+    assert processor.vectorized_files == [changed_file]
+    assert processor.vectorized_dirs == [root_uri]
+
+
+async def _run_semantic_processor_with_fake_executor(monkeypatch, has_effective_changes):
+    parent_queue = _CapturedSemanticQueue()
+    fake_qm = _FakeQueueManager(parent_queue)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: fake_qm,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: SimpleNamespace(exists=AsyncMock(return_value=True)),
+    )
+
+    class _FakeSemanticScope:
+        def __init__(self):
+            self.lock = MagicMock()
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticLockScope.resolve",
+        AsyncMock(return_value=_FakeSemanticScope()),
+    )
+
+    effective_changes = has_effective_changes
+
+    class _FakeExecutor:
+        stale = False
+        has_effective_changes = effective_changes
+
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+        async def run(self, uri):
+            return None
+
+        def get_stats(self):
+            return DagStats()
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticDagExecutor",
+        _FakeExecutor,
+    )
+
+    processor = SemanticProcessor(max_concurrent_llm=1)
+    msg = SemanticMsg(
+        uri="viking://resources/_tmp/repeat-add",
+        context_type="resource",
+        account_id="acc1",
+        user_id="user1",
+        agent_id="agent1",
+        role=Role.USER.value,
+        target_uri="viking://resources/codeask/wiki/repeat-add",
+        target_preexisting=True,
+    )
+
+    await processor.on_dequeue(msg.to_dict())
+    return parent_queue.messages
+
+
+@pytest.mark.asyncio
+async def test_incremental_resource_skips_parent_refresh_without_effective_changes(monkeypatch):
+    messages = await _run_semantic_processor_with_fake_executor(
+        monkeypatch,
+        has_effective_changes=False,
+    )
+
+    assert messages == []
+
+
+@pytest.mark.asyncio
+async def test_incremental_resource_enqueues_parent_refresh_with_effective_changes(monkeypatch):
+    messages = await _run_semantic_processor_with_fake_executor(
+        monkeypatch,
+        has_effective_changes=True,
+    )
+
+    assert len(messages) == 1
+    parent_msg = messages[0]
+    assert isinstance(parent_msg, SemanticMsg)
+    assert parent_msg.uri == "viking://resources/codeask/wiki"
+    assert parent_msg.recursive is False
+    assert parent_msg.changes == {
+        "modified": ["viking://resources/codeask/wiki/repeat-add"]
+    }

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -112,6 +112,61 @@ class _FakeProcessor:
 
 
 @pytest.mark.asyncio
+async def test_incremental_missing_summary_does_not_trigger_content_regen(monkeypatch):
+    _mock_transaction_layer(monkeypatch)
+
+    root_uri = "viking://resources/root"
+    target_uri = "viking://resources/target"
+    tree = {
+        root_uri: [{"name": "a.txt", "isDir": False}],
+        target_uri: [{"name": "a.txt", "isDir": False}],
+    }
+
+    fake_fs = _FakeVikingFS(
+        tree=tree,
+        file_contents={
+            f"{root_uri}/a.txt": "hello",
+            f"{target_uri}/a.txt": "hello",
+            f"{target_uri}/.overview.md": "FILES:\n",
+            f"{target_uri}/.abstract.md": "old-abstract",
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1", "agent1"), role=Role.USER)
+
+    executor1 = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=target_uri,
+    )
+    monkeypatch.setattr(executor1, "_add_vectorize_task", AsyncMock())
+    await executor1.run(root_uri)
+
+    assert fake_fs._file_contents[f"{root_uri}/.overview.md"] == "FILES:\n"
+    assert fake_fs._file_contents[f"{target_uri}/.overview.md"] == "FILES:\n"
+    first_run_calls = len(processor.summarized_files)
+
+    executor2 = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=target_uri,
+    )
+    monkeypatch.setattr(executor2, "_add_vectorize_task", AsyncMock())
+    await executor2.run(root_uri)
+
+    assert len(processor.summarized_files) == first_run_calls
+    assert first_run_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_direct_incremental_update_uses_changes_without_temp_sync(monkeypatch):
     _mock_transaction_layer(monkeypatch)
 


### PR DESCRIPTION
## Description

Fix incremental semantic refresh logic so that unchanged files do not trigger redundant summary regeneration and embedding work during repeated `add_resource` calls.

When a directory is re-imported without any file changes, the semantic DAG executor was not correctly short-circuiting the incremental path, causing unnecessary LLM calls and embedding queue work.

## Related Issue

Fixes #2383

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Fixed incremental detection logic in `semantic_dag.py` to properly skip unchanged files
- Corrected `semantic_processor.py` to avoid re-triggering content regeneration for unchanged nodes
- Added comprehensive test coverage in `test_issue_2383_incremental_behavior.py`
- Updated existing incremental tests in `test_semantic_dag_incremental.py`

## Testing

- Added `tests/storage/test_issue_2383_incremental_behavior.py` with 391 lines of test cases
- Updated `tests/storage/test_semantic_dag_incremental.py` with additional coverage
- All tests pass locally