### PR TITLE
fix(docs): update search gateway host

### DIFF
--- a/docs/.vitepress/theme/OpenVikingSearch.vue
+++ b/docs/.vitepress/theme/OpenVikingSearch.vue
@@ -22,7 +22,7 @@ type RemoteSearchResponse =
   | { ok: true; results: DocsSearchResult[] }
   | { ok: false; reason: RemoteSearchFailureReason }
 
-const PRODUCTION_SEARCH_URL = 'https://openviking.ai/studio/gateway/docs/search'
+const PRODUCTION_SEARCH_URL = 'https://openviking.net/studio/gateway/docs/search'
 const SEARCH_LIMIT = 8
 const REMOTE_SEARCH_DEBOUNCE_MS = 1000
 const REMOTE_SEARCH_TIMEOUT_MS = 15000


### PR DESCRIPTION
## Description

Updates the docs search gateway host from `openviking.ai` to `openviking.net` so the OpenViking-powered docs search uses the current public gateway endpoint.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Updated the production docs search URL to `https://openviking.net/studio/gateway/docs/search`.
- Left the existing search request shape, fallback behavior, and timeout unchanged.
- Kept the change scoped to the VitePress docs search component.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed locally:

- `npm run test:search` from `docs/`
- `npm run docs:build` from `docs/`
- `DOCS_BASE=/docs/ npm run docs:build` from `docs/`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The VitePress build still emits existing syntax-highlight fallback warnings for `promql` and `caddyfile`; the build completes successfully and this change does not introduce those warnings.
