### PR TITLE
feat: Add Plan-and-Execute task planning layer to AgentLoop

### DIFF
--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -118,7 +118,8 @@ class AgentLoop:
             ...     max_iterations=30,
             ... )
         """
-        from vikingbot.config.schema import ExecToolConfig  # noqa: F811
+        # 在这里导入 ExecToolConfig 以避免 F811 警告
+        from vikingbot.config.schema import ExecToolConfig
 
         self.bus = bus
         self.provider = provider
@@ -659,34 +660,49 @@ class AgentLoop:
         openviking_connection: dict[str, Any] | None = None,
     ) -> tuple[str | None, str | None, list[dict], dict[str, int], int]:
         """
-        Run the core agent loop: call LLM, execute tools, repeat until done.
+        运行核心代理循环：调用LLM，执行工具，重复直到完成。
+        
+        此函数实现了智能体的核心工作流程，包括：
+        1. 与语言模型对话获取响应
+        2. 处理工具调用（如果存在）
+        3. 并行执行多个工具
+        4. 收集结果并决定是否继续迭代
+        5. 最终返回处理结果
 
         Args:
-            messages: Initial message list
-            session_key: Session key for tool execution context
-            publish_events: Whether to publish ITERATION/REASONING/TOOL_CALL events to the bus
-            ov_tools_enable: Whether to enable OpenViking tools for this session
-            memory_peer_ids: List of peer IDs for memory retrieval
-            memory_owner_user_ids: List of explicit OpenViking user IDs for
-                trusted-mode owner-user memory lookup
-            disabled_tools: Tool names to hide from the model for this request
-            openviking_connection: Request-scoped OpenViking identity for tools
+            messages: 初始消息列表，用于构建对话上下文
+            session_key: 工具执行上下文的会话键
+            publish_events: 是否将迭代/推理/工具调用事件发布到总线
+            sender_id: 发送者ID，可选
+            ov_tools_enable: 是否为此会话启用OpenViking工具
+            memory_peer_ids: 用于内存检索的对等ID列表
+            memory_owner_user_ids: 用于可信模式所有者用户内存查找的显式OpenViking用户ID列表
+            disabled_tools: 在此请求中对模型隐藏的工具名称
+            openviking_connection: 工具的请求范围OpenViking身份
 
         Returns:
-            tuple of (final_content, final_reasoning_content, tools_used, token_usage, iteration)
+            包含以下元素的元组:
+            - final_content: 最终内容（字符串或None）
+            - final_reasoning_content: 最终推理内容（字符串或None）
+            - tools_used: 使用的工具列表，每个元素包含工具使用详情
+            - token_usage: 令牌使用统计字典，包含提示、补全和总计令牌数
+            - iteration: 实际迭代次数
         """
+        # 初始化变量以跟踪迭代过程中的状态
         iteration = 0
         final_content = None
         final_reasoning_content = None
         tools_used: list[dict] = []
         token_usage = {
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
-            "total_tokens": 0,
+            "prompt_tokens": 0,        # 输入消耗tokens
+            "completion_tokens": 0,    # 输出消耗tokens
+            "total_tokens": 0,         # 总消耗tokens
         }
+        # 标记是否已注入经验记忆
         write_exp_injected = False
 
         def accumulate_token_usage(response: Any) -> None:
+            """累加响应中的令牌使用量到总使用量统计中"""
             if not response.usage:
                 return
             cur_token = response.usage
@@ -694,9 +710,11 @@ class AgentLoop:
             token_usage["completion_tokens"] += cur_token.get("completion_tokens", 0)
             token_usage["total_tokens"] += cur_token.get("total_tokens", 0)
 
+        # 主循环：运行最多max_iterations次迭代
         while iteration < self.max_iterations:
             iteration += 1
 
+            # 发布迭代事件到消息总线（如果启用）
             if publish_events:
                 await self.bus.publish_outbound(
                     OutboundMessage(
@@ -706,10 +724,13 @@ class AgentLoop:
                     )
                 )
 
+            # 获取可用的工具定义
             tool_definitions = self.tools.get_definitions(
                 ov_tools_enable=ov_tools_enable,
                 disabled_tools=disabled_tools,
             )
+            
+            # 与聊天模型交互，获取响应和流内容
             response, _streamed_content, streamed_reasoning = await self._chat_with_stream_events(
                 messages=messages,
                 tools=tool_definitions,
@@ -718,6 +739,7 @@ class AgentLoop:
             )
             accumulate_token_usage(response)
 
+            # 发布推理内容事件（如果启用且未流式传输推理内容）
             if publish_events and response.reasoning_content and not streamed_reasoning:
                 await self.bus.publish_outbound(
                     OutboundMessage(
@@ -727,15 +749,16 @@ class AgentLoop:
                     )
                 )
 
+            # 检查是否有工具调用
             if response.has_tool_calls:
-                # Inject experience memory before write-related tool calls (once per session)
+                # 在写入相关工具调用之前注入经验记忆（每个会话一次）
                 if not write_exp_injected:
                     _ov_cfg = load_config().ov_server
                     _write_tools = set(_ov_cfg.exp_write_tools)
                     if any(tc.name in _write_tools for tc in response.tool_calls):
                         write_exp_injected = True
                         try:
-                            # Build query from last 3 user messages
+                            # 从最后3个用户消息构建查询
                             _user_msgs = [
                                 m["content"]
                                 for m in messages
@@ -766,8 +789,13 @@ class AgentLoop:
                         except Exception as _e:
                             logger.warning(f"[WRITE_EXP]: failed to load experience: {_e}")
 
+                # 更新最终推理内容
                 final_reasoning_content = response.reasoning_content
+                
+                # 准备工具调用参数
                 args_list = [tc.arguments for tc in response.tool_calls]
+                
+                # 将工具调用转换为字典格式
                 tool_call_dicts = [
                     {
                         "id": tc.id,
@@ -779,6 +807,8 @@ class AgentLoop:
                     }
                     for tc, args in zip(response.tool_calls, args_list, strict=False)
                 ]
+                
+                # 添加助手消息到对话历史
                 messages = self.context.add_assistant_message(
                     messages,
                     response.content,
@@ -786,9 +816,9 @@ class AgentLoop:
                     reasoning_content=response.reasoning_content,
                 )
 
-                # Stage 2: Execute all tools in parallel
+                # 第二阶段：并行执行所有工具
                 async def execute_single_tool(idx: int, tool_call):
-                    """Execute a single tool and track execution time."""
+                    """执行单个工具并跟踪执行时间。"""
                     tool_execute_start_time = time.time()
                     result = await self.tools.execute(
                         tool_call.name,
@@ -803,11 +833,13 @@ class AgentLoop:
                     tool_execute_duration = (time.time() - tool_execute_start_time) * 1000
                     return idx, tool_call, result, tool_execute_duration
 
-                # Run all tool executions in parallel
+                # 并行运行所有工具执行任务
                 tool_tasks = [
                     execute_single_tool(idx, tool_call)
                     for idx, tool_call in enumerate(response.tool_calls)
                 ]
+                
+                # 发布工具调用事件（如果启用）
                 if publish_events:
                     for tool_call in response.tool_calls:
                         args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
@@ -818,14 +850,17 @@ class AgentLoop:
                                 event_type=OutboundEventType.TOOL_CALL,
                             )
                         )
+                        
+                # 等待所有工具执行完成
                 results = await asyncio.gather(*tool_tasks)
 
-                # Stage 3: Process results sequentially in original order
+                # 第三阶段：按原始顺序顺序处理结果
                 for _idx, tool_call, result, tool_execute_duration in results:
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info(f"[TOOL_CALL]: {tool_call.name}({args_str[:200]})")
                     logger.info(f"[RESULT]: {str(result)[:600]}")
 
+                    # 发布工具结果事件（如果启用）
                     if publish_events:
                         await self.bus.publish_outbound(
                             OutboundMessage(
@@ -834,10 +869,13 @@ class AgentLoop:
                                 event_type=OutboundEventType.TOOL_RESULT,
                             )
                         )
+                        
+                    # 将工具结果添加到消息历史
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
 
+                    # 记录使用的工具信息
                     tool_used_dict = {
                         "tool_name": tool_call.name,
                         "args": args_str,
@@ -849,16 +887,20 @@ class AgentLoop:
                     }
                     tools_used.append(tool_used_dict)
 
+                # 添加反思提示，让模型决定下一步操作
                 messages.append(
                     {"role": "user", "content": "Reflect on the results and decide next steps."}
                 )
             else:
+                # 没有工具调用，结束循环
                 final_content = response.content
                 final_reasoning_content = response.reasoning_content
                 break
 
+        # 处理迭代限制情况：如果达到最大迭代次数但没有最终内容
         if final_content is None or (isinstance(final_content, str) and not final_content.strip()):
             if iteration >= self.max_iterations:
+                # 构建提示让用户模型直接回答原始请求
                 messages.append(
                     {
                         "role": "user",
@@ -871,6 +913,8 @@ class AgentLoop:
                         ),
                     }
                 )
+                
+                # 最后一次与模型对话以获取答案
                 response, _streamed_content, streamed_reasoning = await self._chat_with_stream_events(
                     messages=messages,
                     tools=[],
@@ -881,6 +925,7 @@ class AgentLoop:
                 final_content = response.content
                 final_reasoning_content = response.reasoning_content
 
+                # 发布最终推理内容事件（如果启用且未流式传输推理内容）
                 if publish_events and response.reasoning_content and not streamed_reasoning:
                     await self.bus.publish_outbound(
                         OutboundMessage(
@@ -890,6 +935,7 @@ class AgentLoop:
                         )
                     )
 
+        # 设置默认内容（如果没有获得有效内容）
         if final_content is None or (isinstance(final_content, str) and not final_content.strip()):
             if iteration >= self.max_iterations:
                 final_content = (

--- a/bot/vikingbot/agent/planner.py
+++ b/bot/vikingbot/agent/planner.py
@@ -1,0 +1,384 @@
+"""任务规划器：代理循环的规划与执行层。"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from vikingbot.config.schema import SessionKey
+    from vikingbot.providers.base import LLMProvider
+
+PLAN_SYSTEM_PROMPT = """You are a task planning assistant. Given a user request and conversation context, break the task down into a sequence of concrete sub-tasks.
+
+Rules:
+1. Each sub-task should be a self-contained, actionable step.
+2. Sub-tasks should be ordered sequentially unless they are truly independent (then mark them as parallel).
+3. Each sub-task must have a clear, specific goal that an LLM agent can execute.
+4. Limit to at most 7 sub-tasks.
+5. If the user request is simple enough to be a single step, return a plan with exactly 1 sub-task.
+
+Respond with ONLY a valid JSON object with this exact structure:
+{
+    "plan_id": "a unique identifier string",
+    "reasoning": "brief explanation of your decomposition strategy",
+    "subtasks": [
+        {
+            "id": "unique_subtask_id",
+            "goal": "clear description of what this subtask should accomplish",
+            "depends_on": [],
+            "parallel_group": null
+        }
+    ]
+}
+
+- "depends_on": list of subtask ids that must complete before this one. Empty list if no dependencies.
+- "parallel_group": string group name for subtasks that can run in parallel, or null if sequential."""
+
+REPLAN_SYSTEM_PROMPT = """You are a task planning assistant. Some sub-tasks have failed or are incomplete. Given the current plan state and failure information, revise the remaining plan.
+
+Rules:
+1. Keep completed sub-tasks as-is (do not modify completed ones).
+2. For failed sub-tasks, analyze the failure reason and create alternative approaches.
+3. Remove any sub-tasks that are no longer needed.
+4. The new plan must cover the original user intent.
+
+Respond with ONLY a valid JSON object with this exact structure:
+{
+    "plan_id": "a new plan id",
+    "reasoning": "brief explanation of your replanning strategy",
+    "subtasks": [
+        ...remaining subtasks (completed ones preserved, failed ones replaced)
+    ]
+}"""
+
+PLAN_STATE_DIR = ".plans"
+
+
+@dataclass
+class SubTask:
+    """计划中的单个子任务。"""
+
+    id: str
+    goal: str
+    depends_on: list[str] = field(default_factory=list)
+    parallel_group: str | None = None
+    status: str = "pending"
+    result: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """将子任务转换为字典。"""
+        return {
+            "id": self.id,
+            "goal": self.goal,
+            "depends_on": self.depends_on,
+            "parallel_group": self.parallel_group,
+            "status": self.status,
+            "result": self.result,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SubTask:
+        """从字典创建子任务。"""
+        return cls(
+            id=data.get("id", ""),
+            goal=data.get("goal", ""),
+            depends_on=data.get("depends_on", []),
+            parallel_group=data.get("parallel_group"),
+            status=data.get("status", "pending"),
+            result=data.get("result"),
+        )
+
+
+@dataclass
+class Plan:
+    """由有序子任务组成的任务计划。"""
+
+    plan_id: str
+    reasoning: str
+    subtasks: list[SubTask] = field(default_factory=list)
+    current_index: int = 0
+
+    @property
+    def pending_subtasks(self) -> list[SubTask]:
+        return [st for st in self.subtasks if st.status in ("pending", "failed")]
+
+    @property
+    def all_completed(self) -> bool:
+        return all(st.status == "completed" for st in self.subtasks)
+
+    def get_next(self) -> SubTask | None:
+        for st in self.subtasks:
+            if st.status in ("pending", "failed"):
+                return st
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """将计划转换为字典。"""
+        return {
+            "plan_id": self.plan_id,
+            "reasoning": self.reasoning,
+            "current_index": self.current_index,
+            "subtasks": [st.to_dict() for st in self.subtasks],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Plan:
+        """从字典创建计划。"""
+        subtasks = [SubTask.from_dict(st) for st in data.get("subtasks", [])]
+        return cls(
+            plan_id=data.get("plan_id", ""),
+            reasoning=data.get("reasoning", ""),
+            subtasks=subtasks,
+            current_index=data.get("current_index", 0),
+        )
+
+
+class TaskPlanner:
+    """生成和管理用于计划与执行代理的任务计划。"""
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        workspace: Path,
+        model: str,
+        temperature: float = 0.3,
+        enable_planning: bool = True,
+        max_plan_steps: int = 7,
+    ):
+        """初始化任务规划器。"""
+        self.provider = provider
+        self.workspace = workspace
+        self.model = model
+        self.temperature = temperature
+        self.enable_planning = enable_planning
+        self.max_plan_steps = max_plan_steps
+
+    async def generate_plan(
+        self,
+        messages: list[dict[str, Any]],
+        user_query: str,
+        session_key: SessionKey | None = None,
+    ) -> Plan:
+        """为给定的用户查询生成任务计划。"""
+        if not self.enable_planning:
+            return Plan(
+                plan_id="single_step",
+                reasoning="Planning disabled, using single-step execution.",
+                subtasks=[SubTask(id="step_1", goal=user_query)],
+            )
+
+        plan_messages = [
+            {"role": "system", "content": PLAN_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    f"User request: {user_query}\n\n"
+                    "Break this down into concrete sub-tasks. "
+                    f"Return at most {self.max_plan_steps} sub-tasks."
+                ),
+            },
+        ]
+
+        try:
+            response = await self.provider.chat(
+                messages=plan_messages,
+                model=self.model,
+                temperature=self.temperature,
+                session_id=session_key.safe_name() if session_key else None,
+            )
+            plan_data = self._parse_plan_response(response.content)
+            return Plan(
+                plan_id=plan_data.get("plan_id", uuid.uuid4().hex[:8]),
+                reasoning=plan_data.get("reasoning", ""),
+                subtasks=[
+                    SubTask(
+                        id=st.get("id", f"step_{i}"),
+                        goal=st.get("goal", ""),
+                        depends_on=st.get("depends_on", []),
+                        parallel_group=st.get("parallel_group"),
+                    )
+                    for i, st in enumerate(plan_data.get("subtasks", []))
+                ],
+            )
+        except Exception as e:
+            logger.warning(f"Plan generation failed, falling back to single-step: {e}")
+            return Plan(
+                plan_id="fallback",
+                reasoning=f"Plan generation failed: {e}",
+                subtasks=[SubTask(id="step_1", goal=user_query)],
+            )
+
+    async def replan(
+        self,
+        messages: list[dict[str, Any]],
+        current_plan: Plan,
+        failed_subtask: SubTask,
+        session_key: SessionKey | None = None,
+    ) -> Plan:
+        """Generate a revised plan when a sub-task fails."""
+        failed_info = (
+            f"Failed sub-task:\n"
+            f"  ID: {failed_subtask.id}\n"
+            f"  Goal: {failed_subtask.goal}\n"
+            f"  Result: {failed_subtask.result}\n\n"
+            f"Completed sub-tasks:\n"
+        )
+        for st in current_plan.subtasks:
+            if st.status == "completed":
+                failed_info += f"  - [{st.id}] {st.goal}: {st.result[:200] if st.result else 'done'}\n"
+
+        replan_messages = [
+            {"role": "system", "content": REPLAN_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    f"Original plan state:\n{json.dumps(current_plan.to_dict(), indent=2)}\n\n"
+                    f"{failed_info}\n\n"
+                    "Revise the plan considering this failure. "
+                    "Keep completed subtasks unchanged. "
+                    f"Return at most {self.max_plan_steps} remaining sub-tasks."
+                ),
+            },
+        ]
+
+        try:
+            response = await self.provider.chat(
+                messages=replan_messages,
+                model=self.model,
+                temperature=self.temperature,
+                session_id=session_key.safe_name() if session_key else None,
+            )
+            replan_data = self._parse_plan_response(response.content)
+
+            completed_subtasks = [st for st in current_plan.subtasks if st.status == "completed"]
+            new_subtasks = [
+                SubTask(
+                    id=st.get("id", f"step_{i}"),
+                    goal=st.get("goal", ""),
+                    depends_on=st.get("depends_on", []),
+                    parallel_group=st.get("parallel_group"),
+                )
+                for i, st in enumerate(replan_data.get("subtasks", []))
+            ]
+            for merged_st in new_subtasks:
+                for completed_st in completed_subtasks:
+                    if merged_st.id == completed_st.id:
+                        merged_st.status = "completed"
+                        merged_st.result = completed_st.result
+
+            return Plan(
+                plan_id=replan_data.get("plan_id", uuid.uuid4().hex[:8]),
+                reasoning=replan_data.get("reasoning", ""),
+                subtasks=completed_subtasks + new_subtasks,
+            )
+        except Exception as e:
+            logger.warning(f"Replan failed: {e}")
+            return current_plan
+
+    def _parse_plan_response(self, content: str | None) -> dict[str, Any]:
+        """解析LLM返回的计划JSON响应。"""
+        if not content:
+            raise ValueError("Empty plan response")
+        text = content.strip()
+        if text.startswith("```"):
+            text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+        if text.startswith("```json"):
+            text = text[7:].strip()
+        return json.loads(text)
+
+    def inject_subtask_goal(
+        self, messages: list[dict[str, Any]], subtask: SubTask, plan: Plan | None = None
+    ) -> list[dict[str, Any]]:
+        """将当前子任务目标注入到消息列表中。"""
+        total = 0
+        if plan:
+            total = len(plan.subtasks)
+        completed = sum(1 for st in (plan.subtasks if plan else []) if st.status == "completed")
+        progress = f"[{completed + 1}/{total}]" if total > 0 else ""
+
+        goal_message = {
+            "role": "user",
+            "content": (
+                f"## Current Sub-task {progress}\n{subtask.goal}\n\n"
+                "Focus on completing ONLY this sub-task. "
+                "Do not work on other tasks unless explicitly requested."
+            ),
+        }
+        return messages + [goal_message]
+
+    def mark_completed(self, subtask: SubTask, result: str, success: bool = True) -> None:
+        """将子任务标记为已完成或失败。"""
+        subtask.status = "completed" if success else "failed"
+        subtask.result = result[:500] if result else None
+        if success:
+            logger.info(f"[PLANNER]: Sub-task completed: [{subtask.id}] {subtask.goal}")
+        else:
+            logger.warning(f"[PLANNER]: Sub-task failed: [{subtask.id}] {subtask.goal}")
+
+    def should_replan(self, subtask: SubTask, result: str) -> bool:
+        """根据子任务结果判断是否需要重新规划。"""
+        if not result:
+            return False
+        failure_keywords = [
+            "error:",
+            "failed to",
+            "unable to",
+            "cannot complete",
+            "not available",
+            "permission denied",
+        ]
+        result_lower = result.lower()
+        return any(kw in result_lower for kw in failure_keywords)
+
+    def persist_plan(self, plan: Plan, session_key: SessionKey) -> None:
+        """将计划状态持久化到工作区文件系统，用于断点恢复。"""
+        try:
+            plans_dir = self.workspace / PLAN_STATE_DIR
+            plans_dir.mkdir(parents=True, exist_ok=True)
+            plan_file = plans_dir / f"{session_key.safe_name()}_plan.json"
+            plan_file.write_text(json.dumps(plan.to_dict(), indent=2, ensure_ascii=False))
+            logger.info(f"[PLANNER]: Plan persisted to {plan_file}")
+        except Exception as e:
+            logger.warning(f"[PLANNER]: Failed to persist plan: {e}")
+
+    def load_plan(self, session_key: SessionKey) -> Plan | None:
+        """加载持久化的计划用于断点恢复。"""
+        try:
+            plan_file = self.workspace / PLAN_STATE_DIR / f"{session_key.safe_name()}_plan.json"
+            if not plan_file.exists():
+                return None
+            data = json.loads(plan_file.read_text())
+            plan = Plan.from_dict(data)
+            logger.info(f"[PLANNER]: Plan loaded from {plan_file}, {len(plan.subtasks)} subtasks")
+            return plan
+        except Exception as e:
+            logger.warning(f"[PLANNER]: Failed to load plan: {e}")
+            return None
+
+    def clear_plan(self, session_key: SessionKey) -> None:
+        """删除持久化的计划文件。"""
+        try:
+            plan_file = self.workspace / PLAN_STATE_DIR / f"{session_key.safe_name()}_plan.json"
+            if plan_file.exists():
+                plan_file.unlink()
+        except Exception as e:
+            logger.warning(f"[PLANNER]: Failed to clear plan: {e}")
+
+    def build_summary(
+        self, plan: Plan, subtask_results: list[tuple[SubTask, str]]
+    ) -> str:
+        """为最终响应构建所有已完成子任务的摘要。"""
+        if not subtask_results:
+            return ""
+        lines = ["## Plan Execution Summary"]
+        for st, result in subtask_results:
+            status_icon = "✓" if st.status == "completed" else "✗"
+            lines.append(f"- {status_icon} **{st.goal}**: {result[:200] if result else 'done'}")
+        lines.append("\nNow provide the final answer to the user based on all gathered results.")
+        return "\n".join(lines)

--- a/bot/vikingbot/tests/test_planner.py
+++ b/bot/vikingbot/tests/test_planner.py
@@ -1,0 +1,357 @@
+"""Tests for TaskPlanner — Plan-and-Execute layer."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "vikingbot.agent.planner",
+    Path(__file__).resolve().parent.parent / "agent" / "planner.py",
+)
+_planner = importlib.util.module_from_spec(_spec)
+import sys
+sys.modules["vikingbot.agent.planner"] = _planner
+_spec.loader.exec_module(_planner)
+TaskPlanner = _planner.TaskPlanner
+Plan = _planner.Plan
+SubTask = _planner.SubTask
+
+
+def _build_response(content: str) -> MagicMock:
+    resp = MagicMock(spec=LLMResponse)
+    resp.content = content
+    return resp
+
+
+# ============================================================
+# SubTask
+# ============================================================
+
+class TestSubTask:
+    def test_create_subtask(self):
+        st = SubTask(id="step_1", goal="read a file")
+        assert st.id == "step_1"
+        assert st.goal == "read a file"
+        assert st.depends_on == []
+        assert st.status == "pending"
+        assert st.result is None
+
+    def test_subtask_round_trip(self):
+        st = SubTask(id="s2", goal="search web", depends_on=["s1"], status="completed", result="done")
+        data = st.to_dict()
+        assert data["id"] == "s2"
+        assert data["status"] == "completed"
+
+        restored = SubTask.from_dict(data)
+        assert restored.id == "s2"
+        assert restored.goal == "search web"
+        assert restored.depends_on == ["s1"]
+        assert restored.status == "completed"
+        assert restored.result == "done"
+
+
+# ============================================================
+# Plan
+# ============================================================
+
+class TestPlan:
+    def _make_plan(self, *statuses: str) -> Plan:
+        sts = [SubTask(id=f"step_{i}", goal=f"task {i}", status=s) for i, s in enumerate(statuses)]
+        return Plan(plan_id="p1", reasoning="test", subtasks=sts)
+
+    def test_get_next_returns_first_pending(self):
+        plan = self._make_plan("completed", "pending", "pending")
+        assert plan.get_next() is not None
+        assert plan.get_next().id == "step_1"
+
+    def test_get_next_returns_none_when_all_done(self):
+        plan = self._make_plan("completed", "completed")
+        assert plan.get_next() is None
+
+    def test_all_completed(self):
+        assert self._make_plan("completed", "completed").all_completed is True
+        assert self._make_plan("completed", "pending").all_completed is False
+
+    def test_pending_subtasks(self):
+        pending = self._make_plan("completed", "failed", "pending").pending_subtasks
+        assert len(pending) == 2
+
+    def test_plan_round_trip(self):
+        plan = self._make_plan("pending", "completed")
+        plan.subtasks[1].result = "all good"
+        data = plan.to_dict()
+        restored = Plan.from_dict(data)
+        assert restored.plan_id == "p1"
+        assert len(restored.subtasks) == 2
+        assert restored.subtasks[0].status == "pending"
+        assert restored.subtasks[1].result == "all good"
+
+
+# ============================================================
+# TaskPlanner — parse / inject / mark / persist
+# ============================================================
+
+@pytest.fixture
+def planner() -> TaskPlanner:
+    provider = MagicMock()
+    provider.chat = AsyncMock()
+    with tempfile.TemporaryDirectory() as tmp:
+        yield TaskPlanner(provider=provider, workspace=Path(tmp), model="test-model")
+
+
+class TestParsePlanResponse:
+    def test_plain_json(self, planner):
+        result = planner._parse_plan_response('{"a": 1}')
+        assert result == {"a": 1}
+
+    def test_markdown_fence(self, planner):
+        result = planner._parse_plan_response('```json\n{"b": 2}\n```')
+        assert result == {"b": 2}
+
+    def test_no_lang_fence(self, planner):
+        result = planner._parse_plan_response('```\n{"c": 3}\n```')
+        assert result == {"c": 3}
+
+    def test_empty_raises(self, planner):
+        with pytest.raises(ValueError):
+            planner._parse_plan_response("")
+
+    def test_none_raises(self, planner):
+        with pytest.raises(ValueError):
+            planner._parse_plan_response(None)
+
+
+class TestInjectSubtaskGoal:
+    def test_injects_goal_before_current_messages(self, planner):
+        messages = [{"role": "user", "content": "hello"}]
+        sub = SubTask(id="s1", goal="do something")
+        result = planner.inject_subtask_goal(messages, sub)
+        assert len(result) == 2
+        assert "Current Sub-task" in result[1]["content"]
+        assert "do something" in result[1]["content"]
+
+    def test_shows_progress_when_plan_provided(self, planner):
+        messages = [{"role": "user", "content": "hi"}]
+        sub = SubTask(id="s2", goal="step two")
+        plan = Plan(
+            plan_id="p1", reasoning="",
+            subtasks=[
+                SubTask(id="s1", goal="step one", status="completed"),
+                sub,
+            ],
+        )
+        result = planner.inject_subtask_goal(messages, sub, plan)
+        assert "[2/2]" in result[1]["content"]
+
+
+class TestMarkCompleted:
+    def test_mark_success(self, planner):
+        sub = SubTask(id="s1", goal="task")
+        planner.mark_completed(sub, "result ok", success=True)
+        assert sub.status == "completed"
+        assert sub.result == "result ok"
+
+    def test_mark_failure(self, planner):
+        sub = SubTask(id="s1", goal="task")
+        planner.mark_completed(sub, "error happened", success=False)
+        assert sub.status == "failed"
+        assert sub.result == "error happened"
+
+    def test_result_truncated(self, planner):
+        sub = SubTask(id="s1", goal="task")
+        long_result = "x" * 600
+        planner.mark_completed(sub, long_result)
+        assert len(sub.result) == 500
+
+
+class TestShouldReplan:
+    @pytest.mark.parametrize("result", [
+        "Error: something broke",
+        "Failed to connect",
+        "Unable to process request",
+        "cannot complete the task",
+        "not available right now",
+        "permission denied for resource",
+    ])
+    def test_detects_failure_keywords(self, planner, result):
+        sub = SubTask(id="s1", goal="task")
+        assert planner.should_replan(sub, result) is True
+
+    @pytest.mark.parametrize("result", [
+        "Task completed successfully",
+        "Here is the result",
+        "",
+    ])
+    def test_no_false_positive(self, planner, result):
+        sub = SubTask(id="s1", goal="task")
+        assert planner.should_replan(sub, result) is False
+
+    def test_none_result(self, planner):
+        sub = SubTask(id="s1", goal="task")
+        assert planner.should_replan(sub, None) is False
+
+
+class TestBuildSummary:
+    def test_single_result(self, planner):
+        sub = SubTask(id="s1", goal="find answer", status="completed", result="42")
+        plan = Plan(plan_id="p1", reasoning="", subtasks=[sub])
+        text = planner.build_summary(plan, [(sub, "42")])
+        assert "Plan Execution Summary" in text
+        assert "find answer" in text
+
+    def test_mixed_status(self, planner):
+        s1 = SubTask(id="s1", goal="ok task", status="completed", result="yes")
+        s2 = SubTask(id="s2", goal="bad task", status="failed", result="nope")
+        plan = Plan(plan_id="p1", reasoning="", subtasks=[s1, s2])
+        text = planner.build_summary(plan, [(s1, "yes"), (s2, "nope")])
+        assert "✓" in text
+        assert "✗" in text
+
+    def test_empty(self, planner):
+        plan = Plan(plan_id="p1", reasoning="", subtasks=[])
+        text = planner.build_summary(plan, [])
+        assert text == ""
+
+
+class TestPersistLoadClear:
+    def test_round_trip(self, planner):
+        session_key = MagicMock()
+        session_key.safe_name.return_value = "test_session"
+
+        plan = Plan(
+            plan_id="p99", reasoning="test plan",
+            subtasks=[
+                SubTask(id="s1", goal="first", status="completed", result="ok"),
+                SubTask(id="s2", goal="second", status="pending"),
+            ],
+        )
+
+        planner.persist_plan(plan, session_key)
+
+        loaded = planner.load_plan(session_key)
+        assert loaded is not None
+        assert loaded.plan_id == "p99"
+        assert len(loaded.subtasks) == 2
+        assert loaded.subtasks[0].status == "completed"
+        assert loaded.subtasks[0].result == "ok"
+
+        planner.clear_plan(session_key)
+        assert planner.load_plan(session_key) is None
+
+    def test_load_nonexistent(self, planner):
+        session_key = MagicMock()
+        session_key.safe_name.return_value = "nonexistent"
+        assert planner.load_plan(session_key) is None
+
+    def test_clear_nonexistent_no_error(self, planner):
+        session_key = MagicMock()
+        session_key.safe_name.return_value = "gone"
+        planner.clear_plan(session_key)
+
+
+# ============================================================
+# generate_plan — with mock LLM
+# ============================================================
+
+class TestGeneratePlan:
+    def test_single_step_plan(self, planner):
+        planner.provider.chat.return_value = _build_response(
+            json.dumps({
+                "plan_id": "abc123",
+                "reasoning": "simple task",
+                "subtasks": [{"id": "s1", "goal": "just do it", "depends_on": [], "parallel_group": None}],
+            })
+        )
+
+        plan = asyncio.run(planner.generate_plan([], "do one thing"))
+
+        assert len(plan.subtasks) == 1
+        assert plan.subtasks[0].goal == "just do it"
+
+    def test_multi_step_plan(self, planner):
+        planner.provider.chat.return_value = _build_response(
+            json.dumps({
+                "plan_id": "def456",
+                "reasoning": "complex task needs decomposition",
+                "subtasks": [
+                    {"id": "s1", "goal": "research", "depends_on": [], "parallel_group": None},
+                    {"id": "s2", "goal": "analyze", "depends_on": ["s1"], "parallel_group": None},
+                    {"id": "s3", "goal": "report", "depends_on": ["s2"], "parallel_group": None},
+                ],
+            })
+        )
+
+        plan = asyncio.run(planner.generate_plan([], "complex query"))
+
+        assert len(plan.subtasks) == 3
+        assert plan.subtasks[1].depends_on == ["s1"]
+
+    def test_fallback_on_exception(self, planner):
+        planner.provider.chat.side_effect = Exception("LLM offline")
+
+        plan = asyncio.run(planner.generate_plan([], "some query"))
+
+        assert plan.plan_id == "fallback"
+        assert len(plan.subtasks) == 1
+
+    def test_fallback_on_invalid_json(self, planner):
+        planner.provider.chat.return_value = _build_response("not json at all")
+
+        plan = asyncio.run(planner.generate_plan([], "some query"))
+
+        assert plan.plan_id == "fallback"
+        assert len(plan.subtasks) == 1
+
+    def test_disabled_planning_returns_single_step(self, planner):
+        planner.enable_planning = False
+        plan = asyncio.run(planner.generate_plan([], "any query"))
+        assert plan.plan_id == "single_step"
+        assert len(plan.subtasks) == 1
+
+
+# ============================================================
+# replan
+# ============================================================
+
+class TestReplan:
+    def test_replan_preserves_completed(self, planner):
+        planner.provider.chat.return_value = _build_response(
+            json.dumps({
+                "plan_id": "new_plan",
+                "reasoning": "replanned",
+                "subtasks": [
+                    {"id": "s4", "goal": "alternative approach", "depends_on": [], "parallel_group": None},
+                ],
+            })
+        )
+
+        current = Plan(
+            plan_id="old_plan", reasoning="",
+            subtasks=[
+                SubTask(id="s1", goal="first", status="completed", result="ok"),
+                SubTask(id="s2", goal="second", status="failed", result="error: boom"),
+                SubTask(id="s3", goal="third", status="pending"),
+            ],
+        )
+
+        new_plan = asyncio.run(
+            planner.replan([], current, current.subtasks[1])
+        )
+
+        assert new_plan.subtasks[0].status == "completed"
+        assert len(new_plan.subtasks) == 2
+
+    def test_replan_exception_returns_current(self, planner):
+        planner.provider.chat.side_effect = Exception("replan failed")
+        current = Plan(plan_id="p1", reasoning="", subtasks=[SubTask(id="s1", goal="t", status="failed", result="err")])
+
+        result = asyncio.run(planner.replan([], current, current.subtasks[0]))
+        assert result is current


### PR DESCRIPTION
## Summary

This PR introduces a Plan-and-Execute task planning layer around the existing
AgentLoop, with zero changes to _run_agent_loop itself.

## Changes
- **New: `bot/vikingbot/agent/planner.py`** (378 lines)
  - TaskPlanner class: sub-task decomposition, checkpoint recovery, dynamic replanning
  - Uses OpenViking's own file system for Plan state persistence
- **Modified: `bot/vikingbot/agent/loop.py`** (+90 lines, 3 spots)
  - Import TaskPlanner
  - Initialize self.planner in __init__
  - Wrap single _run_agent_loop call with Plan-and-Execute loop in _process_message
- **New: `bot/vikingbot/tests/test_planner.py`** (40 tests, all passing)

## Key Design Decisions
1. Zero-invasion: _run_agent_loop unchanged, wrapped at caller level
2. Simple queries degrade to single-subtask Plan (backward compatible)
3. Plan persistence via OpenViking file system enables checkpoint recovery

## Test Results