### PR TITLE
fix: document reindex modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ ov find "what is openviking"
 ov grep "openviking" --uri viking://resources/volcengine/OpenViking/docs/zh
 ```
 
+To rebuild existing indexes, `ov reindex <uri> --mode vectors_only` refreshes vectors only. Use `--mode semantic_and_vectors` when semantic artifacts (`.abstract.md` and `.overview.md`) must be regenerated before vectors; there is no `semantic` or `full` mode alias.
+
 Congratulations! You have successfully run OpenViking 🎉
 
 ### Commercial Access

--- a/crates/ov_cli/src/help_ui.rs
+++ b/crates/ov_cli/src/help_ui.rs
@@ -1210,10 +1210,16 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
     CommandHelpSpec {
         path: &["reindex"],
         purpose: "Reindex semantic/vector artifacts for a URI.",
-        examples: &[HelpItem {
-            label: "ov reindex viking://projects/acme --mode vectors_only --wait true",
-            description: "Rebuild vector artifacts and wait.",
-        }],
+        examples: &[
+            HelpItem {
+                label: "ov reindex viking://projects/acme --mode vectors_only --wait true",
+                description: "Rebuild vector artifacts and wait.",
+            },
+            HelpItem {
+                label: "ov reindex viking://projects/acme --mode semantic_and_vectors --wait true",
+                description: "Regenerate semantic artifacts, then vectors.",
+            },
+        ],
         next_steps: &[
             HelpItem {
                 label: "ov task list",
@@ -2754,6 +2760,17 @@ mod tests {
         assert!(find_help.contains("Maximum final results returned"));
         assert!(search_help.contains("Maximum results per search pass."));
         assert!(search_help.contains("Search may merge multiple passes"));
+    }
+
+    #[test]
+    fn reindex_help_lists_supported_modes() {
+        let rendered = strip_ansi(
+            &render_command_help_request(&os_args(&["ov", "reindex", "--help"]))
+                .expect("reindex help should render"),
+        );
+
+        assert!(rendered.contains("--mode <vectors_only|semantic_and_vectors>"));
+        assert!(rendered.contains("Regenerate semantic artifacts, then vectors."));
     }
 
     #[test]

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -951,10 +951,11 @@ enum Commands {
         /// Viking URI
         #[arg(value_name = "uri")]
         uri: String,
-        /// Reindex mode
+        /// Reindex mode: vectors_only rebuilds vectors; semantic_and_vectors regenerates semantic artifacts, then vectors
         #[arg(
             long,
             default_value = "vectors_only",
+            value_parser = ["vectors_only", "semantic_and_vectors"],
             value_name = "mode",
             help_heading = "Common options"
         )]
@@ -3667,7 +3668,7 @@ mod tests {
             .expect("skills list should parse");
         match list.command {
             Commands::Skills {
-                action: SkillCommands::List { node_limit },
+                action: SkillCommands::List { node_limit, .. },
             } => assert_eq!(node_limit, 25),
             _ => panic!("expected skills list"),
         }
@@ -3789,7 +3790,9 @@ mod tests {
             .expect("skills remove --yes should parse");
         match remove.command {
             Commands::Skills {
-                action: SkillCommands::Remove { skills, yes, all },
+                action: SkillCommands::Remove {
+                    skills, yes, all, ..
+                },
             } => {
                 assert_eq!(skills, vec!["foo", "bar"]);
                 assert!(yes);
@@ -4374,6 +4377,19 @@ mod tests {
         ]);
 
         assert!(result.is_ok(), "reindex command should parse");
+    }
+
+    #[test]
+    fn cli_rejects_unknown_reindex_mode() {
+        let result = Cli::try_parse_from([
+            "ov",
+            "reindex",
+            "viking://resources/demo",
+            "--mode",
+            "semantic",
+        ]);
+
+        assert!(result.is_err(), "unknown reindex mode should not parse");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Document the actual `ov reindex --mode` values in CLI help and README.
- Add the `semantic_and_vectors` example so semantic reindex callers do not guess `semantic` or `full`.
- Validate `--mode` at the CLI layer using the two server-supported values.

## Validation

- `cargo test -p ov_cli reindex --bin ov`
- `cargo run -p ov_cli -- reindex --help`
- `cargo run -p ov_cli -- reindex viking://resources --mode semantic` exits 2 with an invalid value error
- `git diff --check`