### PR TITLE
feat: filter stale vector hits from retrieval

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1895,6 +1895,7 @@ class VikingFS:
             resources=resources,
             skills=skills,
         )
+        await self._drop_stale_retrieval_hits(find_result, real_ctx)
         telemetry.set("vector.returned", find_result.total)
         return find_result
 
@@ -2025,8 +2026,65 @@ class VikingFS:
             query_plan=query_plan,
             query_results=query_results,
         )
+        await self._drop_stale_retrieval_hits(find_result, real_ctx)
         telemetry.set("vector.returned", find_result.total)
         return find_result
+
+    async def _drop_stale_retrieval_hits(
+        self,
+        find_result: Any,
+        ctx: RequestContext,
+    ) -> None:
+        """Drop retrieval hits whose backing AGFS content is gone, and clean their vectors."""
+        vector_store = self._get_vector_store()
+        checked: Dict[tuple[str, str], bool] = {}
+        sidecars = {0: ".abstract.md", 1: ".overview.md"}
+
+        async def _is_live(match: Any) -> bool:
+            uri = str(getattr(match, "uri", "") or "")
+            if not uri:
+                return True
+
+            check_uri = vector_uri = uri if uri.endswith("://") else uri.rstrip("/")
+            sidecar = sidecars.get(getattr(match, "level", 2))
+            if sidecar:
+                suffix = f"/{sidecar}"
+                vector_uri = check_uri.removesuffix(suffix)
+                check_uri = uri if uri.endswith(suffix) else f"{vector_uri}{suffix}"
+
+            key = (check_uri, vector_uri)
+            if key in checked:
+                return checked[key]
+
+            try:
+                await self.stat(check_uri, ctx=ctx, skip_count=True)
+                checked[key] = True
+            except Exception as exc:
+                if not is_not_found_error(exc):
+                    logger.debug("[VikingFS] stale-hit check skipped for %s: %s", check_uri, exc)
+                    checked[key] = True
+                else:
+                    checked[key] = False
+                    if vector_store:
+                        try:
+                            await vector_store.delete_uris(ctx, [vector_uri])
+                        except Exception as delete_exc:
+                            logger.debug(
+                                "[VikingFS] stale-vector cleanup failed for %s: %s",
+                                vector_uri,
+                                delete_exc,
+                            )
+            return checked[key]
+
+        async def _filter(contexts: List[Any]) -> List[Any]:
+            return [match for match in contexts if await _is_live(match)]
+
+        for attr in ("memories", "resources", "skills"):
+            setattr(find_result, attr, await _filter(getattr(find_result, attr)))
+        if find_result.query_results:
+            for query_result in find_result.query_results:
+                query_result.matched_contexts = await _filter(query_result.matched_contexts)
+        find_result.total = sum(len(getattr(find_result, attr)) for attr in ("memories", "resources", "skills"))
 
     # ========== Relation Management ==========
 

--- a/tests/storage/test_viking_fs_stale_retrieval.py
+++ b/tests/storage/test_viking_fs_stale_retrieval.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import NotFoundError
+from openviking_cli.retrieve.types import (
+    ContextType,
+    FindResult,
+    MatchedContext,
+    QueryResult,
+    TypedQuery,
+)
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _DummyAgfs:
+    pass
+
+
+class _FakeVectorStore:
+    def __init__(self, *, fail_delete: bool = False):
+        self.fail_delete = fail_delete
+        self.deleted = []
+
+    async def delete_uris(self, ctx, uris):
+        self.deleted.append((ctx.account_id, uris))
+        if self.fail_delete:
+            raise RuntimeError("delete failed")
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+
+
+@pytest.mark.asyncio
+async def test_stale_retrieval_hits_are_filtered_and_cleaned(monkeypatch):
+    fs = VikingFS(agfs=_DummyAgfs())
+    vector_store = _FakeVectorStore()
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        del ctx, skip_count
+        if uri == "viking://resources/live.md":
+            return {"isDir": False}
+        raise NotFoundError(uri, "file")
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+
+    live = MatchedContext(
+        uri="viking://resources/live.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    stale_file = MatchedContext(
+        uri="viking://resources/missing.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    stale_abstract = MatchedContext(
+        uri="viking://resources/missing-dir/.abstract.md",
+        context_type=ContextType.RESOURCE,
+        level=0,
+    )
+    query_result = QueryResult(
+        query=TypedQuery(query="missing", context_type=None, intent=""),
+        matched_contexts=[live, stale_file, stale_abstract],
+        searched_directories=[],
+    )
+    result = FindResult(
+        memories=[],
+        resources=[live, stale_file, stale_abstract],
+        skills=[],
+        query_results=[query_result],
+    )
+
+    await fs._drop_stale_retrieval_hits(result, _ctx())
+
+    assert result.resources == [live]
+    assert query_result.matched_contexts == [live]
+    assert result.total == 1
+    assert vector_store.deleted == [
+        ("default", ["viking://resources/missing.md"]),
+        ("default", ["viking://resources/missing-dir"]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stale_cleanup_failure_is_silent_but_hit_is_filtered(monkeypatch):
+    fs = VikingFS(agfs=_DummyAgfs())
+    vector_store = _FakeVectorStore(fail_delete=True)
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        del ctx, skip_count
+        raise NotFoundError(uri, "file")
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    stale = MatchedContext(
+        uri="viking://resources/missing.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    result = FindResult(memories=[], resources=[stale], skills=[])
+
+    await fs._drop_stale_retrieval_hits(result, _ctx())
+
+    assert result.resources == []
+    assert result.total == 0
+    assert vector_store.deleted == [("default", ["viking://resources/missing.md"])]
+
+
+@pytest.mark.asyncio
+async def test_retrieval_stat_errors_keep_hit_and_skip_cleanup(monkeypatch):
+    fs = VikingFS(agfs=_DummyAgfs())
+    vector_store = _FakeVectorStore()
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        del uri, ctx, skip_count
+        raise RuntimeError("agfs unavailable")
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    matched = MatchedContext(
+        uri="viking://resources/maybe-live.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    result = FindResult(memories=[], resources=[matched], skills=[])
+
+    await fs._drop_stale_retrieval_hits(result, _ctx())
+
+    assert result.resources == [matched]
+    assert result.total == 1
+    assert vector_store.deleted == []


### PR DESCRIPTION
## Summary

- Filter `find` / `search` retrieval results whose backing AGFS content is already gone.
- Check only unique final retrieval hits, concurrently, using `stat(skip_count=True)`.
- Best-effort delete stale vector URIs through the existing `delete_uris` path in one batch.
- Keep results on non-not-found stat errors to avoid deleting valid vectors during transient AGFS failures.

## Ponytail choice

This intentionally does not add a new vector-store API. L0/L1 sidecar hits map back to the directory URI and reuse existing URI deletion; if that removes multiple levels for the same URI, semantic refresh can rebuild them. No semaphore yet: default result counts are small, add one only if high-limit searches stress AGFS.

## Validation

- `ruff check openviking/storage/viking_fs.py tests/storage/test_viking_fs_stale_retrieval.py`
- `pytest -q tests/storage/test_viking_fs_stale_retrieval.py`
- `pytest -q tests/client/test_search.py` fails on clean `origin/main` before this change is involved: `LocalClient.__init__() got an unexpected keyword argument 'agent_id'`.
