### PR TITLE
feat(docs): add page-view + traffic-source analytics via Viewer-Counter

### DIFF
--- a/.github/workflows/_docs-deploy.yml
+++ b/.github/workflows/_docs-deploy.yml
@@ -34,6 +34,7 @@ jobs:
         working-directory: docs
         env:
           DOCS_BASE: /
+          VITE_COUNTER_URL: ${{ vars.VITE_COUNTER_URL }}
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6

--- a/.github/workflows/docs-tos.yml
+++ b/.github/workflows/docs-tos.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Build docs
         run: npm run docs:build
         working-directory: docs
+        env:
+          VITE_COUNTER_URL: ${{ vars.VITE_COUNTER_URL }}
 
       - name: Check TOS configuration
         id: tos_config

--- a/docs/.vitepress/theme/OpenVikingSearch.vue
+++ b/docs/.vitepress/theme/OpenVikingSearch.vue
@@ -4,6 +4,7 @@ import { useData, withBase } from 'vitepress'
 
 import { searchCopyForLocale } from './openviking-search-i18n'
 import { localizeSearchResultTitles } from './openviking-search-results'
+import { trackEvent } from './track'
 import type { RemoteSearchFailureReason } from './openviking-search-i18n'
 import type {
   DocsIndexRecord,
@@ -201,6 +202,8 @@ async function runSearch() {
     isLoading.value = false
     return
   }
+
+  trackEvent('docs-search')
 
   isLoading.value = true
   const controller = new AbortController()

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,8 +1,10 @@
 import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
+import type { EnhanceAppContext } from 'vitepress'
 import CopyMarkdownButton from './CopyMarkdownButton.vue'
 import LlmsTxtLink from './LlmsTxtLink.vue'
 import OpenVikingSearch from './OpenVikingSearch.vue'
+import { trackPageView } from './track'
 import './custom.css'
 
 type OpenVikingPreference = {
@@ -304,5 +306,16 @@ export default {
       'doc-footer-before': () => h(LlmsTxtLink),
       'nav-bar-content-before': () => h(OpenVikingSearch)
     })
+  },
+  enhanceApp({ router }: EnhanceAppContext) {
+    if (import.meta.env.SSR || typeof window === 'undefined') return
+
+    trackPageView(window.location.pathname)
+
+    const previousHook = router.onAfterRouteChanged
+    router.onAfterRouteChanged = (to: string) => {
+      previousHook?.(to)
+      trackPageView(to.split('?')[0].split('#')[0])
+    }
   }
 }

--- a/docs/.vitepress/theme/track.ts
+++ b/docs/.vitepress/theme/track.ts
@@ -1,0 +1,88 @@
+/**
+ * Minimal usage beacons to a Viewer-Counter instance
+ * (https://github.com/t0saki/Viewer-Counter).
+ *
+ * Disabled unless VITE_COUNTER_URL is set at build time, so default/local/PR
+ * builds carry no tracking. Page views are reported with the route pathname;
+ * the search action
+ * is reported as an event pseudo-page under /e/ (the counter is configured to
+ * skip visitor dedup for that prefix, so events keep raw counts while page
+ * views stay deduplicated).
+ *
+ * The `site` dimension is derived from the current hostname so the docs served
+ * on openviking.ai and openviking.net are counted separately.
+ *
+ * Beacons are fire-and-forget: failures are swallowed and never surface to the
+ * page.
+ */
+
+const COUNTER_URL = (
+  (import.meta.env.VITE_COUNTER_URL as string | undefined) ?? ''
+).replace(/\/+$/, '')
+
+export type TrackEventName = 'docs-search'
+
+function resolveSite(): string {
+  if (typeof window === 'undefined') return 'docs'
+  const host = window.location.hostname
+  if (host === 'openviking.ai' || host.endsWith('.openviking.ai')) return 'docs-ai'
+  if (host === 'openviking.net' || host.endsWith('.openviking.net')) return 'docs-net'
+  return 'docs'
+}
+
+function beacon(page: string, ref?: string): void {
+  if (!COUNTER_URL) return
+  const params = new URLSearchParams({ page, site: resolveSite() })
+  if (ref) params.set('ref', ref)
+  const url = `${COUNTER_URL}/api/v1/hit?${params.toString()}`
+  try {
+    // Prefer sendBeacon; fall through to the Image() beacon whenever it is
+    // unavailable, throws, or reports the payload was not queued.
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      if (navigator.sendBeacon(url)) return
+    }
+  } catch {
+    // fall through to the Image() fallback below
+  }
+  try {
+    new Image().src = url
+  } catch {
+    // Tracking must never break the page.
+  }
+}
+
+/** Reduce the referrer to origin + pathname so query strings never leave the page. */
+function normalizeReferrer(raw: string): string | undefined {
+  if (!raw) return undefined
+  try {
+    const url = new URL(raw)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return undefined
+  }
+}
+
+let lastPath: string | null = null
+let referrerSent = false
+
+/**
+ * Report a page view. Consecutive duplicates (e.g. search-param-only
+ * navigations resolving to the same pathname) are collapsed. The first call
+ * attaches document.referrer as the traffic source — the beacon's own Referer
+ * header would only echo the docs URL.
+ */
+export function trackPageView(pathname: string): void {
+  if (pathname === lastPath) return
+  lastPath = pathname
+  let ref: string | undefined
+  if (!referrerSent) {
+    referrerSent = true
+    ref = normalizeReferrer(document.referrer)
+  }
+  beacon(pathname, ref)
+}
+
+/** Report a user action as an /e/ pseudo-page. */
+export function trackEvent(name: TrackEventName): void {
+  beacon(`/e/${name}`)
+}


### PR DESCRIPTION
## Description

Adds lightweight, privacy-respecting page-view and traffic-source analytics to the docs site, backed by the existing [Viewer-Counter](https://counter.openviking.net/) service. Tracking is fully disabled unless `VITE_COUNTER_URL` is set at build time, so local and PR builds carry no tracking.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- New `docs/.vitepress/theme/track.ts`: fire-and-forget beacon (`sendBeacon` + `Image()` fallback), no-op when `VITE_COUNTER_URL` is unset. Sends `document.referrer` as `ref` on first view so traffic source is captured for the SPA.
- `site` is derived at runtime from the hostname (`docs-ai` / `docs-net` / `docs`) so `openviking.ai` and `openviking.net` are counted separately.
- Wired page views into `theme/index.ts` via `enhanceApp` — fires on initial load and every client-side route change (`lastPath` dedup avoids double counts).
- Search usage reported as an `/e/docs-search` event from `OpenVikingSearch.vue` when a query executes.
- Injected `VITE_COUNTER_URL: ${{ vars.VITE_COUNTER_URL }}` into the two production build workflows (`_docs-deploy.yml`, `docs-tos.yml`); the PR-check build is intentionally left untracked.

## Testing

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] macOS

- `npm run docs:build` passes; env-unset bundle contains no counter URL (no-op verified).
- Building with `VITE_COUNTER_URL=https://counter.openviking.net` inlines the endpoint and `docs-ai` / `docs-net` site literals as expected.
- `npm run test:search` — 4/4 passing.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Requires a one-time repo **Actions Variable** `VITE_COUNTER_URL = https://counter.openviking.net` (Settings → Secrets and variables → Actions → Variables). Until it is set, tracking stays silently disabled. No server-side change needed — the counter already accepts `ref` and skips dedup for the `/e/` prefix.
