### PR TITLE
修复签名视频链接的解析路由 / Fix signed video URL parser routing

### DIFF
--- a/openviking/parse/parser_router.py
+++ b/openviking/parse/parser_router.py
@@ -8,6 +8,7 @@ Routing is controlled by ov.conf (OpenVikingConfig.parser_api).
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from openviking.parse.accessors.base import LocalResource
@@ -48,9 +49,16 @@ class ParserRouter:
         if not parser_api or not getattr(parser_api, "enable", False):
             return False
 
-        ext = Path(source_path).suffix.lower().lstrip(".")
+        ext = self._extract_extension(source_path)
         extensions = getattr(parser_api, "extensions", None) or []
         return ext in extensions
+
+    def _extract_extension(self, source_path: Union[str, Path]) -> str:
+        source = str(source_path)
+        parsed = urlparse(source)
+        if parsed.scheme.lower() in {"http", "https"} and parsed.netloc:
+            source = parsed.path
+        return Path(source).suffix.lower().lstrip(".")
 
     async def parse(self, source: Union[str, Path, "LocalResource"], **kwargs) -> ParseResult:
         """

--- a/tests/parse/test_parser_router.py
+++ b/tests/parse/test_parser_router.py
@@ -1,0 +1,19 @@
+from types import SimpleNamespace
+
+from openviking.parse.parser_router import ParserRouter
+
+
+def test_should_use_understanding_api_for_signed_video_url(monkeypatch):
+    config = SimpleNamespace(
+        parser_api=SimpleNamespace(enable=True, extensions=["mp4"]),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.open_viking_config.get_openviking_config",
+        lambda: config,
+    )
+
+    router = ParserRouter(parser_registry=object())
+
+    assert router.should_use_understanding_api(
+        "https://example.com/media/video.mp4?X-Tos-Signature=abc&X-Tos-Expires=60"
+    )


### PR DESCRIPTION
中文：对 HTTP/HTTPS URL 使用 urlparse(url).path 提取扩展名，确保 video.mp4?signature=... 命中 UnderstandingAPI fast path。新增带签名视频 URL 的 ParserRouter 回归测试。

English: Parse HTTP/HTTPS URL paths before checking extensions so signed video URLs hit the UnderstandingAPI fast path. Add a ParserRouter regression test for signed video URLs.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
