### PR TITLE
Fix web studio i18n literals

### DIFF
--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -537,8 +537,23 @@ const en = {
       loadingEditor: 'Loading editor...',
       markdownPreview: 'Preview',
       markdownSource: 'Source',
+      noDirectoryContext:
+        'No abstract or overview available for this folder.',
       save: 'Save',
+      selectDirectoryContext: 'Select a chip to show folder context.',
       unsupportedBinary: 'Binary files do not support text preview.',
+      jsonl: {
+        collapse: 'Collapse',
+        dialogMode: 'Dialog',
+        emptyJsonl: 'Empty JSONL.',
+        emptyMessage: 'Empty message',
+        expand: 'Expand',
+        noArguments: 'No arguments',
+        rawMode: 'JSONL',
+        recordCount: '{{count}} record',
+        recordCount_other: '{{count}} records',
+        toolcall: 'toolcall',
+      },
     },
   },
   retrieval: {
@@ -626,6 +641,15 @@ const en = {
       toolInput: 'Input',
       toolResult: 'Result',
       loadMoreRefs: 'Load {{count}} more ({{remaining}} remaining)',
+      relativeTime: {
+        justNow: 'Just now',
+        minutesAgo: '{{count}} minute ago',
+        minutesAgo_other: '{{count}} minutes ago',
+        hoursAgo: '{{count}} hour ago',
+        hoursAgo_other: '{{count}} hours ago',
+        daysAgo: '{{count}} day ago',
+        daysAgo_other: '{{count}} days ago',
+      },
       toolStatus: {
         completed: 'Completed',
         failed: 'Failed',
@@ -717,6 +741,10 @@ const en = {
     explorer: {
       title: 'Context tree',
       addResource: 'Add resource',
+      abstractLevel: 'L0',
+      empty: 'empty',
+      loading: 'loading',
+      overviewLevel: 'L1',
       search: 'Search context',
       refresh: 'Refresh tree',
       namespaces: {
@@ -746,6 +774,7 @@ const en = {
         title: 'Please enable bot mode',
         description:
           'The current service has not enabled Agent chat. Start the service in bot mode and try again.',
+        command: 'openviking-server --with-bot',
         retry: 'Detect again',
       },
       empty: {
@@ -774,6 +803,7 @@ const en = {
       searchScopeLine: 'Search scope: {{scope}}',
       helpParameters: 'Parameters',
       helpExamples: 'Examples',
+      helpSubcommands: 'Subcommands',
       noParameters: 'No parameters',
       currentScopeAction: 'Use current directory',
       readUsage: 'Usage: /read viking://resources/...',
@@ -1110,6 +1140,30 @@ const en = {
         session: {
           description: 'Manage Agent sessions',
           usage: '/session subcommand',
+        },
+        tree: {
+          description: 'Show directory tree',
+          usage: '/tree [viking://resources/...]',
+        },
+        stat: {
+          description: 'Show resource metadata',
+          usage: '/stat viking://resources/...',
+        },
+        abstract: {
+          description: 'Read directory abstract',
+          usage: '/abstract viking://resources/...',
+        },
+        overview: {
+          description: 'Read directory overview',
+          usage: '/overview viking://resources/...',
+        },
+        health: {
+          description: 'Show backend health',
+          usage: '/health',
+        },
+        wait: {
+          description: 'Wait for service readiness',
+          usage: '/wait [--timeout seconds]',
         },
       },
     },

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -525,8 +525,21 @@ const zhCN = {
       loadingEditor: '加载编辑器...',
       markdownPreview: '预览',
       markdownSource: '源码',
+      noDirectoryContext: '这个目录暂无摘要或概览。',
       save: '保存',
+      selectDirectoryContext: '选择一个标签查看目录上下文。',
       unsupportedBinary: '二进制文件不支持文本预览。',
+      jsonl: {
+        collapse: '收起',
+        dialogMode: '对话',
+        emptyJsonl: '空 JSONL。',
+        emptyMessage: '空消息',
+        expand: '展开',
+        noArguments: '无参数',
+        rawMode: 'JSONL',
+        recordCount: '{{count}} 条记录',
+        toolcall: '工具调用',
+      },
     },
   },
   retrieval: {
@@ -614,6 +627,12 @@ const zhCN = {
       toolInput: '输入',
       toolResult: '结果',
       loadMoreRefs: '加载更多 {{count}} 条（剩余 {{remaining}} 条）',
+      relativeTime: {
+        justNow: '刚刚',
+        minutesAgo: '{{count}} 分钟前',
+        hoursAgo: '{{count}} 小时前',
+        daysAgo: '{{count}} 天前',
+      },
       toolStatus: {
         completed: '完成',
         failed: '失败',
@@ -698,6 +717,10 @@ const zhCN = {
     explorer: {
       title: '上下文目录',
       addResource: '添加资源',
+      abstractLevel: 'L0',
+      empty: '空',
+      loading: '加载中',
+      overviewLevel: 'L1',
       search: '搜索上下文',
       refresh: '刷新目录',
       namespaces: {
@@ -726,6 +749,7 @@ const zhCN = {
         title: '请开启 bot 模式',
         description:
           '当前服务未启用 Agent 对话能力，请使用 bot 模式启动服务后重试。',
+        command: 'openviking-server --with-bot',
         retry: '重新检测',
       },
       empty: {
@@ -753,6 +777,7 @@ const zhCN = {
       searchScopeLine: '搜索范围：{{scope}}',
       helpParameters: '参数',
       helpExamples: '示例',
+      helpSubcommands: '子命令',
       noParameters: '无参数',
       currentScopeAction: '使用当前目录',
       readUsage: '用法：/read viking://resources/...',
@@ -1082,6 +1107,30 @@ const zhCN = {
         session: {
           description: '管理 Agent 会话',
           usage: '/session 子命令',
+        },
+        tree: {
+          description: '展示目录树',
+          usage: '/tree [viking://resources/...]',
+        },
+        stat: {
+          description: '查看资源元信息',
+          usage: '/stat viking://resources/...',
+        },
+        abstract: {
+          description: '读取目录摘要',
+          usage: '/abstract viking://resources/...',
+        },
+        overview: {
+          description: '读取目录概览',
+          usage: '/overview viking://resources/...',
+        },
+        health: {
+          description: '查看后端健康状态',
+          usage: '/health',
+        },
+        wait: {
+          description: '等待服务就绪',
+          usage: '/wait [--timeout seconds]',
         },
       },
     },

--- a/web-studio/src/routes/playground/-components/agent-panel.tsx
+++ b/web-studio/src/routes/playground/-components/agent-panel.tsx
@@ -182,7 +182,7 @@ export function AgentPanel({
     )
 
     return playgroundSessionIds
-      .map((sessionId) => sessionById.get(sessionId))
+      .map((playgroundSessionId) => sessionById.get(playgroundSessionId))
       .filter((session): session is NonNullable<typeof session> =>
         Boolean(session),
       )
@@ -394,7 +394,7 @@ export function BotModePrompt({
           </div>
         </div>
         <code className="rounded-lg border bg-background px-3 py-2 font-mono text-xs text-foreground">
-          openviking-server --with-bot
+          {t('agent.botPrompt.command')}
         </code>
         {detail ? (
           <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs leading-5 text-muted-foreground">

--- a/web-studio/src/routes/playground/-components/context-explorer.tsx
+++ b/web-studio/src/routes/playground/-components/context-explorer.tsx
@@ -229,6 +229,7 @@ export function ContextTreeNode({
   onSelectFile: (entry: VikingFsEntry) => void
   selectedFileUri?: string | null
 }) {
+  const { t } = useTranslation('playground')
   const isOpen = expandedKeys.has(entry.uri)
   const isFileSelected = !entry.isDir && selectedFileUri === entry.uri
   const isDirSelected =
@@ -339,11 +340,11 @@ export function ContextTreeNode({
         ) : null}
         {entry.name === '_abstract.md' ? (
           <span className="shrink-0 rounded bg-muted px-1 font-sans text-[10px] text-muted-foreground">
-            L0
+            {t('explorer.abstractLevel')}
           </span>
         ) : entry.name === '_overview.md' ? (
           <span className="shrink-0 rounded bg-muted px-1 font-sans text-[10px] text-muted-foreground">
-            L1
+            {t('explorer.overviewLevel')}
           </span>
         ) : null}
       </div>
@@ -357,7 +358,7 @@ export function ContextTreeNode({
             >
               <TreeIndentGuides level={level + 1} />
               <Loader2Icon className="size-3 animate-spin" />
-              loading
+              {t('explorer.loading')}
             </div>
           ) : children.length > 0 ? (
             children.map((child) => (
@@ -379,7 +380,7 @@ export function ContextTreeNode({
               style={{ paddingLeft: treeChildContentPadding(level) }}
             >
               <TreeIndentGuides level={level + 1} />
-              empty
+              {t('explorer.empty')}
             </div>
           )}
         </div>

--- a/web-studio/src/routes/playground/-components/terminal-panel.tsx
+++ b/web-studio/src/routes/playground/-components/terminal-panel.tsx
@@ -93,289 +93,7 @@ const URI_ARGUMENT_COMMANDS = new Set([
   '/tree',
 ])
 
-const COMMAND_HELP_FALLBACKS: Partial<
-  Record<string, { description: string; usage: string }>
-> = {
-  '/abstract': {
-    description: '读取目录摘要',
-    usage: '/abstract viking://resources/...',
-  },
-  '/add-resource': {
-    description: '添加外部资源',
-    usage: '/add-resource',
-  },
-  '/find': {
-    description: '查找相关资源',
-    usage: '/find 查询词',
-  },
-  '/health': {
-    description: '查看后端健康状态',
-    usage: '/health',
-  },
-  '/ls': {
-    description: '查看已有资源',
-    usage: '/ls [viking://resources/...]',
-  },
-  '/overview': {
-    description: '读取目录概览',
-    usage: '/overview viking://resources/...',
-  },
-  '/read': {
-    description: '读取资源文件',
-    usage: '/read viking://resources/.../file.md',
-  },
-  '/search': {
-    description: '语义检索上下文',
-    usage: '/search 查询词',
-  },
-  '/session': {
-    description: '管理 Agent 会话',
-    usage: '/session 子命令',
-  },
-  '/stat': {
-    description: '查看资源元信息',
-    usage: '/stat viking://resources/...',
-  },
-  '/status': {
-    description: '检查连通状态',
-    usage: '/status',
-  },
-  '/tree': {
-    description: '展示目录树',
-    usage: '/tree [viking://resources/...]',
-  },
-  '/wait': {
-    description: '等待服务就绪',
-    usage: '/wait [--timeout seconds]',
-  },
-}
-
-const PARAMETER_HELP_FALLBACKS: Record<
-  TerminalCommandParameterKey,
-  { description: string; name: string }
-> = {
-  archiveId: {
-    description: '读取 archive 时必填。',
-    name: 'archive_id',
-  },
-  contextChars: {
-    description: 'tool-search 子命令使用，控制命中上下文长度。',
-    name: '--context-chars 数量',
-  },
-  contexts: {
-    description: 'used 子命令可重复传入，记录本轮实际使用的上下文。',
-    name: '--context uri',
-  },
-  keepRecent: {
-    description: 'commit 子命令使用，提交后保留最近 N 条 live messages。',
-    name: '--keep-recent 数量',
-  },
-  limit: {
-    description: 'tool result 列表、读取或搜索时限制返回数量。',
-    name: '--limit 数量',
-  },
-  messageContent: {
-    description: 'message 子命令使用，要追加到 session 的文本内容。',
-    name: 'content',
-  },
-  messageRole: {
-    description: 'message 子命令使用，支持 user 或 assistant。',
-    name: 'role',
-  },
-  offset: {
-    description: 'tool-result 子命令使用，从指定字符偏移开始读取。',
-    name: '--offset 数量',
-  },
-  query: {
-    description: '要检索的关键词或语义问题。',
-    name: '查询词',
-  },
-  scope: {
-    description: '可选。不填则全局搜索；传 . 使用当前目录；传 uri 使用指定目录。',
-    name: '--scope <.|uri>',
-  },
-  sessionAction: {
-    description:
-      'current、list、create、switch、get、context、messages、archive、commit、extract、message、used、tool-results、tool-result、tool-search、delete。',
-    name: '子命令',
-  },
-  sessionId: {
-    description: '可选。省略时多数子命令使用当前 Agent session；delete 必须显式指定。',
-    name: 'session_id',
-  },
-  skillJson: {
-    description: 'used 子命令使用，记录实际使用的 skill 信息。',
-    name: '--skill-json JSON',
-  },
-  timeout: {
-    description: '可选。等待服务就绪的最长时间。',
-    name: '--timeout 秒',
-  },
-  tokenBudget: {
-    description: 'context 子命令使用，限制组装上下文的 token 预算。',
-    name: '--token-budget 数量',
-  },
-  toolName: {
-    description: 'tool-results 子命令使用，按工具名过滤。',
-    name: '--tool-name 名称',
-  },
-  toolResultId: {
-    description: '读取或搜索外部化 tool result 时必填。',
-    name: 'tool_result_id',
-  },
-  uri: {
-    description: '可选或必填的 viking:// 资源路径，取决于命令用法。',
-    name: 'uri',
-  },
-}
-
-const EXAMPLE_HELP_FALLBACKS: Partial<
-  Record<string, { code: string; description: string }>
-> = {
-  'abstract.target': {
-    code: '/abstract viking://resources/',
-    description: '读取目录摘要',
-  },
-  'addResource.default': {
-    code: '/add-resource',
-    description: '打开添加资源表单',
-  },
-  'find.current': {
-    code: '/find agent --scope .',
-    description: '使用当前高亮目录',
-  },
-  'find.global': {
-    code: '/find agent',
-    description: '全局查找相关资源',
-  },
-  'find.scoped': {
-    code: '/find agent --scope viking://resources/',
-    description: '只在指定目录查找',
-  },
-  'health.default': {
-    code: '/health',
-    description: '查看后端健康状态',
-  },
-  'ls.current': {
-    code: '/ls',
-    description: '列出当前目录',
-  },
-  'ls.target': {
-    code: '/ls viking://resources/',
-    description: '列出指定目录',
-  },
-  'overview.target': {
-    code: '/overview viking://resources/',
-    description: '读取目录概览',
-  },
-  'read.file': {
-    code: '/read viking://resources/file.md',
-    description: '读取并打开文件',
-  },
-  'search.current': {
-    code: '/search agent --scope .',
-    description: '使用当前高亮目录',
-  },
-  'search.global': {
-    code: '/search agent',
-    description: '全局语义检索',
-  },
-  'search.scoped': {
-    code: '/search agent --scope viking://resources/',
-    description: '只在指定目录检索',
-  },
-  'session.archive': {
-    code: '/session archive [session_id] <archive_id>',
-    description: '读取指定 archive',
-  },
-  'session.commit': {
-    code: '/session commit [session_id] --keep-recent 10',
-    description: '归档并触发记忆提取',
-  },
-  'session.context': {
-    code: '/session context [session_id] --token-budget 8000',
-    description: '读取组装后的 session context',
-  },
-  'session.create': {
-    code: '/session create [session_id]',
-    description: '创建并切换到新 session',
-  },
-  'session.current': {
-    code: '/session',
-    description: '查看当前 active session',
-  },
-  'session.delete': {
-    code: '/session delete <session_id>',
-    description: '删除指定 session',
-  },
-  'session.extract': {
-    code: '/session extract [session_id]',
-    description: '从 session 中提取记忆',
-  },
-  'session.get': {
-    code: '/session get [session_id]',
-    description: '查看 session 元信息',
-  },
-  'session.list': {
-    code: '/session list',
-    description: '列出所有 session',
-  },
-  'session.message': {
-    code: '/session message [session_id] user hello',
-    description: '向 session 追加消息',
-  },
-  'session.messages': {
-    code: '/session messages [session_id]',
-    description: '读取 session 消息列表',
-  },
-  'session.switch': {
-    code: '/session switch <session_id>',
-    description: '切换 Agent 面板会话',
-  },
-  'session.toolResult': {
-    code: '/session tool-result [session_id] <tool_result_id>',
-    description: '读取一个 tool result',
-  },
-  'session.toolResults': {
-    code: '/session tool-results [session_id] --limit 20',
-    description: '列出外部化 tool results',
-  },
-  'session.toolSearch': {
-    code: '/session tool-search [session_id] <tool_result_id> query',
-    description: '在 tool result 中搜索',
-  },
-  'session.used': {
-    code: '/session used [session_id] --context viking://resources/...',
-    description: '记录实际使用的上下文或 skill',
-  },
-  'stat.target': {
-    code: '/stat viking://resources/file.md',
-    description: '查看资源元信息',
-  },
-  'status.default': {
-    code: '/status',
-    description: '检查 Agent 和 API 连通状态',
-  },
-  'tree.current': {
-    code: '/tree',
-    description: '展示当前目录树',
-  },
-  'tree.target': {
-    code: '/tree viking://resources/',
-    description: '展示指定目录树',
-  },
-  'wait.default': {
-    code: '/wait',
-    description: '等待服务就绪',
-  },
-  'wait.timeout': {
-    code: '/wait --timeout 30',
-    description: '指定等待秒数',
-  },
-}
-
 type SessionSubcommandHelp = {
-  description: string
   examples: string[]
   insertText: string
   key: string
@@ -385,7 +103,6 @@ type SessionSubcommandHelp = {
 
 const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
   {
-    description: '查看当前 active session',
     examples: ['session.current'],
     insertText: '/session current',
     key: 'current',
@@ -393,7 +110,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session current',
   },
   {
-    description: '列出所有 session',
     examples: ['session.list'],
     insertText: '/session list',
     key: 'list',
@@ -401,7 +117,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session list',
   },
   {
-    description: '创建并切换到新 session',
     examples: ['session.create'],
     insertText: '/session create ',
     key: 'create',
@@ -409,7 +124,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session create [session_id]',
   },
   {
-    description: '切换 Agent 面板会话',
     examples: ['session.switch'],
     insertText: '/session switch ',
     key: 'switch',
@@ -417,7 +131,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session switch <session_id>',
   },
   {
-    description: '查看 session 元信息',
     examples: ['session.get'],
     insertText: '/session get ',
     key: 'get',
@@ -425,7 +138,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session get [session_id]',
   },
   {
-    description: '读取组装后的 session context',
     examples: ['session.context'],
     insertText: '/session context ',
     key: 'context',
@@ -433,7 +145,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session context [session_id] --token-budget 8000',
   },
   {
-    description: '读取 session 消息列表',
     examples: ['session.messages'],
     insertText: '/session messages ',
     key: 'messages',
@@ -441,7 +152,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session messages [session_id]',
   },
   {
-    description: '读取指定 archive',
     examples: ['session.archive'],
     insertText: '/session archive ',
     key: 'archive',
@@ -449,7 +159,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session archive [session_id] <archive_id>',
   },
   {
-    description: '归档并触发记忆提取',
     examples: ['session.commit'],
     insertText: '/session commit ',
     key: 'commit',
@@ -457,7 +166,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session commit [session_id] --keep-recent 10',
   },
   {
-    description: '从 session 中提取记忆',
     examples: ['session.extract'],
     insertText: '/session extract ',
     key: 'extract',
@@ -465,7 +173,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session extract [session_id]',
   },
   {
-    description: '向 session 追加消息',
     examples: ['session.message'],
     insertText: '/session message ',
     key: 'message',
@@ -473,7 +180,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session message [session_id] user hello',
   },
   {
-    description: '记录实际使用的上下文或 skill',
     examples: ['session.used'],
     insertText: '/session used ',
     key: 'used',
@@ -481,7 +187,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session used [session_id] --context viking://resources/...',
   },
   {
-    description: '列出外部化 tool results',
     examples: ['session.toolResults'],
     insertText: '/session tool-results ',
     key: 'tool-results',
@@ -489,7 +194,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session tool-results [session_id] --limit 20',
   },
   {
-    description: '读取一个 tool result',
     examples: ['session.toolResult'],
     insertText: '/session tool-result ',
     key: 'tool-result',
@@ -497,7 +201,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session tool-result [session_id] <tool_result_id>',
   },
   {
-    description: '在 tool result 中搜索',
     examples: ['session.toolSearch'],
     insertText: '/session tool-search ',
     key: 'tool-search',
@@ -505,7 +208,6 @@ const SESSION_SUBCOMMANDS: SessionSubcommandHelp[] = [
     usage: '/session tool-search [session_id] <tool_result_id> query',
   },
   {
-    description: '删除指定 session',
     examples: ['session.delete'],
     insertText: '/session delete ',
     key: 'delete',
@@ -781,15 +483,10 @@ export function TerminalPanel({
           connectionRole === 'admin' ||
           connectionRole === 'root',
       ).map((item) => {
-        const fallback = COMMAND_HELP_FALLBACKS[item.command]
         return {
           ...item,
-          description: t(`terminal.commands.${item.key}.description`, {
-            defaultValue: fallback?.description ?? item.command,
-          }),
-          usage: t(`terminal.commands.${item.key}.usage`, {
-            defaultValue: fallback?.usage ?? item.insertText.trim(),
-          }),
+          description: t(`terminal.commands.${item.key}.description`),
+          usage: t(`terminal.commands.${item.key}.usage`),
         }
       }),
     [connectionRole, t],
@@ -896,25 +593,23 @@ export function TerminalPanel({
             if (!isChoosingSubcommand) return []
 
             return SESSION_SUBCOMMANDS.filter(
-              (item) =>
-                !partial ||
-                item.key.toLowerCase().startsWith(partial.toLowerCase()) ||
-                item.description.toLowerCase().includes(partial.toLowerCase()),
+              (item) => {
+                const description = t(
+                  `terminal.commandExamples.${item.examples[0]}.description`,
+                )
+                return (
+                  !partial ||
+                  item.key.toLowerCase().startsWith(partial.toLowerCase()) ||
+                  description.toLowerCase().includes(partial.toLowerCase())
+                )
+              },
             ).map((item) => {
-              const exampleKey = item.examples[0]
-              const fallback = exampleKey
-                ? EXAMPLE_HELP_FALLBACKS[exampleKey]
-                : undefined
-              const description = t(
-                `terminal.commandExamples.${exampleKey}.description`,
-                {
-                  defaultValue: fallback?.description ?? item.description,
-                },
-              )
               return {
                 ...activeCommand,
                 command: item.key,
-                description,
+                description: t(
+                  `terminal.commandExamples.${item.examples[0]}.description`,
+                ),
                 group: 'subcommand' as const,
                 id: `subcommand:session:${item.key}`,
                 insertText: item.insertText,
@@ -975,14 +670,9 @@ export function TerminalPanel({
     () =>
       SESSION_SUBCOMMANDS.map((item) => {
         const exampleKey = item.examples[0]
-        const fallback = exampleKey
-          ? EXAMPLE_HELP_FALLBACKS[exampleKey]
-          : undefined
         return {
           ...item,
-          description: t(`terminal.commandExamples.${exampleKey}.description`, {
-            defaultValue: fallback?.description ?? item.description,
-          }),
+          description: t(`terminal.commandExamples.${exampleKey}.description`),
         }
       }),
     [t],
@@ -997,11 +687,6 @@ export function TerminalPanel({
   const helpDescription = selectedSessionSubcommand
     ? t(
         `terminal.commandExamples.${selectedSessionSubcommand.examples[0]}.description`,
-        {
-          defaultValue:
-            EXAMPLE_HELP_FALLBACKS[selectedSessionSubcommand.examples[0]]
-              ?.description ?? selectedSessionSubcommand.description,
-        },
       )
     : helpCommand?.description
   const helpUsage = selectedSessionSubcommand
@@ -1014,15 +699,10 @@ export function TerminalPanel({
         selectedSessionSubcommand?.parameters ??
         (showSessionSubcommandList ? [] : (helpCommand?.parameters ?? []))
       ).map((key) => {
-        const fallback = PARAMETER_HELP_FALLBACKS[key]
         return {
-          description: t(`terminal.commandParameters.${key}.description`, {
-            defaultValue: fallback.description,
-          }),
+          description: t(`terminal.commandParameters.${key}.description`),
           key,
-          name: t(`terminal.commandParameters.${key}.name`, {
-            defaultValue: fallback.name,
-          }),
+          name: t(`terminal.commandParameters.${key}.name`),
         }
       }),
     [helpCommand, selectedSessionSubcommand, showSessionSubcommandList, t],
@@ -1034,14 +714,9 @@ export function TerminalPanel({
         selectedSessionSubcommand?.examples ??
         (showSessionSubcommandList ? [] : (helpCommand?.examples ?? []))
       ).map((key) => {
-        const fallback = EXAMPLE_HELP_FALLBACKS[key]
         return {
-          code: t(`terminal.commandExamples.${key}.code`, {
-            defaultValue: fallback?.code ?? key,
-          }),
-          description: t(`terminal.commandExamples.${key}.description`, {
-            defaultValue: fallback?.description ?? '',
-          }),
+          code: t(`terminal.commandExamples.${key}.code`),
+          description: t(`terminal.commandExamples.${key}.description`),
           key,
         }
       }),
@@ -1666,11 +1341,11 @@ export function TerminalPanel({
         title: t('terminal.quickStart.addMemory.title'),
       },
       {
-        action: () => void runCommand('/find openviking 有什么价值？'),
         code: t('terminal.quickStart.find.code'),
         command: t('terminal.quickStart.find.command'),
         key: 'find',
         title: t('terminal.quickStart.find.title'),
+        action: () => void runCommand(t('terminal.quickStart.find.command')),
       },
     ],
     [runCommand, t],
@@ -1830,9 +1505,7 @@ export function TerminalPanel({
                       {showSessionSubcommandList ? (
                         <div className="min-w-0">
                           <div className="mb-1.5 text-[11px] font-medium text-muted-foreground">
-                            {t('terminal.helpSubcommands', {
-                              defaultValue: '子命令',
-                            })}
+                            {t('terminal.helpSubcommands')}
                           </div>
                           <div className="overflow-hidden rounded-md border">
                             <table className="w-full table-fixed border-collapse text-xs">

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -135,6 +135,8 @@ const DIRECTORY_LEVEL_META: Array<{
 
 const JSONL_MESSAGE_PREVIEW_LIMIT = 720
 const JSONL_TOOLCALL_STORAGE_KEY = 'openviking.playground.jsonlToolCall'
+const COLLAPSE_SYMBOL = '▾'
+const EXPAND_SYMBOL = '▸'
 
 type JsonlRecord = {
   error: Error | null
@@ -776,7 +778,7 @@ function JsonlRawRow({ record }: { record: JsonlRecord }) {
         onClick={() => setOpen((current) => !current)}
       >
         <span>{record.index + 1}</span>
-        <span>{open ? '▾' : '▸'}</span>
+        <span aria-hidden="true">{open ? COLLAPSE_SYMBOL : EXPAND_SYMBOL}</span>
       </button>
       <div className="min-w-0 px-3 py-2">
         {open ? (
@@ -813,6 +815,7 @@ function JsonlRawRow({ record }: { record: JsonlRecord }) {
 }
 
 function JsonlToolBody({ text, toolName }: { text: string; toolName: string }) {
+  const { t } = useTranslation('resources')
   const afterTag = text.replace(/^\[tool:\s*[^\]]+\]\s*/, '')
   const parsed = useMemo(() => {
     if (!toolName || !afterTag.trim()) return null
@@ -829,25 +832,27 @@ function JsonlToolBody({ text, toolName }: { text: string; toolName: string }) {
     </pre>
   ) : (
     <pre className="whitespace-pre-wrap break-words text-xs leading-5">
-      {afterTag || 'No arguments'}
+      {afterTag || t('filePreview.jsonl.noArguments')}
     </pre>
   )
 }
 
 function JsonlMarkdownBody({ content }: { content: string }) {
+  const { t } = useTranslation('resources')
   return (
     <div className="prose prose-sm max-w-none break-words dark:prose-invert dark:prose-pre:bg-muted-foreground/20">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={markdownComponents}
       >
-        {content || 'Empty message'}
+        {content || t('filePreview.jsonl.emptyMessage')}
       </ReactMarkdown>
     </div>
   )
 }
 
 function JsonlMessageCard({ record }: { record: JsonlRecord }) {
+  const { t } = useTranslation('resources')
   const [expanded, setExpanded] = useState(false)
   const message = useMemo(() => getJsonlMessage(record), [record])
   const isTool = Boolean(message.toolName || message.kind === 'tool-result')
@@ -893,7 +898,7 @@ function JsonlMessageCard({ record }: { record: JsonlRecord }) {
         <JsonlMarkdownBody content={body} />
       ) : (
         <pre className="whitespace-pre-wrap break-words text-xs leading-5">
-          {body || 'Empty message'}
+          {body || t('filePreview.jsonl.emptyMessage')}
         </pre>
       )}
 
@@ -908,7 +913,9 @@ function JsonlMessageCard({ record }: { record: JsonlRecord }) {
             className="ml-auto rounded border px-2 py-0.5 font-medium text-primary hover:border-primary"
             onClick={() => setExpanded((current) => !current)}
           >
-            {expanded ? 'Collapse' : 'Expand'}
+            {expanded
+              ? t('filePreview.jsonl.collapse')
+              : t('filePreview.jsonl.expand')}
           </button>
         ) : null}
       </div>
@@ -917,6 +924,7 @@ function JsonlMessageCard({ record }: { record: JsonlRecord }) {
 }
 
 function JsonlPreview({ content }: { content: string }) {
+  const { t } = useTranslation('resources')
   const [dialogMode, setDialogMode] = useState(true)
   const [showTools, setShowTools] = useState(() => {
     if (typeof window === 'undefined') return true
@@ -943,7 +951,7 @@ function JsonlPreview({ content }: { content: string }) {
   if (!records.length) {
     return (
       <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
-        Empty JSONL.
+        {t('filePreview.jsonl.emptyJsonl')}
       </div>
     )
   }
@@ -952,12 +960,14 @@ function JsonlPreview({ content }: { content: string }) {
     <div className="grid gap-3">
       <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
         <span className="font-medium text-primary">
-          {records.length} record{records.length === 1 ? '' : 's'}
+          {t('filePreview.jsonl.recordCount', { count: records.length })}
         </span>
         <div className="flex items-center gap-2">
           {dialogMode && hasTools ? (
             <label className="inline-flex cursor-pointer items-center gap-2">
-              <span className="font-medium">toolcall</span>
+              <span className="font-medium">
+                {t('filePreview.jsonl.toolcall')}
+              </span>
               <input
                 type="checkbox"
                 className="peer sr-only"
@@ -975,7 +985,9 @@ function JsonlPreview({ content }: { content: string }) {
           ) : null}
           <label className="inline-flex cursor-pointer items-center gap-2">
             <span className="font-medium">
-              {dialogMode ? 'Dialog' : 'JSONL'}
+              {dialogMode
+                ? t('filePreview.jsonl.dialogMode')
+                : t('filePreview.jsonl.rawMode')}
             </span>
             <input
               type="checkbox"
@@ -1355,11 +1367,11 @@ export function FilePreview({
                   </div>
                 ) : availableDirectoryLevels.length === 0 ? (
                   <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
-                    No abstract or overview available for this folder.
+                    {t('filePreview.noDirectoryContext')}
                   </div>
                 ) : visibleDirectoryLevels.length === 0 ? (
                   <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
-                    Select a chip to show folder context.
+                    {t('filePreview.selectDirectoryContext')}
                   </div>
                 ) : (
                   <div className="grid gap-5">

--- a/web-studio/src/routes/sessions/-components/composer.tsx
+++ b/web-studio/src/routes/sessions/-components/composer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ArrowUpIcon, SquareIcon } from 'lucide-react'
 
 import { cn } from '#/lib/utils'
@@ -16,6 +17,7 @@ export function Composer({
   isStreaming,
   variant = 'default',
 }: ComposerProps) {
+  const { t } = useTranslation('sessions')
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const isCompact = variant === 'compact'
@@ -65,7 +67,7 @@ export function Composer({
         <textarea
           ref={textareaRef}
           autoFocus
-          placeholder="回复..."
+          placeholder={t('chat.placeholder')}
           rows={1}
           value={value}
           onChange={(e) => {

--- a/web-studio/src/routes/sessions/-components/message-list.tsx
+++ b/web-studio/src/routes/sessions/-components/message-list.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useState } from 'react'
-import { CheckIcon, CopyIcon, UserIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { CheckIcon, CopyIcon, UserIcon } from 'lucide-react'
+import type { TFunction } from 'i18next'
 
 import { resolvePublicAsset } from '#/lib/public-path'
 import type { Message, MessagePart, ToolPart } from '#/lib/sessions/types/message'
@@ -57,17 +58,17 @@ function stripPlaygroundContextSuffix(text: string): string {
 }
 
 /** Format relative time */
-function formatRelativeTime(iso: string): string {
+function formatRelativeTime(iso: string, t: TFunction<'sessions'>): string {
   const now = Date.now()
   const then = new Date(iso).getTime()
   const diff = Math.max(0, now - then)
   const minutes = Math.floor(diff / 60000)
-  if (minutes < 1) return '刚刚'
-  if (minutes < 60) return `${minutes} 分钟前`
+  if (minutes < 1) return t('chat.relativeTime.justNow')
+  if (minutes < 60) return t('chat.relativeTime.minutesAgo', { count: minutes })
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours} 小时前`
+  if (hours < 24) return t('chat.relativeTime.hoursAgo', { count: hours })
   const days = Math.floor(hours / 24)
-  return `${days} 天前`
+  return t('chat.relativeTime.daysAgo', { count: days })
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +166,7 @@ const UserMessage = memo(function UserMessage({
   message: Message
   compact?: boolean
 }) {
+  const { t } = useTranslation('sessions')
   const text = stripPlaygroundContextSuffix(getTextFromParts(message))
 
   return (
@@ -173,7 +175,7 @@ const UserMessage = memo(function UserMessage({
     >
       <div className="flex items-end gap-1.5 self-end opacity-0 transition-opacity group-hover/msg:opacity-100">
         <span className="text-[10px] text-muted-foreground/40 opacity-0 transition-opacity group-hover/msg:opacity-100 select-none">
-          {formatRelativeTime(message.created_at)}
+          {formatRelativeTime(message.created_at, t)}
         </span>
         <CopyButton text={text} />
       </div>
@@ -209,6 +211,7 @@ const AssistantMessage = memo(function AssistantMessage({
   compact?: boolean
   onResourceClick?: (uri: string) => void
 }) {
+  const { t } = useTranslation('sessions')
   const textContent = getTextFromParts(message)
 
   return (
@@ -248,7 +251,7 @@ const AssistantMessage = memo(function AssistantMessage({
         <div className="absolute right-2 top-2 flex items-center gap-1.5 rounded-lg bg-background/85 px-1.5 py-1 opacity-0 shadow-sm ring-1 ring-border/40 backdrop-blur transition-opacity group-hover/msg:opacity-100">
           <CopyButton text={textContent} />
           <span className="text-[10px] text-muted-foreground/60 select-none">
-            {formatRelativeTime(message.created_at)}
+            {formatRelativeTime(message.created_at, t)}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Description

Fix remaining hard-coded user-facing strings in Web Studio by moving them into the existing i18n locale files. This keeps locale switching consistent and clears the Studio i18n lint warnings.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Moved terminal command help, parameter labels, examples, and subcommand labels into the `playground` locale namespace.
- Localized session composer placeholder text, relative timestamps, context tree status labels, bot-mode command copy, and file preview / JSONL empty states.
- Removed duplicated hard-coded terminal fallback copy now covered by `en` and `zh-CN` locale entries.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Manual checks run locally:

- `npm run lint -- --max-warnings=0`
- `npm run build`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No documentation changes were needed because this only moves existing UI copy into locale resources.
