### PR TITLE
fix(reindex): stop chunking memory vectors

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -1143,23 +1143,6 @@ class ReindexExecutor:
                     counters.failed_records += 1
                     counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
                     continue
-                for chunk_uri, chunk_text in self._chunk_memory_body(file_uri, body):
-                    counters.scanned_records += 1
-                    try:
-                        await self._upsert_context(
-                            uri=chunk_uri,
-                            parent_uri=file_uri,
-                            abstract=detail_abstract,
-                            vector_text=chunk_text,
-                            is_leaf=True,
-                            context_type=ContextType.MEMORY.value,
-                            level=ContextLevel.DETAIL,
-                            ctx=ctx,
-                        )
-                        counters.rebuilt_records += 1
-                    except Exception as exc:
-                        counters.failed_records += 1
-                        counters.warnings.append(f"Failed to reindex {chunk_uri} vector: {exc}")
                 continue
 
             try:
@@ -1426,28 +1409,6 @@ class ReindexExecutor:
             return str(content or "")
         except Exception:
             return ""
-
-    def _chunk_memory_body(self, uri: str, body: str) -> Iterable[tuple[str, str]]:
-        semantic = get_openviking_config().semantic
-        chunk_chars = semantic.memory_chunk_chars
-        overlap = semantic.memory_chunk_overlap
-        if len(body) <= chunk_chars:
-            return []
-
-        chunks: list[str] = []
-        start = 0
-        while start < len(body):
-            end = start + chunk_chars
-            if end < len(body):
-                boundary = body.rfind("\n\n", start, end)
-                if boundary > start + chunk_chars // 2:
-                    end = boundary + 2
-            chunks.append(body[start:end].strip())
-            start = end - overlap
-            if start >= len(body):
-                break
-
-        return [(f"{uri}#chunk_{idx:04d}", chunk) for idx, chunk in enumerate(chunks) if chunk]
 
     def _best_non_empty(self, *values: str) -> str:
         for value in values:

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -987,7 +987,6 @@ async def test_reindex_memory_l2_falls_back_to_body_when_abstract_missing(monkey
     monkeypatch.setattr(ReindexExecutor, "_safe_read_text", fake_safe_read_text)
     monkeypatch.setattr(ReindexExecutor, "_fetch_existing_record", fake_fetch_existing_record)
     monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
-    monkeypatch.setattr(ReindexExecutor, "_chunk_memory_body", lambda self, uri, body: [])
     monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
 
     service = ReindexExecutor()
@@ -1039,7 +1038,6 @@ async def test_reindex_memory_l2_strips_memory_fields_from_abstract(monkeypatch)
     monkeypatch.setattr(ReindexExecutor, "_safe_read_text", fake_safe_read_text)
     monkeypatch.setattr(ReindexExecutor, "_fetch_existing_record", fake_fetch_existing_record)
     monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
-    monkeypatch.setattr(ReindexExecutor, "_chunk_memory_body", lambda self, uri, body: [])
     monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
 
     service = ReindexExecutor()
@@ -1115,7 +1113,6 @@ async def test_reindex_memory_vectors_walks_deep_subtree(monkeypatch):
     monkeypatch.setattr(ReindexExecutor, "_safe_read_text", fake_safe_read_text)
     monkeypatch.setattr(ReindexExecutor, "_fetch_existing_record", fake_fetch_existing_record)
     monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
-    monkeypatch.setattr(ReindexExecutor, "_chunk_memory_body", lambda self, uri, body: [])
     monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
 
     service = ReindexExecutor()
@@ -1203,7 +1200,6 @@ async def test_reindex_memory_vectors_rebuilds_directory_levels_without_regenera
     monkeypatch.setattr(ReindexExecutor, "_safe_read_text", fake_safe_read_text)
     monkeypatch.setattr(ReindexExecutor, "_fetch_existing_record", fake_fetch_existing_record)
     monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
-    monkeypatch.setattr(ReindexExecutor, "_chunk_memory_body", lambda self, uri, body: [])
     monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
 
     service = ReindexExecutor()


### PR DESCRIPTION
## Description

Stop memory vector reindex from creating extra `#chunk_*` vector records. This keeps reindex behavior aligned with the normal memory write path, which indexes one vector record per memory file.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Removed long-memory chunk vector generation from memory reindex.
- Removed obsolete test monkeypatches for the deleted chunk helper.
- Left existing stored chunk vectors and migration behavior unchanged.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Tested with:

```bash
uv run pytest tests/server/test_admin_rebuild_api.py::test_reindex_memory_l2_falls_back_to_body_when_abstract_missing tests/server/test_admin_rebuild_api.py::test_reindex_memory_l2_strips_memory_fields_from_abstract tests/server/test_admin_rebuild_api.py::test_reindex_memory_vectors_walks_deep_subtree tests/server/test_admin_rebuild_api.py::test_reindex_memory_vectors_rebuilds_directory_levels_without_regenerating_semantics -q
```
