### PR TITLE
fix: 修复 git 多版本管理接口遇到的路径问题

### DIFF
--- a/crates/ragfs/src/git/service.rs
+++ b/crates/ragfs/src/git/service.rs
@@ -21,6 +21,7 @@ use tracing::warn;
 
 use crate::core::filesystem::FileSystem;
 use crate::core::types::FileInfo;
+use crate::core::{FsContextInner, FS_CTX};
 use crate::git::{
     error::{GitError, ObjectStoreError, RefStoreError},
     index_store::{CommitIndex, IndexStore},
@@ -122,6 +123,18 @@ impl GitService {
     /// error silently falls back to the slow path; a stale or corrupt
     /// index can never produce an incorrect commit.
     pub async fn commit(&self, req: CommitRequest) -> Result<CommitResponse, GitError> {
+        validate_account_id(&req.account)?;
+        if let Some(paths) = &req.paths {
+            for path in paths {
+                validate_relative_path(path)?;
+            }
+        }
+
+        let ctx = Arc::new(FsContextInner::new(req.account.clone()));
+        FS_CTX.scope(ctx, self.commit_impl(req)).await
+    }
+
+    async fn commit_impl(&self, req: CommitRequest) -> Result<CommitResponse, GitError> {
         let CommitRequest {
             account,
             branch,
@@ -130,12 +143,6 @@ impl GitService {
             author_name,
             author_email,
         } = req;
-        validate_account_id(&account)?;
-        if let Some(ps) = &paths {
-            for p in ps {
-                validate_relative_path(p)?;
-            }
-        }
         let ref_name = format!("refs/heads/{branch}");
 
         // 1. Resolve current HEAD (may not exist → root commit).
@@ -677,6 +684,16 @@ impl GitService {
     /// - `GitError::ConcurrentCommit` — branch ref changed between our read
     ///   and the CAS swap.
     pub async fn restore(&self, req: RestoreRequest) -> Result<RestoreResponse, GitError> {
+        validate_account_id(&req.account)?;
+        if let Some(project_dir) = &req.project_dir {
+            validate_project_dir(project_dir)?;
+        }
+
+        let ctx = Arc::new(FsContextInner::new(req.account.clone()));
+        FS_CTX.scope(ctx, self.restore_impl(req)).await
+    }
+
+    async fn restore_impl(&self, req: RestoreRequest) -> Result<RestoreResponse, GitError> {
         let RestoreRequest {
             account,
             branch,
@@ -687,12 +704,6 @@ impl GitService {
             author_name: _,
             author_email: _,
         } = &req;
-
-        validate_account_id(account)?;
-
-        if let Some(project_dir) = project_dir {
-            validate_project_dir(project_dir)?;
-        }
         let ref_name = format!("refs/heads/{branch}");
 
         // 1. Resolve both commits.
@@ -5421,6 +5432,75 @@ mod fast_path1_tests {
         assert!(
             loaded.entries.contains_key("other/c.md"),
             "files outside the partial scope must be preserved verbatim"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_directory_path_sets_fs_context_for_mountable_multiwrite() {
+        use crate::core::builder::{build_default_stack, RagfsConfig};
+        use crate::core::{BackendItemConfig, BackendsConfig, ConfigValue, PluginConfig};
+
+        let store_dir = tempfile::tempdir().unwrap();
+        let primary_dir = tempfile::tempdir().unwrap();
+        let backup_dir = tempfile::tempdir().unwrap();
+
+        std::fs::create_dir_all(primary_dir.path().join("acct").join("docs")).unwrap();
+        std::fs::write(
+            primary_dir.path().join("acct").join("docs").join("a.md"),
+            b"AA",
+        )
+        .unwrap();
+
+        let stack = build_default_stack(RagfsConfig::default()).await;
+        let mut params = HashMap::new();
+        params.insert(
+            "local_dir".to_string(),
+            ConfigValue::String(primary_dir.path().to_str().unwrap().to_string()),
+        );
+        stack
+            .mountable
+            .mount(PluginConfig {
+                name: "localfs".to_string(),
+                mount_path: "/local".to_string(),
+                params,
+                backups: Some(BackendsConfig {
+                    sync_type: "async".to_string(),
+                    write_ack_count: None,
+                    write_ack_timeout_ms: None,
+                    write_concurrency: None,
+                    retry_interval_ms: None,
+                    retry_backoff_base_ms: None,
+                    retry_max_retries_per_round: None,
+                    retry_quarantine_after_failures: None,
+                    read_probe_cache_ttl_ms: None,
+                    items: vec![BackendItemConfig {
+                        name: "backup1".to_string(),
+                        backend: "localfs".to_string(),
+                        params: serde_json::json!({
+                            "local_dir": backup_dir.path().to_str().unwrap(),
+                        }),
+                        timeout: None,
+                        encryption: None,
+                        operations: None,
+                        excludes: None,
+                    }],
+                }),
+                ..PluginConfig::default()
+            })
+            .await
+            .unwrap();
+
+        let object_store = Arc::new(LocalObjectStore::new(store_dir.path()));
+        let ref_store = Arc::new(LocalRefStore::new(store_dir.path()));
+        let svc = GitService::new(stack.top.clone(), object_store, ref_store);
+
+        let resp = svc
+            .commit(req("acct", "main", Some(vec!["docs".into()])))
+            .await
+            .expect("commit should provide FS_CTX to mountable multi-write VFS");
+        assert!(
+            matches!(resp, CommitResponse::Created { changed: 1, .. }),
+            "directory commit should succeed through mountable multi-write stack"
         );
     }
 }


### PR DESCRIPTION
## Description

Fix an internal `FsContext` propagation bug in `GitService` so directory-based `commit(paths=...)` works correctly when the VFS is mounted under `/local` and wrapped by multi-write/backups.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) 
- [ ] New feature (non-breaking change that adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 
- [ ] Documentation update 
- [ ] Refactoring (no functional changes) 
- [ ] Performance improvement 
- [x] Test update 

## Changes Made

- Wrap `GitService::commit()` in an account-scoped `FS_CTX.scope(...)` so VFS operations resolve the correct tenant context under mountable multi-write backends.
- Apply the same `FS_CTX` scoping fix to `GitService::restore()` to keep VFS access consistent across git workflows.
- Add a regression test covering `MountableFS + /local + backups + localfs`, verifying directory commit no longer fails with `cannot resolve FsContext from path`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works 
- [x] New and existing unit tests pass locally with my changes 
- [x] I have tested this on the following platforms: 
  - [ ] Linux 
  - [x] macOS 
  - [ ] Windows 

Local test commands:
- `cargo test -p ragfs commit_directory_path_sets_fs_context_for_mountable_multiwrite -- --nocapture`
- `cargo test -p ragfs partial_commit_with_directory_path_purges_index_by_prefix -- --nocapture`
- `cargo test -p ragfs test_restore_does_not_touch_paths_outside_project_dir -- --nocapture`

## Checklist

- [x] My code follows the project's coding style 
- [x] I have performed a self-review of my code 
- [ ] I have commented my code, particularly in hard-to-understand areas 
- [ ] I have made corresponding changes to the documentation 
- [ ] My changes generate no new warnings 
- [ ] Any dependent changes have been merged and published 

## Screenshots (if applicable)

N/A

## Additional Notes

The failure being fixed was triggered when `commit(paths=...)` passed a directory path through `GitService` into a mountable multi-write VFS without a scoped `FS_CTX`. In that case, downstream context resolution could fall back to mount-relative paths like `/default/...` and fail with `cannot resolve FsContext from path`.