### PR TITLE
fix(retrieval): offload rerank from event loop

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -226,7 +226,7 @@ class HierarchicalRetriever:
             # Step 3: Pick recursive entry points from directory hits and explicit roots.
             directory_scores = [self._finite_score(r.get("_score", 0.0)) for r in global_results]
             if self._rerank_client and mode == RetrieverMode.THINKING:
-                directory_scores = self._rerank_scores(
+                directory_scores = await self._rerank_scores(
                     query.query,
                     [str(r.get("abstract", "")) for r in global_results],
                     directory_scores,
@@ -318,7 +318,7 @@ class HierarchicalRetriever:
             return score >= threshold
         return score > threshold
 
-    def _rerank_scores(
+    async def _rerank_scores(
         self,
         query: str,
         documents: List[str],
@@ -329,7 +329,7 @@ class HierarchicalRetriever:
             return fallback_scores
 
         try:
-            scores = self._rerank_client.rerank_batch(query, documents)
+            scores = await asyncio.to_thread(self._rerank_client.rerank_batch, query, documents)
         except Exception as e:
             logger.warning(
                 "[HierarchicalRetriever] Rerank failed, fallback to vector scores: %s", e
@@ -453,7 +453,7 @@ class HierarchicalRetriever:
                 query_scores = [self._finite_score(r.get("_score", 0.0)) for r in results]
                 if self._rerank_client and mode == RetrieverMode.THINKING:
                     documents = [str(r.get("abstract", "")) for r in results]
-                    query_scores = self._rerank_scores(query, documents, query_scores)
+                    query_scores = await self._rerank_scores(query, documents, query_scores)
 
                 for r, score in zip(results, query_scores, strict=True):
                     uri = r.get("uri", "")

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -3,6 +3,10 @@
 
 """Hierarchical retriever rerank behavior tests."""
 
+import asyncio
+import threading
+import time
+
 import pytest
 
 from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever, RetrieverMode
@@ -286,6 +290,38 @@ async def test_retrieve_falls_back_to_vector_scores_when_rerank_returns_none(mon
         "viking://resources/file-a",
     ]
     assert fake_client.calls
+
+
+@pytest.mark.asyncio
+async def test_rerank_scores_runs_blocking_client_off_event_loop():
+    class SlowRerankClient:
+        def __init__(self):
+            self.thread_id = None
+
+        def rerank_batch(self, query: str, documents: list[str]):
+            self.thread_id = threading.get_ident()
+            time.sleep(0.2)
+            return [0.9 for _ in documents]
+
+    retriever = HierarchicalRetriever(
+        storage=DummyStorage(),
+        embedder=DummyEmbedder(),
+        rerank_config=None,
+    )
+    fake_client = SlowRerankClient()
+    retriever._rerank_client = fake_client
+
+    started = time.monotonic()
+    rerank_task = asyncio.create_task(retriever._rerank_scores("hello", ["doc"], [0.1]))
+
+    ticks = 0
+    while time.monotonic() - started < 0.15:
+        await asyncio.sleep(0.01)
+        ticks += 1
+
+    assert await rerank_task == [0.9]
+    assert fake_client.thread_id != threading.get_ident()
+    assert ticks >= 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Offload synchronous rerank provider calls from the async hierarchical retrieval path so slow rerank requests do not block the server event loop.

## Related Issue

Fixes #3045

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Changed `HierarchicalRetriever._rerank_scores` to run sync `rerank_batch` calls through `asyncio.to_thread`.
- Awaited rerank score calculation from both THINKING-mode rerank call sites.
- Added a regression test that verifies a blocking rerank client does not block event-loop progress.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test commands run:

- `uv run pytest tests/retrieve/test_hierarchical_retriever_rerank.py`
- `uv run ruff format --check openviking/retrieve/hierarchical_retriever.py tests/retrieve/test_hierarchical_retriever_rerank.py`
- `uv run ruff check openviking/retrieve/hierarchical_retriever.py tests/retrieve/test_hierarchical_retriever_rerank.py`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

`uv.lock` has pre-existing local changes and is not included in this PR.
