### PR TITLE
feat(resource): expose resource tools to LLM during overview generation

### DIFF
--- a/openviking/prompts/templates/semantic/overview_generation.yaml
+++ b/openviking/prompts/templates/semantic/overview_generation.yaml
@@ -27,6 +27,11 @@ variables:
     description: "Language code for output (e.g., 'en', 'zh-CN', 'ja', 'ko', 'ru', 'ar')"
     required: true
 
+  - name: "available_tools"
+    type: "boolean"
+    description: "Whether resource tools are exposed for the LLM to call during overview generation"
+    default: false
+
 template: |
   Output Language: {{ output_language }}
 
@@ -70,6 +75,28 @@ template: |
      - Use the file summaries or subdirectory summaries provided above as description content
 
   Total length: 400-800 words
+
+  {% if available_tools %}
+  ## Optional Tools
+
+  You have access to the following tools to enrich the overview when the file
+  summaries alone are insufficient. Use them sparingly — only when you need a
+  fact that is clearly missing from the provided summaries.
+
+  Tool usage guidelines:
+  - Call a tool only when a specific fact (e.g., a table schema, a config
+    value, a function signature) would materially improve the overview.
+  - Do NOT call tools for information already present in the file summaries
+    or children abstracts above.
+  - After receiving a tool result, integrate the relevant facts into the
+    overview prose; do not dump raw tool output.
+  - If a tool call fails or returns an error, proceed with the available
+    summaries and note the gap if critical.
+
+  When you have gathered enough context (or decide no tool call is needed),
+  produce the final overview following the structure above. The final
+  response must be the Markdown overview only, with no further tool calls.
+  {% endif %}
 
 llm_config:
   temperature: 0.0

--- a/openviking/resource/__init__.py
+++ b/openviking/resource/__init__.py
@@ -2,6 +2,33 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Resource monitoring and management module."""
 
+from openviking.resource.tools import (
+    DEFAULT_MAX_RESULT_CHARS,
+    ResourceTool,
+    execute_resource_tool,
+    expose_to_llm,
+    get_resource_tool,
+    get_resource_tool_schemas,
+    hide_from_llm,
+    list_resource_tools,
+    register_resource_tool,
+    reset_resource_tools,
+)
+from openviking.resource.resource_loop import run_resource_tool_loop
 from openviking.resource.watch_manager import WatchManager, WatchTask
 
-__all__ = ["WatchManager", "WatchTask"]
+__all__ = [
+    "DEFAULT_MAX_RESULT_CHARS",
+    "ResourceTool",
+    "WatchManager",
+    "WatchTask",
+    "execute_resource_tool",
+    "expose_to_llm",
+    "get_resource_tool",
+    "get_resource_tool_schemas",
+    "hide_from_llm",
+    "list_resource_tools",
+    "register_resource_tool",
+    "reset_resource_tools",
+    "run_resource_tool_loop",
+]

--- a/openviking/resource/resource_loop.py
+++ b/openviking/resource/resource_loop.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+ReAct tool-calling loop for resource tools.
+
+Reference: session/memory/extract_loop.py
+"""
+
+import asyncio
+import json
+from typing import Any, Dict, List, Optional
+
+from openviking.resource.tools import (
+    execute_resource_tool,
+    get_resource_tool,
+    get_resource_tool_schemas,
+)
+from openviking.telemetry import tracer
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+_FINAL_INSTRUCTION = (
+    "You have reached the final iteration. Using the information gathered "
+    "so far, produce the final overview now. Do not call any more tools — "
+    "return only the Markdown overview following the structure specified "
+    "above."
+)
+
+
+def _add_tool_call_pair_to_messages(
+    messages: List[Dict[str, Any]],
+    call_id: str,
+    tool_name: str,
+    params: Dict[str, Any],
+    result: str,
+) -> None:
+    """
+    Append a tool-call/result pair to the message history.
+
+    Encoded as a single user-role JSON message to stay backend-agnostic
+    (works with providers that do not support native tool_result roles).
+    """
+    messages.append(
+        {
+            "role": "user",
+            "content": json.dumps(
+                {"tool_call_name": tool_name, "args": params, "result": result},
+                ensure_ascii=False,
+            ),
+        }
+    )
+
+
+async def run_resource_tool_loop(
+    *,
+    vlm,
+    prompt: str,
+    max_iterations: int = 3,
+    max_total_tool_chars: int = 60000,
+    tool_timeout: float = 30.0,
+    thinking: bool = False,
+) -> str:
+    """
+    Run the ReAct loop with resource tools and return the final overview text.
+
+    Args:
+        vlm: VLM client exposing ``get_completion_async``.
+        prompt: The rendered overview_generation prompt.
+        max_iterations: Initial max number of VLM round-trips. The budget
+            is dynamically extended (up to 2x) when the LLM calls tools,
+            so it has a chance to integrate results before being forced
+            to finalize.
+        max_total_tool_chars: Hard cap on cumulative tool-result characters.
+        tool_timeout: Per-tool execution timeout in seconds.
+        thinking: Whether to enable VLM extended thinking.
+
+    Returns:
+        The final overview markdown text from the VLM.
+
+    Raises:
+        RuntimeError: if the loop exhausts all iterations (including
+            extensions) without a final content response, or if total
+            tool-result chars exceed budget.
+    """
+    schemas = get_resource_tool_schemas()
+    if not schemas:
+        logger.debug("No resource tools exposed, running plain completion")
+        response = await vlm.get_completion_async(prompt, thinking=thinking)
+        return response.content or ""
+
+    messages: List[Dict[str, Any]] = [{"role": "user", "content": prompt}]
+    total_tool_chars = 0
+    iteration = 0
+    # Hard cap prevents unbounded extension. Allow at most 2x the initial
+    # budget (with a floor of max_iterations + 2 for small configs).
+    hard_cap = max(max_iterations * 2, max_iterations + 2)
+    effective_max = max_iterations
+    disable_tools_next = False
+
+    while iteration < effective_max:
+        iteration += 1
+        is_last = iteration >= effective_max
+        can_extend = effective_max < hard_cap
+
+        # On the last iteration before the hard cap, nudge the LLM to
+        # finalize but still allow tool calls (which trigger extension).
+        # At the hard cap, withhold tools entirely to force a text answer.
+        if is_last:
+            messages.append({"role": "user", "content": _FINAL_INSTRUCTION})
+
+        force_no_tools = (is_last and not can_extend) or disable_tools_next
+        call_tools: Optional[List[Dict[str, Any]]] = None if force_no_tools else schemas
+
+        logger.debug(
+            "Resource tool loop iteration %d/%d (tools=%s, force=%s)",
+            iteration, effective_max,
+            "off" if call_tools is None else "on",
+            force_no_tools,
+        )
+
+        try:
+            response = await vlm.get_completion_async(
+                prompt=None,
+                thinking=thinking,
+                tools=call_tools,
+                messages=messages,
+            )
+        except Exception as e:
+            tracer.error(f"VLM call failed at iteration {iteration}: {e}")
+            raise
+
+        # Reset for the next round.
+        disable_tools_next = False
+
+        if not response.has_tool_calls:
+            return response.content or ""
+
+        if not response.tool_calls:
+            logger.warning(
+                "VLM reported has_tool_calls=True with empty list at "
+                "iteration %d; treating content as final",
+                iteration,
+            )
+            return response.content or ""
+
+        # At the hard cap with tools withheld: salvage any text content;
+        # otherwise surface the failure.
+        if is_last and not can_extend:
+            content = response.content or ""
+            if content:
+                logger.warning(
+                    "LLM returned tool_calls at hard cap (iteration %d); "
+                    "salvaging available content",
+                    iteration,
+                )
+                return content
+            raise RuntimeError(
+                f"Resource tool loop exhausted {iteration} iterations; "
+                f"LLM continued requesting tools at the hard cap."
+            )
+
+        saw_unknown_tool = False
+        for call in response.tool_calls or []:
+            call_id = call.id if hasattr(call, "id") else str(iteration)
+            tool_name = call.name
+            params = call.arguments or {}
+
+            logger.debug(
+                "Executing tool '%s' (call_id=%s, args=%s)",
+                tool_name, call_id, params,
+            )
+
+            if get_resource_tool(tool_name) is None:
+                saw_unknown_tool = True
+                result = json.dumps(
+                    {"error": f"Unknown tool: {tool_name}"},
+                    ensure_ascii=False,
+                )
+                logger.warning(
+                    "Unknown tool called: %s (iteration %d)",
+                    tool_name, iteration,
+                )
+            else:
+                try:
+                    result = await asyncio.wait_for(
+                        execute_resource_tool(tool_name, **params),
+                        timeout=tool_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    result = json.dumps(
+                        {"error": f"Tool '{tool_name}' timed out after {tool_timeout}s"},
+                        ensure_ascii=False,
+                    )
+                    logger.warning(
+                        "Tool '%s' timed out after %ss",
+                        tool_name, tool_timeout,
+                    )
+
+            total_tool_chars += len(result)
+            if total_tool_chars > max_total_tool_chars:
+                tracer.error(
+                    "Total tool-result chars (%d) exceeded budget (%d)",
+                    total_tool_chars, max_total_tool_chars,
+                )
+                raise RuntimeError(
+                    f"Resource tool loop exceeded total tool char budget "
+                    f"({total_tool_chars}/{max_total_tool_chars})"
+                )
+
+            _add_tool_call_pair_to_messages(
+                messages, call_id, tool_name, params, result,
+            )
+
+        if saw_unknown_tool:
+            disable_tools_next = True
+            logger.info(
+                "Unknown tool called at iteration %d; tools will be "
+                "withheld next iteration",
+                iteration,
+            )
+
+        # Dynamic extension: if the LLM called tools on the last iteration
+        # and we haven't hit the hard cap, extend the budget by one so the
+        # LLM can integrate the results before being forced to finalize.
+        if is_last and can_extend:
+            effective_max += 1
+            tracer.info(
+                "Extended max_iterations to %d for tool integration",
+                effective_max,
+            )
+
+    raise RuntimeError(
+        f"Resource tool loop exhausted {iteration} iterations without "
+        f"a final content response"
+    )

--- a/openviking/resource/tools.py
+++ b/openviking/resource/tools.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Resource tools - expose resource services as LLM-callable tools for ReAct loop.
+
+"""
+
+import json
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from openviking.telemetry import tracer
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Default cap for a single tool result before truncation (chars).
+DEFAULT_MAX_RESULT_CHARS = 8000
+
+
+def _serialize_result(result: Any) -> str:
+    """Serialize tool result to a compact JSON string."""
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(result)
+
+
+def _truncate_result(result_str: str, max_chars: int) -> str:
+    """Truncate result string to max_chars, with a tail indicator."""
+    if len(result_str) <= max_chars:
+        return result_str
+    head = result_str[:max_chars]
+    return f"{head}\n...[truncated, {len(result_str) - max_chars} more chars]"
+
+
+class ResourceTool(ABC):
+    """Abstract base class for resource tools."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Tool name used in function calls (must be unique in registry)."""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description shown to the LLM."""
+        pass
+
+    @property
+    @abstractmethod
+    def parameters(self) -> Dict[str, Any]:
+        """JSON Schema describing the tool's parameters."""
+        pass
+
+    @abstractmethod
+    async def execute(self, **kwargs: Any) -> Any:
+        """
+        Execute the tool with LLM-provided parameters.
+
+        Args:
+            **kwargs: Parameters validated against ``self.parameters``.
+
+        Returns:
+            Any JSON-serializable value (dict, list, str, etc.).
+        """
+        pass
+
+    @property
+    def max_result_chars(self) -> int:
+        """Max chars of this tool's result before truncation."""
+        return DEFAULT_MAX_RESULT_CHARS
+
+    def to_schema(self) -> Dict[str, Any]:
+        """Convert to OpenAI function-calling schema format."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
+
+_RESOURCE_TOOL_REGISTRY: Dict[str, ResourceTool] = {}
+_LLM_EXPOSED_TOOLS: List[str] = []
+
+
+def register_resource_tool(tool: ResourceTool) -> None:
+    """Register a resource tool instance."""
+    name = tool.name
+    if name in _RESOURCE_TOOL_REGISTRY:
+        logger.warning("Resource tool '%s' already registered, overwriting", name)
+    _RESOURCE_TOOL_REGISTRY[name] = tool
+    logger.info("Registered resource tool: %s", name)
+
+
+def get_resource_tool(name: str) -> Optional[ResourceTool]:
+    """Get a registered resource tool by name."""
+    return _RESOURCE_TOOL_REGISTRY.get(name)
+
+
+def list_resource_tools() -> List[str]:
+    """List all registered resource tool names."""
+    return list(_RESOURCE_TOOL_REGISTRY.keys())
+
+
+def expose_to_llm(tool_name: str) -> None:
+    """
+    Mark a registered tool as callable by the LLM in the ReAct loop.
+
+    Raises:
+        KeyError: if ``tool_name`` is not registered.
+    """
+    if tool_name not in _RESOURCE_TOOL_REGISTRY:
+        raise KeyError(
+            f"Cannot expose unregistered tool '{tool_name}'. "
+            f"Register it first with register_resource_tool()."
+        )
+    if tool_name not in _LLM_EXPOSED_TOOLS:
+        _LLM_EXPOSED_TOOLS.append(tool_name)
+        logger.info("Exposed resource tool to LLM: %s", tool_name)
+
+
+def hide_from_llm(tool_name: str) -> None:
+    """Remove a tool from the LLM-visible whitelist (keeps it registered)."""
+    if tool_name in _LLM_EXPOSED_TOOLS:
+        _LLM_EXPOSED_TOOLS.remove(tool_name)
+
+
+def get_resource_tool_schemas() -> List[Dict[str, Any]]:
+    """
+    Get schemas for all LLM-exposed resource tools in OpenAI format.
+
+    Returns an empty list when no tools are exposed — callers should fall
+    back to the plain prompt path in that case.
+    """
+    schemas: List[Dict[str, Any]] = []
+    for name in _LLM_EXPOSED_TOOLS:
+        tool = _RESOURCE_TOOL_REGISTRY.get(name)
+        if tool is not None:
+            schemas.append(tool.to_schema())
+    return schemas
+
+
+def reset_resource_tools() -> None:
+    """Clear all registered tools and the LLM whitelist."""
+    _RESOURCE_TOOL_REGISTRY.clear()
+    _LLM_EXPOSED_TOOLS.clear()
+
+
+async def execute_resource_tool(tool_name: str, **kwargs: Any) -> str:
+    """
+    Execute a resource tool by name and return a truncated JSON string.
+
+    Args:
+        tool_name: Registered tool name.
+        **kwargs: LLM-provided parameters.
+
+    Returns:
+        Truncated, serialized result string. On error, returns
+        ``{"error": "..."}`` JSON.
+    """
+    tool = _RESOURCE_TOOL_REGISTRY.get(tool_name)
+    if tool is None:
+        return json.dumps({"error": f"Unknown tool: {tool_name}"}, ensure_ascii=False)
+    try:
+        result = await tool.execute(**kwargs)
+    except Exception as e:
+        tracer.error(f"Resource tool '{tool_name}' execution failed: {e}")
+        return json.dumps({"error": str(e)}, ensure_ascii=False)
+    result_str = _serialize_result(result)
+    return _truncate_result(result_str, tool.max_result_chars)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1414,6 +1414,12 @@ class SemanticProcessor(DequeueHandlerBase):
         vlm = config.vlm
 
         try:
+            from openviking.resource.resource_loop import run_resource_tool_loop
+            from openviking.resource.tools import get_resource_tool_schemas
+
+            tool_schemas = get_resource_tool_schemas()
+            available_tools = bool(tool_schemas)
+
             prompt = render_prompt(
                 "semantic.overview_generation",
                 {
@@ -1421,11 +1427,15 @@ class SemanticProcessor(DequeueHandlerBase):
                     "file_summaries": file_summaries_str,
                     "children_abstracts": children_abstracts_str,
                     "output_language": output_language,
+                    "available_tools": available_tools,
                 },
             )
 
             with bind_telemetry_stage("resource_summarize"):
-                overview = await vlm.get_completion_async(prompt)
+                if available_tools:
+                    overview = await run_resource_tool_loop(vlm=vlm, prompt=prompt)
+                else:
+                    overview = await vlm.get_completion_async(prompt)
 
             overview = self._replace_index_references(overview, file_index_map)
 

--- a/tests/resource/test_resource_tools.py
+++ b/tests/resource/test_resource_tools.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for resource tools (registry + ReAct loop).
+
+Covers:
+- ResourceTool ABC contract
+- register_resource_tool / expose_to_llm / get_resource_tool_schemas
+- execute_resource_tool serialization and truncation
+- run_resource_tool_loop: plain fallback, tool_call iteration, final answer
+"""
+
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.models.vlm.base import ToolCall, VLMResponse
+from openviking.resource.tools import (
+    DEFAULT_MAX_RESULT_CHARS,
+    ResourceTool,
+    execute_resource_tool,
+    expose_to_llm,
+    get_resource_tool,
+    get_resource_tool_schemas,
+    hide_from_llm,
+    list_resource_tools,
+    register_resource_tool,
+    reset_resource_tools,
+)
+from openviking.resource.resource_loop import run_resource_tool_loop
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+class _EchoTool(ResourceTool):
+    """Echoes the 'message' kwarg back as a dict."""
+
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    @property
+    def description(self) -> str:
+        return "Echo a message back."
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return {"echo": kwargs.get("message", "")}
+
+
+class _BigTool(ResourceTool):
+    """Returns a string larger than the default cap to test truncation."""
+
+    @property
+    def name(self) -> str:
+        return "big"
+
+    @property
+    def description(self) -> str:
+        return "Return a big string."
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return "x" * (DEFAULT_MAX_RESULT_CHARS * 2)
+
+
+class _BoomTool(ResourceTool):
+    """Always raises — used to verify error serialization."""
+
+    @property
+    def name(self) -> str:
+        return "boom"
+
+    @property
+    def description(self) -> str:
+        return "Always fail."
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> Any:
+        raise RuntimeError("kaboom")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Each test starts with a clean registry."""
+    reset_resource_tools()
+    yield
+    reset_resource_tools()
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+def test_register_and_get_tool():
+    tool = _EchoTool()
+    register_resource_tool(tool)
+    assert get_resource_tool("echo") is tool
+    assert "echo" in list_resource_tools()
+
+
+def test_register_overwrites_duplicate():
+    t1, t2 = _EchoTool(), _EchoTool()
+    register_resource_tool(t1)
+    register_resource_tool(t2)
+    assert get_resource_tool("echo") is t2
+
+
+def test_expose_to_llm_requires_registration():
+    with pytest.raises(KeyError):
+        expose_to_llm("not_registered")
+
+
+def test_expose_and_hide():
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+    assert len(get_resource_tool_schemas()) == 1
+    hide_from_llm("echo")
+    assert get_resource_tool_schemas() == []
+
+
+def test_schema_format_matches_openai():
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+    schema = get_resource_tool_schemas()[0]
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == "echo"
+    assert schema["function"]["parameters"]["required"] == ["message"]
+
+
+# ---------------------------------------------------------------------------
+# execute_resource_tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_serializes_dict_result():
+    register_resource_tool(_EchoTool())
+    result = await execute_resource_tool("echo", message="hi")
+    assert '"echo": "hi"' in result
+
+
+@pytest.mark.asyncio
+async def test_execute_truncates_large_result():
+    register_resource_tool(_BigTool())
+    result = await execute_resource_tool("big")
+    # Result is capped at DEFAULT_MAX_RESULT_CHARS plus a trailing indicator
+    # of the form "...[truncated, N more chars]".
+    assert result.startswith("x" * DEFAULT_MAX_RESULT_CHARS)
+    assert "truncated" in result
+    assert len(result) > DEFAULT_MAX_RESULT_CHARS
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_tool_returns_error_json():
+    result = await execute_resource_tool("nope")
+    assert "Unknown tool" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_serializes_exception():
+    register_resource_tool(_BoomTool())
+    result = await execute_resource_tool("boom")
+    assert "kaboom" in result
+
+
+# ---------------------------------------------------------------------------
+# run_resource_tool_loop tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeVLM:
+    """Programmable VLM double for loop tests.
+
+    Records the ``tools`` argument on each call so tests can assert whether
+    tools were withheld (e.g. on the final iteration or after an unknown
+    tool).
+    """
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+        self.call_tools_history: list = []
+
+    async def get_completion_async(self, prompt="", thinking=False,
+                                   tools=None, tool_choice=None, messages=None):
+        self.calls += 1
+        self.call_tools_history.append(tools)
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_loop_falls_back_to_plain_when_no_tools():
+    vlm = _FakeVLM([VLMResponse(content="# hello")])
+    out = await run_resource_tool_loop(vlm=vlm, prompt="p")
+    assert out == "# hello"
+    assert vlm.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_single_tool_then_finishes():
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+
+    first = VLMResponse(
+        tool_calls=[ToolCall(id="1", name="echo", arguments={"message": "hi"})]
+    )
+    second = VLMResponse(content="# done")
+    vlm = _FakeVLM([first, second])
+
+    out = await run_resource_tool_loop(vlm=vlm, prompt="p")
+    assert out == "# done"
+    assert vlm.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_loop_exhausts_iterations():
+    """LLM keeps calling tools past the hard cap → RuntimeError."""
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+
+    looping = VLMResponse(
+        tool_calls=[ToolCall(id="1", name="echo", arguments={"message": "x"})]
+    )
+    # max_iterations=3, hard_cap=6: need 6 looping responses (3 normal +
+    # 3 extensions). The 6th iteration withholds tools but the fake VLM
+    # still returns tool_calls, triggering the hard-cap failure path.
+    vlm = _FakeVLM([looping] * 6)
+
+    with pytest.raises(RuntimeError, match="hard cap"):
+        await run_resource_tool_loop(vlm=vlm, prompt="p", max_iterations=3)
+
+
+@pytest.mark.asyncio
+async def test_loop_enforces_total_char_budget():
+    register_resource_tool(_BigTool())
+    expose_to_llm("big")
+
+    looping = VLMResponse(
+        tool_calls=[ToolCall(id="1", name="big", arguments={})]
+    )
+    vlm = _FakeVLM([looping, looping])
+
+    with pytest.raises(RuntimeError, match="char budget"):
+        await run_resource_tool_loop(
+            vlm=vlm, prompt="p", max_iterations=2, max_total_tool_chars=100
+        )
+
+
+# ---------------------------------------------------------------------------
+# ReAct best-practice tests (mirrored from extract_loop.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_dynamically_extends_iterations():
+    """When the LLM calls tools on the last iteration, the budget extends."""
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+
+    looping = VLMResponse(
+        tool_calls=[ToolCall(id="1", name="echo", arguments={"message": "x"})]
+    )
+    final = VLMResponse(content="# done")
+
+    # max_iterations=2, hard_cap=4.
+    # iter 1: normal, tools on, tool_call → execute (no extension, not last)
+    # iter 2: last+can_extend, tools on, tool_call → execute → extend to 3
+    # iter 3: last+can_extend, tools on, tool_call → execute → extend to 4
+    # iter 4: last+hard_cap, tools off, content → return
+    vlm = _FakeVLM([looping, looping, looping, final])
+
+    out = await run_resource_tool_loop(vlm=vlm, prompt="p", max_iterations=2)
+    assert out == "# done"
+    assert vlm.calls == 4
+    # Tools were withheld on the final (hard-cap) iteration.
+    assert vlm.call_tools_history[-1] is None
+
+
+@pytest.mark.asyncio
+async def test_loop_forces_final_at_hard_cap():
+    """At the hard cap, tools are withheld and a final answer is demanded."""
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+
+    looping = VLMResponse(
+        tool_calls=[ToolCall(id="1", name="echo", arguments={"message": "x"})]
+    )
+    final = VLMResponse(content="# forced")
+
+    # max_iterations=1, hard_cap=max(2, 3)=3.
+    # iter 1: last+can_extend, tools on, tool_call → extend to 2
+    # iter 2: last+can_extend, tools on, tool_call → extend to 3
+    # iter 3: last+hard_cap, tools OFF, content → return
+    vlm = _FakeVLM([looping, looping, final])
+
+    out = await run_resource_tool_loop(vlm=vlm, prompt="p", max_iterations=1)
+    assert out == "# forced"
+    assert vlm.calls == 3
+    # The last call must have had tools withheld.
+    assert vlm.call_tools_history[-1] is None
+    # Earlier calls had tools on.
+    assert vlm.call_tools_history[0] is not None
+
+
+@pytest.mark.asyncio
+async def test_loop_degrades_on_unknown_tool():
+    """Unknown tool name → tools withheld next iteration."""
+    # Register a real tool so schemas are non-empty (otherwise the loop
+    # falls back to plain completion). The LLM calls a *different* tool
+    # name that is not registered.
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+
+    looping = VLMResponse(
+        tool_calls=[ToolCall(id="1", name="nonexistent", arguments={})]
+    )
+    final = VLMResponse(content="# degraded")
+
+    # max_iterations=2, hard_cap=4.
+    # iter 1: tools on, LLM calls "nonexistent" → error result, disable_tools_next=True
+    # iter 2: last+can_extend, but disable_tools_next → tools OFF, content → return
+    vlm = _FakeVLM([looping, final])
+
+    out = await run_resource_tool_loop(vlm=vlm, prompt="p", max_iterations=2)
+    assert out == "# degraded"
+    assert vlm.calls == 2
+    # Tools were on for iter 1, off for iter 2.
+    assert vlm.call_tools_history[0] is not None
+    assert vlm.call_tools_history[1] is None
+
+
+@pytest.mark.asyncio
+async def test_loop_final_instruction_appended_on_last_iteration():
+    """The final-iteration nudge message is appended when is_last is True."""
+    register_resource_tool(_EchoTool())
+    expose_to_llm("echo")
+
+    looping = VLMResponse(
+        tool_calls=[ToolCall(id="1", name="echo", arguments={"message": "x"})]
+    )
+    final = VLMResponse(content="# done")
+
+    # max_iterations=1, hard_cap=3.
+    # iter 1: is_last, can_extend → append FINAL, tools on, tool_call → extend
+    # iter 2: is_last, can_extend → append FINAL, tools on, tool_call → extend
+    # iter 3: is_last, hard_cap → append FINAL, tools off, content → return
+    vlm = _FakeVLM([looping, looping, final])
+
+    await run_resource_tool_loop(vlm=vlm, prompt="p", max_iterations=1)
+
+    # The messages list isn't directly accessible, but we can verify the
+    # behavior indirectly: the loop ran 3 iterations (2 extensions + 1 final).
+    assert vlm.calls == 3


### PR DESCRIPTION
## Description

The quality of `.overview` and `.abstract` directly determines retrieval quality. Currently, their generation relies solely on file summaries and children abstracts  into the prompt the LLM cannot actively fetch supplementary information from external services during generation. Therefore, I think it is necessary to support resource tools, similar to the existing memory tool implementation, allowing users to define custom tools to assist `.overview`/`.abstract` generation and improve content quality.



## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

1. New openviking/resource/tools.py (179 lines)
  - ResourceTool ABC: defines tool interface (name, description, parameters, execute)
2. New openviking/resource/resource_loop.py (236 lines)
  - ReAct loop: run_resource_tool_loop() drives multi-turn tool calling
  3. overview_generation.yaml (+27 lines)
  - New available_tools variable (boolean, default false)
  - New {% if available_tools %} conditional block: Optional Tools guidance (use sparingly, don't duplicate existing info, integrate rather than dump, degrade on failure)
  4. semantic_processor.py (+12 lines)
  - Integration point: routes to run_resource_tool_loop when tools are exposed, otherwise keeps original vlm.get_completion_async path
  5. openviking/resource/__init__.py (+29 lines)
  - Exports 13 public symbols
  6. New tests/resource/test_resource_tools.py (372 lines, 17 tests)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
