### PR TITLE
fix(vectordb): handle Windows 11 platform.machine() empty string and circular import

### DIFF
--- a/openviking/storage/vectordb/engine/__init__.py
+++ b/openviking/storage/vectordb/engine/__init__.py
@@ -51,8 +51,7 @@ def _module_exists(module_name: str) -> bool:
             return False
         try:
             for fn in os.listdir(str(module_path)):
-                name, dot, ext = fn.rpartition(".")
-                if dot == "." and ext == "pyd" and name == module_name:
+                if fn in (f"{module_name}.pyd", f"{module_name}.abi3.pyd"):
                     return True
         except OSError:
             return False

--- a/openviking/storage/vectordb/engine/__init__.py
+++ b/openviking/storage/vectordb/engine/__init__.py
@@ -33,11 +33,30 @@ _WINDOWS_DLL_DIR_HANDLES = []
 
 def _is_x86_machine(machine: str | None = None) -> bool:
     normalized = (machine or platform.machine() or "").strip().lower()
+    # platform.machine() returns empty string on some Windows 11 builds.
+    # Default to x86 on Windows since ARM is not yet widely deployed.
+    if not normalized:
+        return sys.platform == "win32"
     return any(token in normalized for token in ("x86_64", "amd64", "x64", "i386", "i686"))
 
 
 def _module_exists(module_name: str) -> bool:
-    return importlib.util.find_spec(f".{module_name}", __name__) is not None
+    try:
+        return importlib.util.find_spec(f".{module_name}", __name__) is not None
+    except ModuleNotFoundError:
+        # During module initialization find_spec may fail because __path__
+        # is not yet assigned. Fall back to checking the filesystem.
+        module_path = Path(__file__).resolve().parent
+        if not module_path.is_dir():
+            return False
+        try:
+            for fn in os.listdir(str(module_path)):
+                name, dot, ext = fn.rpartition(".")
+                if dot == "." and ext == "pyd" and name == module_name:
+                    return True
+        except OSError:
+            return False
+        return False
 
 
 def _available_variants(is_x86: bool) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary

- `_is_x86_machine()`: On Windows 11 (build 26200), `platform.machine()` returns an empty string, causing the engine to incorrectly treat the CPU as non-x86 and attempt to load a non-existent `native` backend. Fix: default to x86 on `win32` when the machine string is empty.
- `_module_exists()`: `importlib.util.find_spec()` raises `ModuleNotFoundError` during module initialization because `__path__` has not been assigned yet. This is a circular-import timing issue that makes the engine think zero backend variants are available. Fix: catch the exception and fall back to a filesystem `.pyd` check.

## Test plan

- [x] `_is_x86_machine()` returns `True` when `platform.machine()` is empty on `win32`
- [x] Explicit machine override (`AMD64`, `aarch64`) still works correctly
- [x] `_module_exists()` does not crash when `find_spec` raises `ModuleNotFoundError`
- [x] Filesystem fallback correctly detects `.pyd` files