### PR TITLE
openclaw: store completed tool parts as user

### DIFF
--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -551,6 +551,43 @@ describe("context-engine afterTurn()", () => {
     expect(client.addSessionMessage.mock.calls[2][1]).toBe("assistant");
   });
 
+  it("stores completed event tool_result blocks as user-role tool parts", async () => {
+    const { engine, client } = makeEngine();
+
+    const messages = [
+      { role: "assistant", content: [
+        { type: "text", text: "calling tool" },
+        { type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.txt" } },
+      ] },
+      { role: "assistant", content: [
+        { type: "tool_result", tool_use_id: "call_1", content: "content of a" },
+        { type: "text", text: "all done" },
+      ] },
+    ];
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(3);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[1][1]).toBe("user");
+    const toolParts = client.addSessionMessage.mock.calls[1][2] as Array<{
+      type?: string;
+      tool_id?: string;
+      tool_name?: string;
+      tool_input?: Record<string, unknown>;
+      tool_output?: string;
+      tool_status?: string;
+    }>;
+    expect(toolParts).toEqual([{ type: "tool", tool_id: "call_1", tool_name: "read", tool_input: { path: "a.txt" }, tool_output: "content of a", tool_status: "completed" }]);
+    expect(client.addSessionMessage.mock.calls[2][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[2][2][0].text).toBe("all done");
+  });
+
   it("sanitizes <relevant-memories> from assistant content", async () => {
     const { engine, client } = makeEngine();
 

--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -191,6 +191,26 @@ describe("extractNewTurnTexts", () => {
     expect(texts[0]).toContain("found 3 matches");
   });
 
+  it("formats embedded tool_result blocks from completed events", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "grep", arguments: { pattern: "TODO" } }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_result", tool_use_id: "call_1", content: "found 3 matches" },
+          { type: "text", text: "Done." },
+        ],
+      },
+    ];
+    const { texts } = extractNewTurnTexts(messages, 0);
+    expect(texts).toContain('[toolUse: grep] {"pattern":"TODO"}');
+    expect(texts).toContain("[grep result]: found 3 matches");
+    expect(texts).toContain("[assistant]: Done.");
+  });
+
   it("respects startIndex parameter", () => {
     const messages = [
       { role: "user", content: "old message" },

--- a/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
@@ -69,6 +69,41 @@ describe("extractNewTurnMessages: toolCallId propagation", () => {
     const { messages: extracted } = extractNewTurnMessages(messages, 0);
     expect(extracted[0]!.role).toBe("user");
   });
+
+  it("maps embedded completed tool_result blocks to user-role tool parts", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "toolUse", id: "call_abc123", name: "exec", input: { command: "ls" } },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_result", tool_use_id: "call_abc123", content: "file1.txt\nfile2.txt" },
+          { type: "text", text: "Done." },
+        ],
+      },
+    ];
+
+    const { messages: extracted } = extractNewTurnMessages(messages, 0);
+
+    expect(extracted).toHaveLength(3);
+    expect(extracted[0]!.role).toBe("assistant");
+    expect(extracted[1]!.role).toBe("user");
+    const toolPart = extracted[1]!.parts[0]!;
+    expect(toolPart.type).toBe("tool");
+    if (toolPart.type === "tool") {
+      expect(toolPart.toolCallId).toBe("call_abc123");
+      expect(toolPart.toolName).toBe("exec");
+      expect(toolPart.toolInput).toEqual({ command: "ls" });
+      expect(toolPart.toolOutput).toContain("file1.txt");
+      expect(toolPart.toolStatus).toBe("completed");
+    }
+    expect(extracted[2]).toEqual({ role: "assistant", parts: [{ type: "text", text: "Done." }] });
+  });
 });
 
 describe("convertToAgentMessages: structured tool round-trip", () => {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -304,6 +304,62 @@ function formatToolResultContent(content: unknown): string {
   return "";
 }
 
+function normalizeToolContentType(value: unknown): string {
+  return typeof value === "string" ? value.replace(/[_-]/g, "").toLowerCase() : "";
+}
+
+function isToolResultContentBlock(block: unknown): block is Record<string, unknown> {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  return normalizeToolContentType((block as Record<string, unknown>).type) === "toolresult";
+}
+
+function isToolCallContentBlock(block: unknown): block is Record<string, unknown> {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = normalizeToolContentType((block as Record<string, unknown>).type);
+  return type === "toolcall" || type === "tooluse";
+}
+
+function readToolCallId(record: Record<string, unknown>): string | undefined {
+  for (const field of ["toolCallId", "toolUseId", "tool_call_id", "tool_use_id", "id"] as const) {
+    const value = record[field];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readToolName(record: Record<string, unknown>): string | undefined {
+  for (const field of ["toolName", "tool_name", "name"] as const) {
+    const value = record[field];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readToolInput(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  const input = record.arguments ?? record.input ?? record.toolInput ?? record.tool_input;
+  return input && typeof input === "object" && !Array.isArray(input)
+    ? input as Record<string, unknown>
+    : undefined;
+}
+
+function readToolResultIsError(record: Record<string, unknown>): boolean {
+  if (typeof record.isError === "boolean") {
+    return record.isError;
+  }
+  if (typeof record.is_error === "boolean") {
+    return record.is_error;
+  }
+  return false;
+}
+
 /**
  * 提取消息中的一个 part 的文本内容，并清理时间戳等噪音
  */
@@ -356,9 +412,10 @@ export function extractNewTurnMessages(
   const result: ExtractedMessage[] = [];
   let count = 0;
 
-  // First pass: collect toolUse inputs indexed by toolCallId/toolUseId
-  // Scan all messages (including after startIndex) to find toolUse before each toolResult
+  // First pass: collect toolUse inputs and names indexed by toolCallId/toolUseId.
+  // Scan all messages (including after startIndex) to find toolUse before each toolResult.
   const toolUseInputs: Record<string, Record<string, unknown>> = {};
+  const toolUseNames: Record<string, string> = {};
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i] as Record<string, unknown>;
     if (!msg || typeof msg !== "object") continue;
@@ -367,15 +424,16 @@ export function extractNewTurnMessages(
       const content = msg.content;
       if (Array.isArray(content)) {
         for (const block of content) {
-          const b = block as Record<string, unknown>;
-          // Handle toolCall, toolUse, tool_call types
-          if (b?.type === "toolCall" || b?.type === "toolUse" || b?.type === "tool_call") {
-            const id = (b.id as string) || (b.toolUseId as string) || (b.toolCallId as string);
-            // Try multiple field names for tool input: arguments, input, toolInput
-            const input = b.arguments ?? b.input ?? b.toolInput;
-            if (id && input && typeof input === "object") {
-              toolUseInputs[id] = input as Record<string, unknown>;
-            }
+          if (!isToolCallContentBlock(block)) continue;
+          const id = readToolCallId(block);
+          if (!id) continue;
+          const name = readToolName(block);
+          if (name) {
+            toolUseNames[id] = name;
+          }
+          const input = readToolInput(block);
+          if (input) {
+            toolUseInputs[id] = input;
           }
         }
       }
@@ -391,35 +449,57 @@ export function extractNewTurnMessages(
 
     count++;
 
-    // toolResult -> type: "tool"
+    // OV canonical session shape stores completed tool result parts on user-role messages.
     if (role === "toolResult") {
-      const toolName = typeof msg.toolName === "string" ? msg.toolName : "tool";
+      const toolCallId = readToolCallId(msg);
+      const toolName = readToolName(msg) ?? (toolCallId ? toolUseNames[toolCallId] : undefined) ?? "tool";
       const output = formatToolResultContent(msg.content) || "";
-      // Try multiple field names for tool call ID
-      const toolCallId = (msg.toolCallId as string) || (msg.toolUseId as string) || (msg.tool_call_id as string);
-      const toolInput = toolCallId && toolUseInputs[toolCallId]
-        ? toolUseInputs[toolCallId]
-        : (typeof msg.toolInput === "object" && msg.toolInput !== null
-          ? msg.toolInput as Record<string, unknown>
-          : undefined);
+      const toolInput = (toolCallId && toolUseInputs[toolCallId]) || readToolInput(msg);
       if (output) {
         result.push({
           role: "user",
           parts: [{
             type: "tool",
-            toolCallId: toolCallId || undefined,
+            toolCallId,
             toolName,
             toolInput,
             toolOutput: output,
-            toolStatus: "completed",
+            toolStatus: readToolResultIsError(msg) ? "error" : "completed",
           }],
         });
       }
       continue;
     }
 
-    // user/assistant -> type: "text"
+    // Some OpenClaw runtimes deliver completed tool-result content as blocks inside
+    // a user/assistant message instead of as a top-level role="toolResult" turn.
+    // Persist those blocks as OV ToolParts under role="user" so uploaded session
+    // messages follow OpenViking's standard tool-result ownership contract.
     const content = msg.content;
+    if (Array.isArray(content)) {
+      const toolParts: Array<Extract<ExtractedMessage["parts"][number], { type: "tool" }>> = [];
+      for (const block of content) {
+        if (!isToolResultContentBlock(block)) continue;
+        const toolCallId = readToolCallId(block);
+        const toolName = readToolName(block) ?? (toolCallId ? toolUseNames[toolCallId] : undefined) ?? "tool";
+        const output = formatToolResultContent(block.content ?? block.text ?? block.output ?? block.result) || "";
+        const toolInput = (toolCallId && toolUseInputs[toolCallId]) || readToolInput(block);
+        if (!output) continue;
+        toolParts.push({
+          type: "tool",
+          toolCallId,
+          toolName,
+          toolInput,
+          toolOutput: output,
+          toolStatus: readToolResultIsError(block) ? "error" : "completed",
+        });
+      }
+      if (toolParts.length > 0) {
+        result.push({ role: "user", parts: toolParts });
+      }
+    }
+
+    // user/assistant -> type: "text"
     const text = extractPartText(content);
 
     if (text) {


### PR DESCRIPTION
## Summary
- Parse embedded OpenClaw `tool_result` / `toolResult` completed-event blocks during `afterTurn` capture.
- Upload completed tool results as OV standard user-role `tool` parts, preserving tool id, name, input, output, and error/completed status.
- Add regression coverage for extractor, round-trip, and `afterTurn` upload behavior.

## Tests
- `npm test -- --run tests/ut/text-utils.test.ts tests/ut/tool-round-trip.test.ts tests/ut/context-engine-afterTurn.test.ts`
- `npm run typecheck`
- `npm run build`
