### PR TITLE
fix(session): extract meaningful archive abstract instead of markdown heading (#3136)

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2163,7 +2163,20 @@ class Session:
         return len([line for line in content.strip().split("\n") if line.strip()])
 
     def _extract_abstract_from_summary(self, summary: str) -> str:
-        """Extract one-sentence overview from structured summary."""
+        """Extract a one-sentence abstract from a structured summary.
+
+        Prefer an explicit ``**Key**: value`` overview line (the legacy /
+        ``structured_summary`` format). Otherwise return the first meaningful
+        content line, skipping markdown headings (``#``), horizontal rules
+        (``---``), blank lines, and italic-only section descriptions
+        (``_..._``) that are template placeholders rather than real content.
+
+        Working Memory documents (``compression.ov_wm_v2``) open with a
+        ``# Working Memory`` heading and contain no ``**Key**: value`` line, so
+        the previous "first line" fallback collapsed every archive abstract to
+        the identical ``# Working Memory`` heading, polluting recall and the
+        directory-level semantic abstract tree.
+        """
         if not summary:
             return ""
 
@@ -2171,8 +2184,17 @@ class Session:
         if match:
             return match.group(1).strip()
 
-        first_line = summary.split("\n")[0].strip()
-        return first_line if first_line else ""
+        for line in summary.split("\n"):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith("---"):
+                continue
+            if stripped.startswith("_") and stripped.endswith("_"):
+                continue
+            if len(stripped) > 3:
+                return stripped[:200]
+
+        # Fallback: strip leading heading markers from the first line.
+        return summary.split("\n")[0].strip().lstrip("#").strip()
 
     @staticmethod
     def _format_message_for_wm(m: Message) -> str:

--- a/tests/session/test_session_archive_abstract.py
+++ b/tests/session/test_session_archive_abstract.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Unit tests for _extract_abstract_from_summary.
+
+These call the method directly without a runtime Session to avoid importing
+the full client / config / storage fixture chain.
+"""
+
+import pytest
+
+from openviking.session import Session
+
+
+@pytest.fixture(autouse=True)
+def _drain_background_tasks():
+    """Override the conftest autouse fixture that depends on client."""
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+WM_V2_EXAMPLE = """# Working Memory
+
+## Session Title
+OV archive count verification + post-reset pending token investigation
+
+## Current State
+Still investigating why the pending token counters reset after a deployment restart.
+No root cause identified yet. Next step: check observer metrics dump.
+
+## Task & Goals
+Investigate the archive count mismatch between OV internal counters and the FUSE mount.
+Verify whether post-reset pending tokens are a regression or expected behavior.
+
+## Key Facts & Decisions
+- Archive count from ov status: 97, FUSE mount: 71 (26 missing)
+- The difference is reproducible across multiple restarts.
+- Hypothesis: some archives are never indexed or the index is stale.
+
+## Files & Context
+- /home/ov/data/archives – inspected
+- /var/log/openviking/server.log – reviewed for indexer errors
+
+## Errors & Corrections
+- Initial assumption: FUSE mount lag. Corrected: mount is fresh but still 26 archives short.
+
+## Open Issues
+- Why are 26 archives missing from FUSE?
+- Is the pending token reset a bug or an expected cleanup?
+"""
+
+LEGACY_STRUCTURED_SUMMARY = """# Session Summary
+
+**One-sentence overview**: The user investigated search recall quality and discovered a 90% result drop with sparse dense models.
+
+## Historical Context Carried Forward
+- None
+"""
+
+NO_VLM_FALLBACK = """# Session Summary
+
+**Overview**: 5 turns, 12 messages"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_wm_v2_extracts_session_title():
+    """The WM v2 format starts with ``# Working Memory`` then
+    ``## Session Title`` then the actual title.  The old code returned
+    ``# Working Memory`` as the abstract for **every** archive."""
+    abstract = Session._extract_abstract_from_summary(None, WM_V2_EXAMPLE)
+    assert abstract == "OV archive count verification + post-reset pending token investigation"
+
+
+def test_legacy_structured_summary_still_works():
+    """Regression guard: the regex path for ``**Key**: value`` summaries
+    must not be changed."""
+    abstract = Session._extract_abstract_from_summary(None, LEGACY_STRUCTURED_SUMMARY)
+    assert "search recall" in abstract
+
+
+def test_no_vlm_fallback_extracts_overview_value():
+    """When the VLM is unavailable the code generates a simple
+    ``**Overview**: N turns, M messages`` summary.  The regex path
+    should extract the value after the colon."""
+    abstract = Session._extract_abstract_from_summary(None, NO_VLM_FALLBACK)
+    assert "5 turns" in abstract
+
+
+def test_empty_summary_returns_empty_string():
+    assert Session._extract_abstract_from_summary(None, "") == ""
+
+
+def test_whitespace_only_returns_empty():
+    assert Session._extract_abstract_from_summary(None, "   \n\t\n  ") == ""
+
+
+def test_only_headings_returns_stripped_heading():
+    """If every line is a heading, the fallback strips '#' from the first
+    line.  This is a degenerate case — it should return *something*."""
+    abstract = Session._extract_abstract_from_summary(None, "# Just a heading")
+    assert abstract == "Just a heading"
+
+
+def test_template_placeholder_line_skipped():
+    """The ov_wm_v2 template wraps section descriptions in ``_..._``.
+    If the model leaves them unchanged, they should be skipped."""
+    abstract = Session._extract_abstract_from_summary(
+        None,
+        "# Working Memory\n"
+        "_A short and distinctive 5-10 word descriptive title._\n"
+        "Real session title goes here\n"
+        "## Current State\n",
+    )
+    assert abstract == "Real session title goes here"


### PR DESCRIPTION
## Summary

Fixes #3136.

`Session._extract_abstract_from_summary()` is used to build each archive's `.abstract.md` (written in `_generate_archive_summary_async` and read back in `_read_archive_abstract` for `recall`). When a summary has no legacy `**Key**: value` line, the old fallback returned `summary.split("\n")[0]` — the **first line**.

Working Memory documents produced by `compression.ov_wm_v2` open with:

```markdown
# Working Memory

## Session Title
<real title>
...
```

There is no `**Key**: value` line, so every archive's abstract collapsed to the identical `# Working Memory` heading. As reported (production v0.4.8, ~240K messages / 97 archives), 97/97 `.abstract.md` were either empty or the 16-byte string `# Working Memory`. Since these abstracts are indexed for vector search and aggregated into the directory-level semantic abstract tree, this is pure noise for recall.

## Fix

In the fallback path, walk the document and return the first **meaningful** content line, skipping:
- markdown headings (`#`)
- horizontal rules (`---`)
- blank lines
- italic-only section descriptions (`_..._`) — these are the template's placeholder descriptions in `ov_wm_v2.yaml`, skipped in case a model echoes them verbatim

The result is capped at 200 chars. The `**Key**: value` regex path (used by the `structured_summary` template and the no-VLM `**Overview**: N turns` fallback) is returned before the loop and is **unchanged**.

For the WM v2 example above, the abstract now becomes the actual `## Session Title` content instead of `# Working Memory`.

## Tests

Added `tests/session/test_session_archive_abstract.py` with regression coverage:
- WM v2 format → returns the Session Title
- legacy `**One-sentence overview**: ...` (structured_summary) → unchanged
- no-VLM `**Overview**: N turns, M messages` fallback → value after colon
- empty / whitespace-only input → `""`
- headings-only degenerate input → stripped heading
- italic template-placeholder line → skipped

The method uses no instance state, so the tests call it directly (`Session._extract_abstract_from_summary(None, ...)`) and override the `_drain_background_tasks` autouse fixture, matching the existing pure-unit-test pattern in `tests/session/test_tool_result_synopsis.py` (no `client`/config/storage fixtures required).

## Verification

- Confirmed the buggy fallback against the current `main` source (`openviking/session/session.py:2165`).
- Confirmed the two summary formats against the actual prompt templates: `compression/structured_summary.yaml` (has `**One-sentence overview**:`, hits the regex path) and `compression/ov_wm_v2.yaml` (opens with `# Working Memory` / `## Session Title`, hits the fallback).