### PR TITLE
fix(storage): preserve glob result URI scheme

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -993,12 +993,11 @@ class VikingFS:
     ) -> Dict:
         """File pattern matching, supports **/*.md recursive."""
         entries = await self.tree(uri, node_limit=1000000, level_limit=None, ctx=ctx)
-        base_uri = uri.rstrip("/")
         matches = []
         for entry in entries:
             rel_path = entry.get("rel_path", "")
             if PurePath(rel_path).match(pattern):
-                matches.append(f"{base_uri}/{rel_path}")
+                matches.append(entry["uri"])
         # Now apply node limit to the filtered matches
         if node_limit is not None and node_limit > 0:
             matches = matches[:node_limit]


### PR DESCRIPTION
## Description

Fix `glob` result URI formatting when the query scope is the root `viking://` URI. The implementation now reuses the URI already produced by `tree()` instead of rebuilding it from `uri.rstrip("/")` and `rel_path`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Reuse `entry["uri"]` from `tree()` for glob matches.
- Remove manual `base_uri = uri.rstrip("/")` URI reconstruction.
- Preserve existing canonical and legacy alias URI handling for glob results.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Not run; change is a minimal URI formatting fix and no test was requested.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This fixes the `viking:/...` output caused by stripping the trailing slashes from the root `viking://` URI before concatenating a relative path.
