### PR TITLE
Isolate Studio sessions by identity

### DIFF
--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -451,7 +451,7 @@ async def add_message(
     service = get_service()
 
     async def _add() -> dict[str, Any]:
-        session = await service.sessions.get(session_id, _ctx, auto_create=True)
+        session = await service.sessions.get_or_create_writable(session_id, _ctx)
         parts = _resolve_message_parts(request)
 
         session.add_messages(
@@ -491,7 +491,7 @@ async def batch_add_messages(
     service = get_service()
 
     async def _batch_add() -> dict[str, Any]:
-        session = await service.sessions.get(session_id, _ctx, auto_create=True)
+        session = await service.sessions.get_or_create_writable(session_id, _ctx)
         specs = []
         for msg_request in request.messages:
             parts = _resolve_message_parts(msg_request)
@@ -526,7 +526,7 @@ async def record_used(
 ):
     """Record actually used contexts and skills in a session."""
     service = get_service()
-    session = await service.sessions.get(session_id, _ctx, auto_create=False)
+    session = await service.sessions.get_writable(session_id, _ctx, auto_create=False)
 
     # Resolve path variables in contexts
     resolved_contexts = None

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -9,6 +9,7 @@ Provides session management operations: session, sessions, add_message, commit, 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from openviking.core.namespace import canonical_session_uri, legacy_session_uri
+from openviking.message import Message
 from openviking.server.config import ToolOutputExternalizationConfig
 from openviking.server.identity import RequestContext
 from openviking.service.task_tracker import get_task_tracker
@@ -212,6 +213,71 @@ class SessionService:
             auto_create=auto_create,
             legacy_fallback=False,
         )
+
+    @staticmethod
+    def _append_unique_message(
+        messages: List[Message], seen: set[str], message: Message
+    ) -> None:
+        if message.id in seen:
+            return
+        seen.add(message.id)
+        messages.append(message)
+
+    async def _readable_messages_for_canonical_copy(self, session: Session) -> List[Message]:
+        """Collect user-visible legacy messages in chronological display order."""
+        messages: List[Message] = []
+        seen: set[str] = set()
+
+        commit_count = max(0, int(session.meta.commit_count or 0))
+        for index in range(1, commit_count + 1):
+            try:
+                archive = await session.get_session_archive(f"archive_{index:03d}")
+            except Exception:
+                continue
+            for raw_message in archive.get("messages", []):
+                if not isinstance(raw_message, dict):
+                    continue
+                try:
+                    self._append_unique_message(
+                        messages,
+                        seen,
+                        Message.from_dict(raw_message),
+                    )
+                except Exception:
+                    continue
+
+        for message in session.messages:
+            self._append_unique_message(messages, seen, message)
+
+        return messages
+
+    async def get_or_create_writable(self, session_id: str, ctx: RequestContext) -> Session:
+        """Get a canonical user session, migrating readable legacy history on first write."""
+        try:
+            session = self.session(ctx, session_id)
+            legacy_messages: List[Message] = []
+
+            if not await session.exists():
+                legacy_session = self.session(
+                    ctx,
+                    session_id,
+                    session_uri=legacy_session_uri(session_id),
+                )
+                if await legacy_session.exists():
+                    await legacy_session.load()
+                    legacy_messages = await self._readable_messages_for_canonical_copy(
+                        legacy_session
+                    )
+                await session.ensure_exists()
+
+            await session.load()
+            if legacy_messages:
+                session.import_messages(legacy_messages)
+            self._record_lifecycle_metric("get", "ok")
+            return session
+        except Exception:
+            self._record_lifecycle_metric("get", "error")
+            raise
 
     async def sessions(self, ctx: RequestContext) -> List[Dict[str, Any]]:
         """Get all sessions for the current user.

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -8,7 +8,7 @@ Provides session management operations: session, sessions, add_message, commit, 
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from openviking.core.namespace import canonical_session_uri
+from openviking.core.namespace import canonical_session_uri, legacy_session_uri
 from openviking.server.config import ToolOutputExternalizationConfig
 from openviking.server.identity import RequestContext
 from openviking.service.task_tracker import get_task_tracker
@@ -142,10 +142,11 @@ class SessionService:
         self._record_lifecycle_metric("create", "attempt")
         try:
             if session_id:
-                existing = self.session(ctx, session_id)
-                if await existing.exists():
+                session = self.session(ctx, session_id)
+                if await session.exists():
                     raise AlreadyExistsError(f"Session '{session_id}' already exists")
-            session = self.session(ctx, session_id)
+            else:
+                session = self.session(ctx, session_id)
             if memory_policy is not None:
                 policy = MemoryPolicy.from_dict(memory_policy)
                 policy.validate_memory_types(
@@ -160,7 +161,12 @@ class SessionService:
             raise
 
     async def get(
-        self, session_id: str, ctx: RequestContext, *, auto_create: bool = False
+        self,
+        session_id: str,
+        ctx: RequestContext,
+        *,
+        auto_create: bool = False,
+        legacy_fallback: bool = True,
     ) -> Session:
         """Get an existing session.
 
@@ -169,19 +175,43 @@ class SessionService:
             ctx: Request context
             auto_create: If True, create the session when it does not exist.
                          Default is False (raise NotFoundError).
+            legacy_fallback: If True, allow read-only fallback to pre-user-namespace
+                             legacy sessions when the canonical session is absent.
         """
         try:
             session = self.session(ctx, session_id)
             if not await session.exists():
-                if not auto_create:
+                if auto_create:
+                    await session.ensure_exists()
+                elif legacy_fallback:
+                    legacy_session = self.session(
+                        ctx,
+                        session_id,
+                        session_uri=legacy_session_uri(session_id),
+                    )
+                    if await legacy_session.exists():
+                        session = legacy_session
+                    else:
+                        raise NotFoundError(session_id, "session")
+                else:
                     raise NotFoundError(session_id, "session")
-                await session.ensure_exists()
             await session.load()
             self._record_lifecycle_metric("get", "ok")
             return session
         except Exception:
             self._record_lifecycle_metric("get", "error")
             raise
+
+    async def get_writable(
+        self, session_id: str, ctx: RequestContext, *, auto_create: bool = False
+    ) -> Session:
+        """Get a canonical user session for mutating operations."""
+        return await self.get(
+            session_id,
+            ctx,
+            auto_create=auto_create,
+            legacy_fallback=False,
+        )
 
     async def sessions(self, ctx: RequestContext) -> List[Dict[str, Any]]:
         """Get all sessions for the current user.
@@ -233,13 +263,12 @@ class SessionService:
         """
         self._ensure_initialized()
 
-        session_uri = canonical_session_uri(ctx, session_id)
-        session = await self.get(session_id, ctx)
+        session = await self.get_writable(session_id, ctx)
         if not await session.exists():
             self._record_lifecycle_metric("delete", "error")
             raise NotFoundError(session_id, "session")
 
-        await self._viking_fs.rm(session_uri, recursive=True, ctx=ctx)
+        await self._viking_fs.rm(session.uri, recursive=True, ctx=ctx)
         logger.info(f"Deleted session: {session_id}")
         self._record_lifecycle_metric("delete", "ok")
         return True
@@ -288,7 +317,7 @@ class SessionService:
             archive_uri, archived
         """
         self._ensure_initialized()
-        session = await self.get(session_id, ctx)
+        session = await self.get_writable(session_id, ctx)
         result = await session.commit_async(keep_recent_count=keep_recent_count)
         self._record_lifecycle_metric("commit", "ok" if result.get("status") else "error")
         self._record_archive_metric("ok" if result.get("archived") else "skip")
@@ -316,7 +345,7 @@ class SessionService:
         if not self._session_compressor:
             raise NotInitializedError("SessionCompressorV2")
 
-        session = await self.get(session_id, ctx)
+        session = await self.get_writable(session_id, ctx)
         archive_uri = f"{session.uri}/manual_extract"
 
         memories = await self._session_compressor.extract_long_term_memories(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -958,6 +958,14 @@ class Session:
         self._append_messages(all_messages)
         return all_messages
 
+    def import_messages(self, messages: List[Message]) -> None:
+        """Import existing messages while preserving their IDs and timestamps."""
+        if not messages:
+            return
+        self._append_messages(
+            [Message.from_dict(message.to_dict()) for message in messages]
+        )
+
     def add_message(
         self,
         role: str,

--- a/tests/service/test_session_service_metrics.py
+++ b/tests/service/test_session_service_metrics.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 import openviking.service.session_service as session_service_module
+from openviking.message import Message, TextPart
 from openviking.metrics.datasources.session import SessionLifecycleDataSource
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
@@ -17,6 +18,15 @@ def _make_ctx() -> RequestContext:
     return RequestContext(
         user=UserIdentifier("acme", "alice"),
         role=Role.ADMIN,
+    )
+
+
+def _message(message_id: str, text: str) -> Message:
+    return Message(
+        id=message_id,
+        role="assistant" if message_id.startswith("assistant") else "user",
+        parts=[TextPart(text=text)],
+        created_at="2026-06-29T00:00:00Z",
     )
 
 
@@ -203,3 +213,39 @@ async def test_writable_session_does_not_fall_back_to_legacy_scope(
     canonical.load.assert_not_awaited()
     legacy.exists.assert_not_awaited()
     legacy.load.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_writable_imports_readable_legacy_messages(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service = SessionService(viking_fs=Mock())
+    ctx = _make_ctx()
+    canonical = Mock()
+    canonical.exists = AsyncMock(return_value=False)
+    canonical.ensure_exists = AsyncMock()
+    canonical.load = AsyncMock()
+    canonical.import_messages = Mock()
+    legacy = Mock()
+    legacy.exists = AsyncMock(return_value=True)
+    legacy.load = AsyncMock()
+    legacy.meta.commit_count = 1
+    legacy.get_session_archive = AsyncMock(
+        return_value={"messages": [_message("archive-1", "archived").to_dict()]}
+    )
+    legacy.messages = [_message("live-1", "live")]
+
+    def _session(_ctx, session_id, *, session_uri=None):
+        assert session_id == "legacy-session"
+        return legacy if session_uri == "viking://session/legacy-session" else canonical
+
+    monkeypatch.setattr(service, "session", Mock(side_effect=_session))
+
+    result = await service.get_or_create_writable("legacy-session", ctx)
+
+    assert result is canonical
+    canonical.ensure_exists.assert_awaited_once()
+    canonical.load.assert_awaited_once()
+    canonical.import_messages.assert_called_once()
+    imported = canonical.import_messages.call_args.args[0]
+    assert [message.id for message in imported] == ["archive-1", "live-1"]

--- a/tests/service/test_session_service_metrics.py
+++ b/tests/service/test_session_service_metrics.py
@@ -9,6 +9,7 @@ import openviking.service.session_service as session_service_module
 from openviking.metrics.datasources.session import SessionLifecycleDataSource
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
+from openviking_cli.exceptions import NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -124,3 +125,81 @@ async def test_sessions_merges_canonical_and_legacy_session_scope():
             "is_dir": True,
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_falls_back_to_legacy_session_scope(monkeypatch: pytest.MonkeyPatch):
+    service = SessionService(viking_fs=Mock())
+    ctx = _make_ctx()
+    canonical = Mock()
+    canonical.exists = AsyncMock(return_value=False)
+    canonical.load = AsyncMock()
+    legacy = Mock()
+    legacy.exists = AsyncMock(return_value=True)
+    legacy.load = AsyncMock()
+
+    def _session(_ctx, session_id, *, session_uri=None):
+        assert session_id == "legacy-session"
+        return legacy if session_uri == "viking://session/legacy-session" else canonical
+
+    monkeypatch.setattr(service, "session", Mock(side_effect=_session))
+
+    result = await service.get("legacy-session", ctx)
+
+    assert result is legacy
+    canonical.load.assert_not_awaited()
+    legacy.load.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_auto_create_ignores_legacy_session_scope(monkeypatch: pytest.MonkeyPatch):
+    service = SessionService(viking_fs=Mock())
+    ctx = _make_ctx()
+    canonical = Mock()
+    canonical.exists = AsyncMock(return_value=False)
+    canonical.ensure_exists = AsyncMock()
+    canonical.load = AsyncMock()
+    legacy = Mock()
+    legacy.exists = AsyncMock(return_value=True)
+    legacy.load = AsyncMock()
+
+    def _session(_ctx, session_id, *, session_uri=None):
+        assert session_id == "legacy-session"
+        return legacy if session_uri == "viking://session/legacy-session" else canonical
+
+    monkeypatch.setattr(service, "session", Mock(side_effect=_session))
+
+    result = await service.get("legacy-session", ctx, auto_create=True)
+
+    assert result is canonical
+    canonical.ensure_exists.assert_awaited_once()
+    canonical.load.assert_awaited_once()
+    legacy.exists.assert_not_awaited()
+    legacy.load.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_writable_session_does_not_fall_back_to_legacy_scope(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service = SessionService(viking_fs=Mock())
+    ctx = _make_ctx()
+    canonical = Mock()
+    canonical.exists = AsyncMock(return_value=False)
+    canonical.load = AsyncMock()
+    legacy = Mock()
+    legacy.exists = AsyncMock(return_value=True)
+    legacy.load = AsyncMock()
+
+    def _session(_ctx, session_id, *, session_uri=None):
+        assert session_id == "legacy-session"
+        return legacy if session_uri == "viking://session/legacy-session" else canonical
+
+    monkeypatch.setattr(service, "session", Mock(side_effect=_session))
+
+    with pytest.raises(NotFoundError):
+        await service.get_writable("legacy-session", ctx)
+
+    canonical.load.assert_not_awaited()
+    legacy.exists.assert_not_awaited()
+    legacy.load.assert_not_awaited()

--- a/web-studio/src/lib/sessions/api.test.ts
+++ b/web-studio/src/lib/sessions/api.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Message } from './types/message'
+
+const sdkMocks = vi.hoisted(() => ({
+  deleteSessionBySessionId: vi.fn(),
+  getSessionBySessionId: vi.fn(),
+  getSessionIdArchiveByArchiveId: vi.fn(),
+  getSessionIdContext: vi.fn(),
+  getSessions: vi.fn(),
+  postBotV1Chat: vi.fn(),
+  postSessions: vi.fn(),
+  postSessionIdCommit: vi.fn(),
+  postSessionIdExtract: vi.fn(),
+  postSessionIdMessages: vi.fn(),
+  postSessionIdUsed: vi.fn(),
+}))
+
+vi.mock('#/gen/ov-client/sdk.gen', () => sdkMocks)
+
+vi.mock('#/lib/ov-client', () => ({
+  OvClientError: class OvClientError extends Error {},
+  getOvResult: async <T>(value: T | Promise<T>): Promise<T> => value,
+  normalizeOvClientError: (error: unknown) => error,
+  ovClient: {
+    instance: {
+      get: vi.fn(),
+    },
+  },
+}))
+
+import { fetchSessionMessages } from './api'
+
+function message(id: string, text: string): Message {
+  return {
+    created_at: `2026-06-29T00:00:0${id.length}Z`,
+    id,
+    parts: [{ type: 'text', text }],
+    role: id.startsWith('assistant') ? 'assistant' : 'user',
+  }
+}
+
+describe('fetchSessionMessages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('merges all readable archive messages before live messages', async () => {
+    sdkMocks.getSessionIdContext.mockResolvedValue({
+      messages: [message('live-1', 'live')],
+    })
+    sdkMocks.getSessionBySessionId.mockResolvedValue({ commit_count: 3 })
+    sdkMocks.getSessionIdArchiveByArchiveId.mockImplementation(({ path }) => {
+      if (path.archive_id === 'archive_002') {
+        return Promise.reject(new Error('pending archive'))
+      }
+      return Promise.resolve({
+        messages:
+          path.archive_id === 'archive_001'
+            ? [message('archive-1', 'first')]
+            : [message('archive-3', 'third')],
+      })
+    })
+
+    const messages = await fetchSessionMessages('session-1')
+
+    expect(messages.map((item) => item.id)).toEqual([
+      'archive-1',
+      'archive-3',
+      'live-1',
+    ])
+    expect(sdkMocks.getSessionIdArchiveByArchiveId).toHaveBeenCalledTimes(3)
+  })
+
+  it('deduplicates messages returned by archives and context', async () => {
+    sdkMocks.getSessionIdContext.mockResolvedValue({
+      messages: [message('shared', 'live copy'), message('live-2', 'live')],
+    })
+    sdkMocks.getSessionBySessionId.mockResolvedValue({ commit_count: 1 })
+    sdkMocks.getSessionIdArchiveByArchiveId.mockResolvedValue({
+      messages: [message('shared', 'archived copy')],
+    })
+
+    const messages = await fetchSessionMessages('session-1')
+
+    expect(messages.map((item) => item.id)).toEqual(['shared', 'live-2'])
+    expect(messages[0].parts).toEqual([{ type: 'text', text: 'archived copy' }])
+  })
+})

--- a/web-studio/src/lib/sessions/api.ts
+++ b/web-studio/src/lib/sessions/api.ts
@@ -31,6 +31,65 @@ import type {
 } from '@ov-server/api/v1/sessions'
 import type { UsedRequest } from '#/gen/ov-client/types.gen'
 
+function isSessionMessage(value: unknown): value is Message {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    'role' in value &&
+    'parts' in value
+  )
+}
+
+function normalizeSessionMessages(value: unknown): Message[] {
+  return Array.isArray(value) ? value.filter(isSessionMessage) : []
+}
+
+export function archiveIdFromIndex(index: number): string {
+  return `archive_${String(index).padStart(3, '0')}`
+}
+
+function readCommitCount(meta: SessionMeta): number {
+  const value = (meta as { commit_count?: unknown }).commit_count
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function appendUniqueMessages(
+  current: Message[],
+  messages: Message[],
+): Message[] {
+  const seen = new Set(current.map((message) => message.id))
+  const next = [...current]
+
+  for (const message of messages) {
+    if (seen.has(message.id)) continue
+    seen.add(message.id)
+    next.push(message)
+  }
+
+  return next
+}
+
+async function fetchArchivedMessages(
+  sessionId: string,
+  commitCount: number,
+): Promise<Message[]> {
+  let archivedMessages: Message[] = []
+  for (let index = 1; index <= commitCount; index += 1) {
+    try {
+      const archive = (await fetchSessionArchive(
+        sessionId,
+        archiveIdFromIndex(index),
+      )) as { messages?: unknown }
+      const messages = normalizeSessionMessages(archive.messages)
+      archivedMessages = appendUniqueMessages(archivedMessages, messages)
+    } catch {
+      // Archives can be missing, failed, or still pending; keep the readable ones.
+    }
+  }
+  return archivedMessages
+}
+
 // ---------------------------------------------------------------------------
 // Session CRUD
 // ---------------------------------------------------------------------------
@@ -100,22 +159,22 @@ export async function deleteSession(
 export async function fetchSessionMessages(
   sessionId: string,
 ): Promise<Message[]> {
-  const result = await getOvResult<SessionContextResult>(
-    getSessionIdContext({
-      path: { session_id: sessionId },
-    }),
-  )
-  const raw = result.messages
-  if (!Array.isArray(raw)) return []
+  const [result, meta] = await Promise.all([
+    getOvResult<SessionContextResult>(
+      getSessionIdContext({
+        path: { session_id: sessionId },
+      }),
+    ),
+    fetchSession(sessionId),
+  ])
   // Each item is Message.to_dict() — { id, role, parts, created_at }
-  return raw.filter(
-    (m): m is Message =>
-      typeof m === 'object' &&
-      m !== null &&
-      'id' in m &&
-      'role' in m &&
-      'parts' in m,
-  )
+  const messages = normalizeSessionMessages(result.messages)
+
+  const commitCount = readCommitCount(meta)
+  if (commitCount <= 0) return messages
+
+  const archivedMessages = await fetchArchivedMessages(sessionId, commitCount)
+  return appendUniqueMessages(archivedMessages, messages)
 }
 
 export async function addMessage(

--- a/web-studio/src/lib/sessions/generate-title.ts
+++ b/web-studio/src/lib/sessions/generate-title.ts
@@ -9,9 +9,11 @@ export async function generateTitle(
   assistantReply: string,
 ): Promise<string> {
   const prompt = [
-    '请用10个字以内为以下对话生成一个简短标题，只返回标题本身，不要加引号或其他标点：',
-    `用户：${userMessage.slice(0, 200)}`,
-    `助手：${assistantReply.slice(0, 300)}`,
+    'Create a concise conversation title in the same language as the conversation.',
+    'Return only the title, without quotes or trailing punctuation.',
+    'Keep it under 10 Chinese characters or 6 English words.',
+    `User: ${userMessage.slice(0, 200)}`,
+    `Assistant: ${assistantReply.slice(0, 300)}`,
   ].join('\n')
 
   const res = await sendChat({

--- a/web-studio/src/lib/sessions/query-keys.test.ts
+++ b/web-studio/src/lib/sessions/query-keys.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ConnectionDraft } from '#/hooks/use-app-connection'
+import { getSessionScopeKey } from './query-keys'
+
+function connection(
+  overrides: Partial<ConnectionDraft> = {},
+): ConnectionDraft {
+  return {
+    accountId: 'default',
+    adminApiKey: '',
+    apiKey: '',
+    baseUrl: 'http://openviking.test',
+    userId: 'alice',
+    ...overrides,
+  }
+}
+
+describe('getSessionScopeKey', () => {
+  it('uses the user API key as the session data scope when both keys exist', () => {
+    const first = getSessionScopeKey(
+      connection({ adminApiKey: 'admin-one', apiKey: 'user-key' }),
+      'admin',
+    )
+    const second = getSessionScopeKey(
+      connection({ adminApiKey: 'admin-two', apiKey: 'user-key' }),
+      'admin',
+    )
+
+    expect(first.keySource).toBe('api')
+    expect(second.keySource).toBe('api')
+    expect(first.keyHash).toBe(second.keyHash)
+  })
+
+  it('falls back to the admin API key when no user API key is configured', () => {
+    const scope = getSessionScopeKey(
+      connection({ adminApiKey: 'admin-key', apiKey: '' }),
+      'root',
+    )
+
+    expect(scope.keySource).toBe('admin')
+    expect(scope.keyHash).not.toBe('none')
+  })
+})

--- a/web-studio/src/lib/sessions/query-keys.ts
+++ b/web-studio/src/lib/sessions/query-keys.ts
@@ -1,0 +1,61 @@
+import type {
+  ConnectionDraft,
+  ConnectionRole,
+} from '#/hooks/use-app-connection'
+
+export const SESSIONS_KEY = ['sessions'] as const
+
+export type SessionScopeKey = {
+  accountId: string
+  baseUrl: string
+  keyHash: string
+  keySource: 'api' | 'admin' | 'none'
+  role: ConnectionRole
+  userId: string
+}
+
+function hashSecret(value: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+export function getSessionScopeKey(
+  connection: ConnectionDraft,
+  connectionRole: ConnectionRole,
+): SessionScopeKey {
+  const sessionKey = connection.apiKey || connection.adminApiKey
+  return {
+    accountId: connection.accountId,
+    baseUrl: connection.baseUrl,
+    keyHash: sessionKey ? hashSecret(sessionKey) : 'none',
+    keySource: connection.apiKey
+      ? 'api'
+      : connection.adminApiKey
+        ? 'admin'
+        : 'none',
+    role: connectionRole,
+    userId: connection.userId,
+  }
+}
+
+export function getSessionsQueryKey(scope: SessionScopeKey) {
+  return [...SESSIONS_KEY, scope] as const
+}
+
+export function getSessionQueryKey(
+  scope: SessionScopeKey,
+  sessionId: string | undefined,
+) {
+  return [...SESSIONS_KEY, scope, sessionId] as const
+}
+
+export function getSessionMessagesQueryKey(
+  scope: SessionScopeKey,
+  sessionId: string,
+) {
+  return [...SESSIONS_KEY, scope, sessionId, 'messages'] as const
+}

--- a/web-studio/src/lib/sessions/use-chat.ts
+++ b/web-studio/src/lib/sessions/use-chat.ts
@@ -209,7 +209,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
   const pendingInitialMessagesRef = useRef<Message[] | undefined>(undefined)
   messagesRef.current = messages
 
-  // Reset state when sessionId changes
+  // Reset state when the visible session scope changes.
   useEffect(() => {
     abortRef.current?.abort()
     abortRef.current = null
@@ -223,7 +223,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
     setStreamingReasoning('')
     setStreamingParts([])
     setIteration(0)
-  }, [sessionId])
+  }, [sessionId, scope])
 
   // Sync initialMessages into state when they load or when switching sessions.
   useEffect(() => {
@@ -243,7 +243,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
 
     lastSyncedInitialMessagesRef.current = nextInitialMessages
     setMessages(nextInitialMessages)
-  }, [initialMessages, sessionId, status])
+  }, [initialMessages, sessionId, scope, status])
 
   const abort = useCallback(() => {
     abortRef.current?.abort()

--- a/web-studio/src/lib/sessions/use-chat.ts
+++ b/web-studio/src/lib/sessions/use-chat.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 
 import type { ChatStatus, StreamToolCall } from './types/chat'
 import type {
@@ -10,6 +11,11 @@ import type {
   ToolPart,
 } from './types/message'
 import { addMessage, sendChatStream, serializeParts } from './api'
+import { useAppConnection } from '#/hooks/use-app-connection'
+import {
+  getSessionMessagesQueryKey,
+  getSessionScopeKey,
+} from './query-keys'
 import { parseSseStream, streamEventDataToText } from './sse'
 import { setSessionTitle } from './use-session-titles'
 import { createBrowserId } from '../browser-crypto'
@@ -73,6 +79,23 @@ function waitForNextFrame(): Promise<void> {
   return new Promise((resolve) => {
     window.requestAnimationFrame(() => resolve())
   })
+}
+
+function appendMessagesToCache(
+  current: Message[] | undefined,
+  messages: Message[],
+): Message[] {
+  const existing = current ?? []
+  const seen = new Set(existing.map((message) => message.id))
+  const next = [...existing]
+
+  for (const message of messages) {
+    if (seen.has(message.id)) continue
+    seen.add(message.id)
+    next.push(message)
+  }
+
+  return next
 }
 
 type SendOptions = {
@@ -155,6 +178,19 @@ export interface UseChatReturn {
 
 export function useChat(options: UseChatOptions): UseChatReturn {
   const { sessionId, initialMessages, persistMessages = true } = options
+  const queryClient = useQueryClient()
+  const { connection, connectionRole } = useAppConnection()
+  const scope = useMemo(
+    () => getSessionScopeKey(connection, connectionRole),
+    [
+      connection.accountId,
+      connection.adminApiKey,
+      connection.apiKey,
+      connection.baseUrl,
+      connection.userId,
+      connectionRole,
+    ],
+  )
 
   const [messages, setMessages] = useState<Message[]>(initialMessages ?? [])
   const [status, setStatus] = useState<ChatStatus>('idle')
@@ -478,6 +514,14 @@ export function useChat(options: UseChatOptions): UseChatReturn {
               undefined,
               serializeParts(assistantMsg.parts),
             )
+            queryClient.setQueryData<Message[]>(
+              getSessionMessagesQueryKey(scope, sessionId),
+              (current) =>
+                appendMessagesToCache(current, [userMsg, assistantMsg]),
+            )
+            void queryClient.invalidateQueries({
+              queryKey: getSessionMessagesQueryKey(scope, sessionId),
+            })
           } catch {
             // Persistence failure is non-blocking
           }
@@ -513,7 +557,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
         abortRef.current = null
       }
     },
-    [status, sessionId, persistMessages],
+    [status, sessionId, persistMessages, queryClient, scope],
   )
 
   return {

--- a/web-studio/src/lib/sessions/use-sessions.ts
+++ b/web-studio/src/lib/sessions/use-sessions.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo } from 'react'
 
 import {
   createSession,
@@ -8,10 +9,48 @@ import {
   fetchSessionMessages,
   fetchSessions,
 } from './api'
+import { useAppConnection } from '#/hooks/use-app-connection'
+import {
+  getSessionMessagesQueryKey,
+  getSessionQueryKey,
+  getSessionScopeKey,
+  getSessionsQueryKey,
+} from './query-keys'
 import type { Message } from './types/message'
+import type { CreateSessionResult, SessionListItem } from './types/session'
 
-const SESSIONS_KEY = ['sessions'] as const
 const BOT_HEALTH_KEY = ['bot', 'health'] as const
+
+function useSessionScope() {
+  const { connection, connectionRole } = useAppConnection()
+  return useMemo(
+    () => getSessionScopeKey(connection, connectionRole),
+    [
+      connection.accountId,
+      connection.adminApiKey,
+      connection.apiKey,
+      connection.baseUrl,
+      connection.userId,
+      connectionRole,
+    ],
+  )
+}
+
+function appendSessionToList(
+  sessions: SessionListItem[] | undefined,
+  result: CreateSessionResult,
+): SessionListItem[] {
+  const nextSession = {
+    is_dir: true,
+    session_id: result.session_id,
+    uri: result.uri,
+  } satisfies SessionListItem
+  const existing = sessions ?? []
+  if (existing.some((session) => session.session_id === result.session_id)) {
+    return existing
+  }
+  return [...existing, nextSession]
+}
 
 export function useBotHealth() {
   return useQuery({
@@ -23,16 +62,20 @@ export function useBotHealth() {
 }
 
 export function useSessionList() {
+  const scope = useSessionScope()
+
   return useQuery({
-    queryKey: SESSIONS_KEY,
+    queryKey: getSessionsQueryKey(scope),
     queryFn: fetchSessions,
     staleTime: 30_000,
   })
 }
 
 export function useSession(sessionId: string | undefined) {
+  const scope = useSessionScope()
+
   return useQuery({
-    queryKey: [...SESSIONS_KEY, sessionId],
+    queryKey: getSessionQueryKey(scope, sessionId),
     queryFn: () => fetchSession(sessionId!),
     enabled: Boolean(sessionId),
     staleTime: 15_000,
@@ -41,8 +84,12 @@ export function useSession(sessionId: string | undefined) {
 
 /** Fetch message history for a session. */
 export function useSessionMessages(sessionId: string | undefined) {
+  const scope = useSessionScope()
+
   return useQuery<Message[]>({
-    queryKey: [...SESSIONS_KEY, sessionId, 'messages'],
+    queryKey: sessionId
+      ? getSessionMessagesQueryKey(scope, sessionId)
+      : getSessionQueryKey(scope, sessionId),
     queryFn: () => fetchSessionMessages(sessionId!),
     enabled: Boolean(sessionId),
     staleTime: 30_000, // cache for 30s to avoid flash on session switch
@@ -51,22 +98,30 @@ export function useSessionMessages(sessionId: string | undefined) {
 
 export function useCreateSession() {
   const queryClient = useQueryClient()
+  const scope = useSessionScope()
+  const sessionsKey = getSessionsQueryKey(scope)
 
   return useMutation({
     mutationFn: (sessionId?: string) => createSession(sessionId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: SESSIONS_KEY })
+    onSuccess: (result) => {
+      queryClient.setQueryData<SessionListItem[]>(sessionsKey, (sessions) =>
+        appendSessionToList(sessions, result),
+      )
+      void queryClient.invalidateQueries({ queryKey: sessionsKey })
     },
   })
 }
 
 export function useDeleteSession() {
   const queryClient = useQueryClient()
+  const scope = useSessionScope()
 
   return useMutation({
     mutationFn: (sessionId: string) => deleteSession(sessionId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: SESSIONS_KEY })
+      void queryClient.invalidateQueries({
+        queryKey: getSessionsQueryKey(scope),
+      })
     },
   })
 }

--- a/web-studio/src/routes/playground/-components/agent-panel.tsx
+++ b/web-studio/src/routes/playground/-components/agent-panel.tsx
@@ -35,6 +35,7 @@ import { MessageList } from '#/routes/sessions/-components/message-list'
 
 import type { ResourceOpenHandler } from '../-lib/types'
 import {
+  createPlaygroundAgentSessionId,
   getErrorMessage,
   readPlaygroundAgentSessionIds,
   registerPlaygroundAgentSessionId,
@@ -81,7 +82,7 @@ export function AgentPanel({
 
     try {
       const result = await withTimeout(
-        createSession.mutateAsync(undefined),
+        createSession.mutateAsync(createPlaygroundAgentSessionId()),
         12_000,
         t('agent.createTimeout'),
       )
@@ -109,7 +110,7 @@ export function AgentPanel({
 
     try {
       const result = await withTimeout(
-        createSession.mutateAsync(undefined),
+        createSession.mutateAsync(createPlaygroundAgentSessionId()),
         12_000,
         t('agent.createTimeout'),
       )

--- a/web-studio/src/routes/playground/-lib/utils.test.ts
+++ b/web-studio/src/routes/playground/-lib/utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { createPlaygroundAgentSessionId } from './utils'
+
+describe('createPlaygroundAgentSessionId', () => {
+  it('creates vikingbot-style session ids for Studio Agent sessions', () => {
+    const sessionId = createPlaygroundAgentSessionId()
+
+    expect(sessionId).toMatch(
+      /^bot-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    )
+  })
+})

--- a/web-studio/src/routes/playground/-lib/utils.ts
+++ b/web-studio/src/routes/playground/-lib/utils.ts
@@ -7,6 +7,7 @@ import {
 import type { VikingFsEntry } from '#/routes/resources/-types/viking-fm'
 import type { FindResultItem, GroupedFindResult } from '#/lib/retrieval'
 
+import { createRandomUuid } from '#/lib/browser-crypto'
 import { cleanVikingUri } from '#/lib/viking-uri'
 
 import { ROOT_URI, PLAYGROUND_AGENT_SESSIONS_STORAGE_KEY } from './constants'
@@ -121,6 +122,10 @@ export function registerPlaygroundAgentSessionId(sessionId: string): string[] {
   writeStoredJson(PLAYGROUND_AGENT_SESSIONS_STORAGE_KEY, next)
 
   return next
+}
+
+export function createPlaygroundAgentSessionId(): string {
+  return `bot-${createRandomUuid()}`
 }
 
 export function createEntryFromUri(uri: string, isDir: boolean): VikingFsEntry {

--- a/web-studio/src/routes/settings/route.tsx
+++ b/web-studio/src/routes/settings/route.tsx
@@ -760,8 +760,13 @@ function SettingsRoute() {
         Boolean(current.userId) && userIds.includes(current.userId)
       const userId = hasCurrentUser ? current.userId : preferred
       const selectedUser = users.find((user) => user.userId === userId)
-      const apiKey = selectedUser?.apiKey || ''
-      const next = { ...current, apiKey, userId }
+      const next = selectedUser?.apiKey
+        ? buildDataKeyConnection(current, {
+            accountId: current.accountId || DEFAULT_ACCOUNT_ID,
+            apiKey: selectedUser.apiKey,
+            userId,
+          })
+        : { ...current, userId }
 
       if (next.apiKey !== current.apiKey || next.userId !== current.userId) {
         saveConnection(next)
@@ -900,19 +905,32 @@ function SettingsRoute() {
     setManagedAccountIds((current) =>
       sortedAccountIds([...current, accountId], ''),
     )
-    updateDraft({
-      accountId,
-      apiKey: selectedUser?.apiKey || '',
-      userId: selectedUser?.userId || DEFAULT_USER_ID,
-    })
+    const next = selectedUser?.apiKey
+      ? buildDataKeyConnection(draft, {
+          accountId,
+          apiKey: selectedUser.apiKey,
+          userId: selectedUser.userId,
+        })
+      : {
+          ...draft,
+          accountId,
+          userId: selectedUser?.userId || DEFAULT_USER_ID,
+        }
+    setDraft(next)
+    saveConnection(next)
   }
 
   function updateConnectionUser(userId: string): void {
     const selectedUser = findSelectedUser(draft.accountId, userId)
-    updateDraft({
-      apiKey: selectedUser?.apiKey || '',
-      userId,
-    })
+    const next = selectedUser?.apiKey
+      ? buildDataKeyConnection(draft, {
+          accountId: draft.accountId || DEFAULT_ACCOUNT_ID,
+          apiKey: selectedUser.apiKey,
+          userId,
+        })
+      : { ...draft, userId }
+    setDraft(next)
+    saveConnection(next)
   }
 
   function buildDataKeyConnection(


### PR DESCRIPTION
## Description

Fix Studio session behavior across identity switches and legacy session scopes. This keeps session lists/messages cached per active identity, preserves readable legacy sessions, and prevents mutating operations from writing back into legacy scope.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Scope Studio session React Query keys by base URL, role, account, user, and key hash.
- Merge readable archived messages before live session messages and dedupe by message id.
- Preserve read-only fallback for legacy `viking://session/{id}` sessions while forcing writes to canonical user session scope.
- Generate stable Playground agent session IDs and make title generation language-neutral.
- Add backend and frontend tests for legacy fallback, session cache keys, archived messages, and Playground session IDs.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Checks run:

- `git diff --check`
- `uv run pytest tests/service/test_session_service_metrics.py`
- `npm run test -- src/lib/sessions/api.test.ts src/lib/sessions/query-keys.test.ts src/routes/playground/-lib/utils.test.ts`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Split out from #2882 so reviewers can evaluate session/cache compatibility separately from console metrics/log access and performance chunk splitting.