### PR TITLE
feat(storage): add Milvus vector adapter

### DIFF
--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -194,11 +194,41 @@ Search and Find requests default to `limit: 10`; override the limit on each API 
 |---|---|---|---|
 | `workspace` | path | `"./data"` | OpenViking workspace |
 | `agfs.backend` | `local`, `memory`, `s3` | `local` | File and metadata backend |
-| `vectordb.backend` | `local`, `cuvs`, `http`, `volcengine`, `vikingdb` | `local` | Vector database backend |
+| `vectordb.backend` | `local`, `cuvs`, `http`, `milvus`, `volcengine`, `vikingdb` | `local` | Vector database backend |
 | `vectordb.dimension` | integer | follows Embedding | Vector collection dimension |
 | `skip_process_lock` | boolean | `false` | Skip the workspace process lock; use only when accepting concurrent-write risk |
 
 Remote backends also require endpoint, bucket/collection, credentials, and timeout fields. See [Configuration](../guides/01-configuration.md#storage) for complete examples.
+
+The Milvus backend is opt-in; install it with `uv sync --extra milvus` and set
+`vectordb.backend` to `milvus`. The default remains `local`, and importing or starting
+OpenViking with the default configuration does not require PyMilvus. A file URI such as
+`./milvus.db` starts Milvus Lite. HTTP endpoints and tokens select Milvus Server or Zilliz
+Cloud explicitly.
+
+Endpoint precedence is `milvus.uri`, then the legacy `vectordb.url`, then
+`vectordb.custom_params.uri`, and finally `./milvus.db`. An explicitly configured
+`milvus.uri` is never replaced by the local default.
+
+Milvus Lite creates physical `INVERTED` scalar indexes for supported `VARCHAR`, `INT64`, and
+`BOOL` fields. Lite does not support `ARRAY` scalar indexes, so grant arrays remain filterable
+but are reported as unavailable rather than as successfully indexed. Sparse and hybrid search
+is rejected because this adapter cannot guarantee complete sparse candidate recall. Scalar
+ordering and grouped aggregation also fail clearly when more than 10,000 matching rows would
+otherwise be truncated.
+
+Collections created by an older OpenViking schema can add ACL fields through dynamic fields;
+legacy null ACL values are read as public defaults. A static collection missing required fields,
+or a collection with an incompatible vector field/dimension, primary key, `auto_id`, dynamic
+schema setting, or array element/capacity, must be migrated or rebuilt before use. Validation
+finishes before OpenViking changes collection properties or sidecar metadata.
+
+New sidecar/property metadata records the exact logical project, logical collection, physical
+naming version, and physical collection name. A pre-existing physical collection or old sidecar
+without this verifiable ownership identity is not bound automatically and cannot be read,
+updated, or deleted through the adapter. Migrate or rebuild it, or establish an explicit binding
+only after independently verifying its owner. Business names that resolve to OpenViking's current
+or legacy metadata namespaces are rejected.
 
 ## Queue Worker Settings
 

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1438,7 +1438,7 @@ Vector database storage configuration
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `backend` | str | VectorDB backend type: 'local' (file-based), 'http' (remote service), 'volcengine' (cloud VikingDB), 'vikingdb' (private deployment), or 'cuvs' (local storage + GPU dense search) | "local" |
+| `backend` | str | VectorDB backend type: 'local' (file-based), 'http' (remote service), 'volcengine' (cloud VikingDB), 'vikingdb' (private deployment), 'cuvs' (local storage + GPU dense search), or 'milvus' | "local" |
 | `name` | str | VectorDB collection name | "context" |
 | `url` | str | Remote service URL for 'http' type (e.g., 'http://localhost:5000') | null |
 | `project_name` | str | Project name (alias project) | "default" |
@@ -1448,6 +1448,7 @@ Vector database storage configuration
 | `volcengine` | object | 'volcengine' type VikingDB configuration | - |
 | `vikingdb` | object | 'vikingdb' type private deployment configuration | - |
 | `cuvs` | object | NVIDIA cuVS configuration for the 'cuvs' backend and the opt-in memory-aware auto mode on 'local'; see the [cuVS guide](./16-cuvs.md) | - |
+| `milvus` | object | 'milvus' type Milvus or Zilliz Cloud configuration | - |
 
 Default local mode
 ```
@@ -1497,38 +1498,35 @@ Local backends add the fields to an existing collection and rebuild the scalar i
 For existing remote collections, including Volcengine VikingDB, provision these fields and scalar indexes before startup; OpenViking validates but does not alter the remote schema. Volcengine API-key data-plane mode also requires the context collection and configured index to exist. See [Resource Access Control (ACL)](../concepts/15-acl.md) for permission semantics.
 
 <details>
-<summary><b>openGauss</b></summary>
+<summary><b>Milvus</b></summary>
 
-Requires an openGauss server with native `vector` support and a remote-capable database user.
-Install the optional driver with `pip install "openviking[opengauss]"`.
-In the official container, the initial `omm` user may be restricted for remote login; create a normal user for OpenViking if needed.
+Install the `milvus` optional extra before using this backend. The default `uri`
+uses Milvus Lite and stores data in a local `milvus.db` file. Use an HTTP URI for
+self-hosted Milvus, or a cloud endpoint plus `token` for Zilliz Cloud.
 
 ```json
 {
   "storage": {
     "vectordb": {
       "name": "context",
-      "backend": "opengauss",
+      "backend": "milvus",
       "project": "default",
       "distance_metric": "cosine",
       "dimension": 1024,
-      "opengauss": {
-        "host": "127.0.0.1",
-        "port": 5432,
-        "user": "openviking",
-        "password": "your-password",
-        "db_name": "postgres",
-        "schema": "public",
-        "mode": "standalone"
+      "milvus": {
+        "uri": "./milvus.db",
+        "token": null,
+        "db_name": null,
+        "consistency_level": "Session"
       }
     }
   }
 }
 ```
 
-Set `mode` to `"distributed"` for openGauss distributed deployments; OpenViking will attempt to mark metadata tables as reference tables and distribute collection tables by `id`.
+For a self-hosted server, set `"uri": "http://localhost:19530"`. For Zilliz Cloud,
+set `"uri"` to the cloud endpoint and provide `"token"`.
 </details>
-
 
 ## Config Files
 

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1286,7 +1286,7 @@ Vector database storage configuration
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `backend` | str | VectorDB backend type: 'local' (file-based), 'http' (remote service), 'volcengine' (cloud VikingDB), 'vikingdb' (private deployment), 'cuvs' (local storage + GPU dense search), 'qdrant', or 'opengauss' | "local" |
+| `backend` | str | VectorDB backend type: 'local' (file-based), 'http' (remote service), 'volcengine' (cloud VikingDB), 'vikingdb' (private deployment), 'cuvs' (local storage + GPU dense search), 'qdrant', 'milvus', or 'opengauss' | "local" |
 | `name` | str | VectorDB collection name | "context" |
 | `url` | str | Remote service URL for 'http' type (e.g., 'http://localhost:5000') | null |
 | `project_name` | str | Project name (alias project) | "default" |
@@ -1297,6 +1297,7 @@ Vector database storage configuration
 | `vikingdb` | object | 'vikingdb' type private deployment configuration | - |
 | `cuvs` | object | NVIDIA cuVS configuration for the 'cuvs' backend and the opt-in memory-aware auto mode on 'local'; see the [cuVS guide](./16-cuvs.md) | - |
 | `qdrant` | object | 'qdrant' type Qdrant configuration | - |
+| `milvus` | object | 'milvus' type Milvus or Zilliz Cloud configuration | - |
 | `opengauss` | object | 'opengauss' native vector backend configuration | - |
 
 Default local mode
@@ -1329,6 +1330,37 @@ Supports cloud-deployed VikingDB on Volcengine
   }
 }
 ```
+</details>
+
+<details>
+<summary><b>Milvus</b></summary>
+
+Install the `milvus` optional extra before using this backend. The default `uri`
+uses Milvus Lite and stores data in a local `milvus.db` file. Use an HTTP URI for
+self-hosted Milvus, or a cloud endpoint plus `token` for Zilliz Cloud.
+
+```json
+{
+  "storage": {
+    "vectordb": {
+      "name": "context",
+      "backend": "milvus",
+      "project": "default",
+      "distance_metric": "cosine",
+      "dimension": 1024,
+      "milvus": {
+        "uri": "./milvus.db",
+        "token": null,
+        "db_name": null,
+        "consistency_level": "Session"
+      }
+    }
+  }
+}
+```
+
+For a self-hosted server, set `"uri": "http://localhost:19530"`. For Zilliz Cloud,
+set `"uri"` to the cloud endpoint and provide `"token"`.
 </details>
 
 <details>

--- a/docs/zh/configuration/01-server.md
+++ b/docs/zh/configuration/01-server.md
@@ -194,11 +194,38 @@ Search 和 Find 请求的默认 `limit` 为 `10`，可以在每次 API 或 SDK �
 |---|---|---|---|
 | `workspace` | path | `"./data"` | OpenViking 工作目录 |
 | `agfs.backend` | `local`、`memory`、`s3` | `local` | 文件与元数据存储后端 |
-| `vectordb.backend` | `local`、`cuvs`、`http`、`volcengine`、`vikingdb` | `local` | 向量数据库后端 |
+| `vectordb.backend` | `local`、`cuvs`、`http`、`milvus`、`volcengine`、`vikingdb` | `local` | 向量数据库后端 |
 | `vectordb.dimension` | integer | 跟随 Embedding | 向量集合维度 |
 | `skip_process_lock` | boolean | `false` | 是否跳过 workspace 进程锁；仅在明确接受并发写风险时启用 |
 
 远程存储后端还需要配置 endpoint、bucket/collection、鉴权和超时等字段。完整后端示例见[配置指南](../guides/01-configuration.md#storage)。
+
+Milvus 后端需要显式启用：先执行 `uv sync --extra milvus`，再把
+`vectordb.backend` 设置为 `milvus`。默认后端仍为 `local`，默认配置下导入或启动
+OpenViking 不依赖 PyMilvus。`./milvus.db` 这类文件 URI 会启动 Milvus Lite；HTTP
+endpoint 和 token 则显式选择 Milvus Server 或 Zilliz Cloud。
+
+endpoint 的优先级依次为显式 `milvus.uri`、旧版 `vectordb.url`、
+`vectordb.custom_params.uri`，最后才是 `./milvus.db`。显式配置的 `milvus.uri` 不会被本地
+默认值覆盖。
+
+Milvus Lite 会为支持的 `VARCHAR`、`INT64` 和 `BOOL` 字段创建真实 `INVERTED`
+标量索引。Lite 不支持 `ARRAY` 标量索引，因此授权数组仍可过滤，但 metadata 会将其
+报告为不可用，不会误报为成功创建。由于当前 adapter 无法保证完整的 sparse 候选召回，
+sparse/hybrid 检索会明确拒绝。标量排序和分组聚合若匹配超过 10,000 条、可能发生截断，
+也会明确报错。
+
+旧 OpenViking 动态 schema collection 可通过动态字段补充 ACL 字段；读取时会把旧记录的
+NULL ACL 值归一化为公开默认值。若静态 collection 缺少必需字段，或已有字段类型不兼容，
+以及 vector 字段/维度、主键、`auto_id`、动态 schema 设置、ARRAY element/capacity 任一
+不兼容，都必须先迁移或重建。完成全部校验前，OpenViking 不会修改 collection property
+或 sidecar metadata。
+
+新 metadata 会同时保存精确的 logical project、logical collection、physical naming
+version 和 physical collection name。若旧 physical collection 或旧 sidecar 缺少可验证的
+ownership identity，adapter 不会自动绑定，也不会通过该绑定读取、更新或删除；应先迁移或
+重建，或在独立确认 owner 后建立显式绑定。任何会解析为当前或旧 metadata namespace 的
+业务名称都会被拒绝。
 
 ## 队列 Worker 配置
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1255,7 +1255,7 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
-| `backend` | str | VectorDB 后端类型: 'local'（基于文件）, 'http'（远程服务）, 'volcengine'（云上 VikingDB）, 'vikingdb'（私有部署）, 'cuvs'（本地存储 + GPU dense search）, 'qdrant' 或 'opengauss' | "local" |
+| `backend` | str | VectorDB 后端类型: 'local'（基于文件）, 'http'（远程服务）, 'volcengine'（云上 VikingDB）, 'vikingdb'（私有部署）, 'cuvs'（本地存储 + GPU dense search）, 'qdrant'、'milvus' 或 'opengauss' | "local" |
 | `name` | str | VectorDB 的集合名称 | "context" |
 | `url` | str | 'http' 类型的远程服务 URL（例如 'http://localhost:5000'） | null |
 | `project_name` | str | 项目名称（别名 project） | "default" |
@@ -1266,6 +1266,7 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 | `vikingdb` | object | 'vikingdb' 类型的私有部署配置 | - |
 | `cuvs` | object | NVIDIA cuVS 配置，也用于在 'local' 下显式开启显存感知自动模式，参见 [cuVS 使用指南](./16-cuvs.md) | - |
 | `qdrant` | object | 'qdrant' 类型的 Qdrant 配置 | - |
+| `milvus` | object | 'milvus' 类型的 Milvus 或 Zilliz Cloud 配置 | - |
 | `opengauss` | object | 'opengauss' 原生向量后端配置 | - |
 
 默认使用本地模式
@@ -1298,6 +1299,37 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
   }
 }
 ```
+</details>
+
+<details>
+<summary><b>Milvus</b></summary>
+
+使用该后端前需要安装 `milvus` 可选依赖。默认 `uri` 使用 Milvus Lite，
+并把数据写入本地 `milvus.db` 文件。自托管 Milvus 使用 HTTP URI；
+Zilliz Cloud 使用云端 endpoint 并配置 `token`。
+
+```json
+{
+  "storage": {
+    "vectordb": {
+      "name": "context",
+      "backend": "milvus",
+      "project": "default",
+      "distance_metric": "cosine",
+      "dimension": 1024,
+      "milvus": {
+        "uri": "./milvus.db",
+        "token": null,
+        "db_name": null,
+        "consistency_level": "Session"
+      }
+    }
+  }
+}
+```
+
+如果连接自托管服务，可设置 `"uri": "http://localhost:19530"`。如果使用
+Zilliz Cloud，把 `"uri"` 设置为云端 endpoint，并填写 `"token"`。
 </details>
 
 <details>

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1413,7 +1413,7 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
-| `backend` | str | VectorDB 后端类型: 'local'（基于文件）, 'http'（远程服务）, 'volcengine'（云上 VikingDB）, 'vikingdb'（私有部署）或 'cuvs'（本地存储 + GPU dense search） | "local" |
+| `backend` | str | VectorDB 后端类型: 'local'（基于文件）, 'http'（远程服务）, 'volcengine'（云上 VikingDB）, 'vikingdb'（私有部署）, 'cuvs'（本地存储 + GPU dense search）或 'milvus' | "local" |
 | `name` | str | VectorDB 的集合名称 | "context" |
 | `url` | str | 'http' 类型的远程服务 URL（例如 'http://localhost:5000'） | null |
 | `project_name` | str | 项目名称（别名 project） | "default" |
@@ -1423,6 +1423,7 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 | `volcengine` | object | 'volcengine' 类型的 VikingDB 配置 | - |
 | `vikingdb` | object | 'vikingdb' 类型的私有部署配置 | - |
 | `cuvs` | object | NVIDIA cuVS 配置，也用于在 'local' 下显式开启显存感知自动模式，参见 [cuVS 使用指南](./16-cuvs.md) | - |
+| `milvus` | object | 'milvus' 类型的 Milvus 或 Zilliz Cloud 配置 | - |
 
 默认使用本地模式
 ```
@@ -1472,39 +1473,35 @@ acl_inherited_grants
 火山向量库等远端 backend 的存量 collection 需要由部署方预先添加这些字段和 scalar index，OpenViking 只校验 schema。`volcengine` API key 数据面模式还要求 context collection 和配置的 index 已存在。权限模型详见 [资源访问控制（ACL）](../concepts/15-acl.md)。
 
 <details>
-<summary><b>openGauss</b></summary>
+<summary><b>Milvus</b></summary>
 
-需要 openGauss 服务端支持原生 `vector` 类型，并使用允许远程连接的数据库用户。
-可通过 `pip install "openviking[opengauss]"` 安装可选驱动。
-官方容器中的初始 `omm` 用户可能限制远程登录，必要时请为 OpenViking 创建普通数据库用户。
+使用该后端前需要安装 `milvus` 可选依赖。默认 `uri` 使用 Milvus Lite，
+并把数据写入本地 `milvus.db` 文件。自托管 Milvus 使用 HTTP URI；
+Zilliz Cloud 使用云端 endpoint 并配置 `token`。
 
 ```json
 {
   "storage": {
     "vectordb": {
       "name": "context",
-      "backend": "opengauss",
+      "backend": "milvus",
       "project": "default",
       "distance_metric": "cosine",
       "dimension": 1024,
-      "opengauss": {
-        "host": "127.0.0.1",
-        "port": 5432,
-        "user": "openviking",
-        "password": "your-password",
-        "db_name": "postgres",
-        "schema": "public",
-        "mode": "standalone"
+      "milvus": {
+        "uri": "./milvus.db",
+        "token": null,
+        "db_name": null,
+        "consistency_level": "Session"
       }
     }
   }
 }
 ```
 
-分布式 openGauss 部署可将 `mode` 设为 `"distributed"`；OpenViking 会尝试把元数据表标记为 reference table，并按 `id` 分布集合表。
+如果连接自托管服务，可设置 `"uri": "http://localhost:19530"`。如果使用
+Zilliz Cloud，把 `"uri"` 设置为云端 endpoint，并填写 `"token"`。
 </details>
-
-
 
 ## 配置文件
 

--- a/openviking/storage/vectordb_adapters/README.md
+++ b/openviking/storage/vectordb_adapters/README.md
@@ -202,6 +202,7 @@ from typing import Any, Dict
 
 from openviking.storage.vectordb_adapters.base import CollectionAdapter
 
+
 class ThirdPartyCollectionAdapter(CollectionAdapter):
     def __init__(self, *, endpoint: str, token: str, collection_name: str):
         super().__init__(collection_name=collection_name)

--- a/openviking/storage/vectordb_adapters/README.md
+++ b/openviking/storage/vectordb_adapters/README.md
@@ -178,6 +178,35 @@
 （如 `http://localhost:19530`）或 Zilliz Cloud endpoint，认证统一使用
 `token` 字段。
 
+连接地址按显式 `milvus.uri`、`vectordb.url`、`custom_params.uri`、
+`./milvus.db` 的顺序选择；显式 `milvus.uri` 始终优先。
+
+Milvus 是可选后端，需要通过 `uv sync --extra milvus` 安装
+`pymilvus[milvus-lite]>=3.0.0`。未显式选择 Milvus 时，默认 `local` 后端的 import
+和启动不会加载 PyMilvus。
+
+兼容性边界：
+
+- Milvus Lite 会为 `VARCHAR`、`INT64`、`BOOL` 字段创建真实 `INVERTED` 索引；
+  Lite 不支持的 `ARRAY` 索引会明确降级，metadata 只把实际创建成功的字段列入
+  `ScalarIndex`，并在 `ScalarIndexUnavailable` 中记录降级字段。
+- 授权数组仍使用 `ARRAY_CONTAINS` 过滤。写入会物化 ACL 默认值，旧记录的 NULL ACL
+  值在读取和公开记录过滤时按 `False` / `[]` 处理。
+- 当前实现不提供 sparse/hybrid 检索；非零 `sparse_weight` 或 sparse query 会直接报错，
+  避免静默漏召回或忽略权重。
+- 标量排序和分组聚合在超过 10,000 条匹配记录时会明确报错，避免返回截断结果。
+- 旧动态 schema collection 可在重启时补充 ACL metadata；静态 schema 缺字段或字段类型
+  不兼容时会要求迁移或重建。绑定已有 collection 前还会完整校验 vector field/dim、
+  primary key、`auto_id`、dynamic schema 以及 ARRAY element/capacity；失败不会改写
+  sidecar 或 collection property。
+- 新 metadata 保存精确 logical project、logical collection、physical naming version
+  和 physical name。缺少可验证 identity 的旧 physical collection/sidecar 不会自动绑定，
+  也不能经该 adapter 读取、更新或删除；需要迁移/重建，或在确认 owner 后显式绑定。
+  当前与旧 metadata namespace 均保留，业务名称不得落入这些 namespace。
+- index metadata 与 collection property 更新失败会回滚本次新增的物理索引和两份 metadata；
+  Milvus Lite 的 drop-index 会连带清空 collection 索引，因此 rollback 会按原定义恢复既有
+  索引并恢复此前 load 状态。若恢复失败，adapter 会报告明确的不一致错误。
+
 
 
 ---

--- a/openviking/storage/vectordb_adapters/README.md
+++ b/openviking/storage/vectordb_adapters/README.md
@@ -152,6 +152,32 @@
 1. `backend`: 填写 Adapter 类的完整 Python 路径（例如 `my_project.adapters.MyAdapter`）。
 2. `custom_params`: 这是一个字典，你可以放入任何自定义参数，Adapter 的 `from_config` 方法可以通过 `config.custom_params` 获取这些值。
 
+内置 Milvus 后端可直接使用 registry 名称，并通过 `milvus` 配置块传递连接信息：
+
+```json
+{
+  "storage": {
+    "vectordb": {
+      "backend": "milvus",
+      "name": "context",
+      "project": "default",
+      "distance_metric": "cosine",
+      "dimension": 1024,
+      "milvus": {
+        "uri": "./milvus.db",
+        "token": null,
+        "db_name": null,
+        "consistency_level": "Session"
+      }
+    }
+  }
+}
+```
+
+`uri` 默认为 Milvus Lite 本地文件；也可以设置为自建 Milvus 服务
+（如 `http://localhost:19530`）或 Zilliz Cloud endpoint，认证统一使用
+`token` 字段。
+
 
 
 ---

--- a/openviking/storage/vectordb_adapters/__init__.py
+++ b/openviking/storage/vectordb_adapters/__init__.py
@@ -6,6 +6,7 @@ from .base import CollectionAdapter
 from .factory import create_collection_adapter
 from .http_adapter import HttpCollectionAdapter
 from .local_adapter import CuVSCollectionAdapter, LocalCollectionAdapter
+from .milvus_adapter import MilvusCollectionAdapter
 from .opengauss_adapter import OpenGaussCollectionAdapter
 from .qdrant_adapter import QdrantCollectionAdapter
 from .vikingdb_private_adapter import VikingDBPrivateCollectionAdapter
@@ -16,6 +17,7 @@ __all__ = [
     "LocalCollectionAdapter",
     "CuVSCollectionAdapter",
     "HttpCollectionAdapter",
+    "MilvusCollectionAdapter",
     "OpenGaussCollectionAdapter",
     "QdrantCollectionAdapter",
     "VolcengineCollectionAdapter",

--- a/openviking/storage/vectordb_adapters/__init__.py
+++ b/openviking/storage/vectordb_adapters/__init__.py
@@ -6,6 +6,7 @@ from .base import CollectionAdapter
 from .factory import create_collection_adapter
 from .http_adapter import HttpCollectionAdapter
 from .local_adapter import CuVSCollectionAdapter, LocalCollectionAdapter
+from .milvus_adapter import MilvusCollectionAdapter
 from .vikingdb_private_adapter import VikingDBPrivateCollectionAdapter
 from .volcengine_adapter import VolcengineCollectionAdapter
 
@@ -14,6 +15,7 @@ __all__ = [
     "LocalCollectionAdapter",
     "CuVSCollectionAdapter",
     "HttpCollectionAdapter",
+    "MilvusCollectionAdapter",
     "VolcengineCollectionAdapter",
     "VikingDBPrivateCollectionAdapter",
     "create_collection_adapter",

--- a/openviking/storage/vectordb_adapters/factory.py
+++ b/openviking/storage/vectordb_adapters/factory.py
@@ -9,6 +9,7 @@ import importlib
 from .base import CollectionAdapter
 from .http_adapter import HttpCollectionAdapter
 from .local_adapter import CuVSCollectionAdapter, LocalCollectionAdapter
+from .milvus_adapter import MilvusCollectionAdapter
 from .opengauss_adapter import OpenGaussCollectionAdapter
 from .qdrant_adapter import QdrantCollectionAdapter
 from .vikingdb_private_adapter import VikingDBPrivateCollectionAdapter
@@ -18,6 +19,7 @@ _ADAPTER_REGISTRY: dict[str, type[CollectionAdapter]] = {
     "local": LocalCollectionAdapter,
     "cuvs": CuVSCollectionAdapter,
     "http": HttpCollectionAdapter,
+    "milvus": MilvusCollectionAdapter,
     "opengauss": OpenGaussCollectionAdapter,
     "qdrant": QdrantCollectionAdapter,
     "volcengine": VolcengineCollectionAdapter,

--- a/openviking/storage/vectordb_adapters/factory.py
+++ b/openviking/storage/vectordb_adapters/factory.py
@@ -9,6 +9,7 @@ import importlib
 from .base import CollectionAdapter
 from .http_adapter import HttpCollectionAdapter
 from .local_adapter import CuVSCollectionAdapter, LocalCollectionAdapter
+from .milvus_adapter import MilvusCollectionAdapter
 from .vikingdb_private_adapter import VikingDBPrivateCollectionAdapter
 from .volcengine_adapter import VolcengineCollectionAdapter
 
@@ -16,6 +17,7 @@ _ADAPTER_REGISTRY: dict[str, type[CollectionAdapter]] = {
     "local": LocalCollectionAdapter,
     "cuvs": CuVSCollectionAdapter,
     "http": HttpCollectionAdapter,
+    "milvus": MilvusCollectionAdapter,
     "volcengine": VolcengineCollectionAdapter,
     "vikingdb": VikingDBPrivateCollectionAdapter,
 }

--- a/openviking/storage/vectordb_adapters/milvus_adapter.py
+++ b/openviking/storage/vectordb_adapters/milvus_adapter.py
@@ -1,0 +1,1644 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Milvus-backed vector collection adapter."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import re
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from openviking.storage.expr import (
+    And,
+    Contains,
+    Eq,
+    FilterExpr,
+    In,
+    Or,
+    PathScope,
+    Range,
+    RawDSL,
+    TimeRange,
+)
+from openviking.storage.vectordb.collection.collection import Collection, ICollection
+from openviking.storage.vectordb.collection.result import (
+    AggregateResult,
+    DataItem,
+    FetchDataInCollectionResult,
+    SearchItemResult,
+    SearchResult,
+)
+from openviking.storage.vectordb.index.index import IIndex
+from openviking.storage.vectordb.store.data import DeltaRecord
+from openviking.storage.vectordb_adapters.base import CollectionAdapter
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_URI = "./milvus.db"
+_DEFAULT_TIMEOUT_SECONDS = 30
+_DEFAULT_QUERY_LIMIT = 10_000
+_MILVUS_MAX_COLLECTION_NAME_LENGTH = 255
+_MILVUS_VARCHAR_MAX_LENGTH = 65_535
+_ID_MAX_LENGTH = 512
+_URI_MAX_LENGTH = 4096
+_FIELD_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_COLLECTION_NAME_RE = re.compile(r"[^A-Za-z0-9_]+")
+_VECTOR_FIELD_TYPES = {"vector", "float_vector"}
+_LIST_STRING_FIELD_TYPES = {"list<string>", "array<string>"}
+_STRING_FIELD_TYPES = {"string", "path", "text", "date_time"}
+_INT_FIELD_TYPES = {"int64", "int32", "integer", "long"}
+_FLOAT_FIELD_TYPES = {"float", "double"}
+_BOOL_FIELD_TYPES = {"bool", "boolean"}
+_META_PROPERTY_KEY = "openviking_meta"
+_INDEX_META_PROPERTY_PREFIX = "openviking_index_"
+_META_COLLECTION_NAME = "ov_openviking_milvus_meta"
+_META_VECTOR_FIELD = "meta_vector"
+
+
+def _import_pymilvus():
+    try:
+        import pymilvus  # type: ignore  # noqa: PLC0415
+
+        return pymilvus
+    except ImportError as exc:  # pragma: no cover - exercised only without optional driver
+        raise ImportError(
+            "The Milvus backend requires pymilvus with Milvus Lite support. "
+            "Install the `openviking[milvus]` optional extra."
+        ) from exc
+
+
+def _safe_collection_name(*parts: Any, prefix: str = "ov") -> str:
+    raw = "_".join(str(part or "") for part in parts)
+    normalized = _COLLECTION_NAME_RE.sub("_", raw).strip("_")
+    if not normalized:
+        normalized = "default"
+    if normalized[0].isdigit():
+        normalized = f"{prefix}_{normalized}"
+    elif prefix and not normalized.startswith(f"{prefix}_"):
+        normalized = f"{prefix}_{normalized}"
+    if len(normalized) <= _MILVUS_MAX_COLLECTION_NAME_LENGTH:
+        return normalized
+
+    import hashlib
+
+    digest = hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:10]
+    keep = _MILVUS_MAX_COLLECTION_NAME_LENGTH - len(digest) - 1
+    return f"{normalized[:keep]}_{digest}"
+
+
+def _normalize_distance(distance: str) -> str:
+    value = (distance or "cosine").strip().lower()
+    if value not in {"cosine", "l2", "ip"}:
+        raise ValueError(
+            f"Milvus backend supports only cosine, l2, and ip distance metrics; got {distance!r}"
+        )
+    return value
+
+
+def _milvus_metric(distance: str) -> str:
+    return {"cosine": "COSINE", "l2": "L2", "ip": "IP"}[_normalize_distance(distance)]
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    return str(value)
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=_json_default)
+
+
+def _json_loads(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _truncate_utf8(value: str, byte_limit: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= byte_limit:
+        return value
+    cut = byte_limit
+    while cut > 0 and (encoded[cut] & 0xC0) == 0x80:
+        cut -= 1
+    return encoded[:cut].decode("utf-8")
+
+
+def _encode_scope_roots(value: Any) -> str:
+    roots = value if isinstance(value, list) else [value]
+    normalized = [str(root) for root in roots if root is not None]
+    return "\n" + "\n".join(normalized) + "\n" if normalized else "\n"
+
+
+def _sparse_dot(left: Optional[Dict[str, float]], right: Optional[Dict[str, float]]) -> float:
+    if not left or not right:
+        return 0.0
+    total = 0.0
+    for key, raw_value in left.items():
+        try:
+            total += float(raw_value) * float(right.get(key, 0.0))
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _coerce_datetime_value(value: Any) -> Any:
+    if isinstance(value, dt.datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=dt.timezone.utc)
+        return value.isoformat()
+    if isinstance(value, dt.date):
+        return value.isoformat()
+    return value
+
+
+def _format_number(value: Any) -> str:
+    if isinstance(value, bool):
+        raise ValueError("Boolean values are not valid numeric filter operands")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"Invalid numeric filter value: {value!r}")
+    if number.is_integer():
+        return str(int(number))
+    return format(number, ".12g")
+
+
+def _quote_value(value: Any) -> str:
+    value = _coerce_datetime_value(value)
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return _format_number(value)
+    text = (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace('"', '\\"')
+    )
+    return f'"{text}"'
+
+
+def _format_value_list(values: Iterable[Any]) -> str:
+    return "[" + ", ".join(_quote_value(value) for value in values) + "]"
+
+
+def _score_from_hit(hit: Dict[str, Any], distance_metric: str) -> float:
+    raw_score = (
+        hit.get("score")
+        if hit.get("score") is not None
+        else hit.get("distance", hit.get("_distance", 0.0))
+    )
+    try:
+        score = float(raw_score)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(score):
+        return 0.0
+    if distance_metric == "l2":
+        return 1.0 / (1.0 + max(score, 0.0))
+    return score
+
+
+class MilvusIndex(IIndex):
+    """Metadata-only logical index facade for Milvus."""
+
+    def __init__(self, collection: "MilvusCollection", index_name: str, meta: Dict[str, Any]):
+        super().__init__(meta=meta)
+        self._collection = collection
+        self._index_name = index_name
+        self._meta = dict(meta)
+
+    def upsert_data(self, delta_list: List[DeltaRecord]):
+        raise NotImplementedError("MilvusIndex.upsert_data is managed at collection level")
+
+    def delete_data(self, delta_list: List[DeltaRecord]):
+        raise NotImplementedError("MilvusIndex.delete_data is managed at collection level")
+
+    def search(
+        self,
+        query_vector: Optional[List[float]],
+        limit: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        sparse_raw_terms: Optional[List[str]] = None,
+        sparse_values: Optional[List[float]] = None,
+    ):
+        raise NotImplementedError("MilvusIndex.search is not exposed via raw index interface")
+
+    def aggregate(self, filters: Optional[Dict[str, Any]] = None):
+        raise NotImplementedError("MilvusIndex.aggregate is not exposed via raw index interface")
+
+    def update(
+        self, scalar_index: Optional[Dict[str, Any]] = None, description: Optional[str] = None
+    ):
+        self._collection.update_index(
+            index_name=self._index_name,
+            scalar_index=scalar_index,
+            description=description,
+        )
+        self._meta = self._collection.get_index_meta_data(self._index_name) or self._meta
+
+    def get_meta_data(self):
+        return dict(self._meta)
+
+    def close(self):
+        return None
+
+    def drop(self):
+        self._collection.drop_index(self._index_name)
+
+
+class MilvusCollection(ICollection):
+    """A single OpenViking collection stored in Milvus."""
+
+    INTERNAL_PATH_FIELDS = {
+        "parent_uri": "path",
+        "scope_roots": "string",
+        "uri_depth": "int64",
+    }
+
+    def __init__(
+        self,
+        *,
+        client: Any,
+        logical_collection_name: str,
+        physical_collection_name: str,
+        project_name: str,
+        dense_vector_name: str,
+        sparse_vector_name: str,
+        distance_metric: str,
+        timeout_seconds: int,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self._client = client
+        self._logical_collection_name = logical_collection_name
+        self._physical_collection_name = physical_collection_name
+        self._project_name = project_name
+        self._dense_vector_name = dense_vector_name
+        self._sparse_vector_name = sparse_vector_name
+        self._distance_metric = _normalize_distance(distance_metric)
+        self._timeout_seconds = int(timeout_seconds)
+        self._meta = dict(meta or {})
+        self._field_types = self._build_field_type_map(self._meta)
+        self._varchar_lengths = self._build_varchar_length_map()
+        self._vector_dim = self._extract_vector_dim(self._meta)
+
+    @property
+    def collection_name(self) -> str:
+        return self._physical_collection_name
+
+    @staticmethod
+    def _extract_vector_dim(meta: Dict[str, Any]) -> int:
+        for field in meta.get("Fields", []) or []:
+            if str(field.get("FieldType") or "").lower() in _VECTOR_FIELD_TYPES:
+                try:
+                    return int(field.get("Dim") or 0)
+                except (TypeError, ValueError):
+                    return 0
+        return 0
+
+    @classmethod
+    def _build_field_type_map(cls, meta: Dict[str, Any]) -> Dict[str, str]:
+        mapping: Dict[str, str] = {}
+        for field in meta.get("Fields", []) or []:
+            name = field.get("FieldName")
+            field_type = field.get("FieldType")
+            if name and field_type:
+                mapping[str(name)] = str(field_type).lower()
+        mapping.setdefault("id", "string")
+        mapping.setdefault("vector", "vector")
+        mapping.setdefault("sparse_vector", "json")
+        mapping.update(cls.INTERNAL_PATH_FIELDS)
+        return mapping
+
+    def _build_varchar_length_map(self) -> Dict[str, int]:
+        lengths: Dict[str, int] = {
+            "id": _ID_MAX_LENGTH,
+            "uri": _URI_MAX_LENGTH,
+            "parent_uri": _URI_MAX_LENGTH,
+            "scope_roots": _MILVUS_VARCHAR_MAX_LENGTH,
+        }
+        for field_name, field_type in self._field_types.items():
+            if field_type in _STRING_FIELD_TYPES:
+                lengths.setdefault(field_name, _MILVUS_VARCHAR_MAX_LENGTH)
+        return lengths
+
+    def collection_exists(self) -> bool:
+        return bool(
+            self._client.has_collection(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
+            )
+        )
+
+    def _collection_properties(self) -> Dict[str, Any]:
+        try:
+            desc = self._client.describe_collection(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
+            )
+        except Exception:
+            return {}
+        props = desc.get("properties") if isinstance(desc, dict) else None
+        return dict(props or {})
+
+    def _ensure_meta_collection(self) -> None:
+        try:
+            if self._client.has_collection(
+                collection_name=_META_COLLECTION_NAME,
+                timeout=self._timeout_seconds,
+            ):
+                return
+            pymilvus = _import_pymilvus()
+            DataType = pymilvus.DataType
+            schema = self._client.create_schema(auto_id=False, enable_dynamic_field=False)
+            schema.add_field(
+                field_name="id",
+                datatype=DataType.VARCHAR,
+                is_primary=True,
+                max_length=_MILVUS_MAX_COLLECTION_NAME_LENGTH,
+            )
+            schema.add_field(
+                field_name="meta_json",
+                datatype=DataType.VARCHAR,
+                max_length=_MILVUS_VARCHAR_MAX_LENGTH,
+            )
+            schema.add_field(field_name="indexes_json", datatype=DataType.JSON, nullable=True)
+            schema.add_field(field_name=_META_VECTOR_FIELD, datatype=DataType.FLOAT_VECTOR, dim=1)
+            self._client.create_collection(
+                collection_name=_META_COLLECTION_NAME,
+                schema=schema,
+                timeout=self._timeout_seconds,
+            )
+        except Exception as exc:
+            logger.warning("Failed to ensure Milvus metadata collection: %s", exc)
+
+    def _load_meta_record(self) -> Dict[str, Any]:
+        self._ensure_meta_collection()
+        try:
+            rows = self._client.get(
+                collection_name=_META_COLLECTION_NAME,
+                ids=[self._physical_collection_name],
+                output_fields=["meta_json", "indexes_json"],
+                timeout=self._timeout_seconds,
+            )
+        except Exception:
+            return {}
+        return dict(rows[0]) if rows else {}
+
+    def _save_meta_record(self, *, meta: Optional[Dict[str, Any]] = None) -> None:
+        self._ensure_meta_collection()
+        existing = self._load_meta_record()
+        meta_json = _json_dumps(meta if meta is not None else self._meta)
+        indexes_json = existing.get("indexes_json") if existing else {}
+        try:
+            self._client.upsert(
+                collection_name=_META_COLLECTION_NAME,
+                data=[
+                    {
+                        "id": self._physical_collection_name,
+                        "meta_json": meta_json,
+                        "indexes_json": indexes_json if isinstance(indexes_json, dict) else {},
+                        _META_VECTOR_FIELD: [0.0],
+                    }
+                ],
+                timeout=self._timeout_seconds,
+            )
+        except Exception as exc:
+            logger.warning("Failed to persist Milvus metadata record: %s", exc)
+
+    def load_remote_meta(self) -> Optional[Dict[str, Any]]:
+        record = self._load_meta_record()
+        raw_meta = record.get("meta_json")
+        if isinstance(raw_meta, str):
+            try:
+                meta = json.loads(raw_meta)
+            except (TypeError, ValueError):
+                meta = None
+            if isinstance(meta, dict):
+                self._meta = meta
+                self._field_types = self._build_field_type_map(meta)
+                self._varchar_lengths = self._build_varchar_length_map()
+                self._vector_dim = self._extract_vector_dim(meta)
+                return meta
+
+        props = self._collection_properties()
+        raw_meta = props.get(_META_PROPERTY_KEY)
+        if isinstance(raw_meta, str):
+            try:
+                meta = json.loads(raw_meta)
+            except (TypeError, ValueError):
+                meta = None
+            if isinstance(meta, dict):
+                self._meta = meta
+                self._field_types = self._build_field_type_map(meta)
+                self._varchar_lengths = self._build_varchar_length_map()
+                self._vector_dim = self._extract_vector_dim(meta)
+                return meta
+
+        return None
+
+    def create_remote_collection(
+        self,
+        meta_data: Dict[str, Any],
+        *,
+        consistency_level: Optional[str] = None,
+    ) -> None:
+        self._meta = dict(meta_data)
+        self._field_types = self._build_field_type_map(self._meta)
+        self._varchar_lengths = self._build_varchar_length_map()
+        self._vector_dim = self._extract_vector_dim(self._meta)
+        if self._vector_dim <= 0:
+            raise ValueError("Milvus collection requires a positive dense vector dimension")
+
+        pymilvus = _import_pymilvus()
+        schema = self._build_schema(pymilvus)
+        create_kwargs: Dict[str, Any] = {}
+        if consistency_level:
+            create_kwargs["consistency_level"] = consistency_level
+        self._client.create_collection(
+            collection_name=self._physical_collection_name,
+            schema=schema,
+            timeout=self._timeout_seconds,
+            **create_kwargs,
+        )
+        self._save_collection_meta()
+
+    def _build_schema(self, pymilvus: Any):
+        DataType = pymilvus.DataType
+        schema = self._client.create_schema(
+            auto_id=False,
+            enable_dynamic_field=True,
+            description=self._meta.get("Description") or "",
+        )
+        seen = set()
+        for field in self._iter_schema_fields():
+            field_name = str(field["FieldName"])
+            if field_name in seen:
+                continue
+            seen.add(field_name)
+            field_type = str(field.get("FieldType") or "").lower()
+            kwargs: Dict[str, Any] = {}
+            if field_name == "id":
+                kwargs.update(is_primary=True, max_length=_ID_MAX_LENGTH)
+                datatype = DataType.VARCHAR
+            elif field_type in _VECTOR_FIELD_TYPES:
+                dim = int(field.get("Dim") or self._vector_dim)
+                if dim <= 0:
+                    raise ValueError("Milvus vector field requires Dim")
+                datatype = DataType.FLOAT_VECTOR
+                kwargs["dim"] = dim
+            elif field_name == self._sparse_vector_name or field_type in {"json", "sparse_vector"}:
+                datatype = DataType.JSON
+                kwargs["nullable"] = True
+            elif field_type in _LIST_STRING_FIELD_TYPES:
+                datatype = DataType.ARRAY
+                kwargs.update(
+                    element_type=DataType.VARCHAR,
+                    max_capacity=1024,
+                    max_length=1024,
+                    nullable=True,
+                )
+            elif field_type in _INT_FIELD_TYPES:
+                datatype = DataType.INT64
+                kwargs["nullable"] = True
+            elif field_type in _FLOAT_FIELD_TYPES:
+                datatype = DataType.DOUBLE
+                kwargs["nullable"] = True
+            elif field_type in _BOOL_FIELD_TYPES:
+                datatype = DataType.BOOL
+                kwargs["nullable"] = True
+            else:
+                datatype = DataType.VARCHAR
+                kwargs.update(
+                    max_length=self._varchar_lengths.get(field_name, _MILVUS_VARCHAR_MAX_LENGTH),
+                    nullable=True,
+                )
+            schema.add_field(field_name=field_name, datatype=datatype, **kwargs)
+        return schema
+
+    def _iter_schema_fields(self) -> List[Dict[str, Any]]:
+        fields = [dict(field) for field in self._meta.get("Fields", []) or []]
+        names = {field.get("FieldName") for field in fields}
+        for field_name, field_type in self.INTERNAL_PATH_FIELDS.items():
+            if field_name not in names:
+                fields.append({"FieldName": field_name, "FieldType": field_type})
+        return fields
+
+    def _save_collection_meta(self) -> None:
+        self._save_meta_record(meta=self._meta)
+        try:
+            self._client.alter_collection_properties(
+                collection_name=self._physical_collection_name,
+                properties={_META_PROPERTY_KEY: _json_dumps(self._meta)},
+                timeout=self._timeout_seconds,
+            )
+        except Exception as exc:
+            logger.debug("Milvus collection properties are not available: %s", exc)
+
+    def update(self, fields: Optional[Dict[str, Any]] = None, description: Optional[str] = None):
+        if fields:
+            self._meta.update(fields)
+        if description is not None:
+            self._meta["Description"] = description
+        self._save_collection_meta()
+        return dict(self._meta)
+
+    def get_meta_data(self):
+        if not self._meta:
+            self.load_remote_meta()
+        return dict(self._meta)
+
+    def close(self):
+        return None
+
+    def drop(self):
+        if self.collection_exists():
+            self._client.drop_collection(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
+            )
+        try:
+            self._client.delete(
+                collection_name=_META_COLLECTION_NAME,
+                ids=[self._physical_collection_name],
+                timeout=self._timeout_seconds,
+            )
+        except Exception:
+            pass
+
+    def create_index(self, index_name: str, meta_data: Dict[str, Any]) -> IIndex:
+        meta = dict(meta_data or {})
+        vector_meta = dict(meta.get("VectorIndex") or {})
+        metric_type = _milvus_metric(vector_meta.get("Distance") or self._distance_metric)
+        existing_indexes = set(self.list_indexes() or [])
+        if index_name in existing_indexes or self._dense_vector_name in existing_indexes:
+            meta["VectorIndex"] = {
+                **vector_meta,
+                "IndexType": "AUTOINDEX",
+                "Distance": self._distance_metric,
+            }
+            self._save_index_meta(index_name, meta)
+            return MilvusIndex(self, index_name, meta)
+
+        index_params = self._client.prepare_index_params()
+        index_params.add_index(
+            field_name=self._dense_vector_name,
+            index_name=index_name,
+            index_type="AUTOINDEX",
+            metric_type=metric_type,
+        )
+        try:
+            self._client.create_index(
+                collection_name=self._physical_collection_name,
+                index_params=index_params,
+                timeout=self._timeout_seconds,
+            )
+        except Exception as exc:
+            if "index already" not in str(exc).lower():
+                raise
+        try:
+            self._client.load_collection(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
+            )
+        except Exception as exc:
+            logger.debug("Milvus collection load skipped or failed: %s", exc)
+        meta["VectorIndex"] = {
+            **vector_meta,
+            "IndexType": "AUTOINDEX",
+            "Distance": self._distance_metric,
+        }
+        self._save_index_meta(index_name, meta)
+        return MilvusIndex(self, index_name, meta)
+
+    def _save_index_meta(self, index_name: str, meta: Dict[str, Any]) -> None:
+        self._ensure_meta_collection()
+        record = self._load_meta_record()
+        indexes = record.get("indexes_json") if record else {}
+        if not isinstance(indexes, dict):
+            indexes = {}
+        indexes[index_name] = meta
+        try:
+            self._client.upsert(
+                collection_name=_META_COLLECTION_NAME,
+                data=[
+                    {
+                        "id": self._physical_collection_name,
+                        "meta_json": record.get("meta_json") or _json_dumps(self._meta),
+                        "indexes_json": indexes,
+                        _META_VECTOR_FIELD: [0.0],
+                    }
+                ],
+                timeout=self._timeout_seconds,
+            )
+        except Exception as exc:
+            logger.warning("Failed to persist Milvus index metadata: %s", exc)
+        try:
+            self._client.alter_collection_properties(
+                collection_name=self._physical_collection_name,
+                properties={f"{_INDEX_META_PROPERTY_PREFIX}{index_name}": _json_dumps(meta)},
+                timeout=self._timeout_seconds,
+            )
+        except Exception as exc:
+            logger.debug("Milvus index properties are not available: %s", exc)
+
+    def has_index(self, index_name: str) -> bool:
+        return self.get_index_meta_data(index_name) is not None or index_name in (
+            self.list_indexes() or []
+        )
+
+    def get_index(self, index_name: str) -> Optional[IIndex]:
+        meta = self.get_index_meta_data(index_name)
+        return MilvusIndex(self, index_name, meta) if meta else None
+
+    def update_index(
+        self,
+        index_name: str,
+        scalar_index: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+    ):
+        meta = self.get_index_meta_data(index_name) or {"IndexName": index_name}
+        if scalar_index is not None:
+            meta["ScalarIndex"] = (
+                list(scalar_index.keys()) if isinstance(scalar_index, dict) else list(scalar_index)
+            )
+        if description is not None:
+            meta["Description"] = description
+        self._save_index_meta(index_name, meta)
+        return meta
+
+    def get_index_meta_data(self, index_name: str):
+        record = self._load_meta_record()
+        indexes = record.get("indexes_json") if record else {}
+        if isinstance(indexes, dict) and isinstance(indexes.get(index_name), dict):
+            return indexes[index_name]
+
+        props = self._collection_properties()
+        raw_meta = props.get(f"{_INDEX_META_PROPERTY_PREFIX}{index_name}")
+        if not isinstance(raw_meta, str):
+            return None
+        try:
+            meta = json.loads(raw_meta)
+        except (TypeError, ValueError):
+            return None
+        return meta if isinstance(meta, dict) else None
+
+    def list_indexes(self):
+        try:
+            return list(
+                self._client.list_indexes(
+                    collection_name=self._physical_collection_name,
+                    timeout=self._timeout_seconds,
+                )
+                or []
+            )
+        except Exception:
+            return []
+
+    def drop_index(self, index_name: str):
+        try:
+            self._client.release_collection(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
+            )
+        except Exception:
+            pass
+        for remote_name in list(self.list_indexes() or []):
+            if remote_name == index_name or str(remote_name).startswith(f"{index_name}_"):
+                try:
+                    self._client.drop_index(
+                        collection_name=self._physical_collection_name,
+                        index_name=remote_name,
+                        timeout=self._timeout_seconds,
+                    )
+                except Exception as exc:
+                    logger.warning("Failed to drop Milvus index %s: %s", remote_name, exc)
+        try:
+            self._client.drop_collection_properties(
+                collection_name=self._physical_collection_name,
+                property_keys=[f"{_INDEX_META_PROPERTY_PREFIX}{index_name}"],
+                timeout=self._timeout_seconds,
+            )
+        except Exception:
+            pass
+        try:
+            record = self._load_meta_record()
+            indexes = record.get("indexes_json") if record else {}
+            if isinstance(indexes, dict) and index_name in indexes:
+                indexes.pop(index_name, None)
+                self._client.upsert(
+                    collection_name=_META_COLLECTION_NAME,
+                    data=[
+                        {
+                            "id": self._physical_collection_name,
+                            "meta_json": record.get("meta_json") or _json_dumps(self._meta),
+                            "indexes_json": indexes,
+                            _META_VECTOR_FIELD: [0.0],
+                        }
+                    ],
+                    timeout=self._timeout_seconds,
+                )
+        except Exception:
+            pass
+
+    def _prepare_record_for_write(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        prepared: Dict[str, Any] = {}
+        for field_name, value in record.items():
+            if value is None:
+                continue
+            field_type = self._field_types.get(field_name, "")
+            if field_name == "id":
+                text = str(value)
+                if len(text.encode("utf-8")) > _ID_MAX_LENGTH:
+                    raise ValueError("Milvus record id exceeds 512 bytes")
+                prepared[field_name] = text
+            elif field_name == self._dense_vector_name:
+                prepared[field_name] = self._coerce_dense_vector(value)
+            elif field_name == "scope_roots":
+                prepared[field_name] = _encode_scope_roots(value)
+            elif field_name == self._sparse_vector_name or field_type == "sparse_vector":
+                prepared[field_name] = self._coerce_sparse_vector(value)
+            elif field_type in _LIST_STRING_FIELD_TYPES:
+                prepared[field_name] = [str(item) for item in (value or []) if item is not None]
+            elif field_type in _INT_FIELD_TYPES:
+                prepared[field_name] = int(value)
+            elif field_type in _FLOAT_FIELD_TYPES:
+                number = float(value)
+                prepared[field_name] = number if math.isfinite(number) else 0.0
+            elif field_type in _BOOL_FIELD_TYPES:
+                prepared[field_name] = bool(value)
+            elif field_type == "date_time":
+                prepared[field_name] = str(_coerce_datetime_value(value))
+            elif isinstance(value, str):
+                limit = self._varchar_lengths.get(field_name)
+                prepared[field_name] = _truncate_utf8(value, limit) if limit else value
+            else:
+                prepared[field_name] = value
+        return prepared
+
+    def _coerce_dense_vector(self, value: Any) -> List[float]:
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            raise ValueError("Milvus dense vector must be a sequence of floats")
+        vector = []
+        for item in value:
+            number = float(item)
+            vector.append(number if math.isfinite(number) else 0.0)
+        if self._vector_dim > 0 and len(vector) != self._vector_dim:
+            raise ValueError(
+                f"Milvus dense vector dimension mismatch: expected {self._vector_dim}, "
+                f"got {len(vector)}"
+            )
+        return vector
+
+    @staticmethod
+    def _coerce_sparse_vector(value: Any) -> Dict[str, float]:
+        if value in (None, ""):
+            return {}
+        if isinstance(value, str):
+            decoded = _json_loads(value)
+            value = decoded if isinstance(decoded, dict) else {}
+        if not isinstance(value, dict):
+            return {}
+        result: Dict[str, float] = {}
+        for key, raw_value in value.items():
+            try:
+                number = float(raw_value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(number):
+                result[str(key)] = number
+        return result
+
+    def _record_from_entity(self, entity: Dict[str, Any]) -> tuple[Any, Dict[str, Any]]:
+        record = dict(entity or {})
+        record_id = record.pop("id", None)
+        if record_id is None:
+            record_id = entity.get("pk") or entity.get("primary_key")
+        return record_id, self._decode_record(record)
+
+    def _decode_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        decoded = dict(record)
+        sparse = decoded.get(self._sparse_vector_name)
+        if isinstance(sparse, str):
+            parsed = _json_loads(sparse)
+            decoded[self._sparse_vector_name] = parsed if isinstance(parsed, dict) else sparse
+        return decoded
+
+    def _select_output_fields(
+        self,
+        output_fields: Optional[List[str]],
+        *,
+        include_vector: bool = False,
+        include_sparse: bool = False,
+    ) -> List[str]:
+        if output_fields:
+            fields = [field for field in output_fields if field != "id"]
+        else:
+            fields = [field for field in self._field_types if field != "id"]
+        if not include_vector:
+            fields = [field for field in fields if field != self._dense_vector_name]
+        if not include_sparse:
+            fields = [field for field in fields if field != self._sparse_vector_name]
+        return list(dict.fromkeys(fields))
+
+    def search_by_vector(
+        self,
+        index_name: str,
+        dense_vector: Optional[List[float]] = None,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[str] = None,
+        sparse_vector: Optional[Dict[str, float]] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        del index_name
+        if limit <= 0:
+            return SearchResult()
+        if dense_vector is None:
+            return self._search_by_sparse(sparse_vector, limit, offset, filters, output_fields)
+
+        fetch_limit = max(limit + offset, limit)
+        fields = self._select_output_fields(
+            output_fields,
+            include_vector=False,
+            include_sparse=bool(sparse_vector),
+        )
+        raw_results = self._client.search(
+            collection_name=self._physical_collection_name,
+            data=[self._coerce_dense_vector(dense_vector)],
+            anns_field=self._dense_vector_name,
+            filter=filters or "",
+            limit=fetch_limit,
+            output_fields=fields,
+            search_params={"metric_type": _milvus_metric(self._distance_metric)},
+            timeout=self._timeout_seconds,
+        )
+        hits = raw_results[0] if raw_results else []
+        items: List[SearchItemResult] = []
+        for hit in hits:
+            entity = hit.get("entity") if isinstance(hit, dict) else None
+            entity = dict(entity or {})
+            if "id" not in entity and isinstance(hit, dict):
+                entity["id"] = hit.get("id")
+            record_id, payload = self._record_from_entity(entity)
+            score = _score_from_hit(hit, self._distance_metric) if isinstance(hit, dict) else 0.0
+            if sparse_vector:
+                sparse_payload = payload.pop(self._sparse_vector_name, None)
+                score += _sparse_dot(
+                    sparse_vector, sparse_payload if isinstance(sparse_payload, dict) else None
+                )
+            items.append(SearchItemResult(id=record_id, fields=payload, score=score))
+        if sparse_vector:
+            items.sort(key=lambda item: item.score or 0.0, reverse=True)
+        return SearchResult(data=items[offset : offset + limit])
+
+    def _search_by_sparse(
+        self,
+        sparse_vector: Optional[Dict[str, float]],
+        limit: int,
+        offset: int,
+        filters: Optional[str],
+        output_fields: Optional[List[str]],
+    ) -> SearchResult:
+        if not sparse_vector:
+            return SearchResult()
+        fields = self._select_output_fields(output_fields, include_sparse=True)
+        rows = self._client.query(
+            collection_name=self._physical_collection_name,
+            filter=filters or "",
+            output_fields=fields,
+            limit=max(limit + offset, _DEFAULT_QUERY_LIMIT),
+            timeout=self._timeout_seconds,
+        )
+        items = []
+        for row in rows:
+            record_id, payload = self._record_from_entity(row)
+            sparse_payload = payload.pop(self._sparse_vector_name, None)
+            score = _sparse_dot(
+                sparse_vector, sparse_payload if isinstance(sparse_payload, dict) else None
+            )
+            if score > 0:
+                items.append(SearchItemResult(id=record_id, fields=payload, score=score))
+        items.sort(key=lambda item: item.score or 0.0, reverse=True)
+        return SearchResult(data=items[offset : offset + limit])
+
+    def search_by_keywords(
+        self,
+        index_name: str,
+        keywords: Optional[List[str]] = None,
+        query: Optional[str] = None,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[str] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        del index_name
+        query_text = query or " ".join(keywords or [])
+        if not query_text.strip():
+            return SearchResult()
+        compiler = MilvusFilterCompiler(self._field_types)
+        text_filter = compiler.compile_legacy_filter(
+            {
+                "op": "or",
+                "conds": [
+                    {"op": "contains", "field": field, "substring": query_text}
+                    for field in ("name", "description", "abstract", "tags", "content")
+                    if field in self._field_types
+                ],
+            }
+        )
+        combined = (
+            f"({filters}) and ({text_filter})"
+            if filters and text_filter
+            else filters or text_filter
+        )
+        return self.search_by_random("", limit, offset, combined, output_fields)
+
+    def search_by_id(
+        self,
+        index_name: str,
+        id: Any,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[str] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        rows = self._client.get(
+            collection_name=self._physical_collection_name,
+            ids=[str(id)],
+            output_fields=self._select_output_fields(
+                None,
+                include_vector=True,
+                include_sparse=True,
+            ),
+            timeout=self._timeout_seconds,
+        )
+        if not rows:
+            return SearchResult()
+        dense_vector = rows[0].get(self._dense_vector_name)
+        sparse_vector = rows[0].get(self._sparse_vector_name)
+        result = self.search_by_vector(
+            index_name=index_name,
+            dense_vector=dense_vector,
+            sparse_vector=sparse_vector if isinstance(sparse_vector, dict) else None,
+            limit=limit + offset + 1,
+            offset=0,
+            filters=filters,
+            output_fields=output_fields,
+        )
+        data = [item for item in result.data if str(item.id) != str(id)]
+        return SearchResult(data=data[offset : offset + limit])
+
+    def search_by_multimodal(
+        self,
+        index_name: str,
+        text: Optional[str],
+        image: Optional[Any],
+        video: Optional[Any],
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[str] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        raise NotImplementedError("MilvusCollection.search_by_multimodal is not supported")
+
+    def search_by_random(
+        self,
+        index_name: str,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[str] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        del index_name
+        rows = self._client.query(
+            collection_name=self._physical_collection_name,
+            filter=filters or "",
+            output_fields=self._select_output_fields(output_fields),
+            limit=limit,
+            offset=offset,
+            timeout=self._timeout_seconds,
+        )
+        items = []
+        for row in rows:
+            record_id, payload = self._record_from_entity(row)
+            items.append(SearchItemResult(id=record_id, fields=payload, score=1.0))
+        return SearchResult(data=items)
+
+    def search_by_scalar(
+        self,
+        index_name: str,
+        field: str,
+        order: Optional[str] = "desc",
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[str] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        del index_name
+        fields = self._select_output_fields(output_fields)
+        if field not in fields:
+            fields.append(field)
+        rows = self._client.query(
+            collection_name=self._physical_collection_name,
+            filter=filters or "",
+            output_fields=fields,
+            limit=max(limit + offset, _DEFAULT_QUERY_LIMIT),
+            timeout=self._timeout_seconds,
+        )
+        reverse = (order or "desc").lower() == "desc"
+        rows.sort(key=lambda row: (row.get(field) is None, row.get(field)), reverse=reverse)
+        items = []
+        for row in rows[offset : offset + limit]:
+            record_id, payload = self._record_from_entity(row)
+            score = (
+                payload.pop(field, None)
+                if output_fields and field not in output_fields
+                else payload.get(field)
+            )
+            items.append(
+                SearchItemResult(
+                    id=record_id,
+                    fields=payload,
+                    score=score if isinstance(score, (int, float)) else None,
+                )
+            )
+        return SearchResult(data=items)
+
+    def upsert_data(self, data_list: List[Dict[str, Any]], ttl=0):
+        del ttl
+        if not data_list:
+            return []
+        records = [self._prepare_record_for_write(record) for record in data_list]
+        self._client.upsert(
+            collection_name=self._physical_collection_name,
+            data=records,
+            timeout=self._timeout_seconds,
+        )
+        return [record.get("id") for record in records if record.get("id") is not None]
+
+    def update_data(self, data_list: List[Dict[str, Any]]):
+        updated_records: List[Dict[str, Any]] = []
+        updated_ids: List[Any] = []
+        for raw_data in data_list:
+            if "id" not in raw_data or raw_data.get("id") in (None, ""):
+                raise ValueError("Milvus update requires id")
+            record_id = str(raw_data["id"])
+            existing = self.fetch_data([record_id]).items
+            if not existing:
+                raise ValueError(f"Milvus entity does not exist for update: {record_id}")
+            merged = dict(existing[0].fields or {})
+            merged["id"] = existing[0].id
+            merged.update(raw_data)
+            updated_records.append(self._prepare_record_for_write(merged))
+            updated_ids.append(record_id)
+        if updated_records:
+            self._client.upsert(
+                collection_name=self._physical_collection_name,
+                data=updated_records,
+                timeout=self._timeout_seconds,
+            )
+        return updated_ids
+
+    def fetch_data(self, primary_keys: List[Any]):
+        if not primary_keys:
+            return FetchDataInCollectionResult()
+        rows = self._client.get(
+            collection_name=self._physical_collection_name,
+            ids=[str(pk) for pk in primary_keys],
+            output_fields=self._select_output_fields(
+                None,
+                include_vector=True,
+                include_sparse=True,
+            ),
+            timeout=self._timeout_seconds,
+        )
+        items = []
+        found_ids = set()
+        for row in rows:
+            record_id, payload = self._record_from_entity(row)
+            if record_id is not None:
+                found_ids.add(str(record_id))
+            items.append(DataItem(id=record_id, fields=payload))
+        return FetchDataInCollectionResult(
+            items=items,
+            ids_not_exist=[pk for pk in primary_keys if str(pk) not in found_ids],
+        )
+
+    def delete_data(self, primary_keys: List[Any]):
+        if not primary_keys:
+            return None
+        self._client.delete(
+            collection_name=self._physical_collection_name,
+            ids=[str(pk) for pk in primary_keys],
+            timeout=self._timeout_seconds,
+        )
+        return None
+
+    def delete_all_data(self):
+        self._client.delete(
+            collection_name=self._physical_collection_name,
+            filter='id != ""',
+            timeout=self._timeout_seconds,
+        )
+
+    def aggregate_data(
+        self,
+        index_name: str,
+        op: str = "count",
+        field: Optional[str] = None,
+        filters: Optional[str] = None,
+        cond: Optional[Dict[str, Any]] = None,
+    ) -> AggregateResult:
+        del index_name
+        if op != "count":
+            return AggregateResult(agg={}, op=op, field=field)
+        if not field:
+            try:
+                rows = self._client.query(
+                    collection_name=self._physical_collection_name,
+                    filter=filters or "",
+                    output_fields=["count(*)"],
+                    timeout=self._timeout_seconds,
+                )
+                total = int((rows[0] if rows else {}).get("count(*)", 0))
+            except Exception:
+                rows = self._client.query(
+                    collection_name=self._physical_collection_name,
+                    filter=filters or "",
+                    output_fields=["id"],
+                    limit=_DEFAULT_QUERY_LIMIT,
+                    timeout=self._timeout_seconds,
+                )
+                total = len(rows)
+            return AggregateResult(agg={"_total": total}, op=op, field=None)
+
+        rows = self._client.query(
+            collection_name=self._physical_collection_name,
+            filter=filters or "",
+            output_fields=[field],
+            limit=_DEFAULT_QUERY_LIMIT,
+            timeout=self._timeout_seconds,
+        )
+        grouped: Dict[Any, int] = {}
+        for row in rows:
+            value = row.get(field)
+            if value is not None:
+                grouped[value] = grouped.get(value, 0) + 1
+        if cond:
+            grouped = {
+                key: value
+                for key, value in grouped.items()
+                if (cond.get("gt") is None or value > cond["gt"])
+                and (cond.get("gte") is None or value >= cond["gte"])
+                and (cond.get("lt") is None or value < cond["lt"])
+                and (cond.get("lte") is None or value <= cond["lte"])
+            }
+        return AggregateResult(agg=grouped, op=op, field=field)
+
+
+class MilvusFilterCompiler:
+    """Compile OpenViking filters to safe Milvus boolean expressions."""
+
+    def __init__(self, field_types: Optional[Dict[str, str]] = None) -> None:
+        self._field_types = field_types or {}
+
+    def compile(self, expr: FilterExpr | Dict[str, Any] | str | None) -> str:
+        if expr is None:
+            return ""
+        if isinstance(expr, str):
+            return expr.strip()
+        if isinstance(expr, dict):
+            if "op" in expr:
+                return self.compile_legacy_filter(expr)
+            return self._compile_mapping(expr)
+        if isinstance(expr, RawDSL):
+            payload = expr.payload
+            if isinstance(payload, dict) and "expr" in payload:
+                return str(payload["expr"]).strip()
+            return self.compile(payload)
+        if isinstance(expr, And):
+            return self._join("and", [self.compile(cond) for cond in expr.conds if cond])
+        if isinstance(expr, Or):
+            return self._join("or", [self.compile(cond) for cond in expr.conds if cond])
+        if isinstance(expr, Eq):
+            return self._eq(expr.field, expr.value)
+        if isinstance(expr, In):
+            return self._in(expr.field, list(expr.values))
+        if isinstance(expr, Range):
+            return self._range(
+                expr.field,
+                gte=expr.gte,
+                gt=expr.gt,
+                lte=expr.lte,
+                lt=expr.lt,
+            )
+        if isinstance(expr, TimeRange):
+            return self._range(
+                expr.field,
+                gte=_coerce_datetime_value(expr.start),
+                lt=_coerce_datetime_value(expr.end),
+            )
+        if isinstance(expr, Contains):
+            return self._contains(expr.field, expr.substring)
+        if isinstance(expr, PathScope):
+            path = MilvusCollectionAdapter._normalize_path(
+                CollectionAdapter._encode_uri_field_value(expr.path)
+                if expr.field in CollectionAdapter._URI_FIELD_NAMES
+                else expr.path
+            )
+            if expr.depth == 0:
+                return self._eq(expr.field, path)
+            if expr.depth == 1:
+                return self._eq("parent_uri", path)
+            if expr.depth == -1:
+                return self._contains("scope_roots", f"\n{path}\n")
+            raise ValueError(
+                f"Milvus adapter only supports PathScope depth 0/1/-1, got {expr.depth}"
+            )
+        raise TypeError(f"Unsupported filter expr type: {type(expr)!r}")
+
+    def compile_legacy_filter(self, payload: Dict[str, Any]) -> str:
+        op = str(payload.get("op") or "").lower()
+        if not op:
+            return self._compile_mapping(payload)
+        if op in {"and", "or"}:
+            return self._join(
+                op,
+                [self.compile_legacy_filter(cond) for cond in payload.get("conds", []) if cond],
+            )
+        if op == "must":
+            field = payload.get("field")
+            values = payload.get("conds", []) or []
+            if not values:
+                return ""
+            if field in CollectionAdapter._URI_FIELD_NAMES:
+                values = [
+                    MilvusCollectionAdapter._normalize_path(
+                        CollectionAdapter._encode_uri_field_value(value)
+                    )
+                    for value in values
+                ]
+            return (
+                self._in(str(field), list(values))
+                if len(values) > 1
+                else self._eq(field, values[0])
+            )
+        if op == "must_not":
+            field = payload.get("field")
+            values = payload.get("conds", []) or []
+            if not values:
+                return ""
+            expr = (
+                self._in(str(field), list(values))
+                if len(values) > 1
+                else self._eq(field, values[0])
+            )
+            return f"not ({expr})" if expr else ""
+        if op in {"range", "time_range"}:
+            return self._range(
+                str(payload.get("field")),
+                gte=payload.get("gte"),
+                gt=payload.get("gt"),
+                lte=payload.get("lte"),
+                lt=payload.get("lt"),
+            )
+        if op == "range_out":
+            field = str(payload.get("field"))
+            branches = []
+            if payload.get("gte") is not None:
+                branches.append(self._range(field, lt=payload["gte"]))
+            if payload.get("lte") is not None:
+                branches.append(self._range(field, gt=payload["lte"]))
+            return self._join("or", branches)
+        if op == "contains":
+            return self._contains(str(payload.get("field")), str(payload.get("substring", "")))
+        if op == "prefix":
+            field = str(payload.get("field"))
+            prefix = str(payload.get("prefix", ""))
+            if field in CollectionAdapter._URI_FIELD_NAMES:
+                return self.compile(PathScope(field, prefix, depth=-1))
+            return self._like(field, f"{prefix}%")
+        return self._compile_mapping(payload)
+
+    def _compile_mapping(self, payload: Dict[str, Any]) -> str:
+        return self._join("and", [self._eq(str(key), value) for key, value in payload.items()])
+
+    @staticmethod
+    def _join(op: str, exprs: Iterable[str]) -> str:
+        items = [expr for expr in exprs if expr]
+        if not items:
+            return ""
+        if len(items) == 1:
+            return items[0]
+        return f" {op} ".join(f"({item})" for item in items)
+
+    def _validate_field(self, field: Any) -> str:
+        if not isinstance(field, str) or not _FIELD_NAME_RE.match(field):
+            raise ValueError(f"Invalid Milvus filter field: {field!r}")
+        return field
+
+    def _eq(self, field: Any, value: Any) -> str:
+        field_name = self._validate_field(field)
+        field_type = self._field_types.get(field_name, "")
+        if value is None:
+            return f"{field_name} is null"
+        if field_type in _LIST_STRING_FIELD_TYPES:
+            return f"ARRAY_CONTAINS({field_name}, {_quote_value(value)})"
+        return f"{field_name} == {_quote_value(value)}"
+
+    def _in(self, field: str, values: List[Any]) -> str:
+        field_name = self._validate_field(field)
+        if not values:
+            return ""
+        field_type = self._field_types.get(field_name, "")
+        if field_type in _LIST_STRING_FIELD_TYPES:
+            return self._join(
+                "or",
+                [f"ARRAY_CONTAINS({field_name}, {_quote_value(value)})" for value in values],
+            )
+        non_null = [value for value in values if value is not None]
+        expr = f"{field_name} in {_format_value_list(non_null)}" if non_null else ""
+        if any(value is None for value in values):
+            null_expr = f"{field_name} is null"
+            return self._join("or", [expr, null_expr])
+        return expr
+
+    def _range(self, field: str, **bounds: Any) -> str:
+        field_name = self._validate_field(field)
+        parts = []
+        operators = {"gte": ">=", "gt": ">", "lte": "<=", "lt": "<"}
+        for key, operator in operators.items():
+            value = bounds.get(key)
+            if value is not None:
+                parts.append(f"{field_name} {operator} {_quote_value(value)}")
+        return " and ".join(parts)
+
+    def _contains(self, field: str, substring: str) -> str:
+        field_name = self._validate_field(field)
+        field_type = self._field_types.get(field_name, "")
+        if field_type in _LIST_STRING_FIELD_TYPES:
+            return f"ARRAY_CONTAINS({field_name}, {_quote_value(substring)})"
+        return self._like(field_name, f"%{substring}%")
+
+    def _like(self, field: str, pattern: str) -> str:
+        field_name = self._validate_field(field)
+        return f"{field_name} like {_quote_value(pattern)}"
+
+
+class MilvusCollectionAdapter(CollectionAdapter):
+    """CollectionAdapter backed by Milvus or Zilliz Cloud."""
+
+    mode = "milvus"
+    INTERNAL_PATH_FIELDS = ["parent_uri", "scope_roots", "uri_depth"]
+
+    def __init__(
+        self,
+        *,
+        uri: str,
+        token: Optional[str],
+        db_name: Optional[str],
+        consistency_level: Optional[str],
+        timeout_seconds: int,
+        project_name: str,
+        collection_name: str,
+        index_name: str,
+        distance_metric: str,
+        dense_vector_name: str,
+        sparse_vector_name: str,
+    ) -> None:
+        super().__init__(collection_name=collection_name, index_name=index_name)
+        self._uri = uri
+        self._token = token
+        self._db_name = db_name
+        self._consistency_level = consistency_level
+        self._timeout_seconds = int(timeout_seconds)
+        self._project_name = project_name
+        self._distance_metric = _normalize_distance(distance_metric)
+        self._dense_vector_name = dense_vector_name
+        self._sparse_vector_name = sparse_vector_name
+        self._client = None
+
+    @classmethod
+    def from_config(cls, config: Any):
+        cfg = getattr(config, "milvus", None)
+        params = dict(getattr(config, "custom_params", {}) or {})
+        uri = getattr(cfg, "uri", None) or getattr(config, "url", None) or params.get("uri")
+        token = getattr(cfg, "token", None) or params.get("token")
+        db_name = getattr(cfg, "db_name", None) or params.get("db_name")
+        consistency_level = getattr(cfg, "consistency_level", None) or params.get(
+            "consistency_level"
+        )
+        return cls(
+            uri=str(uri or _DEFAULT_URI),
+            token=str(token) if token else None,
+            db_name=str(db_name) if db_name else None,
+            consistency_level=str(consistency_level) if consistency_level else None,
+            timeout_seconds=int(
+                getattr(cfg, "timeout_seconds", None)
+                or params.get("timeout_seconds")
+                or _DEFAULT_TIMEOUT_SECONDS
+            ),
+            project_name=config.project_name or "default",
+            collection_name=config.name or "context",
+            index_name=config.index_name or "default",
+            distance_metric=config.distance_metric or "cosine",
+            dense_vector_name=str(
+                getattr(cfg, "dense_vector_name", None)
+                or params.get("dense_vector_name")
+                or "vector"
+            ),
+            sparse_vector_name=str(
+                getattr(cfg, "sparse_vector_name", None)
+                or params.get("sparse_vector_name")
+                or "sparse_vector"
+            ),
+        )
+
+    @property
+    def physical_collection_name(self) -> str:
+        return _safe_collection_name(self._project_name, self._collection_name)
+
+    def _connect(self):
+        if self._client is not None:
+            return self._client
+        pymilvus = _import_pymilvus()
+        kwargs: Dict[str, Any] = {
+            "uri": self._uri,
+            "timeout": self._timeout_seconds,
+        }
+        if self._token:
+            kwargs["token"] = self._token
+        if self._db_name:
+            kwargs["db_name"] = self._db_name
+        self._client = pymilvus.MilvusClient(**kwargs)
+        return self._client
+
+    def _new_collection(self, meta: Optional[Dict[str, Any]] = None) -> MilvusCollection:
+        return MilvusCollection(
+            client=self._connect(),
+            logical_collection_name=self._collection_name,
+            physical_collection_name=self.physical_collection_name,
+            project_name=self._project_name,
+            dense_vector_name=self._dense_vector_name,
+            sparse_vector_name=self._sparse_vector_name,
+            distance_metric=self._distance_metric,
+            timeout_seconds=self._timeout_seconds,
+            meta=meta,
+        )
+
+    def _load_existing_collection_if_needed(self) -> None:
+        if self._collection is not None:
+            return
+        raw_collection = self._new_collection()
+        if not raw_collection.collection_exists():
+            return
+        meta = raw_collection.load_remote_meta()
+        if not meta:
+            raise RuntimeError(
+                "Milvus collection exists but OpenViking metadata is missing: "
+                f"{self.physical_collection_name}. Use a different project/name, restore metadata, "
+                "or drop the stale Milvus collection."
+            )
+        self._collection = Collection(raw_collection)
+
+    def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
+        raw_collection = self._new_collection(meta)
+        raw_collection.create_remote_collection(meta, consistency_level=self._consistency_level)
+        return Collection(raw_collection)
+
+    def close(self) -> None:
+        super().close()
+        if self._client is not None:
+            close = getattr(self._client, "close", None)
+            if callable(close):
+                close()
+            self._client = None
+
+    def _sanitize_scalar_index_fields(
+        self,
+        scalar_index_fields: list[str],
+        fields_meta: list[dict[str, Any]],
+    ) -> list[str]:
+        del fields_meta
+        return list(dict.fromkeys(list(scalar_index_fields) + self.INTERNAL_PATH_FIELDS))
+
+    def _build_default_index_meta(
+        self,
+        *,
+        index_name: str,
+        distance: str,
+        use_sparse: bool,
+        sparse_weight: float,
+        scalar_index_fields: list[str],
+    ) -> Dict[str, Any]:
+        if use_sparse:
+            logger.warning(
+                "Milvus adapter stores sparse vectors but currently searches dense vectors first; "
+                "sparse scores are only applied to returned dense candidates."
+            )
+        return {
+            "IndexName": index_name,
+            "VectorIndex": {
+                "IndexType": "AUTOINDEX",
+                "Distance": _normalize_distance(distance),
+                "Quant": "int8",
+                "EnableSparse": bool(use_sparse),
+                "SearchWithSparseLogitAlpha": sparse_weight,
+            },
+            "ScalarIndex": scalar_index_fields,
+        }
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        stripped = (path or "").strip()
+        if not stripped:
+            return "/"
+        if not stripped.startswith("/"):
+            stripped = f"/{stripped}"
+        if len(stripped) > 1:
+            stripped = stripped.rstrip("/")
+        return stripped or "/"
+
+    @classmethod
+    def _compute_parent_uri(cls, uri: str) -> str:
+        normalized = cls._normalize_path(uri)
+        if normalized == "/":
+            return "/"
+        parts = normalized.strip("/").split("/")
+        if len(parts) <= 1:
+            return "/"
+        return "/" + "/".join(parts[:-1])
+
+    @classmethod
+    def _compute_scope_roots(cls, uri: str) -> List[str]:
+        normalized = cls._normalize_path(uri)
+        if normalized == "/":
+            return ["/"]
+        parts = normalized.strip("/").split("/")
+        roots = ["/"]
+        current_parts: List[str] = []
+        for part in parts[:-1]:
+            current_parts.append(part)
+            roots.append("/" + "/".join(current_parts))
+        return roots
+
+    def _normalize_record_for_write(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = dict(super()._normalize_record_for_write(record))
+        raw_uri = normalized.get("uri")
+        if isinstance(raw_uri, str):
+            normalized_uri = self._normalize_path(raw_uri)
+            normalized["uri"] = normalized_uri
+            normalized["parent_uri"] = self._compute_parent_uri(normalized_uri)
+            normalized["scope_roots"] = self._compute_scope_roots(normalized_uri)
+            normalized["uri_depth"] = len(
+                [part for part in normalized_uri.strip("/").split("/") if part]
+            )
+        return normalized
+
+    def _normalize_record_for_read(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = super()._normalize_record_for_read(record)
+        for field_name in self.INTERNAL_PATH_FIELDS:
+            normalized.pop(field_name, None)
+        return normalized
+
+    def _field_types_for_filter(self) -> Dict[str, str]:
+        try:
+            collection = self.get_collection()
+            meta = collection.get_meta_data() or {}
+            field_types = MilvusCollection._build_field_type_map(meta)
+        except Exception:
+            field_types = {
+                "id": "string",
+                self._dense_vector_name: "vector",
+                self._sparse_vector_name: "sparse_vector",
+                "uri": "path",
+                "parent_uri": "path",
+                "scope_roots": "string",
+                "uri_depth": "int64",
+                "level": "int64",
+                "active_count": "int64",
+                "search_tags": "list<string>",
+            }
+        return field_types
+
+    def _compile_filter(self, expr: FilterExpr | Dict[str, Any] | str | None) -> str:
+        return MilvusFilterCompiler(self._field_types_for_filter()).compile(expr)
+
+    def update_data(self, data_list: List[Dict[str, Any]]):
+        collection = self.get_collection()
+        normalized = [self._normalize_record_for_write(item) for item in data_list]
+        result = collection.update_data(normalized)
+        return [str(item) for item in (result or []) if item is not None]

--- a/openviking/storage/vectordb_adapters/milvus_adapter.py
+++ b/openviking/storage/vectordb_adapters/milvus_adapter.py
@@ -205,6 +205,8 @@ def _score_from_hit(hit: Dict[str, Any], distance_metric: str) -> float:
         return 0.0
     if not math.isfinite(score):
         return 0.0
+    if distance_metric == "cosine":
+        return 1.0 - score
     if distance_metric == "l2":
         return 1.0 / (1.0 + max(score, 0.0))
     return score

--- a/openviking/storage/vectordb_adapters/milvus_adapter.py
+++ b/openviking/storage/vectordb_adapters/milvus_adapter.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import json
 import math
 import re
+from copy import deepcopy
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from openviking.storage.expr import (
@@ -40,6 +42,7 @@ logger = get_logger(__name__)
 _DEFAULT_URI = "./milvus.db"
 _DEFAULT_TIMEOUT_SECONDS = 30
 _DEFAULT_QUERY_LIMIT = 10_000
+_TRUNCATION_PROBE_LIMIT = _DEFAULT_QUERY_LIMIT + 1
 _MILVUS_MAX_COLLECTION_NAME_LENGTH = 255
 _MILVUS_VARCHAR_MAX_LENGTH = 65_535
 _ID_MAX_LENGTH = 512
@@ -54,13 +57,20 @@ _FLOAT_FIELD_TYPES = {"float", "double"}
 _BOOL_FIELD_TYPES = {"bool", "boolean"}
 _META_PROPERTY_KEY = "openviking_meta"
 _INDEX_META_PROPERTY_PREFIX = "openviking_index_"
-_META_COLLECTION_NAME = "ov_openviking_milvus_meta"
+_DATA_COLLECTION_PREFIX = "ov_data"
+_META_COLLECTION_NAME = "ov_internal_metadata_v1"
+_LEGACY_META_COLLECTION_NAME = "ov_openviking_milvus_meta"
+_META_IDENTITY_KEY = "_openviking_identity"
+_PHYSICAL_NAMING_VERSION = 2
 _META_VECTOR_FIELD = "meta_vector"
+_META_VECTOR_INDEX = "meta_vector_index"
+_META_VECTOR_DIM = 2
+_META_VECTOR_VALUE = [0.0] * _META_VECTOR_DIM
 
 
 def _import_pymilvus():
     try:
-        import pymilvus  # type: ignore  # noqa: PLC0415
+        import pymilvus  # noqa: PLC0415
 
         return pymilvus
     except ImportError as exc:  # pragma: no cover - exercised only without optional driver
@@ -71,7 +81,8 @@ def _import_pymilvus():
 
 
 def _safe_collection_name(*parts: Any, prefix: str = "ov") -> str:
-    raw = "_".join(str(part or "") for part in parts)
+    raw_parts = [str(part or "") for part in parts]
+    raw = "_".join(raw_parts)
     normalized = _COLLECTION_NAME_RE.sub("_", raw).strip("_")
     if not normalized:
         normalized = "default"
@@ -79,14 +90,40 @@ def _safe_collection_name(*parts: Any, prefix: str = "ov") -> str:
         normalized = f"{prefix}_{normalized}"
     elif prefix and not normalized.startswith(f"{prefix}_"):
         normalized = f"{prefix}_{normalized}"
+    digest = hashlib.sha256("\0".join(raw_parts).encode("utf-8")).hexdigest()[:12]
+    keep = _MILVUS_MAX_COLLECTION_NAME_LENGTH - len(digest) - 1
+    return f"{normalized[:keep]}_{digest}"
+
+
+def _legacy_collection_name(*parts: Any) -> str:
+    """Return the pre-hash physical name for restart compatibility."""
+    raw = "_".join(str(part or "") for part in parts)
+    normalized = _COLLECTION_NAME_RE.sub("_", raw).strip("_") or "default"
+    if normalized[0].isdigit():
+        normalized = f"ov_{normalized}"
+    elif not normalized.startswith("ov_"):
+        normalized = f"ov_{normalized}"
     if len(normalized) <= _MILVUS_MAX_COLLECTION_NAME_LENGTH:
         return normalized
-
-    import hashlib
-
     digest = hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:10]
     keep = _MILVUS_MAX_COLLECTION_NAME_LENGTH - len(digest) - 1
     return f"{normalized[:keep]}_{digest}"
+
+
+def _validate_business_namespace(project_name: str, collection_name: str) -> None:
+    reserved = {_META_COLLECTION_NAME, _LEGACY_META_COLLECTION_NAME}
+    candidates = {
+        str(project_name),
+        str(collection_name),
+        _legacy_collection_name(project_name),
+        _legacy_collection_name(collection_name),
+        _legacy_collection_name(project_name, collection_name),
+    }
+    if candidates & reserved:
+        raise ValueError(
+            "Milvus project/collection name resolves to a reserved OpenViking metadata "
+            "namespace; choose a different business name"
+        )
 
 
 def _normalize_distance(distance: str) -> str:
@@ -135,18 +172,6 @@ def _encode_scope_roots(value: Any) -> str:
     roots = value if isinstance(value, list) else [value]
     normalized = [str(root) for root in roots if root is not None]
     return "\n" + "\n".join(normalized) + "\n" if normalized else "\n"
-
-
-def _sparse_dot(left: Optional[Dict[str, float]], right: Optional[Dict[str, float]]) -> float:
-    if not left or not right:
-        return 0.0
-    total = 0.0
-    for key, raw_value in left.items():
-        try:
-            total += float(raw_value) * float(right.get(key, 0.0))
-        except (TypeError, ValueError):
-            continue
-    return total
 
 
 def _coerce_datetime_value(value: Any) -> Any:
@@ -199,14 +224,14 @@ def _score_from_hit(hit: Dict[str, Any], distance_metric: str) -> float:
         if hit.get("score") is not None
         else hit.get("distance", hit.get("_distance", 0.0))
     )
+    if raw_score is None:
+        return 0.0
     try:
         score = float(raw_score)
     except (TypeError, ValueError):
         return 0.0
     if not math.isfinite(score):
         return 0.0
-    if distance_metric == "cosine":
-        return 1.0 - score
     if distance_metric == "l2":
         return 1.0 / (1.0 + max(score, 0.0))
     return score
@@ -280,6 +305,7 @@ class MilvusCollection(ICollection):
         sparse_vector_name: str,
         distance_metric: str,
         timeout_seconds: int,
+        allow_legacy_sidecar: bool = False,
         meta: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
@@ -291,10 +317,14 @@ class MilvusCollection(ICollection):
         self._sparse_vector_name = sparse_vector_name
         self._distance_metric = _normalize_distance(distance_metric)
         self._timeout_seconds = int(timeout_seconds)
-        self._meta = dict(meta or {})
-        self._field_types = self._build_field_type_map(self._meta)
-        self._varchar_lengths = self._build_varchar_length_map()
-        self._vector_dim = self._extract_vector_dim(self._meta)
+        self._allow_legacy_sidecar = bool(allow_legacy_sidecar)
+        _validate_business_namespace(project_name, logical_collection_name)
+        self._meta: Dict[str, Any] = {}
+        self._field_types: Dict[str, str] = {}
+        self._field_defaults: Dict[str, Any] = {}
+        self._varchar_lengths: Dict[str, int] = {}
+        self._vector_dim = 0
+        self._set_meta(dict(meta or {}))
 
     @property
     def collection_name(self) -> str:
@@ -324,6 +354,21 @@ class MilvusCollection(ICollection):
         mapping.update(cls.INTERNAL_PATH_FIELDS)
         return mapping
 
+    @staticmethod
+    def _build_field_default_map(meta: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            str(field["FieldName"]): deepcopy(field["DefaultValue"])
+            for field in meta.get("Fields", []) or []
+            if field.get("FieldName") and "DefaultValue" in field
+        }
+
+    def _set_meta(self, meta: Dict[str, Any]) -> None:
+        self._meta = dict(meta)
+        self._field_types = self._build_field_type_map(self._meta)
+        self._field_defaults = self._build_field_default_map(self._meta)
+        self._varchar_lengths = self._build_varchar_length_map()
+        self._vector_dim = self._extract_vector_dim(self._meta)
+
     def _build_varchar_length_map(self) -> Dict[str, int]:
         lengths: Dict[str, int] = {
             "id": _ID_MAX_LENGTH,
@@ -345,23 +390,78 @@ class MilvusCollection(ICollection):
         )
 
     def _collection_properties(self) -> Dict[str, Any]:
-        try:
-            desc = self._client.describe_collection(
-                collection_name=self._physical_collection_name,
-                timeout=self._timeout_seconds,
-            )
-        except Exception:
-            return {}
+        desc = self._client.describe_collection(
+            collection_name=self._physical_collection_name,
+            timeout=self._timeout_seconds,
+        )
         props = desc.get("properties") if isinstance(desc, dict) else None
         return dict(props or {})
 
-    def _ensure_meta_collection(self) -> None:
+    def _identity(self) -> Dict[str, Any]:
+        naming_version = (
+            _PHYSICAL_NAMING_VERSION
+            if self._physical_collection_name
+            == _safe_collection_name(
+                self._project_name,
+                self._logical_collection_name,
+                prefix=_DATA_COLLECTION_PREFIX,
+            )
+            else 1
+        )
+        return {
+            "logical_project": self._project_name,
+            "logical_collection": self._logical_collection_name,
+            "naming_version": naming_version,
+            "physical_collection": self._physical_collection_name,
+        }
+
+    def _encode_owned_meta(self, meta: Dict[str, Any]) -> str:
+        persisted = deepcopy(meta)
+        persisted[_META_IDENTITY_KEY] = self._identity()
+        return _json_dumps(persisted)
+
+    def _decode_owned_meta(self, raw_meta: Any, *, source: str) -> Dict[str, Any]:
         try:
-            if self._client.has_collection(
-                collection_name=_META_COLLECTION_NAME,
-                timeout=self._timeout_seconds,
-            ):
-                return
+            persisted = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Milvus {source} metadata is invalid; migration/rebuild is required"
+            ) from exc
+        if not isinstance(persisted, dict):
+            raise RuntimeError(
+                f"Milvus {source} metadata is invalid; migration/rebuild is required"
+            )
+        identity = persisted.get(_META_IDENTITY_KEY)
+        if not isinstance(identity, dict):
+            raise RuntimeError(
+                f"Milvus {source} metadata has no verifiable ownership identity; refusing "
+                "automatic binding. Migrate/rebuild the collection or add an explicit, "
+                "verified binding."
+            )
+        expected = self._identity()
+        if identity != expected:
+            raise RuntimeError(
+                f"Milvus {source} ownership identity does not match the requested logical "
+                "project/collection and physical name; refusing read, update, or delete. "
+                "Migrate/rebuild the collection or use an explicit, verified binding."
+            )
+        schema_meta = deepcopy(persisted)
+        schema_meta.pop(_META_IDENTITY_KEY, None)
+        return schema_meta
+
+    def _validate_meta_record_identity(
+        self, record: Dict[str, Any], *, source: str
+    ) -> Dict[str, Any]:
+        if record:
+            self._decode_owned_meta(record.get("meta_json"), source=source)
+        return record
+
+    def _ensure_meta_collection(self) -> None:
+        collection_exists = self._client.has_collection(
+            collection_name=_META_COLLECTION_NAME,
+            timeout=self._timeout_seconds,
+        )
+        if not collection_exists:
             pymilvus = _import_pymilvus()
             DataType = pymilvus.DataType
             schema = self._client.create_schema(auto_id=False, enable_dynamic_field=False)
@@ -377,77 +477,117 @@ class MilvusCollection(ICollection):
                 max_length=_MILVUS_VARCHAR_MAX_LENGTH,
             )
             schema.add_field(field_name="indexes_json", datatype=DataType.JSON, nullable=True)
-            schema.add_field(field_name=_META_VECTOR_FIELD, datatype=DataType.FLOAT_VECTOR, dim=1)
+            schema.add_field(
+                field_name=_META_VECTOR_FIELD,
+                datatype=DataType.FLOAT_VECTOR,
+                dim=_META_VECTOR_DIM,
+            )
             self._client.create_collection(
                 collection_name=_META_COLLECTION_NAME,
                 schema=schema,
                 timeout=self._timeout_seconds,
             )
-        except Exception as exc:
-            logger.warning("Failed to ensure Milvus metadata collection: %s", exc)
+
+        indexes = list(
+            self._client.list_indexes(
+                collection_name=_META_COLLECTION_NAME,
+                timeout=self._timeout_seconds,
+            )
+            or []
+        )
+        if _META_VECTOR_FIELD not in indexes and _META_VECTOR_INDEX not in indexes:
+            index_params = self._client.prepare_index_params()
+            index_params.add_index(
+                field_name=_META_VECTOR_FIELD,
+                index_name=_META_VECTOR_INDEX,
+                index_type="AUTOINDEX",
+                metric_type="COSINE",
+            )
+            self._client.create_index(
+                collection_name=_META_COLLECTION_NAME,
+                index_params=index_params,
+                timeout=self._timeout_seconds,
+            )
+        self._client.load_collection(
+            collection_name=_META_COLLECTION_NAME,
+            timeout=self._timeout_seconds,
+        )
 
     def _load_meta_record(self) -> Dict[str, Any]:
         self._ensure_meta_collection()
-        try:
-            rows = self._client.get(
-                collection_name=_META_COLLECTION_NAME,
-                ids=[self._physical_collection_name],
-                output_fields=["meta_json", "indexes_json"],
-                timeout=self._timeout_seconds,
+        rows = self._client.get(
+            collection_name=_META_COLLECTION_NAME,
+            ids=[self._physical_collection_name],
+            output_fields=["meta_json", "indexes_json"],
+            timeout=self._timeout_seconds,
+        )
+        if rows:
+            return self._validate_meta_record_identity(
+                dict(rows[0]), source=f"sidecar {_META_COLLECTION_NAME!r}"
             )
-        except Exception:
+        if not self._allow_legacy_sidecar or self._identity()["naming_version"] != 1:
             return {}
-        return dict(rows[0]) if rows else {}
+        if not self._client.has_collection(
+            collection_name=_LEGACY_META_COLLECTION_NAME,
+            timeout=self._timeout_seconds,
+        ):
+            return {}
+        self._client.load_collection(
+            collection_name=_LEGACY_META_COLLECTION_NAME,
+            timeout=self._timeout_seconds,
+        )
+        legacy_rows = self._client.get(
+            collection_name=_LEGACY_META_COLLECTION_NAME,
+            ids=[self._physical_collection_name],
+            output_fields=["meta_json", "indexes_json"],
+            timeout=self._timeout_seconds,
+        )
+        if not legacy_rows:
+            return {}
+        return self._validate_meta_record_identity(
+            dict(legacy_rows[0]), source=f"legacy sidecar {_LEGACY_META_COLLECTION_NAME!r}"
+        )
 
     def _save_meta_record(self, *, meta: Optional[Dict[str, Any]] = None) -> None:
         self._ensure_meta_collection()
         existing = self._load_meta_record()
-        meta_json = _json_dumps(meta if meta is not None else self._meta)
-        indexes_json = existing.get("indexes_json") if existing else {}
-        try:
-            self._client.upsert(
-                collection_name=_META_COLLECTION_NAME,
-                data=[
-                    {
-                        "id": self._physical_collection_name,
-                        "meta_json": meta_json,
-                        "indexes_json": indexes_json if isinstance(indexes_json, dict) else {},
-                        _META_VECTOR_FIELD: [0.0],
-                    }
-                ],
-                timeout=self._timeout_seconds,
-            )
-        except Exception as exc:
-            logger.warning("Failed to persist Milvus metadata record: %s", exc)
+        meta_json = self._encode_owned_meta(meta if meta is not None else self._meta)
+        indexes_json = deepcopy(existing.get("indexes_json")) if existing else {}
+        self._client.upsert(
+            collection_name=_META_COLLECTION_NAME,
+            data=[
+                {
+                    "id": self._physical_collection_name,
+                    "meta_json": meta_json,
+                    "indexes_json": indexes_json if isinstance(indexes_json, dict) else {},
+                    _META_VECTOR_FIELD: _META_VECTOR_VALUE,
+                }
+            ],
+            timeout=self._timeout_seconds,
+        )
 
     def load_remote_meta(self) -> Optional[Dict[str, Any]]:
         record = self._load_meta_record()
         raw_meta = record.get("meta_json")
-        if isinstance(raw_meta, str):
-            try:
-                meta = json.loads(raw_meta)
-            except (TypeError, ValueError):
-                meta = None
-            if isinstance(meta, dict):
-                self._meta = meta
-                self._field_types = self._build_field_type_map(meta)
-                self._varchar_lengths = self._build_varchar_length_map()
-                self._vector_dim = self._extract_vector_dim(meta)
-                return meta
+        if raw_meta is not None:
+            meta = self._decode_owned_meta(raw_meta, source="sidecar")
+            property_raw = self._collection_properties().get(_META_PROPERTY_KEY)
+            if property_raw is not None:
+                property_meta = self._decode_owned_meta(property_raw, source="collection property")
+                if property_meta != meta:
+                    raise RuntimeError(
+                        "Milvus collection metadata is inconsistent between sidecar and "
+                        "collection property; repair or rebuild before binding"
+                    )
+            self._set_meta(meta)
+            return meta
 
         props = self._collection_properties()
         raw_meta = props.get(_META_PROPERTY_KEY)
-        if isinstance(raw_meta, str):
-            try:
-                meta = json.loads(raw_meta)
-            except (TypeError, ValueError):
-                meta = None
-            if isinstance(meta, dict):
-                self._meta = meta
-                self._field_types = self._build_field_type_map(meta)
-                self._varchar_lengths = self._build_varchar_length_map()
-                self._vector_dim = self._extract_vector_dim(meta)
-                return meta
+        if raw_meta is not None:
+            meta = self._decode_owned_meta(raw_meta, source="collection property")
+            self._set_meta(meta)
+            return meta
 
         return None
 
@@ -457,10 +597,7 @@ class MilvusCollection(ICollection):
         *,
         consistency_level: Optional[str] = None,
     ) -> None:
-        self._meta = dict(meta_data)
-        self._field_types = self._build_field_type_map(self._meta)
-        self._varchar_lengths = self._build_varchar_length_map()
-        self._vector_dim = self._extract_vector_dim(self._meta)
+        self._set_meta(dict(meta_data))
         if self._vector_dim <= 0:
             raise ValueError("Milvus collection requires a positive dense vector dimension")
 
@@ -475,7 +612,24 @@ class MilvusCollection(ICollection):
             timeout=self._timeout_seconds,
             **create_kwargs,
         )
-        self._save_collection_meta()
+        try:
+            self._save_collection_meta()
+        except Exception as exc:
+            try:
+                self._client.drop_collection(
+                    collection_name=self._physical_collection_name,
+                    timeout=self._timeout_seconds,
+                )
+                self._delete_meta_record(ignore_missing=True)
+            except Exception as rollback_exc:
+                raise RuntimeError(
+                    "Milvus collection metadata persistence failed and rollback left an "
+                    f"inconsistent collection {self._physical_collection_name!r}: {rollback_exc}"
+                ) from exc
+            raise RuntimeError(
+                f"Milvus collection metadata persistence failed; rolled back "
+                f"{self._physical_collection_name!r}"
+            ) from exc
 
     def _build_schema(self, pymilvus: Any):
         DataType = pymilvus.DataType
@@ -527,6 +681,8 @@ class MilvusCollection(ICollection):
                     max_length=self._varchar_lengths.get(field_name, _MILVUS_VARCHAR_MAX_LENGTH),
                     nullable=True,
                 )
+            if "DefaultValue" in field and field_type not in _LIST_STRING_FIELD_TYPES:
+                kwargs["default_value"] = deepcopy(field["DefaultValue"])
             schema.add_field(field_name=field_name, datatype=datatype, **kwargs)
         return schema
 
@@ -538,16 +694,173 @@ class MilvusCollection(ICollection):
                 fields.append({"FieldName": field_name, "FieldType": field_type})
         return fields
 
+    @staticmethod
+    def _expected_physical_type(field: Dict[str, Any], sparse_vector_name: str) -> str:
+        field_name = str(field.get("FieldName") or "")
+        field_type = str(field.get("FieldType") or "").lower()
+        if field_type in _VECTOR_FIELD_TYPES:
+            return "FLOAT_VECTOR"
+        if field_name == sparse_vector_name or field_type in {"json", "sparse_vector"}:
+            return "JSON"
+        if field_type in _LIST_STRING_FIELD_TYPES:
+            return "ARRAY"
+        if field_type in _INT_FIELD_TYPES:
+            return "INT64"
+        if field_type in _FLOAT_FIELD_TYPES:
+            return "DOUBLE"
+        if field_type in _BOOL_FIELD_TYPES:
+            return "BOOL"
+        return "VARCHAR"
+
+    def ensure_schema_compatible(self, desired_meta: Dict[str, Any]) -> None:
+        """Upgrade dynamic metadata or fail before using an incompatible static schema."""
+        desc = self._client.describe_collection(
+            collection_name=self._physical_collection_name,
+            timeout=self._timeout_seconds,
+        )
+        described_fields = {
+            str(field.get("name")): field
+            for field in (desc.get("fields", []) if isinstance(desc, dict) else [])
+            if field.get("name")
+        }
+        desired_fields = [dict(field) for field in desired_meta.get("Fields", []) or []]
+        desired_names = {str(field.get("FieldName")) for field in desired_fields}
+        for field_name, field_type in self.INTERNAL_PATH_FIELDS.items():
+            if field_name not in desired_names:
+                desired_fields.append({"FieldName": field_name, "FieldType": field_type})
+
+        mismatches: List[str] = []
+        missing: List[str] = []
+        if bool(desc.get("auto_id")):
+            mismatches.append("collection auto_id (True != False)")
+        if not bool(desc.get("enable_dynamic_field")):
+            mismatches.append("collection enable_dynamic_field (False != True)")
+
+        vector_fields = [
+            str(field.get("FieldName") or "")
+            for field in desired_fields
+            if str(field.get("FieldType") or "").lower() in _VECTOR_FIELD_TYPES
+        ]
+        if vector_fields != [self._dense_vector_name]:
+            mismatches.append(
+                f"dense vector field ({vector_fields!r} != {[self._dense_vector_name]!r})"
+            )
+        desired_primary = [
+            str(field.get("FieldName") or "")
+            for field in desired_fields
+            if field.get("IsPrimaryKey")
+        ]
+        if desired_primary != ["id"]:
+            mismatches.append(f"logical primary key ({desired_primary!r} != ['id'])")
+        physical_primary = [
+            name for name, field in described_fields.items() if bool(field.get("is_primary"))
+        ]
+        if physical_primary != ["id"]:
+            mismatches.append(f"physical primary key ({physical_primary!r} != ['id'])")
+
+        for field in desired_fields:
+            field_name = str(field.get("FieldName") or "")
+            if not field_name:
+                continue
+            physical_field = described_fields.get(field_name)
+            if physical_field is None:
+                missing.append(field_name)
+                continue
+            actual_type = self._physical_type_name(physical_field)
+            expected_type = self._expected_physical_type(field, self._sparse_vector_name)
+            if actual_type != expected_type:
+                mismatches.append(f"{field_name} ({actual_type} != {expected_type})")
+                continue
+            params = physical_field.get("params") or {}
+            if expected_type == "FLOAT_VECTOR":
+                expected_dim = int(field.get("Dim") or 0)
+                actual_dim = int(params.get("dim") or 0)
+                if actual_dim != expected_dim:
+                    mismatches.append(f"{field_name}.dim ({actual_dim} != {expected_dim})")
+            elif expected_type == "ARRAY":
+                element_type = self._physical_type_name(
+                    {"type": physical_field.get("element_type")}
+                )
+                if element_type != "VARCHAR":
+                    mismatches.append(f"{field_name}.element_type ({element_type} != VARCHAR)")
+                actual_capacity = int(params.get("max_capacity") or 0)
+                if actual_capacity != 1024:
+                    mismatches.append(f"{field_name}.max_capacity ({actual_capacity} != 1024)")
+            elif expected_type == "VARCHAR":
+                expected_length = self._varchar_lengths.get(field_name, _MILVUS_VARCHAR_MAX_LENGTH)
+                actual_length = int(params.get("max_length") or 0)
+                if actual_length != expected_length:
+                    mismatches.append(
+                        f"{field_name}.max_length ({actual_length} != {expected_length})"
+                    )
+            if field_name == "id" and not bool(physical_field.get("is_primary")):
+                mismatches.append("id.is_primary (False != True)")
+            if field_name not in {"id", self._dense_vector_name} and not bool(
+                physical_field.get("nullable")
+            ):
+                mismatches.append(f"{field_name}.nullable (False != True)")
+        if mismatches:
+            raise RuntimeError(
+                "Existing Milvus schema is incompatible and requires migration/rebuild: "
+                + ", ".join(mismatches)
+            )
+        if missing and not bool(desc.get("enable_dynamic_field")):
+            raise RuntimeError(
+                "Existing static Milvus schema is missing fields and requires migration/rebuild: "
+                + ", ".join(sorted(missing))
+            )
+
+        upgraded = dict(desired_meta)
+        existing_fields = [dict(field) for field in self._meta.get("Fields", []) or []]
+        desired_field_names = {field.get("FieldName") for field in desired_fields}
+        upgraded["Fields"] = desired_fields + [
+            field for field in existing_fields if field.get("FieldName") not in desired_field_names
+        ]
+        self._set_meta(upgraded)
+        self._save_collection_meta()
+
     def _save_collection_meta(self) -> None:
         self._save_meta_record(meta=self._meta)
-        try:
-            self._client.alter_collection_properties(
-                collection_name=self._physical_collection_name,
-                properties={_META_PROPERTY_KEY: _json_dumps(self._meta)},
+        self._client.alter_collection_properties(
+            collection_name=self._physical_collection_name,
+            properties={_META_PROPERTY_KEY: self._encode_owned_meta(self._meta)},
+            timeout=self._timeout_seconds,
+        )
+
+    def _delete_meta_record(self, *, ignore_missing: bool = False) -> None:
+        owned_records = []
+        collection_names = [_META_COLLECTION_NAME]
+        if self._allow_legacy_sidecar and self._identity()["naming_version"] == 1:
+            collection_names.append(_LEGACY_META_COLLECTION_NAME)
+        for collection_name in collection_names:
+            exists = self._client.has_collection(
+                collection_name=collection_name,
                 timeout=self._timeout_seconds,
             )
-        except Exception as exc:
-            logger.debug("Milvus collection properties are not available: %s", exc)
+            if not exists:
+                if ignore_missing:
+                    continue
+                if collection_name == _META_COLLECTION_NAME:
+                    raise RuntimeError("Milvus metadata collection is missing")
+                continue
+            rows = self._client.get(
+                collection_name=collection_name,
+                ids=[self._physical_collection_name],
+                output_fields=["meta_json"],
+                timeout=self._timeout_seconds,
+            )
+            if not rows:
+                continue
+            self._validate_meta_record_identity(
+                dict(rows[0]), source=f"sidecar {collection_name!r}"
+            )
+            owned_records.append(collection_name)
+        for collection_name in owned_records:
+            self._client.delete(
+                collection_name=collection_name,
+                ids=[self._physical_collection_name],
+                timeout=self._timeout_seconds,
+            )
 
     def update(self, fields: Optional[Dict[str, Any]] = None, description: Optional[str] = None):
         if fields:
@@ -567,94 +880,330 @@ class MilvusCollection(ICollection):
 
     def drop(self):
         if self.collection_exists():
+            if not self.load_remote_meta():
+                raise RuntimeError(
+                    "Milvus collection has no verifiable ownership metadata; refusing delete. "
+                    "Migrate/rebuild the collection or use an explicit, verified binding."
+                )
+            self._validate_all_sidecar_ownership()
             self._client.drop_collection(
                 collection_name=self._physical_collection_name,
                 timeout=self._timeout_seconds,
             )
-        try:
-            self._client.delete(
-                collection_name=_META_COLLECTION_NAME,
+        self._delete_meta_record(ignore_missing=True)
+
+    def _validate_all_sidecar_ownership(self) -> None:
+        collection_names = [_META_COLLECTION_NAME]
+        if self._allow_legacy_sidecar and self._identity()["naming_version"] == 1:
+            collection_names.append(_LEGACY_META_COLLECTION_NAME)
+        for collection_name in collection_names:
+            if not self._client.has_collection(
+                collection_name=collection_name,
+                timeout=self._timeout_seconds,
+            ):
+                continue
+            rows = self._client.get(
+                collection_name=collection_name,
                 ids=[self._physical_collection_name],
+                output_fields=["meta_json"],
                 timeout=self._timeout_seconds,
             )
-        except Exception:
-            pass
+            if rows:
+                self._validate_meta_record_identity(
+                    dict(rows[0]), source=f"sidecar {collection_name!r}"
+                )
 
     def create_index(self, index_name: str, meta_data: Dict[str, Any]) -> IIndex:
         meta = dict(meta_data or {})
         vector_meta = dict(meta.get("VectorIndex") or {})
         metric_type = _milvus_metric(vector_meta.get("Distance") or self._distance_metric)
-        existing_indexes = set(self.list_indexes() or [])
-        if index_name in existing_indexes or self._dense_vector_name in existing_indexes:
+        actual_scalar_fields: List[str] = []
+        degraded_scalar_fields: List[str] = []
+        initial_index_definitions = self._physical_index_definitions()
+        initial_physical_indexes = {
+            field_name: str(definition["index_name"])
+            for field_name, definition in initial_index_definitions.items()
+        }
+        was_loaded = self._is_collection_loaded()
+        load_attempted = False
+        try:
+            physical_fields = self._physical_field_types()
+            physical_indexes = dict(initial_physical_indexes)
+            if self._dense_vector_name not in physical_indexes:
+                index_params = self._client.prepare_index_params()
+                index_params.add_index(
+                    field_name=self._dense_vector_name,
+                    index_name=index_name,
+                    index_type="AUTOINDEX",
+                    metric_type=metric_type,
+                )
+                self._client.create_index(
+                    collection_name=self._physical_collection_name,
+                    index_params=index_params,
+                    timeout=self._timeout_seconds,
+                )
+                physical_indexes = self._physical_indexes()
+
+            requested_scalar_fields = list(dict.fromkeys(meta.get("ScalarIndex") or []))
+            for field_name in requested_scalar_fields:
+                field_type = physical_fields.get(field_name)
+                if field_type not in {"VARCHAR", "INT64", "BOOL"}:
+                    degraded_scalar_fields.append(field_name)
+                    continue
+                if field_name not in physical_indexes:
+                    scalar_params = self._client.prepare_index_params()
+                    scalar_params.add_index(
+                        field_name=field_name,
+                        index_name=f"{index_name}_{field_name}",
+                        index_type="INVERTED",
+                    )
+                    self._client.create_index(
+                        collection_name=self._physical_collection_name,
+                        index_params=scalar_params,
+                        timeout=self._timeout_seconds,
+                    )
+                    physical_indexes = self._physical_indexes()
+                if field_name in physical_indexes:
+                    actual_scalar_fields.append(field_name)
+
+            if degraded_scalar_fields:
+                logger.warning(
+                    "Milvus scalar indexes are unavailable for fields %s; Lite does not support "
+                    "ARRAY indexes and dynamic-only fields cannot be indexed",
+                    ", ".join(sorted(degraded_scalar_fields)),
+                )
             meta["VectorIndex"] = {
                 **vector_meta,
                 "IndexType": "AUTOINDEX",
                 "Distance": self._distance_metric,
             }
-            self._save_index_meta(index_name, meta)
-            return MilvusIndex(self, index_name, meta)
-
-        index_params = self._client.prepare_index_params()
-        index_params.add_index(
-            field_name=self._dense_vector_name,
-            index_name=index_name,
-            index_type="AUTOINDEX",
-            metric_type=metric_type,
-        )
-        try:
-            self._client.create_index(
-                collection_name=self._physical_collection_name,
-                index_params=index_params,
-                timeout=self._timeout_seconds,
-            )
-        except Exception as exc:
-            if "index already" not in str(exc).lower():
-                raise
-        try:
+            meta["ScalarIndex"] = actual_scalar_fields
+            if degraded_scalar_fields:
+                meta["ScalarIndexUnavailable"] = degraded_scalar_fields
+            else:
+                meta.pop("ScalarIndexUnavailable", None)
+            load_attempted = True
             self._client.load_collection(
                 collection_name=self._physical_collection_name,
                 timeout=self._timeout_seconds,
             )
+            self._save_index_meta(index_name, meta)
         except Exception as exc:
-            logger.debug("Milvus collection load skipped or failed: %s", exc)
-        meta["VectorIndex"] = {
-            **vector_meta,
-            "IndexType": "AUTOINDEX",
-            "Distance": self._distance_metric,
-        }
-        self._save_index_meta(index_name, meta)
+            rollback_errors: List[str] = []
+            current_indexes = self._physical_indexes()
+            created_index_names = [
+                remote_name
+                for field_name, remote_name in current_indexes.items()
+                if field_name not in initial_physical_indexes
+            ]
+            released_for_rollback = False
+            if created_index_names or (load_attempted and not was_loaded):
+                try:
+                    self._client.release_collection(
+                        collection_name=self._physical_collection_name,
+                        timeout=self._timeout_seconds,
+                    )
+                    released_for_rollback = True
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"release: {rollback_exc}")
+            for remote_name in reversed(created_index_names):
+                try:
+                    if remote_name not in (
+                        self._client.list_indexes(
+                            collection_name=self._physical_collection_name,
+                            timeout=self._timeout_seconds,
+                        )
+                        or []
+                    ):
+                        continue
+                    self._client.drop_index(
+                        collection_name=self._physical_collection_name,
+                        index_name=remote_name,
+                        timeout=self._timeout_seconds,
+                    )
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"drop {remote_name}: {rollback_exc}")
+            try:
+                remaining_fields = set(self._physical_indexes())
+                for field_name, definition in initial_index_definitions.items():
+                    if field_name in remaining_fields:
+                        continue
+                    restore_params = self._client.prepare_index_params()
+                    restore_kwargs = {
+                        "field_name": field_name,
+                        "index_name": definition["index_name"],
+                        "index_type": definition["index_type"],
+                    }
+                    restore_metric: Optional[str] = definition.get("metric_type")
+                    if restore_metric and restore_metric != "NONE":
+                        restore_kwargs["metric_type"] = restore_metric
+                    restore_params.add_index(**restore_kwargs)
+                    self._client.create_index(
+                        collection_name=self._physical_collection_name,
+                        index_params=restore_params,
+                        timeout=self._timeout_seconds,
+                    )
+                    remaining_fields.add(field_name)
+            except Exception as rollback_exc:
+                rollback_errors.append(f"restore existing indexes: {rollback_exc}")
+            if was_loaded and released_for_rollback:
+                try:
+                    self._client.load_collection(
+                        collection_name=self._physical_collection_name,
+                        timeout=self._timeout_seconds,
+                    )
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"restore load state: {rollback_exc}")
+            if rollback_errors:
+                raise RuntimeError(
+                    "Milvus index creation failed and rollback left physical indexes or load "
+                    f"state inconsistent: {'; '.join(rollback_errors)}"
+                ) from exc
+            raise RuntimeError(
+                "Milvus index creation failed; new physical indexes rolled back"
+            ) from exc
         return MilvusIndex(self, index_name, meta)
+
+    def _is_collection_loaded(self) -> bool:
+        try:
+            load_state = self._client.get_load_state(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
+            )
+        except (AttributeError, NotImplementedError):
+            return True
+        state = load_state.get("state") if isinstance(load_state, dict) else load_state
+        state_name = getattr(state, "name", str(state))
+        return str(state_name).lower() == "loaded"
+
+    @staticmethod
+    def _physical_type_name(field: Dict[str, Any]) -> str:
+        value = field.get("type")
+        name = getattr(value, "name", None)
+        if name:
+            return str(name).upper()
+        text = str(value or "").upper()
+        return text.rsplit(".", 1)[-1]
+
+    def _physical_field_types(self) -> Dict[str, str]:
+        desc = self._client.describe_collection(
+            collection_name=self._physical_collection_name,
+            timeout=self._timeout_seconds,
+        )
+        return {
+            str(field.get("name")): self._physical_type_name(field)
+            for field in (desc.get("fields", []) if isinstance(desc, dict) else [])
+            if field.get("name")
+        }
+
+    def _physical_indexes(self) -> Dict[str, str]:
+        return {
+            field_name: str(definition["index_name"])
+            for field_name, definition in self._physical_index_definitions().items()
+        }
+
+    def _physical_index_definitions(self) -> Dict[str, Dict[str, str]]:
+        result: Dict[str, Dict[str, str]] = {}
+        remote_names = (
+            self._client.list_indexes(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
+            )
+            or []
+        )
+        for remote_name in remote_names:
+            desc = self._client.describe_index(
+                collection_name=self._physical_collection_name,
+                index_name=remote_name,
+                timeout=self._timeout_seconds,
+            )
+            field_name = desc.get("field_name") if isinstance(desc, dict) else None
+            actual_name = desc.get("index_name") if isinstance(desc, dict) else None
+            if field_name:
+                result[str(field_name)] = {
+                    "field_name": str(field_name),
+                    "index_name": str(actual_name or remote_name),
+                    "index_type": str(desc.get("index_type") or "AUTOINDEX"),
+                    "metric_type": str(desc.get("metric_type") or "NONE"),
+                }
+        return result
 
     def _save_index_meta(self, index_name: str, meta: Dict[str, Any]) -> None:
         self._ensure_meta_collection()
-        record = self._load_meta_record()
-        indexes = record.get("indexes_json") if record else {}
-        if not isinstance(indexes, dict):
-            indexes = {}
-        indexes[index_name] = meta
-        try:
-            self._client.upsert(
-                collection_name=_META_COLLECTION_NAME,
-                data=[
-                    {
-                        "id": self._physical_collection_name,
-                        "meta_json": record.get("meta_json") or _json_dumps(self._meta),
-                        "indexes_json": indexes,
-                        _META_VECTOR_FIELD: [0.0],
-                    }
-                ],
-                timeout=self._timeout_seconds,
+        record = deepcopy(self._load_meta_record())
+        if not record:
+            raise RuntimeError(
+                "Milvus collection metadata is missing; refusing index update until the "
+                "collection is migrated/rebuilt"
             )
-        except Exception as exc:
-            logger.warning("Failed to persist Milvus index metadata: %s", exc)
+        old_indexes = deepcopy(record.get("indexes_json"))
+        if not isinstance(old_indexes, dict):
+            old_indexes = {}
+        property_key = f"{_INDEX_META_PROPERTY_PREFIX}{index_name}"
+        old_property = self._collection_properties().get(property_key)
+        old_sidecar_meta = old_indexes.get(index_name)
+        if old_sidecar_meta is not None and old_property is not None:
+            parsed_property = _json_loads(old_property)
+            if parsed_property != old_sidecar_meta:
+                raise RuntimeError(
+                    "Milvus index metadata is inconsistent between sidecar and collection "
+                    "properties; repair or rebuild before retrying"
+                )
+
+        indexes = deepcopy(old_indexes)
+        indexes[index_name] = deepcopy(meta)
+        persisted_record = {
+            "id": self._physical_collection_name,
+            "meta_json": record["meta_json"],
+            "indexes_json": deepcopy(old_indexes),
+            _META_VECTOR_FIELD: _META_VECTOR_VALUE,
+        }
+        new_record = deepcopy(persisted_record)
+        new_record["indexes_json"] = indexes
         try:
             self._client.alter_collection_properties(
                 collection_name=self._physical_collection_name,
-                properties={f"{_INDEX_META_PROPERTY_PREFIX}{index_name}": _json_dumps(meta)},
+                properties={property_key: _json_dumps(meta)},
+                timeout=self._timeout_seconds,
+            )
+            self._client.upsert(
+                collection_name=_META_COLLECTION_NAME,
+                data=[new_record],
                 timeout=self._timeout_seconds,
             )
         except Exception as exc:
-            logger.debug("Milvus index properties are not available: %s", exc)
+            rollback_errors: List[str] = []
+            try:
+                self._client.upsert(
+                    collection_name=_META_COLLECTION_NAME,
+                    data=[persisted_record],
+                    timeout=self._timeout_seconds,
+                )
+            except Exception as rollback_exc:
+                rollback_errors.append(f"sidecar: {rollback_exc}")
+            try:
+                if old_property is not None:
+                    self._client.alter_collection_properties(
+                        collection_name=self._physical_collection_name,
+                        properties={property_key: old_property},
+                        timeout=self._timeout_seconds,
+                    )
+                else:
+                    self._client.drop_collection_properties(
+                        collection_name=self._physical_collection_name,
+                        property_keys=[property_key],
+                        timeout=self._timeout_seconds,
+                    )
+            except Exception as rollback_exc:
+                rollback_errors.append(f"property: {rollback_exc}")
+            if rollback_errors:
+                raise RuntimeError(
+                    "Milvus index metadata persistence failed and rollback left an "
+                    f"inconsistent state: {'; '.join(rollback_errors)}"
+                ) from exc
+            raise RuntimeError(
+                "Milvus index metadata persistence failed; sidecar and property rolled back"
+            ) from exc
 
     def has_index(self, index_name: str) -> bool:
         return self.get_index_meta_data(index_name) is not None or index_name in (
@@ -678,36 +1227,38 @@ class MilvusCollection(ICollection):
             )
         if description is not None:
             meta["Description"] = description
+        if scalar_index is not None:
+            updated = self.create_index(index_name, meta)
+            return updated.get_meta_data()
         self._save_index_meta(index_name, meta)
         return meta
 
     def get_index_meta_data(self, index_name: str):
         record = self._load_meta_record()
         indexes = record.get("indexes_json") if record else {}
-        if isinstance(indexes, dict) and isinstance(indexes.get(index_name), dict):
-            return indexes[index_name]
-
+        sidecar_meta = indexes.get(index_name) if isinstance(indexes, dict) else None
         props = self._collection_properties()
         raw_meta = props.get(f"{_INDEX_META_PROPERTY_PREFIX}{index_name}")
-        if not isinstance(raw_meta, str):
-            return None
-        try:
-            meta = json.loads(raw_meta)
-        except (TypeError, ValueError):
-            return None
-        return meta if isinstance(meta, dict) else None
+        property_meta = _json_loads(raw_meta) if raw_meta is not None else None
+        if property_meta is not None and not isinstance(property_meta, dict):
+            raise RuntimeError("Milvus index collection property contains invalid metadata")
+        if sidecar_meta is not None and property_meta is not None and sidecar_meta != property_meta:
+            raise RuntimeError(
+                "Milvus index metadata is inconsistent between sidecar and collection "
+                "properties; repair or rebuild before retrying"
+            )
+        if isinstance(sidecar_meta, dict):
+            return deepcopy(sidecar_meta)
+        return deepcopy(property_meta) if isinstance(property_meta, dict) else None
 
     def list_indexes(self):
-        try:
-            return list(
-                self._client.list_indexes(
-                    collection_name=self._physical_collection_name,
-                    timeout=self._timeout_seconds,
-                )
-                or []
+        return list(
+            self._client.list_indexes(
+                collection_name=self._physical_collection_name,
+                timeout=self._timeout_seconds,
             )
-        except Exception:
-            return []
+            or []
+        )
 
     def drop_index(self, index_name: str):
         try:
@@ -715,49 +1266,57 @@ class MilvusCollection(ICollection):
                 collection_name=self._physical_collection_name,
                 timeout=self._timeout_seconds,
             )
-        except Exception:
-            pass
-        for remote_name in list(self.list_indexes() or []):
-            if remote_name == index_name or str(remote_name).startswith(f"{index_name}_"):
-                try:
-                    self._client.drop_index(
-                        collection_name=self._physical_collection_name,
-                        index_name=remote_name,
-                        timeout=self._timeout_seconds,
-                    )
-                except Exception as exc:
-                    logger.warning("Failed to drop Milvus index %s: %s", remote_name, exc)
-        try:
+        except Exception as exc:
+            logger.debug("Milvus collection release before index drop failed: %s", exc)
+
+        meta = self.get_index_meta_data(index_name) or {}
+        physical_indexes = self._physical_indexes()
+        if meta:
+            target_fields = [self._dense_vector_name, *(meta.get("ScalarIndex") or [])]
+        else:
+            target_fields = [
+                field_name
+                for field_name, remote_name in physical_indexes.items()
+                if field_name == index_name or remote_name == index_name
+            ]
+        for field_name in target_fields:
+            remote_name = physical_indexes.get(field_name)
+            if remote_name:
+                self._client.drop_index(
+                    collection_name=self._physical_collection_name,
+                    index_name=remote_name,
+                    timeout=self._timeout_seconds,
+                )
+        if meta:
             self._client.drop_collection_properties(
                 collection_name=self._physical_collection_name,
                 property_keys=[f"{_INDEX_META_PROPERTY_PREFIX}{index_name}"],
                 timeout=self._timeout_seconds,
             )
-        except Exception:
-            pass
-        try:
-            record = self._load_meta_record()
-            indexes = record.get("indexes_json") if record else {}
-            if isinstance(indexes, dict) and index_name in indexes:
-                indexes.pop(index_name, None)
-                self._client.upsert(
-                    collection_name=_META_COLLECTION_NAME,
-                    data=[
-                        {
-                            "id": self._physical_collection_name,
-                            "meta_json": record.get("meta_json") or _json_dumps(self._meta),
-                            "indexes_json": indexes,
-                            _META_VECTOR_FIELD: [0.0],
-                        }
-                    ],
-                    timeout=self._timeout_seconds,
-                )
-        except Exception:
-            pass
+        record = self._load_meta_record()
+        indexes = record.get("indexes_json") if record else {}
+        if isinstance(indexes, dict) and index_name in indexes:
+            indexes.pop(index_name, None)
+            self._client.upsert(
+                collection_name=_META_COLLECTION_NAME,
+                data=[
+                    {
+                        "id": self._physical_collection_name,
+                        "meta_json": record.get("meta_json") or _json_dumps(self._meta),
+                        "indexes_json": indexes,
+                        _META_VECTOR_FIELD: _META_VECTOR_VALUE,
+                    }
+                ],
+                timeout=self._timeout_seconds,
+            )
 
     def _prepare_record_for_write(self, record: Dict[str, Any]) -> Dict[str, Any]:
         prepared: Dict[str, Any] = {}
-        for field_name, value in record.items():
+        materialized = dict(record)
+        for field_name, default_value in self._field_defaults.items():
+            if materialized.get(field_name) is None:
+                materialized[field_name] = deepcopy(default_value)
+        for field_name, value in materialized.items():
             if value is None:
                 continue
             field_type = self._field_types.get(field_name, "")
@@ -832,6 +1391,9 @@ class MilvusCollection(ICollection):
 
     def _decode_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
         decoded = dict(record)
+        for field_name, default_value in self._field_defaults.items():
+            if decoded.get(field_name) is None:
+                decoded[field_name] = deepcopy(default_value)
         sparse = decoded.get(self._sparse_vector_name)
         if isinstance(sparse, str):
             parsed = _json_loads(sparse)
@@ -868,6 +1430,11 @@ class MilvusCollection(ICollection):
         del index_name
         if limit <= 0:
             return SearchResult()
+        if sparse_vector:
+            raise NotImplementedError(
+                "Milvus sparse and hybrid search is not supported because candidate recall "
+                "cannot be made complete"
+            )
         if dense_vector is None:
             return self._search_by_sparse(sparse_vector, limit, offset, filters, output_fields)
 
@@ -875,7 +1442,7 @@ class MilvusCollection(ICollection):
         fields = self._select_output_fields(
             output_fields,
             include_vector=False,
-            include_sparse=bool(sparse_vector),
+            include_sparse=False,
         )
         raw_results = self._client.search(
             collection_name=self._physical_collection_name,
@@ -896,14 +1463,7 @@ class MilvusCollection(ICollection):
                 entity["id"] = hit.get("id")
             record_id, payload = self._record_from_entity(entity)
             score = _score_from_hit(hit, self._distance_metric) if isinstance(hit, dict) else 0.0
-            if sparse_vector:
-                sparse_payload = payload.pop(self._sparse_vector_name, None)
-                score += _sparse_dot(
-                    sparse_vector, sparse_payload if isinstance(sparse_payload, dict) else None
-                )
             items.append(SearchItemResult(id=record_id, fields=payload, score=score))
-        if sparse_vector:
-            items.sort(key=lambda item: item.score or 0.0, reverse=True)
         return SearchResult(data=items[offset : offset + limit])
 
     def _search_by_sparse(
@@ -916,25 +1476,11 @@ class MilvusCollection(ICollection):
     ) -> SearchResult:
         if not sparse_vector:
             return SearchResult()
-        fields = self._select_output_fields(output_fields, include_sparse=True)
-        rows = self._client.query(
-            collection_name=self._physical_collection_name,
-            filter=filters or "",
-            output_fields=fields,
-            limit=max(limit + offset, _DEFAULT_QUERY_LIMIT),
-            timeout=self._timeout_seconds,
+        del limit, offset, filters, output_fields
+        raise NotImplementedError(
+            "Milvus sparse search is not supported because a complete sparse candidate set "
+            "cannot be guaranteed"
         )
-        items = []
-        for row in rows:
-            record_id, payload = self._record_from_entity(row)
-            sparse_payload = payload.pop(self._sparse_vector_name, None)
-            score = _sparse_dot(
-                sparse_vector, sparse_payload if isinstance(sparse_payload, dict) else None
-            )
-            if score > 0:
-                items.append(SearchItemResult(id=record_id, fields=payload, score=score))
-        items.sort(key=lambda item: item.score or 0.0, reverse=True)
-        return SearchResult(data=items[offset : offset + limit])
 
     def search_by_keywords(
         self,
@@ -990,11 +1536,10 @@ class MilvusCollection(ICollection):
         if not rows:
             return SearchResult()
         dense_vector = rows[0].get(self._dense_vector_name)
-        sparse_vector = rows[0].get(self._sparse_vector_name)
         result = self.search_by_vector(
             index_name=index_name,
             dense_vector=dense_vector,
-            sparse_vector=sparse_vector if isinstance(sparse_vector, dict) else None,
+            sparse_vector=None,
             limit=limit + offset + 1,
             offset=0,
             filters=filters,
@@ -1025,6 +1570,11 @@ class MilvusCollection(ICollection):
         output_fields: Optional[List[str]] = None,
     ) -> SearchResult:
         del index_name
+        if limit + offset > _DEFAULT_QUERY_LIMIT:
+            raise ValueError(
+                "Milvus scalar ordering supports at most 10000 rows; the requested window "
+                "would be incomplete"
+            )
         rows = self._client.query(
             collection_name=self._physical_collection_name,
             filter=filters or "",
@@ -1057,9 +1607,13 @@ class MilvusCollection(ICollection):
             collection_name=self._physical_collection_name,
             filter=filters or "",
             output_fields=fields,
-            limit=max(limit + offset, _DEFAULT_QUERY_LIMIT),
+            limit=_TRUNCATION_PROBE_LIMIT,
             timeout=self._timeout_seconds,
         )
+        if len(rows) >= _TRUNCATION_PROBE_LIMIT:
+            raise ValueError(
+                "Milvus scalar ordering cannot safely process more than 10000 matching rows"
+            )
         reverse = (order or "desc").lower() == "desc"
         rows.sort(key=lambda row: (row.get(field) is None, row.get(field)), reverse=reverse)
         items = []
@@ -1181,9 +1735,13 @@ class MilvusCollection(ICollection):
                     collection_name=self._physical_collection_name,
                     filter=filters or "",
                     output_fields=["id"],
-                    limit=_DEFAULT_QUERY_LIMIT,
+                    limit=_TRUNCATION_PROBE_LIMIT,
                     timeout=self._timeout_seconds,
                 )
+                if len(rows) >= _TRUNCATION_PROBE_LIMIT:
+                    raise ValueError(
+                        "Milvus count fallback cannot safely process more than 10000 rows"
+                    )
                 total = len(rows)
             return AggregateResult(agg={"_total": total}, op=op, field=None)
 
@@ -1191,9 +1749,13 @@ class MilvusCollection(ICollection):
             collection_name=self._physical_collection_name,
             filter=filters or "",
             output_fields=[field],
-            limit=_DEFAULT_QUERY_LIMIT,
+            limit=_TRUNCATION_PROBE_LIMIT,
             timeout=self._timeout_seconds,
         )
+        if len(rows) >= _TRUNCATION_PROBE_LIMIT:
+            raise ValueError(
+                "Milvus grouped aggregation cannot safely process more than 10000 matching rows"
+            )
         grouped: Dict[Any, int] = {}
         for row in rows:
             value = row.get(field)
@@ -1308,7 +1870,10 @@ class MilvusFilterCompiler:
                 if len(values) > 1
                 else self._eq(field, values[0])
             )
-            return f"not ({expr})" if expr else ""
+            if not expr:
+                return ""
+            field_name = self._validate_field(field)
+            return self._join("or", [f"not ({expr})", f"{field_name} is null"])
         if op in {"range", "time_range"}:
             return self._range(
                 str(payload.get("field")),
@@ -1422,22 +1987,34 @@ class MilvusCollectionAdapter(CollectionAdapter):
         sparse_vector_name: str,
     ) -> None:
         super().__init__(collection_name=collection_name, index_name=index_name)
+        self._collection: Optional[Collection]
         self._uri = uri
         self._token = token
         self._db_name = db_name
         self._consistency_level = consistency_level
         self._timeout_seconds = int(timeout_seconds)
         self._project_name = project_name
+        _validate_business_namespace(project_name, collection_name)
         self._distance_metric = _normalize_distance(distance_metric)
         self._dense_vector_name = dense_vector_name
         self._sparse_vector_name = sparse_vector_name
         self._client = None
+        self._resolved_physical_collection_name: Optional[str] = None
 
     @classmethod
     def from_config(cls, config: Any):
         cfg = getattr(config, "milvus", None)
         params = dict(getattr(config, "custom_params", {}) or {})
-        uri = getattr(cfg, "uri", None) or getattr(config, "url", None) or params.get("uri")
+        cfg_fields_set: set[str] = (
+            getattr(cfg, "model_fields_set", set()) if cfg is not None else set()
+        )
+        explicit_uri = getattr(cfg, "uri", None) if "uri" in cfg_fields_set else None
+        uri = (
+            explicit_uri
+            or getattr(config, "url", None)
+            or params.get("uri")
+            or getattr(cfg, "uri", None)
+        )
         token = getattr(cfg, "token", None) or params.get("token")
         db_name = getattr(cfg, "db_name", None) or params.get("db_name")
         consistency_level = getattr(cfg, "consistency_level", None) or params.get(
@@ -1471,7 +2048,15 @@ class MilvusCollectionAdapter(CollectionAdapter):
 
     @property
     def physical_collection_name(self) -> str:
-        return _safe_collection_name(self._project_name, self._collection_name)
+        return self._resolved_physical_collection_name or _safe_collection_name(
+            self._project_name,
+            self._collection_name,
+            prefix=_DATA_COLLECTION_PREFIX,
+        )
+
+    @property
+    def legacy_physical_collection_name(self) -> str:
+        return _legacy_collection_name(self._project_name, self._collection_name)
 
     def _connect(self):
         if self._client is not None:
@@ -1488,16 +2073,27 @@ class MilvusCollectionAdapter(CollectionAdapter):
         self._client = pymilvus.MilvusClient(**kwargs)
         return self._client
 
-    def _new_collection(self, meta: Optional[Dict[str, Any]] = None) -> MilvusCollection:
+    def _new_collection(
+        self,
+        meta: Optional[Dict[str, Any]] = None,
+        *,
+        physical_collection_name: Optional[str] = None,
+    ) -> MilvusCollection:
+        resolved_physical_name = physical_collection_name or self.physical_collection_name
+        allow_legacy_sidecar = (
+            self._resolved_physical_collection_name == resolved_physical_name
+            and resolved_physical_name == self.legacy_physical_collection_name
+        )
         return MilvusCollection(
             client=self._connect(),
             logical_collection_name=self._collection_name,
-            physical_collection_name=self.physical_collection_name,
+            physical_collection_name=resolved_physical_name,
             project_name=self._project_name,
             dense_vector_name=self._dense_vector_name,
             sparse_vector_name=self._sparse_vector_name,
             distance_metric=self._distance_metric,
             timeout_seconds=self._timeout_seconds,
+            allow_legacy_sidecar=allow_legacy_sidecar,
             meta=meta,
         )
 
@@ -1506,7 +2102,14 @@ class MilvusCollectionAdapter(CollectionAdapter):
             return
         raw_collection = self._new_collection()
         if not raw_collection.collection_exists():
-            return
+            legacy_name = self.legacy_physical_collection_name
+            if legacy_name == self.physical_collection_name:
+                return
+            raw_collection = self._new_collection(physical_collection_name=legacy_name)
+            if not raw_collection.collection_exists():
+                return
+            self._resolved_physical_collection_name = legacy_name
+            raw_collection = self._new_collection(physical_collection_name=legacy_name)
         meta = raw_collection.load_remote_meta()
         if not meta:
             raise RuntimeError(
@@ -1516,10 +2119,75 @@ class MilvusCollectionAdapter(CollectionAdapter):
             )
         self._collection = Collection(raw_collection)
 
+    def create_collection(
+        self,
+        name: str,
+        schema: Dict[str, Any],
+        *,
+        distance: str,
+        sparse_weight: float,
+        index_name: str,
+    ) -> bool:
+        if sparse_weight > 0.0:
+            raise NotImplementedError(
+                "Milvus sparse and hybrid indexes are not supported because complete recall "
+                "cannot be guaranteed"
+            )
+        _validate_business_namespace(self._project_name, name)
+        self._collection_name = name
+        self._index_name = index_name
+        self._load_existing_collection_if_needed()
+        if self._collection is None:
+            return super().create_collection(
+                name,
+                schema,
+                distance=distance,
+                sparse_weight=sparse_weight,
+                index_name=index_name,
+            )
+
+        raw_collection = self._new_collection()
+        remote_meta = raw_collection.load_remote_meta()
+        if not remote_meta:
+            raise RuntimeError(
+                f"Existing Milvus collection {self.physical_collection_name!r} has no metadata"
+            )
+        raw_collection.ensure_schema_compatible(schema)
+        scalar_fields = self._sanitize_scalar_index_fields(
+            scalar_index_fields=schema.get("ScalarIndex", []),
+            fields_meta=schema.get("Fields", []),
+        )
+        raw_collection.create_index(
+            index_name,
+            self._build_default_index_meta(
+                index_name=index_name,
+                distance=distance,
+                use_sparse=False,
+                sparse_weight=0.0,
+                scalar_index_fields=scalar_fields,
+            ),
+        )
+        self._collection = Collection(raw_collection)
+        return False
+
     def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
         raw_collection = self._new_collection(meta)
         raw_collection.create_remote_collection(meta, consistency_level=self._consistency_level)
         return Collection(raw_collection)
+
+    def drop_collection(self) -> bool:
+        """Drop an owned business collection before removing its exact sidecar row."""
+        self._load_existing_collection_if_needed()
+        raw_collection = self._new_collection()
+        if not raw_collection.collection_exists():
+            raw_collection._validate_all_sidecar_ownership()
+            raw_collection._delete_meta_record(ignore_missing=True)
+            self._collection = None
+            return False
+
+        raw_collection.drop()
+        self._collection = None
+        return True
 
     def close(self) -> None:
         super().close()
@@ -1528,6 +2196,7 @@ class MilvusCollectionAdapter(CollectionAdapter):
             if callable(close):
                 close()
             self._client = None
+        self._resolved_physical_collection_name = None
 
     def _sanitize_scalar_index_fields(
         self,
@@ -1547,9 +2216,9 @@ class MilvusCollectionAdapter(CollectionAdapter):
         scalar_index_fields: list[str],
     ) -> Dict[str, Any]:
         if use_sparse:
-            logger.warning(
-                "Milvus adapter stores sparse vectors but currently searches dense vectors first; "
-                "sparse scores are only applied to returned dense candidates."
+            raise NotImplementedError(
+                "Milvus sparse and hybrid indexes are not supported because complete recall "
+                "cannot be guaranteed"
             )
         return {
             "IndexName": index_name,
@@ -1617,24 +2286,9 @@ class MilvusCollectionAdapter(CollectionAdapter):
         return normalized
 
     def _field_types_for_filter(self) -> Dict[str, str]:
-        try:
-            collection = self.get_collection()
-            meta = collection.get_meta_data() or {}
-            field_types = MilvusCollection._build_field_type_map(meta)
-        except Exception:
-            field_types = {
-                "id": "string",
-                self._dense_vector_name: "vector",
-                self._sparse_vector_name: "sparse_vector",
-                "uri": "path",
-                "parent_uri": "path",
-                "scope_roots": "string",
-                "uri_depth": "int64",
-                "level": "int64",
-                "active_count": "int64",
-                "search_tags": "list<string>",
-            }
-        return field_types
+        collection = self.get_collection()
+        meta = collection.get_meta_data() or {}
+        return MilvusCollection._build_field_type_map(meta)
 
     def _compile_filter(self, expr: FilterExpr | Dict[str, Any] | str | None) -> str:
         return MilvusFilterCompiler(self._field_types_for_filter()).compile(expr)

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -241,7 +241,6 @@ class MilvusConfig(BaseModel):
             raise ValueError("Milvus timeout_seconds must be positive")
         return self
 
-
 class VectorDBBackendConfig(BaseModel):
     """
     Configuration for VectorDB backend.

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -220,11 +220,12 @@ class MilvusConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_milvus(self):
-        self.uri = (self.uri or "./milvus.db").strip()
-        if not self.uri:
+        normalized_uri = (self.uri or "./milvus.db").strip()
+        if not normalized_uri:
             raise ValueError("Milvus uri must not be empty")
-        if self.uri.startswith(("http://", "https://")):
-            self.uri = self.uri.rstrip("/")
+        if normalized_uri.startswith(("http://", "https://")):
+            normalized_uri = normalized_uri.rstrip("/")
+        object.__setattr__(self, "uri", normalized_uri)
         if self.consistency_level:
             allowed = {"Strong", "Session", "Bounded", "Eventually"}
             normalized = self.consistency_level.strip()
@@ -234,12 +235,15 @@ class MilvusConfig(BaseModel):
                     "Milvus consistency_level must be one of: "
                     f"{sorted(allowed)}; got {self.consistency_level!r}"
                 )
-            self.consistency_level = title_value
-        self.dense_vector_name = (self.dense_vector_name or "vector").strip()
-        self.sparse_vector_name = (self.sparse_vector_name or "sparse_vector").strip()
+            object.__setattr__(self, "consistency_level", title_value)
+        object.__setattr__(self, "dense_vector_name", (self.dense_vector_name or "vector").strip())
+        object.__setattr__(
+            self, "sparse_vector_name", (self.sparse_vector_name or "sparse_vector").strip()
+        )
         if self.timeout_seconds <= 0:
             raise ValueError("Milvus timeout_seconds must be positive")
         return self
+
 
 class VectorDBBackendConfig(BaseModel):
     """
@@ -385,11 +389,13 @@ class VectorDBBackendConfig(BaseModel):
                 raise ValueError("VectorDB vikingdb backend requires 'host' to be set")
 
         elif self.backend == "milvus":
+            explicit_milvus_uri = (
+                self.milvus.uri
+                if self.milvus is not None and "uri" in self.milvus.model_fields_set
+                else None
+            )
             milvus_uri = (
-                (self.milvus.uri if self.milvus else None)
-                or self.url
-                or self.custom_params.get("uri")
-                or "./milvus.db"
+                explicit_milvus_uri or self.url or self.custom_params.get("uri") or "./milvus.db"
             )
             if self.milvus is None:
                 self.milvus = MilvusConfig()

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -267,6 +267,7 @@ class MilvusConfig(BaseModel):
             raise ValueError("Milvus timeout_seconds must be positive")
         return self
 
+
 _OPENGAUSS_MODES = {"standalone", "distributed"}
 
 

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -214,6 +214,59 @@ class CuVSConfig(BaseModel):
         return self
 
 
+class MilvusConfig(BaseModel):
+    """Configuration for Milvus backend."""
+
+    uri: str = Field(
+        default="./milvus.db",
+        description=(
+            "Milvus URI. Use a local .db path for Milvus Lite, "
+            "'http://localhost:19530' for self-hosted Milvus, or a Zilliz Cloud endpoint."
+        ),
+    )
+    token: Optional[str] = Field(
+        default=None,
+        description="Optional token for authenticated Milvus or Zilliz Cloud deployments.",
+    )
+    db_name: Optional[str] = Field(
+        default=None,
+        description="Optional Milvus database name for server or cloud deployments.",
+    )
+    consistency_level: Optional[str] = Field(
+        default=None,
+        description="Optional Milvus consistency level: Strong, Session, Bounded, or Eventually.",
+    )
+    timeout_seconds: int = Field(default=30, description="Milvus client timeout in seconds")
+    dense_vector_name: str = Field(default="vector", description="Dense vector field name")
+    sparse_vector_name: str = Field(
+        default="sparse_vector", description="Sparse vector JSON field name"
+    )
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def validate_milvus(self):
+        self.uri = (self.uri or "./milvus.db").strip()
+        if not self.uri:
+            raise ValueError("Milvus uri must not be empty")
+        if self.uri.startswith(("http://", "https://")):
+            self.uri = self.uri.rstrip("/")
+        if self.consistency_level:
+            allowed = {"Strong", "Session", "Bounded", "Eventually"}
+            normalized = self.consistency_level.strip()
+            title_value = normalized[:1].upper() + normalized[1:].lower()
+            if title_value not in allowed:
+                raise ValueError(
+                    "Milvus consistency_level must be one of: "
+                    f"{sorted(allowed)}; got {self.consistency_level!r}"
+                )
+            self.consistency_level = title_value
+        self.dense_vector_name = (self.dense_vector_name or "vector").strip()
+        self.sparse_vector_name = (self.sparse_vector_name or "sparse_vector").strip()
+        if self.timeout_seconds <= 0:
+            raise ValueError("Milvus timeout_seconds must be positive")
+        return self
+
 _OPENGAUSS_MODES = {"standalone", "distributed"}
 
 
@@ -277,7 +330,7 @@ class VectorDBBackendConfig(BaseModel):
         description=(
             "VectorDB backend type: 'local', 'cuvs', 'http', "
             "'volcengine' (AK/SK signed or API key data-plane only), "
-            "'vikingdb' (private deployment), 'qdrant', or 'opengauss'"
+            "'vikingdb' (private deployment), 'qdrant', 'milvus', or 'opengauss'"
         ),
     )
 
@@ -341,6 +394,11 @@ class VectorDBBackendConfig(BaseModel):
         description="NVIDIA cuVS dense-vector search configuration for the 'cuvs' backend",
     )
 
+    milvus: Optional[MilvusConfig] = Field(
+        default_factory=MilvusConfig,
+        description="Milvus configuration for 'milvus' type",
+    )
+
     opengauss: Optional[OpenGaussConfig] = Field(
         default_factory=OpenGaussConfig,
         description="openGauss configuration for 'opengauss' type",
@@ -363,6 +421,7 @@ class VectorDBBackendConfig(BaseModel):
             "volcengine",
             "vikingdb",
             "qdrant",
+            "milvus",
             "opengauss",
         ]
 
@@ -424,6 +483,21 @@ class VectorDBBackendConfig(BaseModel):
             if self.qdrant is None:
                 self.qdrant = QdrantConfig()
             self.qdrant.url = str(qdrant_url).strip().rstrip("/")
+            if self.url:
+                self.url = self.url.strip().rstrip("/")
+
+        elif self.backend == "milvus":
+            milvus_uri = (
+                (self.milvus.uri if self.milvus else None)
+                or self.url
+                or self.custom_params.get("uri")
+                or "./milvus.db"
+            )
+            if self.milvus is None:
+                self.milvus = MilvusConfig()
+            self.milvus.uri = str(milvus_uri).strip()
+            if self.milvus.uri.startswith(("http://", "https://")):
+                self.milvus.uri = self.milvus.uri.rstrip("/")
             if self.url:
                 self.url = self.url.strip().rstrip("/")
 

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -188,6 +188,60 @@ class CuVSConfig(BaseModel):
         return self
 
 
+class MilvusConfig(BaseModel):
+    """Configuration for Milvus backend."""
+
+    uri: str = Field(
+        default="./milvus.db",
+        description=(
+            "Milvus URI. Use a local .db path for Milvus Lite, "
+            "'http://localhost:19530' for self-hosted Milvus, or a Zilliz Cloud endpoint."
+        ),
+    )
+    token: Optional[str] = Field(
+        default=None,
+        description="Optional token for authenticated Milvus or Zilliz Cloud deployments.",
+    )
+    db_name: Optional[str] = Field(
+        default=None,
+        description="Optional Milvus database name for server or cloud deployments.",
+    )
+    consistency_level: Optional[str] = Field(
+        default=None,
+        description="Optional Milvus consistency level: Strong, Session, Bounded, or Eventually.",
+    )
+    timeout_seconds: int = Field(default=30, description="Milvus client timeout in seconds")
+    dense_vector_name: str = Field(default="vector", description="Dense vector field name")
+    sparse_vector_name: str = Field(
+        default="sparse_vector", description="Sparse vector JSON field name"
+    )
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def validate_milvus(self):
+        self.uri = (self.uri or "./milvus.db").strip()
+        if not self.uri:
+            raise ValueError("Milvus uri must not be empty")
+        if self.uri.startswith(("http://", "https://")):
+            self.uri = self.uri.rstrip("/")
+        if self.consistency_level:
+            allowed = {"Strong", "Session", "Bounded", "Eventually"}
+            normalized = self.consistency_level.strip()
+            title_value = normalized[:1].upper() + normalized[1:].lower()
+            if title_value not in allowed:
+                raise ValueError(
+                    "Milvus consistency_level must be one of: "
+                    f"{sorted(allowed)}; got {self.consistency_level!r}"
+                )
+            self.consistency_level = title_value
+        self.dense_vector_name = (self.dense_vector_name or "vector").strip()
+        self.sparse_vector_name = (self.sparse_vector_name or "sparse_vector").strip()
+        if self.timeout_seconds <= 0:
+            raise ValueError("Milvus timeout_seconds must be positive")
+        return self
+
+
 class VectorDBBackendConfig(BaseModel):
     """
     Configuration for VectorDB backend.
@@ -201,7 +255,7 @@ class VectorDBBackendConfig(BaseModel):
         description=(
             "VectorDB backend type: 'local', 'cuvs', 'http', "
             "'volcengine' (AK/SK signed or API key data-plane only), "
-            "or 'vikingdb' (private deployment)"
+            "'vikingdb' (private deployment), or 'milvus'"
         ),
     )
 
@@ -260,6 +314,11 @@ class VectorDBBackendConfig(BaseModel):
         description="NVIDIA cuVS dense-vector search configuration for the 'cuvs' backend",
     )
 
+    milvus: Optional[MilvusConfig] = Field(
+        default_factory=MilvusConfig,
+        description="Milvus configuration for 'milvus' type",
+    )
+
     custom_params: Dict[str, Any] = Field(
         default_factory=dict,
         description="Custom parameters for custom backend adapters",
@@ -276,6 +335,7 @@ class VectorDBBackendConfig(BaseModel):
             "http",
             "volcengine",
             "vikingdb",
+            "milvus",
         ]
 
         # Allow custom backend classes (containing dot) without standard validation
@@ -324,5 +384,20 @@ class VectorDBBackendConfig(BaseModel):
         elif self.backend == "vikingdb":
             if not self.vikingdb or not self.vikingdb.host:
                 raise ValueError("VectorDB vikingdb backend requires 'host' to be set")
+
+        elif self.backend == "milvus":
+            milvus_uri = (
+                (self.milvus.uri if self.milvus else None)
+                or self.url
+                or self.custom_params.get("uri")
+                or "./milvus.db"
+            )
+            if self.milvus is None:
+                self.milvus = MilvusConfig()
+            self.milvus.uri = str(milvus_uri).strip()
+            if self.milvus.uri.startswith(("http://", "https://")):
+                self.milvus.uri = self.milvus.uri.rstrip("/")
+            if self.url:
+                self.url = self.url.strip().rstrip("/")
 
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ test = [
 opengauss = [
     "psycopg2-binary>=2.9",
 ]
+milvus = [
+    "pymilvus[milvus_lite]>=2.6.0",
+]
 dev = [
     "mypy>=1.0.0",
     "ruff>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ auth = [
   "httpx>=0.25.0",
   "python-ldap>=3.4.0",
 ]
+milvus = [
+    "pymilvus[milvus_lite]>=2.6.0",
+]
 dev = [
     "mypy>=1.0.0",
     "ruff>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ auth = [
   "python-ldap>=3.4.0",
 ]
 milvus = [
-    "pymilvus[milvus_lite]>=2.6.0",
+    "pymilvus[milvus-lite]>=3.0.0",
 ]
 dev = [
     "mypy>=1.0.0",

--- a/tests/storage/test_milvus_adapter.py
+++ b/tests/storage/test_milvus_adapter.py
@@ -198,6 +198,13 @@ def test_scope_roots_encoding_is_token_safe():
     assert "\n/a/c\n" not in encoded
 
 
+def test_score_from_cosine_distance_is_higher_is_better():
+    from openviking.storage.vectordb_adapters.milvus_adapter import _score_from_hit
+
+    assert _score_from_hit({"distance": 0.0}, "cosine") == pytest.approx(1.0)
+    assert _score_from_hit({"distance": 1.0}, "cosine") == pytest.approx(0.0)
+
+
 class _FakeSchema:
     def __init__(self) -> None:
         self.fields = []
@@ -358,6 +365,7 @@ def test_milvus_lite_adapter_integration_smoke(tmp_path):
             output_fields=["id", "uri", "abstract", "level"],
         )
         assert [item["id"] for item in result] == ["doc-1"]
+        assert result[0]["_score"] == pytest.approx(1.0)
         assert adapter.count(Eq("account_id", "missing")) == 0
         assert adapter.count() == 2
         assert adapter.delete(ids=["doc-2"]) == 1

--- a/tests/storage/test_milvus_adapter.py
+++ b/tests/storage/test_milvus_adapter.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from openviking.storage.expr import And, Contains, Eq, PathScope, TimeRange
+from openviking.storage.vectordb_adapters.factory import create_collection_adapter
+from openviking.storage.vectordb_adapters.milvus_adapter import (
+    MilvusCollection,
+    MilvusCollectionAdapter,
+    MilvusFilterCompiler,
+    _encode_scope_roots,
+    _normalize_distance,
+    _safe_collection_name,
+)
+from openviking_cli.utils.config.vectordb_config import VectorDBBackendConfig
+
+
+def _build_config() -> VectorDBBackendConfig:
+    return VectorDBBackendConfig.model_validate(
+        {
+            "backend": "milvus",
+            "project": "default",
+            "name": "context",
+            "index_name": "default",
+            "distance_metric": "cosine",
+            "milvus": {
+                "uri": "./milvus.db",
+                "token": "test-token",
+                "db_name": "default",
+                "consistency_level": "session",
+                "timeout_seconds": 7,
+                "dense_vector_name": "vector",
+                "sparse_vector_name": "sparse_vector",
+            },
+        }
+    )
+
+
+def _schema() -> dict:
+    return {
+        "CollectionName": "context",
+        "Description": "test collection",
+        "Fields": [
+            {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+            {"FieldName": "uri", "FieldType": "path"},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": 2},
+            {"FieldName": "sparse_vector", "FieldType": "sparse_vector"},
+            {"FieldName": "abstract", "FieldType": "string"},
+            {"FieldName": "level", "FieldType": "int64"},
+            {"FieldName": "updated_at", "FieldType": "date_time"},
+            {"FieldName": "search_tags", "FieldType": "list<string>"},
+            {"FieldName": "account_id", "FieldType": "string"},
+        ],
+        "ScalarIndex": ["uri", "level", "updated_at", "search_tags", "account_id"],
+    }
+
+
+def test_milvus_backend_config_validation():
+    config = _build_config()
+
+    assert config.backend == "milvus"
+    assert config.milvus is not None
+    assert config.milvus.uri == "./milvus.db"
+    assert config.milvus.token == "test-token"
+    assert config.milvus.db_name == "default"
+    assert config.milvus.consistency_level == "Session"
+
+
+def test_factory_creates_milvus_adapter_without_connecting():
+    adapter = create_collection_adapter(_build_config())
+
+    assert isinstance(adapter, MilvusCollectionAdapter)
+    assert adapter.mode == "milvus"
+    assert adapter.collection_name == "context"
+    assert adapter.index_name == "default"
+    assert adapter.physical_collection_name == "ov_default_context"
+
+
+def test_augments_path_fields_on_write_and_hides_them_on_read():
+    adapter = MilvusCollectionAdapter.from_config(_build_config())
+    source_record = {
+        "id": "1",
+        "uri": "viking://resources/acme/docs/a.md",
+        "vector": [0.1, 0.2],
+    }
+
+    normalized = adapter._normalize_record_for_write(source_record)
+
+    assert normalized["uri"] == "/resources/acme/docs/a.md"
+    assert normalized["parent_uri"] == "/resources/acme/docs"
+    assert normalized["scope_roots"] == [
+        "/",
+        "/resources",
+        "/resources/acme",
+        "/resources/acme/docs",
+    ]
+    assert normalized["uri_depth"] == 4
+    assert source_record["uri"] == "viking://resources/acme/docs/a.md"
+
+    public_record = adapter.normalize_record_for_read(normalized)
+    assert public_record["uri"] == "viking://resources/acme/docs/a.md"
+    assert "parent_uri" not in public_record
+    assert "scope_roots" not in public_record
+    assert "uri_depth" not in public_record
+
+
+def test_compiles_filter_exprs():
+    compiler = MilvusFilterCompiler(
+        {
+            "account_id": "string",
+            "scope_roots": "string",
+            "updated_at": "date_time",
+            "abstract": "string",
+        }
+    )
+
+    compiled = compiler.compile(
+        And(
+            [
+                Eq("account_id", "acme"),
+                PathScope("uri", "viking://resources/acme/docs", depth=-1),
+                TimeRange(
+                    "updated_at",
+                    start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                    end=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                ),
+                Contains("abstract", "quarterly report"),
+            ]
+        )
+    )
+
+    assert compiled == (
+        '(account_id == "acme") and '
+        '(scope_roots like "%\\n/resources/acme/docs\\n%") and '
+        '(updated_at >= "2026-05-01T00:00:00+00:00" and '
+        'updated_at < "2026-06-01T00:00:00+00:00") and '
+        '(abstract like "%quarterly report%")'
+    )
+
+
+def test_compiles_legacy_dict_filters():
+    compiler = MilvusFilterCompiler(
+        {
+            "account_id": "string",
+            "updated_at": "date_time",
+            "scope_roots": "string",
+        }
+    )
+
+    compiled = compiler.compile(
+        {
+            "op": "and",
+            "conds": [
+                {"op": "must", "field": "account_id", "conds": ["acme"]},
+                {
+                    "op": "time_range",
+                    "field": "updated_at",
+                    "gte": "2026-05-01T00:00:00Z",
+                    "lt": "2026-06-01T00:00:00Z",
+                },
+                {"op": "prefix", "field": "uri", "prefix": "viking://resources/acme/docs"},
+            ],
+        }
+    )
+
+    assert compiled == (
+        '(account_id == "acme") and '
+        '(updated_at >= "2026-05-01T00:00:00Z" and '
+        'updated_at < "2026-06-01T00:00:00Z") and '
+        '(scope_roots like "%\\n/resources/acme/docs\\n%")'
+    )
+
+
+def test_vector_literal_and_collection_name_safety():
+    name = _safe_collection_name("Project/With Space", "Context.Table")
+
+    assert name.startswith("ov_Project_With_Space_Context_Table")
+    assert len(name) <= 255
+    assert _normalize_distance("ip") == "ip"
+
+    with pytest.raises(ValueError, match="supports only cosine, l2, and ip"):
+        _normalize_distance("dot")
+
+
+def test_scope_roots_encoding_is_token_safe():
+    encoded = _encode_scope_roots(["/a", "/a/b"])
+
+    assert encoded == "\n/a\n/a/b\n"
+    assert "\n/a\n" in encoded
+    assert "\n/a/b\n" in encoded
+    assert "\n/a/c\n" not in encoded
+
+
+class _FakeSchema:
+    def __init__(self) -> None:
+        self.fields = []
+
+    def add_field(self, **kwargs):
+        self.fields.append(kwargs)
+
+
+class _FakeIndexParams:
+    def __init__(self) -> None:
+        self.indexes = []
+
+    def add_index(self, **kwargs):
+        self.indexes.append(kwargs)
+
+
+class _FakeMilvusClient:
+    def __init__(self) -> None:
+        self.schema = _FakeSchema()
+        self.index_params = _FakeIndexParams()
+        self.created_collection = None
+        self.created_index = None
+        self.properties = {}
+        self.loaded = False
+
+    def create_schema(self, **kwargs):
+        self.schema_kwargs = kwargs
+        return self.schema
+
+    def create_collection(self, **kwargs):
+        self.created_collection = kwargs
+
+    def alter_collection_properties(self, collection_name, properties, timeout=None):
+        self.properties.update(properties)
+
+    def prepare_index_params(self):
+        return self.index_params
+
+    def create_index(self, **kwargs):
+        self.created_index = kwargs
+
+    def load_collection(self, collection_name, timeout=None):
+        self.loaded = True
+
+
+def test_collection_creation_uses_explicit_schema_and_autoindex():
+    client = _FakeMilvusClient()
+    collection = MilvusCollection(
+        client=client,
+        logical_collection_name="context",
+        physical_collection_name="ov_default_context",
+        project_name="default",
+        dense_vector_name="vector",
+        sparse_vector_name="sparse_vector",
+        distance_metric="cosine",
+        timeout_seconds=7,
+        meta=_schema(),
+    )
+
+    collection.create_remote_collection(_schema(), consistency_level="Session")
+    collection.create_index(
+        "default",
+        {
+            "IndexName": "default",
+            "VectorIndex": {"IndexType": "AUTOINDEX", "Distance": "cosine"},
+            "ScalarIndex": ["uri", "level", "parent_uri", "scope_roots"],
+        },
+    )
+
+    assert client.schema_kwargs["auto_id"] is False
+    assert client.schema_kwargs["enable_dynamic_field"] is True
+    field_names = {field["field_name"] for field in client.schema.fields}
+    assert {"id", "uri", "vector", "sparse_vector", "parent_uri", "scope_roots"} <= field_names
+    vector_field = next(field for field in client.schema.fields if field["field_name"] == "vector")
+    assert vector_field["dim"] == 2
+    assert client.created_collection["collection_name"] == "ov_default_context"
+    assert client.created_collection["consistency_level"] == "Session"
+    assert client.index_params.indexes[0] == {
+        "field_name": "vector",
+        "index_name": "default",
+        "index_type": "AUTOINDEX",
+        "metric_type": "COSINE",
+    }
+    assert client.loaded is True
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_adapter_integration_smoke(tmp_path):
+    pytest.importorskip("pymilvus")
+
+    suffix = uuid.uuid4().hex[:8]
+    uri = str(tmp_path / "milvus.db")
+    project_name = f"pytest_{suffix}"
+
+    def _new_adapter() -> MilvusCollectionAdapter:
+        return MilvusCollectionAdapter(
+            uri=uri,
+            token=None,
+            db_name=None,
+            consistency_level="Strong",
+            timeout_seconds=30,
+            project_name=project_name,
+            collection_name="context",
+            index_name="default",
+            distance_metric="cosine",
+            dense_vector_name="vector",
+            sparse_vector_name="sparse_vector",
+        )
+
+    adapter = _new_adapter()
+
+    try:
+        assert adapter.create_collection(
+            "context",
+            _schema(),
+            distance="cosine",
+            sparse_weight=0.0,
+            index_name="default",
+        )
+        adapter.upsert(
+            [
+                {
+                    "id": "doc-1",
+                    "uri": "viking://resources/acme/docs/a.md",
+                    "vector": [1.0, 0.0],
+                    "sparse_vector": {"quarter": 1.0},
+                    "abstract": "quarterly report",
+                    "level": 1,
+                    "updated_at": "2026-05-15T00:00:00+00:00",
+                    "search_tags": ["finance"],
+                    "account_id": "acme",
+                },
+                {
+                    "id": "doc-2",
+                    "uri": "viking://resources/acme/notes/b.md",
+                    "vector": [0.0, 1.0],
+                    "sparse_vector": {"notes": 1.0},
+                    "abstract": "meeting notes",
+                    "level": 2,
+                    "updated_at": "2026-05-16T00:00:00+00:00",
+                    "search_tags": ["notes"],
+                    "account_id": "acme",
+                },
+            ]
+        )
+
+        adapter.close()
+        adapter = _new_adapter()
+        assert adapter.collection_exists() is True
+
+        result = adapter.query(
+            query_vector=[1.0, 0.0],
+            limit=1,
+            filter=PathScope("uri", "viking://resources/acme/docs", depth=-1),
+            output_fields=["id", "uri", "abstract", "level"],
+        )
+        assert [item["id"] for item in result] == ["doc-1"]
+        assert adapter.count(Eq("account_id", "missing")) == 0
+        assert adapter.count() == 2
+        assert adapter.delete(ids=["doc-2"]) == 1
+        assert adapter.count() == 1
+    finally:
+        adapter.drop_collection()
+        adapter.close()

--- a/tests/storage/test_milvus_adapter.py
+++ b/tests/storage/test_milvus_adapter.py
@@ -4,18 +4,21 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import uuid
 from datetime import datetime, timezone
+from typing import Any, cast
 
 import pytest
 
-from openviking.storage.expr import And, Contains, Eq, PathScope, TimeRange
+from openviking.storage.expr import And, Contains, Eq, In, Or, PathScope, RawDSL, TimeRange
 from openviking.storage.vectordb_adapters.factory import create_collection_adapter
 from openviking.storage.vectordb_adapters.milvus_adapter import (
     MilvusCollection,
     MilvusCollectionAdapter,
     MilvusFilterCompiler,
     _encode_scope_roots,
+    _legacy_collection_name,
     _normalize_distance,
     _safe_collection_name,
 )
@@ -57,9 +60,39 @@ def _schema() -> dict:
             {"FieldName": "updated_at", "FieldType": "date_time"},
             {"FieldName": "search_tags", "FieldType": "list<string>"},
             {"FieldName": "account_id", "FieldType": "string"},
+            {"FieldName": "acl_enabled", "FieldType": "bool", "DefaultValue": False},
+            {
+                "FieldName": "acl_direct_grants",
+                "FieldType": "list<string>",
+                "DefaultValue": [],
+            },
+            {
+                "FieldName": "acl_inherited_grants",
+                "FieldType": "list<string>",
+                "DefaultValue": [],
+            },
         ],
-        "ScalarIndex": ["uri", "level", "updated_at", "search_tags", "account_id"],
+        "ScalarIndex": [
+            "uri",
+            "level",
+            "updated_at",
+            "search_tags",
+            "account_id",
+            "acl_enabled",
+            "acl_direct_grants",
+            "acl_inherited_grants",
+        ],
     }
+
+
+def _acl_filter(*grants: str) -> Or:
+    return Or(
+        [
+            RawDSL({"op": "must_not", "field": "acl_enabled", "conds": [True]}),
+            In("acl_direct_grants", list(grants)),
+            In("acl_inherited_grants", list(grants)),
+        ]
+    )
 
 
 def test_milvus_backend_config_validation():
@@ -80,7 +113,27 @@ def test_factory_creates_milvus_adapter_without_connecting():
     assert adapter.mode == "milvus"
     assert adapter.collection_name == "context"
     assert adapter.index_name == "default"
-    assert adapter.physical_collection_name == "ov_default_context"
+    assert adapter.physical_collection_name.startswith("ov_data_default_context_")
+
+
+def test_default_local_factory_does_not_import_pymilvus(monkeypatch):
+    import builtins
+
+    imported = []
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "pymilvus" or name.startswith("pymilvus."):
+            imported.append(name)
+            raise AssertionError("default local backend imported pymilvus")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    config = VectorDBBackendConfig.model_validate({"backend": "local"})
+    adapter = create_collection_adapter(config)
+
+    assert adapter.mode == "local"
+    assert imported == []
 
 
 def test_augments_path_fields_on_write_and_hides_them_on_read():
@@ -178,11 +231,44 @@ def test_compiles_legacy_dict_filters():
     )
 
 
+def test_acl_filters_include_legacy_null_and_array_grants():
+    compiler = MilvusFilterCompiler(
+        {
+            "acl_enabled": "bool",
+            "acl_direct_grants": "list<string>",
+            "acl_inherited_grants": "list<string>",
+        }
+    )
+
+    compiled = compiler.compile(
+        Or(
+            [
+                RawDSL({"op": "must_not", "field": "acl_enabled", "conds": [True]}),
+                In("acl_direct_grants", ["user:alice"]),
+                In("acl_inherited_grants", ["team:docs"]),
+            ]
+        )
+    )
+
+    assert "not (acl_enabled == true)" in compiled
+    assert "acl_enabled is null" in compiled
+    assert 'ARRAY_CONTAINS(acl_direct_grants, "user:alice")' in compiled
+    assert 'ARRAY_CONTAINS(acl_inherited_grants, "team:docs")' in compiled
+
+
 def test_vector_literal_and_collection_name_safety():
     name = _safe_collection_name("Project/With Space", "Context.Table")
 
-    assert name.startswith("ov_Project_With_Space_Context_Table")
+    assert name.startswith("ov_Project_With_Space_Context_Table_")
     assert len(name) <= 255
+    assert _safe_collection_name("team-a", "context") != _safe_collection_name("team_a", "context")
+    assert _legacy_collection_name("team-a", "context") == _legacy_collection_name(
+        "team_a", "context"
+    )
+    assert (
+        _safe_collection_name("internal", "metadata_v1", prefix="ov_data")
+        != "ov_internal_metadata_v1"
+    )
     assert _normalize_distance("ip") == "ip"
 
     with pytest.raises(ValueError, match="supports only cosine, l2, and ip"):
@@ -198,97 +284,923 @@ def test_scope_roots_encoding_is_token_safe():
     assert "\n/a/c\n" not in encoded
 
 
-def test_score_from_cosine_distance_is_higher_is_better():
+def test_score_from_cosine_similarity_is_higher_is_better():
     from openviking.storage.vectordb_adapters.milvus_adapter import _score_from_hit
 
-    assert _score_from_hit({"distance": 0.0}, "cosine") == pytest.approx(1.0)
-    assert _score_from_hit({"distance": 1.0}, "cosine") == pytest.approx(0.0)
+    assert _score_from_hit({"distance": 1.0}, "cosine") == pytest.approx(1.0)
+    assert _score_from_hit({"distance": 0.0}, "cosine") == pytest.approx(0.0)
 
 
-class _FakeSchema:
-    def __init__(self) -> None:
-        self.fields = []
-
-    def add_field(self, **kwargs):
-        self.fields.append(kwargs)
+class _QueryStub:
+    def query(self, **kwargs):
+        return [{"id": str(index), "level": index % 3} for index in range(10_001)]
 
 
-class _FakeIndexParams:
-    def __init__(self) -> None:
-        self.indexes = []
-
-    def add_index(self, **kwargs):
-        self.indexes.append(kwargs)
-
-
-class _FakeMilvusClient:
-    def __init__(self) -> None:
-        self.schema = _FakeSchema()
-        self.index_params = _FakeIndexParams()
-        self.created_collection = None
-        self.created_index = None
-        self.properties = {}
-        self.loaded = False
-
-    def create_schema(self, **kwargs):
-        self.schema_kwargs = kwargs
-        return self.schema
-
-    def create_collection(self, **kwargs):
-        self.created_collection = kwargs
-
-    def alter_collection_properties(self, collection_name, properties, timeout=None):
-        self.properties.update(properties)
-
-    def prepare_index_params(self):
-        return self.index_params
-
-    def create_index(self, **kwargs):
-        self.created_index = kwargs
-
-    def load_collection(self, collection_name, timeout=None):
-        self.loaded = True
-
-
-def test_collection_creation_uses_explicit_schema_and_autoindex():
-    client = _FakeMilvusClient()
-    collection = MilvusCollection(
-        client=client,
+def _unit_collection(client=None, meta: dict | None = None) -> MilvusCollection:
+    return MilvusCollection(
+        client=client or object(),
         logical_collection_name="context",
-        physical_collection_name="ov_default_context",
+        physical_collection_name="ov_data_default_context_test",
         project_name="default",
         dense_vector_name="vector",
         sparse_vector_name="sparse_vector",
         distance_metric="cosine",
         timeout_seconds=7,
-        meta=_schema(),
+        meta=meta or _schema(),
     )
 
-    collection.create_remote_collection(_schema(), consistency_level="Session")
-    collection.create_index(
+
+def test_materializes_defaults_and_normalizes_legacy_nulls():
+    collection = _unit_collection()
+
+    first = collection._prepare_record_for_write({"id": "one", "vector": [1.0, 0.0]})
+    second = collection._prepare_record_for_write({"id": "two", "vector": [0.0, 1.0]})
+
+    assert first["acl_enabled"] is False
+    assert first["acl_direct_grants"] == []
+    assert first["acl_inherited_grants"] == []
+    assert first["acl_direct_grants"] is not second["acl_direct_grants"]
+    decoded = collection._decode_record(
+        {
+            "acl_enabled": None,
+            "acl_direct_grants": None,
+            "acl_inherited_grants": None,
+        }
+    )
+    assert decoded == {
+        "acl_enabled": False,
+        "acl_direct_grants": [],
+        "acl_inherited_grants": [],
+    }
+
+
+def test_sparse_and_hybrid_queries_fail_fast():
+    collection = _unit_collection()
+    adapter = MilvusCollectionAdapter.from_config(_build_config())
+
+    with pytest.raises(NotImplementedError, match="cannot be made complete"):
+        collection.search_by_vector("default", dense_vector=[1.0, 0.0], sparse_vector={"term": 1.0})
+    with pytest.raises(NotImplementedError, match="cannot be made complete"):
+        collection.search_by_vector("default", sparse_vector={"term": 1.0})
+    with pytest.raises(NotImplementedError, match="complete recall"):
+        adapter._build_default_index_meta(
+            index_name="default",
+            distance="cosine",
+            use_sparse=True,
+            sparse_weight=0.5,
+            scalar_index_fields=[],
+        )
+
+
+def test_scalar_order_and_group_fail_fast_at_10001_rows():
+    collection = _unit_collection(_QueryStub())
+
+    with pytest.raises(ValueError, match="more than 10000"):
+        collection.search_by_scalar("default", "level")
+    with pytest.raises(ValueError, match="more than 10000"):
+        collection.aggregate_data("default", field="level")
+
+
+def test_uri_precedence_does_not_connect():
+    cases: list[tuple[dict[str, Any], str]] = [
+        (
+            {"milvus": {"uri": "http://explicit:19530"}, "url": "http://url:19530"},
+            "http://explicit:19530",
+        ),
+        ({"milvus": {}, "url": "http://url:19530"}, "http://url:19530"),
+        (
+            {"milvus": {}, "custom_params": {"uri": "http://custom:19530"}},
+            "http://custom:19530",
+        ),
+        ({"milvus": {}}, "./milvus.db"),
+    ]
+    for extra, expected in cases:
+        config = VectorDBBackendConfig.model_validate(
+            {"backend": "milvus", "project": "safe", "name": "context", **extra}
+        )
+        adapter = MilvusCollectionAdapter.from_config(config)
+        assert adapter._uri == expected
+        assert adapter._client is None
+
+
+@pytest.mark.parametrize(
+    ("project_name", "collection_name"),
+    [
+        ("default", "ov_internal_metadata_v1"),
+        ("default", "ov_openviking_milvus_meta"),
+        ("internal", "metadata-v1"),
+    ],
+)
+def test_reserved_metadata_names_are_rejected(project_name, collection_name):
+    with pytest.raises(ValueError, match="reserved OpenViking metadata namespace"):
+        MilvusCollectionAdapter(
+            uri="./unused.db",
+            token=None,
+            db_name=None,
+            consistency_level="Strong",
+            timeout_seconds=30,
+            project_name=project_name,
+            collection_name=collection_name,
+            index_name="default",
+            distance_metric="cosine",
+            dense_vector_name="vector",
+            sparse_vector_name="sparse_vector",
+        )
+
+
+def _lite_adapter(
+    uri: str, project_name: str, collection_name: str = "context"
+) -> MilvusCollectionAdapter:
+    return MilvusCollectionAdapter(
+        uri=uri,
+        token=None,
+        db_name=None,
+        consistency_level="Strong",
+        timeout_seconds=30,
+        project_name=project_name,
+        collection_name=collection_name,
+        index_name="default",
+        distance_metric="cosine",
+        dense_vector_name="vector",
+        sparse_vector_name="sparse_vector",
+    )
+
+
+class _OneShotFaultProxy:
+    def __init__(self, client, method, predicate, *, after=False):
+        self._client = client
+        self._method = method
+        self._predicate = predicate
+        self._after = after
+        self._armed = True
+        self.calls: list[tuple[str, dict]] = []
+
+    def __getattr__(self, name):
+        target = getattr(self._client, name)
+        if not callable(target):
+            return target
+
+        def delegated(*args, **kwargs):
+            self.calls.append((name, dict(kwargs)))
+            should_fail = self._armed and name == self._method and self._predicate(kwargs)
+            if should_fail and not self._after:
+                self._armed = False
+                raise RuntimeError(f"injected {name} failure")
+            result = target(*args, **kwargs)
+            if should_fail:
+                self._armed = False
+                raise RuntimeError(f"injected post-{name} failure")
+            return result
+
+        return delegated
+
+
+class _CollectionAuditProxy:
+    def __init__(self, client):
+        self._client = client
+        self.calls: list[tuple[str, str | None]] = []
+
+    def __getattr__(self, name):
+        target = getattr(self._client, name)
+        if not callable(target):
+            return target
+
+        def delegated(*args, **kwargs):
+            self.calls.append((name, kwargs.get("collection_name")))
+            return target(*args, **kwargs)
+
+        return delegated
+
+
+def _create_legacy_metadata_collection(client, rows):
+    pymilvus = pytest.importorskip("pymilvus")
+    schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+    schema.add_field(
+        field_name="id",
+        datatype=pymilvus.DataType.VARCHAR,
+        is_primary=True,
+        max_length=512,
+    )
+    schema.add_field(
+        field_name="meta_json",
+        datatype=pymilvus.DataType.VARCHAR,
+        max_length=65_535,
+    )
+    schema.add_field(
+        field_name="indexes_json",
+        datatype=pymilvus.DataType.JSON,
+        nullable=True,
+    )
+    schema.add_field(field_name="meta_vector", datatype=pymilvus.DataType.FLOAT_VECTOR, dim=2)
+    client.create_collection(collection_name="ov_openviking_milvus_meta", schema=schema)
+    index_params = client.prepare_index_params()
+    index_params.add_index(
+        field_name="meta_vector",
+        index_name="legacy_meta_vector_index",
+        index_type="AUTOINDEX",
+        metric_type="COSINE",
+    )
+    client.create_index(
+        collection_name="ov_openviking_milvus_meta",
+        index_params=index_params,
+    )
+    client.alter_collection_properties(
+        collection_name="ov_openviking_milvus_meta",
+        properties={"legacy_sentinel": "unchanged"},
+    )
+    client.upsert(collection_name="ov_openviking_milvus_meta", data=rows)
+
+
+def _index_fields(client, collection_name):
+    return {
+        client.describe_index(collection_name=collection_name, index_name=index_name)[
+            "field_name"
+        ]: index_name
+        for index_name in client.list_indexes(collection_name=collection_name)
+    }
+
+
+def _collection_is_loaded(client, collection_name):
+    state = client.get_load_state(collection_name=collection_name)["state"]
+    return str(getattr(state, "name", state)).lower() == "loaded"
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_v2_never_accesses_preexisting_legacy_metadata(tmp_path):
+    pymilvus = pytest.importorskip("pymilvus")
+    uri = str(tmp_path / "v2-legacy-isolation.db")
+    client = pymilvus.MilvusClient(uri)
+    adapter = _lite_adapter(uri, "v2-legacy-isolation")
+    physical_name = adapter.physical_collection_name
+    exact_meta = _schema()
+    exact_meta["_openviking_identity"] = {
+        "logical_project": "v2-legacy-isolation",
+        "logical_collection": "context",
+        "naming_version": 2,
+        "physical_collection": physical_name,
+    }
+    rows = [
+        {
+            "id": "unrelated-legacy-row",
+            "meta_json": json.dumps({"sentinel": "unrelated"}),
+            "indexes_json": {"sentinel": "unrelated"},
+            "meta_vector": [0.0, 0.0],
+        },
+        {
+            "id": physical_name,
+            "meta_json": json.dumps(exact_meta),
+            "indexes_json": {"sentinel": "exact-v2-id"},
+            "meta_vector": [0.0, 0.0],
+        },
+    ]
+    _create_legacy_metadata_collection(client, rows)
+    row_ids = [row["id"] for row in rows]
+    rows_before = client.get(
+        collection_name="ov_openviking_milvus_meta",
+        ids=row_ids,
+        output_fields=["meta_json", "indexes_json", "meta_vector"],
+    )
+    indexes_before = _index_fields(client, "ov_openviking_milvus_meta")
+    properties_before = client.describe_collection("ov_openviking_milvus_meta")["properties"]
+    client.release_collection(collection_name="ov_openviking_milvus_meta")
+    assert not _collection_is_loaded(client, "ov_openviking_milvus_meta")
+
+    proxy = _CollectionAuditProxy(client)
+    cast(Any, adapter)._client = proxy
+    assert adapter.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    adapter.upsert(
+        {
+            "id": "isolated",
+            "uri": "viking://resources/isolated.md",
+            "vector": [1.0, 0.0],
+            "level": 1,
+        }
+    )
+    assert adapter.get(["isolated"])[0]["id"] == "isolated"
+    assert [
+        item["id"] for item in adapter.query(query_vector=[1.0, 0.0], limit=1, output_fields=["id"])
+    ] == ["isolated"]
+    assert adapter.delete(ids=["isolated"]) == 1
+    adapter.upsert({"id": "drop-me", "vector": [1.0, 0.0]})
+    assert adapter.drop_collection() is True
+
+    assert [
+        (method, collection_name)
+        for method, collection_name in proxy.calls
+        if collection_name == "ov_openviking_milvus_meta"
+    ] == []
+    assert not _collection_is_loaded(client, "ov_openviking_milvus_meta")
+    assert _index_fields(client, "ov_openviking_milvus_meta") == indexes_before
+    assert (
+        client.describe_collection("ov_openviking_milvus_meta")["properties"] == properties_before
+    )
+    assert client.get(collection_name="ov_internal_metadata_v1", ids=[physical_name]) == []
+
+    client.load_collection(collection_name="ov_openviking_milvus_meta")
+    rows_after = client.get(
+        collection_name="ov_openviking_milvus_meta",
+        ids=row_ids,
+        output_fields=["meta_json", "indexes_json", "meta_vector"],
+    )
+    assert rows_after == rows_before
+    client.release_collection(collection_name="ov_openviking_milvus_meta")
+    assert not _collection_is_loaded(client, "ov_openviking_milvus_meta")
+    adapter.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_verified_legacy_binding_uses_legacy_sidecar(tmp_path):
+    pytest.importorskip("pymilvus")
+    uri = str(tmp_path / "verified-legacy-binding.db")
+    owner = _lite_adapter(uri, "legacy-owner")
+    owner._resolved_physical_collection_name = owner.legacy_physical_collection_name
+    physical_name = owner.physical_collection_name
+    assert owner.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    owner.upsert({"id": "owned", "vector": [1.0, 0.0]})
+    client = owner._connect()
+    current_row = client.get(
+        collection_name="ov_internal_metadata_v1",
+        ids=[physical_name],
+        output_fields=["meta_json", "indexes_json"],
+    )[0]
+    identity = json.loads(current_row["meta_json"])["_openviking_identity"]
+    assert identity["naming_version"] == 1
+    _create_legacy_metadata_collection(
+        client,
+        [
+            {
+                "id": physical_name,
+                "meta_json": current_row["meta_json"],
+                "indexes_json": current_row["indexes_json"],
+                "meta_vector": [0.0, 0.0],
+            }
+        ],
+    )
+    client.delete(collection_name="ov_internal_metadata_v1", ids=[physical_name])
+    client.release_collection(collection_name="ov_openviking_milvus_meta")
+    owner.close()
+
+    recovered = _lite_adapter(uri, "legacy-owner")
+    assert recovered.collection_exists() is True
+    assert recovered.physical_collection_name == physical_name
+    assert recovered.get(["owned"])[0]["id"] == "owned"
+    assert recovered.drop_collection() is True
+    client = recovered._connect()
+    assert not client.has_collection(physical_name)
+    assert client.get(collection_name="ov_internal_metadata_v1", ids=[physical_name]) == []
+    assert client.get(collection_name="ov_openviking_milvus_meta", ids=[physical_name]) == []
+    recovered.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_ownership_collision_matrix_and_wrong_project_drop(tmp_path):
+    pytest.importorskip("pymilvus")
+    matrix_uri = str(tmp_path / "ownership-matrix.db")
+    projects = ["team-a", "team_a", "team.a", "team/a", "team a"]
+    physical_names = []
+    for position, project in enumerate(projects):
+        adapter = _lite_adapter(matrix_uri, project)
+        assert adapter.create_collection(
+            "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+        )
+        adapter.upsert([{"id": f"doc-{position}", "vector": [1.0, 0.0]}])
+        physical_names.append(adapter.physical_collection_name)
+        adapter.close()
+    assert len(set(physical_names)) == len(projects)
+
+    from pymilvus import MilvusClient
+
+    client = MilvusClient(matrix_uri)
+    for position, physical_name in enumerate(physical_names):
+        rows = client.get(collection_name=physical_name, ids=[f"doc-{position}"])
+        assert [row["id"] for row in rows] == [f"doc-{position}"]
+    client.close()
+
+    legacy_uri = str(tmp_path / "legacy-owner.db")
+    owner = _lite_adapter(legacy_uri, "team-a")
+    owner._resolved_physical_collection_name = owner.legacy_physical_collection_name
+    legacy_name = owner.physical_collection_name
+    assert owner.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    owner.upsert([{"id": "owned", "vector": [1.0, 0.0]}])
+    owner_client = owner._connect()
+    identity = json.loads(
+        owner_client.get(
+            collection_name="ov_internal_metadata_v1",
+            ids=[legacy_name],
+            output_fields=["meta_json"],
+        )[0]["meta_json"]
+    )["_openviking_identity"]
+    assert identity == {
+        "logical_project": "team-a",
+        "logical_collection": "context",
+        "naming_version": 1,
+        "physical_collection": legacy_name,
+    }
+    owner.close()
+
+    wrong_project = _lite_adapter(legacy_uri, "team_a")
+    assert wrong_project.legacy_physical_collection_name == legacy_name
+    with pytest.raises(RuntimeError, match="ownership identity does not match"):
+        wrong_project.drop_collection()
+    wrong_project.close()
+
+    client = MilvusClient(legacy_uri)
+    assert client.has_collection(legacy_name)
+    assert [row["id"] for row in client.get(collection_name=legacy_name, ids=["owned"])] == [
+        "owned"
+    ]
+    client.close()
+
+    owner = _lite_adapter(legacy_uri, "team-a")
+    assert owner.drop_collection() is True
+    owner.close()
+    for project in projects:
+        adapter = _lite_adapter(matrix_uri, project)
+        assert adapter.drop_collection() is True
+        adapter.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_rejects_legacy_sidecar_without_identity(tmp_path):
+    pytest.importorskip("pymilvus")
+    uri = str(tmp_path / "unowned-legacy.db")
+    adapter = _lite_adapter(uri, "team-a")
+    adapter._resolved_physical_collection_name = adapter.legacy_physical_collection_name
+    physical_name = adapter.physical_collection_name
+    assert adapter.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    adapter.upsert([{"id": "owned", "vector": [1.0, 0.0]}])
+    client = adapter._connect()
+    record = client.get(
+        collection_name="ov_internal_metadata_v1",
+        ids=[physical_name],
+        output_fields=["indexes_json"],
+    )[0]
+    client.upsert(
+        collection_name="ov_internal_metadata_v1",
+        data=[
+            {
+                "id": physical_name,
+                "meta_json": json.dumps(_schema()),
+                "indexes_json": record["indexes_json"],
+                "meta_vector": [0.0, 0.0],
+            }
+        ],
+    )
+    client.alter_collection_properties(
+        collection_name=physical_name,
+        properties={"openviking_meta": json.dumps(_schema())},
+    )
+    adapter.close()
+
+    unowned = _lite_adapter(uri, "team-a")
+    with pytest.raises(RuntimeError, match="no verifiable ownership identity"):
+        unowned.collection_exists()
+    with pytest.raises(RuntimeError, match="no verifiable ownership identity"):
+        unowned.drop_collection()
+    client = unowned._connect()
+    assert client.has_collection(physical_name)
+    assert [row["id"] for row in client.get(collection_name=physical_name, ids=["owned"])] == [
+        "owned"
+    ]
+    unowned.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+@pytest.mark.parametrize(
+    ("fault_method", "after"), [("alter_collection_properties", False), ("upsert", True)]
+)
+def test_milvus_lite_collection_metadata_failure_rolls_back_and_retries(
+    tmp_path, fault_method, after
+):
+    pymilvus = pytest.importorskip("pymilvus")
+    uri = str(tmp_path / f"collection-rollback-{fault_method}.db")
+    client = pymilvus.MilvusClient(uri)
+    adapter = _lite_adapter(uri, "collection-rollback")
+    physical_name = adapter.physical_collection_name
+
+    def predicate(kwargs):
+        if fault_method == "upsert":
+            return kwargs.get("collection_name") == "ov_internal_metadata_v1"
+        return kwargs.get("collection_name") == physical_name and "openviking_meta" in kwargs.get(
+            "properties", {}
+        )
+
+    proxy = _OneShotFaultProxy(client, fault_method, predicate, after=after)
+    cast(Any, adapter)._client = proxy
+    with pytest.raises(RuntimeError, match="rolled back"):
+        adapter.create_collection(
+            "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+        )
+    assert not client.has_collection(physical_name)
+    assert client.get(collection_name="ov_internal_metadata_v1", ids=[physical_name]) == []
+
+    assert adapter.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    assert client.has_collection(physical_name)
+    assert adapter.drop_collection() is True
+    adapter.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+@pytest.mark.parametrize(
+    ("fault_method", "after"), [("alter_collection_properties", False), ("upsert", True)]
+)
+def test_milvus_lite_index_failure_rolls_back_only_new_indexes(tmp_path, fault_method, after):
+    pytest.importorskip("pymilvus")
+    uri = str(tmp_path / f"index-rollback-{fault_method}.db")
+    initial_schema = _schema()
+    initial_schema["ScalarIndex"] = ["uri"]
+    adapter = _lite_adapter(uri, "rollback")
+    assert adapter.create_collection(
+        "context", initial_schema, distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    client = adapter._connect()
+    physical_name = adapter.physical_collection_name
+    indexes_before = _index_fields(client, physical_name)
+    sidecar_before = client.get(
+        collection_name="ov_internal_metadata_v1",
+        ids=[physical_name],
+        output_fields=["meta_json", "indexes_json"],
+    )[0]
+    properties_before = client.describe_collection(physical_name)["properties"]
+
+    raw = adapter._new_collection()
+    assert raw.load_remote_meta() == initial_schema
+
+    def predicate(kwargs):
+        if fault_method == "upsert":
+            return kwargs.get("collection_name") == "ov_internal_metadata_v1"
+        return "openviking_index_default" in kwargs.get("properties", {})
+
+    proxy = _OneShotFaultProxy(client, fault_method, predicate, after=after)
+    raw._client = proxy
+    with pytest.raises(RuntimeError, match="rolled back"):
+        raw.create_index(
+            "default",
+            {
+                "IndexName": "default",
+                "VectorIndex": {"Distance": "cosine"},
+                "ScalarIndex": ["uri", "level"],
+            },
+        )
+
+    assert _index_fields(client, physical_name) == indexes_before
+    assert client.has_collection(physical_name)
+    assert (
+        client.get(
+            collection_name="ov_internal_metadata_v1",
+            ids=[physical_name],
+            output_fields=["meta_json", "indexes_json"],
+        )[0]
+        == sidecar_before
+    )
+    assert client.describe_collection(physical_name)["properties"] == properties_before
+    called = [name for name, _ in proxy.calls]
+    assert "release_collection" in called
+    assert "drop_index" in called
+    assert "load_collection" in called
+    adapter.close()
+
+    restarted = _lite_adapter(uri, "rollback")
+    assert restarted.collection_exists()
+    raw = restarted._new_collection()
+    raw.load_remote_meta()
+    raw.create_index(
         "default",
         {
             "IndexName": "default",
-            "VectorIndex": {"IndexType": "AUTOINDEX", "Distance": "cosine"},
-            "ScalarIndex": ["uri", "level", "parent_uri", "scope_roots"],
+            "VectorIndex": {"Distance": "cosine"},
+            "ScalarIndex": ["uri", "level"],
         },
     )
+    client = restarted._connect()
+    assert set(_index_fields(client, physical_name)) == set(indexes_before) | {"level"}
+    sidecar_meta = client.get(
+        collection_name="ov_internal_metadata_v1",
+        ids=[physical_name],
+        output_fields=["indexes_json"],
+    )[0]["indexes_json"]["default"]
+    property_meta = json.loads(
+        client.describe_collection(physical_name)["properties"]["openviking_index_default"]
+    )
+    assert sidecar_meta == property_meta
+    assert restarted.drop_collection() is True
+    restarted.close()
 
-    assert client.schema_kwargs["auto_id"] is False
-    assert client.schema_kwargs["enable_dynamic_field"] is True
-    field_names = {field["field_name"] for field in client.schema.fields}
-    assert {"id", "uri", "vector", "sparse_vector", "parent_uri", "scope_roots"} <= field_names
-    vector_field = next(field for field in client.schema.fields if field["field_name"] == "vector")
-    assert vector_field["dim"] == 2
-    assert client.created_collection["collection_name"] == "ov_default_context"
-    assert client.created_collection["consistency_level"] == "Session"
-    assert client.index_params.indexes[0] == {
-        "field_name": "vector",
-        "index_name": "default",
-        "index_type": "AUTOINDEX",
-        "metric_type": "COSINE",
-    }
-    assert client.loaded is True
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_successful_index_update_loads_collection(tmp_path):
+    pytest.importorskip("pymilvus")
+    uri = str(tmp_path / "index-load.db")
+    adapter = _lite_adapter(uri, "index-load")
+    assert adapter.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    client = adapter._connect()
+    physical_name = adapter.physical_collection_name
+    assert _collection_is_loaded(client, physical_name)
+
+    client.release_collection(collection_name=physical_name)
+    assert not _collection_is_loaded(client, physical_name)
+    assert (
+        adapter.create_collection(
+            "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+        )
+        is False
+    )
+    assert _collection_is_loaded(client, physical_name)
+    assert adapter.drop_collection() is True
+    adapter.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+@pytest.mark.parametrize("after", [False, True], ids=["before-effect", "after-effect"])
+def test_milvus_lite_load_failure_restores_unloaded_collection(tmp_path, after):
+    pytest.importorskip("pymilvus")
+    uri = str(tmp_path / f"index-load-rollback-{after}.db")
+    adapter = _lite_adapter(uri, f"index-load-rollback-{after}")
+    assert adapter.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    adapter.upsert(
+        {
+            "id": "preserved",
+            "uri": "viking://resources/preserved.md",
+            "vector": [1.0, 0.0],
+            "level": 1,
+        }
+    )
+    assert (
+        adapter.create_collection(
+            "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+        )
+        is False
+    )
+    client = adapter._connect()
+    physical_name = adapter.physical_collection_name
+    data_before = client.get(collection_name=physical_name, ids=["preserved"])
+    indexes_before = _index_fields(client, physical_name)
+    properties_before = client.describe_collection(physical_name)["properties"]
+    sidecar_before = client.get(
+        collection_name="ov_internal_metadata_v1",
+        ids=[physical_name],
+        output_fields=["meta_json", "indexes_json"],
+    )[0]
+
+    client.release_collection(collection_name=physical_name)
+    assert not _collection_is_loaded(client, physical_name)
+    proxy = _OneShotFaultProxy(
+        client,
+        "load_collection",
+        lambda kwargs: kwargs.get("collection_name") == physical_name,
+        after=after,
+    )
+    cast(Any, adapter)._client = proxy
+    with pytest.raises(RuntimeError, match="rolled back"):
+        adapter.create_collection(
+            "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+        )
+
+    assert not _collection_is_loaded(client, physical_name)
+    assert _index_fields(client, physical_name) == indexes_before
+    assert client.describe_collection(physical_name)["properties"] == properties_before
+    assert (
+        client.get(
+            collection_name="ov_internal_metadata_v1",
+            ids=[physical_name],
+            output_fields=["meta_json", "indexes_json"],
+        )[0]
+        == sidecar_before
+    )
+    called = [name for name, _ in proxy.calls]
+    assert "create_index" not in called
+    assert "load_collection" in called
+    assert "release_collection" in called
+
+    assert (
+        adapter.create_collection(
+            "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+        )
+        is False
+    )
+    assert _collection_is_loaded(client, physical_name)
+    assert client.get(collection_name=physical_name, ids=["preserved"]) == data_before
+    result = adapter.query(
+        query_vector=[1.0, 0.0],
+        limit=1,
+        output_fields=["id"],
+    )
+    assert [item["id"] for item in result] == ["preserved"]
+    assert adapter.drop_collection() is True
+    adapter.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_drop_failure_preserves_collection_state(tmp_path):
+    pytest.importorskip("pymilvus")
+    uri = str(tmp_path / "drop-rollback.db")
+    adapter = _lite_adapter(uri, "drop-rollback")
+    assert adapter.create_collection(
+        "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+    )
+    adapter.upsert(
+        {
+            "id": "preserved",
+            "uri": "viking://resources/preserved.md",
+            "vector": [1.0, 0.0],
+            "level": 1,
+        }
+    )
+    client = adapter._connect()
+    physical_name = adapter.physical_collection_name
+    indexes_before = _index_fields(client, physical_name)
+    properties_before = client.describe_collection(physical_name)["properties"]
+    sidecar_before = client.get(
+        collection_name="ov_internal_metadata_v1",
+        ids=[physical_name],
+        output_fields=["meta_json", "indexes_json"],
+    )[0]
+    assert _collection_is_loaded(client, physical_name)
+
+    proxy = _OneShotFaultProxy(
+        client,
+        "drop_collection",
+        lambda kwargs: kwargs.get("collection_name") == physical_name,
+    )
+    cast(Any, adapter)._client = proxy
+    with pytest.raises(RuntimeError, match="injected drop_collection failure"):
+        adapter.drop_collection()
+
+    assert client.has_collection(physical_name)
+    assert [row["id"] for row in client.get(collection_name=physical_name, ids=["preserved"])] == [
+        "preserved"
+    ]
+    assert _index_fields(client, physical_name) == indexes_before
+    assert _collection_is_loaded(client, physical_name)
+    assert client.describe_collection(physical_name)["properties"] == properties_before
+    assert (
+        client.get(
+            collection_name="ov_internal_metadata_v1",
+            ids=[physical_name],
+            output_fields=["meta_json", "indexes_json"],
+        )[0]
+        == sidecar_before
+    )
+    called = [name for name, _ in proxy.calls]
+    assert "drop_index" not in called
+    assert "drop_collection_properties" not in called
+    assert "release_collection" not in called
+
+    assert adapter.drop_collection() is True
+    assert not client.has_collection(physical_name)
+    assert client.get(collection_name="ov_internal_metadata_v1", ids=[physical_name]) == []
+    adapter.close()
+
+
+def _create_mismatched_lite_collection(uri, mismatch):
+    pymilvus = pytest.importorskip("pymilvus")
+    client = pymilvus.MilvusClient(uri)
+    project_name = f"schema-{mismatch}"
+    physical_name = _safe_collection_name(project_name, "context", prefix="ov_data")
+    auto_id = mismatch == "auto_id"
+    dynamic = mismatch != "dynamic"
+    schema = client.create_schema(auto_id=auto_id, enable_dynamic_field=dynamic)
+    fields = list(_schema()["Fields"]) + [
+        {"FieldName": "parent_uri", "FieldType": "path"},
+        {"FieldName": "scope_roots", "FieldType": "string"},
+        {"FieldName": "uri_depth", "FieldType": "int64"},
+    ]
+    for field in fields:
+        name = field["FieldName"]
+        field_type = field["FieldType"]
+        kwargs: dict[str, Any] = {}
+        if name == "id":
+            if auto_id:
+                data_type = pymilvus.DataType.INT64
+                kwargs["is_primary"] = True
+            else:
+                data_type = pymilvus.DataType.VARCHAR
+                kwargs["max_length"] = 512
+                kwargs["is_primary"] = mismatch != "primary_key"
+                if mismatch == "primary_key":
+                    kwargs["nullable"] = True
+        elif field_type == "vector":
+            data_type = pymilvus.DataType.FLOAT_VECTOR
+            kwargs["dim"] = 3 if mismatch == "dimension" else 2
+        elif field_type == "list<string>":
+            data_type = pymilvus.DataType.ARRAY
+            kwargs.update(
+                element_type=pymilvus.DataType.VARCHAR,
+                max_capacity=8 if mismatch == "array" and name == "search_tags" else 1024,
+                max_length=1024,
+                nullable=True,
+            )
+        elif field_type == "int64":
+            data_type = pymilvus.DataType.INT64
+            kwargs["nullable"] = True
+        elif field_type == "bool":
+            data_type = pymilvus.DataType.BOOL
+            kwargs["nullable"] = True
+        elif field_type == "sparse_vector":
+            data_type = pymilvus.DataType.JSON
+            kwargs["nullable"] = True
+        else:
+            data_type = pymilvus.DataType.VARCHAR
+            kwargs.update(
+                max_length=4096 if name in {"uri", "parent_uri"} else 65_535,
+                nullable=True,
+            )
+            if mismatch == "primary_key" and name == "uri":
+                kwargs.pop("nullable", None)
+                kwargs["is_primary"] = True
+        schema.add_field(field_name=name, datatype=data_type, **kwargs)
+    client.create_collection(collection_name=physical_name, schema=schema)
+    raw = MilvusCollection(
+        client=client,
+        logical_collection_name="context",
+        physical_collection_name=physical_name,
+        project_name=project_name,
+        dense_vector_name="vector",
+        sparse_vector_name="sparse_vector",
+        distance_metric="cosine",
+        timeout_seconds=30,
+        meta=_schema(),
+    )
+    raw._save_collection_meta()
+    sidecar = client.get(
+        collection_name="ov_internal_metadata_v1",
+        ids=[physical_name],
+        output_fields=["meta_json", "indexes_json"],
+    )[0]
+    properties = client.describe_collection(physical_name)["properties"]
+    client.close()
+    return project_name, physical_name, sidecar, properties
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+@pytest.mark.parametrize("mismatch", ["dimension", "primary_key", "auto_id", "array", "dynamic"])
+def test_milvus_lite_existing_schema_mismatch_is_read_only(tmp_path, mismatch):
+    uri = str(tmp_path / f"schema-{mismatch}.db")
+    project_name, physical_name, sidecar_before, properties_before = (
+        _create_mismatched_lite_collection(uri, mismatch)
+    )
+    adapter = _lite_adapter(uri, project_name)
+    with pytest.raises(RuntimeError, match="incompatible.*migration/rebuild"):
+        adapter.create_collection(
+            "context", _schema(), distance="cosine", sparse_weight=0.0, index_name="default"
+        )
+
+    client = adapter._connect()
+    assert client.has_collection(physical_name)
+    assert (
+        client.get(
+            collection_name="ov_internal_metadata_v1",
+            ids=[physical_name],
+            output_fields=["meta_json", "indexes_json"],
+        )[0]
+        == sidecar_before
+    )
+    assert client.describe_collection(physical_name)["properties"] == properties_before
+    adapter.close()
 
 
 @pytest.mark.skipif(
@@ -302,22 +1214,7 @@ def test_milvus_lite_adapter_integration_smoke(tmp_path):
     uri = str(tmp_path / "milvus.db")
     project_name = f"pytest_{suffix}"
 
-    def _new_adapter() -> MilvusCollectionAdapter:
-        return MilvusCollectionAdapter(
-            uri=uri,
-            token=None,
-            db_name=None,
-            consistency_level="Strong",
-            timeout_seconds=30,
-            project_name=project_name,
-            collection_name="context",
-            index_name="default",
-            distance_metric="cosine",
-            dense_vector_name="vector",
-            sparse_vector_name="sparse_vector",
-        )
-
-    adapter = _new_adapter()
+    adapter = _lite_adapter(uri, project_name)
 
     try:
         assert adapter.create_collection(
@@ -350,12 +1247,63 @@ def test_milvus_lite_adapter_integration_smoke(tmp_path):
                     "updated_at": "2026-05-16T00:00:00+00:00",
                     "search_tags": ["notes"],
                     "account_id": "acme",
+                    "acl_enabled": True,
+                    "acl_direct_grants": ["user:alice"],
+                },
+                {
+                    "id": "doc-3",
+                    "uri": "viking://resources/acme/shared/c.md",
+                    "vector": [0.8, 0.2],
+                    "abstract": "shared report",
+                    "level": 3,
+                    "updated_at": "2026-05-17T00:00:00+00:00",
+                    "search_tags": ["shared"],
+                    "account_id": "acme",
+                    "acl_enabled": True,
+                    "acl_inherited_grants": ["team:docs"],
                 },
             ]
         )
 
+        saved = adapter.get(["doc-1"])[0]
+        assert saved["acl_enabled"] is False
+        assert saved["acl_direct_grants"] == []
+        assert saved["acl_inherited_grants"] == []
+        adapter.update_data([{"id": "doc-1", "abstract": "updated report"}])
+        assert adapter.get(["doc-1"])[0]["abstract"] == "updated report"
+
+        client = adapter._connect()
+        physical_indexes = {
+            client.describe_index(
+                collection_name=adapter.physical_collection_name,
+                index_name=name,
+            )["field_name"]
+            for name in client.list_indexes(collection_name=adapter.physical_collection_name)
+        }
+        assert {"vector", "uri", "level", "account_id", "acl_enabled"} <= physical_indexes
+        assert "search_tags" not in physical_indexes
+        assert "acl_direct_grants" not in physical_indexes
+        assert "acl_inherited_grants" not in physical_indexes
+        index_meta = adapter.get_collection().get_index_meta_data("default")
+        assert set(index_meta["ScalarIndex"]) <= physical_indexes
+        assert {"search_tags", "acl_direct_grants", "acl_inherited_grants"} <= set(
+            index_meta["ScalarIndexUnavailable"]
+        )
+        sidecar = client.get(
+            collection_name="ov_internal_metadata_v1",
+            ids=[adapter.physical_collection_name],
+            output_fields=["meta_json"],
+        )[0]
+        identity = json.loads(sidecar["meta_json"])["_openviking_identity"]
+        assert identity == {
+            "logical_project": project_name,
+            "logical_collection": "context",
+            "naming_version": 2,
+            "physical_collection": adapter.physical_collection_name,
+        }
+
         adapter.close()
-        adapter = _new_adapter()
+        adapter = _lite_adapter(uri, project_name)
         assert adapter.collection_exists() is True
 
         result = adapter.query(
@@ -366,10 +1314,119 @@ def test_milvus_lite_adapter_integration_smoke(tmp_path):
         )
         assert [item["id"] for item in result] == ["doc-1"]
         assert result[0]["_score"] == pytest.approx(1.0)
+        direct = adapter.query(
+            query_vector=[0.0, 1.0],
+            limit=5,
+            filter=_acl_filter("user:alice"),
+            output_fields=["id"],
+        )
+        assert {item["id"] for item in direct} == {"doc-1", "doc-2"}
+        inherited = adapter.query(
+            query_vector=[1.0, 0.0],
+            limit=5,
+            filter=_acl_filter("team:docs"),
+            output_fields=["id"],
+        )
+        assert {item["id"] for item in inherited} == {"doc-1", "doc-3"}
         assert adapter.count(Eq("account_id", "missing")) == 0
-        assert adapter.count() == 2
+        assert adapter.count() == 3
         assert adapter.delete(ids=["doc-2"]) == 1
-        assert adapter.count() == 1
+        assert adapter.count() == 2
+    finally:
+        adapter.drop_collection()
+        adapter.close()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("milvus_lite") is None,
+    reason="milvus_lite is not installed",
+)
+def test_milvus_lite_dynamic_pre_acl_restart_recovery(tmp_path):
+    pytest.importorskip("pymilvus")
+    old_schema = _schema()
+    old_schema["Fields"] = [
+        field for field in old_schema["Fields"] if not field["FieldName"].startswith("acl_")
+    ]
+    old_schema["ScalarIndex"] = [
+        field for field in old_schema["ScalarIndex"] if not field.startswith("acl_")
+    ]
+    uri = str(tmp_path / "legacy.db")
+    project_name = f"legacy_{uuid.uuid4().hex[:8]}"
+
+    adapter = _lite_adapter(uri, project_name)
+    try:
+        hashed_name = adapter.physical_collection_name
+        legacy_name = adapter.legacy_physical_collection_name
+        assert hashed_name != legacy_name
+        adapter._resolved_physical_collection_name = legacy_name
+        assert adapter.create_collection(
+            "context",
+            old_schema,
+            distance="cosine",
+            sparse_weight=0.0,
+            index_name="default",
+        )
+        adapter.upsert(
+            [
+                {
+                    "id": "legacy-public",
+                    "uri": "viking://resources/legacy.md",
+                    "vector": [1.0, 0.0],
+                    "level": 1,
+                }
+            ]
+        )
+        adapter.close()
+
+        adapter = _lite_adapter(uri, project_name)
+        assert adapter.physical_collection_name == hashed_name
+        assert (
+            adapter.create_collection(
+                "context",
+                _schema(),
+                distance="cosine",
+                sparse_weight=0.0,
+                index_name="default",
+            )
+            is False
+        )
+        assert adapter.physical_collection_name == legacy_name
+        adapter.upsert(
+            [
+                {
+                    "id": "direct",
+                    "uri": "viking://resources/direct.md",
+                    "vector": [0.9, 0.1],
+                    "acl_enabled": True,
+                    "acl_direct_grants": ["user:alice"],
+                },
+                {
+                    "id": "inherited",
+                    "uri": "viking://resources/inherited.md",
+                    "vector": [0.8, 0.2],
+                    "acl_enabled": True,
+                    "acl_inherited_grants": ["team:docs"],
+                },
+            ]
+        )
+        adapter.close()
+
+        adapter = _lite_adapter(uri, project_name)
+        legacy = adapter.get(["legacy-public"])[0]
+        assert legacy["acl_enabled"] is False
+        assert legacy["acl_direct_grants"] == []
+        assert legacy["acl_inherited_grants"] == []
+        visible = adapter.query(
+            query_vector=[1.0, 0.0],
+            limit=10,
+            filter=_acl_filter("user:alice", "team:docs"),
+            output_fields=["id"],
+        )
+        assert {item["id"] for item in visible} == {
+            "legacy-public",
+            "direct",
+            "inherited",
+        }
     finally:
         adapter.drop_collection()
         adapter.close()

--- a/tests/storage/test_milvus_adapter.py
+++ b/tests/storage/test_milvus_adapter.py
@@ -104,7 +104,7 @@ def test_augments_path_fields_on_write_and_hides_them_on_read():
     assert normalized["uri_depth"] == 4
     assert source_record["uri"] == "viking://resources/acme/docs/a.md"
 
-    public_record = adapter.normalize_record_for_read(normalized)
+    public_record = adapter._normalize_record_for_read(normalized)
     assert public_record["uri"] == "viking://resources/acme/docs/a.md"
     assert "parent_uri" not in public_record
     assert "scope_roots" not in public_record

--- a/uv.lock
+++ b/uv.lock
@@ -527,6 +527,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1228,7 +1237,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1242,6 +1251,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/34/6b04ef5bae3eada6b5a9457d7875cce041c040d53c890815cbd1e9821c65/faiss_cpu-1.14.3-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:f9d0e84d909194f63f027bbd3c1e35e905e48c9345c2db6e6f24da09a6bc5906", size = 6925734, upload-time = "2026-06-13T02:19:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/b451af4b3c6dd18749ecfb58ccb68503b77e49c9aa4a89d950e9d521e058/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d734cfa9ac90b6a5dfed3a27cb706d05f22824703dafc3969b4e2071877a31c", size = 9661210, upload-time = "2026-06-13T02:19:06.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ed/57335bc18c9e18677587bec9bf070c675b29c8e683e13f4def0440731ca0/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8780b526c06e57aad90a8c4655dfba2ff1b3195bd600ff4499752fc45159c9fc", size = 18506292, upload-time = "2026-06-13T02:19:09.621Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d3/c6ca8c44a63b909e78aa8a69e14501c79c89613e62261d58455ea603d710/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b28ba083e8c02f2c9be03783402537fd3f00d27e68799c44bf88931500ee12ec", size = 11238800, upload-time = "2026-06-13T02:19:12.821Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5f/b405692913a301251749cb175cb3f564ed257fdaa80a22c9a36444d0095d/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cdcb90850cb4b7c27d270839b37bcc0dc8d1fb6a62d1e13053e51ac95061ca25", size = 19237637, upload-time = "2026-06-13T02:19:15.531Z" },
 ]
 
 [[package]]
@@ -2205,13 +2232,13 @@ name = "langchain-classic"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-text-splitters", marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core" },
+    { name = "langchain-text-splitters" },
+    { name = "langsmith" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/6f/59da67274d8ceea16d0610142af33e348a24750894f08c0688de01504ff2/langchain_classic-1.0.2.tar.gz", hash = "sha256:bbf686613d0051905794f2646ecb6a79fa398db399750a4af039107d93054335", size = 10533928, upload-time = "2026-03-06T20:19:46.176Z" }
 wheels = [
@@ -2226,18 +2253,18 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.11'" },
-    { name = "dataclasses-json", marker = "python_full_version < '3.11'" },
-    { name = "httpx-sse", marker = "python_full_version < '3.11'" },
-    { name = "langchain", marker = "python_full_version < '3.11'" },
-    { name = "langchain-core", marker = "python_full_version < '3.11'" },
-    { name = "langsmith", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version < '3.11'" },
-    { name = "tenacity", marker = "python_full_version < '3.11'" },
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "httpx-sse" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langsmith" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/49/2ff5354273809e9811392bc24bcffda545a196070666aef27bc6aacf1c21/langchain_community-0.3.31.tar.gz", hash = "sha256:250e4c1041539130f6d6ac6f9386cb018354eafccd917b01a4cff1950b80fd81", size = 33241237, upload-time = "2025-10-07T20:17:57.857Z" }
 wheels = [
@@ -2263,18 +2290,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
-    { name = "dataclasses-json", marker = "python_full_version >= '3.11'" },
-    { name = "httpx-sse", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-classic", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic-settings", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version >= '3.11'" },
-    { name = "tenacity", marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "httpx-sse" },
+    { name = "langchain-classic" },
+    { name = "langchain-core" },
+    { name = "langsmith" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/97/a03585d42b9bdb6fbd935282d6e3348b10322a24e6ce12d0c99eb461d9af/langchain_community-0.4.1.tar.gz", hash = "sha256:f3b211832728ee89f169ddce8579b80a085222ddb4f4ed445a46e977d17b1e85", size = 33241144, upload-time = "2025-10-27T15:20:32.504Z" }
 wheels = [
@@ -2319,7 +2346,7 @@ name = "langchain-text-splitters"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/38/14121ead61e0e75f79c3a35e5148ac7c2fe754a55f76eab3eed573269524/langchain_text_splitters-1.1.1.tar.gz", hash = "sha256:34861abe7c07d9e49d4dc852d0129e26b32738b60a74486853ec9b6d6a8e01d2", size = 279352, upload-time = "2026-02-18T23:02:42.798Z" }
 wheels = [
@@ -2715,7 +2742,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -2741,7 +2768,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -2890,6 +2917,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "milvus-lite"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faiss-cpu" },
+    { name = "grpcio" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyarrow" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/42/dee08ae3bfc1731572f193d00b248c9370b0b9dff12becb0ffd8b2ee8d56/milvus_lite-3.0-py3-none-any.whl", hash = "sha256:d9a094eab84bdaa4253da3721482282c939da1cce6f4e1759f947e8d3e53406e", size = 230490, upload-time = "2026-05-13T07:14:00.816Z" },
 ]
 
 [[package]]
@@ -3177,12 +3221,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -3208,12 +3252,12 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
@@ -3763,6 +3807,9 @@ gemini-async = [
 local-embed = [
     { name = "llama-cpp-python" },
 ]
+milvus = [
+    { name = "pymilvus", extra = ["milvus-lite"] },
+]
 ocr = [
     { name = "pytesseract" },
 ]
@@ -3861,6 +3908,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'bot'", specifier = ">=2.0.0" },
     { name = "pygments", marker = "extra == 'bot'", specifier = ">=2.16.0" },
+    { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'milvus'", specifier = ">=2.6.0" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
@@ -3917,7 +3965,7 @@ requires-dist = [
     { name = "xlrd", specifier = ">=2.0.1" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
-provides-extras = ["test", "opengauss", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "local-embed"]
+provides-extras = ["test", "opengauss", "milvus", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "local-embed"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]
@@ -4088,10 +4136,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4163,9 +4211,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -4960,6 +5008,30 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymilvus"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "grpcio" },
+    { name = "orjson" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "protobuf" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/c1/01647e61f3a82fd881382746b6dde3401d65b88cd4f75bd059901fb2392b/pymilvus-3.0.0-1-py3-none-any.whl", hash = "sha256:57c8e7c87fbbf579f122b4df893949bc78e50bca2988527864891bd544817b05", size = 344817, upload-time = "2026-05-07T14:57:45.235Z" },
+]
+
+[package.optional-dependencies]
+milvus-lite = [
+    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -5923,23 +5995,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -5956,23 +6028,23 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -5995,23 +6067,23 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -3889,7 +3889,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'bot'", specifier = ">=2.0.0" },
     { name = "pygments", marker = "extra == 'bot'", specifier = ">=2.16.0" },
-    { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'milvus'", specifier = ">=2.6.0" },
+    { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'milvus'", specifier = ">=3.0.0" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -527,6 +527,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz", hash = "sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50", size = 40680, upload-time = "2026-08-01T21:20:40.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl", hash = "sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0", size = 16830, upload-time = "2026-08-01T21:20:38.977Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1218,7 +1227,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1232,6 +1241,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/68/20e91694ad9a8b2bb48af956899e52b645cb1501e7e2ec31cb733da4d4c5/faiss_cpu-1.15.0-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:50ea471ef1f4f3580eda8ab0ec9727d4bf65fd71c444bf306ce7cdbba8a42b21", size = 4904897, upload-time = "2026-08-03T17:49:37.003Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cd/ef4cf498977c4a84af7a8920bc97ca49fc19060c8464c63fab58847b4692/faiss_cpu-1.15.0-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:dd383bb1ce06fabcff5785f998f253aa88f88dcbe1fe36c922417cd6666dd896", size = 7087977, upload-time = "2026-08-03T17:49:38.947Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c8/88b072bf55714405d0d7e11c12349510f15a69ae56033b1cd894fb2be7d6/faiss_cpu-1.15.0-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d0a2d5d33fe023e263d0d355a837f20db67578e3be27fc5f4012a273274abf6", size = 9835009, upload-time = "2026-08-03T17:49:40.8Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/3b/8878dbfc78a0084bbd408b34827a58b530be98132fcf620b7e15f9191614/faiss_cpu-1.15.0-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ec9b29aae29e428c085c2d49dbb02e4673cdea75db418d420f9e60e0b4184498", size = 18764625, upload-time = "2026-08-03T17:49:43.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/2a/654116e6ee2808562a6b2a11c396bdb46d45689e3bf7206ee99400589cab/faiss_cpu-1.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:30da3029952f0de69f16ce31946fd63fc3e292c867749bbcd2c0a0f09fd06f65", size = 11413863, upload-time = "2026-08-03T17:49:46.471Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/0a0f09659c1972aa83b9820cd3dd7f68f6678cfcfebde542e1c23d7d8663/faiss_cpu-1.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:88fbe1acac6978869063cb2f9477f85718da596a6e0a17751618f9c756bce255", size = 19470092, upload-time = "2026-08-03T17:49:50.253Z" },
 ]
 
 [[package]]
@@ -2210,13 +2237,13 @@ name = "langchain-classic"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-text-splitters", marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core" },
+    { name = "langchain-text-splitters" },
+    { name = "langsmith" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/6f/59da67274d8ceea16d0610142af33e348a24750894f08c0688de01504ff2/langchain_classic-1.0.2.tar.gz", hash = "sha256:bbf686613d0051905794f2646ecb6a79fa398db399750a4af039107d93054335", size = 10533928, upload-time = "2026-03-06T20:19:46.176Z" }
 wheels = [
@@ -2231,18 +2258,18 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.11'" },
-    { name = "dataclasses-json", marker = "python_full_version < '3.11'" },
-    { name = "httpx-sse", marker = "python_full_version < '3.11'" },
-    { name = "langchain", marker = "python_full_version < '3.11'" },
-    { name = "langchain-core", marker = "python_full_version < '3.11'" },
-    { name = "langsmith", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version < '3.11'" },
-    { name = "tenacity", marker = "python_full_version < '3.11'" },
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "httpx-sse" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langsmith" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/49/2ff5354273809e9811392bc24bcffda545a196070666aef27bc6aacf1c21/langchain_community-0.3.31.tar.gz", hash = "sha256:250e4c1041539130f6d6ac6f9386cb018354eafccd917b01a4cff1950b80fd81", size = 33241237, upload-time = "2025-10-07T20:17:57.857Z" }
 wheels = [
@@ -2268,18 +2295,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
-    { name = "dataclasses-json", marker = "python_full_version >= '3.11'" },
-    { name = "httpx-sse", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-classic", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic-settings", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version >= '3.11'" },
-    { name = "tenacity", marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "httpx-sse" },
+    { name = "langchain-classic" },
+    { name = "langchain-core" },
+    { name = "langsmith" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/97/a03585d42b9bdb6fbd935282d6e3348b10322a24e6ce12d0c99eb461d9af/langchain_community-0.4.1.tar.gz", hash = "sha256:f3b211832728ee89f169ddce8579b80a085222ddb4f4ed445a46e977d17b1e85", size = 33241144, upload-time = "2025-10-27T15:20:32.504Z" }
 wheels = [
@@ -2324,7 +2351,7 @@ name = "langchain-text-splitters"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/38/14121ead61e0e75f79c3a35e5148ac7c2fe754a55f76eab3eed573269524/langchain_text_splitters-1.1.1.tar.gz", hash = "sha256:34861abe7c07d9e49d4dc852d0129e26b32738b60a74486853ec9b6d6a8e01d2", size = 279352, upload-time = "2026-02-18T23:02:42.798Z" }
 wheels = [
@@ -2720,7 +2747,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -2746,7 +2773,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -2895,6 +2922,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "milvus-lite"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faiss-cpu" },
+    { name = "grpcio" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyarrow" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/59/caab693e260fb00704672838f332eb0ffeff552806d270ee61f736e14dd4/milvus_lite-3.2.0.tar.gz", hash = "sha256:d6735d7a5bcb14fed2cc9a42da84d7396fef0040a0f7c2d1cace9f2134925571", size = 719788, upload-time = "2026-08-06T08:58:39.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/f8/1b710dd8cf8d1e957086b59d5cf3a7ca1b0d58b3e5199917c3d02a7b3873/milvus_lite-3.2.0-py3-none-any.whl", hash = "sha256:f0f5656b033b1b5cbcfdfb8a9d676e52236338f102c8011d7bbf611afe512bb4", size = 268734, upload-time = "2026-08-06T08:58:32.811Z" },
 ]
 
 [[package]]
@@ -3182,12 +3226,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -3213,12 +3257,12 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
@@ -3749,6 +3793,9 @@ gemini-async = [
 local-embed = [
     { name = "llama-cpp-python" },
 ]
+milvus = [
+    { name = "pymilvus", extra = ["milvus-lite"] },
+]
 ocr = [
     { name = "pytesseract" },
 ]
@@ -3842,6 +3889,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'bot'", specifier = ">=2.0.0" },
     { name = "pygments", marker = "extra == 'bot'", specifier = ">=2.16.0" },
+    { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'milvus'", specifier = ">=2.6.0" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
@@ -3899,7 +3947,7 @@ requires-dist = [
     { name = "wheel", marker = "extra == 'build'" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
-provides-extras = ["test", "auth", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "local-embed"]
+provides-extras = ["test", "auth", "milvus", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "local-embed"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]
@@ -4070,10 +4118,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4145,9 +4193,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -4879,6 +4927,30 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymilvus"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "grpcio" },
+    { name = "orjson" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "protobuf" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/78/6bd0dba340706bc63346af96f0ebe36ff17f75404f5de935fda94d476c98/pymilvus-3.0.1.tar.gz", hash = "sha256:c02389059088b18d6e598cd175541e445c772fab4926c5e527c4913be34887f1", size = 347593, upload-time = "2026-07-29T14:55:43.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/9d/7011887b29f452905745e8bd321f404068d5bfe78fe84e42c0b7cd81a065/pymilvus-3.0.1-py3-none-any.whl", hash = "sha256:c5a8d5c1fa1de7b416e3529d383d8cc2e7da2170433ffa4a2d9087e14f70171a", size = 386820, upload-time = "2026-07-29T14:55:44.279Z" },
+]
+
+[package.optional-dependencies]
+milvus-lite = [
+    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -5868,23 +5940,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -5901,23 +5973,23 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -5940,23 +6012,23 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Add a Milvus vector database adapter with Milvus Lite defaults and configurable URI, token, database, and consistency level.
- Register the backend in the VectorDB adapter factory and add configuration/schema support.
- Document Milvus Lite, self-hosted Milvus, and Zilliz Cloud configuration examples.

## Testing
- `uvx ruff format --check openviking/storage/vectordb_adapters/milvus_adapter.py tests/storage/test_milvus_adapter.py openviking_cli/utils/config/vectordb_config.py`
- `uvx ruff check openviking/storage/vectordb_adapters/milvus_adapter.py tests/storage/test_milvus_adapter.py openviking/storage/vectordb_adapters/factory.py openviking/storage/vectordb_adapters/__init__.py openviking_cli/utils/config/vectordb_config.py`
- `python3.10 -m py_compile openviking/storage/vectordb_adapters/milvus_adapter.py tests/storage/test_milvus_adapter.py openviking_cli/utils/config/vectordb_config.py`
- `git diff --check origin/main...HEAD`
- `uv lock --check`
- `PYTHONPATH=. uv run --no-project --python 3.10 --with pytest --with pydantic --with typing-extensions --with pyyaml --with httpx --with loguru --with 'pymilvus[milvus_lite]' --with apscheduler --with json-repair --with xxhash --with volcengine pytest --confcutdir=tests/storage -o addopts= tests/storage/test_milvus_adapter.py -q`
