### PR TITLE
fix(openclaw-plugin): require OpenClaw 2026.5.27

### DIFF
--- a/examples/openclaw-plugin/INSTALL-AGENT.md
+++ b/examples/openclaw-plugin/INSTALL-AGENT.md
@@ -153,11 +153,11 @@ openclaw --version
 Requirements:
 
 - Node.js >= 22
-- OpenClaw >= 2026.4.8
+- OpenClaw >= 2026.5.27
 
 Version boundaries:
 
-- `2026.4.8` is the minimum supported OpenClaw version for the current `@openviking/openclaw-plugin` plugin.
+- `2026.5.27` is the minimum supported OpenClaw version for the current `@openviking/openclaw-plugin` plugin.
 - `2026.5.3` starts requiring compiled JavaScript runtime output during package install when a plugin package declares TypeScript entries.
 - `2026.5.4` and later no longer fall back to `.ts` source for installed/global plugin runtime loading when the compiled JavaScript output is missing; the plugin may be skipped.
 - Published ClawHub packages are built before release and include `dist/*.js`, so normal users do not need to build locally.

--- a/examples/openclaw-plugin/INSTALL-ZH.md
+++ b/examples/openclaw-plugin/INSTALL-ZH.md
@@ -27,13 +27,13 @@ openclaw plugins install clawhub:@openviking/openclaw-plugin
 | 组件 | 要求 |
 | --- | --- |
 | Node.js | >= 22 |
-| OpenClaw | >= 2026.4.8 |
+| OpenClaw | >= 2026.5.27 |
 
 插件以远程模式连接到已有的 OpenViking 服务。它不会帮你启动 OpenViking server。需要先启动 OpenViking，并保持服务运行，再把插件的 `baseUrl` 指向这个 HTTP 服务。默认本地地址是 `http://127.0.0.1:1933`。
 
 OpenClaw 插件包版本边界：
 
-- `2026.4.8` 是当前插件支持的最低 OpenClaw 版本。
+- `2026.5.27` 是当前插件支持的最低 OpenClaw 版本。这个版本下限包含 2026 年 7 月 2 日 OpenClaw 安全公告批次的修复，包括 GHSA-8wg3-5mcm-fjq8 和 GHSA-83w9-h5wv-j9xm。
 - `2026.5.3` 开始，OpenClaw 在安装包时会校验 TypeScript 插件入口是否有编译后的 JavaScript 产物。
 - `2026.5.4` 及之后，已安装/全局插件如果缺少编译后的 JavaScript，运行时不再回退加载 `.ts` 源码，插件可能被跳过。
 - 推荐的 `openclaw plugins install clawhub:@openviking/openclaw-plugin` 会安装已经发布并包含 `dist/*.js` 的插件包，普通用户不需要本地编译。

--- a/examples/openclaw-plugin/INSTALL.md
+++ b/examples/openclaw-plugin/INSTALL.md
@@ -27,13 +27,13 @@ openclaw plugins install clawhub:@openviking/openclaw-plugin
 | Component | Required |
 | --- | --- |
 | Node.js | >= 22 |
-| OpenClaw | >= 2026.4.8 |
+| OpenClaw | >= 2026.5.27 |
 
 The plugin connects to an existing OpenViking server. It does not start the OpenViking server for you. Start OpenViking first, keep it running, then point the plugin `baseUrl` at that HTTP service. The default local URL is `http://127.0.0.1:1933`.
 
 OpenClaw plugin package boundaries:
 
-- `2026.4.8` is the minimum supported OpenClaw version for the current plugin.
+- `2026.5.27` is the minimum supported OpenClaw version for the current plugin. This floor includes the July 2, 2026 OpenClaw advisory batch fixes, including GHSA-8wg3-5mcm-fjq8 and GHSA-83w9-h5wv-j9xm.
 - `2026.5.3` starts validating package installs so TypeScript plugin entries need compiled JavaScript output.
 - `2026.5.4` and later stop falling back to `.ts` source for installed/global plugin runtime loading when compiled JavaScript is missing.
 - The recommended `openclaw plugins install clawhub:@openviking/openclaw-plugin` path installs a published package that already includes `dist/*.js`.

--- a/examples/openclaw-plugin/docs/openviking-openclaw-plugin-guide.md
+++ b/examples/openclaw-plugin/docs/openviking-openclaw-plugin-guide.md
@@ -393,7 +393,7 @@ bash install.sh --source tos --channel prod --version 2026.6.2
 | 组件 | 要求 |
 | --- | --- |
 | Node.js | >= 22 |
-| OpenClaw | >= 2026.4.8 |
+| OpenClaw | >= 2026.5.27 |
 | OpenViking Server | >= 0.4.1 |
 
 兼容性声明在 `install-manifest.json` 的 `compatibility` 字段。

--- a/examples/openclaw-plugin/install-manifest.json
+++ b/examples/openclaw-plugin/install-manifest.json
@@ -52,7 +52,7 @@
     "pruneAfterBuild": true
   },
   "compatibility": {
-    "minOpenclawVersion": "2026.4.8",
+    "minOpenclawVersion": "2026.5.27",
     "recommendedOpenclawVersion": "2026.6.6",
     "minOpenvikingVersion": "0.4.1",
     "recommendedOpenvikingVersion": "0.4.1"

--- a/examples/openclaw-plugin/package-lock.json
+++ b/examples/openclaw-plugin/package-lock.json
@@ -19,7 +19,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "openclaw": ">=2026.4.8"
+        "openclaw": ">=2026.5.27"
       }
     },
     "node_modules/@emnapi/core": {

--- a/examples/openclaw-plugin/package.json
+++ b/examples/openclaw-plugin/package.json
@@ -47,7 +47,7 @@
     "test:watch": "vitest"
   },
   "engines": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.5.27"
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
@@ -69,12 +69,12 @@
     ],
     "setupEntry": "./dist/commands/setup.js",
     "compat": {
-      "pluginApi": ">=2026.4.8",
-      "minGatewayVersion": "2026.4.8"
+      "pluginApi": ">=2026.5.27",
+      "minGatewayVersion": "2026.5.27"
     },
     "build": {
-      "openclawVersion": "2026.4.8",
-      "pluginSdkVersion": "2026.4.8"
+      "openclawVersion": "2026.5.27",
+      "pluginSdkVersion": "2026.5.27"
     }
   },
   "devDependencies": {

--- a/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
+++ b/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
@@ -91,8 +91,8 @@ openclaw --version
 
 **If `openclaw` is missing:**
 
-> (CN) 你的系统没有安装 OpenClaw。请先安装 OpenClaw（>= 2026.4.8），然后再回来找我。
-> (EN) OpenClaw is not installed. Please install OpenClaw (>= 2026.4.8) first, then come back.
+> (CN) 你的系统没有安装 OpenClaw。请先安装 OpenClaw（>= 2026.5.27），然后再回来找我。
+> (EN) OpenClaw is not installed. Please install OpenClaw (>= 2026.5.27) first, then come back.
 
 **Stop. Do NOT continue.**
 
@@ -736,7 +736,7 @@ Match against actual stderr / JSON `error` strings.
 
 | Symptom (exact string) | Likely cause | Fix |
 |---|---|---|
-| `command not found: openclaw` | OpenClaw not installed | Stop. Ask user to install OpenClaw >= 2026.4.8. |
+| `command not found: openclaw` | OpenClaw not installed | Stop. Ask user to install OpenClaw >= 2026.5.27. |
 | `command not found: node` / `'node' is not recognized` | Node missing | Stop. Ask user to install Node.js >= 22. |
 | `429` / `rate limit` / `Too Many Requests` from `plugins install` | ClawHub throttle | Switch to backup Path B (`ov-install`). |
 | `not logged in` / `please log in` from `plugins install` | Anonymous user hit limit | Switch to backup Path B (`ov-install`). |

--- a/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
+++ b/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
@@ -16,8 +16,13 @@ const manifest = JSON.parse(
 const packageJson = JSON.parse(
   readFileSync(resolve(pluginRoot, "package.json"), "utf8"),
 ) as {
+  engines?: { openclaw?: string };
   version?: string;
   files?: string[];
+  openclaw?: {
+    compat?: { pluginApi?: string; minGatewayVersion?: string };
+    build?: { openclawVersion?: string; pluginSdkVersion?: string };
+  };
   scripts?: Record<string, string>;
 };
 const installManifest = JSON.parse(
@@ -127,15 +132,25 @@ describe("OpenClaw 5.5 package runtime contract", () => {
       "package.json",
       "openclaw.plugin.json",
     ]));
-    expect(installManifest.compatibility?.minOpenclawVersion).toBe("2026.4.8");
+    expect(installManifest.compatibility?.minOpenclawVersion).toBe("2026.5.27");
   });
 
   it("declares compatibility floors and recommended versions, and keeps version fields in sync", () => {
     expect(installManifest.compatibility).toMatchObject({
-      minOpenclawVersion: "2026.4.8",
+      minOpenclawVersion: "2026.5.27",
       recommendedOpenclawVersion: "2026.6.6",
       minOpenvikingVersion: "0.4.1",
       recommendedOpenvikingVersion: "0.4.1",
+    });
+    // OpenClaw installers read these package fields as host-version floor metadata.
+    expect(packageJson.engines?.openclaw).toBe(">=2026.5.27");
+    expect(packageJson.openclaw?.compat).toMatchObject({
+      pluginApi: ">=2026.5.27",
+      minGatewayVersion: "2026.5.27",
+    });
+    expect(packageJson.openclaw?.build).toMatchObject({
+      openclawVersion: "2026.5.27",
+      pluginSdkVersion: "2026.5.27",
     });
     // package.json version and install-manifest pluginVersion must stay identical.
     expect(installManifest.pluginVersion).toBe(packageJson.version);


### PR DESCRIPTION
## Summary

- raise the OpenClaw plugin install floor from `2026.4.8` to `2026.5.27`
- keep `package.json`, `package-lock.json`, `install-manifest.json`, install guides, and the manifest contract test aligned
- call out the July 2, 2026 OpenClaw advisory batch in the user-facing install docs

OpenClaw versions below `2026.5.27` are covered by the July 2 advisory batch, including `GHSA-8wg3-5mcm-fjq8` and `GHSA-83w9-h5wv-j9xm`. The package `openclaw.*` fields are intentionally kept aligned with the install manifest minimum because the installer treats them as host-version floor metadata.

## Verification

- `python3 -m json.tool` on `package.json`, `package-lock.json`, and `install-manifest.json`
- checked the updated install/package contract surface for stale `2026.4.8` references
- Codex adversarial review: `VERDICT: approve`
