### PR TITLE
fix: fallback to range content for empty event summaries

### DIFF
--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -283,12 +283,16 @@ class ExtractContext:
                     continue
         return datetime.now().strftime("%Y%m%d%H%M%S")
 
-    def get_event_content(self, ranges_str: str, summary: str, ratio_threshold: float = 0.2) -> str:
+    def get_event_content(
+        self, ranges_str: str, summary: str | None, ratio_threshold: float = 0.2
+    ) -> str:
         """根据原始消息与 summary 的字符数比例，决定返回原始消息还是摘要。"""
-        if not ranges_str or not summary:
+        if not ranges_str:
             return summary or ""
         msg_range = self.read_message_ranges(ranges_str)
         original = msg_range.pretty_print()
+        if not summary or not summary.strip():
+            return original or ""
         if not original:
             return summary
         if len(summary) / len(original) >= ratio_threshold:

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -139,6 +139,22 @@ class TestMemoryUpdater:
         assert "Resource abstract" not in content
         assert "User reason" not in content
 
+    def test_extract_context_event_content_falls_back_to_range_when_summary_empty(self):
+        extract_context = ExtractContext(
+            messages=[
+                Message(
+                    id="1",
+                    role="user",
+                    parts=[TextPart(text="Gina can expand her clothing store now.")],
+                    created_at="2023-02-01T00:48:00",
+                )
+            ]
+        )
+
+        content = extract_context.get_event_content("0", "")
+
+        assert "Gina can expand her clothing store now." in content
+
     def test_create(self):
         """Test creating a MemoryUpdater."""
         updater = MemoryUpdater()


### PR DESCRIPTION
## Summary
- fall back to the event range ChatLog when an event summary is empty
- add regression coverage for empty event summary rendering

## Testing
- python -m pytest tests/session/memory/test_memory_updater.py -q
- python -m ruff check openviking/session/memory/memory_updater.py tests/session/memory/test_memory_updater.py
- python -m ruff format --check openviking/session/memory/memory_updater.py tests/session/memory/test_memory_updater.py