### PR TITLE
fix(vikingdb): drop schema version from embedding metadata

### DIFF
--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -41,8 +41,6 @@ from openviking_cli.utils.config.open_viking_config import OpenVikingConfig
 logger = get_logger(__name__)
 EMBEDDING_META_MARKER = "\n\n[openviking.embedding]\n"
 
-# Minimum OV version that supports content field + FullText config for grep bm25
-_FULLTEXT_MIN_VERSION = "0.3.18"
 _EMBEDDING_COMPATIBILITY_KEYS = ("provider", "model", "dimension", "model_identity")
 
 
@@ -190,14 +188,11 @@ def _build_embedding_metadata(config: "OpenVikingConfig") -> Dict[str, Any]:
         except Exception:
             model_identity = model
 
-    from openviking import __version__
-
     return {
         "provider": provider,
         "model": model,
         "dimension": dimension,
         "model_identity": model_identity,
-        "schema_version": __version__,
     }
 
 
@@ -313,17 +308,11 @@ async def init_context_collection(storage) -> bool:
     if (
         "Fields" in existing_meta or "FullText" in existing_meta
     ) and not _collection_has_content_fulltext(existing_meta):
-        existing_schema_version = "unknown"
-        if existing_embedding_meta:
-            existing_schema_version = existing_embedding_meta.get("schema_version", "0.0.0")
         logger.warning(
             "Collection schema does not support VikingDB full-text grep "
-            "(created by OV %s, feature requires >= %s). "
             "Missing 'content' field or FullText config. "
             "grep engine=auto will fall back to fs. "
-            "Recreate the collection to enable vikingdb-based grep.",
-            existing_schema_version,
-            _FULLTEXT_MIN_VERSION,
+            "Recreate the collection to enable vikingdb-based grep."
         )
 
     if _embedding_metadata_compatible(existing_embedding_meta, embedding_meta):

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -251,6 +251,7 @@ def test_build_embedding_metadata_hashes_resolved_local_model_path(tmp_path):
     assert payload["provider"] == "local"
     assert payload["model"] == "bge-small-zh-v1.5-f16"
     assert payload["model_identity"] == hashlib.sha256(expected.encode("utf-8")).hexdigest()
+    assert "schema_version" not in payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Remove `schema_version` from collection embedding metadata so the metadata only describes embedding vector compatibility. The full-text grep capability path already checks the actual collection schema fields (`content` + `FullText`), so keeping a version field in the embedding payload is unnecessary and can cause confusing metadata drift before release.

## Related Issue

#2144

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Stop writing `schema_version` into embedding metadata.
- Remove schema-version text from the outdated FullText warning.
- Add a regression assertion that embedding metadata does not contain `schema_version`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`uv run pytest tests/storage/test_collection_schemas.py::test_build_embedding_metadata_hashes_resolved_local_model_path tests/storage/test_collection_schemas.py::test_init_context_collection_rejects_mismatched_nonempty_collection -q -o addopts=''`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This follows up on #2835. `schema_version` has not been released publicly, so removing it avoids carrying a misleading compatibility signal.
