### PR TITLE
修复 ov write 抢锁失败返回 409 / return 409 on write lock contention

### DIFF
--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -16,6 +16,7 @@ from openviking.session.memory.utils.resource_refs import (
     RESOURCE_REF_SOURCE_CONTENT_WRITE,
     sync_memory_resource_refs,
 )
+from openviking.storage.errors import ResourceBusyError
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
 from openviking.storage.transaction import get_lock_manager
@@ -249,7 +250,10 @@ class ContentWriteCoordinator:
         acquired = await lock_manager.acquire_exact_path(handle, lock_path)
         if not acquired:
             await lock_manager.release(handle)
-            raise InvalidArgumentError(f"resource is busy and cannot be written now: {uri}")
+            raise ResourceBusyError(
+                f"resource is busy and cannot be written now: {uri}",
+                uri=uri,
+            )
 
         previous_content: Optional[str] = None
         content_written = False
@@ -559,7 +563,10 @@ class ContentWriteCoordinator:
         acquired = await lock_manager.acquire_exact_path(handle, lock_path)
         if not acquired:
             await lock_manager.release(handle)
-            raise InvalidArgumentError(f"resource is busy and cannot be written now: {uri}")
+            raise ResourceBusyError(
+                f"resource is busy and cannot be written now: {uri}",
+                uri=uri,
+            )
 
         released = False
         request_registered = False

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -9,6 +9,7 @@ from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.dataclass import MemoryFile
 from openviking.session.memory.utils import MemoryFileUtils
 from openviking.storage.content_write import ContentWriteCoordinator
+from openviking.storage.errors import ResourceBusyError
 from openviking_cli.exceptions import (
     AlreadyExistsError,
     DeadlineExceededError,
@@ -293,8 +294,15 @@ class _FakeHandle:
 
 
 class _FakeLockManager:
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        acquire_exact_path_result: bool = True,
+        acquire_tree_result: bool = True,
+    ):
         self.handle = _FakeHandle("lock-1")
+        self.acquire_exact_path_result = acquire_exact_path_result
+        self.acquire_tree_result = acquire_tree_result
         self.release_calls = []
 
     def create_handle(self):
@@ -302,11 +310,11 @@ class _FakeLockManager:
 
     async def acquire_tree(self, handle, path):
         del handle, path
-        return True
+        return self.acquire_tree_result
 
     async def acquire_exact_path(self, handle, path):
         del handle, path
-        return True
+        return self.acquire_exact_path_result
 
     async def release(self, handle):
         self.release_calls.append(handle.id)
@@ -460,6 +468,58 @@ async def test_write_timeout_after_enqueue_releases_resource_lock(monkeypatch):
     assert lock_manager.release_calls == ["lock-1"]
     assert viking_fs.delete_temp_calls == []
     assert viking_fs.content[file_uri] == "updated"
+
+
+@pytest.mark.asyncio
+async def test_resource_write_lock_conflict_raises_resource_busy(monkeypatch):
+    file_uri = "viking://resources/demo/doc.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    lock_manager = _FakeLockManager(acquire_exact_path_result=False)
+
+    monkeypatch.setattr(
+        "openviking.storage.content_write.get_lock_manager",
+        lambda: lock_manager,
+    )
+
+    with pytest.raises(ResourceBusyError) as exc_info:
+        await coordinator.write(
+            uri=file_uri,
+            content="updated",
+            ctx=ctx,
+        )
+
+    assert exc_info.value.uri == file_uri
+    assert lock_manager.release_calls == ["lock-1"]
+    assert viking_fs.content[file_uri] == "original"
+
+
+@pytest.mark.asyncio
+async def test_memory_write_lock_conflict_raises_resource_busy(monkeypatch):
+    file_uri = "viking://user/default/memories/preferences/theme.md"
+    root_uri = "viking://user/default/memories/preferences"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    lock_manager = _FakeLockManager(acquire_exact_path_result=False)
+
+    monkeypatch.setattr(
+        "openviking.storage.content_write.get_lock_manager",
+        lambda: lock_manager,
+    )
+
+    with pytest.raises(ResourceBusyError) as exc_info:
+        await coordinator.write(
+            uri=file_uri,
+            content="updated",
+            ctx=ctx,
+        )
+
+    assert exc_info.value.uri == file_uri
+    assert lock_manager.release_calls == ["lock-1"]
+    assert viking_fs.content[file_uri] == "original"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Return `ResourceBusyError` when `ContentWriteCoordinator` fails to acquire the exact write lock for resource writes.
- Apply the same lock-conflict behavior to memory writes so the existing error mapping returns `CONFLICT` / HTTP 409.
- Add regression coverage for both resource and memory `ov write` lock conflict paths.

## Tests
- `pytest --no-cov tests/server/test_content_write_service.py::test_resource_write_lock_conflict_raises_resource_busy tests/server/test_content_write_service.py::test_memory_write_lock_conflict_raises_resource_busy tests/server/test_error_mapping.py::test_resource_busy_maps_to_structured_conflict -q`
- `pytest --no-cov tests/server/test_content_write_service.py::test_write_timeout_after_enqueue_releases_resource_lock tests/server/test_content_write_service.py::test_write_direct_reuses_outer_lock_handle_for_viking_fs tests/server/test_content_write_service.py::test_resource_write_updates_target_and_queues_refresh_before_return tests/server/test_content_write_service.py::test_resource_write_rolls_back_replace_when_enqueue_fails tests/server/test_content_write_service.py::test_resource_write_rolls_back_create_when_enqueue_fails tests/server/test_content_write_service.py::test_memory_write_wait_skips_semantic_queue_and_releases_write_lock tests/server/test_content_write_service.py::test_resource_write_lock_conflict_raises_resource_busy tests/server/test_content_write_service.py::test_memory_write_lock_conflict_raises_resource_busy -q`
- `git diff --check -- openviking/storage/content_write.py tests/server/test_content_write_service.py`

## Notes
- `pytest --no-cov tests/server/test_content_write_service.py -q` currently reports 36 passed and 7 failures outside this lock-conflict change.