### PR TITLE
fix(recall): restore L2 document-level hits in global search

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -199,7 +199,7 @@ class HierarchicalRetriever:
                     context_type=context_type,
                     target_directories=target_dirs,
                     extra_filter=scope_dsl,
-                    level=[0, 1],
+                    level=[0, 1, 2] if level is None else [0, 1],
                     limit=max(limit, self.GLOBAL_SEARCH_TOPK),
                 )
             telemetry.count("vector.searches", 1)
@@ -251,6 +251,15 @@ class HierarchicalRetriever:
             if level is not None:
                 for result, score in zip(global_results, directory_scores, strict=True):
                     if result.get("level", 2) not in level:
+                        continue
+                    candidate = dict(result)
+                    candidate["_score"] = score
+                    initial_candidates.append(candidate)
+            else:
+                # When no explicit level filter, include document-level (L2) hits
+                # from the global search as initial candidates (matching 0.4.5 behavior).
+                for result, score in zip(global_results, directory_scores, strict=True):
+                    if result.get("level", 2) != 2:
                         continue
                     candidate = dict(result)
                     candidate["_score"] = score


### PR DESCRIPTION
## Summary

Fixes #3134: After the 0.4.6 hierarchical search refactor, the `find` endpoint returns 90% fewer results because L2 (document-level) hits are excluded from global search.

## Root Cause

Two changes in `openviking/retrieve/hierarchical_retriever.py` that collectively drop L2 documents:

1. **Global search scope narrowed** (line 202): `level=[0, 1]` searches only directory levels. When `level=None` (default, meaning "all levels"), L2 documents should be included.

2. **initial_candidates empty when level=None** (line 255): The `if level is not None:` guard means that when `level=None` (default), `initial_candidates` is empty — L2 documents from global search never enter the rerank pipeline.

## Changes

Two-line fix in `openviking/retrieve/hierarchical_retriever.py`:

1. `level=[0, 1]` → `level=[0, 1, 2] if level is None else [0, 1]` — restore full-level search when no explicit level filter
2. Add `else` branch to collect L2 documents as `initial_candidates` when `level=None`

## Verification

| Metric | Before | After |
|--------|--------|-------|
| find() results (same query) | 3 | 30 |
| Top score | 0.00004 | 0.997 |
| Auto-recall injection rate | 22% | 100% |
| Memories injected/turn | 0-1 | 3-5 |

Tested on: openviking 0.4.8, Python 3.12.3, Ubuntu 24.04, Qdrant 1.13, 983 memory points