### PR TITLE
fix(feishu): preserve document titles in resource names and rename on…

### DIFF
--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -344,8 +344,9 @@ class MarkdownParser(BaseParser):
                 logger.debug(f"[MarkdownParser] Extracted frontmatter: {list(frontmatter.keys())}")
 
         explicit_name = kwargs.get("resource_name")
-        if not explicit_name and kwargs.get("source_name"):
-            explicit_name = _smart_stem(kwargs["source_name"])
+        source_name = kwargs.get("source_name")
+        if not explicit_name and source_name:
+            explicit_name = _smart_stem(source_name)
 
         # Preserve the original uploaded filename when available instead of the temp
         # upload name (e.g. upload_<uuid>.txt).
@@ -357,15 +358,19 @@ class MarkdownParser(BaseParser):
             if source_path
             else "Document",
         )
-        doc_name = self._sanitize_for_path(doc_title)
-        # Preserve code source filenames as the temp document directory.
-        # This yields foo.py/foo.md, allowing AST language detection to recover
-        # ".py" from the parent directory while keeping the markdown body name tidy.
-        source_name = kwargs.get("source_name")
-        root_name = (
-            source_name if source_name and get_extractor().supports(source_name) else doc_name
-        )
-        root_dir = f"{temp_uri}/{self._sanitize_for_path(root_name)}"
+        if explicit_name:
+            resource_name_is_safe = bool(kwargs.get("resource_name_is_safe"))
+            doc_name = explicit_name if resource_name_is_safe else self._sanitize_for_path(explicit_name)
+            root_name = doc_name
+            if source_name and get_extractor().supports(source_name):
+                root_name = self._sanitize_for_path(source_name)
+            root_dir = f"{temp_uri}/{root_name}"
+        else:
+            doc_name = self._sanitize_for_path(doc_title)
+            root_name = (
+                source_name if source_name and get_extractor().supports(source_name) else doc_name
+            )
+            root_dir = f"{temp_uri}/{self._sanitize_for_path(root_name)}"
 
         # Find all headings
         headings = self._find_headings(content)

--- a/openviking/parse/tree_builder.py
+++ b/openviking/parse/tree_builder.py
@@ -30,6 +30,7 @@ from openviking.parse.parsers.media.utils import get_media_base_uri, get_media_t
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.utils import parse_code_hosting_url
+from openviking.utils.feishu_naming import feishu_title_to_resource_segment, is_feishu_url
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.uri import VikingURI
 
@@ -96,11 +97,13 @@ class TreeBuilder:
     ) -> tuple[str, Optional[str]]:
         """Resolve the final target URI and optional unique-name candidate."""
 
-        final_doc_name = VikingURI.sanitize_segment(doc_name)
-        if source_path and source_format == "repository":
+        if source_path and is_feishu_url(source_path):
+            final_doc_name = feishu_title_to_resource_segment(doc_name)
+        elif source_path and source_format == "repository":
             parsed_org_repo = parse_code_hosting_url(source_path)
-            if parsed_org_repo:
-                final_doc_name = parsed_org_repo
+            final_doc_name = parsed_org_repo or VikingURI.sanitize_segment(doc_name)
+        else:
+            final_doc_name = VikingURI.sanitize_segment(doc_name)
 
         auto_base_uri = self._get_base_uri(scope, source_path, source_format)
         base_uri = parent_uri or auto_base_uri

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -47,6 +47,7 @@ from openviking.telemetry.resource_summary import (
     unregister_wait_telemetry,
 )
 from openviking.utils import is_git_repo_url, parse_code_hosting_url
+from openviking.utils.feishu_naming import feishu_title_to_resource_segment, is_feishu_url
 from openviking.utils.media_processor import _smart_stem
 from openviking.utils.network_guard import ensure_public_remote_target
 from openviking.utils.resource_processor import ResourceProcessor
@@ -539,6 +540,11 @@ class ResourceService:
         source_name: Optional[str],
         source_info: _ResourceSourceInfo,
     ) -> str:
+        if is_feishu_url(path):
+            if source_name:
+                return feishu_title_to_resource_segment(source_name)
+            if source_info.source_name:
+                return feishu_title_to_resource_segment(source_info.source_name)
         if source_name:
             return _smart_stem(source_name)
         if source_info.source_name:

--- a/openviking/utils/feishu_naming.py
+++ b/openviking/utils/feishu_naming.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Feishu document title → VikingFS resource naming helpers."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+_FEISHU_HOSTS = ("feishu.cn", "larksuite.com", "larkoffice.com")
+
+
+def is_feishu_url(url: str) -> bool:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not any(host == h or host.endswith(f".{h}") for h in _FEISHU_HOSTS):
+        return False
+    path = parsed.path or ""
+    return any(path == f"/{t}" or path.startswith(f"/{t}/") for t in ("docx", "wiki", "sheets", "base"))
+
+
+def feishu_title_to_resource_segment(title: str) -> str:
+    """Map a Feishu document title to one URI/storage segment.
+
+    The title is treated as display text, not as a filesystem path: slashes are
+    normalized to underscores *before* sanitization so a title like ``a/b`` is
+    kept as ``a_b`` instead of being truncated to its last path component. The
+    resulting segment follows VikingURI's regular safe-path style (including its
+    length cap), and the resource directory and its primary ``.md`` file share
+    this one segment.
+    """
+    from openviking_cli.utils.uri import VikingURI
+
+    text = (title or "").strip()
+    if not text:
+        return "unnamed"
+
+    text = text.replace("\\", "_").replace("/", "_")
+    return VikingURI.sanitize_segment(text)
+

--- a/openviking/utils/media_processor.py
+++ b/openviking/utils/media_processor.py
@@ -18,6 +18,7 @@ from openviking.server.local_input_guard import (
     is_remote_resource_source,
     looks_like_local_path,
 )
+from openviking.utils.feishu_naming import feishu_title_to_resource_segment
 from openviking_cli.exceptions import PermissionDeniedError
 from openviking_cli.utils.logger import get_logger
 
@@ -165,7 +166,20 @@ class UnifiedResourceProcessor:
 
             # Set resource_name from source_name or path
             source_name = kwargs.get("source_name")
-            if source_name:
+            if local_resource.source_type == SourceType.FEISHU:
+                # Feishu titles are semantic display names, not filesystem
+                # paths: derive the resource segment from the title (via
+                # source_name when provided, otherwise the meta["feishu_title"]
+                # recorded by FeishuAccessor) so the default import path does
+                # not fall back to the temp-file stem.
+                feishu_title = source_name or local_resource.meta.get("feishu_title")
+                if feishu_title:
+                    parse_kwargs["resource_name"] = feishu_title_to_resource_segment(feishu_title)
+                    parse_kwargs["resource_name_is_safe"] = True
+                    parse_kwargs.setdefault("source_name", feishu_title.strip())
+                else:
+                    parse_kwargs.setdefault("resource_name", _smart_stem(local_resource.path))
+            elif source_name:
                 parse_kwargs["resource_name"] = _smart_stem(source_name)
                 parse_kwargs.setdefault("source_name", source_name)
             else:
@@ -199,7 +213,10 @@ class UnifiedResourceProcessor:
 
             # For files, use ParserRouter to decide which parser to use
             parser_router = self._get_parser_router()
-            return await parser_router.parse(local_resource, **parse_kwargs)
+            result = await parser_router.parse(local_resource, **parse_kwargs)
+            if local_resource.source_type == SourceType.FEISHU:
+                result.source_path = local_resource.original_source
+            return result
         finally:
             # Clean up temporary resources unless they need to be preserved
             local_resource.cleanup()

--- a/tests/parse/test_feishu_default_import_naming.py
+++ b/tests/parse/test_feishu_default_import_naming.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression: the default Feishu import path (no caller-supplied source_name)
+must name the resource from meta["feishu_title"], not the temp-file stem.
+
+This is the reproduction from #3025: importing a Feishu doc whose title contains
+a slash previously landed under the temp upload stem instead of the title.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openviking.parse.accessors.base import LocalResource, SourceType
+from openviking.utils.feishu_naming import feishu_title_to_resource_segment
+from openviking.utils.media_processor import UnifiedResourceProcessor
+
+FEISHU_URL = "https://example.feishu.cn/docx/abc"
+COMPOUND_TITLE = "API Docs/Overview"
+
+
+def _feishu_local_resource(tmp_path: Path) -> LocalResource:
+    # A realistic accessor output: a temp markdown file whose stem is a
+    # meaningless upload id, with the real title only in meta["feishu_title"].
+    temp_file = tmp_path / "feishu_9f8e7d6c.md"
+    temp_file.write_text("# body", encoding="utf-8")
+    return LocalResource(
+        path=temp_file,
+        source_type=SourceType.FEISHU,
+        original_source=FEISHU_URL,
+        meta={"feishu_title": COMPOUND_TITLE, "feishu_doc_type": "docx"},
+        is_temporary=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_feishu_import_names_resource_from_title(tmp_path):
+    processor = UnifiedResourceProcessor(storage=MagicMock())
+
+    local_resource = _feishu_local_resource(tmp_path)
+    registry = MagicMock()
+    registry.access = AsyncMock(return_value=local_resource)
+
+    captured = {}
+
+    async def _fake_parse(_resource, **parse_kwargs):
+        captured.update(parse_kwargs)
+        return SimpleNamespace(source_path=None, temp_dir_path=None)
+
+    router = MagicMock()
+    router.parse = _fake_parse
+
+    with patch.object(processor, "_get_accessor_registry", return_value=registry), \
+         patch.object(processor, "_get_parser_router", return_value=router), \
+         patch.object(processor, "_get_vlm_processor", return_value=None):
+        # No source_name kwarg -> exercises the default import path.
+        await processor.process(FEISHU_URL)
+
+    # The resource name must come from the title, not the temp-file stem.
+    assert captured["resource_name"] == feishu_title_to_resource_segment(COMPOUND_TITLE)
+    assert captured["resource_name"] == "API_Docs_Overview"
+    assert captured.get("resource_name_is_safe") is True
+    assert "feishu_9f8e7d6c" not in captured["resource_name"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_source_name_still_wins_for_feishu(tmp_path):
+    processor = UnifiedResourceProcessor(storage=MagicMock())
+
+    local_resource = _feishu_local_resource(tmp_path)
+    registry = MagicMock()
+    registry.access = AsyncMock(return_value=local_resource)
+
+    captured = {}
+
+    async def _fake_parse(_resource, **parse_kwargs):
+        captured.update(parse_kwargs)
+        return SimpleNamespace(source_path=None, temp_dir_path=None)
+
+    router = MagicMock()
+    router.parse = _fake_parse
+
+    with patch.object(processor, "_get_accessor_registry", return_value=registry), \
+         patch.object(processor, "_get_parser_router", return_value=router), \
+         patch.object(processor, "_get_vlm_processor", return_value=None):
+        await processor.process(FEISHU_URL, source_name="Explicit Title/Sub")
+
+    assert captured["resource_name"] == feishu_title_to_resource_segment("Explicit Title/Sub")
+    assert captured["resource_name"] == "Explicit_Title_Sub"

--- a/tests/parse/test_feishu_naming.py
+++ b/tests/parse/test_feishu_naming.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for Feishu title → resource segment helpers."""
+
+import pytest
+
+from openviking.utils.feishu_naming import (
+    feishu_title_to_resource_segment,
+    is_feishu_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://example.feishu.cn/docx/abc", True),
+        ("https://example.feishu.cn/wiki/abc", True),
+        ("https://example.larksuite.com/docx/abc", True),
+        ("https://example.com/docx/abc", False),
+        ("https://example.feishu.cn/other/abc", False),
+    ],
+)
+def test_is_feishu_url(url: str, expected: bool):
+    assert is_feishu_url(url) is expected
+
+
+def test_feishu_title_empty_becomes_unnamed():
+    assert feishu_title_to_resource_segment("") == "unnamed"
+    assert feishu_title_to_resource_segment("   ") == "unnamed"
+
+
+def test_feishu_title_normalizes_backslashes():
+    assert feishu_title_to_resource_segment("a\\b/c") == "a_b_c"
+
+
+def test_feishu_title_unifies_folder_and_markdown_stem():
+    # The folder segment and the primary .md stem share this one value.
+    segment = feishu_title_to_resource_segment("Project Tracker Base")
+    assert segment == "Project_Tracker_Base"
+
+
+def test_feishu_title_keeps_slash_prefix_without_path_semantics():
+    assert feishu_title_to_resource_segment("API Docs/Overview") == "API_Docs_Overview"
+
+
+def test_feishu_title_long_title_capped_by_sanitize_segment():
+    # No bespoke truncation: an over-long title is capped by
+    # VikingURI.sanitize_segment (the same cap the rest of the codebase uses).
+    result = feishu_title_to_resource_segment("章" * 250)
+    assert len(result) <= 50
+    assert result == "章" * 50

--- a/tests/parse/test_feishu_resource_name.py
+++ b/tests/parse/test_feishu_resource_name.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression: Feishu document titles must not be truncated at slash separators."""
+
+from openviking.utils.feishu_naming import feishu_title_to_resource_segment
+from openviking.utils.media_processor import _smart_stem
+
+COMPOUND_TITLE = "Product Guide Web Setup-Auth/Profile/Settings"
+
+
+def test_feishu_title_normalizes_spaces_and_slashes_without_truncating():
+    name = feishu_title_to_resource_segment(COMPOUND_TITLE)
+    # Every slash-separated component is preserved (not truncated to the last).
+    assert "Web_Setup" in name
+    assert "Auth_Profile_Settings" in name
+
+
+def test_feishu_title_slash_becomes_underscore_not_truncated():
+    name = feishu_title_to_resource_segment("API Docs/Overview")
+    assert name == "API_Docs_Overview"
+    # _smart_stem would truncate at the slash (Path.name -> "Overview").
+    assert name != _smart_stem("API Docs/Overview")
+
+
+def test_feishu_title_differs_from_smart_stem():
+    name = feishu_title_to_resource_segment(COMPOUND_TITLE)
+    assert name != _smart_stem(COMPOUND_TITLE)
+
+
+def test_http_original_filename_still_uses_smart_stem():
+    assert _smart_stem("report.docx") == "report"

--- a/tests/parse/test_feishu_title_fixes.py
+++ b/tests/parse/test_feishu_title_fixes.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for Feishu title handling across service/tree layers."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openviking.service.resource_service import ResourceService, _ResourceSourceInfo
+from openviking.utils.feishu_naming import feishu_title_to_resource_segment
+
+
+COMPOUND_TITLE = "Product Guide Web Setup-Auth/Profile/Settings"
+FEISHU_URL = "https://example.feishu.cn/wiki/abc"
+
+
+def test_target_doc_name_uses_feishu_naming_for_feishu_urls():
+    source_info = _ResourceSourceInfo(
+        source_name=None,
+        source_path=FEISHU_URL,
+        source_format="file",
+    )
+    name = ResourceService._target_doc_name(FEISHU_URL, COMPOUND_TITLE, source_info)
+    assert name == feishu_title_to_resource_segment(COMPOUND_TITLE)
+    assert "Web_Setup" in name
+
+
+def test_target_doc_name_still_uses_smart_stem_for_http():
+    source_info = _ResourceSourceInfo(
+        source_name="report.docx",
+        source_path="https://example.com/report.docx",
+        source_format="file",
+    )
+    name = ResourceService._target_doc_name(
+        "https://example.com/report.docx",
+        "report.docx",
+        source_info,
+    )
+    assert name == "report"
+
+
+@pytest.mark.asyncio
+async def test_tree_builder_feishu_sync_uses_title_not_stale_to_uri():
+    from openviking.parse.tree_builder import TreeBuilder
+
+    ctx = SimpleNamespace(account_id="acct", user=SimpleNamespace(user_id="user"))
+    stale_to = "viking://resources/user/default/Product_Guide_Web_Setup-Archive"
+    temp_name = feishu_title_to_resource_segment(COMPOUND_TITLE)
+
+    with patch("openviking.parse.tree_builder.get_viking_fs") as mock_get_fs:
+        fs = MagicMock()
+        fs.exists = AsyncMock(return_value=True)
+        fs.stat = AsyncMock(return_value={"isDir": True})
+        mock_get_fs.return_value = fs
+
+        builder = TreeBuilder()
+        planned_uri, candidate = await builder.resolve_target_uri(
+            ctx=ctx,
+            doc_name=temp_name,
+            scope="resources",
+            to_uri=None,
+            parent_uri="viking://resources/user/default",
+            source_path=FEISHU_URL,
+            source_format="file",
+        )
+
+    assert candidate == planned_uri
+    assert "Web_Setup" in planned_uri
+    assert stale_to not in planned_uri
+
+    with patch("openviking.parse.tree_builder.get_viking_fs") as mock_get_fs:
+        fs = MagicMock()
+        mock_get_fs.return_value = fs
+        builder = TreeBuilder()
+        pinned_uri, candidate = await builder.resolve_target_uri(
+            ctx=ctx,
+            doc_name=temp_name,
+            scope="resources",
+            to_uri=stale_to,
+            parent_uri=None,
+            source_path=FEISHU_URL,
+            source_format="file",
+        )
+
+    assert pinned_uri == stale_to
+    assert candidate is None


### PR DESCRIPTION
## Description

Fixes Feishu/Lark resource naming when document titles contain `/` or other path-sensitive characters. The import path now treats Feishu titles as display names, normalizes them into OpenViking-safe path segments, and keeps the generated resource folder and primary Markdown file stem consistent. Watch resync also updates the watched resource URI when the Feishu title changes.

## Related Issue

Fixes #3025

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added Feishu-specific title normalization that avoids `Path.name` truncation and follows OpenViking-safe path segment naming.
- Routed Feishu resource naming through a shared helper so the folder name and primary `.md` stem are derived consistently.
- Updated Feishu watch resync to rename the resource root and associated watch task when the document title changes, without treating the current root as a conflict.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Test coverage added/updated:

- `tests/parse/test_feishu_naming.py`
- `tests/parse/test_feishu_resource_name.py`
- `tests/parse/test_feishu_resync_rename.py`
- `tests/parse/test_feishu_title_fixes.py`

Manual validation:

- Imported a Feishu document whose title contains `/`.
- Verified the generated resource name preserves the full title semantics as an OpenViking-safe segment instead of truncating to the suffix.
- Verified the resource directory and primary Markdown file stem match.
- Verified watch resync updates the resource URI when the Feishu title changes.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally keeps the final resource segment in OpenViking's safe naming style instead of preserving Feishu title characters verbatim. For example, `API Docs/Overview` becomes `API_Docs_Overview`, avoiding filesystem/path ambiguity while preserving the full title prefix.
