### PR TITLE
fix(vlm): omit unset default max_tokens

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -233,8 +233,8 @@ class OpenAIVLM(VLMBase):
         else:
             kwargs["temperature"] = self.temperature
         self._apply_provider_specific_extra_body(kwargs, effective_thinking)
-        max_tokens = self.max_tokens or 32768
-        kwargs["max_completion_tokens" if is_reasoning else "max_tokens"] = max_tokens
+        if self.max_tokens is not None:
+            kwargs["max_completion_tokens" if is_reasoning else "max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
@@ -271,8 +271,8 @@ class OpenAIVLM(VLMBase):
         else:
             kwargs["temperature"] = self.temperature
         self._apply_provider_specific_extra_body(kwargs, effective_thinking)
-        max_tokens = self.max_tokens or 32768
-        kwargs["max_completion_tokens" if is_reasoning else "max_tokens"] = max_tokens
+        if self.max_tokens is not None:
+            kwargs["max_completion_tokens" if is_reasoning else "max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"


### PR DESCRIPTION
## Description

Remove hardcoded VLM `max_tokens=32768` fallbacks. When `vlm.max_tokens` is not configured, OpenViking now omits the token-limit parameter and lets the selected model/provider apply its own default.

## Related Issue

Fixes #2751

Alternative to #2755: removes the backend fallback instead of lowering it to another hardcoded value.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Stop sending `max_tokens`/`max_completion_tokens` when `vlm.max_tokens` is unset.
- Apply the same behavior across OpenAI, LiteLLM, VolcEngine, and Kimi VLM backends.
- Remove the Kimi-specific default `max_tokens` constant and stale unit-test assertion.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Not run locally; this is a small request-parameter change and the earlier `uv run` validation was interrupted before completion.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Leaving the parameter unset avoids hardcoding one completion-token budget for models and providers with different limits.
