### PR TITLE
fix(skills): keep scoped update/remove exact

### DIFF
--- a/crates/ov_cli/src/commands/skills.rs
+++ b/crates/ov_cli/src/commands/skills.rs
@@ -222,7 +222,7 @@ pub async fn update(
     parent: Option<&str>,
 ) -> Result<()> {
     let update_all = skill_names.is_empty();
-    let names = resolve_installed_skill_names(client, skill_names).await?;
+    let names = resolve_installed_skill_names(client, skill_names, parent).await?;
     if names.is_empty() {
         output_message_result(
             serde_json::json!({ "updated": [], "total": 0 }),
@@ -245,7 +245,7 @@ pub async fn update(
     let mut updated = Vec::new();
     let mut skipped = Vec::new();
     for name in names {
-        let update_target = match resolve_update_target(client, &name, !update_all).await {
+        let update_target = match resolve_update_target(client, &name, !update_all, parent).await {
             Ok(target) => target,
             Err(error) if update_all => {
                 skipped.push(json!({
@@ -302,7 +302,7 @@ pub async fn remove(
     }
     let requested_names = normalize_skill_names(skill_names)?;
     let names = if all {
-        resolve_installed_skill_names(client, Vec::new()).await?
+        resolve_installed_skill_names(client, Vec::new(), parent).await?
     } else if !requested_names.is_empty() {
         requested_names
     } else {
@@ -311,7 +311,7 @@ pub async fn remove(
                 "Specify at least one skill name, or pass --all.".to_string(),
             ));
         }
-        match prompt_remove_skill_selection(client).await? {
+        match prompt_remove_skill_selection(client, parent).await? {
             Some(selected) => selected,
             None => {
                 output_message_result(
@@ -1154,8 +1154,9 @@ async fn resolve_update_target(
     client: &HttpClient,
     name: &str,
     allow_prompt: bool,
+    parent: Option<&str>,
 ) -> Result<AddTarget> {
-    if let Some(record) = read_skill_source_record(client, name).await? {
+    if let Some(record) = read_skill_source_record(client, name, parent).await? {
         return update_target_from_record(&record, name, allow_prompt);
     }
 
@@ -1172,9 +1173,10 @@ async fn resolve_update_target(
 async fn read_skill_source_record(
     client: &HttpClient,
     name: &str,
+    parent: Option<&str>,
 ) -> Result<Option<SkillSourceRecord>> {
     let result = client
-        .skill_show(name, false, false, true, Some(0), None)
+        .skill_show(name, false, false, true, Some(0), parent)
         .await?;
     let Some(source) = result.get("source") else {
         return Ok(None);
@@ -1351,21 +1353,25 @@ fn resolve_named_skill_dir(root: &Path, name: &str) -> Result<PathBuf> {
 async fn resolve_installed_skill_names(
     client: &HttpClient,
     requested: Vec<String>,
+    parent: Option<&str>,
 ) -> Result<Vec<String>> {
     let requested = normalize_skill_names(requested)?;
     if !requested.is_empty() {
         return Ok(requested);
     }
 
-    Ok(list_installed_skills(client)
+    Ok(list_installed_skills(client, parent)
         .await?
         .into_iter()
         .map(|skill| skill.name)
         .collect())
 }
 
-async fn list_installed_skills(client: &HttpClient) -> Result<Vec<InstalledSkillSummary>> {
-    let result = client.skills_list(10000, None).await?;
+async fn list_installed_skills(
+    client: &HttpClient,
+    parent: Option<&str>,
+) -> Result<Vec<InstalledSkillSummary>> {
+    let result = client.skills_list(10000, parent).await?;
     let skills = result
         .get("skills")
         .and_then(Value::as_array)
@@ -1385,8 +1391,11 @@ async fn list_installed_skills(client: &HttpClient) -> Result<Vec<InstalledSkill
     Ok(skills)
 }
 
-async fn prompt_remove_skill_selection(client: &HttpClient) -> Result<Option<Vec<String>>> {
-    let skills = list_installed_skills(client).await?;
+async fn prompt_remove_skill_selection(
+    client: &HttpClient,
+    parent: Option<&str>,
+) -> Result<Option<Vec<String>>> {
+    let skills = list_installed_skills(client, parent).await?;
     if skills.is_empty() {
         return Ok(Some(Vec::new()));
     }

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -358,7 +358,13 @@ class LocalClient(BaseClient):
         ctx = self._ctx
 
         # Verify the skill exists and determine its root URI
-        root_uri = await _require_skill(service, ctx, skill_name, target_uri)
+        root_uri = await _require_skill(
+            service,
+            ctx,
+            skill_name,
+            target_uri,
+            allow_fallback=target_uri is None,
+        )
         skill_root_parent = root_uri.rsplit("/", 1)[0]
 
         execution = await run_with_telemetry(
@@ -475,7 +481,13 @@ class LocalClient(BaseClient):
         """Delete a skill."""
         service = self._service
         ctx = self._ctx
-        root_uri = await _require_skill(service, ctx, skill_name, target_uri)
+        root_uri = await _require_skill(
+            service,
+            ctx,
+            skill_name,
+            target_uri,
+            allow_fallback=target_uri is None,
+        )
         result = await service.fs.rm(root_uri, ctx=ctx, recursive=True)
         return {"name": skill_name, "uri": root_uri, "root_uri": root_uri, "deleted": True}
 

--- a/openviking/server/routers/skills.py
+++ b/openviking/server/routers/skills.py
@@ -405,8 +405,20 @@ def _skill_root_from_hit_uri(hit_uri: str) -> str:
     return trimmed
 
 
-async def _require_skill(service, ctx: RequestContext, skill_name: str, target_uri: Optional[str] = None) -> str:
-    if target_uri:
+async def _require_skill(
+    service,
+    ctx: RequestContext,
+    skill_name: str,
+    target_uri: Optional[str] = None,
+    *,
+    allow_fallback: bool = True,
+) -> str:
+    if target_uri is not None:
+        if not target_uri.strip():
+            raise InvalidArgumentError(
+                "Skill target URI cannot be empty",
+                details={"field": "target_uri"},
+            )
         resolved_uri = resolve_path_variables(target_uri)
         root_uri = _skill_root_uri(ctx, skill_name, resolved_uri)
         try:
@@ -417,6 +429,8 @@ async def _require_skill(service, ctx: RequestContext, skill_name: str, target_u
             pass
         except Exception as exc:
             raise NotFoundError(root_uri, "skill") from exc
+        if not allow_fallback:
+            raise NotFoundError(root_uri, "skill")
 
     user_root_uri = _skill_root_uri(ctx, skill_name)
     try:
@@ -738,7 +752,13 @@ async def update_skill(
 ):
     """Replace an existing agent skill with new content."""
     service = get_service()
-    root_uri = await _require_skill(service, _ctx, skill_name, request.target_uri)
+    root_uri = await _require_skill(
+        service,
+        _ctx,
+        skill_name,
+        request.target_uri,
+        allow_fallback=request.target_uri is None,
+    )
 
     data = request.data
     allow_local_path_resolution = False
@@ -866,7 +886,13 @@ async def delete_skill(
 ):
     """Remove one installed agent skill."""
     service = get_service()
-    root_uri = await _require_skill(service, _ctx, skill_name, target_uri)
+    root_uri = await _require_skill(
+        service,
+        _ctx,
+        skill_name,
+        target_uri,
+        allow_fallback=target_uri is None,
+    )
     result = await service.fs.rm(root_uri, ctx=_ctx, recursive=True)
     privacy_deleted = False
     privacy = service.privacy_configs

--- a/tests/server/test_api_skills.py
+++ b/tests/server/test_api_skills.py
@@ -207,6 +207,95 @@ async def test_skills_api_update_requires_matching_name(client):
     assert shown["source"]["skill_name"] == "update-skill"
 
 
+async def test_skills_api_update_with_target_uri_does_not_fallback_to_user_skill(client):
+    await _add_skill(client, "scoped-update-skill", "User scoped update skill")
+
+    response = await client.put(
+        "/api/v1/skills/scoped-update-skill",
+        json={
+            "target_uri": "viking://agent/skills",
+            "data": _skill_md(
+                "scoped-update-skill",
+                "Agent scoped update skill",
+                "This should not replace the user-scope skill.",
+            ),
+            "wait": True,
+        },
+    )
+    assert response.status_code == 404
+
+    show_response = await client.get(
+        "/api/v1/skills/scoped-update-skill",
+        params={"include_content": True},
+    )
+    assert show_response.status_code == 200, show_response.text
+    shown = show_response.json()["result"]
+    assert shown["root_uri"].endswith("/user/default/skills/scoped-update-skill")
+    assert shown["description"] == "User scoped update skill"
+    assert "This should not replace" not in shown["content"]
+
+
+async def test_skills_api_delete_with_target_uri_does_not_fallback_to_user_skill(client):
+    await _add_skill(client, "scoped-delete-skill", "User scoped delete skill")
+
+    response = await client.delete(
+        "/api/v1/skills/scoped-delete-skill",
+        params={"target_uri": "viking://agent/skills"},
+    )
+    assert response.status_code == 404
+
+    show_response = await client.get("/api/v1/skills/scoped-delete-skill")
+    assert show_response.status_code == 200, show_response.text
+    assert show_response.json()["result"]["root_uri"].endswith(
+        "/user/default/skills/scoped-delete-skill"
+    )
+
+
+async def test_skills_api_update_rejects_empty_target_uri_without_user_fallback(client):
+    await _add_skill(client, "empty-target-update-skill", "User scoped update skill")
+
+    response = await client.put(
+        "/api/v1/skills/empty-target-update-skill",
+        json={
+            "target_uri": "",
+            "data": _skill_md(
+                "empty-target-update-skill",
+                "Should not update",
+                "This should not replace the user-scope skill.",
+            ),
+            "wait": True,
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+    show_response = await client.get(
+        "/api/v1/skills/empty-target-update-skill",
+        params={"include_content": True},
+    )
+    assert show_response.status_code == 200, show_response.text
+    shown = show_response.json()["result"]
+    assert shown["description"] == "User scoped update skill"
+    assert "This should not replace" not in shown["content"]
+
+
+async def test_skills_api_delete_rejects_empty_target_uri_without_user_fallback(client):
+    await _add_skill(client, "empty-target-delete-skill", "User scoped delete skill")
+
+    response = await client.delete(
+        "/api/v1/skills/empty-target-delete-skill",
+        params={"target_uri": ""},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+    show_response = await client.get("/api/v1/skills/empty-target-delete-skill")
+    assert show_response.status_code == 200, show_response.text
+    assert show_response.json()["result"]["root_uri"].endswith(
+        "/user/default/skills/empty-target-delete-skill"
+    )
+
+
 async def test_skills_api_update_accepts_temp_uploaded_single_file_with_arbitrary_name(
     client,
     tmp_path,

--- a/tests/server/test_skill_target_resolution.py
+++ b/tests/server/test_skill_target_resolution.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Skill target resolution tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.server.identity import RequestContext
+from openviking.server.routers.skills import _require_skill
+from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
+
+
+class _FakeFS:
+    def __init__(self, existing: set[str]):
+        self.existing = existing
+
+    async def stat(self, uri: str, ctx=None):
+        if uri in self.existing:
+            return {"uri": uri, "isDir": True}
+        raise NotFoundError(uri, "skill")
+
+
+def _service_with_skills(*uris: str):
+    return SimpleNamespace(fs=_FakeFS(set(uris)))
+
+
+@pytest.mark.asyncio
+async def test_require_skill_can_fallback_from_missing_target_uri_to_user_skill():
+    service = _service_with_skills("viking://user/default/skills/demo")
+    ctx = RequestContext(user_id="default", account_id="default")
+
+    root_uri = await _require_skill(service, ctx, "demo", "viking://agent/skills")
+
+    assert root_uri == "viking://user/default/skills/demo"
+
+
+@pytest.mark.asyncio
+async def test_require_skill_rejects_explicit_exact_target_when_fallback_disabled():
+    service = _service_with_skills("viking://user/default/skills/demo")
+    ctx = RequestContext(user_id="default", account_id="default")
+
+    with pytest.raises(NotFoundError):
+        await _require_skill(
+            service,
+            ctx,
+            "demo",
+            "viking://agent/skills",
+            allow_fallback=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_require_skill_rejects_empty_target_uri_without_fallback():
+    service = _service_with_skills("viking://user/default/skills/demo")
+    ctx = RequestContext(user_id="default", account_id="default")
+
+    with pytest.raises(InvalidArgumentError) as exc_info:
+        await _require_skill(service, ctx, "demo", "")
+
+    assert "target URI cannot be empty" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- make explicit `target_uri` update/remove requests exact instead of falling back to a same-named user/agent skill
- reject blank skill `target_uri` values before any fallback lookup
- keep the legacy fallback behavior for non-mutating/unscoped helper calls
- scope CLI `skills update --all` / interactive remove listings and update source-record lookup to the requested parent

## Checks
- `python3 -m py_compile openviking/server/routers/skills.py openviking/client/local.py tests/server/test_api_skills.py tests/server/test_skill_target_resolution.py`
- `cargo check --manifest-path crates/ov_cli/Cargo.toml -q`
- `git diff --check`

## Notes
- I attempted focused pytest runs for the new server regressions, but local `uv run pytest ...` hung during package build/import startup before executing tests. The direct compile checks above pass.
- Codex adversarial review found the original exact-scope patch was too broad and missed blank `target_uri`; this version preserves fallback by default and opts out only for update/delete, and rejects blank explicit targets.
