### PR TITLE
fix(ragfs): sort directory listings dirs first

### DIFF
--- a/crates/ragfs/src/core/filesystem.rs
+++ b/crates/ragfs/src/core/filesystem.rs
@@ -7,6 +7,7 @@
 use async_trait::async_trait;
 use regex::Regex;
 use std::any::Any;
+use std::cmp::Ordering;
 
 use super::errors::{Error, Result};
 use super::types::{FileInfo, GrepResult, TreeEntry, WriteFlag};
@@ -21,6 +22,22 @@ pub(crate) fn normalize_prefix_path(path: &str) -> String {
     } else {
         path.trim_end_matches('/').to_string()
     }
+}
+
+/// Compare listing names case-insensitively, with the original name as tie-breaker.
+pub(crate) fn compare_listing_names(a: &str, b: &str) -> Ordering {
+    a.to_lowercase()
+        .cmp(&b.to_lowercase())
+        .then_with(|| a.cmp(b))
+}
+
+/// Sort listing entries with directories first, then case-insensitive name.
+pub(crate) fn sort_directory_entries(entries: &mut [FileInfo]) {
+    entries.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| compare_listing_names(&a.name, &b.name))
+    });
 }
 
 /// Check whether `path` is under `exclude_path` (including itself).
@@ -487,7 +504,8 @@ pub trait FileSystem: Send + Sync + Any {
             }
         }
 
-        let entries = self.read_dir(current_path).await?;
+        let mut entries = self.read_dir(current_path).await?;
+        sort_directory_entries(&mut entries);
 
         for entry in entries {
             if node_limit.is_some_and(|limit| result.len() >= limit) {
@@ -853,22 +871,25 @@ mod tests {
     #[tokio::test]
     async fn test_tree_nested_dfs_order() {
         let fs = TreeFS::default()
-            .with_dir_entries("/root", vec![("a.txt", false), ("sub", true)])
-            .with_dir_entries("/root/sub", vec![("b.txt", false)]);
+            .with_dir_entries("/root", vec![("a.txt", false), ("Sub", true), ("b", true)])
+            .with_dir_entries("/root/Sub", vec![("b.txt", false)])
+            .with_dir_entries("/root/b", vec![]);
 
         let entries = root_tree(&fs, false, None, None).await;
 
-        assert_eq!(entries.len(), 3);
-        assert_tree_names(&entries, &["a.txt", "sub", "b.txt"]);
-        assert_tree_rel_paths(&entries, &["a.txt", "sub", "sub/b.txt"]);
+        assert_eq!(entries.len(), 4);
+        assert_tree_names(&entries, &["b", "Sub", "b.txt", "a.txt"]);
+        assert_tree_rel_paths(&entries, &["b", "Sub", "Sub/b.txt", "a.txt"]);
         assert_eq!(
             tree_paths(&entries),
-            vec!["/root/a.txt", "/root/sub", "/root/sub/b.txt"]
+            vec!["/root/b", "/root/Sub", "/root/Sub/b.txt", "/root/a.txt"]
         );
-        assert_eq!(entries[0].info.mode, 0o644);
-        assert!(!entries[0].info.is_dir);
+        assert_eq!(entries[0].info.mode, 0o755);
+        assert!(entries[0].info.is_dir);
         assert_eq!(entries[1].info.mode, 0o755);
         assert!(entries[1].info.is_dir);
+        assert_eq!(entries[2].info.mode, 0o644);
+        assert!(!entries[2].info.is_dir);
         assert!(entries.iter().all(|entry| entry.extra.is_empty()));
     }
 
@@ -877,11 +898,11 @@ mod tests {
         let fs = TreeFS::default().with_dir_entries(
             "/root",
             vec![
-                ("a.txt", false),
-                ("b.txt", false),
-                ("c.txt", false),
-                ("d.txt", false),
                 ("e.txt", false),
+                ("c.txt", false),
+                ("a.txt", false),
+                ("d.txt", false),
+                ("b.txt", false),
             ],
         );
 

--- a/crates/ragfs/src/core/mountable.rs
+++ b/crates/ragfs/src/core/mountable.rs
@@ -21,7 +21,7 @@ const PATH_LOCK_FILE: &str = ".path.ovlock";
 
 use super::encryption_wrapper::EncryptionWrappedFS;
 use super::errors::{Error, Result};
-use super::filesystem::FileSystem;
+use super::filesystem::{sort_directory_entries, FileSystem};
 use super::multibackend_wrapper::MultiWriteWrappedFS;
 use super::plugin::ServicePlugin;
 use super::stats::{FilesystemStats, StatsCollector};
@@ -763,6 +763,7 @@ impl FileSystem for MountableFS {
         let (mount_info, rel_path) = self.find_mount(path).await?;
         let mut entries = mount_info.fs.read_dir(&rel_path).await?;
         entries.retain(|e| e.name != PATH_LOCK_FILE);
+        sort_directory_entries(&mut entries);
         Ok(entries)
     }
 
@@ -1020,7 +1021,11 @@ mod tests {
         }
 
         async fn read_dir(&self, _path: &str) -> Result<Vec<FileInfo>> {
-            Ok(vec![])
+            Ok(self
+                .tree_entries
+                .iter()
+                .map(|entry| entry.info.clone())
+                .collect())
         }
 
         async fn stat(&self, path: &str) -> Result<FileInfo> {
@@ -1715,6 +1720,32 @@ mod tests {
             },
             extra: HashMap::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn test_read_dir_sorts_dirs_first_then_name() {
+        let mfs = MountableFS::new();
+        let plugin = MockPlugin::with_tree_entries(
+            "sorted",
+            vec![
+                make_tree_entry("/b.txt", "b.txt", "b.txt", false),
+                make_tree_entry("/A.txt", "A.txt", "A.txt", false),
+                make_tree_entry("/c", "c", "c", true),
+                make_tree_entry("/B", "B", "B", true),
+            ],
+        );
+        mfs.register_plugin(plugin).await;
+        mfs.mount(test_config("sorted", "/sorted")).await.unwrap();
+
+        let names: Vec<String> = mfs
+            .read_dir("/sorted")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+
+        assert_eq!(names, vec!["B", "c", "A.txt", "b.txt"]);
     }
 
     #[tokio::test]

--- a/crates/ragfs/src/plugins/s3fs/mod.rs
+++ b/crates/ragfs/src/plugins/s3fs/mod.rs
@@ -27,7 +27,7 @@ use futures::stream::{self, StreamExt};
 use regex::Regex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::core::filesystem::{relative_depth, relative_match_file};
+use crate::core::filesystem::{relative_depth, relative_match_file, sort_directory_entries};
 use crate::core::{
     ConfigParameter, Error, FileInfo, FileSystem, GrepMatch, GrepResult, PluginConfig, Result,
     ServicePlugin, TreeEntry, WriteFlag,
@@ -546,8 +546,7 @@ impl FileSystem for S3FileSystem {
             });
         }
 
-        // Sort by name
-        files.sort_by(|a, b| a.name.cmp(&b.name));
+        sort_directory_entries(&mut files);
 
         // Cache
         self.dir_cache.put(normalized.clone(), files.clone()).await;

--- a/crates/ragfs/src/plugins/s3fs/tree.rs
+++ b/crates/ragfs/src/plugins/s3fs/tree.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::time::SystemTime;
 
 use super::client;
-use crate::core::filesystem::{relative_depth, relative_match_file};
+use crate::core::filesystem::{compare_listing_names, relative_depth, relative_match_file};
 use crate::core::{FileInfo, Result, TreeEntry};
 
 /// Extract the last path component (file/dir name) from a path.
@@ -21,8 +21,9 @@ fn s3_file_name(path: &str) -> String {
 ///
 /// Reconstructs synthetic directories (from directory markers and from file
 /// parent prefixes), filters hidden files and entries beyond `level_limit`,
-/// and orders entries by path-component lexicographic order so the output is
-/// stable and consistent with the default DFS implementation.
+/// and orders entries by DFS order with sibling directories first, then by
+/// case-insensitive name, so the output is stable and consistent with the
+/// default DFS implementation.
 ///
 /// `query_root` is the normalized query root path; `key_to_path` maps an S3
 /// object key to a filesystem path (allowing prefix stripping to be injected).
@@ -110,7 +111,19 @@ where
             .split('/')
             .filter(|p| !p.is_empty())
             .collect();
-        a_parts.cmp(&b_parts)
+        for i in 0..a_parts.len().min(b_parts.len()) {
+            if a_parts[i] == b_parts[i] {
+                continue;
+            }
+            let a_prefix = format!("/{}", a_parts[..=i].join("/"));
+            let b_prefix = format!("/{}", b_parts[..=i].join("/"));
+            let a_is_dir = seen_dirs.contains(&a_prefix);
+            let b_is_dir = seen_dirs.contains(&b_prefix);
+            return b_is_dir
+                .cmp(&a_is_dir)
+                .then_with(|| compare_listing_names(a_parts[i], b_parts[i]));
+        }
+        a_parts.len().cmp(&b_parts.len())
     });
 
     let mut result = Vec::new();
@@ -213,7 +226,7 @@ mod tests {
         let paths: Vec<&str> = result.iter().map(|e| e.path.as_str()).collect();
         assert_eq!(
             paths,
-            vec!["/a", "/a/a.txt", "/a/b", "/a/b/c.txt", "/a/b.txt"]
+            vec!["/a", "/a/b", "/a/b/c.txt", "/a/a.txt", "/a/b.txt"]
         );
     }
 
@@ -221,8 +234,8 @@ mod tests {
     fn test_build_tree_entries_level_limit() {
         let objects = vec![
             make_meta("a.txt", 100, false),
-            make_meta("sub/b.txt", 200, false),
-            make_meta("sub/deep/c.txt", 300, false),
+            make_meta("CONTRIBUTING_CN/file.txt", 200, false),
+            make_meta("b/file.txt", 300, false),
         ];
         let result = build_tree_entries_from_flat_listing(
             "/",
@@ -233,7 +246,7 @@ mod tests {
         )
         .unwrap();
         let paths: Vec<&str> = result.iter().map(|e| e.path.as_str()).collect();
-        assert_eq!(paths, vec!["/a.txt", "/sub"]);
+        assert_eq!(paths, vec!["/b", "/CONTRIBUTING_CN", "/a.txt"]);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Make AGFS directory listings deterministic by sorting entries with directories first, then by case-insensitive name. This keeps `ov ls` and recursive tree traversal stable without mixing files ahead of sibling directories, and matches human name ordering for mixed-case names such as `b` before `CONTRIBUTING_CN`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add a shared directory-listing sorter that orders directories first, then names alphabetically case-insensitively.
- Apply the sorter in `MountableFS::read_dir`, default `tree_directory`, and S3FS `read_dir`.
- Update S3 flat tree reconstruction to preserve DFS order while sorting sibling directories before files with the same case-insensitive name comparison.
- Add/adjust focused tests for directory-first, mixed-case listing and tree traversal order.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
cargo test --manifest-path crates/ragfs/Cargo.toml test_tree_nested_dfs_order --quiet
cargo test --manifest-path crates/ragfs/Cargo.toml test_read_dir_sorts_dirs_first_then_name --quiet
cargo test --manifest-path crates/ragfs/Cargo.toml test_build_tree_entries_level_limit --quiet
cargo test --manifest-path crates/ragfs/Cargo.toml test_build_tree_entries_dfs_order --quiet
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The local test run still reports existing missing-docs/dead-code warnings unrelated to this change.
