### PR TITLE
fix(web-studio): send identity headers in /health identity probe

### DIFF
--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -184,6 +184,14 @@ async function detectConnectionIdentity(
   if (apiKey) {
     headers['X-API-Key'] = apiKey
   }
+  // Identity headers are required for trusted-mode identity resolution.
+  // In api_key mode the server strips them, so they are always safe to send.
+  if (connection.accountId) {
+    headers['X-OpenViking-Account'] = connection.accountId
+  }
+  if (connection.userId) {
+    headers['X-OpenViking-User'] = connection.userId
+  }
 
   const response = await fetch(
     `${normalizeBaseUrl(connection.baseUrl)}/health`,


### PR DESCRIPTION
## Summary

Fixes #2977 for the web-studio side. The studio's connection identity probe (`detectConnectionIdentity`) calls `/health` with `X-API-Key` but was missing `X-OpenViking-Account` and `X-OpenViking-User` headers.

In **trusted mode**, the auth plugin requires these identity headers to resolve the caller's role. Without them, `resolve_identity` raises `InvalidArgumentError`, the health handler swallows it, and the response omits `role`/`account_id`/`user_id` — so the studio falls back to `connectionRole = 'unknown'` and gates the admin UI behind "Usage/Audit 未初始化，暂无实时统计".

In **api_key mode**, sending these headers is safe — the server explicitly strips them from the request scope.

## Changes

- `web-studio/src/hooks/use-app-connection.tsx`: `detectConnectionIdentity` now includes `X-OpenViking-Account` and `X-OpenViking-User` headers when present in the connection config.

## Verification

- [x] ESLint passes on changed file
- [x] TypeScript errors are all pre-existing (unrelated to this change)
- [x] api_key mode: headers are silently ignored by server
- [x] trusted mode: headers enable correct role resolution