### PR TITLE
fix(pack): allow user import and export

### DIFF
--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -419,8 +419,8 @@ Below are all HTTP API endpoints provided by OpenViking, grouped by functional m
 
 | Method | Path | Description | Permission |
 |--------|------|-------------|------------|
-| POST | `/api/v1/pack/export` | Export .ovpack | ROOT/ADMIN |
-| POST | `/api/v1/pack/import` | Import .ovpack | ROOT/ADMIN |
+| POST | `/api/v1/pack/export` | Export .ovpack | ROOT/ADMIN/USER, subject to normal URI ACL |
+| POST | `/api/v1/pack/import` | Import .ovpack | ROOT/ADMIN/USER, subject to normal URI ACL |
 | POST | `/api/v1/pack/backup` | Back up public scopes | ROOT/ADMIN |
 | POST | `/api/v1/pack/restore` | Restore backup package | ROOT/ADMIN |
 

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -415,8 +415,8 @@ JSON 输出 - 错误：
 
 | 方法 | 路径 | 说明 | 权限 |
 |------|------|------|------|
-| POST | `/api/v1/pack/export` | 导出 .ovpack 文件 | ROOT/ADMIN |
-| POST | `/api/v1/pack/import` | 导入 .ovpack 文件 | ROOT/ADMIN |
+| POST | `/api/v1/pack/export` | 导出 .ovpack 文件 | ROOT/ADMIN/USER，受正常 URI ACL 限制 |
+| POST | `/api/v1/pack/import` | 导入 .ovpack 文件 | ROOT/ADMIN/USER，受正常 URI ACL 限制 |
 | POST | `/api/v1/pack/backup` | 备份公开 scope | ROOT/ADMIN |
 | POST | `/api/v1/pack/restore` | 恢复备份包 | ROOT/ADMIN |
 

--- a/openviking/server/routers/pack.py
+++ b/openviking/server/routers/pack.py
@@ -12,10 +12,14 @@ from pydantic import BaseModel, ConfigDict
 from starlette.background import BackgroundTask
 
 from openviking.core.path_variables import resolve_path_variables
-from openviking.server.auth import get_request_context, require_auth_root_or_admin
+from openviking.server.auth import (
+    get_request_context,
+    require_auth_role,
+    require_auth_root_or_admin,
+)
 from openviking.server.dependencies import get_service
 from openviking.server.error_mapping import map_exception
-from openviking.server.identity import RequestContext
+from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.server.temp_upload_store import TempUploadStore
 
@@ -67,7 +71,7 @@ class RestoreRequest(BaseModel):
 
 
 @router.post("/export")
-@require_auth_root_or_admin
+@require_auth_role(Role.ROOT, Role.ADMIN, Role.USER)
 async def export_ovpack(
     request: Request,
     body: ExportRequest,
@@ -159,7 +163,7 @@ async def backup_ovpack(
 
 
 @router.post("/import")
-@require_auth_root_or_admin
+@require_auth_role(Role.ROOT, Role.ADMIN, Role.USER)
 async def import_ovpack(
     request: Request,
     body: ImportRequest,

--- a/tests/server/ovpack_test_helpers.py
+++ b/tests/server/ovpack_test_helpers.py
@@ -58,7 +58,7 @@ def build_ovpack_bytes(
     index_records = _index_records_bytes()
     manifest = {
         "kind": "openviking.ovpack",
-        "format_version": 2,
+        "format_version": 3,
         "root": {
             "name": root_name,
             "uri": f"viking://resources/{root_name}",


### PR DESCRIPTION
## Description

Allow regular USER callers to invoke pack import/export endpoints while continuing to rely on existing VikingFS URI ACL checks for actual read/write authorization.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Allow USER role through `/api/v1/pack/export` and `/api/v1/pack/import` route authorization.
- Keep `/api/v1/pack/backup` and `/api/v1/pack/restore` restricted to ROOT/ADMIN.
- Document that pack import/export are subject to normal URI ACL and update the ovpack test helper to current format version 3.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:
- `OPENVIKING_CONFIG_FILE=/tmp/openviking-test-ov.conf pytest tests/server/test_api_local_input_security.py::test_import_ovpack_accepts_temp_uploaded_file tests/server/test_api_local_input_security.py::test_import_ovpack_conflict_returns_structured_conflict -q`
- `.venv/bin/python -m ruff check openviking/server/routers/pack.py tests/server/test_api_local_input_security.py tests/server/ovpack_test_helpers.py`
- `git diff --check -- openviking/server/routers/pack.py tests/server/test_api_local_input_security.py tests/server/ovpack_test_helpers.py docs/en/api/01-overview.md docs/zh/api/01-overview.md`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No new route-level ACL tests were added because URI authorization is existing VikingFS behavior; this PR only widens the route role gate so callers can reach that existing check.
