### PR TITLE
fix: reject file URI for consistency check

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -36,7 +36,7 @@ from openviking.utils.agfs_utils import (
 )
 from openviking.utils.resource_processor import ResourceProcessor
 from openviking.utils.skill_processor import SkillProcessor
-from openviking_cli.exceptions import NotInitializedError
+from openviking_cli.exceptions import InvalidArgumentError, NotInitializedError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import OPENVIKING_ENABLE_RECORDER_ENV, get_openviking_config
@@ -513,6 +513,9 @@ class OpenVikingService:
             raise NotInitializedError("VikingFS")
 
         effective_ctx = ctx or RequestContext(user=self.user, role=Role.ROOT)
+        stat = await self._viking_fs.stat(uri, ctx=effective_ctx, skip_count=True)
+        if not stat.get("isDir", False):
+            raise InvalidArgumentError("Consistency check only supports directory URIs.")
         entries = await self._viking_fs.tree(
             uri,
             show_all_hidden=True,

--- a/tests/unit/service/test_core_consistency.py
+++ b/tests/unit/service/test_core_consistency.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for system consistency URI validation."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.service.core import OpenVikingService
+from openviking.storage.index_consistency import IndexConsistencyReport
+from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _service_with_fs(stat_result: dict) -> tuple[OpenVikingService, AsyncMock]:
+    service = OpenVikingService.__new__(OpenVikingService)
+    service._initialized = True
+    service._user = UserIdentifier.the_default_user()
+    service._vikingdb_manager = AsyncMock()
+    service._viking_fs = AsyncMock()
+    service._viking_fs.stat.return_value = stat_result
+    return service, service._viking_fs
+
+
+@pytest.mark.asyncio
+async def test_check_consistency_rejects_file_uri() -> None:
+    service, viking_fs = _service_with_fs({"isDir": False})
+    ctx = RequestContext(user=service.user, role=Role.ROOT)
+
+    with pytest.raises(
+        InvalidArgumentError,
+        match="Consistency check only supports directory URIs",
+    ):
+        await service.check_consistency(
+            uri="viking://resources/consistency-file.md",
+            ctx=ctx,
+        )
+
+    viking_fs.tree.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_consistency_preserves_directory_behavior() -> None:
+    service, viking_fs = _service_with_fs({"isDir": True})
+    viking_fs.tree.return_value = []
+    ctx = RequestContext(user=service.user, role=Role.ROOT)
+    report = IndexConsistencyReport(expected=(), missing_records=())
+
+    with patch(
+        "openviking.service.core.check_index_consistency",
+        new=AsyncMock(return_value=report),
+    ) as check:
+        result = await service.check_consistency(uri="viking://resources", ctx=ctx)
+
+    assert result == report.to_dict()
+    viking_fs.stat.assert_awaited_once_with(
+        "viking://resources",
+        ctx=ctx,
+        skip_count=True,
+    )
+    viking_fs.tree.assert_awaited_once()
+    check.assert_awaited_once()


### PR DESCRIPTION
## 动机

修复 #3086。

`POST /api/v1/system/consistency` 当前会把任意 URI 交给只接受目录的 `VikingFS.tree`。当 URI 指向文件时，storage layer 抛出 `AGFSPluginError: not a directory`，最终被错误映射为 HTTP 503。

## 改动思路

在目录遍历前先读取 URI metadata：文件 URI 走已有 `InvalidArgumentError` 合同并返回 HTTP 400 / `INVALID_ARGUMENT`；目录 URI 继续执行原来的 consistency traversal 和 report 路径。

## 关键调用链 / 伪代码

```text
stat = VikingFS.stat(uri, skip_count=True)
if stat is not directory:
    raise InvalidArgumentError
return VikingFS.tree(uri) -> existing consistency report
```

## 具体改动

- 在 traversal 前调用 `VikingFS.stat(..., skip_count=True)`；
- 对非目录 URI 返回既有 public invalid-argument error contract；
- 保持目录遍历、consistency algorithm 与 report schema 不变；
- 增加文件 URI 回归和目录 control case。

## 修复后复现

向 consistency endpoint 传入文件 URI。修复前该 URI 会进入目录 traversal 并得到 HTTP 503；修复后会稳定返回 HTTP 400。目录 URI 仍生成原有 report。

## 验证

- `pytest tests/unit/service/test_core_consistency.py`：2 passed；
- `pytest tests/server/test_error_mapping.py tests/unit/service/test_core_consistency.py`：17 passed；
- 改动文件 `ruff check`：passed；
- 改动文件 `ruff format --check`：passed。

## 对主干的风险与未覆盖

每次 consistency 请求会增加一次 metadata read；`skip_count=True` 避免不必要的 vector-index count。report schema、permission context 与 consistency algorithm 均不改变。本地 native engine binding 早于当前 `PersistStore` API，因此没有运行完整 HTTP integration；service regression 与 server error-mapping suite 分别覆盖了改动行为和 HTTP 合同。

Fixes #3086
