### PR TITLE
fix(memory): roll up child abstracts during semantic reindex

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -57,6 +57,18 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+_DIRECTORY_ABSTRACT_NOT_READY_SUFFIX = "[Directory abstract is not ready]"
+
+
+def _is_not_ready_directory_abstract(text: str) -> bool:
+    if not text:
+        return True
+    head = text.rstrip()
+    if not head.endswith(_DIRECTORY_ABSTRACT_NOT_READY_SUFFIX):
+        return False
+    head = head[: -len(_DIRECTORY_ABSTRACT_NOT_READY_SUFFIX)].strip()
+    return head.startswith("#") and "\n" not in head
+
 
 @dataclass
 class DiffResult:
@@ -547,16 +559,23 @@ class SemanticProcessor(DequeueHandlerBase):
                 raise RuntimeError(f"Failed to list memory directory {dir_uri}: {e}") from e
 
             file_paths: List[str] = []
+            child_dirs: List[str] = []
             for entry in entries:
                 name = entry.get("name", "")
                 if not name or name.startswith(".") or name in [".", ".."]:
                     continue
-                if not entry.get("isDir", False):
-                    item_uri = VikingURI(dir_uri).join(name).uri
+                item_uri = VikingURI(dir_uri).join(name).uri
+                if entry.get("isDir", False):
+                    child_dirs.append(item_uri)
+                else:
                     file_paths.append(item_uri)
 
-            if not file_paths:
-                logger.info(f"No memory files found in {dir_uri}")
+            children_abstracts = (
+                await self._collect_children_abstracts(child_dirs, ctx=ctx) if child_dirs else []
+            )
+
+            if not file_paths and not children_abstracts:
+                logger.info(f"No memory files or child abstracts found in {dir_uri}")
                 _mark_done()
                 return
 
@@ -654,7 +673,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 if file_path in paths_to_vectorize and summary is not None
             ]
             generated_content = await self._generate_overview(
-                dir_uri, completed_summaries, [], llm_sem=llm_sem
+                dir_uri, completed_summaries, children_abstracts, llm_sem=llm_sem
             )
             overview, abstract = self._normalize_overview_generation(generated_content)
 
@@ -1032,7 +1051,13 @@ class SemanticProcessor(DequeueHandlerBase):
         results = []
 
         for child_uri in children_uris:
-            abstract = await viking_fs.abstract(child_uri, ctx=ctx)
+            try:
+                abstract = await viking_fs.abstract(child_uri, ctx=ctx)
+            except Exception as e:
+                logger.debug(f"Failed to read child abstract for {child_uri}: {e}")
+                continue
+            if _is_not_ready_directory_abstract(abstract):
+                continue
             dir_name = child_uri.split("/")[-1]
             results.append({"name": dir_name, "abstract": abstract})
         return results

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -153,6 +153,21 @@ class _FakeMemoryDirFS:
         ]
 
 
+class _FakeMemoryParentDirFS:
+    async def ls(self, uri, node_limit=None, ctx=None):
+        del uri, node_limit, ctx
+        return [
+            {"name": "2026", "isDir": True},
+            {"name": "empty", "isDir": True},
+        ]
+
+    async def abstract(self, uri, ctx=None):
+        del ctx
+        if uri.endswith("/2026"):
+            return "# 2026\n\nrolled up event summaries"
+        return f"# {uri} [Directory abstract is not ready]"
+
+
 @pytest.mark.asyncio
 async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
     lock_manager = _FakeLockManager()
@@ -249,6 +264,54 @@ async def test_memory_directory_summarizes_all_uncached_files(monkeypatch):
     )
 
     assert [item["name"] for item in summaries] == ["first.md", "second.md"]
+
+
+@pytest.mark.asyncio
+async def test_memory_directory_rolls_up_child_abstracts_without_direct_files(monkeypatch):
+    processor = SemanticProcessor(max_concurrent_llm=4)
+    dir_uri = "viking://user/default/memories/events"
+    captured_children = []
+    captured_directory_vectorize = []
+
+    async def generate_overview(dir_uri, file_summaries, children_abstracts, llm_sem=None):
+        del dir_uri, file_summaries, llm_sem
+        captured_children.extend(children_abstracts)
+        return "overview"
+
+    async def write_semantics(**kwargs):
+        del kwargs
+        return True
+
+    async def vectorize_directory(**kwargs):
+        captured_directory_vectorize.append(kwargs)
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: _FakeMemoryParentDirFS(),
+    )
+    monkeypatch.setattr(processor, "_generate_overview", generate_overview)
+    monkeypatch.setattr(
+        processor,
+        "_normalize_overview_generation",
+        lambda overview: (overview, "abstract"),
+    )
+    monkeypatch.setattr(processor, "_write_memory_directory_semantics", write_semantics)
+    monkeypatch.setattr(processor, "_vectorize_directory", vectorize_directory)
+
+    await processor._process_memory_directory(
+        SemanticMsg(
+            uri=dir_uri,
+            context_type="memory",
+        )
+    )
+
+    assert captured_children == [
+        {"name": "2026", "abstract": "# 2026\n\nrolled up event summaries"}
+    ]
+    assert len(captured_directory_vectorize) == 1
+    assert captured_directory_vectorize[0]["uri"] == dir_uri
+    assert captured_directory_vectorize[0]["abstract"] == "abstract"
+    assert captured_directory_vectorize[0]["overview"] == "overview"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- collect child memory-directory abstracts when a parent directory has no direct memory files
- skip placeholder "directory abstract is not ready" content during rollups
- add coverage for parent memory directories that should vectorize from child abstracts only

Fixes #2797

## Verification
- python3 -m py_compile openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_queue_memory_dedupe.py
- uvx ruff check openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_queue_memory_dedupe.py
- uvx ruff format --check openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_queue_memory_dedupe.py

## Notes
- Targeted pytest was not run because the base Python environment lacks pytest and full uv project sync did not complete in this session.