### PR TITLE
Fix/ 修复兼容逻辑加入assistent消息的peerid后，user记忆会归入peer目录的问题

### DIFF
--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -71,22 +71,15 @@ class MemoryIsolationHandler:
     def _message_target_id(self, msg: Any) -> Optional[str]:
         raw_peer_id = getattr(msg, "peer_id", None)
         peer_id = safe_peer_id(raw_peer_id)
-        if peer_id and self._can_write_peer(peer_id):
+        if peer_id and self._is_peer_owner_message(msg) and self._can_write_peer(peer_id):
             return peer_id
         if raw_peer_id in (None, "") and self.allow_self:
             return _SELF_PEER_ID
         return None
 
-    def _first_target_id_in_messages(self) -> Optional[str]:
-        targets = [
-            target_id
-            for msg in self._messages()
-            if (target_id := self._message_target_id(msg))
-        ]
-        for target_id in targets:
-            if target_id != _SELF_PEER_ID:
-                return target_id
-        return targets[0] if targets else None
+    @staticmethod
+    def _is_peer_owner_message(msg: Any) -> bool:
+        return getattr(msg, "role", None) == "user"
 
     def get_read_scope(self) -> RoleScope:
         user_ids = set()
@@ -139,6 +132,17 @@ class MemoryIsolationHandler:
     def _can_write_peer(self, peer_id: str) -> bool:
         return self.allow_peer and peer_id in self.allowed_peer_ids
 
+    def _unique_peer_target_id_in_messages(self) -> Optional[str]:
+        targets = [
+            peer_id
+            for msg in self._messages()
+            if (peer_id := safe_peer_id(getattr(msg, "peer_id", None)))
+            and self._is_peer_owner_message(msg)
+            and self._can_write_peer(peer_id)
+        ]
+        peer_ids = list(dict.fromkeys(targets))
+        return peer_ids[0] if len(peer_ids) == 1 else None
+
     def render_schema_directories(self, memory_type_schema: MemoryTypeSchema) -> List[str]:
         user_id = self.ctx.user.user_id if self.ctx and self.ctx.user else "default"
         user_space = user_id
@@ -183,12 +187,11 @@ class MemoryIsolationHandler:
             return _SELF_PEER_ID
         if peer_id and self._can_write_peer(peer_id):
             return peer_id
-        fallback_target_id = self._first_target_id_in_messages()
-        if fallback_target_id:
-            return fallback_target_id
+        if raw_peer_id not in (None, ""):
+            return None
         if self.allow_self:
             return _SELF_PEER_ID
-        return None
+        return self._unique_peer_target_id_in_messages()
 
     def calculate_memory_uris(
         self,

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -90,6 +90,7 @@ def _message_peer_ids(messages: List[Message]) -> set[str]:
     return {
         peer_id
         for message in messages
+        if getattr(message, "role", None) == "user"
         if (peer_id := safe_peer_id(getattr(message, "peer_id", None)))
     }
 

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -86,42 +86,18 @@ def _default_memory_counts() -> Dict[str, int]:
     return {"total": 0}
 
 
-@dataclass(frozen=True)
-class _MessagePeerIds:
-    user_peer_ids: set[str]
-    assistant_peer_ids: set[str]
-
-    @property
-    def allowed_peer_ids(self) -> set[str]:
-        return self.user_peer_ids | self.assistant_peer_ids
-
-
-def _message_peer_ids(messages: List[Message]) -> _MessagePeerIds:
-    user_peer_ids: set[str] = set()
-    assistant_peer_ids: set[str] = set()
-
-    for message in messages:
-        peer_id = safe_peer_id(getattr(message, "peer_id", None))
-        if not peer_id:
-            continue
-
-        role = getattr(message, "role", None)
-        if role == "user":
-            user_peer_ids.add(peer_id)
-        elif role == "assistant":
-            assistant_peer_ids.add(peer_id)
-
-    return _MessagePeerIds(
-        user_peer_ids=user_peer_ids,
-        assistant_peer_ids=assistant_peer_ids,
-    )
+def _message_peer_ids(messages: List[Message]) -> set[str]:
+    return {
+        peer_id
+        for message in messages
+        if getattr(message, "role", None) == "user"
+        if (peer_id := safe_peer_id(getattr(message, "peer_id", None)))
+    }
 
 
 @dataclass(frozen=True)
 class _MemoryExtractionScope:
     allow_self_memory: bool
-    user_peer_ids: set[str]
-    assistant_peer_ids: set[str]
     allowed_peer_ids: set[str]
     include_session_skills: bool
     memory_types: Optional[set[str]]
@@ -135,17 +111,11 @@ def _resolve_memory_extraction_scope(
     config_session_skill_extraction_enabled: bool,
 ) -> _MemoryExtractionScope:
     allow_self_memory = policy.self_enabled
-    message_peer_ids = (
-        _message_peer_ids(messages)
-        if policy.peer_enabled
-        else _MessagePeerIds(user_peer_ids=set(), assistant_peer_ids=set())
-    )
+    allowed_peer_ids = _message_peer_ids(messages) if policy.peer_enabled else set()
 
     return _MemoryExtractionScope(
         allow_self_memory=allow_self_memory,
-        user_peer_ids=message_peer_ids.user_peer_ids,
-        assistant_peer_ids=message_peer_ids.assistant_peer_ids,
-        allowed_peer_ids=message_peer_ids.allowed_peer_ids,
+        allowed_peer_ids=allowed_peer_ids,
         include_session_skills=config_session_skill_extraction_enabled and allow_self_memory,
         memory_types=policy.memory_types,
     )

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -90,7 +90,6 @@ def _message_peer_ids(messages: List[Message]) -> set[str]:
     return {
         peer_id
         for message in messages
-        if getattr(message, "role", None) == "user"
         if (peer_id := safe_peer_id(getattr(message, "peer_id", None)))
     }
 

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -86,18 +86,42 @@ def _default_memory_counts() -> Dict[str, int]:
     return {"total": 0}
 
 
-def _message_peer_ids(messages: List[Message]) -> set[str]:
-    return {
-        peer_id
-        for message in messages
-        if getattr(message, "role", None) == "user"
-        if (peer_id := safe_peer_id(getattr(message, "peer_id", None)))
-    }
+@dataclass(frozen=True)
+class _MessagePeerIds:
+    user_peer_ids: set[str]
+    assistant_peer_ids: set[str]
+
+    @property
+    def allowed_peer_ids(self) -> set[str]:
+        return self.user_peer_ids | self.assistant_peer_ids
+
+
+def _message_peer_ids(messages: List[Message]) -> _MessagePeerIds:
+    user_peer_ids: set[str] = set()
+    assistant_peer_ids: set[str] = set()
+
+    for message in messages:
+        peer_id = safe_peer_id(getattr(message, "peer_id", None))
+        if not peer_id:
+            continue
+
+        role = getattr(message, "role", None)
+        if role == "user":
+            user_peer_ids.add(peer_id)
+        elif role == "assistant":
+            assistant_peer_ids.add(peer_id)
+
+    return _MessagePeerIds(
+        user_peer_ids=user_peer_ids,
+        assistant_peer_ids=assistant_peer_ids,
+    )
 
 
 @dataclass(frozen=True)
 class _MemoryExtractionScope:
     allow_self_memory: bool
+    user_peer_ids: set[str]
+    assistant_peer_ids: set[str]
     allowed_peer_ids: set[str]
     include_session_skills: bool
     memory_types: Optional[set[str]]
@@ -111,11 +135,17 @@ def _resolve_memory_extraction_scope(
     config_session_skill_extraction_enabled: bool,
 ) -> _MemoryExtractionScope:
     allow_self_memory = policy.self_enabled
-    allowed_peer_ids = _message_peer_ids(messages) if policy.peer_enabled else set()
+    message_peer_ids = (
+        _message_peer_ids(messages)
+        if policy.peer_enabled
+        else _MessagePeerIds(user_peer_ids=set(), assistant_peer_ids=set())
+    )
 
     return _MemoryExtractionScope(
         allow_self_memory=allow_self_memory,
-        allowed_peer_ids=allowed_peer_ids,
+        user_peer_ids=message_peer_ids.user_peer_ids,
+        assistant_peer_ids=message_peer_ids.assistant_peer_ids,
+        allowed_peer_ids=message_peer_ids.allowed_peer_ids,
         include_session_skills=config_session_skill_extraction_enabled and allow_self_memory,
         memory_types=policy.memory_types,
     )

--- a/tests/integration/test_compressor_v2_xiaomei.py
+++ b/tests/integration/test_compressor_v2_xiaomei.py
@@ -13,6 +13,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 import openviking as ov
+
 try:
     from openviking_live_auth import API_KEY_HELP, resolve_api_key
 except ModuleNotFoundError:  # pytest/package import path
@@ -25,6 +26,7 @@ DEFAULT_URL = "http://localhost:1934"
 PANEL_WIDTH = 78
 DEFAULT_API_KEY = None
 DEFAULT_SESSION_ID = "xiaomei-demo"
+ASSISTANT_PEER_ID = "xiaomei-demo-assistant"
 
 
 console = Console()
@@ -134,6 +136,7 @@ def run_ingest(client: ov.SyncHTTPClient, session_id: str, wait_seconds: float):
             role="assistant",
             parts=[{"type": "text", "text": turn["assistant"]}],
             created_at=session_time_str,
+            peer_id=ASSISTANT_PEER_ID,
         )
 
     console.print()

--- a/tests/session/memory/test_memory_isolation_handler.py
+++ b/tests/session/memory/test_memory_isolation_handler.py
@@ -108,8 +108,6 @@ class TestGetReadScope:
 
         assert scope.user_ids == ["default_user"]
 
-
-
     def test_get_read_scope_filters_self_sentinel_from_peer_scope(self):
         ctx = create_ctx(user_id="support_bot")
         messages = [create_message("user")]
@@ -481,9 +479,49 @@ class TestCalculateMemoryUris:
         assert "peer_id" not in operation.memory_fields
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
-    def test_calculate_memory_uris_unallowed_peer_id_falls_back_to_first_peer(
-        self, mock_generate_uri
-    ):
+    def test_calculate_memory_uris_ranges_ignore_assistant_peer_ids(self, mock_generate_uri):
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        )
+
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("assistant", "bot ack", peer_id="assistant-bot"),
+            create_message("user", "peer event", peer_id="web-visitor-alice"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [messages]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=True,
+            allowed_peer_ids={"assistant-bot", "web-visitor-alice"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "0-1"},
+            memory_type="events",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == ["viking://user/support_bot/peers/web-visitor-alice/memories/events/demo"]
+        assert operation.memory_fields["user_id"] == "support_bot"
+        assert "peer_id" not in operation.memory_fields
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_calculate_memory_uris_unallowed_peer_id_does_not_fallback(self, mock_generate_uri):
         mock_generate_uri.side_effect = lambda **kwargs: (
             f"viking://user/{kwargs.get('user_space')}/memories/preferences"
         )
@@ -516,13 +554,12 @@ class TestCalculateMemoryUris:
 
         uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
 
-        assert uris == [
-            "viking://user/support_bot/peers/web-visitor-bob/memories/preferences"
-        ]
-        assert operation.memory_fields["peer_id"] == "web-visitor-bob"
+        assert uris == []
+        assert "peer_id" not in operation.memory_fields
+        mock_generate_uri.assert_not_called()
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
-    def test_calculate_memory_uris_missing_peer_id_prefers_first_peer_even_when_self_exists(
+    def test_calculate_memory_uris_missing_peer_id_prefers_self_when_allowed(
         self, mock_generate_uri
     ):
         mock_generate_uri.side_effect = lambda **kwargs: (
@@ -559,14 +596,12 @@ class TestCalculateMemoryUris:
 
         uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
 
-        assert uris == [
-            "viking://user/support_bot/peers/web-visitor-alice/memories/preferences"
-        ]
+        assert uris == ["viking://user/support_bot/memories/preferences"]
         assert operation.memory_fields["user_id"] == "support_bot"
-        assert operation.memory_fields["peer_id"] == "web-visitor-alice"
+        assert "peer_id" not in operation.memory_fields
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
-    def test_calculate_memory_uris_missing_peer_id_falls_back_to_first_peer_when_self_absent(
+    def test_calculate_memory_uris_missing_peer_id_uses_unique_user_peer_when_self_absent(
         self, mock_generate_uri
     ):
         mock_generate_uri.side_effect = lambda **kwargs: (
@@ -577,14 +612,14 @@ class TestCalculateMemoryUris:
         messages = [
             create_message("user", "peer turn one", peer_id="web-visitor-bob"),
             create_message("assistant", "ack", peer_id="web-visitor-bob"),
-            create_message("user", "peer turn two", peer_id="web-visitor-alice"),
+            create_message("assistant", "bot ack", peer_id="assistant-bot"),
         ]
         extract_ctx = create_mock_extract_context(messages)
         handler = MemoryIsolationHandler(
             ctx,
             extract_ctx,
-            allow_self=True,
-            allowed_peer_ids={"web-visitor-alice", "web-visitor-bob"},
+            allow_self=False,
+            allowed_peer_ids={"assistant-bot", "web-visitor-bob"},
         )
 
         from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
@@ -607,6 +642,88 @@ class TestCalculateMemoryUris:
         assert operation.memory_fields["user_id"] == "support_bot"
         assert operation.memory_fields["peer_id"] == "web-visitor-bob"
 
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_calculate_memory_uris_missing_peer_id_ignores_assistant_peer_when_self_absent(
+        self, mock_generate_uri
+    ):
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/preferences"
+        )
+
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("assistant", "bot ack", peer_id="assistant-bot"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"assistant-bot"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="preferences",
+            filename_template="preferences.md",
+            directory="viking://user/{user_space}/memories",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={},
+            memory_type="preferences",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == []
+        assert operation.memory_fields["user_id"] == "support_bot"
+        assert "peer_id" not in operation.memory_fields
+        mock_generate_uri.assert_not_called()
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_calculate_memory_uris_missing_peer_id_drops_ambiguous_peer_when_self_absent(
+        self, mock_generate_uri
+    ):
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/preferences"
+        )
+
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("user", "peer turn one", peer_id="web-visitor-bob"),
+            create_message("user", "peer turn two", peer_id="web-visitor-alice"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"web-visitor-alice", "web-visitor-bob"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="preferences",
+            filename_template="preferences.md",
+            directory="viking://user/{user_space}/memories",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={},
+            memory_type="preferences",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == []
+        assert operation.memory_fields["user_id"] == "support_bot"
+        assert "peer_id" not in operation.memory_fields
+        mock_generate_uri.assert_not_called()
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
     def test_peer_enabled_false_forces_self_scope_and_strips_peer_id(self, mock_generate_uri):
@@ -727,9 +844,7 @@ class TestCalculateMemoryUris:
         assert "peer_id" not in operation.memory_fields
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
-    def test_calculate_memory_uris_invalid_peer_id_falls_back_to_first_peer(
-        self, mock_generate_uri
-    ):
+    def test_calculate_memory_uris_invalid_peer_id_does_not_fallback(self, mock_generate_uri):
         mock_generate_uri.side_effect = lambda **kwargs: (
             f"viking://user/{kwargs.get('user_space')}/memories/preferences"
         )
@@ -759,7 +874,6 @@ class TestCalculateMemoryUris:
 
         uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
 
-        assert uris == [
-            "viking://user/support_bot/peers/web-visitor-bob/memories/preferences"
-        ]
-        assert operation.memory_fields["peer_id"] == "web-visitor-bob"
+        assert uris == []
+        assert "peer_id" not in operation.memory_fields
+        mock_generate_uri.assert_not_called()

--- a/tests/session/test_memory_extraction_scope.py
+++ b/tests/session/test_memory_extraction_scope.py
@@ -40,7 +40,7 @@ def test_owner_memory_extraction_scope_uses_message_peer_ids():
     assert scope.include_session_skills is True
 
 
-def test_owner_memory_extraction_scope_ignores_assistant_peer_ids():
+def test_owner_memory_extraction_scope_includes_assistant_peer_ids():
     assistant_message = _message("assistant-bot")
     assistant_message.role = "assistant"
 
@@ -52,7 +52,7 @@ def test_owner_memory_extraction_scope_ignores_assistant_peer_ids():
     )
 
     assert scope.allow_self_memory is True
-    assert scope.allowed_peer_ids == {"alice"}
+    assert scope.allowed_peer_ids == {"alice", "assistant-bot"}
     assert scope.include_session_skills is True
 
 

--- a/tests/session/test_memory_extraction_scope.py
+++ b/tests/session/test_memory_extraction_scope.py
@@ -40,6 +40,22 @@ def test_owner_memory_extraction_scope_uses_message_peer_ids():
     assert scope.include_session_skills is True
 
 
+def test_owner_memory_extraction_scope_ignores_assistant_peer_ids():
+    assistant_message = _message("assistant-bot")
+    assistant_message.role = "assistant"
+
+    scope = _resolve_memory_extraction_scope(
+        _ctx(),
+        MemoryPolicy(peer_enabled=True),
+        [_message("alice"), assistant_message],
+        config_session_skill_extraction_enabled=True,
+    )
+
+    assert scope.allow_self_memory is True
+    assert scope.allowed_peer_ids == {"alice"}
+    assert scope.include_session_skills is True
+
+
 def test_actor_memory_extraction_scope_still_uses_policy_and_messages():
     scope = _resolve_memory_extraction_scope(
         _ctx("alice"),

--- a/tests/session/test_memory_extraction_scope.py
+++ b/tests/session/test_memory_extraction_scope.py
@@ -36,11 +36,13 @@ def test_owner_memory_extraction_scope_uses_message_peer_ids():
     )
 
     assert scope.allow_self_memory is True
+    assert scope.user_peer_ids == {"alice", "bob"}
+    assert scope.assistant_peer_ids == set()
     assert scope.allowed_peer_ids == {"alice", "bob"}
     assert scope.include_session_skills is True
 
 
-def test_owner_memory_extraction_scope_ignores_assistant_peer_ids():
+def test_owner_memory_extraction_scope_includes_assistant_peer_ids():
     assistant_message = _message("assistant-bot")
     assistant_message.role = "assistant"
 
@@ -52,7 +54,9 @@ def test_owner_memory_extraction_scope_ignores_assistant_peer_ids():
     )
 
     assert scope.allow_self_memory is True
-    assert scope.allowed_peer_ids == {"alice"}
+    assert scope.user_peer_ids == {"alice"}
+    assert scope.assistant_peer_ids == {"assistant-bot"}
+    assert scope.allowed_peer_ids == {"alice", "assistant-bot"}
     assert scope.include_session_skills is True
 
 
@@ -65,5 +69,25 @@ def test_actor_memory_extraction_scope_still_uses_policy_and_messages():
     )
 
     assert scope.allow_self_memory is True
+    assert scope.user_peer_ids == {"bob"}
+    assert scope.assistant_peer_ids == set()
     assert scope.allowed_peer_ids == {"bob"}
+    assert scope.include_session_skills is True
+
+
+def test_memory_extraction_scope_omits_peer_ids_when_policy_disables_peer_memory():
+    assistant_message = _message("assistant-bot")
+    assistant_message.role = "assistant"
+
+    scope = _resolve_memory_extraction_scope(
+        _ctx(),
+        MemoryPolicy(peer_enabled=False),
+        [_message("alice"), assistant_message],
+        config_session_skill_extraction_enabled=True,
+    )
+
+    assert scope.allow_self_memory is True
+    assert scope.user_peer_ids == set()
+    assert scope.assistant_peer_ids == set()
+    assert scope.allowed_peer_ids == set()
     assert scope.include_session_skills is True

--- a/tests/session/test_memory_extraction_scope.py
+++ b/tests/session/test_memory_extraction_scope.py
@@ -36,13 +36,11 @@ def test_owner_memory_extraction_scope_uses_message_peer_ids():
     )
 
     assert scope.allow_self_memory is True
-    assert scope.user_peer_ids == {"alice", "bob"}
-    assert scope.assistant_peer_ids == set()
     assert scope.allowed_peer_ids == {"alice", "bob"}
     assert scope.include_session_skills is True
 
 
-def test_owner_memory_extraction_scope_includes_assistant_peer_ids():
+def test_owner_memory_extraction_scope_ignores_assistant_peer_ids():
     assistant_message = _message("assistant-bot")
     assistant_message.role = "assistant"
 
@@ -54,9 +52,7 @@ def test_owner_memory_extraction_scope_includes_assistant_peer_ids():
     )
 
     assert scope.allow_self_memory is True
-    assert scope.user_peer_ids == {"alice"}
-    assert scope.assistant_peer_ids == {"assistant-bot"}
-    assert scope.allowed_peer_ids == {"alice", "assistant-bot"}
+    assert scope.allowed_peer_ids == {"alice"}
     assert scope.include_session_skills is True
 
 
@@ -69,25 +65,5 @@ def test_actor_memory_extraction_scope_still_uses_policy_and_messages():
     )
 
     assert scope.allow_self_memory is True
-    assert scope.user_peer_ids == {"bob"}
-    assert scope.assistant_peer_ids == set()
     assert scope.allowed_peer_ids == {"bob"}
-    assert scope.include_session_skills is True
-
-
-def test_memory_extraction_scope_omits_peer_ids_when_policy_disables_peer_memory():
-    assistant_message = _message("assistant-bot")
-    assistant_message.role = "assistant"
-
-    scope = _resolve_memory_extraction_scope(
-        _ctx(),
-        MemoryPolicy(peer_enabled=False),
-        [_message("alice"), assistant_message],
-        config_session_skill_extraction_enabled=True,
-    )
-
-    assert scope.allow_self_memory is True
-    assert scope.user_peer_ids == set()
-    assert scope.assistant_peer_ids == set()
-    assert scope.allowed_peer_ids == set()
     assert scope.include_session_skills is True


### PR DESCRIPTION
## Description

修复兼容逻辑加入assistent消息的peerid后，user记忆会归入peer目录的问题。

现在 peer/self 归属逻辑变成：

 ### 1. LLM 显式输出 peer_id

  如果 memory operation 里显式有：

  peer_id=<peer_id>

  且该 peer_id 在 allowed_peer_ids 中，则允许写 peer memory：

  viking://user/<user_id>/peers/<peer_id>/...

  这里 user peer 和 assistant peer 都可以。

  ### 2. LLM 未输出 peer_id

  如果没有 peer_id：

  - allow_self=True：优先写 self

    viking://user/<user_id>/...

  - allow_self=False：才尝试 fallback 到 peer
    但 fallback 只从 role == "user" 的消息里找 peer：
      - 唯一 user peer：写该 peer
      - 多个 / 没有：不写

  ### 3. ranges 类 memory

  带 ranges 的 memory 根据 range 覆盖消息推导 target：

  - role == "user" 且 peer_id 在 allowed_peer_ids：写对应 peer
  - 无 peer_id 且 allow_self=True：写 self
  - assistant 消息上的 peer_id 不会因为 ranges 自动成为 target



## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
