### PR TITLE
feat(blog): add page-view + traffic-source analytics via Viewer-Counter

### DIFF
--- a/.github/workflows/blog-build.yml
+++ b/.github/workflows/blog-build.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Build blog
         run: npm run build
         working-directory: blog
+        env:
+          VITE_COUNTER_URL: ${{ vars.VITE_COUNTER_URL }}
 
       - name: Check TOS configuration
         id: tos_config

--- a/blog/src/shell-ui.jsx
+++ b/blog/src/shell-ui.jsx
@@ -10,6 +10,7 @@ import {
   sharedThemeToBlogTheme, blogThemeToSharedTheme, writeCookiePreferences,
 } from './shell-core';
 import { ZoukInteractiveBlog } from './zouk-embed';
+import { trackPageView } from './track';
 
 /* ---------- topbar ---------- */
 
@@ -392,6 +393,8 @@ export default function App() {
   const onToggleTheme = () => setTheme(t => t === THEME_LIGHT ? THEME_DARK : THEME_LIGHT);
 
   useEffect(() => { window.scrollTo({ top: 0, behavior: 'instant' in window ? 'instant' : 'auto' }); }, [router.route.name, router.route.slug]);
+
+  useEffect(() => { trackPageView(window.location.pathname); }, [router.route.name, router.route.slug]);
 
   const S = useShellStrings(lang);
   const formatDate = useMemo(() => makeFormatDate(lang), [lang]);

--- a/blog/src/track.js
+++ b/blog/src/track.js
@@ -1,0 +1,77 @@
+/**
+ * Minimal usage beacons to a Viewer-Counter instance
+ * (https://github.com/t0saki/Viewer-Counter).
+ *
+ * Disabled unless VITE_COUNTER_URL is set at build time, so default/local/PR
+ * builds carry no tracking. Page views are reported with the route pathname;
+ * document.referrer (origin + pathname only) is attached on the first view so
+ * the traffic source is captured for the SPA.
+ *
+ * The `site` dimension is derived from the current hostname so the blog served
+ * on openviking.ai and openviking.net is counted separately.
+ *
+ * Beacons are fire-and-forget: failures are swallowed and never surface to the
+ * page.
+ */
+
+const COUNTER_URL = (import.meta.env.VITE_COUNTER_URL || '').replace(/\/+$/, '');
+
+function resolveSite() {
+  if (typeof window === 'undefined') return 'blog';
+  const host = window.location.hostname;
+  if (host === 'openviking.ai' || host.endsWith('.openviking.ai')) return 'blog-ai';
+  if (host === 'openviking.net' || host.endsWith('.openviking.net')) return 'blog-net';
+  return 'blog';
+}
+
+function beacon(page, ref) {
+  if (!COUNTER_URL) return;
+  const params = new URLSearchParams({ page, site: resolveSite() });
+  if (ref) params.set('ref', ref);
+  const url = `${COUNTER_URL}/api/v1/hit?${params.toString()}`;
+  try {
+    // Prefer sendBeacon; fall through to the Image() beacon whenever it is
+    // unavailable, throws, or reports the payload was not queued.
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      if (navigator.sendBeacon(url)) return;
+    }
+  } catch {
+    // fall through to the Image() fallback below
+  }
+  try {
+    new Image().src = url;
+  } catch {
+    // Tracking must never break the page.
+  }
+}
+
+/** Reduce the referrer to origin + pathname so query strings never leave the page. */
+function normalizeReferrer(raw) {
+  if (!raw) return undefined;
+  try {
+    const url = new URL(raw);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
+let lastPath = null;
+let referrerSent = false;
+
+/**
+ * Report a page view. Consecutive duplicates (e.g. query-only navigations such
+ * as language switches resolving to the same pathname) are collapsed. The first
+ * call attaches document.referrer as the traffic source — the beacon's own
+ * Referer header would only echo the blog URL.
+ */
+export function trackPageView(pathname) {
+  if (pathname === lastPath) return;
+  lastPath = pathname;
+  let ref;
+  if (!referrerSent) {
+    referrerSent = true;
+    ref = normalizeReferrer(document.referrer);
+  }
+  beacon(pathname, ref);
+}


### PR DESCRIPTION
## Description

Adds lightweight, privacy-respecting page-view and traffic-source analytics to the blog, backed by the existing [Viewer-Counter](https://counter.openviking.net/) service. Tracking is fully disabled unless `VITE_COUNTER_URL` is set at build time, so local and PR builds carry no tracking. Mirrors the docs integration.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- New `blog/src/track.js`: fire-and-forget beacon (`sendBeacon` with `Image()` fallback when it is unavailable, throws, or does not queue), no-op when `VITE_COUNTER_URL` is unset. Sends the referrer (normalized to origin + pathname, so query strings never leave the page) as `ref` on the first view.
- `site` is derived at runtime from the hostname (`blog-ai` / `blog-net` / `blog`) so `openviking.ai` and `openviking.net` are counted separately.
- Wired into the SPA router in `shell-ui.jsx` — a page view fires on initial load and on every client-side route change (`lastPath` dedup avoids double counts on query-only navigations such as language switches).
- Injected `VITE_COUNTER_URL: ${{ vars.VITE_COUNTER_URL }}` into the blog build workflow; PR builds inline it but are never deployed, so no counter traffic is generated from CI.

## Testing

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] macOS

- `npm run build` (Vite client + SSR + static render) passes; the env-unset bundle contains no counter URL (no-op verified) and prerendered HTML is unaffected.
- Building with `VITE_COUNTER_URL=https://counter.openviking.net` inlines the endpoint and `blog-ai` / `blog-net` site literals into the client JS only.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Reuses the same repo **Actions Variable** `VITE_COUNTER_URL = https://counter.openviking.net` (Settings → Secrets and variables → Actions → Variables) as the docs integration. Until it is set, tracking stays silently disabled. No server-side change needed — the counter already accepts `ref`.
