### PR TITLE
docs(config): note legacy VikingDB grep fallback after schema upgrade

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -902,6 +902,8 @@ Grep engine configuration for content pattern search. These settings are server-
 
 For VikingDB / Volcengine FullText grep, OpenViking writes a `content` text field for BM25 recall. The source context keeps the full content, while the vector-store write payload truncates this field to **1 MB** at the final adapter boundary to stay within backend payload limits.
 
+Legacy VikingDB collections created before the `content` FullText field was added still start normally. With `engine: "auto"`, OpenViking logs the schema mismatch and falls back to local filesystem search until the collection is recreated with the current schema.
+
 ### storage
 
 Storage configuration for context data, including file storage (RAGFS) and vector database storage (VectorDB).

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -873,6 +873,8 @@ Grep 引擎配置，用于内容模式搜索。这些设置为服务端配置，
 
 对于 VikingDB / Volcengine FullText grep，OpenViking 会写入 `content` text 字段用于 BM25 召回。源上下文中保留完整内容，仅在最终写入向量库 adapter payload 时将该字段截断到 **1 MB**，以满足后端 payload 限制。
 
+在加入 `content` FullText 字段之前创建的旧 VikingDB collection 仍会正常启动。使用 `engine: "auto"` 时，OpenViking 会记录 schema 不匹配并回退到本地文件系统搜索；如需恢复 VikingDB BM25 召回，需要用当前 schema 重新创建该 collection。
+
 ### storage
 
 用于存储上下文数据 ，包括文件存储（RAGFS）和向量库存储（VectorDB）。


### PR DESCRIPTION
Follow-up to #2835.

That change keeps legacy VikingDB collections usable when they were created before the `content` FullText field existed: OpenViking logs the schema mismatch and `engine: "auto"` falls back to local filesystem search instead of blocking startup.

This adds the upgrade behavior to the existing `storage.grep` section in both EN and ZH docs, so operators know why BM25 recall is unavailable and that recreating the collection with the current schema restores VikingDB grep.

Docs-only change; source checked against `openviking/storage/collection_schemas.py`.
