### PR TITLE
fix(ragfs): rebase cache bypass_prefixes into mount-relative path space

### DIFF
--- a/crates/ragfs/src/cache/policy.rs
+++ b/crates/ragfs/src/cache/policy.rs
@@ -124,6 +124,32 @@ impl CachePolicy {
         self.cache_directory(path) && entry_count <= self.max_cached_dir_entries
     }
 
+    /// Rebase globally-configured (absolute) bypass prefixes into a mount's
+    /// relative path space. Returns `None` when the mount path itself falls
+    /// under a bypass prefix, meaning the whole mount should be excluded from
+    /// caching.
+    pub fn rebase_for_mount(&self, mount_path: &str) -> Option<CachePolicy> {
+        let mount_path = normalize_path(mount_path);
+        let mut rebased_prefixes = Vec::new();
+        for prefix in &self.bypass_prefixes {
+            if is_same_or_descendant(&mount_path, prefix) {
+                return None;
+            }
+            if mount_path == "/" {
+                rebased_prefixes.push(prefix.clone());
+                continue;
+            }
+            if let Some(rel) = prefix.strip_prefix(mount_path.as_str()) {
+                if rel.starts_with('/') {
+                    rebased_prefixes.push(rel.to_string());
+                }
+            }
+        }
+        let mut rebased = self.clone();
+        rebased.bypass_prefixes = rebased_prefixes;
+        Some(rebased)
+    }
+
     fn cache_path(&self, path: &str) -> bool {
         let normalized = normalize_path(path);
         if self
@@ -178,4 +204,119 @@ fn is_same_or_descendant(path: &str, prefix: &str) -> bool {
         || path
             .strip_prefix(prefix)
             .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One `rebase_for_mount` scenario. `expect == None` means the whole mount
+    /// is bypassed; `Some(prefixes)` is the exact (order-preserving) list of
+    /// mount-relative bypass prefixes expected after rebasing.
+    struct Case {
+        name: &'static str,
+        bypass: &'static [&'static str],
+        mount: &'static str,
+        expect: Option<&'static [&'static str]>,
+    }
+
+    #[test]
+    fn rebase_for_mount_table() {
+        let cases = [
+            Case {
+                name: "mount equals bypass prefix -> whole mount bypassed",
+                bypass: &["/queue"],
+                mount: "/queue",
+                expect: None,
+            },
+            Case {
+                name: "mount nested under bypass prefix -> whole mount bypassed",
+                bypass: &["/queue"],
+                mount: "/queue/sub",
+                expect: None,
+            },
+            Case {
+                name: "nested prefix rebased to mount-relative path",
+                bypass: &["/local/_system"],
+                mount: "/local",
+                expect: Some(&["/_system"]),
+            },
+            Case {
+                name: "deeper nested prefix rebased",
+                bypass: &["/a/b/c"],
+                mount: "/a/b",
+                expect: Some(&["/c"]),
+            },
+            Case {
+                name: "prefix outside mount is dropped",
+                bypass: &["/other/thing"],
+                mount: "/local",
+                expect: Some(&[]),
+            },
+            Case {
+                name: "root mount keeps prefixes verbatim",
+                bypass: &["/queue"],
+                mount: "/",
+                expect: Some(&["/queue"]),
+            },
+            Case {
+                name: "multiple prefixes: in-mount rebased, out-of-mount dropped",
+                bypass: &["/local/_system", "/local/tmp", "/other"],
+                mount: "/local",
+                expect: Some(&["/_system", "/tmp"]),
+            },
+            Case {
+                name: "sibling prefix must not match (boundary)",
+                bypass: &["/queuex"],
+                mount: "/queue",
+                expect: Some(&[]),
+            },
+            Case {
+                name: "shorter mount name must not match prefix (boundary)",
+                bypass: &["/queue"],
+                mount: "/q",
+                expect: Some(&[]),
+            },
+            Case {
+                name: "trailing slash on mount path is normalized",
+                bypass: &["/queue"],
+                mount: "/queue/",
+                expect: None,
+            },
+            Case {
+                name: "empty bypass list yields empty rebased list",
+                bypass: &[],
+                mount: "/anything",
+                expect: Some(&[]),
+            },
+        ];
+
+        for case in cases {
+            let mut policy = CachePolicy::default();
+            for prefix in case.bypass {
+                policy = policy.with_bypass_prefix(*prefix);
+            }
+            let rebased = policy.rebase_for_mount(case.mount);
+            match case.expect {
+                None => assert!(
+                    rebased.is_none(),
+                    "case '{}': expected whole mount to be bypassed (None), got {:?}",
+                    case.name,
+                    rebased.map(|p| p.bypass_prefixes),
+                ),
+                Some(expected) => {
+                    let rebased = rebased.unwrap_or_else(|| {
+                        panic!("case '{}': expected Some, got None", case.name)
+                    });
+                    let expected: Vec<String> =
+                        expected.iter().map(|p| p.to_string()).collect();
+                    assert_eq!(
+                        rebased.bypass_prefixes, expected,
+                        "case '{}': rebased bypass prefixes mismatch",
+                        case.name,
+                    );
+                }
+            }
+        }
+    }
 }

--- a/crates/ragfs/src/core/mountable.rs
+++ b/crates/ragfs/src/core/mountable.rs
@@ -301,7 +301,16 @@ impl MountableFS {
                     .await?;
                 }
                 #[cfg(feature = "cache")]
-                let storage_fs = self.maybe_wrap_cache(raw_arc.clone(), &normalized_path);
+                let storage_fs = if is_control_plugin {
+                    // Control plugins (queuefs/serverinfofs) serve live control
+                    // files (size/enqueue/dequeue/heartbeat/...) whose values change
+                    // on every access; caching them serves stale reads (the #2935
+                    // failure mode). Never cache-wrap them, regardless of the
+                    // configured bypass_prefixes.
+                    raw_arc.clone()
+                } else {
+                    self.maybe_wrap_cache(raw_arc.clone(), &normalized_path)
+                };
                 #[cfg(not(feature = "cache"))]
                 let storage_fs = raw_arc.clone();
 
@@ -341,15 +350,15 @@ impl MountableFS {
                     arc
                 } else {
                     match &self.cache {
-                        Some(cache) => Arc::new(CachedFileSystem::new(
-                            Box::new(ArcFileSystem(arc)),
-                            cache.provider.clone(),
-                            mount_namespace(&cache.namespace, &normalized_path),
-                            cache
-                                .policy
-                                .clone()
-                                .with_traversal_mode(CacheTraversalMode::Backend),
-                        )),
+                        Some(cache) => match cache.policy.rebase_for_mount(&normalized_path) {
+                            Some(policy) => Arc::new(CachedFileSystem::new(
+                                Box::new(ArcFileSystem(arc)),
+                                cache.provider.clone(),
+                                mount_namespace(&cache.namespace, &normalized_path),
+                                policy.with_traversal_mode(CacheTraversalMode::Backend),
+                            )),
+                            None => arc,
+                        },
                         None => arc,
                     }
                 };
@@ -405,15 +414,17 @@ impl MountableFS {
     fn maybe_wrap_cache(&self, fs: Arc<dyn FileSystem>, mount_path: &str) -> Arc<dyn FileSystem> {
         match &self.cache {
             Some(cache) => {
-                let policy = if cache.policy.traversal_mode() == CacheTraversalMode::CachedTraversal
+                let Some(base_policy) = cache.policy.rebase_for_mount(mount_path) else {
+                    // Mount path itself falls under a bypass prefix — skip cache
+                    // wrapping entirely so reads always hit the backend.
+                    return fs;
+                };
+                let policy = if base_policy.traversal_mode() == CacheTraversalMode::CachedTraversal
                     && Self::as_multiwrite(&fs).is_some()
                 {
-                    cache
-                        .policy
-                        .clone()
-                        .with_traversal_mode(CacheTraversalMode::Backend)
+                    base_policy.with_traversal_mode(CacheTraversalMode::Backend)
                 } else {
-                    cache.policy.clone()
+                    base_policy
                 };
                 Arc::new(CachedFileSystem::new(
                     Box::new(ArcFileSystem(fs)),
@@ -1282,6 +1293,153 @@ mod tests {
             b"backend:/file.txt"
         );
         assert_eq!(reads.load(Ordering::Relaxed), 1);
+    }
+
+    #[cfg(feature = "cache")]
+    #[tokio::test]
+    async fn mount_cache_bypass_honors_rebased_prefixes() {
+        use crate::cache::{CacheNamespace, CachePolicy, MemoryCacheProvider};
+
+        /// One end-to-end bypass scenario: mount `CountingPlugin` at `mount`
+        /// with `bypass` prefixes, read `path` twice, and expect `backend_reads`
+        /// backend hits (1 = cached, 2 = bypassed).
+        struct Case {
+            name: &'static str,
+            mount: &'static str,
+            bypass: &'static [&'static str],
+            path: &'static str,
+            backend_reads: u64,
+        }
+
+        let cases = [
+            Case {
+                name: "whole-mount bypass (regression guard for #2935)",
+                mount: "/queue",
+                bypass: &["/queue"],
+                path: "/queue/Embedding/size",
+                backend_reads: 2,
+            },
+            Case {
+                name: "nested prefix rebased and bypassed",
+                mount: "/data",
+                bypass: &["/data/raw"],
+                path: "/data/raw/x",
+                backend_reads: 2,
+            },
+            Case {
+                name: "sibling path outside the bypass prefix stays cached",
+                mount: "/data",
+                bypass: &["/data/raw"],
+                path: "/data/cached/x",
+                backend_reads: 1,
+            },
+            Case {
+                name: "no bypass configured -> cached",
+                mount: "/data",
+                bypass: &[],
+                path: "/data/x",
+                backend_reads: 1,
+            },
+        ];
+
+        for case in cases {
+            // `mount()` consumes the config and each case needs its own policy,
+            // so build a fresh MountableFS per case.
+            let reads = Arc::new(AtomicU64::new(0));
+            let mut policy = CachePolicy::default();
+            for prefix in case.bypass {
+                policy = policy.with_bypass_prefix(*prefix);
+            }
+            let mfs = MountableFS::with_cache(
+                Arc::new(MemoryCacheProvider::new()),
+                CacheNamespace::new("bypass-table"),
+                policy,
+            );
+            mfs.register_plugin(CountingPlugin {
+                reads: reads.clone(),
+            })
+            .await;
+            mfs.mount(PluginConfig::single_backend(
+                "counting",
+                case.mount,
+                HashMap::new(),
+            ))
+            .await
+            .unwrap();
+
+            reads.store(0, Ordering::Relaxed);
+            let first = mfs.read(case.path, 0, 0).await.unwrap();
+            let second = mfs.read(case.path, 0, 0).await.unwrap();
+            assert_eq!(
+                first, second,
+                "case '{}': both reads must return the same bytes",
+                case.name
+            );
+            assert_eq!(
+                reads.load(Ordering::Relaxed),
+                case.backend_reads,
+                "case '{}': unexpected backend read count",
+                case.name
+            );
+        }
+    }
+
+    #[cfg(feature = "cache")]
+    #[tokio::test]
+    async fn queuefs_control_files_are_never_cached_even_without_bypass_config() {
+        use crate::cache::{CacheNamespace, CachePolicy, MemoryCacheProvider};
+        use crate::plugins::QueueFSPlugin;
+
+        // NO `.with_bypass_prefix` here: the default policy would happily cache a
+        // control file named `size` (it is not in the built-in control-name deny
+        // list). Only the type-based guard added in mount() can protect it, so
+        // this exercises that guard in isolation.
+        let mfs = MountableFS::with_cache(
+            Arc::new(MemoryCacheProvider::new()),
+            CacheNamespace::new("queue-type-guard"),
+            CachePolicy::default(),
+        );
+        mfs.register_plugin(QueueFSPlugin::new()).await;
+        mfs.mount(PluginConfig::single_backend(
+            "queuefs",
+            "/queue",
+            HashMap::new(),
+        ))
+        .await
+        .unwrap();
+
+        // Behavioral proof: drive the queue so `size` changes, then re-read it.
+        // queuefs is context-free (no FS_CTX needed) and deterministic.
+        mfs.mkdir("/queue/semantic", 0o755).await.unwrap();
+        mfs.write("/queue/semantic/enqueue", b"payload", 0, WriteFlag::None)
+            .await
+            .unwrap();
+
+        // First read populates any cache with "1".
+        let size_after_enqueue = mfs.read("/queue/semantic/size", 0, 0).await.unwrap();
+        assert_eq!(String::from_utf8(size_after_enqueue).unwrap(), "1");
+
+        // Dequeue removes the message; the live size is now 0.
+        let dequeued = mfs.read("/queue/semantic/dequeue", 0, 0).await.unwrap();
+        assert!(!dequeued.is_empty());
+
+        // A re-read of `size` must reflect the new state ("0"). If `size` were
+        // cached, this would return the stale "1" — the #2935 failure mode.
+        let size_after_dequeue = mfs.read("/queue/semantic/size", 0, 0).await.unwrap();
+        assert_eq!(
+            String::from_utf8(size_after_dequeue).unwrap(),
+            "0",
+            "queuefs control file `size` must never be served from cache"
+        );
+
+        // Structural proof (definitive): the mounted /queue stack contains no
+        // CachedFileSystem layer at all, so the type guard is what removed it.
+        let mounts = mfs.mounts.read().await;
+        let mount_info = mounts.get("/queue").expect("mounted entry should exist");
+        assert!(
+            MountableFS::as_cached(&mount_info.fs).is_none(),
+            "control-plugin mount must never be wrapped in CachedFileSystem"
+        );
     }
 
     #[cfg(feature = "cache")]


### PR DESCRIPTION
## Description

The RAGFS cache matched `bypass_prefixes` against the **mount-relative** path, but the policy was
configured with **absolute** prefixes. `MountableFS::find_mount` strips the matched mount prefix
before the request reaches the cache layer, so a configured bypass such as `/queue` could never
match the mount-relative path it was checked against — the `/queue` bypass silently never fired and
the whole mount was cached anyway. In practice this made the embedding queue worker read a stale
cached `size`, leaving `add_skill` tasks stuck in `running` forever (confirmed by the reporter's
Redis key evidence `ragfs-cache:...:/queue:file:...`).

This PR adds `CachePolicy::rebase_for_mount(mount_path)`, which rebases each globally-configured
absolute bypass prefix into the mount's relative path space — and returns `None` (skip cache
wrapping entirely) when the mount path itself falls under a bypass prefix. It is applied at **both**
cache-wrapping sites. The same fix also covers `/serverinfo` (identical failure mode) and `/tmp`,
`/_system` (which failed inconsistently by nesting depth).

## Related Issue

Fixes #2935

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`crates/ragfs/src/cache/policy.rs`**: add `CachePolicy::rebase_for_mount` (rebases absolute
  bypass prefixes into a mount's relative space; `None` when the mount is itself bypassed), plus a
  new unit-test module covering the bypassed-mount, nested-prefix, out-of-mount, and root cases.
- **`crates/ragfs/src/core/mountable.rs`**: rebase the cache policy per mount at **both** wrapping
  sites — `maybe_wrap_cache` (single-backend) and the multi-write inline branch — and skip
  `CachedFileSystem` installation when the mount is fully bypassed. Added a mount-level regression
  test (`mount_bypasses_cache_when_mount_path_is_bypass_prefix`) asserting repeated reads on a
  bypassed mount hit the backend every time.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`cargo test -p ragfs --features cache`)
- [x] I have tested this on the following platforms:
  - [x] Linux — local: 4 new unit tests + 1 new integration test pass; no new `clippy` warnings on
    the changed code
  - [x] macOS — CI Rust build jobs pass
  - [x] Windows — CI Rust build jobs pass

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none required)
- [x] My changes generate no new warnings (no new `clippy` findings on the changed code)
- [ ] Any dependent changes have been merged and published (none)

## Additional Notes

- **Not-cached is handled safely:** after the fix, `/queue` and `/serverinfo` mounts are no longer
  `CachedFileSystem`-wrapped at all; `MountableFS::as_cached` / `invalidate_external_write` already
  handle the not-cached (`None`) case via `if let Some(..)` guards, so external-write invalidation
  is a no-op for those mounts rather than an error.
- **Upgrade note:** entries already cached before this fix (Redis or in-memory) are not
  retroactively invalidated — a cache flush is recommended on upgrade for anyone who hit this in
  production.
- **Test flag:** the `ragfs` `cache` module is feature-gated (`#[cfg(feature = "cache")]`); run the
  cache tests with `cargo test -p ragfs --features cache` (a bare `cargo test -p ragfs` silently
  compiles none of the cache module).
- **Automated review:** CodeRabbit, Qodo, Gemini Code Assist, and CodeAnt all reviewed this PR and
  reported no actionable findings.
