### PR TITLE
locomo数据导入优化

### DIFF
--- a/benchmark/locomo/vikingbot/import_to_ov.py
+++ b/benchmark/locomo/vikingbot/import_to_ov.py
@@ -89,6 +89,28 @@ def load_locomo_data(
     return data
 
 
+def build_message_text(msg: Dict[str, Any]) -> str:
+    """Preserve LoCoMo image metadata as labelled text for memory extraction."""
+    text = (msg.get("text") or "").strip()
+
+    blip_caption_value = msg.get("blip_caption")
+    blip_caption = str(blip_caption_value or "").strip()
+
+    query = str(msg.get("query") or "").strip()
+
+    image_parts = []
+    if blip_caption:
+        image_parts.append(f"image description: {blip_caption}")
+    if query:
+        image_parts.append(f"image search/query text: {query}")
+
+    if not image_parts:
+        return text
+
+    image_note = f"(attached image; {'; '.join(image_parts)})"
+    return f"{text}\n{image_note}" if text else image_note
+
+
 def build_session_messages(
     item: Dict[str, Any],
     session_range: Optional[Tuple[int, int]] = None,
@@ -126,7 +148,7 @@ def build_session_messages(
         messages = []
         for idx, msg in enumerate(conv[sk]):
             speaker = msg.get("speaker", "unknown")
-            text = msg.get("text", "")
+            text = build_message_text(msg)
             if group_chat:
                 messages.append(
                     {


### PR DESCRIPTION
## Description

This PR improves the LoCoMo benchmark import flow by preserving image-related metadata during message ingestion. Image captions and image query text are now converted into labeled text so they can be used during memory extraction.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Added a helper to build message text while preserving LoCoMo image metadata.
- Included `blip_caption` as an image description during import.
- Included `query` as image search/query text during import.
- Updated session message construction to use the normalized message text for both group and non-group chat modes.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Verified with:

```bash
python3 -m py_compile benchmark/locomo/vikingbot/import_to_ov.py