### PR TITLE
docs: add OpenViking Helper download section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ With OpenViking, developers can build an Agent's brain just like managing local 
 
 > 💡 **Want to see it in action first?** Try [OpenViking Studio](https://openviking.ai/studio) — a live hosted instance with a context playground, semantic search, and a multi-agent hub. No installation required.
 
+### OpenViking Helper for macOS (Beta)
+
+**OpenViking Helper** is a macOS desktop app for OpenViking users. It brings local agent setup, session traces, memories, and skills into a visual console, making it easier to verify setup and sync local context into OpenViking.
+
+Highlights:
+
+- **Visual local Agent setup**: Detect OpenViking CLI, Claude Code, Codex, Cursor, Trae, and OpenCode, then configure supported plugin, MCP, Hook, and CLI integrations.
+- **Session trace inspection**: Parse Claude Code, Codex, and Trae sessions to show OpenViking recall, prompt injection, MCP calls, capture, and commit events.
+- **Local memory and skill management**: View local memory / rule files and `SKILL.md` skills, then sync them to OpenViking.
+
+> OpenViking Helper is currently in beta and supports macOS only.
+
+Download:
+
+- [macOS Apple Silicon (arm64)](https://lf3-cdn-tos.bytegoofy.com/obj/tron-demo/7654844610543360265/418715779/0.0.18/darwin-arm64/openviking-helper-0.0.18-arm64.dmg)
+- [macOS Intel (x64)](https://lf3-cdn-tos.bytegoofy.com/obj/tron-demo/7654844610543360265/418715779/0.0.18/darwin-x64/openviking-helper-0.0.18-x64.dmg)
+
 ### Local Deployment
 
 #### Prerequisites

--- a/README_CN.md
+++ b/README_CN.md
@@ -61,6 +61,23 @@
 
 > 💡 **想先看看实际效果？** 试试 [OpenViking Studio](https://openviking.net/studio)——在线托管实例，提供上下文实验场、语义检索和多智能体 Hub，无需安装。
 
+### OpenViking Helper macOS 桌面端（Beta）
+
+**OpenViking Helper** 是面向 OpenViking 用户的 macOS 桌面应用，把本机 Agent 接入、会话轨迹、记忆和技能放到可视化界面里，方便用户确认接入状态，并把本地上下文同步到 OpenViking。
+
+核心特性：
+
+- **可视化接入本地 Agent**：检测 OpenViking CLI、Claude Code、Codex、Cursor、Trae、OpenCode，并配置支持的插件、MCP、Hook 和 CLI 接入。
+- **回看会话生效过程**：解析 Claude Code、Codex、Trae 会话，展示 OpenViking 的召回、Prompt 注入、MCP 调用、捕获和提交事件。
+- **管理本地记忆与技能**：查看本地 memory / rule 文件和 `SKILL.md` 技能，并同步到 OpenViking。
+
+> OpenViking Helper 目前仍处于 Beta 阶段，暂时仅支持 macOS。
+
+下载：
+
+- [macOS Apple Silicon 版（arm64）](https://lf3-cdn-tos.bytegoofy.com/obj/tron-demo/7654844610543360265/418715779/0.0.18/darwin-arm64/openviking-helper-0.0.18-arm64.dmg)
+- [macOS Intel 版（x64）](https://lf3-cdn-tos.bytegoofy.com/obj/tron-demo/7654844610543360265/418715779/0.0.18/darwin-x64/openviking-helper-0.0.18-x64.dmg)
+
 ### 本地部署
 
 #### 前置条件


### PR DESCRIPTION
## Description

Adds an OpenViking Helper for macOS beta section to the English and Chinese README quick start areas. The section describes the app from the implemented Helper feature surface and provides Apple Silicon and Intel macOS download links.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Added an OpenViking Helper beta section to `README.md`.
- Added the corresponding Chinese section to `README_CN.md`.
- Included feature copy for agent setup, session trace inspection, local memory / skill management, and macOS arm64/x64 download links.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Validation performed:

- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR is documentation-only; no runtime tests were run.
