### PR TITLE
fix(installer): avoid silent exit after harness selection

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,6 +45,7 @@ jobs:
             examples/trae-memory-hooks/scripts/trae-hooks.test.mjs \
             examples/memory-plugin-shared/install-agent-hooks.test.mjs \
             examples/memory-plugin-shared/install-opencode-jsonc.test.mjs \
+            examples/memory-plugin-shared/install-tui.test.mjs \
             examples/memory-plugin-shared/sync.test.mjs \
             examples/memory-plugin-shared/recall-core.test.mjs \
             examples/memory-plugin-shared/workspace-peer.test.mjs \

--- a/examples/memory-plugin-shared/install-tui.test.mjs
+++ b/examples/memory-plugin-shared/install-tui.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const installer = fileURLToPath(new URL("./install.sh", import.meta.url));
+const installerSource = readFileSync(installer, "utf8");
+const mainMarker = "# ---------------------------------------------------------------------------\n# Main\n";
+const installerPrelude = installerSource.slice(0, installerSource.indexOf(mainMarker));
+
+function runInstallerPrelude(body) {
+  return spawnSync("/bin/bash", [], {
+    encoding: "utf8",
+    env: { ...process.env, OPENVIKING_LANG: "en" },
+    input: `${installerPrelude}\n${body}\n`,
+    timeout: 10_000,
+  });
+}
+
+test("finishing TUI selection succeeds when the final harness is not selected", () => {
+  const result = runInstallerPrelude(`
+SEL_CLAUDE_BINS=claude
+SEL_CODEX_BINS=codex
+SEL_OPENCODE=1
+SEL_PI=1
+SEL_CURSOR_APP=1
+SEL_TRAE=1
+SEL_TRAE_CN=0
+tui_finish_selection
+printf '%s\\n' "$SELECTED_HARNESSES"
+`);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "claude,codex,opencode,pi,cursor,trae");
+});
+
+test("unexpected installer failures include actionable diagnostics", () => {
+  const result = runInstallerPrelude(`
+installer_test_failure() {
+  false
+}
+installer_test_failure
+`);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /OpenViking installer stopped unexpectedly\./);
+  assert.match(result.stderr, /Exit status: 1/);
+  assert.match(result.stderr, /Script line: [0-9]+/);
+  assert.match(result.stderr, /Command: false/);
+});

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -41,7 +41,7 @@
 #
 # Targets bash 3.2+ (macOS /bin/bash) and Linux.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 OV_HOME="${OPENVIKING_HOME:-$HOME/.openviking}"
 REPO_URL="${OPENVIKING_REPO_URL:-https://github.com/volcengine/OpenViking.git}"
@@ -113,6 +113,25 @@ heading() { printf '\n%s%s%s\n' "$BOLD" "$*" "$RESET"; }
 
 # t <english> <chinese> — pick the UI language variant.
 t() { if [ "$UI_LANG" = "zh" ]; then printf '%s' "$2"; else printf '%s' "$1"; fi; }
+
+report_unexpected_error() { # report_unexpected_error <status> <line> <command>
+  local status="$1" line="$2" command="$3"
+  # Avoid duplicate reports while the same failure unwinds through nested
+  # functions. EXIT traps still run afterwards and restore any active TUI.
+  trap - ERR
+  if [ "${BASH_SUBSHELL:-0}" -gt 0 ]; then
+    return "$status"
+  fi
+  printf '\033[?25h' >/dev/tty 2>/dev/null || true
+  printf '\n' >&2
+  err "$(t 'OpenViking installer stopped unexpectedly.' 'OpenViking 安装程序意外退出。')"
+  printf '    %s: %s\n' "$(t 'Exit status' '状态码')" "$status" >&2
+  printf '    %s: %s\n' "$(t 'Script line' '脚本行号')" "$line" >&2
+  printf '    %s: %s\n' "$(t 'Command' '失败命令')" "$command" >&2
+  return "$status"
+}
+
+trap 'report_unexpected_error "$?" "$LINENO" "$BASH_COMMAND"' ERR
 
 # Pure-bash substring test. Never pipe `claude/codex plugin list` into
 # `grep -q`: with pipefail, grep exiting early SIGPIPEs the producer and the
@@ -763,6 +782,7 @@ tui_finish_selection() {
   [ "$SEL_CURSOR_APP" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}cursor"
   [ "$SEL_TRAE" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}trae"
   [ "$SEL_TRAE_CN" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}trae-cn"
+  return 0
 }
 
 tui_select_harnesses() {


### PR DESCRIPTION
## Summary

- make harness TUI confirmation return success regardless of whether TRAE CN is selected
- add a bilingual unexpected-error diagnostic with exit status, script line, and failed command
- restore the terminal cursor before reporting an unexpected error
- add regression coverage to the memory plugin PR test suite

## Root cause

`tui_finish_selection` ended with a conditional expression for the final TRAE CN item. When TRAE CN was not selected, that expression returned status 1. Because the installer uses `set -e`, pressing Enter after the harness menu terminated the script silently before the next step.

## Impact

Interactive installs can proceed past harness selection when the last list item is unselected. Future unhandled shell errors are visible and actionable instead of appearing as a silent TUI exit.

## Validation

- `node --test` for the full memory plugin PR test list: 100 passed
- `bash -n examples/memory-plugin-shared/install.sh`
- `git diff --check`
