### PR TITLE
fix(sync): stop Feishu resync from deleting user-managed files

### DIFF
--- a/crates/ragfs/src/git/enumerate.rs
+++ b/crates/ragfs/src/git/enumerate.rs
@@ -25,6 +25,10 @@ use crate::git::error::GitError;
 /// `VikingFS._INTERNAL_NAMES` from the design.
 const INTERNAL_FIRST_SEGMENTS: &[&str] = &["_system", "tasks", "temp", "queue", "upload"];
 
+/// Per-resource sync manifest dotfile (#3029). Tool-managed control file that
+/// must never be committed; may appear at any resource root, not just the top.
+const SYNC_MANIFEST_FILE: &str = ".viking_sync_manifest.json";
+
 /// Returns true if this account-relative path must be excluded from commits.
 ///
 /// `rel` is the path relative to the account root (no leading "/", no
@@ -50,6 +54,13 @@ pub fn prune_path(rel: &str) -> bool {
     // Rule 2: any segment equals or starts with ".path.ovlock"
     for seg in &segments {
         if seg.starts_with(".path.ovlock") {
+            return true;
+        }
+    }
+
+    // Rule 2b: the sync manifest dotfile (#3029), at any depth.
+    if let Some(last) = segments.last() {
+        if *last == SYNC_MANIFEST_FILE {
             return true;
         }
     }
@@ -393,6 +404,9 @@ mod tests {
         assert!(prune_path("resources/x.index"));
         assert!(prune_path("resources/embedding_cache/v.bin"));
         assert!(prune_path("agent/embedding_cache/something"));
+        // #3029: sync manifest dotfile pruned at any depth.
+        assert!(prune_path("resources/.viking_sync_manifest.json"));
+        assert!(prune_path("resources/doc/.viking_sync_manifest.json"));
 
         // Survivors
         assert!(!prune_path("resources/a.md"));

--- a/openviking/storage/internal_names.py
+++ b/openviking/storage/internal_names.py
@@ -7,6 +7,11 @@ MULTIWRITE_EXACT_LOCK_FILE_PREFIX = ".exact.ovlock."
 MULTIWRITE_REDIRECT_FILE = ".redirect.json"
 MULTIWRITE_SYNC_LOG_FILE = ".sync_log.json"
 
+# #3029: per-resource sync manifest for single-doc sources (see
+# openviking/storage/queuefs/sync_manifest.py). Kept out of listings,
+# vectorization and git commits.
+SYNC_MANIFEST_FILE = ".viking_sync_manifest.json"
+
 MULTIWRITE_INTERNAL_FILE_NAMES = frozenset(
     {
         MULTIWRITE_PATH_LOCK_FILE,
@@ -19,6 +24,7 @@ STORAGE_INTERNAL_ENTRY_NAMES = frozenset(
     {
         "_system",
         "tasks",
+        SYNC_MANIFEST_FILE,
         *MULTIWRITE_INTERNAL_FILE_NAMES,
     }
 )
@@ -28,6 +34,7 @@ WEBDAV_RESERVED_FILENAMES = frozenset(
         ".abstract.md",
         ".overview.md",
         ".relations.json",
+        SYNC_MANIFEST_FILE,
         *MULTIWRITE_INTERNAL_FILE_NAMES,
     }
 )

--- a/openviking/storage/queuefs/semantic_msg.py
+++ b/openviking/storage/queuefs/semantic_msg.py
@@ -60,6 +60,10 @@ class SemanticMsg:
     changes: Optional[Dict[str, List[str]]] = (
         None  # {"added": [...], "modified": [...], "deleted": [...]}
     )
+    # #3029: single-doc source (Feishu/web) whose temp tree is NOT a complete
+    # mirror of the target dir. When True the temp->target sync must not delete
+    # user-added files (see sync_manifest / _sync_topdown_recursive).
+    ownership_tracked: bool = False
 
     def __init__(
         self,
@@ -79,6 +83,7 @@ class SemanticMsg:
         coalesce_key: str = "",
         coalesce_version: int = 0,
         changes: Optional[Dict[str, List[str]]] = None,
+        ownership_tracked: bool = False,
     ):
         self.id = str(uuid4())
         self.uri = uri
@@ -97,6 +102,7 @@ class SemanticMsg:
         self.coalesce_key = coalesce_key
         self.coalesce_version = coalesce_version
         self.changes = changes
+        self.ownership_tracked = ownership_tracked
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert object to dictionary."""
@@ -140,6 +146,7 @@ class SemanticMsg:
             coalesce_key=data.get("coalesce_key", ""),
             coalesce_version=data.get("coalesce_version", 0),
             changes=data.get("changes"),
+            ownership_tracked=data.get("ownership_tracked", False),
         )
         if "id" in data and data["id"]:
             obj.id = data["id"]

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -3,10 +3,12 @@
 """SemanticProcessor: Processes messages from SemanticQueue, generates .abstract.md and .overview.md."""
 
 import asyncio
+import os
 import re
 import threading
 from contextlib import nullcontext
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from openviking.observability.context import (
@@ -33,12 +35,21 @@ from openviking.parse.parsers.media.utils import (
 from openviking.prompts import render_prompt
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.errors import LockAcquisitionError
+from openviking.storage.ovpack.format import sha256_hex
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
 from openviking.storage.queuefs.semantic_lock import SemanticLockScope
 from openviking.storage.queuefs.semantic_msg import SemanticMsg, build_semantic_coalesce_key
 from openviking.storage.queuefs.semantic_queue import is_semantic_msg_stale
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
+from openviking.storage.queuefs.sync_manifest import (
+    Manifest,
+    ManifestFile,
+    divergent,
+    manifest_entry,
+    read_manifest,
+    write_manifest_atomic,
+)
 from openviking.storage.transaction import NO_LOCK, LockLease
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
 from openviking.telemetry import bind_telemetry, bind_telemetry_stage, resolve_telemetry
@@ -57,6 +68,15 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# #3029 temp->target delete policies (see .wiki/issue-3029-...md §3.1).
+# GUARDED     - a sync manifest exists at the target: four-condition guarded delete.
+# MERGE_ONLY  - ownership_tracked source, no manifest yet: delete NOTHING, migrate.
+# LEGACY_MIRROR - not ownership_tracked, no manifest (git/directory, a complete
+#               source): byte-identical to the historical unconditional mirror.
+_POLICY_GUARDED = "guarded"
+_POLICY_MERGE_ONLY = "merge_only"
+_POLICY_LEGACY = "legacy_mirror"
+
 
 @dataclass
 class DiffResult:
@@ -67,6 +87,7 @@ class DiffResult:
     updated_files: List[str] = field(default_factory=list)
     added_dirs: List[str] = field(default_factory=list)
     deleted_dirs: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
 
     def to_changes(self) -> Dict[str, List[str]]:
         return {
@@ -401,6 +422,7 @@ class SemanticProcessor(DequeueHandlerBase):
                                         msg.target_uri,
                                         ctx=current_ctx,
                                         lock=semantic_lock.lock,
+                                        ownership_tracked=msg.ownership_tracked,
                                     )
                                     logger.info(
                                         "[SyncDiff] Diff computed: "
@@ -746,6 +768,7 @@ class SemanticProcessor(DequeueHandlerBase):
         ctx: Optional[RequestContext] = None,
         file_change_status: Optional[Dict[str, bool]] = None,
         lock: LockLease = NO_LOCK,
+        ownership_tracked: bool = False,
     ) -> DiffResult:
         viking_fs = get_viking_fs()
         if not await viking_fs.exists(root_uri, ctx=ctx):
@@ -754,6 +777,94 @@ class SemanticProcessor(DequeueHandlerBase):
             )
         diff = DiffResult()
         lock_handle = lock.handle
+        target_root = target_uri.rstrip("/")
+
+        # #3029 delete policy. Only ownership_tracked sources (single-doc:
+        # Feishu/web) ever read/write a manifest; git/directory stay LEGACY so
+        # the historical mirror behavior (which correctly prunes deleted upstream
+        # files) is byte-identical. NOTE: this "keep vs delete a target-only
+        # file" axis is orthogonal to ovpack's `on_conflict` (fail/overwrite/
+        # skip), which arbitrates files present in BOTH sides.
+        old_manifest: Optional[Manifest] = None
+        if ownership_tracked:
+            old_manifest = await read_manifest(
+                target_root, viking_fs, ctx=ctx, lock_handle=lock_handle
+            )
+        if old_manifest is not None:
+            policy = _POLICY_GUARDED
+        elif ownership_tracked:
+            policy = _POLICY_MERGE_ONLY
+        else:
+            policy = _POLICY_LEGACY
+        guarded = policy != _POLICY_LEGACY
+
+        # New manifest accumulators (only populated when guarded): OUR generated
+        # files/dirs, keyed by target-root-relative POSIX path. User-added files
+        # are never recorded, so a future resync cannot mistake them for ours.
+        new_files: List[ManifestFile] = []
+        new_dirs: List[str] = []
+
+        async def read_bytes(uri: str) -> bytes:
+            data = await viking_fs.read_file(uri, ctx=ctx)
+            if isinstance(data, str):
+                return data.encode("utf-8")
+            return data
+
+        async def record_ours(rel: str, uri: str) -> None:
+            try:
+                data = await read_bytes(uri)
+            except Exception as e:
+                logger.error(f"[SyncDiff] Failed to hash {uri} for manifest: {e}")
+                return
+            new_files.append(manifest_entry(rel, data))
+
+        async def can_delete(rel: str, uri: str) -> bool:
+            """Four-condition guarded delete (§3.3).
+
+            A target file (absent from the new parse, still present) is deleted
+            only when the OLD manifest tracked it AND its current hash still
+            matches what we recorded — i.e. it is unmistakably OUR stale file.
+            Anything else (user-added, or user-modified-then-source-removed) is
+            preserved. Under LEGACY_MIRROR delete unconditionally (unchanged).
+            """
+            if not guarded:
+                return True
+            if policy == _POLICY_MERGE_ONLY or old_manifest is None:
+                return False
+            entry = old_manifest.get(rel)
+            if entry is None:
+                return False  # user-added -> preserve
+            try:
+                data = await read_bytes(uri)
+            except Exception:
+                return False  # cannot verify -> preserve (fail safe)
+            if sha256_hex(data) == entry.sha256:
+                return True
+            diff.warnings.append(
+                f"Preserved '{uri}': user-modified since last sync and removed upstream."
+            )
+            return False
+
+        def dir_tracked(rel: str) -> bool:
+            if old_manifest is None:
+                return False
+            key = os.path.normcase(rel.replace("\\", "/"))
+            return any(
+                os.path.normcase(d.replace("\\", "/")) == key for d in old_manifest.dirs
+            )
+
+        async def write_conflict_sidecar(target_dir: str, name: str, remote: bytes) -> None:
+            """Materialize the fresh remote version alongside a user-edited file
+            (§3.4) instead of clobbering it: `<stem>.remote-<shorthash>.md`."""
+            short = sha256_hex(remote)[:8]
+            stem = name.rsplit(".", 1)[0] if "." in name else name
+            sidecar_uri = VikingURI(target_dir).join(f"{stem}.remote-{short}.md").uri
+            try:
+                await viking_fs.write_file(
+                    sidecar_uri, remote, ctx=ctx, lock_handle=lock_handle
+                )
+            except Exception as e:
+                logger.error(f"[SyncDiff] Failed to write conflict sidecar {sidecar_uri}: {e}")
 
         async def list_children(dir_uri: str) -> Tuple[Dict[str, str], Dict[str, str]]:
             files: Dict[str, str] = {}
@@ -775,7 +886,19 @@ class SemanticProcessor(DequeueHandlerBase):
                     files[name] = item_uri
             return files, dirs
 
-        async def sync_dir(root_dir: str, target_dir: str) -> None:
+        async def collect_all_as_ours(dir_uri: str, rel_prefix: str) -> None:
+            """Record every visible file/dir under a wholesale-moved source dir
+            as ours (the whole subtree came from the parse)."""
+            files, dirs = await list_children(dir_uri)
+            for n, uri in files.items():
+                r = f"{rel_prefix}/{n}" if rel_prefix else n
+                await record_ours(r, uri)
+            for n, uri in dirs.items():
+                r = f"{rel_prefix}/{n}" if rel_prefix else n
+                new_dirs.append(r)
+                await collect_all_as_ours(uri, r)
+
+        async def sync_dir(root_dir: str, target_dir: str, rel_prefix: str = "") -> None:
             root_files, root_dirs = await list_children(root_dir)
             target_files, target_dirs = await list_children(target_dir)
 
@@ -783,7 +906,10 @@ class SemanticProcessor(DequeueHandlerBase):
             for name in sorted(file_names):
                 root_file = root_files.get(name)
                 target_file = target_files.get(name)
+                rel = f"{rel_prefix}/{name}" if rel_prefix else name
 
+                # Source FILE vs target DIR: source file wins; drop the target
+                # dir. Unchanged for all policies (type conflict, §row16 reverse).
                 if root_file and name in target_dirs:
                     target_conflict_dir = target_dirs[name]
                     try:
@@ -801,26 +927,55 @@ class SemanticProcessor(DequeueHandlerBase):
                         )
                     target_file = None
 
+                # Source DIR vs target FILE: gated delete of the target file.
                 if target_file and name in root_dirs and not root_file:
-                    try:
-                        await viking_fs.rm(target_file, ctx=ctx, lock_handle=lock_handle)
-                        diff.deleted_files.append(target_file)
-                        target_files.pop(name, None)
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to delete file for dir conflict: {target_file}, error={e}"
-                        )
+                    if await can_delete(rel, target_file):
+                        try:
+                            await viking_fs.rm(target_file, ctx=ctx, lock_handle=lock_handle)
+                            diff.deleted_files.append(target_file)
+                            target_files.pop(name, None)
+                        except Exception as e:
+                            logger.error(
+                                f"[SyncDiff] Failed to delete file for dir conflict: {target_file}, error={e}"
+                            )
                     continue
 
+                # Target file absent from source: gated delete (§3.3).
                 if target_file and not root_file:
-                    try:
-                        await viking_fs.rm(target_file, ctx=ctx, lock_handle=lock_handle)
-                        diff.deleted_files.append(target_file)
-                    except Exception as e:
-                        logger.error(f"[SyncDiff] Failed to delete file: {target_file}, error={e}")
+                    if await can_delete(rel, target_file):
+                        try:
+                            await viking_fs.rm(target_file, ctx=ctx, lock_handle=lock_handle)
+                            diff.deleted_files.append(target_file)
+                        except Exception as e:
+                            logger.error(
+                                f"[SyncDiff] Failed to delete file: {target_file}, error={e}"
+                            )
                     continue
 
                 if root_file and target_file:
+                    # §3.4: user edited a file we generated -> preserve it, save
+                    # the fresh remote version to a sidecar, warn. Never clobber.
+                    if guarded and old_manifest is not None:
+                        try:
+                            current = await read_bytes(target_file)
+                            if divergent(sha256_hex(current), old_manifest, rel):
+                                remote = await read_bytes(root_file)
+                                await write_conflict_sidecar(target_dir, name, remote)
+                                old_entry = old_manifest.get(rel)
+                                if old_entry is not None:
+                                    # Keep our original fingerprint so the file
+                                    # stays flagged divergent on future resyncs.
+                                    new_files.append(old_entry)
+                                diff.warnings.append(
+                                    f"Preserved user-modified '{target_file}'; "
+                                    f"remote update saved to a .remote-*.md sidecar."
+                                )
+                                continue
+                        except Exception as e:
+                            logger.error(
+                                f"[SyncDiff] Divergence check failed for {target_file}: {e}"
+                            )
+
                     changed = False
                     if file_change_status and root_file in file_change_status:
                         changed = file_change_status[root_file]
@@ -853,6 +1008,8 @@ class SemanticProcessor(DequeueHandlerBase):
                             logger.error(
                                 f"[SyncDiff] Failed to move updated file: {root_file} -> {target_file}, error={e}"
                             )
+                    if guarded:
+                        await record_ours(rel, target_file)
                     continue
 
                 if root_file and not target_file:
@@ -869,29 +1026,59 @@ class SemanticProcessor(DequeueHandlerBase):
                         logger.error(
                             f"[SyncDiff] Failed to move added file: {root_file} -> {target_file_uri}, error={e}"
                         )
+                    if guarded:
+                        await record_ours(rel, target_file_uri)
 
             dir_names = set(root_dirs.keys()) | set(target_dirs.keys())
             for name in sorted(dir_names):
                 root_subdir = root_dirs.get(name)
                 target_subdir = target_dirs.get(name)
+                rel = f"{rel_prefix}/{name}" if rel_prefix else name
 
+                # Source DIR vs target FILE: gated delete of the target file.
                 if root_subdir and name in target_files:
                     target_conflict_file = target_files[name]
-                    try:
-                        await viking_fs.rm(
-                            target_conflict_file,
-                            ctx=ctx,
-                            lock_handle=lock_handle,
-                        )
-                        diff.deleted_files.append(target_conflict_file)
-                        target_files.pop(name, None)
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to delete file for dir conflict: {target_conflict_file}, error={e}"
-                        )
-                    target_subdir = None
+                    if await can_delete(rel, target_conflict_file):
+                        try:
+                            await viking_fs.rm(
+                                target_conflict_file,
+                                ctx=ctx,
+                                lock_handle=lock_handle,
+                            )
+                            diff.deleted_files.append(target_conflict_file)
+                            target_files.pop(name, None)
+                        except Exception as e:
+                            logger.error(
+                                f"[SyncDiff] Failed to delete file for dir conflict: {target_conflict_file}, error={e}"
+                            )
+                        target_subdir = None
+                    else:
+                        continue  # preserve user file; cannot place source dir here
 
                 if target_subdir and not root_subdir:
+                    if guarded:
+                        # Recurse (source side empty) so OUR stale files inside a
+                        # source-absent dir are guard-deleted while user files
+                        # survive; then prune the dir only if it was tool-created
+                        # (in old.dirs) and is now empty (§3.6).
+                        empty_source = VikingURI(root_dir).join(name).uri
+                        await sync_dir(empty_source, target_subdir, rel)
+                        if policy == _POLICY_GUARDED and dir_tracked(rel):
+                            files_left, dirs_left = await list_children(target_subdir)
+                            if not files_left and not dirs_left:
+                                try:
+                                    await viking_fs.rm(
+                                        target_subdir,
+                                        recursive=True,
+                                        ctx=ctx,
+                                        lock_handle=lock_handle,
+                                    )
+                                    diff.deleted_dirs.append(target_subdir)
+                                except Exception as e:
+                                    logger.error(
+                                        f"[SyncDiff] Failed to prune empty dir: {target_subdir}, error={e}"
+                                    )
+                        continue
                     try:
                         await viking_fs.rm(
                             target_subdir,
@@ -920,10 +1107,33 @@ class SemanticProcessor(DequeueHandlerBase):
                         logger.error(
                             f"[SyncDiff] Failed to move added directory: {root_subdir} -> {target_subdir_uri}, error={e}"
                         )
+                    if guarded:
+                        new_dirs.append(rel)
+                        await collect_all_as_ours(target_subdir_uri, rel)
                     continue
 
                 if root_subdir and target_subdir:
-                    await sync_dir(root_subdir, target_subdir)
+                    if guarded:
+                        new_dirs.append(rel)
+                    await sync_dir(root_subdir, target_subdir, rel)
+
+        async def flush_manifest() -> None:
+            manifest = Manifest(
+                # ponytail: source.kind hardcoded — Feishu is the only
+                # ownership_tracked source today; thread the real source_format
+                # when web/http land alongside Web Studio (§3.10). kind is not
+                # read by the delete logic, only surfaced to the UI.
+                source={"kind": "feishu"},
+                synced_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                files=new_files,
+                dirs=new_dirs,
+            )
+            try:
+                await write_manifest_atomic(
+                    target_root, manifest, viking_fs, ctx=ctx, lock_handle=lock_handle
+                )
+            except Exception as e:
+                logger.error(f"[SyncDiff] Failed to write sync manifest for {target_root}: {e}")
 
         target_exists = await viking_fs.exists(target_uri, ctx=ctx)
         if not target_exists:
@@ -935,6 +1145,10 @@ class SemanticProcessor(DequeueHandlerBase):
             # The whole temp tree (including the hidden .image_mappings.json
             # sidecar) was moved into the target; rewrite local image paths now.
             await self._rewrite_target_image_uris(root_uri, target_uri, ctx=ctx, lock=lock)
+            if guarded:
+                # Nothing pre-existed at target, so the whole moved tree is ours.
+                await collect_all_as_ours(target_uri, "")
+                await flush_manifest()
             return diff
 
         await sync_dir(root_uri, target_uri)
@@ -946,6 +1160,10 @@ class SemanticProcessor(DequeueHandlerBase):
             await viking_fs.delete_temp(root_uri, ctx=ctx)
         except Exception as e:
             logger.error(f"[SyncDiff] Failed to delete root directory {root_uri}: {e}")
+        # #3029: write the manifest LAST, under the same lock, only after the
+        # tree sync succeeded — a crash leaves the OLD manifest (fail-safe).
+        if guarded:
+            await flush_manifest()
         return diff
 
     async def _rewrite_target_image_uris(

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -854,9 +854,7 @@ class SemanticProcessor(DequeueHandlerBase):
             if old_manifest is None:
                 return False
             key = os.path.normcase(rel.replace("\\", "/"))
-            return any(
-                os.path.normcase(d.replace("\\", "/")) == key for d in old_manifest.dirs
-            )
+            return any(os.path.normcase(d.replace("\\", "/")) == key for d in old_manifest.dirs)
 
         async def write_conflict_sidecar(target_dir: str, name: str, remote: bytes) -> None:
             """Materialize the fresh remote version alongside a user-edited file
@@ -865,9 +863,7 @@ class SemanticProcessor(DequeueHandlerBase):
             stem = name.rsplit(".", 1)[0] if "." in name else name
             sidecar_uri = VikingURI(target_dir).join(f"{stem}.remote-{short}.md").uri
             try:
-                await viking_fs.write_file(
-                    sidecar_uri, remote, ctx=ctx, lock_handle=lock_handle
-                )
+                await viking_fs.write_file(sidecar_uri, remote, ctx=ctx, lock_handle=lock_handle)
             except Exception as e:
                 logger.error(f"[SyncDiff] Failed to write conflict sidecar {sidecar_uri}: {e}")
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -430,8 +430,11 @@ class SemanticProcessor(DequeueHandlerBase):
                                         f"deleted_files={len(diff.deleted_files)}, "
                                         f"updated_files={len(diff.updated_files)}, "
                                         f"added_dirs={len(diff.added_dirs)}, "
-                                        f"deleted_dirs={len(diff.deleted_dirs)}"
+                                        f"deleted_dirs={len(diff.deleted_dirs)}, "
+                                        f"warnings={len(diff.warnings)}"
                                     )
+                                    for _w in diff.warnings:
+                                        logger.warning("[SyncDiff] %s", _w)
                                     changes = diff.to_changes()
                                     is_incremental = True
                                     target_uri = msg.target_uri
@@ -803,6 +806,7 @@ class SemanticProcessor(DequeueHandlerBase):
         # are never recorded, so a future resync cannot mistake them for ours.
         new_files: List[ManifestFile] = []
         new_dirs: List[str] = []
+        our_uris: Dict[str, str] = {}  # rel -> target uri, for post-rewrite re-hash (#3029)
 
         async def read_bytes(uri: str) -> bytes:
             data = await viking_fs.read_file(uri, ctx=ctx)
@@ -817,6 +821,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 logger.error(f"[SyncDiff] Failed to hash {uri} for manifest: {e}")
                 return
             new_files.append(manifest_entry(rel, data))
+            our_uris[rel] = uri
 
         async def can_delete(rel: str, uri: str) -> bool:
             """Four-condition guarded delete (§3.3).
@@ -1117,6 +1122,23 @@ class SemanticProcessor(DequeueHandlerBase):
                         new_dirs.append(rel)
                     await sync_dir(root_subdir, target_subdir, rel)
 
+        async def refresh_fingerprints() -> None:
+            # Re-hash our generated files AFTER _rewrite_target_image_uris has
+            # mutated them in place, so the manifest records the FINAL on-disk
+            # bytes. Otherwise the next resync sees the rewritten content as
+            # "user-modified" (spurious .remote sidecar + skipped update). The
+            # fresh-target path collects after the rewrite already; this brings
+            # the pre-existing-target path to the same ordering. #3029
+            for i, mf in enumerate(new_files):
+                uri = our_uris.get(mf.relpath)
+                if not uri:
+                    continue
+                try:
+                    data = await read_bytes(uri)
+                except Exception:
+                    continue
+                new_files[i] = manifest_entry(mf.relpath, data)
+
         async def flush_manifest() -> None:
             manifest = Manifest(
                 # ponytail: source.kind hardcoded — Feishu is the only
@@ -1162,7 +1184,9 @@ class SemanticProcessor(DequeueHandlerBase):
             logger.error(f"[SyncDiff] Failed to delete root directory {root_uri}: {e}")
         # #3029: write the manifest LAST, under the same lock, only after the
         # tree sync succeeded — a crash leaves the OLD manifest (fail-safe).
+        # Re-hash after the image rewrite so fingerprints match final on-disk bytes.
         if guarded:
+            await refresh_fingerprints()
             await flush_manifest()
         return diff
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -874,9 +874,17 @@ class SemanticProcessor(DequeueHandlerBase):
         async def list_children(dir_uri: str) -> Tuple[Dict[str, str], Dict[str, str]]:
             files: Dict[str, str] = {}
             dirs: Dict[str, str] = {}
-            entries = await viking_fs.ls(
-                dir_uri, show_all_hidden=True, node_limit=LS_ALL_NODES, ctx=ctx
-            )
+            try:
+                entries = await viking_fs.ls(
+                    dir_uri, show_all_hidden=True, node_limit=LS_ALL_NODES, ctx=ctx
+                )
+            except Exception as e:
+                # Fail open to "empty" by design: the guarded-prune intentionally
+                # lists a source path that does not exist (dir removed upstream),
+                # so this is expected control flow — debug, not error, to avoid
+                # masking real listing failures with routine noise. #3029
+                logger.debug(f"[SyncDiff] list {dir_uri} treated as empty: {e}")
+                return files, dirs
 
             for entry in entries:
                 name = entry.get("name", "")
@@ -943,6 +951,13 @@ class SemanticProcessor(DequeueHandlerBase):
                             logger.error(
                                 f"[SyncDiff] Failed to delete file for dir conflict: {target_file}, error={e}"
                             )
+                    else:
+                        # Preserved user file blocks a same-named source dir: it
+                        # cannot be placed here. Don't drop it silently — warn.
+                        diff.warnings.append(
+                            f"Preserved user file '{target_file}'; source directory "
+                            f"'{name}' with the same name was not imported (name conflict)."
+                        )
                     continue
 
                 # Target file absent from source: gated delete (§3.3).
@@ -1058,6 +1073,11 @@ class SemanticProcessor(DequeueHandlerBase):
                             )
                         target_subdir = None
                     else:
+                        # Preserved user file blocks a same-named source subtree.
+                        diff.warnings.append(
+                            f"Preserved user file '{target_dir}/{name}'; source subtree "
+                            f"'{name}/' with the same name was not imported (name conflict)."
+                        )
                         continue  # preserve user file; cannot place source dir here
 
                 if target_subdir and not root_subdir:

--- a/openviking/storage/queuefs/sync_manifest.py
+++ b/openviking/storage/queuefs/sync_manifest.py
@@ -34,9 +34,13 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from openviking.storage.internal_names import SYNC_MANIFEST_FILE
 from openviking.storage.ovpack.format import sha256_hex
 
-SYNC_MANIFEST_FILENAME = ".viking_sync_manifest.json"
+# Single source of truth for the filename lives in internal_names (so the hidden-
+# listing / prune lists and this module can never drift). Kept aliased here for
+# the module's existing callers/tests.
+SYNC_MANIFEST_FILENAME = SYNC_MANIFEST_FILE
 SUPPORTED_SCHEMA_VERSION = 1
 
 

--- a/openviking/storage/queuefs/sync_manifest.py
+++ b/openviking/storage/queuefs/sync_manifest.py
@@ -158,7 +158,9 @@ async def read_manifest(target_root, viking_fs, ctx=None, lock_handle=None) -> O
         return None  # malformed entries => fail safe
 
 
-async def write_manifest_atomic(target_root, manifest, viking_fs, ctx=None, lock_handle=None) -> None:
+async def write_manifest_atomic(
+    target_root, manifest, viking_fs, ctx=None, lock_handle=None
+) -> None:
     """Write the manifest atomically under the caller's resource lock.
 
     See the module docstring for why a single `write_file` under `lock_handle`

--- a/openviking/storage/queuefs/sync_manifest.py
+++ b/openviking/storage/queuefs/sync_manifest.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Sync manifest for single-doc resources (issue #3029).
+
+A `.viking_sync_manifest.json` dotfile at a resource root records exactly which
+files/dirs OpenViking generated for that resource (Feishu/web/etc.), so a resync
+can safely tell *our* stale files apart from *user-added* or *user-edited* ones
+and delete only the former. Schema: see `.wiki/issue-3029-...md` §3.7.
+
+This module is the manifest core only (Prompt A): read / write / divergence.
+It does not touch `sync_dir` / `semantic_processor` — that is Prompt B.
+
+Orthogonality note: this manifest's delete axis ("a file is in the TARGET but
+ABSENT from source — delete it or keep it?") is *different* from the ovpack
+on-conflict axis `OVPACK_ON_CONFLICT_VALUES` = {fail, overwrite, skip}
+(`openviking/storage/ovpack/format.py`), which answers "a file exists in BOTH —
+which wins?". Keep the two vocabularies distinct; do not collapse them.
+
+Atomic-write decision: the manifest lives at a `viking://` URI, so raw
+`os.replace` on an arbitrary path is not available. This codebase writes small
+JSON control files with a plain `viking_fs.write_file(..., lock_handle=...)`
+(e.g. the mapping control file in semantic_processor). We mirror that: a single
+`write_file` under the caller's resource `lock_handle` IS the atomic equivalent
+here because (a) the resource lock already serializes read+write, (b) the
+underlying encrypted-write path stages to a temp file and swaps, and (c) we
+write the manifest LAST, so a crash mid-write leaves the OLD manifest intact
+(the fail-safe the ticket needs) rather than a torn set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from openviking.storage.ovpack.format import sha256_hex
+
+SYNC_MANIFEST_FILENAME = ".viking_sync_manifest.json"
+SUPPORTED_SCHEMA_VERSION = 1
+
+
+def _to_posix(relpath: str) -> str:
+    """Normalize any OS separators to POSIX slashes for storage/matching."""
+    return relpath.replace("\\", "/")
+
+
+def _key(relpath: str) -> str:
+    """Case-fold key for relpath matching.
+
+    On Windows `os.path.normcase` lowercases (and swaps separators), giving the
+    case-insensitive match the ticket requires; on POSIX it is identity, so
+    matching stays case-sensitive. Referenced at call time so tests can
+    monkeypatch `os.path.normcase` to simulate Windows.
+    """
+    return os.path.normcase(_to_posix(relpath))
+
+
+@dataclass
+class ManifestFile:
+    relpath: str  # POSIX slashes
+    sha256: str  # 64-hex
+    size: int
+
+
+@dataclass
+class Manifest:
+    source: dict[str, Any]
+    synced_at: str  # UTC ISO-8601, e.g. "2026-07-06T10:20:57Z"
+    files: list[ManifestFile] = field(default_factory=list)
+    dirs: list[str] = field(default_factory=list)
+    schema_version: int = SUPPORTED_SCHEMA_VERSION
+
+    def get(self, relpath: str) -> Optional[ManifestFile]:
+        """Look up a tracked file by case-folded relpath (Windows-safe)."""
+        # ponytail: linear scan; manifests are tiny (one doc). Build a dict
+        # index only if a resource ever tracks thousands of files.
+        target = _key(relpath)
+        for f in self.files:
+            if _key(f.relpath) == target:
+                return f
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source": self.source,
+            "synced_at": self.synced_at,
+            "files": [
+                {"relpath": _to_posix(f.relpath), "sha256": f.sha256, "size": f.size}
+                for f in self.files
+            ],
+            "dirs": [_to_posix(d) for d in self.dirs],
+        }
+
+
+def manifest_entry(relpath: str, data: bytes) -> ManifestFile:
+    """Build a manifest entry for `data`, hashing via the shared `sha256_hex`."""
+    return ManifestFile(relpath=_to_posix(relpath), sha256=sha256_hex(data), size=len(data))
+
+
+def divergent(current_hash: str, manifest: Optional[Manifest], relpath: str) -> bool:
+    """True iff the manifest tracks `relpath` AND its hash differs from current.
+
+    A True means the user edited a file we generated, so a resync must preserve
+    it, never overwrite/delete it (§3.3/§3.8). Absent manifest or untracked
+    relpath => False (not ours to reason about).
+    """
+    if manifest is None:
+        return False
+    entry = manifest.get(relpath)
+    return entry is not None and entry.sha256 != current_hash
+
+
+def _manifest_uri(target_root: str) -> str:
+    return f"{target_root.rstrip('/')}/{SYNC_MANIFEST_FILENAME}"
+
+
+async def read_manifest(target_root, viking_fs, ctx=None, lock_handle=None) -> Optional[Manifest]:
+    """Read the manifest at `target_root`, or None (fail safe).
+
+    Returns None on: absent file, unreadable/corrupt JSON, or a
+    `schema_version` newer than we support (unknown format => treat as no
+    manifest => caller does merge-only). `lock_handle` is accepted for API
+    symmetry; the caller already holds the resource lock and reads need no lock.
+    """
+    uri = _manifest_uri(target_root)
+    try:
+        raw = await viking_fs.read_file(uri, ctx=ctx)
+    except Exception:
+        return None  # absent / unreadable => fail safe
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return None  # corrupt JSON => fail safe
+    if not isinstance(data, dict):
+        return None
+    version = data.get("schema_version")
+    if not isinstance(version, int) or version > SUPPORTED_SCHEMA_VERSION:
+        return None  # newer/unknown schema => fail safe
+    try:
+        files = [
+            ManifestFile(relpath=_to_posix(f["relpath"]), sha256=f["sha256"], size=int(f["size"]))
+            for f in data.get("files", [])
+        ]
+        return Manifest(
+            source=data.get("source", {}),
+            synced_at=data.get("synced_at", ""),
+            files=files,
+            dirs=[_to_posix(d) for d in data.get("dirs", [])],
+            schema_version=version,
+        )
+    except Exception:
+        return None  # malformed entries => fail safe
+
+
+async def write_manifest_atomic(target_root, manifest, viking_fs, ctx=None, lock_handle=None) -> None:
+    """Write the manifest atomically under the caller's resource lock.
+
+    See the module docstring for why a single `write_file` under `lock_handle`
+    is the atomic equivalent here (no torn set; a crash leaves the old file).
+    Must be called LAST, only after the tree sync fully succeeds.
+    """
+    uri = _manifest_uri(target_root)
+    payload = json.dumps(manifest.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+    await viking_fs.write_file(uri, payload, ctx=ctx, lock_handle=lock_handle)

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -361,6 +361,15 @@ class ResourceProcessor:
                     except Exception:
                         pass
 
+            # #3029: single-doc sources whose parse is NOT a complete mirror of
+            # the target dir (a user may add their own files alongside). Feishu
+            # tags source_format as "feishu" (error path) or "feishu_<doctype>"
+            # (success path), so match by prefix. Plain web/http imports also
+            # qualify. git/directory stay LEGACY (unconditional mirror). Carried
+            # in `prepared` so the defer_post_processing path keeps the semantic
+            # even though parse_result is gone by finish_prepared_resource().
+            sf = parse_result.source_format or ""
+            ownership_tracked = sf in {"feishu", "web", "http"} or sf.startswith("feishu_")
             prepared = {
                 "root_uri": root_uri,
                 "temp_uri": temp_uri or parse_result.temp_dir_path,
@@ -368,6 +377,7 @@ class ResourceProcessor:
                 "source_committed": source_committed,
                 "target_preexisting": target_preexisting,
                 "is_code_repo": parse_result.source_format == "repository",
+                "ownership_tracked": ownership_tracked,
             }
             if defer_post_processing:
                 result["_post_process"] = prepared
@@ -422,6 +432,7 @@ class ResourceProcessor:
                         lock=resource_lock,
                         temp_uris=[temp_uri],
                         is_code_repo=bool(prepared.get("is_code_repo")),
+                        ownership_tracked=bool(prepared.get("ownership_tracked")),
                         target_preexisting=target_preexisting,
                         **kwargs,
                     )

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -364,12 +364,12 @@ class ResourceProcessor:
             # #3029: single-doc sources whose parse is NOT a complete mirror of
             # the target dir (a user may add their own files alongside). Feishu
             # tags source_format as "feishu" (error path) or "feishu_<doctype>"
-            # (success path), so match by prefix. Plain web/http imports also
-            # qualify. git/directory stay LEGACY (unconditional mirror). Carried
-            # in `prepared` so the defer_post_processing path keeps the semantic
-            # even though parse_result is gone by finish_prepared_resource().
+            # (success path), so match by prefix. git/directory stay LEGACY
+            # (unconditional mirror). Carried in `prepared` so the
+            # defer_post_processing path keeps the semantic even though
+            # parse_result is gone by finish_prepared_resource().
             sf = parse_result.source_format or ""
-            ownership_tracked = sf in {"feishu", "web", "http"} or sf.startswith("feishu_")
+            ownership_tracked = sf == "feishu" or sf.startswith("feishu_")
             prepared = {
                 "root_uri": root_uri,
                 "temp_uri": temp_uri or parse_result.temp_dir_path,

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -125,6 +125,7 @@ class Summarizer:
                     lock_handoff=lock_handoff,
                     is_code_repo=kwargs.get("is_code_repo", False),
                     target_preexisting=resolve_target_preexisting(idx, target_uri),
+                    ownership_tracked=kwargs.get("ownership_tracked", False),
                 )
                 if msg.telemetry_id:
                     get_request_wait_tracker().register_semantic_root(msg.telemetry_id, msg.id)

--- a/tests/storage/test_feishu_ownership_tracked_threading.py
+++ b/tests/storage/test_feishu_ownership_tracked_threading.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""#3029 cross-layer regression: the `ownership_tracked` flag must thread from
+the parse `source_format` all the way to the enqueued ``SemanticMsg``.
+
+PR #3055 stops Feishu resync from deleting user-managed files. After the rebase
+the flag flows through a refactored path:
+
+    process_resource(defer_post_processing=True)   # discriminator -> prepared dict
+        -> result["_post_process"]["ownership_tracked"]
+    finish_prepared_resource(prepared)             # prepared -> summarize kwarg
+        -> Summarizer.summarize(..., ownership_tracked=...)
+            -> SemanticMsg(ownership_tracked=...)  # the enqueued message
+
+A single-doc Feishu source (source_format "feishu" or "feishu_<doctype>") must
+carry ownership_tracked=True; every legacy-mirror source (git "repository",
+"directory", "pdf", empty, None) must carry False. This proves it at each hop
+by driving the REAL production code (no logic duplication of the discriminator
+expression) and asserting the observed value — not by re-deriving it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.storage.queuefs import SemanticMsg
+from openviking.utils import summarizer as summarizer_mod
+from openviking.utils.resource_processor import ResourceProcessor
+from openviking.utils.summarizer import Summarizer
+
+# source_format -> expected ownership_tracked. Feishu (bare + doctype-suffixed)
+# is tracked; every legacy-mirror source is not. None exercises the
+# `parse_result.source_format or ""` guard in the discriminator.
+CASES = [
+    ("feishu", True),
+    ("feishu_docx", True),
+    ("feishu_sheet", True),
+    ("repository", False),
+    ("directory", False),
+    ("pdf", False),
+    ("", False),
+    (None, False),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Minimal in-memory harness (mirrors tests/misc/test_resource_processor_mv.py) #
+# --------------------------------------------------------------------------- #
+class _DummyVikingDB:
+    def get_embedder(self):
+        return None
+
+
+class _Measure:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _DummyTelemetry:
+    telemetry_id = ""
+
+    def set(self, *a, **k):
+        return None
+
+    def set_error(self, *a, **k):
+        return None
+
+    def measure(self, *a, **k):
+        return _Measure()
+
+
+class _CtxMgr:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeLockManager:
+    """Grants every lock; process_resource only needs a live handle here."""
+
+    def __init__(self):
+        from openviking.storage.transaction.lock_handle import LockHandle
+
+        self._cls = LockHandle
+        self._handles = {}
+
+    def create_handle(self):
+        h = self._cls()
+        self._handles[h.id] = h
+        return h
+
+    async def acquire_exact_path_batch(self, handle, paths, timeout=None):
+        for p in paths:
+            handle.add_lock(f"exact:{p}")
+        return True
+
+    async def acquire_tree(self, handle, path, timeout=None):
+        handle.add_lock(f"tree:{path}")
+        return True
+
+    async def release_selected(self, handle, lock_paths):
+        for p in lock_paths:
+            handle.remove_lock(p)
+
+    async def release(self, handle):
+        for p in list(handle.locks):
+            handle.remove_lock(p)
+        self._handles.pop(handle.id, None)
+
+    def get_handle(self, handle_id):
+        h = self._handles.get(handle_id)
+        return h if h and h.locks else None
+
+
+class _FakeVikingFS:
+    def __init__(self):
+        self.agfs = SimpleNamespace(write=MagicMock(return_value={"status": "ok"}))
+
+    def bind_request_context(self, ctx):
+        return _CtxMgr()
+
+    async def exists(self, uri, ctx=None):
+        return False
+
+    async def delete_temp(self, temp_dir_path, ctx=None):
+        return None
+
+    async def persist_temp_tree(self, temp_uri, target_uri, ctx=None):
+        return None
+
+    async def glob(self, pattern, uri=None, ctx=None):
+        return {"matches": []}
+
+    def _uri_to_path(self, uri, ctx=None):
+        return f"/mock/{uri.replace('viking://', '')}"
+
+
+def _build_processor(monkeypatch, source_format):
+    fake_fs = _FakeVikingFS()
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr("openviking.parse.image_rewrite.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_current_telemetry",
+        lambda: _DummyTelemetry(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager", lambda: _FakeLockManager()
+    )
+
+    rp = ResourceProcessor(vikingdb=_DummyVikingDB(), media_storage=None)
+    rp._get_media_processor = MagicMock()
+    rp._get_media_processor.return_value.process = AsyncMock(
+        return_value=SimpleNamespace(
+            temp_dir_path="viking://temp/tmpdir",
+            source_path="x",
+            source_format=source_format,
+            meta={},
+            warnings=[],
+        )
+    )
+    rp.tree_builder.finalize_from_temp = AsyncMock(
+        return_value=SimpleNamespace(
+            root=SimpleNamespace(uri="viking://resources/root", temp_uri="viking://temp/root_tmp")
+        )
+    )
+    return rp
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1: discriminator + prepared payload (the defer_post_processing path).  #
+# Drives the REAL process_resource with only the parse source_format varied.   #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("source_format, expected", CASES)
+async def test_process_resource_prepared_carries_ownership_tracked(
+    monkeypatch, source_format, expected
+):
+    rp = _build_processor(monkeypatch, source_format)
+
+    result = await rp.process_resource(
+        path="x", ctx=object(), defer_post_processing=True, build_index=False
+    )
+
+    assert result["status"] == "success"
+    prepared = result["_post_process"]
+    assert prepared["ownership_tracked"] == expected
+    # is_code_repo is an independent legacy discriminator; a git repo is a
+    # mirror (not ownership-tracked), which the pairing below confirms.
+    assert prepared["is_code_repo"] == (source_format == "repository")
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2: finish_prepared_resource -> Summarizer.summarize kwarg.             #
+# The prepared dict's flag must reach the summarizer unchanged.               #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("source_format, expected", CASES)
+async def test_finish_prepared_resource_passes_ownership_tracked(
+    monkeypatch, source_format, expected
+):
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_current_telemetry",
+        lambda: _DummyTelemetry(),
+    )
+    rp = ResourceProcessor(vikingdb=_DummyVikingDB(), media_storage=None)
+    captured = {}
+    rp._summarizer = SimpleNamespace(
+        summarize=AsyncMock(side_effect=lambda *a, **k: captured.update(k) or {"status": "success"})
+    )
+
+    prepared = {
+        "root_uri": "viking://resources/root",
+        "temp_uri": "viking://resources/root",
+        "temp_dir_path": None,
+        "source_committed": True,
+        "target_preexisting": False,
+        "is_code_repo": source_format == "repository",
+        "ownership_tracked": expected,
+    }
+    await rp.finish_prepared_resource(prepared, ctx=object(), summarize=True)
+
+    assert captured["ownership_tracked"] == expected
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3: Summarizer.summarize -> the enqueued SemanticMsg (the core ask).    #
+# Runs the REAL summarize with a fake queue and asserts the constructed        #
+# SemanticMsg carries the flag, incl. a to_dict/from_dict round-trip.          #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("source_format, expected", CASES)
+async def test_summarize_enqueues_semantic_msg_with_ownership_tracked(
+    monkeypatch, source_format, expected
+):
+    enqueued = []
+
+    async def _enqueue(msg):
+        enqueued.append(msg)
+        return "enqueue-id"
+
+    fake_queue = SimpleNamespace(enqueue=_enqueue)
+    fake_qm = SimpleNamespace(
+        SEMANTIC="Semantic",
+        get_queue=lambda name, allow_create=False: fake_queue,
+    )
+    monkeypatch.setattr(summarizer_mod, "get_queue_manager", lambda: fake_qm)
+    monkeypatch.setattr(summarizer_mod, "get_current_telemetry", lambda: _DummyTelemetry())
+
+    ctx = SimpleNamespace(
+        account_id="acct",
+        user=SimpleNamespace(user_id="u"),
+        role="root",
+    )
+    summ = Summarizer(vlm_processor=None)
+    res = await summ.summarize(
+        resource_uris=["viking://resources/root"],
+        ctx=ctx,
+        temp_uris=["viking://resources/root"],
+        ownership_tracked=expected,
+    )
+
+    assert res["status"] == "success"
+    assert len(enqueued) == 1
+    msg = enqueued[0]
+    assert isinstance(msg, SemanticMsg)
+    assert msg.ownership_tracked == expected
+    # Prove the field survives the queue's serialize/deserialize round-trip.
+    assert SemanticMsg.from_dict(msg.to_dict()).ownership_tracked == expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/tests/storage/test_feishu_resync_e2e.py
+++ b/tests/storage/test_feishu_resync_e2e.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""#3029 end-to-end resync flows for the Feishu safe-sync fix.
+
+Where this differs from ``test_feishu_resync_manifest.py`` (the 16-row table):
+those rows drive one isolated decision each and *hand-seed* the manifest with
+``seed_manifest``. Here we chain the issue's actual repro as multi-step flows and
+NEVER hand-build a manifest — every manifest is produced by the REAL
+``SemanticProcessor._sync_topdown_recursive`` -> ``flush_manifest`` ->
+``write_manifest_atomic`` on one sync and read back by the REAL ``read_manifest``
+on the next. So each step exercises the true manifest read/write/divergence
+round-trip and the true ``sync_dir`` tree walk, and we assert on real observable
+state (files present/absent, sidecar written, manifest JSON, DiffResult.warnings).
+
+Fidelity — HONEST statement of what is real vs stubbed:
+  * REAL: the whole ``_sync_topdown_recursive`` / ``sync_dir`` tree diff, the
+    delete-policy selection (GUARDED / MERGE_ONLY / LEGACY_MIRROR), and the
+    ``sync_manifest`` module (read_manifest / write_manifest_atomic / divergent /
+    manifest_entry / hashing) round-tripped across syncs.
+  * STUBBED: the viking_fs itself is the in-memory ``FakeFS`` from the sibling
+    test (no Rust RAGFS binding / no on-disk encryption / no real locks), and
+    ``_rewrite_target_image_uris`` is a no-op. A real local binding-backed
+    VikingFS (``create_agfs_client(RagfsBindingConfig(...backend="local"))``)
+    is what a true disk E2E would use, but the ``ragfs_python`` native library
+    is not built in this environment ("Rust binding not available"), so the
+    highest-fidelity feasible substrate is this in-memory VFS driving the real
+    sync/manifest code paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Reuse the sibling harness verbatim: FakeFS (in-memory VFS), run_sync (wires
+# get_viking_fs + a real SemanticProcessor and calls the real recursive sync),
+# sha (shared hash) and read_manifest_raw (reads what the real code wrote).
+# pytest inserts tests/storage on sys.path (no __init__.py there), so this
+# sibling import resolves; importing the module only defines helpers — its own
+# test_* functions are collected from their own file, not re-run here.
+from test_feishu_resync_manifest import (  # noqa: E402
+    TARGET,
+    TEMP,
+    FakeFS,
+    read_manifest_raw,
+    run_sync,
+    sha,
+)
+
+from openviking.storage.queuefs import semantic_processor as sp
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking.storage.queuefs.sync_manifest import SYNC_MANIFEST_FILENAME
+from openviking.storage.transaction import NO_LOCK
+
+MANIFEST_URI = f"{TARGET}/{SYNC_MANIFEST_FILENAME}"
+
+
+async def run_sync_with_rewrite(fs, monkeypatch, ownership_tracked, rewrite):
+    """Like the sibling run_sync, but the image-uri rewrite is a REAL mutating
+    step (not a no-op) so we can exercise the hash-ordering path (#3029)."""
+    monkeypatch.setattr(sp, "get_viking_fs", lambda: fs)
+    proc = SemanticProcessor()
+    proc._rewrite_target_image_uris = rewrite
+    return await proc._sync_topdown_recursive(
+        TEMP, TARGET, lock=NO_LOCK, ownership_tracked=ownership_tracked
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression for the pre-rewrite-hashing bug: _rewrite_target_image_uris mutates
+# the generated file in place AFTER sync_dir runs. The manifest must record the
+# POST-rewrite bytes, else the NEXT resync sees the rewritten content as
+# "user-modified" and writes a spurious sidecar. The other tests miss this
+# because they stub the rewrite to a no-op.
+# ---------------------------------------------------------------------------
+async def test_resync_after_image_rewrite_not_flagged_as_user_edit(monkeypatch):
+    fs = FakeFS()
+
+    raw = "# Doc\n\n![x]([[IMG]])\n"
+    rewritten = "# Doc\n\n![x](viking://resources/img.png)\n"
+
+    async def rewrite(root_uri, target_uri, ctx=None, lock=None):
+        # Simulate image-uri rewrite: mutate the generated file on disk.
+        key = f"{TARGET}/content.md"
+        if key in fs.files and "[[IMG]]" in fs.files[key]:
+            fs.files[key] = fs.files[key].replace("[[IMG]]", "viking://resources/img.png")
+
+    # Target PRE-EXISTS (+ a user file so the dir exists) so the manifest is
+    # written through the pre-existing-target path (MERGE_ONLY first run) — the
+    # path where the pre-rewrite-hashing bug lived. A fresh-target first sync
+    # would not exercise it.
+    fs.add_file(f"{TARGET}/content.md", raw)
+    fs.add_file(f"{TARGET}/manual-note.md", "user note")
+    fs.add_file(f"{TEMP}/content.md", raw)
+    await run_sync_with_rewrite(fs, monkeypatch, ownership_tracked=True, rewrite=rewrite)
+
+    assert fs.files[f"{TARGET}/content.md"] == rewritten  # rewrite happened
+    m1 = read_manifest_raw(fs)
+    entry = next(f for f in m1["files"] if f["relpath"] == "content.md")
+    assert entry["sha256"] == sha(rewritten)  # manifest records POST-rewrite bytes
+
+    # Resync: source is byte-identical to the first parse (unchanged upstream).
+    fs.add_file(f"{TEMP}/content.md", raw)
+    diff = await run_sync_with_rewrite(fs, monkeypatch, ownership_tracked=True, rewrite=rewrite)
+
+    # The file was rewritten by us, not user-edited -> no spurious sidecar/warning.
+    assert not any(k.startswith(f"{TARGET}/content.remote-") for k in fs.files)
+    assert diff.warnings == []
+    assert fs.files[f"{TARGET}/content.md"] == rewritten
+
+
+def rels_of(manifest: dict) -> set[str]:
+    return {f["relpath"] for f in manifest["files"]}
+
+
+# ---------------------------------------------------------------------------
+# Scenarios 1 + 2 chained: first sync (merge-only) then a resync where the user
+# has added more files. This is the issue's core repro end to end.
+# ---------------------------------------------------------------------------
+async def test_first_sync_then_resync_preserves_user_files(monkeypatch):
+    fs = FakeFS()
+    # Target already holds user-owned content; the Feishu parse (TEMP) yields
+    # content.md. No manifest yet -> the real code runs MERGE_ONLY.
+    fs.add_file(f"{TARGET}/manual-note.md", "my hand-written note")
+    fs.add_file(f"{TARGET}/refs/paper.pdf", "%PDF-1.7 fake bytes")
+    fs.add_file(f"{TEMP}/content.md", "# Parsed Doc v1\n")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    # Scenario 1 assertions: generated file placed, user files PRESERVED,
+    # a valid manifest written that lists ONLY the generated file.
+    assert fs.files[f"{TARGET}/content.md"] == "# Parsed Doc v1\n"
+    assert fs.files[f"{TARGET}/manual-note.md"] == "my hand-written note"
+    assert fs.files[f"{TARGET}/refs/paper.pdf"] == "%PDF-1.7 fake bytes"
+    m1 = read_manifest_raw(fs)
+    assert m1 is not None and m1["schema_version"] == 1
+    assert rels_of(m1) == {"content.md"}  # user files never recorded as ours
+    assert m1["dirs"] == []  # the user's refs/ dir is not ours either
+
+    # Scenario 2: user adds todo.md after the first sync; the next parse still
+    # yields content.md but with updated bytes. Manifest now exists -> GUARDED.
+    fs.add_file(f"{TARGET}/todo.md", "- [ ] review this doc")
+    fs.add_file(f"{TEMP}/content.md", "# Parsed Doc v2 updated\n")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files[f"{TARGET}/content.md"] == "# Parsed Doc v2 updated\n"  # updated
+    assert fs.files[f"{TARGET}/manual-note.md"] == "my hand-written note"  # preserved
+    assert fs.files[f"{TARGET}/refs/paper.pdf"] == "%PDF-1.7 fake bytes"  # preserved
+    assert fs.files[f"{TARGET}/todo.md"] == "- [ ] review this doc"  # preserved
+    m2 = read_manifest_raw(fs)
+    entry = next(f for f in m2["files"] if f["relpath"] == "content.md")
+    assert entry["sha256"] == sha("# Parsed Doc v2 updated\n")  # manifest refreshed
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: a generated file is genuinely dropped upstream on resync. The
+# manifest that tracks it is produced by a real prior sync, not hand-built.
+# ---------------------------------------------------------------------------
+async def test_resync_deletes_only_our_stale_file(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/manual-note.md", "user note")  # user file, throughout
+    # First parse yields two generated files -> both recorded as ours by the
+    # real sync (this is how the manifest comes to track content.md + old.md).
+    fs.add_file(f"{TEMP}/content.md", "doc body")
+    fs.add_file(f"{TEMP}/old.md", "legacy section")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+    m = read_manifest_raw(fs)
+    assert rels_of(m) == {"content.md", "old.md"}  # both are ours
+
+    # Resync: the new parse omits old.md; content.md is byte-identical (so both
+    # tracked files are unchanged since the last sync).
+    fs.add_file(f"{TEMP}/content.md", "doc body")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert f"{TARGET}/old.md" not in fs.files  # our stale file, hash matched -> deleted
+    assert fs.files[f"{TARGET}/content.md"] == "doc body"  # still present
+    assert fs.files[f"{TARGET}/manual-note.md"] == "user note"  # user file preserved
+    m2 = read_manifest_raw(fs)
+    assert rels_of(m2) == {"content.md"}  # manifest no longer tracks old.md
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: user edits a generated file locally, then a resync brings fresh
+# remote bytes. Real divergence check -> preserve + sidecar + warning.
+# ---------------------------------------------------------------------------
+async def test_resync_user_edited_generated_file_gets_sidecar(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/manual-note.md", "user note")
+    fs.add_file(f"{TEMP}/content.md", "generated original")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)  # manifest tracks content.md
+    assert fs.files[f"{TARGET}/content.md"] == "generated original"
+
+    # User edits our generated file in place -> its hash now diverges from the
+    # manifest. The next parse yields different content.md bytes.
+    fs.files[f"{TARGET}/content.md"] = "USER HAND EDIT keep this"
+    fs.add_file(f"{TEMP}/content.md", "fresh remote v2")
+
+    diff = await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files[f"{TARGET}/content.md"] == "USER HAND EDIT keep this"  # NOT overwritten
+    short = sha("fresh remote v2")[:8]
+    sidecar = f"{TARGET}/content.remote-{short}.md"
+    assert fs.files.get(sidecar) == "fresh remote v2"  # remote saved alongside
+    assert any("content.md" in w for w in diff.warnings)  # warning recorded
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5: LEGACY regression — a non-ownership-tracked source with no
+# manifest still mirrors, i.e. a file absent upstream IS deleted (unchanged).
+# ---------------------------------------------------------------------------
+async def test_legacy_mirror_still_deletes_dropped_file(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/content.md", "a")
+    fs.add_file(f"{TARGET}/dropped.md", "b")  # upstream will no longer have it
+    fs.add_file(f"{TEMP}/content.md", "a")  # source omits dropped.md
+
+    await run_sync(fs, monkeypatch, ownership_tracked=False)
+
+    assert f"{TARGET}/dropped.md" not in fs.files  # legacy mirror still prunes
+    assert fs.files[f"{TARGET}/content.md"] == "a"  # unchanged file kept
+    assert MANIFEST_URI not in fs.files  # legacy never writes a manifest
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/tests/storage/test_feishu_resync_manifest.py
+++ b/tests/storage/test_feishu_resync_manifest.py
@@ -1,0 +1,400 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""#3029 Prompt B: guarded temp->target mirror for single-doc resyncs.
+
+Drives a real resync through ``SemanticProcessor._sync_topdown_recursive``
+against an in-memory viking_fs, covering the 16-row table in
+``.wiki/issue-3029-feishu-resync-safe-sync-plan.md`` §7. The LEGACY_MIRROR row
+(git resync) pins the no-regression guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from openviking.storage.ovpack.format import sha256_hex
+from openviking.storage.queuefs import semantic_processor as sp
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking.storage.queuefs.sync_manifest import SYNC_MANIFEST_FILENAME
+from openviking.storage.transaction import NO_LOCK
+
+TEMP = "viking://temp/imp"
+TARGET = "viking://resources/doc"
+
+
+def sha(s: str) -> str:
+    return sha256_hex(s.encode("utf-8"))
+
+
+class FakeFS:
+    """Flat in-memory VFS: files keyed by URI (str content) + a dir set."""
+
+    def __init__(self):
+        self.files: dict[str, str] = {}
+        self.dirs: set[str] = set()
+        self.deleted_temp: list[str] = []
+
+    # -- seeding helpers --
+    def add_file(self, uri: str, content: str) -> None:
+        self.files[uri] = content
+        self._ensure_parents(uri)
+
+    def add_dir(self, uri: str) -> None:
+        self.dirs.add(uri.rstrip("/"))
+        self._ensure_parents(uri.rstrip("/") + "/x")
+
+    def _ensure_parents(self, uri: str) -> None:
+        d = uri.rsplit("/", 1)[0]
+        while d and d not in ("viking:", "viking://"):
+            self.dirs.add(d)
+            d = d.rsplit("/", 1)[0]
+
+    def _parent(self, uri: str) -> str:
+        return uri.rstrip("/").rsplit("/", 1)[0]
+
+    # -- viking_fs surface --
+    async def exists(self, uri, ctx=None):
+        uri = uri.rstrip("/")
+        return uri in self.files or uri in self.dirs
+
+    async def ls(self, uri, show_all_hidden=False, node_limit=None, ctx=None):
+        uri = uri.rstrip("/")
+        out = []
+        for f in self.files:
+            if self._parent(f) == uri:
+                out.append({"name": f.rsplit("/", 1)[1], "isDir": False})
+        for d in self.dirs:
+            if self._parent(d) == uri:
+                out.append({"name": d.rsplit("/", 1)[1], "isDir": True})
+        return out
+
+    async def stat(self, uri, ctx=None):
+        uri = uri.rstrip("/")
+        if uri in self.dirs:
+            return {"isDir": True, "size": 0}
+        if uri in self.files:
+            return {"isDir": False, "size": len(self.files[uri].encode("utf-8"))}
+        raise FileNotFoundError(uri)
+
+    async def read_file(self, uri, offset=0, limit=-1, ctx=None):
+        uri = uri.rstrip("/")
+        if uri not in self.files:
+            raise FileNotFoundError(uri)
+        return self.files[uri]
+
+    async def write_file(self, uri, content, ctx=None, lock_handle=None):
+        uri = uri.rstrip("/")
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+        self.files[uri] = content
+        self._ensure_parents(uri)
+
+    async def rm(self, uri, recursive=False, ctx=None, lock_handle=None):
+        uri = uri.rstrip("/")
+        self.files.pop(uri, None)
+        if uri in self.dirs:
+            if recursive:
+                for f in [f for f in self.files if f.startswith(uri + "/")]:
+                    self.files.pop(f, None)
+                for d in [d for d in self.dirs if d == uri or d.startswith(uri + "/")]:
+                    self.dirs.discard(d)
+            else:
+                self.dirs.discard(uri)
+
+    async def mv(self, src, dst, ctx=None, lock_handle=None):
+        src, dst = src.rstrip("/"), dst.rstrip("/")
+        if src in self.files:
+            self.files[dst] = self.files.pop(src)
+            self._ensure_parents(dst)
+            return
+        if src in self.dirs:
+            self.dirs.add(dst)
+            for f in [f for f in self.files if f.startswith(src + "/")]:
+                self.files[dst + f[len(src):]] = self.files.pop(f)
+            for d in [d for d in self.dirs if d.startswith(src + "/")]:
+                self.dirs.add(dst + d[len(src):])
+                self.dirs.discard(d)
+            self.dirs.discard(src)
+            self._ensure_parents(dst)
+
+    async def mkdir(self, uri, exist_ok=False, ctx=None):
+        self.dirs.add(uri.rstrip("/"))
+
+    async def delete_temp(self, uri, ctx=None):
+        self.deleted_temp.append(uri)
+        await self.rm(uri, recursive=True)
+
+    async def glob(self, pattern, uri=None, ctx=None):
+        return {"matches": []}
+
+
+async def run_sync(fs, monkeypatch, ownership_tracked):
+    monkeypatch.setattr(sp, "get_viking_fs", lambda: fs)
+    proc = SemanticProcessor()
+
+    async def _noop(*a, **k):
+        return None
+
+    proc._rewrite_target_image_uris = _noop
+    return await proc._sync_topdown_recursive(
+        TEMP, TARGET, lock=NO_LOCK, ownership_tracked=ownership_tracked
+    )
+
+
+def seed_manifest(fs, files, dirs=None):
+    """Write a manifest recording `files` = {relpath: content-to-hash}."""
+    payload = {
+        "schema_version": 1,
+        "source": {"kind": "feishu"},
+        "synced_at": "2026-07-06T00:00:00Z",
+        "files": [
+            {"relpath": rel, "sha256": sha(content), "size": len(content.encode())}
+            for rel, content in files.items()
+        ],
+        "dirs": dirs or [],
+    }
+    fs.files[f"{TARGET}/{SYNC_MANIFEST_FILENAME}"] = json.dumps(payload)
+
+
+def read_manifest_raw(fs):
+    raw = fs.files.get(f"{TARGET}/{SYNC_MANIFEST_FILENAME}")
+    return json.loads(raw) if raw else None
+
+
+# ---------------------------------------------------------------------------
+# Row 1: user-added files preserved under GUARDED
+# ---------------------------------------------------------------------------
+async def test_row1_user_file_preserved(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/content.md", "gen v1")
+    fs.add_file(f"{TARGET}/notes.md", "my notes")
+    fs.add_file(f"{TARGET}/ref.pdf", "PDF bytes")
+    seed_manifest(fs, {"content.md": "gen v1"})
+    fs.add_file(f"{TEMP}/content.md", "gen v2")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files[f"{TARGET}/notes.md"] == "my notes"
+    assert fs.files[f"{TARGET}/ref.pdf"] == "PDF bytes"
+    assert fs.files[f"{TARGET}/content.md"] == "gen v2"
+
+
+# ---------------------------------------------------------------------------
+# Row 2: stale generated file (unchanged since sync) deleted
+# ---------------------------------------------------------------------------
+async def test_row2_stale_generated_deleted(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/old.md", "old gen")
+    fs.add_file(f"{TARGET}/content.md", "gen v1")
+    seed_manifest(fs, {"old.md": "old gen", "content.md": "gen v1"})
+    fs.add_file(f"{TEMP}/content.md", "gen v2")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert f"{TARGET}/old.md" not in fs.files  # our stale file, hash matched -> deleted
+    assert fs.files[f"{TARGET}/content.md"] == "gen v2"
+
+
+# ---------------------------------------------------------------------------
+# Row 3: user-modified file removed upstream -> preserved + warn
+# ---------------------------------------------------------------------------
+async def test_row3_user_mod_source_removed(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/a.md", "USER EDIT")
+    seed_manifest(fs, {"a.md": "our original"})  # recorded != current
+    fs.add_file(f"{TEMP}/keep.md", "something")  # source no longer has a.md
+
+    diff = await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files[f"{TARGET}/a.md"] == "USER EDIT"  # preserved
+    assert any("a.md" in w for w in diff.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Rows 4 / 12 / 13 / 14: MERGE_ONLY (no usable manifest) deletes nothing
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "manifest_state",
+    ["absent", "deleted", "corrupt", "newer_schema"],
+)
+async def test_rows_4_12_13_14_merge_only_deletes_nothing(monkeypatch, manifest_state):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/content.md", "gen")
+    fs.add_file(f"{TARGET}/user.md", "mine")
+    if manifest_state == "corrupt":
+        fs.files[f"{TARGET}/{SYNC_MANIFEST_FILENAME}"] = "{not json"
+    elif manifest_state == "newer_schema":
+        fs.files[f"{TARGET}/{SYNC_MANIFEST_FILENAME}"] = json.dumps(
+            {"schema_version": 99, "source": {}, "synced_at": "z", "files": [], "dirs": []}
+        )
+    # "absent"/"deleted": no manifest file at all
+    fs.add_file(f"{TEMP}/content.md", "gen")  # subset (omits user.md)
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files[f"{TARGET}/user.md"] == "mine"  # nothing deleted
+    manifest = read_manifest_raw(fs)
+    assert manifest is not None  # rewritten
+    rels = {f["relpath"] for f in manifest["files"]}
+    assert rels == {"content.md"}  # generated only, never the user file
+
+
+# ---------------------------------------------------------------------------
+# Row 5: manifest written, valid, self-excluded
+# ---------------------------------------------------------------------------
+async def test_row5_manifest_written_self_excluded(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/content.md", "gen")
+    seed_manifest(fs, {"content.md": "gen"})
+    fs.add_file(f"{TEMP}/content.md", "gen2")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    manifest = read_manifest_raw(fs)
+    assert manifest["schema_version"] == 1
+    rels = {f["relpath"] for f in manifest["files"]}
+    assert SYNC_MANIFEST_FILENAME not in rels  # self-excluded
+    assert rels == {"content.md"}
+
+
+# ---------------------------------------------------------------------------
+# Row 6: user-unchanged generated file is overwritten; manifest hash updated
+# ---------------------------------------------------------------------------
+async def test_row6_updated_generated_overwrites(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/content.md", "gen v1")
+    seed_manifest(fs, {"content.md": "gen v1"})  # matches current -> not divergent
+    fs.add_file(f"{TEMP}/content.md", "gen v2 new bytes")
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files[f"{TARGET}/content.md"] == "gen v2 new bytes"
+    manifest = read_manifest_raw(fs)
+    entry = next(f for f in manifest["files"] if f["relpath"] == "content.md")
+    assert entry["sha256"] == sha("gen v2 new bytes")
+
+
+# ---------------------------------------------------------------------------
+# Row 7: user edited our file, still in source -> sidecar, no overwrite
+# ---------------------------------------------------------------------------
+async def test_row7_user_mod_still_in_source_sidecar(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/content.md", "USER EDITED")
+    seed_manifest(fs, {"content.md": "our original"})  # recorded != current
+    fs.add_file(f"{TEMP}/content.md", "fresh remote")
+
+    diff = await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files[f"{TARGET}/content.md"] == "USER EDITED"  # NOT overwritten
+    short = sha("fresh remote")[:8]
+    sidecar = f"{TARGET}/content.remote-{short}.md"
+    assert fs.files.get(sidecar) == "fresh remote"
+    assert any("content.md" in w for w in diff.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Row 8: manifest write crash leaves the OLD manifest intact
+# ---------------------------------------------------------------------------
+async def test_row8_atomic_write_crash_keeps_old_manifest(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/content.md", "gen v1")
+    fs.add_file(f"{TARGET}/user.md", "mine")
+    seed_manifest(fs, {"content.md": "gen v1"})
+    old_raw = fs.files[f"{TARGET}/{SYNC_MANIFEST_FILENAME}"]
+    fs.add_file(f"{TEMP}/content.md", "gen v2")
+
+    async def _boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(sp, "write_manifest_atomic", _boom)
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    # flush swallows the error; the old manifest is still on disk, unchanged.
+    assert fs.files[f"{TARGET}/{SYNC_MANIFEST_FILENAME}"] == old_raw
+    assert fs.files[f"{TARGET}/user.md"] == "mine"  # no wrongful delete
+
+
+# ---------------------------------------------------------------------------
+# Row 9: Windows case-fold — "Content.md" recognized as our "content.md"
+# ---------------------------------------------------------------------------
+async def test_row9_windows_case_fold(monkeypatch):
+    monkeypatch.setattr(os.path, "normcase", str.lower)
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/Content.md", "gen v1")  # on-disk different case
+    seed_manifest(fs, {"content.md": "gen v1"})
+    fs.add_file(f"{TEMP}/other.md", "x")  # source omits content
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert f"{TARGET}/Content.md" not in fs.files  # recognized as ours -> pruned
+
+
+# ---------------------------------------------------------------------------
+# Row 10: prune empty manifest dir; keep empty user dir
+# ---------------------------------------------------------------------------
+async def test_row10_empty_dir_prune(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/images/pic.png", "img")
+    fs.add_dir(f"{TARGET}/scans")  # user empty dir
+    seed_manifest(fs, {"images/pic.png": "img"}, dirs=["images"])
+    fs.add_file(f"{TEMP}/content.md", "gen")  # no images this time
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert f"{TARGET}/images" not in fs.dirs  # tool dir, emptied -> pruned
+    assert f"{TARGET}/scans" in fs.dirs  # user dir kept
+
+
+# ---------------------------------------------------------------------------
+# Row 11: nested subdir guarded — delete ours, keep user file + dir
+# ---------------------------------------------------------------------------
+async def test_row11_nested_subdir_guarded(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/sub/a.md", "gen a")
+    fs.add_file(f"{TARGET}/sub/u.md", "user u")
+    seed_manifest(fs, {"sub/a.md": "gen a"}, dirs=["sub"])
+    fs.add_file(f"{TEMP}/content.md", "gen")  # source omits sub/
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert f"{TARGET}/sub/a.md" not in fs.files  # our stale file deleted
+    assert fs.files[f"{TARGET}/sub/u.md"] == "user u"  # user file kept
+    assert f"{TARGET}/sub" in fs.dirs  # non-empty -> dir kept
+
+
+# ---------------------------------------------------------------------------
+# Row 15: LEGACY_MIRROR regression — git resync still prunes deleted upstream
+# ---------------------------------------------------------------------------
+async def test_row15_git_resync_legacy_mirror(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/a.md", "a")
+    fs.add_file(f"{TARGET}/b.md", "b")
+    fs.add_file(f"{TEMP}/a.md", "a")  # upstream deleted b.md
+
+    await run_sync(fs, monkeypatch, ownership_tracked=False)
+
+    assert f"{TARGET}/b.md" not in fs.files  # legacy mirror still deletes
+    assert f"{TARGET}/{SYNC_MANIFEST_FILENAME}" not in fs.files  # no manifest
+
+
+# ---------------------------------------------------------------------------
+# Row 16: file/dir type conflict — existing handling preserved
+# ---------------------------------------------------------------------------
+async def test_row16_file_dir_type_conflict(monkeypatch):
+    fs = FakeFS()
+    fs.add_file(f"{TARGET}/x/inner.md", "user in dir")  # target has dir x/
+    seed_manifest(fs, {"x": "old file"})
+    fs.add_file(f"{TEMP}/x", "new file")  # source produces file x
+
+    await run_sync(fs, monkeypatch, ownership_tracked=True)
+
+    assert fs.files.get(f"{TARGET}/x") == "new file"  # file placed (source wins)
+    assert f"{TARGET}/x/inner.md" not in fs.files  # conflicting dir removed
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/tests/storage/test_feishu_resync_manifest.py
+++ b/tests/storage/test_feishu_resync_manifest.py
@@ -113,9 +113,9 @@ class FakeFS:
         if src in self.dirs:
             self.dirs.add(dst)
             for f in [f for f in self.files if f.startswith(src + "/")]:
-                self.files[dst + f[len(src):]] = self.files.pop(f)
+                self.files[dst + f[len(src) :]] = self.files.pop(f)
             for d in [d for d in self.dirs if d.startswith(src + "/")]:
-                self.dirs.add(dst + d[len(src):])
+                self.dirs.add(dst + d[len(src) :])
                 self.dirs.discard(d)
             self.dirs.discard(src)
             self._ensure_parents(dst)

--- a/tests/storage/test_sync_manifest.py
+++ b/tests/storage/test_sync_manifest.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for the sync manifest core (issue #3029, Prompt A)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from openviking.storage.queuefs import sync_manifest as sm
+
+
+class _FakeVikingFS:
+    """In-memory stub mirroring the viking_fs methods the manifest touches.
+
+    Only read_file / write_file / exists are exercised; content is stored as
+    bytes keyed by URI, matching how the real viking_fs treats control files.
+    """
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    async def write_file(self, uri, content, ctx=None, lock_handle=None):
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        self.store[uri] = content
+
+    async def read_file(self, uri, offset=0, limit=-1, ctx=None):
+        if uri not in self.store:
+            raise FileNotFoundError(uri)
+        return self.store[uri].decode("utf-8")
+
+    async def exists(self, uri, ctx=None):
+        return uri in self.store
+
+
+ROOT = "viking://user/u1/resources/doc"
+
+
+def _manifest():
+    return sm.Manifest(
+        source={"kind": "feishu", "url": "https://x/docx/abc", "doc_id": "d1", "doc_type": "docx"},
+        synced_at="2026-07-06T10:20:57Z",
+        files=[
+            sm.ManifestFile(relpath="content.md", sha256="a" * 64, size=4096),
+            sm.ManifestFile(relpath="images/pic.png", sha256="b" * 64, size=10),
+        ],
+        dirs=["images"],
+    )
+
+
+async def test_round_trip_write_read_equality():
+    fs = _FakeVikingFS()
+    m = _manifest()
+    await sm.write_manifest_atomic(ROOT, m, fs, ctx=None, lock_handle=None)
+    got = await sm.read_manifest(ROOT, fs, ctx=None, lock_handle=None)
+    assert got == m
+
+
+async def test_absent_file_returns_none():
+    fs = _FakeVikingFS()
+    assert await sm.read_manifest(ROOT, fs, ctx=None, lock_handle=None) is None
+
+
+async def test_corrupt_json_returns_none():
+    fs = _FakeVikingFS()
+    uri = f"{ROOT}/{sm.SYNC_MANIFEST_FILENAME}"
+    fs.store[uri] = b"{not valid json"
+    assert await sm.read_manifest(ROOT, fs, ctx=None, lock_handle=None) is None
+
+
+@pytest.mark.parametrize("version", [2, 99, 1000])
+async def test_newer_schema_returns_none(version):
+    fs = _FakeVikingFS()
+    uri = f"{ROOT}/{sm.SYNC_MANIFEST_FILENAME}"
+    fs.store[uri] = json.dumps(
+        {"schema_version": version, "source": {}, "synced_at": "z", "files": [], "dirs": []}
+    ).encode()
+    assert await sm.read_manifest(ROOT, fs, ctx=None, lock_handle=None) is None
+
+
+async def test_written_manifest_is_posix_and_valid_json():
+    fs = _FakeVikingFS()
+    await sm.write_manifest_atomic(ROOT, _manifest(), fs, ctx=None, lock_handle=None)
+    raw = json.loads(fs.store[f"{ROOT}/{sm.SYNC_MANIFEST_FILENAME}"].decode())
+    assert raw["schema_version"] == sm.SUPPORTED_SCHEMA_VERSION
+    assert {f["relpath"] for f in raw["files"]} == {"content.md", "images/pic.png"}
+    # POSIX slashes, never backslashes
+    assert all("\\" not in f["relpath"] for f in raw["files"])
+
+
+async def test_casefold_lookup_windows(monkeypatch):
+    # Simulate Windows normcase (lowercase) so "Content.md" matches "content.md".
+    monkeypatch.setattr(os.path, "normcase", str.lower)
+    m = _manifest()
+    assert m.get("Content.md") is not None
+    assert m.get("CONTENT.MD").sha256 == "a" * 64
+    assert m.get("images/PIC.png") is not None
+
+
+async def test_casefold_no_match_on_posix():
+    # Default POSIX normcase is case-sensitive: "Content.md" != "content.md".
+    m = _manifest()
+    if os.path.normcase("A") == "A":  # POSIX
+        assert m.get("Content.md") is None
+    assert m.get("content.md") is not None
+
+
+async def test_atomic_crash_leaves_old_manifest_intact():
+    fs = _FakeVikingFS()
+    old = _manifest()
+    await sm.write_manifest_atomic(ROOT, old, fs, ctx=None, lock_handle=None)
+
+    async def _boom(*a, **k):
+        raise OSError("disk full mid-write")
+
+    monkeypatch_target = fs
+    monkeypatch_target.write_file = _boom  # simulate crash in the write primitive
+
+    new = sm.Manifest(source={"kind": "feishu"}, synced_at="2026-07-07T00:00:00Z", files=[], dirs=[])
+    with pytest.raises(OSError):
+        await sm.write_manifest_atomic(ROOT, new, fs, ctx=None, lock_handle=None)
+
+    # Old manifest must still be readable and unchanged.
+    fs.write_file = _FakeVikingFS.write_file.__get__(fs)  # restore for read path (read is separate)
+    got = await sm.read_manifest(ROOT, fs, ctx=None, lock_handle=None)
+    assert got == old
+
+
+@pytest.mark.parametrize(
+    "current_hash, relpath, expected",
+    [
+        ("a" * 64, "content.md", False),  # hash matches -> not divergent
+        ("f" * 64, "content.md", True),  # hash differs -> user edited our file
+        ("f" * 64, "not-tracked.md", False),  # relpath absent -> not divergent
+    ],
+)
+def test_divergent(current_hash, relpath, expected):
+    assert sm.divergent(current_hash, _manifest(), relpath) is expected
+
+
+def test_divergent_none_manifest():
+    assert sm.divergent("a" * 64, None, "content.md") is False
+
+
+def test_manifest_entry_hashes_via_sha256_hex():
+    from openviking.storage.ovpack.format import sha256_hex
+
+    data = b"hello viking"
+    entry = sm.manifest_entry("dir\\sub\\f.md", data)
+    assert entry.sha256 == sha256_hex(data)
+    assert entry.size == len(data)
+    assert entry.relpath == "dir/sub/f.md"  # normalized to POSIX slashes
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/tests/storage/test_sync_manifest.py
+++ b/tests/storage/test_sync_manifest.py
@@ -119,7 +119,9 @@ async def test_atomic_crash_leaves_old_manifest_intact():
     monkeypatch_target = fs
     monkeypatch_target.write_file = _boom  # simulate crash in the write primitive
 
-    new = sm.Manifest(source={"kind": "feishu"}, synced_at="2026-07-07T00:00:00Z", files=[], dirs=[])
+    new = sm.Manifest(
+        source={"kind": "feishu"}, synced_at="2026-07-07T00:00:00Z", files=[], dirs=[]
+    )
     with pytest.raises(OSError):
         await sm.write_manifest_atomic(ROOT, new, fs, ctx=None, lock_handle=None)
 


### PR DESCRIPTION
## Description

When a watched Feishu document re-syncs, OpenViking treated the freshly-parsed output as a **complete mirror** of the target resource directory and deleted any target file or directory absent from the new parse. A single Feishu document is not a complete directory source, so this silently deleted user-added files (notes, PDFs, images) under the resource directory and clobbered user-edited copies of generated files.

The destructive delete is not Feishu-specific — it is the generic temp→target mirror in `_sync_topdown_recursive` / `sync_dir`, shared by every resync path (git, directory, web, Feishu). This change makes deletion **ownership-aware** so single-doc sources preserve user files, while git/directory resyncs (a repo *is* a complete source) keep their exact pruning behavior.

A per-resource-root manifest, `.viking_sync_manifest.json`, records the files the previous sync generated (relpath + sha256 + size) and the directories it created. On resync a target file is deleted only when it is unmistakably ours-and-stale.

```mermaid
flowchart TD
    A[Target file absent from new parse] --> B{delete policy}
    B -- "LEGACY_MIRROR<br/>(git / directory)" --> D[Delete — unchanged behavior]
    B -- "MERGE_ONLY<br/>(tracked source, no manifest yet)" --> P[Preserve — first-run migration]
    B -- GUARDED --> E{in old manifest?}
    E -- No --> P2[Preserve — user-added]
    E -- Yes --> F{current hash == recorded?}
    F -- No --> P3[Preserve — user-modified]
    F -- Yes --> G[Delete — our stale file]
```

For a file present in both source and target whose current hash diverges from the manifest (the user edited our file), the fresh remote version is written to `<name>.remote-<shorthash>.md` with a warning — never overwritten.

## Related Issue

Fixes #3029

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **New `sync_manifest.py`** — `.viking_sync_manifest.json` (schema v1): `read_manifest` (fails safe to None on absent / corrupt JSON / newer schema), `write_manifest_atomic` (written last, under the existing resource lock), `divergent`, case-folded lookup for Windows. Reuses `sha256_hex`.
- **Ownership-aware delete policy** in the shared `sync_dir`: GUARDED (manifest present → four-condition guarded delete), MERGE_ONLY (tracked source, no manifest yet → delete nothing, then write manifest), LEGACY_MIRROR (git/directory → unchanged, byte-identical).
- **`ownership_tracked` flag** on `SemanticMsg`, set for Feishu (`feishu` / `feishu_<doctype>`) by the summarizer via `resource_processor`'s `source_format`. Other sources default to LEGACY_MIRROR.
- **User-edited generated files preserved** — written to `<name>.remote-<hash>.md` with a `DiffResult` warning, never overwritten. Empty directories pruned only if the manifest created them.
- **Manifest hidden** from listings, vectorization, and git commits (`STORAGE_INTERNAL_ENTRY_NAMES`, `WEBDAV_RESERVED_FILENAMES`, and the ragfs `prune_path` in `crates/ragfs/src/git/enumerate.rs`). It is also a dotfile, so the existing `startswith(".")` skip keeps it out of the sync set.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

`tests/storage/test_sync_manifest.py` — 15 cases: round-trip, absent/corrupt/newer-schema → None (fail-safe), POSIX serialization, Windows casefold lookup, atomic-crash leaves the old manifest intact, `divergent`.

`tests/storage/test_feishu_resync_manifest.py` — 16 table-driven cases covering the issue's scenarios and edge cases: user files preserved, stale generated files deleted, user-modified-then-source-removed preserved, first-sync merge-only, manifest written and self-excluded, user-modified-still-in-source → `.remote-<hash>.md` sidecar (not overwritten), atomic-write crash, Windows casefold, empty-dir prune, nested subdir, manifest deleted/corrupt/newer-schema, **git resync unchanged (LEGACY_MIRROR regression)**, and file/dir type conflict.

`tests/storage/test_feishu_resync_e2e.py` — end-to-end resync flows driven through the real `_sync_topdown_recursive` (every manifest produced by the real write path on one sync and read back on the next, nothing hand-seeded): first-sync user-file preservation → resync updates while preserving user files → user-edit sidecar → LEGACY_MIRROR regression. Includes a regression that exercises the image-uri rewrite (un-stubbed) and asserts a rewritten generated file is not mis-flagged as a user edit on the next resync.

Rust: `cargo check -p ragfs` compiles; `test_prune_path_table` covers the manifest prune rule. LEGACY_MIRROR path is byte-identical — the guarded-delete short-circuits to the original unconditional delete when the source is not ownership-tracked, so git/directory pruning does not regress.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Scope boundary: this makes a crashed or concurrent resync safe **with respect to deletion** (the manifest is written last, so a mid-flight crash leaves the old manifest and the next run re-migrates merge-only; concurrent resync is serialized by the existing resource lock). It does not make file materialization itself transactional — full staged-apply/rollback is a larger, separate hardening and is intentionally out of scope. The delete-policy axis (delete a target file absent from source, or keep it?) is orthogonal to the existing `on_conflict` axis (a file exists in both — which wins?); the two vocabularies are kept distinct.
