### PR TITLE
fix(session): extract real abstract instead of markdown heading from structured summaries

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2171,7 +2171,17 @@ class Session:
         if match:
             return match.group(1).strip()
 
-        first_line = summary.split("\n")[0].strip()
+        # Skip markdown headings, separators, and blank lines;
+        # return the first meaningful content line.
+        for line in summary.split("\n"):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith("---"):
+                continue
+            if len(stripped) > 3:
+                return stripped[:200]
+
+        # Fallback: strip heading markers from the first line
+        first_line = summary.split("\n")[0].strip().lstrip("#").strip()
         return first_line if first_line else ""
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes `_extract_abstract_from_summary()` in `openviking/session/session.py` — it was returning the markdown heading (`# Working Memory`) as the abstract for every single archive, instead of extracting the real first-content line.

## Root Cause

When no `**Key**: value` pattern matched, the fallback was:

```python
first_line = summary.split("\n")[0].strip()
```

For structured markdown overviews (`# Working Memory\n\n## Session Title\n...`), the first line is always the heading — not a meaningful abstract. This caused all 97 archives in a production v0.4.8 instance to have `.abstract.md` = `# Working Memory` (16B, identical), making the abstracts useless for vector search and semantic tree building.

## Fix

Skip markdown headings (`#`), horizontal rules (`---`), and blank lines. Take the first real paragraph line (>3 chars) as the abstract.

**Change**: 1 file, +11 −1 lines

## Closes

Closes #3136

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Structured overview with `# Working Memory` heading | `# Working Memory` | Actual session title |
| `**Key**: value` format | unchanged | unchanged |
| Empty summary | `""` | `""` (no regression) |
| First line is heading, real content on L3 | heading copy | real content |