### PR TITLE
fix(bot): add missing sender_name param in Slack and Email channels

### DIFF
--- a/bot/vikingbot/channels/email.py
+++ b/bot/vikingbot/channels/email.py
@@ -89,6 +89,7 @@ class EmailChannel(BaseChannel):
 
                     await self._handle_message(
                         sender_id=sender,
+                        sender_name=sender,
                         chat_id=sender,
                         content=item["content"],
                         metadata=item.get("metadata", {}),

--- a/bot/vikingbot/channels/slack.py
+++ b/bot/vikingbot/channels/slack.py
@@ -167,6 +167,7 @@ class SlackChannel(BaseChannel):
 
         await self._handle_message(
             sender_id=sender_id,
+            sender_name=sender_id,
             chat_id=chat_id,
             content=text,
             metadata={


### PR DESCRIPTION
## Problem

Commit `4d34025c` ("feat(bot):enhance Feishu mentions and name display") added a required `sender_name: str` parameter to `BaseChannel._handle_message()` and updated `feishu.py`, but `slack.py` and `email.py` were not updated in the same commit.

This causes a `TypeError` on **every** inbound message in both channels:

```
TypeError: _handle_message() missing 1 required positional argument: 'sender_name'
```

Because the Slack SDK swallows exceptions raised inside asyncio listener callbacks, the error is completely silent — the bot successfully receives events and adds emoji reactions (👀), but **never calls the LLM or sends any reply**.

The same issue affects `EmailChannel`: every polled email triggers a `TypeError` with no response sent.

## Fix

Pass the missing argument in both callers:

- `SlackChannel._on_socket_request`: `sender_name=sender_id`
- `EmailChannel.start`: `sender_name=sender`

## Testing

- Verified by reading git history: `git show 4d34025c --name-only` confirms only `base.py` and `feishu.py` were modified, not `slack.py` or `email.py`
- After applying this fix, Slack bot correctly responds to mentions and DMs