### PR TITLE
fix(embedding): stop re-enqueueing auth errors forever (#2916)

### DIFF
--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -33,7 +33,11 @@ from openviking.utils.circuit_breaker import (
     CircuitBreakerOpen,
     classify_api_error,
 )
-from openviking.utils.model_retry import ERROR_CLASS_INPUT_TOO_LARGE, ERROR_CLASS_PERMANENT
+from openviking.utils.model_retry import (
+    ERROR_CLASS_AUTH,
+    ERROR_CLASS_INPUT_TOO_LARGE,
+    ERROR_CLASS_PERMANENT,
+)
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config.open_viking_config import OpenVikingConfig
@@ -650,6 +654,19 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         if error_class == ERROR_CLASS_PERMANENT:
                             logger.critical(error_msg)
                             self._circuit_breaker.record_failure(embed_err)
+                            self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
+                            request_failed_message = error_msg
+                            report_error_args = (error_msg, data)
+                            return None
+
+                        if error_class == ERROR_CLASS_AUTH:
+                            # Bad/expired credential: retrying cannot succeed. Fail
+                            # terminally instead of re-enqueueing, which would cycle
+                            # forever and hold this resource's tree lock and its
+                            # add-resource --wait open. Don't trip the breaker: an open
+                            # breaker re-enqueues later messages and reintroduces the
+                            # same leak. See #2916.
+                            logger.error(error_msg)
                             self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
                             request_failed_message = error_msg
                             report_error_args = (error_msg, data)

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -338,6 +338,48 @@ async def test_embedding_handler_open_breaker_logs_summary_instead_of_per_item_w
 
 
 @pytest.mark.asyncio
+async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypatch):
+    """A credential (401/403) failure must fail terminally, not re-enqueue: an
+    infinite re-enqueue holds the resource's tree lock and add-resource --wait
+    open, and must not trip the circuit breaker (which re-enqueues too). #2916."""
+
+    class _QueueingVikingDB:
+        is_closing = False
+        has_queue_manager = True
+
+        def __init__(self):
+            self.enqueued = []
+
+        async def enqueue_embedding_msg(self, msg):
+            self.enqueued.append(msg.id)
+            return None
+
+    class _AuthErrorEmbedder(_DummyEmbedder):
+        async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
+            raise RuntimeError("Error code: 401 - {'code': 'AuthenticationError'} Unauthorized")
+
+    vikingdb = _QueueingVikingDB()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(_AuthErrorEmbedder()),
+    )
+    handler = TextEmbeddingHandler(vikingdb)
+    status = {"success": 0, "requeue": 0, "error": 0}
+    handler.set_callbacks(
+        on_success=lambda: status.__setitem__("success", status["success"] + 1),
+        on_requeue=lambda: status.__setitem__("requeue", status["requeue"] + 1),
+        on_error=lambda *_: status.__setitem__("error", status["error"] + 1),
+    )
+
+    result = await handler.on_dequeue(_build_queue_payload_for_account("acct"))
+
+    assert result is None
+    assert vikingdb.enqueued == []  # terminal: not re-enqueued
+    assert status == {"success": 0, "requeue": 0, "error": 1}
+    handler._circuit_breaker.check()  # breaker not tripped (would raise if open)
+
+
+@pytest.mark.asyncio
 async def test_embedding_handler_treats_shutdown_write_lock_as_success(monkeypatch):
     class _ClosingDuringUpsertVikingDB:
         def __init__(self):


### PR DESCRIPTION
## Description

Fixes #2916, the CI flake where `06. API & CLI Integration Tests` fails only on no-secrets fork PRs with a constant `3 failed / 25 passed / 7 skipped / 11 errors`, all cascading from `add-resource` hitting `CONFLICT: Resource is busy`.

The embedding handler classified 401/403 auth errors as transient and re-enqueued them forever, tripping the circuit breaker. `add-resource` holds the resource tree lock and blocks `--wait` until embeddings drain, so the dummy CI keys hung the lock and the request indefinitely. Fix: route `ERROR_CLASS_AUTH` to terminal failure (no re-enqueue, no breaker trip) so the tracker drains, `--wait` completes, and the lock releases. Resource is left un-vectorized; reindex recovers it once creds are valid.

修复 #2916：`06. API & CLI Integration Tests` 只在没有 secrets 的 fork PR 上失败，计数恒为 `3 failed / 25 passed / 7 skipped / 11 errors`，均由 `add-resource` 命中 `CONFLICT: Resource is busy` 级联。embedding handler 把 401/403 认证错误判为 transient 并无限重新入队，触发熔断器；而 `add-resource` 持有 tree lock 且 `--wait` 会等 embedding 清空，于是 CI 的 dummy key 让锁和请求一直挂起。修复：把 `ERROR_CLASS_AUTH` 走终态失败（不重新入队、不触发熔断器），tracker 清空、`--wait` 完成、锁释放。资源本次不向量化，凭证修好后 reindex 即可恢复。

## Related Issue

Fixes #2916

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `collection_schemas.py`: route `ERROR_CLASS_AUTH` (401/403) to terminal failure instead of the transient re-enqueue path. Only auth errors change; transient/permanent handling is unchanged.<br>`collection_schemas.py`：把 `ERROR_CLASS_AUTH`（401/403）走终态失败，不再落到 transient 重新入队分支。仅认证错误变化，transient/permanent 处理不变。
- Added a unit test in `tests/storage/test_collection_schemas.py`.<br>在 `tests/storage/test_collection_schemas.py` 新增单测。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

New unit test + `tests/unit/test_model_retry.py` pass on macOS; the full integration job is green on Linux in CI (this PR's own run reproduces the flake end to end).

新增单测与 `test_model_retry.py` 在 macOS 通过；完整集成任务在 CI Linux 上变绿（本 PR 的 run 即端到端复现）。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (none)

## Screenshots (if applicable)

N/A

## Additional Notes

Release and `--wait` completion both require `pending_embedding_roots` to empty; auth errors that re-enqueue forever never mark embeddings done or failed, so making them terminal drains both.

锁释放与 `--wait` 完成都要求 `pending_embedding_roots` 清空；无限重新入队的认证错误既不标记完成也不标记失败，改为终态即可让两者清空。
