### PR TITLE
fix(vlm): omit unset default max_tokens

### DIFF
--- a/openviking/models/vlm/backends/kimi_vlm.py
+++ b/openviking/models/vlm/backends/kimi_vlm.py
@@ -9,7 +9,6 @@ from .openai_vlm import OpenAIVLM
 
 DEFAULT_KIMI_API_BASE = "https://api.kimi.com/coding"
 DEFAULT_KIMI_MODEL = "kimi-code"
-DEFAULT_KIMI_MAX_TOKENS = 32768
 DEFAULT_KIMI_USER_AGENT = "KimiCLI/1.30.0"
 KIMI_LEGACY_MODEL_ALIASES = {
     "kimi-code": "kimi-for-coding",
@@ -31,7 +30,6 @@ class KimiVLM(OpenAIVLM):
         normalized["provider"] = "kimi"
         normalized["api_base"] = _normalize_kimi_api_base(normalized.get("api_base"))
         normalized["model"] = KIMI_LEGACY_MODEL_ALIASES.get(model, model)
-        normalized.setdefault("max_tokens", DEFAULT_KIMI_MAX_TOKENS)
         extra_headers = dict(normalized.get("extra_headers") or {})
         extra_headers.setdefault("User-Agent", DEFAULT_KIMI_USER_AGENT)
         normalized["extra_headers"] = extra_headers

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -271,8 +271,8 @@ class LiteLLMVLMProvider(VLMBase):
             "temperature": self.temperature,
             "timeout": self.timeout,
         }
-        max_tokens = self.max_tokens or 32768
-        kwargs["max_tokens"] = max_tokens
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
 
         if self._should_forward_api_key(model):
             kwargs["api_key"] = self.api_key

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -130,8 +130,8 @@ class VolcEngineVLM(OpenAIVLM):
             "thinking": {"type": "disabled" if not effective_thinking else "enabled"},
             "extra_headers": self.extra_headers,
         }
-        max_tokens = self.max_tokens or 32768
-        kwargs["max_tokens"] = max_tokens
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
@@ -165,8 +165,8 @@ class VolcEngineVLM(OpenAIVLM):
             "thinking": {"type": "disabled" if not effective_thinking else "enabled"},
             "extra_headers": self.extra_headers,
         }
-        max_tokens = self.max_tokens or 32768
-        kwargs["max_tokens"] = max_tokens
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
@@ -346,8 +346,8 @@ class VolcEngineVLM(OpenAIVLM):
             "thinking": {"type": "disabled" if not effective_thinking else "enabled"},
             "extra_headers": self.extra_headers,
         }
-        max_tokens = self.max_tokens or 32768
-        kwargs["max_tokens"] = max_tokens
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
@@ -390,8 +390,8 @@ class VolcEngineVLM(OpenAIVLM):
             "thinking": {"type": "disabled" if not effective_thinking else "enabled"},
             "extra_headers": self.extra_headers,
         }
-        max_tokens = self.max_tokens or 32768
-        kwargs["max_tokens"] = max_tokens
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"

--- a/tests/unit/test_kimi_glm_vlm.py
+++ b/tests/unit/test_kimi_glm_vlm.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 from openviking.models.vlm import VLMFactory
 from openviking.models.vlm.backends.glm_vlm import DEFAULT_GLM_API_BASE, GLMVLM
 from openviking.models.vlm.backends.kimi_vlm import (
-    DEFAULT_KIMI_MAX_TOKENS,
     DEFAULT_KIMI_USER_AGENT,
     KimiVLM,
 )
@@ -57,7 +56,6 @@ def test_kimi_backend_sets_openai_compatible_defaults():
     assert vlm.provider == "kimi"
     assert vlm.api_base == "https://api.kimi.com/coding/v1"
     assert vlm.model == "kimi-for-coding"
-    assert vlm.max_tokens == DEFAULT_KIMI_MAX_TOKENS
     assert vlm.extra_headers == {"User-Agent": DEFAULT_KIMI_USER_AGENT}
 
 


### PR DESCRIPTION
## Description

Remove the remaining hardcoded VLM `max_tokens=32768` fallbacks outside the OpenAI backend. When `vlm.max_tokens` is not configured, these backends now omit the token-limit parameter and let the selected model/provider apply its own default.

## Related Issue

Fixes #2751

Follow-up to #2946, which already removed the OpenAI backend fallback.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Stop sending `max_tokens` when `vlm.max_tokens` is unset in LiteLLM and VolcEngine VLM backends.
- Remove the Kimi-specific default `max_tokens` constant and fallback.
- Remove the stale Kimi unit-test assertion for the old default.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Not run locally; this is a small request-parameter change and the earlier `uv run` validation was interrupted before completion.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Leaving the parameter unset avoids hardcoding one completion-token budget for models and providers with different limits.
