### PR TITLE
fix(web-studio): pin assumed account to admin key's own account

### DIFF
--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -171,9 +171,14 @@ function applyConnection(
   })
 }
 
-async function detectConnectionRole(
+type ConnectionIdentity = {
+  accountId: string
+  role: ConnectionRole
+}
+
+async function detectConnectionIdentity(
   connection: ConnectionDraft,
-): Promise<ConnectionRole> {
+): Promise<ConnectionIdentity> {
   const headers: Record<string, string> = {}
   const apiKey = connection.adminApiKey || connection.apiKey
   if (apiKey) {
@@ -185,13 +190,20 @@ async function detectConnectionRole(
     { headers },
   )
   if (!response.ok) {
-    return 'unknown'
+    return { accountId: '', role: 'unknown' }
   }
 
+  // /health resolves the presented key and echoes back its identity:
+  // { role, account_id, user_id }. We use role to gate the admin UI and
+  // account_id to pin the assumed account for an account-admin key.
   const data = (await response.json().catch(() => null)) as {
+    account_id?: unknown
     role?: unknown
   } | null
-  return isConnectionRole(data?.role) ? data.role : 'unknown'
+  return {
+    accountId: typeof data?.account_id === 'string' ? data.account_id : '',
+    role: isConnectionRole(data?.role) ? data.role : 'unknown',
+  }
 }
 
 function readInitialConnection(): ConnectionDraft {
@@ -328,13 +340,23 @@ export function AppConnectionProvider({
       }
     }
 
-    void detectConnectionRole(connection)
-      .then((role) => {
+    void detectConnectionIdentity(connection)
+      .then(({ accountId, role }) => {
         if (cancelled) {
           return
         }
         setConnectionRole(role)
         setConnectionRoleLoading(false)
+        // An account-admin Root key is scoped to its own account. Pin that
+        // account as the assumed identity so admin and data calls target the
+        // right tenant instead of failing with a mismatch (the server rejects
+        // a foreign account with "ADMIN can only manage account: <x>"). A root
+        // key is not account-scoped, so its account selection is left intact.
+        if (role === 'admin' && accountId) {
+          setConnection((prev) =>
+            prev.accountId === accountId ? prev : { ...prev, accountId },
+          )
+        }
       })
       .catch(() => {
         if (!cancelled) {

--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -158,7 +158,7 @@ const en = {
       apiKey: 'API key',
       baseUrl: 'Server URL',
       dataApiKey: 'User API key',
-      rootApiKey: 'Root API Key',
+      rootApiKey: 'Root or Admin API Key',
       userApiKey: 'User API Key',
       role: 'Role',
       user: 'User',

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -157,7 +157,7 @@ const zhCN = {
       apiKey: 'API key',
       baseUrl: '服务地址',
       dataApiKey: 'User API key',
-      rootApiKey: 'Root API Key',
+      rootApiKey: 'Root or Admin API Key',
       userApiKey: 'User API Key',
       role: '角色',
       user: 'User',


### PR DESCRIPTION
## Problem

When the **Root API Key** field holds an **account-admin** key (not a root key), Studio kept the previously-selected / `default` assumed account. An account-admin key is scoped to its own account, so admin/data calls against any other account were rejected by the server:

> Could not verify the Root API Key: **ADMIN can only manage account: bytedance**

Clearing the assumed account doesn't help — it just falls back to `default`, which still mismatches the admin key's real account.

## Fix

`/health` already resolves the presented key and echoes back its identity (`role` + `account_id` + `user_id`). The provider previously read only `role` and discarded `account_id`.

- `detectConnectionRole` → `detectConnectionIdentity`, now also returns `account_id`.
- In the role-detection effect, when the key resolves as an **admin** key, pin the assumed account to the admin key's own `account_id`. Admin probe then falls back to `/admin/accounts/<account>/users` → **OK**.
- **Root** keys are not account-scoped, so their account selection is left untouched.
- Per product decision: adopt **account only** (the data user still comes from the User API Key adopted later).

Also relabels the field **"Root API Key" → "Root or Admin API Key"** (en + zh) to reflect that an account-admin key is accepted there.

## Testing

- `tsc --noEmit` and `eslint` clean on changed files.
- `vitest run` — 12/12 pass.
- Verified live against an account-admin key: **Admin control** flips from *Error* to *OK*, assumed account auto-fills to the key's account.

## Note

There is a brief one-time role flicker when the admin account is adopted (role resets to *checking* → *admin* as `account_id` updates and `/health` re-runs once). Harmless; can smooth out in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)