### PR TITLE
fix(storage): block deleting the write-protected viking://agent root (parity with #2873)

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -385,6 +385,16 @@ class VikingFS:
                 "or current-user content path instead.",
                 resource=normalized_uri,
             )
+        if parts == ["agent"]:
+            # Parity with _ensure_supported_write_namespace, which forbids the
+            # account-shared viking://agent root: deleting it would recursively
+            # wipe every account's agent skills/endpoints/tools/payments. Concrete
+            # sub-paths (viking://agent/skills/...) remain deletable.
+            raise PermissionDeniedError(
+                "Deleting viking://agent root is not supported; use a concrete "
+                "agent sub-path (e.g. viking://agent/skills/...) instead.",
+                resource=normalized_uri,
+            )
 
     def _ensure_supported_write_namespace(self, normalized_uri: str) -> None:
         parts = [p for p in normalized_uri[len("viking://") :].strip("/").split("/") if p]

--- a/tests/misc/test_vikingfs_uri_guard.py
+++ b/tests/misc/test_vikingfs_uri_guard.py
@@ -113,6 +113,8 @@ class TestVikingFSURITraversalGuard:
             "viking://user/",
             "/user",
             "user",
+            "viking://agent",
+            "viking://agent/",
         ],
     )
     async def test_rm_rejects_protected_namespace_roots_before_side_effects(


### PR DESCRIPTION
## Summary

`_ensure_supported_delete_namespace` (added in #2873) rejects `viking://` and `viking://user`, but not the account-shared **`viking://agent`** root — which the sibling `_ensure_supported_write_namespace` already forbids (*"Writing to viking://agent root is not supported."*).

Because the two guards are asymmetric, a non-root user can `rm("viking://agent", recursive=True)` (WebDAV / HTTP `DELETE`) and recursively wipe account-wide agent `skills` / `endpoints` / `tools` / `payments` — the shared skill root re-enabled in v0.4.6.

## Change

Mirror the write guard's bare-agent-root rejection into the delete guard. The check is `parts == ["agent"]`, so it protects **only** the bare root; concrete sub-paths (`viking://agent/skills/...`) stay deletable, and `viking://session` / `viking://resources` remain intentionally reachable (unchanged, still covered by `test_rm_allows_public_scope_roots_to_reach_agfs`).

## Tests

Extends `test_rm_rejects_protected_namespace_roots_before_side_effects` with `viking://agent` and `viking://agent/` (trailing-slash normalization).

Parity follow-up to #2873 (delete guard) and #2898 (mv-source parity).
