### PR TITLE
feat(system): expose disk safety status

### DIFF
--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -3,6 +3,8 @@
 """System endpoints for OpenViking HTTP Server."""
 
 import asyncio
+import shutil
+from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Request
@@ -18,6 +20,7 @@ from openviking.server.identity import AuthMode, RequestContext, Role
 from openviking.server.models import Response
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils import get_logger
+from openviking_cli.utils.config.open_viking_config import get_openviking_config
 
 logger = get_logger(__name__)
 
@@ -35,6 +38,16 @@ def _is_ready_check_ok(value) -> bool:
             return True
         return all(_is_ready_check_ok(item) for item in nested.values())
     return value in ("ok", "not_configured", "not_supported")
+
+
+def _disk_pressure_state(usage_percent: float, disk_pressure_config) -> str:
+    warning_threshold = float(getattr(disk_pressure_config, "warning_threshold_percent", 85))
+    critical_threshold = float(getattr(disk_pressure_config, "critical_threshold_percent", 95))
+    if usage_percent >= critical_threshold:
+        return "critical"
+    if usage_percent >= warning_threshold:
+        return "warning"
+    return "normal"
 
 
 async def _probe_agfs_readiness() -> dict[str, object]:
@@ -199,6 +212,37 @@ async def readiness_check(request: Request):
     return JSONResponse(
         status_code=status_code,
         content={"status": "ready" if all_ok else "not_ready", "checks": checks},
+    )
+
+
+@router.get("/api/v1/system/disk", tags=["system"])
+async def disk_status(
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Return workspace disk usage for probes and dashboards."""
+    del ctx
+    ov_config = get_openviking_config()
+    workspace = Path(ov_config.storage.workspace).expanduser().resolve()
+    usage = shutil.disk_usage(workspace)
+    usage_percent = 0.0 if usage.total <= 0 else (usage.used / usage.total) * 100
+    disk_pressure = ov_config.storage.safety.disk_pressure
+    state = _disk_pressure_state(usage_percent, disk_pressure)
+
+    return Response(
+        status="ok",
+        result={
+            "state": state,
+            "enabled": bool(disk_pressure.enabled),
+            "workspace": str(workspace),
+            "usage_percent": round(usage_percent, 2),
+            "total_bytes": usage.total,
+            "used_bytes": usage.used,
+            "free_bytes": usage.free,
+            "free_gb": round(usage.free / (1024**3), 2),
+            "warning_threshold_percent": disk_pressure.warning_threshold_percent,
+            "critical_threshold_percent": disk_pressure.critical_threshold_percent,
+            "action_on_critical": disk_pressure.action_on_critical,
+        },
     )
 
 

--- a/openviking_cli/utils/config/storage_config.py
+++ b/openviking_cli/utils/config/storage_config.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -12,6 +12,48 @@ from .transaction_config import TransactionConfig
 from .vectordb_config import VectorDBBackendConfig
 
 logger = get_logger(__name__)
+
+
+class ResourceRetentionSafetyConfig(BaseModel):
+    """Opt-in resource version retention controls."""
+
+    enabled: bool = False
+    max_versions: int = Field(default=5, ge=1)
+    prune_on_import: bool = True
+
+    model_config = {"extra": "forbid"}
+
+
+class DiskPressureSafetyConfig(BaseModel):
+    """Opt-in disk pressure awareness controls."""
+
+    enabled: bool = False
+    check_interval_seconds: int = Field(default=30, gt=0)
+    warning_threshold_percent: float = Field(default=85, ge=0, le=100)
+    critical_threshold_percent: float = Field(default=95, ge=0, le=100)
+    action_on_critical: Literal["warn", "block_writes"] = "block_writes"
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def validate_thresholds(self):
+        if self.critical_threshold_percent < self.warning_threshold_percent:
+            raise ValueError(
+                "critical_threshold_percent must be greater than or equal to "
+                "warning_threshold_percent"
+            )
+        return self
+
+
+class StorageSafetyConfig(BaseModel):
+    """Defense-in-depth storage safety features, disabled by default."""
+
+    resource_retention: ResourceRetentionSafetyConfig = Field(
+        default_factory=ResourceRetentionSafetyConfig
+    )
+    disk_pressure: DiskPressureSafetyConfig = Field(default_factory=DiskPressureSafetyConfig)
+
+    model_config = {"extra": "forbid"}
 
 
 class StorageConfig(BaseModel):
@@ -45,6 +87,10 @@ class StorageConfig(BaseModel):
 
     params: Dict[str, Any] = Field(
         default_factory=dict, description="Additional storage-specific parameters"
+    )
+    safety: StorageSafetyConfig = Field(
+        default_factory=StorageSafetyConfig,
+        description="Opt-in operational safety features",
     )
 
     model_config = {"extra": "forbid"}

--- a/tests/server/test_server_health.py
+++ b/tests/server/test_server_health.py
@@ -80,6 +80,46 @@ async def test_system_status(client: httpx.AsyncClient):
     assert body["result"]["initialized"] is True
 
 
+async def test_system_disk_status_reports_workspace_usage(
+    client: httpx.AsyncClient,
+    tmp_path,
+    monkeypatch,
+):
+    disk_pressure = SimpleNamespace(
+        enabled=False,
+        warning_threshold_percent=85,
+        critical_threshold_percent=95,
+        action_on_critical="block_writes",
+    )
+    fake_config = SimpleNamespace(
+        storage=SimpleNamespace(
+            workspace=str(tmp_path),
+            safety=SimpleNamespace(disk_pressure=disk_pressure),
+        )
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.system.get_openviking_config",
+        lambda: fake_config,
+    )
+    monkeypatch.setattr(
+        "openviking.server.routers.system.shutil.disk_usage",
+        lambda path: SimpleNamespace(total=100, used=90, free=10),
+    )
+
+    resp = await client.get("/api/v1/system/disk")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    result = body["result"]
+    assert result["state"] == "warning"
+    assert result["enabled"] is False
+    assert result["workspace"] == str(tmp_path.resolve())
+    assert result["usage_percent"] == 90.0
+    assert result["free_bytes"] == 10
+    assert result["action_on_critical"] == "block_writes"
+
+
 async def test_backend_sync_status_endpoint(client: httpx.AsyncClient, service):
     calls: list[str] = []
 

--- a/tests/test_task_backend_config.py
+++ b/tests/test_task_backend_config.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import pytest
+
 from openviking.service.task_store import PersistentTaskStore
 from openviking.service.task_tracker import TaskTracker
 from openviking_cli.utils.config import storage_config as storage_config_module
-from openviking_cli.utils.config.storage_config import StorageConfig
+from openviking_cli.utils.config.storage_config import DiskPressureSafetyConfig, StorageConfig
 
 
 class _FakeAgfs:
@@ -48,6 +50,23 @@ def test_storage_config_defaults_skip_process_lock_to_false():
 def test_storage_config_accepts_skip_process_lock():
     config = StorageConfig(skip_process_lock=True)
     assert config.skip_process_lock is True
+
+
+def test_storage_safety_defaults_are_disabled():
+    config = StorageConfig()
+    assert config.safety.resource_retention.enabled is False
+    assert config.safety.disk_pressure.enabled is False
+    assert config.safety.disk_pressure.warning_threshold_percent == 85
+    assert config.safety.disk_pressure.critical_threshold_percent == 95
+    assert config.safety.disk_pressure.action_on_critical == "block_writes"
+
+
+def test_disk_pressure_rejects_critical_below_warning():
+    with pytest.raises(ValueError, match="critical_threshold_percent"):
+        DiskPressureSafetyConfig(
+            warning_threshold_percent=90,
+            critical_threshold_percent=80,
+        )
 
 
 def test_storage_config_builds_persistent_task_tracker():


### PR DESCRIPTION
## Summary
- add disabled-by-default storage.safety config for resource retention and disk pressure settings
- expose /api/v1/system/disk with workspace disk usage, threshold state, and configured critical action
- add config and API coverage for disk safety defaults and endpoint output

Fixes #2816

## Verification
- python3 -m py_compile openviking/server/routers/system.py openviking_cli/utils/config/storage_config.py tests/server/test_server_health.py tests/test_task_backend_config.py
- uvx ruff check openviking/server/routers/system.py openviking_cli/utils/config/storage_config.py tests/server/test_server_health.py tests/test_task_backend_config.py
- uvx ruff format --check openviking/server/routers/system.py openviking_cli/utils/config/storage_config.py tests/server/test_server_health.py tests/test_task_backend_config.py

## Notes
- Targeted pytest was not run because the base Python environment lacks pytest and full uv project sync did not complete in this session.