### PR TITLE
fix(server): persist OAuth DCR client scope to fix invalid_scope for MCP clients

### DIFF
--- a/openviking/server/oauth/provider.py
+++ b/openviking/server/oauth/provider.py
@@ -120,6 +120,7 @@ class OpenVikingOAuthProvider(
             token_endpoint_auth_method=record["token_endpoint_auth_method"],
             grant_types=record["grant_types"],
             response_types=record["response_types"],
+            scope=record.get("scope"),
             client_name=record.get("client_name"),
             client_id_issued_at=record["created_at"],
         )
@@ -161,6 +162,7 @@ class OpenVikingOAuthProvider(
                 if client_info.response_types
                 else None,
                 client_secret=None,  # public client; never stored
+                scope=client_info.scope,
             )
         except ValueError as exc:
             raise RegistrationError(

--- a/openviking/server/oauth/router.py
+++ b/openviking/server/oauth/router.py
@@ -237,6 +237,7 @@ async def oauth_protected_resource(request: Request) -> JSONResponse:
     metadata = ProtectedResourceMetadata(
         resource=AnyHttpUrl(resource),
         authorization_servers=[AnyHttpUrl(issuer)],
+        scopes_supported=["mcp"],
         bearer_methods_supported=["header"],
         resource_name="OpenViking MCP",
     )

--- a/openviking/server/oauth/storage.py
+++ b/openviking/server/oauth/storage.py
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
     grant_types TEXT NOT NULL DEFAULT '["authorization_code","refresh_token"]',
     response_types TEXT NOT NULL DEFAULT '["code"]',
     client_name TEXT,
+    scope TEXT,
     created_at INTEGER NOT NULL
 );
 
@@ -168,6 +169,7 @@ class OAuthStore:
         ALTER TABLE ADD COLUMN guarded by a ``PRAGMA table_info`` check.
         """
         column_additions = (
+            ("oauth_clients", "scope", "TEXT"),
             ("oauth_codes", "authorizing_key_fp", "TEXT"),
             ("oauth_pending_authorizations", "verified_key_fp", "TEXT"),
             ("oauth_refresh_tokens", "authorizing_key_fp", "TEXT"),
@@ -199,6 +201,7 @@ class OAuthStore:
         grant_types: Optional[list[str]] = None,
         response_types: Optional[list[str]] = None,
         client_secret: Optional[str] = None,
+        scope: Optional[str] = None,
     ) -> dict[str, Any]:
         """Persist a freshly registered client and return the public record.
 
@@ -220,6 +223,7 @@ class OAuthStore:
             "grant_types": grant_types or ["authorization_code", "refresh_token"],
             "response_types": response_types or ["code"],
             "client_name": client_name,
+            "scope": scope,
             "created_at": now,
         }
 
@@ -229,7 +233,7 @@ class OAuthStore:
                 "INSERT INTO oauth_clients "
                 "(client_id, client_secret_hash, redirect_uris, "
                 "token_endpoint_auth_method, grant_types, response_types, "
-                "client_name, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "client_name, scope, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     record["client_id"],
                     record["client_secret_hash"],
@@ -238,6 +242,7 @@ class OAuthStore:
                     json.dumps(record["grant_types"]),
                     json.dumps(record["response_types"]),
                     record["client_name"],
+                    record["scope"],
                     record["created_at"],
                 ),
             )

--- a/tests/server/oauth/test_storage.py
+++ b/tests/server/oauth/test_storage.py
@@ -100,14 +100,17 @@ async def test_register_and_get_client(store):
     record = await store.register_client(
         redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
         client_name="Claude.ai",
+        scope="mcp",
     )
     assert record["client_id"]
     assert record["redirect_uris"] == ["https://claude.ai/api/mcp/auth_callback"]
     assert record["token_endpoint_auth_method"] == "none"
+    assert record["scope"] == "mcp"
     fetched = await store.get_client(record["client_id"])
     assert fetched is not None
     assert fetched["redirect_uris"] == ["https://claude.ai/api/mcp/auth_callback"]
     assert fetched["client_name"] == "Claude.ai"
+    assert fetched["scope"] == "mcp"
     assert "authorization_code" in fetched["grant_types"]
 
 


### PR DESCRIPTION
## Description

OAuth Dynamic Client Registration silently dropped the client `scope`, so any
spec-compliant MCP client that requests a scope (e.g. `scope=mcp`) failed
`/authorize` with `invalid_scope`. The MCP SDK's `client.validate_scope()`
requires requested scopes to be a subset of the registered `client.scope`, which
was always `None` because `register_client()` never stored it. Clients that omit
scope (e.g. Claude Code) were unaffected, which masked the bug.

## Related Issue

Fixes #2920

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `storage.py`: add `scope` column to `oauth_clients` (+ idempotent migration) and persist it in `register_client()`
- `provider.py`: pass `client_info.scope` on registration; return `scope` from `get_client()` so `validate_scope()` sees the registered scope
- `router.py`: advertise `scopes_supported=["mcp"]` in the RFC 9728 PRM document
- tests: assert scope round-trips through register/get

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Manual verification: DCR with `scope=mcp` now persists; a subsequent
`/authorize?scope=mcp` proceeds to consent instead of returning `invalid_scope`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Root cause confirmed against MCP SDK 1.27.0 (`mcp/shared/auth.py`
`validate_scope`, `mcp/server/auth/handlers/authorize.py`). Repro'd on `main`.