### PR TITLE
feat(core): initialize shared agent skills directory

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -138,6 +138,18 @@ PRESET_DIRECTORIES: Dict[str, DirectoryDefinition] = {
         overview="Globally shared resource storage, organized by project/topic. "
         "No preset subdirectory structure, users create project directories as needed.",
     ),
+    "agent": DirectoryDefinition(
+        path="",
+        abstract="Agent scope. Account-shared agent capabilities and configuration.",
+        overview="Use this directory for account-shared agent capability definitions and runtime configuration.",
+        children=[
+            DirectoryDefinition(
+                path="skills",
+                abstract="Shared agent skill registry. Stores callable skill definitions available account-wide.",
+                overview="Access when agents need shared skills that are not owned by a single user.",
+            ),
+        ],
+    ),
 }
 
 
@@ -167,20 +179,16 @@ class DirectoryInitializer:
         by ``initialize_user_directories``.
         """
         count = 0
-        scope_roots = {
-            "resources": PRESET_DIRECTORIES["resources"],
-        }
-        for scope, defn in scope_roots.items():
-            root_uri = f"viking://{scope}"
-            created = await self._ensure_directory(
-                uri=root_uri,
-                parent_uri=None,
-                defn=defn,
-                scope=scope,
-                ctx=ctx,
-            )
-            if created:
-                count += 1
+        resources_root = PRESET_DIRECTORIES["resources"]
+        if await self._ensure_directory(
+            uri="viking://resources",
+            parent_uri=None,
+            defn=resources_root,
+            scope="resources",
+            ctx=ctx,
+        ):
+            count += 1
+        count += await self.initialize_agent_directories(ctx)
         return count
 
     async def initialize_user_directories(self, ctx: RequestContext) -> int:
@@ -219,8 +227,13 @@ class DirectoryInitializer:
         return count
 
     async def initialize_agent_directories(self, ctx: RequestContext) -> int:
-        """Deprecated compatibility hook; agent directories are no longer initialized."""
-        return 0
+        """Initialize account-shared agent capability roots."""
+        if "agent" not in PRESET_DIRECTORIES:
+            return 0
+        agent_tree = PRESET_DIRECTORIES["agent"]
+        return await self._initialize_children(
+            "agent", agent_tree.children, "viking://agent", ctx=ctx
+        )
 
     async def _ensure_container_directory(
         self,

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -115,6 +115,8 @@ def relative_uri_path(root_uri: str, uri: str) -> str:
 
 def _content_segment_index(parts: tuple[str, ...]) -> Optional[int]:
     """Return the first content segment after a user namespace root."""
+    if len(parts) >= 2 and parts[0] == "agent" and parts[1] == "skills":
+        return 1
     if len(parts) >= 3 and parts[0] == "agent" and parts[2] in _CONTENT_TYPES_BY_SCOPE["agent"]:
         return 2
     if len(parts) < 2 or parts[0] != "user":

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -549,7 +549,7 @@ class OpenVikingService:
         return await self._directory_initializer.initialize_user_directories(ctx)
 
     async def initialize_agent_directories(self, ctx: RequestContext) -> int:
-        """Initialize current user's current-agent directory tree."""
+        """Initialize account-shared agent capability roots."""
         self._ensure_initialized()
         if not self._directory_initializer:
             return 0

--- a/tests/api_test/filesystem/test_link_relations.py
+++ b/tests/api_test/filesystem/test_link_relations.py
@@ -1,29 +1,30 @@
 import json
+import uuid
 
 
 class TestLinkRelations:
     def test_link_relations_unlink(self, api_client):
+        random_id = uuid.uuid4().hex[:8]
+        file1 = f"viking://resources/test-link-src-{random_id}"
+        file2 = f"viking://resources/test-link-dst-{random_id}"
         try:
-            response = api_client.fs_ls("viking://")
-            print(f"\nList root directory API status code: {response.status_code}")
+            response = api_client.fs_mkdir(file1)
+            print(f"\nCreate relation source API status code: {response.status_code}")
             assert response.status_code == 200, (
-                f"Failed to list root directory: {response.status_code}"
+                f"Failed to create relation source: {response.status_code}"
             )
-
             data = response.json()
             assert data.get("status") == "ok", f"Expected status 'ok', got {data.get('status')}"
             assert data.get("error") is None, f"Expected error to be null, got {data.get('error')}"
 
-            result = data.get("result", [])
-            assert len(result) >= 2, (
-                f"Not enough files in root directory to test link/relations/unlink, found {len(result)} files"
+            response = api_client.fs_mkdir(file2)
+            print(f"\nCreate relation target API status code: {response.status_code}")
+            assert response.status_code == 200, (
+                f"Failed to create relation target: {response.status_code}"
             )
-
-            file1 = result[0].get("uri")
-            file2 = result[1].get("uri")
-
-            assert file1 is not None, "First file URI should not be None"
-            assert file2 is not None, "Second file URI should not be None"
+            data = response.json()
+            assert data.get("status") == "ok", f"Expected status 'ok', got {data.get('status')}"
+            assert data.get("error") is None, f"Expected error to be null, got {data.get('error')}"
 
             response = api_client.link(file1, [file2], "Test link")
             print(f"\nLink API status code: {response.status_code}")
@@ -61,3 +62,6 @@ class TestLinkRelations:
         except Exception as e:
             print(f"Error: {e}")
             raise
+        finally:
+            api_client.fs_rm(file1, recursive=True)
+            api_client.fs_rm(file2, recursive=True)

--- a/tests/misc/test_vikingfs_uri_guard.py
+++ b/tests/misc/test_vikingfs_uri_guard.py
@@ -153,6 +153,16 @@ class TestVikingFSURITraversalGuard:
 
         fs.agfs.stat.assert_called_once_with("/local/acct1/user/alice/sessions")
 
+    def test_agent_shared_write_guard_allows_shared_content_roots_only(self) -> None:
+        fs = _make_viking_fs()
+
+        fs._ensure_supported_write_namespace("viking://agent/skills")
+
+        with pytest.raises(PermissionDeniedError, match="Writing to viking://agent root"):
+            fs._ensure_supported_write_namespace("viking://agent")
+        with pytest.raises(PermissionDeniedError, match="viking://agent/\\{agent_id\\}"):
+            fs._ensure_supported_write_namespace("viking://agent/code-agent")
+
     @pytest.mark.asyncio
     async def test_rm_rejects_temp_root_for_non_root_before_side_effects(self) -> None:
         fs = _make_viking_fs()

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -245,12 +245,12 @@ async def test_reindex_executor_infers_user_namespace_root():
 
 
 @pytest.mark.asyncio
-async def test_reindex_executor_rejects_deprecated_agent_namespace_root():
+async def test_reindex_executor_rejects_agent_namespace_root():
     from openviking.service.reindex_executor import ReindexExecutor
 
     service = ReindexExecutor()
 
-    with pytest.raises(OpenVikingError, match="viking://agent is deprecated"):
+    with pytest.raises(OpenVikingError, match="viking://agent/\\{agent_id\\}"):
         service._infer_target_type("viking://agent/")
 
 

--- a/tests/unit/test_directory_initializer.py
+++ b/tests/unit/test_directory_initializer.py
@@ -56,3 +56,49 @@ async def test_initialize_user_directories_creates_root_and_first_level_only():
 
     assert second_count == 0
     assert set(viking_fs.contexts) == expected_uris
+
+
+@pytest.mark.asyncio
+async def test_initialize_account_directories_creates_agent_shared_roots():
+    vikingdb = _FakeVikingDB()
+    viking_fs = _FakeVikingFS()
+    initializer = DirectoryInitializer(vikingdb, viking_fs=viking_fs)
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.ADMIN)
+
+    count = await initializer.initialize_account_directories(ctx)
+
+    expected_uris = {
+        "viking://resources",
+        *(f"viking://agent/{child.path}" for child in PRESET_DIRECTORIES["agent"].children),
+    }
+    assert count == len(expected_uris)
+    assert set(viking_fs.contexts) == expected_uris
+    assert "viking://agent/skills" in viking_fs.contexts
+    assert "viking://agent/endpoints" not in viking_fs.contexts
+    assert "viking://agent/tools" not in viking_fs.contexts
+    assert "viking://agent/payments" not in viking_fs.contexts
+
+    second_count = await initializer.initialize_account_directories(ctx)
+
+    assert second_count == 0
+    assert set(viking_fs.contexts) == expected_uris
+
+
+@pytest.mark.asyncio
+async def test_initialize_agent_directories_creates_only_agent_shared_roots():
+    vikingdb = _FakeVikingDB()
+    viking_fs = _FakeVikingFS()
+    initializer = DirectoryInitializer(vikingdb, viking_fs=viking_fs)
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.ADMIN)
+
+    count = await initializer.initialize_agent_directories(ctx)
+
+    expected_uris = {
+        *(f"viking://agent/{child.path}" for child in PRESET_DIRECTORIES["agent"].children),
+    }
+    assert count == len(expected_uris)
+    assert set(viking_fs.contexts) == expected_uris
+    assert "viking://agent/skills" in viking_fs.contexts
+    assert "viking://agent/endpoints" not in viking_fs.contexts
+    assert "viking://agent/tools" not in viking_fs.contexts
+    assert "viking://agent/payments" not in viking_fs.contexts

--- a/tests/unit/test_namespace_uri_classification.py
+++ b/tests/unit/test_namespace_uri_classification.py
@@ -27,6 +27,8 @@ def test_context_type_for_uri_uses_path_segments():
     assert context_type_for_uri("viking://user/memories/entities/m1.md") == "memory"
     assert context_type_for_uri("viking://user/alice/skills/demo") == "skill"
     assert context_type_for_uri("viking://user/skills/demo") == "skill"
+    assert context_type_for_uri("viking://agent/skills") == "skill"
+    assert context_type_for_uri("viking://agent/skills/demo") == "skill"
     assert (
         context_type_for_uri(
             "viking://user/support_bot/peers/web-visitor-alice/memories/profile.md"


### PR DESCRIPTION
## Summary
- Add an account-shared `viking://agent/skills` preset directory and initialize it from account/agent directory setup.
- Classify `viking://agent/skills` URIs as skill content while continuing to reject deprecated `viking://agent/{agent_id}` roots.
- Cover shared agent skills initialization, URI classification, and write-guard behavior with focused tests.

## Test plan
- [x] `uv run pytest tests/unit/test_directory_initializer.py tests/unit/test_namespace_uri_classification.py tests/misc/test_vikingfs_uri_guard.py tests/server/test_admin_rebuild_api.py::test_reindex_executor_rejects_agent_namespace_root`
- [ ] Full `tests/server/test_admin_rebuild_api.py` currently has unrelated existing failures in local config/vector-text cases.
