### PR TITLE
fix: batch child directory overview summaries

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1351,13 +1351,15 @@ class SemanticProcessor(DequeueHandlerBase):
         # Budget guard: check if prompt would be oversized
         estimated_size = len(file_summaries_str) + len(children_abstracts_str)
         over_budget = estimated_size > semantic.max_overview_prompt_chars
-        many_files = len(file_summaries) > semantic.overview_batch_size
+        entry_count = len(file_summaries) + len(children_abstracts)
+        many_entries = entry_count > semantic.overview_batch_size
 
-        if over_budget and many_files:
-            # Many files, oversized prompt → batch and merge
+        if over_budget and many_entries:
+            # Many entries, oversized prompt → batch and merge
             logger.info(
                 f"Overview prompt for {dir_uri} exceeds budget "
-                f"({estimated_size} chars, {len(file_summaries)} files). "
+                f"({estimated_size} chars, {len(file_summaries)} files, "
+                f"{len(children_abstracts)} subdirectories). "
                 f"Splitting into batches of {semantic.overview_batch_size}."
             )
             overview = await self._batched_generate_overview(
@@ -1447,10 +1449,10 @@ class SemanticProcessor(DequeueHandlerBase):
         llm_sem: Optional[asyncio.Semaphore] = None,
         output_language: str = "en",
     ) -> str:
-        """Generate overview by batching file summaries and merging.
+        """Generate overview by batching file and subdirectory summaries.
 
-        Splits file summaries into batches, generates a partial overview per
-        batch, then merges all partials into a final overview.
+        Splits both input kinds into batches, generates a partial overview per
+        batch, then merges the partials without repeating the raw inputs.
         """
         config = get_openviking_config()
         vlm = config.vlm
@@ -1458,46 +1460,36 @@ class SemanticProcessor(DequeueHandlerBase):
         batch_size = semantic.overview_batch_size
         dir_name = dir_uri.split("/")[-1]
 
-        # Split file summaries into batches
-        batches = [
-            file_summaries[i : i + batch_size] for i in range(0, len(file_summaries), batch_size)
+        work_items = [("file", index, item) for index, item in enumerate(file_summaries, 1)] + [
+            ("child", None, item) for item in children_abstracts
         ]
+        batches = [work_items[i : i + batch_size] for i in range(0, len(work_items), batch_size)]
         logger.info(f"Generating overview for {dir_uri} in {len(batches)} batches")
 
-        # Build children abstracts string (used in first batch + merge)
-        children_abstracts_str = (
-            "\n".join(f"- {item['name']}/: {item['abstract']}" for item in children_abstracts)
-            if children_abstracts
-            else "None"
-        )
-
-        # Generate partial overview per batch concurrently using global file indices
+        # Generate partial overviews concurrently using global file indices.
         if llm_sem is None:
             llm_sem = asyncio.Semaphore(self.max_concurrent_llm)
         partial_overviews = [None] * len(batches)
-        global_offset = 0
         batch_prompts: List[Tuple[int, str, Dict[int, str]]] = []
 
         for batch_idx, batch in enumerate(batches):
-            # Build per-batch index map using global offsets
             batch_lines = []
+            child_lines = []
             batch_index_map = {}
-            for local_idx, item in enumerate(batch):
-                global_idx = global_offset + local_idx + 1
-                batch_index_map[global_idx] = item["name"]
-                batch_lines.append(f"[{global_idx}] {item['name']}: {item['summary']}")
-            batch_str = "\n".join(batch_lines)
-            global_offset += len(batch)
-
-            # Include children abstracts in the first batch
-            children_str = children_abstracts_str if batch_idx == 0 else "None"
+            for entry_kind, global_idx, item in batch:
+                if entry_kind == "file":
+                    assert global_idx is not None
+                    batch_index_map[global_idx] = item["name"]
+                    batch_lines.append(f"[{global_idx}] {item['name']}: {item['summary']}")
+                else:
+                    child_lines.append(f"- {item['name']}/: {item['abstract']}")
 
             prompt = render_prompt(
                 "semantic.overview_generation",
                 {
                     "dir_name": dir_name,
-                    "file_summaries": batch_str,
-                    "children_abstracts": children_str,
+                    "file_summaries": "\n".join(batch_lines) or "None",
+                    "children_abstracts": "\n".join(child_lines) or "None",
                     "output_language": output_language,
                 },
             )
@@ -1526,7 +1518,7 @@ class SemanticProcessor(DequeueHandlerBase):
         if len(partial_overviews) == 1:
             return partial_overviews[0]
 
-        # Merge partials into a final overview (include children for context)
+        # Merge partials only; each child abstract is already represented once.
         combined = "\n\n---\n\n".join(partial_overviews)
         try:
             prompt = render_prompt(
@@ -1534,7 +1526,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 {
                     "dir_name": dir_name,
                     "file_summaries": combined,
-                    "children_abstracts": children_abstracts_str,
+                    "children_abstracts": "None",
                     "output_language": output_language,
                 },
             )

--- a/tests/storage/test_semantic_processor_overview_batching.py
+++ b/tests/storage/test_semantic_processor_overview_batching.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.storage.queuefs import semantic_processor as semantic_processor_module
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+
+class RecordingVLM:
+    def __init__(self):
+        self.prompts = []
+
+    def is_available(self):
+        return True
+
+    async def get_completion_async(self, prompt):
+        self.prompts.append(prompt)
+        return f"overview-{len(self.prompts)}"
+
+
+@pytest.mark.asyncio
+async def test_children_only_oversized_overview_is_batched(monkeypatch):
+    vlm = RecordingVLM()
+    config = SimpleNamespace(
+        vlm=vlm,
+        semantic=SimpleNamespace(
+            max_overview_prompt_chars=20,
+            overview_batch_size=2,
+        ),
+        output_language_override="en",
+    )
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "render_prompt",
+        lambda _name, values: (
+            f"files={values['file_summaries']}|children={values['children_abstracts']}"
+        ),
+    )
+    children = [{"name": f"child-{index}", "abstract": "x" * 20} for index in range(3)]
+
+    overview = await SemanticProcessor()._generate_overview(
+        "viking://resources/root",
+        file_summaries=[],
+        children_abstracts=children,
+    )
+
+    assert overview == "overview-3"
+    assert len(vlm.prompts) == 3
+    assert "child-0" in vlm.prompts[0]
+    assert "child-1" in vlm.prompts[0]
+    assert "child-2" not in vlm.prompts[0]
+    assert "child-2" in vlm.prompts[1]
+    assert all(f"child-{index}" not in vlm.prompts[2] for index in range(3))


### PR DESCRIPTION
## 动机

修复 #3153。

目录 overview 的提示词大小已经把直属文件摘要和子目录摘要都算进去，但原来的批处理门槛只统计直属文件数量。这样一来，包含大量子目录、却没有多少直属文件的目录（issue 中实际有 183 个子目录）即使远超提示词预算，仍会走单次 VLM 请求，最终容易超时并丢失目录摘要。

## 改动思路

把“是否需要批处理”和“如何切分批次”统一到同一套 entry 语义：直属文件摘要与子目录摘要都会占用提示词预算，也都应参与批次计数和切分。

## 具体改动

- 使用直属文件数与子目录数之和判断是否进入超预算批处理。
- 把两类输入合并为有类型的 work items，再按 `overview_batch_size` 分批。
- 保留文件的全局索引映射，避免批次切分改变引用关系。
- 最终合并时只传入各批次生成的 partial overview，不再重复拼接原始子目录摘要。

## 验证

- 修复前复现：仅包含子目录且超过预算时，代码仍只发起一次 VLM 请求。
- 新增 `test_children_only_oversized_overview_is_batched`，覆盖纯子目录输入的分批、合并以及原始摘要不重复进入最终 prompt。
- `uv run --extra dev ruff check openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_processor_overview_batching.py`
- `uv run --extra dev ruff format --check openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_processor_overview_batching.py`
- `uv run --extra dev --extra test pytest -o addopts='' --tb=short -q tests/storage/test_semantic_processor_overview_batching.py tests/storage/test_semantic_processor_l0_l1.py tests/storage/test_semantic_processor_identity.py tests/storage/test_semantic_processor_lock_ownership.py tests/storage/test_semantic_processor_target_preexisting.py` — 18 passed
- GitHub `plugin-tests`、`API & CLI Integration Tests`、`check-deps` 均通过。

## 对主干的风险与未覆盖

改动只影响已经超过 overview 提示词预算、且 entry 数量超过批次阈值的路径；小目录仍保持原来的单次请求行为。当前测试用 RecordingVLM 验证批次与 prompt 组成，没有在真实慢模型上复现 183 个子目录的端到端耗时改善。
