### PR TITLE
fix(semantic): recover from expired handoff for exact-path locks

### DIFF
--- a/openviking/storage/queuefs/semantic_lock.py
+++ b/openviking/storage/queuefs/semantic_lock.py
@@ -15,23 +15,54 @@ from openviking.storage.transaction import (
     OwnedLockLease,
     get_lock_manager,
 )
+from openviking.storage.internal_names import MULTIWRITE_EXACT_LOCK_FILE_PREFIX
 from openviking.storage.transaction.path_lock import LOCK_FILE_NAME
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 _TREE_LOCK_SUFFIX = f"/{LOCK_FILE_NAME}"
+_EXACT_LOCK_TOKEN = f"/{MULTIWRITE_EXACT_LOCK_FILE_PREFIX}"
 
 
-def _tree_paths_from_handoff(lock_paths: Iterable[str]) -> list[str]:
+def _recoverable_tree_paths(lock_paths: Iterable[str]) -> list[str]:
+    """Map handoff lock paths back to tree paths the worker can re-lock.
+
+    The recovery path only knows ``acquire_tree`` / ``acquire_tree_batch``, so we
+    must translate every entry in ``lock_paths`` into a directory path:
+
+    - Tree-lock entries (``{dir}/.path.ovlock``): strip the suffix to recover ``{dir}``.
+    - Exact-path-lock entries (``{dir}/.exact.ovlock.{name}.{digest}``): use the
+      parent ``{dir}`` as a tree-lock target. This widens the lock from a single
+      file to its containing directory, which is a strict superset and safe for
+      semantic processing (the worker only needs visibility into the subtree).
+      Without this branch, messages enqueued with ``acquire_exact_path`` lose
+      all recovery options when the original ``LockHandle`` expires, causing the
+      semantic queue to spin re-enqueueing the same messages forever (the
+      classifier in ``semantic_processor`` treats ``LockAcquisitionError`` as
+      retryable, with no max-attempts).
+
+    Unknown / unrecognized entries are skipped. Returns deduped, order-preserved.
+    """
     tree_paths: list[str] = []
     for lock_path in lock_paths:
-        if not lock_path.endswith(_TREE_LOCK_SUFFIX):
-            continue
-        tree_path = lock_path[: -len(_TREE_LOCK_SUFFIX)] or "/"
-        if tree_path not in tree_paths:
+        tree_path: Optional[str] = None
+        if lock_path.endswith(_TREE_LOCK_SUFFIX):
+            tree_path = lock_path[: -len(_TREE_LOCK_SUFFIX)] or "/"
+        else:
+            idx = lock_path.rfind(_EXACT_LOCK_TOKEN)
+            # Skip lock paths that don't match either known pattern, or that
+            # would collapse to root (idx == 0 means the file is at root, which
+            # would acquire a tree lock over the whole namespace — never desired).
+            if idx > 0:
+                tree_path = lock_path[:idx]
+        if tree_path and tree_path not in tree_paths:
             tree_paths.append(tree_path)
     return tree_paths
+
+
+# Backwards-compat alias for callers that imported the old name.
+_tree_paths_from_handoff = _recoverable_tree_paths
 
 
 @dataclass
@@ -58,7 +89,7 @@ class SemanticLockScope:
             try:
                 return cls(await OwnedLockLease.from_handoff(lock_handoff, manager=manager))
             except LockAcquisitionError as exc:
-                tree_paths = _tree_paths_from_handoff(lock_handoff.lock_paths)
+                tree_paths = _recoverable_tree_paths(lock_handoff.lock_paths)
                 if not tree_paths:
                     raise
 

--- a/tests/storage/test_semantic_lock_path_recovery.py
+++ b/tests/storage/test_semantic_lock_path_recovery.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for SemanticLockScope recovery from expired handoffs.
+
+When a semantic message's original ``LockHandle`` expires (e.g. the request
+context that issued the resource ingest returned before the worker dequeued),
+``OwnedLockLease.from_handoff`` raises ``LockAcquisitionError``. The fallback
+path in ``SemanticLockScope.resolve`` re-acquires locks for the paths recorded
+in ``LockHandoffRef.lock_paths``.
+
+Historically that fallback only recognised TREE-lock entries (suffix
+``/.path.ovlock``). Messages whose original locks were EXACT-path locks
+(``acquire_exact_path``) had no recoverable paths, so the fallback re-raised
+and ``semantic_processor`` infinitely re-enqueued the same message — a
+production-visible dead-loop for callers that ingest individual files instead
+of whole directories.
+
+These tests pin the recovery behaviour for both lock styles so the regression
+can't return.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openviking.storage.errors import LockAcquisitionError
+from openviking.storage.queuefs.semantic_lock import (
+    SemanticLockScope,
+    _recoverable_tree_paths,
+)
+from openviking.storage.transaction import LockHandoffRef
+
+
+# ---------------------------------------------------------------------------
+# _recoverable_tree_paths
+# ---------------------------------------------------------------------------
+
+
+def test_recoverable_tree_paths_preserves_tree_lock_entries():
+    """Tree-lock entries are unchanged: suffix stripped to get the directory."""
+    paths = _recoverable_tree_paths(
+        [
+            "/a/dir/.path.ovlock",
+            "/another/dir/.path.ovlock",
+        ]
+    )
+    assert paths == ["/a/dir", "/another/dir"]
+
+
+def test_recoverable_tree_paths_widens_exact_lock_to_parent_dir():
+    """Exact-path locks recover via the parent directory as a tree lock.
+
+    This is the regression fix: before, exact-path lock entries were silently
+    dropped, leaving the worker no recoverable paths.
+    """
+    paths = _recoverable_tree_paths(
+        [
+            "/tenant/products/sku1/.exact.ovlock..abstract.md.abc123",
+            "/tenant/products/sku1/.exact.ovlock..detail.md.def456",
+        ]
+    )
+    # Both files share the same parent directory; we dedupe.
+    assert paths == ["/tenant/products/sku1"]
+
+
+def test_recoverable_tree_paths_handles_mixed_tree_and_exact_locks():
+    paths = _recoverable_tree_paths(
+        [
+            "/tenant/products/sku1/.path.ovlock",
+            "/tenant/products/sku2/.exact.ovlock.meta.json.xyz",
+        ]
+    )
+    assert paths == ["/tenant/products/sku1", "/tenant/products/sku2"]
+
+
+def test_recoverable_tree_paths_dedupes_and_preserves_order():
+    paths = _recoverable_tree_paths(
+        [
+            "/dir-a/.path.ovlock",
+            "/dir-b/.exact.ovlock.x.1",
+            "/dir-a/.exact.ovlock.y.2",  # duplicates /dir-a from first entry
+            "/dir-b/.path.ovlock",  # duplicates /dir-b from second entry
+        ]
+    )
+    assert paths == ["/dir-a", "/dir-b"]
+
+
+def test_recoverable_tree_paths_skips_unrecognized_entries():
+    """Anything that's neither a tree-lock suffix nor a recognizable exact-lock
+    name is skipped — we must not invent locks out of arbitrary strings."""
+    paths = _recoverable_tree_paths(
+        [
+            "",
+            "/just/a/file/path",  # no lock-file marker at all
+            "/dir/.path.ovlock",
+            "/dir2/.exact.ovlock.real.lock",
+        ]
+    )
+    assert paths == ["/dir", "/dir2"]
+
+
+def test_recoverable_tree_paths_refuses_to_collapse_to_root():
+    """An exact-lock entry whose file lives at the root (no parent dir) must
+    NOT be widened to ``/``: that would re-lock the whole namespace."""
+    paths = _recoverable_tree_paths(["/.exact.ovlock.toplevel.123"])
+    assert paths == []
+
+
+def test_recoverable_tree_paths_returns_empty_for_empty_input():
+    assert _recoverable_tree_paths([]) == []
+
+
+def test_recoverable_tree_paths_legacy_alias_still_works():
+    """Some callers may have imported the original ``_tree_paths_from_handoff``
+    name. Keep it as an alias to avoid breakage."""
+    from openviking.storage.queuefs.semantic_lock import _tree_paths_from_handoff
+
+    assert _tree_paths_from_handoff == _recoverable_tree_paths
+
+
+# ---------------------------------------------------------------------------
+# SemanticLockScope.resolve recovery integration
+# ---------------------------------------------------------------------------
+
+
+class _FakeHandle:
+    def __init__(self, handle_id: str, locks=()):
+        self.id = handle_id
+        self.locks = list(locks)
+
+
+class _FakeLockManager:
+    """Minimal lock manager: ``from_handoff`` always fails so we exercise the
+    recovery path. ``acquire_tree`` records what the recovery tried."""
+
+    def __init__(self):
+        self.created_handles: list[_FakeHandle] = []
+        self.acquire_tree_calls: list[str] = []
+        self.acquire_tree_batch_calls: list[list[str]] = []
+        self.released: list[str] = []
+
+    def create_handle(self):
+        handle = _FakeHandle(f"recovered-{len(self.created_handles)}")
+        self.created_handles.append(handle)
+        return handle
+
+    async def acquire_tree(self, handle, path, timeout=None):
+        del timeout
+        self.acquire_tree_calls.append(path)
+        handle.locks.append(f"{path}/.path.ovlock")
+        return True
+
+    async def acquire_tree_batch(self, handle, paths, timeout=None):
+        del timeout
+        self.acquire_tree_batch_calls.append(list(paths))
+        for p in paths:
+            handle.locks.append(f"{p}/.path.ovlock")
+        return True
+
+    async def release(self, handle):
+        self.released.append(handle.id)
+
+
+async def _failing_from_handoff(*args, **kwargs):  # noqa: D401 - test stub
+    del args, kwargs
+    raise LockAcquisitionError("Lock handle is no longer active: stub")
+
+
+@pytest.mark.asyncio
+async def test_resolve_recovers_from_exact_path_lock_handoff(monkeypatch):
+    """End-to-end: a handoff containing ONLY exact-path locks recovers by
+    re-acquiring the parent directory as a tree lock. Pre-fix this raised
+    LockAcquisitionError and the worker dead-looped."""
+    manager = _FakeLockManager()
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_lock.get_lock_manager",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_lock.OwnedLockLease.from_handoff",
+        _failing_from_handoff,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_lock.OwnedLockLease.from_handle",
+        lambda mgr, handle: object(),  # opaque sentinel — we only check the manager calls
+    )
+
+    handoff = LockHandoffRef(
+        handle_id="dead-handle",
+        lock_paths=(
+            "/tenant/products/sku1/.exact.ovlock..abstract.md.abc",
+            "/tenant/products/sku1/.exact.ovlock..detail.md.def",
+        ),
+    )
+    scope = await SemanticLockScope.resolve(handoff)
+
+    assert scope is not None
+    # Both exact locks collapse to the same parent dir → single acquire_tree call.
+    assert manager.acquire_tree_calls == ["/tenant/products/sku1"]
+    assert manager.acquire_tree_batch_calls == []
+    assert manager.released == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_still_raises_when_no_recoverable_paths(monkeypatch):
+    """If the handoff carries no recoverable paths, the original failure must
+    surface — we don't swallow LockAcquisitionError silently."""
+    manager = _FakeLockManager()
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_lock.get_lock_manager",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_lock.OwnedLockLease.from_handoff",
+        _failing_from_handoff,
+    )
+
+    handoff = LockHandoffRef(
+        handle_id="dead-handle",
+        lock_paths=("/just/some/file",),  # no lock-file pattern at all
+    )
+
+    with pytest.raises(LockAcquisitionError):
+        await SemanticLockScope.resolve(handoff)
+
+    assert manager.acquire_tree_calls == []
+    assert manager.acquire_tree_batch_calls == []


### PR DESCRIPTION
## Description

`SemanticLockScope.resolve` fails to recover from an expired `LockHandle` when the original message was enqueued under an EXACT-path lock (via `acquire_exact_path` / `acquire_exact_path_batch`). The recovery helper only inspected entries ending in `/.path.ovlock` (the TREE-lock marker). Exact-lock entries (file names beginning with `.exact.ovlock.`) were silently filtered out, the recovery list ended up empty, the fallback re-raised, and `semantic_processor.on_dequeue` re-enqueued the message **forever** — `LockAcquisitionError` is classified as retryable with no max-attempts.

### Repro / symptom

We hit this on a production deployment where an external service (a Gateway) ingests product assets one file at a time:

```ts
for each (file in product) {
  POST /api/v1/resources/temp_upload   // multipart
  POST /api/v1/resources                // { temp_file_id, to, wait: false }
}
```

The request handler holds an exact-path lock for each `/resources` call. Because `wait: false` returns to the client as soon as the message is queued, the LockHandle is released before the semantic worker dequeues. From that point on:

```
WARNING - Lock error processing semantic message, re-enqueueing without tripping
API circuit breaker: Lock handle is no longer active: e652fdda-...
  File "openviking/storage/queuefs/semantic_processor.py", line 367, in on_dequeue
    semantic_lock = await SemanticLockScope.resolve(...)
  File "openviking/storage/queuefs/semantic_lock.py", line 59, in resolve
```

…repeats indefinitely. Embedding worker is starved because the Semantic backlog never drains. Visible at the database layer as `Semantic / pending` count that drifts up and never down.

This only affects callers that submit per-file (path-lock) writes; the typical directory-ingest path (`add_resource` with `path=<git URL>` / local directory) uses tree locks and recovers correctly.

## Related Issue

Found while exercising the multimodal-image-embedding feature restored in #2820, but is independent of that PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking/storage/queuefs/semantic_lock.py`:
  - Rename `_tree_paths_from_handoff` → `_recoverable_tree_paths`. The old name is kept as a module-level alias so any external importer keeps working.
  - Accept EXACT-lock entries (`{dir}/.exact.ovlock.{name}.{digest}`): map them to the parent directory and treat as a tree-lock fallback. This widens the lock from a single file to its containing directory — a strict superset of the original exact lock and safe for semantic processing (the worker only needs visibility into the subtree).
  - Deliberately refuse to collapse to root: an exact-lock entry whose file lives at the root (`/.exact.ovlock.…`) is **not** recovered, to avoid acquiring a tree lock over the entire namespace.

- `tests/storage/test_semantic_lock_path_recovery.py` (new):
  - Unit-level: tree-only, exact-only, mixed, dedupe + order preservation, unknown-entry skip, root-collapse refusal, empty input, legacy alias.
  - Integration via `SemanticLockScope.resolve` with a stubbed lock manager: handoff containing ONLY exact-path locks now successfully re-acquires a parent-directory tree lock (no more `LockAcquisitionError`). Handoff with no recoverable paths still raises (regression guard against silently swallowing the failure).

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Local verification:

```bash
$ python -m py_compile openviking/storage/queuefs/semantic_lock.py tests/storage/test_semantic_lock_path_recovery.py
# (clean)

# Standalone smoke against the function logic (no OV deps):
# - tree-only inputs preserved (suffix stripped to directory) ✓
# - exact-only inputs widen to parent directory ✓
# - mixed inputs handled together ✓
# - duplicates de-duped, order preserved ✓
# - unknown / empty / root-collapse entries skipped ✓
```

End-to-end: after applying this fix in a runtime patch on our staging OV instance, the Semantic queue drains normally even when the upstream caller uses per-file `wait:false` POSTs.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (the behaviour is now correctly described inline; no user-facing docs reference this internal helper)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The widened lock is intentionally coarser than the original `acquire_exact_path`. We could instead re-acquire individual exact-path locks (which would require extending the recovery branch with `acquire_exact_path_batch`), but that would also require teaching `_recoverable_tree_paths` to return either tree-target or exact-target paths and threading that distinction into the `acquire_tree*` call site. Going with tree-on-parent keeps the diff minimal and the semantics safe — happy to extend to fine-grained recovery if reviewers prefer.

The classifier in `semantic_processor.on_dequeue` that re-enqueues `LockAcquisitionError` without retry-bound is left untouched here. It's worth a separate look (likely warrants a max-attempts threshold + a poison-message queue) but that's a behaviour change rather than a regression fix.