### PR TITLE
feat(openclaw-plugin): add image preview URLs

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -12,6 +12,7 @@ import {
   resolveRecallSearchPlan,
   type RecallResourceType,
 } from "./registries/recall-resource-types.js";
+import { isPreviewableImageResourceUri, withPreviewUrls } from "./preview-url.js";
 import {
   type RecallTraceEntry,
   type RecallTraceResult,
@@ -99,6 +100,12 @@ export type BuildMemoryLinesOptions = {
 };
 
 function memoryCategory(item: FindResultItem): string {
+  if (item.preview_url && isPreviewableImageResourceUri(item.uri)) {
+    return item.category?.trim() || "resource:image";
+  }
+  if (item.uri.startsWith("viking://resources/")) {
+    return item.category?.trim() || "resource";
+  }
   return item.category?.trim() || "memory";
 }
 
@@ -116,14 +123,18 @@ function formatMemoryLine(
 ): string {
   const category = memoryCategory(item);
   if (!options.includeUri) {
-    return `- [${category}] ${content}`;
+    return [
+      `- [${category}] ${content}`,
+      item.preview_url ? `  <preview_url>${item.preview_url}</preview_url>` : "",
+    ].filter(Boolean).join("\n");
   }
 
   return [
     `- [${category}]`,
     `  <uri>${item.uri}</uri>`,
+    item.preview_url ? `  <preview_url>${item.preview_url}</preview_url>` : "",
     indentContent(content),
-  ].join("\n");
+  ].filter(Boolean).join("\n");
 }
 
 async function resolveMemoryContent(
@@ -212,13 +223,17 @@ export async function buildMemoryLinesWithBudget(
 }
 
 export function buildRecallContextBlock(memoryLines: string[]): string {
+  const previewInstruction = memoryLines.some((line) => line.includes("<preview_url>"))
+    ? "If you reference an image result, copy its exact <preview_url> into the answer; do not invent or rewrite preview URLs."
+    : "";
   return [
     "<relevant-memories>",
     AUTO_RECALL_SOURCE_MARKER,
     "The following OpenViking memories may be relevant:",
+    previewInstruction,
     ...memoryLines,
     "</relevant-memories>",
-  ].join("\n");
+  ].filter(Boolean).join("\n");
 }
 
 function newTraceId(): string {
@@ -482,8 +497,11 @@ export async function buildAutoRecallContext(params: {
         return { memoryCount: 0, estimatedTokens: 0 };
       }
 
+      const memoriesWithPreview = cfg.enableResourcePreviewUrls
+        ? await withPreviewUrls(memories, client, agentId)
+        : memories;
       const { lines: memoryLines, estimatedTokens } = await buildMemoryLinesWithBudget(
-        memories,
+        memoriesWithPreview,
         (uri) => client.read(uri, agentId),
         {
           recallPreferAbstract,
@@ -505,10 +523,10 @@ export async function buildAutoRecallContext(params: {
         `openviking: injecting ${memoryLines.length} memories (${block.length} chars, ~${estimatedTokens} tokens, maxInjectedChars=${maxInjectedChars})`,
       );
       verbose?.(
-        `openviking: inject-detail ${toJsonLog({ count: memories.length, memories: summarizeInjectionMemories(memories) })}`,
+        `openviking: inject-detail ${toJsonLog({ count: memoriesWithPreview.length, memories: summarizeInjectionMemories(memoriesWithPreview) })}`,
       );
 
-      await recordTrace(memories.slice(0, memoryLines.length), memoryLines.length, estimatedTokens);
+      await recordTrace(memoriesWithPreview.slice(0, memoryLines.length), memoryLines.length, estimatedTokens);
       return { block, memoryCount: memoryLines.length, estimatedTokens };
     })(),
     cfg.autoRecallTimeoutMs,

--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -21,6 +21,7 @@ export type FindResultItem = {
   category?: string;
   score?: number;
   match_reason?: string;
+  preview_url?: string;
 };
 
 export type FindResult = {
@@ -28,6 +29,10 @@ export type FindResult = {
   resources?: FindResultItem[];
   skills?: FindResultItem[];
   total?: number;
+};
+
+export type PreviewUrlResult = {
+  preview_url: string;
 };
 
 export type FsListEntry = string | Record<string, unknown>;
@@ -483,6 +488,16 @@ export class OpenVikingClient {
       undefined,
       actorPeerId,
     );
+  }
+
+  async getPreviewUrl(uri: string, actorPeerId?: string): Promise<string> {
+    const result = await this.request<PreviewUrlResult>(
+      `/api/v1/content/preview_url?uri=${encodeURIComponent(uri)}`,
+      {},
+      undefined,
+      actorPeerId,
+    );
+    return result.preview_url;
   }
 
   async list(

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -20,6 +20,8 @@ export type MemoryOpenVikingConfig = {
   autoRecall?: boolean;
   /** Outer time budget for the whole auto-recall flow, including search, ranking, and reads. */
   autoRecallTimeoutMs?: number;
+  /** Hidden switch for temporary preview URLs on recalled image resources. Default false. */
+  enableResourcePreviewUrls?: boolean;
   /** Include resources in auto-recall and default memory_recall search. Default false. */
   recallResources?: boolean;
   recallLimit?: number;
@@ -394,6 +396,7 @@ export const memoryOpenVikingConfigSchema = {
         "captureMaxLength",
         "autoRecall",
         "autoRecallTimeoutMs",
+        "enableResourcePreviewUrls",
         "recallResources",
         "recallLimit",
         "recallScoreThreshold",
@@ -503,6 +506,7 @@ export const memoryOpenVikingConfigSchema = {
         1000,
         Math.min(300_000, Math.floor(toNumber(cfg.autoRecallTimeoutMs, DEFAULT_AUTO_RECALL_TIMEOUT_MS))),
       ),
+      enableResourcePreviewUrls: cfg.enableResourcePreviewUrls === true,
       recallResources,
       recallLimit: Math.max(1, Math.floor(toNumber(cfg.recallLimit, DEFAULT_RECALL_LIMIT))),
       recallScoreThreshold: Math.min(

--- a/examples/openclaw-plugin/install-manifest.json
+++ b/examples/openclaw-plugin/install-manifest.json
@@ -13,6 +13,7 @@
       "context-engine.ts",
       "auto-recall.ts",
       "client.ts",
+      "preview-url.ts",
       "process-manager.ts",
       "memory-ranking.ts",
       "token-estimator.ts",

--- a/examples/openclaw-plugin/plugin/openviking-memory-recall-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-memory-recall-tools.ts
@@ -5,6 +5,7 @@ import type { BuildMemoryLinesWithBudgetOptions } from "../auto-recall.js";
 import type { RankingOptions } from "../memory-ranking.js";
 import type { EffectiveQueryConfig, QueryConfigContext, RuntimeQueryParams } from "../query-config.js";
 import type { RecallResourceType } from "../registries/recall-resource-types.js";
+import { withPreviewUrls } from "../preview-url.js";
 import type {
   RecallTraceEntry,
   RecallTraceResult,
@@ -36,6 +37,7 @@ export type OpenVikingMemoryRecallClient = {
     },
   ) => Promise<FindResult>;
   read: (uri: string, agentId?: string) => Promise<string>;
+  getPreviewUrl?: (uri: string, actorPeerId?: string) => Promise<string>;
   getDefaultAgentId: () => string;
 };
 
@@ -89,6 +91,7 @@ export type OpenVikingMemoryRecallToolsDeps = {
     traceRecallPreviewChars: number;
     traceRecallQueryMaxChars: number;
     logFindRequests: boolean;
+    enableResourcePreviewUrls?: boolean;
   };
   logger: {
     info?: (message: string) => void;
@@ -254,16 +257,22 @@ export function registerOpenVikingMemoryRecallTools(
           };
         }
 
-        const leafOnly = (result.memories ?? []).filter((m) => !m.level || m.level === 2);
+        const leafOnly = [
+          ...(result.memories ?? []),
+          ...(result.resources ?? []),
+        ].filter((m) => !m.level || m.level === 2);
         const processed = deps.postProcessMemories(leafOnly, {
           limit: requestLimit,
           scoreThreshold,
         });
-        const memories = deps.pickMemoriesForInjection(processed, limit, query, scoreThreshold, {
+        const pickedMemories = deps.pickMemoriesForInjection(processed, limit, query, scoreThreshold, {
           weights: queryConfig.rankingWeights,
           categoryWeights: queryConfig.categoryWeights,
           resourceTypeWeights: queryConfig.resourceTypeWeights,
         });
+        const memories = deps.cfg.enableResourcePreviewUrls
+          ? await withPreviewUrls(pickedMemories, recallClient, session.agentId)
+          : pickedMemories;
         const candidateTraceResults = leafOnly
           .map((item) => toTraceResult(item, deps.inferRecallResourceType(item.uri) === "resource" ? "resource" : "memory", deps))
           .slice(0, deps.cfg.traceRecallMaxResultsPerSearch);

--- a/examples/openclaw-plugin/plugin/openviking-query-formatters.ts
+++ b/examples/openclaw-plugin/plugin/openviking-query-formatters.ts
@@ -22,6 +22,7 @@ export function formatOVSearchRows(result: FindResult): string[] {
   if (items.length === 0) {
     return [];
   }
+  const includePreviewUrls = items.some(({ item }) => Boolean(item.preview_url));
   const numberHeader = "no";
   const numberWidth = Math.max(numberHeader.length, String(items.length).length);
   const typeWidth = Math.max("type".length, ...items.map(({ contextType }) => contextType.length));
@@ -31,12 +32,17 @@ export function formatOVSearchRows(result: FindResult): string[] {
     "score".length,
     ...items.map(({ item }) => (typeof item.score === "number" ? item.score.toFixed(2).length : 0)),
   );
+  const previewWidth = includePreviewUrls
+    ? Math.max("preview_url".length, ...items.map(({ item }) => item.preview_url?.length ?? 0))
+    : 0;
+  const previewHeader = includePreviewUrls ? `  ${"preview_url".padEnd(previewWidth)}` : "";
   return [
-    `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}  abstract`,
+    `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}${previewHeader}  abstract`,
     ...items.map(({ contextType, item }, index) => {
       const score = typeof item.score === "number" ? item.score.toFixed(2) : "";
+      const previewColumn = includePreviewUrls ? `  ${(item.preview_url ?? "").padEnd(previewWidth)}` : "";
       const summary = truncateSummary(item.abstract || item.overview || "(no summary)");
-      return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}  ${summary}`;
+      return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}${previewColumn}  ${summary}`;
     }),
   ];
 }

--- a/examples/openclaw-plugin/plugin/openviking-query-runtime.ts
+++ b/examples/openclaw-plugin/plugin/openviking-query-runtime.ts
@@ -1,4 +1,5 @@
 import type { FindResult, FindResultItem, FsListResult } from "../client.js";
+import { withFindResultPreviewUrls } from "../preview-url.js";
 import type { RecallResourceType } from "../registries/recall-resource-types.js";
 import type { RecallTraceEntry, RecallTraceResult } from "../recall-trace.js";
 
@@ -52,6 +53,7 @@ type OpenVikingQueryClient = {
     agentId?: string,
   ) => Promise<FindResult>;
   read: (uri: string, agentId?: string) => Promise<unknown>;
+  getPreviewUrl?: (uri: string, actorPeerId?: string) => Promise<string>;
   list: (
     uri: string,
     options?: { recursive?: boolean; simple?: boolean; nodeLimit?: number },
@@ -77,6 +79,7 @@ export type OpenVikingQueryRuntimeDeps<TQueryConfigContext> = {
     traceRecallMaxResultsPerSearch: number;
     traceRecallPreviewChars: number;
     traceRecallQueryMaxChars: number;
+    enableResourcePreviewUrls?: boolean;
   };
 };
 
@@ -117,6 +120,7 @@ function formatOVSearchRows(result: FindResult): string[] {
   if (items.length === 0) {
     return [];
   }
+  const includePreviewUrls = items.some(({ item }) => Boolean(item.preview_url));
   const numberHeader = "no";
   const numberWidth = Math.max(numberHeader.length, String(items.length).length);
   const typeWidth = Math.max("type".length, ...items.map(({ contextType }) => contextType.length));
@@ -126,12 +130,17 @@ function formatOVSearchRows(result: FindResult): string[] {
     "score".length,
     ...items.map(({ item }) => (typeof item.score === "number" ? item.score.toFixed(2).length : 0)),
   );
+  const previewWidth = includePreviewUrls
+    ? Math.max("preview_url".length, ...items.map(({ item }) => item.preview_url?.length ?? 0))
+    : 0;
+  const previewHeader = includePreviewUrls ? `  ${"preview_url".padEnd(previewWidth)}` : "";
   return [
-    `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}  abstract`,
+    `${numberHeader.padEnd(numberWidth)}  ${"type".padEnd(typeWidth)}  ${"uri".padEnd(uriWidth)}  ${"level".padEnd(levelWidth)}  ${"score".padEnd(scoreWidth)}${previewHeader}  abstract`,
     ...items.map(({ contextType, item }, index) => {
       const score = typeof item.score === "number" ? item.score.toFixed(2) : "";
+      const previewColumn = includePreviewUrls ? `  ${(item.preview_url ?? "").padEnd(previewWidth)}` : "";
       const summary = truncateSummary(item.abstract || item.overview || "(no summary)");
-      return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}  ${summary}`;
+      return `${String(index + 1).padEnd(numberWidth)}  ${contextType.padEnd(typeWidth)}  ${item.uri.padEnd(uriWidth)}  ${String(item.level ?? "").padEnd(levelWidth)}  ${score.padEnd(scoreWidth)}${previewColumn}  ${summary}`;
     }),
   ];
 }
@@ -411,6 +420,9 @@ export function createOpenVikingQueryRuntime<TQueryConfigContext>(deps: OpenViki
         deps.logger.warn?.(`openviking: skill search failed: ${String(skillsSettled.reason)}`);
       }
       result = mergeFindResults(successful);
+    }
+    if (deps.cfg.enableResourcePreviewUrls) {
+      result = await withFindResultPreviewUrls(result, client, agentId);
     }
     const selected = [
       ...(result.memories ?? []).map((item) => ({

--- a/examples/openclaw-plugin/preview-url.ts
+++ b/examples/openclaw-plugin/preview-url.ts
@@ -1,0 +1,68 @@
+import type { FindResult, FindResultItem } from "./client.js";
+
+const IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".gif",
+  ".bmp",
+  ".svg",
+  ".avif",
+]);
+
+export type PreviewUrlClient = {
+  getPreviewUrl?: (uri: string, actorPeerId?: string) => Promise<string>;
+};
+
+export function stripUriFragment(uri: string): string {
+  const hashIndex = uri.indexOf("#");
+  return hashIndex >= 0 ? uri.slice(0, hashIndex) : uri;
+}
+
+export function isPreviewableImageResourceUri(uri: string): boolean {
+  const normalized = stripUriFragment(uri).toLowerCase();
+  if (!normalized.startsWith("viking://resources/")) {
+    return false;
+  }
+  return [...IMAGE_EXTENSIONS].some((ext) => normalized.endsWith(ext));
+}
+
+export async function withPreviewUrls(
+  items: FindResultItem[],
+  client: PreviewUrlClient,
+  actorPeerId?: string,
+): Promise<FindResultItem[]> {
+  const getPreviewUrl = client.getPreviewUrl;
+  if (typeof getPreviewUrl !== "function") {
+    return items;
+  }
+
+  const enriched = await Promise.all(items.map(async (item) => {
+    if (item.preview_url || !isPreviewableImageResourceUri(item.uri)) {
+      return item;
+    }
+    try {
+      const previewUrl = await getPreviewUrl(stripUriFragment(item.uri), actorPeerId);
+      return previewUrl ? { ...item, preview_url: previewUrl } : item;
+    } catch {
+      return item;
+    }
+  }));
+
+  return enriched;
+}
+
+export async function withFindResultPreviewUrls(
+  result: FindResult,
+  client: PreviewUrlClient,
+  actorPeerId?: string,
+): Promise<FindResult> {
+  const resources = result.resources
+    ? await withPreviewUrls(result.resources, client, actorPeerId)
+    : result.resources;
+  return {
+    ...result,
+    resources,
+  };
+}

--- a/examples/openclaw-plugin/setup-helper/install.js
+++ b/examples/openclaw-plugin/setup-helper/install.js
@@ -71,6 +71,7 @@ const FALLBACK_CURRENT = {
     "context-engine.ts",
     "auto-recall.ts",
     "client.ts",
+    "preview-url.ts",
     "process-manager.ts",
     "memory-ranking.ts",
     "text-utils.ts",

--- a/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
+++ b/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
@@ -84,6 +84,52 @@ describe("buildMemoryLines", () => {
     ]);
   });
 
+  it("includes preview_url metadata when present", async () => {
+    const memories = [
+      makeMemory({
+        uri: "viking://resources/gallery/photo.png",
+        category: "",
+        abstract: "A reference photo.",
+        preview_url: "https://tos.example.com/photo.png?sig=1",
+      }),
+    ];
+    const readFn = vi.fn();
+
+    const lines = await buildMemoryLines(memories, readFn, {
+      recallPreferAbstract: true,
+      includeUri: true,
+    });
+
+    expect(lines).toEqual([
+      [
+        "- [resource:image]",
+        "  <uri>viking://resources/gallery/photo.png</uri>",
+        "  <preview_url>https://tos.example.com/photo.png?sig=1</preview_url>",
+        "  A reference photo.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("includes preview_url without uri metadata for explicit recall output", async () => {
+    const memories = [
+      makeMemory({
+        uri: "viking://resources/gallery/photo.jpg",
+        category: "",
+        abstract: "A second reference photo.",
+        preview_url: "https://tos.example.com/photo.jpg?sig=1",
+      }),
+    ];
+    const readFn = vi.fn();
+
+    const lines = await buildMemoryLines(memories, readFn, {
+      recallPreferAbstract: true,
+    });
+
+    expect(lines).toEqual([
+      "- [resource:image] A second reference photo.\n  <preview_url>https://tos.example.com/photo.jpg?sig=1</preview_url>",
+    ]);
+  });
+
   it("uses abstract when recallPreferAbstract=true", async () => {
     const memories = [makeMemory({ abstract: "The abstract text" })];
     const readFn = vi.fn();
@@ -217,6 +263,30 @@ describe("buildMemoryLinesWithBudget", () => {
       {
         recallPreferAbstract: true,
         recallMaxInjectedChars: 20,
+      },
+    );
+
+    expect(lines).toHaveLength(0);
+    expect(estimatedTokens).toBe(0);
+  });
+
+  it("counts preview_url text against the injected character budget", async () => {
+    const memories = [
+      makeMemory({
+        uri: "viking://resources/gallery/too-large.png",
+        abstract: "short",
+        preview_url: "https://tos.example.com/" + "x".repeat(100),
+      }),
+    ];
+    const readFn = vi.fn();
+
+    const { lines, estimatedTokens } = await buildMemoryLinesWithBudget(
+      memories,
+      readFn,
+      {
+        recallPreferAbstract: true,
+        recallMaxInjectedChars: 30,
+        includeUri: true,
       },
     );
 
@@ -452,5 +522,96 @@ describe("buildAutoRecallContext trace", () => {
     });
     expect(recorded.selected[0]).toMatchObject({ injected: true });
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("auto-recall search failed"));
+  });
+
+  it("injects preview_url for auto-recalled image resources", async () => {
+    const cfg = makeCfg({
+      recallTargetTypes: ["resource"],
+      recallPreferAbstract: true,
+      enableResourcePreviewUrls: true,
+    });
+    const image = makeMemory({
+      uri: "viking://resources/gallery/photo.png#chunk-1",
+      category: "",
+      abstract: "Reference product image.",
+      score: 0.9,
+    });
+    const client = {
+      healthCheck: vi.fn().mockResolvedValue(undefined),
+      find: vi.fn().mockResolvedValue({ resources: [image], total: 1 }),
+      read: vi.fn().mockResolvedValue("unused"),
+      getPreviewUrl: vi.fn().mockResolvedValue("https://tos.example.com/photo.png?sig=1"),
+    };
+
+    const result = await buildAutoRecallContext({
+      cfg,
+      client: client as any,
+      agentId: "agent-1",
+      queryText: "show me the product image",
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(client.getPreviewUrl).toHaveBeenCalledWith("viking://resources/gallery/photo.png", "agent-1");
+    expect(result.block).toContain("<preview_url>https://tos.example.com/photo.png?sig=1</preview_url>");
+    expect(result.block).toContain("If you reference an image result");
+  });
+
+  it("does not call preview_url lookup when resource preview urls are disabled", async () => {
+    const cfg = makeCfg({ recallTargetTypes: ["resource"], recallPreferAbstract: true });
+    const image = makeMemory({
+      uri: "viking://resources/gallery/photo.png#chunk-1",
+      category: "",
+      abstract: "Reference product image.",
+      score: 0.9,
+    });
+    const client = {
+      healthCheck: vi.fn().mockResolvedValue(undefined),
+      find: vi.fn().mockResolvedValue({ resources: [image], total: 1 }),
+      read: vi.fn().mockResolvedValue("unused"),
+      getPreviewUrl: vi.fn().mockResolvedValue("https://tos.example.com/photo.png?sig=1"),
+    };
+
+    const result = await buildAutoRecallContext({
+      cfg,
+      client: client as any,
+      agentId: "agent-1",
+      queryText: "show me the product image",
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(client.getPreviewUrl).not.toHaveBeenCalled();
+    expect(result.block).toContain("Reference product image.");
+    expect(result.block).not.toContain("<preview_url>");
+    expect(result.block).not.toContain("If you reference an image result");
+  });
+
+  it("keeps auto-recall injection when preview_url lookup fails", async () => {
+    const cfg = makeCfg({
+      recallTargetTypes: ["resource"],
+      recallPreferAbstract: true,
+      enableResourcePreviewUrls: true,
+    });
+    const image = makeMemory({
+      uri: "viking://resources/gallery/photo.webp",
+      abstract: "Fallback image abstract.",
+      score: 0.9,
+    });
+    const client = {
+      healthCheck: vi.fn().mockResolvedValue(undefined),
+      find: vi.fn().mockResolvedValue({ resources: [image], total: 1 }),
+      read: vi.fn().mockResolvedValue("unused"),
+      getPreviewUrl: vi.fn().mockRejectedValue(new Error("preview unavailable")),
+    };
+
+    const result = await buildAutoRecallContext({
+      cfg,
+      client: client as any,
+      agentId: "agent-1",
+      queryText: "show me the fallback image",
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(result.block).toContain("Fallback image abstract.");
+    expect(result.block).not.toContain("<preview_url>https://");
   });
 });

--- a/examples/openclaw-plugin/tests/ut/client.test.ts
+++ b/examples/openclaw-plugin/tests/ut/client.test.ts
@@ -82,6 +82,35 @@ describe("isMemoryUri", () => {
 });
 
 describe("OpenVikingClient resource and skill import", () => {
+  it("getPreviewUrl requests the content preview URL with plugin auth headers", async () => {
+    const transport = vi.fn().mockResolvedValue(
+      okResponse({ preview_url: "https://tos.example.com/image.png?sig=1" }),
+    );
+
+    const client = new OpenVikingClient("http://127.0.0.1:1933", "sk-user", "agent", 5000, "", "", undefined, false, true, { transport });
+    const result = await client.getPreviewUrl("viking://resources/gallery/image.png#chunk-1", "agent-main");
+
+    expect(result).toBe("https://tos.example.com/image.png?sig=1");
+    expect(transport).toHaveBeenCalledTimes(1);
+    const [url, init] = transport.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:1933/api/v1/content/preview_url?uri=viking%3A%2F%2Fresources%2Fgallery%2Fimage.png%23chunk-1");
+    const headers = new Headers(init.headers);
+    expect(headers.get("X-API-Key")).toBe("sk-user");
+    expect(headers.get("X-OpenViking-Actor-Peer")).toBe("agent-main");
+  });
+
+  it("getPreviewUrl surfaces OpenViking error payloads through the shared request path", async () => {
+    const transport = vi.fn().mockResolvedValue(
+      errorResponse("cannot preview directory", "InvalidParameter"),
+    );
+
+    const client = new OpenVikingClient("http://127.0.0.1:1933", "sk-user", "agent", 5000, "", "", undefined, false, true, { transport });
+
+    await expect(client.getPreviewUrl("viking://resources/gallery/")).rejects.toThrow(
+      "OpenViking request failed [InvalidParameter]: cannot preview directory",
+    );
+  });
+
   it("addResource posts remote URL as path", async () => {
     const transport = vi.fn().mockResolvedValue(
       okResponse({ root_uri: "viking://resources/site", status: "success" }),

--- a/examples/openclaw-plugin/tests/ut/config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/config.test.ts
@@ -23,6 +23,7 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
     expect(cfg.captureMode).toBe("semantic");
     expect(cfg.captureMaxLength).toBe(24000);
     expect(cfg.autoRecallTimeoutMs).toBe(5000);
+    expect(cfg.enableResourcePreviewUrls).toBe(false);
     expect(cfg.recallMaxContentChars).toBe(5000);
     expect(cfg.peer_role).toBe("assistant");
     expect(cfg.peer_prefix).toBe("");
@@ -62,6 +63,14 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
     expect(enabled.enableAddResourceTool).toBe(true);
     expect(enabled.enabledTools).toContain("add_resource");
     expect(enabled.disabledTools).not.toContain("add_resource");
+  });
+
+  it("enables resource preview urls only when explicitly allowed", () => {
+    const disabled = memoryOpenVikingConfigSchema.parse({});
+    expect(disabled.enableResourcePreviewUrls).toBe(false);
+
+    const enabled = memoryOpenVikingConfigSchema.parse({ enableResourcePreviewUrls: true });
+    expect(enabled.enableResourcePreviewUrls).toBe(true);
   });
 
   it("expands enabled and disabled tool groups", () => {

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -292,6 +292,99 @@ describe("plugin module seams", () => {
     expect(readResult.content[0].text).toContain("--- START OF viking://resources/spec.md ---");
   });
 
+  it("adds preview_url to ov_search image resource output", async () => {
+    const find = vi.fn().mockResolvedValue({
+      memories: [],
+      resources: [{
+        uri: "viking://resources/gallery/photo.png#chunk-1",
+        abstract: "Reference image",
+        score: 0.91,
+        category: "image",
+      }],
+      skills: [],
+      total: 1,
+    });
+    const getPreviewUrl = vi.fn().mockResolvedValue("https://tos.example.com/photo.png?sig=1");
+    const runtime = createOpenVikingQueryRuntime({
+      getClient: async () => ({
+        find,
+        read: vi.fn(),
+        list: vi.fn().mockResolvedValue([]),
+        getPreviewUrl,
+      }),
+      queryConfigStore: { getEffective: vi.fn().mockResolvedValue({ ovSearchLimit: 2 }) },
+      toQueryConfigContext: (session) => session,
+      traceRecorder: { recordAndFlush: vi.fn() },
+      inferRecallResourceType: () => "resource",
+      createTraceId: () => "trace-query-preview",
+      boundTraceQuery: (query) => ({ query }),
+      previewText: (value) => typeof value === "string" ? value : undefined,
+      logger: { warn: vi.fn() },
+      cfg: {
+        traceRecallMaxResultsPerSearch: 5,
+        traceRecallPreviewChars: 80,
+        traceRecallQueryMaxChars: 120,
+        enableResourcePreviewUrls: true,
+      },
+    });
+
+    const search = await runtime.searchOpenViking(
+      { query: "photo", uri: "viking://resources/gallery" },
+      "agent-main",
+      { agentId: "agent-main", sessionId: "session-1" },
+    ) as any;
+
+    expect(getPreviewUrl).toHaveBeenCalledWith("viking://resources/gallery/photo.png", "agent-main");
+    expect(search.content[0].text).toContain("https://tos.example.com/photo.png?sig=1");
+    expect(search.details.resources[0].preview_url).toBe("https://tos.example.com/photo.png?sig=1");
+  });
+
+  it("does not fetch preview_url for ov_search when resource preview urls are disabled", async () => {
+    const find = vi.fn().mockResolvedValue({
+      memories: [],
+      resources: [{
+        uri: "viking://resources/gallery/photo.png#chunk-1",
+        abstract: "Reference image",
+        score: 0.91,
+        category: "image",
+      }],
+      skills: [],
+      total: 1,
+    });
+    const getPreviewUrl = vi.fn().mockResolvedValue("https://tos.example.com/photo.png?sig=1");
+    const runtime = createOpenVikingQueryRuntime({
+      getClient: async () => ({
+        find,
+        read: vi.fn(),
+        list: vi.fn().mockResolvedValue([]),
+        getPreviewUrl,
+      }),
+      queryConfigStore: { getEffective: vi.fn().mockResolvedValue({ ovSearchLimit: 2 }) },
+      toQueryConfigContext: (session) => session,
+      traceRecorder: { recordAndFlush: vi.fn() },
+      inferRecallResourceType: () => "resource",
+      createTraceId: () => "trace-query-preview-disabled",
+      boundTraceQuery: (query) => ({ query }),
+      previewText: (value) => typeof value === "string" ? value : undefined,
+      logger: { warn: vi.fn() },
+      cfg: {
+        traceRecallMaxResultsPerSearch: 5,
+        traceRecallPreviewChars: 80,
+        traceRecallQueryMaxChars: 120,
+      },
+    });
+
+    const search = await runtime.searchOpenViking(
+      { query: "photo", uri: "viking://resources/gallery" },
+      "agent-main",
+      { agentId: "agent-main", sessionId: "session-1" },
+    ) as any;
+
+    expect(getPreviewUrl).not.toHaveBeenCalled();
+    expect(search.content[0].text).not.toContain("preview_url");
+    expect(search.details.resources[0].preview_url).toBeUndefined();
+  });
+
   it("handles OpenViking query config commands through a dedicated module", async () => {
     const session = { agentId: "agent-main", sessionId: "session-1", sessionKey: "key-1", ovSessionId: "ov-session-1" };
     const queryCtx = { agentId: "agent-main", sessionId: "session-1", sessionKey: "key-1", ovSessionId: "ov-session-1" };
@@ -1004,5 +1097,83 @@ describe("plugin module seams", () => {
       requestLimit: 4,
       recallMaxInjectedChars: 500,
     });
+  });
+
+  it("adds preview_url to memory_recall image resource lines before formatting", async () => {
+    const registerTool = vi.fn();
+    const image = {
+      uri: "viking://resources/gallery/photo.png#chunk-2",
+      category: "",
+      abstract: "Reference product image.",
+      score: 0.93,
+      level: 2,
+    };
+    const find = vi.fn().mockResolvedValue({ memories: [], resources: [image], total: 1 });
+    const read = vi.fn().mockResolvedValue("Reference product image.");
+    const getPreviewUrl = vi.fn().mockResolvedValue("https://tos.example.com/photo.png?sig=1");
+    const getDefaultAgentId = vi.fn().mockReturnValue("default-agent");
+    const buildMemoryLinesWithBudget = vi.fn(async (items, readFn) => {
+      await readFn(items[0].uri);
+      return {
+        lines: [`- [resource:image] ${items[0].abstract}\n  <preview_url>${items[0].preview_url}</preview_url>`],
+        estimatedTokens: 12,
+      };
+    });
+
+    registerOpenVikingMemoryRecallTools({
+      registerTool,
+      getClient: async () => ({ find, read, getPreviewUrl, getDefaultAgentId }),
+      queryConfigStore: {
+        getEffective: vi.fn().mockResolvedValue({
+          recallLimit: 1,
+          scoreThreshold: 0.5,
+          targetUri: "viking://resources/gallery",
+          resourceTypes: ["resource"],
+          candidateLimit: 4,
+          maxInjectedChars: 500,
+          rankingWeights: {},
+          categoryWeights: {},
+          resourceTypeWeights: {},
+        }),
+      },
+      toQueryConfigContext: (session) => ({ agentId: session.agentId, sessionId: session.sessionId, sessionKey: session.sessionKey, ovSessionId: session.ovSessionId }),
+      resolvePluginSessionRouting: () => ({
+        agentId: "agent-main",
+        sessionId: "session-1",
+        sessionKey: "agent:agent-main:session-1",
+        ovSessionId: "ov-session-1",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
+      resolveRecallSearchPlan: vi.fn(),
+      postProcessMemories: (items) => items,
+      pickMemoriesForInjection: (items) => items.slice(0, 1),
+      buildMemoryLinesWithBudget,
+      inferRecallResourceType: (uri) => uri.startsWith("viking://resources/") ? "resource" : "user",
+      createTraceId: () => "memory_recall-preview-trace",
+      boundTraceQuery: (query) => ({ query }),
+      previewText: (value) => typeof value === "string" ? value : undefined,
+      traceRecorder: { recordAndFlush: vi.fn() },
+      cfg: {
+        recallTargetTypes: ["resource"],
+        traceRecallMaxResultsPerSearch: 5,
+        traceRecallPreviewChars: 120,
+        traceRecallQueryMaxChars: 200,
+        logFindRequests: false,
+        enableResourcePreviewUrls: true,
+      },
+      logger: { info: vi.fn() },
+    });
+
+    const recallFactory = registerTool.mock.calls[0]?.[0];
+    const recallTool = recallFactory({ sessionId: "session-1" });
+    const result = await recallTool.execute("call-1", { query: "product image" });
+
+    expect(getPreviewUrl).toHaveBeenCalledWith("viking://resources/gallery/photo.png", "agent-main");
+    expect(buildMemoryLinesWithBudget.mock.calls[0]![0][0]).toMatchObject({
+      uri: "viking://resources/gallery/photo.png#chunk-2",
+      preview_url: "https://tos.example.com/photo.png?sig=1",
+    });
+    expect(result.content[0].text).toContain("<preview_url>https://tos.example.com/photo.png?sig=1</preview_url>");
   });
 });

--- a/examples/openclaw-plugin/tests/ut/plugin-query-formatters.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-query-formatters.test.ts
@@ -16,7 +16,12 @@ describe("openviking query formatters", () => {
         { uri: "viking://user/memory/1", level: 2, score: 0.987, abstract: "remember this" },
       ],
       resources: [
-        { uri: "viking://resources/doc", score: 0.7, overview: "resource overview" },
+        {
+          uri: "viking://resources/doc",
+          score: 0.7,
+          overview: "resource overview",
+          preview_url: "https://tos.example.com/doc?sig=1",
+        },
       ],
       skills: [
         { uri: "skill://openviking-context-database", abstract: "skill overview" },
@@ -25,12 +30,24 @@ describe("openviking query formatters", () => {
     });
 
     expect(rows[0]).toContain("no  type");
+    expect(rows[0]).toContain("preview_url");
     expect(rows[1]).toContain("memory");
     expect(rows[1]).toContain("viking://user/memory/1");
     expect(rows[1]).toContain("0.99");
     expect(rows[1]).toContain("remember this");
     expect(rows.join("\n")).toContain("resource overview");
+    expect(rows.join("\n")).toContain("https://tos.example.com/doc?sig=1");
     expect(rows.join("\n")).toContain("skill overview");
+  });
+
+  it("omits preview_url column when no search row has a preview url", () => {
+    const rows = formatOVSearchRows({
+      resources: [{ uri: "viking://resources/doc", score: 0.7, overview: "resource overview" }],
+      total: 1,
+    });
+
+    expect(rows[0]).not.toContain("preview_url");
+    expect(rows.join("\n")).toContain("resource overview");
   });
 
   it("formats search text and empty search text", () => {


### PR DESCRIPTION
## Summary
- 为 OpenClaw 插件新增图片资源预览 URL 能力：当召回结果是 `viking://resources/...` 下的图片时，可调用 OpenViking `/api/v1/content/preview_url` 获取临时预览地址。
- 新增隐藏开关 `enableResourcePreviewUrls`，默认 `false`；不开启时不会调用预览接口，也不会在 `ov_search` 表格中显示空的 `preview_url` 列，安装/setup 流程不暴露该配置。
- 覆盖三条输出链路：`auto-recall` 注入上下文、`memory_recall` 工具输出、`ov_search` 表格与 `details.resources[].preview_url`。
- 补齐发布安装清单和 fallback 文件列表，确保新增 `preview-url.ts` 在发布包和远端安装路径中可用。

## 背景

OpenViking 服务新增了内容预览接口：

```http
GET /api/v1/content/preview_url?uri=<OpenViking 文件 URI>
```

成功响应：

```json
{
  "status": "ok",
  "result": {
    "preview_url": "https://tos.example.com/openviking/gallery/photo.png?X-Amz-Signature=***"
  },
  "time": 0.012
}
```

插件侧需要在召回到图片资源时，把该临时预览地址透出给模型或工具调用方。最终回答中是否展示 URL 仍由业务/模型回答层决定；OpenViking 插件只负责把 URL 放到可见上下文或工具输出中。

## 数据结构

### 1. 召回结果项

`FindResultItem` 新增可选字段：

```ts
export type FindResultItem = {
  uri: string;
  level?: number;
  abstract?: string;
  overview?: string;
  content?: string;
  category?: string;
  score?: number;
  match_reason?: string;
  preview_url?: string;
};
```

字段语义：
- `preview_url` 是本次运行临时补充的预览地址。
- 只用于工具输出 / auto-recall 注入上下文。
- 不写入 recall trace，不作为长期记忆或资源元数据持久化。
- 只有 `enableResourcePreviewUrls: true` 且命中图片资源时才会尝试补充。

### 2. 预览接口返回结构

```ts
export type PreviewUrlResult = {
  preview_url: string;
};
```

客户端新增方法：

```ts
async getPreviewUrl(uri: string, actorPeerId?: string): Promise<string>
```

它复用现有 `request()`，因此继续带上 API Key、租户头和 `X-OpenViking-Actor-Peer`。

### 3. 配置结构

`MemoryOpenVikingConfig` 新增隐藏开关：

```ts
export type MemoryOpenVikingConfig = {
  enableResourcePreviewUrls?: boolean;
};
```

默认值：

```json
{
  "enableResourcePreviewUrls": false
}
```

手工开启示例：

```json
{
  "plugins": {
    "entries": {
      "openviking": {
        "config": {
          "mode": "remote",
          "baseUrl": "http://127.0.0.1:1933",
          "apiKey": "${OPENVIKING_API_KEY}",
          "recallTargetTypes": ["resource", "user", "agent"],
          "enableResourcePreviewUrls": true
        }
      }
    }
  }
}
```

该字段没有加入 `uiHints`，因此不会在安装/setup 流程中暴露。

## 处理流程

### auto-recall

代码流程是：

```ts
const memories = pickMemoriesForInjection(processed, recallLimit, queryText, scoreThreshold, ...);

const memoriesWithPreview = cfg.enableResourcePreviewUrls
  ? await withPreviewUrls(memories, client, agentId)
  : memories;

const { lines: memoryLines } = await buildMemoryLinesWithBudget(
  memoriesWithPreview,
  (uri) => client.read(uri, agentId),
  {
    recallPreferAbstract,
    recallMaxInjectedChars: maxInjectedChars,
    includeUri: true,
  },
);

const block = buildRecallContextBlock(memoryLines);
```

`withPreviewUrls()` 的规则：
- 只处理 `viking://resources/` 开头的资源。
- 只处理图片后缀：`.png`、`.jpg`、`.jpeg`、`.webp`、`.gif`、`.bmp`、`.svg`、`.avif`。
- 请求预览 URL 前会去掉 fragment：`viking://resources/gallery/photo.png#chunk-1` 会用 `viking://resources/gallery/photo.png` 请求。
- 预览接口失败时保留原结果，静默降级，不影响召回注入。

### Claw 实际看到的上下文形态

这里不是把 JSON 字段直接给 Claw。`FindResultItem.preview_url` 是插件内部字段，最终会被 `formatMemoryLine()` 渲染成 `<preview_url>...</preview_url>` 文本。

`buildRecallContextBlock(memoryLines)` 实际结构是：

```ts
[
  "<relevant-memories>",
  "Source: openviking-auto-recall",
  "The following OpenViking memories may be relevant:",
  previewInstruction,
  ...memoryLines,
  "</relevant-memories>",
].filter(Boolean).join("\n")
```

因此 topK 多条结果会展开成多条 `memoryLines`。开启预览 URL 且第一条图片成功补到 URL 时，latest user message 前面会 prepend 类似内容：

```text
<relevant-memories>
Source: openviking-auto-recall
The following OpenViking memories may be relevant:
If you reference an image result, copy its exact <preview_url> into the answer; do not invent or rewrite preview URLs.
- [resource:image]
  <uri>viking://resources/gallery/product-card.png#chunk-1</uri>
  <preview_url>https://tos.example.com/openviking/gallery/product-card.png?X-Amz-Signature=***</preview_url>
  Product card screenshot for checkout page.
- [resource]
  <uri>viking://resources/docs/checkout-spec.md#chunk-2</uri>
  Checkout page spec says the product card image should use a 4:3 crop.
- [preferences]
  <uri>viking://user/memories/answer-style</uri>
  User prefers concise Chinese answers with concrete examples.
</relevant-memories>

用户原始问题...
```

不开启 `enableResourcePreviewUrls`，或者没有图片资源成功补到 URL 时，结构保持原样，不会出现提示行和 `<preview_url>`：

```text
<relevant-memories>
Source: openviking-auto-recall
The following OpenViking memories may be relevant:
- [resource]
  <uri>viking://resources/gallery/product-card.png#chunk-1</uri>
  Product card screenshot for checkout page.
- [resource]
  <uri>viking://resources/docs/checkout-spec.md#chunk-2</uri>
  Checkout page spec says the product card image should use a 4:3 crop.
- [preferences]
  <uri>viking://user/memories/answer-style</uri>
  User prefers concise Chinese answers with concrete examples.
</relevant-memories>

用户原始问题...
```

### memory_recall

`memory_recall` 也会在开关开启时对选中的图片资源补 `preview_url`，然后通过 `buildMemoryLinesWithBudget()` 输出。例如：

```text
Found 1 memories:

- [resource:image] Reference product image.
  <preview_url>https://tos.example.com/openviking/gallery/photo.png?X-Amz-Signature=***</preview_url>
```

### ov_search

`ov_search` 在开关开启且资源命中图片 URL 时，会在表格中按需增加 `preview_url` 列，并在结构化 details 中返回：

```ts
result.details.resources[0].preview_url
```

输出示例：

```text
no  type      uri                                           level  score  preview_url                                                           abstract
1   resource  viking://resources/gallery/photo.png#chunk-1         0.91   https://tos.example.com/openviking/gallery/photo.png?X-Amz-Signature=***  Reference image
```

不开启时不会显示空列：

```text
no  type      uri                                           level  score  abstract
1   resource  viking://resources/gallery/photo.png#chunk-1         0.91   Reference image
```

## Test plan
- [x] `npm test -- --run tests/ut/config.test.ts tests/ut/client.test.ts tests/ut/build-memory-lines.test.ts tests/ut/plugin-query-formatters.test.ts tests/ut/plugin-modules.test.ts`
- [x] `npm test -- --run tests/ut/manifest-contracts.test.ts tests/ut/setup-modules.test.ts tests/ut/setup-config-writer.test.ts tests/ut/setup-command.test.ts tests/ut/setup-cli.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `git diff --check`
