### PR TITLE
feat(examples/pi): adapt OpenViking extension to pi 0.81 (agent_settled commits + entry rendering)

### DIFF
--- a/examples/pi-coding-agent-extension/README.md
+++ b/examples/pi-coding-agent-extension/README.md
@@ -246,7 +246,7 @@ Both plugins share the same core design (informed by each other):
 | Tool delivery       | OV server's MCP endpoint (16 tools)     | pi.registerTool() (7 tools)            |
 | Write path          | Detached worker (async)                 | Async promise (pi's event loop)        |
 | Installation        | `claude plugin install` + setup script  | Copy directory → auto-discovered       |
-| Memory index        | None (flashlight search model)          | Built (map model — model sees what OV knows) |
+| Memory index        | None (flashlight search model)          | None (on-demand recall; startup index dropped for latency) |
 | Subagent isolation  | Explicit hook management                | Natural process-level isolation        |
 
 ## Extension Structure

--- a/examples/pi-coding-agent-extension/TAKEOVER.md
+++ b/examples/pi-coding-agent-extension/TAKEOVER.md
@@ -23,16 +23,26 @@ State is persisted as a pi custom entry:
 pi.appendEntry("ov-takeover", state)
 ```
 
+On pi >= 0.81 these entries are rendered in interactive mode via
+`pi.registerEntryRenderer("ov-takeover", ...)` — a dim one-line boundary
+status (expand to preview the overview) that never enters the LLM context.
+
 On startup the extension scans the branch from the end, restores the latest
 entry, and restores `SyncManager`'s watermark so `pi -c` does not resend the
 same branch entries to OpenViking.
 
 ## Runtime Flow
 
-1. `turn_end` captures new branch entries into the OpenViking session.
+1. `turn_end` captures new branch entries into the OpenViking session and
+   accumulates token pressure. It never commits: the commit sequence includes
+   an overview poll (up to `overviewPollMax × overviewPollMs`) that must not
+   stall an in-flight agent run.
 2. The capture path uses a disk pending queue when OpenViking is temporarily
    unreachable.
-3. When `pendingTokens >= takeover.tokenThreshold`, takeover tries to advance.
+3. When `pendingTokens >= takeover.tokenThreshold`, takeover tries to advance
+   from `agent_settled` (pi >= 0.81: the run is fully settled, no retry,
+   compaction, or queued continuation pending). On older pi the advance runs
+   fire-and-forget from the next `before_agent_start` instead.
 4. Advance requires a successful flush barrier: all current-session
    `addMessage` queue entries must be delivered. Pending `commitSession`
    entries and entries for other sessions do not block the barrier.

--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -18,6 +18,7 @@ import { RecallManager } from "./recall.js";
 import { SyncManager } from "./sync.js";
 import { buildProfileBlock } from "./shared/profile-inject.mjs";
 import { guardVikingUriToolCall } from "./lib/uri-guard-adapter.mjs";
+import { TAKEOVER_ENTRY_TYPE } from "./lib/takeover-core.mjs";
 import { registerTools } from "./tools.js";
 import { createTakeoverManager } from "./takeover.js";
 
@@ -43,6 +44,28 @@ export default async function (pi: ExtensionAPI) {
     }
   };
   const takeover = createTakeoverManager({ pi, client, sync, config, log: debugLog });
+
+  // Takeover state entries are persisted via pi.appendEntry and never reach the
+  // LLM; on pi >= 0.81 render them in the TUI so the archive boundary is visible.
+  if (config.takeoverEnabled && typeof (pi as any).registerEntryRenderer === "function") {
+    try {
+      const { Box, Text } = await import("@earendil-works/pi-tui");
+      (pi as any).registerEntryRenderer(TAKEOVER_ENTRY_TYPE, (entry: any, opts: any, theme: any) => {
+        const d = entry?.data ?? {};
+        const box = new Box(1, 0, (text: string) => text);
+        box.addChild(new Text(
+          theme.fg("dim", `◆ OV takeover · ${d.coveredUserTurns ?? 0}/${d.lastSeenUserTurns ?? 0} turns archived · ~${d.pendingTokens ?? 0} tokens pending`),
+          0, 0,
+        ));
+        if (opts?.expanded && typeof d.overview === "string" && d.overview) {
+          box.addChild(new Text(theme.fg("dim", d.overview.slice(0, 600)), 0, 0));
+        }
+        return box;
+      });
+    } catch {
+      // pi-tui unavailable (headless or older pi); entries just render as default.
+    }
+  }
 
   // Session state
   let connected = false;
@@ -132,10 +155,15 @@ export default async function (pi: ExtensionAPI) {
 
   // --- before_agent_start ---
   pi.on("before_agent_start", async (event, ctx) => {
-    // session_start doesn't fire for pi -c continuations.
+    // pi < 0.81 doesn't fire session_start for `pi -c` continuations; on 0.81+
+    // this is a cheap idempotent no-op after session_start(reason: "resume").
     await start(ctx);
 
     if (!connected || bypassed) return;
+
+    // Fallback commit point for pi < 0.81 where agent_settled never fires.
+    // Fire-and-forget: never delay the prompt; commitAndAdvance self-serializes.
+    if (config.takeoverEnabled) void takeover.commitIfDue();
 
     // Queue recall for the context hook. Pi renders the user message before
     // that hook, so recall latency does not delay the message appearing.
@@ -186,8 +214,20 @@ export default async function (pi: ExtensionAPI) {
     const branch = ctx.sessionManager.getBranch();
     const result = await sync.syncBranch(branch);
     debugLog(`turn_end: synced ${result.added} entries, ~${result.tokens} tokens`);
-    await takeover.onTurnSynced(result.tokens);
+    // Accumulate only. The threshold commit (flush + commit + overview poll,
+    // up to pollMax×pollMs) runs from agent_settled so it never stalls a run.
+    takeover.noteSynced(result.tokens);
     updateStatus(ctx, connected, result.added, sync.sessionId, config, takeover.state);
+  });
+
+  // --- agent_settled --- (pi >= 0.81: run fully settled, no retry/compaction pending)
+  pi.on("agent_settled", async (_event, ctx) => {
+    if (!connected || bypassed || !config.takeoverEnabled) return;
+    const committed = await takeover.commitIfDue();
+    if (committed) {
+      debugLog(`agent_settled: takeover boundary advanced to ${takeover.state.coveredUserTurns} turns`);
+      updateStatus(ctx, connected, 0, sync.sessionId, config, takeover.state);
+    }
   });
 
   // --- session_before_compact ---

--- a/examples/pi-coding-agent-extension/lib/takeover-core.d.mts
+++ b/examples/pi-coding-agent-extension/lib/takeover-core.d.mts
@@ -58,6 +58,8 @@ export class TakeoverCore {
   };
   restore(entries: any[]): this["state"];
   transformContext(messages: TakeoverMessage[]): TakeoverMessage[];
+  noteSynced(estTokens: number): void;
+  commitIfDue(): Promise<boolean>;
   onTurnSynced(estTokens: number): Promise<boolean>;
   commitAndAdvance(): Promise<boolean>;
   handleBeforeCompact(preparation?: { firstKeptEntryId?: string; tokensBefore?: number }): Promise<

--- a/examples/pi-coding-agent-extension/lib/takeover-core.mjs
+++ b/examples/pi-coding-agent-extension/lib/takeover-core.mjs
@@ -251,12 +251,27 @@ export class TakeoverCore {
     ];
   }
 
-  async onTurnSynced(estTokens) {
-    if (!this.enabled) return false;
+  noteSynced(estTokens) {
+    if (!this.enabled) return;
     this.pendingTokens += Math.max(0, Math.floor(Number(estTokens) || 0));
+  }
+
+  /**
+   * Commit iff the threshold has been crossed. Callers decide *when*: turn_end
+   * only accumulates (noteSynced); the commit — which includes an overview poll
+   * of up to pollMax×pollMs — runs from agent_settled / before_agent_start so
+   * it never stalls an in-flight agent run.
+   */
+  async commitIfDue() {
+    if (!this.enabled) return false;
     if (this.pendingTokens < this.config.takeoverTokenThreshold) return false;
     if (this.lastSeenUserTurns <= this.config.takeoverKeepRecentTurns) return false;
     return this.commitAndAdvance();
+  }
+
+  async onTurnSynced(estTokens) {
+    this.noteSynced(estTokens);
+    return this.commitIfDue();
   }
 
   async commitAndAdvance() {

--- a/examples/pi-coding-agent-extension/tests/takeover-core.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/takeover-core.test.mjs
@@ -229,6 +229,40 @@ test("onTurnSynced waits for threshold and enough user turns", async () => {
   assert.equal(calls.committed, 1);
 });
 
+test("noteSynced accumulates without committing even past threshold", async () => {
+  const { core, calls } = makeCore({ config: { takeoverTokenThreshold: 50, takeoverKeepRecentTurns: 1 } });
+  core.transformContext([user("one"), user("two"), user("three")]);
+  core.noteSynced(200);
+  assert.equal(core.state.pendingTokens, 200);
+  assert.equal(calls.committed, 0);
+});
+
+test("commitIfDue commits only when threshold and turn gates pass", async () => {
+  const { core, calls } = makeCore({ config: { takeoverTokenThreshold: 50, takeoverKeepRecentTurns: 1 } });
+  core.transformContext([user("one"), user("two"), user("three")]);
+
+  core.noteSynced(10);
+  assert.equal(await core.commitIfDue(), false);
+  assert.equal(calls.committed, 0);
+
+  core.noteSynced(60);
+  assert.equal(await core.commitIfDue(), true);
+  assert.equal(calls.committed, 1);
+  assert.equal(core.state.pendingTokens, 0);
+
+  // Nothing pending afterwards: idempotent no-op.
+  assert.equal(await core.commitIfDue(), false);
+  assert.equal(calls.committed, 1);
+});
+
+test("commitIfDue respects keepRecentTurns gate", async () => {
+  const { core, calls } = makeCore({ config: { takeoverTokenThreshold: 50, takeoverKeepRecentTurns: 3 } });
+  core.transformContext([user("one"), user("two")]);
+  core.noteSynced(200);
+  assert.equal(await core.commitIfDue(), false);
+  assert.equal(calls.committed, 0);
+});
+
 test("commitAndAdvance advances boundary and persists after overview is ready", async () => {
   const { core, calls, setWatermark } = makeCore({
     watermark: 4,


### PR DESCRIPTION
## What

main already carries the full OV context-takeover extension (#3081, #3079, #3099, #3233). This PR does **not** re-do takeover — it adapts it to pi 0.81's new extension primitives, without regressing any existing behavior. Rebuilt on current main; single commit.

- **Threshold commits no longer stall the agent run.** The takeover commit (flush + commit + overview poll, worst case pollMax×pollMs ≈ 30s) previously ran inline in `turn_end`, blocking the in-flight run. `turn_end` now only accumulates token pressure (`noteSynced`); the commit runs from `agent_settled` (pi ≥ 0.81, run fully settled), with a fire-and-forget `before_agent_start` fallback for older pi. `onTurnSynced` split into `noteSynced()` + `commitIfDue()`.
- **`ov-takeover` state rendered in the TUI** via `registerEntryRenderer` (pi ≥ 0.81): a dim one-line archive-boundary status, expandable to preview the overview; never enters LLM context. Optional, zero logic risk.
- README comparison table aligned with code (startup memory index was dropped for latency in favor of on-demand recall).

## Dropped after necessity review

- `mirrorMemoryWrites` — mirroring `.memory/MEMORY.md` duplicates OV's own turn-based memory extraction (and re-mirrors unchanged content every shutdown). Removed.
- `commitOnShutdown` — near-dead switch (only affects non-takeover mode; takeover is on by default). Removed.

## Test

- `cd examples/pi-coding-agent-extension && node --test tests/*.test.mjs` — 44 pass.
- End-to-end on pi 0.81.1 against a local OpenViking server: `agent_settled` advances the boundary 121ms after the run; `pi -c` restores boundary/watermark; cross-boundary facts recalled from the overview.

## Note (out of scope)

`DESIGN.md` (pre-existing on main) still documents `mirrorMemoryWrites`/`commitOnShutdown` as implemented — a doc/code mismatch predating this PR, left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRy5Epi4rQ7vCzSk3BLQcA