### PR TITLE
fix(cli): Fix remote fetch auth failures misreported as API key errors

### DIFF
--- a/crates/ov_cli/src/error_ui.rs
+++ b/crates/ov_cli/src/error_ui.rs
@@ -190,6 +190,13 @@ pub(crate) fn report_for_plain_help_error(
     )])
 }
 
+fn is_client_auth_error(status: Option<u16>, message: &str) -> bool {
+    if matches!(status, Some(code) if (500..600).contains(&code)) {
+        return false;
+    }
+    looks_like_auth_error(message)
+}
+
 pub(crate) fn report_for_runtime_error(command: impl Into<String>, error: &Error) -> ErrorReport {
     let language = Language::current();
     let command = command.into();
@@ -231,7 +238,7 @@ pub(crate) fn report_for_runtime_error(command: impl Into<String>, error: &Error
             ErrorAction::new("ov health", copy(language, "Run a quick server health check", "快速检查服务器健康状态")),
             ErrorAction::new("ov config switch", copy(language, "Switch to another config", "切换到其他配置")),
         ]),
-        Error::Api { message, .. } if looks_like_auth_error(message) => ErrorReport::new(
+        Error::Api { message, status } if is_client_auth_error(*status, message) => ErrorReport::new(
             copy(language, "Authentication Error", "认证错误"),
             copy(language, "OpenViking rejected the API key for the active config.", "OpenViking 拒绝了当前配置的 API Key。"),
         )
@@ -1138,6 +1145,31 @@ Usage: ov config [OPTIONS] [COMMAND]
 
         assert!(verbose.contains("Detail:"));
         assert!(verbose.contains("Request ID"));
+    }
+
+    #[test]
+    fn remote_resource_auth_failure_wrapped_as_5xx_is_not_api_key_error() {
+        let error = Error::api_with_status(
+            "HTTP request failed: authentication error (401). Check your credentials or permissions. URL: https://example.com/private"
+                .to_string(),
+            500,
+        );
+        let report = report_for_runtime_error("ov add-resource https://example.com/private", &error);
+        let normal = strip_ansi(&render_report(&report, false));
+
+        assert!(normal.contains("OpenViking API Error"));
+        assert!(!normal.contains("Authentication Error"));
+        assert!(!normal.contains("OpenViking rejected the API key"));
+    }
+
+    #[test]
+    fn server_401_is_still_api_key_error() {
+        let error = Error::api_with_status("API key invalid".to_string(), 401);
+        let report = report_for_runtime_error("ov status", &error);
+        let normal = strip_ansi(&render_report(&report, false));
+
+        assert!(normal.contains("Authentication Error"));
+        assert!(normal.contains("OpenViking rejected the API key"));
     }
 
     #[test]

--- a/openviking/parse/accessors/http_accessor.py
+++ b/openviking/parse/accessors/http_accessor.py
@@ -578,8 +578,10 @@ class HTTPAccessor(DataAccessor):
                     raise RuntimeError(f"{user_msg} URL: {url}. Details: {e}") from e
                 except httpx.HTTPStatusError as e:
                     status_code = e.response.status_code if e.response else "unknown"
-                    if status_code == 401 or status_code == 403:
+                    if status_code == 401:
                         user_msg = f"HTTP request failed: authentication error ({status_code}). Check your credentials or permissions."
+                    elif status_code == 403:
+                        user_msg = f"HTTP request failed: access denied ({status_code}). The site blocked the request (login or anti-bot may be required)."
                     elif status_code == 404:
                         user_msg = f"HTTP request failed: not found ({status_code}). The URL may be invalid or the resource was removed."
                     elif 500 <= status_code < 600:


### PR DESCRIPTION
## Description
修复 CLI 的一个错误分类问题：当服务端抓取的远程 URL 返回 401/403 时，CLI 会误报为「OpenViking rejected the API key」，让用户以为是自己本地配置的 API Key 出了问题，而实际上是被抓取的目标站点拒绝了请求（需要登录或触发了反爬）。

服务端在抓取远程资源失败时，会把原始失败包装成 5xx 信封返回。但是原有逻辑通过关键词匹配，仅凭错误消息文本里含有 authentication/forbidden 之类字样就判定为「本地 API Key 被拒」，从而给出误导性的认证错误提示。


## Related Issue
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made
- 新增 is_client_auth_error(status, message) ：仅当状态码 不是 5xx 时才依据消息文本判定为客户端认证错误；5xx（服务端抓取远程资源失败的信封）一律不再当作「本地 API Key 被拒」。
- 运行时错误渲染的匹配分支由 looks_like_auth_error(message) 改为 is_client_auth_error(*status, message) ，让认证错误提示以状态码为准。
- 拆分 http_accessor.py 中 401 与 403 的抓取报错文案：401 保留「authentication error」，403 改为「access denied … The site blocked the request (login or anti-bot may be required)」，更贴近「被目标站点拦截」而非「凭证错误」的真实语义。
## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

新增两个单元测试：
- remote_resource_auth_failure_wrapped_as_5xx_is_not_api_key_error ：远程 401 被包成 5xx 时，不再渲染「Authentication Error / rejected the API key」，而是显示为普通的 OpenViking API 错误。
- server_401_is_still_api_key_error ：服务端真实返回 401 时，仍然正确提示为认证错误，保证原有行为不回退。

run
```bash
cargo test -p ov_cli remote_resource_auth_failure_wrapped_as_5xx_is_not_api_key_error server_401_is_still_api_key_error
```

## Checklist
- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
修改前
<img width="871" height="178" alt="image" src="https://github.com/user-attachments/assets/856678d9-d839-462f-abe3-7df9a11f2aeb" />

修改后
<img width="856" height="286" alt="image" src="https://github.com/user-attachments/assets/ca6bbe15-400d-4171-a204-c6dd299744cd" />

## Additional Notes
改动仅涉及 crates/ov_cli/src/error_ui.rs 与 openviking/parse/accessors/http_accessor.py 两个文件，不改变服务端行为，仅修正 CLI 的错误呈现与 401/403 文案。