### PR TITLE
session: filter unchanged memory diff updates

### DIFF
--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -17,7 +17,7 @@ from openviking.message import Message
 from openviking.server.identity import RequestContext
 from openviking.session.memory import ExtractLoop, MemoryUpdater
 from openviking.session.memory.constants import EXECUTION_MEMORY_TYPES
-from openviking.session.memory.dataclass import ResolvedOperations, StoredLink
+from openviking.session.memory.dataclass import MemoryFile, ResolvedOperations, StoredLink
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import (
     MemoryUpdateResult,
@@ -1168,14 +1168,43 @@ class SessionCompressorV2:
                 }
             )
 
-        # Read new content for adds and updates
-        for item in adds + updates:
+        # Read new content for adds and updates.
+        # Some upsert operations can be reported as successful even when the
+        # final file body is identical to the pre-existing content (for
+        # example, a no-op merge/patch or a write that only re-serializes the
+        # same memory). memory_diff.json should only include effective content
+        # changes, so filter no-op updates after the final content is known.
+        effective_adds = []
+        for item in adds:
             try:
                 content = await viking_fs.read_file(uri=item["uri"], ctx=ctx)
                 mf = MemoryFileUtils.read(content)
                 item["after"] = mf.content
             except Exception:
                 pass
+            effective_adds.append(item)
+
+        effective_updates = []
+        for item in updates:
+            op = upsert_by_uri.get(item["uri"])
+            old_file = op.old_memory_file_content if op else None
+            new_file = None
+            try:
+                content = await viking_fs.read_file(uri=item["uri"], ctx=ctx)
+                new_file = MemoryFileUtils.read(content, uri=item["uri"])
+                item["after"] = new_file.content
+            except Exception:
+                pass
+            if old_file is not None and self._same_memory_file(old_file, new_file):
+                logger.info(
+                    "Skipping unchanged memory file in memory_diff.json: %s",
+                    item.get("uri"),
+                )
+                continue
+            effective_updates.append(item)
+
+        adds = effective_adds
+        updates = effective_updates
 
         return {
             "archive_uri": archive_uri,
@@ -1191,6 +1220,18 @@ class SessionCompressorV2:
                 "total_deletes": len(deletes),
             },
         }
+
+    @staticmethod
+    def _same_memory_file(before: Optional[MemoryFile], after: Optional[MemoryFile]) -> bool:
+        """Return whether two parsed memory files represent the same stored memory."""
+        if before is None or after is None:
+            return False
+        # memory_type is commonly known from the operation/URI even when the raw
+        # memory file does not serialize it, so do not treat that metadata-only
+        # representation difference as a real file update.
+        return before.model_dump(exclude={"uri", "memory_type"}) == after.model_dump(
+            exclude={"uri", "memory_type"}
+        )
 
     def _get_memory_type_from_uri(self, uri: str) -> str:
         """Extract memory type from URI.

--- a/tests/session/memory/test_memory_diff.py
+++ b/tests/session/memory/test_memory_diff.py
@@ -214,6 +214,190 @@ class TestMemoryDiffArchive:
         assert "New content" in update["after"]
 
     @pytest.mark.asyncio
+    async def test_build_memory_diff_skips_unchanged_update(
+        self, compressor, mock_viking_fs, mock_ctx
+    ):
+        """Unchanged existing files should not be included as memory diff updates."""
+        uri = "memory/user/test/identity.md"
+        result = MemoryUpdateResult()
+        result.edited_uris = [uri]
+
+        old_mf = MemoryFile(
+            uri=uri,
+            content="# Identity\n\nSame identity content",
+            memory_type="identity",
+        )
+        operation = ResolvedOperation(
+            uris=[uri],
+            memory_type="identity",
+            memory_fields={},
+            old_memory_file_content=old_mf,
+        )
+        operations = ResolvedOperations(
+            upsert_operations=[operation],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        mock_viking_fs.read_file = AsyncMock(return_value="# Identity\n\nSame identity content")
+
+        diff = await compressor._build_memory_diff(
+            result=result,
+            operations=operations,
+            viking_fs=mock_viking_fs,
+            ctx=mock_ctx,
+        )
+
+        assert diff["operations"]["updates"] == []
+        assert diff["summary"]["total_updates"] == 0
+
+    @pytest.mark.asyncio
+    async def test_build_memory_diff_skips_unchanged_written_existing_file(
+        self, compressor, mock_viking_fs, mock_ctx
+    ):
+        """Existing files reported via written_uris are also filtered when unchanged."""
+        uri = "memory/user/test/identity.md"
+        result = MemoryUpdateResult()
+        result.written_uris = [uri]
+
+        old_mf = MemoryFile(
+            uri=uri,
+            content="Same identity content",
+            memory_type="identity",
+            extra_fields={"name": "same"},
+        )
+        operation = ResolvedOperation(
+            uris=[uri],
+            memory_type="identity",
+            memory_fields={},
+            old_memory_file_content=old_mf,
+        )
+        operations = ResolvedOperations(
+            upsert_operations=[operation],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        mock_viking_fs.read_file = AsyncMock(
+            return_value=(
+                'Same identity content\n\n<!-- MEMORY_FIELDS\n{"memory_type":"identity","name":"same"}\n-->'
+            )
+        )
+
+        diff = await compressor._build_memory_diff(
+            result=result,
+            operations=operations,
+            viking_fs=mock_viking_fs,
+            ctx=mock_ctx,
+        )
+
+        assert diff["operations"]["updates"] == []
+        assert diff["summary"]["total_updates"] == 0
+
+    @pytest.mark.asyncio
+    async def test_build_memory_diff_keeps_changed_update_with_unchanged_sibling(
+        self, compressor, mock_viking_fs, mock_ctx
+    ):
+        """Only unchanged files are filtered when a diff has mixed update results."""
+        unchanged_uri = "memory/user/test/identity.md"
+        changed_uri = "memory/user/test/preferences.md"
+        result = MemoryUpdateResult()
+        result.edited_uris = [unchanged_uri, changed_uri]
+
+        unchanged_old = MemoryFile(
+            uri=unchanged_uri,
+            content="Same identity content",
+            memory_type="identity",
+        )
+        changed_old = MemoryFile(
+            uri=changed_uri,
+            content="Old preference content",
+            memory_type="preferences",
+        )
+        operations = ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    uris=[unchanged_uri],
+                    memory_type="identity",
+                    memory_fields={},
+                    old_memory_file_content=unchanged_old,
+                ),
+                ResolvedOperation(
+                    uris=[changed_uri],
+                    memory_type="preferences",
+                    memory_fields={},
+                    old_memory_file_content=changed_old,
+                ),
+            ],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        async def mock_read(uri, ctx=None):
+            if uri == unchanged_uri:
+                return "Same identity content"
+            if uri == changed_uri:
+                return "New preference content"
+            raise AssertionError(f"unexpected uri: {uri}")
+
+        mock_viking_fs.read_file.side_effect = mock_read
+
+        diff = await compressor._build_memory_diff(
+            result=result,
+            operations=operations,
+            viking_fs=mock_viking_fs,
+            ctx=mock_ctx,
+        )
+
+        assert diff["summary"]["total_updates"] == 1
+        assert [item["uri"] for item in diff["operations"]["updates"]] == [changed_uri]
+        assert diff["operations"]["updates"][0]["before"] == "Old preference content"
+        assert diff["operations"]["updates"][0]["after"] == "New preference content"
+
+    @pytest.mark.asyncio
+    async def test_build_memory_diff_keeps_metadata_only_update(
+        self, compressor, mock_viking_fs, mock_ctx
+    ):
+        """A file with metadata changes is still an effective memory update."""
+        uri = "memory/user/test/identity.md"
+        result = MemoryUpdateResult()
+        result.edited_uris = [uri]
+
+        old_mf = MemoryFile(
+            uri=uri,
+            content="Same identity content",
+            memory_type="identity",
+            extra_fields={"name": "old"},
+        )
+        operation = ResolvedOperation(
+            uris=[uri],
+            memory_type="identity",
+            memory_fields={},
+            old_memory_file_content=old_mf,
+        )
+        operations = ResolvedOperations(
+            upsert_operations=[operation],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        mock_viking_fs.read_file = AsyncMock(
+            return_value=(
+                'Same identity content\n\n<!-- MEMORY_FIELDS\n{"memory_type":"identity","name":"new"}\n-->'
+            )
+        )
+
+        diff = await compressor._build_memory_diff(
+            result=result,
+            operations=operations,
+            viking_fs=mock_viking_fs,
+            ctx=mock_ctx,
+        )
+
+        assert diff["summary"]["total_updates"] == 1
+        assert diff["operations"]["updates"][0]["uri"] == uri
+
+    @pytest.mark.asyncio
     async def test_build_memory_diff_mixed(self, compressor, mock_viking_fs, mock_ctx):
         """Test building memory_diff with mixed operations."""
         # Setup: one file exists (update), one doesn't (add)


### PR DESCRIPTION
## Summary
- filter no-op memory update entries out of `memory_diff.json`
- compare parsed before/after memory files after reading final content
- add regression coverage for unchanged edited/written updates, mixed updates, and metadata-only updates

## Test Plan
- `PYTHONPATH=$PWD pytest tests/session/memory/test_memory_diff.py -q --no-cov --confcutdir=tests/session/memory`
- `ruff check openviking/session/compressor_v2.py tests/session/memory/test_memory_diff.py`
- `ruff format --check openviking/session/compressor_v2.py tests/session/memory/test_memory_diff.py`
- `git diff --check`
