### PR TITLE
fix(embedding): keep failover retryable when only some creds auth-fail (#2916)

### DIFF
--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -8,6 +8,8 @@ import threading
 import time
 from typing import Awaitable, Callable, TypeVar
 
+from openviking.utils.exceptions import AllCredentialsFailedError
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
@@ -115,6 +117,27 @@ def _pattern_matches(text_lower: str, text_compact: str, pattern: str) -> bool:
     return pattern in text_lower or pattern in text_compact
 
 
+def _aggregate_failover_error_class(error: AllCredentialsFailedError) -> str:
+    """Classify an aggregated multi-credential failure from its per-credential
+    classes rather than its concatenated message.
+
+    FailoverEmbedder/VLM only wraps NON-fail-fast failures (auth / transient /
+    quota). If any credential failed transiently the request may still succeed on
+    retry, so the aggregate must stay retryable; string scanning would let
+    ``auth`` win and drop a mixed auth+transient failure as terminal (#2916 review).
+    """
+    classes = [ec for (_cid, ec, _exc, _idx) in getattr(error, "errors", []) if ec]
+    if not classes:
+        return ERROR_CLASS_UNKNOWN
+    if ERROR_CLASS_TRANSIENT in classes:
+        return ERROR_CLASS_TRANSIENT
+    if ERROR_CLASS_QUOTA_EXCEEDED in classes:
+        return ERROR_CLASS_QUOTA_EXCEEDED
+    if ERROR_CLASS_AUTH in classes:
+        return ERROR_CLASS_AUTH
+    return classes[0]
+
+
 def classify_api_error(error: Exception) -> str:
     """Classify an API error into one of the ERROR_CLASS_* categories.
 
@@ -128,7 +151,14 @@ def classify_api_error(error: Exception) -> str:
     - ``quota_exceeded`` is checked before ``transient`` because quota errors
       typically include "429" / "TooManyRequests" which would otherwise match
       the transient category.
+    - an aggregated ``AllCredentialsFailedError`` is classified from its
+      per-credential classes, not its concatenated message: if any credential
+      failed transiently the request may still succeed on retry, so scanning the
+      message (where ``auth`` wins) would wrongly drop it as terminal.
     """
+    if isinstance(error, AllCredentialsFailedError):
+        return _aggregate_failover_error_class(error)
+
     for exc in (error, getattr(error, "__cause__", None)):
         if exc is not None and isinstance(exc, _PERMANENT_IO_ERRORS):
             return ERROR_CLASS_PERMANENT

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -117,27 +117,6 @@ def _pattern_matches(text_lower: str, text_compact: str, pattern: str) -> bool:
     return pattern in text_lower or pattern in text_compact
 
 
-def _aggregate_failover_error_class(error: AllCredentialsFailedError) -> str:
-    """Classify an aggregated multi-credential failure from its per-credential
-    classes rather than its concatenated message.
-
-    FailoverEmbedder/VLM only wraps NON-fail-fast failures (auth / transient /
-    quota). If any credential failed transiently the request may still succeed on
-    retry, so the aggregate must stay retryable; string scanning would let
-    ``auth`` win and drop a mixed auth+transient failure as terminal (#2916 review).
-    """
-    classes = [ec for (_cid, ec, _exc, _idx) in getattr(error, "errors", []) if ec]
-    if not classes:
-        return ERROR_CLASS_UNKNOWN
-    if ERROR_CLASS_TRANSIENT in classes:
-        return ERROR_CLASS_TRANSIENT
-    if ERROR_CLASS_QUOTA_EXCEEDED in classes:
-        return ERROR_CLASS_QUOTA_EXCEEDED
-    if ERROR_CLASS_AUTH in classes:
-        return ERROR_CLASS_AUTH
-    return classes[0]
-
-
 def classify_api_error(error: Exception) -> str:
     """Classify an API error into one of the ERROR_CLASS_* categories.
 
@@ -152,12 +131,17 @@ def classify_api_error(error: Exception) -> str:
       typically include "429" / "TooManyRequests" which would otherwise match
       the transient category.
     - an aggregated ``AllCredentialsFailedError`` is classified from its
-      per-credential classes, not its concatenated message: if any credential
-      failed transiently the request may still succeed on retry, so scanning the
-      message (where ``auth`` wins) would wrongly drop it as terminal.
+      per-credential classes, not its concatenated message.
     """
     if isinstance(error, AllCredentialsFailedError):
-        return _aggregate_failover_error_class(error)
+        classes = [ec for (_cid, ec, _exc, _idx) in error.errors if ec]
+        if ERROR_CLASS_TRANSIENT in classes:
+            return ERROR_CLASS_TRANSIENT
+        if ERROR_CLASS_QUOTA_EXCEEDED in classes:
+            return ERROR_CLASS_QUOTA_EXCEEDED
+        if classes and all(ec == ERROR_CLASS_AUTH for ec in classes):
+            return ERROR_CLASS_AUTH
+        return ERROR_CLASS_UNKNOWN
 
     for exc in (error, getattr(error, "__cause__", None)):
         if exc is not None and isinstance(exc, _PERMANENT_IO_ERRORS):

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from openviking.utils.exceptions import AllCredentialsFailedError
 from openviking.utils.model_retry import (
     ERROR_CLASS_AUTH,
     ERROR_CLASS_CONTENT_SAFETY,
@@ -11,6 +12,7 @@ from openviking.utils.model_retry import (
     ERROR_CLASS_PERMANENT,
     ERROR_CLASS_QUOTA_EXCEEDED,
     ERROR_CLASS_TRANSIENT,
+    ERROR_CLASS_UNKNOWN,
     classify_api_error,
     retry_async,
     retry_sync,
@@ -19,6 +21,32 @@ from openviking.utils.model_retry import (
 
 def test_classify_api_error_recognizes_request_burst_too_fast():
     assert classify_api_error(RuntimeError("RequestBurstTooFast")) == ERROR_CLASS_TRANSIENT
+
+
+def test_classify_all_credentials_failed_prefers_transient_over_auth():
+    # A mixed multi-credential failure (one 401, one 500) must stay retryable:
+    # scanning the concatenated message would let auth win and drop it. #2916 review.
+    err = AllCredentialsFailedError(
+        [
+            ("cred-a", ERROR_CLASS_AUTH, RuntimeError("401 Unauthorized"), 0),
+            ("cred-b", ERROR_CLASS_TRANSIENT, RuntimeError("500 server error"), 1),
+        ]
+    )
+    assert classify_api_error(err) == ERROR_CLASS_TRANSIENT
+
+
+def test_classify_all_credentials_failed_all_auth_is_terminal_auth():
+    err = AllCredentialsFailedError(
+        [
+            ("cred-a", ERROR_CLASS_AUTH, RuntimeError("401 Unauthorized"), 0),
+            ("cred-b", ERROR_CLASS_AUTH, RuntimeError("403 Forbidden"), 1),
+        ]
+    )
+    assert classify_api_error(err) == ERROR_CLASS_AUTH
+
+
+def test_classify_all_credentials_failed_empty_is_unknown():
+    assert classify_api_error(AllCredentialsFailedError([])) == ERROR_CLASS_UNKNOWN
 
 
 def test_retry_sync_retries_transient_error_until_success():

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -12,7 +12,6 @@ from openviking.utils.model_retry import (
     ERROR_CLASS_PERMANENT,
     ERROR_CLASS_QUOTA_EXCEEDED,
     ERROR_CLASS_TRANSIENT,
-    ERROR_CLASS_UNKNOWN,
     classify_api_error,
     retry_async,
     retry_sync,
@@ -24,8 +23,6 @@ def test_classify_api_error_recognizes_request_burst_too_fast():
 
 
 def test_classify_all_credentials_failed_prefers_transient_over_auth():
-    # A mixed multi-credential failure (one 401, one 500) must stay retryable:
-    # scanning the concatenated message would let auth win and drop it. #2916 review.
     err = AllCredentialsFailedError(
         [
             ("cred-a", ERROR_CLASS_AUTH, RuntimeError("401 Unauthorized"), 0),
@@ -33,20 +30,6 @@ def test_classify_all_credentials_failed_prefers_transient_over_auth():
         ]
     )
     assert classify_api_error(err) == ERROR_CLASS_TRANSIENT
-
-
-def test_classify_all_credentials_failed_all_auth_is_terminal_auth():
-    err = AllCredentialsFailedError(
-        [
-            ("cred-a", ERROR_CLASS_AUTH, RuntimeError("401 Unauthorized"), 0),
-            ("cred-b", ERROR_CLASS_AUTH, RuntimeError("403 Forbidden"), 1),
-        ]
-    )
-    assert classify_api_error(err) == ERROR_CLASS_AUTH
-
-
-def test_classify_all_credentials_failed_empty_is_unknown():
-    assert classify_api_error(AllCredentialsFailedError([])) == ERROR_CLASS_UNKNOWN
 
 
 def test_retry_sync_retries_transient_error_until_success():


### PR DESCRIPTION
## Description

Follow-up to #2919, addressing @qin-ctx's review. #2919 routes `ERROR_CLASS_AUTH` to terminal failure, but `classify_api_error` scans an exception's whole message with auth winning over transient. So an `AllCredentialsFailedError` from `FailoverEmbedder` whose message contains both a credential's `401` and a later credential's transient `500/429` classifies as auth and gets dropped as terminal, even though retrying the transient credential could still succeed.

Fix: classify `AllCredentialsFailedError` from its structured per-credential classes (its `errors` tuples) instead of the concatenated message. Return transient if any credential failed transiently, quota if any hit quota, and auth only when every credential auth-failed.

#2919 的后续，处理 @qin-ctx 的评审意见。#2919 把 `ERROR_CLASS_AUTH` 走终态失败，但 `classify_api_error` 是扫描整条异常消息、且 auth 优先于 transient。于是 `FailoverEmbedder` 抛出的 `AllCredentialsFailedError`，若消息里同时含某个凭证的 `401` 和后一个凭证的 transient `500/429`，会被判为 auth 并被当作终态丢弃，尽管重试那个 transient 凭证仍可能成功。

修复：改为根据 `AllCredentialsFailedError` 里结构化的每凭证分类（`errors` 元组）来判定，而不是拼接的消息。任一凭证 transient 则返回 transient，任一命中 quota 则返回 quota，只有全部凭证都是 auth 失败时才返回 auth。

## Related Issue

Relates to #2916; addresses review feedback on #2919.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `model_retry.py`: `classify_api_error` special-cases `AllCredentialsFailedError`, aggregating its per-credential classes (retryable wins).<br>`model_retry.py`：`classify_api_error` 特判 `AllCredentialsFailedError`，按每凭证分类聚合（可重试优先）。
- Added unit tests for mixed / all-auth / empty aggregates in `tests/unit/test_model_retry.py`.<br>在 `tests/unit/test_model_retry.py` 新增混合 / 全 auth / 空聚合的单测。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`tests/unit/test_model_retry.py` passes (31 tests) on macOS.

`tests/unit/test_model_retry.py` 在 macOS 通过（31 个用例）。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (#2919 merged)

## Screenshots (if applicable)

N/A
