### PR TITLE
fix(retrieve): budget rerank input documents

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -50,6 +50,8 @@ class HierarchicalRetriever:
     DIRECTORY_DOMINANCE_RATIO = 1.2  # Directory score must exceed max child score
     GLOBAL_SEARCH_TOPK = 10  # Global retrieval count (more candidates = better rerank precision)
     MAX_PARALLEL_CHILD_SEARCHES = 4  # Limit per-request fan-out against remote vector stores
+    MAX_RERANK_DOCUMENT_CHARS = 4000  # Keep one oversized abstract from breaking a rerank batch
+    MAX_RERANK_BATCH_CHARS = 12000  # Leave query/instruction headroom across providers
     LEVEL_URI_SUFFIX = {0: ".abstract.md", 1: ".overview.md"}
 
     def __init__(
@@ -226,10 +228,8 @@ class HierarchicalRetriever:
             # Step 3: Pick recursive entry points from directory hits and explicit roots.
             directory_scores = [self._finite_score(r.get("_score", 0.0)) for r in global_results]
             if self._rerank_client and mode == RetrieverMode.THINKING:
-                directory_scores = self._rerank_scores(
-                    query.query,
-                    [str(r.get("abstract", "")) for r in global_results],
-                    directory_scores,
+                directory_scores = self._rerank_scores_with_budget(
+                    self._rerank_scores, query.query, global_results, directory_scores
                 )
 
             starting_points = []
@@ -347,6 +347,39 @@ class HierarchicalRetriever:
             normalized_scores.append(self._finite_score(score, fallback))
         return normalized_scores
 
+    @classmethod
+    def _rerank_scores_with_budget(
+        cls,
+        rerank_scores,
+        query: str,
+        results: List[Dict[str, Any]],
+        fallback_scores: List[float],
+    ) -> List[float]:
+        """Rerank documents after bounding each abstract's input size.
+
+        Oversized L2 abstracts are truncated before rerank so one long abstract
+        does not force the whole batch back to vector scores.
+        """
+        documents: List[str] = []
+        for result, _fallback in zip(results, fallback_scores, strict=True):
+            document = str(result.get("abstract", ""))
+            if len(document) > cls.MAX_RERANK_DOCUMENT_CHARS:
+                document = document[: cls.MAX_RERANK_DOCUMENT_CHARS]
+            documents.append(document)
+
+        if not documents:
+            return fallback_scores
+
+        available_chars = max(len(documents), cls.MAX_RERANK_BATCH_CHARS - len(query))
+        per_document_batch_chars = max(1, available_chars // len(documents))
+        if per_document_batch_chars < cls.MAX_RERANK_DOCUMENT_CHARS:
+            documents = [
+                document[:per_document_batch_chars]
+                for document in documents
+            ]
+
+        return rerank_scores(query, documents, fallback_scores)
+
     async def _recursive_search(
         self,
         vector_proxy: VikingDBManagerProxy,
@@ -452,8 +485,9 @@ class HierarchicalRetriever:
 
                 query_scores = [self._finite_score(r.get("_score", 0.0)) for r in results]
                 if self._rerank_client and mode == RetrieverMode.THINKING:
-                    documents = [str(r.get("abstract", "")) for r in results]
-                    query_scores = self._rerank_scores(query, documents, query_scores)
+                    query_scores = self._rerank_scores_with_budget(
+                        self._rerank_scores, query, results, query_scores
+                    )
 
                 for r, score in zip(results, query_scores, strict=True):
                     uri = r.get("uri", "")

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -234,6 +234,75 @@ def test_retriever_initializes_rerank_client(monkeypatch):
     assert retriever._rerank_client is fake_client
 
 
+def test_rerank_scores_with_budget_truncates_oversized_docs():
+    calls = []
+
+    def rerank_scores(query, documents, fallback_scores):
+        calls.append((query, list(documents), list(fallback_scores)))
+        return [0.91, 0.52, 0.73]
+
+    oversized = "x" * (HierarchicalRetriever.MAX_RERANK_DOCUMENT_CHARS + 1)
+    results = [
+        _result("viking://resources/short-a", 0.2, abstract="short A"),
+        _result("viking://resources/too-large", 0.8, abstract=oversized),
+        _result("viking://resources/short-b", 0.4, abstract="short B"),
+    ]
+
+    scores = HierarchicalRetriever._rerank_scores_with_budget(
+        rerank_scores, "hello", results, [0.2, 0.8, 0.4]
+    )
+
+    assert scores == [0.91, 0.52, 0.73]
+    assert calls == [
+        (
+            "hello",
+            ["short A", oversized[: HierarchicalRetriever.MAX_RERANK_DOCUMENT_CHARS], "short B"],
+            [0.2, 0.8, 0.4],
+        )
+    ]
+
+
+def test_rerank_scores_with_budget_falls_back_for_truncated_batch_failure():
+    def rerank_scores(query, documents, fallback_scores):
+        return fallback_scores
+
+    results = [
+        _result(
+            "viking://resources/too-large",
+            0.8,
+            abstract="x" * (HierarchicalRetriever.MAX_RERANK_DOCUMENT_CHARS + 1),
+        )
+    ]
+
+    scores = HierarchicalRetriever._rerank_scores_with_budget(
+        rerank_scores, "hello", results, [0.8]
+    )
+
+    assert scores == [0.8]
+
+
+def test_rerank_scores_with_budget_caps_total_document_chars(monkeypatch):
+    calls = []
+    monkeypatch.setattr(HierarchicalRetriever, "MAX_RERANK_DOCUMENT_CHARS", 100)
+    monkeypatch.setattr(HierarchicalRetriever, "MAX_RERANK_BATCH_CHARS", 15)
+
+    def rerank_scores(query, documents, fallback_scores):
+        calls.append((query, list(documents), list(fallback_scores)))
+        return [0.91, 0.73]
+
+    results = [
+        _result("viking://resources/a", 0.2, abstract="abcdefghij"),
+        _result("viking://resources/b", 0.4, abstract="klmnopqrst"),
+    ]
+
+    scores = HierarchicalRetriever._rerank_scores_with_budget(
+        rerank_scores, "hello", results, [0.2, 0.4]
+    )
+
+    assert scores == [0.91, 0.73]
+    assert calls == [("hello", ["abcde", "klmno"], [0.2, 0.4])]
+
+
 @pytest.mark.asyncio
 async def test_retrieve_uses_rerank_scores_in_thinking_mode(monkeypatch):
     fake_client = FakeRerankClient([0.95, 0.05, 0.11, 0.95])


### PR DESCRIPTION
## Summary
- bound each rerank abstract before calling the reranker
- add an aggregate character budget that accounts for query length and keeps all candidates in one rerank score space
- add regression tests for oversized abstracts, fallback behavior, and aggregate batch capping

## Context
Addresses #2739 without dropping L2 candidates from the comparison. Earlier #2741 was closed because it removed all L2 data; this keeps the candidate set intact and only trims the text sent to the reranker.

## Tests
- `python3 -m py_compile openviking/retrieve/hierarchical_retriever.py tests/retrieve/test_hierarchical_retriever_rerank.py`
- `python3 -m pytest tests/retrieve/test_hierarchical_retriever_rerank.py -q -k budget` could not run in this local Python 3.14 environment because project dependencies/platform wheels were unavailable (`json_repair`, then `tree-sitter-php` via `uv run --frozen --extra test`)

Codex review note: broker timed out without a verdict on the final rerank diff, so I treated this as degraded review and kept the change narrow with direct regression coverage.
