### PR TITLE
fix(cli): avoid misreporting upstream model auth errors

### DIFF
--- a/crates/ov_cli/src/error_ui.rs
+++ b/crates/ov_cli/src/error_ui.rs
@@ -194,6 +194,9 @@ fn is_client_auth_error(status: Option<u16>, message: &str) -> bool {
     if matches!(status, Some(code) if (500..600).contains(&code)) {
         return false;
     }
+    if message.contains("Upstream model ") {
+        return false;
+    }
     looks_like_auth_error(message)
 }
 
@@ -1170,6 +1173,24 @@ Usage: ov config [OPTIONS] [COMMAND]
 
         assert!(normal.contains("Authentication Error"));
         assert!(normal.contains("OpenViking rejected the API key"));
+    }
+
+    #[test]
+    fn upstream_model_auth_error_is_not_cli_api_key_error() {
+        let error = Error::api_with_status(
+            "[UNAUTHENTICATED] Upstream model authentication failed: invalid api key".to_string(),
+            401,
+        );
+        let report = report_for_runtime_error("ov find hello", &error);
+        let normal = strip_ansi(&render_report(&report, false));
+        let verbose = strip_ansi(&render_report(&report, true));
+
+        assert!(normal.contains("OpenViking API Error"));
+        assert!(!normal.contains("Authentication Error"));
+        assert!(!normal.contains("OpenViking rejected the API key"));
+
+        assert!(verbose.contains("Detail:"));
+        assert!(verbose.contains("Upstream model authentication failed"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

修复 CLI 运行时错误提示中对上游 embedding 模型鉴权错误的误判。

此前当 `ov find` 等命令触发服务端 embedding 调用，且 `ov.conf` 中 embedding provider API key 配置错误时，服务端会返回包含 `authentication` / `api key` 关键词的 `Upstream model authentication failed` 错误。CLI 会因为关键词匹配将其误包装成 `ovcli.conf` 当前 API key 被 OpenViking 拒绝，导致用户被误导去检查错误的配置文件。

本 PR 对该实际可触发场景做最小修复：当错误信息来自 `Upstream model` 时，不再归类为 CLI client API key 鉴权错误，而是按普通 OpenViking API Error 展示原始上游模型错误信息。

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 在 CLI runtime error 的 client auth 判断中排除 `Upstream model` 错误，避免将 embedding provider 鉴权失败误报为 `ovcli.conf` API key 错误
- 增加回归测试，覆盖 `ov find` 场景下上游模型鉴权失败不应显示 `Authentication Error` / `OpenViking rejected the API key`

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

测试命令：

```bash
cargo test -p ov_cli upstream_model_auth_error_is_not_cli_api_key_error
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
修改前
<img width="566" height="177" alt="image" src="https://github.com/user-attachments/assets/eaf939d1-7586-419d-a8b1-85f0c35f9ca3" />

修改后
<img width="666" height="212" alt="image" src="https://github.com/user-attachments/assets/c6d89ece-fb26-4b7e-91b6-20acb6bc9e21" />


## Additional Notes

