### PR TITLE
fix: show configured VLM in status without usage

### DIFF
--- a/openviking/storage/observers/models_observer.py
+++ b/openviking/storage/observers/models_observer.py
@@ -61,12 +61,15 @@ class ModelsObserver(BaseObserver):
 
         # VLM section
         if self._vlm_instance:
+            vlm_data = None
             try:
                 vlm_data = self._get_vlm_usage()
-                if vlm_data:
-                    sections.append(("VLM", vlm_data))
             except Exception as e:
                 logger.warning(f"Error getting VLM usage: {e}")
+            if not vlm_data:
+                vlm_data = self._get_configured_vlm()
+            if vlm_data:
+                sections.append(("VLM", vlm_data))
 
         # Embedding section
         if self._embedding_instance:
@@ -124,6 +127,20 @@ class ModelsObserver(BaseObserver):
                 )
 
         return data
+
+    def _get_configured_vlm(self) -> Optional[list]:
+        """Return configured VLM identity when usage data is unavailable."""
+        model = getattr(self._vlm_instance, "model", None)
+        if not model:
+            return None
+
+        return [
+            {
+                "Model": model,
+                "Provider": getattr(self._vlm_instance, "provider", None) or "unknown",
+                "Status": "configured",
+            }
+        ]
 
     def _get_embedding_usage(self) -> Optional[list]:
         """Get Embedding token usage data."""

--- a/tests/misc/test_models_observer.py
+++ b/tests/misc/test_models_observer.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Focused tests for model status observability."""
+
+from openviking.storage.observers.models_observer import ModelsObserver
+
+
+class _ConfiguredVLM:
+    model = "astron-code-latest"
+    provider = "litellm"
+
+    def get_token_usage(self):
+        return {"usage_by_model": {}}
+
+
+class _ConfiguredVLMWithUnavailableUsage(_ConfiguredVLM):
+    def get_token_usage(self):
+        raise RuntimeError("usage backend unavailable")
+
+
+def test_configured_vlm_is_visible_before_usage_is_recorded():
+    status = ModelsObserver(vlm_instance=_ConfiguredVLM()).get_status_table()
+
+    assert "VLM Models:" in status
+    assert "astron-code-latest" in status
+    assert "litellm" in status
+    assert "configured" in status
+
+
+def test_configured_vlm_is_visible_when_usage_lookup_fails():
+    status = ModelsObserver(vlm_instance=_ConfiguredVLMWithUnavailableUsage()).get_status_table()
+
+    assert "VLM Models:" in status
+    assert "astron-code-latest" in status


### PR DESCRIPTION
## 为什么要修

`ov status` 会从服务端的 `VLM Models` 观测表读取模型名。当 token usage 为空或暂时查询失败时，整段 VLM 信息会被省略，导致已经正确配置、也能正常使用的 VLM 被显示成 `unknown`，容易让用户误判配置失效。

修复 #3124。

## 做了什么

- usage 数据可用时，继续展示原有的详细统计。
- usage 为空或查询失败时，回退展示配置中的公开 model/provider，并标记为 `configured`。
- 不暴露凭据、请求内容，也不改变模型调用和 token 统计逻辑。
- 增加两个回归用例，分别覆盖空 usage 和 usage 查询异常。

## 验证

- `pytest --no-cov -q tests/misc/test_models_observer.py`：2 passed
- `cargo test -p ov_cli status_ui::tests`：5 passed
- 变更文件的 `ruff check`、`ruff format --check`：passed
- PR CI：相关检查全部通过

## 风险与未覆盖

改动仅影响状态展示，不影响模型调用或计费统计。未运行全量测试；扩展到 `tests/misc/test_debug_service.py` 时发现 5 个既有 mock 与当前 `embedding` 配置不兼容的失败，与本补丁无关。
