### PR TITLE
fix(grep): fall back to fs on empty VikingDB recall and query timeout (#2850)

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -1086,6 +1086,14 @@ class VikingFS:
         # use the maximum limit to avoid truncation.
         remote_return_limit = min(node_limit * 5, 100000) if node_limit else 100000
 
+        # VikingDB BM25 can silently time out / return empty on large corpora
+        # (see #2850). Bound the query so a hung remote cannot stall grep; a
+        # timeout is treated as unreliability and falls back to fs, same as an
+        # raised exception.
+        vikingdb_timeout = float(
+            os.environ.get("OPENVIKING_GREP_VIKINGDB_TIMEOUT_SEC", "10")
+        )
+
         # Step 1: vikingdb recall candidate files
         try:
             logger.debug(
@@ -1096,11 +1104,31 @@ class VikingFS:
                 filter_expr,
                 ["uri"],
             )
-            result = await vector_store.search_by_keywords(
-                query=query,
-                limit=remote_return_limit,
-                filter=filter_expr,
-                output_fields=["uri"],
+            result = await asyncio.wait_for(
+                vector_store.search_by_keywords(
+                    query=query,
+                    limit=remote_return_limit,
+                    filter=filter_expr,
+                    output_fields=["uri"],
+                    ctx=ctx,
+                ),
+                timeout=vikingdb_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "grep vikingdb query timed out (%.1fs) for pattern %r at %s, "
+                "falling back to fs",
+                vikingdb_timeout,
+                pattern,
+                uri,
+            )
+            return await self._grep_fs(
+                uri=uri,
+                pattern=pattern,
+                exclude_uri=exclude_uri,
+                case_insensitive=case_insensitive,
+                node_limit=node_limit,
+                level_limit=level_limit,
                 ctx=ctx,
             )
         except Exception as e:
@@ -1123,8 +1151,25 @@ class VikingFS:
                 if u != excluded_prefix and not u.startswith(excluded_prefix + "/")
             ]
         if not candidate_uris:
-            # BM25 returned no candidates — the index confirms no matching content
-            return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+            # BM25 returned no candidates. On large/stale corpora this can be a
+            # false negative (silent timeout, index lag) rather than a true
+            # absence of matches (#2850). Retry with fs grep so a VikingDB gap
+            # does not masquerade as "no matching content".
+            logger.warning(
+                "grep vikingdb returned 0 candidates for pattern %r at %s, "
+                "retrying with fs grep",
+                pattern,
+                uri,
+            )
+            return await self._grep_fs(
+                uri=uri,
+                pattern=pattern,
+                exclude_uri=exclude_uri,
+                case_insensitive=case_insensitive,
+                node_limit=node_limit,
+                level_limit=level_limit,
+                ctx=ctx,
+            )
 
         # Step 2: local fs precise matching on candidate files
         return await self._grep_in_files(

--- a/tests/storage/test_viking_fs_grep.py
+++ b/tests/storage/test_viking_fs_grep.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import asyncio
 import time
 
 import pytest
@@ -147,12 +148,103 @@ async def test_grep_vikingdb_remote_error_falls_back_to_fs(monkeypatch):
     ]
 
 
+class _SlowVectorStore:
+    """Vector store whose search_by_keywords never returns within the timeout."""
+
+    async def search_by_keywords(self, **kwargs):
+        await asyncio.sleep(30)
+        return []
+
+
+@pytest.mark.asyncio
+async def test_grep_vikingdb_empty_recall_falls_back_to_fs(monkeypatch):
+    """VikingDB returning zero candidates must retry via fs grep (#2850)."""
+    fs = VikingFS(agfs=_DummyAgfs())
+    # _DummyVectorStore() defaults to empty results -> empty recall.
+    vector_store = _DummyVectorStore()
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+    monkeypatch.setattr(fs, "_ensure_access", lambda uri, ctx=None: None)
+
+    calls = []
+
+    async def fake_grep_fs(**kwargs):
+        calls.append(kwargs)
+        return {
+            "matches": [{"uri": "viking://resources/a.md"}],
+            "count": 1,
+            "match_count": 1,
+            "files_scanned": 1,
+        }
+
+    monkeypatch.setattr(fs, "_grep_fs", fake_grep_fs)
+
+    result = await fs._grep_vikingdb_then_fs(
+        uri="viking://resources",
+        pattern="needle",
+        exclude_uri=None,
+        case_insensitive=False,
+        node_limit=10,
+        level_limit=3,
+        ctx=None,
+    )
+
+    # fs fallback was invoked and its result surfaced (not the empty VikingDB hit).
+    assert len(calls) == 1
+    assert calls[0]["pattern"] == "needle"
+    assert result["count"] == 1
+    assert result["matches"][0]["uri"] == "viking://resources/a.md"
+
+
+@pytest.mark.asyncio
+async def test_grep_vikingdb_timeout_falls_back_to_fs(monkeypatch):
+    """A VikingDB query that exceeds the timeout must fall back to fs (#2850)."""
+    fs = VikingFS(agfs=_DummyAgfs())
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: _SlowVectorStore())
+    monkeypatch.setattr(fs, "_ensure_access", lambda uri, ctx=None: None)
+    # Keep the test fast: 0.1s timeout instead of the 10s default.
+    monkeypatch.setenv("OPENVIKING_GREP_VIKINGDB_TIMEOUT_SEC", "0.1")
+
+    calls = []
+
+    async def fake_grep_fs(**kwargs):
+        calls.append(kwargs)
+        return {
+            "matches": [{"uri": "viking://resources/b.md"}],
+            "count": 1,
+            "match_count": 1,
+            "files_scanned": 1,
+        }
+
+    monkeypatch.setattr(fs, "_grep_fs", fake_grep_fs)
+
+    result = await fs._grep_vikingdb_then_fs(
+        uri="viking://resources",
+        pattern="needle",
+        exclude_uri=None,
+        case_insensitive=False,
+        node_limit=10,
+        level_limit=3,
+        ctx=None,
+    )
+
+    assert len(calls) == 1
+    assert result["count"] == 1
+    assert result["matches"][0]["uri"] == "viking://resources/b.md"
+
+
 @pytest.mark.asyncio
 async def test_grep_vikingdb_pushes_exclude_uri_to_filter(monkeypatch):
     fs = VikingFS(agfs=_DummyAgfs())
     vector_store = _DummyVectorStore()
     monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
     monkeypatch.setattr(fs, "_ensure_access", lambda uri, ctx=None: None)
+
+    # Empty VikingDB recall now falls back to fs grep (#2850); stub fs so the
+    # exclude_uri filter assertion stays focused on the remote query path.
+    async def fake_grep_fs(**kwargs):
+        return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+
+    monkeypatch.setattr(fs, "_grep_fs", fake_grep_fs)
 
     result = await fs._grep_vikingdb_then_fs(
         uri="viking://resources",


### PR DESCRIPTION
## What & Why

Re-fixes #2850, replacing the rejected #2854 (which sat at the MCP layer). Per @qin-ctx's review there, the fix belongs inside `VikingFS._grep_vikingdb_then_fs()` — not wrapped around the MCP endpoint — and must cover the **empty-result** case, not just exceptions/timeouts.

#2850 has two failure modes, both rooted in VikingDB unreliability on large/stale corpora:

1. **Silent empty recall.** BM25 returns `[]` even though matching content exists (index lag, silent timeout). The old code treated an empty candidate list as a *definitive* "no matching content" and short-circuited with an empty result. The user sees "no matches" when matches exist.
2. **Hung query.** `search_by_keywords` can hang indefinitely, stalling grep with no fallback.

## Changes (storage layer only — `openviking/storage/viking_fs.py`)

`_grep_vikingdb_then_fs()` now:

- **Empty recall → fs fallback.** When `candidate_uris` is empty, retry via `_grep_fs(...)` instead of returning an empty dict. This is the case #2854 missed and @qin-ctx explicitly called out. A warning is logged so the gap is observable, not silent.
- **Bounded VikingDB query.** `search_by_keywords(...)` is wrapped in `asyncio.wait_for(..., timeout=vikingdb_timeout)`. On `asyncio.TimeoutError`, fall back to `_grep_fs(...)` — same treatment as a raised exception. Default 10 s, configurable via `OPENVIKING_GREP_VIKINGDB_TIMEOUT_SEC` (no `GrepConfig` schema change needed, since `GrepConfig` is `extra=forbid`).
- **Existing exception fallback preserved.** The `except Exception` branch is untouched; timeout is a sibling `except`, not a replacement.

This matches the three points in @qin-ctx's review: converge on `_grep_vikingdb_then_fs()`, keep the existing exception fallback, add empty-result fallback at the `candidate_uris` empty site, and wrap only `search_by_keywords` (not the whole grep) if a timeout is wanted.

## Why not the MCP layer

The MCP endpoint already delegates to `service.fs.grep(...)`; wrapping it again there (as #2854 did) just re-calls the same path without forcing fs, and can't see VikingDB's empty recall at all. The storage layer is where both failure modes are visible.

## Tests (`tests/storage/test_viking_fs_grep.py`)

- `test_grep_vikingdb_empty_recall_falls_back_to_fs` — `_DummyVectorStore` returns `[]`; asserts `_grep_fs` is called and its result surfaces (not the empty VikingDB hit).
- `test_grep_vikingdb_timeout_falls_back_to_fs` — `_SlowVectorStore` (30 s sleep) + `OPENVIKING_GREP_VIKINGDB_TIMEOUT_SEC=0.1`; asserts fs fallback result surfaces.
- `test_grep_vikingdb_pushes_exclude_uri_to_filter` — updated to stub `_grep_fs` returning empty, since empty recall now falls through to fs (keeps the exclude_uri filter assertion focused on the remote query path).
- Existing exception-fallback and DFS/concurrency tests unchanged.

```text
$ uv run --no-sync python -m pytest tests/storage/test_viking_fs_grep.py -q --no-cov
17 passed in 2.18s

$ ruff check openviking/storage/viking_fs.py tests/storage/test_viking_fs_grep.py
All checks passed!
```

## Scope

- `openviking/storage/viking_fs.py` (+59/-7)
- `tests/storage/test_viking_fs_grep.py` (+92)

No `uv.lock` churn, no MCP changes, no `GrepConfig` schema change. Default behavior is unchanged when VikingDB returns non-empty results promptly.

Closes #2850. Supersedes #2854.
