### PR TITLE
fix(openclaw): send peer_id for session messages

### DIFF
--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -759,19 +759,19 @@ export class OpenVikingClient {
     }>,
     actorPeerId?: string,
     createdAt?: string,
-    roleId?: string,
+    peerId?: string,
   ): Promise<void> {
     const body: {
       role: string;
-      role_id?: string;
+      peer_id?: string;
       parts: typeof parts;
       created_at?: string;
     } = { role, parts };
     if (createdAt) {
       body.created_at = createdAt;
     }
-    if (roleId) {
-      body.role_id = roleId;
+    if (peerId) {
+      body.peer_id = peerId;
     }
     await this.emitRoutingDebug(
       "session message POST (with parts)",
@@ -779,7 +779,7 @@ export class OpenVikingClient {
         path: `/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
         sessionId,
         role,
-        role_id: roleId ?? null,
+        peer_id: peerId ?? null,
         partCount: parts.length,
         created_at: createdAt ?? null,
       },

--- a/examples/openclaw-plugin/tests/ut/architecture-boundaries.test.ts
+++ b/examples/openclaw-plugin/tests/ut/architecture-boundaries.test.ts
@@ -515,7 +515,7 @@ describe("architecture boundaries", () => {
   it("keeps canonical namespace client tests on the injected transport seam", () => {
     const clientTestSource = readFileSync(join(rootDir, "tests/ut/client.test.ts"), "utf8");
     const start = clientTestSource.indexOf('describe("OpenVikingClient canonical namespace policy"');
-    const end = clientTestSource.indexOf('  it("includes role_id when addSessionMessage receives one"', start);
+    const end = clientTestSource.indexOf('  it("includes peer_id when addSessionMessage receives one"', start);
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
@@ -527,7 +527,7 @@ describe("architecture boundaries", () => {
 
   it("keeps addSessionMessage client tests on the injected transport seam", () => {
     const clientTestSource = readFileSync(join(rootDir, "tests/ut/client.test.ts"), "utf8");
-    const start = clientTestSource.indexOf('it("includes role_id when addSessionMessage receives one"');
+    const start = clientTestSource.indexOf('it("includes peer_id when addSessionMessage receives one"');
     const end = clientTestSource.indexOf('\n});', start);
 
     expect(start).toBeGreaterThanOrEqual(0);

--- a/examples/openclaw-plugin/tests/ut/client.test.ts
+++ b/examples/openclaw-plugin/tests/ut/client.test.ts
@@ -598,7 +598,7 @@ describe("OpenVikingClient canonical namespace policy", () => {
     expect(body.target_uri).toBe("viking://user/skills");
   });
 
-  it("includes role_id when addSessionMessage receives one", async () => {
+  it("includes peer_id when addSessionMessage receives one", async () => {
     const transport = vi.fn().mockResolvedValue(okResponse({ session_id: "s1" }));
 
     const client = new OpenVikingClient("http://127.0.0.1:1933", "", "agent", 5000, "", "", undefined, false, true, { transport });
@@ -613,6 +613,7 @@ describe("OpenVikingClient canonical namespace policy", () => {
 
     const [, init] = transport.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(String(init.body));
-    expect(body.role_id).toBe("telegram_12345");
+    expect(body.peer_id).toBe("telegram_12345");
+    expect(body).not.toHaveProperty("role_id");
   });
 });

--- a/examples/openclaw-plugin/tests/ut/tools.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tools.test.ts
@@ -455,7 +455,7 @@ describe("Tool: memory_store (behavioral)", () => {
     expect(store!.description).toContain("threshold/commit dependent");
   });
 
-  it("uses requesterSenderId to populate role_id for user writes", async () => {
+  it("uses requesterSenderId to populate peer_id for user writes", async () => {
     const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith("/api/v1/system/status")) {
         return okResponse({ user: "default" });
@@ -494,7 +494,8 @@ describe("Tool: memory_store (behavioral)", () => {
     const [, init] = messageCall as [string, RequestInit];
     const body = JSON.parse(String(init.body));
     expect(body.role).toBe("user");
-    expect(body.role_id).toBe("wx_user-01_abc");
+    expect(body.peer_id).toBe("wx_user-01_abc");
+    expect(body).not.toHaveProperty("role_id");
   });
 
   it("uses a temporary session by default instead of the current tool session", async () => {


### PR DESCRIPTION
## Summary

- send OpenClaw session-message peer identity as `peer_id`, matching the current OpenViking server request schema
- align the routing debug payload with the same field name
- update direct client, `memory_store`, and architecture-boundary regression coverage

## Motivation

`OpenVikingClient.addSessionMessage()` currently serializes its peer identity as `role_id`, while `AddMessageRequest` accepts `peer_id`. Pydantic ignores the unknown field, so user messages reach the server with `peer_id=None` and cannot populate the expected peer memory space.

The plugin declares OpenViking `0.4.1` as its minimum supported version, where the peer identity contract is `peer_id`.

## Implementation

- rename the method-local identity parameter from `roleId` to `peerId`
- serialize `body.peer_id` and emit `peer_id` in routing diagnostics
- assert that client and `memory_store` requests contain `peer_id` and do not contain legacy `role_id`
- keep architecture-boundary test markers aligned with the renamed regression test

## Validation

- focused peer routing/boundary tests: 4 passed
- complete `tests/ut/client.test.ts`: 38 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- full OpenClaw plugin Vitest: 730 passed, 4 pre-existing architecture-boundary failures

The four full-suite failures check unrelated compatibility cleanup already absent from the test expectations but still present at the pinned base revision: recall-trace helper exports, direct setup fetch usage, client-side upload file reads, and the legacy `isMemoryUri` export. This patch does not touch those behaviors.

## Risk and gaps

- Low risk: the change is limited to the session-message JSON key, its diagnostic label, and regression tests; the TypeScript parameter rename is internal and positional call sites are unchanged.
- No live Telegram/OpenClaw/VLM environment was used. The focused transport tests verify both the direct client and `memory_store` sender path without external services.
- Merge is intentionally left to maintainers.

Fixes #3102

Related: #3112
