### PR TITLE
fix(embedding): restore image_vectorization config field accidentally removed in #2468

### DIFF
--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -633,6 +633,17 @@ class EmbeddingConfig(BaseModel):
         default="content_only",
         description="Text source for file vectorization: summary_first|summary_only|content_only",
     )
+    image_vectorization: str = Field(
+        default="summary_only",
+        description=(
+            "How IMAGE files are vectorized: "
+            "'summary_only' embeds only the generated text summary (text embedding); "
+            "'image_only' sends the image itself to a multimodal embedder; "
+            "'image_and_summary' sends both the image and its text summary together. "
+            "'image_only' and 'image_and_summary' require a multimodal-capable embedder "
+            "(e.g. Volcengine with input='multimodal')."
+        ),
+    )
     max_input_tokens: int = Field(
         default=4096,
         ge=100,
@@ -680,6 +691,11 @@ class EmbeddingConfig(BaseModel):
         if self.text_source not in {"summary_first", "summary_only", "content_only"}:
             raise ValueError(
                 "embedding.text_source must be one of: summary_first, summary_only, content_only"
+            )
+        if self.image_vectorization not in {"summary_only", "image_only", "image_and_summary"}:
+            raise ValueError(
+                "embedding.image_vectorization must be one of: "
+                "summary_only, image_only, image_and_summary"
             )
         return self
 

--- a/tests/unit/test_embedding_vectorize_strategy.py
+++ b/tests/unit/test_embedding_vectorize_strategy.py
@@ -52,3 +52,32 @@ def test_embedding_runtime_config_includes_max_input_tokens():
 def test_embedding_max_input_tokens_validation_rejects_too_small_value():
     with pytest.raises(ValueError):
         _cfg(max_input_tokens=10)
+
+
+# image_vectorization
+#
+# Regression: PR #2460 added an `image_vectorization` config field that selects
+# between `summary_only` (text-only embedding of the VLM summary), `image_only`
+# (multimodal embedding of the image bytes), and `image_and_summary` (both).
+# The field was inadvertently dropped from EmbeddingConfig during the
+# multi-credential refactor in PR #2468, but the consumer in
+# `openviking/utils/embedding_utils.py` still reads it via getattr — meaning
+# the feature became unreachable in user configs (always defaulting to
+# summary_only). These tests pin the field back in place.
+
+
+def test_embedding_image_vectorization_validation_accepts_supported_values():
+    for value in ["summary_only", "image_only", "image_and_summary"]:
+        cfg = _cfg(image_vectorization=value)
+        assert cfg.image_vectorization == value
+
+
+def test_embedding_image_vectorization_defaults_to_summary_only():
+    cfg = _cfg()
+    assert cfg.image_vectorization == "summary_only"
+
+
+@pytest.mark.parametrize("bad_value", ["image", "summary", "both", "auto", ""])
+def test_embedding_image_vectorization_validation_rejects_invalid_values(bad_value):
+    with pytest.raises(ValueError, match="embedding.image_vectorization"):
+        _cfg(image_vectorization=bad_value)


### PR DESCRIPTION
## Description

PR #2460 added `embedding.image_vectorization` to let operators choose between three image vectorization strategies:

- `summary_only` (default) — embed only the VLM-generated text summary
- `image_only` — send the image itself to a multimodal embedder
- `image_and_summary` — send both together

The multi-credential refactor in PR #2468 **inadvertently dropped the `image_vectorization` field from `EmbeddingConfig`**, but did not remove the consumer in `openviking/utils/embedding_utils.py`:

```python
# openviking/utils/embedding_utils.py:393
image_vectorization = getattr(embedding_cfg, "image_vectorization", "summary_only")
# ...
elif content_type == ResourceContentType.IMAGE and image_vectorization in {"image_only", "image_and_summary"}:
    context.set_vectorize(Vectorize(text=text, images=[image_uri]))
```

Because `EmbeddingConfig` is `model_config = {"extra": "forbid"}`, users can no longer set this in `ov.conf` — pydantic rejects it. And `getattr` silently falls back to `"summary_only"`, so the `image_only` / `image_and_summary` code paths in `vectorize_file` became permanently unreachable for any user config.

Net effect: anyone using a multimodal-capable embedder (e.g. Volcengine with `input='multimodal'`) loses the ability to actually feed image bytes into the embedder. Image resources end up indexed by their VLM-generated text summary only, defeating the purpose of having a multimodal embedder configured.

PR #2468's body and "Changes Made" section do not mention removing `image_vectorization`, so this appears to be unintentional collateral damage from the EmbeddingConfig refactor rather than a deliberate deprecation.

## Related Issue

- Original feature: #2460 (feat: 计算图片embed向量时支持图文embed)
- Regression introduced by: #2468 (feat: implement multi-credential priority call design)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking_cli/utils/config/embedding_config.py` — restore the `image_vectorization: str = Field(default="summary_only", ...)` declaration on `EmbeddingConfig`, with the identical description and validator clause as PR #2460. No semantic change to consumer code.
- `tests/unit/test_embedding_vectorize_strategy.py` — add three regression tests covering the default, the accepted values (`summary_only|image_only|image_and_summary`), and rejection of invalid values. These pin the field in the schema so a future refactor can't drop it silently again.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Local verification:

```bash
$ python -m py_compile openviking_cli/utils/config/embedding_config.py tests/unit/test_embedding_vectorize_strategy.py
syntax OK

# Module-level smoke test (pydantic validation):
# - default: image_vectorization == "summary_only"  ✓
# - accepts: summary_only / image_only / image_and_summary  ✓
# - rejects: "image" / "summary" / "both" / ""  with "embedding.image_vectorization" in error message  ✓
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (the `embedding.image_vectorization` config option is documented inline via the Field `description`; no other doc references this field yet)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The diff is intentionally small (a literal restoration plus tests) so it is easy to verify against the original PR #2460. Open to splitting the regression tests into a separate PR if reviewers prefer.

If the maintainers do want to phase out `image_vectorization` entirely, the consumer in `openviking/utils/embedding_utils.py:393` should also be removed as a follow-up. Right now the asymmetry between the schema (field absent) and the consumer (`getattr` with default) is a foot-gun for anyone trying to enable multimodal image embedding.