### PR TITLE
feat(resources): stage async uploads before processing

### DIFF
--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -12,6 +12,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Query
 
 from openviking.server.auth import get_request_context
+from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.service.task_store import SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID
@@ -49,6 +50,26 @@ async def get_task(
             details={"resource": task_id, "type": "task"},
         )
     return Response(status="ok", result=task.to_dict())
+
+
+@router.post("/tasks/{task_id}/trigger")
+async def trigger_task(
+    task_id: str,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Trigger a staged resource ingestion task."""
+    result = await get_service().resources.trigger_staged_resource(task_id, ctx=_ctx)
+    return Response(status="ok", result=result)
+
+
+@router.post("/tasks/{task_id}/cancel")
+async def cancel_task(
+    task_id: str,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Cancel a staged resource ingestion task before processing starts."""
+    result = await get_service().resources.cancel_staged_resource(task_id, ctx=_ctx)
+    return Response(status="ok", result=result)
 
 
 @router.get("/tasks")

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -8,8 +8,10 @@ Provides resource management operations: add_resource, add_skill, wait_processed
 
 import asyncio
 import contextlib
+import hashlib
 import inspect
 import json
+import shutil
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -24,7 +26,7 @@ from openviking.resource.feishu_watch_auth import (
     create_feishu_auth_state,
     load_feishu_app_credentials,
 )
-from openviking.server.identity import RequestContext
+from openviking.server.identity import RequestContext, Role
 from openviking.server.local_input_guard import (
     is_remote_resource_source,
     require_remote_resource_source,
@@ -56,6 +58,7 @@ from openviking_cli.exceptions import (
     DeadlineExceededError,
     InvalidArgumentError,
     NotInitializedError,
+    OpenVikingError,
 )
 from openviking_cli.utils import get_logger
 
@@ -113,6 +116,16 @@ class _NormalizedAddResourceArgs:
     watch_auth_state: Optional[Dict[str, Any]] = None
 
 
+@dataclass
+class _StagedAddResourceTask:
+    ctx: RequestContext
+    add_kwargs: Dict[str, Any]
+    resource_lock: LockLease
+    cleanup_paths: List[str]
+    trigger_task: Optional[asyncio.Task[Any]] = None
+    started: bool = False
+
+
 class ResourceService:
     """Resource management service."""
 
@@ -132,6 +145,8 @@ class ResourceService:
         self._watch_scheduler = watch_scheduler
         self._resource_memory_link_service = resource_memory_link_service
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._staged_add_resource_tasks: Dict[str, _StagedAddResourceTask] = {}
+        self._staged_task_lock = asyncio.Lock()
 
     def set_dependencies(
         self,
@@ -230,12 +245,16 @@ class ResourceService:
                 except ConflictError:
                     raise
                 except Exception as e:
-                    logger.warning(f"[ResourceService] Failed to create watch task for {watch_to}: {e}")
+                    logger.warning(
+                        f"[ResourceService] Failed to create watch task for {watch_to}: {e}"
+                    )
             elif target.to:
                 try:
                     await self._handle_watch_task_cancellation(to_uri=target.to, ctx=ctx)
                 except Exception as e:
-                    logger.warning(f"[ResourceService] Failed to cancel watch task for {target.to}: {e}")
+                    logger.warning(
+                        f"[ResourceService] Failed to cancel watch task for {target.to}: {e}"
+                    )
 
     def _normalize_add_resource_args(
         self,
@@ -305,13 +324,396 @@ class ResourceService:
 
     async def close_background_tasks(self) -> None:
         """Cancel in-flight background resource ingestion tasks during service shutdown."""
-        if not self._background_tasks:
-            return
-        tasks = list(self._background_tasks)
+        if self._background_tasks:
+            tasks = list(self._background_tasks)
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._background_tasks.clear()
+
+        staged_tasks = list(self._staged_add_resource_tasks.values())
+        self._staged_add_resource_tasks.clear()
+        for staged in staged_tasks:
+            if staged.trigger_task is not None:
+                staged.trigger_task.cancel()
+            await staged.resource_lock.close()
+            self._cleanup_staged_paths(staged.cleanup_paths)
+
+    def _resource_staging_delay_seconds(self) -> float:
+        try:
+            from openviking_cli.utils.config.open_viking_config import get_openviking_config
+
+            pipeline = getattr(get_openviking_config(), "pipeline", None)
+            return float(getattr(pipeline, "auto_trigger_seconds", 0) or 0)
+        except FileNotFoundError:
+            return 0.0
+        except Exception as exc:
+            logger.debug("[ResourceService] Resource staging config unavailable: %s", exc)
+            return 0.0
+
+    @staticmethod
+    def _hash_file(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _resource_source_fingerprint(
+        self,
+        *,
+        path: str,
+        target: ContentTargetSpec,
+        source_name: Optional[str],
+        allow_local_path_resolution: bool,
+    ) -> str:
+        source_path = Path(path)
+        if allow_local_path_resolution and source_path.is_file():
+            stat = source_path.stat()
+            source: Dict[str, Any] = {
+                "kind": "file",
+                "name": source_name or source_path.name,
+                "size": stat.st_size,
+                "sha256": self._hash_file(source_path),
+            }
+        else:
+            source = {
+                "kind": "source",
+                "path": str(path).strip(),
+                "name": source_name or "",
+            }
+
+        payload = {
+            "scope": "resources",
+            "source": source,
+            "to": target.to or "",
+            "parent": target.parent or "",
+            "create_parent": bool(target.create_parent),
+        }
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _copy_local_source_for_staging(
+        *,
+        path: str,
+        task_id: str,
+        allow_local_path_resolution: bool,
+    ) -> tuple[str, List[str]]:
+        source_path = Path(path)
+        if not allow_local_path_resolution or not source_path.is_file():
+            return path, []
+
+        from openviking_cli.utils.config.open_viking_config import get_openviking_config
+
+        staged_dir = get_openviking_config().storage.get_upload_temp_dir() / "staged_resources"
+        staged_dir.mkdir(parents=True, exist_ok=True)
+        suffix = source_path.suffix or ".tmp"
+        staged_path = staged_dir / f"{task_id}{suffix}"
+        shutil.copy2(source_path, staged_path)
+        return str(staged_path), [str(staged_path)]
+
+    @staticmethod
+    def _cleanup_staged_paths(paths: List[str]) -> None:
+        for path in paths:
+            with contextlib.suppress(FileNotFoundError):
+                Path(path).unlink()
+
+    async def _active_resource_task_for_fingerprint(
+        self,
+        *,
+        fingerprint: str,
+        ctx: RequestContext,
+    ) -> Optional[Dict[str, Any]]:
+        from openviking.service.task_tracker import TaskStatus, get_task_tracker
+
+        task_tracker = get_task_tracker()
+        tasks = await task_tracker.list_tasks(
+            task_type="add_resource",
+            limit=200,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
+        )
         for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        self._background_tasks.clear()
+            if task.status not in (TaskStatus.PENDING, TaskStatus.RUNNING):
+                continue
+            result = task.result if isinstance(task.result, dict) else {}
+            if result.get("source_fingerprint") != fingerprint:
+                continue
+            return {
+                "status": "success",
+                "root_uri": result.get("root_uri") or task.resource_id,
+                "task_id": task.task_id,
+                "stage": task.stage,
+                "staged": task.stage == "staged",
+                "idempotent": True,
+            }
+        return None
+
+    async def _stage_add_resource_if_configured(
+        self,
+        *,
+        path: str,
+        ctx: RequestContext,
+        target: ContentTargetSpec,
+        reason: str,
+        instruction: str,
+        timeout: Optional[float],
+        build_index: bool,
+        summarize: bool,
+        watch_interval: float,
+        skip_watch_management: bool,
+        allow_local_path_resolution: bool,
+        enforce_public_remote_targets: bool,
+        wait: bool,
+        resource_lock: Optional[LockLease],
+        kwargs: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        delay = self._resource_staging_delay_seconds()
+        if wait or resource_lock is not None or delay <= 0:
+            return None
+
+        async with self._staged_task_lock:
+            if enforce_public_remote_targets and is_remote_resource_source(path):
+                path = require_remote_resource_source(path)
+                kwargs.setdefault("request_validator", ensure_public_remote_target)
+
+            source_name = kwargs.get("source_name")
+            fingerprint = self._resource_source_fingerprint(
+                path=path,
+                target=target,
+                source_name=source_name,
+                allow_local_path_resolution=allow_local_path_resolution,
+            )
+            existing = await self._active_resource_task_for_fingerprint(
+                fingerprint=fingerprint,
+                ctx=ctx,
+            )
+            if existing is not None:
+                return existing
+
+            if is_git_repo_url(path):
+                source_info = await self._preflight_git_source(path)
+                source_name = source_name or source_info.source_name
+                if source_name:
+                    kwargs["source_name"] = source_name
+            else:
+                source_info = _ResourceSourceInfo(
+                    source_name=source_name,
+                    source_path=path,
+                    source_format="file" if allow_local_path_resolution else None,
+                )
+
+            from openviking.service.task_tracker import get_task_tracker
+
+            task_tracker = get_task_tracker()
+            resource_lock_to_stage: LockLease = NO_LOCK
+            task = None
+            cleanup_paths: List[str] = []
+            try:
+                root_uri, resource_lock_to_stage = await self._plan_resource_target(
+                    path=path,
+                    ctx=ctx,
+                    target=target,
+                    source_name=source_name,
+                    source_info=source_info,
+                )
+                task = await task_tracker.create(
+                    "add_resource",
+                    resource_id=root_uri,
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
+                )
+                staged_path, cleanup_paths = self._copy_local_source_for_staging(
+                    path=path,
+                    task_id=task.task_id,
+                    allow_local_path_resolution=allow_local_path_resolution,
+                )
+                add_kwargs = dict(
+                    kwargs,
+                    path=staged_path,
+                    ctx=ctx,
+                    to=root_uri,
+                    parent=None,
+                    reason=reason,
+                    instruction=instruction,
+                    timeout=timeout,
+                    build_index=build_index,
+                    summarize=summarize,
+                    watch_interval=watch_interval,
+                    skip_watch_management=skip_watch_management,
+                    allow_local_path_resolution=bool(cleanup_paths) or allow_local_path_resolution,
+                    enforce_public_remote_targets=enforce_public_remote_targets,
+                )
+                staged_until = time.time() + delay
+                result = {
+                    "root_uri": root_uri,
+                    "source_fingerprint": fingerprint,
+                    "auto_trigger_seconds": delay,
+                    "staged_until": staged_until,
+                }
+                await task_tracker.update_stage(
+                    task.task_id,
+                    "staged",
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
+                )
+                await task_tracker.update_result(
+                    task.task_id,
+                    result,
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
+                )
+
+                staged = _StagedAddResourceTask(
+                    ctx=ctx,
+                    add_kwargs=add_kwargs,
+                    resource_lock=resource_lock_to_stage,
+                    cleanup_paths=cleanup_paths,
+                )
+                staged.trigger_task = asyncio.create_task(
+                    self._auto_trigger_staged_resource(task.task_id, delay)
+                )
+                self._background_tasks.add(staged.trigger_task)
+                staged.trigger_task.add_done_callback(self._background_tasks.discard)
+                self._staged_add_resource_tasks[task.task_id] = staged
+                resource_lock_to_stage = NO_LOCK
+                cleanup_paths = []
+                return {
+                    "status": "success",
+                    "root_uri": root_uri,
+                    "task_id": task.task_id,
+                    "stage": "staged",
+                    "staged": True,
+                    "auto_trigger_seconds": delay,
+                    "staged_until": staged_until,
+                }
+            except Exception as exc:
+                self._cleanup_staged_paths(cleanup_paths)
+                await resource_lock_to_stage.close()
+                if task is not None:
+                    with contextlib.suppress(Exception):
+                        await task_tracker.fail(
+                            task.task_id,
+                            str(exc),
+                            account_id=ctx.account_id,
+                            user_id=ctx.user.user_id,
+                        )
+                raise
+
+    async def _auto_trigger_staged_resource(self, task_id: str, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+            staged = self._staged_add_resource_tasks.get(task_id)
+            if staged is None:
+                return
+            await self.trigger_staged_resource(task_id, ctx=staged.ctx)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[ResourceService] Failed to auto-trigger staged resource %s: %s", task_id, exc
+            )
+
+    @staticmethod
+    def _can_control_staged_task(ctx: RequestContext, owner_ctx: RequestContext) -> bool:
+        if ctx.role == Role.ROOT:
+            return True
+        return ctx.account_id == owner_ctx.account_id and ctx.user.user_id == owner_ctx.user.user_id
+
+    async def trigger_staged_resource(
+        self,
+        task_id: str,
+        *,
+        ctx: RequestContext,
+    ) -> Dict[str, Any]:
+        """Start a staged add_resource task."""
+        async with self._staged_task_lock:
+            staged = self._staged_add_resource_tasks.get(task_id)
+            if staged is None:
+                raise OpenVikingError(
+                    "Staged resource task is not available",
+                    code="NOT_FOUND",
+                    details={"resource": task_id, "type": "task"},
+                )
+            if not self._can_control_staged_task(ctx, staged.ctx):
+                raise OpenVikingError("Permission denied", code="PERMISSION_DENIED")
+            if staged.started:
+                return {
+                    "status": "success",
+                    "task_id": task_id,
+                    "root_uri": staged.add_kwargs.get("to"),
+                    "stage": "processing",
+                }
+
+            staged.started = True
+            self._staged_add_resource_tasks.pop(task_id, None)
+            current_task = asyncio.current_task()
+            if staged.trigger_task is not None and staged.trigger_task is not current_task:
+                staged.trigger_task.cancel()
+
+            background = asyncio.create_task(
+                self._run_add_resource_task(
+                    task_id,
+                    ctx=staged.ctx,
+                    add_kwargs=staged.add_kwargs,
+                    resource_lock=staged.resource_lock,
+                    cleanup_paths=staged.cleanup_paths,
+                )
+            )
+            self._background_tasks.add(background)
+            background.add_done_callback(self._background_tasks.discard)
+            return {
+                "status": "success",
+                "task_id": task_id,
+                "root_uri": staged.add_kwargs.get("to"),
+                "stage": "processing",
+            }
+
+    async def cancel_staged_resource(
+        self,
+        task_id: str,
+        *,
+        ctx: RequestContext,
+    ) -> Dict[str, Any]:
+        """Cancel a staged add_resource task before processing starts."""
+        from openviking.service.task_tracker import get_task_tracker
+
+        async with self._staged_task_lock:
+            staged = self._staged_add_resource_tasks.get(task_id)
+            if staged is None:
+                raise OpenVikingError(
+                    "Staged resource task is not available",
+                    code="NOT_FOUND",
+                    details={"resource": task_id, "type": "task"},
+                )
+            if not self._can_control_staged_task(ctx, staged.ctx):
+                raise OpenVikingError("Permission denied", code="PERMISSION_DENIED")
+            if staged.started:
+                raise OpenVikingError(
+                    "Task is already processing and cannot be cancelled from staging",
+                    code="FAILED_PRECONDITION",
+                    details={"resource": task_id, "type": "task"},
+                )
+
+            self._staged_add_resource_tasks.pop(task_id, None)
+            if staged.trigger_task is not None:
+                staged.trigger_task.cancel()
+            await staged.resource_lock.close()
+            self._cleanup_staged_paths(staged.cleanup_paths)
+
+        task_tracker = get_task_tracker()
+        await task_tracker.fail(
+            task_id,
+            "staged resource cancelled",
+            account_id=staged.ctx.account_id,
+            user_id=staged.ctx.user.user_id,
+        )
+        return {
+            "status": "success",
+            "task_id": task_id,
+            "stage": "cancelled",
+        }
 
     async def enqueue_git_add_resource(
         self,
@@ -421,6 +823,7 @@ class ResourceService:
         ctx: RequestContext,
         add_kwargs: Dict[str, Any],
         resource_lock: LockLease,
+        cleanup_paths: Optional[List[str]] = None,
     ) -> None:
         from openviking.service.task_tracker import get_task_tracker
 
@@ -439,7 +842,7 @@ class ResourceService:
                 task_id,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
-                stage="queued",
+                stage="processing",
             )
             result = await self.add_resource(
                 wait=True,
@@ -488,6 +891,8 @@ class ResourceService:
             )
         finally:
             await resource_lock.close()
+            if cleanup_paths:
+                self._cleanup_staged_paths(cleanup_paths)
 
     async def _plan_resource_target(
         self,
@@ -654,6 +1059,34 @@ class ResourceService:
             if default_parent:
                 parent = default_parent
                 kwargs["create_parent"] = True
+
+        target = ContentTargetSpec.from_fields(
+            ctx=ctx,
+            kind="resource",
+            to=to,
+            parent=parent,
+            create_parent=bool(kwargs.get("create_parent", False)),
+        )
+        staged_result = await self._stage_add_resource_if_configured(
+            path=path,
+            ctx=ctx,
+            target=target,
+            reason=reason,
+            instruction=instruction,
+            timeout=timeout,
+            build_index=build_index,
+            summarize=summarize,
+            watch_interval=watch_interval,
+            skip_watch_management=skip_watch_management,
+            allow_local_path_resolution=allow_local_path_resolution,
+            enforce_public_remote_targets=enforce_public_remote_targets,
+            wait=wait,
+            resource_lock=resource_lock,
+            kwargs=kwargs,
+        )
+        if staged_result is not None:
+            return staged_result
+
         if not wait and is_git_repo_url(path):
             return await self.enqueue_git_add_resource(
                 path=path,
@@ -688,13 +1121,6 @@ class ResourceService:
         telemetry.set("resource.flags.watch_enabled", watch_enabled)
 
         try:
-            target = ContentTargetSpec.from_fields(
-                ctx=ctx,
-                kind="resource",
-                to=to,
-                parent=parent,
-                create_parent=bool(kwargs.get("create_parent", False)),
-            )
             if enforce_public_remote_targets and is_remote_resource_source(path):
                 path = require_remote_resource_source(path)
                 kwargs.setdefault("request_validator", ensure_public_remote_target)
@@ -722,7 +1148,10 @@ class ResourceService:
                 )
                 doc_name = self._target_doc_name(path, source_name, source_info)
                 source_path = source_info.source_path or source_name or path
-                root_uri, candidate_uri = await self._resource_processor.tree_builder.resolve_target_uri(
+                (
+                    root_uri,
+                    candidate_uri,
+                ) = await self._resource_processor.tree_builder.resolve_target_uri(
                     ctx=ctx,
                     doc_name=doc_name,
                     scope="resources",
@@ -743,7 +1172,9 @@ class ResourceService:
                 async def _reserve_tree(uri: str) -> LockLease:
                     dst_path = self._viking_fs._uri_to_path(uri, ctx=ctx)
                     try:
-                        return await OwnedLockLease.acquire_tree(lock_manager, dst_path, timeout=0.0)
+                        return await OwnedLockLease.acquire_tree(
+                            lock_manager, dst_path, timeout=0.0
+                        )
                     except LockAcquisitionError as exc:
                         raise ResourceBusyError(
                             f"Resource is busy: {uri}",
@@ -756,7 +1187,9 @@ class ResourceService:
                     max_attempts = 100
                     reserved = False
                     for attempt in range(max_attempts + 1):
-                        attempt_uri = candidate_uri if attempt == 0 else f"{candidate_uri}_{attempt}"
+                        attempt_uri = (
+                            candidate_uri if attempt == 0 else f"{candidate_uri}_{attempt}"
+                        )
                         if await self._viking_fs.exists(attempt_uri, ctx=ctx):
                             continue
                         try:

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -352,6 +352,23 @@ class TaskTracker:
                 with self._lock:
                     self._tasks[task.task_id] = task
 
+    async def update_result(
+        self,
+        task_id: str,
+        result: Optional[Dict[str, Any]],
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> None:
+        """Update task result metadata without changing lifecycle status."""
+        async with self._async_lock:
+            task = await self._load_for_update(task_id, account_id, user_id)
+            if task:
+                task.result = result
+                task.updated_at = time.time()
+                await self._store.update(task)
+                with self._lock:
+                    self._tasks[task.task_id] = task
+
     async def complete(
         self,
         task_id: str,

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -102,6 +102,21 @@ class ParserApiConfig(BaseModel):
         return self
 
 
+class PipelineConfig(BaseModel):
+    """Controls for upload-to-processing pipeline behavior."""
+
+    auto_trigger_seconds: float = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Delay resource processing after upload. 0 preserves the legacy "
+            "immediate pipeline; values > 0 stage uploads and trigger later."
+        ),
+    )
+
+    model_config = {"extra": "forbid"}
+
+
 class OpenVikingConfig(BaseModel):
     """Main configuration for OpenViking."""
 
@@ -200,6 +215,11 @@ class OpenVikingConfig(BaseModel):
     parser_api: ParserApiConfig = Field(
         default_factory=ParserApiConfig,
         description="Third-party parser API configuration (files/responses)",
+    )
+
+    pipeline: PipelineConfig = Field(
+        default_factory=PipelineConfig,
+        description="Resource ingestion pipeline controls",
     )
 
     auto_generate_l0: bool = Field(

--- a/tests/server/test_resource_staging.py
+++ b/tests/server/test_resource_staging.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for staged resource ingestion."""
+
+import asyncio
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _stage_upload(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+) -> dict:
+    resp = await client.post(
+        "/api/v1/resources",
+        json={
+            "temp_file_id": sample_markdown_file.name,
+            "reason": "stage before processing",
+            "wait": False,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["result"]
+
+
+async def test_add_resource_stages_and_dedupes_same_upload(
+    client: httpx.AsyncClient,
+    service,
+    sample_markdown_file,
+    upload_temp_dir,
+    monkeypatch,
+):
+    monkeypatch.setattr(service.resources, "_resource_staging_delay_seconds", lambda: 3600.0)
+
+    first = await _stage_upload(client, sample_markdown_file)
+    second = await _stage_upload(client, sample_markdown_file)
+
+    assert first["staged"] is True
+    assert first["stage"] == "staged"
+    assert second["idempotent"] is True
+    assert second["task_id"] == first["task_id"]
+    assert second["root_uri"] == first["root_uri"]
+
+    task_resp = await client.get(f"/api/v1/tasks/{first['task_id']}")
+    assert task_resp.status_code == 200, task_resp.text
+    task = task_resp.json()["result"]
+    assert task["status"] == "pending"
+    assert task["stage"] == "staged"
+    assert task["result"]["root_uri"] == first["root_uri"]
+
+
+async def test_trigger_staged_resource_starts_task(
+    client: httpx.AsyncClient,
+    service,
+    sample_markdown_file,
+    upload_temp_dir,
+    monkeypatch,
+):
+    monkeypatch.setattr(service.resources, "_resource_staging_delay_seconds", lambda: 3600.0)
+    staged = await _stage_upload(client, sample_markdown_file)
+
+    async def fake_run_add_resource_task(
+        task_id,
+        *,
+        ctx,
+        add_kwargs,
+        resource_lock,
+        cleanup_paths=None,
+    ):
+        from openviking.service.task_tracker import get_task_tracker
+
+        tracker = get_task_tracker()
+        await tracker.start(
+            task_id,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
+            stage="processing",
+        )
+        await tracker.complete(
+            task_id,
+            {"root_uri": add_kwargs["to"]},
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
+        )
+        await resource_lock.close()
+        service.resources._cleanup_staged_paths(cleanup_paths or [])
+
+    monkeypatch.setattr(
+        service.resources,
+        "_run_add_resource_task",
+        fake_run_add_resource_task,
+    )
+
+    trigger_resp = await client.post(f"/api/v1/tasks/{staged['task_id']}/trigger")
+    assert trigger_resp.status_code == 200, trigger_resp.text
+    assert trigger_resp.json()["result"]["stage"] == "processing"
+
+    await asyncio.sleep(0)
+
+    task_resp = await client.get(f"/api/v1/tasks/{staged['task_id']}")
+    task = task_resp.json()["result"]
+    assert task["status"] == "completed"
+    assert task["result"]["root_uri"] == staged["root_uri"]

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -236,6 +236,21 @@ def test_openviking_config_retrieval_hotness_alpha_defaults_to_zero(monkeypatch)
     OpenVikingConfigSingleton.reset_instance()
 
 
+def test_openviking_config_preserves_pipeline_auto_trigger_seconds(monkeypatch):
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, "/tmp/codex-no-config.json")
+
+    from openviking_cli.utils.config.open_viking_config import (
+        OpenVikingConfig,
+        OpenVikingConfigSingleton,
+    )
+
+    config = OpenVikingConfig.from_dict({"pipeline": {"auto_trigger_seconds": 30}})
+
+    assert config.pipeline.auto_trigger_seconds == 30
+
+    OpenVikingConfigSingleton.reset_instance()
+
+
 def test_openviking_config_transaction_redo_recovery_enabled_can_be_disabled(monkeypatch):
     monkeypatch.setenv(OPENVIKING_CONFIG_ENV, "/tmp/codex-no-config.json")
 

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -141,6 +141,26 @@ async def test_update_stage(tracker: TaskTracker):
     assert retrieved.stage == "parsing"
 
 
+async def test_update_result_preserves_task_status(tracker: TaskTracker):
+    task = await tracker.create(
+        "add_resource", resource_id="viking://resources/a", **_owner_kwargs()
+    )
+
+    await tracker.update_result(
+        task.task_id,
+        {"root_uri": "viking://resources/a", "source_fingerprint": "abc"},
+        **_owner_kwargs(),
+    )
+
+    retrieved = await tracker.get(task.task_id, **_owner_kwargs())
+    assert retrieved is not None
+    assert retrieved.status == TaskStatus.PENDING
+    assert retrieved.result == {
+        "root_uri": "viking://resources/a",
+        "source_fingerprint": "abc",
+    }
+
+
 async def test_complete_task(tracker: TaskTracker):
     task = await tracker.create("session_commit", resource_id="s1", **_owner_kwargs())
     await tracker.start(task.task_id)


### PR DESCRIPTION
## Summary
- add pipeline.auto_trigger_seconds, defaulting to 0 to preserve immediate processing
- stage non-wait resource uploads when configured, return queryable task metadata, and dedupe identical active uploads by source/scope
- add task trigger/cancel endpoints and reuse the existing background add_resource worker once processing starts

Fixes #2560

## Verification
- python3 -m py_compile openviking/server/routers/tasks.py openviking/service/resource_service.py openviking/service/task_tracker.py openviking_cli/utils/config/open_viking_config.py tests/server/test_resource_staging.py tests/test_config_loader.py tests/test_task_tracker.py
- uvx ruff check openviking/server/routers/tasks.py openviking/service/resource_service.py openviking/service/task_tracker.py openviking_cli/utils/config/open_viking_config.py tests/server/test_resource_staging.py tests/test_config_loader.py tests/test_task_tracker.py
- uvx ruff format --check openviking/server/routers/tasks.py openviking/service/resource_service.py openviking/service/task_tracker.py openviking_cli/utils/config/open_viking_config.py tests/server/test_resource_staging.py tests/test_config_loader.py tests/test_task_tracker.py

## Notes
- Targeted pytest was not run because the base Python environment lacks pytest and full uv project sync did not complete in this session.
- This PR implements the backend staging/idempotency/trigger core; UI batch management and token estimation remain larger follow-up surfaces.