### PR TITLE
fix(logging): use concurrent-safe rotating file handler to avoid Windows PermissionError on midnight rollover

### DIFF
--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -59,6 +59,42 @@ except ImportError:
     format_trace_id = None
 
 
+# Concurrent-safe rotating file handler. Its doRollover() coordinates across
+# processes/handles, avoiding the Windows PermissionError [WinError 32] the
+# stdlib TimedRotatingFileHandler raises at midnight rollover when another
+# handle holds the log file open.
+#
+# concurrent-log-handler is a REQUIRED dependency (declared in pyproject.toml), so
+# this import normally succeeds. The guard is a defensive last resort: rather than
+# crash the whole logging subsystem in a broken/incomplete environment, we degrade
+# to the stdlib handler and warn loudly.
+#
+# We catch ImportError (the parent of ModuleNotFoundError) so BOTH degraded cases
+# fall back: the package absent entirely (ModuleNotFoundError naming
+# concurrent_log_handler) and the package present-but-incompatible so the symbol is
+# missing (a plain ImportError, which is NOT a ModuleNotFoundError). We re-raise
+# only a ModuleNotFoundError naming some *other* module (e.g. a missing transitive
+# dep such as portalocker), so genuine install breakage surfaces instead of being
+# silently masked.
+try:
+    from concurrent_log_handler import ConcurrentTimedRotatingFileHandler
+except ImportError as exc:
+    if isinstance(exc, ModuleNotFoundError) and exc.name != "concurrent_log_handler":
+        raise
+    import warnings
+
+    warnings.warn(
+        "concurrent-log-handler is unavailable; falling back to the stdlib "
+        "TimedRotatingFileHandler. Midnight log rotation is NOT concurrent-safe and "
+        "can raise PermissionError [WinError 32] on Windows. Reinstall the required "
+        "'concurrent-log-handler' package to restore safe rotation.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+    ConcurrentTimedRotatingFileHandler = TimedRotatingFileHandler  # type: ignore[assignment,misc]
+
+
 # Global OTel log handler state
 _otel_log_handler_initialized = False
 _otel_log_handler: Any = None
@@ -66,6 +102,7 @@ _otel_log_handler: Any = None
 _MANAGED_LOGGER_ROOTS = ("openviking", "openviking_cli", "uvicorn")
 _shared_log_handler: Optional[logging.Handler] = None
 _shared_log_handler_key: Optional[tuple[Any, ...]] = None
+_shared_log_handler_lock = threading.RLock()
 
 # QueueListeners for thread-safe stdout/stderr logging (avoids StreamHandler stalls
 # on application threads when process managers redirect streams).
@@ -719,7 +756,7 @@ def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handl
                         when = log_rotation_interval
                         interval = 1
 
-                    return TimedRotatingFileHandler(
+                    return ConcurrentTimedRotatingFileHandler(
                         log_output,
                         when=when,
                         interval=interval,
@@ -728,7 +765,21 @@ def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handl
                     )
                 else:
                     return logging.FileHandler(log_output, encoding="utf-8")
-            except Exception:
+            except Exception as exc:
+                # Preserve the fallback — a working non-rotating handler beats
+                # crashing logging setup — but make the downgrade observable.
+                # Otherwise a ConcurrentTimedRotatingFileHandler construction
+                # failure (e.g. a portalocker lock error on a network/cloud-synced
+                # path) would silently discard the concurrent-safe rotation this
+                # module configures, with nothing explaining why rotation stopped.
+                logging.getLogger(__name__).warning(
+                    "Falling back to a non-rotating FileHandler for %r: could not "
+                    "construct the rotating log handler (%s: %s). Log rotation is "
+                    "disabled for this handler.",
+                    log_output,
+                    type(exc).__name__,
+                    exc,
+                )
                 return logging.FileHandler(log_output, encoding="utf-8")
         else:
             return logging.FileHandler(log_output, encoding="utf-8")
@@ -766,22 +817,23 @@ def _get_shared_handler(
 ) -> logging.Handler:
     global _shared_log_handler, _shared_log_handler_key
 
-    if config is None:
-        handler_key = (log_output, format_string, None)
-    else:
-        handler_key = (
-            log_output,
-            format_string,
-            bool(config.log.rotation),
-            config.log.rotation_interval,
-            config.log.rotation_days,
-        )
-    if not force and _shared_log_handler is not None and _shared_log_handler_key == handler_key:
-        return _shared_log_handler
+    with _shared_log_handler_lock:
+        if config is None:
+            handler_key = (log_output, format_string, None)
+        else:
+            handler_key = (
+                log_output,
+                format_string,
+                bool(config.log.rotation),
+                config.log.rotation_interval,
+                config.log.rotation_days,
+            )
+        if not force and _shared_log_handler is not None and _shared_log_handler_key == handler_key:
+            return _shared_log_handler
 
-    _shared_log_handler = _build_standard_handler(log_output, config, format_string)
-    _shared_log_handler_key = handler_key
-    return _shared_log_handler
+        _shared_log_handler = _build_standard_handler(log_output, config, format_string)
+        _shared_log_handler_key = handler_key
+        return _shared_log_handler
 
 
 def _configure_logger_instance(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "openai>=1.0.0",
     "requests>=2.31.0",
     "charset-normalizer>=3.4,<4",
+    "concurrent-log-handler>=0.9.25",
     "python-docx>=1.0.0",
     "olefile>=0.47",
     "xlrd>=2.0.1",

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for logger utilities."""
+
+from types import SimpleNamespace
+
+from openviking_cli.utils.logger import (
+    ConcurrentTimedRotatingFileHandler,
+    _create_log_handler,
+)
+
+
+def test_create_log_handler_uses_concurrent_rotating_handler(tmp_path):
+    config = SimpleNamespace(
+        log=SimpleNamespace(
+            rotation=True,
+            rotation_days=7,
+            rotation_interval="midnight",
+        )
+    )
+    handler = _create_log_handler(str(tmp_path / "app.log"), config)
+    try:
+        # concurrent-log-handler is a required dependency, so the real concurrent
+        # handler must be in use here — not the stdlib fallback that the import
+        # guard aliases to the same symbol name. Assert the concrete module so this
+        # regression test cannot silently pass on the degraded fallback path.
+        assert ConcurrentTimedRotatingFileHandler.__module__.startswith("concurrent_log_handler")
+        assert isinstance(handler, ConcurrentTimedRotatingFileHandler)
+    finally:
+        handler.close()

--- a/uv.lock
+++ b/uv.lock
@@ -779,6 +779,18 @@ wheels = [
 ]
 
 [[package]]
+name = "concurrent-log-handler"
+version = "0.9.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "portalocker" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/ba185acc438cff6b58cd8f8dec27e7f4fcabf6968a1facbb6d0cacbde7fe/concurrent_log_handler-0.9.29.tar.gz", hash = "sha256:bc37a76d3f384cbf4a98f693ebd770543edc0f4cd5c6ab6bc70e9e1d7d582265", size = 42114, upload-time = "2026-02-22T18:18:25.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/f3/3e3188fdb3e53c6343fd1c7de41c55d4db626f07db3877eae77b28d58bd2/concurrent_log_handler-0.9.29-py3-none-any.whl", hash = "sha256:0d6c077fbaef2dae49a25975dcf72a602fe0a6a4ce80a3b7c37696d37e10459a", size = 32052, upload-time = "2026-02-22T18:18:24.558Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1039,6 +1051,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "diff-match-patch"
 version = "20241021"
 source = { registry = "https://pypi.org/simple" }
@@ -1265,6 +1286,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
     { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -3501,9 +3534,12 @@ dependencies = [
     { name = "apscheduler" },
     { name = "argon2-cffi" },
     { name = "charset-normalizer" },
+    { name = "concurrent-log-handler" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "ebooklib" },
     { name = "fastapi" },
+    { name = "feedparser" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "json-repair" },
@@ -3728,16 +3764,19 @@ requires-dist = [
     { name = "build", marker = "extra == 'build'" },
     { name = "charset-normalizer", specifier = ">=3.4,<4" },
     { name = "cmake", marker = "extra == 'build'", specifier = ">=3.15" },
+    { name = "concurrent-log-handler", specifier = ">=0.9.25" },
     { name = "croniter", marker = "extra == 'bot'", specifier = ">=2.0.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "datasets", marker = "extra == 'benchmark'", specifier = ">=2.0.0" },
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=2.0.0" },
     { name = "datasets", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "ddgs", marker = "extra == 'bot'", specifier = ">=9.0.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "diff-match-patch", marker = "extra == 'test'", specifier = ">=20200713" },
     { name = "dingtalk-stream", marker = "extra == 'bot-dingtalk'", specifier = ">=0.4.0" },
     { name = "ebooklib", specifier = ">=0.18.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "feedparser", specifier = ">=6.0.0" },
     { name = "fusepy", marker = "extra == 'bot-fuse'", specifier = ">=3.0.1" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.0.0" },
     { name = "google-genai", marker = "extra == 'gemini-async'", specifier = ">=1.0.0" },
@@ -3758,7 +3797,7 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
     { name = "lark-oapi", specifier = ">=1.5.3" },
     { name = "lark-oapi", marker = "extra == 'bot-feishu'", specifier = ">=1.0.0" },
-    { name = "litellm", specifier = ">=1.83.7,<1.86.3" },
+    { name = "litellm", specifier = ">=1.83.7,<1.89.3" },
     { name = "llama-cpp-python", marker = "extra == 'local-embed'", specifier = ">=0.3.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "markdownify", specifier = ">=0.11.0" },
@@ -4288,6 +4327,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]
@@ -5661,6 +5712,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e26375
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl", hash = "sha256:f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a", size = 21695, upload-time = "2026-03-27T15:57:03.969Z" },
 ]
+
+[[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
 name = "shellingham"


### PR DESCRIPTION
## Description

Fixes a Windows-only crash in timed log rotation. The stdlib
`TimedRotatingFileHandler.doRollover()` calls `os.rename()` on the still-open log file at
midnight, which raises `PermissionError [WinError 32]` on Windows whenever another handle holds the
file open — e.g. a concurrent uvicorn access-log write, or another worker process when
`config.workers > 1`. This PR swaps it for `concurrent-log-handler`'s
`ConcurrentTimedRotatingFileHandler`, whose `doRollover()` coordinates the rotation across
processes/handles. It also closes a latent handler-leak race: `_get_shared_handler` performed its
cache check-and-set with no lock, unlike the sibling stdout/stderr path guarded by
`_std_stream_handlers_lock`.

## Related Issue

Fixes #2939

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`pyproject.toml` / `uv.lock`**: add `concurrent-log-handler>=0.9.25` as a dependency and refresh
  the lockfile so CI's `uv sync --frozen` actually installs it (regenerating the lock also picked up
  pre-existing drift already stale on the base: `feedparser`/`defusedxml`/`sgmllib3k` and a
  `litellm` requires-dist bound — metadata sync only, no resolved-version change).
- **`openviking_cli/utils/logger.py`**:
  - `_create_log_handler` constructs `ConcurrentTimedRotatingFileHandler` (identical
    `when`/`interval`/`backupCount`/`encoding` arguments) for rotation-enabled file logs.
  - Import guard treats the package as a **required** dependency with a **defensive** fallback:
    catches `ImportError`, re-raises a `ModuleNotFoundError` naming any *other* module (e.g. a
    broken transitive dep like `portalocker`) so real install breakage surfaces, and emits a
    `RuntimeWarning` on fallback so a degrade is never silent.
  - Added `_shared_log_handler_lock` (`RLock`) around `_get_shared_handler`'s check-and-set,
    mirroring `_std_stream_handlers_lock`.
  - The runtime rotating-handler construction fallback now **logs the swallowed exception** (it was
    silent), so a downgrade to a non-rotating handler is observable.
- **`tests/test_logger.py`**: new regression test asserting the concrete `concurrent_log_handler`
  module is used when rotation is enabled — not the stdlib fallback alias.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux — local: `pytest tests/test_logger.py` passes; `ruff format`/`ruff check` clean;
    `mypy` clean (zero new errors vs. baseline)
  - [x] macOS — CI build/distribution jobs pass
  - [x] Windows — CI build/distribution jobs pass (target platform of the fix; the Windows-runner
    behavioural repro of the midnight rollover itself is not automated — logic is verified via the
    handler-type assertion and the import guard)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none required)
- [x] My changes generate no new warnings (`ruff`/`mypy` clean on the changed module)
- [x] Any dependent changes have been merged and published (`concurrent-log-handler` 0.9.29 is on
  PyPI, Apache-2.0)

## Additional Notes

- **Cross-platform:** applies on POSIX too — `ConcurrentTimedRotatingFileHandler` writes a small
  `.lock` sidecar per log file and adds minor per-rollover overhead; an intentional, low-cost trade
  for cross-platform safety.
- **License:** `concurrent-log-handler` is Apache-2.0 — compatible with this project's AGPL-3.0 —
  and is a constructor-compatible drop-in.
- **Automated review addressed:** feedback from CodeRabbit, Qodo, and Gemini Code Assist was triaged
  and resolved (all review threads resolved). Specifically: uv.lock pinning so `uv sync --frozen`
  installs the handler; the required-dep-with-defensive-fallback import guard (narrowed exception
  handling that re-raises foreign `ModuleNotFoundError`, plus a `RuntimeWarning`); the stronger
  module-level regression assertion; and logging the swallowed construction-fallback exception.
