### PR TITLE
fix(storage): support file resources as relation sources (ENOTDIR) #3067

### DIFF
--- a/openviking/storage/internal_names.py
+++ b/openviking/storage/internal_names.py
@@ -19,6 +19,7 @@ STORAGE_INTERNAL_ENTRY_NAMES = frozenset(
     {
         "_system",
         "tasks",
+        ".relations",
         *MULTIWRITE_INTERNAL_FILE_NAMES,
     }
 )
@@ -28,6 +29,7 @@ WEBDAV_RESERVED_FILENAMES = frozenset(
         ".abstract.md",
         ".overview.md",
         ".relations.json",
+        ".relations",
         *MULTIWRITE_INTERNAL_FILE_NAMES,
     }
 )

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -2999,28 +2999,42 @@ class VikingFS:
 
     # ========== Relation Table Internal Methods ==========
 
+    async def _relation_table_path(
+        self, source_path: str, ctx: Optional[RequestContext] = None
+    ) -> str:
+        """Return the correct .relations.json location for dir or file source.
+
+        Dir sources: <dir>/.relations.json (byte-identical, zero migration).
+        File sources: <parent>/.relations/<name>/.relations.json (sidecar).
+        """
+        try:
+            info = await self._async_agfs.stat(source_path)
+            is_dir = info.get("isDir", info.get("is_dir", True))
+        except Exception:
+            is_dir = True  # fallback to legacy child path
+        if is_dir:
+            return f"{source_path}/.relations.json"
+        parent, _, name = source_path.rpartition("/")
+        return f"{parent}/.relations/{name}/.relations.json"
+
     async def _read_relation_table(
         self, dir_path: str, ctx: Optional[RequestContext] = None
     ) -> List[RelationEntry]:
-        """Read .relations.json."""
-        table_path = f"{dir_path}/.relations.json"
+        """Read .relations.json (routed through _relation_table_path)."""
+        table_path = await self._relation_table_path(dir_path, ctx=ctx)
         try:
             content = self._handle_agfs_read(await self._async_agfs.read(table_path))
             data = json.loads(content.decode("utf-8"))
         except FileNotFoundError:
             return []
         except Exception:
-            # logger.warning(f"[VikingFS] Failed to read relation table {table_path}: {e}")
             return []
 
         entries = []
-        # Compatible with old format (nested) and new format (flat)
         if isinstance(data, list):
-            # New format: flat list
             for entry_data in data:
                 entries.append(RelationEntry.from_dict(entry_data))
         elif isinstance(data, dict):
-            # Old format: nested {namespace: {user: [entries]}}
             for _namespace, user_dict in data.items():
                 for _user, entry_list in user_dict.items():
                     for entry_data in entry_list:
@@ -3030,15 +3044,14 @@ class VikingFS:
     async def _write_relation_table(
         self, dir_path: str, entries: List[RelationEntry], ctx: Optional[RequestContext] = None
     ) -> None:
-        """Write .relations.json."""
-        # Use flat list format
+        """Write .relations.json (routed through _relation_table_path + ensure parents for sidecars)."""
+        table_path = await self._relation_table_path(dir_path, ctx=ctx)
         data = [entry.to_dict() for entry in entries]
-
         content = json.dumps(data, ensure_ascii=False, indent=2)
-        table_path = f"{dir_path}/.relations.json"
         if isinstance(content, str):
             content = content.encode("utf-8")
-
+        if "/.relations/" in table_path:
+            await self._ensure_parent_dirs(table_path, ctx=ctx)
         await self._async_agfs.write(table_path, content)
 
     # ========== Batch Read (backward compatible) ==========

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -3050,7 +3050,11 @@ class VikingFS:
         content = json.dumps(data, ensure_ascii=False, indent=2)
         if isinstance(content, str):
             content = content.encode("utf-8")
-        if "/.relations/" in table_path:
+        # File sources route to a sidecar (<parent>/.relations/<name>/.relations.json)
+        # whose intermediate dirs don't exist yet. Detect that by comparing to the
+        # legacy dir-source form rather than substring-matching an assumed-rooted
+        # path — correct even if source_path were ever relative. refs #3067
+        if table_path != f"{dir_path}/.relations.json":
             await self._ensure_parent_dirs(table_path, ctx=ctx)
         await self._async_agfs.write(table_path, content)
 

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -613,6 +613,7 @@ class VikingFS:
             estimated_count = await _estimate_deleted_count(path, real_ctx)
             await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
             logger.info(f"[VikingFS] rm target not found, cleaned orphan index: {uri}")
+            await self._remove_file_relation_sidecar(path, ctx=ctx)
             return {"estimated_deleted_count": estimated_count}
 
         if is_dir:
@@ -657,6 +658,8 @@ class VikingFS:
                     result["estimated_deleted_count"] = estimated_count
                 else:
                     result = {"estimated_deleted_count": estimated_count}
+                if not is_dir:
+                    await self._remove_file_relation_sidecar(path, ctx=ctx)
                 return result
         except LockAcquisitionError:
             raise ResourceBusyError(f"Resource is being processed: {uri}", uri=uri)
@@ -788,8 +791,19 @@ class VikingFS:
                     pass
                 raise
 
+            # Migrate a file source's relation sidecar (a dir source carries its table
+            # inside the moved subtree; a file's sidecar is a sibling the body copy
+            # misses). Read while the source body still exists, write to the new sidecar,
+            # then drop the old one after the source body is removed. refs #3067
+            if not is_dir:
+                moved_relations = await self._read_relation_table(old_path, ctx=ctx)
+                if moved_relations:
+                    await self._write_relation_table(new_path, moved_relations, ctx=ctx)
+
             # Delete source
             await self._async_agfs.rm(old_path, recursive=is_dir)
+            if not is_dir:
+                await self._remove_file_relation_sidecar(old_path, ctx=ctx)
             return {}
 
     async def system_sync_status(
@@ -3057,6 +3071,28 @@ class VikingFS:
         if table_path != f"{dir_path}/.relations.json":
             await self._ensure_parent_dirs(table_path, ctx=ctx)
         await self._async_agfs.write(table_path, content)
+
+    async def _remove_file_relation_sidecar(
+        self, source_path: str, ctx: Optional[RequestContext] = None
+    ) -> None:
+        """Best-effort removal of a file source's relation sidecar dir.
+
+        Directory sources keep their table inside the body subtree, so rm/mv of the
+        directory carries it. A file source's table lives in a sibling sidecar
+        (<parent>/.relations/<name>/.relations.json) the body rm/mv never touches —
+        remove it explicitly so a rebuilt/moved file does not inherit stale
+        relations. refs #3067
+        """
+        parent, _, name = source_path.rpartition("/")
+        if not name:
+            return
+        sidecar_dir = f"{parent}/.relations/{name}"
+        try:
+            await self._async_agfs.rm(sidecar_dir, recursive=True)
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.warning(f"[VikingFS] failed to remove relation sidecar {sidecar_dir}: {e}")
 
     # ========== Batch Read (backward compatible) ==========
 

--- a/tests/storage/test_relation_file_source.py
+++ b/tests/storage/test_relation_file_source.py
@@ -44,6 +44,7 @@ async def test_relation_table_path_dir(vfs):
 async def test_relation_table_path_file(vfs, monkeypatch):
     async def file_stat(path):
         return {"isDir": False, "is_dir": False}
+
     monkeypatch.setattr(vfs._async_agfs, "stat", file_stat)
     p = "/local/test_account/resources/project/a.md"
     tbl = await vfs._relation_table_path(p)
@@ -53,6 +54,7 @@ async def test_relation_table_path_file(vfs, monkeypatch):
 async def test_relation_table_path_fallback(vfs, monkeypatch):
     async def bad_stat(path):
         raise RuntimeError("boom")
+
     monkeypatch.setattr(vfs._async_agfs, "stat", bad_stat)
     p = "/local/test_account/resources/project/a.md"
     tbl = await vfs._relation_table_path(p)
@@ -66,13 +68,22 @@ async def test_relation_table_path_fallback(vfs, monkeypatch):
     [
         ("/local/test_account/resources/project/", True, "/.relations.json"),  # row1 dir->dir
         ("/local/test_account/resources/project/d/", True, "/.relations.json"),  # row2 dir->file
-        ("/local/test_account/resources/project/a.md", False, "/.relations/a.md/.relations.json"),  # row3 file->dir FIXED
-        ("/local/test_account/resources/project/b.md", False, "/.relations/b.md/.relations.json"),  # row4 file->file FIXED
+        (
+            "/local/test_account/resources/project/a.md",
+            False,
+            "/.relations/a.md/.relations.json",
+        ),  # row3 file->dir FIXED
+        (
+            "/local/test_account/resources/project/b.md",
+            False,
+            "/.relations/b.md/.relations.json",
+        ),  # row4 file->file FIXED
     ],
 )
 async def test_relation_table_path_param(vfs, monkeypatch, source, is_dir, expected_suffix):
     async def stat_fn(path):
         return {"isDir": is_dir, "is_dir": is_dir}
+
     monkeypatch.setattr(vfs._async_agfs, "stat", stat_fn)
     tbl = await vfs._relation_table_path(source)
     assert tbl.endswith(expected_suffix)
@@ -83,8 +94,10 @@ async def test_relation_table_path_param(vfs, monkeypatch, source, is_dir, expec
 async def test_relation_table_path_name_collision(vfs, monkeypatch):
     """row11: dir x and file x.md in same parent get distinct tables (no collision)."""
     results = {}
+
     async def stat_fn(path):
         return {"isDir": not str(path).endswith(".md"), "is_dir": not str(path).endswith(".md")}
+
     monkeypatch.setattr(vfs._async_agfs, "stat", stat_fn)
     for p in [
         "/local/test_account/resources/project/x",
@@ -93,7 +106,10 @@ async def test_relation_table_path_name_collision(vfs, monkeypatch):
         results[p] = await vfs._relation_table_path(p)
     assert results["/local/test_account/resources/project/x"].endswith("x/.relations.json")
     assert results["/local/test_account/resources/project/x.md"].endswith("x.md/.relations.json")
-    assert results["/local/test_account/resources/project/x"] != results["/local/test_account/resources/project/x.md"]
+    assert (
+        results["/local/test_account/resources/project/x"]
+        != results["/local/test_account/resources/project/x.md"]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +151,9 @@ class _FakeBackendFs:
         p = self._norm(path)
         if p in self.files:
             return {"isDir": False, "is_dir": False}
-        return {"isDir": True, "is_dir": True}
+        if p in self.dirs:
+            return {"isDir": True, "is_dir": True}
+        raise FileNotFoundError(path)
 
     async def read(self, path):
         p = self._norm(path)
@@ -161,6 +179,18 @@ class _FakeBackendFs:
             cur = cur + "/" + part
             self.dirs.add(cur)
         return True
+
+    async def rm(self, path, recursive=False):
+        p = self._norm(path)
+        self.files.pop(p, None)
+        self.dirs.discard(p)
+        if recursive:
+            prefix = p.rstrip("/") + "/"
+            for k in [k for k in self.files if k.startswith(prefix)]:
+                del self.files[k]
+            for k in [k for k in self.dirs if k.startswith(prefix)]:
+                self.dirs.discard(k)
+        return {}
 
 
 @pytest.fixture
@@ -234,6 +264,112 @@ async def test_dir_source_link_unchanged_e2e(e2e_vfs):
     assert "/local/test_account/resources/project/.relations" not in backend.files
     entries = await vfs.get_relation_table(d)
     assert entries[0].uris == [target]
+
+
+@pytest.fixture
+def e2e_rm_mv_vfs(e2e_vfs, monkeypatch):
+    """Extend e2e_vfs with the infra rm/mv touch beyond link/unlink, neutralized.
+
+    rm/mv wrap work in a LockContext and consult the vector store; none of that is
+    under test here — only the file-sidecar migration/cleanup the fix adds.
+    """
+    vfs, backend = e2e_vfs
+
+    class _NoopLock:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr("openviking.storage.transaction.LockContext", _NoopLock)
+    monkeypatch.setattr("openviking.storage.transaction.get_lock_manager", lambda: None)
+    monkeypatch.setattr(vfs, "_ensure_delete_access", lambda *a, **k: None)
+
+    async def _no_uris(*a, **k):
+        return []
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(vfs, "_collect_uris", _no_uris)
+    monkeypatch.setattr(vfs, "_delete_from_vector_store", _noop)
+    monkeypatch.setattr(vfs, "_update_vector_store_uris", _noop)
+    monkeypatch.setattr(vfs, "_get_vector_store", lambda: None)
+    monkeypatch.setattr(
+        vfs,
+        "_path_to_uri",
+        lambda path, **k: path.replace("/local/test_account/", "viking://"),
+    )
+    return vfs, backend
+
+
+async def test_file_source_rm_clears_stale_relations_e2e(e2e_rm_mv_vfs):
+    """link -> rm -> recreate same URI: rebuilt file must not inherit stale relations."""
+    vfs, backend = e2e_rm_mv_vfs
+    a = "viking://resources/project/a.md"
+    b = "viking://resources/project/b.md"
+    a_path = "/local/test_account/resources/project/a.md"
+    sidecar = "/local/test_account/resources/project/.relations/a.md/.relations.json"
+
+    await vfs.link(a, [b], reason="test")
+    assert sidecar in backend.files
+
+    await vfs.rm(a)
+    assert sidecar not in backend.files, "rm of a file must drop its relation sidecar"
+
+    # Recreate the file at the same URI; its relation table must be empty.
+    backend.files[a_path] = b"a"
+    assert await vfs.get_relation_table(a) == []
+
+
+async def test_file_source_rm_not_found_clears_sidecar_e2e(e2e_rm_mv_vfs):
+    """rm's idempotent not-found branch must still drop the file sidecar.
+
+    Body already gone (rm takes the not-found path) -> recreate at same URI must
+    not inherit stale relations. refs #3067
+    """
+    vfs, backend = e2e_rm_mv_vfs
+    a = "viking://resources/project/a.md"
+    b = "viking://resources/project/b.md"
+    a_path = "/local/test_account/resources/project/a.md"
+    sidecar = "/local/test_account/resources/project/.relations/a.md/.relations.json"
+
+    await vfs.link(a, [b], reason="test")
+    assert sidecar in backend.files
+
+    # Simulate the body already being gone so rm hits the not-found branch.
+    backend.files.pop(a_path, None)
+    await vfs.rm(a)
+    assert sidecar not in backend.files, "not-found rm must still drop the sidecar"
+
+    backend.files[a_path] = b"a"
+    assert await vfs.get_relation_table(a) == []
+
+
+async def test_file_source_mv_migrates_relations_e2e(e2e_rm_mv_vfs):
+    """link -> mv: new URI keeps the relations, old sidecar is gone (no orphan)."""
+    vfs, backend = e2e_rm_mv_vfs
+    a = "viking://resources/project/a.md"
+    a2 = "viking://resources/project/a2.md"
+    b = "viking://resources/project/b.md"
+    old_sidecar = "/local/test_account/resources/project/.relations/a.md/.relations.json"
+    new_sidecar = "/local/test_account/resources/project/.relations/a2.md/.relations.json"
+
+    await vfs.link(a, [b], reason="test")
+    assert old_sidecar in backend.files
+
+    await vfs.mv(a, a2)
+
+    assert new_sidecar in backend.files, "moved file must carry its relations to the new sidecar"
+    assert old_sidecar not in backend.files, "old sidecar must not be orphaned"
+
+    entries = await vfs.get_relation_table(a2)
+    assert len(entries) == 1
+    assert entries[0].uris == [b]
 
 
 async def test_relations_container_registered_internal():

--- a/tests/storage/test_relation_file_source.py
+++ b/tests/storage/test_relation_file_source.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for file resources as relation sources (issue #3067).
+
+Unit tests for the _relation_table_path helper (core of the fix).
+Covers plan §5 Test-plan rows via path logic + registration side effects.
+"""
+
+import pytest
+
+from openviking.storage.viking_fs import VikingFS
+
+pytestmark = pytest.mark.asyncio
+
+
+class _MockAgfs:
+    async def stat(self, path):
+        is_dir = not str(path).endswith((".md", ".txt"))
+        return {"isDir": is_dir, "is_dir": is_dir}
+
+    async def read(self, path):
+        raise FileNotFoundError
+
+    async def write(self, path, content):
+        return True
+
+    async def ensure_parent_dirs(self, path):
+        return True
+
+
+@pytest.fixture
+def vfs():
+    vfs = VikingFS(agfs=_MockAgfs())
+    return vfs
+
+
+async def test_relation_table_path_dir(vfs):
+    p = "/local/test_account/resources/project/"
+    tbl = await vfs._relation_table_path(p)
+    assert tbl == f"{p}/.relations.json"
+
+
+async def test_relation_table_path_file(vfs, monkeypatch):
+    async def file_stat(path):
+        return {"isDir": False, "is_dir": False}
+    monkeypatch.setattr(vfs._async_agfs, "stat", file_stat)
+    p = "/local/test_account/resources/project/a.md"
+    tbl = await vfs._relation_table_path(p)
+    assert tbl == "/local/test_account/resources/project/.relations/a.md/.relations.json"
+
+
+async def test_relation_table_path_fallback(vfs, monkeypatch):
+    async def bad_stat(path):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(vfs._async_agfs, "stat", bad_stat)
+    p = "/local/test_account/resources/project/a.md"
+    tbl = await vfs._relation_table_path(p)
+    # falls back to legacy child path
+    assert tbl == f"{p}/.relations.json"
+
+
+# Table-driven coverage for plan §5 rows 1-4,5,7 (path logic for all Source×Target; read/write route)
+@pytest.mark.parametrize(
+    "source, is_dir, expected_suffix",
+    [
+        ("/local/test_account/resources/project/", True, "/.relations.json"),  # row1 dir->dir
+        ("/local/test_account/resources/project/d/", True, "/.relations.json"),  # row2 dir->file
+        ("/local/test_account/resources/project/a.md", False, "/.relations/a.md/.relations.json"),  # row3 file->dir FIXED
+        ("/local/test_account/resources/project/b.md", False, "/.relations/b.md/.relations.json"),  # row4 file->file FIXED
+    ],
+)
+async def test_relation_table_path_param(vfs, monkeypatch, source, is_dir, expected_suffix):
+    async def stat_fn(path):
+        return {"isDir": is_dir, "is_dir": is_dir}
+    monkeypatch.setattr(vfs._async_agfs, "stat", stat_fn)
+    tbl = await vfs._relation_table_path(source)
+    assert tbl.endswith(expected_suffix)
+    if not is_dir:
+        assert "/.relations/" in tbl and tbl.endswith("/.relations.json")
+
+
+async def test_relation_table_path_name_collision(vfs, monkeypatch):
+    """row11: dir x and file x.md in same parent get distinct tables (no collision)."""
+    results = {}
+    async def stat_fn(path):
+        return {"isDir": not str(path).endswith(".md"), "is_dir": not str(path).endswith(".md")}
+    monkeypatch.setattr(vfs._async_agfs, "stat", stat_fn)
+    for p in [
+        "/local/test_account/resources/project/x",
+        "/local/test_account/resources/project/x.md",
+    ]:
+        results[p] = await vfs._relation_table_path(p)
+    assert results["/local/test_account/resources/project/x"].endswith("x/.relations.json")
+    assert results["/local/test_account/resources/project/x.md"].endswith("x.md/.relations.json")
+    assert results["/local/test_account/resources/project/x"] != results["/local/test_account/resources/project/x.md"]

--- a/tests/storage/test_relation_file_source.py
+++ b/tests/storage/test_relation_file_source.py
@@ -94,3 +94,149 @@ async def test_relation_table_path_name_collision(vfs, monkeypatch):
     assert results["/local/test_account/resources/project/x"].endswith("x/.relations.json")
     assert results["/local/test_account/resources/project/x.md"].endswith("x.md/.relations.json")
     assert results["/local/test_account/resources/project/x"] != results["/local/test_account/resources/project/x.md"]
+
+
+# ---------------------------------------------------------------------------
+# Real end-to-end: drive the ACTUAL VikingFS.link -> persist -> relations
+# read-back -> unlink path (not just the path helper), through a backend that
+# faithfully models localfs ENOTDIR semantics (a file cannot hold children).
+# This both reproduces the #3067 bug (control assertion) and proves the fix
+# routes a file source's table to the sidecar so the write succeeds.
+# The entire fix lives in Python; the fake stands in only for the storage
+# syscalls below the fix (Rust is untouched by design).
+# ---------------------------------------------------------------------------
+
+from openviking.storage.internal_names import (  # noqa: E402
+    STORAGE_INTERNAL_ENTRY_NAMES,
+    WEBDAV_RESERVED_FILENAMES,
+)
+
+
+class _FakeBackendFs:
+    """In-memory fs that raises ENOTDIR when asked to create a child of a file."""
+
+    def __init__(self):
+        self.files = {}  # normalized path -> bytes
+        self.dirs = {"/"}
+
+    @staticmethod
+    def _norm(path):
+        return "/" + path.strip("/") if path.strip("/") else "/"
+
+    def _enotdir_if_file_ancestor(self, path):
+        # Mirrors localfs open(): open("a.md/child") fails because a.md is a file.
+        cur = ""
+        for part in [p for p in self._norm(path).strip("/").split("/") if p][:-1]:
+            cur = cur + "/" + part
+            if cur in self.files:
+                raise OSError("failed to open file: Not a directory (os error 20)")
+
+    async def stat(self, path):
+        p = self._norm(path)
+        if p in self.files:
+            return {"isDir": False, "is_dir": False}
+        return {"isDir": True, "is_dir": True}
+
+    async def read(self, path):
+        p = self._norm(path)
+        if p in self.files:
+            return self.files[p]
+        raise FileNotFoundError(path)
+
+    async def write(self, path, content):
+        p = self._norm(path)
+        self._enotdir_if_file_ancestor(p)
+        self.files[p] = content
+        return True
+
+    async def mkdir(self, path):
+        self.dirs.add(self._norm(path))
+        return True
+
+    async def ensure_parent_dirs(self, path):
+        parent = self._norm(path).rsplit("/", 1)[0] or "/"
+        self._enotdir_if_file_ancestor(parent + "/x")
+        cur = ""
+        for part in [p for p in parent.strip("/").split("/") if p]:
+            cur = cur + "/" + part
+            self.dirs.add(cur)
+        return True
+
+
+@pytest.fixture
+def e2e_vfs(monkeypatch):
+    backend = _FakeBackendFs()
+    # Pre-create the two file resources so stat() reports them as files.
+    backend.files["/local/test_account/resources/project/a.md"] = b"a"
+    backend.files["/local/test_account/resources/project/b.md"] = b"b"
+    backend.dirs.update(
+        {
+            "/local",
+            "/local/test_account",
+            "/local/test_account/resources",
+            "/local/test_account/resources/project",
+        }
+    )
+    vfs = VikingFS(agfs=backend)
+    # Drive the async backend directly (VikingFS wraps a *sync* agfs in a
+    # threadpool client; our fake is already async, matching the exact call
+    # surface the relation helpers use: stat/read/write/ensure_parent_dirs).
+    vfs._async_agfs = backend
+    # Focus on the relation-table routing (the fix), not access control.
+    monkeypatch.setattr(vfs, "_ensure_mutable_access", lambda *a, **k: None)
+    monkeypatch.setattr(vfs, "_ensure_access", lambda *a, **k: None)
+    monkeypatch.setattr(
+        vfs,
+        "_uri_to_path",
+        lambda uri, **k: uri.replace("viking://", "/local/test_account/").rstrip("/"),
+    )
+    return vfs, backend
+
+
+async def test_file_source_link_persist_readback_unlink_e2e(e2e_vfs):
+    """rows 3/4/5/6: real link -> persist -> relations -> unlink for a FILE source."""
+    vfs, backend = e2e_vfs
+    a = "viking://resources/project/a.md"
+    b = "viking://resources/project/b.md"
+
+    # Control: the pre-fix path (child of the file) genuinely raises ENOTDIR,
+    # proving the backend models the bug the fix must route around.
+    with pytest.raises(OSError, match="Not a directory"):
+        await backend.write("/local/test_account/resources/project/a.md/.relations.json", b"x")
+
+    # rows 3/4 file->file link now succeeds (was ENOTDIR).
+    await vfs.link(a, [b], reason="test")
+
+    sidecar = "/local/test_account/resources/project/.relations/a.md/.relations.json"
+    assert sidecar in backend.files, "file-source table must land in the sidecar"
+    assert "/local/test_account/resources/project/a.md/.relations.json" not in backend.files
+
+    # row 5: read-back routes to the same sidecar and returns the target + reason.
+    entries = await vfs.get_relation_table(a)
+    assert len(entries) == 1
+    assert entries[0].uris == [b]
+    assert entries[0].reason == "test"
+
+    # row 6: unlink removes the entry; table persists as empty.
+    await vfs.unlink(a, b)
+    assert await vfs.get_relation_table(a) == []
+
+
+async def test_dir_source_link_unchanged_e2e(e2e_vfs):
+    """rows 1/2 + row 10: dir source keeps writing to <dir>/.relations.json (byte-identical)."""
+    vfs, backend = e2e_vfs
+    d = "viking://resources/project/"  # existing dir source
+    target = "viking://resources/project/b.md"
+    await vfs.link(d, [target], reason="dir-test")
+
+    assert "/local/test_account/resources/project/.relations.json" in backend.files
+    # dir table is separate from any file sidecar (no collision).
+    assert "/local/test_account/resources/project/.relations" not in backend.files
+    entries = await vfs.get_relation_table(d)
+    assert entries[0].uris == [target]
+
+
+async def test_relations_container_registered_internal():
+    """rows 8/12: .relations dir is hidden from ls (storage) and WebDAV listings."""
+    assert ".relations" in STORAGE_INTERNAL_ENTRY_NAMES
+    assert ".relations" in WEBDAV_RESERVED_FILENAMES

--- a/tests/storage/test_relation_file_source.py
+++ b/tests/storage/test_relation_file_source.py
@@ -240,3 +240,59 @@ async def test_relations_container_registered_internal():
     """rows 8/12: .relations dir is hidden from ls (storage) and WebDAV listings."""
     assert ".relations" in STORAGE_INTERNAL_ENTRY_NAMES
     assert ".relations" in WEBDAV_RESERVED_FILENAMES
+
+
+# ---------------------------------------------------------------------------
+# Review round 2: the write path must decide "create sidecar parent dirs"
+# WITHOUT substring-matching an assumed-rooted path. It ensures parents only
+# when the table routed to a file sidecar, not for any dir whose own path
+# happens to contain a ".relations" segment. (refs #3067)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "source, is_dir, expect_ensure",
+    [
+        # dir source -> <dir>/.relations.json ; parent (the dir) exists, no ensure
+        ("/local/test_account/resources/project", True, False),
+        # file source -> sidecar under <parent>/.relations/<name>/ ; must ensure
+        ("/local/test_account/resources/project/a.md", False, True),
+        # dir whose path itself contains a ".relations" segment: the OLD
+        # substring guard ("/.relations/" in table_path) misfired here and
+        # ensured parents for a plain dir write; the exact-compare guard must not.
+        ("/local/test_account/resources/.relations/notes", True, False),
+    ],
+)
+async def test_write_ensures_parents_only_for_file_sidecar(
+    vfs, monkeypatch, source, is_dir, expect_ensure
+):
+    async def stat_fn(path):
+        return {"isDir": is_dir, "is_dir": is_dir}
+
+    monkeypatch.setattr(vfs._async_agfs, "stat", stat_fn)
+
+    calls = []
+
+    async def spy_ensure(path, ctx=None):
+        calls.append(path)
+
+    monkeypatch.setattr(vfs, "_ensure_parent_dirs", spy_ensure)
+
+    await vfs._write_relation_table(source, [], ctx=None)
+    assert bool(calls) is expect_ensure
+
+
+async def test_file_sidecar_is_rooted_no_relative_path(vfs, monkeypatch):
+    """Reject-evidence for the 'relative no-dirname' comment: callers derive
+    source_path via _uri_to_path, which always yields a rooted /local/... path,
+    so the sidecar is always well-formed (never a bare /.relations/... at root).
+    """
+    real = vfs._uri_to_path("viking://resources/project/a.md")
+    assert real.startswith("/local/") and "/" in real.rstrip("/")
+
+    async def file_stat(path):
+        return {"isDir": False, "is_dir": False}
+
+    monkeypatch.setattr(vfs._async_agfs, "stat", file_stat)
+    tbl = await vfs._relation_table_path(real)
+    assert tbl.startswith("/local/")
+    assert not tbl.startswith("/.relations/")
+    assert tbl.endswith("/.relations/a.md/.relations.json")


### PR DESCRIPTION
## Description
File resources can now be sources for `ov link` / relations (previously ENOTDIR when source was a file). Directory sources unchanged (byte-identical on-disk format, zero migration).

## Related Issue
Fixes #3067

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Added `_relation_table_path(source_path, ctx)` in `viking_fs.py` that stats the source and returns `<dir>/.relations.json` (dirs) or `<parent>/.relations/<name>/.relations.json` (files)
- Routed both `_read_relation_table` and `_write_relation_table` (and callers `link`/`unlink`/`get_relation_table`) through the helper
- `_write_relation_table` now calls `_ensure_parent_dirs` for sidecar paths
- Registered `.relations` in `STORAGE_INTERNAL_ENTRY_NAMES` + `WEBDAV_RESERVED_FILENAMES` (`internal_names.py`) so sidecars are hidden from ls, not vectorized, not exported, not exposed over WebDAV

## Testing
- New `tests/storage/test_relation_file_source.py` (11 tests):
  - Path-helper coverage for all Source×Target combos + name collision + stat-failure fallback
  - A real end-to-end test that drives the actual `VikingFS.link` -> persist -> `get_relation_table` read-back -> `unlink` path for a **file** source through an in-memory backend modeling localfs `ENOTDIR` (a file cannot hold children) — it reproduces the original bug via a control assertion, then proves the sidecar routing makes the link succeed
  - Dir-source link asserted byte-identical (`<dir>/.relations.json`); `.relations` asserted registered internal (hidden from ls + WebDAV)
- Existing relation/link, listing, ovpack, and ingest regression surfaces continue to key on the preserved `.relations.json` basename (no filter edits needed)
- Ruff clean

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux

## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
