### PR TITLE
fix(sdk/go): stop sending empty args on AddResource so pre-#2549 instances accept it

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -294,6 +294,10 @@ func TestAddResourceUploadsLocalFile(t *testing.T) {
 			if body["directly_upload_media"] != true {
 				t.Fatalf("directly_upload_media = %#v", body["directly_upload_media"])
 			}
+			// args must be omitted when the caller does not pass any, so the
+			// request is accepted by pre-#2549 instances whose resources route
+			// uses model_config=ConfigDict(extra="forbid").
+			requireBodyKeysAbsent(t, body, "args")
 			writeOK(t, w, map[string]any{"uri": "viking://resources/note.md"})
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
@@ -307,6 +311,78 @@ func TestAddResourceUploadsLocalFile(t *testing.T) {
 	}
 	if result["uri"] != "viking://resources/note.md" {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestAddResourceSendsArgsWhenProvided(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/resources/temp_upload":
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatal(err)
+			}
+			writeOK(t, w, map[string]any{"temp_file_id": "tmp-file"})
+		case "/api/v1/resources":
+			body := readJSONBody(t, r)
+			args, ok := body["args"].(map[string]any)
+			if !ok {
+				t.Fatalf("args = %#v, want map", body["args"])
+			}
+			if args["key"] != "value" {
+				t.Fatalf("args[key] = %#v", args["key"])
+			}
+			writeOK(t, w, map[string]any{"uri": "viking://resources/note.md"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer closeServer()
+
+	if _, err := client.AddResource(context.Background(), filePath, &AddResourceOptions{
+		Args: map[string]any{"key": "value"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// An explicitly-provided but empty Args map is treated the same as no args: the
+// key is omitted so the request stays compatible with pre-#2549 instances. The
+// resources create route defaults args to {} server-side, so "absent" and
+// "present-but-empty" are equivalent here. Mirrors the Python SDK #2834.
+func TestAddResourceOmitsExplicitlyEmptyArgs(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/resources/temp_upload":
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatal(err)
+			}
+			writeOK(t, w, map[string]any{"temp_file_id": "tmp-file"})
+		case "/api/v1/resources":
+			body := readJSONBody(t, r)
+			requireBodyKeysAbsent(t, body, "args")
+			writeOK(t, w, map[string]any{"uri": "viking://resources/note.md"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer closeServer()
+
+	if _, err := client.AddResource(context.Background(), filePath, &AddResourceOptions{
+		Args: map[string]any{},
+	}); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/sdk/go/resources.go
+++ b/sdk/go/resources.go
@@ -21,7 +21,6 @@ func (c *Client) AddResource(ctx context.Context, path string, opts *AddResource
 		"strict":                opts.Strict,
 		"directly_upload_media": boolValue(opts.DirectlyUploadMedia, true),
 		"watch_interval":        opts.WatchInterval,
-		"args":                  map[string]any{},
 	}
 	setString(payload, "to", opts.To)
 	setString(payload, "parent", opts.Parent)
@@ -33,7 +32,12 @@ func (c *Client) AddResource(ctx context.Context, path string, opts *AddResource
 		payload["preserve_structure"] = *opts.PreserveStructure
 	}
 	setAny(payload, "telemetry", opts.Telemetry)
-	if opts.Args != nil {
+	// Only attach args when arguments were actually provided. Instances that
+	// predate #2549 (which added the args field to the resources route under
+	// model_config=ConfigDict(extra="forbid")) reject an empty args object with
+	// "body.args: Extra inputs are not permitted". Mirrors the Python SDK
+	// _compact_request_body (#2834) and the Rust CLI compact_request_body (#2799).
+	if len(opts.Args) > 0 {
 		payload["args"] = opts.Args
 	}
 	if err := c.addLocalUpload(ctx, payload, path, true); err != nil {


### PR DESCRIPTION
## Problem

`AddResource` (Go SDK) builds its request body with `"args": map[string]any{}` unconditionally, then only overrides it when `opts.Args != nil`. So when a caller passes no args — the common case, e.g. `client.AddResource(ctx, path, nil)` — an empty `args` object is always sent.

Instances that predate #2549 (which added the `args` field to the resources route under `model_config = ConfigDict(extra="forbid")`) have no `args` field, so `extra="forbid"` rejects the request with:

```
body.args: Extra inputs are not permitted
```

i.e. `AddResource` fails entirely against older / hosted OpenViking endpoints.

## Fix

Drop the unconditional `args: {}` from the payload literal and only attach `args` when arguments were actually provided (`len(opts.Args) > 0`). This is the Go counterpart of the same cross-client backward-compat sweep already merged for the other surfaces:

- Rust CLI — #2799 (`compact_request_body`)
- Python SDK — #2834 (`_compact_request_body`)

Scope is intentionally `args`-only, matching #2834. All other fields, including `directly_upload_media`, are unchanged. The Go `Find`/`Search` paths already omit unset optionals via `setString`/`setAny`, so `AddResource`'s empty `args` was the only remaining Go surface with this issue.

Note (intentional): `len(opts.Args) > 0` treats `nil` and an explicitly-empty `map[string]any{}` the same — both omit the key. On this create route the server defaults `args` to `{}` (`Field(default_factory=dict)` from #2549), so "absent" and "present-but-empty" are equivalent; and omitting an explicit empty map is what keeps the request compatible with pre-#2549 instances. This mirrors `_compact_request_body` in #2834 (which is not used for PATCH/update bodies where `null` could mean "clear").

## Tests

`go test ./sdk/go` passes. Added/extended coverage for all three arg states:

- `TestAddResourceUploadsLocalFile` — asserts `args` is absent when the caller passes `nil`
- `TestAddResourceOmitsExplicitlyEmptyArgs` — asserts `args` is absent for an explicitly-empty map
- `TestAddResourceSendsArgsWhenProvided` — asserts `args` is forwarded when populated
