### PR TITLE
feat(train): improve rollout polling resilience and zero-epoch support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ reports/
 test-results.xml
 test-reports/
 report.html
+temp/
 
 # Virtual environments
 .env

--- a/openviking/session/train/components/dataset_service.py
+++ b/openviking/session/train/components/dataset_service.py
@@ -640,11 +640,21 @@ def rollout_from_dict(data: dict[str, Any]) -> Rollout:
 
     return Rollout(
         case=case_from_dict(data["case"]),
-        messages=[Message.from_dict(item) for item in data.get("messages", [])],
+        messages=[
+            Message.from_dict(_message_dict_with_defaults(item, index))
+            for index, item in enumerate(data.get("messages", []))
+        ],
         policy_snapshot_id=data["policy_snapshot_id"],
         evaluation=evaluation_from_dict(data.get("evaluation")),
         metadata=dict(data.get("metadata") or {}),
     )
+
+
+def _message_dict_with_defaults(data: dict[str, Any], index: int) -> dict[str, Any]:
+    """Accept lightweight remote message payloads that omit OpenViking-only ids."""
+    item = dict(data)
+    item.setdefault("id", f"remote_message_{index}")
+    return item
 
 
 def evaluation_from_dict(data: dict[str, Any] | None) -> RubricEvaluation | None:

--- a/openviking/session/train/components/remote.py
+++ b/openviking/session/train/components/remote.py
@@ -213,6 +213,7 @@ class RemoteRolloutExecutor:
         transient_errors = 0
         missing_execution_errors = 0
         last_transient_error: BaseException | None = None
+        last_transient_response: httpx.Response | None = None
         while True:
             try:
                 response = await client.get(f"/v1/rollouts/executions/{execution_id}")
@@ -244,6 +245,17 @@ class RemoteRolloutExecutor:
                     min(self.poll_interval_seconds * missing_execution_errors, 10.0)
                 )
                 continue
+            if _is_retryable_poll_response(response):
+                transient_errors += 1
+                last_transient_response = response
+                if loop.time() >= deadline:
+                    raise TimeoutError(
+                        f"rollout execution {execution_id} polling timed out for case {case.name} "
+                        f"after {self.execution_timeout_seconds}s; last polling response: "
+                        f"{response.status_code} {_response_text(response)}"
+                    )
+                await asyncio.sleep(min(self.poll_interval_seconds * transient_errors, 10.0))
+                continue
             response.raise_for_status()
             data = response.json()
             status = data.get("status")
@@ -262,7 +274,12 @@ class RemoteRolloutExecutor:
                     f"; last polling error: {type(last_transient_error).__name__}: "
                     f"{last_transient_error}"
                     if last_transient_error is not None
-                    else ""
+                    else (
+                        f"; last polling response: {last_transient_response.status_code} "
+                        f"{_response_text(last_transient_response)}"
+                        if last_transient_response is not None
+                        else ""
+                    )
                 )
                 raise TimeoutError(
                     f"rollout execution {execution_id} timed out for case {case.name} "
@@ -301,6 +318,10 @@ def _require_execution_id(data: dict[str, Any], *, case: Case) -> str:
     if not isinstance(execution_id, str) or not execution_id:
         raise RuntimeError(f"rollout service did not return execution_id for case {case.name}")
     return execution_id
+
+
+def _is_retryable_poll_response(response: httpx.Response) -> bool:
+    return response.status_code == 408 or response.status_code == 429 or response.status_code >= 500
 
 
 def _response_text(response: httpx.Response, *, max_chars: int = 500) -> str:

--- a/openviking/session/train/pipeline.py
+++ b/openviking/session/train/pipeline.py
@@ -81,7 +81,8 @@ class OfflinePolicyOptimizationPipeline:
         context: PipelineContext | Any,
     ) -> PipelineResult:
         ctx = context if isinstance(context, PipelineContext) else PipelineContext()
-        max_epochs = max(1, int(ctx.max_epochs or 1))
+        requested_epochs = ctx.max_epochs if ctx.max_epochs is not None else 1
+        max_epochs = max(0, int(requested_epochs))
         case_loader = _train_case_loader(case_loader, ctx)
         current_policy_set = policy_set
         epoch_results: list[PipelineEpochResult] = []

--- a/openviking/session/train/run_batch_train_eval.py
+++ b/openviking/session/train/run_batch_train_eval.py
@@ -36,6 +36,12 @@ def parse_args() -> argparse.Namespace:
         default=200,
         help="Concurrent OpenViking session.commit submissions during train (default: 200)",
     )
+    parser.add_argument(
+        "--commit-timeout-seconds",
+        type=float,
+        default=None,
+        help="Max seconds to wait for each OpenViking session.commit task. Default waits indefinitely.",
+    )
     parser.add_argument("--config", default=None, help="ov.conf path (optional)")
     parser.add_argument("--server-url", default=None, help="OpenViking server URL. Defaults to ov.conf/ovcli.conf")
     parser.add_argument("--api-key", default=None, help="OpenViking API key. Defaults to ov.conf/ovcli.conf")
@@ -188,6 +194,7 @@ async def main_async() -> int:
             batch_size=args.batch_size,
             concurrency=args.concurrency,
             commit_concurrency=args.commit_concurrency,
+            commit_timeout_seconds=args.commit_timeout_seconds,
             config_path=str(Path(args.config).expanduser()) if args.config else None,
             server_url=args.server_url,
             api_key=args.api_key,

--- a/tests/session/train/test_train_framework.py
+++ b/tests/session/train/test_train_framework.py
@@ -352,6 +352,34 @@ async def test_default_policy_optimization_pipeline_runs_one_batch():
 
 
 @pytest.mark.asyncio
+async def test_policy_optimization_pipeline_allows_zero_epochs_without_training():
+    snapshotter = DummySnapshotter()
+    pipeline = OfflinePolicyOptimizationPipeline(
+        snapshotter=snapshotter,
+        rollout_executor=DummyExecutor(),
+        rollout_analyzer=DummyAnalyzer(),
+        gradient_estimator=DummyEstimator(),
+        policy_optimizer=DummyOptimizer(),
+        policy_updater=DummyUpdater(),
+    )
+
+    initial_policy_set = _policy_set()
+    result = await pipeline.train(
+        case_loader=ListCaseLoader([_case()]),
+        policy_set=initial_policy_set,
+        context=PipelineContext(max_epochs=0),
+    )
+
+    assert result.analyses == []
+    assert result.gradients == []
+    assert result.epochs == []
+    assert result.evaluation_passes == []
+    assert result.apply_result.updated_policy_set is initial_policy_set
+    assert result.metadata["max_epochs"] == 0
+    assert result.metadata["completed_epochs"] == 0
+
+
+@pytest.mark.asyncio
 async def test_offline_policy_optimization_pipeline_supports_train_and_eval():
     snapshotter = DummySnapshotter()
     pipeline = OfflinePolicyOptimizationPipeline(

--- a/tests/unit/test_remote_rollout_executor.py
+++ b/tests/unit/test_remote_rollout_executor.py
@@ -128,3 +128,80 @@ def test_remote_rollout_executor_retries_transient_missing_execution(monkeypatch
     assert len(rollouts) == 1
     assert rollouts[0].case.name == "case-1"
     assert calls.count(f"GET /v1/rollouts/executions/{execution_id}") == 2
+
+
+def test_remote_rollout_executor_retries_transient_poll_5xx(monkeypatch):
+    calls: list[str] = []
+    execution_id = "rollout_exec_gateway_blip"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(f"{request.method} {request.url.path}")
+        if request.method == "POST" and request.url.path == "/v1/rollouts/execute":
+            return httpx.Response(200, json={"execution_id": execution_id, "status": "running"})
+        if request.method == "GET" and request.url.path.endswith(execution_id):
+            get_count = sum(1 for call in calls if call.startswith("GET "))
+            if get_count == 1:
+                return httpx.Response(502, text="Bad Gateway")
+            return httpx.Response(
+                200,
+                json={
+                    "execution_id": execution_id,
+                    "status": "completed",
+                    "rollout": {
+                        "case": {
+                            "name": "case-1",
+                            "task_signature": "booking_duplicate",
+                            "input": {"user_request": "cancel duplicate booking"},
+                            "rubric": {
+                                "name": "booking_rubric",
+                                "description": "Cancel only the verified duplicate booking.",
+                                "criteria": [
+                                    {
+                                        "name": "verify_duplicate",
+                                        "description": "Verify duplicate status first.",
+                                        "required": True,
+                                        "weight": 1.0,
+                                        "metadata": {},
+                                    }
+                                ],
+                                "metadata": {},
+                            },
+                            "metadata": {},
+                        },
+                        "messages": [],
+                        "policy_snapshot_id": "snapshot-1",
+                        "evaluation": None,
+                        "metadata": {},
+                    },
+                },
+            )
+        return httpx.Response(500, json={"error": "unexpected request"})
+
+    original_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: original_async_client(
+            transport=httpx.MockTransport(handler),
+            base_url=kwargs.get("base_url"),
+            timeout=kwargs.get("timeout"),
+        ),
+    )
+
+    executor = RemoteRolloutExecutor(
+        service_url="http://rollout-service",
+        poll_interval_seconds=0.01,
+        execution_timeout_seconds=1.0,
+    )
+
+    rollouts = asyncio.run(
+        executor.execute(
+            [_case()],
+            _policy_set(),
+            ExecutionContext(policy_snapshot_id="snapshot-1"),
+        )
+    )
+
+    assert len(rollouts) == 1
+    assert rollouts[0].case.name == "case-1"
+    assert calls.count(f"GET /v1/rollouts/executions/{execution_id}") == 2


### PR DESCRIPTION
## 描述

本 PR 优化训练与远程 rollout 相关逻辑，提升 eval-only / 0 epoch 场景、远端轮询瞬时异常以及轻量级远端消息 payload 的兼容性。

## 主要变更

- 支持 `PipelineContext(max_epochs=0)`，用于只跑 baseline/eval 或显式跳过训练的场景；此时 pipeline 会返回空训练结果，并保留传入的原始 policy set。
- 优化 `RemoteRolloutExecutor` 的轮询容错：对 `408`、`429` 和 `5xx` 响应按瞬时错误重试，并在超时时带上最后一次轮询响应，便于定位远端服务异常。
- 兼容远端返回的轻量级 message payload：当 rollout message 缺少 OpenViking 内部 `id` 字段时，反序列化时自动补默认 id。
- 为 batch train/eval CLI 增加 `--commit-timeout-seconds` 参数，并透传到 `BatchTrainEvalConfig`，方便控制 `session.commit` 等待时间。
- 将本地临时目录 `temp/` 加入 `.gitignore`。

## 测试

- 新增 pipeline 0 epoch 单测，覆盖跳过训练时的返回结果与 metadata。
- 新增远端 rollout 轮询遇到 transient `5xx` 后重试成功的单测。
- 当前 GitHub checks 状态：`check-deps` 已通过，`API & CLI Integration Tests (ubuntu-24.04)` 仍在 pending，`build` 为 skipping。

## 影响范围

- 主要影响训练 pipeline、batch train/eval CLI 和远程 rollout 执行器。
- 对默认训练流程保持兼容；未显式传入 `max_epochs=0` 时仍默认执行 1 个 epoch。
