### PR TITLE
fix(parse): route mislabeled OOXML Word files correctly

### DIFF
--- a/openviking/parse/parsers/legacy_doc.py
+++ b/openviking/parse/parsers/legacy_doc.py
@@ -9,6 +9,7 @@ then delegates to MarkdownParser for tree structure creation.
 
 import asyncio
 import struct
+import zipfile
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -24,6 +25,7 @@ logger = get_logger(__name__)
 _MAX_STREAM_SIZE = 50 * 1024 * 1024
 # Max character count sanity cap for ccpText
 _MAX_CCP_TEXT = 10_000_000
+_ZIP_SIGNATURES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
 
 
 class LegacyDocParser(BaseParser):
@@ -50,6 +52,28 @@ class LegacyDocParser(BaseParser):
         path = Path(source)
 
         if path.exists():
+            if self._has_zip_signature(path):
+                package_type = await asyncio.to_thread(self._classify_zip_package, path)
+                if package_type == "docx":
+                    # python-docx writes OOXML regardless of the filename suffix. This
+                    # also occurs in real uploads whose extension says .doc while the
+                    # payload is a modern Word ZIP package. Never pass those bytes to
+                    # the legacy UTF-16 fallback: it turns ZIP data into plausible but
+                    # meaningless Unicode and silently persists corrupted Markdown.
+                    from openviking.parse.parsers.word import WordParser
+
+                    logger.info(
+                        "Detected OOXML Word content in %s; routing to WordParser",
+                        path.name,
+                    )
+                    return await WordParser(config=self.config).parse(
+                        path,
+                        instruction=instruction,
+                        **kwargs,
+                    )
+
+                raise ValueError(f"{path.name} is a ZIP package, not a legacy Word .doc file")
+
             text = await asyncio.to_thread(self._extract_text, path)
             result = await self._md_parser.parse_content(
                 text, source_path=str(path), instruction=instruction, **kwargs
@@ -61,6 +85,29 @@ class LegacyDocParser(BaseParser):
         result.source_format = "doc"
         result.parser_name = "LegacyDocParser"
         return result
+
+    @staticmethod
+    def _has_zip_signature(path: Path) -> bool:
+        """Return whether the payload starts with a recognized ZIP signature."""
+        with path.open("rb") as file_obj:
+            return file_obj.read(4) in _ZIP_SIGNATURES
+
+    @staticmethod
+    def _classify_zip_package(path: Path) -> str:
+        """Identify a ZIP-backed Word package without extracting archive members."""
+        try:
+            with zipfile.ZipFile(path) as archive:
+                try:
+                    archive.getinfo("[Content_Types].xml")
+                    archive.getinfo("word/document.xml")
+                except KeyError:
+                    return "zip"
+                return "docx"
+        except (zipfile.BadZipFile, zipfile.LargeZipFile):
+            # A payload with ZIP magic is still not a legacy OLE .doc. Classify
+            # malformed archives as generic ZIP so callers fail closed instead of
+            # feeding binary bytes into the permissive legacy text fallback.
+            return "zip"
 
     async def parse_content(
         self, content: str, source_path: Optional[str] = None, instruction: str = "", **kwargs

--- a/tests/parse/test_document_parser_threading.py
+++ b/tests/parse/test_document_parser_threading.py
@@ -3,6 +3,7 @@
 """Regression tests for offloading synchronous document conversions."""
 
 import sys
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable
@@ -209,3 +210,52 @@ async def test_legacy_doc_parser_offloads_doc_extraction(monkeypatch, tmp_path: 
     assert seen["content"] == "# converted doc"
     assert result.source_format == "doc"
     assert result.parser_name == "LegacyDocParser"
+
+
+@pytest.mark.asyncio
+async def test_legacy_doc_parser_routes_ooxml_payload_to_word_parser(monkeypatch, tmp_path: Path):
+    parser = legacy_doc.LegacyDocParser()
+    _stub_markdown_parse(parser)
+    source = tmp_path / "mislabeled.doc"
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types />")
+        archive.writestr("word/document.xml", "<w:document />")
+
+    seen: dict[str, Any] = {}
+
+    async def parse_word(self, source_path, instruction="", **kwargs):
+        seen["source"] = source_path
+        seen["instruction"] = instruction
+        seen["kwargs"] = kwargs
+        return create_parse_result(
+            root=ResourceNode(type=NodeType.ROOT),
+            source_path=str(source_path),
+            source_format="docx",
+            parser_name="WordParser",
+        )
+
+    monkeypatch.setattr(word.WordParser, "parse", parse_word)
+
+    result = await parser.parse(
+        source,
+        instruction="preserve tables",
+        source_name="mislabeled.doc",
+    )
+
+    assert seen == {
+        "source": source,
+        "instruction": "preserve tables",
+        "kwargs": {"source_name": "mislabeled.doc"},
+    }
+    assert result.source_format == "docx"
+    assert result.parser_name == "WordParser"
+
+
+@pytest.mark.asyncio
+async def test_legacy_doc_parser_rejects_non_word_zip_payload(tmp_path: Path):
+    source = tmp_path / "not-a-word-document.doc"
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr("payload.bin", b"binary")
+
+    with pytest.raises(ValueError, match="ZIP package"):
+        await legacy_doc.LegacyDocParser().parse(source)


### PR DESCRIPTION
## Description

Prevent modern OOXML Word packages with a `.doc` filename from being decoded as legacy binary Word files. Previously, `olefile` rejected these ZIP-backed payloads and the permissive fallback decoded the raw archive bytes as UTF-16LE, producing plausible-looking but corrupted Markdown that was then persisted as resource content.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Detect ZIP signatures before invoking the legacy `.doc` extraction path.
- Route archives containing the required OOXML Word members through `WordParser`, preserving parser arguments and instructions.
- Reject malformed or non-Word ZIP payloads instead of feeding binary bytes into the legacy text fallback.
- Add regression tests for both mislabeled OOXML routing and generic ZIP rejection.

## Testing

- [x] I have added tests that prove the fix is effective.
- [x] Focused parser and routing tests pass locally: 85 passed.
- [x] Ruff formatting and lint checks pass for both changed files.
- [x] Tested on macOS with an isolated local OpenViking server and temporary home/configuration:
  - A genuine OOXML document named with a `.doc` suffix produced clean Chinese Markdown; semantic processing, embedding, `ov read`, and retrieval all succeeded.
  - A generic ZIP archive named with a `.doc` suffix failed without creating a resource.

The broader parser suite completed with 567 passing tests and eight existing directory-parser failures. The same eight failures reproduce on the unchanged upstream `main` checkout.

## Checklist

- [x] My code follows the project's coding style.
- [x] I have performed a self-review of my code.
- [x] I have commented the non-obvious archive-routing behavior.
- [x] Documentation changes are not required because this does not change the public API.
- [x] My changes generate no new warnings.
- [x] This change has no dependent changes.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

True legacy OLE `.doc` files continue to use the existing extraction path unchanged.
