### PR TITLE
fix(task): reconcile interrupted tasks after restart

### DIFF
--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -152,6 +152,7 @@ class TaskTracker:
 
     def __init__(self, store: TaskStore) -> None:
         self._store = store
+        self._started_at = time.time()
         self._tasks: Dict[str, TaskRecord] = {}
         self._lock = threading.Lock()
         self._async_lock = asyncio.Lock()
@@ -494,15 +495,29 @@ class TaskTracker:
         payload = await self._store.get(task_id, account_id=account_id, user_id=user_id)
         if payload is None:
             return None
-        return self._record_from_payload(payload)
+        return await self._reconcile_loaded_task(self._record_from_payload(payload))
 
     async def _load_all_from_store(
         self, account_id: str, user_id: Optional[str]
     ) -> List[TaskRecord]:
-        return [
-            self._record_from_payload(payload)
-            for payload in await self._store.list(account_id, user_id=user_id)
-        ]
+        tasks = []
+        for payload in await self._store.list(account_id, user_id=user_id):
+            tasks.append(await self._reconcile_loaded_task(self._record_from_payload(payload)))
+        return tasks
+
+    async def _reconcile_loaded_task(self, task: TaskRecord) -> TaskRecord:
+        # ponytail: Reconcile lazily until TaskStore supports owner enumeration for a startup scan.
+        if (
+            task.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
+            and task.updated_at < self._started_at
+        ):
+            task.status = TaskStatus.FAILED
+            task.stage = "failed"
+            task.error = "Task interrupted by server restart"
+            task.updated_at = time.time()
+            await self._store.update(task)
+            logger.warning("[TaskTracker] Reconciled interrupted task %s", task.task_id)
+        return task
 
     @staticmethod
     def _copy(task: TaskRecord) -> TaskRecord:

--- a/openviking/storage/transaction/lock_manager.py
+++ b/openviking/storage/transaction/lock_manager.py
@@ -449,10 +449,52 @@ class LockManager:
             try:
                 info = await self._redo_log.read_async(task_id)
                 if info:
-                    await self._redo_session_memory(info)
+                    try:
+                        await self._redo_session_memory(info)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        await self._write_redo_terminal_marker(
+                            info,
+                            "Redo recovery failed after server restart",
+                        )
+                        raise
+                    await self._write_redo_terminal_marker(
+                        info,
+                        "Task interrupted by server restart; redo recovery completed",
+                    )
                 await self._redo_log.mark_done_async(task_id)
             except Exception as e:
                 logger.error(f"Redo recovery failed for {task_id}: {e}", exc_info=True)
+
+    async def _write_redo_terminal_marker(self, info: Dict[str, Any], error: str) -> None:
+        """Mark an interrupted archive terminal so later commits cannot wait forever."""
+        from openviking.server.identity import RequestContext, Role
+        from openviking.storage.viking_fs import get_viking_fs
+        from openviking_cli.session.user_id import UserIdentifier
+
+        archive_uri = info.get("archive_uri")
+        if not archive_uri:
+            return
+        account_id = info.get("account_id", "default")
+        user_id = info.get("user_id", "default")
+        ctx = RequestContext(
+            user=UserIdentifier(account_id=account_id, user_id=user_id),
+            role=Role(info.get("role", "root")),
+        )
+        await get_viking_fs().write_file(
+            uri=f"{archive_uri}/.failed.json",
+            content=json.dumps(
+                {
+                    "stage": "redo_recovery",
+                    "error": error,
+                    "failed_at": int(time.time()),
+                    "skipped": True,
+                },
+                ensure_ascii=False,
+            ),
+            ctx=ctx,
+        )
 
     async def _redo_session_memory(self, info: Dict[str, Any]) -> None:
         """Re-extract memories from archive.

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -477,7 +477,7 @@ async def test_persistent_store_keeps_tasktracker_tasks_dict():
     assert task.task_id in tracker._tasks
 
 
-async def test_persistent_store_survives_tracker_reset():
+async def test_persistent_store_fails_active_task_after_tracker_reset():
     agfs = _FakeAgfs()
     tracker1 = TaskTracker(store=PersistentTaskStore(agfs))
     task = await tracker1.create("session_commit", resource_id="sess-123", **_owner_kwargs())
@@ -487,7 +487,13 @@ async def test_persistent_store_survives_tracker_reset():
     loaded = await tracker2.get(task.task_id, account_id="acme", user_id="alice")
 
     assert loaded is not None
-    assert loaded.status == TaskStatus.RUNNING
+    assert loaded.status == TaskStatus.FAILED
+    assert loaded.stage == "failed"
+    assert loaded.error == "Task interrupted by server restart"
+    persisted = json.loads(
+        agfs.files[f"/local/acme/_system/tasks/alice/{task.task_id}.json"].decode("utf-8")
+    )
+    assert persisted["status"] == "failed"
 
 
 async def test_persistent_store_ignores_existing_task_dirs():

--- a/tests/transaction/test_lock_manager.py
+++ b/tests/transaction/test_lock_manager.py
@@ -3,6 +3,7 @@
 """Tests for LockManager."""
 
 import asyncio
+import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
@@ -113,6 +114,31 @@ class TestLockManagerBasic:
             await lm._recover_pending_redo()
 
         lm._redo_log.mark_done_async.assert_not_awaited()
+
+    async def test_recover_pending_redo_writes_terminal_archive_marker(self, lm, monkeypatch):
+        info = {
+            "archive_uri": "viking://user/alice/sessions/demo/history/archive_001",
+            "session_uri": "viking://user/alice/sessions/demo",
+            "account_id": "acme",
+            "user_id": "alice",
+            "role": "admin",
+        }
+        lm._redo_log = MagicMock()
+        lm._redo_log.list_pending_async = AsyncMock(return_value=["redo-task"])
+        lm._redo_log.read_async = AsyncMock(return_value=info)
+        lm._redo_log.mark_done_async = AsyncMock()
+        lm._redo_session_memory = AsyncMock()
+        viking_fs = MagicMock()
+        viking_fs.write_file = AsyncMock()
+        monkeypatch.setattr("openviking.storage.viking_fs.get_viking_fs", lambda: viking_fs)
+
+        await lm._recover_pending_redo()
+
+        viking_fs.write_file.assert_awaited_once()
+        marker = viking_fs.write_file.await_args.kwargs
+        assert marker["uri"] == f"{info['archive_uri']}/.failed.json"
+        assert json.loads(marker["content"])["stage"] == "redo_recovery"
+        lm._redo_log.mark_done_async.assert_awaited_once_with("redo-task")
 
     async def test_start_skips_redo_recovery_when_disabled(self, client):
         lm_disabled = LockManager(


### PR DESCRIPTION
## Description

Background tasks interrupted by a server restart can remain in `pending` or `running` forever. Session redo recovery can also leave an archive without a terminal marker, causing later commits to wait indefinitely.

This change reconciles stale persisted tasks and ensures redo recovery leaves interrupted archives in an explicit terminal state.

## Related Issue

Fixes #3023

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Reconcile persisted `pending` and `running` tasks created before the current process as failed when they are loaded.
- Persist a terminal `.failed.json` marker after redo recovery so subsequent session archives can continue.
- Add regression coverage for task reconciliation, persisted state, archive markers, and cancellation behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Validation command:

```bash
python -m pytest -o addopts='' tests/test_task_tracker.py \
  tests/transaction/test_lock_manager.py::TestLockManagerBasic::test_recover_pending_redo_preserves_cancelled_error \
  tests/transaction/test_lock_manager.py::TestLockManagerBasic::test_recover_pending_redo_writes_terminal_archive_marker -q
```

Result: 44 passed.

A container restart test also confirmed that the interrupted task transitions to `failed`, the terminal archive marker is created, and the next commit completes successfully.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No documentation or dependent package changes are required for this fix.
