### PR TITLE
fix(skills): index SKILL.md body as L1 vector alongside L0 abstract

### DIFF
--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-from openviking.core.context import Context, ContextType, Vectorize
+from openviking.core.context import Context, ContextLevel, ContextType, Vectorize
 from openviking.core.mcp_converter import is_mcp_format, mcp_to_skill
 from openviking.core.namespace import canonical_user_root, user_space_fragment
 from openviking.core.skill_loader import SkillLoader
@@ -238,6 +238,7 @@ class SkillProcessor:
             await self._index_skill(
                 context=context,
                 skill_dir_uri=skill_dir_uri,
+                skill_content=skill_dict.get("content", ""),
             )
             telemetry.set(
                 "skill.index.duration_ms", round((time.perf_counter() - index_start) * 1000, 3)
@@ -578,14 +579,43 @@ class SkillProcessor:
             else:
                 await viking_fs.write_file_bytes(aux_uri, file_bytes, ctx=ctx)
 
-    async def _index_skill(self, context: Context, skill_dir_uri: str):
-        """Write skill directory vector via async queue as L0."""
-        context.uri = skill_dir_uri
-        context.is_leaf = False
-        context.level = 0
+    async def _index_skill(
+        self,
+        context: Context,
+        skill_dir_uri: str,
+        skill_content: str = "",
+    ):
+        await self._enqueue_skill_embedding(
+            context, skill_dir_uri, ContextLevel.ABSTRACT, context.abstract
+        )
+        if skill_content:
+            await self._enqueue_skill_embedding(
+                context, skill_dir_uri, ContextLevel.OVERVIEW, skill_content
+            )
 
-        context.set_vectorize(Vectorize(text=context.abstract))
-        embedding_msg = EmbeddingMsgConverter.from_context(context)
+    async def _enqueue_skill_embedding(
+        self,
+        context: Context,
+        skill_dir_uri: str,
+        level: ContextLevel,
+        text: str,
+    ):
+        emb_context = Context(
+            uri=skill_dir_uri,
+            parent_uri=context.parent_uri,
+            is_leaf=False,
+            abstract=context.abstract,
+            context_type=context.context_type,
+            level=level,
+            created_at=context.created_at,
+            updated_at=context.updated_at,
+            user=context.user,
+            account_id=context.account_id,
+            owner_space=context.owner_space,
+            meta=context.meta,
+        )
+        emb_context.set_vectorize(Vectorize(text=text, full_text=text))
+        embedding_msg = EmbeddingMsgConverter.from_context(emb_context)
         if embedding_msg:
             if embedding_msg.telemetry_id:
                 get_request_wait_tracker().register_embedding_root(

--- a/tests/unit/test_skill_processor_none.py
+++ b/tests/unit/test_skill_processor_none.py
@@ -187,3 +187,50 @@ async def test_process_skill_preserves_hyphenated_allowed_tools_in_meta(monkeypa
     embedding_msg = vikingdb.enqueue_embedding_msg.await_args.args[0]
     assert embedding_msg.context_data["meta"]["allowed_tools"] == ["Read"]
     assert embedding_msg.context_data["meta"]["tags"] == ["dict"]
+
+
+@pytest.mark.asyncio
+async def test_process_skill_indexes_both_l0_abstract_and_l1_skill_content(monkeypatch):
+    from openviking.core.context import ContextLevel
+
+    config = MagicMock()
+    config.vlm.get_completion_async = AsyncMock(return_value="VLM-generated overview")
+    monkeypatch.setattr(
+        "openviking.utils.skill_processor.get_openviking_config",
+        lambda: config,
+    )
+
+    vikingdb = MagicMock()
+    vikingdb.enqueue_embedding_msg = AsyncMock(return_value=True)
+    viking_fs = MagicMock()
+    viking_fs.write_context = AsyncMock()
+
+    processor = SkillProcessor(vikingdb=vikingdb)
+    await processor.process_skill(
+        data={
+            "name": "dual-level-skill",
+            "description": "Skill with L0+L1 indexing",
+            "content": "# Dual Level Skill\n\nBody content for L1.",
+        },
+        viking_fs=viking_fs,
+        ctx=RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT),
+        allow_local_path_resolution=False,
+    )
+
+    assert vikingdb.enqueue_embedding_msg.await_count == 2
+    calls = vikingdb.enqueue_embedding_msg.await_args_list
+    levels = [call.args[0].context_data["level"] for call in calls]
+    contents = [call.args[0].context_data["content"] for call in calls]
+
+    assert int(ContextLevel.ABSTRACT.value) in levels
+    assert int(ContextLevel.OVERVIEW.value) in levels
+
+    l0_idx = levels.index(int(ContextLevel.ABSTRACT.value))
+    l1_idx = levels.index(int(ContextLevel.OVERVIEW.value))
+    # L0 content is the frontmatter abstract (name/description).
+    assert "dual-level-skill" in contents[l0_idx]
+    # L1 content is the SKILL.md body.
+    assert "Body content for L1." in contents[l1_idx]
+    assert "VLM-generated overview" not in contents[l1_idx]
+
+


### PR DESCRIPTION
## Description

_index_skill only enqueues L0 (skill frontmatter abstract), so when searching skills with level=[0,1], skill L1 cannot be matched (per `02-context-types.md`, skill's L1 layer is the SKILL.md body).


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update


## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
