### PR TITLE
docs(bot): document agents.thinking config option

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -168,6 +168,7 @@ All configurations are under the `bot` field in `ov.conf`, with default values f
 - `agents`: Agent configuration
   - `model`: LLM model name used by the bot. When `provider` is set, use the provider-native model name (for example `doubao-seed-2-0-pro-260215`).
   - `temperature`: Sampling temperature for LLM requests. Defaults to `0.7`.
+  - `thinking`: Enable provider reasoning/thinking mode for bot LLM requests when the selected provider protocol supports an explicit thinking parameter. Defaults to `true`; set to `false` to disable (for example to reduce latency/cost or for models where reasoning params are unsupported). Applied per provider — VolcEngine `thinking={"type": "enabled"}`, DashScope `extra_body.enable_thinking=true`, and OpenAI reasoning models `reasoning_effort`.
   - `timeout`: Per-request timeout in seconds for fetching chat results from the model provider. Inherits `vlm.timeout` when omitted (default `60.0`).
   - `provider`: Optional model provider name. When set, vikingbot uses OpenViking's `VLMFactory` + adapter path to create the backend directly (for example `volcengine`, `openai`, `deepseek`).
   - `api_key`: Optional API key for the agent model provider. Can be configured here directly when you want bot-specific credentials.
@@ -211,6 +212,7 @@ All configurations are under the `bot` field in `ov.conf`, with default values f
       "api_base": "https://ark.cn-beijing.volces.com/api/v3",
       "provider": "volcengine",
       "temperature": 0.7,
+      "thinking": true,
       "timeout": 60.0,
       "max_tool_iterations": 50,
       "memory_window": 50

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -170,6 +170,7 @@ bot 将连接到远程 OpenViking Server，使用前请先启动 OpenViking Serv
 - `agents`：Agent 配置
   - `model`：bot 使用的 LLM 模型名。当设置了 `provider` 时，建议直接使用 provider 原生模型名（例如 `doubao-seed-2-0-pro-260215`）。
   - `temperature`：LLM 请求的采样温度，默认 `0.7`。
+  - `thinking`：当所选 provider 协议支持显式 thinking 参数时，为 bot LLM 请求启用 provider 推理/思考模式。默认 `true`；设为 `false` 可关闭（例如为降低延迟/成本，或用于不支持推理参数的模型）。按 provider 应用——VolcEngine `thinking={"type": "enabled"}`、DashScope `extra_body.enable_thinking=true`、OpenAI 推理模型 `reasoning_effort`。
   - `timeout`：访问模型 provider 获取 chat 结果的单次请求超时时间（秒）。未配置时继承 `vlm.timeout`（默认 `60.0`）。
   - `provider`：可选的模型 provider 名称。设置后，vikingbot 会通过 OpenViking 的 `VLMFactory` + adapter 路径直接创建后端（例如 `volcengine`、`openai`、`deepseek`）。
   - `api_key`：可选，Agent 模型 provider 的 API Key。若希望 bot 使用独立凭证，可直接在这里配置。
@@ -213,6 +214,7 @@ bot 将连接到远程 OpenViking Server，使用前请先启动 OpenViking Serv
       "api_base": "https://ark.cn-beijing.volces.com/api/v3",
       "provider": "volcengine",
       "temperature": 0.7,
+      "thinking": true,
       "timeout": 60.0,
       "max_tool_iterations": 50,
       "memory_window": 50


### PR DESCRIPTION
## Summary

PR #2944 added the `bot.agents.thinking` config option (`AgentsConfig.thinking`, default `true`) which mutates the LLM provider request depending on the selected provider:

- VolcEngine: `thinking={"type": "enabled"}`
- DashScope: `extra_body.enable_thinking=true`
- OpenAI reasoning models: `reasoning_effort`

(see `bot/vikingbot/config/schema.py` and `bot/vikingbot/providers/litellm_provider.py::_apply_thinking_overrides`)

Because it is default-on and changes provider reasoning request params (affecting latency, cost, and compatibility), operators need to be able to discover and disable it. The canonical Vikingbot config reference and sample config in `bot/README.md` / `bot/README_CN.md` were not updated when the option shipped.

## Changes

- Document `agents.thinking` in the EN + ZH Bot Configuration reference, including its default and per-provider behavior.
- Add `"thinking": true` to the EN + ZH sample `bot.agents` config block.

Docs only — no code changes.
