### PR TITLE
feat: filter stale vector hits from retrieval

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from urllib.parse import unquote
 
 from openviking.core.context import ContextLevel
 from openviking.core.namespace import (
@@ -1895,6 +1896,7 @@ class VikingFS:
             resources=resources,
             skills=skills,
         )
+        await self._drop_stale_retrieval_hits(find_result, real_ctx)
         telemetry.set("vector.returned", find_result.total)
         return find_result
 
@@ -2025,8 +2027,78 @@ class VikingFS:
             query_plan=query_plan,
             query_results=query_results,
         )
+        await self._drop_stale_retrieval_hits(find_result, real_ctx)
         telemetry.set("vector.returned", find_result.total)
         return find_result
+
+    async def _drop_stale_retrieval_hits(
+        self,
+        find_result: Any,
+        ctx: RequestContext,
+    ) -> None:
+        """Drop retrieval hits whose backing AGFS content is gone, and clean their vectors."""
+        vector_store = self._get_vector_store()
+        sidecars = {0: ".abstract.md", 1: ".overview.md"}
+
+        def _key(match: Any):
+            uri = str(getattr(match, "uri", "") or "")
+            if not uri:
+                return None
+
+            check_uri = uri if uri.endswith("://") else uri.rstrip("/")
+            sidecar = sidecars.get(getattr(match, "level", 2))
+            if sidecar:
+                suffix = f"/{sidecar}"
+                vector_uri = check_uri.removesuffix(suffix)
+                check_uri = uri if uri.endswith(suffix) else f"{vector_uri}{suffix}"
+
+            record_id = hashlib.md5(f"{ctx.account_id}:{check_uri}".encode("utf-8")).hexdigest()
+            return check_uri, record_id
+
+        def _check_uri_candidates(check_uri: str) -> tuple[str, ...]:
+            decoded = unquote(check_uri)
+            if decoded != check_uri and decoded.count("/") == check_uri.count("/"):
+                return check_uri, decoded
+            return (check_uri,)
+
+        async def _check(key: tuple[str, str]) -> tuple[tuple[str, str], bool]:
+            check_uri, _ = key
+            for candidate in _check_uri_candidates(check_uri):
+                try:
+                    await self.stat(candidate, ctx=ctx, skip_count=True)
+                    return key, True
+                except Exception as exc:
+                    if not is_not_found_error(exc):
+                        logger.debug("[VikingFS] stale-hit check skipped for %s: %s", candidate, exc)
+                        return key, True
+            return key, False
+
+        matches = []
+        for attr in ("memories", "resources", "skills"):
+            matches.extend(getattr(find_result, attr))
+        if find_result.query_results:
+            for query_result in find_result.query_results:
+                matches.extend(query_result.matched_contexts)
+
+        keys = {_key(match) for match in matches}
+        keys.discard(None)
+        checked = dict(await asyncio.gather(*(_check(key) for key in keys)))
+        stale_ids = sorted(record_id for (_, record_id), live in checked.items() if not live)
+        if vector_store and stale_ids:
+            try:
+                await vector_store.delete(stale_ids, ctx=ctx)
+            except Exception as exc:
+                logger.debug("[VikingFS] stale-vector cleanup failed: %s", exc)
+
+        def _filter(contexts: List[Any]) -> List[Any]:
+            return [match for match in contexts if checked.get(_key(match), True)]
+
+        for attr in ("memories", "resources", "skills"):
+            setattr(find_result, attr, _filter(getattr(find_result, attr)))
+        if find_result.query_results:
+            for query_result in find_result.query_results:
+                query_result.matched_contexts = _filter(query_result.matched_contexts)
+        find_result.total = sum(len(getattr(find_result, attr)) for attr in ("memories", "resources", "skills"))
 
     # ========== Relation Management ==========
 

--- a/tests/storage/test_viking_fs_stale_retrieval.py
+++ b/tests/storage/test_viking_fs_stale_retrieval.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import hashlib
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import NotFoundError
+from openviking_cli.retrieve.types import (
+    ContextType,
+    FindResult,
+    MatchedContext,
+    QueryResult,
+    TypedQuery,
+)
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _DummyAgfs:
+    pass
+
+
+class _FakeVectorStore:
+    def __init__(self, *, fail_delete: bool = False):
+        self.fail_delete = fail_delete
+        self.deleted = []
+
+    async def delete(self, ids, *, ctx):
+        self.deleted.append((ctx.account_id, ids))
+        if self.fail_delete:
+            raise RuntimeError("delete failed")
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+
+
+def _vector_id(uri: str, level: int = 2, account_id: str = "default") -> str:
+    if level == 0 and not uri.endswith("/.abstract.md"):
+        uri = f"{uri}/.abstract.md"
+    elif level == 1 and not uri.endswith("/.overview.md"):
+        uri = f"{uri}/.overview.md"
+    return hashlib.md5(f"{account_id}:{uri}".encode("utf-8")).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_stale_retrieval_hits_are_filtered_and_cleaned(monkeypatch):
+    fs = VikingFS(agfs=_DummyAgfs())
+    vector_store = _FakeVectorStore()
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+    stat_calls = []
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        del ctx, skip_count
+        stat_calls.append(uri)
+        if uri == "viking://resources/live.md":
+            return {"isDir": False}
+        raise NotFoundError(uri, "file")
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+
+    live = MatchedContext(
+        uri="viking://resources/live.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    stale_file = MatchedContext(
+        uri="viking://resources/missing.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    stale_abstract = MatchedContext(
+        uri="viking://resources/missing-dir/.abstract.md",
+        context_type=ContextType.RESOURCE,
+        level=0,
+    )
+    query_result = QueryResult(
+        query=TypedQuery(query="missing", context_type=None, intent=""),
+        matched_contexts=[live, stale_file, stale_abstract],
+        searched_directories=[],
+    )
+    result = FindResult(
+        memories=[],
+        resources=[live, stale_file, stale_abstract],
+        skills=[],
+        query_results=[query_result],
+    )
+
+    await fs._drop_stale_retrieval_hits(result, _ctx())
+
+    assert result.resources == [live]
+    assert query_result.matched_contexts == [live]
+    assert result.total == 1
+    assert set(stat_calls) == {
+        "viking://resources/live.md",
+        "viking://resources/missing.md",
+        "viking://resources/missing-dir/.abstract.md",
+    }
+    assert len(stat_calls) == 3
+    assert vector_store.deleted == [
+        (
+            "default",
+            sorted([
+                _vector_id("viking://resources/missing-dir", level=0),
+                _vector_id("viking://resources/missing.md"),
+            ]),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_percent_encoded_hit_is_not_dropped_when_decoded_uri_exists(monkeypatch):
+    fs = VikingFS(agfs=_DummyAgfs())
+    vector_store = _FakeVectorStore()
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+    stat_calls = []
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        del ctx, skip_count
+        stat_calls.append(uri)
+        if uri == "viking://resources/hello world.md":
+            return {"isDir": False}
+        raise NotFoundError(uri, "file")
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    matched = MatchedContext(
+        uri="viking://resources/hello%20world.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    result = FindResult(memories=[], resources=[matched], skills=[])
+
+    await fs._drop_stale_retrieval_hits(result, _ctx())
+
+    assert result.resources == [matched]
+    assert result.total == 1
+    assert stat_calls == [
+        "viking://resources/hello%20world.md",
+        "viking://resources/hello world.md",
+    ]
+    assert vector_store.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_stale_cleanup_failure_is_silent_but_hit_is_filtered(monkeypatch):
+    fs = VikingFS(agfs=_DummyAgfs())
+    vector_store = _FakeVectorStore(fail_delete=True)
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        del ctx, skip_count
+        raise NotFoundError(uri, "file")
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    stale = MatchedContext(
+        uri="viking://resources/missing.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    result = FindResult(memories=[], resources=[stale], skills=[])
+
+    await fs._drop_stale_retrieval_hits(result, _ctx())
+
+    assert result.resources == []
+    assert result.total == 0
+    assert vector_store.deleted == [("default", [_vector_id("viking://resources/missing.md")])]
+
+
+@pytest.mark.asyncio
+async def test_retrieval_stat_errors_keep_hit_and_skip_cleanup(monkeypatch):
+    fs = VikingFS(agfs=_DummyAgfs())
+    vector_store = _FakeVectorStore()
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        del uri, ctx, skip_count
+        raise RuntimeError("agfs unavailable")
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    matched = MatchedContext(
+        uri="viking://resources/maybe-live.md",
+        context_type=ContextType.RESOURCE,
+        level=2,
+    )
+    result = FindResult(memories=[], resources=[matched], skills=[])
+
+    await fs._drop_stale_retrieval_hits(result, _ctx())
+
+    assert result.resources == [matched]
+    assert result.total == 1
+    assert vector_store.deleted == []


### PR DESCRIPTION
## Summary

- Filter `find` / `search` retrieval results whose backing AGFS content is already gone.
- Check only unique final retrieval hits, concurrently, using `stat(skip_count=True)`.
- When raw hit URI returns not found, try the percent-decoded URI once before treating the hit as stale.
- When a hit is missing, derive its deterministic vector record id from `account_id:uri` and delete with `vector_store.delete(ids, ctx=ctx)` in one best-effort batch.
- Preserve L0/L1 precision by deleting `/.abstract.md` or `/.overview.md` ids for sidecar-level hits, while L2 deletes the raw hit URI id.
- Keep results on non-not-found stat errors to avoid deleting valid vectors during transient AGFS failures.

## Ponytail choice

This keeps the fallback local to retrieval post-processing and reuses the existing vector record-id delete path. Cleanup only runs after AGFS says the returned URL is missing, so it does not perform broader URI-filter deletion. No semaphore yet: default result counts are small, add one only if high-limit searches stress AGFS.

## Validation

- `ruff check openviking/storage/viking_fs.py tests/storage/test_viking_fs_stale_retrieval.py`
- `pytest -q tests/storage/test_viking_fs_stale_retrieval.py`
- `pytest -q tests/client/test_search.py` fails on clean `origin/main` before this change is involved: `LocalClient.__init__() got an unexpected keyword argument 'agent_id'`.
