### PR TITLE
docs: update agent authentication wording

### DIFF
--- a/docs/images/agents/en/hermes.md
+++ b/docs/images/agents/en/hermes.md
@@ -6,15 +6,15 @@
 hermes memory setup
 ```
 
-## Step 2: Copy the Base URL and API Key
+## Step 2: Copy the Base URL and Authentication management
 
-After running the setup command, Hermes prompts for the Base URL and API Key. Copy them and paste them into Hermes:
+After running the setup command, Hermes prompts for the Base URL and Authentication management. Copy them and paste them into Hermes:
 
 - Base URL: Copy the following Base URL into Hermes:
 ```text
 https://api.vikingdb.cn-beijing.volces.com/openviking
 ```
-- API Key: Copy the API Key shown on the page into your Hermes terminal
+- Authentication management: Copy the Authentication management shown on the page into your Hermes terminal
 - Tenant account / user / agent ID: Used for multi-tenant deployments
 
 The configuration is saved to Hermes `config.yaml` and `.env` files.

--- a/docs/images/agents/en/trae.md
+++ b/docs/images/agents/en/trae.md
@@ -90,7 +90,7 @@ ov health
 | `mcpServers` | Yes | Root node for MCP Server configuration |
 | `ov-mcp-server` | Yes | Service alias. It can be customized, but keeping this name is recommended for contextual recognition |
 | `url` | Yes | OpenViking MCP endpoint. For CN, use `https://api.vikingdb.cn-beijing.volces.com/openviking/mcp` |
-| `headers.Authorization` | Yes | Format: `Bearer <API Key>`. Source: see chapter 2 |
+| `headers.Authorization` | Yes | Format: `Bearer API Key`. Source: see chapter 2 |
 
 ---
 

--- a/docs/images/agents/zh/hermes.md
+++ b/docs/images/agents/zh/hermes.md
@@ -7,14 +7,14 @@
 hermes memory setup
 ```
 
-## 步骤 2：复制 Base URL 和 API Key
-执行 setup 命令后会依次提示输入 Base URL 和 API Key，可复制后粘贴到你的 Hermes：
+## 步骤 2：复制 Base URL 和 鉴权管理
+执行 setup 命令后会依次提示输入 Base URL 和 鉴权管理，可复制后粘贴到你的 Hermes：
 
 - Base URL: 复制以下 Base URL 到你的 Hermes：
 ```text
 https://api.vikingdb.cn-beijing.volces.com/openviking
 ```
-- API Key: 复制页面中展示的 API Key 到你的 Hermes 终端
+- 鉴权管理: 复制页面中展示的 鉴权管理 到你的 Hermes 终端
 - 租户 account / user / agent ID：多租户部署时使用
 
 配置保存在 Hermes 的 `config.yaml` 和 `.env` 文件中。

--- a/docs/images/agents/zh/trae.md
+++ b/docs/images/agents/zh/trae.md
@@ -92,7 +92,7 @@ ov health
 |`mcpServers`|是|MCP Server 配置根节点|
 |`ov\-mcp\-server`|是|服务别名，可自定义；建议保持与上下文识别一致|
 |`url`|是|OpenViking MCP 服务端点；CN 区固定为 `https://api\.vikingdb\.cn\-beijing\.volces\.com/openviking/mcp`|
-|`headers\.Authorization`|是|格式 `Bearer \&lt;API Key\&gt;`，来源见第二章|
+|`headers\.Authorization`|是|格式 `Bearer API Key`，来源见第二章|
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the OpenViking agent integration documentation to align the authentication wording used in the console UI.

Changes include:

- Update the TRAE integration docs in both Chinese and English:
  - Replace `Bearer <API Key>` with `Bearer API Key` in the `headers.Authorization` configuration field description.
- Update the Hermes integration docs in both Chinese and English:
  - Replace `API Key` with `鉴权管理` in Chinese docs.
  - Replace `API Key` with `Authentication management` in English docs.

## Motivation

The OpenViking console now presents the credential entry as “鉴权管理” / “Authentication management” in the agent integration flow. The documentation previously referred to this field as “API Key”, which could cause users to look for a mismatched label in the UI.

This update keeps the documentation consistent with the product UI and reduces ambiguity during agent setup.

## Files Changed

- `docs/images/agents/zh/trae.md`
- `docs/images/agents/en/trae.md`
- `docs/images/agents/zh/hermes.md`
- `docs/images/agents/en/hermes.md`

## Testing

Documentation-only change. Verified the affected Markdown lines locally.