### PR TITLE
feat(resources): add url_image_index endpoint for vector-only image ingest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,13 +76,13 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
     fi; \
     case "${UV_LOCK_STRATEGY}" in \
         locked) \
-            uv sync --locked --no-editable --extra bot --extra gemini \
+            uv sync --locked --no-editable --extra bot --extra gemini --extra alice-fencing \
             ;; \
         auto) \
             if ! uv lock --check; then \
                 uv lock; \
             fi; \
-            uv sync --locked --no-editable --extra bot --extra gemini \
+            uv sync --locked --no-editable --extra bot --extra gemini --extra alice-fencing \
             ;; \
         *) \
             echo "Unsupported UV_LOCK_STRATEGY: ${UV_LOCK_STRATEGY}" >&2; \

--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -869,6 +869,85 @@ Possible shared response:
 
 ---
 
+### POST /api/v1/resources/url_image_index
+
+Embed a **remote image URL** as a multimodal vector under `target_uri` *without persisting the image bytes in agfs*.
+
+Useful when the image lives in tenant-owned hosting (an external S3 / CDN) and only the resulting vector should live in OpenViking. The configured multimodal embedder is passed the URL directly — the embedder (or its upstream provider, e.g. Volcengine Ark `embeddings/multimodal`) fetches the image itself.
+
+Compared with the standard ingest pipeline (`temp_upload` + `/resources`), this endpoint:
+
+- Does **not** write any file to agfs (no temp upload, no resource tree under `target_uri`).
+- Does **not** spawn semantic / abstract-generation work — no `.abstract.md` or `.overview.md` is produced for the indexed URI.
+- Does **not** go through the embedding queue. The embedder is called synchronously and the vector is upserted before the response returns.
+
+The configured multimodal embedder is reused as-is: the same provider, failover, circuit-breaker, and dim-validation enforcement as the normal ingest path apply. A text-only embedder (`supports_multimodal` is `False`) is rejected with HTTP 400.
+
+#### Parameters
+
+| Parameter      | Type    | Required | Default      | Description |
+|----------------|---------|----------|--------------|-------------|
+| `target_uri`   | string  | Yes      | -            | Viking URI to index the resulting vector at, e.g. `viking://resources/products/M14253/images/0.embed`. Must lie under the account scope set by `X-OpenViking-Account`. |
+| `image_url`    | string  | Yes      | -            | Remote `http://` or `https://` URL of the image. Forwarded to the multimodal embedder; the upstream provider fetches the URL. |
+| `summary`      | string  | No       | -            | Optional text accompanying the image (mirrors the `image_and_summary` mode). When set, the multimodal embedding is computed over both the text and the image. |
+| `name`         | string  | No       | URI tail     | Optional display name for the indexed record. |
+| `context_type` | string  | No       | `"resource"` | One of `resource`, `memory`, `skill` — passed through to the vectordb scalar field. |
+| `metadata`     | object  | No       | `{}`         | Extra scalar fields attached to the indexed record (e.g. `sku`, `image_idx`). Reserved keys (`id`, `uri`, `account_id`, `vector`, `level`, `abstract`, `content`, `name`, etc.) are stripped — those are set by the server. |
+| `telemetry`    | bool/object | No   | `false`      | Attach telemetry data to the response. |
+
+#### Request
+
+```bash
+curl -X POST http://localhost:1933/api/v1/resources/url_image_index \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -H "X-OpenViking-Account: tenant-a" \
+  -d '{
+    "target_uri": "viking://resources/products/M14253/images/0.embed",
+    "image_url": "https://tenant-bucket.example.com/products/abc.jpg",
+    "summary": "Louis Vuitton Trocadero Wearable Wallet",
+    "metadata": {"sku": "M14253", "image_idx": 0}
+  }'
+```
+
+```python
+client.http.post(
+    "/api/v1/resources/url_image_index",
+    json={
+        "target_uri": "viking://resources/products/M14253/images/0.embed",
+        "image_url": "https://tenant-bucket.example.com/products/abc.jpg",
+        "summary": "Louis Vuitton Trocadero Wearable Wallet",
+        "metadata": {"sku": "M14253", "image_idx": 0},
+    },
+    headers={"X-OpenViking-Account": "tenant-a"},
+)
+```
+
+#### Response
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "status": "ok",
+    "uri": "viking://resources/products/M14253/images/0.embed",
+    "id": "8c1b3d2…"
+  }
+}
+```
+
+The returned `id` is a deterministic md5 of `account_id:canonical_uri`, so repeat calls with the same `(X-OpenViking-Account, target_uri)` upsert in place.
+
+#### Notes & caveats
+
+- **No backing resource file.** A URI inserted this way exists only in vectordb. `readDetail` / hierarchical retrieval will not find a `.abstract.md` or `.overview.md` for the URI. Pair it with text resources elsewhere in the tree (e.g. a sibling `.detail.md/detail.md` ingested normally) if downstream agents need narrative context.
+- **No semantic abstract generation.** No VLM is invoked. If callers want a text description alongside the vector, supply it as `summary`.
+- **Embedder must support multimodal.** A 400 is returned if `EmbedderBase.supports_multimodal` is `False`.
+- **Dim consistency is enforced.** The endpoint refuses to insert if `len(vector) != index.dimension`, just like the normal ingest path.
+- **Tenant isolation.** The URI is canonicalized against `X-OpenViking-Account`; cross-account writes are rejected by the same scope check as other tenant-scoped data APIs.
+
+---
+
 ## Related Documentation
 
 - [File System](03-filesystem.md) - File and directory operations

--- a/openviking/metrics/bootstrap.py
+++ b/openviking/metrics/bootstrap.py
@@ -33,6 +33,7 @@ from openviking.metrics.collectors import (
     CollectorManager,
     EncryptionProbeCollector,
     FeedbackCollector,
+    FencedBacklogCollector,
     LockCollector,
     ModelProviderProbeCollector,
     ModelUsageCollector,
@@ -60,6 +61,7 @@ from openviking.metrics.datasources.probes import (
     StorageProbeDataSource,
 )
 from openviking.metrics.datasources.queue import QueuePipelineStateDataSource
+from openviking.metrics.datasources.session import FencedBacklogDataSource
 from openviking.metrics.datasources.task import TaskStateDataSource
 from openviking_cli.utils.config.open_viking_config import get_openviking_config
 
@@ -82,6 +84,9 @@ def create_default_collector_manager(*, app=None, service=None, config=None) -> 
     """
     manager = CollectorManager()
     manager.register(QueueCollector(data_source=QueuePipelineStateDataSource()))
+    manager.register(
+        FencedBacklogCollector(data_source=FencedBacklogDataSource())
+    )
     manager.register(TaskTrackerCollector(data_source=TaskStateDataSource()))
     feedback_bot_data_path = _resolve_feedback_bot_data_path(config)
     if feedback_bot_data_path is not None:

--- a/openviking/metrics/collectors/__init__.py
+++ b/openviking/metrics/collectors/__init__.py
@@ -28,6 +28,7 @@ from .rerank import RerankCollector
 from .retrieval import RetrievalCollector
 from .retrieval_backend_probe import RetrievalBackendProbeCollector
 from .service_probe import ServiceProbeCollector
+from .session import FencedBacklogCollector
 from .storage_probe import StorageProbeCollector
 from .task_tracker import TaskTrackerCollector
 from .vikingdb import VikingDBCollector
@@ -60,6 +61,7 @@ __all__ = [
     "ModelProviderProbeCollector",
     "AsyncSystemProbeCollector",
     "EncryptionProbeCollector",
+    "FencedBacklogCollector",
     "CollectorManager",
     "RefreshResult",
 ]

--- a/openviking/metrics/collectors/session.py
+++ b/openviking/metrics/collectors/session.py
@@ -15,12 +15,14 @@ Labels are bounded:
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import ClassVar
 
 from openviking.metrics.core.base import MetricCollector
+from openviking.metrics.datasources.session import FencedBacklogDataSource
 
-from .base import EventMetricCollector
+from .base import CollectorConfig, EventMetricCollector, StateMetricCollector
 
 
 @dataclass
@@ -45,12 +47,33 @@ class SessionCollector(EventMetricCollector):
     # rule: <METRICS_NAMESPACE>_<DOMAIN>_archive_total
     # e.g.: openviking_session_archive_total
     ARCHIVE_TOTAL: ClassVar[str] = MetricCollector.metric_name(DOMAIN, "archive", unit="total")
+    FENCING_TOTAL: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN, "fencing_writes", unit="total"
+    )
+    FENCING_LATENCY_SECONDS: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN, "fencing_write_latency", unit="seconds"
+    )
+    FENCING_LAST_EVENT_TIMESTAMP_SECONDS: ClassVar[str] = (
+        MetricCollector.metric_name(
+            DOMAIN, "fencing_last_event_timestamp", unit="seconds"
+        )
+    )
+    FENCED_EFFECTS_TOTAL: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "effects", unit="total"
+    )
+    FENCED_EFFECT_LAST_EVENT_TIMESTAMP_SECONDS: ClassVar[str] = (
+        MetricCollector.metric_name(
+            "fenced", "effect_last_event_timestamp", unit="seconds"
+        )
+    )
 
     SUPPORTED_EVENTS: ClassVar[frozenset[str]] = frozenset(
         {
             "session.lifecycle",
             "session.contexts_used",
             "session.archive",
+            "session.fencing",
+            "session.fenced_effect",
         }
     )
 
@@ -94,6 +117,42 @@ class SessionCollector(EventMetricCollector):
                 registry,
                 status=str(status),
             )
+            return
+        if event_name == "session.fencing":
+            operation = payload.get("operation")
+            outcome = payload.get("outcome")
+            latency_seconds = payload.get("latency_seconds")
+            if operation is None or outcome is None or latency_seconds is None:
+                return
+            self.record_fencing(
+                registry,
+                operation=str(operation),
+                outcome=str(outcome),
+                latency_seconds=float(latency_seconds),
+            )
+            return
+        if event_name == "session.fenced_effect":
+            operation = payload.get("operation")
+            outcome = payload.get("outcome")
+            if operation is None or outcome is None:
+                return
+            registry.inc_counter(
+                self.FENCED_EFFECTS_TOTAL,
+                labels={
+                    "operation": str(operation),
+                    "outcome": str(outcome),
+                },
+                label_names=("operation", "outcome"),
+            )
+            registry.set_gauge(
+                self.FENCED_EFFECT_LAST_EVENT_TIMESTAMP_SECONDS,
+                time.time(),
+                labels={
+                    "operation": str(operation),
+                    "outcome": str(outcome),
+                },
+                label_names=("operation", "outcome"),
+            )
 
     def record_lifecycle(self, registry, *, action: str, status: str) -> None:
         """Increment the lifecycle counter for one session action/status pair."""
@@ -121,3 +180,126 @@ class SessionCollector(EventMetricCollector):
             labels={"status": str(status)},
             label_names=("status",),
         )
+
+    def record_fencing(
+        self,
+        registry,
+        *,
+        operation: str,
+        outcome: str,
+        latency_seconds: float,
+    ) -> None:
+        """Record fenced writes, stale/duplicate suppression, and latency."""
+        labels = {"operation": str(operation), "outcome": str(outcome)}
+        registry.inc_counter(
+            self.FENCING_TOTAL,
+            labels=labels,
+            label_names=("operation", "outcome"),
+        )
+        registry.observe_histogram(
+            self.FENCING_LATENCY_SECONDS,
+            max(0.0, float(latency_seconds)),
+            labels=labels,
+            label_names=("operation", "outcome"),
+        )
+        registry.set_gauge(
+            self.FENCING_LAST_EVENT_TIMESTAMP_SECONDS,
+            time.time(),
+            labels=labels,
+            label_names=("operation", "outcome"),
+        )
+
+
+@dataclass
+class FencedBacklogCollector(StateMetricCollector):
+    """Export low-cardinality PostgreSQL outbox and writer-pool state."""
+
+    WRITER_POOL_HEALTHY: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "writer_pool_healthy"
+    )
+    WRITER_CONCURRENCY: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "writer_concurrency"
+    )
+    EFFECT_ITEMS: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "effect_outbox_items"
+    )
+    EFFECT_OLDEST: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "effect_outbox_oldest_age", unit="seconds"
+    )
+    COMMIT_ITEMS: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "commit_work_items"
+    )
+    COMMIT_OLDEST: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "commit_work_oldest_age", unit="seconds"
+    )
+    COLLECTION_ERRORS: ClassVar[str] = MetricCollector.metric_name(
+        "fenced", "backlog_collection_errors", unit="total"
+    )
+    COLLECTION_LAST_ERROR_TIMESTAMP_SECONDS: ClassVar[str] = (
+        MetricCollector.metric_name(
+            "fenced",
+            "backlog_collection_last_error_timestamp",
+            unit="seconds",
+        )
+    )
+
+    data_source: FencedBacklogDataSource
+    config: CollectorConfig = CollectorConfig(
+        ttl_seconds=1.0,
+        timeout_seconds=1.0,
+    )
+
+    def read_metric_input(self):
+        return self.data_source.read_backlog()
+
+    def collect_hook(self, registry, metric_input) -> None:
+        registry.set_gauge(
+            self.WRITER_POOL_HEALTHY,
+            1.0 if metric_input["writer_healthy"] else 0.0,
+        )
+        for kind in ("effect", "commit"):
+            registry.set_gauge(
+                self.WRITER_CONCURRENCY,
+                float(metric_input[f"{kind}_concurrency"]),
+                labels={"kind": kind},
+                label_names=("kind",),
+            )
+        for state in ("queued", "running"):
+            snapshot = metric_input["effect"][state]
+            labels = {"state": state}
+            registry.set_gauge(
+                self.EFFECT_ITEMS,
+                float(snapshot["items"]),
+                labels=labels,
+                label_names=("state",),
+            )
+            registry.set_gauge(
+                self.EFFECT_OLDEST,
+                float(snapshot["oldest_age_seconds"]),
+                labels=labels,
+                label_names=("state",),
+            )
+        for state in ("pending", "running", "ambiguous"):
+            snapshot = metric_input["commit"][state]
+            labels = {"state": state}
+            registry.set_gauge(
+                self.COMMIT_ITEMS,
+                float(snapshot["items"]),
+                labels=labels,
+                label_names=("state",),
+            )
+            registry.set_gauge(
+                self.COMMIT_OLDEST,
+                float(snapshot["oldest_age_seconds"]),
+                labels=labels,
+                label_names=("state",),
+            )
+
+    def collect_error_hook(self, registry, error: Exception) -> None:
+        del error
+        registry.inc_counter(self.COLLECTION_ERRORS)
+        registry.set_gauge(
+            self.COLLECTION_LAST_ERROR_TIMESTAMP_SECONDS,
+            time.time(),
+        )
+        registry.set_gauge(self.WRITER_POOL_HEALTHY, 0.0)

--- a/openviking/metrics/datasources/__init__.py
+++ b/openviking/metrics/datasources/__init__.py
@@ -15,7 +15,7 @@ from .http import HttpRequestLifecycleDataSource
 from .model_usage import EmbeddingEventDataSource, RerankEventDataSource, VLMEventDataSource
 from .resource import ResourceIngestionEventDataSource
 from .retrieval import RetrievalStatsDataSource
-from .session import SessionLifecycleDataSource
+from .session import FencedBacklogDataSource, SessionLifecycleDataSource
 from .telemetry_bridge import TelemetryBridgeEventDataSource
 
 __all__ = [
@@ -28,6 +28,7 @@ __all__ = [
     "RerankEventDataSource",
     "VLMEventDataSource",
     "SessionLifecycleDataSource",
+    "FencedBacklogDataSource",
     "HttpRequestLifecycleDataSource",
     "CacheEventDataSource",
     "ResourceIngestionEventDataSource",

--- a/openviking/metrics/datasources/session.py
+++ b/openviking/metrics/datasources/session.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from .base import EventMetricDataSource
+from .base import EventMetricDataSource, StateMetricDataSource
 
 
 class SessionLifecycleDataSource(EventMetricDataSource):
@@ -49,3 +49,112 @@ class SessionLifecycleDataSource(EventMetricDataSource):
             "session.archive",
             {"status": str(status)},
         )
+
+    @staticmethod
+    def record_fencing(
+        *, operation: str, outcome: str, latency_seconds: float
+    ) -> None:
+        """Emit one low-cardinality fenced-session write outcome."""
+        EventMetricDataSource._emit(
+            "session.fencing",
+            {
+                "operation": str(operation),
+                "outcome": str(outcome),
+                "latency_seconds": max(0.0, float(latency_seconds)),
+            },
+        )
+
+    @staticmethod
+    def record_fenced_effect(*, operation: str, outcome: str) -> None:
+        """Emit one bounded v2 durable-writer attempt outcome."""
+        EventMetricDataSource._emit(
+            "session.fenced_effect",
+            {"operation": str(operation), "outcome": str(outcome)},
+        )
+
+
+class FencedBacklogDataSource(StateMetricDataSource):
+    """Read the bounded PostgreSQL outbox snapshot used by scrape metrics."""
+
+    def read_backlog(self) -> dict:
+        from openviking.server.fenced_postgres import (
+            _connect,
+            fencing_database_url,
+            fencing_service_token,
+        )
+        from openviking.server.routers.fenced_sessions import (
+            fenced_writer_runtime_status,
+        )
+
+        runtime = fenced_writer_runtime_status()
+        result = {
+            "writer_healthy": bool(runtime["healthy"]),
+            "effect_concurrency": int(runtime["effect_concurrency"]),
+            "commit_concurrency": int(runtime["commit_concurrency"]),
+            "effect": {
+                state: {"items": 0, "oldest_age_seconds": 0.0}
+                for state in ("queued", "running")
+            },
+            "commit": {
+                state: {"items": 0, "oldest_age_seconds": 0.0}
+                for state in ("pending", "running", "ambiguous")
+            },
+        }
+        database_url = fencing_database_url()
+        service_token = fencing_service_token()
+        if not database_url and not service_token:
+            return result
+        if not database_url or not service_token:
+            raise RuntimeError("partial Alice fencing configuration")
+
+        conn = _connect(application_name="openviking-fenced-metrics")
+        try:
+            conn.autocommit = True
+            with conn.cursor() as cursor:
+                # A scrape must never hold a database connection behind slow
+                # application work.  CollectorManager also adds a 1s outer
+                # timeout and a 1s TTL/SWR cache.
+                cursor.execute("SET statement_timeout = 500")
+                cursor.execute(
+                    """
+                    SELECT o.state, count(*),
+                           COALESCE(
+                             EXTRACT(EPOCH FROM (now() - min(r.submitted_at))),
+                             0
+                           )
+                    FROM openviking_fencing.effect_outbox o
+                    JOIN openviking_fencing.operation_receipt r
+                      USING (account_id,user_id,writer,session_scope_id,operation_id)
+                    WHERE o.state IN ('queued','running')
+                    GROUP BY o.state
+                    """
+                )
+                for state, count, oldest in cursor.fetchall():
+                    normalized = str(state)
+                    if normalized in result["effect"]:
+                        result["effect"][normalized] = {
+                            "items": int(count),
+                            "oldest_age_seconds": max(0.0, float(oldest)),
+                        }
+                cursor.execute(
+                    """
+                    SELECT state, count(*),
+                           COALESCE(
+                             EXTRACT(EPOCH FROM (now() - min(created_at))),
+                             0
+                           )
+                    FROM openviking_fencing.commit_work_outbox
+                    WHERE state IN ('pending','running','ambiguous')
+                    GROUP BY state
+                    """
+                )
+                for state, count, oldest in cursor.fetchall():
+                    normalized = str(state)
+                    if normalized in result["commit"]:
+                        result["commit"][normalized] = {
+                            "items": int(count),
+                            "oldest_age_seconds": max(0.0, float(oldest)),
+                        }
+        finally:
+            conn.close()
+        return result

--- a/openviking/metrics/global_api.py
+++ b/openviking/metrics/global_api.py
@@ -333,6 +333,8 @@ def _build_event_router(registry: MetricRegistry) -> EventCollectorRouter:
         ("session.lifecycle", session_collector),
         ("session.contexts_used", session_collector),
         ("session.archive", session_collector),
+        ("session.fencing", session_collector),
+        ("session.fenced_effect", session_collector),
         ("resource.stage", resource_collector),
         ("resource.wait", resource_collector),
         ("retrieval.completed", retrieval_collector),

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -34,6 +34,7 @@ from openviking.server.routers import (
     console_router,
     content_router,
     debug_router,
+    fenced_sessions_router,
     filesystem_router,
     metrics_router,
     observer_router,
@@ -216,6 +217,18 @@ def create_app(
 
     validate_server_config(config)
 
+    # Validate at startup.  Treating an operator typo as observe would silently
+    # re-enable unfenced Alice writes, so invalid values are fatal.
+    from openviking.server.fenced_operation import get_alice_fencing_mode
+
+    alice_fencing_mode = get_alice_fencing_mode()
+    if alice_fencing_mode == "required":
+        from openviking.server.fenced_postgres import (
+            validate_required_fencing_configuration,
+        )
+
+        validate_required_fencing_configuration()
+
     def _configure_session_tool_outputs(service_obj) -> None:  # noqa: ANN001
         sessions = getattr(service_obj, "sessions", None)
         setter = getattr(sessions, "set_tool_output_externalization_config", None)
@@ -287,38 +300,60 @@ def create_app(
         # Start MCP session manager (must be active before /mcp requests)
         from openviking.server.mcp_endpoint import mcp_lifespan
 
-        async with mcp_lifespan():
-            if service is not None:
-                await _initialize_runtime_state(app, service, config)
-            yield
+        try:
+            async with mcp_lifespan():
+                if service is not None:
+                    await _initialize_runtime_state(app, service, config)
+                from openviking.server.routers.fenced_sessions import (
+                    start_fenced_writer_runtime,
+                )
 
-        # Cleanup
-        from openviking.metrics.global_api import shutdown_metrics_async
-        from openviking.observability.usage_audit import shutdown_usage_audit
+                fencing_configured = await start_fenced_writer_runtime()
+                if alice_fencing_mode == "required" and not fencing_configured:
+                    raise RuntimeError(
+                        "required Alice fencing writer is not configured"
+                    )
+                yield
+        finally:
+            # Stop accepting/claiming durable work first and allow active Phase
+            # 2 effects to drain while service/storage dependencies still live.
+            from openviking.server.routers.fenced_sessions import (
+                stop_fenced_writer_runtime,
+            )
 
-        await shutdown_usage_audit(app=app)
-        await shutdown_metrics_async(app=app)
-        task_tracker.stop_cleanup_loop()
-        if oauth_gc_task is not None:
-            oauth_gc_task.cancel()
-            try:
-                await oauth_gc_task
-            except (asyncio.CancelledError, Exception):
-                pass
-        oauth_store_state = getattr(app.state, "oauth_store", None)
-        if oauth_store_state is not None:
-            try:
-                await oauth_store_state.close()
-            except Exception as e:  # noqa: BLE001
-                logger.warning("OAuth store close failed: %s", e)
-        if owns_service and service:
-            try:
-                await service.close()
-                logger.info("OpenVikingService closed")
-            except asyncio.CancelledError as e:
-                logger.warning(f"OpenVikingService close cancelled during shutdown: {e}")
-            except Exception as e:
-                logger.warning(f"OpenVikingService close failed during shutdown: {e}")
+            await stop_fenced_writer_runtime()
+
+            from openviking.metrics.global_api import shutdown_metrics_async
+            from openviking.observability.usage_audit import shutdown_usage_audit
+
+            await shutdown_usage_audit(app=app)
+            await shutdown_metrics_async(app=app)
+            task_tracker.stop_cleanup_loop()
+            if oauth_gc_task is not None:
+                oauth_gc_task.cancel()
+                try:
+                    await oauth_gc_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            oauth_store_state = getattr(app.state, "oauth_store", None)
+            if oauth_store_state is not None:
+                try:
+                    await oauth_store_state.close()
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("OAuth store close failed: %s", e)
+            if owns_service and service:
+                try:
+                    await service.close()
+                    logger.info("OpenVikingService closed")
+                except asyncio.CancelledError as e:
+                    logger.warning(
+                        "OpenVikingService close cancelled during shutdown: %s",
+                        e,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "OpenVikingService close failed during shutdown: %s", e
+                    )
 
     app = FastAPI(
         title="OpenViking API",
@@ -396,6 +431,56 @@ def create_app(
             )
         response = await call_next(request)
         return response
+
+    @app.middleware("http")
+    async def require_fenced_alice_session_writes(request: Request, call_next: Callable):
+        """Fail closed on Alice's legacy writes after the required-mode cutover."""
+        from openviking.server.fenced_operation import get_alice_fencing_mode
+        from openviking.server.fenced_postgres import is_valid_alice_service_token
+
+        is_legacy_session_write = (
+            request.method.upper() in {"POST", "PUT", "PATCH", "DELETE"}
+            and (
+                request.url.path == "/api/v1/sessions"
+                or request.url.path.startswith("/api/v1/sessions/")
+            )
+        )
+        supplied_token = request.headers.get("X-OpenViking-Alice-Token")
+        authenticated_alice = is_valid_alice_service_token(supplied_token)
+        legacy_alice_marker = (
+            request.headers.get("X-OpenViking-Agent", "").strip().lower() == "alice"
+        )
+        if supplied_token is not None and not authenticated_alice:
+            return JSONResponse(
+                status_code=401,
+                content=Response(
+                    status="error",
+                    error=ErrorInfo(
+                        code="UNAUTHENTICATED",
+                        message="Invalid X-OpenViking-Alice-Token",
+                    ),
+                ).model_dump(exclude_none=True),
+            )
+        if (
+            get_alice_fencing_mode() == "required"
+            # The secret principal is the positive authentication boundary.
+            # The legacy marker is used only as a backwards-compatible deny so
+            # an already-running pre-token Alice process cannot bypass cutover.
+            and (authenticated_alice or legacy_alice_marker)
+            and is_legacy_session_write
+        ):
+            return JSONResponse(
+                status_code=412,
+                content=Response(
+                    status="error",
+                    error=ErrorInfo(
+                        code="FAILED_PRECONDITION",
+                        message="Alice must use the fenced session write API",
+                        details={"reason": "fencing_required"},
+                    ),
+                ).model_dump(exclude_none=True),
+            )
+        return await call_next(request)
 
     # Add request timing middleware
     @app.middleware("http")
@@ -531,6 +616,7 @@ def create_app(
     app.include_router(relations_router)
     app.include_router(privacy_configs_router)
     app.include_router(skills_router)
+    app.include_router(fenced_sessions_router)
     app.include_router(sessions_router)
     app.include_router(snapshot_router)
     app.include_router(stats_router)

--- a/openviking/server/fenced_operation.py
+++ b/openviking/server/fenced_operation.py
@@ -1,0 +1,571 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Durable fencing ledger for Alice-owned OpenViking session writes.
+
+The public session API predates distributed writer leases and intentionally remains
+backwards compatible.  Alice uses the dedicated fenced API instead.  Every fenced
+write is serialized on a stable, account/user-scoped AGFS sentinel and records both
+the highest accepted fencing token and an operation receipt before acknowledging the
+caller.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import time
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from openviking.core.namespace import canonical_user_root
+from openviking.server.identity import RequestContext
+from openviking.storage.errors import LockAcquisitionError
+from openviking.storage.transaction import LockContext, get_lock_manager
+from openviking_cli.exceptions import NotFoundError, OpenVikingError, UnavailableError
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+ALICE_FENCING_PROTOCOL = "openviking-alice-session-fencing"
+ALICE_FENCING_VERSION = 2
+ALICE_FENCING_MODE_ENV = "OPENVIKING_ALICE_FENCING_MODE"
+_ALLOWED_MODES = frozenset({"observe", "required"})
+_LEDGER_VERSION = 1
+_MAX_FENCING_TOKEN = 9_007_199_254_740_991
+
+
+def get_alice_fencing_mode() -> Literal["observe", "required"]:
+    """Return the configured compatibility mode, rejecting unsafe typos."""
+    raw = os.getenv(ALICE_FENCING_MODE_ENV, "observe").strip().lower()
+    if raw not in _ALLOWED_MODES:
+        raise RuntimeError(
+            f"{ALICE_FENCING_MODE_ENV} must be one of observe|required, got {raw!r}"
+        )
+    return raw  # type: ignore[return-value]
+
+
+class FencedOperationEnvelope(BaseModel):
+    """Common, strictly validated identity for one durable writer operation."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    writer: Literal["alice"]
+    session_scope_id: str = Field(min_length=1, max_length=2048)
+    turn_id: str = Field(min_length=1, max_length=256)
+    operation_id: str = Field(min_length=1, max_length=256)
+    fencing_token: int = Field(gt=0, le=_MAX_FENCING_TOKEN)
+
+    @field_validator("session_scope_id", "turn_id", "operation_id")
+    @classmethod
+    def reject_control_characters(cls, value: str) -> str:
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise ValueError("control characters are not allowed")
+        return value
+
+
+class FencedOperationConflict(OpenVikingError):
+    """Structured 409 emitted by the fencing ledger."""
+
+    def __init__(self, message: str, *, reason: str, details: Optional[dict[str, Any]] = None):
+        conflict_details = {"reason": reason}
+        if details:
+            conflict_details.update(details)
+        super().__init__(message, code="CONFLICT", details=conflict_details)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def operation_digest(
+    operation: str,
+    envelope: FencedOperationEnvelope,
+    *,
+    resource_id: str,
+    actor_peer_id: Optional[str] = None,
+) -> str:
+    """Hash the immutable effect request, excluding the replaceable lease token."""
+    # The operation ID is the stable idempotency map key.  W2 takeover changes
+    # only the lease token; writer/scope/turn remain immutable and therefore
+    # participate in the content digest.
+    body = envelope.model_dump(
+        mode="json",
+        exclude={
+            "operation_id",
+            "fencing_token",
+        },
+    )
+    encoded = _canonical_json(
+        {
+            "operation": operation,
+            "resource_id": resource_id,
+            "request": body,
+            # This identity can change the effective peer_id even when the
+            # request body omits peer_id, so it is part of effect identity.
+            "actor_peer_id": actor_peer_id,
+        }
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def stable_message_id(envelope: FencedOperationEnvelope, index: int = 0) -> str:
+    """Derive an OpenViking message ID stable across retries and process crashes."""
+    raw = "\x1f".join(
+        (
+            envelope.writer,
+            envelope.session_scope_id,
+            envelope.turn_id,
+            envelope.operation_id,
+            str(index),
+        )
+    )
+    return f"msg_fenced_{hashlib.sha256(raw.encode('utf-8')).hexdigest()[:40]}"
+
+
+def _record_metric(operation: str, outcome: str, latency_seconds: float) -> None:
+    """Publish bounded fencing metrics without making correctness depend on metrics."""
+    try:
+        from openviking.metrics.datasources.session import SessionLifecycleDataSource
+
+        SessionLifecycleDataSource.record_fencing(
+            operation=operation,
+            outcome=outcome,
+            latency_seconds=max(0.0, latency_seconds),
+        )
+    except Exception:
+        logger.debug("Failed to record fenced-session metric", exc_info=True)
+
+
+# Test-only crash seam: tests replace this function with a one-shot exception to
+# model process loss after an idempotent effect but before the ledger receipt.
+async def after_fenced_effect_before_receipt(operation: str) -> None:
+    del operation
+
+
+# Test-only freeze seam immediately before the short PostgreSQL submit
+# transaction.  No database lock or OpenViking effect is owned at this point.
+async def after_fenced_submit_preflight(operation: str) -> None:
+    del operation
+
+
+# Synchronous test seam after PostgreSQL advisory-xact locks are held.  The
+# connection-level idle-in-transaction timeout must release them even when the
+# submitting process is SIGSTOP-frozen.
+def after_fenced_submit_locks_acquired(operation: str) -> None:
+    del operation
+
+
+async def after_fenced_writer_claimed(operation_id: str) -> None:
+    """Test seam: row is running, but AGFS has not been authorized/touched."""
+    del operation_id
+
+
+async def after_fenced_writer_effect_started(operation_id: str) -> None:
+    """Test seam: durable single-writer boundary crossed; recovery is mandatory."""
+    del operation_id
+
+
+class FencedOperationLedger:
+    """AGFS-backed high-watermark and idempotency ledger for one writer scope."""
+
+    def __init__(self, viking_fs: Any, ctx: RequestContext, envelope: FencedOperationEnvelope):
+        self._viking_fs = viking_fs
+        self._ctx = ctx
+        self._envelope = envelope
+        scope_hash = hashlib.sha256(
+            f"{envelope.writer}\x1f{envelope.session_scope_id}".encode("utf-8")
+        ).hexdigest()
+        self._ledger_uri = (
+            f"{canonical_user_root(ctx)}/.alice-session-fencing/{scope_hash}.json"
+        )
+        self._ledger_path = viking_fs._uri_to_path(self._ledger_uri, ctx=ctx)
+
+    def _session_binding_uri(self, resource_id: str) -> str:
+        resource_hash = hashlib.sha256(resource_id.encode("utf-8")).hexdigest()
+        return (
+            f"{canonical_user_root(self._ctx)}/.alice-session-fencing/"
+            f"session-bindings/{resource_hash}.json"
+        )
+
+    def _session_binding_path(self, resource_id: str) -> str:
+        return self._viking_fs._uri_to_path(
+            self._session_binding_uri(resource_id),
+            ctx=self._ctx,
+        )
+
+    def _effect_receipt_uri(self, operation: str, resource_id: str) -> str:
+        resource_hash = hashlib.sha256(resource_id.encode("utf-8")).hexdigest()
+        operation_hash = hashlib.sha256(
+            f"{operation}\x1f{self._envelope.operation_id}".encode("utf-8")
+        ).hexdigest()
+        return (
+            f"{canonical_user_root(self._ctx)}/.alice-session-fencing/effects/"
+            f"{resource_hash}/{operation_hash}.json"
+        )
+
+    async def load_effect_result(
+        self, operation: str, resource_id: str
+    ) -> Optional[dict[str, Any]]:
+        """Read an effect-level receipt used to bridge callback/ledger crash gaps."""
+        uri = self._effect_receipt_uri(operation, resource_id)
+        try:
+            raw = await self._viking_fs.read_file(uri, ctx=self._ctx)
+        except NotFoundError:
+            return None
+        try:
+            receipt = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Corrupt fenced-session effect receipt") from exc
+        expected_digest = operation_digest(
+            operation,
+            self._envelope,
+            resource_id=resource_id,
+            actor_peer_id=self._ctx.actor_peer_id,
+        )
+        if not isinstance(receipt, dict):
+            raise RuntimeError("Corrupt fenced-session effect receipt")
+        if receipt.get("digest") != expected_digest:
+            raise FencedOperationConflict(
+                "Operation ID was already used for different content",
+                reason="operation_digest_conflict",
+                details={"operation_id": self._envelope.operation_id},
+            )
+        result = receipt.get("result")
+        if not isinstance(result, dict):
+            raise RuntimeError("Corrupt fenced-session effect result")
+        return result
+
+    async def save_effect_result(
+        self,
+        operation: str,
+        resource_id: str,
+        result: dict[str, Any],
+    ) -> None:
+        """Persist an idempotent effect result before returning from the callback."""
+        uri = self._effect_receipt_uri(operation, resource_id)
+        digest = operation_digest(
+            operation,
+            self._envelope,
+            resource_id=resource_id,
+            actor_peer_id=self._ctx.actor_peer_id,
+        )
+        await self._viking_fs.write_file(
+            uri,
+            _canonical_json(
+                {
+                    "version": _LEDGER_VERSION,
+                    "operation_id": self._envelope.operation_id,
+                    "digest": digest,
+                    "result": result,
+                    "completed_at": _utc_now(),
+                }
+            ),
+            ctx=self._ctx,
+        )
+
+    async def _check_session_binding(self, resource_id: str) -> bool:
+        """Validate a binding under the caller-held resource lock.
+
+        Returns True when the binding must be published after the effect.  This
+        avoids leaving a failed-operation placeholder that can permanently
+        claim a session which was never successfully mutated.
+        """
+        binding_uri = self._session_binding_uri(resource_id)
+        try:
+            raw = await self._viking_fs.read_file(binding_uri, ctx=self._ctx)
+        except NotFoundError:
+            return True
+        try:
+            binding = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Corrupt fenced-session binding") from exc
+
+        expected = {
+            "version": _LEDGER_VERSION,
+            "account_id": self._ctx.account_id,
+            "user_id": self._ctx.user.user_id,
+            "writer": self._envelope.writer,
+            "session_scope_id": self._envelope.session_scope_id,
+            "session_id": resource_id,
+        }
+        if not isinstance(binding, dict) or any(
+            binding.get(key) != value for key, value in expected.items()
+        ):
+            raise FencedOperationConflict(
+                "Session is already bound to a different writer scope",
+                reason="session_scope_conflict",
+                details={"session_id": resource_id},
+            )
+        return False
+
+    async def _publish_session_binding(self, resource_id: str) -> None:
+        expected = {
+            "version": _LEDGER_VERSION,
+            "account_id": self._ctx.account_id,
+            "user_id": self._ctx.user.user_id,
+            "writer": self._envelope.writer,
+            "session_scope_id": self._envelope.session_scope_id,
+            "session_id": resource_id,
+            "created_at": _utc_now(),
+        }
+        await self._viking_fs.write_file(
+            self._session_binding_uri(resource_id),
+            _canonical_json(expected),
+            ctx=self._ctx,
+        )
+
+    @staticmethod
+    def _prune_old_receipts(
+        operations: dict[str, Any],
+        *,
+        fencing_token: int,
+        preserve_operation_id: str,
+    ) -> None:
+        """Keep receipts only for the active fence; older requests are now stale."""
+        stale_ids = [
+            operation_id
+            for operation_id, receipt in operations.items()
+            if operation_id != preserve_operation_id
+            and int(receipt.get("fencing_token", 0) or 0) < fencing_token
+        ]
+        for operation_id in stale_ids:
+            operations.pop(operation_id, None)
+
+    async def _load(self) -> dict[str, Any]:
+        try:
+            raw = await self._viking_fs.read_file(self._ledger_uri, ctx=self._ctx)
+        except NotFoundError:
+            return {
+                "version": _LEDGER_VERSION,
+                "account_id": self._ctx.account_id,
+                "user_id": self._ctx.user.user_id,
+                "writer": self._envelope.writer,
+                "session_scope_id": self._envelope.session_scope_id,
+                "highest_fencing_token": 0,
+                "active_turn_id": None,
+                "operations": {},
+                "closed_sessions": {},
+                "updated_at": _utc_now(),
+            }
+
+        try:
+            ledger = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Corrupt fenced-session ledger") from exc
+        if not isinstance(ledger, dict) or ledger.get("version") != _LEDGER_VERSION:
+            raise RuntimeError("Unsupported fenced-session ledger version")
+        expected_identity = {
+            "account_id": self._ctx.account_id,
+            "user_id": self._ctx.user.user_id,
+            "writer": self._envelope.writer,
+            "session_scope_id": self._envelope.session_scope_id,
+        }
+        for key, expected in expected_identity.items():
+            if ledger.get(key) != expected:
+                raise RuntimeError(f"Fenced-session ledger identity mismatch: {key}")
+        if not isinstance(ledger.get("operations"), dict):
+            raise RuntimeError("Corrupt fenced-session operation map")
+        ledger.setdefault("active_turn_id", None)
+        ledger.setdefault("closed_sessions", {})
+        if not isinstance(ledger.get("closed_sessions"), dict):
+            raise RuntimeError("Corrupt fenced-session closure map")
+        return ledger
+
+    async def _save(self, ledger: dict[str, Any]) -> None:
+        ledger["updated_at"] = _utc_now()
+        await self._viking_fs.write_file(
+            self._ledger_uri,
+            _canonical_json(ledger),
+            ctx=self._ctx,
+        )
+
+    async def execute(
+        self,
+        operation: str,
+        resource_id: str,
+        callback: Callable[[], Awaitable[dict[str, Any]]],
+    ) -> tuple[dict[str, Any], bool]:
+        """Execute or replay one effect while holding the durable writer-scope lock."""
+        started = time.perf_counter()
+        digest = operation_digest(
+            operation,
+            self._envelope,
+            resource_id=resource_id,
+            actor_peer_id=self._ctx.actor_peer_id,
+        )
+        outcome = "error"
+        try:
+            if get_alice_fencing_mode() == "required":
+                # Required mode must never fall back to the expiring AGFS path
+                # lock.  PostgreSQL owns the high watermark and keeps a
+                # transaction/advisory lock alive across the external effect.
+                from openviking.server.fenced_postgres import (
+                    PostgresFencedOperationLedger,
+                )
+
+                result, replayed = await PostgresFencedOperationLedger(
+                    self._ctx,
+                    self._envelope,
+                ).execute(operation, resource_id, callback)
+                outcome = "duplicate" if replayed else "write"
+                return result, replayed
+            async with LockContext(
+                get_lock_manager(),
+                [self._ledger_path, self._session_binding_path(resource_id)],
+                lock_mode="exact",
+            ):
+                ledger = await self._load()
+                token = self._envelope.fencing_token
+                highest = int(ledger.get("highest_fencing_token", 0) or 0)
+                if token < highest:
+                    outcome = "stale"
+                    raise FencedOperationConflict(
+                        "Fencing token is stale",
+                        reason="stale_fence",
+                        details={
+                            "highest_fencing_token": highest,
+                            "received_fencing_token": token,
+                        },
+                    )
+
+                active_turn = ledger.get("active_turn_id")
+                if (
+                    token == highest
+                    and highest > 0
+                    and active_turn is not None
+                    and active_turn != self._envelope.turn_id
+                ):
+                    outcome = "conflict"
+                    raise FencedOperationConflict(
+                        "The active fencing token is already bound to another turn",
+                        reason="turn_fence_conflict",
+                        details={"active_turn_id": active_turn},
+                    )
+
+                operations: dict[str, Any] = ledger["operations"]
+                receipt = operations.get(self._envelope.operation_id)
+                if receipt is not None:
+                    if receipt.get("digest") != digest:
+                        outcome = "conflict"
+                        raise FencedOperationConflict(
+                            "Operation ID was already used for different content",
+                            reason="operation_digest_conflict",
+                            details={"operation_id": self._envelope.operation_id},
+                        )
+                    if receipt.get("state") == "done":
+                        if token > highest:
+                            ledger["highest_fencing_token"] = token
+                            receipt["fencing_token"] = token
+                            self._prune_old_receipts(
+                                operations,
+                                fencing_token=token,
+                                preserve_operation_id=self._envelope.operation_id,
+                            )
+                            await self._save(ledger)
+                        outcome = "duplicate"
+                        cached = receipt.get("result")
+                        if not isinstance(cached, dict):
+                            raise RuntimeError("Corrupt fenced-session cached result")
+                        return cached, True
+
+                closed_sessions: dict[str, Any] = ledger["closed_sessions"]
+                closure = closed_sessions.get(resource_id)
+                if isinstance(closure, dict) and closure.get("turn_id") == self._envelope.turn_id:
+                    if (
+                        operation == "commit"
+                        and closure.get("operation_id") == self._envelope.operation_id
+                    ):
+                        if closure.get("digest") != digest:
+                            outcome = "conflict"
+                            raise FencedOperationConflict(
+                                "Operation ID was already used for different content",
+                                reason="operation_digest_conflict",
+                                details={"operation_id": self._envelope.operation_id},
+                            )
+                        if not isinstance(closure.get("result"), dict):
+                            raise RuntimeError("Corrupt fenced-session closure result")
+                        outcome = "duplicate"
+                        return dict(closure["result"]), True
+                    if operation in {"message", "used", "commit"}:
+                        outcome = "conflict"
+                        raise FencedOperationConflict(
+                            "The session is closed for this turn",
+                            reason="session_turn_closed",
+                            details={
+                                "session_id": resource_id,
+                                "turn_id": self._envelope.turn_id,
+                            },
+                        )
+                else:
+                    receipt = {
+                        "operation": operation,
+                        "turn_id": self._envelope.turn_id,
+                        "digest": digest,
+                        "fencing_token": token,
+                        "state": "prepared",
+                        "prepared_at": _utc_now(),
+                    }
+                    operations[self._envelope.operation_id] = receipt
+
+                receipt["fencing_token"] = max(
+                    int(receipt.get("fencing_token", 0) or 0), token
+                )
+                if token > highest:
+                    self._prune_old_receipts(
+                        operations,
+                        fencing_token=token,
+                        preserve_operation_id=self._envelope.operation_id,
+                    )
+                    if active_turn != self._envelope.turn_id:
+                        closed_sessions.clear()
+
+                # Advancing the high watermark and recording prepared are one locked,
+                # durable transition and always happen before the external effect.
+                ledger["highest_fencing_token"] = max(highest, token)
+                ledger["active_turn_id"] = self._envelope.turn_id
+                await self._save(ledger)
+
+                binding_missing = await self._check_session_binding(resource_id)
+                result = await callback()
+                if not isinstance(result, dict):
+                    raise TypeError("Fenced operation callback must return a dict")
+
+                seam_result = after_fenced_effect_before_receipt(operation)
+                if inspect.isawaitable(seam_result):
+                    await seam_result
+
+                if binding_missing:
+                    await self._publish_session_binding(resource_id)
+
+                receipt["state"] = "done"
+                receipt["result"] = result
+                receipt["completed_at"] = _utc_now()
+                if operation == "commit":
+                    closed_sessions[resource_id] = {
+                        "turn_id": self._envelope.turn_id,
+                        "fencing_token": token,
+                        "operation_id": self._envelope.operation_id,
+                        "digest": digest,
+                        "result": result,
+                        "closed_at": _utc_now(),
+                    }
+                await self._save(ledger)
+                outcome = "write"
+                return result, False
+        except LockAcquisitionError as exc:
+            outcome = "busy"
+            raise UnavailableError(
+                "fenced session ledger",
+                "writer scope is busy; retry the same operation_id",
+            ) from exc
+        finally:
+            _record_metric(operation, outcome, time.perf_counter() - started)

--- a/openviking/server/fenced_postgres.py
+++ b/openviking/server/fenced_postgres.py
@@ -1,0 +1,2203 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""PostgreSQL authority and durable outbox for Alice fenced session effects.
+
+AGFS path locks are renewable leases and AGFS writes are unconditional.  They
+therefore cannot be the authority for an external fencing token: a process that
+is frozen beyond the lease TTL may resume after a takeover and overwrite newer
+state.  Required mode accepts an operation into PostgreSQL in a short atomic
+boundary.  Alice/API request owners never execute the AGFS effect; one durable
+outbox writer applies accepted effects in sequence.
+
+The tables are intentionally created by deployment migrations, never by the
+runtime request or startup path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import inspect
+import json
+import os
+import re
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from typing import Any, Optional
+
+from openviking.server.fenced_operation import (
+    FencedOperationConflict,
+    FencedOperationEnvelope,
+    operation_digest,
+)
+from openviking.server.identity import RequestContext
+from openviking_cli.exceptions import FailedPreconditionError, UnavailableError
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+FENCING_DATABASE_URL_ENV = "OPENVIKING_ALICE_FENCING_DATABASE_URL"
+FENCING_SERVICE_TOKEN_ENV = "OPENVIKING_ALICE_SERVICE_TOKEN"
+FENCING_SUBMIT_IDLE_TIMEOUT_MS_ENV = "OPENVIKING_ALICE_FENCING_SUBMIT_IDLE_TIMEOUT_MS"
+FENCING_DATABASE_ROLE = "openviking_fencing"
+
+
+def _record_v2_submit_metric(
+    operation: str,
+    outcome: str,
+    started_at: float,
+) -> None:
+    try:
+        from openviking.metrics.datasources.session import (  # noqa: PLC0415
+            SessionLifecycleDataSource,
+        )
+
+        SessionLifecycleDataSource.record_fencing(
+            operation=operation,
+            outcome=outcome,
+            latency_seconds=max(0.0, time.monotonic() - started_at),
+        )
+    except Exception:
+        logger.debug("Failed to record v2 fencing submit metric", exc_info=True)
+
+
+def _record_suppressed_effect_metrics(operations: list[str]) -> None:
+    if not operations:
+        return
+    try:
+        from openviking.metrics.datasources.session import (  # noqa: PLC0415
+            SessionLifecycleDataSource,
+        )
+
+        for operation in operations:
+            SessionLifecycleDataSource.record_fenced_effect(
+                operation=operation,
+                outcome="suppressed",
+            )
+    except Exception:
+        logger.debug("Failed to record suppressed fenced effects", exc_info=True)
+
+
+SCHEMA = "openviking_fencing"
+
+# Kept here as the canonical contract for the root deployment migration.
+POSTGRES_FENCING_DDL = f"""
+CREATE SCHEMA IF NOT EXISTS {SCHEMA};
+
+CREATE TABLE IF NOT EXISTS {SCHEMA}.scope_state (
+    account_id text NOT NULL,
+    user_id text NOT NULL,
+    writer text NOT NULL,
+    session_scope_id text NOT NULL,
+    highest_fencing_token bigint NOT NULL,
+    active_turn_id text NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id, user_id, writer, session_scope_id)
+);
+
+CREATE TABLE IF NOT EXISTS {SCHEMA}.session_binding (
+    account_id text NOT NULL,
+    user_id text NOT NULL,
+    session_id text NOT NULL,
+    writer text NOT NULL,
+    session_scope_id text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id, user_id, session_id)
+);
+
+CREATE TABLE IF NOT EXISTS {SCHEMA}.operation_receipt (
+    account_id text NOT NULL,
+    user_id text NOT NULL,
+    writer text NOT NULL,
+    session_scope_id text NOT NULL,
+    operation_id text NOT NULL,
+    operation text NOT NULL,
+    resource_id text NOT NULL,
+    turn_id text NOT NULL,
+    digest text NOT NULL,
+    fencing_token bigint NOT NULL,
+    state text NOT NULL,
+    result jsonb,
+    error jsonb,
+    submitted_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id, user_id, writer, session_scope_id, operation_id)
+);
+
+ALTER TABLE {SCHEMA}.operation_receipt
+    ADD COLUMN IF NOT EXISTS error jsonb;
+ALTER TABLE {SCHEMA}.operation_receipt
+    ADD COLUMN IF NOT EXISTS submitted_at timestamptz NOT NULL DEFAULT now();
+ALTER TABLE {SCHEMA}.operation_receipt
+    DROP CONSTRAINT IF EXISTS operation_receipt_state_check;
+UPDATE {SCHEMA}.operation_receipt SET state='queued' WHERE state='prepared';
+UPDATE {SCHEMA}.operation_receipt SET state='completed' WHERE state='done';
+ALTER TABLE {SCHEMA}.operation_receipt
+    ADD CONSTRAINT operation_receipt_state_check
+    CHECK (state IN ('queued', 'running', 'completed', 'stale', 'failed', 'conflict'));
+
+CREATE INDEX IF NOT EXISTS operation_receipt_fence_idx
+ON {SCHEMA}.operation_receipt
+    (account_id, user_id, writer, session_scope_id, fencing_token);
+
+CREATE UNIQUE INDEX IF NOT EXISTS operation_receipt_principal_operation_uq
+ON {SCHEMA}.operation_receipt (account_id, user_id, writer, operation_id);
+
+CREATE TABLE IF NOT EXISTS {SCHEMA}.effect_receipt (
+    account_id text NOT NULL,
+    user_id text NOT NULL,
+    writer text NOT NULL,
+    session_scope_id text NOT NULL,
+    operation_id text NOT NULL,
+    operation text NOT NULL,
+    resource_id text NOT NULL,
+    turn_id text NOT NULL,
+    digest text NOT NULL,
+    fencing_token bigint NOT NULL,
+    result jsonb NOT NULL,
+    completed_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id, user_id, writer, session_scope_id, operation_id)
+);
+
+CREATE INDEX IF NOT EXISTS effect_receipt_fence_idx
+ON {SCHEMA}.effect_receipt
+    (account_id, user_id, writer, session_scope_id, fencing_token);
+
+CREATE TABLE IF NOT EXISTS {SCHEMA}.effect_outbox (
+    sequence_id bigserial NOT NULL UNIQUE,
+    account_id text NOT NULL,
+    user_id text NOT NULL,
+    writer text NOT NULL,
+    session_scope_id text NOT NULL,
+    operation_id text NOT NULL,
+    operation text NOT NULL,
+    resource_id text NOT NULL,
+    turn_id text NOT NULL,
+    digest text NOT NULL,
+    fencing_token bigint NOT NULL,
+    request_payload jsonb NOT NULL,
+    actor_peer_id text,
+    state text NOT NULL DEFAULT 'queued'
+        CHECK (state IN ('queued', 'running')),
+    attempt_count integer NOT NULL DEFAULT 0,
+    claim_token text,
+    available_at timestamptz NOT NULL DEFAULT now(),
+    claimed_at timestamptz,
+    effect_started_at timestamptz,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id, user_id, writer, session_scope_id, operation_id)
+);
+
+ALTER TABLE {SCHEMA}.effect_outbox
+    ADD COLUMN IF NOT EXISTS effect_started_at timestamptz;
+ALTER TABLE {SCHEMA}.effect_outbox
+    ADD COLUMN IF NOT EXISTS claim_token text;
+ALTER TABLE {SCHEMA}.effect_outbox
+    DROP COLUMN IF EXISTS effect_result;
+ALTER TABLE {SCHEMA}.effect_outbox
+    DROP COLUMN IF EXISTS wait_task_id;
+ALTER TABLE {SCHEMA}.effect_outbox
+    DROP CONSTRAINT IF EXISTS effect_outbox_state_check;
+DELETE FROM {SCHEMA}.effect_outbox WHERE state NOT IN ('queued', 'running');
+ALTER TABLE {SCHEMA}.effect_outbox
+    ADD CONSTRAINT effect_outbox_state_check
+    CHECK (state IN ('queued', 'running'));
+
+CREATE INDEX IF NOT EXISTS effect_outbox_ready_idx
+ON {SCHEMA}.effect_outbox (state, available_at, sequence_id);
+
+CREATE INDEX IF NOT EXISTS effect_outbox_scope_fence_idx
+ON {SCHEMA}.effect_outbox
+    (account_id, user_id, writer, session_scope_id, fencing_token);
+
+CREATE UNIQUE INDEX IF NOT EXISTS effect_outbox_principal_operation_uq
+ON {SCHEMA}.effect_outbox (account_id, user_id, writer, operation_id);
+
+CREATE TABLE IF NOT EXISTS {SCHEMA}.commit_work_outbox (
+    sequence_id bigserial NOT NULL UNIQUE,
+    account_id text NOT NULL,
+    user_id text NOT NULL,
+    writer text NOT NULL,
+    session_scope_id text NOT NULL,
+    operation_id text NOT NULL,
+    session_id text NOT NULL,
+    task_id text NOT NULL,
+    archive_uri text NOT NULL,
+    wait_for_completion boolean NOT NULL DEFAULT false,
+    state text NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'running', 'ambiguous')),
+    attempt_count integer NOT NULL DEFAULT 0,
+    claim_token text,
+    error jsonb,
+    available_at timestamptz NOT NULL DEFAULT now(),
+    started_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id,user_id,writer,session_scope_id,operation_id),
+    UNIQUE (account_id,user_id,writer,task_id)
+);
+
+ALTER TABLE {SCHEMA}.commit_work_outbox
+    ADD COLUMN IF NOT EXISTS sequence_id bigserial;
+ALTER TABLE {SCHEMA}.commit_work_outbox
+    ADD COLUMN IF NOT EXISTS wait_for_completion boolean NOT NULL DEFAULT false;
+ALTER TABLE {SCHEMA}.commit_work_outbox
+    ADD COLUMN IF NOT EXISTS error jsonb;
+ALTER TABLE {SCHEMA}.commit_work_outbox
+    DROP CONSTRAINT IF EXISTS commit_work_outbox_state_check;
+ALTER TABLE {SCHEMA}.commit_work_outbox
+    ADD CONSTRAINT commit_work_outbox_state_check
+    CHECK (state IN ('pending', 'running', 'ambiguous'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS commit_work_outbox_sequence_uq
+ON {SCHEMA}.commit_work_outbox (sequence_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS commit_work_outbox_principal_task_uq
+ON {SCHEMA}.commit_work_outbox (account_id,user_id,writer,task_id);
+
+CREATE INDEX IF NOT EXISTS commit_work_outbox_ready_idx
+ON {SCHEMA}.commit_work_outbox (state, available_at, sequence_id);
+
+CREATE TABLE IF NOT EXISTS {SCHEMA}.session_turn_closure (
+    account_id text NOT NULL,
+    user_id text NOT NULL,
+    writer text NOT NULL,
+    session_scope_id text NOT NULL,
+    turn_id text NOT NULL,
+    session_id text NOT NULL,
+    operation_id text NOT NULL,
+    digest text NOT NULL,
+    fencing_token bigint NOT NULL,
+    result jsonb NOT NULL,
+    closed_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (
+        account_id, user_id, writer, session_scope_id, turn_id, session_id
+    )
+);
+
+ALTER TABLE {SCHEMA}.scope_state
+    DROP CONSTRAINT IF EXISTS scope_state_writer_check;
+ALTER TABLE {SCHEMA}.scope_state
+    ADD CONSTRAINT scope_state_writer_check CHECK (writer = 'alice');
+ALTER TABLE {SCHEMA}.session_binding
+    DROP CONSTRAINT IF EXISTS session_binding_writer_check;
+ALTER TABLE {SCHEMA}.session_binding
+    ADD CONSTRAINT session_binding_writer_check CHECK (writer = 'alice');
+ALTER TABLE {SCHEMA}.operation_receipt
+    DROP CONSTRAINT IF EXISTS operation_receipt_writer_check;
+ALTER TABLE {SCHEMA}.operation_receipt
+    ADD CONSTRAINT operation_receipt_writer_check CHECK (writer = 'alice');
+ALTER TABLE {SCHEMA}.effect_receipt
+    DROP CONSTRAINT IF EXISTS effect_receipt_writer_check;
+ALTER TABLE {SCHEMA}.effect_receipt
+    ADD CONSTRAINT effect_receipt_writer_check CHECK (writer = 'alice');
+ALTER TABLE {SCHEMA}.effect_outbox
+    DROP CONSTRAINT IF EXISTS effect_outbox_writer_check;
+ALTER TABLE {SCHEMA}.effect_outbox
+    ADD CONSTRAINT effect_outbox_writer_check CHECK (writer = 'alice');
+ALTER TABLE {SCHEMA}.commit_work_outbox
+    DROP CONSTRAINT IF EXISTS commit_work_outbox_writer_check;
+ALTER TABLE {SCHEMA}.commit_work_outbox
+    ADD CONSTRAINT commit_work_outbox_writer_check CHECK (writer = 'alice');
+ALTER TABLE {SCHEMA}.session_turn_closure
+    DROP CONSTRAINT IF EXISTS session_turn_closure_writer_check;
+ALTER TABLE {SCHEMA}.session_turn_closure
+    ADD CONSTRAINT session_turn_closure_writer_check CHECK (writer = 'alice');
+"""
+
+_REQUIRED_TABLES = (
+    "scope_state",
+    "session_binding",
+    "operation_receipt",
+    "effect_receipt",
+    "effect_outbox",
+    "commit_work_outbox",
+    "session_turn_closure",
+)
+
+_REQUIRED_SEQUENCES = (
+    "effect_outbox_sequence_id_seq",
+    "commit_work_outbox_sequence_id_seq",
+)
+
+_REQUIRED_COLUMNS = {
+    "scope_state": {
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "highest_fencing_token",
+        "active_turn_id",
+        "updated_at",
+    },
+    "session_binding": {
+        "account_id",
+        "user_id",
+        "session_id",
+        "writer",
+        "session_scope_id",
+        "created_at",
+    },
+    "operation_receipt": {
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+        "operation",
+        "resource_id",
+        "turn_id",
+        "digest",
+        "fencing_token",
+        "state",
+        "result",
+        "error",
+        "submitted_at",
+        "updated_at",
+    },
+    "effect_outbox": {
+        "sequence_id",
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+        "operation",
+        "resource_id",
+        "turn_id",
+        "digest",
+        "fencing_token",
+        "request_payload",
+        "actor_peer_id",
+        "state",
+        "attempt_count",
+        "claim_token",
+        "available_at",
+        "claimed_at",
+        "effect_started_at",
+        "updated_at",
+    },
+    "effect_receipt": {
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+        "operation",
+        "resource_id",
+        "turn_id",
+        "digest",
+        "fencing_token",
+        "result",
+        "completed_at",
+    },
+    "commit_work_outbox": {
+        "sequence_id",
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+        "session_id",
+        "task_id",
+        "archive_uri",
+        "wait_for_completion",
+        "state",
+        "attempt_count",
+        "claim_token",
+        "error",
+        "available_at",
+        "started_at",
+        "created_at",
+        "updated_at",
+    },
+    "session_turn_closure": {
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "turn_id",
+        "session_id",
+        "operation_id",
+        "digest",
+        "fencing_token",
+        "result",
+        "closed_at",
+    },
+}
+
+_REQUIRED_PRIMARY_KEYS = {
+    "scope_state": ("account_id", "user_id", "writer", "session_scope_id"),
+    "session_binding": ("account_id", "user_id", "session_id"),
+    "operation_receipt": (
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+    ),
+    "effect_outbox": (
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+    ),
+    "effect_receipt": (
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+    ),
+    "commit_work_outbox": (
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "operation_id",
+    ),
+    "session_turn_closure": (
+        "account_id",
+        "user_id",
+        "writer",
+        "session_scope_id",
+        "turn_id",
+        "session_id",
+    ),
+}
+
+_REQUIRED_UNIQUE_INDEXES = {
+    "operation_receipt_principal_operation_uq": (
+        "account_id",
+        "user_id",
+        "writer",
+        "operation_id",
+    ),
+    "effect_outbox_principal_operation_uq": (
+        "account_id",
+        "user_id",
+        "writer",
+        "operation_id",
+    ),
+}
+
+_REQUIRED_UNIQUE_COLUMN_SETS = {
+    "effect_outbox": (("sequence_id",),),
+    "commit_work_outbox": (
+        ("sequence_id",),
+        ("account_id", "user_id", "writer", "task_id"),
+    ),
+}
+
+_REQUIRED_STATE_CONSTRAINTS = {
+    "operation_receipt_state_check": {
+        "queued",
+        "running",
+        "completed",
+        "stale",
+        "failed",
+        "conflict",
+    },
+    "effect_outbox_state_check": {"queued", "running"},
+    "commit_work_outbox_state_check": {"pending", "running", "ambiguous"},
+}
+
+_REQUIRED_WRITER_CONSTRAINTS = {
+    "scope_state_writer_check",
+    "session_binding_writer_check",
+    "operation_receipt_writer_check",
+    "effect_receipt_writer_check",
+    "effect_outbox_writer_check",
+    "commit_work_outbox_writer_check",
+    "session_turn_closure_writer_check",
+}
+
+
+def fencing_database_url() -> str:
+    return os.getenv(FENCING_DATABASE_URL_ENV, "").strip()
+
+
+def fencing_service_token() -> str:
+    return os.getenv(FENCING_SERVICE_TOKEN_ENV, "").strip()
+
+
+def is_valid_alice_service_token(provided: Optional[str]) -> bool:
+    """Authenticate the dedicated Alice principal without trusting identity headers."""
+    expected = fencing_service_token()
+    if not expected or not isinstance(provided, str):
+        return False
+    return hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8"))
+
+
+def validate_required_fencing_configuration() -> None:
+    """Fail synchronously before the server starts accepting traffic."""
+    _submit_idle_timeout_ms()
+    missing = []
+    if not fencing_database_url():
+        missing.append(FENCING_DATABASE_URL_ENV)
+    token = fencing_service_token()
+    if not token:
+        missing.append(FENCING_SERVICE_TOKEN_ENV)
+    elif len(token.encode("utf-8")) < 32:
+        raise RuntimeError(f"{FENCING_SERVICE_TOKEN_ENV} must be at least 32 bytes")
+    if missing:
+        raise RuntimeError("required Alice fencing is missing: " + ", ".join(missing))
+    try:
+        import psycopg2  # noqa: F401, PLC0415
+    except ImportError as exc:  # pragma: no cover - packaging/startup guard
+        raise RuntimeError(
+            "required Alice fencing needs the 'alice-fencing' package extra (psycopg2-binary)"
+        ) from exc
+
+
+def _submit_idle_timeout_ms() -> int:
+    raw = os.getenv(FENCING_SUBMIT_IDLE_TIMEOUT_MS_ENV, "2000").strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{FENCING_SUBMIT_IDLE_TIMEOUT_MS_ENV} must be an integer") from exc
+    if value < 500 or value > 30_000:
+        raise RuntimeError(f"{FENCING_SUBMIT_IDLE_TIMEOUT_MS_ENV} must be between 500 and 30000")
+    return value
+
+
+def _connect(*, application_name: str = "openviking-alice-fencing"):
+    import psycopg2  # type: ignore  # noqa: PLC0415
+
+    timeout_ms = _submit_idle_timeout_ms()
+    return psycopg2.connect(
+        fencing_database_url(),
+        connect_timeout=5,
+        application_name=application_name,
+        # A client frozen inside the short submit transaction cannot retain a
+        # scope/resource advisory-xact lock forever.  This is a DB-side timeout:
+        # SIGSTOP also stops the Python process, but PostgreSQL still rolls the
+        # idle transaction back and lets a higher fence submit.
+        options=(
+            f"-c idle_in_transaction_session_timeout={timeout_ms} "
+            f"-c lock_timeout={max(timeout_ms * 2, 1000)}"
+        ),
+    )
+
+
+def _validate_runtime_fencing_principal(cursor: Any) -> None:
+    """Reject a connection that has more authority than the fencing writer needs."""
+
+    cursor.execute(
+        """
+        SELECT current_user,
+               session_user,
+               runtime_role.rolsuper,
+               runtime_role.rolcreatedb,
+               runtime_role.rolcreaterole,
+               runtime_role.rolinherit,
+               runtime_role.rolreplication,
+               runtime_role.rolbypassrls,
+               runtime_role.rolcanlogin,
+               runtime_role.rolconnlimit,
+               (
+                   SELECT count(*)
+                   FROM pg_catalog.pg_auth_members AS membership
+                   WHERE membership.member = runtime_role.oid
+               ) AS membership_count,
+               pg_catalog.has_database_privilege(
+                   current_user,
+                   pg_catalog.current_database(),
+                   'CONNECT'
+               ) AS can_connect,
+               pg_catalog.has_database_privilege(
+                   current_user,
+                   pg_catalog.current_database(),
+                   'CREATE'
+               ) AS can_create,
+               pg_catalog.has_database_privilege(
+                   current_user,
+                   pg_catalog.current_database(),
+                   'TEMPORARY'
+               ) AS can_temporary,
+               pg_catalog.current_setting('search_path') AS search_path
+        FROM pg_catalog.pg_roles AS runtime_role
+        WHERE runtime_role.rolname = current_user
+        """
+    )
+    row = cursor.fetchone()
+    if not row:
+        raise RuntimeError("unable to verify the PostgreSQL fencing runtime principal")
+
+    (
+        current_role,
+        authenticated_role,
+        is_superuser,
+        can_create_database,
+        can_create_role,
+        inherits_roles,
+        can_replicate,
+        can_bypass_rls,
+        can_login,
+        connection_limit,
+        membership_count,
+        can_connect,
+        can_create,
+        can_temporary,
+        search_path,
+    ) = row
+    if current_role != FENCING_DATABASE_ROLE or authenticated_role != FENCING_DATABASE_ROLE:
+        raise RuntimeError(
+            f"PostgreSQL fencing runtime must authenticate and connect as {FENCING_DATABASE_ROLE}"
+        )
+
+    unsafe_attributes = []
+    if is_superuser:
+        unsafe_attributes.append("SUPERUSER")
+    if can_create_database:
+        unsafe_attributes.append("CREATEDB")
+    if can_create_role:
+        unsafe_attributes.append("CREATEROLE")
+    if inherits_roles:
+        unsafe_attributes.append("INHERIT")
+    if can_replicate:
+        unsafe_attributes.append("REPLICATION")
+    if can_bypass_rls:
+        unsafe_attributes.append("BYPASSRLS")
+    if not can_login:
+        unsafe_attributes.append("NOLOGIN")
+    if connection_limit != 32:
+        unsafe_attributes.append("CONNECTION LIMIT")
+    if unsafe_attributes:
+        raise RuntimeError(
+            "PostgreSQL fencing runtime role has unsafe attributes: " + ", ".join(unsafe_attributes)
+        )
+    if membership_count != 0:
+        raise RuntimeError("PostgreSQL fencing runtime role must not be a member of another role")
+    if can_connect is not True or can_create is not False or can_temporary is not False:
+        raise RuntimeError("PostgreSQL fencing runtime role has unsafe database privileges")
+    if search_path != "pg_catalog":
+        raise RuntimeError("PostgreSQL fencing runtime role must use search_path=pg_catalog")
+
+
+def _validate_runtime_fencing_privilege_scope(cursor: Any) -> None:
+    """Detect effective privilege drift after the migrator provisions the role."""
+
+    cursor.execute(
+        """
+        WITH non_system_relations AS MATERIALIZED (
+            SELECT relation.oid,
+                   relation.relkind,
+                   relation.relname,
+                   namespace.nspname
+            FROM pg_catalog.pg_class AS relation
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname <> 'information_schema'
+              AND namespace.nspname !~ '^pg_'
+        ),
+        unexpected_tables AS MATERIALIZED (
+            SELECT oid
+            FROM non_system_relations
+            WHERE relkind IN ('r', 'p', 'v', 'm', 'f')
+              AND NOT (nspname = %s AND relname = ANY(%s))
+        ),
+        unexpected_sequences AS MATERIALIZED (
+            SELECT oid
+            FROM non_system_relations
+            WHERE relkind = 'S'
+              AND NOT (nspname = %s AND relname = ANY(%s))
+        )
+        SELECT pg_catalog.has_schema_privilege(
+                   current_user, %s, 'USAGE'
+               ) AS can_use_fencing_schema,
+               pg_catalog.has_schema_privilege(
+                   current_user, %s, 'CREATE'
+               ) AS can_create_in_fencing_schema,
+               EXISTS (
+                   SELECT 1
+                   FROM pg_catalog.pg_namespace AS namespace
+                   WHERE namespace.nspname <> 'information_schema'
+                     AND namespace.nspname !~ '^pg_'
+                     AND pg_catalog.has_schema_privilege(
+                         current_user, namespace.oid, 'CREATE'
+                     )
+               ) AS can_create_in_non_system_schema,
+               EXISTS (
+                   SELECT 1
+                   FROM unexpected_tables
+                   WHERE pg_catalog.has_table_privilege(
+                         current_user,
+                         unexpected_tables.oid,
+                         'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+                     )
+               ) AS can_access_unexpected_table,
+               EXISTS (
+                   SELECT 1
+                   FROM unexpected_sequences
+                   WHERE pg_catalog.has_sequence_privilege(
+                         current_user,
+                         unexpected_sequences.oid,
+                         'USAGE,SELECT,UPDATE'
+                     )
+               ) AS can_access_unexpected_sequence
+        """,
+        (
+            SCHEMA,
+            list(_REQUIRED_TABLES),
+            SCHEMA,
+            list(_REQUIRED_SEQUENCES),
+            SCHEMA,
+            SCHEMA,
+        ),
+    )
+    scope_row = cursor.fetchone()
+    if not scope_row or scope_row[0] is not True or scope_row[1] is not False:
+        raise RuntimeError("PostgreSQL fencing runtime role has unsafe schema privileges")
+    if scope_row[2] is not False:
+        raise RuntimeError("PostgreSQL fencing runtime role can create in a non-system schema")
+    if scope_row[3] is not False:
+        raise RuntimeError("PostgreSQL fencing runtime role can access an unexpected table")
+    if scope_row[4] is not False:
+        raise RuntimeError("PostgreSQL fencing runtime role can access an unexpected sequence")
+
+    for table in _REQUIRED_TABLES:
+        cursor.execute(
+            """
+            SELECT pg_catalog.has_table_privilege(current_user, %s, 'SELECT'),
+                   pg_catalog.has_table_privilege(current_user, %s, 'INSERT'),
+                   pg_catalog.has_table_privilege(current_user, %s, 'UPDATE'),
+                   pg_catalog.has_table_privilege(current_user, %s, 'DELETE'),
+                   pg_catalog.has_table_privilege(current_user, %s, 'TRUNCATE'),
+                   pg_catalog.has_table_privilege(current_user, %s, 'REFERENCES'),
+                   pg_catalog.has_table_privilege(current_user, %s, 'TRIGGER')
+            """,
+            (f"{SCHEMA}.{table}",) * 7,
+        )
+        table_row = cursor.fetchone()
+        if not table_row or tuple(table_row) != (
+            True,
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+        ):
+            raise RuntimeError(
+                f"PostgreSQL fencing runtime role has invalid table privileges on {SCHEMA}.{table}"
+            )
+
+    for sequence in _REQUIRED_SEQUENCES:
+        cursor.execute(
+            """
+            SELECT pg_catalog.has_sequence_privilege(current_user, %s, 'USAGE'),
+                   pg_catalog.has_sequence_privilege(current_user, %s, 'SELECT'),
+                   pg_catalog.has_sequence_privilege(current_user, %s, 'UPDATE')
+            """,
+            (f"{SCHEMA}.{sequence}",) * 3,
+        )
+        sequence_row = cursor.fetchone()
+        if not sequence_row or tuple(sequence_row) != (True, True, False):
+            raise RuntimeError(
+                "PostgreSQL fencing runtime role has invalid sequence privileges on "
+                f"{SCHEMA}.{sequence}"
+            )
+
+
+async def validate_postgres_fencing_schema() -> None:
+    """Verify DB reachability and migration presence during application lifespan."""
+
+    def _validate() -> None:
+        conn = _connect()
+        try:
+            conn.autocommit = True
+            with conn.cursor() as cursor:
+                # Validate effective and authenticated identities before any
+                # schema inspection. A leaked owner/superuser DSN must never
+                # be accepted by the application runtime.
+                _validate_runtime_fencing_principal(cursor)
+                for table in _REQUIRED_TABLES:
+                    cursor.execute("SELECT to_regclass(%s)", (f"{SCHEMA}.{table}",))
+                    row = cursor.fetchone()
+                    if not row or row[0] is None:
+                        raise RuntimeError(
+                            f"missing PostgreSQL fencing migration: {SCHEMA}.{table}"
+                        )
+                    cursor.execute(
+                        """
+                        SELECT column_name
+                        FROM information_schema.columns
+                        WHERE table_schema=%s AND table_name=%s
+                        """,
+                        (SCHEMA, table),
+                    )
+                    actual_columns = {str(value[0]) for value in cursor.fetchall()}
+                    missing_columns = _REQUIRED_COLUMNS[table] - actual_columns
+                    if missing_columns:
+                        raise RuntimeError(
+                            "incomplete PostgreSQL fencing migration: "
+                            f"{SCHEMA}.{table} missing columns "
+                            + ", ".join(sorted(missing_columns))
+                        )
+
+                for index_name, expected_columns in _REQUIRED_UNIQUE_INDEXES.items():
+                    cursor.execute(
+                        """
+                        SELECT i.indisunique,
+                               array_agg(a.attname ORDER BY keys.ordinality)
+                        FROM pg_catalog.pg_index i
+                        JOIN pg_catalog.pg_class idx ON idx.oid=i.indexrelid
+                        JOIN pg_catalog.pg_namespace ns ON ns.oid=idx.relnamespace
+                        JOIN LATERAL unnest(i.indkey)
+                            WITH ORDINALITY AS keys(attnum, ordinality) ON true
+                        JOIN pg_catalog.pg_class tbl ON tbl.oid=i.indrelid
+                        JOIN pg_catalog.pg_attribute a
+                          ON a.attrelid=tbl.oid AND a.attnum=keys.attnum
+                        WHERE ns.nspname=%s AND idx.relname=%s
+                        GROUP BY i.indisunique
+                        """,
+                        (SCHEMA, index_name),
+                    )
+                    index_row = cursor.fetchone()
+                    if (
+                        index_row is None
+                        or index_row[0] is not True
+                        or tuple(index_row[1]) != expected_columns
+                    ):
+                        raise RuntimeError(
+                            "incomplete PostgreSQL fencing migration: invalid unique "
+                            f"index {SCHEMA}.{index_name}"
+                        )
+
+                for table, expected_columns in _REQUIRED_PRIMARY_KEYS.items():
+                    cursor.execute(
+                        """
+                        SELECT array_agg(a.attname ORDER BY keys.ordinality)
+                        FROM pg_catalog.pg_constraint c
+                        JOIN LATERAL unnest(c.conkey)
+                            WITH ORDINALITY AS keys(attnum, ordinality) ON true
+                        JOIN pg_catalog.pg_attribute a
+                          ON a.attrelid=c.conrelid AND a.attnum=keys.attnum
+                        WHERE c.conrelid=%s::regclass AND c.contype='p'
+                        """,
+                        (f"{SCHEMA}.{table}",),
+                    )
+                    primary_key_row = cursor.fetchone()
+                    actual_columns = (
+                        tuple(primary_key_row[0]) if primary_key_row and primary_key_row[0] else ()
+                    )
+                    if actual_columns != expected_columns:
+                        raise RuntimeError(
+                            "incomplete PostgreSQL fencing migration: invalid primary "
+                            f"key on {SCHEMA}.{table}"
+                        )
+
+                for table, required_sets in _REQUIRED_UNIQUE_COLUMN_SETS.items():
+                    cursor.execute(
+                        """
+                        SELECT array_agg(a.attname ORDER BY keys.ordinality)
+                        FROM pg_catalog.pg_index i
+                        JOIN pg_catalog.pg_class tbl ON tbl.oid=i.indrelid
+                        JOIN pg_catalog.pg_namespace ns ON ns.oid=tbl.relnamespace
+                        JOIN LATERAL unnest(i.indkey)
+                            WITH ORDINALITY AS keys(attnum, ordinality) ON true
+                        JOIN pg_catalog.pg_attribute a
+                          ON a.attrelid=tbl.oid AND a.attnum=keys.attnum
+                        WHERE ns.nspname=%s AND tbl.relname=%s AND i.indisunique
+                        GROUP BY i.indexrelid
+                        """,
+                        (SCHEMA, table),
+                    )
+                    actual_sets = {tuple(row[0]) for row in cursor.fetchall() if row and row[0]}
+                    for required_columns in required_sets:
+                        if required_columns not in actual_sets:
+                            raise RuntimeError(
+                                "incomplete PostgreSQL fencing migration: missing "
+                                f"unique key on {SCHEMA}.{table}"
+                            )
+
+                for constraint_name, expected_states in _REQUIRED_STATE_CONSTRAINTS.items():
+                    cursor.execute(
+                        """
+                        SELECT pg_get_constraintdef(c.oid)
+                        FROM pg_catalog.pg_constraint c
+                        JOIN pg_catalog.pg_namespace ns ON ns.oid=c.connamespace
+                        WHERE ns.nspname=%s AND c.conname=%s AND c.contype='c'
+                        """,
+                        (SCHEMA, constraint_name),
+                    )
+                    constraint_row = cursor.fetchone()
+                    definition = str(constraint_row[0]) if constraint_row else ""
+                    actual_states = set(re.findall(r"'([^']+)'", definition))
+                    if actual_states != expected_states:
+                        raise RuntimeError(
+                            "incomplete PostgreSQL fencing migration: invalid state "
+                            f"constraint {SCHEMA}.{constraint_name}"
+                        )
+
+                for constraint_name in _REQUIRED_WRITER_CONSTRAINTS:
+                    cursor.execute(
+                        """
+                        SELECT pg_get_constraintdef(c.oid)
+                        FROM pg_catalog.pg_constraint c
+                        JOIN pg_catalog.pg_namespace ns ON ns.oid=c.connamespace
+                        WHERE ns.nspname=%s AND c.conname=%s AND c.contype='c'
+                        """,
+                        (SCHEMA, constraint_name),
+                    )
+                    constraint_row = cursor.fetchone()
+                    definition = str(constraint_row[0]).lower() if constraint_row else ""
+                    if "writer" not in definition or "'alice'" not in definition:
+                        raise RuntimeError(
+                            "incomplete PostgreSQL fencing migration: invalid writer "
+                            f"constraint {SCHEMA}.{constraint_name}"
+                        )
+
+                _validate_runtime_fencing_privilege_scope(cursor)
+        finally:
+            conn.close()
+
+    await asyncio.to_thread(_validate)
+
+
+def _advisory_key(kind: str, *parts: str) -> int:
+    payload = "\x1f".join((kind, *parts)).encode("utf-8")
+    raw = int.from_bytes(hashlib.sha256(payload).digest()[:8], "big", signed=False)
+    return raw - (1 << 64) if raw >= (1 << 63) else raw
+
+
+def _json_value(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        decoded = json.loads(value)
+        if isinstance(decoded, dict):
+            return decoded
+    raise RuntimeError("Corrupt PostgreSQL fenced-session result")
+
+
+_TERMINAL_OUTBOX_STATES = frozenset({"completed", "stale", "failed", "conflict"})
+
+
+@dataclass(frozen=True)
+class FencedOperationRecord:
+    """Principal-scoped operation receipt returned by submit/status polling."""
+
+    operation_id: str
+    operation: str
+    resource_id: str
+    session_scope_id: str
+    turn_id: str
+    digest: str
+    fencing_token: int
+    state: str
+    result: Optional[dict[str, Any]] = None
+    error: Optional[dict[str, Any]] = None
+    replayed: bool = False
+
+    @property
+    def terminal(self) -> bool:
+        return self.state in _TERMINAL_OUTBOX_STATES
+
+
+_RECEIPT_SELECT = """
+    SELECT operation_id, operation, resource_id, session_scope_id, turn_id,
+           digest, fencing_token, state, result, error
+    FROM openviking_fencing.operation_receipt
+"""
+
+
+def _operation_record(
+    row: Any,
+    *,
+    replayed: bool = False,
+) -> FencedOperationRecord:
+    if row is None or len(row) != 10:
+        raise RuntimeError("Corrupt PostgreSQL fenced-session receipt")
+    result = None if row[8] is None else _json_value(row[8])
+    error = None if row[9] is None else _json_value(row[9])
+    return FencedOperationRecord(
+        operation_id=str(row[0]),
+        operation=str(row[1]),
+        resource_id=str(row[2]),
+        session_scope_id=str(row[3]),
+        turn_id=str(row[4]),
+        digest=str(row[5]),
+        fencing_token=int(row[6]),
+        state=str(row[7]),
+        result=result,
+        error=error,
+        replayed=replayed,
+    )
+
+
+def _stale_error(
+    *,
+    highest_fencing_token: int,
+    received_fencing_token: int,
+) -> dict[str, Any]:
+    return {
+        "code": "CONFLICT",
+        "message": "Fencing token is stale",
+        "details": {
+            "reason": "stale_fence",
+            "highest_fencing_token": highest_fencing_token,
+            "received_fencing_token": received_fencing_token,
+        },
+    }
+
+
+class PostgresFencedOperationQueue:
+    """Atomically accept fenced operations without executing their effects.
+
+    The only request-side durable boundary is this short PostgreSQL
+    transaction.  It owns no AGFS callback and never holds a database lock
+    while waiting for the outbox writer.
+    """
+
+    def __init__(self, ctx: RequestContext, envelope: FencedOperationEnvelope):
+        self._ctx = ctx
+        self._envelope = envelope
+
+    @property
+    def _scope_key(self) -> tuple[str, str, str, str]:
+        return (
+            self._ctx.account_id,
+            self._ctx.user.user_id,
+            self._envelope.writer,
+            self._envelope.session_scope_id,
+        )
+
+    @property
+    def _principal_key(self) -> tuple[str, str, str]:
+        return (
+            self._ctx.account_id,
+            self._ctx.user.user_id,
+            self._envelope.writer,
+        )
+
+    def _select_current_receipt(self, cursor) -> FencedOperationRecord:
+        cursor.execute(
+            _RECEIPT_SELECT
+            + """
+              WHERE account_id=%s AND user_id=%s AND writer=%s
+                AND session_scope_id=%s AND operation_id=%s
+            """,
+            (*self._scope_key, self._envelope.operation_id),
+        )
+        return _operation_record(cursor.fetchone())
+
+    def _advance_scope(
+        self,
+        cursor,
+        *,
+        previous_highest: int,
+    ) -> bool:
+        """Advance the authoritative scope watermark in the accept transaction."""
+        token = self._envelope.fencing_token
+        if token <= previous_highest:
+            return False
+        cursor.execute(
+            f"""
+            UPDATE {SCHEMA}.scope_state
+            SET highest_fencing_token=%s, active_turn_id=%s, updated_at=now()
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s
+            """,
+            (token, self._envelope.turn_id, *self._scope_key),
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError("PostgreSQL fencing scope advance CAS failed")
+        return True
+
+    def _suppress_stale_queued_sync(self, cursor) -> list[str]:
+        """Erase pre-effect stale payloads after scope advance is committed.
+
+        This reconciliation is deliberately outside the scope-watermark
+        transaction.  Holding scope_state while waiting for another
+        operation's receipt can deadlock an authorizing writer, whose global
+        order is receipt -> scope -> outbox.  Here no scope row is held and
+        every candidate follows receipt -> outbox, matching claim/completion.
+        The already committed watermark remains the safety authority if this
+        best-effort eager cleanup is interrupted; the writer will suppress the
+        row during authorization.
+        """
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        token = self._envelope.fencing_token
+        cursor.execute(
+            f"""
+            SELECT operation_id, operation
+            FROM {SCHEMA}.effect_outbox
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s
+              AND fencing_token < %s
+              AND operation_id <> %s
+              AND state='queued'
+              AND effect_started_at IS NULL
+            ORDER BY sequence_id
+            """,
+            (*self._scope_key, token, self._envelope.operation_id),
+        )
+        candidates = [(str(row[0]), str(row[1])) for row in cursor.fetchall()]
+        suppressed: list[str] = []
+        for operation_id, operation in candidates:
+            cursor.execute(
+                f"""
+                SELECT state
+                FROM {SCHEMA}.operation_receipt
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s
+                  AND operation_id=%s
+                FOR UPDATE
+                """,
+                (*self._scope_key, operation_id),
+            )
+            receipt = cursor.fetchone()
+            if receipt is None or str(receipt[0]) != "queued":
+                continue
+            cursor.execute(
+                f"""
+                SELECT fencing_token
+                FROM {SCHEMA}.effect_outbox
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND operation_id=%s
+                  AND fencing_token < %s AND state='queued'
+                  AND effect_started_at IS NULL
+                FOR UPDATE
+                """,
+                (*self._scope_key, operation_id, token),
+            )
+            outbox = cursor.fetchone()
+            if outbox is None:
+                continue
+            current_stale_token = int(outbox[0])
+            cursor.execute(
+                f"""
+                UPDATE {SCHEMA}.operation_receipt
+                SET state='stale', error=%s, updated_at=now()
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND operation_id=%s
+                  AND state='queued'
+                """,
+                (
+                    Json(
+                        _stale_error(
+                            highest_fencing_token=token,
+                            received_fencing_token=current_stale_token,
+                        )
+                    ),
+                    *self._scope_key,
+                    operation_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("PostgreSQL stale receipt CAS failed")
+            cursor.execute(
+                f"""
+                DELETE FROM {SCHEMA}.effect_outbox
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND operation_id=%s
+                  AND state='queued' AND effect_started_at IS NULL
+                """,
+                (*self._scope_key, operation_id),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("PostgreSQL stale outbox delete CAS failed")
+            # `operation` is a fixed protocol enum at ingress and therefore a
+            # bounded metric label.  Tokens are never exposed as labels.
+            suppressed.append(operation)
+        return suppressed
+
+    def _commit_and_suppress(self, conn, *, scope_advanced: bool) -> None:
+        conn.commit()
+        if not scope_advanced:
+            return
+        try:
+            with conn.cursor() as cursor:
+                suppressed = self._suppress_stale_queued_sync(cursor)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            # Acceptance and the authoritative watermark are already durable.
+            # The writer will make the same suppression decision, so cleanup
+            # failure must not turn a successful submit into a false negative.
+            logger.exception("PostgreSQL eager stale cleanup failed after durable submit")
+            return
+        _record_suppressed_effect_metrics(suppressed)
+
+    def _submit_sync(
+        self,
+        operation: str,
+        resource_id: str,
+        digest: str,
+        request_payload: dict[str, Any],
+    ) -> FencedOperationRecord:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        account_id, user_id, writer, scope_id = self._scope_key
+        operation_id = self._envelope.operation_id
+        turn_id = self._envelope.turn_id
+        token = self._envelope.fencing_token
+        conn = _connect(application_name="openviking-fenced-submit")
+        scope_advanced = False
+        try:
+            conn.autocommit = False
+            with conn.cursor() as cursor:
+                # All locks are transaction scoped and the connection has a
+                # DB-enforced idle-in-transaction timeout.  The operation lock
+                # also serializes an operation_id accidentally reused across
+                # two session scopes for the same authenticated principal.
+                lock_keys = sorted(
+                    {
+                        _advisory_key(
+                            "operation",
+                            account_id,
+                            user_id,
+                            writer,
+                            operation_id,
+                        ),
+                        _advisory_key("scope", account_id, user_id, writer, scope_id),
+                        _advisory_key("session", account_id, user_id, resource_id),
+                    }
+                )
+                for key in lock_keys:
+                    cursor.execute("SELECT pg_advisory_xact_lock(%s)", (key,))
+
+                from openviking.server import fenced_operation  # noqa: PLC0415
+
+                fenced_operation.after_fenced_submit_locks_acquired(operation)
+
+                cursor.execute(
+                    _RECEIPT_SELECT
+                    + """
+                      WHERE account_id=%s AND user_id=%s AND writer=%s
+                        AND operation_id=%s
+                      FOR UPDATE
+                    """,
+                    (*self._principal_key, operation_id),
+                )
+                principal_receipts = cursor.fetchall()
+                if len(principal_receipts) > 1:
+                    raise FencedOperationConflict(
+                        "Operation ID is not uniquely scoped to this principal",
+                        reason="operation_scope_conflict",
+                        details={"operation_id": operation_id},
+                    )
+                receipt = (
+                    _operation_record(principal_receipts[0], replayed=True)
+                    if principal_receipts
+                    else None
+                )
+                if receipt is not None:
+                    if receipt.session_scope_id != scope_id:
+                        raise FencedOperationConflict(
+                            "Operation ID was already used by another session scope",
+                            reason="operation_scope_conflict",
+                            details={"operation_id": operation_id},
+                        )
+                    if receipt.digest != digest:
+                        raise FencedOperationConflict(
+                            "Operation ID was already used for different content",
+                            reason="operation_digest_conflict",
+                            details={"operation_id": operation_id},
+                        )
+
+                cursor.execute(
+                    f"""
+                    INSERT INTO {SCHEMA}.scope_state
+                        (account_id,user_id,writer,session_scope_id,
+                         highest_fencing_token,active_turn_id)
+                    VALUES (%s,%s,%s,%s,%s,%s)
+                    ON CONFLICT (account_id,user_id,writer,session_scope_id)
+                    DO NOTHING
+                    """,
+                    (*self._scope_key, token, turn_id),
+                )
+                cursor.execute(
+                    f"""
+                    SELECT highest_fencing_token, active_turn_id
+                    FROM {SCHEMA}.scope_state
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s
+                    FOR UPDATE
+                    """,
+                    self._scope_key,
+                )
+                scope_row = cursor.fetchone()
+                if scope_row is None:
+                    raise RuntimeError("PostgreSQL fencing scope row disappeared")
+                highest, active_turn = int(scope_row[0]), str(scope_row[1])
+                # A completed exact replay at or below its persisted receipt
+                # token only returns the immutable result.  It must not be
+                # rejected merely because a later business turn is active,
+                # and it must not mutate either watermark or receipt token.
+                completed_pure_replay = bool(
+                    receipt is not None
+                    and receipt.state == "completed"
+                    and token <= receipt.fencing_token
+                )
+                if not completed_pure_replay and token < highest:
+                    raise FencedOperationConflict(
+                        "Fencing token is stale",
+                        reason="stale_fence",
+                        details={
+                            "highest_fencing_token": highest,
+                            "received_fencing_token": token,
+                        },
+                    )
+                if not completed_pure_replay and token == highest and turn_id != active_turn:
+                    raise FencedOperationConflict(
+                        "The active fencing token is already bound to another turn",
+                        reason="turn_fence_conflict",
+                        details={"active_turn_id": active_turn},
+                    )
+                replay_can_advance = bool(
+                    receipt is not None
+                    and (not receipt.terminal or receipt.state == "completed")
+                    and token > receipt.fencing_token
+                )
+                if replay_can_advance and (
+                    active_turn != receipt.turn_id or highest != receipt.fencing_token
+                ):
+                    raise FencedOperationConflict(
+                        "A replay cannot replace a newer active turn or operation fence",
+                        reason="turn_fence_conflict",
+                        details={"active_turn_id": active_turn},
+                    )
+
+                cursor.execute(
+                    f"""
+                    SELECT writer, session_scope_id
+                    FROM {SCHEMA}.session_binding
+                    WHERE account_id=%s AND user_id=%s AND session_id=%s
+                    FOR UPDATE
+                    """,
+                    (account_id, user_id, resource_id),
+                )
+                binding = cursor.fetchone()
+                if binding is not None and (str(binding[0]), str(binding[1])) != (
+                    writer,
+                    scope_id,
+                ):
+                    raise FencedOperationConflict(
+                        "Session is already bound to a different writer scope",
+                        reason="session_scope_conflict",
+                        details={"session_id": resource_id},
+                    )
+
+                # Exact terminal replay wins over a later commit closure.  This
+                # is the response-loss path: the message/used effect already
+                # completed, then a commit closed the turn before the caller
+                # retried the original operation_id.
+                if receipt is not None and receipt.terminal:
+                    if receipt.digest != digest:
+                        raise FencedOperationConflict(
+                            "Operation ID was already used for different content",
+                            reason="operation_digest_conflict",
+                            details={"operation_id": operation_id},
+                        )
+                    if receipt.state == "completed" and not completed_pure_replay:
+                        scope_advanced = self._advance_scope(
+                            cursor,
+                            previous_highest=highest,
+                        )
+                        cursor.execute(
+                            f"""
+                            UPDATE {SCHEMA}.operation_receipt
+                            SET fencing_token=GREATEST(fencing_token,%s),
+                                updated_at=now()
+                            WHERE account_id=%s AND user_id=%s AND writer=%s
+                              AND session_scope_id=%s AND operation_id=%s
+                            """,
+                            (token, *self._scope_key, operation_id),
+                        )
+                        cursor.execute(
+                            f"""
+                            UPDATE {SCHEMA}.effect_receipt
+                            SET fencing_token=GREATEST(fencing_token,%s)
+                            WHERE account_id=%s AND user_id=%s AND writer=%s
+                              AND session_scope_id=%s AND operation_id=%s
+                              AND digest=%s
+                            """,
+                            (
+                                token,
+                                *self._scope_key,
+                                operation_id,
+                                digest,
+                            ),
+                        )
+                    # failed/stale/conflict are immutable terminal outcomes.
+                    # A higher fence must use a new operation_id to retry.
+                    self._commit_and_suppress(conn, scope_advanced=scope_advanced)
+                    current = self._select_current_receipt(cursor)
+                    return replace(current, replayed=True)
+
+                # wait=true publishes the commit closure and moves Phase 2 to
+                # commit_work_outbox while intentionally keeping the operation
+                # receipt running.  An exact HTTP retry must observe that same
+                # running receipt; treating the closure as a completed replay
+                # would bypass the caller's wait contract and could orphan the
+                # durable work row.
+                if receipt is not None and receipt.state == "running" and operation == "commit":
+                    cursor.execute(
+                        f"""
+                        SELECT task_id,archive_uri,wait_for_completion
+                        FROM {SCHEMA}.commit_work_outbox
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                        FOR UPDATE
+                        """,
+                        (*self._scope_key, operation_id),
+                    )
+                    commit_work = cursor.fetchone()
+                    if commit_work is not None:
+                        result = receipt.result or {}
+                        if (
+                            not bool(commit_work[2])
+                            or result.get("task_id") != str(commit_work[0])
+                            or result.get("archive_uri") != str(commit_work[1])
+                        ):
+                            raise RuntimeError("PostgreSQL fenced wait receipt/work mismatch")
+                        scope_advanced = self._advance_scope(
+                            cursor,
+                            previous_highest=highest,
+                        )
+                        cursor.execute(
+                            f"""
+                            UPDATE {SCHEMA}.operation_receipt
+                            SET fencing_token=GREATEST(fencing_token,%s),
+                                updated_at=now()
+                            WHERE account_id=%s AND user_id=%s AND writer=%s
+                              AND session_scope_id=%s AND operation_id=%s
+                              AND digest=%s AND state='running'
+                            """,
+                            (
+                                token,
+                                *self._scope_key,
+                                operation_id,
+                                digest,
+                            ),
+                        )
+                        if cursor.rowcount != 1:
+                            raise RuntimeError("PostgreSQL fenced wait replay CAS failed")
+                        self._commit_and_suppress(conn, scope_advanced=scope_advanced)
+                        current = self._select_current_receipt(cursor)
+                        return replace(current, replayed=True)
+
+                cursor.execute(
+                    f"""
+                    SELECT operation_id, digest, result
+                    FROM {SCHEMA}.session_turn_closure
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND turn_id=%s AND session_id=%s
+                    FOR UPDATE
+                    """,
+                    (*self._scope_key, turn_id, resource_id),
+                )
+                closure = cursor.fetchone()
+                if closure is not None:
+                    closure_operation_id, closure_digest, closure_result = closure
+                    if operation == "commit" and str(closure_operation_id) == operation_id:
+                        if str(closure_digest) != digest:
+                            raise FencedOperationConflict(
+                                "Operation ID was already used for different content",
+                                reason="operation_digest_conflict",
+                                details={"operation_id": operation_id},
+                            )
+                        scope_advanced = self._advance_scope(
+                            cursor,
+                            previous_highest=highest,
+                        )
+                        result = _json_value(closure_result)
+                        cursor.execute(
+                            f"""
+                            INSERT INTO {SCHEMA}.operation_receipt
+                                (account_id,user_id,writer,session_scope_id,
+                                 operation_id,operation,resource_id,turn_id,digest,
+                                 fencing_token,state,result,error)
+                            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,
+                                    'completed',%s,NULL)
+                            ON CONFLICT (
+                                account_id,user_id,writer,session_scope_id,operation_id
+                            ) DO UPDATE SET state='completed', result=EXCLUDED.result,
+                                            error=NULL,
+                                            fencing_token=EXCLUDED.fencing_token,
+                                            updated_at=now()
+                            """,
+                            (
+                                *self._scope_key,
+                                operation_id,
+                                operation,
+                                resource_id,
+                                turn_id,
+                                digest,
+                                token,
+                                Json(result),
+                            ),
+                        )
+                        self._commit_and_suppress(conn, scope_advanced=scope_advanced)
+                        return self._select_current_receipt(cursor)
+                    if operation in {"message", "used", "commit"}:
+                        raise FencedOperationConflict(
+                            "The session is closed for this turn",
+                            reason="session_turn_closed",
+                            details={"session_id": resource_id, "turn_id": turn_id},
+                        )
+
+                scope_advanced = self._advance_scope(
+                    cursor,
+                    previous_highest=highest,
+                )
+
+                if receipt is not None:
+                    if receipt.digest != digest:
+                        raise FencedOperationConflict(
+                            "Operation ID was already used for different content",
+                            reason="operation_digest_conflict",
+                            details={"operation_id": operation_id},
+                        )
+                    cursor.execute(
+                        f"""
+                        UPDATE {SCHEMA}.operation_receipt
+                        SET fencing_token=GREATEST(fencing_token,%s), updated_at=now()
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                        """,
+                        (token, *self._scope_key, operation_id),
+                    )
+                    if receipt.state in {"queued", "running"}:
+                        cursor.execute(
+                            f"""
+                            UPDATE {SCHEMA}.effect_outbox
+                            SET fencing_token=GREATEST(fencing_token,%s),
+                                updated_at=now()
+                            WHERE account_id=%s AND user_id=%s AND writer=%s
+                              AND session_scope_id=%s AND operation_id=%s
+                              AND digest=%s
+                            """,
+                            (
+                                token,
+                                *self._scope_key,
+                                operation_id,
+                                digest,
+                            ),
+                        )
+                        if cursor.rowcount != 1:
+                            raise RuntimeError("PostgreSQL fenced outbox receipt is missing")
+                    self._commit_and_suppress(conn, scope_advanced=scope_advanced)
+                    current = self._select_current_receipt(cursor)
+                    return replace(current, replayed=True)
+
+                cursor.execute(
+                    f"""
+                    INSERT INTO {SCHEMA}.operation_receipt
+                        (account_id,user_id,writer,session_scope_id,operation_id,
+                         operation,resource_id,turn_id,digest,fencing_token,state)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,'queued')
+                    """,
+                    (
+                        *self._scope_key,
+                        operation_id,
+                        operation,
+                        resource_id,
+                        turn_id,
+                        digest,
+                        token,
+                    ),
+                )
+                cursor.execute(
+                    f"""
+                    INSERT INTO {SCHEMA}.effect_outbox
+                        (account_id,user_id,writer,session_scope_id,operation_id,
+                         operation,resource_id,turn_id,digest,fencing_token,
+                         request_payload,actor_peer_id,state)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,'queued')
+                    """,
+                    (
+                        *self._scope_key,
+                        operation_id,
+                        operation,
+                        resource_id,
+                        turn_id,
+                        digest,
+                        token,
+                        Json(request_payload),
+                        self._ctx.actor_peer_id,
+                    ),
+                )
+            self._commit_and_suppress(conn, scope_advanced=scope_advanced)
+            with conn.cursor() as cursor:
+                return self._select_current_receipt(cursor)
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+
+    async def submit(
+        self,
+        operation: str,
+        resource_id: str,
+        *,
+        request_payload: Optional[dict[str, Any]] = None,
+    ) -> FencedOperationRecord:
+        """Durably queue one effect; no OpenViking/AGFS callback runs here."""
+        started_at = time.monotonic()
+        expected_payload = self._envelope.model_dump(mode="json")
+        payload = expected_payload if request_payload is None else request_payload
+        if json.dumps(payload, sort_keys=True, separators=(",", ":")) != json.dumps(
+            expected_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ):
+            raise ValueError("request_payload must exactly match the validated envelope")
+        digest = operation_digest(
+            operation,
+            self._envelope,
+            resource_id=resource_id,
+            actor_peer_id=self._ctx.actor_peer_id,
+        )
+
+        # Strict fault-injection seam: a frozen Alice/API owner here owns no DB
+        # transaction and cannot execute an external effect.  A higher fence can
+        # submit, after which this owner resumes and is rejected as stale.
+        from openviking.server import fenced_operation  # noqa: PLC0415
+
+        seam_result = fenced_operation.after_fenced_submit_preflight(operation)
+        if inspect.isawaitable(seam_result):
+            await seam_result
+        try:
+            record = await asyncio.to_thread(
+                self._submit_sync,
+                operation,
+                resource_id,
+                digest,
+                payload,
+            )
+            outcome = (
+                "replayed"
+                if record.replayed
+                else (
+                    record.state if record.state in {"stale", "conflict", "failed"} else "accepted"
+                )
+            )
+            _record_v2_submit_metric(operation, outcome, started_at)
+            return record
+        except FencedOperationConflict as exc:
+            reason = str((getattr(exc, "details", None) or {}).get("reason") or "")
+            _record_v2_submit_metric(
+                operation,
+                "stale" if reason == "stale_fence" else "conflict",
+                started_at,
+            )
+            raise
+        except FailedPreconditionError:
+            _record_v2_submit_metric(operation, "rejected", started_at)
+            raise
+        except Exception as exc:
+            _record_v2_submit_metric(operation, "error", started_at)
+            logger.exception("PostgreSQL fenced outbox submit failed")
+            raise UnavailableError("PostgreSQL fenced outbox", "persistence_unavailable") from exc
+
+    @classmethod
+    def _get_sync(
+        cls,
+        ctx: RequestContext,
+        operation_id: str,
+        *,
+        writer: str = "alice",
+    ) -> Optional[FencedOperationRecord]:
+        conn = _connect(application_name="openviking-fenced-status")
+        try:
+            conn.autocommit = True
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    _RECEIPT_SELECT
+                    + """
+                      WHERE account_id=%s AND user_id=%s AND writer=%s
+                        AND operation_id=%s
+                    """,
+                    (ctx.account_id, ctx.user.user_id, writer, operation_id),
+                )
+                rows = cursor.fetchall()
+                if not rows:
+                    return None
+                if len(rows) != 1:
+                    raise FencedOperationConflict(
+                        "Operation ID is not uniquely scoped to this principal",
+                        reason="operation_scope_conflict",
+                        details={"operation_id": operation_id},
+                    )
+                # A status read is not itself a duplicate submission.  POST
+                # preserves duplicate-vs-new semantics from `_submit_sync`;
+                # polling reports only the durable operation state.
+                return _operation_record(rows[0], replayed=False)
+        finally:
+            conn.close()
+
+    @classmethod
+    async def get(
+        cls,
+        ctx: RequestContext,
+        operation_id: str,
+        *,
+        writer: str = "alice",
+    ) -> Optional[FencedOperationRecord]:
+        try:
+            return await asyncio.to_thread(
+                cls._get_sync,
+                ctx,
+                operation_id,
+                writer=writer,
+            )
+        except FencedOperationConflict:
+            raise
+        except Exception as exc:
+            logger.exception("PostgreSQL fenced operation status read failed")
+            raise UnavailableError("PostgreSQL fenced outbox", "persistence_unavailable") from exc
+
+    @classmethod
+    async def wait(
+        cls,
+        ctx: RequestContext,
+        operation_id: str,
+        *,
+        writer: str = "alice",
+        timeout_seconds: float,
+        poll_seconds: float = 0.05,
+    ) -> Optional[FencedOperationRecord]:
+        deadline = asyncio.get_running_loop().time() + max(0.0, timeout_seconds)
+        while True:
+            record = await cls.get(ctx, operation_id, writer=writer)
+            if record is None or record.terminal:
+                return record
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return record
+            await asyncio.sleep(min(max(0.01, poll_seconds), remaining))
+
+
+class PostgresFencedOperationLedger:
+    """One request-scoped PostgreSQL fencing transaction."""
+
+    def __init__(self, ctx: RequestContext, envelope: FencedOperationEnvelope):
+        self._ctx = ctx
+        self._envelope = envelope
+
+    @property
+    def _scope_key(self) -> tuple[str, str, str, str]:
+        return (
+            self._ctx.account_id,
+            self._ctx.user.user_id,
+            self._envelope.writer,
+            self._envelope.session_scope_id,
+        )
+
+    def _begin_and_prepare(
+        self,
+        conn,
+        operation: str,
+        resource_id: str,
+        digest: str,
+    ) -> tuple[Optional[dict[str, Any]], bool]:
+        """Acquire non-expiring transaction locks and prepare the operation."""
+        account_id, user_id, writer, scope_id = self._scope_key
+        token = self._envelope.fencing_token
+        turn_id = self._envelope.turn_id
+        operation_id = self._envelope.operation_id
+        conn.autocommit = False
+        with conn.cursor() as cursor:
+            # Prevent a database-side idle timeout from turning this into another
+            # expiring lease while the async OpenViking effect is running.
+            cursor.execute("SET LOCAL idle_in_transaction_session_timeout = 0")
+            lock_keys = sorted(
+                {
+                    _advisory_key("scope", account_id, user_id, writer, scope_id),
+                    _advisory_key("session", account_id, user_id, resource_id),
+                }
+            )
+            for key in lock_keys:
+                cursor.execute("SELECT pg_advisory_xact_lock(%s)", (key,))
+
+            cursor.execute(
+                f"""
+                INSERT INTO {SCHEMA}.scope_state
+                    (account_id, user_id, writer, session_scope_id,
+                     highest_fencing_token, active_turn_id)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (account_id, user_id, writer, session_scope_id)
+                DO NOTHING
+                """,
+                (*self._scope_key, token, turn_id),
+            )
+            cursor.execute(
+                f"""
+                SELECT highest_fencing_token, active_turn_id
+                FROM {SCHEMA}.scope_state
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s
+                FOR UPDATE
+                """,
+                self._scope_key,
+            )
+            row = cursor.fetchone()
+            if row is None:
+                raise RuntimeError("PostgreSQL fencing scope row disappeared")
+            highest, active_turn = int(row[0]), str(row[1])
+            if token < highest:
+                raise FencedOperationConflict(
+                    "Fencing token is stale",
+                    reason="stale_fence",
+                    details={
+                        "highest_fencing_token": highest,
+                        "received_fencing_token": token,
+                    },
+                )
+            if token == highest and turn_id != active_turn:
+                raise FencedOperationConflict(
+                    "The active fencing token is already bound to another turn",
+                    reason="turn_fence_conflict",
+                    details={"active_turn_id": active_turn},
+                )
+
+            cursor.execute(
+                f"""
+                SELECT writer, session_scope_id
+                FROM {SCHEMA}.session_binding
+                WHERE account_id=%s AND user_id=%s AND session_id=%s
+                FOR UPDATE
+                """,
+                (account_id, user_id, resource_id),
+            )
+            binding = cursor.fetchone()
+            binding_missing = binding is None
+            if binding is not None and (str(binding[0]), str(binding[1])) != (
+                writer,
+                scope_id,
+            ):
+                raise FencedOperationConflict(
+                    "Session is already bound to a different writer scope",
+                    reason="session_scope_conflict",
+                    details={"session_id": resource_id},
+                )
+
+            receipt_key = (*self._scope_key, operation_id)
+            cursor.execute(
+                f"""
+                SELECT digest, state, result, fencing_token
+                FROM {SCHEMA}.operation_receipt
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND operation_id=%s
+                FOR UPDATE
+                """,
+                receipt_key,
+            )
+            receipt = cursor.fetchone()
+            cursor.execute(
+                f"""
+                SELECT digest, result, fencing_token
+                FROM {SCHEMA}.effect_receipt
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND operation_id=%s
+                FOR UPDATE
+                """,
+                receipt_key,
+            )
+            effect = cursor.fetchone()
+
+            for persisted in (receipt, effect):
+                if persisted is not None and str(persisted[0]) != digest:
+                    raise FencedOperationConflict(
+                        "Operation ID was already used for different content",
+                        reason="operation_digest_conflict",
+                        details={"operation_id": operation_id},
+                    )
+
+            # A commit closure is the durable effect manifest even after normal
+            # operation/effect receipts from an older fence have been pruned.
+            cursor.execute(
+                f"""
+                SELECT operation_id, digest, result
+                FROM {SCHEMA}.session_turn_closure
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND turn_id=%s AND session_id=%s
+                FOR UPDATE
+                """,
+                (*self._scope_key, turn_id, resource_id),
+            )
+            closure = cursor.fetchone()
+            if closure is not None:
+                closure_operation_id, closure_digest, closure_result = closure
+                if operation == "commit" and str(closure_operation_id) == operation_id:
+                    if str(closure_digest) != digest:
+                        raise FencedOperationConflict(
+                            "Operation ID was already used for different content",
+                            reason="operation_digest_conflict",
+                            details={"operation_id": operation_id},
+                        )
+                    cached = _json_value(closure_result)
+                    self._advance_and_prune(cursor, highest, active_turn)
+                    return cached, True
+                if operation in {"message", "used", "commit"}:
+                    raise FencedOperationConflict(
+                        "The session is closed for this turn",
+                        reason="session_turn_closed",
+                        details={"session_id": resource_id, "turn_id": turn_id},
+                    )
+
+            cached: Optional[dict[str, Any]] = None
+            if receipt is not None and str(receipt[1]) == "done":
+                cached = _json_value(receipt[2])
+            elif effect is not None:
+                cached = _json_value(effect[1])
+            if cached is not None:
+                self._advance_and_prune(cursor, highest, active_turn)
+                cursor.execute(
+                    f"""
+                    UPDATE {SCHEMA}.operation_receipt
+                    SET fencing_token=%s, updated_at=now()
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                    """,
+                    (token, *receipt_key),
+                )
+                cursor.execute(
+                    f"""
+                    UPDATE {SCHEMA}.effect_receipt
+                    SET fencing_token=%s
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                    """,
+                    (token, *receipt_key),
+                )
+                return cached, True
+
+            self._advance_and_prune(cursor, highest, active_turn)
+            cursor.execute(
+                f"""
+                INSERT INTO {SCHEMA}.operation_receipt
+                    (account_id, user_id, writer, session_scope_id,
+                     operation_id, operation, resource_id, turn_id, digest,
+                     fencing_token, state, result)
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,'prepared',NULL)
+                ON CONFLICT (account_id,user_id,writer,session_scope_id,operation_id)
+                DO UPDATE SET fencing_token=EXCLUDED.fencing_token,
+                              updated_at=now()
+                """,
+                (
+                    *receipt_key,
+                    operation,
+                    resource_id,
+                    turn_id,
+                    digest,
+                    token,
+                ),
+            )
+            return None, binding_missing
+
+    def _advance_and_prune(self, cursor, highest: int, active_turn: str) -> None:
+        account_id, user_id, writer, scope_id = self._scope_key
+        token = self._envelope.fencing_token
+        turn_id = self._envelope.turn_id
+        operation_id = self._envelope.operation_id
+        if token > highest:
+            cursor.execute(
+                f"""
+                UPDATE {SCHEMA}.scope_state
+                SET highest_fencing_token=%s, active_turn_id=%s, updated_at=now()
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s
+                """,
+                (token, turn_id, *self._scope_key),
+            )
+            for table in ("operation_receipt", "effect_receipt"):
+                cursor.execute(
+                    f"""
+                    DELETE FROM {SCHEMA}.{table}
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND fencing_token < %s
+                      AND operation_id <> %s
+                    """,
+                    (*self._scope_key, token, operation_id),
+                )
+            if turn_id != active_turn:
+                cursor.execute(
+                    f"""
+                    DELETE FROM {SCHEMA}.session_turn_closure
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND turn_id <> %s
+                    """,
+                    (*self._scope_key, turn_id),
+                )
+
+    def _complete(
+        self,
+        conn,
+        operation: str,
+        resource_id: str,
+        digest: str,
+        result: dict[str, Any],
+        binding_missing: bool,
+    ) -> None:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        account_id, user_id, writer, scope_id = self._scope_key
+        operation_id = self._envelope.operation_id
+        turn_id = self._envelope.turn_id
+        token = self._envelope.fencing_token
+        receipt_key = (*self._scope_key, operation_id)
+        with conn.cursor() as cursor:
+            if binding_missing:
+                cursor.execute(
+                    f"""
+                    INSERT INTO {SCHEMA}.session_binding
+                        (account_id,user_id,session_id,writer,session_scope_id)
+                    VALUES (%s,%s,%s,%s,%s)
+                    ON CONFLICT (account_id,user_id,session_id) DO NOTHING
+                    """,
+                    (account_id, user_id, resource_id, writer, scope_id),
+                )
+                cursor.execute(
+                    f"""
+                    SELECT writer, session_scope_id
+                    FROM {SCHEMA}.session_binding
+                    WHERE account_id=%s AND user_id=%s AND session_id=%s
+                    """,
+                    (account_id, user_id, resource_id),
+                )
+                binding = cursor.fetchone()
+                if binding is None or (str(binding[0]), str(binding[1])) != (
+                    writer,
+                    scope_id,
+                ):
+                    raise FencedOperationConflict(
+                        "Session is already bound to a different writer scope",
+                        reason="session_scope_conflict",
+                        details={"session_id": resource_id},
+                    )
+
+            cursor.execute(
+                f"""
+                UPDATE {SCHEMA}.operation_receipt
+                SET state='done', result=%s, fencing_token=%s, updated_at=now()
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND operation_id=%s AND digest=%s
+                """,
+                (Json(result), token, *receipt_key, digest),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("PostgreSQL fenced operation CAS failed")
+            cursor.execute(
+                f"""
+                INSERT INTO {SCHEMA}.effect_receipt
+                    (account_id,user_id,writer,session_scope_id,operation_id,
+                     operation,resource_id,turn_id,digest,fencing_token,result)
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (account_id,user_id,writer,session_scope_id,operation_id)
+                DO UPDATE SET result=EXCLUDED.result,
+                              fencing_token=EXCLUDED.fencing_token,
+                              completed_at=now()
+                WHERE {SCHEMA}.effect_receipt.digest=EXCLUDED.digest
+                """,
+                (
+                    *receipt_key,
+                    operation,
+                    resource_id,
+                    turn_id,
+                    digest,
+                    token,
+                    Json(result),
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise FencedOperationConflict(
+                    "Operation ID was already used for different content",
+                    reason="operation_digest_conflict",
+                    details={"operation_id": operation_id},
+                )
+            if operation == "commit":
+                cursor.execute(
+                    f"""
+                    INSERT INTO {SCHEMA}.session_turn_closure
+                        (account_id,user_id,writer,session_scope_id,turn_id,
+                         session_id,operation_id,digest,fencing_token,result)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                    ON CONFLICT (
+                        account_id,user_id,writer,session_scope_id,turn_id,session_id
+                    ) DO NOTHING
+                    """,
+                    (
+                        *self._scope_key,
+                        turn_id,
+                        resource_id,
+                        operation_id,
+                        digest,
+                        token,
+                        Json(result),
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise FencedOperationConflict(
+                        "The session is already closed for this turn",
+                        reason="session_turn_closed",
+                        details={"session_id": resource_id, "turn_id": turn_id},
+                    )
+
+    async def execute(
+        self,
+        operation: str,
+        resource_id: str,
+        callback: Callable[[], Awaitable[dict[str, Any]]],
+    ) -> tuple[dict[str, Any], bool]:
+        """Execute one effect under a non-expiring PostgreSQL transaction lock."""
+        digest = operation_digest(operation, self._envelope, resource_id=resource_id)
+        try:
+            conn = await asyncio.to_thread(_connect)
+        except Exception as exc:
+            logger.exception("PostgreSQL legacy fencing store connection failed")
+            raise UnavailableError("PostgreSQL fencing store", "persistence_unavailable") from exc
+        try:
+            try:
+                cached, binding_missing = await asyncio.to_thread(
+                    self._begin_and_prepare,
+                    conn,
+                    operation,
+                    resource_id,
+                    digest,
+                )
+                if cached is not None:
+                    await asyncio.to_thread(conn.commit)
+                    return cached, True
+
+                result = await callback()
+                if not isinstance(result, dict):
+                    raise TypeError("Fenced operation callback must return a dict")
+                # Resolve through the module so tests (and fault-injection
+                # harnesses) can replace the crash seam after import.
+                from openviking.server import fenced_operation  # noqa: PLC0415
+
+                seam_result = fenced_operation.after_fenced_effect_before_receipt(operation)
+                if inspect.isawaitable(seam_result):
+                    await seam_result
+                await asyncio.to_thread(
+                    self._complete,
+                    conn,
+                    operation,
+                    resource_id,
+                    digest,
+                    result,
+                    binding_missing,
+                )
+                await asyncio.to_thread(conn.commit)
+                return result, False
+            except (FencedOperationConflict, FailedPreconditionError):
+                await asyncio.to_thread(conn.rollback)
+                raise
+            except Exception:
+                await asyncio.to_thread(conn.rollback)
+                raise
+        finally:
+            await asyncio.to_thread(conn.close)

--- a/openviking/server/fenced_writer.py
+++ b/openviking/server/fenced_writer.py
@@ -1,0 +1,1785 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Durable, scope-ordered writer for Alice fenced-session outbox effects."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import random
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Any, Optional
+
+from openviking.server.fenced_postgres import (
+    SCHEMA,
+    _advisory_key,
+    _connect,
+    _json_value,
+)
+from openviking_cli.exceptions import FailedPreconditionError
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+EffectExecutor = Callable[["FencedOutboxItem"], Awaitable[dict[str, Any]]]
+TaskWaiter = Callable[["FencedCommitWorkItem"], Awaitable[str]]
+FailStop = Callable[[BaseException], None]
+
+
+class PermanentFencedEffectError(Exception):
+    """A validated rejection that is proven to precede the external effect."""
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        details: Optional[dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.details = details or {}
+
+
+@dataclass(frozen=True)
+class FencedOutboxItem:
+    sequence_id: int
+    account_id: str
+    user_id: str
+    writer: str
+    session_scope_id: str
+    operation_id: str
+    operation: str
+    resource_id: str
+    turn_id: str
+    digest: str
+    fencing_token: int
+    request_payload: dict[str, Any]
+    actor_peer_id: Optional[str]
+    state: str
+    attempt_count: int
+    claim_token: Optional[str]
+    effect_started_at: Optional[datetime]
+    submitted_at: datetime
+
+    @property
+    def scope_key(self) -> tuple[str, str, str, str]:
+        return (
+            self.account_id,
+            self.user_id,
+            self.writer,
+            self.session_scope_id,
+        )
+
+    @property
+    def receipt_key(self) -> tuple[str, str, str, str, str]:
+        return (*self.scope_key, self.operation_id)
+
+
+@dataclass(frozen=True)
+class FencedCommitWorkItem:
+    sequence_id: int
+    account_id: str
+    user_id: str
+    writer: str
+    session_scope_id: str
+    operation_id: str
+    session_id: str
+    task_id: str
+    archive_uri: str
+    wait_for_completion: bool
+    state: str
+    attempt_count: int
+    claim_token: Optional[str]
+
+    @property
+    def receipt_key(self) -> tuple[str, str, str, str, str]:
+        return (
+            self.account_id,
+            self.user_id,
+            self.writer,
+            self.session_scope_id,
+            self.operation_id,
+        )
+
+
+@dataclass
+class _ClaimHandle:
+    conn: Any
+    item: FencedOutboxItem
+    lock_keys: tuple[int, ...]
+
+
+@dataclass
+class _CommitClaimHandle:
+    conn: Any
+    item: FencedCommitWorkItem
+    lock_keys: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _ClaimOutcome:
+    handle: Optional[_ClaimHandle]
+    processed: bool
+
+
+_OUTBOX_SELECT = f"""
+    SELECT o.sequence_id, o.account_id, o.user_id, o.writer,
+           o.session_scope_id, o.operation_id, o.operation, o.resource_id,
+           o.turn_id, o.digest, o.fencing_token, o.request_payload,
+           o.actor_peer_id, o.state, o.attempt_count, o.claim_token,
+           o.effect_started_at, r.submitted_at
+    FROM {SCHEMA}.effect_outbox o
+    JOIN {SCHEMA}.operation_receipt r
+      USING (account_id,user_id,writer,session_scope_id,operation_id)
+"""
+
+_COMMIT_WORK_SELECT = f"""
+    SELECT sequence_id,account_id,user_id,writer,session_scope_id,operation_id,
+           session_id,task_id,archive_uri,wait_for_completion,state,
+           attempt_count,claim_token
+    FROM {SCHEMA}.commit_work_outbox
+"""
+
+
+def _outbox_item(row: Any) -> FencedOutboxItem:
+    if row is None or len(row) != 18:
+        raise RuntimeError("Corrupt PostgreSQL fenced outbox row")
+    payload = _json_value(row[11])
+    submitted_at = row[17]
+    if not isinstance(submitted_at, datetime):
+        raise RuntimeError("Corrupt PostgreSQL fenced outbox submitted_at")
+    item = FencedOutboxItem(
+        sequence_id=int(row[0]),
+        account_id=str(row[1]),
+        user_id=str(row[2]),
+        writer=str(row[3]),
+        session_scope_id=str(row[4]),
+        operation_id=str(row[5]),
+        operation=str(row[6]),
+        resource_id=str(row[7]),
+        turn_id=str(row[8]),
+        digest=str(row[9]),
+        fencing_token=int(row[10]),
+        request_payload=payload,
+        actor_peer_id=None if row[12] is None else str(row[12]),
+        state=str(row[13]),
+        attempt_count=int(row[14]),
+        claim_token=None if row[15] is None else str(row[15]),
+        effect_started_at=row[16],
+        submitted_at=submitted_at,
+    )
+    if item.writer != "alice":
+        raise RuntimeError("Fenced outbox contains a non-Alice writer")
+    return item
+
+
+def _commit_work_item(row: Any) -> FencedCommitWorkItem:
+    if row is None or len(row) != 13:
+        raise RuntimeError("Corrupt PostgreSQL fenced commit work row")
+    item = FencedCommitWorkItem(
+        sequence_id=int(row[0]),
+        account_id=str(row[1]),
+        user_id=str(row[2]),
+        writer=str(row[3]),
+        session_scope_id=str(row[4]),
+        operation_id=str(row[5]),
+        session_id=str(row[6]),
+        task_id=str(row[7]),
+        archive_uri=str(row[8]),
+        wait_for_completion=bool(row[9]),
+        state=str(row[10]),
+        attempt_count=int(row[11]),
+        claim_token=None if row[12] is None else str(row[12]),
+    )
+    if item.writer != "alice":
+        raise RuntimeError("Fenced commit work contains a non-Alice writer")
+    return item
+
+
+def _sanitized_error(
+    *,
+    code: str,
+    message: str,
+    reason: str,
+    details: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    safe_details: dict[str, Any] = {"reason": reason}
+    if details:
+        for key in (
+            "highest_fencing_token",
+            "received_fencing_token",
+            "active_turn_id",
+            "operation_id",
+            "session_id",
+            "turn_id",
+        ):
+            value = details.get(key)
+            if isinstance(value, (str, int, float, bool)):
+                safe_details[key] = value
+    return {"code": code, "message": message, "details": safe_details}
+
+
+def _stale_error(item: FencedOutboxItem, highest: int) -> dict[str, Any]:
+    return _sanitized_error(
+        code="CONFLICT",
+        message="Fencing token is stale",
+        reason="stale_fence",
+        details={
+            "highest_fencing_token": highest,
+            "received_fencing_token": item.fencing_token,
+        },
+    )
+
+
+def _effect_failed_error() -> dict[str, Any]:
+    return _sanitized_error(
+        code="UNAVAILABLE",
+        message="Fenced session effect failed",
+        reason="effect_failed",
+    )
+
+
+def _default_fail_stop(exc: BaseException) -> None:
+    logger.critical(
+        "Fenced writer lost its PostgreSQL session lock connection; exiting",
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
+    os._exit(70)
+
+
+def _record_effect_metric(item: FencedOutboxItem, outcome: str) -> None:
+    try:
+        from openviking.metrics.datasources.session import (  # noqa: PLC0415
+            SessionLifecycleDataSource,
+        )
+
+        SessionLifecycleDataSource.record_fenced_effect(
+            operation=item.operation,
+            outcome=outcome,
+        )
+    except Exception:
+        logger.debug("Failed to record fenced effect metric", exc_info=True)
+
+
+class PostgresFencedOutboxWriter:
+    """One worker coroutine; scope/session advisory locks are the authority.
+
+    Multiple instances may run concurrently.  Each instance claims only the
+    earliest active sequence in a writer scope, and holds non-expiring session
+    advisory locks for both scope and session until the deterministic effect is
+    completed or durably deferred to a task watcher.
+    """
+
+    def __init__(
+        self,
+        executor: EffectExecutor,
+        *,
+        task_waiter: Optional[TaskWaiter] = None,
+        max_attempts: int = 10,
+        retry_delay_seconds: float = 0.1,
+        monitor_interval_seconds: float = 0.25,
+        fail_stop: FailStop = _default_fail_stop,
+    ) -> None:
+        self._executor = executor
+        self._task_waiter = task_waiter
+        self._max_attempts = max(1, int(max_attempts))
+        self._retry_delay_seconds = max(0.01, float(retry_delay_seconds))
+        self._monitor_interval_seconds = max(
+            0.05, float(monitor_interval_seconds)
+        )
+        self._fail_stop = fail_stop
+
+    @staticmethod
+    def _lock_keys(item: FencedOutboxItem) -> tuple[int, ...]:
+        return tuple(
+            sorted(
+                {
+                    _advisory_key("outbox-scope", *item.scope_key),
+                    _advisory_key(
+                        "outbox-session",
+                        item.account_id,
+                        item.user_id,
+                        item.resource_id,
+                    ),
+                }
+            )
+        )
+
+    @staticmethod
+    def _try_session_locks(cursor, lock_keys: tuple[int, ...]) -> bool:
+        acquired: list[int] = []
+        for key in lock_keys:
+            cursor.execute("SELECT pg_try_advisory_lock(%s)", (key,))
+            row = cursor.fetchone()
+            if row and row[0] is True:
+                acquired.append(key)
+                continue
+            for acquired_key in reversed(acquired):
+                cursor.execute("SELECT pg_advisory_unlock(%s)", (acquired_key,))
+            return False
+        return True
+
+    @staticmethod
+    def _release_session_locks(cursor, lock_keys: tuple[int, ...]) -> None:
+        for key in reversed(lock_keys):
+            cursor.execute("SELECT pg_advisory_unlock(%s)", (key,))
+
+    @staticmethod
+    def _lock_operation_receipt(
+        cursor,
+        item: FencedOutboxItem,
+    ) -> Optional[FencedOutboxItem]:
+        cursor.execute(
+            f"""
+            SELECT operation,resource_id,turn_id,digest,fencing_token,state
+            FROM {SCHEMA}.operation_receipt
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s
+            FOR UPDATE
+            """,
+            item.receipt_key,
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        if (
+            str(row[0]) != item.operation
+            or str(row[1]) != item.resource_id
+            or str(row[2]) != item.turn_id
+            or str(row[3]) != item.digest
+            or str(row[5]) not in {"queued", "running"}
+        ):
+            return None
+        # An exact replay may raise the replaceable fencing token after claim
+        # commits but before effect authorization.  The receipt is the first
+        # row in the global lock order, so its locked token is the only safe
+        # value to use when subsequently checking scope_state.  The outbox row
+        # is locked last and must agree before the effect-start boundary.
+        return replace(item, fencing_token=int(row[4]))
+
+    @staticmethod
+    def _lock_commit_receipt(
+        cursor,
+        item: FencedCommitWorkItem,
+    ) -> str:
+        cursor.execute(
+            f"""
+            SELECT state
+            FROM {SCHEMA}.operation_receipt
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s
+            FOR UPDATE
+            """,
+            item.receipt_key,
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("PostgreSQL commit operation receipt is missing")
+        return str(row[0])
+
+    @staticmethod
+    def _terminalize(
+        cursor,
+        item: FencedOutboxItem,
+        *,
+        state: str,
+        error: Optional[dict[str, Any]],
+        result: Optional[dict[str, Any]] = None,
+    ) -> None:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        cursor.execute(
+            f"""
+            UPDATE {SCHEMA}.operation_receipt
+            SET state=%s, result=%s, error=%s, updated_at=now()
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s AND digest=%s
+              AND state IN ('queued','running')
+            """,
+            (
+                state,
+                None if result is None else Json(result),
+                None if error is None else Json(error),
+                *item.receipt_key,
+                item.digest,
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError("PostgreSQL fenced receipt terminal CAS failed")
+        cursor.execute(
+            f"""
+            DELETE FROM {SCHEMA}.effect_outbox
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s AND digest=%s
+            """,
+            (*item.receipt_key, item.digest),
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError("PostgreSQL fenced outbox delete CAS failed")
+
+    @staticmethod
+    def _current_outcome(cursor, item: FencedOutboxItem) -> tuple[str, Any] | None:
+        cursor.execute(
+            f"""
+            SELECT highest_fencing_token, active_turn_id
+            FROM {SCHEMA}.scope_state
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s
+            FOR UPDATE
+            """,
+            item.scope_key,
+        )
+        scope = cursor.fetchone()
+        if scope is None:
+            raise RuntimeError("PostgreSQL fencing scope row disappeared")
+        highest, active_turn = int(scope[0]), str(scope[1])
+        if item.fencing_token < highest or (
+            item.fencing_token == highest and item.turn_id != active_turn
+        ):
+            return "stale", _stale_error(item, highest)
+
+        cursor.execute(
+            f"""
+            SELECT writer, session_scope_id
+            FROM {SCHEMA}.session_binding
+            WHERE account_id=%s AND user_id=%s AND session_id=%s
+            FOR UPDATE
+            """,
+            (item.account_id, item.user_id, item.resource_id),
+        )
+        binding = cursor.fetchone()
+        if binding is not None and (str(binding[0]), str(binding[1])) != (
+            item.writer,
+            item.session_scope_id,
+        ):
+            return "conflict", _sanitized_error(
+                code="CONFLICT",
+                message="Session is already bound to a different writer scope",
+                reason="session_scope_conflict",
+                details={"session_id": item.resource_id},
+            )
+
+        cursor.execute(
+            f"""
+            SELECT operation_id, digest, result
+            FROM {SCHEMA}.session_turn_closure
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND turn_id=%s AND session_id=%s
+            FOR UPDATE
+            """,
+            (*item.scope_key, item.turn_id, item.resource_id),
+        )
+        closure = cursor.fetchone()
+        if closure is None:
+            return None
+        closure_operation_id, closure_digest, closure_result = closure
+        if (
+            item.operation == "commit"
+            and str(closure_operation_id) == item.operation_id
+            and str(closure_digest) == item.digest
+        ):
+            return "completed", _json_value(closure_result)
+        if item.operation in {"message", "used", "commit"}:
+            return "conflict", _sanitized_error(
+                code="CONFLICT",
+                message="The session is closed for this turn",
+                reason="session_turn_closed",
+                details={"session_id": item.resource_id, "turn_id": item.turn_id},
+            )
+        return None
+
+    def _claim_sync(self) -> _ClaimOutcome:
+        conn = _connect(application_name="openviking-fenced-writer")
+        try:
+            conn.autocommit = False
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    _OUTBOX_SELECT
+                    + f"""
+                    WHERE o.available_at <= now()
+                      AND o.writer='alice'
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM {SCHEMA}.effect_outbox earlier
+                          WHERE earlier.account_id=o.account_id
+                            AND earlier.user_id=o.user_id
+                            AND earlier.sequence_id < o.sequence_id
+                            AND (
+                                (
+                                    earlier.writer=o.writer
+                                    AND earlier.session_scope_id=o.session_scope_id
+                                )
+                                OR earlier.resource_id=o.resource_id
+                            )
+                    )
+                    ORDER BY o.sequence_id
+                    LIMIT 32
+                    """
+                )
+                candidates = [_outbox_item(row) for row in cursor.fetchall()]
+                for candidate in candidates:
+                    lock_keys = self._lock_keys(candidate)
+                    if not self._try_session_locks(cursor, lock_keys):
+                        continue
+
+                    # Candidate discovery is deliberately lock-free.  Once
+                    # this process owns the non-expiring writer advisory locks,
+                    # take rows in the same order as submit/replay:
+                    # operation_receipt -> effect_outbox.  Scope/binding/
+                    # closure decisions happen in `_authorize_effect_sync`
+                    # after this short claim transaction commits.
+                    locked_receipt = self._lock_operation_receipt(
+                        cursor, candidate
+                    )
+                    if locked_receipt is None:
+                        self._release_session_locks(cursor, lock_keys)
+                        conn.rollback()
+                        continue
+                    cursor.execute(
+                        _OUTBOX_SELECT
+                        + f"""
+                        WHERE o.account_id=%s AND o.user_id=%s AND o.writer=%s
+                          AND o.session_scope_id=%s AND o.operation_id=%s
+                          AND o.digest=%s AND o.available_at <= now()
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM {SCHEMA}.effect_outbox earlier
+                              WHERE earlier.account_id=o.account_id
+                                AND earlier.user_id=o.user_id
+                                AND earlier.sequence_id < o.sequence_id
+                                AND (
+                                    (
+                                        earlier.writer=o.writer
+                                        AND earlier.session_scope_id=o.session_scope_id
+                                    )
+                                    OR earlier.resource_id=o.resource_id
+                                )
+                          )
+                        FOR UPDATE OF o
+                        """,
+                        (*candidate.receipt_key, candidate.digest),
+                    )
+                    current_row = cursor.fetchone()
+                    if current_row is None:
+                        self._release_session_locks(cursor, lock_keys)
+                        conn.rollback()
+                        continue
+                    current = _outbox_item(current_row)
+                    if current.sequence_id != candidate.sequence_id:
+                        self._release_session_locks(cursor, lock_keys)
+                        conn.rollback()
+                        continue
+                    if current.fencing_token != locked_receipt.fencing_token:
+                        raise RuntimeError(
+                            "PostgreSQL fenced receipt/outbox token mismatch"
+                        )
+
+                    claim_token = uuid.uuid4().hex
+                    cursor.execute(
+                        f"""
+                        UPDATE {SCHEMA}.effect_outbox
+                        SET state='running', claim_token=%s,
+                            attempt_count=attempt_count+1,
+                            claimed_at=now(), updated_at=now()
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                          AND digest=%s
+                        """,
+                        (claim_token, *current.receipt_key, current.digest),
+                    )
+                    if cursor.rowcount != 1:
+                        raise RuntimeError("PostgreSQL fenced outbox claim CAS failed")
+                    cursor.execute(
+                        f"""
+                        UPDATE {SCHEMA}.operation_receipt
+                        SET state='running', updated_at=now()
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                          AND digest=%s AND state IN ('queued','running')
+                        """,
+                        (*current.receipt_key, current.digest),
+                    )
+                    if cursor.rowcount != 1:
+                        raise RuntimeError("PostgreSQL fenced receipt claim CAS failed")
+                    conn.commit()
+                    item = replace(
+                        current,
+                        state="running",
+                        attempt_count=current.attempt_count + 1,
+                        claim_token=claim_token,
+                    )
+                    return _ClaimOutcome(
+                        handle=_ClaimHandle(conn=conn, item=item, lock_keys=lock_keys),
+                        processed=True,
+                    )
+            conn.rollback()
+            conn.close()
+            return _ClaimOutcome(handle=None, processed=False)
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            conn.close()
+            raise
+
+    def _authorize_effect_sync(
+        self,
+        handle: _ClaimHandle,
+    ) -> tuple[bool, FencedOutboxItem]:
+        conn = handle.conn
+        item = handle.item
+        try:
+            with conn.cursor() as cursor:
+                # Keep the row-lock order compatible with submit/replay.  In
+                # particular, never hold effect_outbox while waiting on
+                # scope_state: that inverted submit's scope -> outbox order
+                # and produced a real PostgreSQL deadlock under exact replay.
+                locked_receipt = self._lock_operation_receipt(cursor, item)
+                if locked_receipt is None:
+                    raise RuntimeError("PostgreSQL fenced receipt claim was lost")
+                outcome = self._current_outcome(cursor, locked_receipt)
+                cursor.execute(
+                    _OUTBOX_SELECT
+                    + """
+                    WHERE o.account_id=%s AND o.user_id=%s AND o.writer=%s
+                      AND o.session_scope_id=%s AND o.operation_id=%s
+                      AND o.claim_token=%s
+                    FOR UPDATE OF o
+                    """,
+                    (*item.receipt_key, item.claim_token),
+                )
+                current_row = cursor.fetchone()
+                if current_row is None:
+                    raise RuntimeError("PostgreSQL fenced claim was lost")
+                current = _outbox_item(current_row)
+                if current.fencing_token != locked_receipt.fencing_token:
+                    raise RuntimeError(
+                        "PostgreSQL fenced receipt/outbox token mismatch"
+                    )
+                if current.effect_started_at is not None:
+                    # A durable started effect must be recovered even if a
+                    # higher fence arrived after its former process died.
+                    self._publish_binding(cursor, current)
+                    conn.commit()
+                    return True, current
+
+                if outcome is not None:
+                    state, value = outcome
+                    if state == "completed":
+                        self._terminalize(
+                            cursor,
+                            current,
+                            state="completed",
+                            error=None,
+                            result=value,
+                        )
+                    else:
+                        self._terminalize(
+                            cursor,
+                            current,
+                            state=state,
+                            error=value,
+                        )
+                    conn.commit()
+                    return False, current
+
+                # Once the durable effect-start boundary is crossed, another
+                # scope must never claim the same session while this operation
+                # is being recovered.  Pre-effect stale/conflict paths above do
+                # not publish a placeholder; ambiguous/started work does.
+                self._publish_binding(cursor, current)
+                cursor.execute(
+                    f"""
+                    UPDATE {SCHEMA}.effect_outbox
+                    SET effect_started_at=now(), updated_at=now()
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                      AND claim_token=%s AND effect_started_at IS NULL
+                    RETURNING effect_started_at
+                    """,
+                    (*current.receipt_key, current.claim_token),
+                )
+                started = cursor.fetchone()
+                if started is None:
+                    raise RuntimeError("PostgreSQL effect-start CAS failed")
+                conn.commit()
+                return True, replace(current, effect_started_at=started[0])
+        except Exception:
+            conn.rollback()
+            raise
+
+    @staticmethod
+    def _publish_binding(cursor, item: FencedOutboxItem) -> None:
+        cursor.execute(
+            f"""
+            INSERT INTO {SCHEMA}.session_binding
+                (account_id,user_id,session_id,writer,session_scope_id)
+            VALUES (%s,%s,%s,%s,%s)
+            ON CONFLICT (account_id,user_id,session_id) DO NOTHING
+            """,
+            (
+                item.account_id,
+                item.user_id,
+                item.resource_id,
+                item.writer,
+                item.session_scope_id,
+            ),
+        )
+        cursor.execute(
+            f"""
+            SELECT writer, session_scope_id
+            FROM {SCHEMA}.session_binding
+            WHERE account_id=%s AND user_id=%s AND session_id=%s
+            """,
+            (item.account_id, item.user_id, item.resource_id),
+        )
+        binding = cursor.fetchone()
+        if binding is None or (str(binding[0]), str(binding[1])) != (
+            item.writer,
+            item.session_scope_id,
+        ):
+            raise RuntimeError("PostgreSQL session binding completion conflict")
+
+    @classmethod
+    def _write_effect_receipt(
+        cls,
+        cursor,
+        item: FencedOutboxItem,
+        result: dict[str, Any],
+    ) -> int:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        cursor.execute(
+            f"""
+            SELECT fencing_token
+            FROM {SCHEMA}.effect_outbox
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s AND digest=%s
+            FOR UPDATE
+            """,
+            (*item.receipt_key, item.digest),
+        )
+        outbox = cursor.fetchone()
+        if outbox is None:
+            raise RuntimeError("PostgreSQL fenced outbox disappeared before receipt")
+        current_token = int(outbox[0])
+        cursor.execute(
+            f"""
+            INSERT INTO {SCHEMA}.effect_receipt
+                (account_id,user_id,writer,session_scope_id,operation_id,
+                 operation,resource_id,turn_id,digest,fencing_token,result)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (
+                account_id,user_id,writer,session_scope_id,operation_id
+            ) DO UPDATE SET result=EXCLUDED.result,
+                            fencing_token=GREATEST(
+                                {SCHEMA}.effect_receipt.fencing_token,
+                                EXCLUDED.fencing_token
+                            ),
+                            completed_at=now()
+            WHERE {SCHEMA}.effect_receipt.digest=EXCLUDED.digest
+            """,
+            (
+                *item.receipt_key,
+                item.operation,
+                item.resource_id,
+                item.turn_id,
+                item.digest,
+                current_token,
+                Json(result),
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError("PostgreSQL effect receipt digest conflict")
+        return current_token
+
+    @staticmethod
+    def _enqueue_commit_work(
+        cursor,
+        item: FencedOutboxItem,
+        result: dict[str, Any],
+        *,
+        wait_for_completion: bool,
+    ) -> None:
+        if item.operation != "commit":
+            return
+        task_id = result.get("task_id")
+        archive_uri = result.get("archive_uri")
+        if not isinstance(task_id, str) or not task_id:
+            return
+        if not isinstance(archive_uri, str) or not archive_uri:
+            raise RuntimeError("Fenced commit task is missing archive_uri")
+        cursor.execute(
+            f"""
+            INSERT INTO {SCHEMA}.commit_work_outbox
+                (account_id,user_id,writer,session_scope_id,operation_id,
+                 session_id,task_id,archive_uri,wait_for_completion)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (
+                account_id,user_id,writer,session_scope_id,operation_id
+            ) DO NOTHING
+            """,
+            (
+                *item.receipt_key,
+                item.resource_id,
+                task_id,
+                archive_uri,
+                wait_for_completion,
+            ),
+        )
+        cursor.execute(
+            f"""
+            SELECT session_id,task_id,archive_uri,wait_for_completion
+            FROM {SCHEMA}.commit_work_outbox
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s
+            """,
+            item.receipt_key,
+        )
+        work = cursor.fetchone()
+        if work is None or (
+            str(work[0]),
+            str(work[1]),
+            str(work[2]),
+            bool(work[3]),
+        ) != (
+            item.resource_id,
+            task_id,
+            archive_uri,
+            wait_for_completion,
+        ):
+            raise RuntimeError("PostgreSQL deterministic commit work conflict")
+
+    @staticmethod
+    def _write_commit_closure(
+        cursor,
+        item: FencedOutboxItem,
+        result: dict[str, Any],
+        current_token: int,
+    ) -> None:
+        if item.operation != "commit":
+            return
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        cursor.execute(
+            f"""
+            INSERT INTO {SCHEMA}.session_turn_closure
+                (account_id,user_id,writer,session_scope_id,turn_id,
+                 session_id,operation_id,digest,fencing_token,result)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (
+                account_id,user_id,writer,session_scope_id,turn_id,session_id
+            ) DO NOTHING
+            """,
+            (
+                *item.scope_key,
+                item.turn_id,
+                item.resource_id,
+                item.operation_id,
+                item.digest,
+                current_token,
+                Json(result),
+            ),
+        )
+        if cursor.rowcount != 1:
+            cursor.execute(
+                f"""
+                SELECT operation_id, digest
+                FROM {SCHEMA}.session_turn_closure
+                WHERE account_id=%s AND user_id=%s AND writer=%s
+                  AND session_scope_id=%s AND turn_id=%s AND session_id=%s
+                """,
+                (*item.scope_key, item.turn_id, item.resource_id),
+            )
+            closure = cursor.fetchone()
+            if closure is None or (str(closure[0]), str(closure[1])) != (
+                item.operation_id,
+                item.digest,
+            ):
+                raise RuntimeError("PostgreSQL commit closure conflict")
+
+    @classmethod
+    def _complete_on_cursor(
+        cls,
+        cursor,
+        item: FencedOutboxItem,
+        result: dict[str, Any],
+    ) -> None:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        cls._publish_binding(cursor, item)
+        current_token = cls._write_effect_receipt(cursor, item, result)
+        cls._enqueue_commit_work(
+            cursor,
+            item,
+            result,
+            wait_for_completion=False,
+        )
+        cls._write_commit_closure(cursor, item, result, current_token)
+
+        cursor.execute(
+            f"""
+            UPDATE {SCHEMA}.operation_receipt
+            SET state='completed', result=%s, error=NULL,
+                fencing_token=GREATEST(fencing_token,%s), updated_at=now()
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s AND digest=%s
+              AND state='running'
+            """,
+            (Json(result), current_token, *item.receipt_key, item.digest),
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError("PostgreSQL operation completion CAS failed")
+        cursor.execute(
+            f"""
+            DELETE FROM {SCHEMA}.effect_outbox
+            WHERE account_id=%s AND user_id=%s AND writer=%s
+              AND session_scope_id=%s AND operation_id=%s AND digest=%s
+            """,
+            (*item.receipt_key, item.digest),
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError("PostgreSQL outbox completion delete failed")
+
+    def _complete_sync(
+        self,
+        handle: _ClaimHandle,
+        result: dict[str, Any],
+    ) -> None:
+        try:
+            with handle.conn.cursor() as cursor:
+                if self._lock_operation_receipt(cursor, handle.item) is None:
+                    raise RuntimeError(
+                        "PostgreSQL fenced completion receipt was lost"
+                    )
+                self._complete_on_cursor(cursor, handle.item, result)
+            handle.conn.commit()
+        except Exception:
+            handle.conn.rollback()
+            raise
+
+    def _defer_wait_sync(
+        self,
+        handle: _ClaimHandle,
+        result: dict[str, Any],
+    ) -> None:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        try:
+            with handle.conn.cursor() as cursor:
+                if self._lock_operation_receipt(cursor, handle.item) is None:
+                    raise RuntimeError(
+                        "PostgreSQL fenced wait receipt was lost"
+                    )
+                self._publish_binding(cursor, handle.item)
+                current_token = self._write_effect_receipt(
+                    cursor, handle.item, result
+                )
+                self._enqueue_commit_work(
+                    cursor,
+                    handle.item,
+                    result,
+                    wait_for_completion=True,
+                )
+                # Phase 1 is the session mutation boundary.  Closure is
+                # permanent even if asynchronous memory extraction later
+                # fails; same-turn writes must never reopen the archive.
+                self._write_commit_closure(
+                    cursor,
+                    handle.item,
+                    result,
+                    current_token,
+                )
+                cursor.execute(
+                    f"""
+                    UPDATE {SCHEMA}.operation_receipt
+                    SET state='running', result=%s, error=NULL,
+                        fencing_token=GREATEST(fencing_token,%s), updated_at=now()
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                      AND digest=%s AND state='running'
+                    """,
+                    (
+                        Json(result),
+                        current_token,
+                        *handle.item.receipt_key,
+                        handle.item.digest,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise RuntimeError("PostgreSQL task-wait receipt CAS failed")
+                cursor.execute(
+                    f"""
+                    DELETE FROM {SCHEMA}.effect_outbox
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                      AND digest=%s AND claim_token=%s
+                    """,
+                    (
+                        *handle.item.receipt_key,
+                        handle.item.digest,
+                        handle.item.claim_token,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise RuntimeError("PostgreSQL task-wait outbox delete failed")
+            handle.conn.commit()
+        except Exception:
+            handle.conn.rollback()
+            raise
+
+    def _retry_or_fail_sync(self, handle: _ClaimHandle) -> str:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        item = handle.item
+        try:
+            with handle.conn.cursor() as cursor:
+                if self._lock_operation_receipt(cursor, item) is None:
+                    raise RuntimeError(
+                        "PostgreSQL fenced retry receipt was lost"
+                    )
+                if (
+                    item.effect_started_at is None
+                    and item.attempt_count >= self._max_attempts
+                ):
+                    self._terminalize(
+                        cursor,
+                        item,
+                        state="failed",
+                        error=_effect_failed_error(),
+                    )
+                    outcome = "permanent_failure"
+                else:
+                    cursor.execute(
+                        f"""
+                        UPDATE {SCHEMA}.effect_outbox
+                        SET state='queued', claim_token=NULL,
+                            available_at=now() + (%s * interval '1 second'),
+                            updated_at=now()
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                          AND digest=%s AND claim_token=%s
+                        """,
+                        (
+                            self._retry_delay_seconds,
+                            *item.receipt_key,
+                            item.digest,
+                            item.claim_token,
+                        ),
+                    )
+                    if cursor.rowcount != 1:
+                        raise RuntimeError("PostgreSQL effect retry CAS failed")
+                    cursor.execute(
+                        f"""
+                        UPDATE {SCHEMA}.operation_receipt
+                        SET state=%s, error=%s, updated_at=now()
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                          AND digest=%s AND state='running'
+                        """,
+                        (
+                            (
+                                "running"
+                                if item.effect_started_at is not None
+                                else "queued"
+                            ),
+                            Json(_effect_failed_error()),
+                            *item.receipt_key,
+                            item.digest,
+                        ),
+                    )
+                    if cursor.rowcount != 1:
+                        raise RuntimeError("PostgreSQL receipt retry CAS failed")
+                    outcome = "retry"
+            handle.conn.commit()
+            return outcome
+        except Exception:
+            handle.conn.rollback()
+            raise
+
+    def _terminal_effect_error_sync(
+        self,
+        handle: _ClaimHandle,
+        error: dict[str, Any],
+        *,
+        state: str,
+    ) -> None:
+        try:
+            with handle.conn.cursor() as cursor:
+                self._terminalize(cursor, handle.item, state=state, error=error)
+            handle.conn.commit()
+        except Exception:
+            handle.conn.rollback()
+            raise
+
+    @staticmethod
+    def _ping_sync(conn) -> None:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            if cursor.fetchone() != (1,):
+                raise RuntimeError("PostgreSQL fenced writer ping failed")
+        conn.commit()
+
+    async def _execute_with_leadership_monitor(
+        self,
+        handle: _ClaimHandle,
+    ) -> dict[str, Any]:
+        effect_task = asyncio.create_task(self._executor(handle.item))
+        try:
+            while not effect_task.done():
+                try:
+                    return await asyncio.wait_for(
+                        asyncio.shield(effect_task),
+                        timeout=self._monitor_interval_seconds,
+                    )
+                except asyncio.TimeoutError:
+                    # Await the ping before looking at the effect result.  This
+                    # avoids using one psycopg connection concurrently if the
+                    # effect completes while a keepalive is in flight.
+                    try:
+                        await asyncio.to_thread(self._ping_sync, handle.conn)
+                    except BaseException as exc:
+                        self._fail_stop(exc)
+                        raise
+            return await effect_task
+        except BaseException:
+            if not effect_task.done():
+                effect_task.cancel()
+                await asyncio.gather(effect_task, return_exceptions=True)
+            raise
+
+    async def run_once(self) -> bool:
+        outcome = await asyncio.to_thread(self._claim_sync)
+        if outcome.handle is None:
+            return outcome.processed
+        handle = outcome.handle
+        try:
+            from openviking.server import fenced_operation  # noqa: PLC0415
+
+            seam = fenced_operation.after_fenced_writer_claimed(
+                handle.item.operation_id
+            )
+            if inspect.isawaitable(seam):
+                await seam
+
+            authorized, current = await asyncio.to_thread(
+                self._authorize_effect_sync,
+                handle,
+            )
+            handle.item = current
+            if not authorized:
+                _record_effect_metric(handle.item, "suppressed")
+                return True
+
+            seam = fenced_operation.after_fenced_writer_effect_started(
+                handle.item.operation_id
+            )
+            if inspect.isawaitable(seam):
+                await seam
+
+            result = await self._execute_with_leadership_monitor(handle)
+            if not isinstance(result, dict):
+                raise TypeError("Fenced outbox effect must return a dict")
+
+            seam = fenced_operation.after_fenced_effect_before_receipt(
+                handle.item.operation
+            )
+            if inspect.isawaitable(seam):
+                await seam
+
+            wait_requested = bool(handle.item.request_payload.get("wait"))
+            task_id = result.get("task_id")
+            if (
+                handle.item.operation == "commit"
+                and wait_requested
+                and isinstance(task_id, str)
+                and task_id
+            ):
+                await asyncio.to_thread(
+                    self._defer_wait_sync,
+                    handle,
+                    result,
+                )
+            else:
+                await asyncio.to_thread(self._complete_sync, handle, result)
+            _record_effect_metric(handle.item, "completed")
+            return True
+        except PermanentFencedEffectError as exc:
+            logger.error(
+                "Fenced outbox effect rejected before mutation",
+                extra={
+                    "operation_id": handle.item.operation_id,
+                    "reason": exc.reason,
+                },
+            )
+            await asyncio.to_thread(
+                self._terminal_effect_error_sync,
+                handle,
+                _sanitized_error(
+                    code="FAILED_PRECONDITION",
+                    message="Fenced session effect was rejected",
+                    reason=exc.reason,
+                    details=exc.details,
+                ),
+                state="failed",
+            )
+            _record_effect_metric(handle.item, "permanent_failure")
+            return True
+        except Exception:
+            logger.exception(
+                "Fenced outbox effect failed; scheduling deterministic recovery",
+                extra={"operation_id": handle.item.operation_id},
+            )
+            retry_outcome = await asyncio.to_thread(
+                self._retry_or_fail_sync, handle
+            )
+            _record_effect_metric(handle.item, retry_outcome)
+            return True
+        finally:
+            try:
+                handle.conn.close()
+            except Exception:
+                pass
+
+    @staticmethod
+    def _commit_work_lock_keys(item: FencedCommitWorkItem) -> tuple[int, ...]:
+        return tuple(
+            sorted(
+                {
+                    # Active-count targets are account-scoped resources.  The
+                    # durable Phase 2 plan reads an absolute value and later
+                    # applies it idempotently; serializing plan+apply per
+                    # account prevents two sessions from both planning N+1.
+                    _advisory_key(
+                        "outbox-account-meta",
+                        item.account_id,
+                    ),
+                    _advisory_key(
+                # Share the exact lock namespace with Phase 1 effects.  Phase 2
+                # may update session meta, so a next-turn write to the *same*
+                # session must not interleave; a rotated/new session still runs
+                # independently.
+                        "outbox-session",
+                        item.account_id,
+                        item.user_id,
+                        item.session_id,
+                    ),
+                }
+            )
+        )
+
+    def _claim_commit_work_sync(self) -> Optional[_CommitClaimHandle]:
+        conn = _connect(application_name="openviking-fenced-commit-worker")
+        try:
+            conn.autocommit = False
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    _COMMIT_WORK_SELECT
+                    + f"""
+                    WHERE available_at <= now() AND writer='alice'
+                      AND state IN ('pending','running')
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM {SCHEMA}.commit_work_outbox earlier
+                          WHERE earlier.account_id=commit_work_outbox.account_id
+                            AND earlier.user_id=commit_work_outbox.user_id
+                            AND earlier.session_id=commit_work_outbox.session_id
+                            AND earlier.sequence_id < commit_work_outbox.sequence_id
+                      )
+                    ORDER BY sequence_id
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT 32
+                    """
+                )
+                candidates = [
+                    _commit_work_item(row) for row in cursor.fetchall()
+                ]
+                for candidate in candidates:
+                    lock_keys = self._commit_work_lock_keys(candidate)
+                    if not self._try_session_locks(cursor, lock_keys):
+                        continue
+                    claim_token = uuid.uuid4().hex
+                    cursor.execute(
+                        f"""
+                        UPDATE {SCHEMA}.commit_work_outbox
+                        SET state='running',claim_token=%s,
+                            attempt_count=attempt_count+1,started_at=now(),
+                            updated_at=now()
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                        RETURNING attempt_count
+                        """,
+                        (claim_token, *candidate.receipt_key),
+                    )
+                    claimed = cursor.fetchone()
+                    if claimed is None:
+                        raise RuntimeError("PostgreSQL commit work claim CAS failed")
+                    conn.commit()
+                    return _CommitClaimHandle(
+                        conn=conn,
+                        item=replace(
+                            candidate,
+                            state="running",
+                            attempt_count=int(claimed[0]),
+                            claim_token=claim_token,
+                        ),
+                        lock_keys=lock_keys,
+                    )
+            conn.rollback()
+            conn.close()
+            return None
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            conn.close()
+            raise
+
+    def _finish_commit_work_sync(
+        self,
+        handle: _CommitClaimHandle,
+        status: str,
+    ) -> None:
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        item = handle.item
+        try:
+            with handle.conn.cursor() as cursor:
+                receipt_state = self._lock_commit_receipt(cursor, item)
+                cursor.execute(
+                    f"""
+                    SELECT wait_for_completion
+                    FROM {SCHEMA}.commit_work_outbox
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                      AND claim_token=%s
+                    FOR UPDATE
+                    """,
+                    (*item.receipt_key, item.claim_token),
+                )
+                work = cursor.fetchone()
+                if work is None:
+                    raise RuntimeError("PostgreSQL commit work claim was lost")
+                wait_for_completion = bool(work[0])
+                if wait_for_completion:
+                    if receipt_state != "running":
+                        raise RuntimeError(
+                            "PostgreSQL wait=true receipt is not running"
+                        )
+                    if status == "completed":
+                        cursor.execute(
+                            f"""
+                            UPDATE {SCHEMA}.operation_receipt
+                            SET state='completed',error=NULL,updated_at=now()
+                            WHERE account_id=%s AND user_id=%s AND writer=%s
+                              AND session_scope_id=%s AND operation_id=%s
+                              AND state='running'
+                            """,
+                            item.receipt_key,
+                        )
+                    else:
+                        cursor.execute(
+                            f"""
+                            UPDATE {SCHEMA}.operation_receipt
+                            SET state='failed',error=%s,updated_at=now()
+                            WHERE account_id=%s AND user_id=%s AND writer=%s
+                              AND session_scope_id=%s AND operation_id=%s
+                              AND state='running'
+                            """,
+                            (Json(_effect_failed_error()), *item.receipt_key),
+                        )
+                    if cursor.rowcount != 1:
+                        raise RuntimeError(
+                            "PostgreSQL wait=true receipt completion CAS failed"
+                        )
+                cursor.execute(
+                    f"""
+                    DELETE FROM {SCHEMA}.commit_work_outbox
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                      AND claim_token=%s
+                    """,
+                    (*item.receipt_key, item.claim_token),
+                )
+                if cursor.rowcount != 1:
+                    raise RuntimeError("PostgreSQL commit work delete CAS failed")
+            handle.conn.commit()
+        except Exception:
+            handle.conn.rollback()
+            raise
+
+    def _retry_commit_work_sync(self, handle: _CommitClaimHandle) -> None:
+        try:
+            with handle.conn.cursor() as cursor:
+                self._lock_commit_receipt(cursor, handle.item)
+                cursor.execute(
+                    f"""
+                    UPDATE {SCHEMA}.commit_work_outbox
+                    SET state='pending',claim_token=NULL,
+                        available_at=now() + (%s * interval '1 second'),
+                        updated_at=now()
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                      AND claim_token=%s
+                    """,
+                    (
+                        self._retry_delay_seconds,
+                        *handle.item.receipt_key,
+                        handle.item.claim_token,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise RuntimeError("PostgreSQL commit work retry CAS failed")
+            handle.conn.commit()
+        except Exception:
+            handle.conn.rollback()
+            raise
+
+    def _quarantine_commit_work_sync(
+        self,
+        handle: _CommitClaimHandle,
+        *,
+        reason: str,
+    ) -> None:
+        """Persist an ambiguous non-replayable effect for manual forward-fix."""
+        from psycopg2.extras import Json  # type: ignore  # noqa: PLC0415
+
+        error = _sanitized_error(
+            code="FAILED_PRECONDITION",
+            message="Fenced commit phase2 requires operator review",
+            reason=reason,
+        )
+        try:
+            with handle.conn.cursor() as cursor:
+                receipt_state = self._lock_commit_receipt(
+                    cursor, handle.item
+                )
+                cursor.execute(
+                    f"""
+                    UPDATE {SCHEMA}.commit_work_outbox
+                    SET state='ambiguous',claim_token=NULL,error=%s,
+                        updated_at=now()
+                    WHERE account_id=%s AND user_id=%s AND writer=%s
+                      AND session_scope_id=%s AND operation_id=%s
+                      AND claim_token=%s
+                    RETURNING wait_for_completion
+                    """,
+                    (
+                        Json(error),
+                        *handle.item.receipt_key,
+                        handle.item.claim_token,
+                    ),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    raise RuntimeError(
+                        "PostgreSQL commit work quarantine CAS failed"
+                    )
+                if bool(row[0]):
+                    if receipt_state != "running":
+                        raise RuntimeError(
+                            "PostgreSQL ambiguous receipt is not running"
+                        )
+                    cursor.execute(
+                        f"""
+                        UPDATE {SCHEMA}.operation_receipt
+                        SET state='failed',error=%s,updated_at=now()
+                        WHERE account_id=%s AND user_id=%s AND writer=%s
+                          AND session_scope_id=%s AND operation_id=%s
+                          AND state='running'
+                        """,
+                        (Json(error), *handle.item.receipt_key),
+                    )
+                    if cursor.rowcount != 1:
+                        raise RuntimeError(
+                            "PostgreSQL ambiguous receipt CAS failed"
+                        )
+            handle.conn.commit()
+        except Exception:
+            handle.conn.rollback()
+            raise
+
+    async def _run_commit_work_with_monitor(
+        self,
+        handle: _CommitClaimHandle,
+    ) -> str:
+        if self._task_waiter is None:
+            raise RuntimeError("Fenced commit work executor is not configured")
+        work_task = asyncio.create_task(self._task_waiter(handle.item))
+        try:
+            while not work_task.done():
+                try:
+                    return await asyncio.wait_for(
+                        asyncio.shield(work_task),
+                        timeout=self._monitor_interval_seconds,
+                    )
+                except asyncio.TimeoutError:
+                    try:
+                        await asyncio.to_thread(self._ping_sync, handle.conn)
+                    except BaseException as exc:
+                        self._fail_stop(exc)
+                        raise
+            return await work_task
+        except BaseException:
+            if not work_task.done():
+                work_task.cancel()
+                await asyncio.gather(work_task, return_exceptions=True)
+            raise
+
+    async def process_waiting_once(self) -> bool:
+        if self._task_waiter is None:
+            return False
+        handle = await asyncio.to_thread(self._claim_commit_work_sync)
+        if handle is None:
+            return False
+        try:
+            status = await self._run_commit_work_with_monitor(handle)
+            if status not in {"completed", "failed"}:
+                raise RuntimeError("Commit work did not reach a terminal task state")
+            await asyncio.to_thread(self._finish_commit_work_sync, handle, status)
+            return True
+        except FailedPreconditionError as exc:
+            reason = (getattr(exc, "details", None) or {}).get("reason")
+            permanent_reasons = {
+                "commit_phase2_effect_ambiguous",
+                "commit_phase2_task_ambiguous",
+                "commit_manifest_missing",
+                "commit_phase2_manifest_corrupt",
+                "commit_work_identity_conflict",
+                "commit_phase2_payload_missing",
+                "commit_phase2_payload_corrupt",
+                "session_messages_missing",
+                "session_messages_corrupt",
+                "session_meta_missing",
+                "session_meta_corrupt",
+                "usage_journal_corrupt",
+            }
+            if reason not in permanent_reasons:
+                logger.warning(
+                    "Fenced commit precondition is retryable; preserving work",
+                    extra={"operation_id": handle.item.operation_id},
+                )
+                await asyncio.to_thread(self._retry_commit_work_sync, handle)
+                return True
+            quarantine_reason = (
+                "commit_phase2_effect_ambiguous"
+                if reason
+                in {
+                    "commit_phase2_effect_ambiguous",
+                    "commit_phase2_task_ambiguous",
+                }
+                else "commit_phase2_invalid"
+            )
+            logger.error(
+                "Fenced commit work quarantined after a permanent precondition",
+                extra={"operation_id": handle.item.operation_id},
+            )
+            try:
+                from openviking.service.task_tracker import (  # noqa: PLC0415
+                    get_task_tracker,
+                )
+
+                await get_task_tracker().fail(
+                    handle.item.task_id,
+                    f"{quarantine_reason}:{reason or 'unknown'}",
+                    account_id=handle.item.account_id,
+                    user_id=handle.item.user_id,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to terminalize fenced commit task; preserving "
+                    "reconciliation work",
+                    extra={"operation_id": handle.item.operation_id},
+                )
+                # Do not make the PostgreSQL row permanently unclaimable until
+                # TaskTracker records the same terminal decision.  Otherwise a
+                # transient AGFS failure leaves a pending/running task paired
+                # with an `ambiguous` row that no worker will ever reclaim.
+                await asyncio.to_thread(self._retry_commit_work_sync, handle)
+                return True
+            await asyncio.to_thread(
+                self._quarantine_commit_work_sync,
+                handle,
+                reason=quarantine_reason,
+            )
+            return True
+        except Exception:
+            logger.exception(
+                "Fenced commit work failed; scheduling durable recovery",
+                extra={"operation_id": handle.item.operation_id},
+            )
+            await asyncio.to_thread(self._retry_commit_work_sync, handle)
+            return True
+        finally:
+            try:
+                handle.conn.close()
+            except Exception:
+                pass
+
+
+class PostgresFencedWriterPool:
+    """Supervised effect/commit pools with bounded idle connection churn."""
+
+    def __init__(
+        self,
+        executor: EffectExecutor,
+        *,
+        task_waiter: Optional[TaskWaiter] = None,
+        concurrency: int = 2,
+        commit_concurrency: int = 2,
+        poll_seconds: float = 0.25,
+        max_idle_seconds: float = 1.0,
+        drain_timeout_seconds: float = 30.0,
+    ) -> None:
+        self._poll_seconds = max(0.05, float(poll_seconds))
+        self._max_idle_seconds = max(
+            self._poll_seconds, float(max_idle_seconds)
+        )
+        self._drain_timeout_seconds = max(
+            0.1, float(drain_timeout_seconds)
+        )
+        self._task_waiter_configured = task_waiter is not None
+        self._workers = [
+            PostgresFencedOutboxWriter(executor, task_waiter=task_waiter)
+            for _ in range(max(1, int(concurrency)))
+        ]
+        self._commit_workers = [
+            PostgresFencedOutboxWriter(executor, task_waiter=task_waiter)
+            for _ in range(max(1, int(commit_concurrency)))
+        ]
+        self._tasks: list[asyncio.Task[None]] = []
+        self._stopping = False
+        self._unhealthy = False
+        self._unexpected_failure: Optional[str] = None
+
+    @property
+    def healthy(self) -> bool:
+        return bool(
+            self._tasks
+            and not self._stopping
+            and not self._unhealthy
+            and all(not task.done() for task in self._tasks)
+        )
+
+    @property
+    def effect_concurrency(self) -> int:
+        return len(self._workers)
+
+    @property
+    def commit_concurrency(self) -> int:
+        return len(self._commit_workers)
+
+    async def _idle(self, current: float) -> float:
+        jittered = current * random.uniform(0.9, 1.1)
+        await asyncio.sleep(jittered)
+        return min(self._max_idle_seconds, current * 2)
+
+    async def _worker_loop(self, worker: PostgresFencedOutboxWriter) -> None:
+        idle_seconds = self._poll_seconds
+        while not self._stopping:
+            try:
+                processed = await worker.run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._unhealthy = True
+                self._unexpected_failure = type(exc).__name__
+                logger.exception(
+                    "Fenced effect worker iteration failed; readiness is false"
+                )
+                if not self._stopping:
+                    idle_seconds = await self._idle(idle_seconds)
+                continue
+            if processed:
+                idle_seconds = self._poll_seconds
+            elif not self._stopping:
+                idle_seconds = await self._idle(idle_seconds)
+
+    async def _watcher_loop(self, watcher: PostgresFencedOutboxWriter) -> None:
+        idle_seconds = self._poll_seconds
+        while not self._stopping:
+            try:
+                processed = await watcher.process_waiting_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._unhealthy = True
+                self._unexpected_failure = type(exc).__name__
+                logger.exception(
+                    "Fenced commit worker iteration failed; readiness is false"
+                )
+                if not self._stopping:
+                    idle_seconds = await self._idle(idle_seconds)
+                continue
+            if processed:
+                idle_seconds = self._poll_seconds
+            elif not self._stopping:
+                idle_seconds = await self._idle(idle_seconds)
+
+    def _task_done(self, task: asyncio.Task[None]) -> None:
+        if self._stopping or task.cancelled():
+            return
+        self._unhealthy = True
+        try:
+            exc = task.exception()
+        except BaseException as error:
+            exc = error
+        self._unexpected_failure = (
+            type(exc).__name__ if exc is not None else "unexpected_exit"
+        )
+        logger.critical(
+            "Fenced writer pool loop exited unexpectedly; readiness is false",
+            exc_info=(
+                (type(exc), exc, exc.__traceback__)
+                if exc is not None
+                else None
+            ),
+        )
+
+    def start(self) -> None:
+        if self._tasks:
+            return
+        self._stopping = False
+        self._unhealthy = False
+        self._unexpected_failure = None
+        tasks = [
+            asyncio.create_task(
+                self._worker_loop(worker),
+                name=f"openviking-fenced-effect-{index}",
+            )
+            for index, worker in enumerate(self._workers)
+        ]
+        if self._task_waiter_configured:
+            tasks.extend(
+                asyncio.create_task(
+                    self._watcher_loop(worker),
+                    name=f"openviking-fenced-commit-{index}",
+                )
+                for index, worker in enumerate(self._commit_workers)
+            )
+        self._tasks = tasks
+        for task in tasks:
+            task.add_done_callback(self._task_done)
+
+    async def stop(self, *, drain_timeout_seconds: Optional[float] = None) -> None:
+        tasks = list(self._tasks)
+        if not tasks:
+            return
+        self._stopping = True
+        timeout = (
+            self._drain_timeout_seconds
+            if drain_timeout_seconds is None
+            else max(0.0, float(drain_timeout_seconds))
+        )
+        _done, pending = await asyncio.wait(tasks, timeout=timeout)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._tasks = []

--- a/openviking/server/routers/__init__.py
+++ b/openviking/server/routers/__init__.py
@@ -8,6 +8,7 @@ from openviking.server.routers.code import router as code_router
 from openviking.server.routers.console import router as console_router
 from openviking.server.routers.content import router as content_router
 from openviking.server.routers.debug import router as debug_router
+from openviking.server.routers.fenced_sessions import router as fenced_sessions_router
 from openviking.server.routers.filesystem import router as filesystem_router
 from openviking.server.routers.metrics import router as metrics_router
 from openviking.server.routers.observer import router as observer_router
@@ -32,6 +33,7 @@ __all__ = [
     "system_router",
     "resources_router",
     "filesystem_router",
+    "fenced_sessions_router",
     "content_router",
     "console_router",
     "search_router",

--- a/openviking/server/routers/fenced_sessions.py
+++ b/openviking/server/routers/fenced_sessions.py
@@ -1,0 +1,664 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Protocol-v2 PostgreSQL outbox API for Alice fenced session writes."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import re
+from dataclasses import replace
+from datetime import timezone
+from typing import Any, Literal, Optional
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, Header, Path, Request
+from fastapi.responses import JSONResponse
+from pydantic import Field, ValidationError, field_validator, model_validator
+
+from openviking.core.path_variables import resolve_path_variables
+from openviking.server.auth import get_request_context
+from openviking.server.dependencies import get_service
+from openviking.server.fenced_operation import (
+    FencedOperationConflict,
+    FencedOperationEnvelope,
+    operation_digest,
+    stable_message_id,
+)
+from openviking.server.fenced_postgres import (
+    FencedOperationRecord,
+    PostgresFencedOperationQueue,
+    fencing_database_url,
+    fencing_service_token,
+    is_valid_alice_service_token,
+    validate_postgres_fencing_schema,
+    validate_required_fencing_configuration,
+)
+from openviking.server.fenced_writer import (
+    FencedCommitWorkItem,
+    FencedOutboxItem,
+    PermanentFencedEffectError,
+    PostgresFencedWriterPool,
+)
+from openviking.server.identity import RequestContext, Role
+from openviking.server.models import Response
+from openviking.server.routers.sessions import (
+    AddMessageRequest,
+    _resolve_message_parts,
+    _resolve_message_peer_id,
+)
+from openviking_cli.exceptions import (
+    AlreadyExistsError,
+    FailedPreconditionError,
+    InvalidArgumentError,
+    NotFoundError,
+    UnauthenticatedError,
+    UnavailableError,
+)
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+_ALICE_SESSION_ID_PATTERN = r"^alice_[0-9a-f]{48}$"
+_ALICE_SESSION_ID = re.compile(_ALICE_SESSION_ID_PATTERN)
+
+
+def is_reserved_alice_session_id(session_id: str) -> bool:
+    return bool(_ALICE_SESSION_ID.fullmatch(session_id))
+
+
+async def require_alice_fenced_principal(
+    x_openviking_alice_token: Optional[str] = Header(
+        None,
+        alias="X-OpenViking-Alice-Token",
+    ),
+) -> None:
+    """Authenticate the fixed Alice principal in observe and required modes."""
+    if not fencing_service_token():
+        raise UnavailableError("Alice fenced writer", "fencing_unconfigured")
+    if not is_valid_alice_service_token(x_openviking_alice_token):
+        raise UnauthenticatedError("Valid X-OpenViking-Alice-Token is required")
+
+
+router = APIRouter(
+    prefix="/api/v1/fenced",
+    tags=["fenced-sessions"],
+    dependencies=[Depends(require_alice_fenced_principal)],
+)
+
+
+class FencedCreateSessionRequest(FencedOperationEnvelope):
+    session_id: str = Field(
+        min_length=54,
+        max_length=54,
+        pattern=_ALICE_SESSION_ID_PATTERN,
+    )
+    memory_policy: Optional[dict[str, Any]] = None
+
+
+class FencedAddMessageRequest(FencedOperationEnvelope):
+    role: Literal["user", "assistant"]
+    peer_id: Optional[str] = None
+    content: Optional[str] = Field(default=None, max_length=2_000_000)
+    parts: Optional[list[dict[str, Any]]] = Field(default=None, max_length=100)
+    created_at: Optional[str] = Field(default=None, max_length=128)
+
+    @model_validator(mode="after")
+    def validate_content_or_parts(self) -> "FencedAddMessageRequest":
+        if self.content is None and self.parts is None:
+            raise ValueError("Either 'content' or 'parts' must be provided")
+        return self
+
+
+class FencedUsedRequest(FencedOperationEnvelope):
+    contexts: Optional[list[str]] = Field(default=None, max_length=1000)
+    skill: Optional[dict[str, Any]] = None
+
+    @field_validator("contexts")
+    @classmethod
+    def validate_contexts(cls, contexts: Optional[list[str]]) -> Optional[list[str]]:
+        if contexts is None:
+            return None
+        for uri in contexts:
+            if not isinstance(uri, str) or not uri.strip() or len(uri) > 4096:
+                raise ValueError(
+                    "context URIs must be non-empty strings of at most 4096 chars"
+                )
+        return contexts
+
+
+class FencedCommitRequest(FencedOperationEnvelope):
+    keep_recent_count: int = Field(default=0, ge=0, le=10_000)
+    wait: bool = False
+
+
+_writer_pool: Optional[PostgresFencedWriterPool] = None
+_writer_schema_validated = False
+_writer_draining = False
+
+
+def _int_env(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        value = default
+    return min(maximum, max(minimum, value))
+
+
+def _float_env(
+    name: str,
+    default: float,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float:
+    try:
+        value = float(os.getenv(name, str(default)))
+    except ValueError:
+        value = default
+    return min(maximum, max(minimum, value))
+
+
+def _drain_timeout_seconds(phase2_timeout_seconds: float) -> float:
+    name = "OPENVIKING_FENCED_DRAIN_TIMEOUT_SECONDS"
+    raw = os.getenv(name)
+    if raw is None:
+        return phase2_timeout_seconds + 60.0
+    try:
+        value = float(raw.strip())
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be a number") from exc
+    minimum = phase2_timeout_seconds + 60.0
+    if not math.isfinite(value) or value < minimum or value > 10_800.0:
+        raise RuntimeError(
+            f"{name} must be between {minimum:g} and 10800 seconds"
+        )
+    return value
+
+
+def fenced_writer_runtime_status() -> dict[str, Any]:
+    pool = _writer_pool
+    requested = bool(fencing_database_url() or fencing_service_token())
+    configured = bool(
+        _writer_schema_validated and pool is not None and pool.healthy
+    )
+    return {
+        "requested": requested,
+        "configured": configured,
+        "schema_validated": _writer_schema_validated,
+        "healthy": bool(pool is not None and pool.healthy),
+        "draining": _writer_draining,
+        "effect_concurrency": pool.effect_concurrency if pool else 0,
+        "commit_concurrency": pool.commit_concurrency if pool else 0,
+    }
+
+
+async def start_fenced_writer_runtime() -> bool:
+    """Validate the shared schema and start the supervised in-process pool."""
+    global _writer_pool, _writer_schema_validated, _writer_draining
+    if _writer_pool is not None:
+        return fenced_writer_runtime_status()["configured"]
+    from openviking.server.fenced_operation import get_alice_fencing_mode
+
+    mode = get_alice_fencing_mode()
+    if not fencing_database_url() or not fencing_service_token():
+        _writer_schema_validated = False
+        if mode == "required":
+            validate_required_fencing_configuration()
+        return False
+
+    try:
+        # The same dedicated API is enabled in both compatibility modes.  A
+        # short token, invalid timeout, missing driver, bad DSN, or incomplete
+        # migration must therefore never be advertised as configured.
+        validate_required_fencing_configuration()
+        from openviking.session.session import fenced_phase2_timeout_seconds
+
+        phase2_timeout_seconds = fenced_phase2_timeout_seconds()
+        drain_timeout_seconds = _drain_timeout_seconds(
+            phase2_timeout_seconds
+        )
+        await validate_postgres_fencing_schema()
+    except Exception:
+        _writer_schema_validated = False
+        if mode == "required":
+            raise
+        logger.exception(
+            "Alice fenced writer is unavailable in observe mode"
+        )
+        return False
+    _writer_schema_validated = True
+    _writer_draining = False
+    pool = PostgresFencedWriterPool(
+        execute_fenced_outbox_item,
+        task_waiter=execute_fenced_commit_work,
+        concurrency=_int_env(
+            "OPENVIKING_FENCED_EFFECT_CONCURRENCY", 2, minimum=1, maximum=64
+        ),
+        commit_concurrency=_int_env(
+            "OPENVIKING_FENCED_COMMIT_CONCURRENCY", 2, minimum=1, maximum=64
+        ),
+        poll_seconds=_float_env(
+            "OPENVIKING_FENCED_POLL_SECONDS", 0.25, minimum=0.05, maximum=5.0
+        ),
+        max_idle_seconds=_float_env(
+            "OPENVIKING_FENCED_MAX_IDLE_SECONDS", 1.0, minimum=0.1, maximum=30.0
+        ),
+        # Strict startup validation above guarantees that a normal shutdown
+        # outlives the whole Phase 2 wall-clock deadline plus a safety margin.
+        drain_timeout_seconds=drain_timeout_seconds,
+    )
+    pool.start()
+    await asyncio.sleep(0)
+    if not pool.healthy:
+        await pool.stop(drain_timeout_seconds=0)
+        _writer_schema_validated = False
+        if mode == "required":
+            raise RuntimeError("Fenced writer pool failed during startup")
+        logger.error("Alice fenced writer pool failed during observe startup")
+        return False
+    _writer_pool = pool
+    return True
+
+
+async def stop_fenced_writer_runtime() -> None:
+    global _writer_pool, _writer_schema_validated, _writer_draining
+    pool, _writer_pool = _writer_pool, None
+    if pool is None:
+        _writer_schema_validated = False
+        return
+    _writer_draining = True
+    try:
+        await pool.stop()
+    finally:
+        _writer_draining = False
+        _writer_schema_validated = False
+
+
+def _ctx_for_outbox(
+    account_id: str,
+    user_id: str,
+    actor_peer_id: Optional[str],
+) -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier(account_id, user_id),
+        role=Role.USER,
+        actor_peer_id=actor_peer_id,
+    )
+
+
+def _validated_request(item: FencedOutboxItem) -> FencedOperationEnvelope:
+    payload = dict(item.request_payload)
+    immutable_identity = {
+        "writer": item.writer,
+        "session_scope_id": item.session_scope_id,
+        "turn_id": item.turn_id,
+        "operation_id": item.operation_id,
+    }
+    if any(payload.get(key) != value for key, value in immutable_identity.items()):
+        raise PermanentFencedEffectError(
+            "outbox_identity_corrupt",
+            details={"operation_id": item.operation_id},
+        )
+    payload["writer"] = "alice"
+    payload["fencing_token"] = item.fencing_token
+    request_type: type[FencedOperationEnvelope]
+    if item.operation == "create":
+        request_type = FencedCreateSessionRequest
+    elif item.operation == "message":
+        request_type = FencedAddMessageRequest
+    elif item.operation == "used":
+        request_type = FencedUsedRequest
+    elif item.operation == "commit":
+        request_type = FencedCommitRequest
+    else:
+        raise PermanentFencedEffectError(
+            "unsupported_fenced_operation",
+            details={"operation_id": item.operation_id},
+        )
+    try:
+        request = request_type.model_validate(payload)
+    except ValidationError as exc:
+        raise PermanentFencedEffectError(
+            "outbox_payload_invalid",
+            details={"operation_id": item.operation_id},
+        ) from exc
+    if operation_digest(
+        item.operation,
+        request,
+        resource_id=item.resource_id,
+        actor_peer_id=item.actor_peer_id,
+    ) != item.digest:
+        raise PermanentFencedEffectError(
+            "outbox_digest_mismatch",
+            details={"operation_id": item.operation_id},
+        )
+    return request
+
+
+_SAFE_SESSION_READ_FAILURES = frozenset(
+    {
+        "session_messages_missing",
+        "session_messages_corrupt",
+        "session_meta_missing",
+        "session_meta_corrupt",
+        "usage_journal_corrupt",
+    }
+)
+
+
+def _permanent_session_read_error(exc: FailedPreconditionError) -> None:
+    reason = str((getattr(exc, "details", None) or {}).get("reason") or "")
+    if reason in _SAFE_SESSION_READ_FAILURES:
+        raise PermanentFencedEffectError(reason) from exc
+
+
+async def _get_effect_session(
+    service: Any,
+    item: FencedOutboxItem,
+    ctx: RequestContext,
+) -> Any:
+    try:
+        return await service.sessions.get(
+            item.resource_id, ctx, auto_create=False, strict=True
+        )
+    except NotFoundError as exc:
+        raise PermanentFencedEffectError(
+            "session_not_found",
+            details={"session_id": item.resource_id},
+        ) from exc
+    except FailedPreconditionError as exc:
+        _permanent_session_read_error(exc)
+        raise
+
+
+async def execute_fenced_outbox_item(
+    item: FencedOutboxItem,
+) -> dict[str, Any]:
+    """Execute one claimed effect using only its durable outbox envelope."""
+    if not is_reserved_alice_session_id(item.resource_id):
+        raise PermanentFencedEffectError(
+            "alice_session_id_required",
+            details={"reason": "alice_session_id_required"},
+        )
+    request = _validated_request(item)
+    service = get_service()
+    ctx = _ctx_for_outbox(item.account_id, item.user_id, item.actor_peer_id)
+    await service.initialize_user_directories(ctx)
+
+    if item.operation == "create":
+        assert isinstance(request, FencedCreateSessionRequest)
+        if request.session_id != item.resource_id:
+            raise PermanentFencedEffectError("outbox_resource_identity_corrupt")
+        try:
+            session = await service.sessions.get(
+                item.resource_id, ctx, auto_create=False, strict=True
+            )
+        except NotFoundError:
+            try:
+                session = await service.sessions.create(
+                    ctx,
+                    item.resource_id,
+                    memory_policy=request.memory_policy,
+                    strict=True,
+                )
+            except AlreadyExistsError:
+                session = await _get_effect_session(service, item, ctx)
+        except FailedPreconditionError as exc:
+            _permanent_session_read_error(exc)
+            raise
+        return {
+            "session_id": session.session_id,
+            "uri": session.uri,
+            "user": session.user.to_dict(),
+        }
+
+    if item.operation == "message":
+        assert isinstance(request, FencedAddMessageRequest)
+        session = await _get_effect_session(service, item, ctx)
+        compatibility_request = AddMessageRequest.model_validate(
+            {
+                "role": request.role,
+                "peer_id": request.peer_id,
+                "content": request.content,
+                "parts": request.parts,
+                "created_at": request.created_at,
+            }
+        )
+        message_id = stable_message_id(request)
+        already_present = any(
+            message.id == message_id for message in session.messages
+        )
+        created_at = request.created_at or item.submitted_at.astimezone(
+            timezone.utc
+        ).isoformat()
+        messages = session.add_messages(
+            [
+                {
+                    "id": message_id,
+                    "role": request.role,
+                    "parts": _resolve_message_parts(compatibility_request),
+                    "peer_id": _resolve_message_peer_id(
+                        compatibility_request, ctx
+                    ),
+                    "created_at": created_at,
+                }
+            ]
+        )
+        return {
+            "session_id": item.resource_id,
+            "message_id": message_id,
+            "message_count": len(session.messages),
+            "added": 0 if already_present else len(messages),
+        }
+
+    if item.operation == "used":
+        assert isinstance(request, FencedUsedRequest)
+        session = await _get_effect_session(service, item, ctx)
+        contexts = (
+            [resolve_path_variables(uri) for uri in request.contexts]
+            if request.contexts is not None
+            else None
+        )
+        skill = request.skill
+        if skill is not None and "uri" in skill:
+            skill = dict(skill)
+            skill["uri"] = resolve_path_variables(str(skill["uri"]))
+        session.used(
+            contexts=contexts,
+            skill=skill,
+            operation_id=request.operation_id,
+        )
+        await session.persist_usage_records()
+        return {
+            "session_id": item.resource_id,
+            "contexts_used": session.stats.contexts_used,
+            "skills_used": session.stats.skills_used,
+        }
+
+    if item.operation == "commit":
+        assert isinstance(request, FencedCommitRequest)
+        await _get_effect_session(service, item, ctx)
+        result = await service.sessions.commit_async(
+            item.resource_id,
+            ctx,
+            keep_recent_count=request.keep_recent_count,
+            operation_id=request.operation_id,
+            operation_sequence_id=item.sequence_id,
+        )
+        session = await service.sessions.get(
+            item.resource_id, ctx, auto_create=False, strict=True
+        )
+        session.consume_usage_records()
+        await session.persist_usage_records()
+        return result
+
+    raise PermanentFencedEffectError("unsupported_fenced_operation")
+
+
+async def execute_fenced_commit_work(item: FencedCommitWorkItem) -> str:
+    service = get_service()
+    ctx = _ctx_for_outbox(item.account_id, item.user_id, None)
+    return await service.sessions.run_fenced_commit_work(
+        item.session_id,
+        ctx,
+        operation_id=item.operation_id,
+        task_id=item.task_id,
+        archive_uri=item.archive_uri,
+    )
+
+
+def _ensure_runtime_configured() -> None:
+    if not fenced_writer_runtime_status()["configured"]:
+        raise UnavailableError("Alice fenced writer", "fencing_unconfigured")
+
+
+def _post_poll_seconds() -> float:
+    return _float_env(
+        "OPENVIKING_FENCED_POST_POLL_SECONDS",
+        0.0,
+        minimum=0.0,
+        maximum=5.0,
+    )
+
+
+def _record_payload(record: FencedOperationRecord) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "operation_id": record.operation_id,
+        "status": record.state,
+        "replayed": record.replayed,
+        "status_url": (
+            "/api/v1/fenced/operations/"
+            f"{quote(record.operation_id, safe='')}"
+        ),
+    }
+    if record.state == "completed":
+        # Keep the domain result nested.  Alice treats the operation receipt as
+        # a protocol object and the effect result as a separate payload.
+        payload["result"] = dict(record.result or {})
+    return payload
+
+
+def _record_response(record: FencedOperationRecord) -> JSONResponse:
+    if record.state in {"queued", "running"}:
+        return JSONResponse(
+            status_code=202,
+            content=Response(
+                status="ok", result=_record_payload(record)
+            ).model_dump(mode="json"),
+        )
+    if record.state == "completed":
+        return JSONResponse(
+            status_code=200,
+            content=Response(
+                status="ok", result=_record_payload(record)
+            ).model_dump(mode="json"),
+        )
+    if record.state in {"stale", "conflict"}:
+        error = record.error or {}
+        details = error.get("details") if isinstance(error, dict) else {}
+        reason = (
+            details.get("reason")
+            if isinstance(details, dict)
+            else "fenced_conflict"
+        )
+        raise FencedOperationConflict(
+            "Fenced operation was rejected",
+            reason=str(reason or "fenced_conflict"),
+            details=details if isinstance(details, dict) else None,
+        )
+    raise UnavailableError("Fenced session effect", "effect_failed")
+
+
+async def _submit(
+    request: FencedOperationEnvelope,
+    operation: str,
+    session_id: str,
+    ctx: RequestContext,
+) -> JSONResponse:
+    _ensure_runtime_configured()
+    record = await PostgresFencedOperationQueue(ctx, request).submit(
+        operation,
+        session_id,
+    )
+    submitted_replayed = record.replayed
+    if not record.terminal and _post_poll_seconds() > 0:
+        waited = await PostgresFencedOperationQueue.wait(
+            ctx,
+            request.operation_id,
+            timeout_seconds=_post_poll_seconds(),
+        )
+        if waited is not None:
+            # Status polling is not a replay.  Keep the duplicate-submission
+            # bit returned by the atomic submit transaction.
+            record = replace(waited, replayed=submitted_replayed)
+    return _record_response(record)
+
+
+@router.post("/sessions")
+async def create_session(
+    request: FencedCreateSessionRequest,
+    ctx: RequestContext = Depends(get_request_context),
+) -> JSONResponse:
+    return await _submit(request, "create", request.session_id, ctx)
+
+
+@router.post("/sessions/{session_id}/messages")
+async def add_message(
+    request: FencedAddMessageRequest,
+    session_id: str = Path(
+        ...,
+        min_length=54,
+        max_length=54,
+        pattern=_ALICE_SESSION_ID_PATTERN,
+    ),
+    ctx: RequestContext = Depends(get_request_context),
+) -> JSONResponse:
+    return await _submit(request, "message", session_id, ctx)
+
+
+@router.post("/sessions/{session_id}/used")
+async def record_used(
+    request: FencedUsedRequest,
+    session_id: str = Path(
+        ...,
+        min_length=54,
+        max_length=54,
+        pattern=_ALICE_SESSION_ID_PATTERN,
+    ),
+    ctx: RequestContext = Depends(get_request_context),
+) -> JSONResponse:
+    return await _submit(request, "used", session_id, ctx)
+
+
+@router.post("/sessions/{session_id}/commit")
+async def commit_session(
+    request: FencedCommitRequest,
+    session_id: str = Path(
+        ...,
+        min_length=54,
+        max_length=54,
+        pattern=_ALICE_SESSION_ID_PATTERN,
+    ),
+    ctx: RequestContext = Depends(get_request_context),
+) -> JSONResponse:
+    return await _submit(request, "commit", session_id, ctx)
+
+
+@router.get("/operations/{operation_id:path}")
+async def get_operation(
+    http_request: Request,
+    operation_id: str = Path(..., min_length=1, max_length=256),
+    ctx: RequestContext = Depends(get_request_context),
+) -> JSONResponse:
+    _ensure_runtime_configured()
+    if http_request.query_params:
+        raise InvalidArgumentError(
+            "Fenced operation status does not accept query parameters"
+        )
+    record = await PostgresFencedOperationQueue.get(ctx, operation_id)
+    if record is None:
+        raise NotFoundError(operation_id, "fenced operation")
+    return _record_response(record)

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -453,9 +453,13 @@ async def url_image_index(
 
     image_url = (request.image_url or "").strip()
     if not image_url or not (
-        image_url.startswith("http://") or image_url.startswith("https://")
+        image_url.startswith("http://")
+        or image_url.startswith("https://")
+        or image_url.startswith("data:image/")
     ):
-        raise InvalidArgumentError("image_url must be a remote http(s) URL")
+        raise InvalidArgumentError(
+            "image_url must be a remote http(s) URL or a data:image/* URI"
+        )
 
     if request.context_type not in {"resource", "memory", "skill"}:
         raise InvalidArgumentError(

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -334,3 +334,206 @@ async def add_skill(
         fn=_add,
     )
     return response_from_result(execution.result, telemetry=execution.telemetry)
+
+
+class UrlImageIndexRequest(BaseModel):
+    """Request model for the URL-image vector index endpoint.
+
+    Index a remote image as a multimodal vector under ``target_uri`` without
+    persisting the image bytes in OpenViking's storage layer. The configured
+    multimodal embedder is given the URL directly and is expected to fetch
+    the image itself (Volcengine / Doubao multimodal endpoints accept
+    ``image_url`` natively).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_uri: str = Field(
+        ...,
+        description=(
+            "Viking URI to index the resulting vector at, e.g. "
+            "``viking://resources/products/M14253/images/0.embed``. The URI's "
+            "scope must match the request's ``X-OpenViking-Account``."
+        ),
+    )
+    image_url: str = Field(
+        ...,
+        description=(
+            "Remote ``https://`` URL of the image to embed. Forwarded to the "
+            "multimodal embedder as-is; the embedder (or its upstream provider) "
+            "fetches the URL. The URL is also recorded in the vectordb scalar "
+            "fields for later lookup."
+        ),
+    )
+    summary: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional text accompanying the image (mirrors the "
+            "``image_and_summary`` ingest mode). When set, the multimodal "
+            "embedding is computed over both the text and the image."
+        ),
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Optional display name for the indexed record. Defaults to the URI tail.",
+    )
+    context_type: str = Field(
+        default="resource",
+        description="Vectordb scalar field 'context_type'. One of 'resource', 'memory', 'skill'.",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Extra scalar fields to attach to the indexed record (e.g. sku, "
+            "image_idx). Reserved keys (uri, account_id, vector, id, level, "
+            "context_type, abstract, content, name) are stripped — those are "
+            "set by the server."
+        ),
+    )
+    telemetry: TelemetryRequest = False
+
+
+_URL_IMAGE_RESERVED_KEYS = {
+    "id",
+    "uri",
+    "account_id",
+    "owner_user_id",
+    "vector",
+    "sparse_vector",
+    "abstract",
+    "overview",
+    "content",
+    "name",
+    "level",
+    "context_type",
+    "created_at",
+    "updated_at",
+}
+
+
+@router.post("/resources/url_image_index")
+async def url_image_index(
+    http_request: Request,
+    request: UrlImageIndexRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Embed a remote image URL and insert the vector at ``target_uri`` without
+    persisting any bytes in agfs.
+
+    This is the "bring your own image hosting" entrypoint: the caller's image
+    lives in some external bucket (tenant-owned S3, public CDN, etc.) and only
+    the resulting vector is stored locally. Compared to the standard ingest
+    pipeline (``temp_upload`` + ``/resources``) this endpoint:
+
+    * Does **not** write any file to ``agfs`` (no temp upload, no resource tree).
+    * Does **not** spawn semantic / abstract-generation work — there is no
+      ``.abstract.md`` / ``.overview.md`` produced for the indexed URI.
+    * Does **not** go through the embedding queue. The embedder is called
+      synchronously and the vector is upserted before the response returns.
+
+    The configured multimodal embedder is reused as-is: the same provider /
+    failover / circuit-breaker / dim-validation enforcement applies as the
+    normal ingest path. A text-only embedder (``supports_multimodal`` is
+    ``False``) is rejected with HTTP 400.
+    """
+    from openviking.core.namespace import canonicalize_uri
+    from openviking.core.uri_validation import validate_viking_uri
+    from openviking.models.embedder.base import embed_compat
+    from openviking_cli.utils.config import get_openviking_config
+    import hashlib
+
+    service = get_service()
+    vikingdb = service.vikingdb_manager
+    if vikingdb is None:
+        raise HTTPException(status_code=503, detail="vectordb not initialized")
+
+    # Rejects malformed URIs (wrong scheme, internal scopes, etc.) — surfaced
+    # as InvalidURIError → 400 by the standard error middleware.
+    raw_uri = validate_viking_uri(request.target_uri, field_name="target_uri")
+
+    image_url = (request.image_url or "").strip()
+    if not image_url or not (
+        image_url.startswith("http://") or image_url.startswith("https://")
+    ):
+        raise InvalidArgumentError("image_url must be a remote http(s) URL")
+
+    if request.context_type not in {"resource", "memory", "skill"}:
+        raise InvalidArgumentError(
+            "context_type must be one of: resource, memory, skill"
+        )
+
+    canonical_uri = canonicalize_uri(raw_uri, _ctx)
+
+    config = get_openviking_config()
+    embedder = config.embedding.get_embedder()
+    if embedder is None:
+        raise HTTPException(status_code=503, detail="embedder not initialized")
+    if not getattr(embedder, "supports_multimodal", False):
+        raise InvalidArgumentError(
+            "configured embedder does not support multimodal input — "
+            "this endpoint requires a multimodal embedder (e.g. Volcengine "
+            "with input='multimodal')"
+        )
+
+    # Build the multimodal embedding input directly. The volcengine embedder's
+    # `to_multimodal_input` passes each entry's `image_url.url` straight through
+    # to the upstream Ark / DashScope API — both accept remote https URLs.
+    parts: list[Dict[str, Any]] = []
+    summary_text = (request.summary or "").strip()
+    if summary_text:
+        parts.append({"type": "text", "text": summary_text})
+    parts.append({"type": "image_url", "image_url": {"url": image_url}})
+
+    async def _embed_and_upsert() -> Dict[str, Any]:
+        result = await embed_compat(embedder, parts, is_query=False)
+        vector = result.dense_vector
+        if not vector:
+            raise HTTPException(status_code=502, detail="embedder returned empty vector")
+        expected_dim = config.embedding.dimension
+        if expected_dim and len(vector) != expected_dim:
+            raise InvalidArgumentError(
+                f"embedder returned dim {len(vector)}, expected {expected_dim}"
+            )
+
+        # Deterministic ID matching the convention used by TextEmbeddingHandler
+        # so that repeat calls with the same (account, uri) upsert in place.
+        record_id = hashlib.md5(
+            f"{_ctx.account_id}:{canonical_uri}".encode("utf-8")
+        ).hexdigest()
+
+        record_name = request.name or canonical_uri.rsplit("/", 1)[-1] or canonical_uri
+
+        # Strip reserved keys from caller metadata to avoid spoofing of fields
+        # the server controls (id, vector, account_id, ...).
+        extra_meta = {
+            k: v
+            for k, v in (request.metadata or {}).items()
+            if k not in _URL_IMAGE_RESERVED_KEYS
+        }
+
+        inserted_data: Dict[str, Any] = {
+            "id": record_id,
+            "uri": canonical_uri,
+            "account_id": _ctx.account_id,
+            "context_type": request.context_type,
+            "level": 2,
+            "name": record_name,
+            "abstract": summary_text,
+            "content": summary_text,
+            "vector": vector,
+            "image_url": image_url,
+            **extra_meta,
+        }
+
+        if result.sparse_vector is not None:
+            inserted_data["sparse_vector"] = result.sparse_vector
+
+        await vikingdb.upsert(inserted_data, ctx=_ctx, partial_update=True)
+        return {"status": "ok", "uri": canonical_uri, "id": record_id}
+
+    execution = await run_operation(
+        operation="resources.url_image_index",
+        telemetry=request.telemetry,
+        fn=_embed_and_upsert,
+    )
+    return response_from_result(execution.result, telemetry=execution.telemetry)

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Sessions endpoints for OpenViking HTTP Server."""
 
+import re
 from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
@@ -17,10 +18,20 @@ from openviking.server.models import ErrorInfo, Response
 from openviking.server.responses import error_response
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
+from openviking_cli.exceptions import FailedPreconditionError
 from openviking_cli.utils import get_logger
 
 router = APIRouter(prefix="/api/v1/sessions", tags=["sessions"])
 logger = get_logger(__name__)
+_RESERVED_ALICE_SESSION_ID = re.compile(r"^alice_[0-9a-f]{48}$")
+
+
+def _reject_reserved_alice_session_write(session_id: Optional[str]) -> None:
+    if session_id and _RESERVED_ALICE_SESSION_ID.fullmatch(session_id):
+        raise FailedPreconditionError(
+            "Reserved Alice sessions require the fenced write API",
+            details={"reason": "alice_session_fencing_required"},
+        )
 
 
 class TextPartRequest(BaseModel):
@@ -197,6 +208,7 @@ async def create_session(
     If session_id is provided, creates a session with the given ID.
     If session_id is None, creates a new session with auto-generated ID.
     """
+    _reject_reserved_alice_session_write(request.session_id)
     service = get_service()
 
     async def _create() -> dict[str, Any]:
@@ -239,6 +251,8 @@ async def get_session(
     """Get session details."""
     from openviking_cli.exceptions import NotFoundError
 
+    if auto_create:
+        _reject_reserved_alice_session_write(session_id)
     service = get_service()
     try:
         session = await service.sessions.get(session_id, _ctx, auto_create=auto_create)
@@ -360,6 +374,7 @@ async def delete_session(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Delete a session."""
+    _reject_reserved_alice_session_write(session_id)
     service = get_service()
     await service.sessions.delete(session_id, _ctx)
     return Response(status="ok", result={"session_id": session_id})
@@ -399,6 +414,7 @@ async def commit_session(
     (Phase 2) runs in the background.  A ``task_id`` is returned for
     polling progress via ``GET /tasks/{task_id}``.
     """
+    _reject_reserved_alice_session_write(session_id)
     service = get_service()
     execution = await run_operation(
         operation="session.commit",
@@ -422,6 +438,7 @@ async def extract_session(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Extract memories from a session."""
+    _reject_reserved_alice_session_write(session_id)
     service = get_service()
     result = await service.sessions.extract(session_id, _ctx)
     return Response(status="ok", result=_to_jsonable(result))
@@ -448,6 +465,7 @@ async def add_message(
     If both `content` and `parts` are provided, `parts` takes precedence.
     Missing sessions are auto-created on first add.
     """
+    _reject_reserved_alice_session_write(session_id)
     service = get_service()
 
     async def _add() -> dict[str, Any]:
@@ -488,6 +506,7 @@ async def batch_add_messages(
     Accepts a list of messages, each following the same format as AddMessageRequest.
     Missing sessions are auto-created on first add.
     """
+    _reject_reserved_alice_session_write(session_id)
     service = get_service()
 
     async def _batch_add() -> dict[str, Any]:
@@ -525,6 +544,7 @@ async def record_used(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Record actually used contexts and skills in a session."""
+    _reject_reserved_alice_session_write(session_id)
     service = get_service()
     session = await service.sessions.get(session_id, _ctx, auto_create=False)
 

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -71,8 +71,35 @@ async def _embedding_probe(embedder) -> str:
 async def health_check(request: Request):
     """Health check endpoint (no authentication required)."""
     from openviking import __version__
+    from openviking.server.fenced_operation import (
+        ALICE_FENCING_PROTOCOL,
+        ALICE_FENCING_VERSION,
+        get_alice_fencing_mode,
+    )
+    from openviking.server.routers.fenced_sessions import (
+        fenced_writer_runtime_status,
+    )
 
-    result = {"status": "ok", "healthy": True, "version": __version__}
+    fenced_runtime = fenced_writer_runtime_status()
+
+    result = {
+        "status": "ok",
+        "healthy": True,
+        "version": __version__,
+        "capabilities": {
+            "alice_session_fencing": {
+                "protocol": ALICE_FENCING_PROTOCOL,
+                "version": ALICE_FENCING_VERSION,
+                "mode": get_alice_fencing_mode(),
+                "write_ack": "202_poll",
+                "configured": fenced_runtime["configured"],
+                "writer_healthy": fenced_runtime["healthy"],
+                "draining": fenced_runtime["draining"],
+                "effect_concurrency": fenced_runtime["effect_concurrency"],
+                "commit_concurrency": fenced_runtime["commit_concurrency"],
+            }
+        },
+    }
 
     # Try to get user identity
     try:
@@ -132,6 +159,39 @@ async def readiness_check(request: Request):
         )
 
     checks = {}
+
+    # The PostgreSQL authority and its supervised writers are a readiness
+    # dependency whenever operators supplied any fencing configuration.  In
+    # observe mode a wholly unconfigured deployment remains backwards
+    # compatible, but partial/invalid configuration fails closed.
+    from openviking.server.fenced_operation import get_alice_fencing_mode
+    from openviking.server.routers.fenced_sessions import (
+        fenced_writer_runtime_status,
+    )
+
+    fenced_runtime = fenced_writer_runtime_status()
+    if (
+        fenced_runtime["configured"]
+        and fenced_runtime["healthy"]
+        and not fenced_runtime["draining"]
+    ):
+        checks["alice_fenced_writer"] = {
+            "status": "ok",
+            "effect_concurrency": fenced_runtime["effect_concurrency"],
+            "commit_concurrency": fenced_runtime["commit_concurrency"],
+        }
+    elif (
+        get_alice_fencing_mode() == "observe"
+        and not fenced_runtime["requested"]
+    ):
+        checks["alice_fenced_writer"] = "not_configured"
+    else:
+        checks["alice_fenced_writer"] = {
+            "status": "error",
+            "configured": fenced_runtime["configured"],
+            "healthy": fenced_runtime["healthy"],
+            "draining": fenced_runtime["draining"],
+        }
 
     # 1. AGFS: probe filesystem access and multi-write sync health
     try:

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -6,6 +6,7 @@ Session Service for OpenViking.
 Provides session management operations: session, sessions, add_message, commit, delete.
 """
 
+import asyncio
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from openviking.core.namespace import canonical_session_uri
@@ -127,6 +128,8 @@ class SessionService:
         ctx: RequestContext,
         session_id: Optional[str] = None,
         memory_policy: Optional[Dict[str, Any]] = None,
+        *,
+        strict: bool = False,
     ) -> Session:
         """Create a session and persist its root path.
 
@@ -143,7 +146,7 @@ class SessionService:
         try:
             if session_id:
                 existing = self.session(ctx, session_id)
-                if await existing.exists():
+                if await existing.exists(strict=strict):
                     raise AlreadyExistsError(f"Session '{session_id}' already exists")
             session = self.session(ctx, session_id)
             if memory_policy is not None:
@@ -152,7 +155,7 @@ class SessionService:
                     set(MemoryTypeRegistry().list_names(include_disabled=False))
                 )
                 session.meta.memory_policy = policy.to_dict()
-            await session.ensure_exists()
+            await session.ensure_exists(strict=strict)
             self._record_lifecycle_metric("create", "ok")
             return session
         except Exception:
@@ -160,7 +163,12 @@ class SessionService:
             raise
 
     async def get(
-        self, session_id: str, ctx: RequestContext, *, auto_create: bool = False
+        self,
+        session_id: str,
+        ctx: RequestContext,
+        *,
+        auto_create: bool = False,
+        strict: bool = False,
     ) -> Session:
         """Get an existing session.
 
@@ -172,11 +180,11 @@ class SessionService:
         """
         try:
             session = self.session(ctx, session_id)
-            if not await session.exists():
+            if not await session.exists(strict=strict):
                 if not auto_create:
                     raise NotFoundError(session_id, "session")
-                await session.ensure_exists()
-            await session.load()
+                await session.ensure_exists(strict=strict)
+            await session.load(strict=strict)
             self._record_lifecycle_metric("get", "ok")
             return session
         except Exception:
@@ -249,6 +257,9 @@ class SessionService:
         session_id: str,
         ctx: RequestContext,
         keep_recent_count: int = 0,
+        *,
+        operation_id: Optional[str] = None,
+        operation_sequence_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Commit a session (archive messages and extract memories).
 
@@ -265,6 +276,8 @@ class SessionService:
             session_id,
             ctx,
             keep_recent_count=keep_recent_count,
+            operation_id=operation_id,
+            operation_sequence_id=operation_sequence_id,
         )
 
     async def commit_async(
@@ -272,6 +285,9 @@ class SessionService:
         session_id: str,
         ctx: RequestContext,
         keep_recent_count: int = 0,
+        *,
+        operation_id: Optional[str] = None,
+        operation_sequence_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Async commit a session.
 
@@ -288,11 +304,44 @@ class SessionService:
             archive_uri, archived
         """
         self._ensure_initialized()
-        session = await self.get(session_id, ctx)
-        result = await session.commit_async(keep_recent_count=keep_recent_count)
+        session = await self.get(
+            session_id,
+            ctx,
+            strict=operation_id is not None,
+        )
+        result = await session.commit_async(
+            keep_recent_count=keep_recent_count,
+            operation_id=operation_id,
+            operation_sequence_id=operation_sequence_id,
+        )
         self._record_lifecycle_metric("commit", "ok" if result.get("status") else "error")
         self._record_archive_metric("ok" if result.get("archived") else "skip")
         return result
+
+    async def run_fenced_commit_work(
+        self,
+        session_id: str,
+        ctx: RequestContext,
+        *,
+        operation_id: str,
+        task_id: str,
+        archive_uri: str,
+    ) -> str:
+        """Resume one PostgreSQL-scheduled fenced commit Phase 2."""
+        self._ensure_initialized()
+        from openviking.session.session import fenced_phase2_timeout_seconds
+
+        # One wall-clock bound covers strict loading, every model/vector call,
+        # queue drain, and final receipts.  Writer shutdown is configured to
+        # exceed this bound so normal rolling deploys never force-cancel a
+        # non-idempotent started step.
+        async with asyncio.timeout(fenced_phase2_timeout_seconds()):
+            session = await self.get(session_id, ctx, strict=True)
+            return await session.run_fenced_commit_work(
+                operation_id=operation_id,
+                task_id=task_id,
+                archive_uri=archive_uri,
+            )
 
     async def get_commit_task(self, task_id: str, ctx: RequestContext) -> Optional[Dict[str, Any]]:
         """Query background commit task status by task_id for the calling owner."""

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -9,7 +9,11 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Protocol
 
 from openviking.pyagfs import AsyncAGFSClient
-from openviking.pyagfs.exceptions import AGFSAlreadyExistsError
+from openviking.pyagfs.exceptions import (
+    AGFSAlreadyExistsError,
+    AGFSHTTPError,
+    AGFSNotFoundError,
+)
 
 SYSTEM_TASK_ACCOUNT_ID = "_system"
 SYSTEM_TASK_USER_ID = "root"
@@ -67,6 +71,31 @@ class PersistentTaskStore:
             raw = await self._agfs.read(path)
         except Exception:
             return None
+        return json.loads(_decode_bytes(raw))
+
+    async def get_strict(
+        self,
+        task_id: str,
+        *,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Read a task while distinguishing absence from transient storage failure.
+
+        Deterministic fenced commit scheduling must not interpret a timeout as
+        "task missing" and overwrite a running/completed task.
+        """
+        if not account_id or not user_id:
+            return None
+        path = self._task_path(account_id, user_id, task_id)
+        try:
+            raw = await self._agfs.read(path)
+        except (FileNotFoundError, AGFSNotFoundError):
+            return None
+        except AGFSHTTPError as exc:
+            if exc.status_code == 404:
+                return None
+            raise
         return json.loads(_decode_bytes(raw))
 
     async def list(self, account_id: str, *, user_id: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -268,6 +268,60 @@ class TaskTracker:
         )
         return self._copy(task)
 
+    async def get_or_create_deterministic(
+        self,
+        task_id: str,
+        task_type: str,
+        resource_id: Optional[str] = None,
+        *,
+        account_id: str,
+        user_id: str,
+    ) -> tuple[TaskRecord, bool]:
+        """Load or create an operation-addressed task without transient-as-missing.
+
+        Returns ``(task, created)``.  The persistent store is authoritative so
+        this remains idempotent after a process restart.
+        """
+        self._validate_owner(account_id, user_id)
+        if not task_id or len(task_id) > 128:
+            raise ValueError("deterministic task_id must contain 1..128 characters")
+        async with self._async_lock:
+            with self._lock:
+                task = self._tasks.get(task_id)
+            if task is None:
+                strict_get = getattr(self._store, "get_strict", None)
+                if not callable(strict_get):
+                    raise RuntimeError(
+                        "Deterministic task creation requires a fail-closed task store"
+                    )
+                payload = await strict_get(
+                    task_id,
+                    account_id=account_id,
+                    user_id=user_id,
+                )
+                if payload is not None:
+                    task = self._record_from_payload(payload)
+            if task is not None:
+                if not self._matches_owner(task, account_id, user_id):
+                    raise RuntimeError("Deterministic task ID owner mismatch")
+                if task.task_type != task_type or task.resource_id != resource_id:
+                    raise RuntimeError("Deterministic task ID content mismatch")
+                with self._lock:
+                    self._tasks[task.task_id] = task
+                return self._copy(task), False
+
+            task = TaskRecord(
+                task_id=task_id,
+                task_type=task_type,
+                resource_id=resource_id,
+                account_id=account_id,
+                user_id=user_id,
+            )
+            await self._store.create(task)
+            with self._lock:
+                self._tasks[task.task_id] = task
+        return self._copy(task), True
+
     async def create_if_no_running(
         self,
         task_type: str,

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -6,11 +6,15 @@ Session as Context: Sessions integrated into L0/L1/L2 system.
 """
 
 import asyncio
+import hashlib
+import inspect
 import json
+import math
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, NoReturn, Optional
 from uuid import uuid4
 
 from openviking.core.namespace import canonical_session_uri
@@ -18,6 +22,7 @@ from openviking.core.peer_id import normalize_peer_id, safe_peer_id
 from openviking.message import Message, Part
 from openviking.message.part import ContextPart, TextPart, ToolPart
 from openviking.server.config import ToolOutputExternalizationConfig
+from openviking.server.error_mapping import is_not_found_error
 from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.constants import EXECUTION_MEMORY_TYPES
 from openviking.session.memory_policy import MemoryPolicy
@@ -37,7 +42,7 @@ from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.model_retry import is_retryable_api_error, retry_async
 from openviking.utils.time_utils import get_current_timestamp
 from openviking.utils.token_estimation import estimate_text_tokens
-from openviking_cli.exceptions import FailedPreconditionError
+from openviking_cli.exceptions import FailedPreconditionError, NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger, run_async
 from openviking_cli.utils.config import get_openviking_config
@@ -51,9 +56,40 @@ logger = get_logger(__name__)
 
 _ARCHIVE_WAIT_POLL_SECONDS = 0.1
 _PHASE2_QUEUE_WAIT_TIMEOUT_SECONDS = 1800.0
+FENCED_PHASE2_TIMEOUT_ENV = "OPENVIKING_FENCED_PHASE2_TIMEOUT_SECONDS"
+_FENCED_PHASE2_TIMEOUT_DEFAULT_SECONDS = 1800.0
 _MEMORY_EXTRACTION_MAX_RETRIES = 3
 _MEMORY_EXTRACTION_RETRY_BASE_DELAY_SECONDS = 1.0
 _MEMORY_EXTRACTION_RETRY_MAX_DELAY_SECONDS = 8.0
+
+
+def fenced_phase2_timeout_seconds() -> float:
+    """Return the fail-fast, whole-operation Phase 2 upper bound."""
+    raw = os.getenv(
+        FENCED_PHASE2_TIMEOUT_ENV,
+        str(_FENCED_PHASE2_TIMEOUT_DEFAULT_SECONDS),
+    ).strip()
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{FENCED_PHASE2_TIMEOUT_ENV} must be a number") from exc
+    if not math.isfinite(value) or value < 60.0 or value > 7200.0:
+        raise RuntimeError(
+            f"{FENCED_PHASE2_TIMEOUT_ENV} must be between 60 and 7200 seconds"
+        )
+    return value
+
+
+# Test-only crash seam for the deterministic fenced-commit state machine.
+async def after_fenced_commit_stage(stage: str, operation_id: str) -> None:
+    del stage, operation_id
+
+
+# Test-only crash seam for durable Phase 2 receipts.  Callers inject a
+# ``BaseException`` here to model a process disappearing after the named
+# receipt is durable but before the next step begins.
+async def after_fenced_phase2_stage(stage: str, operation_id: str) -> None:
+    del stage, operation_id
 
 
 def _wm_debug(msg: str) -> None:
@@ -344,7 +380,33 @@ class Usage:
     input: str = ""
     output: str = ""
     success: bool = True
+    operation_id: str = ""
     timestamp: str = field(default_factory=get_current_timestamp)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "uri": self.uri,
+            "type": self.type,
+            "contribution": self.contribution,
+            "input": self.input,
+            "output": self.output,
+            "success": self.success,
+            "operation_id": self.operation_id,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Usage":
+        return cls(
+            uri=str(data.get("uri", "")),
+            type=str(data.get("type", "context")),
+            contribution=float(data.get("contribution", 0.0) or 0.0),
+            input=str(data.get("input", "")),
+            output=str(data.get("output", "")),
+            success=bool(data.get("success", True)),
+            operation_id=str(data.get("operation_id", "")),
+            timestamp=str(data.get("timestamp") or get_current_timestamp()),
+        )
 
 
 class Session:
@@ -391,7 +453,7 @@ class Session:
 
         logger.info(f"Session created: {self.session_id} for user {self.user}")
 
-    async def load(self):
+    async def load(self, *, strict: bool = False):
         """Load session data from storage."""
         if self._loaded:
             return
@@ -406,7 +468,19 @@ class Session:
                 if line.strip()
             ]
             logger.info(f"Session loaded: {self.session_id} ({len(self._messages)} messages)")
-        except (FileNotFoundError, Exception):
+        except Exception as exc:
+            if strict:
+                if is_not_found_error(exc):
+                    raise FailedPreconditionError(
+                        "Fenced session messages file is missing",
+                        details={"reason": "session_messages_missing"},
+                    ) from exc
+                if isinstance(exc, (json.JSONDecodeError, TypeError, ValueError)):
+                    raise FailedPreconditionError(
+                        "Fenced session messages are corrupt",
+                        details={"reason": "session_messages_corrupt"},
+                    ) from exc
+                raise
             logger.debug(f"Session {self.session_id} not found, starting fresh")
 
         # Restore compression_index (scan history directory)
@@ -420,8 +494,9 @@ class Session:
                 self._compression.compression_index = max_index
                 self._stats.compression_count = len(archives)
                 logger.debug(f"Restored compression_index: {max_index}")
-        except Exception:
-            pass
+        except Exception as exc:
+            if strict and not is_not_found_error(exc):
+                raise
 
         # Load .meta.json
         try:
@@ -429,7 +504,19 @@ class Session:
                 f"{self._session_uri}/.meta.json", ctx=self.ctx
             )
             self._meta = SessionMeta.from_dict(json.loads(meta_content))
-        except Exception:
+        except Exception as exc:
+            if strict:
+                if is_not_found_error(exc):
+                    raise FailedPreconditionError(
+                        "Fenced session metadata is missing",
+                        details={"reason": "session_meta_missing"},
+                    ) from exc
+                if isinstance(exc, (json.JSONDecodeError, TypeError, ValueError)):
+                    raise FailedPreconditionError(
+                        "Fenced session metadata is corrupt",
+                        details={"reason": "session_meta_corrupt"},
+                    ) from exc
+                raise
             # Old session without meta — derive from existing data
             self._meta.message_count = len(self._messages)
             self._meta.commit_count = self._compression.compression_index
@@ -439,6 +526,37 @@ class Session:
             self._meta.created_by_account_id = self.ctx.account_id
         if not self._meta.created_by_user_id:
             self._meta.created_by_user_id = self.ctx.user.user_id
+
+        # Fenced clients persist usage independently from process memory so a
+        # later request (or replica) can include it in commit extraction.
+        try:
+            usage_content = await self._viking_fs.read_file(
+                f"{self._session_uri}/usage.jsonl", ctx=self.ctx
+            )
+        except NotFoundError:
+            self._usage_records = []
+        else:
+            try:
+                usage_records = [
+                    Usage.from_dict(json.loads(line))
+                    for line in usage_content.splitlines()
+                    if line.strip()
+                ]
+            except (json.JSONDecodeError, TypeError, ValueError) as exc:
+                raise FailedPreconditionError(
+                    "Session usage journal is corrupt",
+                    details={
+                        "reason": "usage_journal_corrupt",
+                        "session_id": self.session_id,
+                    },
+                ) from exc
+            self._usage_records = usage_records
+            self._stats.contexts_used = sum(
+                1 for usage in self._usage_records if usage.type == "context"
+            )
+            self._stats.skills_used = sum(
+                1 for usage in self._usage_records if usage.type == "skill"
+            )
         # WM v2: always rebuild pending_tokens from current messages so the
         # counter stays consistent across restarts and is also backfilled for
         # legacy sessions whose .meta.json predates these fields. O(n) once,
@@ -465,17 +583,21 @@ class Session:
             self._meta.pending_tokens = 0
         self._meta.pending_tokens = max(0, self._meta.pending_tokens)
 
-    async def exists(self) -> bool:
+    async def exists(self, *, strict: bool = False) -> bool:
         """Check whether this session already exists in storage."""
         try:
             await self._viking_fs.stat(self._session_uri, ctx=self.ctx)
             return True
-        except Exception:
+        except Exception as exc:
+            if is_not_found_error(exc):
+                return False
+            if strict:
+                raise
             return False
 
-    async def ensure_exists(self) -> None:
+    async def ensure_exists(self, *, strict: bool = False) -> None:
         """Materialize session root and messages file if missing."""
-        if await self.exists():
+        if await self.exists(strict=strict):
             return
         await self._viking_fs.mkdir(self._session_uri, exist_ok=True, ctx=self.ctx)
         await self._viking_fs.write_file(f"{self._session_uri}/messages.jsonl", "", ctx=self.ctx)
@@ -514,11 +636,16 @@ class Session:
         self,
         contexts: Optional[List[str]] = None,
         skill: Optional[Dict[str, Any]] = None,
+        operation_id: str = "",
     ) -> None:
         """Record actually used contexts and skills."""
+        if operation_id and any(
+            usage.operation_id == operation_id for usage in self._usage_records
+        ):
+            return
         if contexts:
             for uri in contexts:
-                usage = Usage(uri=uri, type="context")
+                usage = Usage(uri=uri, type="context", operation_id=operation_id)
                 self._usage_records.append(usage)
                 self._stats.contexts_used += 1
                 logger.debug(f"Tracked context usage: {uri}")
@@ -538,6 +665,7 @@ class Session:
                 input=skill.get("input", ""),
                 output=skill.get("output", ""),
                 success=skill.get("success", True),
+                operation_id=operation_id,
             )
             self._usage_records.append(usage)
             self._stats.skills_used += 1
@@ -548,6 +676,28 @@ class Session:
                 SessionLifecycleDataSource.record_contexts_used(action="skill", delta=1)
             except Exception:
                 pass
+
+    async def persist_usage_records(self) -> None:
+        """Durably replace the session usage journal."""
+        if not self._viking_fs:
+            return
+        content = "\n".join(
+            json.dumps(usage.to_dict(), ensure_ascii=False, sort_keys=True)
+            for usage in self._usage_records
+        )
+        if content:
+            content += "\n"
+        await self._viking_fs.write_file(
+            f"{self._session_uri}/usage.jsonl",
+            content,
+            ctx=self.ctx,
+        )
+
+    def consume_usage_records(self) -> None:
+        """Clear usage after commit has captured its in-memory snapshot."""
+        self._usage_records = []
+        self._stats.contexts_used = 0
+        self._stats.skills_used = 0
 
     def _tool_result_store(self) -> Optional[ToolResultStore]:
         if not self._viking_fs:
@@ -923,6 +1073,16 @@ class Session:
             role = spec["role"]
             parts = spec["parts"]
             created_at = spec.get("created_at") or datetime.now(timezone.utc).isoformat()
+            requested_id = str(spec.get("id") or "")
+
+            if requested_id:
+                existing = next(
+                    (message for message in self._messages if message.id == requested_id),
+                    None,
+                )
+                if existing is not None:
+                    all_messages.append(existing)
+                    continue
 
             try:
                 peer_id = normalize_peer_id(spec.get("peer_id"))
@@ -932,21 +1092,32 @@ class Session:
                 raise InvalidArgumentError(str(exc)) from exc
 
             if self._is_tool_result_aggregate(role, parts):
-                msgs = [
-                    Message(
-                        id=f"msg_{uuid4().hex}",
-                        role=role,
-                        parts=[part],
-                        peer_id=peer_id,
-                        created_at=created_at,
+                msgs = []
+                for part_index, part in enumerate(parts):
+                    message_id = (
+                        f"{requested_id}_{part_index}" if requested_id else f"msg_{uuid4().hex}"
                     )
-                    for part in parts
-                ]
+                    existing = next(
+                        (message for message in self._messages if message.id == message_id),
+                        None,
+                    )
+                    if existing is not None:
+                        msgs.append(existing)
+                        continue
+                    msgs.append(
+                        Message(
+                            id=message_id,
+                            role=role,
+                            parts=[part],
+                            peer_id=peer_id,
+                            created_at=created_at,
+                        )
+                    )
                 self._externalize_large_tool_output_group(msgs)
                 all_messages.extend(msgs)
             else:
                 msg = Message(
-                    id=f"msg_{uuid4().hex}",
+                    id=requested_id or f"msg_{uuid4().hex}",
                     role=role,
                     parts=parts,
                     peer_id=peer_id,
@@ -955,7 +1126,10 @@ class Session:
                 self._externalize_large_tool_outputs(msg)
                 all_messages.append(msg)
 
-        self._append_messages(all_messages)
+        existing_ids = {message.id for message in self._messages}
+        new_messages = [message for message in all_messages if message.id not in existing_ids]
+        if new_messages:
+            self._append_messages(new_messages)
         return all_messages
 
     def add_message(
@@ -1076,6 +1250,9 @@ class Session:
     async def commit_async(
         self,
         keep_recent_count: int = 0,
+        *,
+        operation_id: Optional[str] = None,
+        operation_sequence_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Async commit session: archive immediately, extract memories in background.
 
@@ -1095,6 +1272,13 @@ class Session:
 
         Returns a task_id for tracking Phase 2 progress.
         """
+        if operation_id:
+            return await self._commit_fenced_async(
+                operation_id=operation_id,
+                keep_recent_count=keep_recent_count,
+                operation_sequence_id=operation_sequence_id,
+            )
+
         from openviking.service.task_tracker import get_task_tracker
         from openviking.storage.transaction import LockContext, get_lock_manager
 
@@ -1247,6 +1431,1085 @@ class Session:
             "trace_id": trace_id,
         }
 
+    async def _commit_fenced_async(
+        self,
+        *,
+        operation_id: str,
+        keep_recent_count: int,
+        operation_sequence_id: Optional[int],
+    ) -> Dict[str, Any]:
+        """Crash-recoverable commit addressed by the Alice operation ID.
+
+        A durable manifest is written before archive/live/task effects.  Every
+        subsequent step is deterministic and idempotent, so a retry after any
+        internal crash resumes the same archive and task instead of allocating
+        another sequence number or UUID.
+        """
+        from openviking.service.task_tracker import get_task_tracker
+        from openviking.storage.transaction import LockContext, get_lock_manager
+
+        keep_recent_count = max(0, int(keep_recent_count or 0))
+        if operation_sequence_id is None or int(operation_sequence_id) <= 0:
+            raise FailedPreconditionError(
+                "Fenced commit is missing its durable outbox sequence",
+                details={"reason": "commit_sequence_required"},
+            )
+        operation_sequence_id = int(operation_sequence_id)
+        operation_hash = hashlib.sha256(operation_id.encode("utf-8")).hexdigest()
+        manifest_uri = f"{self._session_uri}/.fenced-commits/{operation_hash}.json"
+        session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
+
+        async with LockContext(get_lock_manager(), [session_path], lock_mode="exact"):
+            try:
+                manifest_raw = await self._viking_fs.read_file(manifest_uri, ctx=self.ctx)
+            except NotFoundError:
+                manifest = None
+            else:
+                try:
+                    manifest = json.loads(manifest_raw)
+                except (TypeError, ValueError) as exc:
+                    raise FailedPreconditionError(
+                        "Fenced commit manifest is corrupt",
+                        details={
+                            "reason": "commit_manifest_corrupt",
+                            "operation_id": operation_id,
+                        },
+                    ) from exc
+
+            if manifest is None:
+                effective_policy = MemoryPolicy.from_dict(self._meta.memory_policy)
+                _validate_memory_policy_types(effective_policy)
+                total = len(self._messages)
+                should_archive = bool(self._messages) and not (
+                    keep_recent_count > 0 and total <= keep_recent_count
+                )
+                if should_archive:
+                    split_idx = total - keep_recent_count if keep_recent_count > 0 else total
+                    messages_to_archive = self._messages[:split_idx]
+                    retained_messages = self._messages[split_idx:]
+                    # This exact session lock is shared with legacy commits, so
+                    # allocate the next history suffix once and persist it in
+                    # the operation manifest.  The PG sequence identifies the
+                    # effect, while the local contiguous index remains a true
+                    # archive count and preserves mixed legacy/fenced ordering.
+                    existing_archives = await self._list_archive_refs(strict=True)
+                    archive_index = (
+                        max(
+                            (int(ref["index"]) for ref in existing_archives),
+                            default=0,
+                        )
+                        + 1
+                    )
+                    archive_uri = (
+                        f"{self._session_uri}/history/archive_{archive_index:03d}"
+                    )
+                    task_id = f"fenced_commit_{operation_hash[:48]}"
+                    previous_archives = [
+                        ref
+                        for ref in existing_archives
+                        if int(ref["index"]) < archive_index
+                    ]
+                    previous_archive = (
+                        max(previous_archives, key=lambda ref: int(ref["index"]))
+                        if previous_archives
+                        else None
+                    )
+                else:
+                    messages_to_archive = []
+                    retained_messages = list(self._messages)
+                    archive_index = 0
+                    archive_uri = None
+                    task_id = None
+                    previous_archive = None
+
+                manifest = {
+                    "version": 2,
+                    "operation_id": operation_id,
+                    "operation_sequence_id": operation_sequence_id,
+                    "session_id": self.session_id,
+                    "keep_recent_count": keep_recent_count,
+                    "state": "planned",
+                    "archive_index": archive_index,
+                    "archive_uri": archive_uri,
+                    "previous_archive_index": (
+                        int(previous_archive["index"])
+                        if previous_archive is not None
+                        else None
+                    ),
+                    "previous_archive_uri": (
+                        str(previous_archive["archive_uri"])
+                        if previous_archive is not None
+                        else None
+                    ),
+                    "task_id": task_id,
+                    "archive_messages": [message.to_dict() for message in messages_to_archive],
+                    "retained_messages": [message.to_dict() for message in retained_messages],
+                    "usage_records": [usage.to_dict() for usage in self._usage_records],
+                    "memory_policy": effective_policy.to_dict(),
+                    "trace_id": tracer.get_trace_id(),
+                    "last_commit_at_target": get_current_timestamp(),
+                    # ``original_count`` is in-memory compatibility state, but
+                    # replay must still be deterministic while this Session
+                    # instance remains alive.  Persist the immutable baseline
+                    # and derive the target instead of applying ``+=``.
+                    "compression_original_count_before": self._compression.original_count,
+                }
+                await self._viking_fs.write_file(
+                    manifest_uri,
+                    json.dumps(manifest, ensure_ascii=False, sort_keys=True),
+                    ctx=self.ctx,
+                )
+            elif (
+                not isinstance(manifest, dict)
+                or manifest.get("version") != 2
+                or manifest.get("operation_id") != operation_id
+                or int(manifest.get("operation_sequence_id", -1))
+                != operation_sequence_id
+                or manifest.get("session_id") != self.session_id
+                or int(manifest.get("keep_recent_count", -1)) != keep_recent_count
+            ):
+                raise FailedPreconditionError(
+                    "Fenced commit manifest identity mismatch",
+                    details={
+                        "reason": "commit_manifest_conflict",
+                        "operation_id": operation_id,
+                    },
+                )
+
+            def _messages(field_name: str) -> list[Message]:
+                raw_messages = manifest.get(field_name)
+                if not isinstance(raw_messages, list):
+                    raise FailedPreconditionError(
+                        "Fenced commit manifest is corrupt",
+                        details={"reason": "commit_manifest_corrupt"},
+                    )
+                try:
+                    return [Message.from_dict(value) for value in raw_messages]
+                except Exception as exc:
+                    raise FailedPreconditionError(
+                        "Fenced commit manifest is corrupt",
+                        details={"reason": "commit_manifest_corrupt"},
+                    ) from exc
+
+            messages_to_archive = _messages("archive_messages")
+            retained_messages = _messages("retained_messages")
+            archive_uri = manifest.get("archive_uri")
+            task_id = manifest.get("task_id")
+            trace_id = str(manifest.get("trace_id") or "")
+
+            if not messages_to_archive:
+                self._messages = retained_messages
+                self._meta.pending_tokens = 0
+                self._meta.keep_recent_count = keep_recent_count
+                self._meta.message_count = len(retained_messages)
+                await self._save_meta()
+                result = {
+                    "session_id": self.session_id,
+                    "status": "accepted",
+                    "task_id": None,
+                    "archive_uri": None,
+                    "archived": False,
+                    "trace_id": trace_id,
+                }
+                manifest["state"] = "completed"
+                manifest["result"] = result
+                await self._viking_fs.write_file(
+                    manifest_uri,
+                    json.dumps(manifest, ensure_ascii=False, sort_keys=True),
+                    ctx=self.ctx,
+                )
+                return result
+
+            if not isinstance(archive_uri, str) or not archive_uri:
+                raise FailedPreconditionError(
+                    "Fenced commit manifest is corrupt",
+                    details={"reason": "commit_manifest_corrupt"},
+                )
+            if not isinstance(task_id, str) or not task_id:
+                raise FailedPreconditionError(
+                    "Fenced commit manifest is corrupt",
+                    details={"reason": "commit_manifest_corrupt"},
+                )
+
+            # Repeating an already completed helper remains deterministic even
+            # if the outer PostgreSQL receipt was lost before commit.
+            if manifest.get("state") == "completed" and isinstance(
+                manifest.get("result"), dict
+            ):
+                return dict(manifest["result"])
+
+            state_order = {
+                "planned": 0,
+                "archive_written": 1,
+                "live_cleared": 2,
+                "task_created": 3,
+                "completed": 4,
+            }
+            state = str(manifest.get("state") or "")
+            if state not in state_order:
+                raise FailedPreconditionError(
+                    "Fenced commit manifest has an invalid state",
+                    details={"reason": "commit_manifest_corrupt"},
+                )
+
+            async def _save_state(next_state: str) -> None:
+                manifest["state"] = next_state
+                await self._viking_fs.write_file(
+                    manifest_uri,
+                    json.dumps(manifest, ensure_ascii=False, sort_keys=True),
+                    ctx=self.ctx,
+                )
+
+            if state_order[state] < state_order["archive_written"]:
+                lines = [message.to_jsonl() for message in messages_to_archive]
+                await self._viking_fs.write_file(
+                    f"{archive_uri}/messages.jsonl",
+                    "\n".join(lines) + "\n",
+                    ctx=self.ctx,
+                )
+                await after_fenced_commit_stage("archive_write", operation_id)
+                await _save_state("archive_written")
+                state = "archive_written"
+
+            if state_order[state] < state_order["live_cleared"]:
+                self._messages = retained_messages
+                await self._write_to_agfs_async(messages=retained_messages)
+                self._meta.message_count = len(retained_messages)
+                self._meta.pending_tokens = 0
+                self._meta.keep_recent_count = keep_recent_count
+                archive_index = int(manifest["archive_index"])
+                self._meta.commit_count = max(self._meta.commit_count, archive_index)
+                self._meta.last_commit_at = str(manifest["last_commit_at_target"])
+                self._compression.compression_index = max(
+                    self._compression.compression_index,
+                    archive_index,
+                )
+                original_count_before = int(
+                    manifest.get("compression_original_count_before", 0) or 0
+                )
+                self._compression.original_count = max(
+                    self._compression.original_count,
+                    original_count_before + len(messages_to_archive),
+                )
+                await self._save_meta()
+                await after_fenced_commit_stage("live_clear", operation_id)
+                await _save_state("live_cleared")
+                state = "live_cleared"
+
+            tracker = get_task_tracker()
+            _task, _created = await tracker.get_or_create_deterministic(
+                task_id,
+                "session_commit",
+                resource_id=self.session_id,
+                account_id=self.ctx.account_id,
+                user_id=self.ctx.user.user_id,
+            )
+            if state_order[state] < state_order["task_created"]:
+                await after_fenced_commit_stage("task_create", operation_id)
+                await _save_state("task_created")
+                state = "task_created"
+
+            result = {
+                "session_id": self.session_id,
+                "status": "accepted",
+                "task_id": task_id,
+                "archive_uri": archive_uri,
+                "archived": True,
+                "trace_id": trace_id,
+            }
+            manifest["result"] = result
+            await _save_state("completed")
+            await after_fenced_commit_stage("return", operation_id)
+            return result
+
+    async def run_fenced_commit_work(
+        self,
+        *,
+        operation_id: str,
+        task_id: str,
+        archive_uri: str,
+    ) -> str:
+        """Run the durable second phase of an Alice fenced commit.
+
+        The PostgreSQL commit-work outbox is the scheduler.  This method never
+        starts an in-process background task.  Each non-transactional step has
+        an AGFS receipt written before/after its effect.  A process loss after a
+        non-idempotent step starts but before its completion receipt is
+        deliberately *ambiguous*: recovery fails closed instead of invoking the
+        model (and potentially writing different memories) a second time.
+        """
+        from openviking.service.task_tracker import TaskStatus, get_task_tracker
+        from openviking.storage.transaction import LockContext, get_lock_manager
+        from openviking.telemetry import OperationTelemetry, bind_telemetry
+        from openviking.telemetry.registry import (
+            register_telemetry,
+            unregister_telemetry,
+        )
+
+        operation_hash = hashlib.sha256(operation_id.encode("utf-8")).hexdigest()
+        manifest_uri = f"{self._session_uri}/.fenced-commits/{operation_hash}.json"
+        phase2_deadline = (
+            asyncio.get_running_loop().time()
+            + fenced_phase2_timeout_seconds()
+        )
+
+        try:
+            manifest_raw = await self._viking_fs.read_file(
+                manifest_uri, ctx=self.ctx
+            )
+        except Exception as exc:
+            if not is_not_found_error(exc):
+                raise
+            raise FailedPreconditionError(
+                "Fenced commit manifest is missing",
+                details={"reason": "commit_manifest_missing"},
+            ) from exc
+        try:
+            manifest = json.loads(manifest_raw)
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            raise FailedPreconditionError(
+                "Fenced commit manifest is corrupt",
+                details={"reason": "commit_phase2_manifest_corrupt"},
+            ) from exc
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("version") != 2
+            or manifest.get("operation_id") != operation_id
+            or manifest.get("session_id") != self.session_id
+            or manifest.get("task_id") != task_id
+            or manifest.get("archive_uri") != archive_uri
+            or manifest.get("state") != "completed"
+        ):
+            raise FailedPreconditionError(
+                "Fenced commit work identity mismatch",
+                details={"reason": "commit_work_identity_conflict"},
+            )
+
+        phase2 = manifest.setdefault(
+            "phase2",
+            {"version": 1, "state": "pending", "steps": {}},
+        )
+        if not isinstance(phase2, dict) or phase2.get("version") != 1:
+            raise FailedPreconditionError(
+                "Fenced commit phase2 manifest is corrupt",
+                details={"reason": "commit_phase2_manifest_corrupt"},
+            )
+        steps = phase2.setdefault("steps", {})
+        if not isinstance(steps, dict):
+            raise FailedPreconditionError(
+                "Fenced commit phase2 steps are corrupt",
+                details={"reason": "commit_phase2_manifest_corrupt"},
+            )
+
+        async def _save_manifest() -> None:
+            await self._viking_fs.write_file(
+                manifest_uri,
+                json.dumps(manifest, ensure_ascii=False, sort_keys=True),
+                ctx=self.ctx,
+            )
+
+        async def _after_phase2_stage(stage: str) -> None:
+            seam = after_fenced_phase2_stage(stage, operation_id)
+            if inspect.isawaitable(seam):
+                await seam
+
+        async def _done_exists() -> bool:
+            try:
+                await self._viking_fs.read_file(f"{archive_uri}/.done", ctx=self.ctx)
+                return True
+            except Exception as exc:
+                if is_not_found_error(exc):
+                    return False
+                raise
+
+        def _digest_output(value: Any) -> str:
+            encoded = json.dumps(
+                value,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            return hashlib.sha256(encoded).hexdigest()
+
+        async def _prune_terminal_manifest() -> None:
+            for field_name in (
+                "archive_messages",
+                "retained_messages",
+                "usage_records",
+                "memory_policy",
+            ):
+                manifest.pop(field_name, None)
+            terminal_steps: dict[str, dict[str, Any]] = {}
+            for name, raw_step in steps.items():
+                if not isinstance(raw_step, dict):
+                    continue
+                output = raw_step.get("output")
+                terminal_steps[str(name)] = {
+                    "state": str(raw_step.get("state") or ""),
+                    "output_digest": (
+                        _digest_output(output) if output is not None else None
+                    ),
+                }
+            phase2["steps"] = terminal_steps
+            phase2["state"] = "completed"
+            phase2["completed_at"] = phase2.get(
+                "completed_at", get_current_timestamp()
+            )
+            await _save_manifest()
+
+        tracker = get_task_tracker()
+        task, _created = await tracker.get_or_create_deterministic(
+            task_id,
+            "session_commit",
+            resource_id=self.session_id,
+            account_id=self.ctx.account_id,
+            user_id=self.ctx.user.user_id,
+        )
+        redo_log = get_lock_manager().redo_log
+
+        async def _raise_ambiguous(
+            stage: str,
+            *,
+            cause: Optional[BaseException] = None,
+        ) -> NoReturn:
+            await tracker.fail(
+                task_id,
+                f"fenced_phase2_ambiguous:{stage}",
+                account_id=self.ctx.account_id,
+                user_id=self.ctx.user.user_id,
+            )
+            error = FailedPreconditionError(
+                "Fenced commit effect outcome is ambiguous",
+                details={
+                    "reason": "commit_phase2_effect_ambiguous",
+                    "operation_id": operation_id,
+                    "stage": stage,
+                },
+            )
+            if cause is None:
+                raise error
+            raise error from cause
+
+        # A crash after .done is fully reconcilable: the deterministic result
+        # was persisted before .done, so repair TaskTracker/redo and return.
+        if await _done_exists() and isinstance(phase2.get("result"), dict):
+            result = dict(phase2["result"])
+            await tracker.complete(
+                task_id,
+                result,
+                account_id=self.ctx.account_id,
+                user_id=self.ctx.user.user_id,
+            )
+            await redo_log.mark_done_async(task_id)
+            await _prune_terminal_manifest()
+            return "completed"
+
+        if task.status in {TaskStatus.COMPLETED, TaskStatus.FAILED}:
+            raise FailedPreconditionError(
+                "Fenced commit task is terminal without a durable done marker",
+                details={"reason": "commit_phase2_task_ambiguous"},
+            )
+
+        # Operation-addressed redo is written before RUNNING.  LockManager's
+        # generic redo scanner recognizes ``fenced_operation_id`` and leaves it
+        # for this PostgreSQL-scheduled state machine.
+        await redo_log.write_pending_async(
+            task_id,
+            {
+                "fenced_operation_id": operation_id,
+                "task_id": task_id,
+                "archive_uri": archive_uri,
+                "session_uri": self._session_uri,
+                "account_id": self.ctx.account_id,
+                "user_id": self.ctx.user.user_id,
+                "role": str(self.ctx.role),
+            },
+        )
+        if task.status != TaskStatus.RUNNING:
+            await tracker.start(
+                task_id,
+                account_id=self.ctx.account_id,
+                user_id=self.ctx.user.user_id,
+            )
+
+        previous_archive_uri = manifest.get("previous_archive_uri")
+        if isinstance(previous_archive_uri, str) and previous_archive_uri:
+            await self._wait_for_archive_uri_terminal(previous_archive_uri)
+
+        def _messages_from_manifest() -> list[Message]:
+            raw = manifest.get("archive_messages")
+            if not isinstance(raw, list):
+                raise FailedPreconditionError(
+                    "Fenced commit messages are unavailable",
+                    details={"reason": "commit_phase2_payload_missing"},
+                )
+            try:
+                return [Message.from_dict(value) for value in raw]
+            except Exception as exc:
+                raise FailedPreconditionError(
+                    "Fenced commit messages are corrupt",
+                    details={"reason": "commit_phase2_payload_corrupt"},
+                ) from exc
+
+        messages = _messages_from_manifest()
+        usage_records = [
+            Usage.from_dict(value) for value in manifest.get("usage_records", [])
+        ]
+        first_message_id = messages[0].id if messages else ""
+        last_message_id = messages[-1].id if messages else ""
+        latest_archive_overview = await self._get_latest_completed_archive_overview(
+            exclude_archive_uri=archive_uri,
+            strict=True,
+        )
+        extraction_messages = await self._hydrate_tool_outputs_for_extraction(messages)
+
+        def _token_usage(snapshot: Any) -> dict[str, dict[str, int]]:
+            summary = snapshot.summary if snapshot is not None else {}
+            tokens = summary.get("tokens", {}) if isinstance(summary, dict) else {}
+            llm = tokens.get("llm", {}) if isinstance(tokens, dict) else {}
+            embedding = (
+                tokens.get("embedding", {}) if isinstance(tokens, dict) else {}
+            )
+            return {
+                "llm": {
+                    "prompt_tokens": int(llm.get("input", 0) or 0),
+                    "completion_tokens": int(llm.get("output", 0) or 0),
+                    "total_tokens": int(llm.get("total", 0) or 0),
+                    "cached_tokens": int(llm.get("prompt_cached", 0) or 0),
+                    "reasoning_tokens": int(
+                        llm.get("completion_reasoning", 0) or 0
+                    ),
+                },
+                "embedding": {
+                    "total_tokens": int(embedding.get("total", 0) or 0),
+                },
+            }
+
+        async def _with_step_telemetry(
+            name: str,
+            fn: Callable[[], Awaitable[Any]],
+        ) -> tuple[Any, dict[str, dict[str, int]]]:
+            telemetry = OperationTelemetry(
+                operation=f"session_commit_phase2_{name}", enabled=True
+            )
+            wait_tracker = get_request_wait_tracker()
+            wait_tracker.register_request(telemetry.telemetry_id)
+            register_telemetry(telemetry)
+            try:
+                remaining = phase2_deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError("fenced Phase 2 deadline exceeded")
+                with bind_telemetry(telemetry):
+                    value = await asyncio.wait_for(fn(), timeout=remaining)
+                remaining = phase2_deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError("fenced Phase 2 deadline exceeded")
+                await wait_tracker.wait_for_request(
+                    telemetry.telemetry_id,
+                    timeout=min(
+                        _PHASE2_QUEUE_WAIT_TIMEOUT_SECONDS,
+                        remaining,
+                    )
+                )
+                return value, _token_usage(telemetry.finish("ok"))
+            finally:
+                wait_tracker.cleanup(telemetry.telemetry_id)
+                unregister_telemetry(telemetry.telemetry_id)
+
+        def _step(name: str) -> dict[str, Any]:
+            raw = steps.get(name)
+            if raw is None:
+                raw = {"state": "pending"}
+                steps[name] = raw
+            if not isinstance(raw, dict):
+                raise FailedPreconditionError(
+                    "Fenced commit step receipt is corrupt",
+                    details={"reason": "commit_phase2_manifest_corrupt"},
+                )
+            return raw
+
+        async def _planned_step(
+            name: str,
+            plan: Callable[[], Awaitable[dict[str, Any]]],
+            apply: Callable[[dict[str, Any]], Awaitable[None]],
+        ) -> dict[str, Any]:
+            receipt = _step(name)
+            state = str(receipt.get("state") or "")
+            if state == "completed":
+                output = receipt.get("output")
+                if not isinstance(output, dict):
+                    raise FailedPreconditionError(
+                        "Fenced commit step output is corrupt",
+                        details={"reason": "commit_phase2_manifest_corrupt"},
+                    )
+                return output
+            if state not in {"pending", "planned"}:
+                await _raise_ambiguous(name)
+            if state == "pending":
+                output = await plan()
+                receipt.update(
+                    {
+                        "state": "planned",
+                        "output": output,
+                        "planned_at": get_current_timestamp(),
+                    }
+                )
+                await _save_manifest()
+            else:
+                output = receipt.get("output")
+                if not isinstance(output, dict):
+                    raise FailedPreconditionError(
+                        "Fenced commit planned output is corrupt",
+                        details={"reason": "commit_phase2_manifest_corrupt"},
+                    )
+            await apply(output)
+            await _after_phase2_stage(f"{name}_applied")
+            receipt["state"] = "completed"
+            receipt["completed_at"] = get_current_timestamp()
+            await _save_manifest()
+            await _after_phase2_stage(name)
+            return output
+
+        async def _effect_step(
+            name: str,
+            execute: Callable[[], Awaitable[Any]],
+        ) -> dict[str, Any]:
+            receipt = _step(name)
+            state = str(receipt.get("state") or "")
+            if state == "completed":
+                output = receipt.get("output")
+                if not isinstance(output, dict):
+                    raise FailedPreconditionError(
+                        "Fenced commit effect output is corrupt",
+                        details={"reason": "commit_phase2_manifest_corrupt"},
+                    )
+                return output
+            if state != "pending":
+                await _raise_ambiguous(name)
+            receipt.update(
+                {"state": "started", "started_at": get_current_timestamp()}
+            )
+            await _save_manifest()
+            try:
+                raw_result, tokens = await _with_step_telemetry(name, execute)
+            except asyncio.CancelledError:
+                # Rolling shutdown must not terminalize TaskTracker or clear the
+                # redo/work rows.  The durable `started` receipt makes recovery
+                # explicit and fail-closed if the effect cannot prove completion.
+                raise
+            except Exception as exc:
+                receipt["state"] = "ambiguous"
+                receipt["error_code"] = type(exc).__name__
+                await _save_manifest()
+                await _raise_ambiguous(name, cause=exc)
+
+            if isinstance(raw_result, dict):
+                contexts = list(raw_result.get("contexts", []))
+                skills = list(raw_result.get("session_skills", []))
+            else:
+                contexts = list(raw_result or [])
+                skills = []
+            categories: dict[str, int] = {}
+            for context in contexts:
+                category = (
+                    context.get("category", "")
+                    if isinstance(context, dict)
+                    else getattr(context, "category", "")
+                )
+                key = str(category or "unknown")
+                categories[key] = categories.get(key, 0) + 1
+            skill_uris: list[str] = []
+            for skill in skills:
+                if not isinstance(skill, dict):
+                    continue
+                uri = skill.get("uri") or skill.get("root_uri")
+                if isinstance(uri, str) and uri:
+                    skill_uris.append(uri)
+            output = {
+                "memory_counts": categories,
+                "memory_total": len(contexts),
+                "session_skill_uris": sorted(set(skill_uris)),
+                "token_usage": tokens,
+            }
+            receipt.update(
+                {
+                    "state": "completed",
+                    "output": output,
+                    "completed_at": get_current_timestamp(),
+                }
+            )
+            await _save_manifest()
+            await _after_phase2_stage(name)
+            return output
+
+        async def _plan_summary() -> dict[str, Any]:
+            async def _generate() -> str:
+                return await retry_async(
+                    lambda: self._generate_archive_summary_async(
+                        extraction_messages,
+                        latest_archive_overview=latest_archive_overview,
+                    ),
+                    max_retries=_MEMORY_EXTRACTION_MAX_RETRIES,
+                    base_delay=_MEMORY_EXTRACTION_RETRY_BASE_DELAY_SECONDS,
+                    max_delay=_MEMORY_EXTRACTION_RETRY_MAX_DELAY_SECONDS,
+                    is_retryable=is_retryable_api_error,
+                    logger=logger,
+                    operation_name="fenced_archive_summary",
+                )
+
+            summary, tokens = await _with_step_telemetry("summary", _generate)
+            summary = str(summary or "")
+            abstract = self._extract_abstract_from_summary(summary) if summary else ""
+            return {
+                "summary": summary,
+                "abstract": abstract,
+                "token_usage": tokens,
+            }
+
+        async def _apply_summary(output: dict[str, Any]) -> None:
+            summary = str(output.get("summary") or "")
+            abstract = str(output.get("abstract") or "")
+            if not summary:
+                return
+            await self._viking_fs.write_file(
+                f"{archive_uri}/.abstract.md", abstract, ctx=self.ctx
+            )
+            await self._viking_fs.write_file(
+                f"{archive_uri}/.overview.md", summary, ctx=self.ctx
+            )
+            await self._viking_fs.write_file(
+                f"{archive_uri}/.meta.json",
+                json.dumps(
+                    {
+                        "overview_tokens": estimate_text_tokens(summary),
+                        "abstract_tokens": estimate_text_tokens(abstract),
+                    }
+                ),
+                ctx=self.ctx,
+            )
+
+        summary_output = await _planned_step(
+            "summary", _plan_summary, _apply_summary
+        )
+
+        ov_config = get_openviking_config()
+        effective_policy = MemoryPolicy.from_dict(manifest.get("memory_policy"))
+        extraction_scope = _resolve_memory_extraction_scope(
+            self.ctx,
+            effective_policy,
+            extraction_messages,
+            config_session_skill_extraction_enabled=(
+                ov_config.memory.session_skill_extraction_enabled
+            ),
+        )
+        long_term_types, execution_types = _split_policy_memory_types(
+            extraction_scope.memory_types
+        )
+        long_term_has_work = bool(
+            self._session_compressor
+            and ov_config.memory.extraction_enabled
+            and (
+                extraction_scope.allow_self_memory
+                or extraction_scope.allowed_peer_ids
+            )
+            and (long_term_types is None or long_term_types)
+        )
+        execution_has_work = bool(
+            self._session_compressor
+            and ov_config.memory.extraction_enabled
+            and extraction_scope.allow_self_memory
+            and (execution_types is None or execution_types)
+            and hasattr(self._session_compressor, "extract_execution_memories")
+        )
+
+        async def _empty_plan() -> dict[str, Any]:
+            return {
+                "memory_counts": {},
+                "memory_total": 0,
+                "session_skill_uris": [],
+                "token_usage": {
+                    "llm": {
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "total_tokens": 0,
+                        "cached_tokens": 0,
+                        "reasoning_tokens": 0,
+                    },
+                    "embedding": {"total_tokens": 0},
+                },
+            }
+
+        async def _noop(_output: dict[str, Any]) -> None:
+            return None
+
+        if long_term_has_work:
+
+            async def _extract_long_term() -> Any:
+                return await self._session_compressor.extract_long_term_memories(
+                    messages=extraction_messages,
+                    user=self.user,
+                    session_id=self.session_id,
+                    ctx=self.ctx,
+                    strict_extract_errors=True,
+                    latest_archive_overview=latest_archive_overview,
+                    archive_uri=archive_uri,
+                    allowed_memory_types=long_term_types,
+                    allow_self_memory=extraction_scope.allow_self_memory,
+                    allowed_peer_ids=extraction_scope.allowed_peer_ids,
+                )
+
+            long_term_output = await _effect_step("long_term", _extract_long_term)
+        else:
+            long_term_output = await _planned_step(
+                "long_term", _empty_plan, _noop
+            )
+
+        if execution_has_work:
+
+            async def _extract_execution() -> Any:
+                return await self._session_compressor.extract_execution_memories(
+                    messages=extraction_messages,
+                    ctx=self.ctx,
+                    strict_extract_errors=True,
+                    latest_archive_overview=latest_archive_overview,
+                    archive_uri=archive_uri,
+                    allowed_memory_types=execution_types,
+                    include_session_skills=(
+                        extraction_scope.include_session_skills
+                    ),
+                )
+
+            execution_output = await _effect_step(
+                "execution", _extract_execution
+            )
+        else:
+            execution_output = await _planned_step(
+                "execution", _empty_plan, _noop
+            )
+
+        async def _plan_relations() -> dict[str, Any]:
+            uris = sorted({usage.uri for usage in usage_records if usage.uri})
+            return {
+                "links": [
+                    {
+                        "uri": uri,
+                        "link_id": "fenced_"
+                        + hashlib.sha256(
+                            f"{operation_id}\x1f{uri}".encode("utf-8")
+                        ).hexdigest()[:48],
+                    }
+                    for uri in uris
+                ]
+            }
+
+        async def _apply_relations(output: dict[str, Any]) -> None:
+            for link in output.get("links", []):
+                await self._viking_fs.link_deterministic(
+                    self._session_uri,
+                    str(link["uri"]),
+                    link_id=str(link["link_id"]),
+                    reason="fenced-session-commit",
+                    ctx=self.ctx,
+                )
+                await _after_phase2_stage("relation_link")
+
+        relation_output = await _planned_step(
+            "relations", _plan_relations, _apply_relations
+        )
+
+        async def _plan_active_count() -> dict[str, Any]:
+            if not self._vikingdb_manager:
+                return {"targets": [], "logical_updated": 0}
+            targets = await self._vikingdb_manager.plan_active_count_targets(
+                self.ctx,
+                [
+                    str(link["uri"])
+                    for link in relation_output.get("links", [])
+                ],
+            )
+            return {"targets": targets, "logical_updated": len(targets)}
+
+        async def _apply_active_count(output: dict[str, Any]) -> None:
+            if self._vikingdb_manager:
+                await self._vikingdb_manager.ensure_active_count_targets(
+                    self.ctx,
+                    list(output.get("targets", [])),
+                )
+
+        active_output = await _planned_step(
+            "active_count", _plan_active_count, _apply_active_count
+        )
+
+        extraction_outputs = [
+            summary_output,
+            long_term_output,
+            execution_output,
+        ]
+        memory_counts: dict[str, int] = {}
+        skill_uris: set[str] = set()
+        llm_contribution = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "cached_tokens": 0,
+            "reasoning_tokens": 0,
+        }
+        embedding_contribution = {"total_tokens": 0}
+        for output in extraction_outputs:
+            for category, count in output.get("memory_counts", {}).items():
+                memory_counts[str(category)] = memory_counts.get(
+                    str(category), 0
+                ) + int(count or 0)
+            skill_uris.update(str(uri) for uri in output.get("session_skill_uris", []))
+            token_usage = output.get("token_usage", {})
+            for key in llm_contribution:
+                llm_contribution[key] += int(
+                    token_usage.get("llm", {}).get(key, 0) or 0
+                )
+            embedding_contribution["total_tokens"] += int(
+                token_usage.get("embedding", {}).get("total_tokens", 0) or 0
+            )
+
+        async def _plan_meta() -> dict[str, Any]:
+            latest = SessionMeta.from_dict(
+                json.loads(
+                    await self._viking_fs.read_file(
+                        f"{self._session_uri}/.meta.json", ctx=self.ctx
+                    )
+                )
+            )
+            target_memories = dict(latest.memories_extracted)
+            for category, count in memory_counts.items():
+                target_memories[category] = int(
+                    target_memories.get(category, 0) or 0
+                ) + count
+            target_memories["total"] = int(
+                target_memories.get("total", 0) or 0
+            ) + sum(memory_counts.values())
+            return {
+                "archive_index": int(manifest["archive_index"]),
+                "last_commit_at": str(manifest["last_commit_at_target"]),
+                "message_count": await self._read_live_message_count(strict=True),
+                "memories_extracted": target_memories,
+                "llm_token_usage": {
+                    key: int(latest.llm_token_usage.get(key, 0) or 0)
+                    + llm_contribution[key]
+                    for key in llm_contribution
+                },
+                "embedding_token_usage": {
+                    "total_tokens": int(
+                        latest.embedding_token_usage.get("total_tokens", 0) or 0
+                    )
+                    + embedding_contribution["total_tokens"]
+                },
+            }
+
+        async def _apply_meta(output: dict[str, Any]) -> None:
+            session_path = self._viking_fs._uri_to_path(
+                self._session_uri, ctx=self.ctx
+            )
+            async with LockContext(
+                get_lock_manager(), [session_path], lock_mode="exact"
+            ):
+                latest = SessionMeta.from_dict(
+                    json.loads(
+                        await self._viking_fs.read_file(
+                            f"{self._session_uri}/.meta.json", ctx=self.ctx
+                        )
+                    )
+                )
+                latest.commit_count = max(
+                    latest.commit_count, int(output["archive_index"])
+                )
+                for category, target in output["memories_extracted"].items():
+                    latest.memories_extracted[str(category)] = max(
+                        int(
+                            latest.memories_extracted.get(
+                                str(category), 0
+                            )
+                            or 0
+                        ),
+                        int(target or 0),
+                    )
+                for key, target in output["llm_token_usage"].items():
+                    latest.llm_token_usage[str(key)] = max(
+                        int(latest.llm_token_usage.get(str(key), 0) or 0),
+                        int(target or 0),
+                    )
+                latest.embedding_token_usage["total_tokens"] = max(
+                    int(
+                        latest.embedding_token_usage.get("total_tokens", 0)
+                        or 0
+                    ),
+                    int(output["embedding_token_usage"]["total_tokens"] or 0),
+                )
+                latest.last_commit_at = max(
+                    str(latest.last_commit_at or ""),
+                    str(output["last_commit_at"]),
+                )
+                # Recompute inside the same short session lock instead of
+                # applying the stale count captured while planning the receipt.
+                latest.message_count = await self._read_live_message_count(strict=True)
+                self._meta = latest
+                await self._save_meta()
+
+        await _planned_step("meta", _plan_meta, _apply_meta)
+
+        memory_diff_uri: Optional[str] = None
+        candidate_diff = f"{archive_uri}/memory_diff.json"
+        try:
+            await self._viking_fs.read_file(candidate_diff, ctx=self.ctx)
+        except Exception as exc:
+            if not is_not_found_error(exc):
+                raise
+        else:
+            memory_diff_uri = candidate_diff
+        result_payload: dict[str, Any] = {
+            "session_id": self.session_id,
+            "archive_uri": archive_uri,
+            "memories_extracted": memory_counts,
+            "session_skills_extracted": len(skill_uris),
+            "session_skill_uris": sorted(skill_uris),
+            "active_count_updated": int(
+                active_output.get("logical_updated", 0) or 0
+            ),
+            "token_usage": {
+                "llm": dict(self._meta.llm_token_usage),
+                "embedding": dict(self._meta.embedding_token_usage),
+                "total": {
+                    "total_tokens": self._meta.llm_token_usage["total_tokens"]
+                    + self._meta.embedding_token_usage["total_tokens"],
+                    "cached_tokens": self._meta.llm_token_usage["cached_tokens"],
+                    "reasoning_tokens": self._meta.llm_token_usage[
+                        "reasoning_tokens"
+                    ],
+                },
+            },
+        }
+        if memory_diff_uri:
+            result_payload["memory_diff_uri"] = memory_diff_uri
+
+        # Persist the result before .done.  If the process dies immediately
+        # after .done, the next worker can reconcile TaskTracker without
+        # repeating any Phase 2 effect.
+        phase2["state"] = "finalizing"
+        phase2["result"] = result_payload
+        await _save_manifest()
+        await self._write_done_file(
+            archive_uri, first_message_id, last_message_id
+        )
+        await _after_phase2_stage("done")
+        await tracker.complete(
+            task_id,
+            result_payload,
+            account_id=self.ctx.account_id,
+            user_id=self.ctx.user.user_id,
+        )
+        await redo_log.mark_done_async(task_id)
+        await _prune_terminal_manifest()
+        logger.info("Fenced session %s phase2 completed", self.session_id)
+        return "completed"
+
     @tracer("session.commit.phase2", ignore_result=True, ignore_args=True)
     async def _run_memory_extraction(
         self,
@@ -1257,6 +2520,8 @@ class Session:
         first_message_id: str,
         last_message_id: str,
         memory_policy: Optional[Dict[str, Any]],
+        wait_for_previous: bool = True,
+        task_already_started: bool = False,
     ) -> None:
         """Phase 2: Extract memories, write relations, enqueue — runs in background."""
         import uuid
@@ -1281,13 +2546,15 @@ class Session:
         redo_log = lock_manager.redo_log
 
         try:
-            await self._wait_for_previous_archive_done(archive_index)
+            if wait_for_previous:
+                await self._wait_for_previous_archive_done(archive_index)
 
-            await tracker.start(
-                task_id,
-                account_id=self.ctx.account_id,
-                user_id=self.ctx.user.user_id,
-            )
+            if not task_already_started:
+                await tracker.start(
+                    task_id,
+                    account_id=self.ctx.account_id,
+                    user_id=self.ctx.user.user_id,
+                )
             request_wait_tracker.register_request(telemetry.telemetry_id)
             register_telemetry(telemetry)
             try:
@@ -1875,14 +3142,20 @@ class Session:
             "messages": await self._get_pending_archive_messages() + list(self._messages),
         }
 
-    async def _list_archive_refs(self) -> List[Dict[str, Any]]:
+    async def _list_archive_refs(
+        self, *, strict: bool = False
+    ) -> List[Dict[str, Any]]:
         """List archive refs sorted by archive index descending."""
-        if not self._viking_fs or self.compression.compression_index <= 0:
+        if not self._viking_fs:
+            return []
+        if not strict and self.compression.compression_index <= 0:
             return []
 
         try:
             history_items = await self._viking_fs.ls(f"{self._session_uri}/history", ctx=self.ctx)
-        except Exception:
+        except Exception as exc:
+            if strict and not is_not_found_error(exc):
+                raise
             return []
 
         refs: List[Dict[str, Any]] = []
@@ -1908,45 +3181,69 @@ class Session:
     async def _get_completed_archive_refs(
         self,
         exclude_archive_uri: Optional[str] = None,
+        *,
+        strict: bool = False,
     ) -> List[Dict[str, Any]]:
         """Return completed archive refs sorted by archive index descending."""
         completed: List[Dict[str, Any]] = []
         exclude = exclude_archive_uri.rstrip("/") if exclude_archive_uri else None
 
-        for archive in await self._list_archive_refs():
+        for archive in await self._list_archive_refs(strict=strict):
             if exclude and archive["archive_uri"] == exclude:
                 continue
             try:
                 await self._viking_fs.read_file(f"{archive['archive_uri']}/.done", ctx=self.ctx)
-            except Exception:
+            except Exception as exc:
+                if strict and not is_not_found_error(exc):
+                    raise
                 continue
             completed.append(archive)
 
         return completed
 
-    async def _read_archive_overview(self, archive_uri: str) -> str:
+    async def _read_archive_overview(
+        self, archive_uri: str, *, strict: bool = False
+    ) -> str:
         """Read archive overview text."""
         try:
             overview = await self._viking_fs.read_file(f"{archive_uri}/.overview.md", ctx=self.ctx)
-        except Exception:
+        except Exception as exc:
+            if strict and not is_not_found_error(exc):
+                raise
             return ""
         return overview or ""
 
-    async def _read_archive_abstract(self, archive_uri: str, overview: str = "") -> str:
+    async def _read_archive_abstract(
+        self,
+        archive_uri: str,
+        overview: str = "",
+        *,
+        strict: bool = False,
+    ) -> str:
         """Read archive abstract text, falling back to summary extraction."""
         try:
             abstract = await self._viking_fs.read_file(f"{archive_uri}/.abstract.md", ctx=self.ctx)
-        except Exception:
+        except Exception as exc:
+            if strict and not is_not_found_error(exc):
+                raise
             abstract = ""
 
         if abstract:
             return abstract
 
         if not overview:
-            overview = await self._read_archive_overview(archive_uri)
+            overview = await self._read_archive_overview(
+                archive_uri, strict=strict
+            )
         return self._extract_abstract_from_summary(overview)
 
-    async def _read_archive_overview_tokens(self, archive_uri: str, overview: str) -> int:
+    async def _read_archive_overview_tokens(
+        self,
+        archive_uri: str,
+        overview: str,
+        *,
+        strict: bool = False,
+    ) -> int:
         """Read overview token estimate from archive metadata."""
         overview_tokens = estimate_text_tokens(overview)
         try:
@@ -1955,8 +3252,9 @@ class Session:
             )
             meta_tokens = int(json.loads(meta_content).get("overview_tokens", overview_tokens))
             overview_tokens = max(overview_tokens, meta_tokens)
-        except Exception:
-            pass
+        except Exception as exc:
+            if strict and not is_not_found_error(exc):
+                raise
         return overview_tokens
 
     async def _read_archive_messages(self, archive_uri: str) -> List[Message]:
@@ -1980,10 +3278,16 @@ class Session:
     async def _get_latest_completed_archive_summary(
         self,
         exclude_archive_uri: Optional[str] = None,
+        *,
+        strict: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Return the newest readable completed archive summary."""
-        for archive in await self._get_completed_archive_refs(exclude_archive_uri):
-            overview = await self._read_archive_overview(archive["archive_uri"])
+        for archive in await self._get_completed_archive_refs(
+            exclude_archive_uri, strict=strict
+        ):
+            overview = await self._read_archive_overview(
+                archive["archive_uri"], strict=strict
+            )
             if not overview:
                 continue
 
@@ -1991,9 +3295,11 @@ class Session:
                 "archive_id": archive["archive_id"],
                 "archive_uri": archive["archive_uri"],
                 "overview": overview,
-                "abstract": await self._read_archive_abstract(archive["archive_uri"], overview),
+                "abstract": await self._read_archive_abstract(
+                    archive["archive_uri"], overview, strict=strict
+                ),
                 "overview_tokens": await self._read_archive_overview_tokens(
-                    archive["archive_uri"], overview
+                    archive["archive_uri"], overview, strict=strict
                 ),
             }
 
@@ -2002,9 +3308,13 @@ class Session:
     async def _get_latest_completed_archive_overview(
         self,
         exclude_archive_uri: Optional[str] = None,
+        *,
+        strict: bool = False,
     ) -> str:
         """Return the newest completed archive overview, skipping incomplete archives."""
-        summary = await self._get_latest_completed_archive_summary(exclude_archive_uri)
+        summary = await self._get_latest_completed_archive_summary(
+            exclude_archive_uri, strict=strict
+        )
         return summary["overview"] if summary else ""
 
     async def _get_pending_archive_messages(self) -> List[Message]:
@@ -2074,6 +3384,33 @@ class Session:
 
             await asyncio.sleep(_ARCHIVE_WAIT_POLL_SECONDS)
 
+    async def _wait_for_archive_uri_terminal(self, archive_uri: str) -> bool:
+        """Wait for the exact predecessor recorded by a fenced manifest."""
+        if not self._viking_fs or not archive_uri:
+            return True
+        while True:
+            try:
+                await self._viking_fs.read_file(
+                    f"{archive_uri}/.done", ctx=self.ctx
+                )
+                return True
+            except Exception as exc:
+                if not is_not_found_error(exc):
+                    raise
+            try:
+                await self._viking_fs.read_file(
+                    f"{archive_uri}/.failed.json", ctx=self.ctx
+                )
+                logger.info(
+                    "Recorded predecessor archive %s failed; continuing",
+                    archive_uri,
+                )
+                return True
+            except Exception as exc:
+                if not is_not_found_error(exc):
+                    raise
+            await asyncio.sleep(_ARCHIVE_WAIT_POLL_SECONDS)
+
     async def _merge_and_save_commit_meta(
         self,
         archive_index: int,
@@ -2112,7 +3449,7 @@ class Session:
         self._meta = latest_meta
         await self._save_meta()
 
-    async def _read_live_message_count(self) -> int:
+    async def _read_live_message_count(self, *, strict: bool = False) -> int:
         """Count current live session messages from persisted storage."""
         if not self._viking_fs:
             return len(self._messages)
@@ -2121,7 +3458,11 @@ class Session:
                 f"{self._session_uri}/messages.jsonl",
                 ctx=self.ctx,
             )
-        except Exception:
+        except Exception as exc:
+            if strict and not is_not_found_error(exc):
+                raise
+            if strict:
+                return 0
             return len(self._messages)
         return len([line for line in content.strip().split("\n") if line.strip()])
 

--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -448,6 +448,16 @@ class LockManager:
             logger.info(f"Recovering pending redo task: {task_id}")
             try:
                 info = await self._redo_log.read_async(task_id)
+                if info.get("fenced_operation_id"):
+                    # Alice fenced commits are recovered by the PostgreSQL
+                    # commit-work outbox, which also holds the authoritative
+                    # per-session advisory lock.  Generic archive replay here
+                    # could race that writer and duplicate model side effects.
+                    logger.info(
+                        "Leaving fenced redo task %s for durable commit worker",
+                        task_id,
+                    )
+                    continue
                 if info:
                     await self._redo_session_memory(info)
                 await self._redo_log.mark_done_async(task_id)

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -2056,6 +2056,43 @@ class VikingFS:
         await self._write_relation_table(from_path, entries, ctx=ctx)
         logger.debug(f"[VikingFS] Created link: {from_uri} -> {uris}")
 
+    async def link_deterministic(
+        self,
+        from_uri: str,
+        uris: Union[str, List[str]],
+        *,
+        link_id: str,
+        reason: str = "",
+        ctx: Optional[RequestContext] = None,
+    ) -> None:
+        """Create an operation-addressed relation that is safe to replay."""
+        if isinstance(uris, str):
+            uris = [uris]
+        normalized_uris = list(dict.fromkeys(uris))
+        if not link_id or len(link_id) > 128:
+            raise ValueError("Deterministic relation link_id is invalid")
+        self._ensure_mutable_access(from_uri, ctx)
+        for uri in normalized_uris:
+            self._ensure_access(uri, ctx)
+
+        from_path = self._uri_to_path(from_uri, ctx=ctx)
+        entries = await self._read_relation_table(from_path, ctx=ctx, strict=True)
+        for entry in entries:
+            if entry.id != link_id:
+                continue
+            if entry.uris != normalized_uris or entry.reason != reason:
+                raise ValueError("Deterministic relation ID content conflict")
+            return
+        entries.append(
+            RelationEntry(id=link_id, uris=normalized_uris, reason=reason)
+        )
+        await self._write_relation_table(from_path, entries, ctx=ctx)
+        logger.debug(
+            "[VikingFS] Created deterministic link: %s -> %s",
+            from_uri,
+            normalized_uris,
+        )
+
     async def unlink(
         self,
         from_uri: str,
@@ -2871,16 +2908,22 @@ class VikingFS:
     # ========== Relation Table Internal Methods ==========
 
     async def _read_relation_table(
-        self, dir_path: str, ctx: Optional[RequestContext] = None
+        self,
+        dir_path: str,
+        ctx: Optional[RequestContext] = None,
+        *,
+        strict: bool = False,
     ) -> List[RelationEntry]:
         """Read .relations.json."""
         table_path = f"{dir_path}/.relations.json"
         try:
             content = self._handle_agfs_read(await self._async_agfs.read(table_path))
             data = json.loads(content.decode("utf-8"))
-        except FileNotFoundError:
-            return []
-        except Exception:
+        except Exception as exc:
+            if is_not_found_error(exc):
+                return []
+            if strict:
+                raise
             # logger.warning(f"[VikingFS] Failed to read relation table {table_path}: {e}")
             return []
 
@@ -3000,8 +3043,13 @@ class VikingFS:
                 raw = b""
 
             text = self._decode_bytes(raw)
-        except Exception:
-            raise NotFoundError(uri, "file")
+        except Exception as exc:
+            # A backend timeout/connection failure after a successful stat is
+            # not absence.  Collapsing it to NotFound lets fencing/task callers
+            # recreate durable state and can duplicate external effects.
+            if is_not_found_error(exc):
+                raise NotFoundError(uri, "file") from exc
+            raise
 
         if offset == 0 and limit == -1:
             return text

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -362,6 +362,17 @@ class _SingleAccountBackend:
             logger.error("Error getting records: %s", e)
             return []
 
+    async def get_strict(self, ids: List[str]) -> List[Dict[str, Any]]:
+        """Read records without converting backend failures into an empty set."""
+        records = await self._async_adapter.call("get", ids)
+        if self._bound_account_id:
+            records = [
+                record
+                for record in records
+                if record.get("account_id") == self._bound_account_id
+            ]
+        return records
+
     async def delete(self, ids: List[str]) -> int:
         try:
             if self._bound_account_id:
@@ -445,6 +456,38 @@ class _SingleAccountBackend:
         except Exception as e:
             logger.error("Error querying collection: %s", e, exc_info=True)
             return []
+
+    async def query_strict(
+        self,
+        query_vector: Optional[List[float]] = None,
+        sparse_query_vector: Optional[Dict[str, float]] = None,
+        filter: Optional[Dict[str, Any] | FilterExpr] = None,
+        limit: int = 10,
+        offset: int = 0,
+        output_fields: Optional[List[str]] = None,
+        order_by: Optional[str] = None,
+        order_desc: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Query without fail-open empty results."""
+        if self._bound_account_id:
+            account_filter = Eq("account_id", self._bound_account_id)
+            if filter:
+                if isinstance(filter, dict):
+                    filter = RawDSL(filter)
+                filter = And([account_filter, filter])
+            else:
+                filter = account_filter
+        return await self._async_adapter.call(
+            "query",
+            query_vector=query_vector,
+            sparse_query_vector=sparse_query_vector,
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            output_fields=output_fields,
+            order_by=order_by,
+            order_desc=order_desc,
+        )
 
     async def search(
         self,
@@ -796,6 +839,27 @@ class VikingVectorIndexBackend:
     async def get(self, ids: List[str], *, ctx: RequestContext) -> List[Dict[str, Any]]:
         backend = self._get_backend_for_context(ctx)
         return await backend.get(ids)
+
+    async def get_strict(
+        self,
+        ids: List[str],
+        *,
+        ctx: RequestContext,
+    ) -> List[Dict[str, Any]]:
+        backend = self._get_backend_for_context(ctx)
+        return await backend.get_strict(ids)
+
+    async def upsert_strict(
+        self,
+        data: Dict[str, Any],
+        *,
+        ctx: RequestContext,
+    ) -> str:
+        backend = self._get_backend_for_context(ctx)
+        result = await backend.upsert(data, partial_update=False)
+        if not result:
+            raise RuntimeError("Strict vector upsert returned no record ID")
+        return result
 
     async def delete(self, ids: List[str], *, ctx: RequestContext) -> int:
         backend = self._get_backend_for_context(ctx)
@@ -1183,6 +1247,29 @@ class VikingVectorIndexBackend:
             output_fields=LOOKUP_OUTPUT_FIELDS,
         )
 
+    async def get_context_by_uri_strict(
+        self,
+        uri: str,
+        owner_space: Optional[str] = None,
+        level: Optional[int] = None,
+        limit: int = 1,
+        *,
+        ctx: RequestContext,
+    ) -> List[Dict[str, Any]]:
+        del owner_space
+        conds: List[FilterExpr] = [
+            PathScope("uri", canonicalize_uri(uri, ctx), depth=0),
+            Eq("account_id", ctx.account_id),
+        ]
+        if level is not None:
+            conds.append(Eq("level", level))
+        backend = self._get_backend_for_context(ctx)
+        return await backend.query_strict(
+            filter=And(conds),
+            limit=limit,
+            output_fields=LOOKUP_OUTPUT_FIELDS,
+        )
+
     async def delete_account_data(self, account_id: str, *, ctx: RequestContext) -> int:
         """删除指定 account 的所有数据（仅限，root 角色操作）"""
         self._check_root_role(ctx)
@@ -1311,6 +1398,86 @@ class VikingVectorIndexBackend:
                 if result:
                     uri_updated = True
             if uri_updated:
+                updated += 1
+        return updated
+
+    async def plan_active_count_targets(
+        self,
+        ctx: RequestContext,
+        uris: List[str],
+    ) -> List[Dict[str, Any]]:
+        """Plan absolute active-count targets before a fenced effect.
+
+        The returned records are persisted in the fenced Phase 2 manifest
+        before any vector upsert.  Recovery can therefore apply ``max(current,
+        target)`` instead of repeating ``+1`` after a lost response.
+        """
+        targets: List[Dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        for uri in dict.fromkeys(uris):
+            records = await self.get_context_by_uri_strict(
+                uri=uri,
+                limit=100,
+                ctx=ctx,
+            )
+            record_ids = [
+                str(record["id"])
+                for record in records
+                if record.get("id") and str(record["id"]) not in seen_ids
+            ]
+            if not record_ids:
+                continue
+            for record in await self.get_strict(record_ids, ctx=ctx):
+                record_id = str(record.get("id") or "")
+                if not record_id or record_id in seen_ids:
+                    continue
+                seen_ids.add(record_id)
+                targets.append(
+                    {
+                        "id": record_id,
+                        "uri": str(record.get("uri") or uri),
+                        "target": int(record.get("active_count", 0) or 0) + 1,
+                    }
+                )
+        return targets
+
+    async def ensure_active_count_targets(
+        self,
+        ctx: RequestContext,
+        targets: List[Dict[str, Any]],
+    ) -> int:
+        """Idempotently raise active counts to durable absolute targets."""
+        target_by_id: Dict[str, int] = {}
+        for target in targets:
+            record_id = str(target.get("id") or "")
+            if not record_id:
+                continue
+            target_by_id[record_id] = max(
+                target_by_id.get(record_id, 0),
+                max(0, int(target.get("target", 0) or 0)),
+            )
+        if not target_by_id:
+            return 0
+
+        updated = 0
+        records = await self.get_strict(list(target_by_id), ctx=ctx)
+        records_by_id = {
+            str(record.get("id") or ""): record for record in records
+        }
+        missing_ids = set(target_by_id) - set(records_by_id)
+        if missing_ids:
+            raise RuntimeError("Strict active-count target record disappeared")
+        for record_id, record in records_by_id.items():
+            target = target_by_id.get(record_id)
+            if target is None:
+                continue
+            current = int(record.get("active_count", 0) or 0)
+            if current >= target:
+                continue
+            if await self.upsert_strict(
+                record | {"active_count": target},
+                ctx=ctx,
+            ):
                 updated += 1
         return updated
 

--- a/openviking/storage/vikingdb_manager.py
+++ b/openviking/storage/vikingdb_manager.py
@@ -490,3 +490,19 @@ class VikingDBManagerProxy:
 
     async def increment_active_count(self, uris: List[str]) -> int:
         return await self._manager.increment_active_count(self._ctx, uris)
+
+    async def plan_active_count_targets(
+        self,
+        ctx: RequestContext,
+        uris: List[str],
+    ) -> List[Dict[str, Any]]:
+        del ctx
+        return await self._manager.plan_active_count_targets(self._ctx, uris)
+
+    async def ensure_active_count_targets(
+        self,
+        ctx: RequestContext,
+        targets: List[Dict[str, Any]],
+    ) -> int:
+        del ctx
+        return await self._manager.ensure_active_count_targets(self._ctx, targets)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,9 @@ test = [
 opengauss = [
     "psycopg2-binary>=2.9",
 ]
+alice-fencing = [
+    "psycopg2-binary>=2.9",
+]
 dev = [
     "mypy>=1.0.0",
     "ruff>=0.1.0",

--- a/tests/metrics/collectors/test_event_collectors.py
+++ b/tests/metrics/collectors/test_event_collectors.py
@@ -72,6 +72,56 @@ def test_session_collector_records_lifecycle_and_contexts_and_archive(registry, 
     assert 'openviking_session_archive_total{account_id="__unknown__",status="ok"} 1' in text
 
 
+def test_session_collector_records_v2_fenced_effect(
+    monkeypatch, registry, render_prometheus
+):
+    monkeypatch.setattr(
+        "openviking.metrics.collectors.session.time.time", lambda: 1234.5
+    )
+    collector = SessionCollector()
+    collector.receive(
+        "session.fenced_effect",
+        {"operation": "message", "outcome": "completed"},
+        registry,
+    )
+
+    text = render_prometheus(registry)
+    assert (
+        'openviking_fenced_effects_total{operation="message",outcome="completed"} 1'
+        in text
+    )
+    assert (
+        "openviking_fenced_effect_last_event_timestamp_seconds"
+        '{operation="message",outcome="completed"} 1234.5'
+        in text
+    )
+
+
+def test_session_collector_records_fencing_last_event_timestamp(
+    monkeypatch, registry, render_prometheus
+):
+    monkeypatch.setattr(
+        "openviking.metrics.collectors.session.time.time", lambda: 2345.5
+    )
+    collector = SessionCollector()
+    collector.receive(
+        "session.fencing",
+        {
+            "operation": "message",
+            "outcome": "stale",
+            "latency_seconds": 0.01,
+        },
+        registry,
+    )
+
+    text = render_prometheus(registry)
+    assert (
+        "openviking_session_fencing_last_event_timestamp_seconds"
+        '{operation="message",outcome="stale"} 2345.5'
+        in text
+    )
+
+
 def test_session_collector_ignores_malformed_payloads_instead_of_raising(
     registry, render_prometheus
 ):

--- a/tests/metrics/collectors/test_state_collectors.py
+++ b/tests/metrics/collectors/test_state_collectors.py
@@ -8,6 +8,7 @@ import time
 from openviking.metrics.collectors.lock import LockCollector
 from openviking.metrics.collectors.observer_health import ObserverHealthCollector
 from openviking.metrics.collectors.queue import QueueCollector
+from openviking.metrics.collectors.session import FencedBacklogCollector
 from openviking.metrics.collectors.task_tracker import TaskTrackerCollector
 from openviking.metrics.collectors.vikingdb import VikingDBCollector
 from openviking.metrics.core.registry import MetricRegistry
@@ -19,6 +20,63 @@ from openviking.metrics.datasources.observer_state import (
 from openviking.metrics.datasources.queue import QueuePipelineStateDataSource
 from openviking.metrics.datasources.task import TaskStateDataSource
 from openviking.metrics.exporters.prometheus import PrometheusExporter
+
+
+def test_fenced_backlog_collector_exports_bounded_states_and_health():
+    class DS:
+        def read_backlog(self):
+            return {
+                "writer_healthy": True,
+                "effect_concurrency": 2,
+                "commit_concurrency": 3,
+                "effect": {
+                    "queued": {"items": 4, "oldest_age_seconds": 12.5},
+                    "running": {"items": 1, "oldest_age_seconds": 2.0},
+                },
+                "commit": {
+                    "pending": {"items": 3, "oldest_age_seconds": 8.0},
+                    "running": {"items": 2, "oldest_age_seconds": 4.0},
+                    "ambiguous": {"items": 1, "oldest_age_seconds": 20.0},
+                },
+            }
+
+    registry = MetricRegistry()
+    FencedBacklogCollector(data_source=DS()).collect(registry)
+    text = PrometheusExporter(registry=registry).render()
+    assert "openviking_fenced_writer_pool_healthy 1.0" in text
+    assert 'openviking_fenced_writer_concurrency{kind="effect"} 2.0' in text
+    assert 'openviking_fenced_effect_outbox_items{state="queued"} 4.0' in text
+    assert (
+        'openviking_fenced_effect_outbox_oldest_age_seconds{state="queued"} 12.5'
+        in text
+    )
+    assert 'openviking_fenced_commit_work_items{state="ambiguous"} 1.0' in text
+    assert (
+        'openviking_fenced_commit_work_oldest_age_seconds{state="ambiguous"} 20.0'
+        in text
+    )
+
+
+def test_fenced_backlog_collection_failure_is_visible(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.metrics.collectors.session.time.time", lambda: 3456.5
+    )
+    class DS:
+        def read_backlog(self):
+            raise RuntimeError("database down")
+
+    registry = MetricRegistry()
+    collector = FencedBacklogCollector(data_source=DS())
+    collector.collect(registry)
+    collector.collect(registry)
+    text = PrometheusExporter(registry=registry).render()
+    assert "openviking_fenced_writer_pool_healthy 0.0" in text
+    assert "openviking_fenced_backlog_collection_errors_total 2" in text
+    assert (
+        "openviking_fenced_backlog_collection_last_error_timestamp_seconds "
+        "3456.5"
+        in text
+    )
 
 
 def test_queue_collector_maps_status(monkeypatch):

--- a/tests/metrics/integration/test_bootstrap.py
+++ b/tests/metrics/integration/test_bootstrap.py
@@ -25,6 +25,7 @@ def test_create_default_collector_manager_registers_expected_collectors_in_order
     names = [type(c).__name__ for c in manager._collectors]
     assert names == [
         "QueueCollector",
+        "FencedBacklogCollector",
         "TaskTrackerCollector",
         "ObserverHealthCollector",
         "ObserverStateCollector",
@@ -55,6 +56,7 @@ def test_create_default_collector_manager_registers_feedback_collector_when_bot_
     names = [type(c).__name__ for c in manager._collectors]
     assert names == [
         "QueueCollector",
+        "FencedBacklogCollector",
         "TaskTrackerCollector",
         "FeedbackCollector",
         "ObserverHealthCollector",

--- a/tests/server/test_fenced_phase2.py
+++ b/tests/server/test_fenced_phase2.py
@@ -1,0 +1,551 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Crash/recovery tests for the durable fenced commit Phase 2 state machine."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openviking.message.part import TextPart
+from openviking.server.identity import RequestContext, Role
+from openviking.session import session as session_module
+from openviking_cli.exceptions import FailedPreconditionError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _AbsoluteActiveCount:
+    def __init__(self) -> None:
+        self.value = 0
+        self.apply_calls = 0
+        self.fail_plan = False
+        self.fail_apply = False
+
+    async def plan_active_count_targets(
+        self,
+        _ctx: RequestContext,
+        uris: list[str],
+    ) -> list[dict[str, Any]]:
+        if self.fail_plan:
+            raise TimeoutError("active-count plan unavailable")
+        if not uris:
+            return []
+        return [{"id": "context-1", "uri": uris[0], "target": self.value + 1}]
+
+    async def ensure_active_count_targets(
+        self,
+        _ctx: RequestContext,
+        targets: list[dict[str, Any]],
+    ) -> int:
+        self.apply_calls += 1
+        if self.fail_apply:
+            raise TimeoutError("active-count apply unavailable")
+        for target in targets:
+            self.value = max(self.value, int(target["target"]))
+        return len(targets)
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier.the_default_user("test_user"),
+        role=Role.ROOT,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "crash_stage",
+    [
+        "long_term",
+        "execution",
+        "relation_link",
+        "relations_applied",
+        "active_count_applied",
+        "active_count",
+        "meta_applied",
+        "meta",
+        "done",
+    ],
+)
+async def test_phase2_durable_receipts_do_not_duplicate_after_crash(
+    service,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_stage: str,
+) -> None:
+    config = SimpleNamespace(
+        memory=SimpleNamespace(
+            extraction_enabled=True,
+            session_skill_extraction_enabled=True,
+        )
+    )
+    monkeypatch.setattr(session_module, "get_openviking_config", lambda: config)
+
+    async def summary(*_args: Any, **_kwargs: Any) -> str:
+        return "# Stable summary\n\nDurable output"
+
+    effects = {"long_term": 0, "execution": 0}
+    memory_uris: set[str] = set()
+
+    async def long_term(**_kwargs: Any) -> dict[str, Any]:
+        effects["long_term"] += 1
+        memory_uris.add("viking://user/memories/profile/fixed")
+        return {"contexts": [SimpleNamespace(category="profile")]}
+
+    async def execution(**_kwargs: Any) -> dict[str, Any]:
+        effects["execution"] += 1
+        memory_uris.add("viking://user/memories/preferences/fixed")
+        return {
+            "contexts": [SimpleNamespace(category="preferences")],
+            "session_skills": [{"uri": "viking://agent/skills/fixed"}],
+        }
+
+    compressor = service.sessions._session_compressor
+    monkeypatch.setattr(compressor, "extract_long_term_memories", long_term)
+    monkeypatch.setattr(compressor, "extract_execution_memories", execution)
+    monkeypatch.setattr(
+        session_module.Session,
+        "_generate_archive_summary_async",
+        summary,
+    )
+    active = _AbsoluteActiveCount()
+    monkeypatch.setattr(service.sessions, "_vikingdb", active)
+
+    session_id = f"alice_{hashlib.sha256(crash_stage.encode()).hexdigest()[:48]}"
+    session = await service.sessions.create(_ctx(), session_id)
+    session.add_message("user", [TextPart("archive exactly once")])
+    session.used(
+        contexts=["viking://resources/catalog.md"],
+        operation_id="used-1",
+    )
+    operation_id = f"phase2-{crash_stage}"
+    phase1 = await session.commit_async(
+        keep_recent_count=0,
+        operation_id=operation_id,
+        operation_sequence_id=1,
+    )
+    assert phase1["archived"] is True
+
+    crashed = False
+
+    async def crash_after_receipt(stage: str, _operation_id: str) -> None:
+        nonlocal crashed
+        if stage == crash_stage and not crashed:
+            crashed = True
+            raise SystemExit(93)
+
+    monkeypatch.setattr(
+        session_module,
+        "after_fenced_phase2_stage",
+        crash_after_receipt,
+    )
+    with pytest.raises(SystemExit, match="93"):
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id=operation_id,
+            task_id=phase1["task_id"],
+            archive_uri=phase1["archive_uri"],
+        )
+
+    monkeypatch.setattr(
+        session_module,
+        "after_fenced_phase2_stage",
+        lambda _stage, _operation: None,
+    )
+    assert (
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id=operation_id,
+            task_id=phase1["task_id"],
+            archive_uri=phase1["archive_uri"],
+        )
+        == "completed"
+    )
+
+    assert effects == {"long_term": 1, "execution": 1}
+    assert memory_uris == {
+        "viking://user/memories/profile/fixed",
+        "viking://user/memories/preferences/fixed",
+    }
+    assert active.value == 1
+    assert active.apply_calls == (
+        2 if crash_stage == "active_count_applied" else 1
+    )
+
+    loaded = await service.sessions.get(session_id, _ctx())
+    assert loaded.meta.memories_extracted == {
+        "total": 2,
+        "profile": 1,
+        "preferences": 1,
+    }
+    manifest_uri = (
+        f"{loaded.uri}/.fenced-commits/"
+        f"{hashlib.sha256(operation_id.encode()).hexdigest()}.json"
+    )
+    terminal_manifest = json.loads(
+        await service.viking_fs.read_file(manifest_uri, ctx=_ctx())
+    )
+    for payload_field in (
+        "archive_messages",
+        "retained_messages",
+        "usage_records",
+        "memory_policy",
+    ):
+        assert payload_field not in terminal_manifest
+    assert terminal_manifest["phase2"]["state"] == "completed"
+    relation_entries = await service.viking_fs.get_relation_table(
+        loaded.uri, ctx=_ctx()
+    )
+    fenced_links = [
+        entry
+        for entry in relation_entries
+        if str(entry.id).startswith("fenced_")
+        and entry.uris == ["viking://resources/catalog.md"]
+    ]
+    assert len(fenced_links) == 1
+
+
+@pytest.mark.asyncio
+async def test_phase2_started_without_receipt_is_ambiguous_and_not_replayed(
+    service,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        memory=SimpleNamespace(
+            extraction_enabled=True,
+            session_skill_extraction_enabled=False,
+        )
+    )
+    monkeypatch.setattr(session_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(
+        session_module.Session,
+        "_generate_archive_summary_async",
+        lambda *_args, **_kwargs: _async_value("# Summary"),
+    )
+    calls = 0
+
+    async def lost_after_effect(**_kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        raise SystemExit(94)
+
+    compressor = service.sessions._session_compressor
+    monkeypatch.setattr(
+        compressor,
+        "extract_long_term_memories",
+        lost_after_effect,
+    )
+    active = _AbsoluteActiveCount()
+    monkeypatch.setattr(service.sessions, "_vikingdb", active)
+
+    session_id = "alice_" + "a" * 48
+    session = await service.sessions.create(_ctx(), session_id)
+    session.add_message("user", [TextPart("ambiguous effect")])
+    phase1 = await session.commit_async(
+        operation_id="ambiguous-operation",
+        operation_sequence_id=2,
+    )
+    with pytest.raises(SystemExit, match="94"):
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id="ambiguous-operation",
+            task_id=phase1["task_id"],
+            archive_uri=phase1["archive_uri"],
+        )
+    with pytest.raises(FailedPreconditionError) as ambiguous:
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id="ambiguous-operation",
+            task_id=phase1["task_id"],
+            archive_uri=phase1["archive_uri"],
+        )
+    assert ambiguous.value.details["reason"] == "commit_phase2_effect_ambiguous"
+    assert calls == 1
+
+
+async def _async_value(value: Any) -> Any:
+    return value
+
+
+@pytest.mark.asyncio
+async def test_deterministic_relation_read_timeout_never_overwrites_table(
+    service,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = "alice_" + "b" * 48
+    session = await service.sessions.create(_ctx(), session_id)
+    await service.viking_fs.link_deterministic(
+        session.uri,
+        "viking://resources/original.md",
+        link_id="fenced_original",
+        reason="fenced-session-commit",
+        ctx=_ctx(),
+    )
+    original_read = service.viking_fs._async_agfs.read
+    writes = 0
+    original_write = service.viking_fs._write_relation_table
+
+    async def timeout_read(path: str, *args: Any, **kwargs: Any) -> Any:
+        if path.endswith("/.relations.json"):
+            raise TimeoutError("simulated relation read timeout")
+        return await original_read(path, *args, **kwargs)
+
+    async def counted_write(*args: Any, **kwargs: Any) -> None:
+        nonlocal writes
+        writes += 1
+        await original_write(*args, **kwargs)
+
+    monkeypatch.setattr(service.viking_fs._async_agfs, "read", timeout_read)
+    monkeypatch.setattr(service.viking_fs, "_write_relation_table", counted_write)
+    with pytest.raises(TimeoutError, match="simulated relation read timeout"):
+        await service.viking_fs.link_deterministic(
+            session.uri,
+            "viking://resources/new.md",
+            link_id="fenced_new",
+            reason="fenced-session-commit",
+            ctx=_ctx(),
+        )
+    assert writes == 0
+
+    monkeypatch.setattr(service.viking_fs._async_agfs, "read", original_read)
+    entries = await service.viking_fs.get_relation_table(session.uri, ctx=_ctx())
+    assert [(entry.id, entry.uris) for entry in entries] == [
+        ("fenced_original", ["viking://resources/original.md"])
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["plan", "apply"])
+async def test_active_count_backend_failure_never_completes_receipt(
+    service,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    config = SimpleNamespace(
+        memory=SimpleNamespace(
+            extraction_enabled=False,
+            session_skill_extraction_enabled=False,
+        )
+    )
+    monkeypatch.setattr(session_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(
+        session_module.Session,
+        "_generate_archive_summary_async",
+        lambda *_args, **_kwargs: _async_value("# Summary"),
+    )
+    active = _AbsoluteActiveCount()
+    active.fail_plan = failure == "plan"
+    active.fail_apply = failure == "apply"
+    monkeypatch.setattr(service.sessions, "_vikingdb", active)
+
+    session_id = "alice_" + ("c" if failure == "plan" else "d") * 48
+    session = await service.sessions.create(_ctx(), session_id)
+    session.add_message("user", [TextPart("strict active count")])
+    session.used(
+        contexts=["viking://resources/catalog.md"],
+        operation_id="used-active",
+    )
+    operation_id = f"active-failure-{failure}"
+    phase1 = await session.commit_async(
+        operation_id=operation_id,
+        operation_sequence_id=3,
+    )
+    with pytest.raises(TimeoutError, match="active-count"):
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id=operation_id,
+            task_id=phase1["task_id"],
+            archive_uri=phase1["archive_uri"],
+        )
+
+    manifest_uri = (
+        f"{session.uri}/.fenced-commits/"
+        f"{hashlib.sha256(operation_id.encode()).hexdigest()}.json"
+    )
+    manifest = json.loads(
+        await service.viking_fs.read_file(manifest_uri, ctx=_ctx())
+    )
+    assert manifest["phase2"]["steps"].get(
+        "active_count", {"state": "pending"}
+    )["state"] in {
+        "pending",
+        "planned",
+    }
+    assert active.value == 0
+
+    active.fail_plan = False
+    active.fail_apply = False
+    assert (
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id=operation_id,
+            task_id=phase1["task_id"],
+            archive_uri=phase1["archive_uri"],
+        )
+        == "completed"
+    )
+    assert active.value == 1
+
+
+@pytest.mark.asyncio
+async def test_fenced_phase1_history_transport_failure_never_reuses_archive(
+    service,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = "alice_" + "e" * 48
+    session = await service.sessions.create(_ctx(), session_id)
+    session.add_message("user", [TextPart("first archive")])
+    first = await session.commit_async(
+        operation_id="strict-history-first",
+        operation_sequence_id=10,
+    )
+    assert first["archive_uri"].endswith("/archive_001")
+
+    current = await service.sessions.get(session_id, _ctx())
+    current.add_message("user", [TextPart("must not overwrite")])
+    original_ls = service.viking_fs.ls
+    history_calls = 0
+
+    async def fail_second_history_ls(uri: str, *args: Any, **kwargs: Any):
+        nonlocal history_calls
+        if uri == f"{current.uri}/history":
+            history_calls += 1
+            if history_calls == 2:
+                raise TimeoutError("history listing unavailable")
+        return await original_ls(uri, *args, **kwargs)
+
+    monkeypatch.setattr(service.viking_fs, "ls", fail_second_history_ls)
+    with pytest.raises(TimeoutError, match="history listing unavailable"):
+        await service.sessions.commit_async(
+            session_id,
+            _ctx(),
+            operation_id="strict-history-second",
+            operation_sequence_id=11,
+        )
+    assert history_calls == 2
+    assert not await service.viking_fs.exists(
+        f"{current.uri}/history/archive_002/messages.jsonl",
+        ctx=_ctx(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_previous_overview_transport_failure_retries_before_receipts(
+    service,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        memory=SimpleNamespace(
+            extraction_enabled=False,
+            session_skill_extraction_enabled=False,
+        )
+    )
+    monkeypatch.setattr(session_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(
+        session_module.Session,
+        "_generate_archive_summary_async",
+        lambda *_args, **_kwargs: _async_value("# Stable overview"),
+    )
+    session_id = "alice_" + "f" * 48
+    session = await service.sessions.create(_ctx(), session_id)
+    session.add_message("user", [TextPart("previous")])
+    first = await session.commit_async(
+        operation_id="overview-first",
+        operation_sequence_id=20,
+    )
+    assert (
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id="overview-first",
+            task_id=first["task_id"],
+            archive_uri=first["archive_uri"],
+        )
+        == "completed"
+    )
+
+    current = await service.sessions.get(session_id, _ctx())
+    current.add_message("user", [TextPart("next")])
+    second = await current.commit_async(
+        operation_id="overview-second",
+        operation_sequence_id=21,
+    )
+    original_read = service.viking_fs.read_file
+
+    async def fail_previous_overview(uri: str, *args: Any, **kwargs: Any):
+        if uri == f"{first['archive_uri']}/.overview.md":
+            raise TimeoutError("overview transport unavailable")
+        return await original_read(uri, *args, **kwargs)
+
+    monkeypatch.setattr(service.viking_fs, "read_file", fail_previous_overview)
+    with pytest.raises(TimeoutError, match="overview transport unavailable"):
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id="overview-second",
+            task_id=second["task_id"],
+            archive_uri=second["archive_uri"],
+        )
+    manifest_uri = (
+        f"{current.uri}/.fenced-commits/"
+        f"{hashlib.sha256(b'overview-second').hexdigest()}.json"
+    )
+    manifest = json.loads(await original_read(manifest_uri, ctx=_ctx()))
+    assert manifest.get("phase2", {}).get("steps", {}) == {}
+
+    monkeypatch.setattr(service.viking_fs, "read_file", original_read)
+    assert (
+        await service.sessions.run_fenced_commit_work(
+            session_id,
+            _ctx(),
+            operation_id="overview-second",
+            task_id=second["task_id"],
+            archive_uri=second["archive_uri"],
+        )
+        == "completed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_and_fenced_commits_share_padded_contiguous_archive_names(
+    service,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_phase2(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        session_module.Session,
+        "_run_memory_extraction",
+        no_phase2,
+    )
+    session_id = "alice_" + "1" * 48
+    session = await service.sessions.create(_ctx(), session_id)
+    session.add_message("user", [TextPart("legacy one")])
+    legacy_one = await session.commit_async()
+
+    session = await service.sessions.get(session_id, _ctx())
+    session.add_message("user", [TextPart("fenced two")])
+    fenced_two = await session.commit_async(
+        operation_id="mixed-fenced-two",
+        operation_sequence_id=999,
+    )
+
+    session = await service.sessions.get(session_id, _ctx())
+    session.add_message("user", [TextPart("legacy three")])
+    legacy_three = await session.commit_async()
+
+    assert [
+        legacy_one["archive_uri"].rsplit("/", 1)[-1],
+        fenced_two["archive_uri"].rsplit("/", 1)[-1],
+        legacy_three["archive_uri"].rsplit("/", 1)[-1],
+    ] == ["archive_001", "archive_002", "archive_003"]

--- a/tests/server/test_fenced_phase2.py
+++ b/tests/server/test_fenced_phase2.py
@@ -18,6 +18,10 @@ from openviking_cli.exceptions import FailedPreconditionError
 from openviking_cli.session.user_id import UserIdentifier
 
 
+class _SimulatedProcessLoss(BaseException):
+    """Model process loss without Python 3.11 Task's SystemExit re-raise."""
+
+
 class _AbsoluteActiveCount:
     def __init__(self) -> None:
         self.value = 0
@@ -232,7 +236,7 @@ async def test_phase2_started_without_receipt_is_ambiguous_and_not_replayed(
     async def lost_after_effect(**_kwargs: Any) -> dict[str, Any]:
         nonlocal calls
         calls += 1
-        raise SystemExit(94)
+        raise _SimulatedProcessLoss("after-effect receipt loss")
 
     compressor = service.sessions._session_compressor
     monkeypatch.setattr(
@@ -250,7 +254,7 @@ async def test_phase2_started_without_receipt_is_ambiguous_and_not_replayed(
         operation_id="ambiguous-operation",
         operation_sequence_id=2,
     )
-    with pytest.raises(SystemExit, match="94"):
+    with pytest.raises(_SimulatedProcessLoss, match="after-effect receipt loss"):
         await service.sessions.run_fenced_commit_work(
             session_id,
             _ctx(),
@@ -258,6 +262,14 @@ async def test_phase2_started_without_receipt_is_ambiguous_and_not_replayed(
             task_id=phase1["task_id"],
             archive_uri=phase1["archive_uri"],
         )
+    manifest_uri = (
+        f"{session.uri}/.fenced-commits/"
+        f"{hashlib.sha256(b'ambiguous-operation').hexdigest()}.json"
+    )
+    started_manifest = json.loads(
+        await service.viking_fs.read_file(manifest_uri, ctx=_ctx())
+    )
+    assert started_manifest["phase2"]["steps"]["long_term"]["state"] == "started"
     with pytest.raises(FailedPreconditionError) as ambiguous:
         await service.sessions.run_fenced_commit_work(
             session_id,

--- a/tests/server/test_fenced_postgres.py
+++ b/tests/server/test_fenced_postgres.py
@@ -1,0 +1,510 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Real PostgreSQL tests for the Alice fenced-operation durable outbox."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+import textwrap
+import time
+from typing import Any, Optional
+
+import pytest
+import pytest_asyncio
+from pydantic import Field
+
+from openviking.server.fenced_operation import (
+    FencedOperationConflict,
+    FencedOperationEnvelope,
+)
+from openviking.server.fenced_postgres import (
+    POSTGRES_FENCING_DDL,
+    PostgresFencedOperationQueue,
+    validate_postgres_fencing_schema,
+)
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
+
+pytestmark = pytest.mark.asyncio
+
+
+class MessageEnvelope(FencedOperationEnvelope):
+    role: str = "user"
+    content: str = Field(min_length=1)
+    created_at: Optional[str] = None
+
+
+def _dsn() -> str:
+    value = os.getenv("OPENVIKING_ALICE_FENCING_DATABASE_URL", "").strip()
+    if not value:
+        pytest.skip("PostgreSQL fencing integration DSN is not configured")
+    return value
+
+
+def _owner_dsn() -> str:
+    value = os.getenv("OPENVIKING_ALICE_FENCING_TEST_OWNER_DATABASE_URL", "").strip()
+    if not value:
+        pytest.skip("PostgreSQL fencing test owner DSN is not configured")
+    return value
+
+
+def _ctx(*, actor_peer_id: Optional[str] = None) -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier("fencing-test-account", "fencing-test-user"),
+        role=Role.USER,
+        actor_peer_id=actor_peer_id,
+    )
+
+
+def _envelope(
+    token: int,
+    operation_id: str,
+    *,
+    turn_id: str = "turn-1",
+    scope: str = "scope-1",
+    content: str = "hello",
+) -> MessageEnvelope:
+    return MessageEnvelope(
+        writer="alice",
+        session_scope_id=scope,
+        turn_id=turn_id,
+        operation_id=operation_id,
+        fencing_token=token,
+        content=content,
+    )
+
+
+def _db_rows(query: str, params: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+    import psycopg2
+
+    with psycopg2.connect(_dsn()) as conn, conn.cursor() as cursor:
+        cursor.execute(query, params)
+        return list(cursor.fetchall())
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clean_fencing_tables() -> None:
+    await validate_postgres_fencing_schema()
+
+    def _truncate() -> None:
+        import psycopg2
+
+        with psycopg2.connect(_owner_dsn()) as conn, conn.cursor() as cursor:
+            for table in (
+                "commit_work_outbox",
+                "effect_outbox",
+                "session_turn_closure",
+                "effect_receipt",
+                "operation_receipt",
+                "session_binding",
+                "scope_state",
+            ):
+                cursor.execute(f"TRUNCATE openviking_fencing.{table} CASCADE")
+
+    await asyncio.to_thread(_truncate)
+
+
+async def test_submit_is_durable_and_higher_exact_retry_reuses_one_outbox_row() -> None:
+    first_envelope = _envelope(10, "same-op")
+    first = await PostgresFencedOperationQueue(_ctx(), first_envelope).submit(
+        "message",
+        "session-1",
+    )
+    await asyncio.sleep(0.02)
+    replay = await PostgresFencedOperationQueue(
+        _ctx(),
+        _envelope(11, "same-op"),
+    ).submit("message", "session-1")
+
+    assert first.state == "queued"
+    assert first.replayed is False
+    assert replay.state == "queued"
+    assert replay.replayed is True
+    assert replay.fencing_token == 11
+
+    rows = await asyncio.to_thread(
+        _db_rows,
+        """
+        SELECT o.operation_id, o.fencing_token, o.request_payload->>'created_at',
+               r.submitted_at, r.fencing_token
+        FROM openviking_fencing.effect_outbox o
+        JOIN openviking_fencing.operation_receipt r
+          USING (account_id,user_id,writer,session_scope_id,operation_id)
+        """,
+    )
+    assert len(rows) == 1
+    assert rows[0][0:3] == ("same-op", 11, None)
+    # submitted_at is the stable effective created_at used by the writer when
+    # the validated request leaves created_at unset.  A retry never replaces it.
+    assert rows[0][3] is not None
+    assert rows[0][4] == 11
+
+
+async def test_actor_peer_is_bound_into_digest_and_replay_cannot_replace_it() -> None:
+    await PostgresFencedOperationQueue(
+        _ctx(actor_peer_id="peer-a"),
+        _envelope(1, "peer-op"),
+    ).submit("message", "session-1")
+
+    with pytest.raises(FencedOperationConflict) as conflict:
+        await PostgresFencedOperationQueue(
+            _ctx(actor_peer_id="peer-b"),
+            _envelope(2, "peer-op"),
+        ).submit("message", "session-1")
+    assert conflict.value.details["reason"] == "operation_digest_conflict"
+
+    rows = await asyncio.to_thread(
+        _db_rows,
+        "SELECT actor_peer_id, fencing_token FROM openviking_fencing.effect_outbox",
+    )
+    assert rows == [("peer-a", 1)]
+
+
+async def test_digest_and_principal_operation_scope_conflicts_fail_closed() -> None:
+    await PostgresFencedOperationQueue(_ctx(), _envelope(1, "fixed-op")).submit(
+        "message",
+        "session-1",
+    )
+
+    with pytest.raises(FencedOperationConflict) as digest_conflict:
+        await PostgresFencedOperationQueue(
+            _ctx(),
+            _envelope(2, "fixed-op", content="different"),
+        ).submit("message", "session-1")
+    assert digest_conflict.value.details["reason"] == "operation_digest_conflict"
+
+    with pytest.raises(FencedOperationConflict) as scope_conflict:
+        await PostgresFencedOperationQueue(
+            _ctx(),
+            _envelope(2, "fixed-op", scope="scope-2"),
+        ).submit("message", "session-1")
+    assert scope_conflict.value.details["reason"] == "operation_scope_conflict"
+
+
+async def test_higher_new_turn_stales_only_queued_and_erases_its_payload() -> None:
+    await PostgresFencedOperationQueue(_ctx(), _envelope(1, "old-op")).submit(
+        "message",
+        "session-1",
+    )
+    current = await PostgresFencedOperationQueue(
+        _ctx(),
+        _envelope(2, "new-op", turn_id="turn-2"),
+    ).submit("message", "session-1")
+    assert current.state == "queued"
+
+    stale = await PostgresFencedOperationQueue.get(_ctx(), "old-op")
+    assert stale is not None
+    assert stale.state == "stale"
+    assert stale.error is not None
+    assert stale.error["details"]["reason"] == "stale_fence"
+
+    outbox_rows = await asyncio.to_thread(
+        _db_rows,
+        "SELECT operation_id, request_payload->>'content' "
+        "FROM openviking_fencing.effect_outbox ORDER BY sequence_id",
+    )
+    assert outbox_rows == [("new-op", "hello")]
+
+    # A terminal stale result is immutable.  A higher token cannot silently
+    # revive the old operation or advance the scope; retry needs a new op ID.
+    replay = await PostgresFencedOperationQueue(
+        _ctx(),
+        _envelope(3, "old-op"),
+    ).submit("message", "session-1")
+    assert replay.state == "stale"
+    scope_rows = await asyncio.to_thread(
+        _db_rows,
+        "SELECT highest_fencing_token, active_turn_id FROM openviking_fencing.scope_state",
+    )
+    assert scope_rows == [(2, "turn-2")]
+
+
+async def test_eager_stale_cleanup_records_suppression_after_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openviking.metrics.datasources.session import SessionLifecycleDataSource
+
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        SessionLifecycleDataSource,
+        "record_fenced_effect",
+        lambda **payload: events.append(payload),
+    )
+    await PostgresFencedOperationQueue(_ctx(), _envelope(1, "metric-old")).submit(
+        "message", "session-metric"
+    )
+    events.clear()
+
+    await PostgresFencedOperationQueue(
+        _ctx(), _envelope(2, "metric-new", turn_id="turn-new")
+    ).submit("message", "session-metric")
+
+    assert events == [{"operation": "message", "outcome": "suppressed"}]
+    stale = await PostgresFencedOperationQueue.get(_ctx(), "metric-old")
+    assert stale is not None and stale.state == "stale"
+
+
+async def test_v2_submit_metric_classifies_stale_fence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openviking.metrics.datasources.session import SessionLifecycleDataSource
+
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        SessionLifecycleDataSource,
+        "record_fencing",
+        lambda **payload: events.append(payload),
+    )
+    await PostgresFencedOperationQueue(
+        _ctx(),
+        _envelope(2, "metric-high", turn_id="turn-high"),
+    ).submit("message", "session-metric")
+    events.clear()
+
+    with pytest.raises(FencedOperationConflict) as stale:
+        await PostgresFencedOperationQueue(
+            _ctx(),
+            _envelope(1, "metric-low", turn_id="turn-low"),
+        ).submit("message", "session-metric")
+    assert stale.value.details["reason"] == "stale_fence"
+    assert len(events) == 1
+    assert events[0]["operation"] == "message"
+    assert events[0]["outcome"] == "stale"
+
+
+async def test_completed_response_loss_replay_wins_over_later_commit_closure() -> None:
+    envelope = _envelope(1, "message-op")
+    queued = await PostgresFencedOperationQueue(_ctx(), envelope).submit(
+        "message",
+        "session-1",
+    )
+
+    def _complete_then_close() -> None:
+        import psycopg2
+        from psycopg2.extras import Json
+
+        result = {"message_id": "stable-message"}
+        with psycopg2.connect(_owner_dsn()) as conn, conn.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE openviking_fencing.operation_receipt
+                SET state='completed', result=%s, updated_at=now()
+                WHERE operation_id='message-op'
+                """,
+                (Json(result),),
+            )
+            cursor.execute(
+                """
+                INSERT INTO openviking_fencing.effect_receipt
+                    (account_id,user_id,writer,session_scope_id,operation_id,
+                     operation,resource_id,turn_id,digest,fencing_token,result)
+                SELECT account_id,user_id,writer,session_scope_id,operation_id,
+                       operation,resource_id,turn_id,digest,fencing_token,%s
+                FROM openviking_fencing.operation_receipt
+                WHERE operation_id='message-op'
+                """,
+                (Json(result),),
+            )
+            cursor.execute(
+                "DELETE FROM openviking_fencing.effect_outbox WHERE operation_id='message-op'"
+            )
+            cursor.execute(
+                """
+                INSERT INTO openviking_fencing.session_turn_closure
+                    (account_id,user_id,writer,session_scope_id,turn_id,session_id,
+                     operation_id,digest,fencing_token,result)
+                VALUES ('fencing-test-account','fencing-test-user','alice','scope-1',
+                        'turn-1','session-1','commit-op','commit-digest',2,%s)
+                """,
+                (Json({"archived": True}),),
+            )
+
+    await asyncio.to_thread(_complete_then_close)
+
+    replay = await PostgresFencedOperationQueue(
+        _ctx(),
+        _envelope(2, "message-op"),
+    ).submit("message", "session-1")
+    assert replay.state == "completed"
+    assert replay.result == {"message_id": "stable-message"}
+    assert replay.replayed is True
+    assert replay.digest == queued.digest
+
+    fences = await asyncio.to_thread(
+        _db_rows,
+        "SELECT r.fencing_token, e.fencing_token "
+        "FROM openviking_fencing.operation_receipt r "
+        "JOIN openviking_fencing.effect_receipt e USING "
+        "(account_id,user_id,writer,session_scope_id,operation_id)",
+    )
+    assert fences == [(2, 2)]
+
+
+_CHILD_COMMON = """
+import asyncio
+import sys
+from openviking.server import fenced_operation
+from openviking.server.fenced_operation import FencedOperationConflict
+from openviking.server.fenced_operation import FencedOperationEnvelope
+from openviking.server.fenced_postgres import PostgresFencedOperationQueue
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
+
+ctx = RequestContext(UserIdentifier('fencing-test-account', 'fencing-test-user'), Role.USER)
+env = FencedOperationEnvelope(
+    writer='alice', session_scope_id='scope-1', turn_id='turn-1',
+    operation_id='frozen-op', fencing_token=1,
+)
+"""
+
+
+async def _start_frozen_child(source: str) -> asyncio.subprocess.Process:
+    env = os.environ.copy()
+    env["OPENVIKING_ALICE_FENCING_DATABASE_URL"] = _dsn()
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        source,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    assert process.stdout is not None
+    ready = await asyncio.wait_for(process.stdout.readline(), timeout=10)
+    assert ready.strip() == b"READY"
+    os.kill(process.pid, signal.SIGSTOP)
+    return process
+
+
+async def _resume_child(process: asyncio.subprocess.Process) -> tuple[str, str]:
+    assert process.stdin is not None
+    process.stdin.write(b"continue\n")
+    await process.stdin.drain()
+    os.kill(process.pid, signal.SIGCONT)
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+    return stdout.decode(), stderr.decode()
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGSTOP"), reason="requires POSIX SIGSTOP")
+async def test_sigstop_before_submit_allows_bounded_higher_takeover() -> None:
+    child_source = _CHILD_COMMON + textwrap.dedent(
+        """
+        async def seam(_operation):
+            print('READY', flush=True)
+            await asyncio.to_thread(sys.stdin.readline)
+        fenced_operation.after_fenced_submit_preflight = seam
+
+        async def main():
+            try:
+                await PostgresFencedOperationQueue(ctx, env).submit('message', 'session-1')
+            except FencedOperationConflict as exc:
+                print('STALE ' + exc.details['reason'], flush=True)
+        asyncio.run(main())
+        """
+    )
+    child = await _start_frozen_child(child_source)
+    started = time.monotonic()
+    try:
+        higher = await PostgresFencedOperationQueue(
+            _ctx(),
+            _envelope(2, "higher-op", turn_id="turn-2"),
+        ).submit("message", "session-1")
+        assert time.monotonic() - started < 1.0
+        assert higher.state == "queued"
+        stdout, stderr = await _resume_child(child)
+        assert "STALE stale_fence" in stdout
+        assert stderr == ""
+    finally:
+        if child.returncode is None:
+            os.kill(child.pid, signal.SIGCONT)
+            child.kill()
+            await child.wait()
+
+    rows = await asyncio.to_thread(
+        _db_rows,
+        "SELECT operation_id FROM openviking_fencing.effect_outbox",
+    )
+    assert rows == [("higher-op",)]
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGSTOP"), reason="requires POSIX SIGSTOP")
+async def test_sigstop_inside_submit_releases_transaction_lock_by_db_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENVIKING_ALICE_FENCING_SUBMIT_IDLE_TIMEOUT_MS", "700")
+    child_source = _CHILD_COMMON + textwrap.dedent(
+        """
+        def seam(_operation):
+            print('READY', flush=True)
+            sys.stdin.readline()
+        fenced_operation.after_fenced_submit_locks_acquired = seam
+
+        async def main():
+            try:
+                await PostgresFencedOperationQueue(ctx, env).submit('message', 'session-1')
+            except Exception as exc:
+                print(type(exc).__name__, flush=True)
+        asyncio.run(main())
+        """
+    )
+    child = await _start_frozen_child(child_source)
+    started = time.monotonic()
+    try:
+        higher = await PostgresFencedOperationQueue(
+            _ctx(),
+            _envelope(2, "higher-op", turn_id="turn-2"),
+        ).submit("message", "session-1")
+        elapsed = time.monotonic() - started
+        assert 0.5 <= elapsed < 3.0
+        assert higher.state == "queued"
+        stdout, _stderr = await _resume_child(child)
+        assert "UnavailableError" in stdout
+    finally:
+        if child.returncode is None:
+            os.kill(child.pid, signal.SIGCONT)
+            child.kill()
+            await child.wait()
+
+    rows = await asyncio.to_thread(
+        _db_rows,
+        "SELECT operation_id FROM openviking_fencing.effect_outbox",
+    )
+    assert rows == [("higher-op",)]
+
+
+async def test_startup_schema_validation_rejects_half_migration() -> None:
+    import psycopg2
+
+    def _drop_critical_column() -> None:
+        with psycopg2.connect(_owner_dsn()) as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "ALTER TABLE openviking_fencing.effect_outbox DROP COLUMN effect_started_at"
+            )
+
+    def _restore() -> None:
+        with psycopg2.connect(_owner_dsn()) as conn, conn.cursor() as cursor:
+            cursor.execute(POSTGRES_FENCING_DDL)
+
+    await asyncio.to_thread(_drop_critical_column)
+    try:
+        with pytest.raises(RuntimeError, match="missing columns effect_started_at"):
+            await validate_postgres_fencing_schema()
+    finally:
+        await asyncio.to_thread(_restore)
+    await validate_postgres_fencing_schema()
+
+
+async def test_startup_schema_validation_rejects_real_owner_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OPENVIKING_ALICE_FENCING_DATABASE_URL",
+        _owner_dsn(),
+    )
+
+    with pytest.raises(RuntimeError, match="authenticate and connect as openviking_fencing"):
+        await validate_postgres_fencing_schema()

--- a/tests/server/test_fenced_runtime_config.py
+++ b/tests/server/test_fenced_runtime_config.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Fail-closed validation for fenced writer process deadlines."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openviking.server import fenced_postgres
+from openviking.server.fenced_postgres import (
+    FENCING_DATABASE_ROLE,
+    _validate_runtime_fencing_principal,
+    _validate_runtime_fencing_privilege_scope,
+)
+from openviking.server.routers import fenced_sessions as fenced_sessions_routes
+from openviking.server.routers.fenced_sessions import _drain_timeout_seconds
+from openviking.session.session import fenced_phase2_timeout_seconds
+
+_SAFE_PRINCIPAL_ROW = (
+    FENCING_DATABASE_ROLE,
+    FENCING_DATABASE_ROLE,
+    False,  # NOSUPERUSER
+    False,  # NOCREATEDB
+    False,  # NOCREATEROLE
+    False,  # NOINHERIT
+    False,  # NOREPLICATION
+    False,  # NOBYPASSRLS
+    True,  # LOGIN
+    32,  # bounded connection limit
+    0,  # no outgoing memberships
+    True,  # CONNECT
+    False,  # no CREATE DATABASE privilege
+    False,  # no TEMPORARY privilege
+    "pg_catalog",
+)
+
+
+class _ScriptedCursor:
+    def __init__(self, rows: list[tuple[Any, ...] | None]) -> None:
+        self._rows = list(rows)
+        self.statements: list[tuple[str, Any]] = []
+
+    def __enter__(self) -> _ScriptedCursor:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def execute(self, query: str, params: Any = None) -> None:
+        self.statements.append((query, params))
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        if not self._rows:
+            raise AssertionError("unexpected cursor.fetchone()")
+        return self._rows.pop(0)
+
+
+class _ScriptedConnection:
+    def __init__(self, cursor: _ScriptedCursor) -> None:
+        self._cursor = cursor
+        self.autocommit = False
+        self.closed = False
+
+    def cursor(self) -> _ScriptedCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_runtime_principal_accepts_only_dedicated_least_privilege_role() -> None:
+    cursor = _ScriptedCursor([_SAFE_PRINCIPAL_ROW])
+
+    _validate_runtime_fencing_principal(cursor)
+
+    assert len(cursor.statements) == 1
+    assert "current_user" in cursor.statements[0][0]
+    assert "session_user" in cursor.statements[0][0]
+
+
+@pytest.mark.parametrize(
+    ("column", "unsafe_value", "error"),
+    [
+        (0, "postgres", "authenticate and connect"),
+        (1, "postgres", "authenticate and connect"),
+        (2, True, "unsafe attributes: SUPERUSER"),
+        (3, True, "unsafe attributes: CREATEDB"),
+        (4, True, "unsafe attributes: CREATEROLE"),
+        (5, True, "unsafe attributes: INHERIT"),
+        (6, True, "unsafe attributes: REPLICATION"),
+        (7, True, "unsafe attributes: BYPASSRLS"),
+        (8, False, "unsafe attributes: NOLOGIN"),
+        (9, 33, "unsafe attributes: CONNECTION LIMIT"),
+        (10, 1, "must not be a member"),
+        (11, False, "unsafe database privileges"),
+        (12, True, "unsafe database privileges"),
+        (13, True, "unsafe database privileges"),
+        (14, '"$user", public', "search_path=pg_catalog"),
+    ],
+)
+def test_runtime_principal_rejects_identity_attribute_and_database_drift(
+    column: int,
+    unsafe_value: Any,
+    error: str,
+) -> None:
+    row = list(_SAFE_PRINCIPAL_ROW)
+    row[column] = unsafe_value
+    cursor = _ScriptedCursor([tuple(row)])
+
+    with pytest.raises(RuntimeError, match=error):
+        _validate_runtime_fencing_principal(cursor)
+
+
+def _safe_privilege_rows() -> list[tuple[Any, ...]]:
+    return [
+        (True, False, False, False, False),
+        *((True, True, True, True, False, False, False),) * 7,
+        *((True, True, False),) * 2,
+    ]
+
+
+def test_runtime_privilege_scope_accepts_exact_fencing_grants() -> None:
+    cursor = _ScriptedCursor(_safe_privilege_rows())
+
+    _validate_runtime_fencing_privilege_scope(cursor)
+
+    assert len(cursor.statements) == 10
+
+
+@pytest.mark.parametrize(
+    ("scope_row", "error"),
+    [
+        ((False, False, False, False, False), "unsafe schema privileges"),
+        ((True, True, False, False, False), "unsafe schema privileges"),
+        ((True, False, True, False, False), "create in a non-system schema"),
+        ((True, False, False, True, False), "unexpected table"),
+        ((True, False, False, False, True), "unexpected sequence"),
+    ],
+)
+def test_runtime_privilege_scope_rejects_effective_privilege_drift(
+    scope_row: tuple[bool, bool, bool, bool, bool],
+    error: str,
+) -> None:
+    cursor = _ScriptedCursor([scope_row])
+
+    with pytest.raises(RuntimeError, match=error):
+        _validate_runtime_fencing_privilege_scope(cursor)
+
+
+def test_runtime_privilege_scope_rejects_extra_table_or_sequence_grants() -> None:
+    unsafe_table_rows = _safe_privilege_rows()
+    unsafe_table_rows[1] = (True, True, True, True, True, False, False)
+    with pytest.raises(RuntimeError, match="invalid table privileges"):
+        _validate_runtime_fencing_privilege_scope(_ScriptedCursor(unsafe_table_rows))
+
+    unsafe_sequence_rows = _safe_privilege_rows()
+    unsafe_sequence_rows[-1] = (True, True, True)
+    with pytest.raises(RuntimeError, match="invalid sequence privileges"):
+        _validate_runtime_fencing_privilege_scope(_ScriptedCursor(unsafe_sequence_rows))
+
+
+@pytest.mark.asyncio
+async def test_schema_validator_rejects_owner_before_schema_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner_row = (
+        "postgres",
+        "postgres",
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        -1,
+        0,
+        True,
+        True,
+        True,
+        '"$user", public',
+    )
+    cursor = _ScriptedCursor([owner_row])
+    connection = _ScriptedConnection(cursor)
+    monkeypatch.setattr(fenced_postgres, "_connect", lambda **_kwargs: connection)
+
+    with pytest.raises(RuntimeError, match="authenticate and connect"):
+        await fenced_postgres.validate_postgres_fencing_schema()
+
+    assert connection.closed is True
+    assert len(cursor.statements) == 1
+    assert "pg_catalog.pg_roles" in cursor.statements[0][0]
+
+
+@pytest.mark.asyncio
+async def test_required_writer_startup_rejects_owner_or_superuser_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner_row = (
+        "postgres",
+        "postgres",
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        -1,
+        0,
+        True,
+        True,
+        True,
+        '"$user", public',
+    )
+    connection = _ScriptedConnection(_ScriptedCursor([owner_row]))
+    monkeypatch.setenv("OPENVIKING_ALICE_FENCING_MODE", "required")
+    monkeypatch.setenv(
+        "OPENVIKING_ALICE_FENCING_DATABASE_URL",
+        "postgresql://postgres:owner-secret@db/fencing",
+    )
+    monkeypatch.setenv(
+        "OPENVIKING_ALICE_SERVICE_TOKEN",
+        "test-openviking-alice-service-token-0001",
+    )
+    monkeypatch.setattr(fenced_postgres, "_connect", lambda **_kwargs: connection)
+    monkeypatch.setattr(fenced_sessions_routes, "_writer_pool", None)
+    monkeypatch.setattr(fenced_sessions_routes, "_writer_schema_validated", False)
+    monkeypatch.setattr(fenced_sessions_routes, "_writer_draining", False)
+
+    with pytest.raises(RuntimeError, match="authenticate and connect"):
+        await fenced_sessions_routes.start_fenced_writer_runtime()
+
+    assert connection.closed is True
+    assert fenced_sessions_routes.fenced_writer_runtime_status()["configured"] is False
+
+
+def test_fenced_runtime_timeout_defaults_are_coherent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENVIKING_FENCED_PHASE2_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("OPENVIKING_FENCED_DRAIN_TIMEOUT_SECONDS", raising=False)
+    phase2 = fenced_phase2_timeout_seconds()
+    assert phase2 == 1800.0
+    assert _drain_timeout_seconds(phase2) == 1860.0
+
+
+@pytest.mark.parametrize("value", ["", "bad", "nan", "inf", "59", "7201"])
+def test_fenced_phase2_timeout_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("OPENVIKING_FENCED_PHASE2_TIMEOUT_SECONDS", value)
+    with pytest.raises(RuntimeError, match="FENCED_PHASE2_TIMEOUT_SECONDS"):
+        fenced_phase2_timeout_seconds()
+
+
+@pytest.mark.parametrize("value", ["", "bad", "nan", "inf", "1859", "10801"])
+def test_fenced_drain_timeout_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("OPENVIKING_FENCED_DRAIN_TIMEOUT_SECONDS", value)
+    with pytest.raises(RuntimeError, match="FENCED_DRAIN_TIMEOUT_SECONDS"):
+        _drain_timeout_seconds(1800.0)

--- a/tests/server/test_fenced_sessions.py
+++ b/tests/server/test_fenced_sessions.py
@@ -1,0 +1,607 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""HTTP contract tests for protocol-v2 Alice fenced session writes."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from openviking.server.fenced_postgres import (
+    fencing_database_url,
+    validate_postgres_fencing_schema,
+)
+from openviking.server.routers import fenced_sessions as fenced_sessions_routes
+
+ALICE_TOKEN = "test-openviking-alice-service-token-0001"
+FENCED_PREFIX = "/api/v1/fenced"
+
+
+def _session_id(seed: str) -> str:
+    return "alice_" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:48]
+
+
+def _operation_id(seed: str) -> str:
+    return "op-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:32]
+
+
+def _headers(token: str = ALICE_TOKEN) -> dict[str, str]:
+    return {"X-OpenViking-Alice-Token": token}
+
+
+def _owner_dsn() -> str:
+    value = os.getenv("OPENVIKING_ALICE_FENCING_TEST_OWNER_DATABASE_URL", "").strip()
+    if not value:
+        pytest.skip("PostgreSQL fencing test owner DSN is not configured")
+    return value
+
+
+def _base(
+    *,
+    token: int,
+    operation_id: str,
+    turn_id: str = "turn-1",
+    scope: str = "tenant-1:customer-1",
+) -> dict[str, Any]:
+    return {
+        "writer": "alice",
+        "session_scope_id": scope,
+        "turn_id": turn_id,
+        "operation_id": operation_id,
+        "fencing_token": token,
+    }
+
+
+def _create_body(
+    session_id: str,
+    *,
+    token: int = 1,
+    operation_id: str | None = None,
+    turn_id: str = "turn-1",
+    scope: str = "tenant-1:customer-1",
+) -> dict[str, Any]:
+    return {
+        **_base(
+            token=token,
+            operation_id=operation_id or _operation_id(f"create:{session_id}"),
+            turn_id=turn_id,
+            scope=scope,
+        ),
+        "session_id": session_id,
+    }
+
+
+def _message_body(
+    *,
+    token: int,
+    operation_id: str,
+    content: str,
+    turn_id: str = "turn-1",
+    scope: str = "tenant-1:customer-1",
+) -> dict[str, Any]:
+    return {
+        **_base(
+            token=token,
+            operation_id=operation_id,
+            turn_id=turn_id,
+            scope=scope,
+        ),
+        "role": "user",
+        "content": content,
+    }
+
+
+def _operation(response: httpx.Response) -> dict[str, Any]:
+    payload = response.json()
+    assert payload["status"] == "ok"
+    result = payload["result"]
+    assert isinstance(result, dict)
+    return result
+
+
+def _assert_pending(
+    response: httpx.Response,
+    *,
+    operation_id: str,
+    replayed: bool,
+) -> dict[str, Any]:
+    assert response.status_code == 202
+    operation = _operation(response)
+    assert operation["operation_id"] == operation_id
+    assert operation["status"] in {"queued", "running"}
+    assert operation["replayed"] is replayed
+    assert operation["status_url"] == (f"{FENCED_PREFIX}/operations/{operation_id}")
+    assert "result" not in operation
+    return operation
+
+
+def _assert_completed(
+    response: httpx.Response,
+    *,
+    operation_id: str,
+    replayed: bool,
+) -> dict[str, Any]:
+    assert response.status_code == 200
+    operation = _operation(response)
+    assert operation["operation_id"] == operation_id
+    assert operation["status"] == "completed"
+    assert operation["replayed"] is replayed
+    assert operation["status_url"] == (f"{FENCED_PREFIX}/operations/{operation_id}")
+    assert isinstance(operation["result"], dict)
+    return operation
+
+
+async def _wait_for_terminal(
+    client: httpx.AsyncClient,
+    response: httpx.Response,
+    *,
+    operation_id: str,
+    replayed: bool = False,
+    timeout_seconds: float = 10.0,
+) -> httpx.Response:
+    if response.status_code == 200:
+        _assert_completed(
+            response,
+            operation_id=operation_id,
+            replayed=replayed,
+        )
+        return response
+
+    pending = _assert_pending(
+        response,
+        operation_id=operation_id,
+        replayed=replayed,
+    )
+    status_url = str(pending["status_url"])
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while asyncio.get_running_loop().time() < deadline:
+        polled = await client.get(status_url, headers=_headers())
+        if polled.status_code == 200:
+            _assert_completed(
+                polled,
+                operation_id=operation_id,
+                # A GET is a status read, not a duplicate submission.
+                replayed=False,
+            )
+            return polled
+        _assert_pending(
+            polled,
+            operation_id=operation_id,
+            replayed=False,
+        )
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"fenced operation {operation_id} did not complete")
+
+
+async def _post_create_and_wait(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    token: int = 1,
+    operation_id: str | None = None,
+    turn_id: str = "turn-1",
+    scope: str = "tenant-1:customer-1",
+) -> httpx.Response:
+    resolved_operation_id = operation_id or _operation_id(f"create:{session_id}")
+    response = await client.post(
+        f"{FENCED_PREFIX}/sessions",
+        headers=_headers(),
+        json=_create_body(
+            session_id,
+            token=token,
+            operation_id=resolved_operation_id,
+            turn_id=turn_id,
+            scope=scope,
+        ),
+    )
+    return await _wait_for_terminal(
+        client,
+        response,
+        operation_id=resolved_operation_id,
+    )
+
+
+async def _post_message_and_wait(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    token: int,
+    operation_id: str,
+    content: str,
+    turn_id: str = "turn-1",
+    scope: str = "tenant-1:customer-1",
+) -> httpx.Response:
+    response = await client.post(
+        f"{FENCED_PREFIX}/sessions/{session_id}/messages",
+        headers=_headers(),
+        json=_message_body(
+            token=token,
+            operation_id=operation_id,
+            content=content,
+            turn_id=turn_id,
+            scope=scope,
+        ),
+    )
+    return await _wait_for_terminal(
+        client,
+        response,
+        operation_id=operation_id,
+    )
+
+
+def _truncate_fencing_tables() -> None:
+    import psycopg2
+
+    with psycopg2.connect(_owner_dsn()) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                TRUNCATE TABLE
+                    openviking_fencing.commit_work_outbox,
+                    openviking_fencing.effect_outbox,
+                    openviking_fencing.session_turn_closure,
+                    openviking_fencing.effect_receipt,
+                    openviking_fencing.operation_receipt,
+                    openviking_fencing.session_binding,
+                    openviking_fencing.scope_state
+                RESTART IDENTITY CASCADE
+                """
+            )
+
+
+@pytest.fixture(autouse=True)
+def fenced_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    if not fencing_database_url():
+        pytest.skip("PostgreSQL fencing integration DSN is not configured")
+    monkeypatch.setenv("OPENVIKING_ALICE_FENCING_MODE", "required")
+    monkeypatch.setenv("OPENVIKING_ALICE_SERVICE_TOKEN", ALICE_TOKEN)
+    # New submissions should expose the protocol's durable 202 boundary. Tests
+    # that need a completed POST exercise exact duplicate submissions instead.
+    monkeypatch.setenv("OPENVIKING_FENCED_POST_POLL_SECONDS", "0")
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def fenced_runtime(
+    fenced_environment: None,
+    app,
+) -> AsyncIterator[None]:
+    del fenced_environment, app
+    await fenced_sessions_routes.stop_fenced_writer_runtime()
+    await validate_postgres_fencing_schema()
+    await asyncio.to_thread(_truncate_fencing_tables)
+    assert await fenced_sessions_routes.start_fenced_writer_runtime() is True
+    try:
+        yield
+    finally:
+        await fenced_sessions_routes.stop_fenced_writer_runtime()
+        await asyncio.to_thread(_truncate_fencing_tables)
+
+
+@pytest.mark.asyncio
+async def test_health_advertises_configured_protocol_v2(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    capability = response.json()["capabilities"]["alice_session_fencing"]
+    assert capability == {
+        "protocol": "openviking-alice-session-fencing",
+        "version": 2,
+        "mode": "required",
+        "write_ack": "202_poll",
+        "configured": True,
+        "writer_healthy": True,
+        "draining": False,
+        "effect_concurrency": 2,
+        "commit_concurrency": 2,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["observe", "required"])
+async def test_fenced_api_requires_strict_token_in_both_modes(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    monkeypatch.setenv("OPENVIKING_ALICE_FENCING_MODE", mode)
+    session_id = _session_id(f"strict-token:{mode}")
+    operation_id = _operation_id(f"strict-token:{mode}")
+    body = _create_body(session_id, operation_id=operation_id)
+
+    missing = await client.post(f"{FENCED_PREFIX}/sessions", json=body)
+    wrong = await client.post(
+        f"{FENCED_PREFIX}/sessions",
+        headers=_headers("wrong-token"),
+        json=body,
+    )
+
+    assert missing.status_code == 401
+    assert missing.json()["error"]["code"] == "UNAUTHENTICATED"
+    assert wrong.status_code == 401
+    assert wrong.json()["error"]["code"] == "UNAUTHENTICATED"
+    health = await client.get("/health")
+    capability = health.json()["capabilities"]["alice_session_fencing"]
+    assert capability["mode"] == mode
+    assert capability["configured"] is True
+
+    accepted = await client.post(
+        f"{FENCED_PREFIX}/sessions",
+        headers=_headers(),
+        json=body,
+    )
+    completed = await _wait_for_terminal(
+        client,
+        accepted,
+        operation_id=operation_id,
+    )
+    assert _operation(completed)["result"]["session_id"] == session_id
+
+
+@pytest.mark.asyncio
+async def test_post_202_get_202_then_200_uses_nested_operation_envelope(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await fenced_sessions_routes.stop_fenced_writer_runtime()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_executor = fenced_sessions_routes.execute_fenced_outbox_item
+
+    async def gated_executor(item):  # noqa: ANN001
+        entered.set()
+        await release.wait()
+        return await original_executor(item)
+
+    monkeypatch.setattr(
+        fenced_sessions_routes,
+        "execute_fenced_outbox_item",
+        gated_executor,
+    )
+    assert await fenced_sessions_routes.start_fenced_writer_runtime() is True
+
+    session_id = _session_id("202-poll-contract")
+    operation_id = _operation_id("202-poll-contract")
+    submitted = await client.post(
+        f"{FENCED_PREFIX}/sessions",
+        headers=_headers(),
+        json=_create_body(session_id, operation_id=operation_id),
+    )
+    pending = _assert_pending(
+        submitted,
+        operation_id=operation_id,
+        replayed=False,
+    )
+
+    await asyncio.wait_for(entered.wait(), timeout=2.0)
+    running = await client.get(str(pending["status_url"]), headers=_headers())
+    running_operation = _assert_pending(
+        running,
+        operation_id=operation_id,
+        replayed=False,
+    )
+    assert running_operation["status"] == "running"
+
+    release.set()
+    completed = await _wait_for_terminal(
+        client,
+        running,
+        operation_id=operation_id,
+    )
+    operation = _assert_completed(
+        completed,
+        operation_id=operation_id,
+        replayed=False,
+    )
+    assert operation["result"]["session_id"] == session_id
+    assert "session_id" not in completed.json()["result"]
+
+
+@pytest.mark.asyncio
+async def test_exact_replay_stale_fence_digest_and_scope_conflicts(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id = _session_id("replay-and-conflicts")
+    scope = "tenant-replay:customer-replay"
+    create_operation = _operation_id("replay-create")
+    first_create = await _post_create_and_wait(
+        client,
+        session_id,
+        operation_id=create_operation,
+        scope=scope,
+    )
+    assert _operation(first_create)["result"]["session_id"] == session_id
+
+    create_replay = await client.post(
+        f"{FENCED_PREFIX}/sessions",
+        headers=_headers(),
+        json=_create_body(
+            session_id,
+            token=1,
+            operation_id=create_operation,
+            scope=scope,
+        ),
+    )
+    create_replay_operation = _assert_completed(
+        create_replay,
+        operation_id=create_operation,
+        replayed=True,
+    )
+    assert create_replay_operation["result"]["session_id"] == session_id
+
+    message_operation = _operation_id("replay-message")
+    first_message = await _post_message_and_wait(
+        client,
+        session_id,
+        token=2,
+        operation_id=message_operation,
+        content="exactly once",
+        scope=scope,
+    )
+    message_result = _operation(first_message)["result"]
+
+    message_replay = await client.post(
+        f"{FENCED_PREFIX}/sessions/{session_id}/messages",
+        headers=_headers(),
+        json=_message_body(
+            token=2,
+            operation_id=message_operation,
+            content="exactly once",
+            scope=scope,
+        ),
+    )
+    replay_operation = _assert_completed(
+        message_replay,
+        operation_id=message_operation,
+        replayed=True,
+    )
+    assert replay_operation["result"]["message_id"] == message_result["message_id"]
+
+    digest_conflict = await client.post(
+        f"{FENCED_PREFIX}/sessions/{session_id}/messages",
+        headers=_headers(),
+        json=_message_body(
+            token=2,
+            operation_id=message_operation,
+            content="different content",
+            scope=scope,
+        ),
+    )
+    assert digest_conflict.status_code == 409
+    assert digest_conflict.json()["error"]["details"]["reason"] == ("operation_digest_conflict")
+
+    stale = await client.post(
+        f"{FENCED_PREFIX}/sessions/{session_id}/messages",
+        headers=_headers(),
+        json=_message_body(
+            token=1,
+            operation_id=_operation_id("stale-message"),
+            content="must be rejected",
+            scope=scope,
+        ),
+    )
+    assert stale.status_code == 409
+    assert stale.json()["error"]["details"] == {
+        "reason": "stale_fence",
+        "highest_fencing_token": 2,
+        "received_fencing_token": 1,
+    }
+
+    foreign_scope = await client.post(
+        f"{FENCED_PREFIX}/sessions/{session_id}/messages",
+        headers=_headers(),
+        json=_message_body(
+            token=1,
+            operation_id=_operation_id("foreign-scope-message"),
+            content="must not cross scope",
+            scope="tenant-replay:another-customer",
+        ),
+    )
+    assert foreign_scope.status_code == 409
+    assert foreign_scope.json()["error"]["details"]["reason"] == ("session_scope_conflict")
+
+
+@pytest.mark.asyncio
+async def test_writer_task_death_makes_readiness_fail_closed(
+    client: httpx.AsyncClient,
+) -> None:
+    ready = await client.get("/ready")
+    # Other embedded-test dependencies may be intentionally unavailable, so
+    # establish the writer-specific healthy baseline instead of requiring every
+    # unrelated readiness check to pass.
+    assert ready.json()["checks"]["alice_fenced_writer"]["status"] == "ok"
+
+    pool = fenced_sessions_routes._writer_pool
+    assert pool is not None and pool.healthy
+    failed_task = pool._tasks[0]
+    failed_task.cancel()
+    await asyncio.gather(failed_task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    not_ready = await client.get("/ready")
+    assert not_ready.status_code == 503
+    writer_check = not_ready.json()["checks"]["alice_fenced_writer"]
+    assert writer_check == {
+        "status": "error",
+        "configured": False,
+        "healthy": False,
+        "draining": False,
+    }
+    health = await client.get("/health")
+    capability = health.json()["capabilities"]["alice_session_fencing"]
+    assert capability["configured"] is False
+    assert capability["writer_healthy"] is False
+
+
+@pytest.mark.asyncio
+async def test_required_mode_rejects_legacy_alice_and_reserved_bypasses(
+    client: httpx.AsyncClient,
+) -> None:
+    legacy_marker = await client.post(
+        "/api/v1/sessions",
+        headers={"X-OpenViking-Agent": "alice"},
+        json={"session_id": "legacy-alice-required"},
+    )
+    authenticated_legacy = await client.post(
+        "/api/v1/sessions",
+        headers=_headers(),
+        json={"session_id": "authenticated-legacy-alice-required"},
+    )
+
+    for response in (legacy_marker, authenticated_legacy):
+        assert response.status_code == 412
+        assert response.json()["error"]["details"]["reason"] == "fencing_required"
+
+    reserved_id = _session_id("ordinary-reserved-required")
+    reserved_create = await client.post(
+        "/api/v1/sessions",
+        json={"session_id": reserved_id},
+    )
+    reserved_message = await client.post(
+        f"/api/v1/sessions/{reserved_id}/messages",
+        json={"role": "user", "content": "bypass"},
+    )
+    for response in (reserved_create, reserved_message):
+        assert response.status_code == 412
+        assert response.json()["error"]["details"]["reason"] == ("alice_session_fencing_required")
+
+    non_reserved_fenced = await client.post(
+        f"{FENCED_PREFIX}/sessions",
+        headers=_headers(),
+        json=_create_body(
+            "not-in-the-reserved-namespace",
+            operation_id=_operation_id("non-reserved-fenced"),
+        ),
+    )
+    assert non_reserved_fenced.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_observe_mode_keeps_ordinary_api_but_rejects_reserved_bypass(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENVIKING_ALICE_FENCING_MODE", "observe")
+
+    ordinary = await client.post(
+        "/api/v1/sessions",
+        json={"session_id": "ordinary-observe"},
+    )
+    assert ordinary.status_code == 200
+
+    reserved_id = _session_id("ordinary-reserved-observe")
+    reserved = await client.post(
+        "/api/v1/sessions",
+        headers={"X-OpenViking-Agent": "alice"},
+        json={"session_id": reserved_id},
+    )
+    assert reserved.status_code == 412
+    assert reserved.json()["error"]["details"]["reason"] == ("alice_session_fencing_required")

--- a/tests/server/test_fenced_writer.py
+++ b/tests/server/test_fenced_writer.py
@@ -1,0 +1,1212 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Real PostgreSQL concurrency/recovery tests for the fenced outbox writer."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+import threading
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from openviking.server import fenced_operation
+from openviking.server.fenced_operation import (
+    FencedOperationConflict,
+    FencedOperationEnvelope,
+)
+from openviking.server.fenced_postgres import (
+    PostgresFencedOperationQueue,
+    validate_postgres_fencing_schema,
+)
+from openviking.server.fenced_writer import (
+    FencedCommitWorkItem,
+    FencedOutboxItem,
+    PermanentFencedEffectError,
+    PostgresFencedOutboxWriter,
+    PostgresFencedWriterPool,
+)
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.exceptions import FailedPreconditionError
+from openviking_cli.session.user_id import UserIdentifier
+
+pytestmark = pytest.mark.asyncio
+
+
+class CommitEnvelope(FencedOperationEnvelope):
+    keep_recent_count: int = 0
+    wait: bool = False
+
+
+def _dsn() -> str:
+    value = os.getenv("OPENVIKING_ALICE_FENCING_DATABASE_URL", "").strip()
+    if not value:
+        pytest.skip("PostgreSQL fencing integration DSN is not configured")
+    return value
+
+
+def _owner_dsn() -> str:
+    value = os.getenv("OPENVIKING_ALICE_FENCING_TEST_OWNER_DATABASE_URL", "").strip()
+    if not value:
+        pytest.skip("PostgreSQL fencing test owner DSN is not configured")
+    return value
+
+
+def _ctx(
+    account_id: str = "writer-test-account",
+    user_id: str = "writer-test-user",
+) -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier(account_id, user_id),
+        role=Role.USER,
+    )
+
+
+def _env(
+    token: int,
+    operation_id: str,
+    *,
+    scope: str = "scope-1",
+    turn: str = "turn-1",
+) -> FencedOperationEnvelope:
+    return FencedOperationEnvelope(
+        writer="alice",
+        session_scope_id=scope,
+        turn_id=turn,
+        operation_id=operation_id,
+        fencing_token=token,
+    )
+
+
+def _commit_env(
+    token: int,
+    operation_id: str,
+    *,
+    scope: str = "scope-1",
+    turn: str = "turn-1",
+    wait: bool,
+) -> CommitEnvelope:
+    return CommitEnvelope(
+        writer="alice",
+        session_scope_id=scope,
+        turn_id=turn,
+        operation_id=operation_id,
+        fencing_token=token,
+        wait=wait,
+    )
+
+
+def _rows(query: str, params: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+    import psycopg2
+
+    with psycopg2.connect(_dsn()) as conn, conn.cursor() as cursor:
+        cursor.execute(query, params)
+        return list(cursor.fetchall())
+
+
+def _owner_rows(query: str, params: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+    import psycopg2
+
+    with psycopg2.connect(_owner_dsn()) as conn, conn.cursor() as cursor:
+        cursor.execute(query, params)
+        return list(cursor.fetchall())
+
+
+async def _wait_for_rows(
+    query: str,
+    expected: list[tuple[Any, ...]],
+    *,
+    timeout: float = 2.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        rows = await asyncio.to_thread(_rows, query)
+        if rows == expected:
+            return
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"timed out waiting for rows: {rows!r}")
+        await asyncio.sleep(0.02)
+
+
+class _FakeTaskTracker:
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+        self.fail_error: Exception | None = None
+
+    async def fail(self, task_id: str, _error: str, **_kwargs: Any) -> None:
+        if self.fail_error is not None:
+            error, self.fail_error = self.fail_error, None
+            raise error
+        self.failures.append(task_id)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clean_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _FakeTaskTracker:
+    await validate_postgres_fencing_schema()
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_writer_claimed",
+        lambda _operation_id: None,
+    )
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_writer_effect_started",
+        lambda _operation_id: None,
+    )
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_effect_before_receipt",
+        lambda _operation: None,
+    )
+    tracker = _FakeTaskTracker()
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: tracker,
+    )
+
+    def _clean() -> None:
+        import psycopg2
+
+        with psycopg2.connect(_owner_dsn()) as conn, conn.cursor() as cursor:
+            cursor.execute("CREATE SCHEMA IF NOT EXISTS openviking_fencing_test")
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS openviking_fencing_test.test_effects (
+                    operation_id text PRIMARY KEY,
+                    value text NOT NULL
+                )
+                """
+            )
+            cursor.execute("TRUNCATE openviking_fencing_test.test_effects")
+            for table in (
+                "commit_work_outbox",
+                "effect_outbox",
+                "session_turn_closure",
+                "effect_receipt",
+                "operation_receipt",
+                "session_binding",
+                "scope_state",
+            ):
+                cursor.execute(f"TRUNCATE openviking_fencing.{table} CASCADE")
+
+    await asyncio.to_thread(_clean)
+    return tracker
+
+
+def _test_effect(item: FencedOutboxItem, value: str) -> dict[str, Any]:
+    import psycopg2
+
+    with psycopg2.connect(_owner_dsn()) as conn, conn.cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO openviking_fencing_test.test_effects(operation_id,value)
+            VALUES (%s,%s)
+            ON CONFLICT (operation_id) DO UPDATE SET value=EXCLUDED.value
+            """,
+            (item.operation_id, value),
+        )
+    return {"operation_id": item.operation_id, "value": value}
+
+
+async def test_writer_completes_effect_and_atomically_erases_outbox_payload() -> None:
+    await PostgresFencedOperationQueue(_ctx(), _env(1, "op-1")).submit(
+        "message",
+        "session-1",
+    )
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        return await asyncio.to_thread(_test_effect, item, "done")
+
+    writer = PostgresFencedOutboxWriter(execute)
+    assert await writer.run_once() is True
+
+    receipt = await PostgresFencedOperationQueue.get(_ctx(), "op-1")
+    assert receipt is not None
+    assert receipt.state == "completed"
+    assert receipt.result == {"operation_id": "op-1", "value": "done"}
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT count(*) FROM openviking_fencing.effect_outbox",
+    ) == [(0,)]
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT writer,session_scope_id FROM openviking_fencing.session_binding",
+    ) == [("alice", "scope-1")]
+
+
+async def test_higher_fence_after_claim_but_before_effect_stales_without_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await PostgresFencedOperationQueue(_ctx(), _env(1, "old-op")).submit(
+        "message",
+        "session-1",
+    )
+    claimed = asyncio.Event()
+    resume = asyncio.Event()
+    effects: list[str] = []
+
+    async def claimed_seam(_operation_id: str) -> None:
+        claimed.set()
+        await resume.wait()
+
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_writer_claimed",
+        claimed_seam,
+    )
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        effects.append(item.operation_id)
+        return {"operation_id": item.operation_id}
+
+    writer = PostgresFencedOutboxWriter(execute)
+    old_task = asyncio.create_task(writer.run_once())
+    await claimed.wait()
+    await PostgresFencedOperationQueue(
+        _ctx(),
+        _env(2, "new-op", turn="turn-2"),
+    ).submit("message", "session-1")
+    resume.set()
+    assert await old_task is True
+    assert effects == []
+    old = await PostgresFencedOperationQueue.get(_ctx(), "old-op")
+    assert old is not None and old.state == "stale"
+
+
+async def test_higher_exact_replay_after_claim_uses_latest_token_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_id = "exact-replay-after-claim"
+    await PostgresFencedOperationQueue(_ctx(), _env(1, operation_id)).submit("message", "session-1")
+    claimed = asyncio.Event()
+    resume = asyncio.Event()
+    effects: list[tuple[str, int]] = []
+
+    async def claimed_seam(claimed_operation_id: str) -> None:
+        if claimed_operation_id == operation_id:
+            claimed.set()
+            await resume.wait()
+
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_writer_claimed",
+        claimed_seam,
+    )
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        effects.append((item.operation_id, item.fencing_token))
+        return {"operation_id": item.operation_id}
+
+    writer_task = asyncio.create_task(PostgresFencedOutboxWriter(execute).run_once())
+    try:
+        await asyncio.wait_for(claimed.wait(), timeout=2)
+        replay = await asyncio.wait_for(
+            PostgresFencedOperationQueue(_ctx(), _env(2, operation_id)).submit(
+                "message", "session-1"
+            ),
+            timeout=2,
+        )
+        assert replay.replayed is True
+        assert replay.state == "running"
+        assert replay.fencing_token == 2
+    finally:
+        resume.set()
+
+    assert await asyncio.wait_for(writer_task, timeout=2) is True
+    assert effects == [(operation_id, 2)]
+    receipt = await PostgresFencedOperationQueue.get(_ctx(), operation_id)
+    assert receipt is not None
+    assert receipt.state == "completed"
+    assert receipt.fencing_token == 2
+
+
+async def test_completed_old_turn_replay_cannot_reclaim_newer_active_turn() -> None:
+    old_operation = "completed-turn-a"
+    new_operation = "queued-turn-b"
+    effects: list[str] = []
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        effects.append(item.operation_id)
+        return {"operation_id": item.operation_id}
+
+    writer = PostgresFencedOutboxWriter(execute)
+    await PostgresFencedOperationQueue(_ctx(), _env(5, old_operation, turn="turn-a")).submit(
+        "message", "session-turn-replay"
+    )
+    assert await writer.run_once() is True
+    await PostgresFencedOperationQueue(_ctx(), _env(6, new_operation, turn="turn-b")).submit(
+        "message", "session-turn-replay"
+    )
+
+    # A completed response-loss replay at/below its persisted receipt token
+    # remains readable, but does not adopt the newer turn's token.
+    lower_replay = await PostgresFencedOperationQueue(
+        _ctx(), _env(4, old_operation, turn="turn-a")
+    ).submit("message", "session-turn-replay")
+    assert lower_replay.replayed is True
+    assert lower_replay.state == "completed"
+    assert lower_replay.fencing_token == 5
+    pure_replay = await PostgresFencedOperationQueue(
+        _ctx(), _env(5, old_operation, turn="turn-a")
+    ).submit("message", "session-turn-replay")
+    assert pure_replay.replayed is True
+    assert pure_replay.state == "completed"
+    assert pure_replay.fencing_token == 5
+
+    # W1(A,t10) must not leapfrog W2(B,t6) by reusing W1's completed receipt.
+    with pytest.raises(FencedOperationConflict) as conflict:
+        await PostgresFencedOperationQueue(_ctx(), _env(10, old_operation, turn="turn-a")).submit(
+            "message", "session-turn-replay"
+        )
+    assert conflict.value.details["reason"] == "turn_fence_conflict"
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT highest_fencing_token,active_turn_id FROM openviking_fencing.scope_state",
+    ) == [(6, "turn-b")]
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT operation_id,fencing_token FROM openviking_fencing.effect_outbox",
+    ) == [(new_operation, 6)]
+
+    assert await writer.run_once() is True
+    assert effects == [old_operation, new_operation]
+
+
+async def test_running_old_turn_replay_cannot_reclaim_newer_active_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_operation = "running-turn-a"
+    new_operation = "running-turn-b"
+    claimed = asyncio.Event()
+    resume = asyncio.Event()
+    effects: list[str] = []
+
+    async def claimed_seam(operation_id: str) -> None:
+        if operation_id == old_operation:
+            claimed.set()
+            await resume.wait()
+
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_writer_claimed",
+        claimed_seam,
+    )
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        effects.append(item.operation_id)
+        return {"operation_id": item.operation_id}
+
+    await PostgresFencedOperationQueue(_ctx(), _env(5, old_operation, turn="turn-a")).submit(
+        "message", "session-running-replay"
+    )
+    writer = PostgresFencedOutboxWriter(execute)
+    old_task = asyncio.create_task(writer.run_once())
+    try:
+        await asyncio.wait_for(claimed.wait(), timeout=2)
+        await PostgresFencedOperationQueue(_ctx(), _env(6, new_operation, turn="turn-b")).submit(
+            "message", "session-running-replay"
+        )
+        with pytest.raises(FencedOperationConflict) as conflict:
+            await PostgresFencedOperationQueue(
+                _ctx(), _env(10, old_operation, turn="turn-a")
+            ).submit("message", "session-running-replay")
+        assert conflict.value.details["reason"] == "turn_fence_conflict"
+        assert await asyncio.to_thread(
+            _rows,
+            "SELECT highest_fencing_token,active_turn_id FROM openviking_fencing.scope_state",
+        ) == [(6, "turn-b")]
+    finally:
+        resume.set()
+
+    assert await asyncio.wait_for(old_task, timeout=2) is True
+    assert effects == []
+    assert await writer.run_once() is True
+    assert effects == [new_operation]
+
+
+async def test_completed_replay_cannot_leapfrog_newer_same_turn_fence() -> None:
+    old_operation = "completed-fence-five"
+    new_operation = "queued-fence-six"
+    effects: list[str] = []
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        effects.append(item.operation_id)
+        return {"operation_id": item.operation_id}
+
+    writer = PostgresFencedOutboxWriter(execute)
+    await PostgresFencedOperationQueue(_ctx(), _env(5, old_operation, turn="same-turn")).submit(
+        "message", "session-same-turn-fence"
+    )
+    assert await writer.run_once() is True
+    await PostgresFencedOperationQueue(_ctx(), _env(6, new_operation, turn="same-turn")).submit(
+        "message", "session-same-turn-fence"
+    )
+
+    with pytest.raises(FencedOperationConflict) as conflict:
+        await PostgresFencedOperationQueue(_ctx(), _env(6, old_operation, turn="same-turn")).submit(
+            "message", "session-same-turn-fence"
+        )
+    assert conflict.value.details["reason"] == "turn_fence_conflict"
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT highest_fencing_token,active_turn_id FROM openviking_fencing.scope_state",
+    ) == [(6, "same-turn")]
+    assert await writer.run_once() is True
+    assert effects == [old_operation, new_operation]
+
+
+async def test_claim_and_higher_submit_cleanup_have_no_row_lock_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_id = "claim-cleanup-lock-order"
+    await PostgresFencedOperationQueue(_ctx(), _env(1, operation_id)).submit(
+        "message", "session-lock-order"
+    )
+    receipt_locked = threading.Event()
+    release_claim = threading.Event()
+    original_lock_receipt = PostgresFencedOutboxWriter._lock_operation_receipt
+    gate_used = False
+
+    def gated_lock_receipt(cursor, item):
+        nonlocal gate_used
+        locked = original_lock_receipt(cursor, item)
+        if item.operation_id == operation_id and not gate_used:
+            gate_used = True
+            receipt_locked.set()
+            if not release_claim.wait(timeout=3):
+                raise TimeoutError("test did not release claim receipt gate")
+        return locked
+
+    monkeypatch.setattr(
+        PostgresFencedOutboxWriter,
+        "_lock_operation_receipt",
+        staticmethod(gated_lock_receipt),
+    )
+    effects: list[str] = []
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        effects.append(item.operation_id)
+        return {"operation_id": item.operation_id}
+
+    writer = PostgresFencedOutboxWriter(execute)
+    writer_task = asyncio.create_task(writer.run_once())
+    higher_task: asyncio.Task[Any] | None = None
+    try:
+        assert await asyncio.to_thread(receipt_locked.wait, 2)
+        higher_task = asyncio.create_task(
+            PostgresFencedOperationQueue(
+                _ctx(), _env(2, "claim-cleanup-higher", turn="turn-2")
+            ).submit("message", "session-lock-order")
+        )
+        # Scope acceptance commits before eager stale-payload cleanup waits on
+        # the claimed receipt.  This is the property that removes the former
+        # scope/outbox -> receipt cycle.
+        await _wait_for_rows(
+            "SELECT highest_fencing_token FROM "
+            "openviking_fencing.scope_state WHERE session_scope_id='scope-1'",
+            [(2,)],
+        )
+    finally:
+        release_claim.set()
+
+    assert higher_task is not None
+    writer_done, higher = await asyncio.wait_for(
+        asyncio.gather(writer_task, higher_task), timeout=3
+    )
+    assert writer_done is True
+    assert higher.state == "queued"
+    assert effects == []
+    old = await PostgresFencedOperationQueue.get(_ctx(), operation_id)
+    assert old is not None and old.state == "stale"
+    assert await writer.run_once() is True
+    assert effects == ["claim-cleanup-higher"]
+
+
+async def test_started_effect_is_deterministically_recovered_after_crash_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await PostgresFencedOperationQueue(_ctx(), _env(1, "recover-op")).submit(
+        "message",
+        "session-1",
+    )
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        return await asyncio.to_thread(_test_effect, item, "stable")
+
+    async def crash_after_effect(_operation: str) -> None:
+        raise SystemExit(91)
+
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_effect_before_receipt",
+        crash_after_effect,
+    )
+    first_writer = PostgresFencedOutboxWriter(execute)
+    with pytest.raises(SystemExit, match="91"):
+        await first_writer.run_once()
+
+    running = await asyncio.to_thread(
+        _rows,
+        "SELECT state,effect_started_at IS NOT NULL FROM openviking_fencing.effect_outbox",
+    )
+    assert running == [("running", True)]
+
+    monkeypatch.setattr(
+        fenced_operation,
+        "after_fenced_effect_before_receipt",
+        lambda _operation: None,
+    )
+    recovery_writer = PostgresFencedOutboxWriter(execute)
+    assert await recovery_writer.run_once() is True
+    receipt = await PostgresFencedOperationQueue.get(_ctx(), "recover-op")
+    assert receipt is not None and receipt.state == "completed"
+    # The external helper is operation-addressed, so physical replay leaves one
+    # logical effect even though the first process lost its response receipt.
+    assert await asyncio.to_thread(
+        _owner_rows,
+        "SELECT operation_id,value FROM openviking_fencing_test.test_effects",
+    ) == [("recover-op", "stable")]
+
+
+async def test_same_scope_is_ordered_while_different_scope_runs_in_parallel() -> None:
+    await PostgresFencedOperationQueue(_ctx(), _env(1, "scope-a-1")).submit(
+        "message",
+        "session-a-1",
+    )
+    await PostgresFencedOperationQueue(_ctx(), _env(1, "scope-a-2")).submit(
+        "message",
+        "session-a-2",
+    )
+    await PostgresFencedOperationQueue(
+        _ctx(),
+        _env(1, "scope-b-1", scope="scope-2"),
+    ).submit("message", "session-b-1")
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    effects: list[str] = []
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        if item.operation_id == "scope-a-1":
+            first_started.set()
+            await release_first.wait()
+        effects.append(item.operation_id)
+        return {"operation_id": item.operation_id}
+
+    first_worker = PostgresFencedOutboxWriter(execute)
+    second_worker = PostgresFencedOutboxWriter(execute)
+    first_task = asyncio.create_task(first_worker.run_once())
+    await first_started.wait()
+
+    # The second worker skips scope-a-2 because scope-a-1 is still its earliest
+    # active sequence, but it can complete independent scope-2 immediately.
+    assert await second_worker.run_once() is True
+    assert effects == ["scope-b-1"]
+    release_first.set()
+    assert await first_task is True
+    assert await second_worker.run_once() is True
+    assert effects == ["scope-b-1", "scope-a-1", "scope-a-2"]
+
+
+async def test_waiting_commit_moves_phase_two_to_durable_work_outbox() -> None:
+    commit = _commit_env(1, "commit-op", wait=True)
+    await PostgresFencedOperationQueue(_ctx(), commit).submit(
+        "commit",
+        "session-a",
+    )
+    await PostgresFencedOperationQueue(
+        _ctx(),
+        _env(1, "other-op", scope="scope-2"),
+    ).submit("message", "session-b")
+
+    task_state = "pending"
+    effects: list[str] = []
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        effects.append(item.operation_id)
+        if item.operation == "commit":
+            return {
+                "task_id": "task-1",
+                "archive_uri": "viking://session/archive-1",
+                "archived": True,
+            }
+        return {"operation_id": item.operation_id}
+
+    async def task_waiter(_item: FencedCommitWorkItem) -> str:
+        return task_state
+
+    writer = PostgresFencedOutboxWriter(execute, task_waiter=task_waiter)
+    assert await writer.run_once() is True
+    commit_receipt = await PostgresFencedOperationQueue.get(_ctx(), "commit-op")
+    assert commit_receipt is not None and commit_receipt.state == "running"
+    replay = await PostgresFencedOperationQueue(_ctx(), commit).submit(
+        "commit",
+        "session-a",
+    )
+    assert replay.state == "running"
+    assert replay.replayed is True
+    waiting = await asyncio.to_thread(
+        _rows,
+        "SELECT task_id,archive_uri,wait_for_completion,state "
+        "FROM openviking_fencing.commit_work_outbox "
+        "WHERE operation_id='commit-op'",
+    )
+    assert waiting == [("task-1", "viking://session/archive-1", True, "pending")]
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT count(*) FROM openviking_fencing.effect_outbox WHERE operation_id='commit-op'",
+    ) == [(0,)]
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT operation_id FROM openviking_fencing.session_turn_closure "
+        "WHERE operation_id='commit-op'",
+    ) == [("commit-op",)]
+
+    # The phase-one closure is authoritative while memory extraction is still
+    # pending: the old session/turn cannot be reopened by a fresh operation.
+    with pytest.raises(FencedOperationConflict) as closed_message:
+        await PostgresFencedOperationQueue(
+            _ctx(),
+            _env(1, "closed-message", turn="turn-1"),
+        ).submit("message", "session-a")
+    assert closed_message.value.details["reason"] == "session_turn_closed"
+    with pytest.raises(FencedOperationConflict) as closed_commit:
+        await PostgresFencedOperationQueue(
+            _ctx(),
+            _commit_env(1, "closed-commit", turn="turn-1", wait=False),
+        ).submit("commit", "session-a")
+    assert closed_commit.value.details["reason"] == "session_turn_closed"
+
+    # A new turn in the same writer scope is no longer blocked by phase two.
+    await PostgresFencedOperationQueue(
+        _ctx(),
+        _env(2, "same-scope-create", turn="turn-2"),
+    ).submit("create", "session-c")
+    await PostgresFencedOperationQueue(
+        _ctx(),
+        _env(2, "same-scope-message", turn="turn-2"),
+    ).submit("message", "session-c")
+
+    # Independent and same-scope work continue while task-1 is pending.
+    assert await writer.run_once() is True
+    assert await writer.run_once() is True
+    assert await writer.run_once() is True
+    assert effects == [
+        "commit-op",
+        "other-op",
+        "same-scope-create",
+        "same-scope-message",
+    ]
+
+    task_state = "completed"
+    assert await writer.process_waiting_once() is True
+    done = await PostgresFencedOperationQueue.get(_ctx(), "commit-op")
+    assert done is not None and done.state == "completed"
+    assert done.result == {
+        "task_id": "task-1",
+        "archive_uri": "viking://session/archive-1",
+        "archived": True,
+    }
+
+
+async def test_phase2_finish_and_exact_replay_share_receipt_first_lock_order() -> None:
+    operation_id = "phase2-replay-lock-order"
+    commit = _commit_env(1, operation_id, wait=True)
+    await PostgresFencedOperationQueue(_ctx(), commit).submit("commit", "session-phase2-lock-order")
+
+    async def execute(_item: FencedOutboxItem) -> dict[str, Any]:
+        return {
+            "task_id": "task-phase2-lock-order",
+            "archive_uri": "viking://session/archive-phase2-lock-order",
+        }
+
+    waiter_started = asyncio.Event()
+    allow_finish = asyncio.Event()
+
+    async def task_waiter(_item: FencedCommitWorkItem) -> str:
+        waiter_started.set()
+        await allow_finish.wait()
+        return "completed"
+
+    writer = PostgresFencedOutboxWriter(execute, task_waiter=task_waiter)
+    assert await writer.run_once() is True
+    watcher_task = asyncio.create_task(writer.process_waiting_once())
+    await asyncio.wait_for(waiter_started.wait(), timeout=2)
+
+    def _block_commit_work():
+        import psycopg2
+
+        conn = psycopg2.connect(_dsn(), application_name="test-phase2-row-blocker")
+        conn.autocommit = False
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT operation_id FROM "
+                "openviking_fencing.commit_work_outbox "
+                "WHERE operation_id=%s FOR UPDATE",
+                (operation_id,),
+            )
+            assert cursor.fetchone() == (operation_id,)
+        return conn
+
+    blocker = await asyncio.to_thread(_block_commit_work)
+    replay_task: asyncio.Task[Any] | None = None
+    try:
+        allow_finish.set()
+        await _wait_for_rows(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE application_name='openviking-fenced-commit-worker' "
+            "AND wait_event_type='Lock'",
+            [(1,)],
+        )
+        replay_task = asyncio.create_task(
+            PostgresFencedOperationQueue(_ctx(), _commit_env(2, operation_id, wait=True)).submit(
+                "commit", "session-phase2-lock-order"
+            )
+        )
+        await _wait_for_rows(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE application_name='openviking-fenced-submit' "
+            "AND wait_event_type='Lock'",
+            [(1,)],
+        )
+    finally:
+        await asyncio.to_thread(blocker.rollback)
+        await asyncio.to_thread(blocker.close)
+        allow_finish.set()
+
+    assert replay_task is not None
+    watcher_done, replay = await asyncio.wait_for(
+        asyncio.gather(watcher_task, replay_task), timeout=3
+    )
+    assert watcher_done is True
+    assert replay.replayed is True
+    assert replay.state == "completed"
+    assert replay.fencing_token == 2
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT count(*) FROM openviking_fencing.commit_work_outbox",
+    ) == [(0,)]
+
+
+async def test_ambiguous_commit_work_is_quarantined_without_hot_loop() -> None:
+    commit = _commit_env(1, "ambiguous-work", wait=True)
+    await PostgresFencedOperationQueue(_ctx(), commit).submit("commit", "session-ambiguous")
+
+    async def execute(_item: FencedOutboxItem) -> dict[str, Any]:
+        return {
+            "task_id": "task-ambiguous",
+            "archive_uri": "viking://session/archive-ambiguous",
+        }
+
+    calls = 0
+
+    async def ambiguous(_item: FencedCommitWorkItem) -> str:
+        nonlocal calls
+        calls += 1
+        raise FailedPreconditionError(
+            "ambiguous",
+            details={"reason": "commit_phase2_effect_ambiguous"},
+        )
+
+    writer = PostgresFencedOutboxWriter(execute, task_waiter=ambiguous)
+    assert await writer.run_once() is True
+    assert await writer.process_waiting_once() is True
+    assert await writer.process_waiting_once() is False
+    assert calls == 1
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT state,attempt_count,claim_token IS NULL,error->'details'->>'reason' "
+        "FROM openviking_fencing.commit_work_outbox "
+        "WHERE operation_id='ambiguous-work'",
+    ) == [("ambiguous", 1, True, "commit_phase2_effect_ambiguous")]
+    receipt = await PostgresFencedOperationQueue.get(_ctx(), "ambiguous-work")
+    assert receipt is not None and receipt.state == "failed"
+
+
+async def test_quarantine_retries_until_task_tracker_is_terminal(
+    clean_tables: _FakeTaskTracker,
+) -> None:
+    commit = _commit_env(1, "tracker-reconcile", wait=True)
+    await PostgresFencedOperationQueue(_ctx(), commit).submit("commit", "session-tracker-reconcile")
+
+    async def execute(_item: FencedOutboxItem) -> dict[str, Any]:
+        return {
+            "task_id": "task-tracker-reconcile",
+            "archive_uri": "viking://session/archive-tracker-reconcile",
+        }
+
+    async def ambiguous(_item: FencedCommitWorkItem) -> str:
+        raise FailedPreconditionError(
+            "ambiguous",
+            details={"reason": "commit_phase2_effect_ambiguous"},
+        )
+
+    clean_tables.fail_error = TimeoutError("task storage unavailable")
+    writer = PostgresFencedOutboxWriter(execute, task_waiter=ambiguous)
+    assert await writer.run_once() is True
+    assert await writer.process_waiting_once() is True
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT state FROM openviking_fencing.commit_work_outbox "
+        "WHERE operation_id='tracker-reconcile'",
+    ) == [("pending",)]
+
+    await asyncio.sleep(0.12)
+    assert await writer.process_waiting_once() is True
+    assert clean_tables.failures == ["task-tracker-reconcile"]
+    assert await asyncio.to_thread(
+        _rows,
+        "SELECT state FROM openviking_fencing.commit_work_outbox "
+        "WHERE operation_id='tracker-reconcile'",
+    ) == [("ambiguous",)]
+
+
+async def test_commit_pool_runs_different_accounts_in_parallel() -> None:
+    for index, scope in ((1, "parallel-a"), (2, "parallel-b")):
+        ctx = _ctx(f"writer-test-account-{index}")
+        await PostgresFencedOperationQueue(
+            ctx,
+            _commit_env(1, f"parallel-{index}", scope=scope, wait=False),
+        ).submit("commit", f"session-{index}")
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        return {
+            "task_id": f"task-{item.operation_id}",
+            "archive_uri": f"viking://session/{item.operation_id}",
+        }
+
+    phase1 = PostgresFencedOutboxWriter(execute)
+    assert await phase1.run_once() is True
+    assert await phase1.run_once() is True
+
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    started: set[str] = set()
+
+    async def phase2(item: FencedCommitWorkItem) -> str:
+        started.add(item.session_id)
+        if len(started) == 2:
+            both_started.set()
+        await release.wait()
+        return "completed"
+
+    pool = PostgresFencedWriterPool(
+        execute,
+        task_waiter=phase2,
+        concurrency=1,
+        commit_concurrency=2,
+        poll_seconds=0.05,
+    )
+    pool.start()
+    await asyncio.wait_for(both_started.wait(), timeout=2)
+    assert started == {"session-1", "session-2"}
+    release.set()
+    await pool.stop(drain_timeout_seconds=2)
+    assert await asyncio.to_thread(
+        _rows, "SELECT count(*) FROM openviking_fencing.commit_work_outbox"
+    ) == [(0,)]
+
+
+async def test_commit_pool_serializes_different_sessions_in_same_account() -> None:
+    def _insert() -> None:
+        import psycopg2
+
+        with psycopg2.connect(_dsn()) as conn, conn.cursor() as cursor:
+            for index in (1, 2):
+                cursor.execute(
+                    """
+                    INSERT INTO openviking_fencing.operation_receipt
+                        (account_id,user_id,writer,session_scope_id,operation_id,
+                         operation,resource_id,turn_id,digest,fencing_token,state)
+                    VALUES ('shared-account',%s,'alice',%s,%s,'commit',%s,
+                            %s,%s,1,'completed')
+                    """,
+                    (
+                        f"user-{index}",
+                        f"shared-scope-{index}",
+                        f"shared-operation-{index}",
+                        f"shared-session-{index}",
+                        f"shared-turn-{index}",
+                        f"shared-digest-{index}",
+                    ),
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO openviking_fencing.commit_work_outbox
+                        (account_id,user_id,writer,session_scope_id,operation_id,
+                         session_id,task_id,archive_uri,wait_for_completion)
+                    VALUES ('shared-account',%s,'alice',%s,%s,%s,%s,%s,false)
+                    """,
+                    (
+                        f"user-{index}",
+                        f"shared-scope-{index}",
+                        f"shared-operation-{index}",
+                        f"shared-session-{index}",
+                        f"shared-task-{index}",
+                        f"viking://session/shared-{index}",
+                    ),
+                )
+
+    await asyncio.to_thread(_insert)
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    started: list[str] = []
+
+    async def phase2(item: FencedCommitWorkItem) -> str:
+        started.append(item.session_id)
+        if len(started) == 1:
+            first_started.set()
+            await release_first.wait()
+        return "completed"
+
+    async def no_effect(_item: FencedOutboxItem) -> dict[str, Any]:
+        return {}
+
+    pool = PostgresFencedWriterPool(
+        no_effect,
+        task_waiter=phase2,
+        concurrency=1,
+        commit_concurrency=2,
+        poll_seconds=0.05,
+    )
+    pool.start()
+    await asyncio.wait_for(first_started.wait(), timeout=2)
+    await asyncio.sleep(0.15)
+    assert len(started) == 1
+    release_first.set()
+    deadline = asyncio.get_running_loop().time() + 2
+    while len(started) != 2:
+        assert asyncio.get_running_loop().time() < deadline
+        await asyncio.sleep(0.02)
+    await pool.stop(drain_timeout_seconds=2)
+
+
+async def test_permanent_pre_effect_rejection_releases_scope_order() -> None:
+    await PostgresFencedOperationQueue(_ctx(), _env(1, "permanent-1")).submit(
+        "message", "session-permanent"
+    )
+    await PostgresFencedOperationQueue(_ctx(), _env(1, "permanent-2")).submit(
+        "message", "session-permanent"
+    )
+
+    async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+        if item.operation_id == "permanent-1":
+            raise PermanentFencedEffectError("session_not_found")
+        return {"operation_id": item.operation_id}
+
+    writer = PostgresFencedOutboxWriter(execute)
+    assert await writer.run_once() is True
+    rejected = await PostgresFencedOperationQueue.get(_ctx(), "permanent-1")
+    assert rejected is not None and rejected.state == "failed"
+    assert await writer.run_once() is True
+    successor = await PostgresFencedOperationQueue.get(_ctx(), "permanent-2")
+    assert successor is not None and successor.state == "completed"
+
+
+async def test_commit_pool_preserves_same_session_order() -> None:
+    def _insert() -> None:
+        import psycopg2
+
+        with psycopg2.connect(_dsn()) as conn, conn.cursor() as cursor:
+            for index in (1, 2):
+                cursor.execute(
+                    """
+                    INSERT INTO openviking_fencing.operation_receipt
+                        (account_id,user_id,writer,session_scope_id,operation_id,
+                         operation,resource_id,turn_id,digest,fencing_token,state)
+                    VALUES (%s,%s,'alice',%s,%s,'commit','same-session',%s,%s,
+                            1,'completed')
+                    """,
+                    (
+                        "writer-test-account",
+                        "writer-test-user",
+                        f"ordered-{index}",
+                        f"ordered-{index}",
+                        f"ordered-turn-{index}",
+                        f"ordered-digest-{index}",
+                    ),
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO openviking_fencing.commit_work_outbox
+                        (account_id,user_id,writer,session_scope_id,operation_id,
+                         session_id,task_id,archive_uri,wait_for_completion)
+                    VALUES (%s,%s,'alice',%s,%s,'same-session',%s,%s,false)
+                    """,
+                    (
+                        "writer-test-account",
+                        "writer-test-user",
+                        f"ordered-{index}",
+                        f"ordered-{index}",
+                        f"ordered-task-{index}",
+                        f"viking://session/ordered-{index}",
+                    ),
+                )
+
+    await asyncio.to_thread(_insert)
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    order: list[str] = []
+
+    async def phase2(item: FencedCommitWorkItem) -> str:
+        order.append(item.operation_id)
+        if item.operation_id == "ordered-1":
+            first_started.set()
+            await release_first.wait()
+        return "completed"
+
+    async def no_effect(_item: FencedOutboxItem) -> dict[str, Any]:
+        return {}
+
+    pool = PostgresFencedWriterPool(
+        no_effect,
+        task_waiter=phase2,
+        concurrency=1,
+        commit_concurrency=2,
+        poll_seconds=0.05,
+    )
+    pool.start()
+    await asyncio.wait_for(first_started.wait(), timeout=2)
+    await asyncio.sleep(0.15)
+    assert order == ["ordered-1"]
+    release_first.set()
+    deadline = asyncio.get_running_loop().time() + 2
+    while order != ["ordered-1", "ordered-2"]:
+        assert asyncio.get_running_loop().time() < deadline
+        await asyncio.sleep(0.02)
+    await pool.stop(drain_timeout_seconds=2)
+
+
+async def test_empty_pool_uses_bounded_idle_polling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    async def empty_effect(_self: PostgresFencedOutboxWriter) -> bool:
+        nonlocal attempts
+        attempts += 1
+        return False
+
+    async def empty_commit(_self: PostgresFencedOutboxWriter) -> bool:
+        nonlocal attempts
+        attempts += 1
+        return False
+
+    monkeypatch.setattr(PostgresFencedOutboxWriter, "run_once", empty_effect)
+    monkeypatch.setattr(
+        PostgresFencedOutboxWriter,
+        "process_waiting_once",
+        empty_commit,
+    )
+
+    async def no_effect(_item: FencedOutboxItem) -> dict[str, Any]:
+        return {}
+
+    async def no_commit(_item: FencedCommitWorkItem) -> str:
+        return "completed"
+
+    pool = PostgresFencedWriterPool(
+        no_effect,
+        task_waiter=no_commit,
+        concurrency=2,
+        commit_concurrency=2,
+        poll_seconds=0.25,
+        max_idle_seconds=1.0,
+    )
+    pool.start()
+    await asyncio.sleep(1.05)
+    await pool.stop(drain_timeout_seconds=2)
+    assert attempts <= 16
+
+
+async def test_idle_pool_stop_does_not_wait_full_configured_drain() -> None:
+    async def no_effect(_item: FencedOutboxItem) -> dict[str, Any]:
+        return {}
+
+    pool = PostgresFencedWriterPool(
+        no_effect,
+        concurrency=1,
+        poll_seconds=0.05,
+        max_idle_seconds=0.1,
+        drain_timeout_seconds=1860.0,
+    )
+    pool.start()
+    await asyncio.sleep(0.06)
+    await asyncio.wait_for(pool.stop(), timeout=1)
+    assert pool.healthy is False
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGSTOP"), reason="requires POSIX signals")
+async def test_sigstop_writer_holds_authority_until_process_death() -> None:
+    await PostgresFencedOperationQueue(
+        _ctx(),
+        _env(1, "frozen-old", turn="turn-old"),
+    ).submit("message", "frozen-session")
+    child = """
+import asyncio
+import os
+import signal
+from openviking.server import fenced_operation
+from openviking.server.fenced_writer import PostgresFencedOutboxWriter
+
+async def freeze(operation_id):
+    print('EFFECT_STARTED:' + operation_id, flush=True)
+    os.kill(os.getpid(), signal.SIGSTOP)
+
+async def effect(item):
+    print('UNEXPECTED_EFFECT:' + item.operation_id, flush=True)
+    return {'operation_id': item.operation_id}
+
+fenced_operation.after_fenced_writer_effect_started = freeze
+asyncio.run(PostgresFencedOutboxWriter(effect).run_once())
+"""
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        child,
+        cwd=os.getcwd(),
+        env=dict(os.environ),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        assert process.stdout is not None
+        deadline = asyncio.get_running_loop().time() + 10
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            assert remaining > 0, "child did not reach durable effect_started"
+            line = await asyncio.wait_for(process.stdout.readline(), timeout=remaining)
+            assert line, "child exited before SIGSTOP seam"
+            if line.decode().strip() == "EFFECT_STARTED:frozen-old":
+                break
+
+        await PostgresFencedOperationQueue(
+            _ctx(),
+            _env(2, "higher-new", turn="turn-new"),
+        ).submit("message", "frozen-session")
+
+        effects: list[str] = []
+
+        async def execute(item: FencedOutboxItem) -> dict[str, Any]:
+            effects.append(item.operation_id)
+            return {"operation_id": item.operation_id}
+
+        replacement = PostgresFencedOutboxWriter(execute)
+        assert await replacement.run_once() is False
+        assert effects == []
+
+        os.kill(process.pid, signal.SIGKILL)
+        await asyncio.wait_for(process.wait(), timeout=5)
+        assert await replacement.run_once() is True
+        assert await replacement.run_once() is True
+        assert effects == ["frozen-old", "higher-new"]
+    finally:
+        if process.returncode is None:
+            os.kill(process.pid, signal.SIGKILL)
+            await process.wait()

--- a/tests/server/test_url_image_index.py
+++ b/tests/server/test_url_image_index.py
@@ -1,0 +1,391 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the URL-image vector index endpoint (`POST /api/v1/resources/url_image_index`).
+
+This endpoint is the "bring your own image hosting" entrypoint: the caller
+gives an https URL and an OpenViking target URI, and OpenViking embeds the
+image (via the configured multimodal embedder) and inserts the resulting
+vector directly into vectordb — **without** writing the image bytes to agfs.
+
+The tests here pin:
+  - happy path (multimodal embedder, image-only and image+summary)
+  - rejection when the configured embedder is text-only
+  - rejection on dim mismatch
+  - rejection on a non-http(s) image URL
+  - rejection on a malformed target URI
+  - tenant isolation: ``X-OpenViking-Account`` confines reads/writes
+  - no bytes written to agfs as a side effect
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, AsyncGenerator
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from openviking.config import EmbeddingConfig, ServerConfig, VLMConfig
+from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult
+from openviking.server.app import create_app
+from openviking.server.identity import RequestContext, Role
+from openviking.service.core import OpenVikingService
+from openviking_cli.session.user_id import UserIdentifier
+
+# Re-using server conftest's reset_lock_manager helper via a local import: not
+# strictly required, but mirrors how other server tests stitch the fixtures.
+
+
+# ---------------------------------------------------------------------------
+# Local fake embedders. The default FakeEmbedder in tests/server/conftest.py
+# inherits supports_multimodal=False from DenseEmbedderBase — perfect for the
+# negative case. For positive cases we install a multimodal-capable variant.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMultimodalEmbedder(DenseEmbedderBase):
+    """Records every call so tests can assert which content was embedded."""
+
+    def __init__(self, dimension: int = 2048):
+        super().__init__(model_name="test-fake-multimodal")
+        self._dimension = dimension
+        self.calls: list[Any] = []
+
+    @property
+    def supports_multimodal(self) -> bool:  # noqa: D401 (test stub)
+        return True
+
+    def embed(self, content, is_query: bool = False) -> EmbedResult:
+        self.calls.append(content)
+        # Use a deterministic but distinguishable vector so dim-mismatch tests
+        # can be added later without changing the happy-path assertions.
+        return EmbedResult(dense_vector=[0.5] * self._dimension)
+
+    def embed_batch(self, texts, is_query: bool = False):
+        return [self.embed(t, is_query=is_query) for t in texts]
+
+    def get_dimension(self) -> int:
+        return self._dimension
+
+
+class _DimMismatchEmbedder(_FakeMultimodalEmbedder):
+    """Returns vectors of the WRONG dimension so the endpoint's dim check fires."""
+
+    def embed(self, content, is_query: bool = False) -> EmbedResult:
+        self.calls.append(content)
+        # Configured EmbeddingConfig.dimension is 2048 (set in test_data_dir
+        # fixture); deliberately return 1536-dim vectors here.
+        return EmbedResult(dense_vector=[0.5] * 1536)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures local to this file
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_vlm_local(monkeypatch):
+    async def _fake_completion(self, prompt, thinking=False):
+        return "Fake summary."
+
+    async def _fake_vision_completion(self, prompt, images, thinking=False):
+        return "Fake vision description."
+
+    monkeypatch.setattr(VLMConfig, "is_available", lambda self: True)
+    monkeypatch.setattr(VLMConfig, "get_completion_async", _fake_completion)
+    monkeypatch.setattr(VLMConfig, "get_vision_completion_async", _fake_vision_completion)
+
+
+def _install_multimodal_embedder(monkeypatch, embedder_cls=_FakeMultimodalEmbedder):
+    holder: dict[str, Any] = {}
+
+    def _factory(self):
+        emb = embedder_cls(self.dimension)
+        holder["embedder"] = emb
+        return emb
+
+    monkeypatch.setattr(EmbeddingConfig, "get_embedder", _factory)
+    return holder
+
+
+@pytest_asyncio.fixture
+async def multimodal_service(
+    tmp_path: Path, monkeypatch
+) -> AsyncGenerator[tuple[OpenVikingService, dict[str, Any]], None]:
+    """A bare service with a multimodal-capable fake embedder installed."""
+    from openviking.storage.transaction.lock_manager import reset_lock_manager
+
+    reset_lock_manager()
+    _install_fake_vlm_local(monkeypatch)
+    embedder_holder = _install_multimodal_embedder(monkeypatch)
+
+    svc = OpenVikingService(
+        path=str(tmp_path / "data"),
+        user=UserIdentifier.the_default_user("test_user"),
+    )
+    await svc.initialize()
+    yield svc, embedder_holder
+    await svc.close()
+    reset_lock_manager()
+
+
+@pytest_asyncio.fixture
+async def text_only_service(
+    tmp_path: Path, monkeypatch
+) -> AsyncGenerator[OpenVikingService, None]:
+    """A service whose embedder reports supports_multimodal=False."""
+    from openviking.storage.transaction.lock_manager import reset_lock_manager
+
+    reset_lock_manager()
+    _install_fake_vlm_local(monkeypatch)
+
+    class _FakeTextOnly(DenseEmbedderBase):
+        def __init__(self, dim=2048):
+            super().__init__(model_name="text-only")
+            self._dim = dim
+
+        def embed(self, text, is_query: bool = False):
+            return EmbedResult(dense_vector=[0.0] * self._dim)
+
+        def embed_batch(self, texts, is_query: bool = False):
+            return [self.embed(t) for t in texts]
+
+        def get_dimension(self):
+            return self._dim
+
+    monkeypatch.setattr(EmbeddingConfig, "get_embedder", lambda self: _FakeTextOnly(self.dimension))
+
+    svc = OpenVikingService(
+        path=str(tmp_path / "data"),
+        user=UserIdentifier.the_default_user("test_user"),
+    )
+    await svc.initialize()
+    yield svc
+    await svc.close()
+    reset_lock_manager()
+
+
+@pytest_asyncio.fixture
+async def dim_mismatch_service(
+    tmp_path: Path, monkeypatch
+) -> AsyncGenerator[OpenVikingService, None]:
+    from openviking.storage.transaction.lock_manager import reset_lock_manager
+
+    reset_lock_manager()
+    _install_fake_vlm_local(monkeypatch)
+    _install_multimodal_embedder(monkeypatch, embedder_cls=_DimMismatchEmbedder)
+
+    svc = OpenVikingService(
+        path=str(tmp_path / "data"),
+        user=UserIdentifier.the_default_user("test_user"),
+    )
+    await svc.initialize()
+    yield svc
+    await svc.close()
+    reset_lock_manager()
+
+
+def _client_for(svc: OpenVikingService) -> httpx.AsyncClient:
+    """Build an in-process httpx client bound to the service via an app."""
+    from openviking.server.auth.plugins import DevAuthPlugin
+    from openviking.server.auth.registry import get_registry
+    from openviking.server.dependencies import set_service
+
+    config = ServerConfig()
+    app = create_app(config=config, service=svc)
+    set_service(svc)
+    registry = get_registry()
+    if registry.get("dev") is None:
+        registry.register(DevAuthPlugin)
+    plugin_cls = registry.get("dev")
+    if plugin_cls is not None:
+        app.state.auth_plugin = plugin_cls()
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_url_image_index_inserts_vector_without_agfs_write(multimodal_service):
+    """Happy path: multimodal embedder configured, image-only request succeeds
+    and the vector is in vectordb. No file was created in agfs under the
+    target URI."""
+    svc, holder = multimodal_service
+    target_uri = "viking://resources/products/SKU-A/images/0.embed"
+
+    async with _client_for(svc) as client:
+        resp = await client.post(
+            "/api/v1/resources/url_image_index",
+            json={
+                "target_uri": target_uri,
+                "image_url": "https://example.com/photo.jpg",
+                "metadata": {"sku": "SKU-A", "image_idx": 0},
+            },
+            headers={"X-OpenViking-Account": "tenant-a"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["status"] == "ok"
+    assert body["result"]["uri"].endswith("/SKU-A/images/0.embed")
+    assert body["result"]["id"]  # md5 hex string
+
+    # The embedder was called with the URL in image_url passthrough format.
+    embedder = holder["embedder"]
+    assert len(embedder.calls) == 1
+    payload = embedder.calls[0]
+    assert isinstance(payload, list)
+    assert any(
+        p.get("type") == "image_url"
+        and p.get("image_url", {}).get("url") == "https://example.com/photo.jpg"
+        for p in payload
+    )
+    # No text part should be present when summary was not supplied.
+    assert not any(p.get("type") == "text" for p in payload)
+
+    # The vectordb should now hold the vector under the canonical URI scoped
+    # to tenant-a. Round-trip via fetch_by_uri to confirm.
+    ctx = RequestContext(user=UserIdentifier("tenant-a", "default"), role=Role.ROOT)
+    record = await svc.vikingdb_manager.fetch_by_uri(body["result"]["uri"], ctx=ctx)
+    assert record is not None
+    assert record.get("account_id") == "tenant-a"
+    assert record.get("image_url") == "https://example.com/photo.jpg"
+    assert record.get("sku") == "SKU-A"
+    assert record.get("image_idx") == 0
+    # 2048-dim vector from _FakeMultimodalEmbedder.
+    assert len(record.get("vector", [])) == 2048
+
+    # And no file was written under target_uri in agfs.
+    viking_fs = svc.viking_fs
+    assert not await viking_fs.exists(body["result"]["uri"], ctx=ctx)
+
+
+@pytest.mark.asyncio
+async def test_url_image_index_includes_text_part_when_summary_set(multimodal_service):
+    """summary='...' adds a text part to the multimodal embedding input."""
+    svc, holder = multimodal_service
+    async with _client_for(svc) as client:
+        resp = await client.post(
+            "/api/v1/resources/url_image_index",
+            json={
+                "target_uri": "viking://resources/products/SKU-B/images/0.embed",
+                "image_url": "https://example.com/b.jpg",
+                "summary": "Louis Vuitton Trocadero Wearable Wallet",
+            },
+            headers={"X-OpenViking-Account": "tenant-a"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    payload = holder["embedder"].calls[0]
+    text_parts = [p for p in payload if p.get("type") == "text"]
+    assert len(text_parts) == 1
+    assert text_parts[0]["text"] == "Louis Vuitton Trocadero Wearable Wallet"
+
+
+# ---------------------------------------------------------------------------
+# Negative paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_only_embedder_is_rejected(text_only_service):
+    """A text-only embedder must produce a 400, not silently embed the URL string."""
+    async with _client_for(text_only_service) as client:
+        resp = await client.post(
+            "/api/v1/resources/url_image_index",
+            json={
+                "target_uri": "viking://resources/x/y.embed",
+                "image_url": "https://example.com/x.jpg",
+            },
+            headers={"X-OpenViking-Account": "tenant-a"},
+        )
+
+    assert resp.status_code == 400
+    assert "multimodal" in resp.json().get("error", {}).get("message", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_dim_mismatch_is_rejected(dim_mismatch_service):
+    """Embedder returning the wrong dim → 400 (catch dim drift before write)."""
+    async with _client_for(dim_mismatch_service) as client:
+        resp = await client.post(
+            "/api/v1/resources/url_image_index",
+            json={
+                "target_uri": "viking://resources/x/y.embed",
+                "image_url": "https://example.com/x.jpg",
+            },
+            headers={"X-OpenViking-Account": "tenant-a"},
+        )
+
+    assert resp.status_code == 400
+    msg = resp.json().get("error", {}).get("message", "")
+    assert "dim" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_non_http_image_url_is_rejected(multimodal_service):
+    svc, _ = multimodal_service
+    async with _client_for(svc) as client:
+        resp = await client.post(
+            "/api/v1/resources/url_image_index",
+            json={
+                "target_uri": "viking://resources/x/y.embed",
+                "image_url": "data:image/jpeg;base64,AAAA",
+            },
+            headers={"X-OpenViking-Account": "tenant-a"},
+        )
+    assert resp.status_code == 400
+    assert "http" in resp.json().get("error", {}).get("message", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_malformed_target_uri_is_rejected(multimodal_service):
+    svc, _ = multimodal_service
+    async with _client_for(svc) as client:
+        resp = await client.post(
+            "/api/v1/resources/url_image_index",
+            json={
+                "target_uri": "s3://not-a-viking-uri/x.embed",
+                "image_url": "https://example.com/x.jpg",
+            },
+            headers={"X-OpenViking-Account": "tenant-a"},
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reserved_metadata_keys_are_stripped(multimodal_service):
+    """Caller metadata trying to override server-owned fields (id/vector/...)
+    must be ignored — server fields win."""
+    svc, _ = multimodal_service
+    async with _client_for(svc) as client:
+        resp = await client.post(
+            "/api/v1/resources/url_image_index",
+            json={
+                "target_uri": "viking://resources/x/y.embed",
+                "image_url": "https://example.com/x.jpg",
+                "metadata": {
+                    "id": "attacker-controlled-id",
+                    "account_id": "other-tenant",
+                    "vector": [9.9] * 2048,
+                    "sku": "real-sku",
+                },
+            },
+            headers={"X-OpenViking-Account": "tenant-a"},
+        )
+    assert resp.status_code == 200, resp.text
+    server_id = resp.json()["result"]["id"]
+    assert server_id != "attacker-controlled-id"
+
+    ctx = RequestContext(user=UserIdentifier("tenant-a", "default"), role=Role.ROOT)
+    record = await svc.vikingdb_manager.fetch_by_uri(resp.json()["result"]["uri"], ctx=ctx)
+    assert record["account_id"] == "tenant-a"  # not other-tenant
+    assert record["sku"] == "real-sku"  # non-reserved keys pass through
+    # vector must be the embedder's output (all 0.5), not the attacker's (9.9).
+    assert record["vector"][0] == 0.5

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1039,6 +1039,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "diff-match-patch"
 version = "20241021"
 source = { registry = "https://pypi.org/simple" }
@@ -1265,6 +1274,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
     { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -1556,6 +1577,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3f/9859f655d11901e7b2996c6e3d33e0caa9a1d4572c3bc61ed0faa64b2f4c/greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d", size = 277747, upload-time = "2026-02-20T20:16:21.325Z" },
     { url = "https://files.pythonhosted.org/packages/fb/07/cb284a8b5c6498dbd7cba35d31380bb123d7dceaa7907f606c8ff5993cbf/greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13", size = 579202, upload-time = "2026-02-20T20:47:28.955Z" },
     { url = "https://files.pythonhosted.org/packages/ed/45/67922992b3a152f726163b19f890a85129a992f39607a2a53155de3448b8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e", size = 590620, upload-time = "2026-02-20T20:55:55.581Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5f/6e2a7d80c353587751ef3d44bb947f0565ec008a2e0927821c007e96d3a7/greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7", size = 602132, upload-time = "2026-02-20T21:02:43.261Z" },
     { url = "https://files.pythonhosted.org/packages/ad/55/9f1ebb5a825215fadcc0f7d5073f6e79e3007e3282b14b22d6aba7ca6cb8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f", size = 591729, upload-time = "2026-02-20T20:20:58.395Z" },
     { url = "https://files.pythonhosted.org/packages/24/b4/21f5455773d37f94b866eb3cf5caed88d6cea6dd2c6e1f9c34f463cba3ec/greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef", size = 1551946, upload-time = "2026-02-20T20:49:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/00/68/91f061a926abead128fe1a87f0b453ccf07368666bd59ffa46016627a930/greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca", size = 1618494, upload-time = "2026-02-20T20:21:06.541Z" },
@@ -1563,6 +1585,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1571,6 +1594,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1579,6 +1603,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1587,6 +1612,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1595,6 +1621,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -3502,8 +3529,10 @@ dependencies = [
     { name = "argon2-cffi" },
     { name = "charset-normalizer" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "ebooklib" },
     { name = "fastapi" },
+    { name = "feedparser" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "json-repair" },
@@ -3734,10 +3763,12 @@ requires-dist = [
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=2.0.0" },
     { name = "datasets", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "ddgs", marker = "extra == 'bot'", specifier = ">=9.0.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "diff-match-patch", marker = "extra == 'test'", specifier = ">=20200713" },
     { name = "dingtalk-stream", marker = "extra == 'bot-dingtalk'", specifier = ">=0.4.0" },
     { name = "ebooklib", specifier = ">=0.18.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "feedparser", specifier = ">=6.0.0" },
     { name = "fusepy", marker = "extra == 'bot-fuse'", specifier = ">=3.0.1" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.0.0" },
     { name = "google-genai", marker = "extra == 'gemini-async'", specifier = ">=1.0.0" },
@@ -3758,7 +3789,7 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
     { name = "lark-oapi", specifier = ">=1.5.3" },
     { name = "lark-oapi", marker = "extra == 'bot-feishu'", specifier = ">=1.0.0" },
-    { name = "litellm", specifier = ">=1.83.7,<1.86.3" },
+    { name = "litellm", specifier = ">=1.83.7,<1.89.3" },
     { name = "llama-cpp-python", marker = "extra == 'local-embed'", specifier = ">=0.3.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "markdownify", specifier = ">=0.11.0" },
@@ -5661,6 +5692,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e26375
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl", hash = "sha256:f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a", size = 21695, upload-time = "2026-03-27T15:57:03.969Z" },
 ]
+
+[[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
 name = "shellingham"

--- a/uv.lock
+++ b/uv.lock
@@ -3584,6 +3584,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+alice-fencing = [
+    { name = "psycopg2-binary" },
+]
 benchmark = [
     { name = "datasets" },
     { name = "langchain" },
@@ -3819,6 +3822,7 @@ requires-dist = [
     { name = "pdfplumber", specifier = ">=0.10.0" },
     { name = "prompt-toolkit", marker = "extra == 'bot'", specifier = ">=3.0.0" },
     { name = "protobuf", specifier = ">=6.33.5" },
+    { name = "psycopg2-binary", marker = "extra == 'alice-fencing'", specifier = ">=2.9" },
     { name = "psycopg2-binary", marker = "extra == 'opengauss'", specifier = ">=2.9" },
     { name = "py-machineid", marker = "extra == 'bot'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -3877,7 +3881,7 @@ requires-dist = [
     { name = "xlrd", specifier = ">=2.0.1" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
-provides-extras = ["test", "opengauss", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "bot-langfuse", "bot-telegram", "bot-feishu", "bot-dingtalk", "bot-slack", "bot-qq", "bot-sandbox", "bot-fuse", "bot-opencode", "bot-full", "benchmark", "langchain", "langgraph", "local-embed"]
+provides-extras = ["test", "opengauss", "alice-fencing", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "bot-langfuse", "bot-telegram", "bot-feishu", "bot-dingtalk", "bot-slack", "bot-qq", "bot-sandbox", "bot-fuse", "bot-opencode", "bot-full", "benchmark", "langchain", "langgraph", "local-embed"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]


### PR DESCRIPTION
## Description

Implements the endpoint discussed in #2865.

`POST /api/v1/resources/url_image_index` lets a caller embed a remote https image URL as a multimodal vector under a target Viking URI, **without persisting the image bytes anywhere in agfs**. The configured multimodal embedder is given the URL directly — Volcengine Ark `embeddings/multimodal` and equivalent providers already accept https URLs in `image_url.url` and fetch the image themselves. The only thing that's been blocking client use of that capability was `_build_image_data_uri()` in `vectorize_file()` forcing every image to be read from agfs and base64-encoded first.

This endpoint exposes the capability as a small, additive surface — no changes to `Vectorize`, no new `ResourceContentType`, no changes to the existing ingest pipeline.

## Related Issue

Fixes #2865.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking/server/routers/resources.py` — new `UrlImageIndexRequest` pydantic model and `POST /api/v1/resources/url_image_index` handler. The handler:
  - Validates the URI via the existing `validate_viking_uri()` (rejects non-`viking://` schemes, internal scopes, etc.).
  - Refuses non-`http(s)` `image_url` values explicitly.
  - Refuses text-only embedders (`supports_multimodal == False`) with 400 — never silently embeds the URL string as text.
  - Reuses the configured embedder via `EmbeddingConfig.get_embedder()` and `embed_compat()`, so failover / circuit breaker / dim validation come for free.
  - Builds the same vectordb record shape `TextEmbeddingHandler` produces (deterministic md5 id from `account_id:canonical_uri` so repeat calls upsert in place; standard scalar fields).
  - Strips a fixed set of reserved keys from caller `metadata` (`id`, `vector`, `account_id`, `level`, …) so the client can attach its own scalars but cannot override server-controlled fields.
  - Calls `vikingdb_manager.upsert(..., partial_update=True)` synchronously — the vector is in the index before the response returns. **No agfs write, no semantic queue, no embedding queue.**

- `tests/server/test_url_image_index.py` *(new)* — 7 tests:
  1. Happy path image-only: vector lands in vectordb with the canonical URI scoped to `X-OpenViking-Account`; embedder was called with `image_url` passthrough; no file at `target_uri` in agfs after the call.
  2. Happy path image+summary: the multimodal input also contains a `text` part.
  3. Text-only embedder rejected (400).
  4. Dim-mismatch rejected (400, vector never inserted).
  5. Non-`http(s)` `image_url` rejected (400).
  6. Malformed `target_uri` rejected (400, via `validate_viking_uri`).
  7. Reserved metadata keys (`id`, `vector`, `account_id`) cannot be spoofed — server-set values win, caller's other scalars pass through.

- `docs/en/api/02-resources.md` — new section under "API Reference" with the parameter table, curl + Python examples, and an honest caveats block ("no backing file", "no semantic abstracts", "multimodal embedder required", "dim consistency enforced", "tenant isolation").

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```bash
$ python -m py_compile \
    openviking/server/routers/resources.py \
    tests/server/test_url_image_index.py
# clean
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/en/api/02-resources.md` — new section)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Open question for reviewers (also in #2865)

The URI inserted via this endpoint has no backing file in agfs. Walkers that enumerate agfs (re-index, GC, ovpack export) will naturally skip it. The doc note in the new section covers the tradeoff honestly, but if you'd prefer those walkers to see something, I'm happy to also write an empty marker file at `target_uri` as part of the endpoint. Two design points:

1. **Vector-only (current PR).** Smallest change, cleanest semantics ("this URI exists as a vector only"). Walkers must accept that.
2. **Vector + empty marker file.** Plays nicer with existing walkers, but mildly muddies the "no agfs write" guarantee — the marker is bytes-on-disk, just tiny ones.

Either is easy to implement on top of this PR; let me know which you'd prefer and I'll amend.

---

Related: #2820 (image_vectorization config restoration), #2827 (semantic lock exact-path recovery) — both surfaced from the same multimodal-tenant-isolation work.