### PR TITLE
fix(storage): delete missing-path vector descendants

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -602,7 +602,10 @@ class VikingFS:
             uris_to_delete.append(target_uri)
             real_ctx = self._ctx_or_default(ctx)
             estimated_count = await _estimate_deleted_count(path, real_ctx)
-            await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
+            if recursive:
+                await self._delete_uri_scope_from_vector_store(target_uri, depth=-1, ctx=ctx)
+            else:
+                await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
             logger.info(f"[VikingFS] rm target not found, cleaned orphan index: {uri}")
             return {"estimated_deleted_count": estimated_count}
 
@@ -2916,6 +2919,24 @@ class VikingFS:
                 logger.debug(f"[VikingFS] Deleted from vector store: {uri}")
         except Exception as e:
             logger.warning(f"[VikingFS] Failed to delete from vector store: {e}")
+
+    async def _delete_uri_scope_from_vector_store(
+        self,
+        uri: str,
+        depth: int,
+        ctx: Optional[RequestContext] = None,
+    ) -> None:
+        """Delete records in a URI scope from vector store."""
+        vector_store = self._get_vector_store()
+        if not vector_store:
+            return
+        real_ctx = self._ctx_or_default(ctx)
+
+        try:
+            await vector_store.delete_uri_scope(real_ctx, uri, depth=depth)
+            logger.debug(f"[VikingFS] Deleted vector scope: {uri} depth={depth}")
+        except Exception as e:
+            logger.warning(f"[VikingFS] Failed to delete vector scope: {e}")
 
     async def _update_vector_store_uris(
         self,

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -1200,6 +1200,22 @@ class VikingVectorIndexBackend:
             backend = self._get_backend_for_context(ctx)
             await backend.delete_by_filter(And(conds))
 
+    async def delete_uri_scope(self, ctx: RequestContext, uri: str, depth: int = -1) -> int:
+        canonical_uri = canonicalize_uri(uri, ctx)
+        conds: List[FilterExpr] = [
+            Eq("account_id", ctx.account_id),
+            Or(
+                [
+                    Eq("uri", canonical_uri),
+                    In("uri", [f"{canonical_uri}/"]),
+                    PathScope("uri", canonical_uri, depth=depth),
+                ]
+            ),
+        ]
+
+        backend = self._get_backend_for_context(ctx)
+        return await backend.delete_by_filter(And(conds))
+
     async def update_uri_mapping(
         self,
         ctx: RequestContext,

--- a/tests/storage/test_viking_fs_rm_orphan_cleanup.py
+++ b/tests/storage/test_viking_fs_rm_orphan_cleanup.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.expr import And, Eq, In, Or, PathScope
+from openviking.storage.viking_fs import VikingFS
+from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
+from openviking_cli.exceptions import NotFoundError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _MissingAsyncAgfs:
+    async def stat(self, path):
+        raise NotFoundError(path, "file")
+
+
+class _RecordingVectorStore:
+    def __init__(self, count_result=3):
+        self.count_result = count_result
+        self.count_calls = []
+        self.delete_uris_calls = []
+        self.delete_uri_scope_calls = []
+
+    async def count(self, **kwargs):
+        self.count_calls.append(kwargs)
+        return self.count_result
+
+    async def delete_uris(self, ctx, uris):
+        self.delete_uris_calls.append((ctx, uris))
+
+    async def delete_uri_scope(self, ctx, uri, depth=-1):
+        self.delete_uri_scope_calls.append((ctx, uri, depth))
+        return self.count_result
+
+
+class _RecordingBackend:
+    def __init__(self):
+        self.filters = []
+
+    async def delete_by_filter(self, filter):
+        self.filters.append(filter)
+        return 3
+
+
+def _ctx():
+    return RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+
+def _missing_path_fs(vector_store):
+    fs = VikingFS(agfs=object(), vector_store=vector_store)
+    fs._async_agfs = _MissingAsyncAgfs()
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_recursive_rm_missing_path_deletes_vector_scope():
+    vector_store = _RecordingVectorStore(count_result=3)
+    fs = _missing_path_fs(vector_store)
+
+    result = await fs.rm("viking://resources/project", recursive=True, ctx=_ctx())
+
+    assert result == {"estimated_deleted_count": 3}
+    assert vector_store.delete_uris_calls == []
+    assert vector_store.delete_uri_scope_calls == [(_ctx(), "viking://resources/project", -1)]
+    assert vector_store.count_calls[0]["filter"] == PathScope(
+        "uri", "viking://resources/project", depth=-1
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_recursive_rm_missing_path_preserves_exact_delete():
+    vector_store = _RecordingVectorStore(count_result=1)
+    fs = _missing_path_fs(vector_store)
+
+    result = await fs.rm("viking://resources/project", recursive=False, ctx=_ctx())
+
+    assert result == {"estimated_deleted_count": 1}
+    assert vector_store.delete_uri_scope_calls == []
+    assert vector_store.delete_uris_calls == [(_ctx(), ["viking://resources/project"])]
+
+
+@pytest.mark.asyncio
+async def test_delete_uri_scope_uses_account_scoped_path_filter():
+    backend = _RecordingBackend()
+    vector_backend = object.__new__(VikingVectorIndexBackend)
+    vector_backend._get_backend_for_context = lambda _ctx: backend
+
+    result = await vector_backend.delete_uri_scope(_ctx(), "viking://resources/project", depth=-1)
+
+    assert result == 3
+    assert backend.filters == [
+        And(
+            [
+                Eq("account_id", "default"),
+                Or(
+                    [
+                        Eq("uri", "viking://resources/project"),
+                        In("uri", ["viking://resources/project/"]),
+                        PathScope("uri", "viking://resources/project", depth=-1),
+                    ]
+                ),
+            ]
+        )
+    ]


### PR DESCRIPTION
## Summary

- fix missing-path `VikingFS.rm(..., recursive=True)` cleanup to delete vector records in the same recursive URI scope used for the delete estimate
- keep non-recursive missing-path cleanup exact-only
- add focused storage regressions for recursive scope cleanup, exact non-recursive cleanup, and the account-scoped backend filter

Fixes #3064.

## Testing

- `python3 -m py_compile openviking/storage/viking_fs.py openviking/storage/viking_vector_index_backend.py tests/storage/test_viking_fs_rm_orphan_cleanup.py`
- `uvx ruff@0.14.9 format --check openviking/storage/viking_fs.py openviking/storage/viking_vector_index_backend.py tests/storage/test_viking_fs_rm_orphan_cleanup.py`
- `uvx ruff@0.14.9 check openviking/storage/viking_fs.py openviking/storage/viking_vector_index_backend.py tests/storage/test_viking_fs_rm_orphan_cleanup.py`
- `git diff --check`

I could not run the targeted pytest file in this sparse local checkout because `tests/conftest.py` imports `AsyncOpenViking`, which then requires runtime packages not installed in this environment (`json_repair` first, then additional project deps). The new tests are limited to mocked AGFS/vector-store objects and should run in the normal project test environment.
