### PR TITLE
docs: relax TOS installer options for agent guides

### DIFF
--- a/docs/images/agents/en/claude-code.md
+++ b/docs/images/agents/en/claude-code.md
@@ -5,12 +5,12 @@ Source: [examples/claude-code-memory-plugin](https://github.com/volcengine/OpenV
 ## Step 1: Install
 
 ```bash
-bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) --harness claude --dist tos
+bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh)
 ```
 
-Claude Code and Codex share this one installer. It asks for your language (English/中文) and OpenViking credentials; each step is idempotent, so it is safe to rerun. No shell wrapper is needed anymore — the plugin ships a stdio MCP proxy that reads `~/.openviking/ovcli.conf` at runtime.
+Claude Code and Codex share this one installer. It asks which tools to install, which source to use (GitHub or the TOS mirror), your language (English/中文), and OpenViking credentials; each step is idempotent, so it is safe to rerun. No shell wrapper is needed anymore — the plugin ships a stdio MCP proxy that reads `~/.openviking/ovcli.conf` at runtime.
 
-> The TOS channel registers a local directory marketplace, which cannot auto-update — re-run the command above to update.
+> If you choose the TOS channel for Claude Code, the installer registers a local directory marketplace that cannot auto-update — re-run the command above to update.
 
 After using it for a while, start a new conversation and ask about something you mentioned earlier. It should remember.
 

--- a/docs/images/agents/en/codex.md
+++ b/docs/images/agents/en/codex.md
@@ -5,10 +5,10 @@ Source: [examples/codex-memory-plugin](https://github.com/volcengine/OpenViking/
 ## Step 1: Install
 
 ```bash
-bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) --harness codex --dist tos
+bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh)
 ```
 
-Claude Code and Codex share this one installer. It asks for your language (English/中文) and OpenViking credentials; each step is idempotent, so it is safe to rerun. On the TOS channel Codex installs from a TOS-hosted git repo and can update later with `codex plugin marketplace upgrade openviking`.
+Claude Code and Codex share this one installer. It asks which tools to install, which source to use (GitHub or the TOS mirror), your language (English/中文), and OpenViking credentials; each step is idempotent, so it is safe to rerun. If you choose the TOS channel for Codex, it installs from a TOS-hosted git repo and can update later with `codex plugin marketplace upgrade openviking`.
 
 No shell wrapper is needed anymore — the plugin ships a stdio MCP proxy that reads `~/.openviking/ovcli.conf` at runtime. After installing:
 

--- a/docs/images/agents/zh/claude-code.md
+++ b/docs/images/agents/zh/claude-code.md
@@ -5,12 +5,12 @@
 ## 步骤 1：安装
 
 ```bash
-bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) --harness claude --dist tos
+bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh)
 ```
 
-Claude Code 和 Codex 共用这一个安装脚本。它会依次询问界面语言（English/中文）和 OpenViking 凭据；所有步骤幂等，支持重复运行。不再需要任何 shell wrapper——插件自带的 stdio MCP 代理会在运行时读取 `~/.openviking/ovcli.conf`。
+Claude Code 和 Codex 共用这一个安装脚本。它会依次询问要安装的工具、安装源（GitHub 或 TOS 镜像）、界面语言（English/中文）和 OpenViking 凭据；所有步骤幂等，支持重复运行。不再需要任何 shell wrapper——插件自带的 stdio MCP 代理会在运行时读取 `~/.openviking/ovcli.conf`。
 
-> TOS 渠道注册的是本地目录 marketplace，无法自动更新——更新请重跑上面的安装命令。
+> 若为 Claude Code 选择 TOS 渠道，安装脚本会注册本地目录 marketplace，无法自动更新——更新请重跑上面的安装命令。
 
 使用一段时间后，即便在全新的对话中提及过往的话题，Claude Code 也能准确回忆起来。
 

--- a/docs/images/agents/zh/codex.md
+++ b/docs/images/agents/zh/codex.md
@@ -5,10 +5,10 @@
 ## 步骤 1：安装
 
 ```bash
-bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) --harness codex --dist tos
+bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh)
 ```
 
-Claude Code 和 Codex 共用这一个安装脚本。它会依次询问界面语言（English/中文）和 OpenViking 凭据；所有步骤幂等，可安全地重复执行。Codex 走 TOS 时安装自 TOS 托管的 git 仓库，之后可用 `codex plugin marketplace upgrade openviking` 远程更新。
+Claude Code 和 Codex 共用这一个安装脚本。它会依次询问要安装的工具、安装源（GitHub 或 TOS 镜像）、界面语言（English/中文）和 OpenViking 凭据；所有步骤幂等，可安全地重复执行。若为 Codex 选择 TOS 渠道，安装脚本会使用 TOS 托管的 git 仓库，之后仍可用 `codex plugin marketplace upgrade openviking` 远程更新。
 
 不再需要任何 shell wrapper——插件自带的 stdio MCP 代理会在运行时读取 `~/.openviking/ovcli.conf`。安装完成后：
 


### PR DESCRIPTION
Summary:
- Remove fixed --harness and --dist tos flags from TOS-hosted installer commands in image agent docs.
- Clarify that the installer prompts for harness and GitHub/TOS source selection.

Tests: Not run (docs only).