### PR TITLE
fix(semantic): gate non-substantive content out of L0/L1 generation

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -55,11 +55,15 @@ PRUNE_ORPHAN_CANDIDATE_LIMIT = 100000
 PRUNE_OUTPUT_FIELDS = ["id", "uri", "level", "context_type", "account_id", "owner_user_id"]
 
 
-# Trailing markers VikingFS appends when a directory has no generated .abstract.md/.overview.md
-# (see openviking/storage/viking_fs.py). The rendered value is a placeholder, not semantic
-# content, and must never be embedded as an ABSTRACT (L0) / OVERVIEW (L1) vector (issue #2434).
+# Trailing markers a directory placeholder ends with. The rendered value is a
+# placeholder, not semantic content, and must never be embedded as an ABSTRACT
+# (L0) / OVERVIEW (L1) vector.
+#   not-ready = VikingFS transient placeholder, file not yet generated (#2434).
+#   no-substantive-content = permanent marker for an empty / title-only directory
+#                            that will never have a real summary (issue #3028).
 _ABSTRACT_NOT_READY_SUFFIX = "[Directory abstract is not ready]"
 _OVERVIEW_NOT_READY_SUFFIX = "[Directory overview is not ready]"
+_NO_SUBSTANTIVE_CONTENT_SUFFIX = "[Directory has no substantive content]"
 
 
 def _is_not_ready_sentinel(text: str, suffix: str) -> bool:
@@ -1567,14 +1571,22 @@ class ReindexExecutor:
             value = await get_viking_fs().abstract(uri, ctx=ctx)
         except Exception:
             return ""
-        return "" if _is_not_ready_sentinel(value, _ABSTRACT_NOT_READY_SUFFIX) else value
+        if _is_not_ready_sentinel(value, _ABSTRACT_NOT_READY_SUFFIX) or _is_not_ready_sentinel(
+            value, _NO_SUBSTANTIVE_CONTENT_SUFFIX
+        ):
+            return ""
+        return value
 
     async def _read_directory_overview(self, uri: str, *, ctx: RequestContext) -> str:
         try:
             value = await get_viking_fs().overview(uri, ctx=ctx)
         except Exception:
             return ""
-        return "" if _is_not_ready_sentinel(value, _OVERVIEW_NOT_READY_SUFFIX) else value
+        if _is_not_ready_sentinel(value, _OVERVIEW_NOT_READY_SUFFIX) or _is_not_ready_sentinel(
+            value, _NO_SUBSTANTIVE_CONTENT_SUFFIX
+        ):
+            return ""
+        return value
 
     async def _best_file_summary(self, uri: str, *, ctx: RequestContext) -> str:
         parent_uri = VikingURI(uri).parent.uri

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -679,7 +679,9 @@ class SemanticDagExecutor:
             self._stats.in_progress_nodes = max(0, self._stats.in_progress_nodes - 1)
 
         try:
-            if need_vectorize:
+            # Skip vectorization of non-substantive files (issue #3028); media
+            # and code summaries default True. Keep the existing code-repo logic.
+            if need_vectorize and summary_dict.get("has_substantive_content", True):
                 use_summary = self._is_code_repo and bool(summary_dict.get("summary"))
                 task = VectorizeTask(
                     task_type="file",
@@ -738,7 +740,13 @@ class SemanticDagExecutor:
         for idx, file_path in enumerate(node.file_paths):
             item = node.file_summaries[idx]
             if item is None:
-                summaries.append({"name": file_path.split("/")[-1], "summary": ""})
+                summaries.append(
+                    {
+                        "name": file_path.split("/")[-1],
+                        "summary": "",
+                        "has_substantive_content": False,
+                    }
+                )
             else:
                 summaries.append(item)
         return summaries
@@ -813,6 +821,13 @@ class SemanticDagExecutor:
                         dir_uri, file_summaries, children_abstracts
                     )
                 overview, abstract = self._processor._normalize_overview_generation(overview)
+
+            # Neutral (no-substantive-content) overview: write the sidecar but do
+            # not embed it, matching _is_not_ready_sentinel (issue #3028 / #2434).
+            from openviking.storage.queuefs.semantic_processor import is_neutral_overview
+
+            if is_neutral_overview(overview):
+                need_vectorize = False
 
             # Write directly, protected by the outer semantic lock.
             try:

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -695,6 +695,11 @@ class SemanticDagExecutor:
                     use_summary=use_summary,
                 )
                 await self._add_vectorize_task(task)
+            elif need_vectorize:
+                # Content changed and is now non-substantive: any previously
+                # embedded DETAIL record at this exact URI is stale — remove it
+                # (issue #3028). Idempotent no-op when nothing was embedded.
+                await self._viking_fs._delete_from_vector_store([file_path], ctx=self._ctx)
         except Exception as e:
             logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
         await self._on_file_done(parent_uri, file_path, summary_dict)
@@ -828,6 +833,11 @@ class SemanticDagExecutor:
 
             if is_neutral_overview(overview):
                 need_vectorize = False
+                # Directory became non-substantive: stale L0/L1 records at this
+                # exact URI must be removed (issue #3028). Deliberately inside
+                # this branch only — the write-failure path below also suppresses
+                # vectorization but must keep existing vectors.
+                await self._viking_fs._delete_from_vector_store([dir_uri], ctx=self._ctx)
 
             # Write directly, protected by the outer semantic lock.
             try:

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -5,7 +5,7 @@
 import asyncio
 import threading
 from dataclasses import dataclass, field
-from typing import ClassVar, Dict, List, Optional, Set
+from typing import Any, ClassVar, Dict, List, Optional, Set
 from weakref import WeakKeyDictionary
 
 from openviking.server.identity import RequestContext
@@ -33,7 +33,7 @@ class DirNode:
     file_paths: List[str]
     file_index: Dict[str, int]
     child_index: Dict[str, int]
-    file_summaries: List[Optional[Dict[str, str]]]
+    file_summaries: List[Optional[Dict[str, Any]]]
     children_abstracts: List[Optional[Dict[str, str]]]
     pending: int
     dispatched: bool = False
@@ -60,7 +60,7 @@ class VectorizeTask:
     semantic_msg_id: Optional[str] = None
     # For file tasks
     file_path: Optional[str] = None
-    summary_dict: Optional[Dict[str, str]] = None
+    summary_dict: Optional[Dict[str, Any]] = None
     parent_uri: Optional[str] = None
     use_summary: bool = False
     # For directory tasks
@@ -735,8 +735,8 @@ class SemanticDagExecutor:
         node.overview_scheduled = True
         self._schedule_work(DagWork(kind="overview", dir_uri=dir_uri))
 
-    def _finalize_file_summaries(self, node: DirNode) -> List[Dict[str, str]]:
-        summaries: List[Dict[str, str]] = []
+    def _finalize_file_summaries(self, node: DirNode) -> List[Dict[str, Any]]:
+        summaries: List[Dict[str, Any]] = []
         for idx, file_path in enumerate(node.file_paths):
             item = node.file_summaries[idx]
             if item is None:

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -58,6 +58,105 @@ from openviking_cli.utils.logger import get_logger
 logger = get_logger(__name__)
 
 
+# --- Substantive-content detector (issue #3028) -----------------------------
+# Regex-only markdown strip (no AST). Decides whether a text file has real
+# authored content or is just headings/markup/frontmatter that would make a VLM
+# hallucinate an L0/L1 summary. Spec: .wiki/issue-3028-...md §3.1/§3.2.
+
+# CJK ranges: Unified Ideographs, Hiragana, Katakana, Hangul, CJK punctuation.
+_CJK_RE = re.compile("[　-〿぀-ゟ゠-ヿ一-鿿가-힯]")
+_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)  # leading block only
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+_ATX_RE = re.compile(r"^\s*#{1,6}\s+\S")
+_SETEXT_UNDERLINE_RE = re.compile(r"^(=+|-+)$")  # === (h1) or --- (h2/divider)
+_HR_RE = re.compile(r"^([-*_])(\s*\1){2,}$")  # ---, ***, ___
+_BLOCKQUOTE_RE = re.compile(r"^\s*>+\s?")
+_LIST_RE = re.compile(r"^\s*([-*+]|\d+[.)])\s+")
+_TABLE_SEP_RE = re.compile(r"^[\s|:\-]+$")
+_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")  # keep alt
+_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")  # keep text
+_AUTOLINK_RE = re.compile(r"<[a-z][a-z0-9+.-]*://[^>]*>")
+_BARE_URL_RE = re.compile(r"(https?://|www\.)\S+")
+_EMPHASIS_RE = re.compile(r"(\*\*|\*|__|_|~~)")
+_PUNCT_ONLY_RE = re.compile(r"^[\W_\s]+$")
+
+
+def _weighted_len(residual: str, cjk_weight: float) -> float:
+    """CJK-weighted content length; whitespace excluded (dense CJK has no spaces)."""
+    total = 0.0
+    for ch in residual:
+        if _CJK_RE.match(ch):
+            total += cjk_weight
+        elif not ch.isspace():
+            total += 1.0
+    return total
+
+
+def has_substantive_content(
+    text: str, min_chars: int = 8, cjk_weight: float = 2.5
+) -> tuple[bool, int]:
+    """Return (is_substantive, weighted_residual_len).
+
+    Strips markdown structure (frontmatter, HTML comments, headings, setext/HR,
+    blockquote/list markers, table pipes, code fences, link/image markup,
+    emphasis markers) with regex only — no AST. Keeps code body, table cell
+    text, and link/image label text. Weighted length counts CJK chars heavier.
+    The residual length is returned for telemetry/logging. See issue #3028.
+    """
+    if not text:
+        return False, 0
+
+    # 1. Normalize line endings first (reporter is on Windows → CRLF expected).
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    # 2. Leading YAML frontmatter only — never a mid-doc `---`.
+    text = _FRONTMATTER_RE.sub("", text)
+    # 3. HTML comments.
+    text = _HTML_COMMENT_RE.sub("", text)
+
+    kept: list[str] = []
+    in_fence = False
+    for line in text.split("\n"):
+        # 4. Code fences before heading/list rules, so a `#`/`-` inside a fenced
+        #    block isn't mistaken for a heading/list marker. Keep the body.
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            kept.append(line)  # code body
+            continue
+
+        stripped = line.strip()
+        if _ATX_RE.match(line):
+            continue  # heading marker + text dropped
+        if _SETEXT_UNDERLINE_RE.match(stripped):
+            if kept and kept[-1].strip():
+                kept.pop()  # drop the heading text this underlines
+            continue
+        if _HR_RE.match(stripped):
+            continue
+
+        line = _BLOCKQUOTE_RE.sub("", line)
+        line = _LIST_RE.sub("", line)
+        if "|" in line and _TABLE_SEP_RE.match(line.strip()):
+            continue  # table separator row
+        line = line.replace("|", " ")  # keep cell text, drop pipes
+        line = _IMAGE_RE.sub(r"\1", line)  # keep alt
+        line = _LINK_RE.sub(r"\1", line)  # keep text
+        line = _AUTOLINK_RE.sub("", line)
+        line = _BARE_URL_RE.sub("", line)
+        line = line.replace("`", "")  # inline code markers, keep body
+        line = _EMPHASIS_RE.sub("", line)  # markers only, keep span
+        kept.append(line)
+
+    residual = " ".join(part for part in " ".join(kept).split() if part)
+    if not residual or _PUNCT_ONLY_RE.match(residual):
+        return False, 0
+
+    weighted = _weighted_len(residual, cjk_weight)
+    return weighted >= min_chars, int(weighted)
+
+
 @dataclass
 class DiffResult:
     """Directory diff result for sync operations."""

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -65,7 +65,7 @@ logger = get_logger(__name__)
 
 # CJK ranges: Unified Ideographs, Hiragana, Katakana, Hangul, CJK punctuation.
 _CJK_RE = re.compile("[　-〿぀-ゟ゠-ヿ一-鿿가-힯]")
-_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)  # leading block only
+_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---[ \t]*(?:\n|\Z)", re.DOTALL)  # leading block only; closes at EOF too
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _FENCE_RE = re.compile(r"^\s*(```|~~~)")
 _ATX_RE = re.compile(r"^\s*#{1,6}\s+\S")
@@ -798,7 +798,9 @@ class SemanticProcessor(DequeueHandlerBase):
             file_vectorize_items = [
                 (file_path, summary)
                 for file_path, summary in zip(file_paths, file_summaries, strict=False)
-                if file_path in paths_to_vectorize and summary is not None
+                if file_path in paths_to_vectorize
+                and summary is not None
+                and summary.get("has_substantive_content", True)
             ]
             generated_content = await self._generate_overview(
                 dir_uri, completed_summaries, [], llm_sem=llm_sem
@@ -1485,8 +1487,10 @@ class SemanticProcessor(DequeueHandlerBase):
             return _neutral_directory_overview(dir_uri.split("/")[-1])
 
         if not vlm.is_available():
+            # VLM down is transient (retry later), not "empty" — keep the not-ready
+            # marker here; only genuinely non-substantive dirs get the no-content one.
             logger.warning("VLM not available, using default overview")
-            return _neutral_directory_overview(dir_uri.split("/")[-1])
+            return f"# {dir_uri.split('/')[-1]}\n\n{_OVERVIEW_NOT_READY_MARKER}"
 
         from openviking.session.memory.utils.language import resolve_output_language
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -66,7 +66,9 @@ logger = get_logger(__name__)
 # CJK ranges: Unified Ideographs, Hiragana, Katakana, Hangul, CJK punctuation.
 _CJK_RE = re.compile("[　-〿぀-ゟ゠-ヿ一-鿿가-힯]")
 _CJK_WEIGHT = 2.5  # CJK chars count heavier: 1 char ≈ 1 word (dense CJK has no spaces)
-_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---[ \t]*(?:\n|\Z)", re.DOTALL)  # leading block only; closes at EOF too
+_FRONTMATTER_RE = re.compile(
+    r"\A---\n.*?\n---[ \t]*(?:\n|\Z)", re.DOTALL
+)  # leading block only; closes at EOF too
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _FENCE_RE = re.compile(r"^\s*(```|~~~)")
 _ATX_RE = re.compile(r"^\s*#{1,6}\s+\S")

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -802,6 +802,20 @@ class SemanticProcessor(DequeueHandlerBase):
                 and summary is not None
                 and summary.get("has_substantive_content", True)
             ]
+            # Files whose fresh summary is non-substantive: any previously
+            # embedded DETAIL records at their exact URIs are stale — remove
+            # them (issue #3028). Idempotent no-op when nothing was embedded.
+            # Deleting before the sidecar write below is intentional: these
+            # files must not have vectors regardless of the write outcome.
+            stale_file_uris = [
+                file_path
+                for file_path, summary in zip(file_paths, file_summaries, strict=False)
+                if file_path in paths_to_vectorize
+                and summary is not None
+                and not summary.get("has_substantive_content", True)
+            ]
+            if stale_file_uris:
+                await viking_fs._delete_from_vector_store(stale_file_uris, ctx=ctx)
             generated_content = await self._generate_overview(
                 dir_uri, completed_summaries, [], llm_sem=llm_sem
             )
@@ -857,6 +871,9 @@ class SemanticProcessor(DequeueHandlerBase):
                 )
             if skip_directory_vectorization:
                 logger.info(f"Skipping directory vectorization for neutral overview: {dir_uri}")
+                # Directory became non-substantive: remove stale L0/L1 records
+                # at this exact URI (issue #3028). Idempotent when none exist.
+                await viking_fs._delete_from_vector_store([dir_uri], ctx=ctx)
             else:
                 await self._vectorize_directory(
                     uri=dir_uri,

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -157,6 +157,51 @@ def has_substantive_content(
     return weighted >= min_chars, int(weighted)
 
 
+# Directory placeholder markers, all shaped like reindex_executor's sentinels
+# (single `#` header + suffix) so _is_not_ready_sentinel refuses to embed them.
+#   not-ready = VikingFS transient placeholder (the .overview.md/.abstract.md
+#               file is missing / not yet generated).
+#   no-substantive-content = our PERMANENT marker for an empty / title-only
+#               directory that will never have a real summary (issue #3028).
+_OVERVIEW_NOT_READY_MARKER = "[Directory overview is not ready]"
+_ABSTRACT_NOT_READY_MARKER = "[Directory abstract is not ready]"
+_OVERVIEW_NO_CONTENT_MARKER = "[Directory has no substantive content]"
+
+
+def _neutral_directory_overview(dir_name: str) -> str:
+    """Deterministic directory overview when there is no substantive content — no VLM."""
+    return f"# {dir_name}\n\n{_OVERVIEW_NO_CONTENT_MARKER}"
+
+
+def is_neutral_overview(text: str) -> bool:
+    """True if *text* is the no-substantive-content directory overview.
+
+    Same shape test as ``reindex_executor._is_not_ready_sentinel`` (a single
+    ``#`` header followed only by the marker) so the write-time vectorization
+    skip and the reindex embedding guard agree.
+    """
+    if not text:
+        return False
+    head = text.rstrip()
+    if not head.endswith(_OVERVIEW_NO_CONTENT_MARKER):
+        return False
+    head = head[: -len(_OVERVIEW_NO_CONTENT_MARKER)].strip()
+    return head.startswith("#") and "\n" not in head
+
+
+def _is_placeholder_abstract(text: Optional[str]) -> bool:
+    """True if *text* is empty or a placeholder directory abstract (transient
+    not-ready or permanent no-substantive-content)."""
+    t = (text or "").strip()
+    if not t:
+        return True
+    return (
+        t.endswith(_OVERVIEW_NO_CONTENT_MARKER)
+        or t.endswith(_OVERVIEW_NOT_READY_MARKER)
+        or t.endswith(_ABSTRACT_NOT_READY_MARKER)
+    )
+
+
 @dataclass
 class DiffResult:
     """Directory diff result for sync operations."""
@@ -759,6 +804,9 @@ class SemanticProcessor(DequeueHandlerBase):
                 dir_uri, completed_summaries, [], llm_sem=llm_sem
             )
             overview, abstract = self._normalize_overview_generation(generated_content)
+            # Neutral (no-substantive-content) overview: write the sidecar but do
+            # not embed it, matching _is_not_ready_sentinel (issue #3028 / #2434).
+            skip_directory_vectorization = is_neutral_overview(overview)
 
             try:
                 wrote_semantics = await self._write_memory_directory_semantics(
@@ -790,7 +838,8 @@ class SemanticProcessor(DequeueHandlerBase):
                 tracker = EmbeddingTaskTracker.get_instance()
                 await tracker.register(
                     semantic_msg_id=msg.id,
-                    total_count=2 + len(file_vectorize_items),
+                    total_count=(0 if skip_directory_vectorization else 2)
+                    + len(file_vectorize_items),
                     on_complete=_on_complete,
                     metadata={"uri": dir_uri},
                 )
@@ -804,15 +853,18 @@ class SemanticProcessor(DequeueHandlerBase):
                     semantic_msg_id=msg.id,
                     preserve_existing_created_at=True,
                 )
-            await self._vectorize_directory(
-                uri=dir_uri,
-                context_type="memory",
-                abstract=abstract,
-                overview=overview,
-                ctx=ctx,
-                semantic_msg_id=msg.id,
-            )
-            logger.info(f"Vectorized abstract.md and overview.md for {dir_uri}")
+            if skip_directory_vectorization:
+                logger.info(f"Skipping directory vectorization for neutral overview: {dir_uri}")
+            else:
+                await self._vectorize_directory(
+                    uri=dir_uri,
+                    context_type="memory",
+                    abstract=abstract,
+                    overview=overview,
+                    ctx=ctx,
+                    semantic_msg_id=msg.id,
+                )
+                logger.info(f"Vectorized abstract.md and overview.md for {dir_uri}")
         finally:
             await lock.close()
 
@@ -1146,8 +1198,24 @@ class SemanticProcessor(DequeueHandlerBase):
 
         full_content = content or ""
 
-        def result(summary: str) -> Dict[str, Any]:
-            return {"name": file_name, "summary": summary, "content": full_content}
+        def result(summary: str, has_substantive: bool = True) -> Dict[str, Any]:
+            return {
+                "name": file_name,
+                "summary": summary,
+                "content": full_content,
+                "has_substantive_content": has_substantive,
+            }
+
+        # Substantive-content gate (issue #3028): skip the VLM for empty /
+        # title-only docs so it cannot hallucinate a summary. Run on the
+        # untruncated content; never gate code (code is always substantive).
+        file_type = self._detect_file_type(file_name)
+        if file_type != FILE_TYPE_CODE:
+            min_chars = get_openviking_config().semantic.min_substantive_chars
+            is_substantive, _residual = has_substantive_content(full_content, min_chars=min_chars)
+            if not is_substantive:
+                logger.info("Skipping VLM for non-substantive file: %s", file_path)
+                return result("", has_substantive=False)
 
         # Limit content length
         max_chars = get_openviking_config().semantic.max_file_content_chars
@@ -1163,9 +1231,7 @@ class SemanticProcessor(DequeueHandlerBase):
 
         output_language = resolve_output_language(content)
 
-        # Detect file type and select appropriate prompt
-        file_type = self._detect_file_type(file_name)
-
+        # File type already detected above for the substantive-content gate.
         if file_type == FILE_TYPE_CODE:
             code_mode = get_openviking_config().code.code_summary_mode
 
@@ -1407,9 +1473,20 @@ class SemanticProcessor(DequeueHandlerBase):
         vlm = config.vlm
         semantic = config.semantic
 
+        # Substantive-content gate (issue #3028): drop non-substantive files (and
+        # placeholder child abstracts) from the overview prompt; if nothing
+        # substantive remains, write the deterministic neutral overview without
+        # the VLM so it cannot hallucinate over near-empty input.
+        file_summaries = [s for s in file_summaries if s.get("has_substantive_content", True)]
+        children_abstracts = [
+            c for c in children_abstracts if not _is_placeholder_abstract(c.get("abstract"))
+        ]
+        if not file_summaries and not children_abstracts:
+            return _neutral_directory_overview(dir_uri.split("/")[-1])
+
         if not vlm.is_available():
             logger.warning("VLM not available, using default overview")
-            return f"# {dir_uri.split('/')[-1]}\n\n[Directory overview is not ready]"
+            return _neutral_directory_overview(dir_uri.split("/")[-1])
 
         from openviking.session.memory.utils.language import resolve_output_language
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -65,6 +65,7 @@ logger = get_logger(__name__)
 
 # CJK ranges: Unified Ideographs, Hiragana, Katakana, Hangul, CJK punctuation.
 _CJK_RE = re.compile("[　-〿぀-ゟ゠-ヿ一-鿿가-힯]")
+_CJK_WEIGHT = 2.5  # CJK chars count heavier: 1 char ≈ 1 word (dense CJK has no spaces)
 _FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---[ \t]*(?:\n|\Z)", re.DOTALL)  # leading block only; closes at EOF too
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _FENCE_RE = re.compile(r"^\s*(```|~~~)")
@@ -82,30 +83,28 @@ _EMPHASIS_RE = re.compile(r"(\*\*|\*|__|_|~~)")
 _PUNCT_ONLY_RE = re.compile(r"^[\W_\s]+$")
 
 
-def _weighted_len(residual: str, cjk_weight: float) -> float:
+def _weighted_len(residual: str) -> float:
     """CJK-weighted content length; whitespace excluded (dense CJK has no spaces)."""
     total = 0.0
     for ch in residual:
         if _CJK_RE.match(ch):
-            total += cjk_weight
+            total += _CJK_WEIGHT
         elif not ch.isspace():
             total += 1.0
     return total
 
 
-def has_substantive_content(
-    text: str, min_chars: int = 8, cjk_weight: float = 2.5
-) -> tuple[bool, int]:
-    """Return (is_substantive, weighted_residual_len).
+def has_substantive_content(text: str, min_chars: int = 8) -> bool:
+    """Return True if *text* has substantive content after stripping markdown.
 
     Strips markdown structure (frontmatter, HTML comments, headings, setext/HR,
     blockquote/list markers, table pipes, code fences, link/image markup,
     emphasis markers) with regex only — no AST. Keeps code body, table cell
     text, and link/image label text. Weighted length counts CJK chars heavier.
-    The residual length is returned for telemetry/logging. See issue #3028.
+    See issue #3028.
     """
     if not text:
-        return False, 0
+        return False
 
     # 1. Normalize line endings first (reporter is on Windows → CRLF expected).
     text = text.replace("\r\n", "\n").replace("\r", "\n")
@@ -151,10 +150,9 @@ def has_substantive_content(
 
     residual = " ".join(part for part in " ".join(kept).split() if part)
     if not residual or _PUNCT_ONLY_RE.match(residual):
-        return False, 0
+        return False
 
-    weighted = _weighted_len(residual, cjk_weight)
-    return weighted >= min_chars, int(weighted)
+    return _weighted_len(residual) >= min_chars
 
 
 # Directory placeholder markers, all shaped like reindex_executor's sentinels
@@ -1214,8 +1212,7 @@ class SemanticProcessor(DequeueHandlerBase):
         file_type = self._detect_file_type(file_name)
         if file_type != FILE_TYPE_CODE:
             min_chars = get_openviking_config().semantic.min_substantive_chars
-            is_substantive, _residual = has_substantive_content(full_content, min_chars=min_chars)
-            if not is_substantive:
+            if not has_substantive_content(full_content, min_chars=min_chars):
                 logger.info("Skipping VLM for non-substantive file: %s", file_path)
                 return result("", has_substantive=False)
 

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -651,6 +651,11 @@ class SemanticConfig:
     memory_chunk_overlap: int = 200
     """Character overlap between adjacent memory chunks for context continuity."""
 
+    min_substantive_chars: int = 8
+    """Minimum weighted residual chars for a text file to be considered substantive
+    (heading/markup stripped, CJK weighted). Below this, the file is treated as
+    non-substantive and skipped for VLM summarization/vectorization (issue #3028)."""
+
     def __post_init__(self):
         if self.memory_chunk_chars <= 0:
             raise ValueError("memory_chunk_chars must be positive")

--- a/tests/service/test_reindex_placeholder.py
+++ b/tests/service/test_reindex_placeholder.py
@@ -10,6 +10,7 @@ shape-anchored so legitimate directory content is never dropped.
 
 from openviking.service.reindex_executor import (
     _ABSTRACT_NOT_READY_SUFFIX,
+    _NO_SUBSTANTIVE_CONTENT_SUFFIX,
     _OVERVIEW_NOT_READY_SUFFIX,
     _is_not_ready_sentinel,
 )
@@ -18,6 +19,13 @@ from openviking.service.reindex_executor import (
 def test_real_abstract_sentinel_is_detected():
     rendered = "# viking://memory/projects/foo [Directory abstract is not ready]"
     assert _is_not_ready_sentinel(rendered, _ABSTRACT_NOT_READY_SUFFIX)
+
+
+def test_no_substantive_content_marker_is_detected():
+    # Permanent empty/title-only-directory marker (issue #3028) must also be
+    # refused by the reindex embedding guard.
+    rendered = "# viking://memory/projects/foo\n\n[Directory has no substantive content]"
+    assert _is_not_ready_sentinel(rendered, _NO_SUBSTANTIVE_CONTENT_SUFFIX)
 
 
 def test_real_overview_sentinel_is_detected():

--- a/tests/storage/test_has_substantive_content.py
+++ b/tests/storage/test_has_substantive_content.py
@@ -13,6 +13,7 @@ _CASES = [
     ("heading_only_setext", "Title\n=====\n", False),
     ("heading_plus_body", "# Install\n\nRun `make build` to compile.", True),
     ("frontmatter_only", "---\ntitle: x\ntags: [a]\n---\n", False),
+    ("frontmatter_only_eof", "---\ntitle: Test\n---", False),
     ("html_comment_only", "<!-- generated -->", False),
     ("table_only", "| A | B |\n|---|---|\n| foo | bar |", True),
     ("links_only_with_text", "- [Guide](a.md)\n- [API](b.md)", True),

--- a/tests/storage/test_has_substantive_content.py
+++ b/tests/storage/test_has_substantive_content.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import pytest
+
+from openviking.storage.queuefs.semantic_processor import has_substantive_content
+
+# Plan §7 Table 1 (16 rows) + two robustness rows (CRLF, bold-run body).
+_CASES = [
+    ("empty", "", False),
+    ("whitespace", "   \n\t\n", False),
+    ("heading_only_atx", "# Title\n## Subtitle", False),
+    ("heading_only_setext", "Title\n=====\n", False),
+    ("heading_plus_body", "# Install\n\nRun `make build` to compile.", True),
+    ("frontmatter_only", "---\ntitle: x\ntags: [a]\n---\n", False),
+    ("html_comment_only", "<!-- generated -->", False),
+    ("table_only", "| A | B |\n|---|---|\n| foo | bar |", True),
+    ("links_only_with_text", "- [Guide](a.md)\n- [API](b.md)", True),
+    ("bare_urls_only", "https://a.com\nhttps://b.com", False),
+    ("image_alt_only", "![architecture diagram of the system](d.png)", True),
+    ("image_no_alt", "![](d.png)", False),
+    ("code_only", "```python\ndef f(): return 1\n```", True),
+    ("cjk_title_only", "# 概述\n## 目录", False),
+    ("cjk_heading_plus_body", "# 概述\n\n这是一个测试文档。", True),
+    ("divider_only", "---\n***\n", False),
+    ("crlf_heading_only", "# Title\r\n", False),
+    ("bold_run_body", "# H\r\n\r\nThis is **very** important.", True),
+]
+
+
+@pytest.mark.parametrize("name,text,expected", _CASES, ids=[c[0] for c in _CASES])
+def test_has_substantive_content(name, text, expected):
+    assert has_substantive_content(text)[0] == expected

--- a/tests/storage/test_has_substantive_content.py
+++ b/tests/storage/test_has_substantive_content.py
@@ -31,4 +31,4 @@ _CASES = [
 
 @pytest.mark.parametrize("name,text,expected", _CASES, ids=[c[0] for c in _CASES])
 def test_has_substantive_content(name, text, expected):
-    assert has_substantive_content(text)[0] == expected
+    assert has_substantive_content(text) == expected

--- a/tests/storage/test_semantic_gate_e2e.py
+++ b/tests/storage/test_semantic_gate_e2e.py
@@ -82,6 +82,7 @@ def wired(monkeypatch):
     """Wire the real SemanticProcessor to the disk FS + spy VLM + fake config."""
     vlm = _make_spy_vlm()
     monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(sp, "render_prompt", lambda *a, **k: "prompt")
     monkeypatch.setattr(sp, "get_viking_fs", lambda: _DiskFS())
     # Downstream of the gate; needs real config/language models otherwise.
     monkeypatch.setattr(
@@ -98,9 +99,9 @@ def wired(monkeypatch):
 @pytest.mark.parametrize(
     "name, content, substantive",
     [
-        ("heading_only.md", HEADING_ONLY, False),      # point 1: title-only
+        ("heading_only.md", HEADING_ONLY, False),  # point 1: title-only
         ("frontmatter_only.md", FRONTMATTER_ONLY, False),  # point 2: frontmatter/whitespace
-        ("install.md", SUBSTANTIVE, True),             # point 3: genuine content
+        ("install.md", SUBSTANTIVE, True),  # point 3: genuine content
     ],
 )
 async def test_gate_on_real_file(wired, tmp_path, name, content, substantive):

--- a/tests/storage/test_semantic_gate_e2e.py
+++ b/tests/storage/test_semantic_gate_e2e.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""End-to-end substantive-content gate test (issue #3028).
+
+Unlike ``test_semantic_substantive_gate.py`` (which hands ``_generate_overview``
+pre-built summary dicts), this drives the REAL pipeline: real ``.md`` files on
+disk -> the real ``_generate_single_file_summary`` -> ``_generate_text_summary``
+which reads the file via ``get_viking_fs().read_file(...)`` and runs the real
+``has_substantive_content`` gate. The VLM is a spy that records calls, so
+"no hallucination" is proven as "spy VLM never awaited on non-substantive input".
+
+How end-to-end this is:
+  REAL   file bytes on disk; the read path through _generate_single_file_summary
+         -> _generate_text_summary; _detect_file_type; the has_substantive_content
+         detector + gate; the real _generate_overview neutral-overview branch; the
+         real is_neutral_overview / reindex _is_not_ready_sentinel guards.
+  STUBBED (external services only, all documented at their use site):
+    - viking_fs.read_file  -> reads the real tmp file with open() (no ragfs/DB/queue).
+    - config               -> SimpleNamespace (no config server); mirrors _fake_config
+                              from test_semantic_substantive_gate.py.
+    - vlm                   -> spy AsyncMock (no model server; the whole point is
+                              proving the VLM is bypassed for non-substantive input).
+    - resolve_output_language -> "en" (needs real config/language models; only
+                              reached AFTER the gate, i.e. downstream of what we test).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.storage.queuefs import semantic_processor as sp
+from openviking.storage.queuefs.semantic_processor import (
+    SemanticProcessor,
+    _neutral_directory_overview,
+    is_neutral_overview,
+)
+
+_VLM_MARKER = "a real VLM summary"
+
+HEADING_ONLY = "# Example Wiki Page\n## Subheading\n"
+FRONTMATTER_ONLY = "---\ntitle: Draft\ndate: 2026-01-01\n---\n\n   \n"
+SUBSTANTIVE = "# Install\n\nRun the build script to compile the project.\n"
+
+
+def _fake_config(vlm):
+    # Mirrors test_semantic_substantive_gate.py::_fake_config (no config server).
+    return SimpleNamespace(
+        vlm=vlm,
+        semantic=SimpleNamespace(
+            min_substantive_chars=8,
+            max_file_content_chars=100000,
+            max_overview_prompt_chars=100000,
+            overview_batch_size=50,
+            overview_max_chars=4000,
+            abstract_max_chars=256,
+        ),
+    )
+
+
+class _DiskFS:
+    """viking_fs stand-in whose read_file opens the REAL tmp file from disk.
+
+    Only the read transport is stubbed (no ragfs/DB/queue) — the file CONTENT is
+    100% real and flows unchanged through _generate_text_summary and the gate.
+    """
+
+    async def read_file(self, path, ctx=None):
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+
+
+def _make_spy_vlm(return_value=_VLM_MARKER):
+    vlm = MagicMock()
+    vlm.is_available.return_value = True
+    vlm.get_completion_async = AsyncMock(return_value=return_value)
+    return vlm
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Wire the real SemanticProcessor to the disk FS + spy VLM + fake config."""
+    vlm = _make_spy_vlm()
+    monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(sp, "get_viking_fs", lambda: _DiskFS())
+    # Downstream of the gate; needs real config/language models otherwise.
+    monkeypatch.setattr(
+        "openviking.session.memory.utils.language.resolve_output_language",
+        lambda *a, **k: "en",
+    )
+    return SimpleNamespace(processor=SemanticProcessor(), vlm=vlm)
+
+
+# --------------------------------------------------------------------------- #
+# Points 1-3 — real file on disk -> real read path -> real gate
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name, content, substantive",
+    [
+        ("heading_only.md", HEADING_ONLY, False),      # point 1: title-only
+        ("frontmatter_only.md", FRONTMATTER_ONLY, False),  # point 2: frontmatter/whitespace
+        ("install.md", SUBSTANTIVE, True),             # point 3: genuine content
+    ],
+)
+async def test_gate_on_real_file(wired, tmp_path, name, content, substantive):
+    real_path = tmp_path / name
+    real_path.write_text(content, encoding="utf-8")
+
+    result = await wired.processor._generate_single_file_summary(str(real_path))
+
+    assert result["has_substantive_content"] is substantive
+    if substantive:
+        wired.vlm.get_completion_async.assert_awaited_once()
+        assert result["summary"] == _VLM_MARKER
+    else:
+        wired.vlm.get_completion_async.assert_not_awaited()
+        assert result["summary"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# Point 4 — directory of only non-substantive files -> neutral overview, no VLM.
+# Chains the REAL per-file summaries into the REAL _generate_overview.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_all_nonsubstantive_dir_neutral_overview_e2e(wired, tmp_path):
+    (tmp_path / "heading_only.md").write_text(HEADING_ONLY, encoding="utf-8")
+    (tmp_path / "frontmatter_only.md").write_text(FRONTMATTER_ONLY, encoding="utf-8")
+
+    summaries = [
+        await wired.processor._generate_single_file_summary(str(tmp_path / "heading_only.md")),
+        await wired.processor._generate_single_file_summary(str(tmp_path / "frontmatter_only.md")),
+    ]
+    assert all(s["has_substantive_content"] is False for s in summaries)
+    # Per-file gate already skipped the VLM; reset so the overview assertion is clean.
+    wired.vlm.get_completion_async.reset_mock()
+
+    dir_uri = "viking://user/u/docs"
+    overview = await wired.processor._generate_overview(dir_uri, summaries, [])
+
+    wired.vlm.get_completion_async.assert_not_awaited()
+    assert overview == _neutral_directory_overview("docs")
+    assert is_neutral_overview(overview) is True
+
+    # Point 5 backstop: the reindex embedding guard refuses to embed it.
+    from openviking.service.reindex_executor import (
+        _NO_SUBSTANTIVE_CONTENT_SUFFIX,
+        _is_not_ready_sentinel,
+    )
+
+    assert _is_not_ready_sentinel(overview, _NO_SUBSTANTIVE_CONTENT_SUFFIX) is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/storage/test_semantic_substantive_gate.py
+++ b/tests/storage/test_semantic_substantive_gate.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Pipeline wiring for the substantive-content gate (issue #3028).
+
+Table 2 of .wiki/issue-3028-substantive-content-gate-plan.md §7.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs import semantic_processor as sp
+from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking.storage.queuefs.semantic_processor import (
+    SemanticProcessor,
+    _neutral_directory_overview,
+    is_neutral_overview,
+)
+from openviking_cli.session.user_id import UserIdentifier
+
+HEADING_ONLY = "# Example Wiki Page\n## Subheading\n"
+SUBSTANTIVE = "# Install\n\nRun `make build` to compile the project locally.\n"
+
+
+def _fake_config(vlm):
+    return SimpleNamespace(
+        vlm=vlm,
+        semantic=SimpleNamespace(
+            min_substantive_chars=8,
+            max_file_content_chars=100000,
+            max_overview_prompt_chars=100000,
+            overview_batch_size=50,
+            overview_max_chars=4000,
+            abstract_max_chars=256,
+        ),
+    )
+
+
+class _FakeFS:
+    def __init__(self, contents):
+        self._contents = contents
+
+    async def read_file(self, path, ctx=None):
+        return self._contents[path]
+
+
+# --------------------------------------------------------------------------- #
+# Point 1 — VLM short-circuit in _generate_text_summary
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_nonsubstantive_file_skips_vlm(monkeypatch):
+    vlm = MagicMock()
+    vlm.is_available.return_value = True
+    vlm.get_completion_async = AsyncMock(return_value="hallucinated")
+    monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    path = "viking://user/u/docs/empty.md"
+    monkeypatch.setattr(sp, "get_viking_fs", lambda: _FakeFS({path: HEADING_ONLY}))
+
+    processor = SemanticProcessor()
+    result = await processor._generate_text_summary(path, "empty.md", MagicMock())
+
+    vlm.get_completion_async.assert_not_awaited()
+    assert result["summary"] == ""
+    assert result["has_substantive_content"] is False
+
+
+@pytest.mark.asyncio
+async def test_substantive_file_calls_vlm_and_flags_true(monkeypatch):
+    vlm = MagicMock()
+    vlm.is_available.return_value = True
+    vlm.get_completion_async = AsyncMock(return_value="a real summary")
+    monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(
+        "openviking.session.memory.utils.language.resolve_output_language", lambda *a, **k: "en"
+    )
+    path = "viking://user/u/docs/install.md"
+    monkeypatch.setattr(sp, "get_viking_fs", lambda: _FakeFS({path: SUBSTANTIVE}))
+
+    processor = SemanticProcessor()
+    result = await processor._generate_text_summary(path, "install.md", MagicMock())
+
+    vlm.get_completion_async.assert_awaited_once()
+    assert result["summary"] == "a real summary"
+    assert result["has_substantive_content"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Point 4 — overview filters non-substantive summaries
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_overview_filters_nonsubstantive(monkeypatch):
+    vlm = MagicMock()
+    vlm.is_available.return_value = True
+    monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(
+        "openviking.session.memory.utils.language.resolve_output_language", lambda *a, **k: "en"
+    )
+
+    captured = {}
+
+    async def _fake_single(dir_uri, file_summaries_str, children_abstracts_str, file_index_map, **k):
+        captured["summaries"] = file_summaries_str
+        return "overview"
+
+    processor = SemanticProcessor()
+    monkeypatch.setattr(processor, "_single_generate_overview", _fake_single)
+
+    summaries = [
+        {"name": "substantive.md", "summary": "real", "has_substantive_content": True},
+        {"name": "heading_only.md", "summary": "", "has_substantive_content": False},
+    ]
+    await processor._generate_overview("viking://user/u/docs", summaries, [])
+
+    assert "substantive.md" in captured["summaries"]
+    assert "heading_only.md" not in captured["summaries"]
+
+
+# --------------------------------------------------------------------------- #
+# Point 4 — all-non-substantive dir yields the neutral overview without the VLM
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_all_nonsubstantive_dir_writes_neutral_overview(monkeypatch):
+    vlm = MagicMock()
+    vlm.is_available.return_value = True
+    vlm.get_completion_async = AsyncMock()
+    monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+
+    processor = SemanticProcessor()
+    dir_uri = "viking://user/u/docs"
+    summaries = [
+        {"name": "a.md", "summary": "", "has_substantive_content": False},
+        {"name": "b.md", "summary": "", "has_substantive_content": False},
+    ]
+    overview = await processor._generate_overview(dir_uri, summaries, [])
+
+    vlm.get_completion_async.assert_not_awaited()
+    assert overview == _neutral_directory_overview("docs")
+
+    overview_norm, abstract = processor._normalize_overview_generation(overview)
+    assert overview_norm == overview
+    assert abstract == "[Directory has no substantive content]"
+
+
+# --------------------------------------------------------------------------- #
+# Point 5 backstop — neutral overview is recognized as non-embeddable
+# --------------------------------------------------------------------------- #
+def test_neutral_overview_matches_not_ready_sentinel():
+    from openviking.service.reindex_executor import (
+        _NO_SUBSTANTIVE_CONTENT_SUFFIX,
+        _is_not_ready_sentinel,
+    )
+
+    overview = _neutral_directory_overview("docs")
+    assert overview.endswith("[Directory has no substantive content]")
+    assert is_neutral_overview(overview) is True
+    # The reindex embedding guard refuses the distinct no-content marker too.
+    assert _is_not_ready_sentinel(overview, _NO_SUBSTANTIVE_CONTENT_SUFFIX) is True
+
+
+# --------------------------------------------------------------------------- #
+# DAG wiring — points 3 (file vectorize skip) and 5 (dir vectorize skip)
+# --------------------------------------------------------------------------- #
+def _mock_transaction_layer(monkeypatch):
+    mock_handle = MagicMock()
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aenter__",
+        AsyncMock(return_value=mock_handle),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.lock_context.LockContext.__aexit__",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager", lambda: MagicMock()
+    )
+
+
+class _FakeVikingFS:
+    def __init__(self, tree):
+        self._tree = tree
+        self.writes = []
+
+    async def ls(self, uri, node_limit=None, ctx=None):
+        return self._tree.get(uri, [])
+
+    async def write_file(self, path, content, ctx=None, lock_handle=None):
+        self.writes.append((path, content))
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri.replace("viking://", "/local/acc1/")
+
+
+class _GateFakeProcessor:
+    """Returns a substantive/non-substantive summary per file name and a neutral
+    overview when nothing substantive remains — exercises the DAG gates."""
+
+    def __init__(self):
+        self.vectorized_files = []
+        self.vectorized_dirs = []
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        name = file_path.split("/")[-1]
+        substantive = "sub" in name
+        return {
+            "name": name,
+            "summary": "s" if substantive else "",
+            "has_substantive_content": substantive,
+        }
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        substantive = [s for s in file_summaries if s.get("has_substantive_content", True)]
+        if not substantive and not children_abstracts:
+            return _neutral_directory_overview(dir_uri.split("/")[-1])
+        return "overview"
+
+    def _normalize_overview_generation(self, overview):
+        return overview, "abstract"
+
+    async def _vectorize_directory(self, uri, context_type, abstract, overview, ctx=None,
+                                   semantic_msg_id=None):
+        self.vectorized_dirs.append(uri)
+
+    async def _vectorize_single_file(self, parent_uri, context_type, file_path, summary_dict,
+                                     ctx=None, semantic_msg_id=None, use_summary=False):
+        self.vectorized_files.append(file_path)
+
+
+class _DummyTracker:
+    async def register(self, **_kwargs):
+        return None
+
+
+def _run_executor(monkeypatch, tree, root_uri):
+    _mock_transaction_layer(monkeypatch)
+    fake_fs = _FakeVikingFS(tree)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _DummyTracker(),
+    )
+    processor = _GateFakeProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor, context_type="session", max_concurrent_llm=2, ctx=ctx
+    )
+    return processor, fake_fs, executor
+
+
+@pytest.mark.asyncio
+async def test_nonsubstantive_file_not_vectorized(monkeypatch):
+    root_uri = "viking://session/test-session"
+    tree = {
+        root_uri: [
+            {"name": "substantive.md", "isDir": False},
+            {"name": "heading_only.md", "isDir": False},
+        ],
+    }
+    processor, _fs, executor = _run_executor(monkeypatch, tree, root_uri)
+    await executor.run(root_uri)
+
+    vectorized = [p.split("/")[-1] for p in processor.vectorized_files]
+    assert "substantive.md" in vectorized
+    assert "heading_only.md" not in vectorized
+
+
+@pytest.mark.asyncio
+async def test_all_nonsubstantive_dir_not_vectorized(monkeypatch):
+    root_uri = "viking://session/test-session"
+    tree = {
+        root_uri: [
+            {"name": "a.md", "isDir": False},
+            {"name": "b.md", "isDir": False},
+        ],
+    }
+    processor, fake_fs, executor = _run_executor(monkeypatch, tree, root_uri)
+    await executor.run(root_uri)
+
+    assert processor.vectorized_dirs == []  # neutral overview not embedded
+    written = dict(fake_fs.writes)
+    assert written[f"{root_uri}/.overview.md"] == _neutral_directory_overview("test-session")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/storage/test_semantic_substantive_gate.py
+++ b/tests/storage/test_semantic_substantive_gate.py
@@ -143,6 +143,26 @@ async def test_all_nonsubstantive_dir_writes_neutral_overview(monkeypatch):
     assert abstract == "[Directory has no substantive content]"
 
 
+@pytest.mark.asyncio
+async def test_vlm_unavailable_with_substantive_content_is_not_no_content(monkeypatch):
+    # VLM down is transient — a directory WITH substantive summaries must not be
+    # mislabeled "no substantive content" (which would be treated as permanently
+    # empty and non-embeddable). It gets the transient not-ready marker instead.
+    vlm = MagicMock()
+    vlm.is_available.return_value = False
+    vlm.get_completion_async = AsyncMock()
+    monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+
+    processor = SemanticProcessor()
+    summaries = [{"name": "a.md", "summary": "real content", "has_substantive_content": True}]
+    overview = await processor._generate_overview("viking://user/u/docs", summaries, [])
+
+    vlm.get_completion_async.assert_not_awaited()
+    assert overview != _neutral_directory_overview("docs")
+    assert is_neutral_overview(overview) is False
+    assert "[Directory overview is not ready]" in overview
+
+
 # --------------------------------------------------------------------------- #
 # Point 5 backstop — neutral overview is recognized as non-embeddable
 # --------------------------------------------------------------------------- #

--- a/tests/storage/test_semantic_substantive_gate.py
+++ b/tests/storage/test_semantic_substantive_gate.py
@@ -206,12 +206,16 @@ class _FakeVikingFS:
     def __init__(self, tree):
         self._tree = tree
         self.writes = []
+        self.deleted = []
 
     async def ls(self, uri, node_limit=None, ctx=None):
         return self._tree.get(uri, [])
 
     async def write_file(self, path, content, ctx=None, lock_handle=None):
         self.writes.append((path, content))
+
+    async def _delete_from_vector_store(self, uris, ctx=None):
+        self.deleted.extend(uris)
 
     def _uri_to_path(self, uri, ctx=None):
         return uri.replace("viking://", "/local/acc1/")
@@ -224,10 +228,13 @@ class _GateFakeProcessor:
     def __init__(self):
         self.vectorized_files = []
         self.vectorized_dirs = []
+        # name -> bool; overrides the "sub in name" heuristic. Lets a test
+        # "rewrite" a file from substantive to non-substantive between runs.
+        self.substantive_override = {}
 
     async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
         name = file_path.split("/")[-1]
-        substantive = "sub" in name
+        substantive = self.substantive_override.get(name, "sub" in name)
         return {
             "name": name,
             "summary": "s" if substantive else "",
@@ -266,15 +273,15 @@ class _DummyTracker:
         return None
 
 
-def _run_executor(monkeypatch, tree, root_uri):
+def _run_executor(monkeypatch, tree, root_uri, processor=None, fake_fs=None):
     _mock_transaction_layer(monkeypatch)
-    fake_fs = _FakeVikingFS(tree)
+    fake_fs = fake_fs or _FakeVikingFS(tree)
     monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
     monkeypatch.setattr(
         "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
         lambda: _DummyTracker(),
     )
-    processor = _GateFakeProcessor()
+    processor = processor or _GateFakeProcessor()
     ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
     executor = SemanticDagExecutor(
         processor=processor, context_type="session", max_concurrent_llm=2, ctx=ctx
@@ -314,6 +321,133 @@ async def test_all_nonsubstantive_dir_not_vectorized(monkeypatch):
     assert processor.vectorized_dirs == []  # neutral overview not embedded
     written = dict(fake_fs.writes)
     assert written[f"{root_uri}/.overview.md"] == _neutral_directory_overview("test-session")
+
+
+# --------------------------------------------------------------------------- #
+# Transition cleanup — substantive -> non-substantive must DELETE stale records
+# (PR #3049 review), not merely skip re-vectorization.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_rewritten_nonsubstantive_file_deletes_stale_vector(monkeypatch):
+    root_uri = "viking://session/test-session"
+    tree = {root_uri: [{"name": "sub_notes.md", "isDir": False}]}
+
+    # Pass 1: substantive content gets vectorized, nothing deleted.
+    processor, fake_fs, executor = _run_executor(monkeypatch, tree, root_uri)
+    await executor.run(root_uri)
+    assert len(processor.vectorized_files) == 1
+    file_uri = processor.vectorized_files[0]
+    assert fake_fs.deleted == []
+
+    # Pass 2: same file rewritten to non-substantive. A fresh full run
+    # (need_vectorize=True) exercises the same delete branch the incremental
+    # change-detection path takes.
+    processor.substantive_override["sub_notes.md"] = False
+    _, _, executor2 = _run_executor(
+        monkeypatch, tree, root_uri, processor=processor, fake_fs=fake_fs
+    )
+    await executor2.run(root_uri)
+
+    assert file_uri in fake_fs.deleted  # stale DETAIL record removed
+    assert processor.vectorized_files == [file_uri]  # no new vectorize scheduled
+
+
+@pytest.mark.asyncio
+async def test_dir_turned_neutral_deletes_stale_records(monkeypatch):
+    root_uri = "viking://session/test-session"
+    tree = {root_uri: [{"name": "sub_a.md", "isDir": False}]}
+
+    # Pass 1: dir has substantive content -> L0/L1 vectorized, nothing deleted.
+    processor, fake_fs, executor = _run_executor(monkeypatch, tree, root_uri)
+    await executor.run(root_uri)
+    assert processor.vectorized_dirs == [root_uri]
+    assert root_uri not in fake_fs.deleted
+
+    # Pass 2: only child rewritten non-substantive -> neutral overview.
+    processor.substantive_override["sub_a.md"] = False
+    _, _, executor2 = _run_executor(
+        monkeypatch, tree, root_uri, processor=processor, fake_fs=fake_fs
+    )
+    await executor2.run(root_uri)
+
+    assert root_uri in fake_fs.deleted  # stale L0/L1 records removed
+    assert processor.vectorized_dirs == [root_uri]  # neutral overview not re-embedded
+
+
+@pytest.mark.asyncio
+async def test_write_failure_suppression_does_not_delete(monkeypatch):
+    # A failed sidecar write suppresses vectorization but the content is still
+    # substantive — existing vectors must survive.
+    root_uri = "viking://session/test-session"
+    tree = {root_uri: [{"name": "sub_a.md", "isDir": False}]}
+    processor, fake_fs, executor = _run_executor(monkeypatch, tree, root_uri)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.write_semantic_sidecars",
+        AsyncMock(return_value=False),
+    )
+    await executor.run(root_uri)
+
+    assert processor.vectorized_dirs == []  # suppressed by write failure
+    assert fake_fs.deleted == []  # ...but nothing deleted
+
+
+# --------------------------------------------------------------------------- #
+# Memory path (_process_memory_directory) — same transition cleanup wiring
+# --------------------------------------------------------------------------- #
+class _MemoryFakeVikingFS(_FakeVikingFS):
+    async def read_file(self, path, ctx=None):
+        raise FileNotFoundError(path)
+
+
+async def _run_memory_processor(monkeypatch, file_names):
+    _mock_transaction_layer(monkeypatch)
+    monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(MagicMock()))
+    dir_uri = "viking://user/memories"
+    tree = {dir_uri: [{"name": n, "isDir": False} for n in file_names]}
+    fake_fs = _MemoryFakeVikingFS(tree)
+    monkeypatch.setattr(sp, "get_viking_fs", lambda: fake_fs)
+
+    processor = SemanticProcessor()
+    gate = _GateFakeProcessor()
+    monkeypatch.setattr(
+        processor, "_generate_single_file_summary", gate._generate_single_file_summary
+    )
+
+    async def _fake_overview(dir_uri, file_summaries, children_abstracts, llm_sem=None):
+        return await gate._generate_overview(dir_uri, file_summaries, children_abstracts)
+
+    monkeypatch.setattr(processor, "_generate_overview", _fake_overview)
+    monkeypatch.setattr(processor, "_vectorize_single_file", AsyncMock())
+    monkeypatch.setattr(processor, "_vectorize_directory", AsyncMock())
+
+    from openviking.storage.queuefs.semantic_msg import SemanticMsg
+
+    msg = SemanticMsg(uri=dir_uri, context_type="memory")
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    await processor._process_memory_directory(msg, ctx=ctx)
+    return processor, fake_fs, dir_uri
+
+
+@pytest.mark.asyncio
+async def test_memory_path_deletes_stale_file_vector(monkeypatch):
+    processor, fake_fs, dir_uri = await _run_memory_processor(
+        monkeypatch, ["sub_a.md", "heading_only.md"]
+    )
+
+    assert fake_fs.deleted == [f"{dir_uri}/heading_only.md"]  # stale DETAIL removed
+    processor._vectorize_directory.assert_awaited_once()  # dir still substantive
+
+
+@pytest.mark.asyncio
+async def test_memory_path_deletes_stale_dir_records_when_neutral(monkeypatch):
+    processor, fake_fs, dir_uri = await _run_memory_processor(
+        monkeypatch, ["heading_only.md", "frontmatter.md"]
+    )
+
+    assert f"{dir_uri}/heading_only.md" in fake_fs.deleted
+    assert f"{dir_uri}/frontmatter.md" in fake_fs.deleted
+    assert dir_uri in fake_fs.deleted  # neutral overview -> L0/L1 removed
+    processor._vectorize_directory.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/tests/storage/test_semantic_substantive_gate.py
+++ b/tests/storage/test_semantic_substantive_gate.py
@@ -55,6 +55,7 @@ async def test_nonsubstantive_file_skips_vlm(monkeypatch):
     vlm.is_available.return_value = True
     vlm.get_completion_async = AsyncMock(return_value="hallucinated")
     monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(sp, "render_prompt", lambda *a, **k: "prompt")
     path = "viking://user/u/docs/empty.md"
     monkeypatch.setattr(sp, "get_viking_fs", lambda: _FakeFS({path: HEADING_ONLY}))
 
@@ -72,6 +73,7 @@ async def test_substantive_file_calls_vlm_and_flags_true(monkeypatch):
     vlm.is_available.return_value = True
     vlm.get_completion_async = AsyncMock(return_value="a real summary")
     monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(sp, "render_prompt", lambda *a, **k: "prompt")
     monkeypatch.setattr(
         "openviking.session.memory.utils.language.resolve_output_language", lambda *a, **k: "en"
     )
@@ -94,13 +96,16 @@ async def test_overview_filters_nonsubstantive(monkeypatch):
     vlm = MagicMock()
     vlm.is_available.return_value = True
     monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(sp, "render_prompt", lambda *a, **k: "prompt")
     monkeypatch.setattr(
         "openviking.session.memory.utils.language.resolve_output_language", lambda *a, **k: "en"
     )
 
     captured = {}
 
-    async def _fake_single(dir_uri, file_summaries_str, children_abstracts_str, file_index_map, **k):
+    async def _fake_single(
+        dir_uri, file_summaries_str, children_abstracts_str, file_index_map, **k
+    ):
         captured["summaries"] = file_summaries_str
         return "overview"
 
@@ -126,6 +131,7 @@ async def test_all_nonsubstantive_dir_writes_neutral_overview(monkeypatch):
     vlm.is_available.return_value = True
     vlm.get_completion_async = AsyncMock()
     monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(sp, "render_prompt", lambda *a, **k: "prompt")
 
     processor = SemanticProcessor()
     dir_uri = "viking://user/u/docs"
@@ -152,6 +158,7 @@ async def test_vlm_unavailable_with_substantive_content_is_not_no_content(monkey
     vlm.is_available.return_value = False
     vlm.get_completion_async = AsyncMock()
     monkeypatch.setattr(sp, "get_openviking_config", lambda: _fake_config(vlm))
+    monkeypatch.setattr(sp, "render_prompt", lambda *a, **k: "prompt")
 
     processor = SemanticProcessor()
     summaries = [{"name": "a.md", "summary": "real content", "has_substantive_content": True}]
@@ -192,9 +199,7 @@ def _mock_transaction_layer(monkeypatch):
         "openviking.storage.transaction.lock_context.LockContext.__aexit__",
         AsyncMock(return_value=False),
     )
-    monkeypatch.setattr(
-        "openviking.storage.transaction.get_lock_manager", lambda: MagicMock()
-    )
+    monkeypatch.setattr("openviking.storage.transaction.get_lock_manager", lambda: MagicMock())
 
 
 class _FakeVikingFS:
@@ -238,12 +243,21 @@ class _GateFakeProcessor:
     def _normalize_overview_generation(self, overview):
         return overview, "abstract"
 
-    async def _vectorize_directory(self, uri, context_type, abstract, overview, ctx=None,
-                                   semantic_msg_id=None):
+    async def _vectorize_directory(
+        self, uri, context_type, abstract, overview, ctx=None, semantic_msg_id=None
+    ):
         self.vectorized_dirs.append(uri)
 
-    async def _vectorize_single_file(self, parent_uri, context_type, file_path, summary_dict,
-                                     ctx=None, semantic_msg_id=None, use_summary=False):
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+    ):
         self.vectorized_files.append(file_path)
 
 


### PR DESCRIPTION
## Description

Empty, whitespace-only, or heading/title-only Markdown documents were being sent to the VLM for L0/L1 (abstract/overview) generation. With no substantive content the model invents a plausible-but-nonexistent purpose, audience, and keywords, polluting `.abstract.md`, `.overview.md`, and vector search. For example, a file containing only `# Example Wiki Page` produced a fabricated overview.

This change adds a substantive-content gate to the semantic pipeline. Non-substantive text is detected before any model call, so the VLM never sees it — it cannot hallucinate a summary for content that isn't there — and such content is neither vectorized nor aggregated into directory overviews. A directory with no substantive input gets a deterministic, neutral overview instead of an invented one.

```mermaid
flowchart TD
    A[Text file content] --> B{has_substantive_content?<br/>markup stripped, CJK-weighted}
    B -- No --> C[Empty summary<br/>has_substantive_content = False]
    C --> D[Skip VLM call]
    C --> E[Skip file vectorization]
    B -- Yes --> F[VLM summary as before]
    F --> G[Vectorize file]
    E --> H{Any substantive summary<br/>or child abstract in dir?}
    G --> H
    H -- No --> I["Neutral overview (no VLM)<br/>'[Directory has no substantive content]'"]
    I --> J[Skip directory embedding<br/>reindex guard recognizes marker]
    H -- Yes --> K[Generate directory overview as before]
```

## Related Issue

Fixes #3028

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **New detector** `has_substantive_content(text, min_chars=8)` in `semantic_processor.py` — regex-only Markdown strip (frontmatter, HTML comments, headings, setext/HR, list/table/blockquote markers, code-fence markers, link/image markup, emphasis) that keeps code bodies, table cell text, and link/image label text, then measures a CJK-weighted residual length. Normalizes CRLF first (issue reported on Windows).
- **New config knob** `SemanticConfig.min_substantive_chars` (default `8`, weighted) so the threshold is tunable without a code change.
- **Pipeline gate** in `_generate_text_summary`: non-substantive documentation/generic text short-circuits before the VLM and returns `has_substantive_content=False` on untruncated content. The code branch and media helpers stay substantive.
- **Flag propagation** through `file_summaries` / `summary_dict`; `_finalize_file_summaries` defaults the flag to `False` on its `None`-fallback.
- **Vectorization skip** for non-substantive files in `_file_summary_task`.
- **Directory overview**: `_generate_overview` filters non-substantive summaries; when nothing substantive remains it writes a deterministic neutral overview marked `[Directory has no substantive content]` with no VLM call, in both the DAG and memory write paths, and skips directory embedding.
- **Reindex guard**: `reindex_executor._is_not_ready_sentinel` now also recognizes the new no-content marker, so a neutral overview/abstract is never embedded as an L0/L1 vector (consistent with the existing not-ready placeholder handling).

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

`tests/storage/test_has_substantive_content.py` — 20 table-driven cases covering every edge case in the issue (empty, whitespace, ATX/setext heading-only, heading+body, frontmatter-only, frontmatter-at-EOF, HTML-comment-only, table, links-with-text, bare-URL, image alt / no-alt, code-only, CJK title-only, CJK heading+body, divider-only) plus a **CRLF** case (`# Title\r\n` → non-substantive) and a bold-run body, so the Windows-reported path is exercised on Linux.

`tests/storage/test_semantic_substantive_gate.py` — pipeline behavior: non-substantive file skips the VLM and is not vectorized; a substantive file still calls the VLM and is flagged; overviews filter out non-substantive summaries; an all-non-substantive directory writes the neutral overview/abstract with no VLM call and is not vectorized; a transient VLM outage keeps the retryable *not ready* marker (not the permanent *no content* one); and the reindex guard treats the neutral overview as non-embeddable.

`tests/storage/test_semantic_gate_e2e.py` — end-to-end on real files: writes real `.md` files to disk and drives the actual read → detect → gate → overview path (`_generate_single_file_summary` → `_generate_text_summary` → `read_file`, then `_generate_overview`) with a spy VLM, asserting the model is bypassed for heading-only/frontmatter-only input, called for substantive input, and that an all-non-substantive directory produces the neutral, non-embeddable overview.

`tests/service/test_reindex_placeholder.py` — added a case proving the new no-content marker is recognized by the reindex guard.

Run: `pytest tests/storage/test_has_substantive_content.py tests/storage/test_semantic_substantive_gate.py tests/storage/test_semantic_gate_e2e.py tests/storage/test_semantic_dag_skip_files.py tests/storage/test_semantic_processor_l0_l1.py tests/service/test_reindex_placeholder.py` → **53 passed**. Ruff clean; no new type-check errors.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

The detector is deliberately biased toward recall: the default threshold (8 weighted chars) keeps thin-but-real content (a one-line body such as ``Run `make build` to compile.``) while rejecting title-only files. Dropping a real file from search is worse than summarizing a thin one, and `min_substantive_chars` can be raised if production shows residual hallucination on thin files. CJK content is weighted (×2.5) so a few Chinese characters clear the gate, since character count alone under-counts dense CJK text.
