### PR TITLE
fix(cli): omit null/empty request fields so older instances accept them

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -7,6 +7,32 @@ pub use crate::base_client::{BaseClient, FileUploader, TimeoutConfig};
 
 use crate::error::{Error, Result};
 
+/// Drop null-valued keys (and an empty `args` object) from a request body before
+/// sending it. Older, stricter servers use `extra="forbid"` and reject any field
+/// they do not yet define, so unconditionally attaching optional fields (even as
+/// `null`/`{}`) breaks against instances that predate that field. Omitting them is
+/// safe for read/create routes where a missing optional field and an explicit
+/// `null` are equivalent — do NOT use this for update/PATCH bodies where `null`
+/// may mean "clear this field".
+fn compact_request_body(body: &mut Value) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    obj.retain(|key, value| {
+        if value.is_null() {
+            return false;
+        }
+        // `args` is always attached by the CLI but absent from pre-#2549 models;
+        // only forward it when the caller actually provided arguments.
+        if key == "args" {
+            if let Some(map) = value.as_object() {
+                return !map.is_empty();
+            }
+        }
+        true
+    });
+}
+
 // ============ HttpClient ============
 
 /// High-level HTTP client for OpenViking API
@@ -441,6 +467,7 @@ impl HttpClient {
             "tags": tags,
         });
         self.attach_legacy_agent_scope(&mut body);
+        compact_request_body(&mut body);
         self.post("/api/v1/search/find", &body).await
     }
 
@@ -472,6 +499,7 @@ impl HttpClient {
             "tags": tags,
         });
         self.attach_legacy_agent_scope(&mut body);
+        compact_request_body(&mut body);
         self.post("/api/v1/search/search", &body).await
     }
 
@@ -558,6 +586,7 @@ impl HttpClient {
                     .expect("add_resource request body must be an object")
                     .insert("create_parent".to_string(), serde_json::Value::Bool(true));
             }
+            compact_request_body(&mut body);
             body
         };
 
@@ -1431,6 +1460,37 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::sync::oneshot;
+
+    #[test]
+    fn compact_request_body_drops_null_and_empty_args() {
+        let mut body = json!({
+            "query": "hi",
+            "score_threshold": null,
+            "tags": null,
+            "args": {},
+            "wait": false,
+            "create_parent": true,
+            "filter": {"k": "v"},
+        });
+        super::compact_request_body(&mut body);
+        let obj = body.as_object().unwrap();
+        // Non-null values are kept, including `false` and non-empty objects.
+        assert!(obj.contains_key("query"));
+        assert!(obj.contains_key("wait"));
+        assert!(obj.contains_key("create_parent"));
+        assert!(obj.contains_key("filter"));
+        // Null fields and an empty `args` are dropped so pre-field servers accept it.
+        assert!(!obj.contains_key("score_threshold"));
+        assert!(!obj.contains_key("tags"));
+        assert!(!obj.contains_key("args"));
+    }
+
+    #[test]
+    fn compact_request_body_keeps_non_empty_args() {
+        let mut body = json!({"path": "x", "args": {"feishu_access_token": "u-x"}});
+        super::compact_request_body(&mut body);
+        assert!(body.as_object().unwrap().contains_key("args"));
+    }
 
     #[test]
     fn timeout_config_calculation() {

--- a/crates/ov_cli/src/error_classifier.rs
+++ b/crates/ov_cli/src/error_classifier.rs
@@ -9,9 +9,51 @@ pub(crate) fn looks_like_auth_error(message: &str) -> bool {
             .any(|token| token == "auth")
 }
 
+/// Detect the kernel's pydantic `extra="forbid"` rejection — e.g.
+/// "body.tags: Extra inputs are not permitted" — and return the offending field
+/// name. This usually means the target OpenViking instance is on a different
+/// version than the CLI (the field is missing, renamed, or removed), so callers
+/// can surface a version-mismatch hint instead of the raw API error.
+pub(crate) fn extra_forbidden_field(message: &str) -> Option<String> {
+    if !message.contains("Extra inputs are not permitted") {
+        return None;
+    }
+    // The kernel reports the location as `body.<field>: Extra inputs ...`.
+    let after = message.split("body.").nth(1)?;
+    let field = after
+        .split(|ch: char| ch == ':' || ch.is_whitespace())
+        .next()?
+        .trim();
+    if field.is_empty() {
+        None
+    } else {
+        Some(field.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::looks_like_auth_error;
+    use super::{extra_forbidden_field, looks_like_auth_error};
+
+    #[test]
+    fn extracts_extra_forbidden_field() {
+        assert_eq!(
+            extra_forbidden_field(
+                "[INVALID_ARGUMENT] Invalid request parameters: body.tags: Extra inputs are not permitted."
+            ),
+            Some("tags".to_string())
+        );
+        assert_eq!(
+            extra_forbidden_field("body.args: Extra inputs are not permitted"),
+            Some("args".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_non_extra_forbidden_errors() {
+        assert_eq!(extra_forbidden_field("API key is invalid"), None);
+        assert_eq!(extra_forbidden_field("body.query: Field required"), None);
+    }
 
     #[test]
     fn detects_auth_errors() {

--- a/crates/ov_cli/src/error_ui.rs
+++ b/crates/ov_cli/src/error_ui.rs
@@ -5,7 +5,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     error::Error,
-    error_classifier::looks_like_auth_error,
+    error_classifier::{extra_forbidden_field, looks_like_auth_error},
     i18n::{Language, copy},
     terminal_ui::{fit_to_display_width, truncate_to_display_width},
     theme,
@@ -241,6 +241,27 @@ pub(crate) fn report_for_runtime_error(command: impl Into<String>, error: &Error
             ErrorAction::new("ov config", copy(language, "Edit this config", "编辑这个配置")),
             ErrorAction::new("ov config switch", copy(language, "Use another config", "使用其他配置")),
         ]),
+        Error::Api { message, .. } if extra_forbidden_field(message).is_some() => {
+            let field = extra_forbidden_field(message).unwrap_or_default();
+            ErrorReport::new(
+                copy(language, "OpenViking API Error", "OpenViking API 错误"),
+                match language {
+                    Language::En => format!(
+                        "OpenViking rejected an unsupported field \"{field}\". This instance's version likely does not match your CLI (the field may be missing, renamed, or removed)."
+                    ),
+                    Language::ZhCn => format!(
+                        "OpenViking 拒绝了不支持的字段 \"{field}\"：该实例版本可能与当前 CLI 不匹配（字段可能缺失、改名或已被移除）。"
+                    ),
+                },
+            )
+            .with_command(command)
+            .with_detail(message)
+            .with_actions(vec![
+                ErrorAction::new("ov health", copy(language, "Check the instance version", "查看实例版本")),
+                ErrorAction::new("ov config validate", copy(language, "Check the active config", "检查当前配置")),
+                ErrorAction::new("ov status", copy(language, "Check OpenViking status", "查看 OpenViking 状态")),
+            ])
+        }
         Error::Api { message, .. } => ErrorReport::new(
             copy(language, "OpenViking API Error", "OpenViking API 错误"),
             api_error_message(language, message),


### PR DESCRIPTION
## Summary

The CLI unconditionally attaches optional fields to the `find` / `search` / `add_resource` request bodies — `args` as an empty `{}`, and `tags` / `context_type` as `null` — even when the user never set them. Because OpenViking kernels declare `model_config = ConfigDict(extra="forbid")` on these routes, any instance that predates a given field rejects the entire request with `body.<field>: Extra inputs are not permitted`. This patch stops sending those empty/null fields, and turns the raw rejection into an actionable hint when a field really is set but unsupported.

## Problem

The breakage is purely a field-set mismatch on `extra="forbid"` routes: the set of fields the CLI sends must be a subset of the fields the target instance's model defines. It is not strictly "CLI newer than server" — it bites in both directions (newer CLI sending a not-yet-added field, or older CLI still sending a field the kernel later renamed/removed).

Concrete cases observed against the Volcengine endpoint (same gateway, different instance versions selected by API key):

- `ov add-resource <url>` against a pre-#2549 instance → `body.args: Extra inputs are not permitted` (kernel model has no `args` field; the route has been `extra="forbid"` since #1012). The user never passed `--args`; the CLI sends `args: {}` regardless.
- `ov find <query>` against a strict pre-#2706 instance → `body.tags: Extra inputs are not permitted` (FindRequest became `extra="forbid"` in #2594 but the `tags` field only landed in #2706). The user never passed `--tags`; the CLI sends `tags: null` regardless.

## Fix

- Add `compact_request_body()` and apply it in `find` / `search` / `add_resource`: drop null-valued keys and an empty `args` object right before sending. Scoped to these read/create routes only, where a missing optional field and an explicit `null` are equivalent — deliberately **not** applied globally in `post`, since `null` may carry "clear this field" semantics on a future update/PATCH route. This generalizes the backward-compat convention already used for `create_parent`.
- When a field is explicitly set but the instance does not support it, detect the pydantic `Extra inputs are not permitted` rejection (`extra_forbidden_field`) and render a version-mismatch hint instead of the opaque API error, plus an `ov health` action to check the instance version.

## Verification

- New unit tests: `compact_request_body_drops_null_and_empty_args`, `compact_request_body_keeps_non_empty_args`, `extracts_extra_forbidden_field`, `ignores_non_extra_forbidden_errors` — all pass.
- `cargo test -p ov_cli --bins`: all tests pass except one pre-existing failure (`help_ui … missing clap command set-tags`) that is unrelated to this change and reproduces on `main` with this patch stashed.
- End-to-end: a debug build of the patched CLI now returns results for `ov find` against an instance that previously failed with `body.tags: Extra inputs are not permitted`.
