### PR TITLE
fix: opencode plugin npm publish auth fallback

### DIFF
--- a/.github/workflows/opencode-plugin-release.yml
+++ b/.github/workflows/opencode-plugin-release.yml
@@ -70,10 +70,11 @@ jobs:
       - name: Publish package
         if: steps.published.outputs.exists == 'false'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "::error::Missing NPM_TOKEN secret for npm publish."
-            exit 1
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          else
+            echo "::notice::NPM_TOKEN is not set; npm publish will use Trusted Publishing/OIDC. For first-time packages, publish once with an npm token or configure npm trusted publishing after the package exists."
           fi
           npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Fixes the `OpenCode Plugin Release` workflow so it no longer fails before publish when the repository does not define `NPM_TOKEN`.

Root cause: the failed push run `28101628146` reached `Publish package`, then exited because the step set `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN` and the secret is not present in this repository. The package is still not published on npm.

## Changes

- Use an optional `NPM_TOKEN` env var instead of overriding `NODE_AUTH_TOKEN`.
- If `NPM_TOKEN` exists, write it to npm auth config for token-based publishing.
- If it is absent, continue with npm Trusted Publishing/OIDC and emit a notice explaining the first-publish requirement.

## Validation

From `examples/opencode-plugin`:

- `npm run check`
- `npm test`
- `npm pack --dry-run`

Note: local dependency install emitted an engine warning because this machine is on Node `25.8.2`; the workflow uses Node `24`, which satisfies the dependency engine range.
