### PR TITLE
fix(web-studio): clarify Usage/Audit access requirements

### DIFF
--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -307,6 +307,8 @@ const en = {
     },
     usageDisabled:
       'Usage/Audit is not initialized, so live usage stats are unavailable.',
+    usageAccessRequired:
+      'Current connection has no admin/root role. Configure an API key with Console Usage/Audit access in Connection & Identity.',
   },
   operations: {
     page: {
@@ -314,6 +316,11 @@ const en = {
     },
   },
   requestLogs: {
+    accessRequired: {
+      description:
+        'Current connection has no admin/root role. Configure an API key with Console Usage/Audit access in Connection & Identity.',
+      title: 'Admin access required',
+    },
     clear: 'Clear',
     description:
       'Inspect server-side audited API requests for the current identity, including status, latency, and request identifiers.',
@@ -549,8 +556,7 @@ const en = {
       loadingEditor: 'Loading editor...',
       markdownPreview: 'Preview',
       markdownSource: 'Source',
-      noDirectoryContext:
-        'No abstract or overview available for this folder.',
+      noDirectoryContext: 'No abstract or overview available for this folder.',
       save: 'Save',
       selectDirectoryContext: 'Select a chip to show folder context.',
       unsupportedBinary: 'Binary files do not support text preview.',

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -303,6 +303,8 @@ const zhCN = {
       title: 'tokens 总消耗统计',
     },
     usageDisabled: 'Usage/Audit 未初始化，暂无实时统计。',
+    usageAccessRequired:
+      '当前连接未获取到 admin/root 权限，无法显示 Usage/Audit 数据。请在连接与身份中配置具备 Console Usage/Audit 权限的 API Key。',
   },
   operations: {
     page: {
@@ -310,6 +312,11 @@ const zhCN = {
     },
   },
   requestLogs: {
+    accessRequired: {
+      description:
+        '当前连接未获取到 admin/root 权限，无法显示请求日志。请在连接与身份中配置具备 Console Usage/Audit 权限的 API Key。',
+      title: '需要 admin 权限',
+    },
     clear: '清空',
     description:
       '查看当前身份下服务端审计到的 API 请求，包括状态、耗时和请求标识。',

--- a/web-studio/src/routes/home/-components/context-commits-panel.tsx
+++ b/web-studio/src/routes/home/-components/context-commits-panel.tsx
@@ -30,12 +30,14 @@ const ContextCommitsHeatmap = lazy(() =>
 export function ContextCommitsPanel({
   data,
   disabled: disabledProp,
+  disabledMessage,
   isError,
   isLoading,
   t,
 }: {
   data: ConsoleSeries<ContextCommitItem> | undefined
   disabled?: boolean
+  disabledMessage?: string
   isError: boolean
   isLoading: boolean
   t: HomeT
@@ -82,7 +84,7 @@ export function ContextCommitsPanel({
       ) : isError ? (
         <EmptyState>{t('requestFailed')}</EmptyState>
       ) : disabled ? (
-        <EmptyState>{t('usageDisabled')}</EmptyState>
+        <EmptyState>{disabledMessage ?? t('usageDisabled')}</EmptyState>
       ) : items.length === 0 ? (
         <EmptyState>{t('contextCommits.empty')}</EmptyState>
       ) : (

--- a/web-studio/src/routes/home/-components/metric-panels.tsx
+++ b/web-studio/src/routes/home/-components/metric-panels.tsx
@@ -134,12 +134,14 @@ function MetricPanel({
 export function ContextDataPanel({
   data,
   disabled,
+  disabledMessage,
   isError,
   isLoading,
   t,
 }: {
   data: ContextCounts | undefined
   disabled: boolean
+  disabledMessage: string
   isError: boolean
   isLoading: boolean
   t: HomeT
@@ -155,7 +157,7 @@ export function ContextDataPanel({
       value={isError ? t('requestFailed') : formatNumber(total)}
     >
       {disabled ? (
-        <p className="text-xs text-muted-foreground">{t('usageDisabled')}</p>
+        <p className="text-xs text-muted-foreground">{disabledMessage}</p>
       ) : (
         <>
           <DetailRow
@@ -179,12 +181,14 @@ export function ContextDataPanel({
 export function TodayTokensPanel({
   data,
   disabled,
+  disabledMessage,
   isError,
   isLoading,
   t,
 }: {
   data: TokenCounts | undefined
   disabled: boolean
+  disabledMessage: string
   isError: boolean
   isLoading: boolean
   t: HomeT
@@ -200,7 +204,7 @@ export function TodayTokensPanel({
       value={isError ? t('requestFailed') : formatNumber(total)}
     >
       {disabled ? (
-        <p className="text-xs text-muted-foreground">{t('usageDisabled')}</p>
+        <p className="text-xs text-muted-foreground">{disabledMessage}</p>
       ) : (
         <>
           <DetailRow
@@ -224,12 +228,14 @@ export function TodayTokensPanel({
 export function TodayRetrievalsPanel({
   data,
   disabled,
+  disabledMessage,
   isError,
   isLoading,
   t,
 }: {
   data: RetrievalCounts | undefined
   disabled: boolean
+  disabledMessage: string
   isError: boolean
   isLoading: boolean
   t: HomeT
@@ -245,7 +251,7 @@ export function TodayRetrievalsPanel({
       value={isError ? t('requestFailed') : formatNumber(total)}
     >
       {disabled ? (
-        <p className="text-xs text-muted-foreground">{t('usageDisabled')}</p>
+        <p className="text-xs text-muted-foreground">{disabledMessage}</p>
       ) : (
         <>
           <DetailRow

--- a/web-studio/src/routes/home/-components/token-trend-panel.tsx
+++ b/web-studio/src/routes/home/-components/token-trend-panel.tsx
@@ -17,12 +17,14 @@ const TokenTrendChart = lazy(() =>
 export function TokenTrendPanel({
   data,
   disabled: disabledProp,
+  disabledMessage,
   isError,
   isLoading,
   t,
 }: {
   data: ConsoleSeries<TokenSeriesItem> | undefined
   disabled?: boolean
+  disabledMessage?: string
   isError: boolean
   isLoading: boolean
   t: HomeT
@@ -51,7 +53,7 @@ export function TokenTrendPanel({
       ) : isError ? (
         <EmptyState>{t('requestFailed')}</EmptyState>
       ) : disabled ? (
-        <EmptyState>{t('usageDisabled')}</EmptyState>
+        <EmptyState>{disabledMessage ?? t('usageDisabled')}</EmptyState>
       ) : items.length === 0 ? (
         <EmptyState>{t('tokenTrend.empty')}</EmptyState>
       ) : (

--- a/web-studio/src/routes/home/route.tsx
+++ b/web-studio/src/routes/home/route.tsx
@@ -83,9 +83,12 @@ function HomePage() {
   })
 
   const summary = dashboard.data
-  const metricsUnavailable =
-    (!isConnectionRoleLoading && connectionRole === 'unknown') ||
-    isDisabledPayload(summary)
+  const missingPrivilegedRole =
+    !isConnectionRoleLoading && connectionRole === 'unknown'
+  const metricsUnavailable = missingPrivilegedRole || isDisabledPayload(summary)
+  const unavailableMessage = missingPrivilegedRole
+    ? t('usageAccessRequired')
+    : t('usageDisabled')
   const isMetricsLoading = isConnectionRoleLoading || dashboard.isLoading
   const isSeriesLoading = isConnectionRoleLoading || tokenSeries.isLoading
   const isCommitsLoading = isConnectionRoleLoading || contextCommits.isLoading
@@ -96,6 +99,7 @@ function HomePage() {
         <ContextDataPanel
           data={summary?.context_counts}
           disabled={metricsUnavailable}
+          disabledMessage={unavailableMessage}
           isError={dashboard.isError}
           isLoading={isMetricsLoading}
           t={t}
@@ -103,6 +107,7 @@ function HomePage() {
         <TodayTokensPanel
           data={summary?.today_tokens}
           disabled={metricsUnavailable}
+          disabledMessage={unavailableMessage}
           isError={dashboard.isError}
           isLoading={isMetricsLoading}
           t={t}
@@ -110,6 +115,7 @@ function HomePage() {
         <TodayRetrievalsPanel
           data={summary?.today_retrievals}
           disabled={metricsUnavailable}
+          disabledMessage={unavailableMessage}
           isError={dashboard.isError}
           isLoading={isMetricsLoading}
           t={t}
@@ -119,6 +125,7 @@ function HomePage() {
       <TokenTrendPanel
         data={tokenSeries.data}
         disabled={metricsUnavailable}
+        disabledMessage={unavailableMessage}
         isError={tokenSeries.isError}
         isLoading={isSeriesLoading}
         t={t}
@@ -127,6 +134,7 @@ function HomePage() {
       <ContextCommitsPanel
         data={contextCommits.data}
         disabled={metricsUnavailable}
+        disabledMessage={unavailableMessage}
         isError={contextCommits.isError}
         isLoading={isCommitsLoading}
         t={t}

--- a/web-studio/src/routes/request-logs/route.tsx
+++ b/web-studio/src/routes/request-logs/route.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Navigate, createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { ActivityIcon, BarChart3Icon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { EmptyLogsState } from './-components/empty-logs-state'
 import { MetricCard } from './-components/metric-card'
 import { RequestLogPanel } from './-components/panel'
 import { DEFAULT_FILTERS, DEFAULT_PAGE_SIZE } from './-constants/audit'
@@ -93,51 +94,56 @@ function RequestLogsRoute() {
     setPage(1)
   }
 
-  if (!isConnectionRoleLoading && !canQueryAudit) {
-    return <Navigate replace to="/home" />
-  }
-
   return (
     <div className="flex w-full min-w-0 flex-col gap-5">
       <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
         {scopeLabel}
       </div>
 
-      <div className="grid gap-3 md:grid-cols-2">
-        <MetricCard
-          label={t('metrics.total')}
-          value={total >= 1000 ? '999+' : total}
-          icon={<ActivityIcon className="size-4" />}
+      {!isConnectionRoleLoading && !canQueryAudit ? (
+        <EmptyLogsState
+          title={t('accessRequired.title')}
+          description={t('accessRequired.description')}
         />
-        <MetricCard
-          label={t('metrics.successRate')}
-          value={formatPercent(zeroResult ? 0 : audit.data?.success_rate)}
-          icon={<BarChart3Icon className="size-4" />}
-        />
-      </div>
+      ) : (
+        <>
+          <div className="grid gap-3 md:grid-cols-2">
+            <MetricCard
+              label={t('metrics.total')}
+              value={total >= 1000 ? '999+' : total}
+              icon={<ActivityIcon className="size-4" />}
+            />
+            <MetricCard
+              label={t('metrics.successRate')}
+              value={formatPercent(zeroResult ? 0 : audit.data?.success_rate)}
+              icon={<BarChart3Icon className="size-4" />}
+            />
+          </div>
 
-      <RequestLogPanel
-        disabled={disabled}
-        disabledMessage={audit.data?.message}
-        draftFilters={draftFilters}
-        filters={filters}
-        isError={audit.isError}
-        isFetching={audit.isFetching}
-        isLoading={audit.isLoading}
-        logs={logs}
-        onDraftFiltersChange={setDraftFilters}
-        onLogTypeChange={handleLogTypeChange}
-        onPageChange={setPage}
-        onPageSizeChange={handlePageSizeChange}
-        onRefresh={handleRefresh}
-        onReset={handleReset}
-        onSearch={handleSearch}
-        page={page}
-        pageCount={pageCount}
-        pageSize={pageSize}
-        total={total}
-        zeroResult={zeroResult}
-      />
+          <RequestLogPanel
+            disabled={disabled}
+            disabledMessage={audit.data?.message}
+            draftFilters={draftFilters}
+            filters={filters}
+            isError={audit.isError}
+            isFetching={audit.isFetching}
+            isLoading={isConnectionRoleLoading || audit.isLoading}
+            logs={logs}
+            onDraftFiltersChange={setDraftFilters}
+            onLogTypeChange={handleLogTypeChange}
+            onPageChange={setPage}
+            onPageSizeChange={handlePageSizeChange}
+            onRefresh={handleRefresh}
+            onReset={handleReset}
+            onSearch={handleSearch}
+            page={page}
+            pageCount={pageCount}
+            pageSize={pageSize}
+            total={total}
+            zeroResult={zeroResult}
+          />
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- keep Usage/Audit dashboard and request-log views mounted when the active connection lacks admin/root visibility
- show role-specific access-required copy instead of the generic Usage/Audit disabled message
- preserve the existing disabled-backend copy when Usage/Audit is not initialized

Fixes #2913

## Verification
- npm ci
- npx prettier --check <changed Web Studio files>
- npm run lint
- npm run build