### PR TITLE
Fix blog code block extraction newlines

### DIFF
--- a/blog/src/blog-components.jsx
+++ b/blog/src/blog-components.jsx
@@ -193,33 +193,22 @@ export function Pre({ children, lang = 'js', filename, lineNumbers = true }) {
   const src = typeof children === 'string' ? children : flattenChildren(children);
   const trimmed = src.replace(/^\n+|\n+$/g, '');
   const tokens = useMemo(() => tokenize(trimmed, lang), [trimmed, lang]);
-  const lines = useMemo(() => {
-    const ls = [[]];
-    for (const t of tokens) {
-      const parts = t.text.split('\n');
-      parts.forEach((p, idx) => {
-        if (p.length) ls[ls.length - 1].push({ cls: t.cls, text: p });
-        if (idx < parts.length - 1) ls.push([]);
-      });
-    }
-    return ls;
-  }, [tokens]);
+  const lineCount = useMemo(() => trimmed ? trimmed.split('\n').length : 1, [trimmed]);
+  const code = tokens.map((t, i) => (
+    <span className={`tk-${t.cls}`} key={i}>{t.text}</span>
+  ));
   return (
-    <div className="b-pre">
-      {filename ? <div className="b-pre__bar"><span className="b-pre__file">{filename}</span><span className="b-pre__lang">{lang}</span></div> : null}
-      <pre className={`b-pre__code ${lineNumbers ? 'b-pre__code--numbered' : ''}`}><code className={`language-${lang}`}>
-        {lines.map((line, i) => (
-          <React.Fragment key={i}>
-            <span className="b-pre__line">
-              <span className="b-pre__lc">{line.length === 0 ? <span> </span> : line.map((t, j) => (
-                <span className={`tk-${t.cls}`} key={j}>{t.text}</span>
-              ))}</span>
-            </span>
-            {i < lines.length - 1 ? '\n' : null}
-          </React.Fragment>
-        ))}
-      </code></pre>
-    </div>
+    <figure className="b-pre">
+      {filename ? <figcaption className="b-pre__bar"><span className="b-pre__file">{filename}</span><span className="b-pre__lang" data-lang={lang} aria-hidden="true" /></figcaption> : null}
+      <div className={`b-pre__body ${lineNumbers ? 'b-pre__body--numbered' : ''}`}>
+        {lineNumbers ? (
+          <div className="b-pre__gutter" aria-hidden="true">
+            {Array.from({ length: lineCount }, (_, i) => <span className="b-pre__ln" key={i}>{i + 1}</span>)}
+          </div>
+        ) : null}
+        <pre className="b-pre__code"><code className={`language-${lang}`}>{code}</code></pre>
+      </div>
+    </figure>
   );
 }
 

--- a/blog/src/blog-components.jsx
+++ b/blog/src/blog-components.jsx
@@ -207,14 +207,16 @@ export function Pre({ children, lang = 'js', filename, lineNumbers = true }) {
   return (
     <div className="b-pre">
       {filename ? <div className="b-pre__bar"><span className="b-pre__file">{filename}</span><span className="b-pre__lang">{lang}</span></div> : null}
-      <pre className="b-pre__code"><code>
+      <pre className={`b-pre__code ${lineNumbers ? 'b-pre__code--numbered' : ''}`}><code className={`language-${lang}`}>
         {lines.map((line, i) => (
-          <span className="b-pre__line" key={i}>
-            {lineNumbers ? <span className="b-pre__ln" aria-hidden="true">{String(i+1).padStart(2, ' ')}</span> : null}
-            <span className="b-pre__lc">{line.length === 0 ? <span> </span> : line.map((t, j) => (
-              <span className={`tk-${t.cls}`} key={j}>{t.text}</span>
-            ))}</span>
-          </span>
+          <React.Fragment key={i}>
+            <span className="b-pre__line">
+              <span className="b-pre__lc">{line.length === 0 ? <span> </span> : line.map((t, j) => (
+                <span className={`tk-${t.cls}`} key={j}>{t.text}</span>
+              ))}</span>
+            </span>
+            {i < lines.length - 1 ? '\n' : null}
+          </React.Fragment>
         ))}
       </code></pre>
     </div>

--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -112,12 +112,12 @@ button { font: inherit; color: inherit; }
 .b-pre__bar { display: flex; justify-content: space-between; align-items: center; padding: 8px 14px; background: color-mix(in oklab, var(--th-bg-2) 80%, var(--th-ink) 8%); border-bottom: 1px solid var(--th-line); font-family: var(--th-font-mono); font-size: 12px; color: var(--th-mute); }
 .b-pre__file { color: var(--th-ink); }
 .b-pre__lang { text-transform: uppercase; letter-spacing: 0.1em; opacity: 0.6; }
-.b-pre__code { margin: 0; padding: 14px 14px; overflow-x: auto; font-family: var(--th-font-mono); font-size: 13.5px; line-height: 1.48; tab-size: 2; }
-.b-pre__code code { display: block; }
-.b-pre__code--numbered code { counter-reset: b-pre-line; }
-.b-pre__line { display: flex; gap: 14px; }
-.b-pre__code--numbered .b-pre__line::before { counter-increment: b-pre-line; content: counter(b-pre-line); color: var(--th-mute); opacity: 0.5; user-select: none; min-width: 2ch; text-align: right; flex: 0 0 auto; }
-.b-pre__lc { white-space: pre; flex: 1 1 auto; }
+.b-pre__lang::before { content: attr(data-lang); }
+.b-pre__body { display: flex; align-items: flex-start; overflow-x: auto; font-family: var(--th-font-mono); font-size: 13.5px; line-height: 1.48; tab-size: 2; }
+.b-pre__gutter { flex: 0 0 auto; padding: 14px 0 14px 14px; color: var(--th-mute); opacity: 0.5; user-select: none; text-align: right; }
+.b-pre__ln { display: block; min-width: 2ch; line-height: inherit; }
+.b-pre__code { flex: 1 0 auto; margin: 0; padding: 14px; overflow: visible; font: inherit; line-height: inherit; tab-size: inherit; }
+.b-pre__code code { display: block; white-space: pre; font: inherit; }
 .tk-cm { color: var(--th-mute); font-style: normal; }
 .tk-st { color: var(--th-tk-st, var(--th-accent-2)); }
 .tk-nu { color: var(--th-tk-nu, var(--th-accent)); }

--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -112,10 +112,10 @@ button { font: inherit; color: inherit; }
 .b-pre__bar { display: flex; justify-content: space-between; align-items: center; padding: 8px 14px; background: color-mix(in oklab, var(--th-bg-2) 80%, var(--th-ink) 8%); border-bottom: 1px solid var(--th-line); font-family: var(--th-font-mono); font-size: 12px; color: var(--th-mute); }
 .b-pre__file { color: var(--th-ink); }
 .b-pre__lang { text-transform: uppercase; letter-spacing: 0.1em; opacity: 0.6; }
-.b-pre__code { margin: 0; padding: 16px 14px; overflow-x: auto; font-family: var(--th-font-mono); font-size: 13.5px; line-height: 1.7; tab-size: 2; }
+.b-pre__code { margin: 0; padding: 14px 14px; overflow-x: auto; font-family: var(--th-font-mono); font-size: 13.5px; line-height: 1.48; tab-size: 2; }
 .b-pre__code code { display: block; }
 .b-pre__code--numbered code { counter-reset: b-pre-line; }
-.b-pre__line { display: flex; gap: 16px; }
+.b-pre__line { display: flex; gap: 14px; }
 .b-pre__code--numbered .b-pre__line::before { counter-increment: b-pre-line; content: counter(b-pre-line); color: var(--th-mute); opacity: 0.5; user-select: none; min-width: 2ch; text-align: right; flex: 0 0 auto; }
 .b-pre__lc { white-space: pre; flex: 1 1 auto; }
 .tk-cm { color: var(--th-mute); font-style: normal; }

--- a/blog/src/themes.css
+++ b/blog/src/themes.css
@@ -113,8 +113,10 @@ button { font: inherit; color: inherit; }
 .b-pre__file { color: var(--th-ink); }
 .b-pre__lang { text-transform: uppercase; letter-spacing: 0.1em; opacity: 0.6; }
 .b-pre__code { margin: 0; padding: 16px 14px; overflow-x: auto; font-family: var(--th-font-mono); font-size: 13.5px; line-height: 1.7; tab-size: 2; }
+.b-pre__code code { display: block; }
+.b-pre__code--numbered code { counter-reset: b-pre-line; }
 .b-pre__line { display: flex; gap: 16px; }
-.b-pre__ln { color: var(--th-mute); opacity: 0.5; user-select: none; min-width: 2ch; text-align: right; flex: 0 0 auto; }
+.b-pre__code--numbered .b-pre__line::before { counter-increment: b-pre-line; content: counter(b-pre-line); color: var(--th-mute); opacity: 0.5; user-select: none; min-width: 2ch; text-align: right; flex: 0 0 auto; }
 .b-pre__lc { white-space: pre; flex: 1 1 auto; }
 .tk-cm { color: var(--th-mute); font-style: normal; }
 .tk-st { color: var(--th-tk-st, var(--th-accent-2)); }


### PR DESCRIPTION
## Summary
- Render blog code blocks with reader-friendly semantic markup: `figure`/`figcaption` plus `<pre><code>`.
- Keep extractor-visible `<code>` content as source code only: inline syntax token spans plus real newline text nodes.
- Move visible line numbers into an `aria-hidden` gutter, outside `<code>`.
- Show the language badge through CSS generated content so reading mode/extractors do not read it as code-adjacent text.
- Tighten code block spacing to avoid the loose line-height from the first fix.

## Preview
<img src="https://raw.githubusercontent.com/volcengine/OpenViking/f795492d212293a5a619d83f2ac9c5d16fb4cfef/.github/pr-previews/pr-2884-codeblock.png" alt="Updated blog code block preview" width="640" />

## Why
The deployed `agent-runtime` article rendered code blocks as line spans without newline text nodes, so many HTML extractors saw one flattened line instead of a multi-line code block.

A first pass restored real newlines but still put them between flex line wrappers, which made browser layout look like each code line had an extra blank line. This revision uses the more general pattern: keep code as normal multiline `<pre><code>` content, and keep line numbers/presentation outside the code text.

## Validation
- `npm run build`
- Verified generated `blog/dist/post/agent-runtime/index.html` has no old `.b-pre__line` wrappers in code blocks.
- Verified the `0_run_claude.js` `<code class="language-js">` text starts with source code, contains 42 real newline characters, and does not include line numbers.
- Verified OpenViking `HTMLParser._html_to_markdown(...)` converts the target snippet into `0_run_claude.js` followed by a fenced multi-line code block.
- Verified the previous `0_run_claude.jsjs` artifact is gone from OpenViking markdown output.
- Captured a local headless Chrome screenshot to confirm the final code block renders compactly without extra blank lines.
- GitHub check `Build and Upload Blog to TOS` passed.

## Notes
- Preview image is hosted from a separate preview branch so this PR diff stays limited to the blog component/CSS fix.
- Best-practice reference: keep code samples semantic as `<pre><code>…</code></pre>`, with real whitespace/newlines in the DOM; use separate presentational UI for line numbers and labels.
