### PR TITLE
fix(studio): treat dev-mode connections as root without an API key

### DIFF
--- a/web-studio/src/hooks/use-app-connection.test.ts
+++ b/web-studio/src/hooks/use-app-connection.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveInitialApiKey } from './use-app-connection'
+import {
+  resolveConnectionRoleProbeState,
+  resolveInitialApiKey,
+} from './use-app-connection'
 
 describe('resolveInitialApiKey', () => {
   it('keeps the stored connection key paired with the stored account and user', () => {
@@ -31,5 +34,49 @@ describe('resolveInitialApiKey', () => {
         storedApiKey: 'stored-selected-user-key',
       }),
     ).toBe('env-key')
+  })
+})
+
+describe('resolveConnectionRoleProbeState', () => {
+  it('treats dev mode as root without requiring an API key', () => {
+    expect(
+      resolveConnectionRoleProbeState({
+        apiKey: '',
+        baseUrl: 'http://localhost:3000',
+        serverMode: 'dev',
+      }),
+    ).toEqual({
+      isLoading: false,
+      role: 'root',
+      shouldProbe: false,
+    })
+  })
+
+  it('keeps non-dev no-key connections unknown without probing', () => {
+    expect(
+      resolveConnectionRoleProbeState({
+        apiKey: '',
+        baseUrl: 'http://localhost:3000',
+        serverMode: 'api_key',
+      }),
+    ).toEqual({
+      isLoading: false,
+      role: 'unknown',
+      shouldProbe: false,
+    })
+  })
+
+  it('probes non-dev keyed connections through /health', () => {
+    expect(
+      resolveConnectionRoleProbeState({
+        apiKey: 'root-key',
+        baseUrl: 'http://localhost:3000',
+        serverMode: 'api_key',
+      }),
+    ).toEqual({
+      isLoading: true,
+      role: 'unknown',
+      shouldProbe: true,
+    })
   })
 })

--- a/web-studio/src/hooks/use-app-connection.tsx
+++ b/web-studio/src/hooks/use-app-connection.tsx
@@ -155,6 +155,31 @@ export function resolveInitialApiKey({
   return envApiKey || storedApiKey || defaultApiKey
 }
 
+export function resolveConnectionRoleProbeState({
+  apiKey,
+  baseUrl,
+  serverMode,
+}: {
+  apiKey: string
+  baseUrl: string
+  serverMode: ServerMode
+}): {
+  isLoading: boolean
+  role: ConnectionRole
+  shouldProbe: boolean
+} {
+  if (!baseUrl) {
+    return { isLoading: false, role: 'unknown', shouldProbe: false }
+  }
+  if (serverMode === 'dev') {
+    return { isLoading: false, role: 'root', shouldProbe: false }
+  }
+  if (!apiKey) {
+    return { isLoading: false, role: 'unknown', shouldProbe: false }
+  }
+  return { isLoading: true, role: 'unknown', shouldProbe: true }
+}
+
 function applyConnection(
   connection: ConnectionDraft,
   serverMode: ServerMode,
@@ -339,10 +364,15 @@ export function AppConnectionProvider({
   React.useEffect(() => {
     let cancelled = false
     const apiKey = connection.adminApiKey || connection.apiKey
+    const roleProbe = resolveConnectionRoleProbeState({
+      apiKey,
+      baseUrl: connection.baseUrl,
+      serverMode,
+    })
 
-    setConnectionRole('unknown')
-    setConnectionRoleLoading(Boolean(connection.baseUrl && apiKey))
-    if (!connection.baseUrl || !apiKey) {
+    setConnectionRole(roleProbe.role)
+    setConnectionRoleLoading(roleProbe.isLoading)
+    if (!roleProbe.shouldProbe) {
       return () => {
         cancelled = true
       }
@@ -382,6 +412,7 @@ export function AppConnectionProvider({
     connection.apiKey,
     connection.baseUrl,
     connection.userId,
+    serverMode,
   ])
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- treat Studio dev-mode connections with a configured base URL as `root` without requiring an API key
- skip the `/health` identity probe when dev mode already implies root access
- cover dev/no-key, non-dev/no-key, and non-dev/keyed role-probe states

Fixes #3017.

## Tests
- `git diff --check -- web-studio/src/hooks/use-app-connection.tsx web-studio/src/hooks/use-app-connection.test.ts`
- `pnpm --dir web-studio test src/hooks/use-app-connection.test.ts` (blocked before test execution: pnpm build-script approval gate rejected `esbuild`, `msw`, and `unrs-resolver`)
