### PR TITLE
fix(session): avoid 'None' segments in event URIs for empty ranges

### DIFF
--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -223,29 +223,35 @@ class ExtractContext:
         msg_range = self.read_message_ranges(ranges_str)
         return msg_range._first_message_time_with_weekday()
 
-    def get_year(self, ranges_str: str) -> str | None:
-        """根据 ranges 字符串获取第一条消息的年份"""
-        if not ranges_str:
-            return None
-        msg_range = self.read_message_ranges(ranges_str)
-        first_time = msg_range._first_message_time()
-        return first_time.split("-")[0] if first_time else None
+    def _first_message_date_or_now(self, ranges_str: str) -> str:
+        """根据 ranges 获取第一条消息的日期（YYYY-MM-DD），用于 events URI 分段。
+        Return the first message's date (YYYY-MM-DD) for the events URI segments.
 
-    def get_month(self, ranges_str: str) -> str | None:
-        """根据 ranges 字符串获取第一条消息的月份"""
-        if not ranges_str:
-            return None
-        msg_range = self.read_message_ranges(ranges_str)
-        first_time = msg_range._first_message_time()
-        return first_time.split("-")[1] if first_time else None
+        Fallback 到 datetime.now() 以保证 year/month/day 段总是非空，避免渲染出
+        .../events/None/None/None/... 这样的无效 URI（Jinja2 会把 None 渲染成字面量 "None"）。
+        Falls back to datetime.now() so the year/month/day segments are never empty;
+        otherwise the URI renders as .../events/None/None/None/... because Jinja2
+        prints None as the literal string "None".
+        """
+        from datetime import datetime
 
-    def get_day(self, ranges_str: str) -> str | None:
-        """根据 ranges 字符串获取第一条消息的日期"""
-        if not ranges_str:
-            return None
-        msg_range = self.read_message_ranges(ranges_str)
-        first_time = msg_range._first_message_time()
-        return first_time.split("-")[2] if first_time else None
+        if ranges_str:
+            first_time = self.read_message_ranges(ranges_str)._first_message_time()
+            if first_time:
+                return first_time
+        return datetime.now().strftime("%Y-%m-%d")
+
+    def get_year(self, ranges_str: str) -> str:
+        """根据 ranges 字符串获取第一条消息的年份 / First message's year from ranges."""
+        return self._first_message_date_or_now(ranges_str).split("-")[0]
+
+    def get_month(self, ranges_str: str) -> str:
+        """根据 ranges 字符串获取第一条消息的月份 / First message's month from ranges."""
+        return self._first_message_date_or_now(ranges_str).split("-")[1]
+
+    def get_day(self, ranges_str: str) -> str:
+        """根据 ranges 字符串获取第一条消息的日期 / First message's day from ranges."""
+        return self._first_message_date_or_now(ranges_str).split("-")[2]
 
     def get_timestamp_from_ranges(self, ranges_str: str) -> str:
         """根据 ranges 获取第一条消息的紧凑时间戳（YYYYMMDDHHMMSS），用于文件名去重。

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -155,6 +155,35 @@ class TestMemoryUpdater:
 
         assert "Gina can expand her clothing store now." in content
 
+    def test_extract_context_event_date_uses_first_message_time(self):
+        extract_context = ExtractContext(
+            messages=[
+                Message(
+                    id="1",
+                    role="user",
+                    parts=[TextPart(text="hi")],
+                    created_at="2026-04-17T01:26:14.481Z",
+                )
+            ]
+        )
+
+        assert extract_context.get_year("0") == "2026"
+        assert extract_context.get_month("0") == "04"
+        assert extract_context.get_day("0") == "17"
+
+    def test_extract_context_event_date_falls_back_to_now_without_ranges(self):
+        from datetime import datetime
+
+        extract_context = ExtractContext(
+            messages=[Message(id="1", role="user", parts=[TextPart(text="hi")])]
+        )
+
+        now = datetime.now()
+        # Empty/missing ranges must never render the literal "None" into the URI.
+        assert extract_context.get_year("") == str(now.year)
+        assert extract_context.get_month("") == f"{now.month:02d}"
+        assert extract_context.get_day("") == f"{now.day:02d}"
+
     def test_create(self):
         """Test creating a MemoryUpdater."""
         updater = MemoryUpdater()


### PR DESCRIPTION
## Description

`ExtractContext.get_year`/`get_month`/`get_day` returned `None` when `ranges`
was empty or unresolvable, so Jinja rendered the events `filename_template` as
`.../events/None/None/None/<event>.md`. These malformed URIs pollute storage
and break `recent` retrieval, which walks `YYYY` year directories.

Fall back to `datetime.now()` — the same strategy already used by
`get_timestamp_from_ranges` — so the year/month/day URI segments are always
valid. The shared `_first_message_date_or_now` helper keeps the three accessors
in sync.

## Related Issue

Fixes #2809

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `ExtractContext._first_message_date_or_now()`, which returns the first message's `YYYY-MM-DD` date and falls back to `datetime.now()` when `ranges` is empty or carries no resolvable timestamp.
- Route `get_year` / `get_month` / `get_day` through the helper and tighten their return type from `str | None` to `str`, so an event URI never contains a literal `None` segment.
- Add regression coverage for the populated-range and empty-range paths in `tests/session/memory/test_memory_updater.py`.

## Testing

```
pytest tests/session/memory/test_memory_updater.py tests/session/memory/test_memory_timestamp_parsing.py
# 44 passed

ruff check openviking/session/memory/memory_updater.py tests/session/memory/test_memory_updater.py
ruff format --check openviking/session/memory/memory_updater.py tests/session/memory/test_memory_updater.py
```

I also rendered the events `filename_template` with empty `ranges` and confirmed it now
produces `2026/06/25/<event>.md` instead of `None/None/None/<event>.md`.

Note: a few unrelated tests elsewhere in `tests/session/memory/` fail in my local
environment (locally-built RAGFS binding on Python 3.14); they reproduce on `main`
without this change, so they are pre-existing and not introduced here.

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (the two touched test files pass 44/44; pre-existing unrelated failures noted above)
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A (no documented behavior changes)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published — N/A (no dependent changes)

## Screenshots (if applicable)

N/A — backend change.

## Additional Notes

The fix mirrors the existing `get_timestamp_from_ranges` fallback so behavior stays
consistent across the timestamp helpers, and the `_first_message_date_or_now` helper
avoids triplicating the fallback while keeping the year/month/day segments derived
from a single date.
