### PR TITLE
fix(queuefs-cache): Skip caching control plugins during mount

### DIFF
--- a/crates/ragfs/src/core/mountable.rs
+++ b/crates/ragfs/src/core/mountable.rs
@@ -286,7 +286,8 @@ impl MountableFS {
             None => {
                 // Single backend: initialize plugin, optionally wrap raw storage with cache, then
                 // wrap with encryption. This keeps shared cache providers ciphertext-only.
-                // Control plugins (queuefs, serverinfofs) are never encrypted.
+                // Control plugins (queuefs, serverinfofs) are dynamic virtual filesystems; never
+                // cache or encrypt them.
                 let raw = plugin.initialize(config.clone()).await?;
                 let raw_arc: Arc<dyn FileSystem> = Arc::from(raw);
                 let is_control_plugin = matches!(config.name.as_str(), "queuefs" | "serverinfofs");
@@ -301,7 +302,11 @@ impl MountableFS {
                     .await?;
                 }
                 #[cfg(feature = "cache")]
-                let storage_fs = self.maybe_wrap_cache(raw_arc.clone(), &normalized_path);
+                let storage_fs = if is_control_plugin {
+                    raw_arc.clone()
+                } else {
+                    self.maybe_wrap_cache(raw_arc.clone(), &normalized_path)
+                };
                 #[cfg(not(feature = "cache"))]
                 let storage_fs = raw_arc.clone();
 
@@ -1282,6 +1287,52 @@ mod tests {
             b"backend:/file.txt"
         );
         assert_eq!(reads.load(Ordering::Relaxed), 1);
+    }
+
+    #[cfg(feature = "cache")]
+    #[tokio::test]
+    async fn queuefs_mount_bypasses_cache_even_when_cache_is_configured() {
+        use crate::cache::{CacheNamespace, CachePolicy, MemoryCacheProvider};
+        use crate::plugins::QueueFSPlugin;
+
+        let provider = Arc::new(MemoryCacheProvider::new());
+        let mfs = MountableFS::with_cache(
+            provider.clone(),
+            CacheNamespace::new("queue-cache-test"),
+            CachePolicy::default().with_bypass_prefix("/queue"),
+        );
+        mfs.register_plugin(QueueFSPlugin::new()).await;
+        mfs.mount(PluginConfig::single_backend(
+            "queuefs",
+            "/queue",
+            HashMap::new(),
+        ))
+        .await
+        .unwrap();
+        mfs.mkdir("/queue/Embedding", 0o755).await.unwrap();
+
+        assert_eq!(
+            mfs.read("/queue/Embedding/size", 0, 0).await.unwrap(),
+            b"0"
+        );
+        mfs.write(
+            "/queue/Embedding/enqueue",
+            br#"{"id":"one"}"#,
+            0,
+            WriteFlag::Create,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            mfs.read("/queue/Embedding/size", 0, 0).await.unwrap(),
+            b"1",
+            "queuefs size is dynamic and must not be served from cache"
+        );
+        assert!(
+            provider.keys().await.is_empty(),
+            "queuefs control filesystem should not populate shared cache"
+        );
     }
 
     #[cfg(feature = "cache")]


### PR DESCRIPTION
## Description

Prevent control virtual filesystems from being wrapped by the cache layer. queuefs and serverinfofs are dynamic/control-plane mounts, so they now bypass CachedFileSystem at mount time even when global cache is enabled.

## Related Issue

[issue](https://github.com/volcengine/OpenViking/issues/2935)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Skip cache wrapping for queuefs and serverinfofs during MountableFS::mount().
- Preserve cache wrapping for normal storage backends.
- Add a regression test proving queuefs size is not served from cache after enqueue.
- Confirm cache still works for regular mounted backends.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published


