### PR TITLE
feat(sdk/go): expose target_uri skill scoping (parity with #2813)

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -495,6 +495,140 @@ func TestSkillManagementRequests(t *testing.T) {
 	}
 }
 
+func TestSkillRequestsScopeTargetURI(t *testing.T) {
+	const target = "viking://agent/skills"
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/v1/skills":
+			body := readJSONBody(t, r)
+			if body["target_uri"] != target {
+				t.Fatalf("add target_uri = %#v", body["target_uri"])
+			}
+			writeOK(t, w, map[string]any{"added": true})
+		case "GET /api/v1/skills":
+			if got := r.URL.Query().Get("target_uri"); got != target {
+				t.Fatalf("list target_uri = %q", got)
+			}
+			writeOK(t, w, map[string]any{"total": 0})
+		case "POST /api/v1/skills/find":
+			body := readJSONBody(t, r)
+			if body["target_uri"] != target {
+				t.Fatalf("find target_uri = %#v", body["target_uri"])
+			}
+			writeOK(t, w, map[string]any{"skills": []any{}})
+		case "POST /api/v1/skills/validate":
+			body := readJSONBody(t, r)
+			if body["target_uri"] != target {
+				t.Fatalf("validate target_uri = %#v", body["target_uri"])
+			}
+			writeOK(t, w, map[string]any{"valid": true})
+		case "GET /api/v1/skills/demo":
+			if got := r.URL.Query().Get("target_uri"); got != target {
+				t.Fatalf("get target_uri = %q", got)
+			}
+			writeOK(t, w, map[string]any{"name": "demo"})
+		case "PUT /api/v1/skills/demo":
+			body := readJSONBody(t, r)
+			if body["target_uri"] != target {
+				t.Fatalf("update target_uri = %#v", body["target_uri"])
+			}
+			writeOK(t, w, map[string]any{"updated": true})
+		case "DELETE /api/v1/skills/demo":
+			if got := r.URL.Query().Get("target_uri"); got != target {
+				t.Fatalf("delete target_uri = %q", got)
+			}
+			writeOK(t, w, map[string]any{"deleted": true})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer closeServer()
+
+	ctx := context.Background()
+	if _, err := client.AddSkill(ctx, map[string]any{"name": "demo"}, &AddSkillOptions{TargetURI: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListSkills(ctx, &ListSkillsOptions{TargetURI: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.FindSkills(ctx, "demo", &FindSkillsOptions{TargetURI: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ValidateSkill(ctx, map[string]any{"name": "demo"}, &ValidateSkillOptions{TargetURI: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetSkill(ctx, "demo", &GetSkillOptions{TargetURI: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UpdateSkill(ctx, "demo", map[string]any{"name": "demo"}, &UpdateSkillOptions{TargetURI: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.DeleteSkill(ctx, "demo", &DeleteSkillOptions{TargetURI: target}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSkillRequestsOmitTargetURIWhenUnset(t *testing.T) {
+	assertNoTargetURIQuery := func(t *testing.T, r *http.Request) {
+		if r.URL.Query().Has("target_uri") {
+			t.Fatalf("unexpected target_uri query on %s %s: %s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/v1/skills":
+			requireBodyKeysAbsent(t, readJSONBody(t, r), "target_uri")
+			writeOK(t, w, map[string]any{"added": true})
+		case "POST /api/v1/skills/find":
+			requireBodyKeysAbsent(t, readJSONBody(t, r), "target_uri")
+			writeOK(t, w, map[string]any{"skills": []any{}})
+		case "POST /api/v1/skills/validate":
+			requireBodyKeysAbsent(t, readJSONBody(t, r), "target_uri")
+			writeOK(t, w, map[string]any{"valid": true})
+		case "PUT /api/v1/skills/demo":
+			requireBodyKeysAbsent(t, readJSONBody(t, r), "target_uri")
+			writeOK(t, w, map[string]any{"updated": true})
+		case "GET /api/v1/skills":
+			assertNoTargetURIQuery(t, r)
+			writeOK(t, w, map[string]any{"total": 0})
+		case "GET /api/v1/skills/demo":
+			assertNoTargetURIQuery(t, r)
+			writeOK(t, w, map[string]any{"name": "demo"})
+		case "DELETE /api/v1/skills/demo":
+			assertNoTargetURIQuery(t, r)
+			writeOK(t, w, map[string]any{"deleted": true})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer closeServer()
+
+	ctx := context.Background()
+	if _, err := client.AddSkill(ctx, map[string]any{"name": "demo"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.FindSkills(ctx, "demo", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ValidateSkill(ctx, map[string]any{"name": "demo"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UpdateSkill(ctx, "demo", map[string]any{"name": "demo"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListSkills(ctx, &ListSkillsOptions{NodeLimit: 5}); err != nil {
+		t.Fatal(err)
+	}
+	// Non-nil opts with a nil TargetURI: exercises GetSkill's opts != nil branch
+	// so setQueryAny is actually reached and must still omit target_uri.
+	if _, err := client.GetSkill(ctx, "demo", &GetSkillOptions{IncludeSource: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.DeleteSkill(ctx, "demo"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWatchManagementRequests(t *testing.T) {
 	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {

--- a/sdk/go/helpers.go
+++ b/sdk/go/helpers.go
@@ -1,6 +1,7 @@
 package openviking
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -21,6 +22,19 @@ func setQueryString(values url.Values, key, value string) {
 	if value != "" {
 		values.Set(key, value)
 	}
+}
+
+// setQueryAny mirrors setAny for query parameters: it sets key only when value
+// is non-nil, so an unset optional (e.g. a skill TargetURI) is omitted entirely.
+func setQueryAny(values url.Values, key string, value any) {
+	if value == nil {
+		return
+	}
+	if s, ok := value.(string); ok {
+		values.Set(key, s)
+		return
+	}
+	values.Set(key, fmt.Sprint(value))
 }
 
 func setFloatPtr(m map[string]any, key string, value *float64) {

--- a/sdk/go/skills.go
+++ b/sdk/go/skills.go
@@ -16,6 +16,7 @@ func (c *Client) AddSkill(ctx context.Context, data any, opts *AddSkillOptions) 
 	}
 	setFloatPtr(payload, "timeout", opts.Timeout)
 	setAny(payload, "telemetry", opts.Telemetry)
+	setAny(payload, "target_uri", opts.TargetURI)
 	if err := c.attachSkillData(ctx, payload, data); err != nil {
 		return nil, err
 	}
@@ -32,6 +33,9 @@ func (c *Client) ListSkills(ctx context.Context, opts *ListSkillsOptions) (map[s
 	}
 	query := url.Values{}
 	queryInt(query, "node_limit", nodeLimit)
+	if opts != nil {
+		setQueryAny(query, "target_uri", opts.TargetURI)
+	}
 	var result map[string]any
 	err := c.doJSON(ctx, http.MethodGet, "/api/v1/skills", query, nil, &result)
 	return result, err
@@ -55,6 +59,7 @@ func (c *Client) FindSkills(ctx context.Context, queryText string, opts *FindSki
 		payload["level"] = opts.Level
 	}
 	setAny(payload, "telemetry", opts.Telemetry)
+	setAny(payload, "target_uri", opts.TargetURI)
 	var result map[string]any
 	err := c.doJSON(ctx, http.MethodPost, "/api/v1/skills/find", nil, payload, &result)
 	return result, err
@@ -67,6 +72,7 @@ func (c *Client) ValidateSkill(ctx context.Context, data any, opts *ValidateSkil
 		payload["strict"] = opts.Strict
 		setString(payload, "source_path", opts.SourcePath)
 		setString(payload, "skill_dir_name", opts.SkillDirName)
+		setAny(payload, "target_uri", opts.TargetURI)
 	} else {
 		payload["strict"] = false
 	}
@@ -90,6 +96,7 @@ func (c *Client) GetSkill(ctx context.Context, skillName string, opts *GetSkillO
 		if opts.Level != nil {
 			queryInt(query, "level", *opts.Level)
 		}
+		setQueryAny(query, "target_uri", opts.TargetURI)
 	} else {
 		queryBool(query, "include_source", false)
 	}
@@ -110,6 +117,7 @@ func (c *Client) UpdateSkill(ctx context.Context, skillName string, data any, op
 	setFloatPtr(payload, "timeout", opts.Timeout)
 	setAny(payload, "source_metadata", opts.SourceMetadata)
 	setAny(payload, "telemetry", opts.Telemetry)
+	setAny(payload, "target_uri", opts.TargetURI)
 	if err := c.attachSkillData(ctx, payload, data); err != nil {
 		return nil, err
 	}
@@ -118,10 +126,17 @@ func (c *Client) UpdateSkill(ctx context.Context, skillName string, data any, op
 	return result, err
 }
 
-// DeleteSkill removes an installed agent skill.
-func (c *Client) DeleteSkill(ctx context.Context, skillName string) (map[string]any, error) {
+// DeleteSkill removes an installed agent skill. The optional opts carries a
+// TargetURI to scope the deletion to a specific skills root (e.g.
+// "viking://agent/skills"). opts is variadic so existing DeleteSkill(ctx, name)
+// callers keep compiling; only the first options value is used.
+func (c *Client) DeleteSkill(ctx context.Context, skillName string, opts ...*DeleteSkillOptions) (map[string]any, error) {
+	query := url.Values{}
+	if len(opts) > 0 && opts[0] != nil {
+		setQueryAny(query, "target_uri", opts[0].TargetURI)
+	}
 	var result map[string]any
-	err := c.doJSON(ctx, http.MethodDelete, "/api/v1/skills/"+url.PathEscape(skillName), nil, nil, &result)
+	err := c.doJSON(ctx, http.MethodDelete, "/api/v1/skills/"+url.PathEscape(skillName), query, nil, &result)
 	return result, err
 }
 

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -44,6 +44,10 @@ type AddSkillOptions struct {
 	Wait      bool
 	Timeout   *float64
 	Telemetry any
+	// TargetURI scopes the operation to a skills root such as
+	// "viking://agent/skills" (account-shared) or a per-user root. A nil
+	// value omits target_uri and lets the server use its default root.
+	TargetURI any
 }
 
 // AdminCreateAccountOptions controls AdminCreateAccountWithOptions.
@@ -59,6 +63,7 @@ type AdminRegisterUserOptions struct {
 // ListSkillsOptions controls ListSkills.
 type ListSkillsOptions struct {
 	NodeLimit int
+	TargetURI any
 }
 
 // FindSkillsOptions controls FindSkills.
@@ -67,6 +72,7 @@ type FindSkillsOptions struct {
 	ScoreThreshold *float64
 	Level          []int
 	Telemetry      any
+	TargetURI      any
 }
 
 // ValidateSkillOptions controls ValidateSkill.
@@ -74,6 +80,7 @@ type ValidateSkillOptions struct {
 	Strict       bool
 	SourcePath   string
 	SkillDirName string
+	TargetURI    any
 }
 
 // GetSkillOptions controls GetSkill.
@@ -82,6 +89,7 @@ type GetSkillOptions struct {
 	IncludeFiles   *bool
 	IncludeSource  bool
 	Level          *int
+	TargetURI      any
 }
 
 // UpdateSkillOptions controls UpdateSkill.
@@ -90,6 +98,12 @@ type UpdateSkillOptions struct {
 	Timeout        *float64
 	SourceMetadata map[string]any
 	Telemetry      any
+	TargetURI      any
+}
+
+// DeleteSkillOptions controls DeleteSkill.
+type DeleteSkillOptions struct {
+	TargetURI any
 }
 
 // WaitProcessedOptions controls WaitProcessed.


### PR DESCRIPTION
## What

`#2813` promoted account-shared skills (`viking://agent/skills`) to a first-class, *scoped* capability and shipped a `target_uri` parameter across:

- the **Python SDK** — all 7 skill methods (`add_skill`/`list_skills`/`find_skills`/`validate_skill`/`get_skill`/`update_skill`/`delete_skill`)
- the **Rust CLI** (`crates/ov_cli`)
- the **server skills router** — every endpoint accepts `target_uri`

The **Go SDK** was the only client left without it. Today Go adopters cannot scope skill operations to user-vs-agent roots and have to drop down to Python/CLI to reach account-shared skills.

This PR brings the Go SDK to parity.

## Change

Adds an optional `TargetURI any` field to the six skill option structs plus a new `DeleteSkillOptions`, and threads `target_uri` through every skill method matching the Python SDK + server placement exactly:

| Method | Transport |
|---|---|
| `ListSkills`, `GetSkill`, `DeleteSkill` | query param |
| `AddSkill`, `FindSkills`, `ValidateSkill`, `UpdateSkill` | JSON body |

`target_uri` is sent **only when set** (a `nil` `TargetURI` omits it), mirroring the Python SDK's `if target_uri is not None` semantics and the server's default-root fallback (`_agent_skills_root` treats absent/empty as the default root). The field type matches the existing `TargetURI any` convention already used by `FindOptions`/`SearchOptions` in `types.go`.

Note: unlike retrieval `Find`/`Search` (which client-side normalize via `normalizeTarget`), the skills methods send `target_uri` **as-is** and let the server resolve it — this matches the Python SDK in `#2813` exactly (skill methods pass `target_uri` raw; only `find`/`search` call `_normalize_target_uri`).

`DeleteSkill` previously took no options. To carry the scope without breaking existing `DeleteSkill(ctx, name)` callers, it now takes a **variadic** `opts ...*DeleteSkillOptions` (only the first value is used); the other six methods gain `TargetURI` as a plain additive struct field. So the change is **source-compatible** — no existing call site needs to change.

## Verification

- New `TestSkillRequestsScopeTargetURI` asserts query-vs-body placement of `target_uri` for all 7 methods.
- New `TestSkillRequestsOmitTargetURIWhenUnset` asserts `target_uri` is omitted (no body key / no query param) for all 7 methods when unset, so existing callers are unaffected.
- `go test ./...` and `go vet ./...` pass; `gofmt` clean.

Per-method transport (query vs body) was verified against the server router so the chosen location is the one the server actually reads, not an assumption — `openviking/server/routers/skills.py`:

- body: `FindSkillsRequest.target_uri`, `ValidateSkillRequest.target_uri`, `UpdateSkillRequest.target_uri`, and `add` reads it from the request body (matching Python `add_skill`'s `request_data`)
- query: `list_skills`, `get_skill`, `delete_skill` take `target_uri: Optional[str] = None` as a query parameter

Field names were verified against live `main` (`sdk/go/types.go`, `sdk/go/skills.go`) and the merged `#2813` Python diff — not guessed.
