### PR TITLE
[codex] fix OpenClaw tool call upload roles

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -544,18 +544,28 @@ jobs:
           export OPENVIKING_ROOT_API_KEY="test-root-api-key"
 
           echo "Running CLI integration tests (serial to avoid resource conflicts)..."
-          uv run python -m pytest \
-            test_cli_filesystem.py \
-            test_cli_content.py \
-            test_cli_resources.py \
-            test_cli_search.py \
-            test_cli_sessions.py \
-            test_cli_relations.py \
-            test_cli_system.py \
-            test_cli_skills.py \
-            test_cli_observer.py \
-            -v --tb=short -m cli_remote \
-            --html=cli-test-report.html --self-contained-html
+          if [ "${{ env.HAS_SECRETS }}" = "true" ]; then
+            uv run python -m pytest \
+              test_cli_filesystem.py \
+              test_cli_content.py \
+              test_cli_resources.py \
+              test_cli_search.py \
+              test_cli_sessions.py \
+              test_cli_relations.py \
+              test_cli_system.py \
+              test_cli_skills.py \
+              test_cli_observer.py \
+              -v --tb=short -m cli_remote \
+              --html=cli-test-report.html --self-contained-html
+          else
+            echo "Running CLI tests that do not require VLM/Embedding secrets..."
+            uv run python -m pytest \
+              test_cli_sessions.py \
+              test_cli_system.py \
+              test_cli_observer.py \
+              -v --tb=short -m cli_remote \
+              --html=cli-test-report.html --self-contained-html
+          fi
         continue-on-error: true
 
       - name: Upload test reports

--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -551,6 +551,43 @@ describe("context-engine afterTurn()", () => {
     expect(client.addSessionMessage.mock.calls[2][1]).toBe("assistant");
   });
 
+  it("stores completed event tool_result blocks as user-role tool parts", async () => {
+    const { engine, client } = makeEngine();
+
+    const messages = [
+      { role: "assistant", content: [
+        { type: "text", text: "calling tool" },
+        { type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.txt" } },
+      ] },
+      { role: "assistant", content: [
+        { type: "tool_result", tool_use_id: "call_1", content: "content of a" },
+        { type: "text", text: "all done" },
+      ] },
+    ];
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(3);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[1][1]).toBe("user");
+    const toolParts = client.addSessionMessage.mock.calls[1][2] as Array<{
+      type?: string;
+      tool_id?: string;
+      tool_name?: string;
+      tool_input?: Record<string, unknown>;
+      tool_output?: string;
+      tool_status?: string;
+    }>;
+    expect(toolParts).toEqual([{ type: "tool", tool_id: "call_1", tool_name: "read", tool_input: { path: "a.txt" }, tool_output: "content of a", tool_status: "completed" }]);
+    expect(client.addSessionMessage.mock.calls[2][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[2][2][0].text).toBe("all done");
+  });
+
   it("sanitizes <relevant-memories> from assistant content", async () => {
     const { engine, client } = makeEngine();
 

--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -588,6 +588,46 @@ describe("context-engine afterTurn()", () => {
     expect(client.addSessionMessage.mock.calls[2][2][0].text).toBe("all done");
   });
 
+  it("stores textless assistant tool calls before completed event results", async () => {
+    const { engine, client } = makeEngine();
+
+    const messages = [
+      { role: "assistant", content: [
+        { type: "toolCall", id: "call_read_1", name: "read", arguments: { path: "a.txt" } },
+      ] },
+      { role: "assistant", content: [
+        { type: "tool_result", tool_use_id: "call_read_1", content: "file content" },
+      ] },
+    ];
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.addSessionMessage.mock.calls[0][1]).toBe("assistant");
+    expect(client.addSessionMessage.mock.calls[0][2]).toEqual([{
+      type: "tool",
+      tool_id: "call_read_1",
+      tool_name: "read",
+      tool_input: { path: "a.txt" },
+      tool_output: "",
+      tool_status: "running",
+    }]);
+    expect(client.addSessionMessage.mock.calls[1][1]).toBe("user");
+    expect(client.addSessionMessage.mock.calls[1][2]).toEqual([{
+      type: "tool",
+      tool_id: "call_read_1",
+      tool_name: "read",
+      tool_input: { path: "a.txt" },
+      tool_output: "file content",
+      tool_status: "completed",
+    }]);
+  });
+
   it("sanitizes <relevant-memories> from assistant content", async () => {
     const { engine, client } = makeEngine();
 

--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -191,6 +191,26 @@ describe("extractNewTurnTexts", () => {
     expect(texts[0]).toContain("found 3 matches");
   });
 
+  it("formats embedded tool_result blocks from completed events", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "grep", arguments: { pattern: "TODO" } }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_result", tool_use_id: "call_1", content: "found 3 matches" },
+          { type: "text", text: "Done." },
+        ],
+      },
+    ];
+    const { texts } = extractNewTurnTexts(messages, 0);
+    expect(texts).toContain('[toolUse: grep] {"pattern":"TODO"}');
+    expect(texts).toContain("[grep result]: found 3 matches");
+    expect(texts).toContain("[assistant]: Done.");
+  });
+
   it("respects startIndex parameter", () => {
     const messages = [
       { role: "user", content: "old message" },

--- a/examples/openclaw-plugin/tests/ut/text-utils.test.ts
+++ b/examples/openclaw-plugin/tests/ut/text-utils.test.ts
@@ -243,7 +243,7 @@ describe("extractNewTurnTexts", () => {
 });
 
 describe("extractNewTurnMessages", () => {
-  it("drops assistant toolCall messages that have no text block", () => {
+  it("stores assistant toolCall messages that have no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -257,10 +257,20 @@ describe("extractNewTurnMessages", () => {
     const { messages: extracted, newCount } = extractNewTurnMessages(messages, 0);
 
     expect(newCount).toBe(1);
-    expect(extracted).toEqual([]);
+    expect(extracted).toEqual([{
+      role: "assistant",
+      parts: [{
+        type: "tool",
+        toolCallId: "call_1",
+        toolName: "read_file",
+        toolInput: { path: "a.txt" },
+        toolOutput: "",
+        toolStatus: "running",
+      }],
+    }]);
   });
 
-  it("drops assistant toolUse messages that have no text block", () => {
+  it("stores assistant toolUse messages that have no text block", () => {
     const messages = [
       {
         role: "assistant",
@@ -274,10 +284,20 @@ describe("extractNewTurnMessages", () => {
     const { messages: extracted, newCount } = extractNewTurnMessages(messages, 0);
 
     expect(newCount).toBe(1);
-    expect(extracted).toEqual([]);
+    expect(extracted).toEqual([{
+      role: "assistant",
+      parts: [{
+        type: "tool",
+        toolCallId: "call_2",
+        toolName: "grep",
+        toolInput: { pattern: "TODO" },
+        toolOutput: "",
+        toolStatus: "running",
+      }],
+    }]);
   });
 
-  it("does not synthesize placeholders for multiple textless assistant tool calls", () => {
+  it("stores multiple textless assistant tool calls without text placeholders", () => {
     const messages = [
       {
         role: "assistant",
@@ -290,7 +310,27 @@ describe("extractNewTurnMessages", () => {
 
     const { messages: extracted } = extractNewTurnMessages(messages, 0);
 
-    expect(extracted).toEqual([]);
+    expect(extracted).toEqual([{
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          toolCallId: "call_1",
+          toolName: "read_file",
+          toolInput: undefined,
+          toolOutput: "",
+          toolStatus: "running",
+        },
+        {
+          type: "tool",
+          toolCallId: "call_2",
+          toolName: "grep",
+          toolInput: undefined,
+          toolOutput: "",
+          toolStatus: "running",
+        },
+      ],
+    }]);
   });
 
   it("does not create a placeholder for textless assistant messages without tool calls", () => {

--- a/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
@@ -24,7 +24,7 @@ describe("extractNewTurnMessages: toolCallId propagation", () => {
     const { messages: extracted } = extractNewTurnMessages(messages, 0);
 
     const toolMsg = extracted.find(
-      (m) => m.parts.some((p) => p.type === "tool"),
+      (m) => m.role === "user" && m.parts.some((p) => p.type === "tool"),
     );
     expect(toolMsg).toBeDefined();
 
@@ -92,6 +92,17 @@ describe("extractNewTurnMessages: toolCallId propagation", () => {
 
     expect(extracted).toHaveLength(3);
     expect(extracted[0]!.role).toBe("assistant");
+    expect(extracted[0]!.parts).toEqual([
+      { type: "text", text: "Let me check." },
+      {
+        type: "tool",
+        toolCallId: "call_abc123",
+        toolName: "exec",
+        toolInput: { command: "ls" },
+        toolOutput: "",
+        toolStatus: "running",
+      },
+    ]);
     expect(extracted[1]!.role).toBe("user");
     const toolPart = extracted[1]!.parts[0]!;
     expect(toolPart.type).toBe("tool");
@@ -103,6 +114,49 @@ describe("extractNewTurnMessages: toolCallId propagation", () => {
       expect(toolPart.toolStatus).toBe("completed");
     }
     expect(extracted[2]).toEqual({ role: "assistant", parts: [{ type: "text", text: "Done." }] });
+  });
+
+  it("maps textless assistant tool calls to assistant-role tool parts", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_read_1", name: "read", arguments: { path: "a.txt" } },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_result", tool_use_id: "call_read_1", content: "file content" },
+        ],
+      },
+    ];
+
+    const { messages: extracted } = extractNewTurnMessages(messages, 0);
+
+    expect(extracted).toHaveLength(2);
+    expect(extracted[0]).toEqual({
+      role: "assistant",
+      parts: [{
+        type: "tool",
+        toolCallId: "call_read_1",
+        toolName: "read",
+        toolInput: { path: "a.txt" },
+        toolOutput: "",
+        toolStatus: "running",
+      }],
+    });
+    expect(extracted[1]).toEqual({
+      role: "user",
+      parts: [{
+        type: "tool",
+        toolCallId: "call_read_1",
+        toolName: "read",
+        toolInput: { path: "a.txt" },
+        toolOutput: "file content",
+        toolStatus: "completed",
+      }],
+    });
   });
 });
 

--- a/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
@@ -69,6 +69,41 @@ describe("extractNewTurnMessages: toolCallId propagation", () => {
     const { messages: extracted } = extractNewTurnMessages(messages, 0);
     expect(extracted[0]!.role).toBe("user");
   });
+
+  it("maps embedded completed tool_result blocks to user-role tool parts", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "toolUse", id: "call_abc123", name: "exec", input: { command: "ls" } },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_result", tool_use_id: "call_abc123", content: "file1.txt\nfile2.txt" },
+          { type: "text", text: "Done." },
+        ],
+      },
+    ];
+
+    const { messages: extracted } = extractNewTurnMessages(messages, 0);
+
+    expect(extracted).toHaveLength(3);
+    expect(extracted[0]!.role).toBe("assistant");
+    expect(extracted[1]!.role).toBe("user");
+    const toolPart = extracted[1]!.parts[0]!;
+    expect(toolPart.type).toBe("tool");
+    if (toolPart.type === "tool") {
+      expect(toolPart.toolCallId).toBe("call_abc123");
+      expect(toolPart.toolName).toBe("exec");
+      expect(toolPart.toolInput).toEqual({ command: "ls" });
+      expect(toolPart.toolOutput).toContain("file1.txt");
+      expect(toolPart.toolStatus).toBe("completed");
+    }
+    expect(extracted[2]).toEqual({ role: "assistant", parts: [{ type: "text", text: "Done." }] });
+  });
 });
 
 describe("convertToAgentMessages: structured tool round-trip", () => {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -304,6 +304,62 @@ function formatToolResultContent(content: unknown): string {
   return "";
 }
 
+function normalizeToolContentType(value: unknown): string {
+  return typeof value === "string" ? value.replace(/[_-]/g, "").toLowerCase() : "";
+}
+
+function isToolResultContentBlock(block: unknown): block is Record<string, unknown> {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  return normalizeToolContentType((block as Record<string, unknown>).type) === "toolresult";
+}
+
+function isToolCallContentBlock(block: unknown): block is Record<string, unknown> {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = normalizeToolContentType((block as Record<string, unknown>).type);
+  return type === "toolcall" || type === "tooluse";
+}
+
+function readToolCallId(record: Record<string, unknown>): string | undefined {
+  for (const field of ["toolCallId", "toolUseId", "tool_call_id", "tool_use_id", "id"] as const) {
+    const value = record[field];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readToolName(record: Record<string, unknown>): string | undefined {
+  for (const field of ["toolName", "tool_name", "name"] as const) {
+    const value = record[field];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readToolInput(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  const input = record.arguments ?? record.input ?? record.toolInput ?? record.tool_input;
+  return input && typeof input === "object" && !Array.isArray(input)
+    ? input as Record<string, unknown>
+    : undefined;
+}
+
+function readToolResultIsError(record: Record<string, unknown>): boolean {
+  if (typeof record.isError === "boolean") {
+    return record.isError;
+  }
+  if (typeof record.is_error === "boolean") {
+    return record.is_error;
+  }
+  return false;
+}
+
 /**
  * 提取消息中的一个 part 的文本内容，并清理时间戳等噪音
  */
@@ -356,9 +412,10 @@ export function extractNewTurnMessages(
   const result: ExtractedMessage[] = [];
   let count = 0;
 
-  // First pass: collect toolUse inputs indexed by toolCallId/toolUseId
-  // Scan all messages (including after startIndex) to find toolUse before each toolResult
+  // First pass: collect toolUse inputs and names indexed by toolCallId/toolUseId.
+  // Scan all messages (including after startIndex) to find toolUse before each toolResult.
   const toolUseInputs: Record<string, Record<string, unknown>> = {};
+  const toolUseNames: Record<string, string> = {};
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i] as Record<string, unknown>;
     if (!msg || typeof msg !== "object") continue;
@@ -367,15 +424,16 @@ export function extractNewTurnMessages(
       const content = msg.content;
       if (Array.isArray(content)) {
         for (const block of content) {
-          const b = block as Record<string, unknown>;
-          // Handle toolCall, toolUse, tool_call types
-          if (b?.type === "toolCall" || b?.type === "toolUse" || b?.type === "tool_call") {
-            const id = (b.id as string) || (b.toolUseId as string) || (b.toolCallId as string);
-            // Try multiple field names for tool input: arguments, input, toolInput
-            const input = b.arguments ?? b.input ?? b.toolInput;
-            if (id && input && typeof input === "object") {
-              toolUseInputs[id] = input as Record<string, unknown>;
-            }
+          if (!isToolCallContentBlock(block)) continue;
+          const id = readToolCallId(block);
+          if (!id) continue;
+          const name = readToolName(block);
+          if (name) {
+            toolUseNames[id] = name;
+          }
+          const input = readToolInput(block);
+          if (input) {
+            toolUseInputs[id] = input;
           }
         }
       }
@@ -391,35 +449,57 @@ export function extractNewTurnMessages(
 
     count++;
 
-    // toolResult -> type: "tool"
+    // OV canonical session shape stores completed tool result parts on user-role messages.
     if (role === "toolResult") {
-      const toolName = typeof msg.toolName === "string" ? msg.toolName : "tool";
+      const toolCallId = readToolCallId(msg);
+      const toolName = readToolName(msg) ?? (toolCallId ? toolUseNames[toolCallId] : undefined) ?? "tool";
       const output = formatToolResultContent(msg.content) || "";
-      // Try multiple field names for tool call ID
-      const toolCallId = (msg.toolCallId as string) || (msg.toolUseId as string) || (msg.tool_call_id as string);
-      const toolInput = toolCallId && toolUseInputs[toolCallId]
-        ? toolUseInputs[toolCallId]
-        : (typeof msg.toolInput === "object" && msg.toolInput !== null
-          ? msg.toolInput as Record<string, unknown>
-          : undefined);
+      const toolInput = (toolCallId && toolUseInputs[toolCallId]) || readToolInput(msg);
       if (output) {
         result.push({
           role: "user",
           parts: [{
             type: "tool",
-            toolCallId: toolCallId || undefined,
+            toolCallId,
             toolName,
             toolInput,
             toolOutput: output,
-            toolStatus: "completed",
+            toolStatus: readToolResultIsError(msg) ? "error" : "completed",
           }],
         });
       }
       continue;
     }
 
-    // user/assistant -> type: "text"
+    // Some OpenClaw runtimes deliver completed tool-result content as blocks inside
+    // a user/assistant message instead of as a top-level role="toolResult" turn.
+    // Persist those blocks as OV ToolParts under role="user" so uploaded session
+    // messages follow OpenViking's standard tool-result ownership contract.
     const content = msg.content;
+    if (Array.isArray(content)) {
+      const toolParts: Array<Extract<ExtractedMessage["parts"][number], { type: "tool" }>> = [];
+      for (const block of content) {
+        if (!isToolResultContentBlock(block)) continue;
+        const toolCallId = readToolCallId(block);
+        const toolName = readToolName(block) ?? (toolCallId ? toolUseNames[toolCallId] : undefined) ?? "tool";
+        const output = formatToolResultContent(block.content ?? block.text ?? block.output ?? block.result) || "";
+        const toolInput = (toolCallId && toolUseInputs[toolCallId]) || readToolInput(block);
+        if (!output) continue;
+        toolParts.push({
+          type: "tool",
+          toolCallId,
+          toolName,
+          toolInput,
+          toolOutput: output,
+          toolStatus: readToolResultIsError(block) ? "error" : "completed",
+        });
+      }
+      if (toolParts.length > 0) {
+        result.push({ role: "user", parts: toolParts });
+      }
+    }
+
+    // user/assistant -> type: "text"
     const text = extractPartText(content);
 
     if (text) {

--- a/examples/openclaw-plugin/text-utils.ts
+++ b/examples/openclaw-plugin/text-utils.ts
@@ -471,11 +471,45 @@ export function extractNewTurnMessages(
       continue;
     }
 
+    const content = msg.content;
+    const text = extractPartText(content);
+    const cleanedText = text ? sanitizeUserTextForCapture(text) : "";
+    const hasEmbeddedToolResults = Array.isArray(content) && content.some((block) => isToolResultContentBlock(block));
+
+    // Assistant tool calls are owned by the assistant. Store the request side
+    // separately from completed tool results so OV can link them by tool_id.
+    if (role === "assistant" && !hasEmbeddedToolResults) {
+      const assistantParts: ExtractedMessage["parts"] = [];
+      if (cleanedText) {
+        assistantParts.push({
+          type: "text",
+          text: cleanedText,
+        });
+      }
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!isToolCallContentBlock(block)) continue;
+          const toolCallId = readToolCallId(block);
+          if (!toolCallId) continue;
+          assistantParts.push({
+            type: "tool",
+            toolCallId,
+            toolName: readToolName(block) ?? "tool",
+            toolInput: readToolInput(block),
+            toolOutput: "",
+            toolStatus: "running",
+          });
+        }
+      }
+      if (assistantParts.length > 0) {
+        result.push({ role: "assistant", parts: assistantParts });
+      }
+    }
+
     // Some OpenClaw runtimes deliver completed tool-result content as blocks inside
     // a user/assistant message instead of as a top-level role="toolResult" turn.
     // Persist those blocks as OV ToolParts under role="user" so uploaded session
     // messages follow OpenViking's standard tool-result ownership contract.
-    const content = msg.content;
     if (Array.isArray(content)) {
       const toolParts: Array<Extract<ExtractedMessage["parts"][number], { type: "tool" }>> = [];
       for (const block of content) {
@@ -500,22 +534,23 @@ export function extractNewTurnMessages(
     }
 
     // user/assistant -> type: "text"
-    const text = extractPartText(content);
-
-    if (text) {
+    if (cleanedText && role !== "assistant") {
       // 使用 sanitizeUserTextForCapture 清理所有噪音（Sender 元数据、时间戳等）
-      const cleanedText = sanitizeUserTextForCapture(text);
-      if (cleanedText) {
-        // 保持原始 role，assistant 保持 assistant，user 保持 user
-        const ovRole: "user" | "assistant" = role === "assistant" ? "assistant" : "user";
-        result.push({
-          role: ovRole,
-          parts: [{
-            type: "text",
-            text: cleanedText,
-          }],
-        });
-      }
+      result.push({
+        role: "user",
+        parts: [{
+          type: "text",
+          text: cleanedText,
+        }],
+      });
+    } else if (cleanedText && role === "assistant" && hasEmbeddedToolResults) {
+      result.push({
+        role: "assistant",
+        parts: [{
+          type: "text",
+          text: cleanedText,
+        }],
+      });
     }
   }
 


### PR DESCRIPTION
## Description

Fix OpenClaw plugin session upload so tool transcripts follow the OpenViking ownership model: assistant messages store the tool call/request side, while user messages store completed tool results, linked by the same tool id.

Root cause: the plugin previously handled top-level `role: "toolResult"` messages and, after chenjunwen's fix, embedded completed `tool_result` blocks, but textless assistant tool-call events were still dropped during upload. That lost tool request parameters and left completed results without an explicit assistant call message in OpenViking.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Store embedded completed OpenClaw `tool_result` blocks as user-role OpenViking `ToolPart`s.
- Store assistant `toolCall` / `toolUse` / `tool_call` blocks as assistant-role OpenViking `ToolPart`s with `tool_status: "running"`, preserving tool id, name, and input.
- Keep completed tool results under user-role messages with the same tool id, preserving the assistant-call/user-result pairing.
- Update OpenClaw plugin tests for textless assistant tool calls, embedded completed events, and afterTurn upload behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands run:

```bash
cd examples/openclaw-plugin
npm test -- --run tests/ut/text-utils.test.ts tests/ut/tool-round-trip.test.ts tests/ut/context-engine-afterTurn.test.ts tests/ut/context-engine-assemble.test.ts
npm run typecheck
npm run build
```

Additional checks:

```bash
git diff --check
```

Notes: full OpenClaw plugin `npm test -- --run` currently has pre-existing failures in architecture-boundary assertions and one recall-trace route timeout unrelated to this change. Python `tests/session/test_session_messages.py` is blocked in this environment by local config/native RAGFS binding mismatch; `tests/unit/test_message.py` passed when run in the same invocation.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally keeps completed tool results on user-role messages. The assistant side now records the request/call side so OpenViking has both halves of the tool interaction linked by id.
