### PR TITLE
Api key schema fetch

### DIFF
--- a/openviking/storage/vectordb/collection/volcengine_api_key_collection.py
+++ b/openviking/storage/vectordb/collection/volcengine_api_key_collection.py
@@ -16,6 +16,8 @@ from openviking.storage.vectordb.collection.result import (
     SearchResult,
 )
 from openviking.storage.vectordb.collection.volcengine_clients import (
+    VIKING_DB_VERSION,
+    ClientForConsoleApi,
     ClientForDataApi,
     ClientForDataApiWithApiKey,
 )
@@ -30,6 +32,9 @@ class VolcengineApiKeyCollection(ICollection):
         api_key: str,
         host: Optional[str] = None,
         region: Optional[str] = None,
+        ak: Optional[str] = None,
+        sk: Optional[str] = None,
+        session_token: Optional[str] = None,
         meta_data: Optional[Dict[str, Any]] = None,
     ):
         resolved_host = (host or "").rstrip("/") or (
@@ -42,6 +47,12 @@ class VolcengineApiKeyCollection(ICollection):
         self.project_name = self.meta_data.get("ProjectName", "default")
         self.collection_name = self.meta_data.get("CollectionName", "")
         self.index_name = self.meta_data.get("IndexName", "default")
+        self.console_client = (
+            ClientForConsoleApi(ak, sk, region, session_token=session_token)
+            if ak and sk and region
+            else None
+        )
+        self._fetched_meta_data = self._fetch_meta_data_once()
 
     @staticmethod
     def _build_response_error(response: Any, action: str) -> ConnectionError:
@@ -236,15 +247,54 @@ class VolcengineApiKeyCollection(ICollection):
         )
 
     def get_meta_data(self):
-        from openviking.storage.collection_schemas import CollectionSchemas
+        if self._has_schema_fields(self._fetched_meta_data):
+            return self._fetched_meta_data
+        return {}
 
-        return {
-            "ProjectName": self.project_name,
-            "CollectionName": self.collection_name,
-            "IndexName": self.index_name,
-            "Description": "data-plane only backend",
-            "Fields": CollectionSchemas.context_collection.get("Fields", []),
-        }
+    @staticmethod
+    def _has_schema_fields(meta_data: Any) -> bool:
+        return (
+            isinstance(meta_data, dict)
+            and isinstance(meta_data.get("Fields"), list)
+            and bool(meta_data["Fields"])
+        )
+
+    def _fetch_meta_data_once(self) -> Dict[str, Any]:
+        if self.console_client is None:
+            return {}
+        try:
+            response = self.console_client.do_req(
+                "POST",
+                req_params={
+                    "Action": "GetVikingdbCollection",
+                    "Version": VIKING_DB_VERSION,
+                },
+                req_body={
+                    "ProjectName": self.project_name,
+                    "CollectionName": self.collection_name,
+                },
+            )
+            if response.status_code != 200:
+                logger.warning(
+                    "Failed to fetch Volcengine collection schema for api_key mode: %s %s",
+                    response.status_code,
+                    response.text,
+                )
+                return {}
+            result = response.json()
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch Volcengine collection schema for api_key mode: %s",
+                exc,
+            )
+            return {}
+
+        if not isinstance(result, dict):
+            return {}
+        meta_data = result.get("Result") or result.get("result") or result.get("data") or {}
+        if self._has_schema_fields(meta_data):
+            return meta_data
+        return {}
 
     def close(self):
         pass

--- a/openviking/storage/vectordb_adapters/base.py
+++ b/openviking/storage/vectordb_adapters/base.py
@@ -474,23 +474,7 @@ class CollectionAdapter(ABC):
         coll: Collection,
         output_fields: Optional[list[str]],
     ) -> Optional[list[str]]:
-        if not output_fields:
-            return output_fields
-        try:
-            meta = coll.get_meta_data() or {}
-            fields = meta.get("Fields", [])
-            if not isinstance(fields, list) or not fields:
-                return output_fields
-            allowed = {
-                item.get("FieldName")
-                for item in fields
-                if isinstance(item, dict) and item.get("FieldName")
-            }
-            if not allowed:
-                return output_fields
-            return [field for field in output_fields if field in allowed]
-        except Exception:
-            return output_fields
+        return output_fields
 
     def query(
         self,

--- a/openviking/storage/vectordb_adapters/base.py
+++ b/openviking/storage/vectordb_adapters/base.py
@@ -469,6 +469,29 @@ class CollectionAdapter(ABC):
                 records.append(self._normalize_record_for_read(record))
         return records
 
+    def _filter_output_fields(
+        self,
+        coll: Collection,
+        output_fields: Optional[list[str]],
+    ) -> Optional[list[str]]:
+        if not output_fields:
+            return output_fields
+        try:
+            meta = coll.get_meta_data() or {}
+            fields = meta.get("Fields", [])
+            if not isinstance(fields, list) or not fields:
+                return output_fields
+            allowed = {
+                item.get("FieldName")
+                for item in fields
+                if isinstance(item, dict) and item.get("FieldName")
+            }
+            if not allowed:
+                return output_fields
+            return [field for field in output_fields if field in allowed]
+        except Exception:
+            return output_fields
+
     def query(
         self,
         *,
@@ -483,6 +506,7 @@ class CollectionAdapter(ABC):
     ) -> list[Dict[str, Any]]:
         coll = self.get_collection()
         vectordb_filter = self._compile_filter(filter)
+        output_fields = self._filter_output_fields(coll, output_fields)
 
         if query_vector or sparse_query_vector:
             result = coll.search_by_vector(
@@ -597,6 +621,7 @@ class CollectionAdapter(ABC):
     ) -> list[Dict[str, Any]]:
         coll = self.get_collection()
         compiled_filter = self._compile_filter(filter)
+        output_fields = self._filter_output_fields(coll, output_fields)
         logger.debug(
             "search_by_keywords: keywords=%s query=%s limit=%s offset=%s filter=%s output_fields=%s",
             keywords,

--- a/openviking/storage/vectordb_adapters/volcengine_adapter.py
+++ b/openviking/storage/vectordb_adapters/volcengine_adapter.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb.collection.volcengine_api_key_collection import (
@@ -47,6 +47,7 @@ class VolcengineCollectionAdapter(CollectionAdapter):
         self._api_key = api_key
         self._host = host
         self._project_name = project_name
+        self._schema_field_names: set[str] | None = None
 
     @classmethod
     def from_config(cls, config: Any):
@@ -96,6 +97,36 @@ class VolcengineCollectionAdapter(CollectionAdapter):
     def _uses_api_key_auth(self) -> bool:
         return bool(self._api_key)
 
+    @staticmethod
+    def _schema_field_names_from_meta(meta: Dict[str, Any] | None) -> set[str]:
+        if not isinstance(meta, dict):
+            return set()
+        fields = meta.get("Fields", [])
+        if not isinstance(fields, list):
+            return set()
+        return {
+            item.get("FieldName")
+            for item in fields
+            if isinstance(item, dict) and item.get("FieldName")
+        }
+
+    def _cache_schema_field_names(self, meta: Dict[str, Any] | None) -> None:
+        names = self._schema_field_names_from_meta(meta)
+        if names:
+            self._schema_field_names = names
+
+    def _filter_output_fields(
+        self,
+        coll: Collection,
+        output_fields: Optional[list[str]],
+    ) -> Optional[list[str]]:
+        if not output_fields:
+            return output_fields
+        allowed = self._schema_field_names
+        if not allowed:
+            return output_fields
+        return [field for field in output_fields if field in allowed]
+
     def _new_collection_handle(self) -> Collection:
         if self._uses_api_key_auth():
             return Collection(
@@ -126,11 +157,13 @@ class VolcengineCollectionAdapter(CollectionAdapter):
             return
         if self._uses_api_key_auth():
             self._collection = self._new_collection_handle()
+            self._cache_schema_field_names(self._collection.get_meta_data())
             return
         candidate = self._new_collection_handle()
         meta = candidate.get_meta_data() or {}
         if meta and meta.get("CollectionName"):
             self._collection = candidate
+            self._cache_schema_field_names(meta)
 
     def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
         if self._uses_api_key_auth():
@@ -140,10 +173,12 @@ class VolcengineCollectionAdapter(CollectionAdapter):
             )
         payload = dict(meta)
         payload.update(self._meta())
-        return get_or_create_volcengine_collection(
+        collection = get_or_create_volcengine_collection(
             config=self._config(),
             meta_data=payload,
         )
+        self._cache_schema_field_names(payload)
+        return collection
 
     def _sanitize_scalar_index_fields(
         self,

--- a/openviking/storage/vectordb_adapters/volcengine_adapter.py
+++ b/openviking/storage/vectordb_adapters/volcengine_adapter.py
@@ -111,9 +111,7 @@ class VolcengineCollectionAdapter(CollectionAdapter):
         }
 
     def _cache_schema_field_names(self, meta: Dict[str, Any] | None) -> None:
-        names = self._schema_field_names_from_meta(meta)
-        if names:
-            self._schema_field_names = names
+        self._schema_field_names = self._schema_field_names_from_meta(meta) or None
 
     def _filter_output_fields(
         self,

--- a/openviking/storage/vectordb_adapters/volcengine_adapter.py
+++ b/openviking/storage/vectordb_adapters/volcengine_adapter.py
@@ -103,6 +103,9 @@ class VolcengineCollectionAdapter(CollectionAdapter):
                     api_key=self._api_key or "",
                     host=self._host,
                     region=self._region,
+                    ak=self._ak,
+                    sk=self._sk,
+                    session_token=self._session_token,
                     meta_data=self._data_plane_meta(),
                 )
             )

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -143,7 +143,15 @@ class _SingleAccountBackend:
         try:
             coll = self._get_collection()
             fields = self._get_meta_data(coll).get("Fields", [])
-            allowed = {item.get("FieldName") for item in fields}
+            if not isinstance(fields, list) or not fields:
+                return {k: v for k, v in data.items() if v is not None}
+            allowed = {
+                item.get("FieldName")
+                for item in fields
+                if isinstance(item, dict) and item.get("FieldName")
+            }
+            if not allowed:
+                return {k: v for k, v in data.items() if v is not None}
             return {k: v for k, v in data.items() if k in allowed and v is not None}
         except Exception:
             return data

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -751,6 +751,38 @@ def test_single_account_backend_filters_parent_uri_against_current_schema():
     }
 
 
+def test_single_account_backend_filter_known_fields_fail_open_without_schema_fields():
+    class _Collection:
+        def get_meta_data(self):
+            return {}
+
+    class _Adapter:
+        mode = "volcengine"
+
+        def get_collection(self):
+            return _Collection()
+
+    backend = _SingleAccountBackend(
+        config=VectorDBBackendConfig(
+            backend="volcengine",
+            name="context",
+            dimension=2,
+            volcengine=VolcengineConfig(api_key="vk-test-token", region="cn-beijing"),
+        ),
+        bound_account_id="acc1",
+        shared_adapter=_Adapter(),
+    )
+
+    payload = {
+        "id": "rec-1",
+        "uri": "viking://resources/sample",
+        "abstract": "sample",
+        "parent_uri": "viking://resources",
+    }
+
+    assert backend._filter_known_fields(payload) == payload
+
+
 @pytest.mark.asyncio
 async def test_single_account_backend_upsert_drops_legacy_parent_uri_before_write():
     captured = {}

--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -6,6 +6,7 @@ from openviking.storage.vectordb.collection.volcengine_clients import (
     ClientForDataApiWithApiKey,
 )
 from openviking.storage.vectordb.collection.volcengine_collection import VolcengineCollection
+from openviking.storage.vectordb_adapters.base import CollectionAdapter
 from openviking.storage.vectordb_adapters.volcengine_adapter import VolcengineCollectionAdapter
 from openviking_cli.utils.config.vectordb_config import (
     VectorDBBackendConfig,
@@ -798,22 +799,16 @@ def test_volcengine_adapter_update_data_supports_api_key_mode():
     assert result == ["doc-1"]
 
 
-def test_volcengine_adapter_query_filters_output_fields_against_schema():
-    captured = {}
+def test_volcengine_adapter_query_filters_output_fields_against_cached_schema():
+    captured = {"meta_calls": 0}
 
     class _SearchResult:
         data = []
 
     class _Collection:
         def get_meta_data(self):
-            return {
-                "Fields": [
-                    {"FieldName": "id"},
-                    {"FieldName": "uri"},
-                    {"FieldName": "abstract"},
-                    {"FieldName": "account_id"},
-                ]
-            }
+            captured["meta_calls"] += 1
+            raise AssertionError("query should not read collection metadata")
 
         def search_by_vector(self, **kwargs):
             captured.update(kwargs)
@@ -830,6 +825,16 @@ def test_volcengine_adapter_query_filters_output_fields_against_schema():
         collection_name="context",
         index_name="default",
     )
+    adapter._cache_schema_field_names(
+        {
+            "Fields": [
+                {"FieldName": "id"},
+                {"FieldName": "uri"},
+                {"FieldName": "abstract"},
+                {"FieldName": "account_id"},
+            ]
+        }
+    )
     adapter._collection = _Collection()
 
     adapter.query(
@@ -838,6 +843,51 @@ def test_volcengine_adapter_query_filters_output_fields_against_schema():
     )
 
     assert captured["output_fields"] == ["uri", "abstract"]
+    assert captured["meta_calls"] == 0
+
+
+def test_base_adapter_query_does_not_read_collection_meta_for_output_fields():
+    captured = {"meta_calls": 0}
+
+    class _SearchResult:
+        data = []
+
+    class _Collection:
+        def get_meta_data(self):
+            captured["meta_calls"] += 1
+            return {
+                "Fields": [
+                    {"FieldName": "uri"},
+                    {"FieldName": "abstract"},
+                ]
+            }
+
+        def search_by_vector(self, **kwargs):
+            captured.update(kwargs)
+            return _SearchResult()
+
+    class _Adapter(CollectionAdapter):
+        mode = "test"
+
+        @classmethod
+        def from_config(cls, config):
+            raise NotImplementedError
+
+        def _load_existing_collection_if_needed(self):
+            self._collection = _Collection()
+
+        def _create_backend_collection(self, meta):
+            raise NotImplementedError
+
+    adapter = _Adapter(collection_name="context", index_name="default")
+
+    adapter.query(
+        query_vector=[0.1, 0.2],
+        output_fields=["uri", "search_tags", "abstract"],
+    )
+
+    assert captured["output_fields"] == ["uri", "search_tags", "abstract"]
+    assert captured["meta_calls"] == 0
 
 
 def test_http_collection_update_data_posts_to_update_endpoint(monkeypatch):

--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -846,6 +846,40 @@ def test_volcengine_adapter_query_filters_output_fields_against_cached_schema():
     assert captured["meta_calls"] == 0
 
 
+def test_volcengine_adapter_empty_schema_cache_fails_open_instead_of_reusing_old_schema():
+    captured = {}
+
+    class _SearchResult:
+        data = []
+
+    class _Collection:
+        def search_by_vector(self, **kwargs):
+            captured.update(kwargs)
+            return _SearchResult()
+
+    adapter = VolcengineCollectionAdapter(
+        ak="test-ak",
+        sk="test-sk",
+        region="cn-beijing",
+        session_token=None,
+        api_key="vk-test-token",
+        host="api-vikingdb.vikingdb.cn-beijing.volces.com",
+        project_name="default",
+        collection_name="context",
+        index_name="default",
+    )
+    adapter._cache_schema_field_names({"Fields": [{"FieldName": "uri"}]})
+    adapter._cache_schema_field_names({"Fields": []})
+    adapter._collection = _Collection()
+
+    adapter.query(
+        query_vector=[0.1, 0.2],
+        output_fields=["uri", "search_tags"],
+    )
+
+    assert captured["output_fields"] == ["uri", "search_tags"]
+
+
 def test_base_adapter_query_does_not_read_collection_meta_for_output_fields():
     captured = {"meta_calls": 0}
 

--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -798,6 +798,48 @@ def test_volcengine_adapter_update_data_supports_api_key_mode():
     assert result == ["doc-1"]
 
 
+def test_volcengine_adapter_query_filters_output_fields_against_schema():
+    captured = {}
+
+    class _SearchResult:
+        data = []
+
+    class _Collection:
+        def get_meta_data(self):
+            return {
+                "Fields": [
+                    {"FieldName": "id"},
+                    {"FieldName": "uri"},
+                    {"FieldName": "abstract"},
+                    {"FieldName": "account_id"},
+                ]
+            }
+
+        def search_by_vector(self, **kwargs):
+            captured.update(kwargs)
+            return _SearchResult()
+
+    adapter = VolcengineCollectionAdapter(
+        ak="test-ak",
+        sk="test-sk",
+        region="cn-beijing",
+        session_token=None,
+        api_key="vk-test-token",
+        host="api-vikingdb.vikingdb.cn-beijing.volces.com",
+        project_name="default",
+        collection_name="context",
+        index_name="default",
+    )
+    adapter._collection = _Collection()
+
+    adapter.query(
+        query_vector=[0.1, 0.2],
+        output_fields=["uri", "search_tags", "abstract"],
+    )
+
+    assert captured["output_fields"] == ["uri", "abstract"]
+
+
 def test_http_collection_update_data_posts_to_update_endpoint(monkeypatch):
     captured = {}
 

--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -373,6 +373,107 @@ def test_volcengine_api_key_collection_update_data_sanitizes_uri_fields(monkeypa
     }
 
 
+def test_volcengine_api_key_collection_fetches_console_schema_once(monkeypatch):
+    captured = {"calls": 0}
+
+    class _ConsoleClient:
+        def __init__(self, ak, sk, region, host=None, session_token=None):
+            captured["init"] = {
+                "ak": ak,
+                "sk": sk,
+                "region": region,
+                "host": host,
+                "session_token": session_token,
+            }
+
+        def do_req(self, method, req_params=None, req_body=None):
+            captured["calls"] += 1
+            captured["method"] = method
+            captured["req_params"] = req_params
+            captured["req_body"] = req_body
+
+            class _Response:
+                status_code = 200
+
+                @staticmethod
+                def json():
+                    return {
+                        "Result": {
+                            "ProjectName": "default",
+                            "CollectionName": "context",
+                            "Fields": [
+                                {"FieldName": "id", "FieldType": "string"},
+                                {"FieldName": "uri", "FieldType": "path"},
+                                {"FieldName": "content", "FieldType": "text"},
+                            ],
+                        }
+                    }
+
+            return _Response()
+
+    monkeypatch.setattr(
+        "openviking.storage.vectordb.collection.volcengine_api_key_collection.ClientForConsoleApi",
+        _ConsoleClient,
+    )
+
+    from openviking.storage.vectordb.collection.volcengine_api_key_collection import (
+        VolcengineApiKeyCollection,
+    )
+
+    collection = VolcengineApiKeyCollection(
+        api_key="vk-test-token",
+        host="api-vikingdb.vikingdb.cn-beijing.volces.com",
+        region="cn-beijing",
+        ak="test-ak",
+        sk="test-sk",
+        session_token="test-session-token",
+        meta_data={"ProjectName": "default", "CollectionName": "context", "IndexName": "default"},
+    )
+
+    assert collection.get_meta_data()["Fields"] == [
+        {"FieldName": "id", "FieldType": "string"},
+        {"FieldName": "uri", "FieldType": "path"},
+        {"FieldName": "content", "FieldType": "text"},
+    ]
+    assert collection.get_meta_data()["Fields"][0]["FieldName"] == "id"
+    assert captured["calls"] == 1
+    assert captured["init"]["host"] is None
+    assert captured["init"]["session_token"] == "test-session-token"
+    assert captured["req_params"]["Action"] == "GetVikingdbCollection"
+    assert captured["req_body"] == {
+        "ProjectName": "default",
+        "CollectionName": "context",
+    }
+
+
+def test_volcengine_api_key_collection_schema_fetch_failure_returns_empty_meta(monkeypatch):
+    class _ConsoleClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def do_req(self, *args, **kwargs):
+            raise RuntimeError("console unavailable")
+
+    monkeypatch.setattr(
+        "openviking.storage.vectordb.collection.volcengine_api_key_collection.ClientForConsoleApi",
+        _ConsoleClient,
+    )
+
+    from openviking.storage.vectordb.collection.volcengine_api_key_collection import (
+        VolcengineApiKeyCollection,
+    )
+
+    collection = VolcengineApiKeyCollection(
+        api_key="vk-test-token",
+        region="cn-beijing",
+        ak="test-ak",
+        sk="test-sk",
+        meta_data={"ProjectName": "default", "CollectionName": "context", "IndexName": "default"},
+    )
+
+    assert collection.get_meta_data() == {}
+
+
 def test_volcengine_adapter_update_data_returns_ids():
     adapter = VolcengineCollectionAdapter(
         ak="test-ak",


### PR DESCRIPTION
Title

  fix: support Volcengine API key schema filtering

  Summary

  本 PR 修复 Volcengine API key 模式下 collection schema 不一致导致的写入/查询问题，并增强字段过滤的兼容性。

  主要改动：

  1. Volcengine API key 模式支持可选配置 ak/sk/region/session_token。
      - 如果同时配置了 api_key 和 ak/sk/region，启动时会通过控制面接口拉取一次 collection schema。
      - schema 会缓存在本地，后续写入/查询不会重复拉取控制面 meta。

  2. 写入向量库时按 schema 过滤字段。
      - 当 collection schema 可用时，只写入 schema 中存在的字段。
      - 避免火山向量库因为不存在的字段报错。
      - 如果 schema 不可用，则 fail-open，保持原有行为，不强行过滤。

  3. 查询 output_fields 只在 Volcengine backend 内按 schema 过滤。
      - 修复火山查询时报错：'search_tags' is not a valid output field。
      - base adapter 不再统一读取 collection meta，避免其他 backend 每次 query 都额外访问 meta。
      - 如果 schema 不可用，则 fail-open，原样传递 output_fields。
      - 如果 schema 缓存为空，会清空旧缓存，避免复用过期 schema。

  4. 补充测试覆盖：
      - API key 模式启动时只拉一次 schema。
      - base adapter query 不读取 collection meta。
      - Volcengine query 使用缓存 schema 过滤无效 output_fields。
      - schema 不可用时不会复用旧 schema，而是 fail-open。

  Config Example

  API key 模式只做数据面访问时：

  vectordb:
    backend: volcengine
    name: context
    index_name: default
    project_name: default
    volcengine:
      api_key: ${VOLCENGINE_VIKINGDB_API_KEY}
      region: cn-beijing

  如果希望 API key 模式启动时拉取 collection schema，用于写入字段过滤和查询 output_fields 过滤，需要额外配置 AK/SK：

  vectordb:
    backend: volcengine
    name: context
    index_name: default
    project_name: default
    volcengine:
      api_key: ${VOLCENGINE_VIKINGDB_API_KEY}
      region: cn-beijing
      ak: ${VOLCENGINE_AK}
      sk: ${VOLCENGINE_SK}
      session_token: ${VOLCENGINE_SESSION_TOKEN} # optional

  host 不是必须的；如果配置了 region，会使用 region 推导数据面 host。只有在需要显式指定数据面地址时才配置 host：

  vectordb:
    index_name: default
    project_name: default
    volcengine:
      api_key: ${VOLCENGINE_VIKINGDB_API_KEY}
      host: api-vikingdb.vikingdb.cn-beijing.volces.com
      ak: ${VOLCENGINE_AK}
      sk: ${VOLCENGINE_SK}
      region: cn-beijing