### PR TITLE
feat(sdk/go): expose grep level_limit to control traversal depth

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -887,3 +887,37 @@ func TestSetTagsDefaultsModeAndOmitsTelemetry(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestGrepForwardsLevelLimit(t *testing.T) {
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method+" "+r.URL.Path != "POST /api/v1/search/grep" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		body := readJSONBody(t, r)
+		if got, ok := body["level_limit"]; !ok || got != float64(3) {
+			t.Fatalf("level_limit = %#v (ok=%v)", body["level_limit"], ok)
+		}
+		writeOK(t, w, map[string]any{"matches": []any{}})
+	}))
+	defer closeServer()
+
+	level := 3
+	if _, err := client.Grep(context.Background(), "viking://user", "pat", &GrepOptions{LevelLimit: &level}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGrepOmitsLevelLimitWhenUnset(t *testing.T) {
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readJSONBody(t, r)
+		if _, ok := body["level_limit"]; ok {
+			t.Fatalf("level_limit should be omitted when unset, got %#v", body["level_limit"])
+		}
+		writeOK(t, w, map[string]any{"matches": []any{}})
+	}))
+	defer closeServer()
+
+	if _, err := client.Grep(context.Background(), "viking://user", "pat", nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sdk/go/retrieval.go
+++ b/sdk/go/retrieval.go
@@ -85,6 +85,9 @@ func (c *Client) Grep(ctx context.Context, uri, pattern string, opts *GrepOption
 	if opts.NodeLimit != nil {
 		payload["node_limit"] = *opts.NodeLimit
 	}
+	if opts.LevelLimit != nil {
+		payload["level_limit"] = *opts.LevelLimit
+	}
 	if opts.ExcludeURI != "" {
 		payload["exclude_uri"] = NormalizeURI(opts.ExcludeURI)
 	}

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -214,6 +214,7 @@ type SearchOptions struct {
 type GrepOptions struct {
 	CaseInsensitive bool
 	NodeLimit       *int
+	LevelLimit      *int
 	ExcludeURI      string
 }
 


### PR DESCRIPTION
## Summary

The server's grep endpoint accepts a `level_limit` (traversal depth; `GrepRequest.level_limit: int = 10`, validated and passed into `service.fs.grep(level_limit=...)`), and the Python client exposes it — but the Go SDK's `GrepOptions` had no way to send it. Go callers were therefore silently pinned to the default depth and could not do shallow (perf) or deeper greps.

## Change

- `GrepOptions` gains `LevelLimit *int`.
- `Grep` forwards `payload["level_limit"]` only when set, mirroring `NodeLimit`'s omit-when-nil pattern (so the server default is preserved when unset).

## Compatibility

`LevelLimit` is an additive optional field. Per the SDK's convention, options structs are constructed with keyed literals (as in all SDK tests/examples), and this follows the same additive shape as the merged #2897 (`target_uri` scoping). Adding a struct field only affects unkeyed positional literals, which Go's compatibility rules permit and the SDK does not use.

## Tests

- `TestGrepForwardsLevelLimit` — the value reaches the request body
- `TestGrepOmitsLevelLimitWhenUnset` — the field is omitted when unset

Verified locally: `go build ./...`, `go vet`, `go test .` all pass; `gofmt` clean. Continues the sdk/go client-parity lane (#2897).
