### PR TITLE
ci: add cuVS post-merge regression guards

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -303,6 +303,7 @@ jobs:
 
         cd "$RUNNER_TEMP"
         "$PYTHON_BIN" - <<'PY'
+        import importlib
         import importlib.util
         from importlib.resources import files
 
@@ -322,12 +323,37 @@ jobs:
         if backend_spec is None or backend_spec.origin is None:
             raise SystemExit(f"backend module {module_name} was not installed")
 
+        backend = importlib.import_module(module_name)
+        required_filter_symbols = (
+            "_index_engine_set_filter_layout",
+            "_index_engine_evaluate_filter",
+        )
+        missing_filter_symbols = [
+            symbol for symbol in required_filter_symbols if not hasattr(backend, symbol)
+        ]
+        if missing_filter_symbols:
+            raise SystemExit(
+                f"backend module {module_name} is missing filter ABI symbols: "
+                f"{', '.join(missing_filter_symbols)}"
+            )
+
+        required_filter_methods = ("set_filter_layout", "evaluate_filter")
+        missing_filter_methods = [
+            method for method in required_filter_methods if not hasattr(engine.IndexEngine, method)
+        ]
+        if missing_filter_methods:
+            raise SystemExit(
+                "IndexEngine is missing filter methods: "
+                f"{', '.join(missing_filter_methods)}"
+            )
+
         studio_index = files("openviking").joinpath("web_studio/dist/index.html")
         if not studio_index.is_file():
             raise SystemExit("Web Studio index.html was not installed")
 
         print(f"Imported backend module {module_name}")
         print(f"Backend module origin {backend_spec.origin}")
+        print(f"Validated filter ABI symbols {required_filter_symbols}")
         print(f"Bundled Web Studio index {studio_index}")
         PY
 

--- a/.github/workflows/_test_lite.yml
+++ b/.github/workflows/_test_lite.yml
@@ -81,6 +81,13 @@ jobs:
     - name: Build C++ extensions
       run: uv run python setup.py build_ext --inplace
 
+    - name: Run cuVS CPU-only regression tests
+      run: |
+        uv run pytest -q -o addopts='' \
+          tests/vectordb/test_cuvs_config.py \
+          tests/vectordb/test_cuvs_index.py \
+          tests/vectordb/test_cuvs_collection.py
+
     - name: Run Lite Integration Test (Quick Start)
       shell: bash
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       deps_changed: ${{ steps.check.outputs.deps_changed }}
+      cuvs_changed: ${{ steps.check.outputs.cuvs_changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -78,7 +79,29 @@ jobs:
             echo "deps_changed=false" >> $GITHUB_OUTPUT
           fi
 
+          # Run the CPU-only cuVS regression suite when the optional backend,
+          # its native filter bridge, or its focused tests are modified.
+          CUVS_PATTERN="openviking/storage/vectordb/|openviking/storage/vectordb_adapters/(factory|local_adapter)\.py|openviking_cli/utils/config/vectordb_config\.py|src/|tests/(vectordb/test_cuvs_|benchmark/test_cuvs_)|benchmark/cuvs/|examples/cuvs_smoke\.py|\.github/workflows/_test_lite\.yml"
+          CUVS_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E "$CUVS_PATTERN" || true)
+
+          if [ -n "$CUVS_CHANGED_FILES" ]; then
+            echo "cuVS-related changes detected:"
+            echo "$CUVS_CHANGED_FILES"
+            echo "cuvs_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No cuVS-related changes detected."
+            echo "cuvs_changed=false" >> $GITHUB_OUTPUT
+          fi
+
   build:
     needs: check-deps
     if: ${{ needs.check-deps.outputs.deps_changed == 'true' }}
     uses: ./.github/workflows/_build.yml
+
+  cuvs-tests:
+    needs: check-deps
+    if: ${{ needs.check-deps.outputs.cuvs_changed == 'true' }}
+    uses: ./.github/workflows/_test_lite.yml
+    with:
+      os_json: '["ubuntu-24.04"]'
+      python_json: '["3.11"]'


### PR DESCRIPTION
## Summary

- run the focused, CPU-only cuVS regression suite when local VectorDB, the cuVS adapter, the native filter bridge, or their tests change;
- validate the native filter ABI symbols and Python wrapper methods in built wheels;
- exercise the same wheel contract on the existing Linux x86_64 and aarch64 build matrix.

## Why

The native engine can still import when a wheel or development environment contains an older binary, while the first filtered cuVS query fails only when it calls the newly added filter bridge. Checking the low-level symbols in the installed wheel catches that packaging/ABI mismatch before release.

The focused regression job uses fake cuVS runtimes, so it does not require a GPU and does not make cuVS a default dependency.

## Validation

- 27 focused configuration/index/collection tests passed in a clean CPU test environment;
- 53 cuVS and benchmark-harness tests passed, with 1 environment-dependent skip;
- CUDA 12 and CUDA 13 development environments both passed the focused tests and real collection/service smoke paths, including filter, mutation/rebuild, recovery, and concurrent requests.

---

## 中文说明

### 改动

- 当本地 VectorDB、cuVS adapter、native filter bridge 或对应测试发生变化时，运行定向的 CPU-only cuVS 回归；
- 在构建完成并安装 wheel 后，检查过滤相关的底层 ABI 符号与 Python wrapper 方法；
- 复用现有 Linux x86_64 和 aarch64 wheel matrix 验证同一份 ABI contract。

### 原因

当 wheel 或开发环境意外混入旧版 native engine 时，模块仍可能正常 import，直到第一次带过滤的 cuVS 查询调用新 bridge 才失败。安装 wheel 后直接检查底层符号，可以在发布前发现这种二进制与 Python 源码不一致的问题。

定向测试使用 fake cuVS runtime，不需要 GPU，也不会把 cuVS 变成默认依赖。

### 验证

- 干净 CPU 测试环境中 27 项配置、索引和 collection 定向测试通过；
- 53 项 cuVS 与 benchmark harness 测试通过，1 项按环境条件跳过；
- CUDA 12 和 CUDA 13 开发环境均通过定向测试与真实 collection/service smoke，覆盖过滤、mutation/rebuild、恢复和并发请求。
