### PR TITLE
fix(parse): recognize .jsonl as a text file so upload encoding normalization applies (#2745)

### DIFF
--- a/openviking/parse/parsers/constants.py
+++ b/openviking/parse/parsers/constants.py
@@ -213,6 +213,7 @@ ADDITIONAL_TEXT_EXTENSIONS = {
     ".properties",
     ".toml",
     ".json",
+    ".jsonl",
     ".yaml",
     ".yml",
     ".xml",

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -111,6 +111,11 @@ class TestIsTextFile:
     def test_additional_text_extensions(self) -> None:
         assert is_text_file("settings.ini") is True
         assert is_text_file("data.csv") is True
+        # .jsonl is treated as text (matching .json) so upload-time encoding
+        # normalization applies, mirroring its inclusion in the vectorization
+        # text-extension set (#2745); otherwise a legacy-encoded .jsonl skips
+        # UTF-8 normalization while .json does not (#2744/#2770).
+        assert is_text_file("data.jsonl") is True
 
     def test_non_text_extensions(self) -> None:
         assert is_text_file("photo.png") is False


### PR DESCRIPTION
Completes #2745 (`Fixes #2744`), which added `.jsonl` to the vectorization text-extension set in `embedding_utils.py`, but left the parallel upload-time encoding path treating `.jsonl` as non-text.

## Problem

`is_text_file()` (`openviking/parse/parsers/upload_utils.py`) decides text-vs-binary by exact suffix membership across `CODE_EXTENSIONS` + `DOCUMENTATION_EXTENSIONS` + `ADDITIONAL_TEXT_EXTENSIONS`. `constants.py` has `.json` in `ADDITIONAL_TEXT_EXTENSIONS` but **not** `.jsonl` (the suffix of `data.jsonl` is `.jsonl`, not `.json`), so `is_text_file("data.jsonl")` returns `False`.

`detect_and_convert_encoding()` returns content unchanged when `is_text_file` is `False`, so a legacy-encoded `.jsonl` upload **skips** UTF-8 normalization (`normalize_text_bytes`) — unlike `.json` — and then gets vectorized as text. That's the exact mojibake class #2770 (`fix(parse): normalize legacy text encodings`) fixed for text files. `.jsonl` is a first-class artifact here (session logs, `ovpack` `index_records.jsonl`, eval records), so the gap is real.

## Fix

Add `.jsonl` to `ADDITIONAL_TEXT_EXTENSIONS` (next to `.json`). One set suffices — `is_text_file` unions all three. This makes `.jsonl` consistent with `.json` on the upload-encoding path (UTF-8 normalization applies) and consistent with its own treatment in `embedding_utils.py` from #2745. Behavior for every other extension is unchanged.

## Tests

`tests/test_upload_utils.py::test_additional_text_extensions` now asserts `is_text_file("data.jsonl") is True`.

Refs #2745, #2744, #2770.
