### PR TITLE
fix(storage): serialize local collection lazy load

### DIFF
--- a/openviking/storage/vectordb_adapters/local_adapter.py
+++ b/openviking/storage/vectordb_adapters/local_adapter.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -30,6 +31,7 @@ class LocalCollectionAdapter(CollectionAdapter):
         self.mode = "local"
         self._project_path = project_path
         self._collection_config = dict(collection_config or {})
+        self._load_lock = threading.RLock()
 
     @classmethod
     def from_config(cls, config: Any):
@@ -58,16 +60,17 @@ class LocalCollectionAdapter(CollectionAdapter):
         return str(Path(self._project_path) / self._collection_name)
 
     def _load_existing_collection_if_needed(self) -> None:
-        if self._collection is not None:
-            return
-        collection_path = self._collection_path()
-        if not collection_path:
-            return
-        meta_path = os.path.join(collection_path, "collection_meta.json")
-        if os.path.exists(meta_path):
-            self._collection = get_or_create_local_collection(
-                path=collection_path, config=self._collection_config
-            )
+        with self._load_lock:
+            if self._collection is not None:
+                return
+            collection_path = self._collection_path()
+            if not collection_path:
+                return
+            meta_path = os.path.join(collection_path, "collection_meta.json")
+            if os.path.exists(meta_path):
+                self._collection = get_or_create_local_collection(
+                    path=collection_path, config=self._collection_config
+                )
 
     def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
         collection_path = self._collection_path()


### PR DESCRIPTION
## Description

Serialize local collection lazy loading so concurrent startup paths do not open the same embedded RocksDB collection at the same time.

## Related Issue

Fixes #3069

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add a per-adapter reentrant lock around local collection lazy loading.
- Keep the change scoped to the local embedded vector backend.
- Avoid changing stale LOCK cleanup behavior or log levels.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No tests were added or run per maintainer request.
