### PR TITLE
perf(content-write): anchor semantic refresh at the file's direct parent / 写入语义刷新锚点改为文件直接父目录

### DIFF
--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -80,7 +80,7 @@ class ContentWriteCoordinator:
             raise InvalidArgumentError(f"write only supports existing files, got directory: {uri}")
 
         context_type = context_type_for_uri(normalized_uri)
-        root_uri = await self._resolve_root_uri(normalized_uri, ctx=ctx)
+        root_uri = await self._resolve_root_uri(normalized_uri, ctx=ctx, anchor_to_parent=True)
         written_bytes = len(content.encode("utf-8"))
         telemetry_id = get_current_telemetry().telemetry_id
 
@@ -265,7 +265,6 @@ class ContentWriteCoordinator:
                 context_type=context_type,
                 ctx=ctx,
                 change_type="added" if mode == "create" else "modified",
-                recursive=True,
             )
             semantic_enqueued = True
             await lock_manager.release(handle)
@@ -384,7 +383,9 @@ class ContentWriteCoordinator:
             raise AlreadyExistsError(uri, "file")
 
         context_type = context_type_for_uri(uri)
-        root_uri = await self._resolve_root_uri(uri, ctx=ctx, _allow_not_found=True)
+        root_uri = await self._resolve_root_uri(
+            uri, ctx=ctx, _allow_not_found=True, anchor_to_parent=True
+        )
         written_bytes = len(content.encode("utf-8"))
         telemetry_id = get_current_telemetry().telemetry_id
 
@@ -780,6 +781,7 @@ class ContentWriteCoordinator:
         *,
         ctx: RequestContext,
         _allow_not_found: bool = False,
+        anchor_to_parent: bool = False,
     ) -> str:
         parsed = VikingURI(uri)
         parts = [part for part in parsed.full_path.split("/") if part]
@@ -789,7 +791,19 @@ class ContentWriteCoordinator:
         root_uri = uri
         if parts[0] == "resources":
             if len(parts) >= 2:
-                root_uri = VikingURI.build("resources", parts[1])
+                if anchor_to_parent:
+                    # Content writes anchor the semantic refresh at the written file's
+                    # direct parent directory, so the changed file is a direct child of
+                    # the DAG run root: its own L2 vector and the parent's L0/L1 are
+                    # (re)generated from a single-directory run, while ancestor summaries
+                    # refresh via the existing parent bubble. Collapsing to the project
+                    # root instead would force the run to traverse the whole project
+                    # subtree before the changed file's vector is even dispatched.
+                    parent = parsed.parent
+                    if parent is not None:
+                        root_uri = parent.uri
+                else:
+                    root_uri = VikingURI.build("resources", parts[1])
         elif parts[0] == "user":
             if "resources" in parts:
                 resources_idx = parts.index("resources")

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -497,7 +497,6 @@ async def test_resource_write_updates_target_and_queues_refresh_before_return(mo
     assert captured_enqueue["root_uri"] == root_uri
     assert captured_enqueue["changed_uri"] == file_uri
     assert captured_enqueue["change_type"] == "modified"
-    assert captured_enqueue["recursive"] is True
     assert viking_fs.delete_temp_calls == []
     assert lock_manager.release_calls == ["lock-1"]
 
@@ -935,7 +934,6 @@ async def test_create_mode_resource_scope(monkeypatch):
         assert kwargs["changed_uri"] == file_uri
         assert kwargs["context_type"] == "resource"
         assert kwargs["change_type"] == "added"
-        assert kwargs["recursive"] is True
         del kwargs
         return None
 
@@ -953,42 +951,36 @@ async def test_create_mode_resource_scope(monkeypatch):
     assert viking_fs.content[file_uri] == "content"
 
 
+class _AnyDirVikingFS:
+    """Stats the given file uri as a file and every other uri as a directory."""
+
+    def __init__(self, file_uri: str):
+        self._file_uri = file_uri
+
+    async def stat(self, uri: str, ctx=None):
+        del ctx
+        return {"isDir": uri != self._file_uri}
+
+
 @pytest.mark.asyncio
-async def test_create_mode_nested_resource_refresh_stays_recursive_after_root_changes(monkeypatch):
-    first_uri = "viking://resources/dir_repro/dir1/dir2/test12.md"
-    second_uri = "viking://resources/dir_repro/dir1/dir2/test34.md"
-    resource_root = "viking://resources/dir_repro"
-    first_parent = "viking://resources/dir_repro/dir1/dir2"
+async def test_resource_write_anchors_nested_file_to_direct_parent():
+    """A resource content write anchors the semantic refresh at the written file's
+    direct parent directory (anchor_to_parent=True), so the changed file is a direct
+    child of the DAG run root: its own L2 vector and the parent's L0/L1 are generated
+    from a single-directory run instead of a recursive walk of the whole project subtree.
+    set_tags keeps the project-root collapse (the default), which the derived
+    ``.abstract.md`` sidecar mapping relies on."""
+    file_uri = "viking://resources/dir1/sub_dir/sub_dir_1/test.md"
+    parent_uri = "viking://resources/dir1/sub_dir/sub_dir_1"
+    project_root = "viking://resources/dir1"
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
-    viking_fs = _FakeVikingFSForCreate(
-        file_uri=first_uri,
-        root_uri=resource_root,
-        file_exists=False,
-        existing_dirs=set(),
-    )
-    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
-    lock_manager = _FakeLockManager()
-    enqueued = []
+    coordinator = ContentWriteCoordinator(viking_fs=_AnyDirVikingFS(file_uri))
 
-    monkeypatch.setattr("openviking.storage.content_write.get_lock_manager", lambda: lock_manager)
+    write_anchor = await coordinator._resolve_root_uri(file_uri, ctx=ctx, anchor_to_parent=True)
+    set_tags_anchor = await coordinator._resolve_root_uri(file_uri, ctx=ctx)
 
-    async def _fake_enqueue_semantic_refresh(**kwargs):
-        enqueued.append(kwargs)
-
-    monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
-
-    await coordinator.write(uri=first_uri, content="hello", mode="create", ctx=ctx)
-
-    viking_fs._file_uri = second_uri
-    viking_fs._file_exists = False
-    await coordinator.write(uri=second_uri, content="world", mode="create", ctx=ctx)
-
-    assert enqueued[0]["root_uri"] == first_parent
-    assert enqueued[0]["changed_uri"] == first_uri
-    assert enqueued[0]["recursive"] is True
-    assert enqueued[1]["root_uri"] == resource_root
-    assert enqueued[1]["changed_uri"] == second_uri
-    assert enqueued[1]["recursive"] is True
+    assert write_anchor == parent_uri
+    assert set_tags_anchor == project_root
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary / 概述

**[EN]** #2863 made content writes refresh recursively, but kept the anchor collapsed to
the resource **project root**. A single deeply-nested file write therefore recursively
walks the **entire project subtree**, and — because vectorize tasks are batch-dispatched
only at the end of a DAG run — the changed file's L2 vector is not enqueued for embedding
until that whole walk plus the full bottom-up overview chain (`leaf -> ... -> project
root`) completes.

This PR anchors the refresh at the written file's **direct parent** directory instead.
The changed file is then a direct child of the DAG run root, so its L2 vector and the
parent's L0/L1 come from a **single-directory run**; ancestor summaries still refresh via
the existing parent bubble. Same final refresh set, much lower changed-file vector
latency. The `recursive=True` added in #2863 is no longer needed and is removed.

**[中文]** #2863 把 content write 刷新改成了递归,但锚点仍塌缩到资源**项目根**。于是写一个
深层嵌套文件会递归遍历**整棵项目子树**;又因为向量化任务在一趟 DAG run 末尾才批量派发,被改
文件的 L2 向量要等整棵子树遍历 +自底向上的 overview 链(`叶子 -> … -> 项目根`)全部跑完才入
嵌入队列。

本 PR 把刷新锚点改为被写文件的**直接父目录**:被改文件成为 DAG run 根的直接子文件,它的 L2
向量和父目录 L0/L1 只需**一趟单目录 run** 即可生成,祖先目录摘要仍走现有的父目录冒泡刷新。
最终刷新的目录/向量集合不变,但被改文件向量延迟显著降低。#2863 引入的 `recursive=True` 不再
需要,已移除。

## Behavior / 行为

Relative to #2863, for `viking://resources/<proj>/.../<dir>/<file>`:
- Refreshed directories (L0/L1) and re-embedded vectors are **unchanged** (the changed
  file's directory chain up to the scope root, plus the changed file's own L2 vector).
- The changed file's vector is dispatched at the end of a **single-directory** DAG run
  rather than a whole-project recursive run, so it lands in the embedding queue much
  sooner.
- `set_tags` keeps the project-root collapse (relied on by the `.abstract.md`
  derived-sidecar mapping) via the default `anchor_to_parent=False`.

## Test plan / 测试

- `pytest tests/server/test_content_write_service.py` — adds
  `test_resource_write_anchors_nested_file_to_direct_parent` (write path resolves to the
  direct parent; `set_tags` still resolves to the project root). Removes #2863's
  recursive-specific assertions and test. No new failures vs the base.
- `ruff format` / `ruff check` clean.
