### PR TITLE
fix(plugins): bump memory plugin versions after workspace peer update

### DIFF
--- a/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
+++ b/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Long-term semantic memory for Claude Code, powered by OpenViking. Auto-recall relevant memories at session start and capture important information during conversations.",
   "author": {
     "name": "OpenViking",

--- a/examples/claude-code-memory-plugin/package-lock.json
+++ b/examples/claude-code-memory-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-openviking-memory",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^4.3.6"

--- a/examples/claude-code-memory-plugin/package.json
+++ b/examples/claude-code-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenViking memory plugin for Claude Code — semantic long-term memory",
   "type": "module",
   "scripts": {

--- a/examples/codex-memory-plugin/.codex-plugin/plugin.json
+++ b/examples/codex-memory-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Long-term semantic memory for Codex, powered by OpenViking. Recall on UserPromptSubmit, incremental add_message on Stop (per turn), commit on PreCompact, and active-window heuristic + idle-TTL sweep on SessionStart (source=startup|clear). Includes a local stdio MCP proxy that reads OpenViking credentials from env/ovcli.conf.",
   "author": {
     "name": "OpenViking",

--- a/examples/opencode-plugin/package.json
+++ b/examples/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openviking/opencode-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "@openviking",
   "description": "Unified OpenCode plugin for OpenViking repository retrieval and long-term memory",
   "type": "module",


### PR DESCRIPTION
## Description

Bump the versioned OpenViking memory plugins affected by the workspace-derived peer ID change in #3099.

#3099 added workspace peer routing without changing plugin versions. Version-based caches could therefore keep serving older plugin snapshots, and the OpenCode release workflow skipped publishing because `@openviking/opencode-plugin@0.2.0` already existed.

## Related Issue

Follow-up to #3099.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Bump the Claude Code plugin from `0.4.0` to `0.4.1`.
- Bump the Codex plugin from `0.7.0` to `0.7.1`.
- Bump the OpenCode npm plugin from `0.2.0` to `0.2.1`.
- Keep the Claude Code `package.json` and `package-lock.json` metadata in sync.

The pi extension has no independent version field, so it does not require a version change.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation:

- Plugin CI test command — 137 passed
- `npm run check --prefix examples/opencode-plugin`
- `npm test --prefix examples/opencode-plugin` — 14 passed
- JSON parsing for all changed manifests/package metadata
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The version files were audited from the #3099 merge commit through the latest `main`; none had received a later version bump. No runtime code changes are included.
