### PR TITLE
fix(benchmark): enforce configured search concurrency

### DIFF
--- a/benchmark/vectordb_perf/async_utils.py
+++ b/benchmark/vectordb_perf/async_utils.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Dependency-light async helpers for the VectorDB benchmark."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+from typing import TypeVar
+
+
+_T = TypeVar("_T")
+_R = TypeVar("_R")
+
+
+async def map_bounded_as_completed(
+    items: Iterable[_T],
+    fn: Callable[[_T], Awaitable[_R]],
+    concurrency: int,
+) -> AsyncIterator[_R]:
+    """Run ``fn`` with bounded in-flight calls and yield results as they finish."""
+
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def bounded(item: _T) -> _R:
+        async with semaphore:
+            return await fn(item)
+
+    tasks = [asyncio.create_task(bounded(item)) for item in items]
+    try:
+        for future in asyncio.as_completed(tasks):
+            yield await future
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/benchmark/vectordb_perf/run.py
+++ b/benchmark/vectordb_perf/run.py
@@ -29,6 +29,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Optional, Sequence
 
+from benchmark.vectordb_perf.async_utils import map_bounded_as_completed
+
 from openviking.storage.expr import PathScope
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.collection_schemas import CollectionSchemas
@@ -787,9 +789,9 @@ async def run_search_phase(
             event, rows = await one_query(query)
             return query, event, rows
 
-        pending = [asyncio.create_task(tagged_query(query)) for query in queries]
-        for future in asyncio.as_completed(pending):
-            query, event, rows = await future
+        async for query, event, rows in map_bounded_as_completed(
+            queries, tagged_query, workers
+        ):
             events.append(event)
             results.append((query, rows or []))
             done += 1

--- a/tests/benchmark/test_vectordb_perf_async_utils.py
+++ b/tests/benchmark/test_vectordb_perf_async_utils.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import asyncio
+
+import pytest
+
+from benchmark.vectordb_perf.async_utils import map_bounded_as_completed
+
+
+@pytest.mark.asyncio
+async def test_map_bounded_as_completed_limits_peak_in_flight_calls():
+    active = 0
+    peak_active = 0
+
+    async def worker(value: int) -> int:
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.001)
+        active -= 1
+        return value
+
+    results = [
+        result
+        async for result in map_bounded_as_completed(range(20), worker, concurrency=4)
+    ]
+
+    assert sorted(results) == list(range(20))
+    assert peak_active == 4
+
+
+@pytest.mark.asyncio
+async def test_map_bounded_as_completed_treats_non_positive_concurrency_as_one():
+    active = 0
+    peak_active = 0
+
+    async def worker(value: int) -> int:
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return value
+
+    results = [
+        result
+        async for result in map_bounded_as_completed(range(3), worker, concurrency=0)
+    ]
+
+    assert sorted(results) == [0, 1, 2]
+    assert peak_active == 1


### PR DESCRIPTION
## Summary

- enforce the configured query concurrency in `vectordb_perf`
- preserve completion-order progress reporting
- add regression coverage that asserts peak in-flight calls never exceed the configured limit

## Why

In the benchmark added by #3076, every query was scheduled at once whenever `--concurrency` was greater than one. As a result, values such as 2, 4, and 8 did not bound the number of calls entering the backend, which made the reported latency/QPS difficult to compare across native and cuVS backends.

This change uses a semaphore-backed helper so `--concurrency N` now means at most `N` backend calls are in flight.

## Test

```text
2 passed in 0.08s
```

Follow-up to #3076.
