### PR TITLE
feat(bot):Improve VikingBot subagent delivery and configuration

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -176,6 +176,7 @@ All configurations are under the `bot` field in `ov.conf`, with default values f
   - `extra_headers`: Optional extra HTTP headers passed to the model provider.
   - `max_tool_iterations`: Maximum number of cycles for a single round of conversation tasks, returns results directly if exceeded
   - `memory_window`: Upper limit of conversation rounds for automatically submitting sessions to OpenViking
+  - `subagent_enabled`: Enable the `spawn` tool so the main agent can start background subagents. Defaults to `true`; set to `false` to disable subagents.
   - `gen_image_model`: Model for generating images
 - `gateway`: Gateway configuration
   - `host`: Gateway listening address, default value is `0.0.0.0`
@@ -215,7 +216,8 @@ All configurations are under the `bot` field in `ov.conf`, with default values f
       "thinking": true,
       "timeout": 60.0,
       "max_tool_iterations": 50,
-      "memory_window": 50
+      "memory_window": 50,
+      "subagent_enabled": true
     },
     "gateway": {
       "host": "0.0.0.0",

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -178,6 +178,7 @@ bot 将连接到远程 OpenViking Server，使用前请先启动 OpenViking Serv
   - `extra_headers`：可选，透传给模型 provider 的额外 HTTP 请求头。
   - `max_tool_iterations`：单轮对话任务最大循环次数，超过则直接返回结果。
   - `memory_window`：自动提交 session 到 OpenViking 的对话轮次上限。
+  - `subagent_enabled`：是否启用 `spawn` 工具，让主 Agent 可以启动后台子 Agent。默认 `true`；设为 `false` 可禁用子 Agent。
   - `gen_image_model`：生成图片使用的模型。
 - `gateway`：Gateway 配置
   - host：Gateway 监听地址，默认值为 `0.0.0.0`
@@ -217,7 +218,8 @@ bot 将连接到远程 OpenViking Server，使用前请先启动 OpenViking Serv
       "thinking": true,
       "timeout": 60.0,
       "max_tool_iterations": 50,
-      "memory_window": 50
+      "memory_window": 50,
+      "subagent_enabled": true
     },
     "gateway": {
       "host": "0.0.0.0",

--- a/bot/tests/test_agent_loop_outcome.py
+++ b/bot/tests/test_agent_loop_outcome.py
@@ -1,9 +1,14 @@
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from vikingbot.agent import loop as loop_module
+from vikingbot.agent.context import ContextBuilder
 from vikingbot.agent.loop import AgentLoop
 from vikingbot.bus.events import InboundMessage, OutboundEventType
 from vikingbot.bus.queue import MessageBus
@@ -93,6 +98,41 @@ def test_agents_config_temperature_schema_caps_at_two():
     assert temperature["default"] == 0.7
     assert temperature["minimum"] == 0.0
     assert temperature["maximum"] == 2.0
+
+
+def test_agents_config_enables_subagents_by_default():
+    assert AgentsConfig().subagent_enabled is True
+
+
+def test_agent_loop_omits_spawn_tool_when_subagents_disabled(temp_dir: Path, monkeypatch):
+    monkeypatch.setattr(AgentLoop, "_register_builtin_hooks", lambda self: None)
+    monkeypatch.setattr("vikingbot.agent.loop.SubagentManager", _FakeSubagentManager)
+
+    bus = MessageBus()
+    provider = _RecordingProvider()
+    config = Config(storage_workspace=str(temp_dir), agents={"subagent_enabled": False})
+    monkeypatch.setattr("vikingbot.agent.tools.factory.load_config", lambda: config)
+
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=temp_dir / "workspace",
+        model=config.agents.model,
+        temperature=config.agents.temperature,
+        config=config,
+    )
+
+    assert "spawn" not in loop.tools.tool_names
+
+
+@pytest.mark.asyncio
+async def test_context_prompt_omits_subagent_capability_when_disabled(temp_dir: Path):
+    context = ContextBuilder(workspace=temp_dir / "workspace", enable_subagents=False)
+    session_key = SessionKey(type="cli", channel_id="default", chat_id="session-1")
+
+    prompt = await context._get_identity(session_key)
+
+    assert "Spawn subagents" not in prompt
 
 
 @pytest.mark.asyncio

--- a/bot/tests/test_channel_delivery_metadata.py
+++ b/bot/tests/test_channel_delivery_metadata.py
@@ -10,8 +10,10 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from vikingbot.agent.subagent import SubagentManager  # noqa: E402
 from vikingbot.agent.tools.cron import CronTool  # noqa: E402
 from vikingbot.agent.tools.message import MessageTool  # noqa: E402
+from vikingbot.agent.tools.spawn import SpawnTool  # noqa: E402
 from vikingbot.bus.events import OutboundMessage  # noqa: E402
 from vikingbot.bus.queue import MessageBus  # noqa: E402
 from vikingbot.channels.feishu import FeishuChannel  # noqa: E402
@@ -39,6 +41,55 @@ async def test_message_tool_preserves_channel_metadata():
     assert result.startswith("Message sent")
     assert sent[0].metadata == metadata
     assert sent[0].metadata is not metadata
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_preserves_channel_metadata():
+    metadata = {"reply_to": "oc_chat", "chat_type": "group", "message_id": "om_old"}
+    calls = []
+
+    class FakeSubagentManager:
+        async def spawn(self, **kwargs):
+            calls.append(kwargs)
+            return "started"
+
+    tool = SpawnTool(manager=FakeSubagentManager())
+    context = SimpleNamespace(
+        session_key=SessionKey(type="feishu", channel_id="cli_app", chat_id="oc_chat"),
+        channel_metadata=metadata,
+    )
+
+    result = await tool.execute(context, task="read files", label="read")
+
+    assert result == "started"
+    assert calls[0]["channel_metadata"] == metadata
+
+
+@pytest.mark.asyncio
+async def test_subagent_announcement_preserves_channel_metadata(tmp_path):
+    bus = MessageBus()
+    metadata = {"reply_to": "oc_chat", "chat_type": "group", "message_id": "om_old"}
+    session_key = SessionKey(type="feishu", channel_id="cli_app", chat_id="oc_chat")
+    manager = SubagentManager(
+        provider=SimpleNamespace(get_default_model=lambda: "fake-model"),
+        workspace=tmp_path,
+        bus=bus,
+        config=SimpleNamespace(),
+    )
+
+    await manager._announce_result(
+        "task-id",
+        "read",
+        "read files",
+        "done",
+        session_key,
+        "ok",
+        metadata,
+    )
+
+    inbound = await bus.consume_inbound()
+    assert inbound.metadata == metadata
+    assert inbound.metadata is not metadata
 
 
 @pytest.mark.asyncio

--- a/bot/tests/test_channel_delivery_metadata.py
+++ b/bot/tests/test_channel_delivery_metadata.py
@@ -10,14 +10,15 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from vikingbot.agent.loop import AgentLoop  # noqa: E402
 from vikingbot.agent.subagent import SubagentManager  # noqa: E402
 from vikingbot.agent.tools.cron import CronTool  # noqa: E402
 from vikingbot.agent.tools.message import MessageTool  # noqa: E402
 from vikingbot.agent.tools.spawn import SpawnTool  # noqa: E402
-from vikingbot.bus.events import OutboundMessage  # noqa: E402
+from vikingbot.bus.events import InboundMessage, OutboundMessage  # noqa: E402
 from vikingbot.bus.queue import MessageBus  # noqa: E402
 from vikingbot.channels.feishu import FeishuChannel  # noqa: E402
-from vikingbot.config.schema import FeishuChannelConfig, SessionKey  # noqa: E402
+from vikingbot.config.schema import Config, FeishuChannelConfig, SessionKey  # noqa: E402
 from vikingbot.cron.service import CronService  # noqa: E402
 from vikingbot.cron.types import CronSchedule  # noqa: E402
 
@@ -90,6 +91,51 @@ async def test_subagent_announcement_preserves_channel_metadata(tmp_path):
     inbound = await bus.consume_inbound()
     assert inbound.metadata == metadata
     assert inbound.metadata is not metadata
+
+
+@pytest.mark.asyncio
+async def test_system_message_response_preserves_channel_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(AgentLoop, "_register_builtin_hooks", lambda self: None)
+    monkeypatch.setattr(AgentLoop, "_register_default_tools", lambda self: None)
+    monkeypatch.setattr("vikingbot.agent.loop.SubagentManager", lambda **kwargs: SimpleNamespace())
+
+    metadata = {"reply_to": "oc_chat", "chat_type": "group", "message_id": "om_old"}
+    session_key = SessionKey(type="feishu", channel_id="cli_app", chat_id="oc_chat")
+    config = Config(storage_workspace=str(tmp_path / "data"))
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=SimpleNamespace(get_default_model=lambda: "fake-model"),
+        workspace=tmp_path / "workspace",
+        model=config.agents.model,
+        temperature=config.agents.temperature,
+        config=config,
+    )
+
+    async def fake_build_prompt_history(*args, **kwargs):
+        return []
+
+    async def fake_build_messages(**kwargs):
+        return [{"role": "user", "content": kwargs["current_message"]}]
+
+    async def fake_run_agent_loop(**kwargs):
+        return "summary", None, [], {}, 1
+
+    loop._build_prompt_history = fake_build_prompt_history
+    loop.context = SimpleNamespace(build_messages=fake_build_messages)
+    loop._run_agent_loop = fake_run_agent_loop
+
+    outbound = await loop._process_system_message(
+        InboundMessage(
+            sender_id="subagent",
+            session_key=session_key,
+            content="subagent done",
+            metadata=metadata,
+        )
+    )
+
+    assert outbound.content == "summary"
+    assert outbound.metadata == metadata
+    assert outbound.metadata is not metadata
 
 
 @pytest.mark.asyncio

--- a/bot/tests/test_subagent_skills_context.py
+++ b/bot/tests/test_subagent_skills_context.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from vikingbot.agent.subagent import SubagentManager  # noqa: E402
@@ -60,3 +62,63 @@ Read this only when needed.
     assert "<name>normal-skill</name>" in prompt
     assert "<description>Normal on-demand instructions</description>" in prompt
     assert "<location>skills/normal-skill/SKILL.md</location>" in prompt
+
+
+@pytest.mark.asyncio
+async def test_subagent_prompt_loads_skills_from_session_workspace(tmp_path):
+    source_workspace = tmp_path / "source"
+    session_workspace = tmp_path / "sandboxes" / "session"
+    _write_skill(
+        source_workspace,
+        "global-skill",
+        """---
+description: Global instructions
+always: true
+---
+# Global Skill
+
+Global-loaded instruction.
+""",
+    )
+    _write_skill(
+        session_workspace,
+        "session-skill",
+        """---
+description: Session instructions
+always: true
+---
+# Session Skill
+
+Session-loaded instruction.
+""",
+    )
+
+    class FakeSandboxManager:
+        def __init__(self):
+            self.created_for = []
+
+        async def get_sandbox(self, session_key):
+            self.created_for.append(session_key)
+            return SimpleNamespace()
+
+        def get_workspace_path(self, session_key):
+            return session_workspace
+
+    sandbox_manager = FakeSandboxManager()
+    manager = SubagentManager(
+        provider=SimpleNamespace(get_default_model=lambda: "fake-model"),
+        workspace=source_workspace,
+        bus=MessageBus(),
+        config=SimpleNamespace(),
+        sandbox_manager=sandbox_manager,
+    )
+    session_key = SimpleNamespace()
+
+    prompt_workspace = await manager._get_session_workspace(session_key)
+    prompt = manager._build_subagent_prompt("inspect local files", workspace=prompt_workspace)
+
+    assert sandbox_manager.created_for == [session_key]
+    assert f"Your workspace is at: {session_workspace}" in prompt
+    assert "### Skill: session-skill" in prompt
+    assert "Session-loaded instruction." in prompt
+    assert "Global-loaded instruction." not in prompt

--- a/bot/tests/test_subagent_skills_context.py
+++ b/bot/tests/test_subagent_skills_context.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for subagent prompt skill loading."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vikingbot.agent.subagent import SubagentManager  # noqa: E402
+from vikingbot.bus.queue import MessageBus  # noqa: E402
+
+
+def _write_skill(workspace: Path, name: str, content: str) -> None:
+    skill_dir = workspace / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+
+def test_subagent_prompt_loads_local_skills(tmp_path):
+    _write_skill(
+        tmp_path,
+        "always-skill",
+        """---
+description: Always active instructions
+always: true
+---
+# Always Skill
+
+Always-loaded instruction.
+""",
+    )
+    _write_skill(
+        tmp_path,
+        "normal-skill",
+        """---
+description: Normal on-demand instructions
+---
+# Normal Skill
+
+Read this only when needed.
+""",
+    )
+
+    manager = SubagentManager(
+        provider=SimpleNamespace(get_default_model=lambda: "fake-model"),
+        workspace=tmp_path,
+        bus=MessageBus(),
+        config=SimpleNamespace(),
+    )
+
+    prompt = manager._build_subagent_prompt("inspect local files")
+
+    assert "# Active Skills" in prompt
+    assert "### Skill: always-skill" in prompt
+    assert "Always-loaded instruction." in prompt
+    assert "description: Always active instructions" not in prompt
+    assert "# Skills" in prompt
+    assert "<name>normal-skill</name>" in prompt
+    assert "<description>Normal on-demand instructions</description>" in prompt
+    assert "<location>skills/normal-skill/SKILL.md</location>" in prompt

--- a/bot/vikingbot/agent/context.py
+++ b/bot/vikingbot/agent/context.py
@@ -37,6 +37,7 @@ class ContextBuilder:
         is_group_chat: bool = False,
         eval: bool = False,
         openviking_connection: dict[str, Any] | None = None,
+        enable_subagents: bool = True,
     ):
         self.workspace = workspace
         self._templates_ensured = False
@@ -48,6 +49,7 @@ class ContextBuilder:
         self._is_group_chat = is_group_chat
         self._eval = eval
         self._openviking_connection = openviking_connection
+        self._enable_subagents = enable_subagents
         self.latest_relevant_memories: str | None = None
 
     @property
@@ -288,17 +290,23 @@ Skills with available="false" need dependencies installed first - you can try in
         else:
             workspace_display = workspace_path
 
+        capabilities = [
+            "- Read, search, and grep OpenViking files",
+            "- Read, write, and edit local files",
+            "- Execute shell commands",
+            "- Search the web and fetch web pages",
+            "- Send messages to users on chat channels",
+        ]
+        if self._enable_subagents:
+            capabilities.append("- Spawn subagents for complex background tasks")
+        capabilities_text = "\n".join(capabilities)
+
         return f"""# vikingbot 🐈
 
 You are VikingBot, an AI assistant built based on the OpenViking context database.
 When acquiring information, data, and knowledge, you **prioritize using openviking tools to read and search OpenViking (a context database) above all other sources**.
 You have access to tools that allow you to:
-- Read, search, and grep OpenViking files
-- Read, write, and edit local files
-- Execute shell commands
-- Search the web and fetch web pages
-- Send messages to users on chat channels
-- Spawn subagents for complex background tasks
+{capabilities_text}
 
 ## Runtime
 {runtime}

--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -171,7 +171,11 @@ class AgentLoop:
         self.sandbox_manager = sandbox_manager
         self.config = config
 
-        self.context = ContextBuilder(workspace, sandbox_manager=sandbox_manager)
+        self.context = ContextBuilder(
+            workspace,
+            sandbox_manager=sandbox_manager,
+            enable_subagents=self._subagents_enabled(),
+        )
 
         self._register_builtin_hooks()
         self.sessions = session_manager or SessionManager(
@@ -371,7 +375,12 @@ class AgentLoop:
             send_callback=self.bus.publish_outbound,
             subagent_manager=self.subagents,
             cron_service=self.cron_service,
+            include_spawn_tool=self._subagents_enabled(),
         )
+
+    def _subagents_enabled(self) -> bool:
+        agents_config = getattr(self.config, "agents", None)
+        return bool(getattr(agents_config, "subagent_enabled", True))
 
     def _ov_session_context_enabled(self) -> bool:
         agents_config = getattr(self.config, "agents", None)
@@ -1231,6 +1240,7 @@ class AgentLoop:
                 is_group_chat=is_group_chat,
                 eval=self._eval,
                 openviking_connection=openviking_connection,
+                enable_subagents=self._subagents_enabled(),
             )
 
             # Build initial messages (use OpenViking session context when enabled)

--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -1598,7 +1598,11 @@ class AgentLoop:
         )
         await self.sessions.save(session)
 
-        return OutboundMessage(session_key=msg.session_key, content=final_content)
+        return OutboundMessage(
+            session_key=msg.session_key,
+            content=final_content,
+            metadata=dict(msg.metadata or {}),
+        )
 
     async def _consolidate_memory(self, session, archive_all: bool = False) -> None:
         """Consolidate old messages into MEMORY.md + HISTORY.md. Works on a cloned session."""

--- a/bot/vikingbot/agent/subagent.py
+++ b/bot/vikingbot/agent/subagent.py
@@ -52,6 +52,7 @@ class SubagentManager:
         task: str,
         session_key: SessionKey,
         label: str | None = None,
+        channel_metadata: dict[str, Any] | None = None,
     ) -> str:
         """
         Spawn a subagent to execute a task in the background.
@@ -69,7 +70,15 @@ class SubagentManager:
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
 
         # Create background task
-        bg_task = asyncio.create_task(self._run_subagent(task_id, task, display_label, session_key))
+        bg_task = asyncio.create_task(
+            self._run_subagent(
+                task_id,
+                task,
+                display_label,
+                session_key,
+                dict(channel_metadata or {}),
+            )
+        )
         self._running_tasks[task_id] = bg_task
 
         # Cleanup when done
@@ -79,7 +88,12 @@ class SubagentManager:
         return f"Subagent [{display_label}] started (id: {task_id}). I'll notify you when it completes."
 
     async def _run_subagent(
-        self, task_id: str, task: str, label: str, session_key: SessionKey
+        self,
+        task_id: str,
+        task: str,
+        label: str,
+        session_key: SessionKey,
+        channel_metadata: dict[str, Any] | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info(f"Subagent [{task_id}] starting task: {label}")
@@ -183,12 +197,16 @@ class SubagentManager:
                 final_result = "Task completed but no final response was generated."
 
             logger.info(f"Subagent [{task_id}] completed successfully")
-            await self._announce_result(task_id, label, task, final_result, session_key, "ok")
+            await self._announce_result(
+                task_id, label, task, final_result, session_key, "ok", channel_metadata
+            )
 
         except Exception as e:
             error_msg = f"Error: {str(e)}"
             logger.exception(f"Subagent [{task_id}] failed: {e}")
-            await self._announce_result(task_id, label, task, error_msg, session_key, "error")
+            await self._announce_result(
+                task_id, label, task, error_msg, session_key, "error", channel_metadata
+            )
 
     async def _announce_result(
         self,
@@ -198,6 +216,7 @@ class SubagentManager:
         result: str,
         session_key: SessionKey,
         status: str,
+        channel_metadata: dict[str, Any] | None = None,
     ) -> None:
         """Announce the subagent result to the main agent via the message bus."""
         status_text = "completed successfully" if status == "ok" else "failed"
@@ -216,6 +235,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
             sender_id="subagent",
             session_key=session_key,
             content=announce_content,
+            metadata=dict(channel_metadata or {}),
         )
 
         await self.bus.publish_inbound(msg)
@@ -228,8 +248,9 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
 
         now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
         tz = _time.strftime("%Z") or "UTC"
+        skills_context = self._build_subagent_skills_context()
 
-        return f"""# Subagent
+        prompt = f"""# Subagent
 
 ## Current Time
 {now} ({tz})
@@ -258,6 +279,49 @@ Your workspace is at: {self.workspace}
 Skills are available at: {self.workspace}/skills/ (read SKILL.md files as needed)
 
 When you have completed the task, provide a clear summary of your findings or actions."""
+        if skills_context:
+            prompt = f"{prompt}\n\n{skills_context}"
+        return prompt
+
+    def _build_subagent_skills_context(self) -> str:
+        """Build the same local skills context format used by the main agent."""
+        try:
+            from vikingbot.agent.skills import SkillsLoader
+
+            skills = SkillsLoader(self.workspace)
+            parts: list[str] = []
+
+            always_skills = skills.get_always_skills()
+            if always_skills:
+                always_content = skills.load_skills_for_context(always_skills)
+                if always_content:
+                    parts.append(f"# Active Skills\n\n{always_content}")
+
+            skills_summary = skills.build_skills_summary()
+            if skills_summary:
+                required_skill_note = ""
+                required_skill_candidates = [
+                    "skills/experience_loader/SKILL.md",
+                    "skills/task_case_experience/SKILL.md",
+                ]
+                for skill_path in required_skill_candidates:
+                    if (self.workspace / skill_path).exists():
+                        required_skill_note = (
+                            "\nRequired skill: before taking any task action, you MUST read "
+                            f"`{skill_path}` and apply its instructions.\n"
+                        )
+                        break
+                parts.append(f"""# Skills
+
+The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
+Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
+{required_skill_note}
+{skills_summary}""")
+
+            return "\n\n".join(parts)
+        except Exception as e:
+            logger.warning(f"Failed to build subagent skills context: {e}")
+            return ""
 
     def get_running_count(self) -> int:
         """Return the number of currently running subagents."""

--- a/bot/vikingbot/agent/subagent.py
+++ b/bot/vikingbot/agent/subagent.py
@@ -127,7 +127,8 @@ class SubagentManager:
                 logger.warning(f"Subagent [{task_id}] failed to load experience memory: {e}")
 
             # Build messages with subagent-specific prompt
-            system_prompt = self._build_subagent_prompt(task)
+            prompt_workspace = await self._get_session_workspace(session_key)
+            system_prompt = self._build_subagent_prompt(task, workspace=prompt_workspace)
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": task_content},
@@ -241,14 +242,23 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         await self.bus.publish_inbound(msg)
         logger.debug(f"Subagent [{task_id}] announced result to {session_key}")
 
-    def _build_subagent_prompt(self, task: str) -> str:
+    async def _get_session_workspace(self, session_key: SessionKey) -> Path:
+        """Return the workspace path used by tools for this subagent session."""
+        if not self.sandbox_manager:
+            return self.workspace
+
+        await self.sandbox_manager.get_sandbox(session_key)
+        return self.sandbox_manager.get_workspace_path(session_key)
+
+    def _build_subagent_prompt(self, task: str, workspace: Path | None = None) -> str:
         """Build a focused system prompt for the subagent."""
         from datetime import datetime
         import time as _time
 
+        workspace = workspace or self.workspace
         now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
         tz = _time.strftime("%Z") or "UTC"
-        skills_context = self._build_subagent_skills_context()
+        skills_context = self._build_subagent_skills_context(workspace)
 
         prompt = f"""# Subagent
 
@@ -275,20 +285,21 @@ You are a subagent spawned by the main agent to complete a specific task.
 - Access the main agent's conversation history
 
 ## Workspace
-Your workspace is at: {self.workspace}
-Skills are available at: {self.workspace}/skills/ (read SKILL.md files as needed)
+Your workspace is at: {workspace}
+Skills are available at: {workspace}/skills/ (read SKILL.md files as needed)
 
 When you have completed the task, provide a clear summary of your findings or actions."""
         if skills_context:
             prompt = f"{prompt}\n\n{skills_context}"
         return prompt
 
-    def _build_subagent_skills_context(self) -> str:
+    def _build_subagent_skills_context(self, workspace: Path | None = None) -> str:
         """Build the same local skills context format used by the main agent."""
         try:
             from vikingbot.agent.skills import SkillsLoader
 
-            skills = SkillsLoader(self.workspace)
+            workspace = workspace or self.workspace
+            skills = SkillsLoader(workspace)
             parts: list[str] = []
 
             always_skills = skills.get_always_skills()
@@ -305,7 +316,7 @@ When you have completed the task, provide a clear summary of your findings or ac
                     "skills/task_case_experience/SKILL.md",
                 ]
                 for skill_path in required_skill_candidates:
-                    if (self.workspace / skill_path).exists():
+                    if (workspace / skill_path).exists():
                         required_skill_note = (
                             "\nRequired skill: before taking any task action, you MUST read "
                             f"`{skill_path}` and apply its instructions.\n"

--- a/bot/vikingbot/agent/tools/spawn.py
+++ b/bot/vikingbot/agent/tools/spawn.py
@@ -56,4 +56,5 @@ class SpawnTool(Tool):
             task=task,
             label=label,
             session_key=tool_context.session_key,
+            channel_metadata=tool_context.channel_metadata,
         )

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -456,6 +456,10 @@ class AgentsConfig(BaseModel):
     )
     max_tool_iterations: int = 50
     memory_window: int = 50
+    subagent_enabled: bool = Field(
+        default=True,
+        description="Enable the spawn tool so the main agent can start background subagents.",
+    )
     session_context_enabled: bool = False
     session_context_token_budget: int = 3000
     commit_token_threshold: int = 200000


### PR DESCRIPTION
## 背景

本 PR 完善 VikingBot 子 Agent 相关链路，解决子 Agent 执行完成后在飞书等渠道无法正常回传的问题，并补齐子 Agent 的本地 Skill 上下文加载能力。同时新增配置开关，允许部署方按需禁用子 Agent 能力。

## 主要改动

- 修复子 Agent 完成后结果无法发送到飞书的问题：`spawn` 会透传原始 channel metadata，子 Agent 回灌消息时保留 `reply_to` 等投递信息，避免 Feishu channel 因缺少 `reply_to` 跳过发送。
- 子 Agent 构建 system prompt 时加载本地 `skills/*/SKILL.md`：支持 `always: true` skill 自动注入，并提供可用 skills summary，和主 Agent 的本地 Skill 使用体验保持一致。
- 新增 `bot.agents.subagent_enabled` 配置项，默认开启；设置为 `false` 时不注册 `spawn` 工具，并从主 Agent prompt 能力列表中隐藏子 Agent 能力。
- 更新中英文 bot README，补充 `subagent_enabled` 配置说明和示例。

## 测试

- `python3 -m pytest bot/tests/test_subagent_skills_context.py bot/tests/test_channel_delivery_metadata.py`
- `python3 -m pytest bot/tests/test_agent_loop_outcome.py::test_agents_config_enables_subagents_by_default bot/tests/test_agent_loop_outcome.py::test_agent_loop_omits_spawn_tool_when_subagents_disabled bot/tests/test_agent_loop_outcome.py::test_context_prompt_omits_subagent_capability_when_disabled`

## 影响范围

- 默认配置下保持现有子 Agent 行为不变。
- 仅当 `bot.agents.subagent_enabled=false` 时，主 Agent 不再暴露 `spawn` 工具，也不会在 prompt 中声明可启动子 Agent。
