### PR TITLE
fix(security): prevent Git submodule SSRF

### DIFF
--- a/openviking/parse/accessors/git_accessor.py
+++ b/openviking/parse/accessors/git_accessor.py
@@ -16,7 +16,7 @@ import urllib.request
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Any, Optional, Tuple, Union
-from urllib.parse import unquote, urlparse
+from urllib.parse import quote, unquote, urlparse
 
 from openviking.utils import is_github_url, is_gitlab_url, parse_code_hosting_url
 from openviking.utils.code_hosting_utils import (
@@ -337,9 +337,8 @@ class GitAccessor(DataAccessor):
                 user_msg = (
                     "Git command failed: authentication error. Check your SSH keys or credentials."
                 )
-            raise RuntimeError(
-                f"{user_msg} Command: git {' '.join(args[1:])}. Details: {error_msg}"
-            )
+            logger.warning(f"[GitAccessor] {user_msg} Details: {error_msg}")
+            raise RuntimeError(user_msg)
         return stdout.decode().strip()
 
     async def _has_commit(self, repo_dir: str, commit: str) -> bool:
@@ -376,7 +375,7 @@ class GitAccessor(DataAccessor):
             "clone",
             "--depth",
             "1",
-            "--recursive",
+            "--no-recurse-submodules",
         ]
         if branch and not commit:
             clone_args.extend(["--branch", branch])
@@ -444,10 +443,8 @@ class GitAccessor(DataAccessor):
         # Strip .git suffix for the archive URL
         repo_slug = repo_raw[:-4] if repo_raw.endswith(".git") else repo_raw
 
-        if branch:
-            zip_url = f"https://github.com/{owner}/{repo_slug}/archive/{branch}.zip"
-        else:
-            zip_url = f"https://github.com/{owner}/{repo_slug}/archive/HEAD.zip"
+        ref = quote(branch or "HEAD", safe="/")
+        zip_url = f"https://github.com/{owner}/{repo_slug}/archive/{ref}.zip"
 
         logger.info(f"[GitAccessor] Downloading GitHub ZIP: {zip_url}")
 

--- a/openviking/parse/parsers/code/code.py
+++ b/openviking/parse/parsers/code/code.py
@@ -467,7 +467,7 @@ class CodeRepositoryParser(BaseParser):
             "clone",
             "--depth",
             "1",
-            "--recursive",
+            "--no-recurse-submodules",
         ]
         if branch and not commit:
             clone_args.extend(["--branch", branch])

--- a/tests/unit/test_accessors_git.py
+++ b/tests/unit/test_accessors_git.py
@@ -4,7 +4,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -152,3 +152,43 @@ class TestGitAccessor:
     def test_cannot_handle_other_urls(self, accessor: GitAccessor, source: str) -> None:
         """GitAccessor should not handle non-git URLs or files."""
         assert accessor.can_handle(source) is False
+
+    async def test_git_clone_does_not_fetch_submodules(
+        self, accessor: GitAccessor, tmp_path: Path
+    ) -> None:
+        with patch.object(accessor, "_run_git", new_callable=AsyncMock) as run_git:
+            await accessor._git_clone("https://github.com/volcengine/OpenViking.git", str(tmp_path))
+
+        clone_args = run_git.await_args.args[0]
+        assert "--no-recurse-submodules" in clone_args
+        assert "--recursive" not in clone_args
+
+    async def test_github_archive_encodes_fragment_in_ref(
+        self, accessor: GitAccessor, tmp_path: Path
+    ) -> None:
+        with patch(
+            "openviking.parse.accessors.git_accessor.urllib.request.urlopen",
+            side_effect=OSError("stop before network"),
+        ) as urlopen:
+            with pytest.raises(RuntimeError):
+                await accessor._github_zip_download(
+                    "https://github.com/example/repo", "test#ssrf", str(tmp_path)
+                )
+
+        request = urlopen.call_args.args[0]
+        assert request.full_url == "https://github.com/example/repo/archive/test%23ssrf.zip"
+
+    async def test_git_error_does_not_expose_remote_stderr(self, accessor: GitAccessor) -> None:
+        process = SimpleNamespace(
+            returncode=1,
+            communicate=AsyncMock(return_value=(b"", b"remote: internal metadata")),
+        )
+        with patch(
+            "openviking.parse.accessors.git_accessor.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                await accessor._run_git(["git", "clone", "https://github.com/example/repo"])
+
+        assert str(exc_info.value) == "Git command failed."
+        assert "internal metadata" not in str(exc_info.value)


### PR DESCRIPTION
## Description

修复远程 Git 仓库导入过程中，恶意 `.gitmodules` 可通过递归子模块请求绕过 SSRF Guard 的问题。克隆流程不再自动拉取子模块，GitHub 归档引用会进行 URL 编码，同时 Git 原始错误详情不再返回给 API 调用方。

## Related Issue

安全告警：OpenViking Service 特定条件回显 SSRF（暂无公开 Issue）。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 将所有仓库克隆命令改为 `--no-recurse-submodules`，阻止 `.gitmodules` 触发二次网络请求
- 对 GitHub 归档引用进行 URL 编码，并停止向 API 错误响应暴露 Git `stderr`
- 增加子模块禁用、特殊分支名编码和错误脱敏回归测试

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行结果：

- `tests/unit/test_accessors_git.py`: 28 passed
- `tests/misc/test_code_parser.py tests/misc/test_extract_zip.py`: 14 passed, 1 skipped
- Ruff lint、format 和 `git diff --check` 均通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

这是有意的安全兼容性变更：导入仓库后仍会保留 `.gitmodules` 文件，但不再自动导入子模块内容。生产部署仍建议通过出站网络策略阻止服务访问内网和云元数据地址。
