### PR TITLE
fix(memory): respect agent-only and peer-only memory scopes

### DIFF
--- a/openviking/prompts/templates/memory/experiences.yaml
+++ b/openviking/prompts/templates/memory/experiences.yaml
@@ -7,6 +7,7 @@ directory: "viking://user/{{ user_space }}/memories/experiences"
 filename_template: "{{ experience_name }}.md"
 enabled: true
 operation_mode: "upsert"
+stage: agent
 agent_only: true
 
 fields:

--- a/openviking/prompts/templates/memory/trajectories.yaml
+++ b/openviking/prompts/templates/memory/trajectories.yaml
@@ -14,6 +14,7 @@ directory: "viking://user/{{ user_space }}/memories/trajectories"
 filename_template: "{{ trajectory_name }}_{{ extract_context.get_session_timestamp() }}.md"
 enabled: true
 operation_mode: "add_only"
+stage: agent
 agent_only: true
 
 fields:

--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -132,6 +132,8 @@ class MemoryIsolationHandler:
             return True
         if self.allowed_memory_types is not None and memory_type not in self.allowed_memory_types:
             return False
+        if not self.allow_self and not getattr(memory_type_schema, "peer_enabled", True):
+            return False
         return True
 
     def _can_write_peer(self, peer_id: str) -> bool:
@@ -207,7 +209,7 @@ class MemoryIsolationHandler:
         has_ranges = operation.memory_fields.get("ranges") is not None
         if not getattr(memory_type_schema, "peer_enabled", True):
             operation.memory_fields.pop("peer_id", None)
-            target_ids = [_SELF_PEER_ID]
+            target_ids = [_SELF_PEER_ID] if self.allow_self else []
         elif operation.memory_fields.get("ranges") is not None:
             target_ids = self._range_targets(
                 operation.memory_fields.get("ranges"),

--- a/openviking/session/memory/memory_type_registry.py
+++ b/openviking/session/memory/memory_type_registry.py
@@ -206,6 +206,11 @@ class MemoryTypeRegistry:
         """Parse memory type from YAML data."""
         fields_data = data.get("fields", [])
         fields = []
+        stage = data.get("stage")
+        if stage is None and data.get("agent_only", False):
+            stage = "agent"
+        if stage is None:
+            stage = "user"
 
         for field_data in fields_data:
             field = MemoryField(
@@ -227,7 +232,7 @@ class MemoryTypeRegistry:
             directory=data.get("directory", ""),
             enabled=data.get("enabled", data.get("enable", True)),
             operation_mode=data.get("operation_mode", "upsert"),
-            stage=data.get("stage", "user"),
+            stage=stage,
             peer_enabled=data.get("peer_enabled", True),
             overview_template=data.get("overview_template"),
         )

--- a/tests/session/memory/test_agent_experience_context_provider.py
+++ b/tests/session/memory/test_agent_experience_context_provider.py
@@ -13,6 +13,8 @@ from openviking.session.memory.agent_experience_context_provider import (
 from openviking.session.memory.agent_trajectory_context_provider import (
     AgentTrajectoryContextProvider,
 )
+from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
+from openviking.session.memory.memory_updater import ExtractContext
 from openviking.session.memory.session_extract_context_provider import (
     SessionExtractContextProvider,
 )
@@ -48,6 +50,33 @@ def test_user_memory_provider_splits_but_trajectory_provider_keeps_messages_whol
     assert len(user_provider.get_extract_context().messages) > 1
     assert len(trajectory_provider.get_extract_context().messages) == 1
     assert trajectory_provider.get_extract_context().messages[0] is messages[0]
+
+
+def test_agent_only_schemas_are_excluded_from_peer_user_memory_extraction():
+    messages = [
+        Message(
+            id="1",
+            role="user",
+            parts=[TextPart(text="帮我导出 B 站投稿数据")],
+            peer_id="case_demo_peer",
+        )
+    ]
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="acc", user_id="default"),
+        role=Role.USER,
+    )
+    provider = SessionExtractContextProvider(messages=messages)
+    provider._isolation_handler = MemoryIsolationHandler(
+        ctx,
+        ExtractContext(messages),
+        allow_self=False,
+        allowed_peer_ids={"case_demo_peer"},
+    )
+
+    schema_types = {schema.memory_type for schema in provider.get_memory_schemas(ctx)}
+
+    assert "experiences" not in schema_types
+    assert "trajectories" not in schema_types
 
 
 @pytest.mark.asyncio

--- a/tests/session/memory/test_memory_isolation_handler.py
+++ b/tests/session/memory/test_memory_isolation_handler.py
@@ -646,7 +646,7 @@ class TestCalculateMemoryUris:
         assert "peer_id" not in operation.memory_fields
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
-    def test_peer_enabled_false_uses_self_scope_even_when_self_disabled(self, mock_generate_uri):
+    def test_peer_enabled_false_does_not_write_self_when_self_disabled(self, mock_generate_uri):
         mock_generate_uri.side_effect = lambda **kwargs: (
             f"viking://user/{kwargs.get('user_space')}/memories/cases/demo"
         )
@@ -676,11 +676,12 @@ class TestCalculateMemoryUris:
             uris=[],
         )
 
+        assert handler.allows_schema(schema) is False
+
         uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
 
-        assert uris == ["viking://user/support_bot/memories/cases/demo"]
-        assert operation.memory_fields["user_id"] == "support_bot"
-        assert "peer_id" not in operation.memory_fields
+        assert uris == []
+        mock_generate_uri.assert_not_called()
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
     def test_peer_enabled_false_ignores_ranges_peer_targets(self, mock_generate_uri):


### PR DESCRIPTION
## 背景

在 `memory_policy` 传入 `{"self":{"enabled":false},"peer":{"enabled":true}}` 时，会出现两类异常：

- `experiences` / `trajectories` 虽然在模板里标记了 `agent_only: true`，但普通 session memory 抽取仍会把它们当成 user-stage schema，导致 peer 目录下生成 execution memory。
- `cases` 这类 `peer_enabled: false` 的 self-only schema，在 `self=false` 时仍可能生成 self 路径写入。

## 修复内容

- 在 memory type registry 中兼容历史 `agent_only: true` 字段，未显式配置 `stage` 时自动映射为 `stage=agent`。
- 给 `experiences.yaml` 和 `trajectories.yaml` 显式补充 `stage: agent`，避免进入普通用户长期记忆抽取链路。
- 在 memory isolation 中过滤 `self=false` 场景下的 self-only schema，防止 `peer_enabled:false` 类型绕过 policy 写入 self memory。
- 增加回归测试覆盖 peer-only 用户抽取不包含 agent memory schema，以及 `self=false` 时 self-only schema 不生成写入 URI。

## 验证

```bash
python3 -m pytest tests/session/memory/test_memory_isolation_handler.py tests/session/memory/test_agent_experience_context_provider.py tests/unit/session/test_memory_policy.py -q
```

结果：`40 passed`。