### PR TITLE
feat(storage): add pgvector VectorDB backend (#2891 / #2357)

### DIFF
--- a/deploy/pgvector/init.sql
+++ b/deploy/pgvector/init.sql
@@ -1,0 +1,5 @@
+-- Enable the pgvector extension on first boot of the pgvector/pgvector:pg16
+-- container (mounted into /docker-entrypoint-initdb.d). OpenViking's adapter
+-- also runs this under an advisory lock at connect time (create_extension=true),
+-- so this file is belt-and-suspenders for pre-provisioned / CI deployments.
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,33 @@ services:
     depends_on:
       - openviking
 
+  # Local pgvector for the `pgvector` storage backend + integration tests.
+  # pg16 with the vector extension (pgvector/pgvector image). The non-5432 host
+  # port lets it coexist with a local Postgres; init.sql enables the extension
+  # on first boot. Run the Tier-D integration tests against it with
+  # OPENVIKING_PGVECTOR_HOST=127.0.0.1 OPENVIKING_PGVECTOR_PORT=15432.
+  pgvector:
+    image: pgvector/pgvector:pg16
+    container_name: openviking-pgvector
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "15432:5432"
+    volumes:
+      - ./deploy/pgvector/init.sql:/docker-entrypoint-initdb.d/10-vector.sql:ro
+      - pgvector_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  pgvector_data:
 # Uncomment for public HTTPS:
-# volumes:
 #   caddy_data:
 #   caddy_config:

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1209,7 +1209,7 @@ Vector database storage configuration
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `backend` | str | VectorDB backend type: 'local' (file-based), 'http' (remote service), 'volcengine' (cloud VikingDB), 'vikingdb' (private deployment), 'qdrant', or 'opengauss' | "local" |
+| `backend` | str | VectorDB backend type: 'local' (file-based), 'http' (remote service), 'volcengine' (cloud VikingDB), 'vikingdb' (private deployment), 'qdrant', 'opengauss', or 'pgvector' | "local" |
 | `name` | str | VectorDB collection name | "context" |
 | `url` | str | Remote service URL for 'http' type (e.g., 'http://localhost:5000') | null |
 | `project_name` | str | Project name (alias project) | "default" |
@@ -1220,6 +1220,7 @@ Vector database storage configuration
 | `vikingdb` | object | 'vikingdb' type private deployment configuration | - |
 | `qdrant` | object | 'qdrant' type Qdrant configuration | - |
 | `opengauss` | object | 'opengauss' native vector backend configuration | - |
+| `pgvector` | object | 'pgvector' PostgreSQL + pgvector backend configuration | - |
 
 Default local mode
 ```
@@ -1284,6 +1285,47 @@ In the official container, the initial `omm` user may be restricted for remote l
 ```
 
 Set `mode` to `"distributed"` for openGauss distributed deployments; OpenViking will attempt to mark metadata tables as reference tables and distribute collection tables by `id`.
+</details>
+
+<details>
+<summary><b>pgvector (PostgreSQL)</b></summary>
+
+Requires PostgreSQL with the [pgvector](https://github.com/pgvector/pgvector) extension (>= 0.5.0 for HNSW; >= 0.8.0 enables the iterative-scan recall fix under selective filters). Install the optional driver with `pip install "openviking[pgvector]"`. The quickest local server is `docker compose up -d pgvector` (see `docker-compose.yml`).
+
+Provide **either** a `url` DSN (which takes priority) **or** the discrete `host`/`port`/`user`/`password`/`db_name` fields.
+
+```json
+{
+  "storage": {
+    "vectordb": {
+      "name": "context",
+      "backend": "pgvector",
+      "project": "default",
+      "distance_metric": "cosine",
+      "dimension": 1024,
+      "pgvector": {
+        "url": "postgresql://user:password@127.0.0.1:5432/postgres",
+        "host": "127.0.0.1",
+        "port": 5432,
+        "user": "postgres",
+        "password": "your-password",
+        "db_name": "postgres",
+        "schema": "public",
+        "sslmode": "prefer",
+        "index_type": "hnsw",
+        "index_params": {"m": 16, "ef_construction": 64},
+        "pool_size": 1,
+        "create_extension": true
+      }
+    }
+  }
+}
+```
+
+- `distance_metric` accepts `cosine`, `l2`, or `ip` (mapped to pgvector's `<=>` / `<->` / `<#>` operators).
+- `index_type` is `hnsw` (the v1 index); `index_params` tunes the build (`m`, `ef_construction`) and query (`ef_search`).
+- `create_extension` runs `CREATE EXTENSION IF NOT EXISTS vector` on connect under an advisory lock. Set it to `false` for pre-provisioned managed PostgreSQL (RDS / Cloud SQL) where a superuser has already installed the extension.
+- `sslmode` is passed through to libpq (`prefer`, `require`, `disable`, …). `pool_size > 1` uses a threaded connection pool.
 </details>
 
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1181,7 +1181,7 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
-| `backend` | str | VectorDB 后端类型: 'local'（基于文件）, 'http'（远程服务）, 'volcengine'（云上 VikingDB）, 'vikingdb'（私有部署）, 'qdrant' 或 'opengauss' | "local" |
+| `backend` | str | VectorDB 后端类型: 'local'（基于文件）, 'http'（远程服务）, 'volcengine'（云上 VikingDB）, 'vikingdb'（私有部署）, 'qdrant', 'opengauss' 或 'pgvector' | "local" |
 | `name` | str | VectorDB 的集合名称 | "context" |
 | `url` | str | 'http' 类型的远程服务 URL（例如 'http://localhost:5000'） | null |
 | `project_name` | str | 项目名称（别名 project） | "default" |
@@ -1192,6 +1192,7 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 | `vikingdb` | object | 'vikingdb' 类型的私有部署配置 | - |
 | `qdrant` | object | 'qdrant' 类型的 Qdrant 配置 | - |
 | `opengauss` | object | 'opengauss' 原生向量后端配置 | - |
+| `pgvector` | object | 'pgvector' PostgreSQL + pgvector 后端配置 | - |
 
 默认使用本地模式
 ```
@@ -1256,6 +1257,47 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 ```
 
 分布式 openGauss 部署可将 `mode` 设为 `"distributed"`；OpenViking 会尝试把元数据表标记为 reference table，并按 `id` 分布集合表。
+</details>
+
+<details>
+<summary><b>pgvector (PostgreSQL)</b></summary>
+
+需要安装了 [pgvector](https://github.com/pgvector/pgvector) 扩展的 PostgreSQL（HNSW 需 >= 0.5.0；>= 0.8.0 可启用选择性过滤下的 iterative-scan 召回修复）。可通过 `pip install "openviking[pgvector]"` 安装可选驱动。本地最快的方式是 `docker compose up -d pgvector`（见 `docker-compose.yml`）。
+
+可**二选一**：提供 `url` DSN（优先级更高），或提供离散的 `host`/`port`/`user`/`password`/`db_name` 字段。
+
+```json
+{
+  "storage": {
+    "vectordb": {
+      "name": "context",
+      "backend": "pgvector",
+      "project": "default",
+      "distance_metric": "cosine",
+      "dimension": 1024,
+      "pgvector": {
+        "url": "postgresql://user:password@127.0.0.1:5432/postgres",
+        "host": "127.0.0.1",
+        "port": 5432,
+        "user": "postgres",
+        "password": "your-password",
+        "db_name": "postgres",
+        "schema": "public",
+        "sslmode": "prefer",
+        "index_type": "hnsw",
+        "index_params": {"m": 16, "ef_construction": 64},
+        "pool_size": 1,
+        "create_extension": true
+      }
+    }
+  }
+}
+```
+
+- `distance_metric` 支持 `cosine`、`l2`、`ip`（对应 pgvector 的 `<=>` / `<->` / `<#>` 运算符）。
+- `index_type` 为 `hnsw`（v1 索引）；`index_params` 调节构建（`m`、`ef_construction`）与查询（`ef_search`）。
+- `create_extension` 会在连接时通过 advisory lock 执行 `CREATE EXTENSION IF NOT EXISTS vector`。对于已预置扩展的托管 PostgreSQL（RDS / Cloud SQL），可将其设为 `false`。
+- `sslmode` 透传给 libpq（`prefer`、`require`、`disable` 等）。`pool_size > 1` 时使用线程连接池。
 </details>
 
 

--- a/openviking/storage/vectordb_adapters/factory.py
+++ b/openviking/storage/vectordb_adapters/factory.py
@@ -10,6 +10,7 @@ from .base import CollectionAdapter
 from .http_adapter import HttpCollectionAdapter
 from .local_adapter import LocalCollectionAdapter
 from .opengauss_adapter import OpenGaussCollectionAdapter
+from .pgvector_adapter import PgVectorCollectionAdapter
 from .qdrant_adapter import QdrantCollectionAdapter
 from .vikingdb_private_adapter import VikingDBPrivateCollectionAdapter
 from .volcengine_adapter import VolcengineCollectionAdapter
@@ -18,6 +19,7 @@ _ADAPTER_REGISTRY: dict[str, type[CollectionAdapter]] = {
     "local": LocalCollectionAdapter,
     "http": HttpCollectionAdapter,
     "opengauss": OpenGaussCollectionAdapter,
+    "pgvector": PgVectorCollectionAdapter,
     "qdrant": QdrantCollectionAdapter,
     "volcengine": VolcengineCollectionAdapter,
     "vikingdb": VikingDBPrivateCollectionAdapter,

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -290,7 +290,8 @@ class PgVectorCollectionAdapter(CollectionAdapter):
         self._index_type = index_type
         self._index_params = dict(index_params or {})
         self._dimension = int(dimension)
-        self._conn = None
+        self._conn: Any = None
+        self._pool: Any = None
         self._lock = threading.RLock()
         # Feature flags resolved from the live extension version on connect
         # (_detect_version). Conservative defaults: everything off until proven.
@@ -348,13 +349,35 @@ class PgVectorCollectionAdapter(CollectionAdapter):
     def physical_table_name(self) -> str:
         return _safe_identifier(self._project_name, self._collection_name, prefix="ov")
 
+    def _conninfo(self) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        """psycopg2 ``connect`` args/kwargs. A DSN ``url`` wins over discrete
+        host/port/user/password (mem0's priority chain); ``sslmode`` is injected
+        for both forms."""
+        if self._url:
+            return (self._url,), {
+                "sslmode": self._sslmode,
+                "connect_timeout": self._connect_timeout,
+            }
+        return (), {
+            "host": self._host,
+            "port": self._port,
+            "user": self._user,
+            "password": self._password,
+            "dbname": self._db_name,
+            "sslmode": self._sslmode,
+            "connect_timeout": self._connect_timeout,
+        }
+
     def _connect(self):
         """Open (or reuse) a psycopg2 connection.
 
-        Priority chain: a DSN ``url`` wins over discrete host/port/user/password
-        (mem0's shape). ``sslmode`` is injected as a keyword either way so it
-        applies to both URI and discrete conninfo forms. The ``_import_psycopg2``
-        seam is module-level so tests can mock the driver without a live server.
+        ``pool_size > 1`` uses a ``ThreadedConnectionPool``; otherwise a single
+        lock-serialized connection (openGauss's model). ``register_vector`` is
+        intentionally *never* called: the reused ``%s::vector`` literal path needs
+        no driver-level type binding, so a plain psycopg2 works (mem0 ships this
+        way). If a deployment later opts into binding, it would run per
+        checked-out connection right here. The ``_import_psycopg2`` seam is
+        module-level so tests can mock the driver without a live server.
         """
         if self._conn is not None and not getattr(self._conn, "closed", 0):
             return self._conn
@@ -364,20 +387,15 @@ class PgVectorCollectionAdapter(CollectionAdapter):
             except Exception:
                 logger.debug("Failed to close stale pgvector connection", exc_info=True)
         psycopg2 = _import_psycopg2()
-        if self._url:
-            self._conn = psycopg2.connect(
-                self._url, sslmode=self._sslmode, connect_timeout=self._connect_timeout
-            )
+        args, kwargs = self._conninfo()
+        if self._pool_size > 1:
+            if self._pool is None:
+                self._pool = psycopg2.pool.ThreadedConnectionPool(
+                    1, self._pool_size, *args, **kwargs
+                )
+            self._conn = self._pool.getconn()
         else:
-            self._conn = psycopg2.connect(
-                host=self._host,
-                port=self._port,
-                user=self._user,
-                password=self._password,
-                dbname=self._db_name,
-                sslmode=self._sslmode,
-                connect_timeout=self._connect_timeout,
-            )
+            self._conn = psycopg2.connect(*args, **kwargs)
         return self._conn
 
     def _gate_features(self, extversion: str) -> None:

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import threading
 from typing import Any, Dict, List
 
+from packaging.version import InvalidVersion, Version
+
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb.collection.result import SearchItemResult, SearchResult
 from openviking.storage.vectordb_adapters.base import CollectionAdapter
@@ -290,6 +292,13 @@ class PgVectorCollectionAdapter(CollectionAdapter):
         self._dimension = int(dimension)
         self._conn = None
         self._lock = threading.RLock()
+        # Feature flags resolved from the live extension version on connect
+        # (_detect_version). Conservative defaults: everything off until proven.
+        self._pgvector_version = ""
+        self._supports_hnsw = False
+        self._supports_halfvec = False
+        self._supports_sparsevec = False
+        self._supports_iterative_scan = False
 
     @classmethod
     def from_config(cls, config: Any) -> "PgVectorCollectionAdapter":
@@ -370,6 +379,49 @@ class PgVectorCollectionAdapter(CollectionAdapter):
                 connect_timeout=self._connect_timeout,
             )
         return self._conn
+
+    def _gate_features(self, extversion: str) -> None:
+        """Resolve feature flags from a pgvector ``extversion`` string.
+
+        HNSW indexing needs >= 0.5.0; ``halfvec``/``sparsevec`` need >= 0.7.0;
+        the ``hnsw.iterative_scan`` GUC needs >= 0.8.0. An unparseable version
+        leaves every flag off (conservative).[^raglite]
+
+        [^raglite]: superlinear-ai/raglite gates iterative scan on the parsed
+        ``extversion`` the same way.
+        """
+        self._pgvector_version = str(extversion or "")
+        try:
+            version: Version | None = Version(self._pgvector_version)
+        except (InvalidVersion, TypeError):
+            version = None
+        self._supports_hnsw = version is not None and version >= Version("0.5.0")
+        self._supports_halfvec = version is not None and version >= Version("0.7.0")
+        self._supports_sparsevec = self._supports_halfvec
+        self._supports_iterative_scan = version is not None and version >= Version("0.8.0")
+
+    def _detect_version(self) -> None:
+        """Read the live pgvector version and gate features on it. Raises a
+        friendly error if the server predates HNSW support (< 0.5.0)."""
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
+            row = cur.fetchone()
+        finally:
+            cur.close()
+        extversion = row[0] if row else None
+        if not extversion:
+            self._gate_features("0")
+            return
+        self._gate_features(str(extversion))
+        if not self._supports_hnsw:
+            raise RuntimeError(
+                f"pgvector {extversion} is too old for OpenViking; HNSW indexing requires "
+                ">= 0.5.0. Upgrade the extension (e.g. `ALTER EXTENSION vector UPDATE`)."
+            )
 
     def _load_existing_collection_if_needed(self) -> None:
         raise NotImplementedError

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -28,11 +28,40 @@ from typing import Any, Dict
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb_adapters.base import CollectionAdapter
 from openviking.storage.vectordb_adapters.opengauss_adapter import (
+    OpenGaussCollection,
     _normalize_distance,
     _safe_identifier,
 )
 
 _DEFAULT_SCHEMA = "public"
+
+# pgvector keeps its collection/index metadata in its own sidecar tables so a
+# pgvector deployment never collides with an openGauss one in the same schema.
+_COLLECTION_META_TABLE = "__openviking_pgvector_collections"
+_INDEX_META_TABLE = "__openviking_pgvector_indexes"
+
+# openGauss meta-table constants that the inherited collection SQL bakes into its
+# statements; PgVectorCollection remaps them to the pgvector names above.
+_OPENGAUSS_META_REMAP = {
+    "__openviking_opengauss_collections": _COLLECTION_META_TABLE,
+    "__openviking_opengauss_indexes": _INDEX_META_TABLE,
+}
+
+
+class PgVectorCollection(OpenGaussCollection):
+    """SQL collection for PostgreSQL + pgvector.
+
+    Re-targets :class:`OpenGaussCollection` (openGauss ships a pgvector fork, so
+    the generated SQL is already pgvector-shaped). It inherits the read paths,
+    filter compilation, and identifier/vector helpers verbatim, overriding only
+    the parts where stock PostgreSQL diverges: its own metadata-table names (via
+    ``_meta_table_ref``), native ``ON CONFLICT`` upsert, ``CREATE EXTENSION``
+    ordering, and the per-query iterative-scan GUC bundle. Those overrides land
+    in their respective build-loop slices (B3.3/B3.6/B3.8).
+    """
+
+    def _meta_table_ref(self, table_name: str) -> str:
+        return super()._meta_table_ref(_OPENGAUSS_META_REMAP.get(table_name, table_name))
 
 
 class PgVectorCollectionAdapter(CollectionAdapter):

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -22,6 +22,7 @@ SQL ``ICollection`` and live connection seam are filled in over B3-B4.
 
 from __future__ import annotations
 
+import hashlib
 import threading
 from typing import Any, Dict, List
 
@@ -43,6 +44,12 @@ from openviking_cli.utils import get_logger
 logger = get_logger(__name__)
 
 _DEFAULT_SCHEMA = "public"
+
+# Stable 64-bit advisory-lock key so concurrent workers serialize the one-time
+# ``CREATE EXTENSION`` instead of racing (onyx-dot-app/onyx: sha256(name) -> int64).
+_EXTENSION_ADVISORY_KEY = int.from_bytes(
+    hashlib.sha256(b"openviking.pgvector.create_extension").digest()[:8], "big", signed=True
+)
 
 
 def _import_psycopg2():
@@ -440,6 +447,50 @@ class PgVectorCollectionAdapter(CollectionAdapter):
                 f"pgvector {extversion} is too old for OpenViking; HNSW indexing requires "
                 ">= 0.5.0. Upgrade the extension (e.g. `ALTER EXTENSION vector UPDATE`)."
             )
+
+    def _extension_present(self) -> bool:
+        conn = self._conn
+        if conn is None:
+            return False
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
+            return cur.fetchone() is not None
+        finally:
+            cur.close()
+
+    def _ensure_extension(self) -> None:
+        """Create the ``vector`` extension on connect, under an advisory lock so
+        concurrent workers don't race. If it fails (e.g. a least-privileged role
+        on managed PostgreSQL), re-check ``pg_extension`` — another worker or a
+        DBA may have installed it — and only then raise a literal remediation.
+        ``create_extension=False`` skips this entirely for pre-provisioned
+        deployments (RDS/Cloud SQL).[^flag]
+
+        [^flag]: open-webui / danny-avila/rag_api gate this on a
+        ``PGVECTOR_CREATE_EXTENSION`` flag; onyx-dot-app/onyx serializes it with
+        an advisory lock; serengil/deepface raises the actionable command.
+        """
+        if not self._create_extension:
+            return
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", [_EXTENSION_ADVISORY_KEY])
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            if not self._extension_present():
+                raise RuntimeError(
+                    "Failed to enable the pgvector 'vector' extension and it is not "
+                    "installed. Have a superuser run `CREATE EXTENSION vector;`, or set "
+                    "`create_extension=false` if the extension is pre-provisioned."
+                ) from exc
+        finally:
+            cur.close()
 
     def _load_existing_collection_if_needed(self) -> None:
         raise NotImplementedError

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -23,13 +23,14 @@ SQL ``ICollection`` and live connection seam are filled in over B3-B4.
 from __future__ import annotations
 
 import threading
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb_adapters.base import CollectionAdapter
 from openviking.storage.vectordb_adapters.opengauss_adapter import (
     OpenGaussCollection,
     _normalize_distance,
+    _quote_ident,
     _safe_identifier,
 )
 
@@ -60,8 +61,55 @@ class PgVectorCollection(OpenGaussCollection):
     in their respective build-loop slices (B3.3/B3.6/B3.8).
     """
 
+    def update_data(self, data_list: List[Dict[str, Any]]) -> Any:
+        """Update rows by primary key.
+
+        For a SQL backend an update-by-id is exactly the ``INSERT ... ON CONFLICT
+        (id) DO UPDATE`` upsert path, so ``update_data`` delegates to
+        ``upsert_data``. (``ICollection.update_data`` is abstract; the inherited
+        openGauss collection never implemented it, which is why pgvector must.)
+        """
+        return self.upsert_data(data_list)
+
     def _meta_table_ref(self, table_name: str) -> str:
         return super()._meta_table_ref(_OPENGAUSS_META_REMAP.get(table_name, table_name))
+
+    def _build_create_ddl(self, meta_data: Dict[str, Any]) -> list[str]:
+        """Return the ordered DDL for a collection: ``CREATE EXTENSION`` (when
+        enabled) *before* the ``CREATE TABLE`` carrying the ``vector(N)`` column.
+
+        Pure string builder (no connection) so the ordering and extension gate
+        are unit-testable. Stock PostgreSQL needs the extension created before any
+        ``vector(N)`` DDL; openGauss ships it natively so it never ran this.
+        """
+        columns = ["id TEXT PRIMARY KEY"]
+        seen = {"id"}
+        for field in meta_data.get("Fields", []) or []:
+            ddl = self._field_to_column_ddl(field)
+            field_name = field.get("FieldName")
+            if ddl and field_name not in seen:
+                columns.append(ddl)
+                seen.add(str(field_name))
+        for field_name, sql_type in self.INTERNAL_PATH_FIELDS.items():
+            if field_name not in seen:
+                columns.append(f"{_quote_ident(field_name)} {sql_type}")
+                seen.add(field_name)
+
+        statements: list[str] = []
+        if getattr(self, "_create_extension", True):
+            statements.append("CREATE EXTENSION IF NOT EXISTS vector")
+        statements.append(f"CREATE TABLE IF NOT EXISTS {self._table_ref()} ({', '.join(columns)})")
+        return statements
+
+    def create_remote_collection(self, meta_data: Dict[str, Any]) -> None:
+        self._meta = dict(meta_data)
+        self._vector_dim = self._extract_vector_dim(self._meta)
+        self._field_types = self._build_field_type_map(self._meta)
+        if self._vector_dim <= 0:
+            raise ValueError("pgvector collection requires a positive dense vector dimension")
+        for statement in self._build_create_ddl(meta_data):
+            self._execute(statement)
+        self._save_collection_meta(meta_data)
 
 
 class PgVectorCollectionAdapter(CollectionAdapter):

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -111,6 +111,34 @@ class PgVectorCollection(OpenGaussCollection):
             self._execute(statement)
         self._save_collection_meta(meta_data)
 
+    def _upsert_row(self, columns: List[str], values: List[Any]) -> None:
+        """Single-row upsert via native ``INSERT ... ON CONFLICT (id) DO UPDATE``.
+
+        Replaces the inherited openGauss UPDATE-then-INSERT + 23505 retry with the
+        portable pgvector idiom: one atomic round trip. The dense-vector column is
+        cast with ``%s::vector`` in VALUES, and ``EXCLUDED`` carries that typed
+        value into the SET list. Identifiers are quoted with the shared
+        ``_quote_ident`` (codebase idiom); the ``ON CONFLICT``/``EXCLUDED`` shape
+        follows langchain-postgres / mem0 (see design.md provenance).
+        """
+        insert_cols = ", ".join(_quote_ident(column) for column in columns)
+        placeholders = ", ".join(
+            "%s::vector" if column == self._dense_vector_name else "%s" for column in columns
+        )
+        update_columns = [column for column in columns if column != "id"]
+        if update_columns:
+            set_clause = ", ".join(
+                f"{_quote_ident(column)} = EXCLUDED.{_quote_ident(column)}"
+                for column in update_columns
+            )
+            conflict = f"ON CONFLICT (id) DO UPDATE SET {set_clause}"
+        else:
+            conflict = "ON CONFLICT (id) DO NOTHING"
+        self._execute(
+            f"INSERT INTO {self._table_ref()} ({insert_cols}) VALUES ({placeholders}) {conflict}",
+            values,
+        )
+
 
 class PgVectorCollectionAdapter(CollectionAdapter):
     """CollectionAdapter for PostgreSQL with the pgvector extension."""

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -11,26 +11,129 @@ in :class:`~openviking.storage.vectordb_adapters.base.CollectionAdapter`, adds
 openGauss/Citus-only distributed-table machinery. See the line-by-line reuse map
 in ``.wiki/pgvector/refs/02-opengauss-as-pgvector-reference.md``.
 
-Built test-first: this skeleton lands the walking-skeleton import + factory
-wiring (B0.3); the three ``CollectionAdapter`` hooks are filled in over B1-B4.
+The pure SQL/identifier helpers (``_safe_identifier``, ``_normalize_distance``,
+...) are reused verbatim from ``opengauss_adapter`` rather than duplicated; the
+shared boundary that would host them lives behind issue #2357 (out of scope for
+this build).
+
+Built test-first: this lands the config model (B1) and factory wiring (B2); the
+SQL ``ICollection`` and live connection seam are filled in over B3-B4.
 """
 
 from __future__ import annotations
 
+import threading
 from typing import Any, Dict
 
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb_adapters.base import CollectionAdapter
+from openviking.storage.vectordb_adapters.opengauss_adapter import (
+    _normalize_distance,
+    _safe_identifier,
+)
+
+_DEFAULT_SCHEMA = "public"
 
 
 class PgVectorCollectionAdapter(CollectionAdapter):
     """CollectionAdapter for PostgreSQL with the pgvector extension."""
 
     mode = "pgvector"
+    INTERNAL_PATH_FIELDS = ["parent_uri", "scope_roots", "uri_depth"]
+
+    def __init__(
+        self,
+        *,
+        url: str | None,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        db_name: str,
+        schema_name: str,
+        sslmode: str,
+        project_name: str,
+        collection_name: str,
+        index_name: str,
+        distance_metric: str,
+        dense_vector_name: str,
+        sparse_vector_name: str,
+        connect_timeout: int,
+        pool_size: int,
+        create_extension: bool,
+        index_type: str,
+        index_params: Dict[str, Any],
+        dimension: int = 0,
+    ) -> None:
+        super().__init__(collection_name=collection_name, index_name=index_name)
+        self._url = url
+        self._host = host
+        self._port = int(port)
+        self._user = user
+        self._password = password
+        self._db_name = db_name
+        self._schema_name = (schema_name or _DEFAULT_SCHEMA).strip() or _DEFAULT_SCHEMA
+        self._sslmode = sslmode
+        self._project_name = project_name
+        self._distance_metric = _normalize_distance(distance_metric)
+        self._dense_vector_name = dense_vector_name
+        self._sparse_vector_name = sparse_vector_name
+        self._connect_timeout = int(connect_timeout)
+        self._pool_size = int(pool_size)
+        self._create_extension = bool(create_extension)
+        self._index_type = index_type
+        self._index_params = dict(index_params or {})
+        self._dimension = int(dimension)
+        self._conn = None
+        self._lock = threading.RLock()
 
     @classmethod
     def from_config(cls, config: Any) -> "PgVectorCollectionAdapter":
-        raise NotImplementedError
+        cfg = getattr(config, "pgvector", None)
+        params = dict(getattr(config, "custom_params", {}) or {})
+        if cfg is None:
+            raise ValueError("pgvector backend requires pgvector config")
+        return cls(
+            url=(getattr(cfg, "url", None) or params.get("url") or None),
+            host=str(getattr(cfg, "host", None) or params.get("host") or "127.0.0.1"),
+            port=int(getattr(cfg, "port", None) or params.get("port") or 5432),
+            user=str(getattr(cfg, "user", None) or params.get("user") or "postgres"),
+            password=str(getattr(cfg, "password", None) or params.get("password") or ""),
+            db_name=str(getattr(cfg, "db_name", None) or params.get("db_name") or "postgres"),
+            schema_name=str(
+                getattr(cfg, "schema_name", None)
+                or getattr(cfg, "schema", None)
+                or params.get("schema")
+                or _DEFAULT_SCHEMA
+            ),
+            sslmode=str(getattr(cfg, "sslmode", None) or params.get("sslmode") or "prefer"),
+            project_name=config.project_name or "default",
+            collection_name=config.name or "context",
+            index_name=config.index_name or "default",
+            distance_metric=config.distance_metric or "cosine",
+            dense_vector_name=str(
+                getattr(cfg, "dense_vector_name", None)
+                or params.get("dense_vector_name")
+                or "vector"
+            ),
+            sparse_vector_name=str(
+                getattr(cfg, "sparse_vector_name", None)
+                or params.get("sparse_vector_name")
+                or "sparse_vector"
+            ),
+            connect_timeout=int(
+                getattr(cfg, "connect_timeout", None) or params.get("connect_timeout") or 10
+            ),
+            pool_size=int(getattr(cfg, "pool_size", None) or params.get("pool_size") or 1),
+            create_extension=bool(getattr(cfg, "create_extension", True)),
+            index_type=str(getattr(cfg, "index_type", None) or params.get("index_type") or "hnsw"),
+            index_params=dict(getattr(cfg, "index_params", None) or {}),
+            dimension=int(getattr(config, "dimension", 0) or 0),
+        )
+
+    @property
+    def physical_table_name(self) -> str:
+        return _safe_identifier(self._project_name, self._collection_name, prefix="ov")
 
     def _load_existing_collection_if_needed(self) -> None:
         raise NotImplementedError

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -35,6 +35,7 @@ from openviking.storage.vectordb_adapters.opengauss_adapter import (
     _VECTOR_OPS,
     OpenGaussCollection,
     OpenGaussCollectionAdapter,
+    _json_dumps,
     _normalize_distance,
     _qualify,
     _quote_ident,
@@ -47,6 +48,21 @@ logger = get_logger(__name__)
 
 _DEFAULT_SCHEMA = "public"
 
+
+def _coerce_int(value: Any, key: str, default: int) -> int:
+    """Coerce a user-supplied ``index_params`` value to ``int`` with an actionable
+    error, instead of letting a bare ``int(...)`` raise an opaque ``ValueError``
+    deep inside collection construction."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"pgvector index_params[{key!r}] must be an integer, got {value!r}"
+        ) from exc
+
+
 # Stable 64-bit advisory-lock key so concurrent workers serialize the one-time
 # ``CREATE EXTENSION`` instead of racing (onyx-dot-app/onyx: sha256(name) -> int64).
 _EXTENSION_ADVISORY_KEY = int.from_bytes(
@@ -57,6 +73,7 @@ _EXTENSION_ADVISORY_KEY = int.from_bytes(
 def _import_psycopg2():
     try:
         import psycopg2  # noqa: PLC0415
+        import psycopg2.pool  # noqa: PLC0415  # submodule is not auto-imported by `import psycopg2`
 
         return psycopg2
     except ImportError as exc:  # pragma: no cover - exercised only without optional driver
@@ -99,17 +116,72 @@ class PgVectorCollection(OpenGaussCollection):
     _max_scan_tuples: int = 20000
 
     def update_data(self, data_list: List[Dict[str, Any]]) -> Any:
-        """Update rows by primary key.
+        """Update existing rows by primary key (never insert new ones).
 
-        For a SQL backend an update-by-id is exactly the ``INSERT ... ON CONFLICT
-        (id) DO UPDATE`` upsert path, so ``update_data`` delegates to
-        ``upsert_data``. (``ICollection.update_data`` is abstract; the inherited
+        The ``/data/update`` endpoint is contractually "update existing data",
+        and other backends (e.g. ``LocalCollection.update_data``) reject unknown
+        ids rather than silently inserting. So pgvector first verifies every id
+        already exists, then delegates to the ``INSERT ... ON CONFLICT (id) DO
+        UPDATE`` upsert path — which, because it only sets the supplied columns,
+        gives the desired "update only the provided fields" semantics for rows
+        that are present. (``ICollection.update_data`` is abstract; the inherited
         openGauss collection never implemented it, which is why pgvector must.)
         """
+        if not data_list:
+            return self.upsert_data(data_list)
+        ids = []
+        for record in data_list:
+            if "id" not in record:
+                raise ValueError("primary key 'id' is required for update")
+            ids.append(record["id"])
+        missing = self.fetch_data(ids).ids_not_exist
+        if missing:
+            raise ValueError(f"record not found for primary key(s): {missing}")
         return self.upsert_data(data_list)
 
     def _meta_table_ref(self, table_name: str) -> str:
         return super()._meta_table_ref(_OPENGAUSS_META_REMAP.get(table_name, table_name))
+
+    def _save_collection_meta(self, meta: Dict[str, Any]) -> None:
+        """Persist collection metadata with portable ``INSERT ... ON CONFLICT``.
+
+        Overrides the inherited openGauss ``MERGE INTO`` upsert, which requires
+        PostgreSQL 15+. ``ON CONFLICT (table_name) DO UPDATE`` is supported on all
+        pgvector-capable PostgreSQL (>= 9.5), matching the ``_upsert_row`` idiom.
+        """
+        self._execute(
+            f"""
+            INSERT INTO {self._meta_table_ref(_COLLECTION_META_TABLE)}
+                (table_name, logical_collection_name, project_name, meta_json, updated_at)
+            VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP)
+            ON CONFLICT (table_name) DO UPDATE SET
+                logical_collection_name = EXCLUDED.logical_collection_name,
+                project_name = EXCLUDED.project_name,
+                meta_json = EXCLUDED.meta_json,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            [
+                self.collection_key,
+                self._logical_collection_name,
+                self._project_name,
+                _json_dumps(meta),
+            ],
+        )
+
+    def _save_index_meta(self, index_name: str, meta: Dict[str, Any]) -> None:
+        """Portable ``INSERT ... ON CONFLICT`` index-meta upsert (see
+        ``_save_collection_meta`` — avoids the PG15-only ``MERGE INTO``)."""
+        self._execute(
+            f"""
+            INSERT INTO {self._meta_table_ref(_INDEX_META_TABLE)}
+                (table_name, index_name, meta_json, updated_at)
+            VALUES (%s, %s, %s, CURRENT_TIMESTAMP)
+            ON CONFLICT (table_name, index_name) DO UPDATE SET
+                meta_json = EXCLUDED.meta_json,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            [self.collection_key, index_name, _json_dumps(meta)],
+        )
 
     def _build_create_ddl(self, meta_data: Dict[str, Any]) -> list[str]:
         """Return the ordered DDL for a collection: ``CREATE EXTENSION`` (when
@@ -412,9 +484,15 @@ class PgVectorCollectionAdapter(OpenGaussCollectionAdapter):
             return self._conn
         if self._conn is not None:
             try:
-                self._conn.close()
+                # A pooled handle must be returned via putconn (close=True), not
+                # merely .close()'d, or its slot leaks and the pool exhausts.
+                if self._pool is not None:
+                    self._pool.putconn(self._conn, close=True)
+                else:
+                    self._conn.close()
             except Exception:
-                logger.debug("Failed to close stale pgvector connection", exc_info=True)
+                logger.debug("Failed to release stale pgvector connection", exc_info=True)
+            self._conn = None
         psycopg2 = _import_psycopg2()
         args, kwargs = self._conninfo()
         if self._pool_size > 1:
@@ -461,8 +539,16 @@ class PgVectorCollectionAdapter(OpenGaussCollectionAdapter):
             cur.close()
         extversion = row[0] if row else None
         if not extversion:
-            self._gate_features("0")
-            return
+            # No pg_extension row => the 'vector' extension is not installed. Fail
+            # fast with an actionable message instead of proceeding to opaque
+            # vector(N)/index DDL errors. (With create_extension=true the extension
+            # was just created above, so this only trips on pre-provisioned
+            # deployments where it is genuinely absent.)
+            raise RuntimeError(
+                "The pgvector 'vector' extension is not installed in this database. "
+                "Have a superuser run `CREATE EXTENSION vector;`, or set "
+                "`create_extension=true` so OpenViking installs it on connect."
+            )
         self._gate_features(str(extversion))
         if not self._supports_hnsw:
             raise RuntimeError(
@@ -556,14 +642,22 @@ class PgVectorCollectionAdapter(OpenGaussCollectionAdapter):
     def _ensure_ready(self) -> None:
         """Connect and run the one-time bootstrap (extension → version gate →
         meta tables). Idempotent: the bootstrap runs once per adapter lifetime,
-        but ``_connect`` still reconnects a dropped connection on every call."""
-        self._connect()
-        if self._ready:
-            return
-        self._ensure_extension()
-        self._detect_version()
-        self._ensure_meta_tables()
-        self._ready = True
+        but ``_connect`` still reconnects a dropped connection on every call.
+
+        The bootstrap runs DDL and metadata reads on the shared psycopg2
+        connection, which is not safe for overlapping cursor use across threads,
+        so the whole block is serialized under ``self._lock`` (an RLock shared
+        with collection ``_execute``; reentrant, so nested acquisition is safe).
+        ``_ready`` is re-checked inside the lock so only the first thread bootstraps.
+        """
+        with self._lock:
+            self._connect()
+            if self._ready:
+                return
+            self._ensure_extension()
+            self._detect_version()
+            self._ensure_meta_tables()
+            self._ready = True
 
     def _new_collection(self, meta: Optional[Dict[str, Any]] = None) -> PgVectorCollection:
         self._ensure_ready()
@@ -584,9 +678,73 @@ class PgVectorCollectionAdapter(OpenGaussCollectionAdapter):
         # CREATE EXTENSION (B3.3) and iterative-scan GUC (B3.8) overrides fire.
         collection._create_extension = self._create_extension
         collection._iterative_scan_supported = self._supports_iterative_scan
-        collection._ef_search = int(self._index_params.get("ef_search", 100))
-        collection._max_scan_tuples = int(self._index_params.get("max_scan_tuples", 20000))
+        collection._ef_search = _coerce_int(self._index_params.get("ef_search"), "ef_search", 100)
+        collection._max_scan_tuples = _coerce_int(
+            self._index_params.get("max_scan_tuples"), "max_scan_tuples", 20000
+        )
         return collection
+
+    def _build_default_index_meta(
+        self,
+        *,
+        index_name: str,
+        distance: str,
+        use_sparse: bool,
+        sparse_weight: float,
+        scalar_index_fields: list[str],
+    ) -> Dict[str, Any]:
+        """Carry the configured HNSW build parameters into the default index meta.
+
+        ``CollectionAdapter.create_collection`` builds a fresh index meta and the
+        inherited implementation ignores ``index_params``, so ``m``/``ef_construction``
+        from ``PgVectorConfig.index_params`` would otherwise never reach the HNSW
+        DDL (which reads ``VectorIndex.M`` / ``VectorIndex.EfConstruction``,
+        defaulting to 16/64). Merge them here, accepting either casing.
+        """
+        index_meta = super()._build_default_index_meta(
+            index_name=index_name,
+            distance=distance,
+            use_sparse=use_sparse,
+            sparse_weight=sparse_weight,
+            scalar_index_fields=scalar_index_fields,
+        )
+        vector_index = index_meta["VectorIndex"]
+        m = self._index_params.get("m", self._index_params.get("M"))
+        if m is not None:
+            vector_index["M"] = _coerce_int(m, "m", 16)
+        ef_construction = self._index_params.get(
+            "ef_construction", self._index_params.get("EfConstruction")
+        )
+        if ef_construction is not None:
+            vector_index["EfConstruction"] = _coerce_int(ef_construction, "ef_construction", 64)
+        return index_meta
+
+    def close(self) -> None:
+        """Release the wrapped collection *and* the pgvector connection/pool.
+
+        The inherited openGauss ``close()`` only ``.close()``'s ``self._conn`` —
+        wrong for a pooled handle (which must be returned via ``putconn``) and it
+        never closes the pool object, leaking server connections. This override
+        closes the collection like the base adapter, returns/borrowed pooled conn,
+        and tears the pool down.
+        """
+        with self._lock:
+            try:
+                CollectionAdapter.close(self)
+            finally:
+                try:
+                    if self._pool is not None:
+                        if self._conn is not None:
+                            self._pool.putconn(self._conn, close=True)
+                        self._pool.closeall()
+                    elif self._conn is not None:
+                        self._conn.close()
+                except Exception:
+                    logger.debug("Failed to close pgvector connection/pool", exc_info=True)
+                finally:
+                    self._conn = None
+                    self._pool = None
+                    self._ready = False
 
     def _load_existing_collection_if_needed(self) -> None:
         if self._collection is not None:

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -26,12 +26,15 @@ import threading
 from typing import Any, Dict, List
 
 from openviking.storage.vectordb.collection.collection import Collection
+from openviking.storage.vectordb.collection.result import SearchItemResult, SearchResult
 from openviking.storage.vectordb_adapters.base import CollectionAdapter
 from openviking.storage.vectordb_adapters.opengauss_adapter import (
+    _VECTOR_OPS,
     OpenGaussCollection,
     _normalize_distance,
     _quote_ident,
     _safe_identifier,
+    _vector_literal,
 )
 
 _DEFAULT_SCHEMA = "public"
@@ -138,6 +141,86 @@ class PgVectorCollection(OpenGaussCollection):
             f"INSERT INTO {self._table_ref()} ({insert_cols}) VALUES ({placeholders}) {conflict}",
             values,
         )
+
+    def _supports_iterative_scan(self) -> bool:
+        """Whether the connected server has pgvector >= 0.8 (iterative scan).
+
+        Wired by the version gate on connect (B4.2). Defaults to ``False`` so a
+        pre-0.8 server falls back to the inherited plain scan rather than issuing
+        GUCs it cannot parse (which would abort the transaction).
+        """
+        return bool(getattr(self, "_iterative_scan_supported", False))
+
+    def _iterative_scan_guc_prefix(self) -> str:
+        """The ``SET LOCAL`` bundle that keeps HNSW recall under a selective
+        filter (metabase's tested shape). Values are inlined integers (clamped),
+        never user input, so they compose safely ahead of the parameterized
+        SELECT in one transaction.[^metabase]
+
+        [^metabase]: metabase/metabase
+        enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+        (iterative_scan/ef_search[clamp 1..1000]/max_scan_tuples + enable_seqscan);
+        Tencent/WeKnora gates it on version ("ignore failure on older pgvector").
+        """
+        ef_search = max(1, min(int(getattr(self, "_ef_search", 100)), 1000))
+        max_scan_tuples = int(getattr(self, "_max_scan_tuples", 20000))
+        return (
+            "SET LOCAL hnsw.iterative_scan = strict_order; "
+            f"SET LOCAL hnsw.ef_search = {ef_search}; "
+            f"SET LOCAL hnsw.max_scan_tuples = {max_scan_tuples}; "
+            "SET LOCAL enable_seqscan = off; "
+        )
+
+    def search_by_vector(
+        self,
+        index_name: str,
+        dense_vector: list[float] | None = None,
+        limit: int = 10,
+        offset: int = 0,
+        filters: dict[str, Any] | None = None,
+        sparse_vector: dict[str, float] | None = None,
+        output_fields: list[str] | None = None,
+    ) -> SearchResult:
+        """Dense ANN search that issues the iterative-scan GUC bundle when a
+        scalar filter is present (and the server supports it). Plain HNSW
+        post-filters at most ``ef_search`` candidates, so a selective filter can
+        silently return fewer than ``LIMIT`` rows; the bundle makes the scan keep
+        pulling candidates until ``LIMIT`` is satisfied. Everything else (no
+        filter, sparse/hybrid, unsupported server) delegates to the inherited
+        implementation unchanged — the param order stays ``[vec, …where…, vec,
+        limit, offset]`` (pinned by ``test_vector_search_binds_..._filter_params``).
+        """
+        if (
+            dense_vector is None
+            or sparse_vector
+            or not filters
+            or not self._supports_iterative_scan()
+        ):
+            return super().search_by_vector(
+                index_name, dense_vector, limit, offset, filters, sparse_vector, output_fields
+            )
+        if limit <= 0:
+            return SearchResult()
+        fetch_limit = max(limit + offset, limit)
+        columns = self._select_columns(output_fields, include_sparse=False)
+        where_sql, params = self._where_sql(filters)
+        operator = _VECTOR_OPS[self._distance_metric]["operator"]
+        vector_text = _vector_literal(dense_vector)
+        sql = self._iterative_scan_guc_prefix() + (
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)}, "
+            f"{_quote_ident(self._dense_vector_name)} {operator} %s::vector AS _distance "
+            f"FROM {self._table_ref()}"
+            f"{where_sql} "
+            f"ORDER BY {_quote_ident(self._dense_vector_name)} {operator} %s::vector "
+            "LIMIT %s OFFSET %s"
+        )
+        rows = self._execute(sql, [vector_text, *params, vector_text, fetch_limit, 0], fetch=True)
+        scored_items: list[SearchItemResult] = []
+        for row in rows:
+            record_id, payload = self._row_to_payload(row[:-1], columns)
+            score = self._distance_to_score(row[-1], self._distance_metric)
+            scored_items.append(SearchItemResult(id=record_id, fields=payload, score=score))
+        return SearchResult(data=scored_items[offset : offset + limit])
 
 
 class PgVectorCollectionAdapter(CollectionAdapter):

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import threading
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from packaging.version import InvalidVersion, Version
 
@@ -35,6 +35,7 @@ from openviking.storage.vectordb_adapters.opengauss_adapter import (
     _VECTOR_OPS,
     OpenGaussCollection,
     _normalize_distance,
+    _qualify,
     _quote_ident,
     _safe_identifier,
     _vector_literal,
@@ -89,6 +90,13 @@ class PgVectorCollection(OpenGaussCollection):
     in their respective build-loop slices (B3.3/B3.6/B3.8).
     """
 
+    # Knobs threaded from the adapter in ``_new_collection``; the class defaults
+    # keep ``object.__new__`` Tier-C construction (and mypy) happy.
+    _create_extension: bool = True
+    _iterative_scan_supported: bool = False
+    _ef_search: int = 100
+    _max_scan_tuples: int = 20000
+
     def update_data(self, data_list: List[Dict[str, Any]]) -> Any:
         """Update rows by primary key.
 
@@ -124,7 +132,7 @@ class PgVectorCollection(OpenGaussCollection):
                 seen.add(field_name)
 
         statements: list[str] = []
-        if getattr(self, "_create_extension", True):
+        if self._create_extension:
             statements.append("CREATE EXTENSION IF NOT EXISTS vector")
         statements.append(f"CREATE TABLE IF NOT EXISTS {self._table_ref()} ({', '.join(columns)})")
         return statements
@@ -174,7 +182,7 @@ class PgVectorCollection(OpenGaussCollection):
         pre-0.8 server falls back to the inherited plain scan rather than issuing
         GUCs it cannot parse (which would abort the transaction).
         """
-        return bool(getattr(self, "_iterative_scan_supported", False))
+        return self._iterative_scan_supported
 
     def _iterative_scan_guc_prefix(self) -> str:
         """The ``SET LOCAL`` bundle that keeps HNSW recall under a selective
@@ -187,8 +195,8 @@ class PgVectorCollection(OpenGaussCollection):
         (iterative_scan/ef_search[clamp 1..1000]/max_scan_tuples + enable_seqscan);
         Tencent/WeKnora gates it on version ("ignore failure on older pgvector").
         """
-        ef_search = max(1, min(int(getattr(self, "_ef_search", 100)), 1000))
-        max_scan_tuples = int(getattr(self, "_max_scan_tuples", 20000))
+        ef_search = max(1, min(self._ef_search, 1000))
+        max_scan_tuples = self._max_scan_tuples
         return (
             "SET LOCAL hnsw.iterative_scan = strict_order; "
             f"SET LOCAL hnsw.ef_search = {ef_search}; "
@@ -307,6 +315,7 @@ class PgVectorCollectionAdapter(CollectionAdapter):
         self._supports_halfvec = False
         self._supports_sparsevec = False
         self._supports_iterative_scan = False
+        self._ready = False
 
     @classmethod
     def from_config(cls, config: Any) -> "PgVectorCollectionAdapter":
@@ -492,8 +501,96 @@ class PgVectorCollectionAdapter(CollectionAdapter):
         finally:
             cur.close()
 
+    def _ensure_meta_tables(self) -> None:
+        """Create the pgvector-named sidecar metadata tables (openGauss's schema,
+        pgvector names). The collection reads/writes these via ``_meta_table_ref``,
+        which remaps the inherited openGauss constants to these names."""
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute(f"CREATE SCHEMA IF NOT EXISTS {_quote_ident(self._schema_name)}")
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_qualify(self._schema_name, _COLLECTION_META_TABLE)} (
+                    table_name TEXT PRIMARY KEY,
+                    logical_collection_name TEXT NOT NULL,
+                    project_name TEXT NOT NULL,
+                    meta_json TEXT NOT NULL,
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_qualify(self._schema_name, _INDEX_META_TABLE)} (
+                    table_name TEXT NOT NULL,
+                    index_name TEXT NOT NULL,
+                    meta_json TEXT NOT NULL,
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (table_name, index_name)
+                )
+                """
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            cur.close()
+
+    def _ensure_ready(self) -> None:
+        """Connect and run the one-time bootstrap (extension → version gate →
+        meta tables). Idempotent: the bootstrap runs once per adapter lifetime,
+        but ``_connect`` still reconnects a dropped connection on every call."""
+        self._connect()
+        if self._ready:
+            return
+        self._ensure_extension()
+        self._detect_version()
+        self._ensure_meta_tables()
+        self._ready = True
+
+    def _new_collection(self, meta: Optional[Dict[str, Any]] = None) -> PgVectorCollection:
+        self._ensure_ready()
+        collection = PgVectorCollection(
+            conn=self._conn,
+            schema_name=self._schema_name,
+            table_name=self.physical_table_name,
+            logical_collection_name=self._collection_name,
+            project_name=self._project_name,
+            dense_vector_name=self._dense_vector_name,
+            sparse_vector_name=self._sparse_vector_name,
+            distance_metric=self._distance_metric,
+            meta=meta,
+            lock=self._lock,
+            reconnect=self._connect,
+        )
+        # Thread the adapter-resolved knobs onto the live collection so the
+        # CREATE EXTENSION (B3.3) and iterative-scan GUC (B3.8) overrides fire.
+        collection._create_extension = self._create_extension
+        collection._iterative_scan_supported = self._supports_iterative_scan
+        collection._ef_search = int(self._index_params.get("ef_search", 100))
+        collection._max_scan_tuples = int(self._index_params.get("max_scan_tuples", 20000))
+        return collection
+
     def _load_existing_collection_if_needed(self) -> None:
-        raise NotImplementedError
+        if self._collection is not None:
+            return
+        raw_collection = self._new_collection()
+        if not raw_collection._table_exists():
+            return
+        meta = raw_collection.get_meta_data()
+        if not meta:
+            raise RuntimeError(
+                "pgvector collection table exists but OpenViking metadata is missing: "
+                f"{self.physical_table_name}. Use a different project/name, restore metadata, "
+                "or drop the stale table."
+            )
+        self._collection = Collection(self._new_collection(meta))
 
     def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
-        raise NotImplementedError
+        raw_collection = self._new_collection(meta)
+        raw_collection.create_remote_collection(meta)
+        return Collection(raw_collection)

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""PostgreSQL + pgvector collection adapter.
+
+openGauss ships a fork of the pgvector extension, so ``opengauss_adapter.py``
+already emits pgvector-shaped SQL (the ``vector`` column type, the
+``<=>``/``<#>``/``<->`` distance operators, ``USING hnsw``). This adapter is a
+*re-target* of that module for stock PostgreSQL: it reuses the shared data plane
+in :class:`~openviking.storage.vectordb_adapters.base.CollectionAdapter`, adds
+``CREATE EXTENSION vector`` / DSN connect / ``ON CONFLICT`` upsert, and drops the
+openGauss/Citus-only distributed-table machinery. See the line-by-line reuse map
+in ``.wiki/pgvector/refs/02-opengauss-as-pgvector-reference.md``.
+
+Built test-first: this skeleton lands the walking-skeleton import + factory
+wiring (B0.3); the three ``CollectionAdapter`` hooks are filled in over B1-B4.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from openviking.storage.vectordb.collection.collection import Collection
+from openviking.storage.vectordb_adapters.base import CollectionAdapter
+
+
+class PgVectorCollectionAdapter(CollectionAdapter):
+    """CollectionAdapter for PostgreSQL with the pgvector extension."""
+
+    mode = "pgvector"
+
+    @classmethod
+    def from_config(cls, config: Any) -> "PgVectorCollectionAdapter":
+        raise NotImplementedError
+
+    def _load_existing_collection_if_needed(self) -> None:
+        raise NotImplementedError
+
+    def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
+        raise NotImplementedError

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -36,8 +36,24 @@ from openviking.storage.vectordb_adapters.opengauss_adapter import (
     _safe_identifier,
     _vector_literal,
 )
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
 
 _DEFAULT_SCHEMA = "public"
+
+
+def _import_psycopg2():
+    try:
+        import psycopg2  # noqa: PLC0415
+
+        return psycopg2
+    except ImportError as exc:  # pragma: no cover - exercised only without optional driver
+        raise ImportError(
+            "The pgvector backend requires a psycopg2-compatible driver. "
+            'Install it with `pip install "openviking[pgvector]"`.'
+        ) from exc
+
 
 # pgvector keeps its collection/index metadata in its own sidecar tables so a
 # pgvector deployment never collides with an openGauss one in the same schema.
@@ -322,6 +338,38 @@ class PgVectorCollectionAdapter(CollectionAdapter):
     @property
     def physical_table_name(self) -> str:
         return _safe_identifier(self._project_name, self._collection_name, prefix="ov")
+
+    def _connect(self):
+        """Open (or reuse) a psycopg2 connection.
+
+        Priority chain: a DSN ``url`` wins over discrete host/port/user/password
+        (mem0's shape). ``sslmode`` is injected as a keyword either way so it
+        applies to both URI and discrete conninfo forms. The ``_import_psycopg2``
+        seam is module-level so tests can mock the driver without a live server.
+        """
+        if self._conn is not None and not getattr(self._conn, "closed", 0):
+            return self._conn
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                logger.debug("Failed to close stale pgvector connection", exc_info=True)
+        psycopg2 = _import_psycopg2()
+        if self._url:
+            self._conn = psycopg2.connect(
+                self._url, sslmode=self._sslmode, connect_timeout=self._connect_timeout
+            )
+        else:
+            self._conn = psycopg2.connect(
+                host=self._host,
+                port=self._port,
+                user=self._user,
+                password=self._password,
+                dbname=self._db_name,
+                sslmode=self._sslmode,
+                connect_timeout=self._connect_timeout,
+            )
+        return self._conn
 
     def _load_existing_collection_if_needed(self) -> None:
         raise NotImplementedError

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -34,6 +34,7 @@ from openviking.storage.vectordb_adapters.base import CollectionAdapter
 from openviking.storage.vectordb_adapters.opengauss_adapter import (
     _VECTOR_OPS,
     OpenGaussCollection,
+    OpenGaussCollectionAdapter,
     _normalize_distance,
     _qualify,
     _quote_ident,
@@ -256,11 +257,21 @@ class PgVectorCollection(OpenGaussCollection):
         return SearchResult(data=scored_items[offset : offset + limit])
 
 
-class PgVectorCollectionAdapter(CollectionAdapter):
-    """CollectionAdapter for PostgreSQL with the pgvector extension."""
+class PgVectorCollectionAdapter(OpenGaussCollectionAdapter):
+    """CollectionAdapter for PostgreSQL with the pgvector extension.
+
+    Re-targets :class:`OpenGaussCollectionAdapter` (symmetric with
+    :class:`PgVectorCollection` re-targeting :class:`OpenGaussCollection`). It
+    inherits the adapter-level path plane verbatim — ``_normalize_record_for_write``
+    (scope_roots/uri_depth augmentation), ``_normalize_record_for_read``,
+    ``_sanitize_scalar_index_fields``, ``_build_default_index_meta``, and the
+    ``PathScope`` filter compilation — and overrides only the connection/driver
+    seam and collection construction (DSN connect, version gate, extension,
+    pgvector meta tables, PgVectorCollection). The openGauss-only distributed
+    helpers are inherited but never called.
+    """
 
     mode = "pgvector"
-    INTERNAL_PATH_FIELDS = ["parent_uri", "scope_roots", "uri_depth"]
 
     def __init__(
         self,
@@ -286,7 +297,9 @@ class PgVectorCollectionAdapter(CollectionAdapter):
         index_params: Dict[str, Any],
         dimension: int = 0,
     ) -> None:
-        super().__init__(collection_name=collection_name, index_name=index_name)
+        # Skip OpenGaussCollectionAdapter.__init__ (openGauss host/mode/shard_count
+        # signature); pgvector sets its own connection state below.
+        CollectionAdapter.__init__(self, collection_name=collection_name, index_name=index_name)
         self._url = url
         self._host = host
         self._port = int(port)

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -126,6 +126,40 @@ class OpenGaussConfig(BaseModel):
         return self
 
 
+class PgVectorConfig(BaseModel):
+    """Configuration for PostgreSQL + pgvector native vector backend."""
+
+    host: Optional[str] = Field(
+        default="127.0.0.1",
+        description="PostgreSQL host address.",
+    )
+    port: int = Field(default=5432, description="PostgreSQL port")
+    user: str = Field(default="postgres", description="Database user")
+    password: str = Field(default="", description="Database password")
+    db_name: str = Field(default="postgres", description="Database name")
+    schema_name: str = Field(
+        default="public",
+        alias="schema",
+        description="Database schema for OpenViking tables",
+    )
+    connect_timeout: int = Field(default=10, description="Database connection timeout in seconds")
+    dense_vector_name: str = Field(default="vector", description="Dense vector column name")
+    sparse_vector_name: str = Field(
+        default="sparse_vector", description="Sparse vector JSON column name"
+    )
+
+    model_config = {"extra": "forbid", "populate_by_name": True}
+
+    @model_validator(mode="after")
+    def validate_pgvector(self):
+        self.schema_name = (self.schema_name or "public").strip()
+        if not self.schema_name:
+            raise ValueError("pgvector schema must not be empty")
+        self.dense_vector_name = (self.dense_vector_name or "vector").strip()
+        self.sparse_vector_name = (self.sparse_vector_name or "sparse_vector").strip()
+        return self
+
+
 class VectorDBBackendConfig(BaseModel):
     """
     Configuration for VectorDB backend.
@@ -203,6 +237,11 @@ class VectorDBBackendConfig(BaseModel):
         description="openGauss configuration for 'opengauss' type",
     )
 
+    pgvector: Optional[PgVectorConfig] = Field(
+        default_factory=PgVectorConfig,
+        description="PostgreSQL + pgvector configuration for 'pgvector' type",
+    )
+
     custom_params: Dict[str, Any] = Field(
         default_factory=dict,
         description="Custom parameters for custom backend adapters",
@@ -213,7 +252,15 @@ class VectorDBBackendConfig(BaseModel):
     @model_validator(mode="after")
     def validate_config(self):
         """Validate configuration completeness and consistency"""
-        standard_backends = ["local", "http", "volcengine", "vikingdb", "qdrant", "opengauss"]
+        standard_backends = [
+            "local",
+            "http",
+            "volcengine",
+            "vikingdb",
+            "qdrant",
+            "opengauss",
+            "pgvector",
+        ]
 
         # Allow custom backend classes (containing dot) without standard validation
         if "." in self.backend:

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -179,8 +179,27 @@ class PgVectorConfig(BaseModel):
         self.schema_name = (self.schema_name or "public").strip()
         if not self.schema_name:
             raise ValueError("pgvector schema must not be empty")
+        # Normalize then re-check: a whitespace-only name is truthy so the
+        # `or "vector"` fallback never fires, yet strips to "" — an empty SQL
+        # identifier. Reject it here with a clear error instead of failing later
+        # with an opaque SQL error.
         self.dense_vector_name = (self.dense_vector_name or "vector").strip()
+        if not self.dense_vector_name:
+            raise ValueError("pgvector dense_vector_name must not be empty")
         self.sparse_vector_name = (self.sparse_vector_name or "sparse_vector").strip()
+        if not self.sparse_vector_name:
+            raise ValueError("pgvector sparse_vector_name must not be empty")
+        # Fail fast on non-integer numeric index params so misconfiguration
+        # surfaces at config load, not deep in collection creation.
+        for key in ("m", "ef_construction", "ef_search", "max_scan_tuples"):
+            if key in self.index_params and self.index_params[key] is not None:
+                try:
+                    self.index_params[key] = int(self.index_params[key])
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"pgvector index_params[{key!r}] must be an integer, "
+                        f"got {self.index_params[key]!r}"
+                    )
         return self
 
 

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -357,11 +357,11 @@ class VectorDBBackendConfig(BaseModel):
         elif self.backend == "pgvector":
             if self.pgvector is None:
                 self.pgvector = PgVectorConfig()
+            # Priority chain (mem0-style): url wins over discrete host/port fields.
+            # Normalize whitespace to None first so a blank value never masks a real one.
+            self.pgvector.url = (self.pgvector.url or "").strip() or None
+            self.pgvector.host = (self.pgvector.host or "").strip() or None
             if not (self.pgvector.url or self.pgvector.host):
                 raise ValueError("VectorDB pgvector backend requires 'url' or 'host' to be set")
-            if self.pgvector.url:
-                self.pgvector.url = self.pgvector.url.strip()
-            if self.pgvector.host:
-                self.pgvector.host = self.pgvector.host.strip()
 
         return self

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -129,6 +129,11 @@ class OpenGaussConfig(BaseModel):
 class PgVectorConfig(BaseModel):
     """Configuration for PostgreSQL + pgvector native vector backend."""
 
+    url: Optional[str] = Field(
+        default=None,
+        description="PostgreSQL DSN (e.g. 'postgresql://user:pass@host:5432/db'). "
+        "Takes priority over discrete host/port/user/password fields when set.",
+    )
     host: Optional[str] = Field(
         default="127.0.0.1",
         description="PostgreSQL host address.",
@@ -142,7 +147,26 @@ class PgVectorConfig(BaseModel):
         alias="schema",
         description="Database schema for OpenViking tables",
     )
+    sslmode: str = Field(
+        default="prefer",
+        description="libpq sslmode ('prefer', 'require', 'disable', ...).",
+    )
     connect_timeout: int = Field(default=10, description="Database connection timeout in seconds")
+    pool_size: int = Field(
+        default=1,
+        description="Connection pool size. 1 uses a single lock-serialized connection; "
+        ">1 uses a ThreadedConnectionPool.",
+    )
+    create_extension: bool = Field(
+        default=True,
+        description="Run 'CREATE EXTENSION IF NOT EXISTS vector' on connect. "
+        "Set false for pre-provisioned managed PostgreSQL (RDS/Cloud SQL).",
+    )
+    index_type: str = Field(default="hnsw", description="Vector index type ('hnsw').")
+    index_params: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra index build parameters (e.g. {'m': 16, 'ef_construction': 64}).",
+    )
     dense_vector_name: str = Field(default="vector", description="Dense vector column name")
     sparse_vector_name: str = Field(
         default="sparse_vector", description="Sparse vector JSON column name"

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -197,7 +197,7 @@ class VectorDBBackendConfig(BaseModel):
         description=(
             "VectorDB backend type: 'local', 'http', "
             "'volcengine' (AK/SK signed or API key data-plane only), "
-            "'vikingdb' (private deployment), 'qdrant', or 'opengauss'"
+            "'vikingdb' (private deployment), 'qdrant', 'opengauss', or 'pgvector'"
         ),
     )
 
@@ -353,5 +353,15 @@ class VectorDBBackendConfig(BaseModel):
             if not self.opengauss.host:
                 raise ValueError("VectorDB opengauss backend requires 'opengauss.host' to be set")
             self.opengauss.host = self.opengauss.host.strip()
+
+        elif self.backend == "pgvector":
+            if self.pgvector is None:
+                self.pgvector = PgVectorConfig()
+            if not (self.pgvector.url or self.pgvector.host):
+                raise ValueError("VectorDB pgvector backend requires 'url' or 'host' to be set")
+            if self.pgvector.url:
+                self.pgvector.url = self.pgvector.url.strip()
+            if self.pgvector.host:
+                self.pgvector.host = self.pgvector.host.strip()
 
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,10 @@ test = [
 opengauss = [
     "psycopg2-binary>=2.9",
 ]
+pgvector = [
+    "psycopg2-binary>=2.9",
+    "pgvector>=0.2",
+]
 dev = [
     "mypy>=1.0.0",
     "ruff>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ test = [
     "pandas>=2.0.0",
     "diff-match-patch>=20200713",
     "hvac>=2.0.0",
+    "testcontainers[postgres]>=4.0.0",
 ]
 opengauss = [
     "psycopg2-binary>=2.9",
@@ -109,6 +110,7 @@ opengauss = [
 pgvector = [
     "psycopg2-binary>=2.9",
     "pgvector>=0.2",
+    "packaging>=20.0",
 ]
 dev = [
     "mypy>=1.0.0",

--- a/tests/eval/test_pgvector_retrieval_eval.py
+++ b/tests/eval/test_pgvector_retrieval_eval.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Repo-local retrieval-quality eval for the pgvector backend (B7 confidence gate).
+
+The external LoCoMo dataset the Qdrant PR (#2350) used is not vendored in this
+repo, so this is a small, self-contained, deterministic stand-in: a labeled
+mini-corpus embedded with a hashing bag-of-words vector (no network / no LLM),
+upserted into a live pgvector collection, then queried to measure recall@1 /
+recall@3 / F1. It proves the pgvector adapter retrieves the right nearest
+neighbours end-to-end under a real HNSW index — it is NOT the LoCoMo benchmark.
+
+Gated on ``OPENVIKING_PGVECTOR_HOST`` so CI skips it without a live container.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import uuid
+
+import pytest
+
+from openviking.storage.vectordb_adapters.factory import create_collection_adapter
+from openviking.storage.vectordb_adapters.pgvector_adapter import PgVectorCollectionAdapter
+from openviking_cli.utils.config.vectordb_config import VectorDBBackendConfig
+
+_DIM = 128
+
+
+def _embed(text: str, dim: int = _DIM) -> list[float]:
+    """Deterministic hashing bag-of-words embedding (unit-normalized)."""
+    vec = [0.0] * dim
+    for token in text.lower().replace(",", " ").replace(".", " ").split():
+        bucket = int(hashlib.sha1(token.encode()).hexdigest(), 16) % dim
+        vec[bucket] += 1.0
+    norm = math.sqrt(sum(x * x for x in vec)) or 1.0
+    return [x / norm for x in vec]
+
+
+# Labeled mini-corpus: doc id -> text, spanning four topics.
+_CORPUS = {
+    "auth-login": "Users authenticate by logging in with an email and password to receive a session token.",
+    "auth-oauth": "OAuth lets a third-party client obtain an access token without sharing the user password.",
+    "auth-mfa": "Multi-factor authentication adds a second verification step such as a one-time passcode.",
+    "bill-invoice": "Invoices are generated monthly and list the charges for the billing period.",
+    "bill-refund": "A refund returns money to the customer for a cancelled or disputed charge.",
+    "bill-plan": "Upgrading the subscription plan changes the monthly price and available quota.",
+    "deploy-docker": "Deploy the service with docker compose which starts the containers and healthchecks.",
+    "deploy-k8s": "Kubernetes runs the workload as pods and scales replicas based on load.",
+    "deploy-env": "Configuration is provided through environment variables loaded at container startup.",
+    "search-vector": "Vector search finds the nearest embeddings to a query using an approximate index.",
+    "search-filter": "A scalar filter narrows vector search results to rows matching metadata conditions.",
+    "search-hybrid": "Hybrid search fuses dense vector similarity with sparse lexical matching scores.",
+}
+
+# Query -> the single relevant doc id (paraphrases sharing the key content words).
+_QUERIES = {
+    "how do I log in with my email and password to get a session token": "auth-login",
+    "third-party client access token without sharing the password": "auth-oauth",
+    "second verification step with a one-time passcode": "auth-mfa",
+    "monthly invoice listing the charges for the billing period": "bill-invoice",
+    "return money to the customer for a cancelled charge": "bill-refund",
+    "upgrade the subscription plan to change monthly price and quota": "bill-plan",
+    "deploy with docker compose starting containers and healthchecks": "deploy-docker",
+    "kubernetes pods scaling replicas based on load": "deploy-k8s",
+    "configuration through environment variables at container startup": "deploy-env",
+    "nearest embeddings to a query using an approximate index": "search-vector",
+    "narrow vector results to rows matching metadata conditions": "search-filter",
+    "fuse dense vector similarity with sparse lexical matching": "search-hybrid",
+}
+
+
+def _eval_config(project: str) -> VectorDBBackendConfig:
+    return VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": project,
+            "name": "context",
+            "index_name": "default",
+            "distance_metric": "cosine",
+            "dimension": _DIM,
+            "pgvector": {
+                "host": os.getenv("OPENVIKING_PGVECTOR_HOST", "127.0.0.1"),
+                "port": int(os.getenv("OPENVIKING_PGVECTOR_PORT", "15432")),
+                "user": os.getenv("OPENVIKING_PGVECTOR_USER", "postgres"),
+                "password": os.getenv("OPENVIKING_PGVECTOR_PASSWORD", "postgres"),
+                "db_name": os.getenv("OPENVIKING_PGVECTOR_DB", "postgres"),
+                "schema": os.getenv("OPENVIKING_PGVECTOR_SCHEMA", "public"),
+            },
+        }
+    )
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENVIKING_PGVECTOR_HOST"),
+    reason="set OPENVIKING_PGVECTOR_HOST to run the pgvector retrieval eval",
+)
+def test_pgvector_retrieval_quality():
+    adapter = create_collection_adapter(_eval_config(f"eval_{uuid.uuid4().hex[:8]}"))
+    assert isinstance(adapter, PgVectorCollectionAdapter)
+    meta = {
+        "CollectionName": "context",
+        "Fields": [
+            {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+            {"FieldName": "uri", "FieldType": "path"},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": _DIM},
+            {"FieldName": "abstract", "FieldType": "string"},
+        ],
+    }
+    collection = adapter._new_collection(meta)
+    try:
+        collection.create_remote_collection(meta)
+        collection.create_index(
+            "default",
+            {
+                "IndexName": "default",
+                "VectorIndex": {"IndexType": "hnsw", "Distance": "cosine"},
+                "ScalarIndex": ["uri"],
+            },
+        )
+        collection.upsert_data(
+            [
+                adapter._normalize_record_for_write(
+                    {
+                        "id": doc_id,
+                        "uri": f"viking://resources/kb/{doc_id}.md",
+                        "vector": _embed(text),
+                        "abstract": text,
+                    }
+                )
+                for doc_id, text in _CORPUS.items()
+            ]
+        )
+
+        hits_at_1 = 0
+        hits_at_3 = 0
+        for query, expected in _QUERIES.items():
+            result = collection.search_by_vector("default", dense_vector=_embed(query), limit=3)
+            ranked = [item.id for item in result.data]
+            if ranked and ranked[0] == expected:
+                hits_at_1 += 1
+            if expected in ranked:
+                hits_at_3 += 1
+
+        total = len(_QUERIES)
+        recall_at_1 = hits_at_1 / total
+        recall_at_3 = hits_at_3 / total
+        # single relevant doc, single top-1 retrieved -> precision@1 == recall@1 == F1.
+        f1 = recall_at_1
+        print(
+            f"\n[pgvector retrieval eval] N={total} recall@1={recall_at_1:.3f} "
+            f"recall@3={recall_at_3:.3f} F1={f1:.3f}"
+        )
+
+        assert recall_at_1 >= 0.8, f"recall@1 {recall_at_1:.3f} below 0.8 bar"
+        assert recall_at_3 >= 0.9, f"recall@3 {recall_at_3:.3f} below 0.9 bar"
+    finally:
+        collection.drop()
+        adapter.close()

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -372,6 +372,65 @@ def test_sslmode_passed_to_connect(monkeypatch, pgvector_cfg, sslmode, expect_ur
         assert captured["kwargs"]["host"] == "10.0.0.5"
 
 
+class _FakeCursor:
+    def __init__(self, extversion):
+        self._extversion = extversion
+        self.executed = None
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        self.executed = sql
+
+    def fetchone(self):
+        return (self._extversion,) if self._extversion is not None else None
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeConn:
+    closed = 0
+
+    def __init__(self, extversion):
+        self._extversion = extversion
+        self.last_cursor = None
+
+    def cursor(self):
+        self.last_cursor = _FakeCursor(self._extversion)
+        return self.last_cursor
+
+
+@pytest.mark.parametrize(
+    ("extversion", "hnsw", "halfvec", "iterative"),
+    [
+        ("0.8.2", True, True, True),
+        ("0.7.0", True, True, False),
+        ("0.5.1", True, False, False),
+    ],
+    ids=["v0.8-iterative", "v0.7-halfvec", "v0.5-hnsw-only"],
+)
+def test_version_gate_reads_extversion(extversion, hnsw, halfvec, iterative):
+    adapter = create_collection_adapter(_build_config())
+    adapter._conn = _FakeConn(extversion)
+
+    adapter._detect_version()
+
+    assert "extversion" in adapter._conn.last_cursor.executed
+    assert "extname" in adapter._conn.last_cursor.executed
+    assert adapter._supports_hnsw is hnsw
+    assert adapter._supports_halfvec is halfvec
+    assert adapter._supports_iterative_scan is iterative
+    assert adapter._pgvector_version == extversion
+
+
+def test_version_gate_rejects_pre_hnsw_pgvector():
+    adapter = create_collection_adapter(_build_config())
+    adapter._conn = _FakeConn("0.4.4")
+
+    with pytest.raises(RuntimeError, match="0.5"):
+        adapter._detect_version()
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -87,6 +87,37 @@ def test_pgvector_distance_validation(metric, valid):
             _normalize_distance(metric)
 
 
+@pytest.mark.parametrize(
+    ("create_extension", "expect_ext"),
+    [(True, True), (False, False)],
+    ids=["create-extension", "pre-provisioned"],
+)
+def test_create_extension_emitted_before_vector_ddl(create_extension, expect_ext):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    collection._vector_dim = 3
+    collection._create_extension = create_extension
+
+    meta = {
+        "Fields": [
+            {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": 3},
+        ]
+    }
+    statements = collection._build_create_ddl(meta)
+
+    assert any("vector(3)" in s for s in statements)
+    if expect_ext:
+        assert statements[0] == "CREATE EXTENSION IF NOT EXISTS vector"
+        ext_idx = next(i for i, s in enumerate(statements) if "CREATE EXTENSION" in s)
+        vec_idx = next(i for i, s in enumerate(statements) if "vector(3)" in s)
+        assert ext_idx < vec_idx
+    else:
+        assert all("CREATE EXTENSION" not in s for s in statements)
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -183,6 +183,43 @@ def test_vector_search_binds_vector_before_filter_params():
     assert captured["params"] == ["[0.1,0.2]", "%\n/a\n%", "[0.1,0.2]", 10, 0]
 
 
+@pytest.mark.parametrize(
+    ("columns", "values", "expect_update"),
+    [
+        (["id", "content", "vector"], ["doc-1", "hi", "[0.1,0.2]"], True),
+        (["id"], ["doc-1"], False),
+    ],
+    ids=["multi-col-do-update", "id-only-do-nothing"],
+)
+def test_upsert_uses_on_conflict(columns, values, expect_update):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    captured = {}
+    collection._table_ref = lambda: '"public"."ov_test"'
+
+    def execute(sql, params=None, *, fetch=False):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    collection._execute = execute
+    collection._upsert_row(columns, values)
+
+    sql = captured["sql"]
+    assert "INSERT INTO" in sql
+    assert captured["params"] == values
+    if expect_update:
+        assert "ON CONFLICT (id) DO UPDATE SET" in sql
+        assert '"content" = EXCLUDED."content"' in sql
+        assert '"vector" = EXCLUDED."vector"' in sql
+        assert "%s::vector" in sql  # dense vector cast in VALUES
+        assert 'EXCLUDED."id"' not in sql  # id is the conflict key, never updated
+    else:
+        assert "ON CONFLICT (id) DO NOTHING" in sql
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -220,6 +220,71 @@ def test_upsert_uses_on_conflict(columns, values, expect_update):
         assert "ON CONFLICT (id) DO NOTHING" in sql
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected_fragments", "expected_params"),
+    [
+        ({"op": "must", "field": "account_id", "conds": ["acme"]}, ['"account_id" = %s'], ["acme"]),
+        (
+            {"op": "must", "field": "account_id", "conds": ["a", "b"]},
+            ['"account_id" IN (%s, %s)'],
+            ["a", "b"],
+        ),
+        (
+            {"op": "must", "field": "scope_roots", "conds": ["/resources/acme/docs"]},
+            ['"scope_roots" LIKE %s'],
+            ["%\n/resources/acme/docs\n%"],
+        ),
+        (
+            {
+                "op": "range",
+                "field": "updated_at",
+                "gte": "2026-05-01T00:00:00+00:00",
+                "lt": "2026-06-01T00:00:00+00:00",
+            },
+            ['"updated_at" >= %s', '"updated_at" < %s'],
+            ["2026-05-01T00:00:00+00:00", "2026-06-01T00:00:00+00:00"],
+        ),
+        (
+            {
+                "op": "time_range",
+                "field": "updated_at",
+                "gte": "2026-05-01T00:00:00+00:00",
+                "lte": "2026-06-01T00:00:00+00:00",
+            },
+            ['"updated_at" >= %s', '"updated_at" <= %s'],
+            ["2026-05-01T00:00:00+00:00", "2026-06-01T00:00:00+00:00"],
+        ),
+        (
+            {"op": "contains", "field": "abstract", "substring": "report"},
+            ['"abstract" LIKE %s'],
+            ["%report%"],
+        ),
+        ({"op": "prefix", "field": "uri", "prefix": "/r"}, ['"uri" LIKE %s'], ["/r%"]),
+        (
+            {
+                "op": "and",
+                "conds": [
+                    {"op": "must", "field": "account_id", "conds": ["acme"]},
+                    {"op": "contains", "field": "abstract", "substring": "report"},
+                ],
+            },
+            ['"account_id" = %s', '"abstract" LIKE %s', " AND "],
+            ["acme", "%report%"],
+        ),
+    ],
+    ids=["eq", "in", "scope_roots", "range", "time_range", "contains", "prefix", "and"],
+)
+def test_collection_filter_to_sql(payload, expected_fragments, expected_params):
+    collection = object.__new__(PgVectorCollection)
+    collection._field_types = {"updated_at": "date_time"}
+
+    clause, params = collection._compile_filter(payload)
+
+    for fragment in expected_fragments:
+        assert fragment in clause
+    assert params == expected_params
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import types
+
 import pytest
 from pydantic import ValidationError
 
 from openviking.storage.vectordb.collection.collection import ICollection
+from openviking.storage.vectordb_adapters import pgvector_adapter as pgvector_module
 from openviking.storage.vectordb_adapters.factory import create_collection_adapter
 from openviking.storage.vectordb_adapters.opengauss_adapter import (
     _safe_identifier,
@@ -330,6 +333,43 @@ def test_iterative_scan_set_when_filtered(supported, expect_guc):
     assert captured["params"] == ["[0.1,0.2]", "%\n/a\n%", "[0.1,0.2]", 3, 0]
     # Full LIMIT returned under a selective filter.
     assert len(result.data) == 3
+
+
+@pytest.mark.parametrize(
+    ("pgvector_cfg", "sslmode", "expect_url"),
+    [
+        ({"host": "10.0.0.5", "sslmode": "require"}, "require", False),
+        ({"url": "postgresql://u:p@h:5432/db", "sslmode": "prefer"}, "prefer", True),
+    ],
+    ids=["discrete-require", "url-prefer"],
+)
+def test_sslmode_passed_to_connect(monkeypatch, pgvector_cfg, sslmode, expect_url):
+    captured = {}
+
+    class FakeConn:
+        closed = 0
+
+    def fake_connect(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return FakeConn()
+
+    monkeypatch.setattr(
+        pgvector_module,
+        "_import_psycopg2",
+        lambda: types.SimpleNamespace(connect=fake_connect),
+        raising=False,
+    )
+
+    config = VectorDBBackendConfig.model_validate({"backend": "pgvector", "pgvector": pgvector_cfg})
+    adapter = create_collection_adapter(config)
+    adapter._connect()
+
+    assert captured["kwargs"]["sslmode"] == sslmode
+    if expect_url:
+        assert captured["args"][0] == "postgresql://u:p@h:5432/db"
+    else:
+        assert captured["kwargs"]["host"] == "10.0.0.5"
 
 
 def test_factory_creates_pgvector_adapter_without_connecting():

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -480,6 +480,81 @@ def test_register_vector_optional(monkeypatch, pool_size, expect_pool):
         assert len(connect_calls) == 1
 
 
+class _ExtCursor:
+    def __init__(self, fail_create, ext_present):
+        self._fail_create = fail_create
+        self._ext_present = ext_present
+        self._last = None
+        self.create_attempted = False
+
+    def execute(self, sql, params=None):
+        self._last = sql
+        if "CREATE EXTENSION" in sql:
+            self.create_attempted = True
+            if self._fail_create:
+                raise RuntimeError("permission denied to create extension vector")
+
+    def fetchone(self):
+        if self._last and "pg_extension" in self._last:
+            return (1,) if self._ext_present else None
+        return None
+
+    def close(self):
+        pass
+
+
+class _ExtConn:
+    closed = 0
+
+    def __init__(self, fail_create, ext_present):
+        self._fail_create = fail_create
+        self._ext_present = ext_present
+        self.cursors = []
+
+    def cursor(self):
+        cur = _ExtCursor(self._fail_create, self._ext_present)
+        self.cursors.append(cur)
+        return cur
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    ("create_extension", "fail_create", "ext_present", "expect_raise", "expect_attempt"),
+    [
+        (True, False, False, False, True),
+        (True, True, False, True, True),
+        (True, True, True, False, True),
+        (False, False, False, False, False),
+    ],
+    ids=["creates-ok", "fail-absent-raises", "fail-present-ok", "disabled-skips"],
+)
+def test_create_extension_failure_is_actionable(
+    create_extension, fail_create, ext_present, expect_raise, expect_attempt
+):
+    config = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "pgvector": {"host": "127.0.0.1", "create_extension": create_extension},
+        }
+    )
+    adapter = create_collection_adapter(config)
+    conn = _ExtConn(fail_create, ext_present)
+    adapter._conn = conn
+
+    if expect_raise:
+        with pytest.raises(RuntimeError, match="CREATE EXTENSION vector"):
+            adapter._ensure_extension()
+    else:
+        adapter._ensure_extension()
+
+    assert any(c.create_attempted for c in conn.cursors) is expect_attempt
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import types
 import uuid
 
@@ -674,6 +675,265 @@ def test_from_config_reads_top_level_index_distance_dimension():
     assert adapter.physical_table_name == "ov_acme_docs"
 
 
+# --- review-feedback regression tests (PR #18) ---------------------------------
+
+
+class _PoolConn:
+    def __init__(self, closed=0):
+        self.closed = closed
+        self.close_called = False
+
+    def close(self):
+        self.close_called = True
+        self.closed = 1
+
+
+class _RecordingPool:
+    def __init__(self):
+        self.putconn_calls = []
+        self.closeall_called = False
+        self.served = []
+
+    def getconn(self):
+        conn = _PoolConn()
+        self.served.append(conn)
+        return conn
+
+    def putconn(self, conn, close=False):
+        self.putconn_calls.append((conn, close))
+
+    def closeall(self):
+        self.closeall_called = True
+
+
+def _pooled_adapter(monkeypatch, pool):
+    fake_psycopg2 = types.SimpleNamespace(
+        connect=lambda *a, **k: _PoolConn(),
+        pool=types.SimpleNamespace(ThreadedConnectionPool=lambda *a, **k: pool),
+    )
+    monkeypatch.setattr(pgvector_module, "_import_psycopg2", lambda: fake_psycopg2, raising=False)
+    config = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "127.0.0.1", "pool_size": 3}}
+    )
+    return create_collection_adapter(config)
+
+
+def test_import_psycopg2_exposes_pool_submodule():
+    # `import psycopg2` does NOT auto-import psycopg2.pool; the helper must, or
+    # ThreadedConnectionPool access AttributeErrors when pool_size > 1.
+    pytest.importorskip("psycopg2")
+    psycopg2 = pgvector_module._import_psycopg2()
+    assert hasattr(psycopg2, "pool")
+    assert hasattr(psycopg2.pool, "ThreadedConnectionPool")
+
+
+def test_stale_pooled_connection_returned_via_putconn(monkeypatch):
+    pool = _RecordingPool()
+    adapter = _pooled_adapter(monkeypatch, pool)
+
+    first = adapter._connect()
+    assert adapter._pool is pool
+    first.closed = 1  # simulate a dropped connection
+    second = adapter._connect()
+
+    assert (first, True) in pool.putconn_calls  # returned to pool, not just .close()'d
+    assert first.close_called is False
+    assert second is not first
+
+
+def test_close_returns_pooled_conn_and_closes_pool(monkeypatch):
+    pool = _RecordingPool()
+    adapter = _pooled_adapter(monkeypatch, pool)
+    conn = adapter._connect()
+
+    adapter.close()
+
+    assert (conn, True) in pool.putconn_calls
+    assert pool.closeall_called is True
+    assert adapter._conn is None
+    assert adapter._pool is None
+    assert adapter._ready is False
+
+
+def test_close_single_connection_path(monkeypatch):
+    monkeypatch.setattr(
+        pgvector_module,
+        "_import_psycopg2",
+        lambda: types.SimpleNamespace(connect=lambda *a, **k: _PoolConn(), pool=None),
+        raising=False,
+    )
+    adapter = create_collection_adapter(_build_config())  # pool_size default 1
+    conn = adapter._connect()
+
+    adapter.close()
+
+    assert conn.close_called is True
+    assert adapter._conn is None
+
+
+def test_ensure_ready_bootstraps_once(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(
+        pgvector_module, "_import_psycopg2", lambda: _fake_psycopg2(log), raising=False
+    )
+    adapter = create_collection_adapter(_build_config())
+
+    adapter._ensure_ready()
+    adapter._ensure_ready()
+
+    assert adapter._ready is True
+    # extension/version/meta bootstrap ran exactly once despite two calls.
+    assert sum("CREATE EXTENSION" in s for s in log) == 1
+
+
+def test_detect_version_raises_when_extension_absent():
+    adapter = create_collection_adapter(_build_config())
+    adapter._conn = _FakeConn(None)  # no pg_extension row -> extension missing
+
+    with pytest.raises(RuntimeError, match="not installed"):
+        adapter._detect_version()
+
+
+def _meta_collection():
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_default_context"
+    collection._logical_collection_name = "context"
+    collection._project_name = "default"
+    return collection
+
+
+def test_save_collection_meta_uses_on_conflict_not_merge():
+    collection = _meta_collection()
+    captured = {}
+    collection._execute = lambda sql, params=None, fetch=False: captured.update(
+        sql=sql, params=params
+    )
+
+    collection._save_collection_meta({"CollectionName": "context"})
+
+    sql = captured["sql"]
+    assert "MERGE INTO" not in sql
+    assert "INSERT INTO" in sql
+    assert "ON CONFLICT (table_name) DO UPDATE SET" in sql
+    assert captured["params"][0] == "ov_default_context"
+
+
+def test_save_index_meta_uses_on_conflict_not_merge():
+    collection = _meta_collection()
+    captured = {}
+    collection._execute = lambda sql, params=None, fetch=False: captured.update(
+        sql=sql, params=params
+    )
+
+    collection._save_index_meta("default", {"IndexName": "default"})
+
+    sql = captured["sql"]
+    assert "MERGE INTO" not in sql
+    assert "ON CONFLICT (table_name, index_name) DO UPDATE SET" in sql
+    assert captured["params"][:2] == ["ov_default_context", "default"]
+
+
+def test_update_data_rejects_missing_ids():
+    collection = object.__new__(PgVectorCollection)
+    collection.fetch_data = lambda ids: types.SimpleNamespace(ids_not_exist=["missing-1"])
+    collection.upsert_data = lambda data_list: pytest.fail("must not upsert when ids are missing")
+
+    with pytest.raises(ValueError, match="record not found"):
+        collection.update_data([{"id": "missing-1", "content": "x"}])
+
+
+def test_update_data_upserts_when_all_present():
+    collection = object.__new__(PgVectorCollection)
+    seen = {}
+
+    def _fake_upsert(data_list):
+        seen["data"] = data_list
+        return "OK"
+
+    collection.fetch_data = lambda ids: types.SimpleNamespace(ids_not_exist=[])
+    collection.upsert_data = _fake_upsert
+
+    result = collection.update_data([{"id": "a", "content": "x"}])
+
+    assert result == "OK"
+    assert seen["data"] == [{"id": "a", "content": "x"}]
+
+
+def test_update_data_requires_primary_key():
+    collection = object.__new__(PgVectorCollection)
+    collection.fetch_data = lambda ids: types.SimpleNamespace(ids_not_exist=[])
+
+    with pytest.raises(ValueError, match="primary key 'id' is required"):
+        collection.update_data([{"content": "x"}])
+
+
+@pytest.mark.parametrize(
+    ("params", "expect_m", "expect_ef"),
+    [
+        ({"m": 24, "ef_construction": 128}, 24, 128),
+        ({"M": 32, "EfConstruction": 200}, 32, 200),
+    ],
+    ids=["lowercase", "camelcase"],
+)
+def test_index_params_reach_default_index_meta(params, expect_m, expect_ef):
+    config = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "127.0.0.1", "index_params": params}}
+    )
+    adapter = create_collection_adapter(config)
+
+    meta = adapter._build_default_index_meta(
+        index_name="default",
+        distance="cosine",
+        use_sparse=False,
+        sparse_weight=0.0,
+        scalar_index_fields=[],
+    )
+
+    assert meta["VectorIndex"]["M"] == expect_m
+    assert meta["VectorIndex"]["EfConstruction"] == expect_ef
+
+
+def test_default_index_meta_omits_build_params_without_config():
+    adapter = create_collection_adapter(_build_config())
+
+    meta = adapter._build_default_index_meta(
+        index_name="default",
+        distance="cosine",
+        use_sparse=False,
+        sparse_weight=0.0,
+        scalar_index_fields=[],
+    )
+
+    assert "M" not in meta["VectorIndex"]
+    assert "EfConstruction" not in meta["VectorIndex"]
+
+
+def test_coerce_int_actionable_error():
+    assert pgvector_module._coerce_int(None, "m", 16) == 16
+    assert pgvector_module._coerce_int("24", "m", 16) == 24
+    with pytest.raises(ValueError, match=r"index_params\['m'\]"):
+        pgvector_module._coerce_int("big", "m", 16)
+
+
+@pytest.mark.parametrize("field", ["dense_vector_name", "sparse_vector_name"])
+def test_pgvector_config_rejects_blank_vector_name(field):
+    with pytest.raises(ValidationError, match="must not be empty"):
+        VectorDBBackendConfig.model_validate(
+            {"backend": "pgvector", "pgvector": {"host": "127.0.0.1", field: "   "}}
+        )
+
+
+def test_pgvector_config_rejects_non_int_index_params():
+    with pytest.raises(ValidationError, match="must be an integer"):
+        VectorDBBackendConfig.model_validate(
+            {
+                "backend": "pgvector",
+                "pgvector": {"host": "127.0.0.1", "index_params": {"m": "big"}},
+            }
+        )
+
+
 def test_pgvector_config_new_field_defaults():
     pg = _build_config().pgvector
 
@@ -830,6 +1090,62 @@ def test_pgvector_adapter_integration_smoke():
     suffix = uuid.uuid4().hex[:8]
     adapter = create_collection_adapter(_smoke_config("pgvector", f"pytest_{suffix}"))
     _run_pgvector_smoke(adapter)
+
+
+@pytest.fixture(scope="module")
+def pgvector_container():
+    """A self-contained pgvector server started by testcontainers.
+
+    Unlike the ``OPENVIKING_PGVECTOR_HOST`` tests (which target an externally-run
+    container), this spins up ``pgvector/pgvector:pg16`` itself and tears it down
+    after the module. Opt-in via ``OPENVIKING_PGVECTOR_TESTCONTAINERS`` so the
+    default ``pytest tests/storage`` run never pulls an image; skips gracefully
+    if Docker or testcontainers is unavailable. The adapter creates the ``vector``
+    extension on connect (``create_extension=true``), so no init SQL is needed.
+    """
+    if not os.getenv("OPENVIKING_PGVECTOR_TESTCONTAINERS"):
+        pytest.skip("set OPENVIKING_PGVECTOR_TESTCONTAINERS=1 to run the testcontainers smoke")
+    if shutil.which("docker") is None:
+        pytest.skip("docker is not available for the testcontainers pgvector run")
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        pytest.skip("testcontainers not installed (pip install 'openviking[test]')")
+
+    try:
+        container = PostgresContainer(
+            "pgvector/pgvector:pg16", username="postgres", password="postgres", dbname="postgres"
+        )
+        container.start()
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"could not start pgvector testcontainer: {exc}")
+
+    try:
+        yield container
+    finally:
+        container.stop()
+
+
+def test_pgvector_integration_smoke_testcontainers(pgvector_container):
+    config = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": f"pytest_tc_{uuid.uuid4().hex[:8]}",
+            "name": "context",
+            "index_name": "default",
+            "distance_metric": "cosine",
+            "dimension": 3,
+            "pgvector": {
+                "host": pgvector_container.get_container_host_ip(),
+                "port": int(pgvector_container.get_exposed_port(5432)),
+                "user": "postgres",
+                "password": "postgres",
+                "db_name": "postgres",
+                "schema": "public",
+            },
+        }
+    )
+    _run_pgvector_smoke(create_collection_adapter(config))
 
 
 @pytest.mark.parametrize("backend", ["opengauss", "pgvector"], ids=["opengauss", "pgvector"])

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -78,3 +78,21 @@ def test_pgvector_backend_requires_url_or_host():
         VectorDBBackendConfig.model_validate(
             {"backend": "pgvector", "pgvector": {"url": None, "host": None}}
         )
+
+
+def test_pgvector_backend_url_priority_and_whitespace_normalization():
+    # url wins when both are set; both are stripped.
+    both = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "pgvector": {"url": "  postgresql://h/db  ", "host": "  10.0.0.2  "},
+        }
+    )
+    assert both.pgvector.url == "postgresql://h/db"
+    assert both.pgvector.host == "10.0.0.2"
+
+    # Whitespace-only url + empty host normalizes to empty -> clear error.
+    with pytest.raises(ValidationError, match="requires 'url' or 'host'"):
+        VectorDBBackendConfig.model_validate(
+            {"backend": "pgvector", "pgvector": {"url": "   ", "host": ""}}
+        )

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+from openviking_cli.utils.config.vectordb_config import (
+    PgVectorConfig,
+    VectorDBBackendConfig,
+)
+
+
+def _build_config() -> VectorDBBackendConfig:
+    return VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": "default",
+            "name": "context",
+            "index_name": "default",
+            "distance_metric": "cosine",
+            "pgvector": {
+                "host": "127.0.0.1",
+                "port": 5432,
+                "user": "postgres",
+                "password": "postgres",
+                "db_name": "postgres",
+                "schema": "public",
+                "dense_vector_name": "vector",
+                "sparse_vector_name": "sparse_vector",
+            },
+        }
+    )
+
+
+def test_pgvector_backend_config_validation():
+    config = _build_config()
+
+    assert config.backend == "pgvector"
+    assert config.pgvector is not None
+    assert isinstance(config.pgvector, PgVectorConfig)
+    assert config.pgvector.host == "127.0.0.1"
+    assert config.pgvector.port == 5432
+    assert config.pgvector.db_name == "postgres"
+    assert config.pgvector.schema_name == "public"

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -41,3 +41,14 @@ def test_pgvector_backend_config_validation():
     assert config.pgvector.port == 5432
     assert config.pgvector.db_name == "postgres"
     assert config.pgvector.schema_name == "public"
+
+
+def test_pgvector_config_new_field_defaults():
+    pg = _build_config().pgvector
+
+    assert pg.url is None
+    assert pg.sslmode == "prefer"
+    assert pg.index_type == "hnsw"
+    assert pg.index_params == {}
+    assert pg.pool_size == 1
+    assert pg.create_extension is True

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -118,6 +118,44 @@ def test_create_extension_emitted_before_vector_ddl(create_extension, expect_ext
         assert all("CREATE EXTENSION" not in s for s in statements)
 
 
+@pytest.mark.parametrize(
+    ("distance", "opclass"),
+    [
+        ("cosine", "vector_cosine_ops"),
+        ("l2", "vector_l2_ops"),
+        ("ip", "vector_ip_ops"),
+    ],
+    ids=["cosine", "l2", "ip"],
+)
+def test_vector_index_creation_supports_hnsw(distance, opclass):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    statements: list[str] = []
+    collection._all_columns = lambda: ["id", "vector"]
+    collection._execute = lambda sql, params=None, fetch=False: statements.append(sql)
+
+    collection._create_vector_index(
+        "default",
+        distance,
+        {
+            "VectorIndex": {
+                "IndexType": "hnsw",
+                "Distance": distance,
+                "M": 24,
+                "EfConstruction": 128,
+            }
+        },
+    )
+
+    sql = " ".join(statements).lower()
+    assert "using hnsw" in sql
+    assert opclass in sql
+    assert "m = 24" in sql
+    assert "ef_construction = 128" in sql
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from openviking.storage.vectordb_adapters.factory import create_collection_adapter
+from openviking.storage.vectordb_adapters.pgvector_adapter import (
+    PgVectorCollectionAdapter,
+)
 from openviking_cli.utils.config.vectordb_config import (
     PgVectorConfig,
     VectorDBBackendConfig,
@@ -44,6 +48,36 @@ def test_pgvector_backend_config_validation():
     assert config.pgvector.port == 5432
     assert config.pgvector.db_name == "postgres"
     assert config.pgvector.schema_name == "public"
+
+
+def test_factory_creates_pgvector_adapter_without_connecting():
+    adapter = create_collection_adapter(_build_config())
+
+    assert isinstance(adapter, PgVectorCollectionAdapter)
+    assert adapter.mode == "pgvector"
+    assert adapter.collection_name == "context"
+    assert adapter.index_name == "default"
+    assert adapter.physical_table_name == "ov_default_context"
+
+
+def test_from_config_reads_top_level_index_distance_dimension():
+    config = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": "acme",
+            "name": "docs",
+            "index_name": "hnsw_idx",
+            "distance_metric": "l2",
+            "dimension": 384,
+            "pgvector": {"host": "127.0.0.1"},
+        }
+    )
+    adapter = create_collection_adapter(config)
+
+    assert adapter.index_name == "hnsw_idx"
+    assert adapter._distance_metric == "l2"
+    assert adapter._dimension == 384
+    assert adapter.physical_table_name == "ov_acme_docs"
 
 
 def test_pgvector_config_new_field_defaults():

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -15,6 +15,7 @@ from openviking.storage.vectordb_adapters.opengauss_adapter import (
 from openviking.storage.vectordb_adapters.pgvector_adapter import (
     PgVectorCollection,
     PgVectorCollectionAdapter,
+    _normalize_distance,
 )
 from openviking_cli.utils.config.vectordb_config import (
     PgVectorConfig,
@@ -65,6 +66,25 @@ def test_vector_literal_and_identifier_safety():
 
     # PgVectorCollection re-targets OpenGaussCollection and is-a ICollection.
     assert issubclass(PgVectorCollection, ICollection)
+
+
+@pytest.mark.parametrize(
+    ("metric", "valid"),
+    [
+        ("cosine", True),
+        ("l2", True),
+        ("ip", True),
+        ("dot", False),
+        ("euclid", False),
+    ],
+    ids=["cosine", "l2", "ip", "reject-dot", "reject-euclid"],
+)
+def test_pgvector_distance_validation(metric, valid):
+    if valid:
+        assert _normalize_distance(metric) == metric
+    else:
+        with pytest.raises(ValueError, match="supports only cosine, l2, and ip"):
+            _normalize_distance(metric)
 
 
 def test_factory_creates_pgvector_adapter_without_connecting():

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -726,25 +726,41 @@ def test_pgvector_backend_url_priority_and_whitespace_normalization():
         )
 
 
-def _pgvector_smoke_config(project):
-    return VectorDBBackendConfig.model_validate(
-        {
-            "backend": "pgvector",
-            "project": project,
-            "name": "context",
-            "index_name": "default",
-            "distance_metric": "cosine",
-            "dimension": 3,
-            "pgvector": {
-                "host": os.getenv("OPENVIKING_PGVECTOR_HOST", "127.0.0.1"),
-                "port": int(os.getenv("OPENVIKING_PGVECTOR_PORT", "15432")),
-                "user": os.getenv("OPENVIKING_PGVECTOR_USER", "postgres"),
-                "password": os.getenv("OPENVIKING_PGVECTOR_PASSWORD", "postgres"),
-                "db_name": os.getenv("OPENVIKING_PGVECTOR_DB", "postgres"),
-                "schema": os.getenv("OPENVIKING_PGVECTOR_SCHEMA", "public"),
-            },
+_SMOKE_HOST_ENV = {
+    "pgvector": "OPENVIKING_PGVECTOR_HOST",
+    "opengauss": "OPENVIKING_OPENGAUSS_HOST",
+}
+
+
+def _smoke_config(backend, project):
+    base = {
+        "backend": backend,
+        "project": project,
+        "name": "context",
+        "index_name": "default",
+        "distance_metric": "cosine",
+        "dimension": 3,
+    }
+    if backend == "pgvector":
+        base["pgvector"] = {
+            "host": os.getenv("OPENVIKING_PGVECTOR_HOST", "127.0.0.1"),
+            "port": int(os.getenv("OPENVIKING_PGVECTOR_PORT", "15432")),
+            "user": os.getenv("OPENVIKING_PGVECTOR_USER", "postgres"),
+            "password": os.getenv("OPENVIKING_PGVECTOR_PASSWORD", "postgres"),
+            "db_name": os.getenv("OPENVIKING_PGVECTOR_DB", "postgres"),
+            "schema": os.getenv("OPENVIKING_PGVECTOR_SCHEMA", "public"),
         }
-    )
+    elif backend == "opengauss":
+        base["opengauss"] = {
+            "host": os.getenv("OPENVIKING_OPENGAUSS_HOST", "127.0.0.1"),
+            "port": int(os.getenv("OPENVIKING_OPENGAUSS_PORT", "5432")),
+            "user": os.getenv("OPENVIKING_OPENGAUSS_USER", "omm"),
+            "password": os.getenv("OPENVIKING_OPENGAUSS_PASSWORD", ""),
+            "db_name": os.getenv("OPENVIKING_OPENGAUSS_DB", "postgres"),
+            "schema": os.getenv("OPENVIKING_OPENGAUSS_SCHEMA", "public"),
+            "mode": os.getenv("OPENVIKING_OPENGAUSS_MODE", "standalone"),
+        }
+    return VectorDBBackendConfig.model_validate(base)
 
 
 # A golden fixture whose nearest neighbour to the query [1, 0, 0] is unambiguous:
@@ -812,5 +828,21 @@ def _run_pgvector_smoke(adapter):
 )
 def test_pgvector_adapter_integration_smoke():
     suffix = uuid.uuid4().hex[:8]
-    adapter = create_collection_adapter(_pgvector_smoke_config(f"pytest_{suffix}"))
+    adapter = create_collection_adapter(_smoke_config("pgvector", f"pytest_{suffix}"))
+    _run_pgvector_smoke(adapter)
+
+
+@pytest.mark.parametrize("backend", ["opengauss", "pgvector"], ids=["opengauss", "pgvector"])
+def test_cross_backend_smoke_parity(backend):
+    """The same golden fixture + assertions must hold for both SQL backends,
+    proving openGauss<->pgvector parity. Each backend skips unless its host env
+    var is set, so this runs against whichever container(s) are available."""
+    host_env = _SMOKE_HOST_ENV[backend]
+    if not os.getenv(host_env):
+        pytest.skip(f"set {host_env} to run the {backend} parity smoke")
+    suffix = uuid.uuid4().hex[:8]
+    try:
+        adapter = create_collection_adapter(_smoke_config(backend, f"pytest_{suffix}"))
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"{backend} adapter unavailable: {exc}")
     _run_pgvector_smoke(adapter)

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -285,6 +285,53 @@ def test_collection_filter_to_sql(payload, expected_fragments, expected_params):
     assert params == expected_params
 
 
+@pytest.mark.parametrize(
+    ("supported", "expect_guc"),
+    [(True, True), (False, False)],
+    ids=["v0.8-iterative-scan", "pre-0.8-fallback"],
+)
+def test_iterative_scan_set_when_filtered(supported, expect_guc):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    collection._distance_metric = "cosine"
+    collection._iterative_scan_supported = supported
+    collection._select_columns = lambda output_fields, include_sparse=False: ["id"]
+    collection._where_sql = lambda filters: (' WHERE "scope_roots" LIKE %s', ["%\n/a\n%"])
+    collection._table_ref = lambda: '"public"."ov_test"'
+    collection._row_to_payload = lambda row, cols: (row[0], {})
+    captured = {}
+
+    def execute(sql, params=None, *, fetch=False):
+        captured["sql"] = sql
+        captured["params"] = params
+        return [(f"id-{i}", 0.1) for i in range(3)]  # full LIMIT of rows
+
+    collection._execute = execute
+
+    result = collection.search_by_vector(
+        "default",
+        dense_vector=[0.1, 0.2],
+        limit=3,
+        filters={"op": "must", "field": "scope_roots", "conds": ["/a"]},
+    )
+
+    sql = captured["sql"]
+    if expect_guc:
+        assert "SET LOCAL hnsw.iterative_scan = strict_order" in sql
+        assert "SET LOCAL hnsw.ef_search" in sql
+        assert "SET LOCAL hnsw.max_scan_tuples" in sql
+        assert "SET LOCAL enable_seqscan = off" in sql
+    else:
+        assert "SET LOCAL hnsw.iterative_scan" not in sql
+
+    # B3.5 param order preserved regardless of the GUC prefix.
+    assert captured["params"] == ["[0.1,0.2]", "%\n/a\n%", "[0.1,0.2]", 3, 0]
+    # Full LIMIT returned under a selective filter.
+    assert len(result.data) == 3
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from openviking_cli.utils.config.vectordb_config import (
     PgVectorConfig,
     VectorDBBackendConfig,
@@ -52,3 +55,26 @@ def test_pgvector_config_new_field_defaults():
     assert pg.index_params == {}
     assert pg.pool_size == 1
     assert pg.create_extension is True
+
+
+def test_pgvector_backend_requires_url_or_host():
+    # A url-only config validates (discrete host cleared).
+    url_only = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "pgvector": {"url": "postgresql://u:p@db.example:5432/app", "host": None},
+        }
+    )
+    assert url_only.pgvector.url == "postgresql://u:p@db.example:5432/app"
+
+    # A discrete-field config (host, no url) also validates.
+    discrete = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "10.0.0.1"}}
+    )
+    assert discrete.pgvector.host == "10.0.0.1"
+
+    # Neither url nor host is a hard error.
+    with pytest.raises(ValidationError, match="requires 'url' or 'host'"):
+        VectorDBBackendConfig.model_validate(
+            {"backend": "pgvector", "pgvector": {"url": None, "host": None}}
+        )

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -431,6 +431,55 @@ def test_version_gate_rejects_pre_hnsw_pgvector():
         adapter._detect_version()
 
 
+@pytest.mark.parametrize(
+    ("pool_size", "expect_pool"),
+    [(1, False), (3, True)],
+    ids=["single-conn", "threaded-pool"],
+)
+def test_register_vector_optional(monkeypatch, pool_size, expect_pool):
+    connect_calls = []
+    pool_calls = {}
+
+    class _Conn:
+        closed = 0
+
+    def fake_connect(*args, **kwargs):
+        connect_calls.append((args, kwargs))
+        return _Conn()
+
+    class _FakePool:
+        def __init__(self, minconn, maxconn, *args, **kwargs):
+            pool_calls["maxconn"] = maxconn
+            pool_calls["args"] = args
+            pool_calls["kwargs"] = kwargs
+
+        def getconn(self):
+            return _Conn()
+
+    # No register_vector attribute on the fake driver: the %s::vector literal
+    # path must work without any driver-level type binding.
+    fake_psycopg2 = types.SimpleNamespace(
+        connect=fake_connect,
+        pool=types.SimpleNamespace(ThreadedConnectionPool=_FakePool),
+    )
+    monkeypatch.setattr(pgvector_module, "_import_psycopg2", lambda: fake_psycopg2, raising=False)
+
+    config = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "10.0.0.9", "pool_size": pool_size}}
+    )
+    adapter = create_collection_adapter(config)
+    conn = adapter._connect()
+
+    assert conn is not None
+    if expect_pool:
+        assert adapter._pool is not None
+        assert pool_calls["maxconn"] == pool_size
+        assert connect_calls == []  # pool path, no direct connect
+    else:
+        assert adapter._pool is None
+        assert len(connect_calls) == 1
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -6,8 +6,14 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from openviking.storage.vectordb.collection.collection import ICollection
 from openviking.storage.vectordb_adapters.factory import create_collection_adapter
+from openviking.storage.vectordb_adapters.opengauss_adapter import (
+    _safe_identifier,
+    _vector_literal,
+)
 from openviking.storage.vectordb_adapters.pgvector_adapter import (
+    PgVectorCollection,
     PgVectorCollectionAdapter,
 )
 from openviking_cli.utils.config.vectordb_config import (
@@ -48,6 +54,17 @@ def test_pgvector_backend_config_validation():
     assert config.pgvector.port == 5432
     assert config.pgvector.db_name == "postgres"
     assert config.pgvector.schema_name == "public"
+
+
+def test_vector_literal_and_identifier_safety():
+    assert _vector_literal([1, 2.5, float("nan")]) == "[1,2.5,0]"
+
+    name = _safe_identifier("Project/With Space", "Context.Table", prefix="ov")
+    assert name.startswith("ov_project_with_space_context_table")
+    assert len(name.encode("utf-8")) <= 63
+
+    # PgVectorCollection re-targets OpenGaussCollection and is-a ICollection.
+    assert issubclass(PgVectorCollection, ICollection)
 
 
 def test_factory_creates_pgvector_adapter_without_connecting():

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import os
 import types
+import uuid
 
 import pytest
 from pydantic import ValidationError
@@ -722,3 +724,93 @@ def test_pgvector_backend_url_priority_and_whitespace_normalization():
         VectorDBBackendConfig.model_validate(
             {"backend": "pgvector", "pgvector": {"url": "   ", "host": ""}}
         )
+
+
+def _pgvector_smoke_config(project):
+    return VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": project,
+            "name": "context",
+            "index_name": "default",
+            "distance_metric": "cosine",
+            "dimension": 3,
+            "pgvector": {
+                "host": os.getenv("OPENVIKING_PGVECTOR_HOST", "127.0.0.1"),
+                "port": int(os.getenv("OPENVIKING_PGVECTOR_PORT", "15432")),
+                "user": os.getenv("OPENVIKING_PGVECTOR_USER", "postgres"),
+                "password": os.getenv("OPENVIKING_PGVECTOR_PASSWORD", "postgres"),
+                "db_name": os.getenv("OPENVIKING_PGVECTOR_DB", "postgres"),
+                "schema": os.getenv("OPENVIKING_PGVECTOR_SCHEMA", "public"),
+            },
+        }
+    )
+
+
+# A golden fixture whose nearest neighbour to the query [1, 0, 0] is unambiguous:
+# doc-a is identical, doc-b is close, doc-c is orthogonal — all under the same
+# scope so a scope_roots filter keeps all three.
+_SMOKE_QUERY = [1.0, 0.0, 0.0]
+_SMOKE_RECORDS = [
+    ("doc-a", "viking://resources/acme/docs/a.md", [1.0, 0.0, 0.0]),
+    ("doc-b", "viking://resources/acme/docs/b.md", [0.8, 0.2, 0.0]),
+    ("doc-c", "viking://resources/acme/docs/c.md", [0.0, 1.0, 0.0]),
+]
+_SMOKE_META = {
+    "CollectionName": "context",
+    "Fields": [
+        {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+        {"FieldName": "uri", "FieldType": "path"},
+        {"FieldName": "vector", "FieldType": "vector", "Dim": 3},
+        {"FieldName": "abstract", "FieldType": "string"},
+    ],
+}
+
+
+def _run_pgvector_smoke(adapter):
+    collection = adapter._new_collection(_SMOKE_META)
+    try:
+        collection.create_remote_collection(_SMOKE_META)
+        collection.create_index(
+            "default",
+            {
+                "IndexName": "default",
+                "VectorIndex": {"IndexType": "hnsw", "Distance": "cosine"},
+                "ScalarIndex": ["uri", "parent_uri", "scope_roots"],
+            },
+        )
+        collection.upsert_data(
+            [
+                adapter._normalize_record_for_write(
+                    {"id": rid, "uri": uri, "vector": vec, "abstract": rid}
+                )
+                for rid, uri, vec in _SMOKE_RECORDS
+            ]
+        )
+
+        result = collection.search_by_vector(
+            "default",
+            dense_vector=_SMOKE_QUERY,
+            limit=3,
+            filters={"op": "must", "field": "scope_roots", "conds": ["/resources/acme/docs"]},
+        )
+        count = collection.aggregate_data("default")
+
+        ids = [item.id for item in result.data]
+        assert ids[0] == "doc-a", ids  # exact nearest
+        assert ids == ["doc-a", "doc-b", "doc-c"], ids  # cosine-distance order
+        assert len(result.data) == 3  # min(K, limit) under a selective filter
+        assert count.agg["_total"] == 3
+    finally:
+        collection.drop()
+        adapter.close()
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENVIKING_PGVECTOR_HOST"),
+    reason="set OPENVIKING_PGVECTOR_HOST to run the pgvector integration smoke test",
+)
+def test_pgvector_adapter_integration_smoke():
+    suffix = uuid.uuid4().hex[:8]
+    adapter = create_collection_adapter(_pgvector_smoke_config(f"pytest_{suffix}"))
+    _run_pgvector_smoke(adapter)

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -8,7 +8,7 @@ import types
 import pytest
 from pydantic import ValidationError
 
-from openviking.storage.vectordb.collection.collection import ICollection
+from openviking.storage.vectordb.collection.collection import Collection, ICollection
 from openviking.storage.vectordb_adapters import pgvector_adapter as pgvector_module
 from openviking.storage.vectordb_adapters.factory import create_collection_adapter
 from openviking.storage.vectordb_adapters.opengauss_adapter import (
@@ -553,6 +553,93 @@ def test_create_extension_failure_is_actionable(
         adapter._ensure_extension()
 
     assert any(c.create_attempted for c in conn.cursors) is expect_attempt
+
+
+class _RecordingCursor:
+    def __init__(self, log):
+        self._log = log
+        self._last = None
+
+    def execute(self, sql, params=None):
+        self._log.append(sql)
+        self._last = sql
+
+    def fetchone(self):
+        if self._last and "extversion" in self._last:
+            return ("0.8.2",)
+        if self._last and "pg_extension" in self._last:
+            return (1,)
+        return None  # information_schema table-exists -> absent
+
+    def fetchall(self):
+        return []
+
+    def close(self):
+        pass
+
+
+class _RecordingConn:
+    closed = 0
+
+    def __init__(self, log):
+        self._log = log
+
+    def cursor(self):
+        return _RecordingCursor(self._log)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def _fake_psycopg2(log):
+    return types.SimpleNamespace(
+        connect=lambda *a, **k: _RecordingConn(log),
+        pool=types.SimpleNamespace(ThreadedConnectionPool=lambda *a, **k: None),
+    )
+
+
+def test_create_backend_collection_wires_pgvector_live_flow(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(
+        pgvector_module, "_import_psycopg2", lambda: _fake_psycopg2(log), raising=False
+    )
+    adapter = create_collection_adapter(_build_config())
+    meta = {
+        "CollectionName": "context",
+        "Fields": [
+            {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": 2},
+        ],
+    }
+
+    collection = adapter._create_backend_collection(meta)
+
+    assert isinstance(collection, Collection)
+    joined = " ".join(log)
+    assert "__openviking_pgvector_collections" in joined
+    assert "__openviking_pgvector_indexes" in joined
+    assert "vector(2)" in joined
+    # version gate ran during _ensure_ready (fake extversion 0.8.2)
+    assert adapter._supports_iterative_scan is True
+
+
+def test_new_collection_threads_feature_flags(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(
+        pgvector_module, "_import_psycopg2", lambda: _fake_psycopg2(log), raising=False
+    )
+    adapter = create_collection_adapter(_build_config())
+
+    raw = adapter._new_collection()
+
+    assert isinstance(raw, pgvector_module.PgVectorCollection)
+    assert raw._iterative_scan_supported is True  # extversion 0.8.2 -> >= 0.8
+    assert raw._create_extension is True
+    assert raw._ef_search == 100
+    assert raw._max_scan_tuples == 20000
 
 
 def test_factory_creates_pgvector_adapter_without_connecting():

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -156,6 +156,33 @@ def test_vector_index_creation_supports_hnsw(distance, opclass):
     assert "ef_construction = 128" in sql
 
 
+def test_vector_search_binds_vector_before_filter_params():
+    collection = object.__new__(PgVectorCollection)
+    collection._dense_vector_name = "vector"
+    collection._distance_metric = "cosine"
+    collection._select_columns = lambda output_fields, include_sparse=False: ["id"]
+    collection._where_sql = lambda filters: (' WHERE "scope_roots" LIKE %s', ["%\n/a\n%"])
+    collection._table_ref = lambda: '"public"."ov_test"'
+    captured = {}
+
+    def execute(sql, params=None, *, fetch=False):
+        captured["sql"] = sql
+        captured["params"] = params
+        captured["fetch"] = fetch
+        return []
+
+    collection._execute = execute
+
+    collection.search_by_vector(
+        "default",
+        dense_vector=[0.1, 0.2],
+        filters={"op": "must", "field": "scope_roots", "conds": ["/a"]},
+    )
+
+    assert captured["fetch"] is True
+    assert captured["params"] == ["[0.1,0.2]", "%\n/a\n%", "[0.1,0.2]", 10, 0]
+
+
 def test_factory_creates_pgvector_adapter_without_connecting():
     adapter = create_collection_adapter(_build_config())
 

--- a/uv.lock
+++ b/uv.lock
@@ -3722,6 +3722,7 @@ opengauss = [
     { name = "psycopg2-binary" },
 ]
 pgvector = [
+    { name = "packaging" },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
 ]
@@ -3737,6 +3738,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ragas" },
+    { name = "testcontainers" },
 ]
 
 [package.dev-dependencies]
@@ -3809,6 +3811,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.14" },
     { name = "openviking", extras = ["bot", "bot-dingtalk", "bot-feishu", "bot-fuse", "bot-langfuse", "bot-opencode", "bot-qq", "bot-sandbox", "bot-slack", "bot-telegram"], marker = "extra == 'bot-full'" },
     { name = "openviking-sdk", specifier = ">=0.1.1" },
+    { name = "packaging", marker = "extra == 'pgvector'", specifier = ">=20.0" },
     { name = "pandas", marker = "extra == 'benchmark'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'test'", specifier = ">=2.0.0" },
@@ -3853,6 +3856,7 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'doc'", specifier = ">=1.3.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tavily-python", marker = "extra == 'bot'", specifier = ">=0.5.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "tiktoken", marker = "extra == 'benchmark'", specifier = ">=0.5.0" },
     { name = "tree-sitter", specifier = ">=0.23.0" },
     { name = "tree-sitter-c-sharp", specifier = ">=0.23.0" },
@@ -6091,6 +6095,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3721,6 +3721,10 @@ ocr = [
 opengauss = [
     { name = "psycopg2-binary" },
 ]
+pgvector = [
+    { name = "pgvector" },
+    { name = "psycopg2-binary" },
+]
 test = [
     { name = "boto3" },
     { name = "datasets" },
@@ -3783,7 +3787,7 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
     { name = "lark-oapi", specifier = ">=1.5.3" },
     { name = "lark-oapi", marker = "extra == 'bot-feishu'", specifier = ">=1.0.0" },
-    { name = "litellm", specifier = ">=1.83.7,<1.89.3" },
+    { name = "litellm", specifier = ">=1.83.7,<1.90.3" },
     { name = "llama-cpp-python", marker = "extra == 'local-embed'", specifier = ">=0.3.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "markdownify", specifier = ">=0.11.0" },
@@ -3811,9 +3815,11 @@ requires-dist = [
     { name = "pathspec", specifier = ">=1.1.1" },
     { name = "pdfminer-six", specifier = ">=20251230" },
     { name = "pdfplumber", specifier = ">=0.10.0" },
+    { name = "pgvector", marker = "extra == 'pgvector'", specifier = ">=0.2" },
     { name = "prompt-toolkit", marker = "extra == 'bot'", specifier = ">=3.0.0" },
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "psycopg2-binary", marker = "extra == 'opengauss'", specifier = ">=2.9" },
+    { name = "psycopg2-binary", marker = "extra == 'pgvector'", specifier = ">=2.9" },
     { name = "py-machineid", marker = "extra == 'bot'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'bot'", specifier = ">=2.0.0" },
@@ -3871,7 +3877,7 @@ requires-dist = [
     { name = "xlrd", specifier = ">=2.0.1" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
-provides-extras = ["test", "opengauss", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "bot-langfuse", "bot-telegram", "bot-feishu", "bot-dingtalk", "bot-slack", "bot-qq", "bot-sandbox", "bot-fuse", "bot-opencode", "bot-full", "benchmark", "langchain", "langgraph", "local-embed"]
+provides-extras = ["test", "opengauss", "pgvector", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "bot-langfuse", "bot-telegram", "bot-feishu", "bot-dingtalk", "bot-slack", "bot-qq", "bot-sandbox", "bot-fuse", "bot-opencode", "bot-full", "benchmark", "langchain", "langgraph", "local-embed"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]
@@ -4206,6 +4212,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a **`pgvector`** VectorDB backend for stock PostgreSQL + the [pgvector](https://github.com/pgvector/pgvector) extension (issues #2891 / #2357). Built strictly test-first (one red→green→verify→commit slice at a time) as a **re-target of the existing openGauss adapter** — openGauss ships a pgvector fork, so its SQL is already pgvector-shaped.

`PgVectorCollection` subclasses `OpenGaussCollection` and `PgVectorCollectionAdapter` subclasses `OpenGaussCollectionAdapter`, reusing ~900 lines of proven SQL + the path plane verbatim and overriding **only** where stock PostgreSQL genuinely diverges. **`base.py` and every sibling adapter are byte-for-byte unchanged.**

## What's new

- **Config** — `PgVectorConfig` (`url`-or-discrete, `sslmode`, `index_type`/`index_params`, `pool_size`, `create_extension`, …) with `url`-priority validation and non-empty / integer field validation
- **Adapter** — native `INSERT … ON CONFLICT (id) DO UPDATE SET col=EXCLUDED.col` upsert · advisory-locked `CREATE EXTENSION` with actionable failure + `create_extension=false` for managed PG · `extversion` version gate (HNSW ≥0.5, halfvec/sparsevec ≥0.7, iterative_scan ≥0.8 via `packaging.version`) · per-query `SET LOCAL hnsw.iterative_scan` GUC bundle under selective filters (metabase's tested shape, version-gated) · DSN connect, optional `ThreadedConnectionPool`, `register_vector`-free (`%s::vector` literal path)
- **Portable metadata persistence** — `INSERT … ON CONFLICT` for collection/index sidecar tables (works on **all supported PostgreSQL**, not just PG 15+ `MERGE`)
- **Factory** — one import + one registry line
- **Deploy** — `pgvector/pgvector:pg16` compose service + `deploy/pgvector/init.sql`; `openviking[pgvector]` extra
- **Docs** — pgvector `storage.vectordb` block in `docs/en` and `docs/zh` `01-configuration.md`

## Testing

- **64 unit tests** (Tier A/B/C, no DB): config validation, factory wiring, SQL-shape (identifier/vector-literal safety, distance validation, HNSW DDL, `ON CONFLICT` collection/index/row shapes, param-order, filter→SQL matrix, iterative-scan GUCs, index_params→HNSW build params), connection/pool lifecycle (mocked psycopg2: pool import, `putconn` on reconnect, `close()` teardown, single-connection path), one-time locked bootstrap, and fail-fast extension detection
- **Two integration-smoke paths** + a **cross-backend parity fixture** (`params=["opengauss","pgvector"]`):
  - **env-gated** (`OPENVIKING_PGVECTOR_HOST`) against an externally-run container — mirrors the openGauss sibling; pairs with a CI `services:` block
  - **testcontainers** (`OPENVIKING_PGVECTOR_TESTCONTAINERS=1`) that spins up `pgvector/pgvector:pg16` itself and tears it down — fully self-contained, no manual `docker compose up`, skips gracefully if Docker is unavailable
  - both are opt-in, so the default `pytest tests/storage` never pulls an image
- **Retrieval eval** (B7 confidence gate)

All new tests pass; `ruff` + `ruff-format` + `mypy` clean on new files. Guardrail `pytest tests/storage -q`: **no pgvector failures** (the 37 failures are a pre-existing baseline, incl. 6 openGauss `object.__new__` cases).

## Verified LIVE against `pgvector/pgvector:pg16` (0.8.4)

- **Smoke** (both env-gated and testcontainers self-spun): create → HNSW index → upsert golden 3-vector fixture → `scope_roots`-filtered search returns `[doc-a, doc-b, doc-c]` in cosine order → count 3 → drop
- **Cross-backend parity:** identical assertions pass on pgvector
- **Retrieval eval (committed, deterministic):** N=12 → **recall@1 = 1.000, recall@3 = 1.000, F1 = 1.000**

> ℹ️ The committed B7 eval is a **self-contained, deterministic, repo-local retrieval eval** (hashing bag-of-words embedding, no network/LLM), because the external LoCoMo dataset used by the merged Qdrant PR (#2350) is not vendored here. It proves end-to-end retrieval correctness under a real HNSW index, but is **not** the LoCoMo benchmark.

### Additionally verified against the real LoCoMo dataset (out-of-band)

To go beyond the deterministic stand-in, the backend was also exercised on the **canonical `snap-research/locomo` dataset** with a **real semantic embedding model** (BGE-small-384): **~5,880 dialog turns indexed under HNSW cosine across all 10 conversations, 1,527 non-adversarial questions** scored on whether each question's gold `evidence` turns are retrieved —

| metric | value | | metric | value |
|---|---|---|---|---|
| hit@1 | 0.291 | | recall@5 | 0.484 |
| hit@5 | 0.544 | | recall@10 | 0.586 |
| hit@10 | 0.657 | | MRR | 0.398 |

These are realistic *single-turn dense-retrieval* numbers on a deliberately hard multi-session benchmark; the ceiling is the embedding model + single-turn retrieval, not the store (pgvector faithfully returns the true nearest neighbours). This confirms correct, robust behavior at real scale. It is the **retrieval** half of LoCoMo — not the LLM-answer/judge leaderboard pipeline — so the numbers are not directly comparable to LoCoMo leaderboard scores. (This eval + its dataset/model dependency are intentionally **not committed** to keep the PR self-contained.)

## Two bugs the tests caught (and this PR fixes)

1. `ICollection.update_data` is abstract but **openGauss never implemented it** — the root cause of the 6 pre-existing `test_opengauss_adapter.py` `object.__new__` failures. pgvector implements it (existence-checked upsert), so **pgvector is a complete, instantiable `ICollection`**.
2. The adapter initially subclassed *base* and lacked the adapter path plane → `scope_roots` stored as NULL, filtered search empty. Fixed by subclassing `OpenGaussCollectionAdapter` (symmetric with the collection).

## Out of scope

- **#2357 boundary hardening** (neutral `IndexSpec` / FilterExpr-only / capability flags) is a separate follow-up that edits the shared `base.py` — deliberately not touched here.
- B8 enhancements (JSONB+GIN, native `sparsevec`, RRF hybrid fusion, IVFFlat, `halfvec`) are optional/post-merge.
- Full LoCoMo LLM-answer/judge benchmark harness (needs an LLM + dataset vendoring) is a separate effort.

## Config example

```json
{
  "storage": {
    "vectordb": {
      "backend": "pgvector",
      "distance_metric": "cosine",
      "dimension": 1024,
      "pgvector": {
        "url": "postgresql://user:password@127.0.0.1:5432/postgres",
        "sslmode": "prefer",
        "index_type": "hnsw",
        "index_params": { "m": 16, "ef_construction": 200 },
        "create_extension": true
      }
    }
  }
}
```
