### PR TITLE
fix(search): keep session logs out of retrieval

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -12,8 +12,10 @@ import heapq
 import logging
 import math
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import unquote
 
 from openviking.core.retrieval_targets import default_target_directories
 from openviking.models.embedder.base import EmbedResult, embed_compat
@@ -41,10 +43,292 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+_INTERNAL_SESSION_LOG_FILENAMES = frozenset({"messages.jsonl"})
+_INTERNAL_SESSION_SIDECAR_FILENAMES = frozenset({".abstract.md", ".overview.md"})
+_SESSION_LOG_FILTER_MAX_SCAN_PAGES = 8
+_SESSION_URI_MAX_LENGTH = 4096
+_SESSION_URI_MAX_DECODE_PASSES = 16
+
+
+@dataclass(frozen=True)
+class _SessionLogClassification:
+    is_internal: bool = False
+    incomplete: bool = False
+
+    @property
+    def should_exclude(self) -> bool:
+        return self.is_internal or self.incomplete
+
+
+@dataclass
+class _SessionLogReplacementBudget:
+    remaining: int
+
+    def claim(self) -> bool:
+        if self.remaining <= 0:
+            return False
+        self.remaining -= 1
+        return True
+
+
+def _new_session_log_replacement_budget() -> _SessionLogReplacementBudget:
+    # The first page preserves the pre-filter search call. Only replacement
+    # pages consume the shared request budget.
+    return _SessionLogReplacementBudget(remaining=max(0, _SESSION_LOG_FILTER_MAX_SCAN_PAGES - 1))
+
 
 class RetrieverMode(str):
     THINKING = "thinking"
     QUICK = "quick"
+
+
+def _session_root_depth(parts: List[str], user_id: Optional[str]) -> Optional[int]:
+    if len(parts) >= 2 and parts[0] == "session":
+        return 2
+    if not parts or parts[0] != "user":
+        return None
+
+    is_short = len(parts) >= 3 and parts[1] == "sessions"
+    is_canonical = len(parts) >= 4 and parts[2] == "sessions"
+    if is_short and is_canonical:
+        normalized_user_id = user_id.casefold() if isinstance(user_id, str) else None
+        # A user literally named "sessions" makes the short and canonical
+        # grammars overlap. Retrieval has the request identity, so use it.
+        # Without identity, prefer the canonical shape used by stored records.
+        return 4 if normalized_user_id in (None, parts[1]) else 3
+    if is_canonical:
+        return 4
+    if is_short:
+        return 3
+    return None
+
+
+def _session_uri_tail(uri: str, user_id: Optional[str] = None) -> tuple[Optional[List[str]], bool]:
+    """Return the tail below one authoritative session root and parse status."""
+    scheme = "viking://"
+    if len(uri) < len(scheme) or uri[: len(scheme)].casefold() != scheme:
+        return None, False
+
+    # Find URI delimiters only inside the bounded path prefix. Percent-encoded
+    # '?' and '#' remain path data after decoding.
+    scan_end = min(len(uri), _SESSION_URI_MAX_LENGTH)
+    delimiter_positions = [
+        position
+        for position in (
+            uri.find("?", len(scheme), scan_end),
+            uri.find("#", len(scheme), scan_end),
+        )
+        if position >= 0
+    ]
+    path_end = min(delimiter_positions) if delimiter_positions else scan_end
+    path_complete = bool(delimiter_positions) or len(uri) <= _SESSION_URI_MAX_LENGTH
+    path = uri[len(scheme) : path_end].rstrip("/")
+
+    for _ in range(_SESSION_URI_MAX_DECODE_PASSES):
+        decoded = unquote(path)
+        if decoded == path:
+            break
+        path = decoded
+    else:
+        path_complete = False
+
+    # Split decoded path data directly. Passing it back through a URI parser
+    # would reinterpret encoded '?' or '#' bytes as query/fragment delimiters.
+    parts = [part for part in path.strip("/").casefold().split("/") if part]
+    root_depth = _session_root_depth(parts, user_id)
+    return (parts[root_depth:] if root_depth is not None else None), not path_complete
+
+
+def _classify_session_log_uri(uri: str, user_id: Optional[str] = None) -> _SessionLogClassification:
+    tail, incomplete = _session_uri_tail(uri, user_id)
+    if incomplete:
+        # A recognizable session root fails closed. Other overlong/overencoded
+        # URIs are indeterminate and are excluded by should_exclude as well.
+        return _SessionLogClassification(
+            is_internal=tail is not None,
+            incomplete=True,
+        )
+    return _SessionLogClassification(
+        is_internal=bool(tail is not None and _is_internal_session_log_tail(tail))
+    )
+
+
+def _is_internal_session_log_uri(uri: str, user_id: Optional[str] = None) -> bool:
+    """Return whether a URI names a session transcript or its generated sidecar."""
+    return _classify_session_log_uri(uri, user_id).is_internal
+
+
+def _is_internal_session_log_tail(tail: List[str]) -> bool:
+    if tail in (["messages.jsonl"], [".abstract.md"], [".overview.md"]):
+        return True
+    if (
+        len(tail) == 2
+        and tail[0] in _INTERNAL_SESSION_LOG_FILENAMES
+        and tail[1] in _INTERNAL_SESSION_SIDECAR_FILENAMES
+    ):
+        return True
+    if len(tail) >= 3 and tail[0] == "history" and tail[1].startswith("archive_"):
+        archive_tail = tail[2:]
+        return archive_tail in (
+            ["messages.jsonl"],
+            [".abstract.md"],
+            [".overview.md"],
+            ["messages.jsonl", ".abstract.md"],
+            ["messages.jsonl", ".overview.md"],
+        )
+    return False
+
+
+def _classify_session_log_result(
+    result: Dict[str, Any], user_id: Optional[str] = None
+) -> _SessionLogClassification:
+    """Also catch L0/L1 sidecars represented as a base URI plus a level."""
+    uri = str(result.get("uri", ""))
+    classification = _classify_session_log_uri(uri, user_id)
+    if classification.should_exclude:
+        return classification
+    try:
+        level = int(result.get("level", 2))
+    except (TypeError, ValueError):
+        return classification
+    if level not in (0, 1):
+        return classification
+    tail, _ = _session_uri_tail(uri, user_id)
+    return _SessionLogClassification(
+        is_internal=bool(
+            tail == []
+            or (
+                tail is not None
+                and len(tail) == 2
+                and tail[0] == "history"
+                and tail[1].startswith("archive_")
+            )
+        )
+    )
+
+
+def _is_internal_session_log_result(result: Dict[str, Any], user_id: Optional[str] = None) -> bool:
+    return _classify_session_log_result(result, user_id).is_internal
+
+
+async def _search_in_tenant_excluding_session_logs(
+    vector_proxy: VikingDBManagerProxy,
+    *,
+    desired_limit: int,
+    page_limit: int,
+    query_vector: Optional[List[float]],
+    sparse_query_vector: Optional[Dict[str, float]],
+    context_type: Optional[str],
+    target_directories: List[str],
+    extra_filter: Optional[FilterExpr | Dict[str, Any]],
+    level: Optional[List[int]],
+    session_user_id: Optional[str] = None,
+    replacement_page_budget: Optional[_SessionLogReplacementBudget] = None,
+) -> tuple[List[Dict[str, Any]], int, int, bool]:
+    results: List[Dict[str, Any]] = []
+    searches = 0
+    scanned = 0
+    offset = 0
+    truncated = False
+    budget = replacement_page_budget or _new_session_log_replacement_budget()
+    while True:
+        page = await vector_proxy.search_in_tenant(
+            query_vector=query_vector,
+            sparse_query_vector=sparse_query_vector,
+            context_type=context_type,
+            target_directories=target_directories,
+            extra_filter=extra_filter,
+            level=level,
+            limit=page_limit,
+            offset=offset,
+        )
+        searches += 1
+        scanned += len(page)
+        normalization_incomplete = False
+        for result in page:
+            classification = _classify_session_log_result(result, session_user_id)
+            normalization_incomplete = normalization_incomplete or classification.incomplete
+            if not classification.should_exclude:
+                results.append(result)
+        if normalization_incomplete:
+            truncated = True
+            logger.warning("Session-log filtering excluded an incompletely normalized global URI")
+            get_current_telemetry().count("vector.session_log_filter_truncated", 1)
+        if len(results) >= desired_limit or len(page) < page_limit:
+            break
+        if not budget.claim():
+            truncated = True
+            logger.warning(
+                "Session-log filtering exhausted the request-wide replacement-page "
+                "budget during global search before finding %d eligible results",
+                desired_limit,
+            )
+            get_current_telemetry().count("vector.session_log_filter_truncated", 1)
+            break
+        offset += page_limit
+    return results[:desired_limit], searches, scanned, truncated
+
+
+async def _search_children_excluding_session_logs(
+    vector_proxy: VikingDBManagerProxy,
+    *,
+    parent_uri: str,
+    desired_limit: int,
+    page_limit: int,
+    query_vector: Optional[List[float]],
+    sparse_query_vector: Optional[Dict[str, float]],
+    context_type: Optional[str],
+    target_directories: Optional[List[str]],
+    extra_filter: Optional[FilterExpr | Dict[str, Any]],
+    session_user_id: Optional[str] = None,
+    replacement_page_budget: Optional[_SessionLogReplacementBudget] = None,
+) -> tuple[List[Dict[str, Any]], int, int, bool]:
+    results: List[Dict[str, Any]] = []
+    searches = 0
+    scanned = 0
+    offset = 0
+    truncated = False
+    budget = replacement_page_budget or _new_session_log_replacement_budget()
+    while True:
+        page = await vector_proxy.search_children_in_tenant(
+            parent_uri=parent_uri,
+            query_vector=query_vector,
+            sparse_query_vector=sparse_query_vector,
+            context_type=context_type,
+            target_directories=target_directories,
+            extra_filter=extra_filter,
+            limit=page_limit,
+            offset=offset,
+        )
+        searches += 1
+        scanned += len(page)
+        normalization_incomplete = False
+        for result in page:
+            classification = _classify_session_log_result(result, session_user_id)
+            normalization_incomplete = normalization_incomplete or classification.incomplete
+            if not classification.should_exclude:
+                results.append(result)
+        if normalization_incomplete:
+            truncated = True
+            logger.warning(
+                "Session-log filtering excluded an incompletely normalized child URI under %s",
+                parent_uri,
+            )
+            get_current_telemetry().count("vector.session_log_filter_truncated", 1)
+        if len(results) >= desired_limit or len(page) < page_limit:
+            break
+        if not budget.claim():
+            truncated = True
+            logger.warning(
+                "Session-log filtering exhausted the request-wide replacement-page "
+                "budget under %s before finding %d eligible results",
+                parent_uri,
+                desired_limit,
+            )
+            get_current_telemetry().count("vector.session_log_filter_truncated", 1)
+            break
+        offset += page_limit
+    return results[:desired_limit], searches, scanned, truncated
 
 
 class HierarchicalRetriever:
@@ -172,21 +456,33 @@ class HierarchicalRetriever:
         if image_query and context_type is None:
             context_type = ContextType.RESOURCE.value
 
+        session_user_id = getattr(getattr(ctx, "user", None), "user_id", None)
+        replacement_page_budget = _new_session_log_replacement_budget()
+        retrieval_truncated = False
         if mode == RetrieverMode.QUICK:
             search_limit = max(limit * 5, 50) if image_query else max(limit, self.GLOBAL_SEARCH_TOPK)
             with telemetry.measure("search.vector_retrieval"):
-                quick_results = await vector_proxy.search_in_tenant(
+                (
+                    quick_results,
+                    search_count,
+                    scanned_count,
+                    retrieval_truncated,
+                ) = await _search_in_tenant_excluding_session_logs(
+                    vector_proxy,
+                    desired_limit=search_limit,
+                    page_limit=search_limit,
                     query_vector=query_vector,
                     sparse_query_vector=sparse_query_vector,
                     context_type=context_type,
                     target_directories=target_dirs,
                     extra_filter=scope_dsl,
                     level=level,
-                    limit=search_limit,
+                    session_user_id=session_user_id,
+                    replacement_page_budget=replacement_page_budget,
                 )
-            telemetry.count("vector.searches", 1)
-            telemetry.count("vector.scored", len(quick_results))
-            telemetry.count("vector.scanned", len(quick_results))
+            telemetry.count("vector.searches", search_count)
+            telemetry.count("vector.scored", scanned_count)
+            telemetry.count("vector.scanned", scanned_count)
 
             collected_by_uri: Dict[str, Dict[str, Any]] = {}
             for result in quick_results:
@@ -215,19 +511,29 @@ class HierarchicalRetriever:
             rerank_used = False
         else:
             # Step 2: Global vector search to supplement starting points
+            global_search_limit = max(limit, self.GLOBAL_SEARCH_TOPK)
             with telemetry.measure("search.vector_retrieval"):
-                global_results = await vector_proxy.search_in_tenant(
+                (
+                    global_results,
+                    search_count,
+                    scanned_count,
+                    global_truncated,
+                ) = await _search_in_tenant_excluding_session_logs(
+                    vector_proxy,
+                    desired_limit=global_search_limit,
+                    page_limit=global_search_limit,
                     query_vector=query_vector,
                     sparse_query_vector=sparse_query_vector,
                     context_type=context_type,
                     target_directories=target_dirs,
                     extra_filter=scope_dsl,
                     level=[0, 1],
-                    limit=max(limit, self.GLOBAL_SEARCH_TOPK),
+                    session_user_id=session_user_id,
+                    replacement_page_budget=replacement_page_budget,
                 )
-            telemetry.count("vector.searches", 1)
-            telemetry.count("vector.scored", len(global_results))
-            telemetry.count("vector.scanned", len(global_results))
+            telemetry.count("vector.searches", search_count)
+            telemetry.count("vector.scored", scanned_count)
+            telemetry.count("vector.scanned", scanned_count)
 
             # Debug: Print all URIs in global_results
             if logger.isEnabledFor(logging.DEBUG):
@@ -281,6 +587,7 @@ class HierarchicalRetriever:
 
             # Step 4: Recursive search
             with telemetry.measure("search.vector_retrieval"):
+                recursive_truncation: Dict[str, bool] = {}
                 candidates = await self._recursive_search(
                     vector_proxy=vector_proxy,
                     query=query.query,
@@ -296,7 +603,11 @@ class HierarchicalRetriever:
                     scope_dsl=scope_dsl,
                     initial_candidates=initial_candidates,
                     level=level,
+                    truncation_state=recursive_truncation,
+                    session_user_id=session_user_id,
+                    replacement_page_budget=replacement_page_budget,
                 )
+            retrieval_truncated = global_truncated or recursive_truncation.get("truncated", False)
             apply_hotness = True
             rerank_used = self._rerank_client is not None and mode == RetrieverMode.THINKING
 
@@ -321,6 +632,7 @@ class HierarchicalRetriever:
             query=query,
             matched_contexts=final,
             searched_directories=root_uris,
+            truncated=retrieval_truncated,
         )
 
     def _resolve_threshold(self, threshold: Optional[float]) -> float:
@@ -407,6 +719,9 @@ class HierarchicalRetriever:
         scope_dsl: Optional[FilterExpr | Dict[str, Any]] = None,
         initial_candidates: Optional[List[Dict[str, Any]]] = None,
         level: Optional[List[int]] = None,
+        truncation_state: Optional[Dict[str, bool]] = None,
+        session_user_id: Optional[str] = None,
+        replacement_page_budget: Optional[_SessionLogReplacementBudget] = None,
     ) -> List[Dict[str, Any]]:
         """
         Recursive search with directory priority return and score propagation.
@@ -428,12 +743,16 @@ class HierarchicalRetriever:
         prev_pool_size = 0
         convergence_rounds = 0
         stagnant_rounds = 0
+        replacement_page_budget = replacement_page_budget or _new_session_log_replacement_budget()
 
         # Add initial candidates that match the requested level.
         if initial_candidates:
             for r in initial_candidates:
                 uri = r.get("uri", "")
-                if not uri:
+                classification = _classify_session_log_result(r, session_user_id)
+                if classification.incomplete and truncation_state is not None:
+                    truncation_state["truncated"] = True
+                if not uri or classification.should_exclude:
                     continue
                 if level is None or r.get("level", 2) in level:
                     score = self._finite_score(r.get("_score", 0.0))
@@ -452,17 +771,30 @@ class HierarchicalRetriever:
 
         # Initialize: process starting points
         for uri, score in starting_points:
+            classification = _classify_session_log_uri(uri, session_user_id)
+            if classification.incomplete and truncation_state is not None:
+                truncation_state["truncated"] = True
+            if classification.should_exclude:
+                continue
             heapq.heappush(dir_queue, (-score, uri))
 
-        async def search_children(current_uri: str) -> List[Dict[str, Any]]:
-            return await vector_proxy.search_children_in_tenant(
+        child_search_limit = max(limit * 2, 20)
+
+        async def search_children(
+            current_uri: str,
+        ) -> tuple[List[Dict[str, Any]], int, int, bool]:
+            return await _search_children_excluding_session_logs(
+                vector_proxy,
                 parent_uri=current_uri,
+                desired_limit=child_search_limit,
+                page_limit=child_search_limit,
                 query_vector=query_vector,
-                sparse_query_vector=sparse_query_vector,  # Pass sparse vector
+                sparse_query_vector=sparse_query_vector,
                 context_type=context_type,
                 target_directories=target_dirs,
                 extra_filter=scope_dsl,
-                limit=max(limit * 2, 20),
+                session_user_id=session_user_id,
+                replacement_page_budget=replacement_page_budget,
             )
 
         parallelism = max(1, self.MAX_PARALLEL_CHILD_SEARCHES)
@@ -486,10 +818,17 @@ class HierarchicalRetriever:
             )
 
             telemetry = get_current_telemetry()
-            for (_, current_score), results in zip(batch, batch_results, strict=True):
-                telemetry.count("vector.searches", 1)
-                telemetry.count("vector.scored", len(results))
-                telemetry.count("vector.scanned", len(results))
+            for (_, current_score), (
+                results,
+                search_count,
+                scanned_count,
+                search_truncated,
+            ) in zip(batch, batch_results, strict=True):
+                if search_truncated and truncation_state is not None:
+                    truncation_state["truncated"] = True
+                telemetry.count("vector.searches", search_count)
+                telemetry.count("vector.scored", scanned_count)
+                telemetry.count("vector.scanned", scanned_count)
 
                 if not results:
                     continue
@@ -501,6 +840,11 @@ class HierarchicalRetriever:
 
                 for r, score in zip(results, query_scores, strict=True):
                     uri = r.get("uri", "")
+                    classification = _classify_session_log_result(r, session_user_id)
+                    if classification.incomplete and truncation_state is not None:
+                        truncation_state["truncated"] = True
+                    if not uri or classification.should_exclude:
+                        continue
                     final_score = (
                         alpha * score + (1 - alpha) * current_score if current_score else score
                     )

--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -433,9 +433,7 @@ class HierarchicalRetriever:
         sparse_query_vector = None
         if self.embedder:
             if image_query and not getattr(self.embedder, "supports_multimodal", False):
-                raise InvalidArgumentError(
-                    "Image search requires a multimodal embedding model."
-                )
+                raise InvalidArgumentError("Image search requires a multimodal embedding model.")
             with telemetry.measure("search.embed_query"):
                 embedding_input = getattr(query, "embedding_input", None) or query.query
                 result: EmbedResult = await embed_compat(
@@ -460,7 +458,9 @@ class HierarchicalRetriever:
         replacement_page_budget = _new_session_log_replacement_budget()
         retrieval_truncated = False
         if mode == RetrieverMode.QUICK:
-            search_limit = max(limit * 5, 50) if image_query else max(limit, self.GLOBAL_SEARCH_TOPK)
+            search_limit = (
+                max(limit * 5, 50) if image_query else max(limit, self.GLOBAL_SEARCH_TOPK)
+            )
             with telemetry.measure("search.vector_retrieval"):
                 (
                     quick_results,

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -1268,6 +1268,7 @@ class VikingVectorIndexBackend:
         target_directories: Optional[List[str]] = None,
         extra_filter: Optional[FilterExpr | Dict[str, Any]] = None,
         limit: int = 10,
+        offset: int = 0,
     ) -> List[Dict[str, Any]]:
         # TODO：Better Alternative to Current Temporary Fix
 
@@ -1299,6 +1300,7 @@ class VikingVectorIndexBackend:
             sparse_query_vector=sparse_query_vector,
             filter=merged_filter,
             limit=limit,
+            offset=offset,
             output_fields=RETRIEVAL_OUTPUT_FIELDS,
             ctx=ctx,
         )

--- a/openviking/storage/vikingdb_manager.py
+++ b/openviking/storage/vikingdb_manager.py
@@ -453,6 +453,7 @@ class VikingDBManagerProxy:
         target_directories: Optional[List[str]] = None,
         extra_filter: Optional[FilterExpr | Dict[str, Any]] = None,
         limit: int = 10,
+        offset: int = 0,
     ) -> List[Dict[str, Any]]:
         return await self._manager.search_children_in_tenant(
             self._ctx,
@@ -463,6 +464,7 @@ class VikingDBManagerProxy:
             target_directories=target_directories,
             extra_filter=extra_filter,
             limit=limit,
+            offset=offset,
         )
 
     async def get_context_by_uri(

--- a/openviking_cli/retrieve/types.py
+++ b/openviking_cli/retrieve/types.py
@@ -305,12 +305,14 @@ class QueryResult:
         matched_contexts: List of matched contexts
         searched_directories: Directories that were searched
         thinking_trace: Structured thinking trace for visualization
+        truncated: Whether bounded replacement paging hit its scan cap
     """
 
     query: TypedQuery
     matched_contexts: List[MatchedContext]
     searched_directories: List[str]
     thinking_trace: ThinkingTrace = field(default_factory=ThinkingTrace)
+    truncated: bool = False
 
     def get_trace_messages(self) -> List[str]:
         """Get trace as simple message list."""
@@ -400,6 +402,7 @@ class FindResult:
         return {
             "query": qr.query.query,
             "searched_directories": qr.searched_directories,
+            "truncated": qr.truncated,
             "matched_contexts": [
                 {
                     "uri": ctx.uri,

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -95,6 +95,7 @@ class DummyStorage:
         target_directories=None,
         extra_filter=None,
         limit: int = 10,
+        offset: int = 0,
     ):
         self.child_search_calls.append(
             {
@@ -106,13 +107,15 @@ class DummyStorage:
                 "target_directories": target_directories,
                 "extra_filter": extra_filter,
                 "limit": limit,
+                "offset": offset,
             }
         )
         if parent_uri == "viking://resources":
-            return [
+            results = [
                 _result("viking://resources/file-a", 0.2, abstract="child A", category="doc"),
                 _result("viking://resources/file-b", 0.8, abstract="child B", category="doc"),
             ]
+            return results[offset : offset + limit]
         return []
 
 
@@ -162,6 +165,7 @@ class QuickSearchStorage(DummyStorage):
         target_directories=None,
         extra_filter=None,
         limit: int = 10,
+        offset: int = 0,
     ):
         self.child_search_calls.append(
             {
@@ -173,9 +177,11 @@ class QuickSearchStorage(DummyStorage):
                 "target_directories": target_directories,
                 "extra_filter": extra_filter,
                 "limit": limit,
+                "offset": offset,
             }
         )
-        return [_result(f"{parent_uri}/should-not-be-returned", 1.0, abstract="child")]
+        results = [_result(f"{parent_uri}/should-not-be-returned", 1.0, abstract="child")]
+        return results[offset : offset + limit]
 
 
 class DirectChildProxy:
@@ -188,11 +194,13 @@ class DirectChildProxy:
         target_directories=None,
         extra_filter=None,
         limit: int = 10,
+        offset: int = 0,
     ):
-        return [
+        results = [
             _result(f"{parent_uri}/file-a", 0.2, abstract="child A"),
             _result(f"{parent_uri}/file-b", 0.8, abstract="child B"),
         ]
+        return results[offset : offset + limit]
 
 
 class FakeRerankClient:

--- a/tests/storage/test_hierarchical_retriever_session_logs.py
+++ b/tests/storage/test_hierarchical_retriever_session_logs.py
@@ -10,12 +10,12 @@ from openviking.retrieve import hierarchical_retriever as retriever_module
 from openviking.retrieve.hierarchical_retriever import (
     HierarchicalRetriever,
     RetrieverMode,
-    _SessionLogReplacementBudget,
     _classify_session_log_uri,
     _is_internal_session_log_result,
     _is_internal_session_log_uri,
     _search_children_excluding_session_logs,
     _search_in_tenant_excluding_session_logs,
+    _SessionLogReplacementBudget,
 )
 from openviking.server.identity import Role
 from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
@@ -217,35 +217,37 @@ async def test_filtered_child_search_pages_past_internal_hits():
 
 
 @pytest.mark.asyncio
-async def test_filtered_search_reports_scan_cap(monkeypatch, caplog):
+async def test_filtered_search_reports_scan_cap(monkeypatch):
     class FakeProxy:
         async def search_in_tenant(self, *, limit=10, **kwargs):
             del kwargs
             return [_result(f"viking://session/s{idx}/messages.jsonl") for idx in range(limit)]
 
     monkeypatch.setattr(retriever_module, "_SESSION_LOG_FILTER_MAX_SCAN_PAGES", 2)
-    with caplog.at_level("WARNING"):
-        (
-            results,
-            searches,
-            scanned,
-            truncated,
-        ) = await _search_in_tenant_excluding_session_logs(
-            FakeProxy(),
-            desired_limit=1,
-            page_limit=3,
-            query_vector=None,
-            sparse_query_vector=None,
-            context_type=None,
-            target_directories=[],
-            extra_filter=None,
-            level=None,
-        )
+    warning = MagicMock()
+    monkeypatch.setattr(retriever_module.logger, "warning", warning)
+    (
+        results,
+        searches,
+        scanned,
+        truncated,
+    ) = await _search_in_tenant_excluding_session_logs(
+        FakeProxy(),
+        desired_limit=1,
+        page_limit=3,
+        query_vector=None,
+        sparse_query_vector=None,
+        context_type=None,
+        target_directories=[],
+        extra_filter=None,
+        level=None,
+    )
 
     assert results == []
     assert (searches, scanned) == (2, 6)
     assert truncated is True
-    assert "request-wide replacement-page budget" in caplog.text
+    warning.assert_called_once()
+    assert "request-wide replacement-page budget" in warning.call_args.args[0]
 
     query_result = QueryResult(TypedQuery("notes", None, ""), [], [], truncated=truncated)
     output = FindResult([], [], [], query_results=[query_result]).to_dict(include_provenance=True)

--- a/tests/storage/test_hierarchical_retriever_session_logs.py
+++ b/tests/storage/test_hierarchical_retriever_session_logs.py
@@ -1,0 +1,485 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from openviking.retrieve import hierarchical_retriever as retriever_module
+from openviking.retrieve.hierarchical_retriever import (
+    HierarchicalRetriever,
+    RetrieverMode,
+    _SessionLogReplacementBudget,
+    _classify_session_log_uri,
+    _is_internal_session_log_result,
+    _is_internal_session_log_uri,
+    _search_children_excluding_session_logs,
+    _search_in_tenant_excluding_session_logs,
+)
+from openviking.server.identity import Role
+from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
+from openviking.storage.vikingdb_manager import VikingDBManagerProxy
+from openviking_cli.retrieve import FindResult, QueryResult, TypedQuery
+
+
+def _result(uri: str, *, score: float = 0.5, level: int = 2) -> dict:
+    return {
+        "uri": uri,
+        "_score": score,
+        "context_type": "memory",
+        "level": level,
+        "abstract": uri,
+    }
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://session/s1/messages.jsonl",
+        "VIKING://session/s1/messages.jsonl",
+        "viking://session/s1/messages.jsonl/.abstract.md",
+        "viking://user/sessions/s1/messages.jsonl",
+        "viking://user/alice/sessions/s1/messages.jsonl",
+        "viking://user/alice/sessions/s1/.overview.md",
+        "viking://user/alice/sessions/s1/history/archive_001/messages.jsonl",
+        "viking://user/alice/sessions/s1/history/archive_001/.abstract.md",
+        "viking://user/alice/sessions/s1/history/archive_001/messages.jsonl/.overview.md",
+        "viking://user/alice/sessions/s1/MESSAGES.JSONL",
+        "viking://user/alice/sessions/s1/messages%2Ejsonl",
+        "viking://user/alice/sessions/s1/messages%252Ejsonl",
+        "viking://user/alice/sessions/s1/messages%2525252Ejsonl",
+        "viking://user/alice/sessions/s1/messages.jsonl?version=1",
+        "viking://user/sessions/sessions/s1/messages.jsonl",
+    ],
+)
+def test_internal_session_log_uri_matches_transcripts_and_sidecars(uri):
+    assert _is_internal_session_log_uri(uri) is True
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://resources/project/messages.jsonl",
+        "viking://user/alice/memories/messages.jsonl",
+        "viking://user/alice/resources/sessions/s1/messages.jsonl",
+        "viking://session/s1/notes.txt",
+        "viking://session/s1/export/messages.jsonl",
+        "viking://session/s1/messages.jsonl/.summary.md",
+        "viking://session/s1/messages.jsonl%3Fdraft",
+        "viking://session/s1/messages.jsonl%23draft",
+        "viking://user/alice/sessions/s1/history/archive_001/.summary.md",
+        "messages.jsonl",
+    ],
+)
+def test_internal_session_log_uri_allows_non_internal_files(uri):
+    assert _is_internal_session_log_uri(uri) is False
+
+
+def test_internal_session_log_uri_fails_closed_on_normalization_bounds():
+    encoded_name = "messages%2Ejsonl"
+    for _ in range(retriever_module._SESSION_URI_MAX_DECODE_PASSES):
+        encoded_name = encoded_name.replace("%", "%25")
+    assert _is_internal_session_log_uri(f"viking://session/s1/{encoded_name}") is True
+    assert (
+        _is_internal_session_log_uri(
+            "viking://session/s1/" + "x" * retriever_module._SESSION_URI_MAX_LENGTH
+        )
+        is True
+    )
+    assert (
+        _is_internal_session_log_uri(
+            "viking://resources/" + "x" * retriever_module._SESSION_URI_MAX_LENGTH
+        )
+        is False
+    )
+    encoded_root = "viking://%73ession/s1/" + "x" * retriever_module._SESSION_URI_MAX_LENGTH
+    classification = _classify_session_log_uri(encoded_root)
+    assert classification.is_internal is True
+    assert classification.incomplete is True
+
+
+def test_internal_session_log_uri_uses_request_identity_for_ambiguous_user():
+    uri = "viking://user/sessions/sessions/s1/messages.jsonl"
+    assert _is_internal_session_log_uri(uri, user_id="sessions") is True
+    assert _is_internal_session_log_uri(uri, user_id="alice") is False
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        _result("viking://user/alice/sessions/s1", level=0),
+        _result("viking://user/alice/sessions/s1", level=1),
+        _result("viking://session/s1/history/archive_002", level=0),
+        _result("viking://session/s1/history/archive_002", level=1),
+    ],
+)
+def test_internal_session_log_result_matches_base_uri_sidecars(result):
+    assert _is_internal_session_log_result(result) is True
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        _result("viking://user/alice/sessions/s1", level=2),
+        _result("viking://user/alice/sessions/s1/notes.txt", level=2),
+        _result("viking://user/alice/sessions/s1/notes", level=1),
+    ],
+)
+def test_internal_session_log_result_preserves_explicit_session_content(result):
+    assert _is_internal_session_log_result(result) is False
+
+
+@pytest.mark.asyncio
+async def test_filtered_global_search_pages_past_internal_hits():
+    class FakeProxy:
+        def __init__(self):
+            self.calls = []
+
+        async def search_in_tenant(self, *, limit=10, offset=0, **kwargs):
+            del kwargs
+            self.calls.append((limit, offset))
+            if offset == 0:
+                return [
+                    _result(f"viking://session/s{idx}/messages.jsonl", score=1 - idx / 100)
+                    for idx in range(limit)
+                ]
+            return [
+                _result("viking://session/s1/notes.txt", score=0.6),
+                _result("viking://resources/guide.md", score=0.5),
+            ]
+
+    proxy = FakeProxy()
+    (
+        results,
+        searches,
+        scanned,
+        truncated,
+    ) = await _search_in_tenant_excluding_session_logs(
+        proxy,
+        desired_limit=2,
+        page_limit=3,
+        query_vector=None,
+        sparse_query_vector=None,
+        context_type=None,
+        target_directories=[],
+        extra_filter=None,
+        level=None,
+    )
+
+    assert [result["uri"] for result in results] == [
+        "viking://session/s1/notes.txt",
+        "viking://resources/guide.md",
+    ]
+    assert proxy.calls == [(3, 0), (3, 3)]
+    assert (searches, scanned) == (2, 5)
+    assert truncated is False
+
+
+@pytest.mark.asyncio
+async def test_filtered_child_search_pages_past_internal_hits():
+    class FakeProxy:
+        def __init__(self):
+            self.calls = []
+
+        async def search_children_in_tenant(self, *, limit=10, offset=0, **kwargs):
+            del kwargs
+            self.calls.append((limit, offset))
+            if offset == 0:
+                return [
+                    _result(f"viking://session/s{idx}/messages.jsonl", score=1 - idx / 100)
+                    for idx in range(limit)
+                ]
+            return [_result("viking://session/s1/notes.txt", score=0.4)]
+
+    proxy = FakeProxy()
+    (
+        results,
+        searches,
+        scanned,
+        truncated,
+    ) = await _search_children_excluding_session_logs(
+        proxy,
+        parent_uri="viking://session/s1",
+        desired_limit=1,
+        page_limit=3,
+        query_vector=None,
+        sparse_query_vector=None,
+        context_type=None,
+        target_directories=["viking://session/s1"],
+        extra_filter=None,
+    )
+
+    assert [result["uri"] for result in results] == ["viking://session/s1/notes.txt"]
+    assert proxy.calls == [(3, 0), (3, 3)]
+    assert (searches, scanned) == (2, 4)
+    assert truncated is False
+
+
+@pytest.mark.asyncio
+async def test_filtered_search_reports_scan_cap(monkeypatch, caplog):
+    class FakeProxy:
+        async def search_in_tenant(self, *, limit=10, **kwargs):
+            del kwargs
+            return [_result(f"viking://session/s{idx}/messages.jsonl") for idx in range(limit)]
+
+    monkeypatch.setattr(retriever_module, "_SESSION_LOG_FILTER_MAX_SCAN_PAGES", 2)
+    with caplog.at_level("WARNING"):
+        (
+            results,
+            searches,
+            scanned,
+            truncated,
+        ) = await _search_in_tenant_excluding_session_logs(
+            FakeProxy(),
+            desired_limit=1,
+            page_limit=3,
+            query_vector=None,
+            sparse_query_vector=None,
+            context_type=None,
+            target_directories=[],
+            extra_filter=None,
+            level=None,
+        )
+
+    assert results == []
+    assert (searches, scanned) == (2, 6)
+    assert truncated is True
+    assert "request-wide replacement-page budget" in caplog.text
+
+    query_result = QueryResult(TypedQuery("notes", None, ""), [], [], truncated=truncated)
+    output = FindResult([], [], [], query_results=[query_result]).to_dict(include_provenance=True)
+    assert output["provenance"][0]["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_filtered_search_reports_incomplete_uri_even_when_page_ends():
+    class FakeProxy:
+        async def search_in_tenant(self, **kwargs):
+            del kwargs
+            return [_result("viking://resources/" + "x" * retriever_module._SESSION_URI_MAX_LENGTH)]
+
+    results, searches, scanned, truncated = await _search_in_tenant_excluding_session_logs(
+        FakeProxy(),
+        desired_limit=2,
+        page_limit=2,
+        query_vector=None,
+        sparse_query_vector=None,
+        context_type=None,
+        target_directories=[],
+        extra_filter=None,
+        level=None,
+    )
+
+    assert results == []
+    assert (searches, scanned, truncated) == (1, 1, True)
+
+
+@pytest.mark.asyncio
+async def test_child_offset_flows_through_proxy_and_backend(monkeypatch):
+    offsets = []
+
+    async def fake_search(self, **kwargs):
+        offsets.append(kwargs["offset"])
+        return [_result("viking://resources/guide.md")]
+
+    monkeypatch.setattr(VikingVectorIndexBackend, "search", fake_search)
+    backend = object.__new__(VikingVectorIndexBackend)
+    ctx = SimpleNamespace(
+        account_id="acct",
+        role=Role.USER,
+        user=SimpleNamespace(user_id="alice"),
+        actor_peer_id=None,
+    )
+    proxy = VikingDBManagerProxy(backend, ctx)
+
+    results = await proxy.search_children_in_tenant(
+        parent_uri="viking://resources",
+        query_vector=None,
+        limit=20,
+        offset=40,
+    )
+
+    assert [result["uri"] for result in results] == ["viking://resources/guide.md"]
+    assert offsets == [40]
+
+
+@pytest.mark.asyncio
+async def test_quick_retrieve_replaces_session_logs(monkeypatch):
+    class FakeProxy:
+        collection_name = "test"
+
+        def __init__(self):
+            self.calls = []
+
+        async def collection_exists_bound(self):
+            return True
+
+        async def search_in_tenant(self, *, limit=10, offset=0, **kwargs):
+            del kwargs
+            self.calls.append((limit, offset))
+            if offset == 0:
+                return [
+                    _result(f"viking://session/s{idx}/messages.jsonl", score=1 - idx / 100)
+                    for idx in range(limit)
+                ]
+            return [
+                _result("viking://session/s1/notes.txt", score=0.6),
+                _result("viking://resources/guide.md", score=0.5),
+            ]
+
+    proxy = FakeProxy()
+    monkeypatch.setattr(retriever_module, "VikingDBManagerProxy", lambda _storage, _ctx: proxy)
+    retriever = HierarchicalRetriever(storage=MagicMock(), embedder=None)
+
+    result = await retriever.retrieve(
+        TypedQuery("notes", None, "", target_directories=["viking://session/s1"]),
+        ctx=MagicMock(),
+        limit=2,
+        mode=RetrieverMode.QUICK,
+    )
+
+    assert [context.uri for context in result.matched_contexts] == [
+        "viking://session/s1/notes.txt",
+        "viking://resources/guide.md",
+    ]
+    assert proxy.calls == [(10, 0), (10, 10)]
+
+
+@pytest.mark.asyncio
+async def test_quick_retrieve_exposes_scan_cap(monkeypatch):
+    class FakeProxy:
+        collection_name = "test"
+
+        async def collection_exists_bound(self):
+            return True
+
+        async def search_in_tenant(self, *, limit=10, **kwargs):
+            del kwargs
+            return [_result(f"viking://session/s{idx}/messages.jsonl") for idx in range(limit)]
+
+    monkeypatch.setattr(retriever_module, "_SESSION_LOG_FILTER_MAX_SCAN_PAGES", 1)
+    monkeypatch.setattr(
+        retriever_module, "VikingDBManagerProxy", lambda _storage, _ctx: FakeProxy()
+    )
+    retriever = HierarchicalRetriever(storage=MagicMock(), embedder=None)
+
+    result = await retriever.retrieve(
+        TypedQuery("notes", None, ""),
+        ctx=MagicMock(),
+        limit=1,
+        mode=RetrieverMode.QUICK,
+    )
+
+    assert result.matched_contexts == []
+    assert result.truncated is True
+
+
+@pytest.mark.asyncio
+async def test_quick_image_search_keeps_current_candidate_budget(monkeypatch):
+    class FakeProxy:
+        collection_name = "test"
+
+        def __init__(self):
+            self.calls = []
+
+        async def collection_exists_bound(self):
+            return True
+
+        async def search_in_tenant(self, *, limit=10, offset=0, level=None, **kwargs):
+            del kwargs
+            self.calls.append((limit, offset, level))
+            return [
+                _result(f"viking://resources/image-{idx}.png", score=1 - idx / 1000)
+                for idx in range(limit)
+            ]
+
+    proxy = FakeProxy()
+    monkeypatch.setattr(retriever_module, "VikingDBManagerProxy", lambda _storage, _ctx: proxy)
+    retriever = HierarchicalRetriever(storage=MagicMock(), embedder=None)
+
+    await retriever.retrieve(
+        TypedQuery("image", None, "", image_query=True),
+        ctx=MagicMock(),
+        limit=5,
+    )
+
+    assert proxy.calls == [(50, 0, [2])]
+
+
+@pytest.mark.asyncio
+async def test_recursive_search_replaces_session_log_children():
+    class FakeProxy:
+        def __init__(self):
+            self.calls = []
+
+        async def search_children_in_tenant(self, *, limit=10, offset=0, **kwargs):
+            del kwargs
+            self.calls.append((limit, offset))
+            if offset == 0:
+                return [
+                    _result(
+                        f"viking://user/alice/sessions/s{idx}/messages.jsonl",
+                        score=1 - idx / 100,
+                    )
+                    for idx in range(limit)
+                ]
+            return [_result("viking://user/alice/sessions/s1/notes.txt", score=0.4)]
+
+    proxy = FakeProxy()
+    retriever = HierarchicalRetriever(storage=MagicMock(), embedder=None)
+    truncation_state = {}
+    candidates = await retriever._recursive_search(
+        vector_proxy=proxy,
+        query="notes",
+        query_vector=None,
+        sparse_query_vector=None,
+        starting_points=[("viking://user/alice/sessions/s1", 1.0)],
+        limit=10,
+        mode=RetrieverMode.THINKING,
+        target_dirs=["viking://user/alice/sessions/s1"],
+        truncation_state=truncation_state,
+    )
+
+    assert [candidate["uri"] for candidate in candidates] == [
+        "viking://user/alice/sessions/s1/notes.txt"
+    ]
+    assert proxy.calls == [(20, 0), (20, 20)]
+    assert truncation_state == {}
+
+
+@pytest.mark.asyncio
+async def test_recursive_search_shares_replacement_budget_across_parents():
+    class FakeProxy:
+        def __init__(self):
+            self.calls = []
+
+        async def search_children_in_tenant(self, *, parent_uri, limit=10, offset=0, **kwargs):
+            del kwargs
+            self.calls.append((parent_uri, limit, offset))
+            if offset == 0:
+                return [_result(f"viking://session/s{idx}/messages.jsonl") for idx in range(limit)]
+            return [_result(f"{parent_uri}/note.md", score=0.4)]
+
+    proxy = FakeProxy()
+    retriever = HierarchicalRetriever(storage=MagicMock(), embedder=None)
+    truncation_state = {}
+    candidates = await retriever._recursive_search(
+        vector_proxy=proxy,
+        query="notes",
+        query_vector=None,
+        sparse_query_vector=None,
+        starting_points=[
+            ("viking://resources/one", 1.0),
+            ("viking://resources/two", 0.9),
+        ],
+        limit=1,
+        mode=RetrieverMode.THINKING,
+        truncation_state=truncation_state,
+        replacement_page_budget=_SessionLogReplacementBudget(remaining=1),
+    )
+
+    assert len(proxy.calls) == 3
+    assert sum(offset > 0 for _, _, offset in proxy.calls) == 1
+    assert [candidate["uri"] for candidate in candidates] == ["viking://resources/one/note.md"]
+    assert truncation_state == {"truncated": True}


### PR DESCRIPTION
## Summary

- Filter legacy and canonical session transcripts plus generated L0/L1 sidecars before quick, global, and recursive retrieval.
- Normalize encoded URIs with bounded work, fail closed on incomplete normalization, and expose incomplete replacement scans through `QueryResult.truncated` provenance.
- Page past filtered vector hits within one request-wide replacement budget while preserving each directory's existing first search.
- Thread child-search offsets through the retrieval proxy, manager, and backend.

Fixes #2989.

## Tests

- `ruff check openviking/retrieve/hierarchical_retriever.py openviking/storage/vikingdb_manager.py openviking/storage/viking_vector_index_backend.py openviking_cli/retrieve/types.py tests/storage/test_hierarchical_retriever_session_logs.py`
- `python -m py_compile openviking/retrieve/hierarchical_retriever.py openviking/storage/vikingdb_manager.py openviking/storage/viking_vector_index_backend.py openviking_cli/retrieve/types.py tests/storage/test_hierarchical_retriever_session_logs.py`
- Dependency-isolated current-main behavior harness: 5 groups passed (URI policy, replacement paging, quick/image candidate budgets, recursive paging, and offset forwarding).

Full upstream pytest was not available in the no-clone maintenance environment; GitHub CI is the integration check.
