### PR TITLE
fix(vectordb): only write content field for VikingDB backends

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -900,7 +900,7 @@ Grep engine configuration for content pattern search. These settings are server-
 | `engine` | str | Search engine mode: `"auto"` uses VikingDB BM25 recall when available and falls back to local filesystem search; `"fs"` forces local filesystem search only. | `"auto"` |
 | `switch_to_remote_threshold` | int | L2 record count threshold to switch to VikingDB BM25 recall. When the number of L2 files under the search scope reaches this threshold, VikingDB BM25 is used for phase-1 recall; otherwise local filesystem search is used. Set to `0` to always use VikingDB BM25. Must be ≥ 0. | `10000` |
 
-For VikingDB / Volcengine FullText grep, OpenViking writes a `content` text field for BM25 recall. The source context keeps the full content, while the vector-store write payload truncates this field to **1 MB** at the final adapter boundary to stay within backend payload limits.
+For VikingDB / Volcengine FullText grep, OpenViking writes a `content` text field for BM25 recall. The source context keeps the full content, while the vector-store write payload truncates this field to **1 MB** at the final adapter boundary to stay within backend payload limits. Only VikingDB-backed backends use `content`; on all other backends (`local`, `cuvs`, `qdrant`, `opengauss`, `http`) the field is not written.
 
 ### storage
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -871,7 +871,7 @@ Grep 引擎配置，用于内容模式搜索。这些设置为服务端配置，
 | `engine` | str | 搜索引擎模式：`"auto"` 在可用时使用 VikingDB BM25 召回，不可用时回退到本地文件系统搜索；`"fs"` 强制仅使用本地文件系统搜索。 | `"auto"` |
 | `switch_to_remote_threshold` | int | 切换到 VikingDB BM25 召回的 L2 记录数阈值。当搜索范围内的 L2 文件数达到此阈值时，使用 VikingDB BM25 进行第一阶段召回；否则使用本地文件系统搜索。设为 `0` 表示始终使用 VikingDB BM25。必须 ≥ 0。 | `10000` |
 
-对于 VikingDB / Volcengine FullText grep，OpenViking 会写入 `content` text 字段用于 BM25 召回。源上下文中保留完整内容，仅在最终写入向量库 adapter payload 时将该字段截断到 **1 MB**，以满足后端 payload 限制。
+对于 VikingDB / Volcengine FullText grep，OpenViking 会写入 `content` text 字段用于 BM25 召回。源上下文中保留完整内容，仅在最终写入向量库 adapter payload 时将该字段截断到 **1 MB**，以满足后端 payload 限制。只有 VikingDB 系后端使用 `content`；其它后端（`local`、`cuvs`、`qdrant`、`opengauss`、`http`）不写入该字段。
 
 ### storage
 

--- a/openviking/storage/vectordb_adapters/README.md
+++ b/openviking/storage/vectordb_adapters/README.md
@@ -90,6 +90,12 @@
 - `_sanitize_scalar_index_fields(...)`
 - `_build_default_index_meta(...)`
 
+若后端支持服务端全文检索（BM25 grep）并需要写入 `content` 全文字段，设置类属性：
+
+- `USE_CONTENT_FIELD = True`（默认为 `False`）
+
+默认 `False` 时，写入时会自动跳过 `content` 字段（该字段仅 VikingDB 系后端使用），新增后端无需额外代码。
+
 目的：把后端特性差异收敛在 adapter 内。
 
 ---

--- a/openviking/storage/vectordb_adapters/base.py
+++ b/openviking/storage/vectordb_adapters/base.py
@@ -99,6 +99,13 @@ class CollectionAdapter(ABC):
     # Subclasses backed by VikingDB should set this to ``VIKINGDB_TEXT_FIELD_BYTE_LIMIT``.
     _TEXT_FIELD_BYTE_LIMIT: int | None = None
 
+    # Whether this backend actually stores the ``content`` (full text) field.
+    # Only VikingDB-backed adapters use ``content`` (for server-side full-text grep).
+    # All other backends leave this ``False`` so that ``content`` is silently dropped
+    # on write -- a new backend that does not need ``content`` requires no extra code.
+    # See ``viking_fs._resolve_grep_engine`` which must stay consistent with this flag.
+    USE_CONTENT_FIELD: bool = False
+
     def __init__(self, collection_name: str, index_name: str = DEFAULT_INDEX_NAME):
         self._collection_name = collection_name
         self._index_name = index_name

--- a/openviking/storage/vectordb_adapters/vikingdb_private_adapter.py
+++ b/openviking/storage/vectordb_adapters/vikingdb_private_adapter.py
@@ -18,6 +18,7 @@ class VikingDBPrivateCollectionAdapter(CollectionAdapter):
 
     _DATA_BATCH_SIZE = 100
     _TEXT_FIELD_BYTE_LIMIT = VIKINGDB_TEXT_FIELD_BYTE_LIMIT
+    USE_CONTENT_FIELD = True
 
     def __init__(
         self,

--- a/openviking/storage/vectordb_adapters/volcengine_adapter.py
+++ b/openviking/storage/vectordb_adapters/volcengine_adapter.py
@@ -23,6 +23,7 @@ class VolcengineCollectionAdapter(CollectionAdapter):
 
     _DATA_BATCH_SIZE = 100
     _TEXT_FIELD_BYTE_LIMIT = VIKINGDB_TEXT_FIELD_BYTE_LIMIT
+    USE_CONTENT_FIELD = True
 
     def __init__(
         self,

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -962,6 +962,8 @@ class VikingFS:
             return "fs"
 
         backend_type = getattr(vector_store, "_backend_type", "unknown")
+        # Keep this set consistent with ``CollectionAdapter.USE_CONTENT_FIELD``:
+        # only these backends store the ``content`` field required for full-text grep.
         if backend_type not in ("volcengine", "vikingdb"):
             return "fs"
 

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -165,9 +165,17 @@ class _SingleAccountBackend:
         except Exception:
             pass
 
-        content = result.get("content")
-        if isinstance(content, (str, bytes)):
-            result["content"] = content[:VIKINGDB_CONTENT_MAX_SIZE]
+        # ``content`` (full text) is only meaningful for VikingDB-backed backends,
+        # which use it for server-side full-text grep. Every other backend leaves
+        # ``USE_CONTENT_FIELD=False`` and gets ``content`` dropped here, so its large
+        # payload can't blow past the local engine's per-field byte limit. A new backend
+        # that doesn't need ``content`` requires no extra code.
+        if self._adapter.USE_CONTENT_FIELD:
+            content = result.get("content")
+            if isinstance(content, (str, bytes)):
+                result["content"] = content[:VIKINGDB_CONTENT_MAX_SIZE]
+        else:
+            result.pop("content", None)
 
         return result
 

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -941,6 +941,7 @@ def test_single_account_backend_filters_parent_uri_against_current_schema():
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -987,6 +988,7 @@ async def test_single_account_backend_upsert_drops_legacy_parent_uri_before_writ
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1040,7 +1042,8 @@ async def test_single_account_backend_truncates_content_only_at_vector_write():
             }
 
     class _Adapter:
-        mode = "local"
+        mode = "volcengine"
+        USE_CONTENT_FIELD = True
 
         def get_collection(self):
             return _Collection()
@@ -1050,7 +1053,12 @@ async def test_single_account_backend_truncates_content_only_at_vector_write():
             return [data["id"]]
 
     backend = _SingleAccountBackend(
-        config=VectorDBBackendConfig(backend="local", name="context", dimension=2),
+        config=VectorDBBackendConfig(
+            backend="volcengine",
+            name="context",
+            dimension=2,
+            volcengine=VolcengineConfig(ak="ak", sk="sk", region="cn-beijing"),
+        ),
         bound_account_id="acc1",
         shared_adapter=_Adapter(),
     )
@@ -1070,6 +1078,63 @@ async def test_single_account_backend_truncates_content_only_at_vector_write():
     assert captured["data"]["content"] == full_content[:VIKINGDB_CONTENT_MAX_SIZE]
 
 
+@pytest.mark.asyncio
+async def test_single_account_backend_drops_content_for_non_vikingdb_backend():
+    """Non-VikingDB backends (USE_CONTENT_FIELD=False) must not receive ``content``.
+
+    The schema still declares ``content`` for cross-backend compatibility, but only
+    VikingDB uses it. For every other backend the (potentially huge) content payload is
+    dropped on write, and the schema-required text field is not re-added as an empty
+    placeholder either.
+    """
+    captured = {}
+    full_content = "x" * (1024 * 1024 + 17)
+
+    class _Collection:
+        def get_meta_data(self):
+            return {
+                "Fields": [
+                    {"FieldName": "id"},
+                    {"FieldName": "uri"},
+                    {"FieldName": "abstract", "FieldType": "text"},
+                    {"FieldName": "content", "FieldType": "text"},
+                    {"FieldName": "account_id"},
+                ]
+            }
+
+    class _Adapter:
+        mode = "local"
+        USE_CONTENT_FIELD = False
+
+        def get_collection(self):
+            return _Collection()
+
+        def upsert(self, data):
+            captured["data"] = dict(data)
+            return [data["id"]]
+
+    backend = _SingleAccountBackend(
+        config=VectorDBBackendConfig(backend="local", name="context", dimension=2),
+        bound_account_id="acc1",
+        shared_adapter=_Adapter(),
+    )
+
+    record_id = await backend.upsert(
+        {
+            "id": "rec-1",
+            "uri": "viking://resources/large.txt",
+            "content": full_content,
+            "account_id": "acc1",
+        }
+    )
+
+    assert record_id == "rec-1"
+    # ``content`` is neither written nor re-added as an empty placeholder.
+    assert "content" not in captured["data"]
+    # Other schema-required text fields (e.g. abstract) are still backfilled empty.
+    assert captured["data"]["abstract"] == ""
+
+
 def test_vikingdb_text_field_byte_limit_is_one_mb_and_utf8_safe():
     text = "a" * (1024 * 1024) + "😀"
 
@@ -1086,6 +1151,7 @@ async def test_single_account_backend_collection_exists_runs_in_threadpool(monke
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def collection_exists(self):
             return True
@@ -1130,6 +1196,7 @@ async def test_single_account_backend_upsert_runs_adapter_in_threadpool(monkeypa
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1190,6 +1257,7 @@ async def test_single_account_backend_update_runs_adapter_in_threadpool(monkeypa
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1384,6 +1452,7 @@ async def test_single_account_backend_update_injects_bound_account_id(monkeypatc
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1419,6 +1488,7 @@ async def test_single_account_backend_update_requires_id_before_adapter_call():
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1458,6 +1528,7 @@ async def test_single_account_backend_update_rejects_invalid_context_type_withou
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1502,6 +1573,7 @@ async def test_single_account_backend_update_returns_structured_error_when_adapt
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1539,6 +1611,7 @@ async def test_single_account_backend_update_returns_not_found_when_adapter_repo
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1579,6 +1652,7 @@ async def test_single_account_backend_upsert_partial_update_reads_then_upserts_e
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1644,6 +1718,7 @@ async def test_single_account_backend_upsert_partial_update_creates_when_record_
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()
@@ -1692,6 +1767,7 @@ async def test_single_account_backend_upsert_partial_update_creates_when_record_
 async def test_single_account_backend_upsert_partial_update_returns_empty_when_get_fails():
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get(self, ids):
             del ids
@@ -1720,6 +1796,7 @@ async def test_single_account_backend_upsert_without_partial_update_keeps_legacy
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def upsert(self, data):
             calls.append(data)
@@ -1814,6 +1891,7 @@ async def test_qdrant_backend_upsert_partial_update_reads_then_upserts_existing_
 
     class _Adapter:
         mode = "qdrant"
+        USE_CONTENT_FIELD = False
 
         def get(self, ids):
             calls.append(("get", ids))
@@ -1884,6 +1962,7 @@ async def test_qdrant_backend_upsert_partial_update_creates_when_record_does_not
 
     class _Adapter:
         mode = "qdrant"
+        USE_CONTENT_FIELD = False
 
         def get(self, ids):
             calls.append(("get", ids))
@@ -1942,6 +2021,7 @@ async def test_volcengine_backend_upsert_partial_update_reads_then_upserts_exist
 
     class _Adapter:
         mode = "volcengine"
+        USE_CONTENT_FIELD = True
 
         def get(self, ids):
             calls.append(("get", ids))
@@ -2012,6 +2092,7 @@ async def test_volcengine_backend_upsert_partial_update_creates_when_record_does
 
     class _Adapter:
         mode = "volcengine"
+        USE_CONTENT_FIELD = True
 
         def get(self, ids):
             calls.append(("get", ids))
@@ -2330,6 +2411,7 @@ async def test_single_account_backend_mutations_run_adapter_in_threadpool(monkey
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def drop_collection(self):
             return True
@@ -2397,6 +2479,7 @@ async def test_single_account_backend_query_runs_adapter_in_threadpool(monkeypat
 
     class _Adapter:
         mode = "local"
+        USE_CONTENT_FIELD = False
 
         def get_collection(self):
             return _Collection()


### PR DESCRIPTION
## Description

The `content` (full text) field powers server-side full-text grep, which only exists on
**VikingDB** backends (Volcengine AK/SK, Volcengine API-Key, private VikingDB). All other
backends (`local`, `cuvs`, `qdrant`, `opengauss`, `http`) never use `content`, yet it is
still written to them — a dead field that, on the local engine, can exceed the storage
field-size limit and fail the write.

This PR keeps `content` in the schema for backward compatibility, but **only writes it for
backends that actually use it**. Other backends drop `content` on write.

The design is extensible: a backend that does **not** use `content` needs no code (it
inherits the default), and one that **does** only sets a single class attribute.

## Related Issue

Fixes #2967

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add `USE_CONTENT_FIELD: bool = False` to the `CollectionAdapter` base class; set it
  `True` on `VolcengineCollectionAdapter` (AK/SK + API-Key) and
  `VikingDBPrivateCollectionAdapter`.
- Gate the single write chokepoint `_SingleAccountBackend._prepare_upsert_payload`
  (shared by `upsert` and `update`) on the flag: VikingDB keeps and truncates `content`
  (1 MB) as before; other backends drop it (and don't re-add it as an empty placeholder).
- Add a comment tying `viking_fs._resolve_grep_engine` to `USE_CONTENT_FIELD` so the two
  stay consistent.
- Tests: add a case asserting `content` is dropped for non-VikingDB backends; re-target
  the existing content-truncation test to a VikingDB backend.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`python -m pytest tests/storage/test_collection_schemas.py tests/storage/test_qdrant_adapter.py`
→ **68 passed**.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Scope is limited to the `content` field. Related suggestions in the issue (skipping /
chunking large files, retry limits, ignore-list additions) are orthogonal and left out.
