### PR TITLE
chore(opencode-plugin): scope package and bump to 0.1.6

### DIFF
--- a/examples/opencode-plugin/package.json
+++ b/examples/opencode-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openviking/opencode-plugin",
-  "version": "0.1.5",
-  "author": "tanyouqing",
+  "version": "0.1.6",
+  "author": "@openviking",
   "description": "Unified OpenCode plugin for OpenViking repository retrieval and long-term memory",
   "type": "module",
   "main": "index.mjs",


### PR DESCRIPTION
## Summary
- Bump opencode plugin package version to 0.1.6
- Set package author to "@openviking"
- Change package name to @openviking/opencode-plugin (to match publish workflow expectation)
- Update OpenCode install docs and troubleshooting examples to reference the scoped package name