### PR TITLE
fix(cli): remove unrelated HTTP compat shim

### DIFF
--- a/openviking_cli/client/_http_compat.py
+++ b/openviking_cli/client/_http_compat.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict
 
 from openviking_cli._sdk_import import import_openviking_sdk
 from openviking_cli.exceptions import (
@@ -54,38 +54,6 @@ ERROR_CODE_TO_EXCEPTION = {
 }
 
 
-class _CompatHTTPObserver:
-    def __init__(self, client: "AsyncHTTPClient"):
-        self._client = client
-
-    @property
-    def queue(self) -> Dict[str, Any]:
-        from openviking_cli.utils import run_async
-
-        return run_async(self._client._get_queue_status())
-
-    @property
-    def vikingdb(self) -> Dict[str, Any]:
-        from openviking_cli.utils import run_async
-
-        return run_async(self._client._get_vikingdb_status())
-
-    @property
-    def models(self) -> Dict[str, Any]:
-        from openviking_cli.utils import run_async
-
-        return run_async(self._client._get_models_status())
-
-    @property
-    def system(self) -> Dict[str, Any]:
-        from openviking_cli.utils import run_async
-
-        return run_async(self._client._get_system_status())
-
-    def is_healthy(self) -> bool:
-        return self.system.get("is_healthy", False)
-
-
 def _raise_legacy_exception(error: Dict[str, Any]) -> None:
     code = error.get("code", "UNKNOWN")
     message = error.get("message", "Unknown error")
@@ -118,144 +86,8 @@ def _raise_legacy_exception(error: Dict[str, Any]) -> None:
 
 
 class AsyncHTTPClient(import_openviking_sdk().AsyncHTTPClient):
-    def __init__(self, *args, **kwargs):
-        sdk = import_openviking_sdk()
-        legacy_agent_id = kwargs.get("agent_id")
-        if legacy_agent_id is None and kwargs.get("actor_peer_id") is None:
-            try:
-                cli_config = sdk.config.load_ovcli_config()
-            except ValueError:
-                cli_config = None
-            if cli_config is not None:
-                legacy_agent_id = getattr(cli_config, "agent_id", None)
-        super().__init__(*args, **kwargs)
-        self._legacy_agent_id = legacy_agent_id
-
     def _raise_exception(self, error: Dict[str, Any]) -> None:
         _raise_legacy_exception(error)
-
-    async def initialize(self) -> None:
-        headers: Dict[str, str] = {}
-        if self._api_key:
-            headers["X-API-Key"] = self._api_key
-        if self._account:
-            headers["X-OpenViking-Account"] = self._account
-        if self._user_id:
-            headers["X-OpenViking-User"] = self._user_id
-        if self._actor_peer_id:
-            headers["X-OpenViking-Actor-Peer"] = self._actor_peer_id
-        headers.update(self._extra_headers)
-
-        from openviking_cli.client import http as legacy_http_module
-
-        self._http = legacy_http_module.httpx.AsyncClient(
-            base_url=self._url,
-            headers=headers,
-            timeout=self._timeout,
-            params={"profile": "1"} if self._profile_enabled else None,
-        )
-        self._observer = _CompatHTTPObserver(self)
-
-    @staticmethod
-    def _normalize_context_type(value: Optional[Any]) -> Optional[Any]:
-        if isinstance(value, list):
-            return [getattr(item, "value", item) for item in value]
-        return getattr(value, "value", value)
-
-    def _attach_legacy_agent_id(self, payload: Dict[str, Any]) -> None:
-        if self._legacy_agent_id:
-            payload["agent_id"] = self._legacy_agent_id
-
-    async def find(
-        self,
-        query: str,
-        target_uri: Union[str, List[str]] = "",
-        limit: int = 10,
-        node_limit: Optional[int] = None,
-        score_threshold: Optional[float] = None,
-        filter: Optional[Dict[str, Any]] = None,
-        context_type: Optional[Any] = None,
-        tags: Optional[List[str]] = None,
-        telemetry: Any = False,
-    ) -> Dict[str, Any]:
-        actual_limit = node_limit if node_limit is not None else limit
-        payload = {
-            "query": query,
-            "target_uri": self._normalize_target_uri(target_uri),
-            "limit": actual_limit,
-            "score_threshold": score_threshold,
-            "filter": filter,
-            "context_type": self._normalize_context_type(context_type),
-            "telemetry": telemetry,
-        }
-        if tags is not None:
-            payload["tags"] = tags
-        self._attach_legacy_agent_id(payload)
-        response = await self._http.post("/api/v1/search/find", json=payload)
-        return self._handle_response_data(response).get("result", {})
-
-    async def search(
-        self,
-        query: str,
-        target_uri: Union[str, List[str]] = "",
-        session: Optional[Any] = None,
-        session_id: Optional[str] = None,
-        limit: int = 10,
-        node_limit: Optional[int] = None,
-        score_threshold: Optional[float] = None,
-        filter: Optional[Dict[str, Any]] = None,
-        context_type: Optional[Any] = None,
-        tags: Optional[List[str]] = None,
-        telemetry: Any = False,
-    ) -> Dict[str, Any]:
-        actual_limit = node_limit if node_limit is not None else limit
-        sid = session_id or (session.session_id if session else None)
-        payload = {
-            "query": query,
-            "target_uri": self._normalize_target_uri(target_uri),
-            "session_id": sid,
-            "limit": actual_limit,
-            "score_threshold": score_threshold,
-            "filter": filter,
-            "context_type": self._normalize_context_type(context_type),
-            "telemetry": telemetry,
-        }
-        if tags is not None:
-            payload["tags"] = tags
-        self._attach_legacy_agent_id(payload)
-        response = await self._http.post("/api/v1/search/search", json=payload)
-        return self._handle_response_data(response).get("result", {})
-
-    async def add_message(
-        self,
-        session_id: str,
-        role: str,
-        content: str | None = None,
-        parts: list[dict] | None = None,
-        created_at: str | None = None,
-        peer_id: str | None = None,
-        telemetry: Any = False,
-    ) -> Dict[str, Any]:
-        if self._legacy_agent_id and peer_id is not None:
-            raise InvalidArgumentError("peer_id cannot be used with legacy agent_id")
-        payload: Dict[str, Any] = {"role": role}
-        if parts is not None:
-            payload["parts"] = parts
-        elif content is not None:
-            payload["content"] = content
-        else:
-            raise ValueError("Either content or parts must be provided")
-        if created_at is not None:
-            payload["created_at"] = created_at
-        if peer_id is not None:
-            payload["peer_id"] = peer_id
-        if self._legacy_agent_id and role == "assistant":
-            payload["agent_id"] = self._legacy_agent_id
-        if telemetry is not False:
-            payload["telemetry"] = telemetry
-        session_path = self._path_segment(session_id)
-        response = await self._http.post(f"/api/v1/sessions/{session_path}/messages", json=payload)
-        return self._handle_response_data(response).get("result", {})
 
 
 class SyncHTTPClient(import_openviking_sdk().SyncHTTPClient):

--- a/sdk/python/openviking_sdk/config.py
+++ b/sdk/python/openviking_sdk/config.py
@@ -123,10 +123,7 @@ def load_ovcli_config(config_path: Optional[str] = None) -> Optional[OVCLIConfig
         }
         unknown_keys = sorted(set(data) - allowed_keys)
         if unknown_keys:
-            message = f"Unknown field 'ovcli.{unknown_keys[0]}'"
-            if unknown_keys[0] == "ur":
-                message += ". Did you mean 'ovcli.url'?"
-            raise ValueError(message)
+            raise ValueError(f"Unknown field 'ovcli.{unknown_keys[0]}'")
 
         extra_header_alias = data.get("extra_header")
         extra_headers_value = data.get("extra_headers", extra_header_alias)


### PR DESCRIPTION
## Description

Remove follow-up scope creep from the VikingDB grep/BM25 integration by dropping unrelated legacy HTTP compatibility behavior and SDK config typo guidance.

## Related Issue

Follow-up to #2144

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Remove the legacy HTTP observer compatibility shim added to `_http_compat.py`.
- Remove legacy `find` / `search` / `add_message` request rewriting and `agent_id` injection from the HTTP compatibility layer.
- Revert unrelated `ovcli.ur` typo guidance in the standalone SDK config loader.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `git diff --check`
- `python -m compileall -q openviking_cli/client/_http_compat.py sdk/python/openviking_sdk/config.py`

Note: targeted pytest was not run because the local environment does not have `pytest` installed (`No module named pytest`).

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Pure formatting changes from #2144 were intentionally kept. `User-Agent: openviking/<version>` on VikingDB requests was also kept after review.
