### PR TITLE
fix(storage): honor delete-protected roots on mv source (parity with #2873)

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -608,6 +608,12 @@ class VikingFS:
         from openviking.storage.transaction import LockContext, get_lock_manager
 
         self._ensure_mutable_access(old_uri, ctx)
+        # mv is implemented as copy + recursive rm of the source (see the
+        # ``rm(old_path, recursive=is_dir)`` below), so the source must also clear
+        # the delete guard. Without this, a protected account root such as
+        # ``viking://`` — which rm() rejects up front (#2873) — could still be
+        # destroyed via mv, since the write guard alone permits the bare root.
+        self._ensure_delete_access(old_uri, ctx)
         self._ensure_mutable_access(new_uri, ctx)
         old_path = self._uri_to_path(old_uri, ctx=ctx)
         new_path = self._uri_to_path(new_uri, ctx=ctx)

--- a/tests/misc/test_vikingfs_uri_guard.py
+++ b/tests/misc/test_vikingfs_uri_guard.py
@@ -190,6 +190,40 @@ class TestVikingFSURITraversalGuard:
         fs.agfs.mv.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("source_uri", "match"),
+        [
+            # Bare account root: the net-new gap — rm() rejects it (#2873) but mv()'s
+            # write guard alone used to let it through to the recursive source delete.
+            ("viking://", "Deleting viking://"),
+            ("/", "Deleting viking://"),
+            # viking://user is already blocked by the write guard; assert mv still
+            # refuses it (parity with rm) regardless of which guard fires first.
+            ("viking://user", "viking://user is not supported"),
+            ("viking://user/", "viking://user is not supported"),
+            ("/user", "viking://user is not supported"),
+            ("user", "viking://user is not supported"),
+        ],
+    )
+    async def test_mv_rejects_protected_namespace_roots_in_source_before_side_effects(
+        self, source_uri: str, match: str
+    ) -> None:
+        fs = _make_viking_fs()
+        fs._collect_uris = AsyncMock(return_value=[])
+        fs._update_vector_store_uris = AsyncMock()
+        fs._delete_from_vector_store = AsyncMock()
+
+        with pytest.raises(PermissionDeniedError, match=match):
+            await fs.mv(source_uri, "viking://temp/dst")
+
+        fs._collect_uris.assert_not_called()
+        fs._update_vector_store_uris.assert_not_called()
+        fs._delete_from_vector_store.assert_not_called()
+        fs.agfs.stat.assert_not_called()
+        fs.agfs.rm.assert_not_called()
+        fs.agfs.mv.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_read_file_keeps_valid_uri_behavior(self) -> None:
         fs = _make_viking_fs()
         fs.agfs.stat = AsyncMock(return_value=MagicMock())


### PR DESCRIPTION
## Problem

#2873 ("Block deleting protected VikingFS roots") added a delete-specific guard so `rm("viking://")` and `rm("viking://user")` raise `PermissionDenied` **before any AGFS / vector side effect**.

`mv()` is the sister destructive operation — it is implemented as *copy + recursive `rm` of the source* — but it only guards the source through the **write** guard `_ensure_mutable_access`. `_ensure_supported_write_namespace` rejects `viking://user`, `viking://session*`, and the `viking://agent` root, but it does **not** reject the bare `viking://` account root (only the **delete** guard does). So:

```python
mv("viking://", "viking://temp/x")
```

passes both current guards and proceeds to `rm(old_path, recursive=is_dir)` on the account root — exactly the destruction #2873 set out to forbid for `rm`. The path is externally reachable (the HTTP filesystem service, WebDAV `MOVE`, and the CLI all route into `mv()`).

## Fix

Apply `_ensure_delete_access` to the mv **source** (since the source is recursively removed), keeping `_ensure_mutable_access` on the **destination** (which is written). The change is **additive** — the source must now clear both the write and the delete guard — so it can only reject *more* (the protected bare root), never loosen the existing write-namespace checks. Internal callers (`watch_manager` STORAGE_URI↔BAK, `semantic_processor`) pass concrete subtree URIs and are unaffected.

## Tests

Adds `test_mv_rejects_protected_namespace_roots_in_source_before_side_effects`, mirroring the existing `rm` protected-root test: bare-root sources (`viking://`, `/`) now raise `PermissionDenied` ("Deleting viking://"), and the `viking://user` variants stay rejected — all **before** any `stat` / `rm` / vector-store side effect. I confirmed the bare-root cases fail without this guard and pass with it.

`pytest tests/misc/test_vikingfs_uri_guard.py` → all green; `ruff check` clean.

> Note: `move_file()` (single-file, non-recursive) shares the same source-guard pattern. Its destruction risk is lower (a non-recursive `rm` can't wipe a populated root), so I scoped this PR to `mv()` for #2873 parity — happy to extend the same up-front guard to `move_file()` in a follow-up if you'd like.
