### PR TITLE
fix(storage): set recursive=False in delete refresh to prevent cascade

### DIFF
--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -328,6 +328,7 @@ class FSService:
         msg = SemanticMsg(
             uri=root_uri,
             context_type=context_type,
+            recursive=False,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
             peer_id=ctx.user.user_id,


### PR DESCRIPTION
When deleting a resource folder, _enqueue_delete_refresh created a SemanticMsg with recursive=True (the default), causing the entire resource tree to be re-processed including all unrelated sibling folders. This resulted in thousands of unnecessary embedding tasks.

Setting recursive=False ensures only the parent directory overview is updated using existing child abstracts, without re-processing siblings.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

 Fixes #2959

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
