### PR TITLE
fix: opencode recall request payload

### DIFF
--- a/examples/opencode-plugin/lib/memory-recall.mjs
+++ b/examples/opencode-plugin/lib/memory-recall.mjs
@@ -42,7 +42,7 @@ export function createMemoryRecall({ config }) {
 
   async function performRecallSearch(query) {
     try {
-      const body = { query: query.slice(0, 4000), limit: 20, mode: "auto" }
+      const body = { query: query.slice(0, 4000), limit: 20 }
       const response = await makeRequest(config, {
         method: "POST",
         endpoint: "/api/v1/search/find",

--- a/examples/opencode-plugin/package.json
+++ b/examples/opencode-plugin/package.json
@@ -16,7 +16,7 @@
     "INSTALL-ZH.md"
   ],
   "scripts": {
-    "check": "node --check index.mjs && node --check lib/runtime.mjs && node --check lib/repo-context.mjs && node --check lib/memory-session.mjs && node --check lib/memadd-local.mjs && node --check lib/memory-tools.mjs && node --check lib/code-tools.mjs && node --check lib/memory-recall.mjs && node --check lib/utils.mjs && node --check tests/code-tools-request-options.test.mjs",
+    "check": "node --check index.mjs && node --check lib/runtime.mjs && node --check lib/repo-context.mjs && node --check lib/memory-session.mjs && node --check lib/memadd-local.mjs && node --check lib/memory-tools.mjs && node --check lib/code-tools.mjs && node --check lib/memory-recall.mjs && node --check lib/utils.mjs && node --check tests/*.test.mjs",
     "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {

--- a/examples/opencode-plugin/tests/code-tools-request-options.test.mjs
+++ b/examples/opencode-plugin/tests/code-tools-request-options.test.mjs
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path"
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 const codeToolsPath = join(testDir, "../lib/code-tools.mjs")
+const memoryRecallPath = join(testDir, "../lib/memory-recall.mjs")
 
 test("code tools propagate actorPeerId to every code request", async () => {
   const source = await readFile(codeToolsPath, "utf8")
@@ -24,4 +25,11 @@ test("code tool descriptions restrict use to confirmed viking code repositories"
   assert.match(source, /documentation-only resources/)
   assert.match(source, /chat\/session history/)
   assert.match(source, /local filesystem paths/)
+})
+
+test("memory recall search payload matches strict server schema", async () => {
+  const source = await readFile(memoryRecallPath, "utf8")
+
+  assert.match(source, /const body = \{ query: query\.slice\(0, 4000\), limit: 20 \}/)
+  assert.doesNotMatch(source, /mode:\s*"auto"/)
 })


### PR DESCRIPTION
## Summary

Fixes #2757 for the active OpenCode plugin path.

The old `examples/opencode-memory-plugin/openviking-memory.ts` file is no longer on `main`; the shipped path is `examples/opencode-plugin/lib/memory-recall.mjs`. That path still sent `mode: "auto"` to `/api/v1/search/find`, but the server `FindRequest` rejects extra fields.

## Changes

- Drop `mode: "auto"` from the OpenCode memory recall request body.
- Add a small regression check that the recall payload matches the strict server schema.
- Make `npm run check` syntax-check all plugin tests.

## Validation

- `npm run check` in `examples/opencode-plugin`
- `npm test` in `examples/opencode-plugin`
- `git diff --check`