### PR TITLE
feat: doc update: clarify local CLI binary smoke

### DIFF
--- a/crates/ov_cli/README.md
+++ b/crates/ov_cli/README.md
@@ -151,9 +151,16 @@ ov session commit --session-id $SESSION
 # Build
 cargo build --release
 
+# Smoke the exact binary that was built
+target/release/ov --version
+target/release/ov -o json system health
+
 # Run tests
 cargo test
 
 # Install locally
 cargo install --path .
 ```
+
+When driving external e2e harnesses, point them at `target/release/ov` explicitly
+instead of relying on an older `ov` that may already be installed on `PATH`.


### PR DESCRIPTION
## Summary
- Document how to smoke the exact just-built OpenViking CLI binary.
- Call out that external e2e harnesses should point at target/release/ov explicitly instead of an older ov on PATH.

## Validation
- git diff --check

Docs-only change; left for maintainer review before merge.