### PR TITLE
ci(docker): add Volcengine CR as a third publish registry

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -81,6 +81,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to Volcengine CR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ secrets.VOLCENGINE_CR_REGISTRY }}
+          username: ${{ secrets.VOLCENGINE_CR_USERNAME }}
+          password: ${{ secrets.VOLCENGINE_CR_PASSWORD }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
@@ -88,6 +95,7 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image }}
             docker.io/${{ secrets.DOCKERHUB_USERNAME }}/openviking
+            ${{ secrets.VOLCENGINE_CR_REGISTRY }}/${{ secrets.VOLCENGINE_CR_NAMESPACE }}/openviking
           tags: |
             type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag,enable=${{ github.ref_type == 'tag' }}
@@ -121,6 +129,18 @@ jobs:
           build-args: |
             OPENVIKING_VERSION=${{ steps.openviking-version.outputs.version }}
 
+      - name: Build and push Docker image to Volcengine CR
+        id: push-volcengine
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: |
+            type=image,name=${{ secrets.VOLCENGINE_CR_REGISTRY }}/${{ secrets.VOLCENGINE_CR_NAMESPACE }}/openviking,push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OPENVIKING_VERSION=${{ steps.openviking-version.outputs.version }}
+
       - name: Export GHCR image digest
         run: |
           mkdir -p /tmp/digests-ghcr
@@ -146,6 +166,20 @@ jobs:
         with:
           name: docker-digests-dockerhub-${{ matrix.arch }}
           path: /tmp/digests-dockerhub/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Export Volcengine CR image digest
+        run: |
+          mkdir -p /tmp/digests-volcengine
+          volcengine_digest="${{ steps.push-volcengine.outputs.digest }}"
+          touch "/tmp/digests-volcengine/${volcengine_digest#sha256:}"
+
+      - name: Upload Volcengine CR image digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-digests-volcengine-${{ matrix.arch }}
+          path: /tmp/digests-volcengine/*
           if-no-files-found: error
           retention-days: 1
 
@@ -182,6 +216,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to Volcengine CR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ secrets.VOLCENGINE_CR_REGISTRY }}
+          username: ${{ secrets.VOLCENGINE_CR_USERNAME }}
+          password: ${{ secrets.VOLCENGINE_CR_PASSWORD }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
@@ -189,6 +230,7 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image }}
             docker.io/${{ secrets.DOCKERHUB_USERNAME }}/openviking
+            ${{ secrets.VOLCENGINE_CR_REGISTRY }}/${{ secrets.VOLCENGINE_CR_NAMESPACE }}/openviking
           tags: |
             type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag,enable=${{ github.ref_type == 'tag' }}
@@ -212,13 +254,23 @@ jobs:
           path: /tmp/digests-dockerhub
           merge-multiple: true
 
+      - name: Download Volcengine CR image digests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: docker-digests-volcengine-*
+          path: /tmp/digests-volcengine
+          merge-multiple: true
+
       - name: Create multi-arch manifests
         env:
           SOURCE_TAGS: ${{ steps.meta.outputs.tags }}
+          VOLCENGINE_CR_REGISTRY: ${{ secrets.VOLCENGINE_CR_REGISTRY }}
+          VOLCENGINE_CR_NAMESPACE: ${{ secrets.VOLCENGINE_CR_NAMESPACE }}
         run: |
-          # Collect image references for both registries
+          # Collect image references for all registries
           ghcr_image_refs=()
           dockerhub_image_refs=()
+          volcengine_image_refs=()
           for digest_file in /tmp/digests-ghcr/*; do
             [ -e "$digest_file" ] || continue
             digest="sha256:$(basename "$digest_file")"
@@ -229,6 +281,11 @@ jobs:
             digest="sha256:$(basename "$digest_file")"
             dockerhub_image_refs+=("docker.io/${{ secrets.DOCKERHUB_USERNAME }}/openviking@${digest}")
           done
+          for digest_file in /tmp/digests-volcengine/*; do
+            [ -e "$digest_file" ] || continue
+            digest="sha256:$(basename "$digest_file")"
+            volcengine_image_refs+=("${VOLCENGINE_CR_REGISTRY}/${VOLCENGINE_CR_NAMESPACE}/openviking@${digest}")
+          done
 
           [ ${#ghcr_image_refs[@]} -gt 0 ] || {
             echo "No GHCR image digests found" >&2
@@ -236,6 +293,10 @@ jobs:
           }
           [ ${#dockerhub_image_refs[@]} -gt 0 ] || {
             echo "No Docker Hub image digests found" >&2
+            exit 1
+          }
+          [ ${#volcengine_image_refs[@]} -gt 0 ] || {
+            echo "No Volcengine CR image digests found" >&2
             exit 1
           }
 
@@ -252,5 +313,9 @@ jobs:
               docker buildx imagetools create \
                 --tag "$tag" \
                 "${dockerhub_image_refs[@]}"
+            elif [[ "$tag" == "${VOLCENGINE_CR_REGISTRY}/"* ]]; then
+              docker buildx imagetools create \
+                --tag "$tag" \
+                "${volcengine_image_refs[@]}"
             fi
           done <<< "$SOURCE_TAGS"

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -135,6 +135,11 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          # Volcengine CR (staging) does not accept the SLSA provenance/SBOM
+          # attestation manifest that buildx attaches by default, which stalls
+          # the "exporting to image" push. Push a plain single-manifest image.
+          provenance: false
+          sbom: false
           outputs: |
             type=image,name=${{ secrets.VOLCENGINE_CR_REGISTRY }}/${{ secrets.VOLCENGINE_CR_NAMESPACE }}/openviking,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Mirror the existing Docker Hub flow for Volcengine Container Registry: per-arch push-by-digest builds, digest artifacts, and multi-arch manifest creation. Registry, namespace, and credentials are supplied via secrets.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
