### PR TITLE
fix(rerank): filter empty docs before rerank API call

### DIFF
--- a/openviking/models/rerank/openai_rerank.py
+++ b/openviking/models/rerank/openai_rerank.py
@@ -67,10 +67,28 @@ class OpenAIRerankClient(RerankBase):
         if not documents:
             return []
 
+        # Filter out empty/blank documents that providers like SiliconFlow silently drop.
+        # Track original indices so we can reconstruct a full scores array.
+        non_empty_docs: List[str] = []
+        non_empty_indices: List[int] = []
+        for i, doc in enumerate(documents):
+            text = (doc or "").strip()
+            if text:
+                non_empty_docs.append(text)
+                non_empty_indices.append(i)
+            else:
+                logger.debug(
+                    "[OpenAIRerankClient] Skipping empty document at index %s", i
+                )
+
+        if not non_empty_docs:
+            return [0.0] * len(documents)
+
         req_body = {
             "model": self.model_name,
             "query": query,
-            "documents": documents,
+            "documents": non_empty_docs,
+            "top_n": len(non_empty_docs),
         }
 
         try:
@@ -91,7 +109,7 @@ class OpenAIRerankClient(RerankBase):
             result = response.json()
 
             # Update token usage tracking (estimate, OpenAI rerank doesn't provide token info)
-            self._extract_and_update_token_usage(result, query, documents)
+            self._extract_and_update_token_usage(result, query, non_empty_docs)
 
             # Standard OpenAI/Cohere rerank format: results[].{index, relevance_score}
             results = result.get("results")
@@ -99,26 +117,27 @@ class OpenAIRerankClient(RerankBase):
                 logger.warning(f"[OpenAIRerankClient] Unexpected response format: {result}")
                 return None
 
-            if len(results) != len(documents):
+            if len(results) != len(non_empty_docs):
                 logger.warning(
                     "[OpenAIRerankClient] Unexpected rerank result length: expected=%s actual=%s",
-                    len(documents),
+                    len(non_empty_docs),
                     len(results),
                 )
                 return None
 
-            # Results may not be in original order — sort by index
+            # Map API results (indexed against non_empty_docs) back to original indices
             scores = [0.0] * len(documents)
             for item in results:
-                idx = item.get("index")
-                if idx is None or not (0 <= idx < len(documents)):
+                api_idx = item.get("index")
+                if api_idx is None or not (0 <= api_idx < len(non_empty_docs)):
                     logger.warning(
                         "[OpenAIRerankClient] Out-of-bounds or missing index in result: %s", item
                     )
                     return None
-                scores[idx] = item.get("relevance_score", 0.0)
+                original_idx = non_empty_indices[api_idx]
+                scores[original_idx] = item.get("relevance_score", 0.0)
 
-            logger.debug(f"[OpenAIRerankClient] Reranked {len(documents)} documents")
+            logger.debug(f"[OpenAIRerankClient] Reranked {len(non_empty_docs)} documents")
             return scores
 
         except Exception as e:

--- a/tests/misc/test_rerank_empty_docs.py
+++ b/tests/misc/test_rerank_empty_docs.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 njuboy11
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression test for empty-document handling in OpenAIRerankClient.
+
+SiliconFlow rerank API silently drops empty documents from results. Before the
+fix, this caused length mismatch and fallback to vector scores. After the fix,
+empty docs are filtered out before the call and mapped back as 0.0 scores in
+their original positions.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from openviking.models.rerank import OpenAIRerankClient
+
+
+def _make_client() -> OpenAIRerankClient:
+    return OpenAIRerankClient(
+        api_key="test-key",
+        api_base="https://siliconflow.example/rerank",
+        model_name="BAAI/bge-reranker-v2-m3",
+    )
+
+
+def _mock_post(json_body):
+    resp = MagicMock()
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_rerank_batch_with_empty_doc_keeps_original_length():
+    """24 docs with one empty at index 7 — expect 24 scores, that index = 0.0."""
+    client = _make_client()
+    docs = [f"doc-{i}" if i != 7 else "" for i in range(24)]
+
+    # SiliconFlow returns only 23 results (silently drops empty).
+    mock_resp = _mock_post(
+        {
+            "results": [
+                {"index": i, "relevance_score": 0.5 + i * 0.01}
+                for i in range(23)
+            ]
+        }
+    )
+
+    with patch(
+        "openviking.models.rerank.openai_rerank.requests.post", return_value=mock_resp
+    ):
+        scores = client.rerank_batch("test query", docs)
+
+    assert len(scores) == 24, f"expected 24 scores, got {len(scores)}"
+    assert scores[7] == 0.0, f"empty doc at idx 7 should score 0.0, got {scores[7]}"
+    # Other indices preserve their original positions.
+    for i in range(24):
+        if i == 7:
+            continue
+        assert scores[i] != 0.0, f"non-empty doc at idx {i} should not be 0.0"
+
+
+def test_rerank_batch_top_n_set_to_non_empty_count():
+    """Ensure top_n matches non_empty_docs length to avoid SiliconFlow truncation."""
+    client = _make_client()
+    docs = [f"doc-{i}" for i in range(24)]
+    docs[3] = ""
+    docs[11] = ""
+    docs[19] = ""
+
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured["body"] = json
+        return _mock_post(
+            {"results": [{"index": i, "relevance_score": 0.5} for i in range(21)]}
+        )
+
+    with patch(
+        "openviking.models.rerank.openai_rerank.requests.post",
+        side_effect=fake_post,
+    ):
+        scores = client.rerank_batch("q", docs)
+
+    assert captured["body"]["top_n"] == 21, (
+        f"top_n should be 21 (after filtering 3 empties), "
+        f"got {captured['body']['top_n']}"
+    )
+    assert len(scores) == 24
+    for empty_idx in (3, 11, 19):
+        assert scores[empty_idx] == 0.0
+
+
+def test_rerank_batch_all_empty_returns_zero_scores():
+    """Defensive: every doc empty -> return 0.0 per original index, no API call."""
+    client = _make_client()
+    docs = ["", "  ", "\n\t", ""]
+
+    with patch(
+        "openviking.models.rerank.openai_rerank.requests.post"
+    ) as mock_p:
+        scores = client.rerank_batch("q", docs)
+
+    # Short-circuit: no API call wasted, all slots get 0.0.
+    assert scores == [0.0, 0.0, 0.0, 0.0]
+    mock_p.assert_not_called()


### PR DESCRIPTION
## Problem

 (in ) produces length-mismatch warnings and silently falls back to vector scores when **any** document in the input batch is an empty string.

The SiliconFlow rerank API drops empty documents from its response without comment: send 24 docs with one empty, get 23 results. The client detects the mismatch (), logs , and returns  — causing  to fall back to raw vector scores. That wastes ~180ms per call and produces visibly worse ranking.

Worst-case impact measured locally:



## Fix

- Filter  to non-empty strings before the API call.
- Track original indices via .
- Map results back to original positions; empty slots score .
- Pass  so SiliconFlow does not truncate to its default .

## Out of Scope

A companion PR (#split fix/read-batch-concurrent on njuboy11/OpenViking) addresses VikingFS  serial reads. Splitting the two so they can be reviewed and merged independently — reviewer asks about one fix won't block the other.

## Tests

Three regression cases added in :

1. 24 docs with one empty at index 7 → still returns 24 scores, that index = .
2. 24 docs with 3 empty →  matches non-empty count (21, not 12).
3. All-empty input → returns  without an API call.



Backward-compatible: the new  invariant matches what  already expects from the upstream  fallback.

Refs: #2619 (original combined PR — closing in favour of these splits)