### PR TITLE
fix(fs): avoid recursive semantic refresh on resource delete

### DIFF
--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -341,6 +341,7 @@ class FSService:
         msg = SemanticMsg(
             uri=root_uri,
             context_type=context_type,
+            recursive=False,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
             peer_id=ctx.user.user_id,

--- a/tests/service/test_fs_service.py
+++ b/tests/service/test_fs_service.py
@@ -344,6 +344,7 @@ async def test_resource_rm_wait_registers_request_before_semantic_root(
     assert tracker.registered_requests == ["tm-fs-rm"]
     assert tracker.registered_roots
     assert tracker.registered_roots[0]["request_was_registered"] is True
+    assert queue_manager.messages[0].recursive is False
     assert tracker.wait_calls == [("tm-fs-rm", 3)]
     assert tracker.cleaned == ["tm-fs-rm"]
     assert result["semantic_status"] == "complete"


### PR DESCRIPTION
## Description

Deleting a resource folder enqueues a semantic refresh for the parent directory so
the parent's overview reflects the deleted child. However, `_enqueue_delete_refresh()`
created the `SemanticMsg` without overriding its default `recursive=True`.

That caused a delete under `viking://resources` to recursively re-process unrelated
sibling folders, creating thousands of unnecessary embedding tasks, API 429s, health
check timeouts, and token waste.

This PR makes delete refresh messages non-recursive, so only the parent directory is
refreshed while existing child/sibling abstracts are reused.

## Related Issue

Fixes #2959

## Type of Change

* Bug fix (non-breaking change that fixes an issue)

## Changes Made

* `fs_service.py`: set `recursive=False` when enqueueing delete refresh `SemanticMsg`
* tests: assert resource delete refresh messages are non-recursive

## Testing

* I have added tests that prove my fix is effective or that my feature works
* New and existing unit tests pass locally with my changes
* I have tested this on the following platforms:
  * macOS

Local verification:

```bash
uv run --extra test pytest -q tests/service/test_fs_service.py