### PR TITLE
fix(ingest): populate SessionRef.started_at for claude_code/openclaw so backfill --since is honored

### DIFF
--- a/openviking/ingest/sources/base.py
+++ b/openviking/ingest/sources/base.py
@@ -125,6 +125,36 @@ class JsonlLogSource(LogSource):
             return None
         return None
 
+    @staticmethod
+    def _peek_first_timestamp(path: Path) -> Optional[str]:
+        """First record's top-level string ``timestamp`` (the session start).
+
+        Skips leading records that carry no usable timestamp — e.g. Claude Code's
+        ``summary`` / ``queue-operation`` header lines or OpenClaw's ``session``
+        record — and tolerates a malformed line rather than aborting. Only a
+        non-empty ``str`` is returned: a non-string ``timestamp`` is ignored so
+        ``started_at`` keeps its ``Optional[str]`` contract and the downstream
+        ``--since`` string comparison can't hit a ``TypeError``. Returns ``None``
+        when no record has one (prior every-session-included behavior preserved).
+        """
+        try:
+            with open(path, "rb") as f:
+                for raw in f:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        obj = json.loads(raw)
+                    except ValueError:
+                        continue
+                    if isinstance(obj, dict):
+                        ts = obj.get("timestamp")
+                        if isinstance(ts, str) and ts:
+                            return ts
+        except OSError:
+            return None
+        return None
+
     def read_messages(
         self, ref: SessionRef, cursor: Optional[Cursor], limit: int = DEFAULT_READ_LIMIT
     ) -> Tuple[List[NormalizedMessage], Cursor]:

--- a/openviking/ingest/sources/claude_code.py
+++ b/openviking/ingest/sources/claude_code.py
@@ -39,6 +39,17 @@ class ClaudeCodeSource(JsonlLogSource):
     def default_paths(self) -> List[Path]:
         return [Path.home() / ".claude" / "projects"]
 
+    def session_ref_for_file(self, path: Path) -> SessionRef:
+        # Populate started_at so `ingest backfill --since` is honored (the docs'
+        # canonical example uses --harness claude_code); the per-record top-level
+        # "timestamp" that parse_line already reads is the session-start source.
+        return SessionRef(
+            harness=self.name,
+            native_session_id=self.session_id_for_file(path),
+            locator=str(path),
+            started_at=self._peek_first_timestamp(path),
+        )
+
     def parse_line(self, obj: Dict[str, Any], ref: SessionRef) -> List[NormalizedMessage]:
         if obj.get("type") not in ("user", "assistant"):
             return []

--- a/openviking/ingest/sources/openclaw.py
+++ b/openviking/ingest/sources/openclaw.py
@@ -45,6 +45,17 @@ class OpenClawSource(JsonlLogSource):
     def default_paths(self) -> List[Path]:
         return [Path.home() / ".openclaw" / "agents"]
 
+    def session_ref_for_file(self, path: Path) -> SessionRef:
+        # Populate started_at so `ingest backfill --since` is honored; mirror the
+        # per-record top-level "timestamp" that parse_line already reads (skips the
+        # leading non-timestamped "session" record).
+        return SessionRef(
+            harness=self.name,
+            native_session_id=self.session_id_for_file(path),
+            locator=str(path),
+            started_at=self._peek_first_timestamp(path),
+        )
+
     def parse_line(self, obj: Dict[str, Any], ref: SessionRef) -> List[NormalizedMessage]:
         if obj.get("type") != "message":
             return []

--- a/tests/ingest/test_parsers.py
+++ b/tests/ingest/test_parsers.py
@@ -65,6 +65,9 @@ def test_claude_code(tmp_path):
     src = ClaudeCodeSource(_cfg(root), fallback_user="tester")
     ref, msgs, _ = _read_all(src)
     assert ref.native_session_id == "sess-1"
+    # started_at is the first *timestamped* record, skipping the leading
+    # non-timestamped "queue-operation" header -> `backfill --since` is honored.
+    assert ref.started_at == "2026-06-01T00:00:00Z"
     assert [(m.role, m.text) for m in msgs] == [("user", "hello there"), ("assistant", "hi!")]
     assert msgs[1].peer_id == "claude_code__claude-opus-4-8"
     assert msgs[0].peer_id == "tester"  # no git repo -> configured fallback
@@ -165,9 +168,50 @@ def test_openclaw_assistant_model(tmp_path):
         ],
     )
     src = OpenClawSource(_cfg(root, user_field="sender"), fallback_user="tester")
-    _, msgs, _ = _read_all(src)
+    ref, msgs, _ = _read_all(src)
+    # started_at is the first *timestamped* record, skipping the leading
+    # non-timestamped "session" record -> `backfill --since` is honored.
+    assert ref.started_at == "2026-06-01T00:00:00Z"
     assert [(m.role, m.text) for m in msgs] == [("user", "run it"), ("assistant", "ok")]
     assert msgs[1].peer_id == "openclaw__ark__doubao-x"
+
+
+def test_started_at_skips_non_string_and_missing_timestamp(tmp_path):
+    """started_at only accepts a non-empty *string* timestamp, skipping records
+    with a missing or non-string one, so a malformed log can't make started_at a
+    non-str (which would crash the `--since` string comparison)."""
+    root = tmp_path / "projects"
+    _write_jsonl(
+        root / "slug" / "sess-2.jsonl",
+        [
+            {"type": "summary"},  # no timestamp -> skipped
+            {"type": "user", "timestamp": 1717200000},  # non-string -> skipped
+            {
+                "type": "user",
+                "timestamp": "2026-06-02T00:00:00Z",
+                "message": {"role": "user", "content": "hi"},
+            },
+        ],
+    )
+    src = ClaudeCodeSource(_cfg(root), fallback_user="tester")
+    ref = next(iter(src.discover_sessions()))
+    assert ref.started_at == "2026-06-02T00:00:00Z"
+
+
+def test_started_at_none_when_no_string_timestamp(tmp_path):
+    """No usable string timestamp -> started_at stays None (every-session-included
+    fallback preserved, no crash)."""
+    root = tmp_path / "agents"
+    _write_jsonl(
+        root / "main" / "sessions" / "oc2.jsonl",
+        [
+            {"type": "session", "id": "oc2"},  # no timestamp
+            {"type": "message", "timestamp": {"iso": "x"}},  # non-string -> ignored
+        ],
+    )
+    src = OpenClawSource(_cfg(root, user_field="sender"), fallback_user="tester")
+    ref = next(iter(src.discover_sessions()))
+    assert ref.started_at is None
 
 
 def test_opencode_text_from_part_table(tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #2892. That PR added local agent-harness log replay and populated `SessionRef.started_at` for the **codex / hermes / opencode** adapters, but **claude_code** and **openclaw** were missed. Their `started_at` stays `None`, so `orchestrator.py`'s `--since` guard (`if since and ref.started_at and ref.started_at < since: skip`) is always falsy for them — `ingest backfill --since <ISO>` is a **silent no-op** and replays the entire session history.

This is most visible for **claude_code**, which is the harness in the canonical docs example:

```
openviking-server ingest backfill --harness claude_code --since 2026-06-01
```

A user setting `--since` to bound LLM-extraction cost/privacy silently backfills months of sessions (one extraction per session) instead of the requested window.

## Fix

Mirror the sister adapters: override `session_ref_for_file` in `ClaudeCodeSource` and `OpenClawSource` to set `started_at` from the session's first record. Both adapters' `parse_line` already read the per-record **top-level** `obj["timestamp"]`, so that is the consistent, non-speculative source.

A shared `JsonlLogSource._peek_first_timestamp` helper returns the **first record's non-empty string `timestamp`**, skipping leading records that have none (Claude Code's `summary` / `queue-operation` header, OpenClaw's `session` record) and ignoring a non-string `timestamp`. This keeps `started_at` strictly `Optional[str]`, so a malformed log can't make it a non-string (which would raise in the `--since` comparison); a file with no usable timestamp falls back to `None` (prior every-session-included behavior).

## Tests

`tests/ingest/test_parsers.py`: assert `started_at` for the claude_code and openclaw fixtures (each already has a leading non-timestamped control record, so this also covers the skip), plus two cases for the non-string / missing-timestamp guard and the `None` fallback. Full `tests/ingest` suite passes (26).

## Note

`started_at` is stored as the raw log timestamp string, consistent with the codex/hermes adapters from #2892; the `--since` gate's lexical ISO-string comparison in `orchestrator.py` is unchanged and shared by all adapters. For the UTC `Z` timestamps these harnesses emit it orders chronologically; normalizing to parsed datetimes would be a separate, subsystem-wide change to the gate + every adapter, out of scope for this missed-surface follow-up.
