### PR TITLE
perf(skills): parallelize user+agent skill search

### DIFF
--- a/openviking/server/routers/skills.py
+++ b/openviking/server/routers/skills.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Agent-scope skill management endpoints for OpenViking HTTP Server."""
 
+import asyncio
 import re
 import shutil
 import uuid
@@ -615,34 +616,37 @@ async def find_skills(
         user_root = f"{canonical_user_root(_ctx)}/skills"
         agent_root = "viking://agent/skills"
 
-        user_execution = await run_operation(
-            operation="skills.find",
-            telemetry=request.telemetry,
-            fn=lambda: service.search.find(
-                query=request.query,
-                ctx=_ctx,
-                target_uri=user_root,
-                limit=request.limit,
-                score_threshold=request.score_threshold,
-                level=request.level,
+        user_execution, agent_execution = await asyncio.gather(
+            run_operation(
+                operation="skills.find",
+                telemetry=request.telemetry,
+                fn=lambda: service.search.find(
+                    query=request.query,
+                    ctx=_ctx,
+                    target_uri=user_root,
+                    limit=request.limit,
+                    score_threshold=request.score_threshold,
+                    level=request.level,
+                ),
+            ),
+            run_operation(
+                operation="skills.find",
+                telemetry=request.telemetry,
+                fn=lambda: service.search.find(
+                    query=request.query,
+                    ctx=_ctx,
+                    target_uri=agent_root,
+                    limit=request.limit,
+                    score_threshold=request.score_threshold,
+                    level=request.level,
+                ),
             ),
         )
+
         user_result = user_execution.result
         user_result_dict = user_result.to_dict() if hasattr(user_result, "to_dict") else dict(user_result or {})
         user_hits = [_skill_summary_from_hit(hit) for hit in user_result_dict.get("skills", [])]
 
-        agent_execution = await run_operation(
-            operation="skills.find",
-            telemetry=request.telemetry,
-            fn=lambda: service.search.find(
-                query=request.query,
-                ctx=_ctx,
-                target_uri=agent_root,
-                limit=request.limit,
-                score_threshold=request.score_threshold,
-                level=request.level,
-            ),
-        )
         agent_result = agent_execution.result
         agent_result_dict = agent_result.to_dict() if hasattr(agent_result, "to_dict") else dict(agent_result or {})
         agent_hits = [_skill_summary_from_hit(hit) for hit in agent_result_dict.get("skills", [])]


### PR DESCRIPTION
## Description

Parallelize user and agent skill space search in find_skills from sequential to concurrent execution.
## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
