### PR TITLE
fix: Pending session context archives

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2046,7 +2046,11 @@ class Session:
 
     async def _get_pending_archive_messages(self) -> List[Message]:
         """Return messages from in-progress archives newer than the latest completed archive."""
-        latest_completed_index = max(0, self._meta.commit_count)
+        # commit_count is advanced during commit phase 1, before memory
+        # extraction writes the archive .done marker. Only .done proves an
+        # archive is completed; otherwise get_session_context must still expose
+        # its messages as pending context.
+        latest_completed_index = 0
         pending_archives: List[Dict[str, Any]] = []
         for archive in sorted(await self._list_archive_refs(), key=lambda item: item["index"]):
             try:

--- a/tests/session/test_session_context.py
+++ b/tests/session/test_session_context.py
@@ -395,6 +395,36 @@ class TestGetSessionContext:
         assert context["stats"]["activeTokens"] == session.messages[0].estimated_tokens
         assert context["stats"]["activeTokens"] > _estimate_tokens("Executing tool...")
 
+    async def test_get_session_context_includes_pending_archive_when_commit_count_advanced(
+        self, client: AsyncOpenViking
+    ):
+        session = client.session(session_id="assemble_pending_commit_count_test")
+        pending_messages = [
+            Message(id="pending-user", role="user", parts=[TextPart("Pending user message")]),
+            Message(
+                id="pending-assistant",
+                role="assistant",
+                parts=[TextPart("Pending assistant response")],
+            ),
+        ]
+
+        await session._viking_fs.write_file(
+            uri=f"{session.uri}/history/archive_001/messages.jsonl",
+            content="\n".join(msg.to_jsonl() for msg in pending_messages) + "\n",
+            ctx=session.ctx,
+        )
+        session._compression.compression_index = 1
+        session._meta.commit_count = 1
+        session.add_message("user", [TextPart("Current live message")])
+
+        context = await session.get_session_context()
+
+        assert [message["parts"][0]["text"] for message in context["messages"]] == [
+            "Pending user message",
+            "Pending assistant response",
+            "Current live message",
+        ]
+
     async def test_get_session_context_reads_latest_overview_and_all_archive_abstracts(
         self, client: AsyncOpenViking, monkeypatch
     ):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fix `get_session_context` so it includes pending archive messages while session commit memory extraction is still running.

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
Fixes https://github.com/volcengine/OpenViking/issues/3129

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->
- Changed pending archive detection to treat only `.done` archives as completed.
- Stopped using `commit_count` as the latest completed archive index because it is advanced before memory extraction finishes.
- Added a regression test for the state where `commit_count` has advanced but the archive is still pending.-

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
