### PR TITLE
fix(bot): don't discard vlm-only config when ovcli identity is missing

### DIFF
--- a/bot/vikingbot/config/loader.py
+++ b/bot/vikingbot/config/loader.py
@@ -210,8 +210,20 @@ def _fill_user_api_key_from_ovcli(bot_data: dict) -> None:
     try:
         cli_config = load_ovcli_config()
     except ValueError as e:
-        print(str(e), file=sys.stderr)
-        raise
+        # A missing or invalid ovcli identity only affects OpenViking memory/file
+        # tools. It must NOT abort loading the rest of the bot config (LLM/vlm
+        # provider, agents, channels): load_config() would otherwise catch this
+        # ValueError, discard the whole config and silently fall back to defaults,
+        # so a user who only configured `vlm` ends up on the default
+        # `openai/*` model with no credentials ("Missing credentials ... set
+        # OPENAI_API_KEY") instead of their configured provider. Degraded
+        # OpenViking auth is surfaced separately by validate_openviking_auth().
+        print(
+            f"Warning: could not load OpenViking user API key from ovcli config: {e}\n"
+            "OpenViking memory and file tools may not work until this is fixed.",
+            file=sys.stderr,
+        )
+        return
     if cli_config and cli_config.api_key:
         bot_data["api_key"] = cli_config.api_key
 

--- a/bot/vikingbot/tests/unit/test_config/test_vlm_only_config_survives_ovcli_error.py
+++ b/bot/vikingbot/tests/unit/test_config/test_vlm_only_config_survives_ovcli_error.py
@@ -1,0 +1,71 @@
+"""Regression test for vlm-only ov.conf losing its provider on ovcli errors.
+
+Repro: with only a `vlm` section configured (no `bot.agents`) and a `server`
+section whose effective auth mode is `api_key`, load_config() used to call
+_fill_user_api_key_from_ovcli() -> load_ovcli_config(), which raises ValueError
+when no valid ovcli identity exists. load_config()'s broad
+`except (json.JSONDecodeError, ValueError)` then swallowed it and fell back to a
+default Config(), discarding the vlm-derived model/provider/credentials. The bot
+then ran on the default `openai/*` model with no key and failed with
+"Missing credentials ... set OPENAI_API_KEY".
+
+An ovcli/user-identity problem must only degrade OpenViking memory/file tools,
+never discard the unrelated LLM/vlm provider config.
+"""
+
+import json
+
+from vikingbot.config import loader
+
+
+def _write_conf(tmp_path, monkeypatch):
+    conf = tmp_path / "ov.conf"
+    conf.write_text(
+        json.dumps(
+            {
+                "vlm": {
+                    "provider": "deepseek",
+                    "api_base": "https://api.deepseek.com",
+                    "api_key": "sk-deepseek-test-key",
+                    "model": "deepseek-chat",
+                },
+                # api_key auth mode is what drives the ovcli user-key lookup.
+                "server": {"auth_mode": "api_key"},
+            }
+        )
+    )
+    monkeypatch.setattr(loader, "CONFIG_PATH", conf)
+    return conf
+
+
+def test_vlm_config_preserved_when_ovcli_lookup_fails(tmp_path, monkeypatch):
+    _write_conf(tmp_path, monkeypatch)
+
+    def _raise(*_args, **_kwargs):
+        raise ValueError("Invalid CLI config: no ovcli identity configured")
+
+    monkeypatch.setattr(loader, "load_ovcli_config", _raise)
+
+    config = loader.load_config()
+
+    # The vlm-derived agent config must survive the ovcli failure.
+    assert config.agents.model == "deepseek-chat"
+    assert config.agents.provider == "deepseek"
+    assert config.agents.api_key == "sk-deepseek-test-key"
+    assert config.agents.api_base == "https://api.deepseek.com"
+
+
+def test_vlm_config_used_when_ovcli_supplies_user_key(tmp_path, monkeypatch):
+    _write_conf(tmp_path, monkeypatch)
+
+    class _Cli:
+        api_key = "user-api-key"
+
+    monkeypatch.setattr(loader, "load_ovcli_config", lambda *a, **k: _Cli())
+
+    config = loader.load_config()
+
+    # LLM provider still comes from vlm; ovcli only fills the OpenViking user key.
+    assert config.agents.provider == "deepseek"
+    assert config.agents.model == "deepseek-chat"
+    assert config.ov_server.api_key == "user-api-key"


### PR DESCRIPTION
## Problem

`ov chat --with-bot` regressed between **0.4.3** (works) and **0.4.5+** (broken). With an `ov.conf` that configures **only** a `vlm` section (no `bot.agents`) and a `server` section whose effective auth mode is `api_key`, chatting fails with:

```
Error calling LLM in LiteLLM stream: litellm.InternalServerError:
InternalServerError: OpenAIException - Missing credentials. Please pass an
api_key ... or set the OPENAI_API_KEY environment variable.
```

...even though the user configured a real provider (e.g. `deepseek`).

## Root cause

The 0.4.5 ov_server auth rewrite made `_merge_current_ov_server_config` call `_fill_user_api_key_from_ovcli()` → `load_ovcli_config()` whenever the effective auth mode is `api_key`. When the user only configured `vlm` and has no valid ovcli (OpenViking user) identity, `load_ovcli_config()` raises `ValueError`, which was **re-raised**.

`load_config()`'s broad `except (json.JSONDecodeError, ValueError)` then swallows it and silently falls back to a default `Config()` — model `openai/doubao-seed-2-0-pro-260215`, empty `provider`, empty `api_key`. `_make_provider` takes the legacy `LiteLLMProvider` branch on that `openai/*` model with no key → LiteLLM routes to OpenAI → the missing-credentials error.

In 0.4.3 the ovcli lookup only ran in `remote` mode (api_key present), so a vlm-only config never hit it. The vikingbot `_make_provider` / `_merge_vlm_model_config` / `AgentsConfig` code is byte-identical between the two releases (verified against the published wheels) — the behavior change is entirely this ovcli side effect + the broad fallback.

## Fix

A missing/invalid ovcli identity only affects OpenViking **memory/file tools** — it must not abort loading the rest of the bot config (LLM/vlm provider, agents, channels). On `load_ovcli_config()` failure, warn and continue with the user api_key unset instead of re-raising. Degraded OpenViking auth is still surfaced separately by `validate_openviking_auth()`.

This restores 0.4.3 behavior for vlm-only configs while keeping the user-key auto-fill when ovcli **is** configured.

## Verification

Reproduced against the real 0.4.3 vs 0.4.5 PyPI wheels: with `{vlm: {provider: deepseek, ...}, server: {auth_mode: api_key}}` and no ovcli identity, 0.4.3 resolves `provider=deepseek` (key SET); 0.4.5 falls back to `openai/doubao-...` (key EMPTY). With this patch the vlm config is preserved.

Adds `test_vlm_only_config_survives_ovcli_error.py` covering both the ovcli-fails and ovcli-succeeds paths. The first test fails on the unpatched loader and passes with the fix.

## Follow-up suggestion (not in this PR)

`load_config()`'s broad `except (json.JSONDecodeError, ValueError): ... return Config()` is a latent footgun — any validation error anywhere in the load path silently discards the entire config and swaps in unrelated defaults, turning specific misconfig into confusing downstream errors (as here). Worth narrowing so genuine config errors surface loudly instead of falling back to a working-looking-but-wrong default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)