### PR TITLE
fix(cli): preserve mixed warning output fields

### DIFF
--- a/crates/ov_cli/src/output.rs
+++ b/crates/ov_cli/src/output.rs
@@ -194,9 +194,13 @@ fn print_table<T: Serialize>(result: T, compact: bool) {
                     }
                 }
             }
+            let expandable_lists_are_entire_payload =
+                obj.keys().filter(|key| key.as_str() != "profile").count()
+                    == dict_lists.len() + prim_lists.len();
 
             // Rule 3a: single list[primitive] -> one item per line
-            if dict_lists.is_empty() && prim_lists.len() == 1 {
+            if expandable_lists_are_entire_payload && dict_lists.is_empty() && prim_lists.len() == 1
+            {
                 let (key, items) = &prim_lists[0];
                 let col = if key.ends_with("es") {
                     key.strip_suffix("es").unwrap_or(key)
@@ -218,7 +222,8 @@ fn print_table<T: Serialize>(result: T, compact: bool) {
             }
 
             // Rule 3b: single list[dict] -> render directly
-            if dict_lists.len() == 1 && prim_lists.is_empty() {
+            if expandable_lists_are_entire_payload && dict_lists.len() == 1 && prim_lists.is_empty()
+            {
                 let (_key, items) = &dict_lists[0];
                 if let Some(table) = format_array_to_table(items, compact) {
                     println!("{}", append_profile_section(table, obj));
@@ -227,7 +232,7 @@ fn print_table<T: Serialize>(result: T, compact: bool) {
             }
 
             // Rule 2: multiple list[dict] -> flatten with type column
-            if !dict_lists.is_empty() {
+            if expandable_lists_are_entire_payload && !dict_lists.is_empty() {
                 let mut merged: Vec<serde_json::Value> = Vec::new();
                 for (key, items) in &dict_lists {
                     let type_name = if key.ends_with("es") {
@@ -418,9 +423,12 @@ fn value_to_table(value: &serde_json::Value, compact: bool) -> Option<String> {
                 }
             }
         }
+        let expandable_lists_are_entire_payload =
+            obj.keys().filter(|key| key.as_str() != "profile").count()
+                == dict_lists.len() + prim_lists.len();
 
         // Rule 3a: single list[primitive] -> one item per line
-        if dict_lists.is_empty() && prim_lists.len() == 1 {
+        if expandable_lists_are_entire_payload && dict_lists.is_empty() && prim_lists.len() == 1 {
             let (key, items) = &prim_lists[0];
             let col = if key.ends_with("es") {
                 key.strip_suffix("es").unwrap_or(key)
@@ -439,13 +447,13 @@ fn value_to_table(value: &serde_json::Value, compact: bool) -> Option<String> {
         }
 
         // Rule 3b: single list[dict] -> render directly
-        if dict_lists.len() == 1 && prim_lists.is_empty() {
+        if expandable_lists_are_entire_payload && dict_lists.len() == 1 && prim_lists.is_empty() {
             let (_key, items) = &dict_lists[0];
             return format_array_to_table(items, compact);
         }
 
         // Rule 2: multiple list[dict] -> flatten with type column
-        if !dict_lists.is_empty() {
+        if expandable_lists_are_entire_payload && !dict_lists.is_empty() {
             let mut merged: Vec<serde_json::Value> = Vec::new();
             for (key, items) in &dict_lists {
                 let type_name = if key.ends_with("es") {
@@ -1097,6 +1105,27 @@ mod tests {
                 .join("\n")
             )
         );
+    }
+
+    #[test]
+    fn test_mixed_object_with_warnings_keeps_scalar_fields() {
+        let value = json!({
+            "status": "success",
+            "root_uri": "viking://resources/www.volcengine.com_1",
+            "task_id": "task-1",
+            "warnings": [
+                "'viking://resources/www.volcengine.com' already exists. Creating 'viking://resources/www.volcengine.com_1'."
+            ]
+        });
+
+        let rendered = value_to_table_with_profile(&value, true).expect("table should render");
+        let rendered = strip_ansi(&rendered);
+
+        assert!(rendered.contains("status"));
+        assert!(rendered.contains("root_uri"));
+        assert!(rendered.contains("task_id"));
+        assert!(rendered.contains("warnings"));
+        assert!(rendered.contains("viking://resources/www.volcengine.com_1"));
     }
 
     fn strip_ansi(input: &str) -> String {


### PR DESCRIPTION
## Description

Fixes the Rust CLI table renderer so warning arrays no longer hide scalar result fields when an API response contains both.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Require expandable list rendering to apply only when list fields make up the entire payload.
- Preserve mixed scalar/list responses like `status`, `root_uri`, `task_id`, and `warnings` as full key/value output.
- Add a regression test for add-resource-style warning responses.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

```bash
cargo test -p ov_cli output::tests
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This keeps pure list payloads rendered as tables while avoiding the misleading warning-only output for mixed API results.
