### PR TITLE
fix(observer): account for aggregate retrieval yield

### DIFF
--- a/openviking/storage/observers/retrieval_observer.py
+++ b/openviking/storage/observers/retrieval_observer.py
@@ -21,8 +21,11 @@ class RetrievalObserver(BaseObserver):
     and formats them for display via the observer API.
     """
 
-    # A zero-result rate above this threshold is considered unhealthy.
+    # A zero-result rate at or above this threshold is suspicious.
     UNHEALTHY_ZERO_RESULT_RATE = 0.5
+    # Sparse fan-out may include expected empty branches. Treat it as unhealthy
+    # only when the aggregate workload returns fewer than one result per query.
+    MIN_HEALTHY_AVG_RESULTS_PER_QUERY = 1.0
 
     @staticmethod
     def _get_collector():
@@ -84,16 +87,24 @@ class RetrievalObserver(BaseObserver):
     def __str__(self) -> str:
         return self.get_status_table()
 
+    @classmethod
+    def _has_unhealthy_yield(cls, stats) -> bool:
+        """Return whether empty branches coincide with low aggregate yield."""
+        return (
+            stats.zero_result_rate >= cls.UNHEALTHY_ZERO_RESULT_RATE
+            and stats.avg_results_per_query < cls.MIN_HEALTHY_AVG_RESULTS_PER_QUERY
+        )
+
     def is_healthy(self) -> bool:
-        """Retrieval is healthy when the zero-result rate is acceptable."""
+        """Retrieval is healthy when empty branches still produce useful yield."""
         stats = self._get_collector().snapshot()
         if stats.total_queries == 0:
             return True
-        return stats.zero_result_rate < self.UNHEALTHY_ZERO_RESULT_RATE
+        return not self._has_unhealthy_yield(stats)
 
     def has_errors(self) -> bool:
-        """Errors are flagged when too many queries return zero results."""
+        """Errors are flagged when empty branches also have low aggregate yield."""
         stats = self._get_collector().snapshot()
         if stats.total_queries < 5:
             return False
-        return stats.zero_result_rate >= self.UNHEALTHY_ZERO_RESULT_RATE
+        return self._has_unhealthy_yield(stats)

--- a/tests/unit/retrieve/test_retrieval_stats.py
+++ b/tests/unit/retrieve/test_retrieval_stats.py
@@ -145,6 +145,17 @@ class TestRetrievalObserver:
         assert observer.is_healthy() is False
         assert observer.has_errors() is True
 
+    def test_healthy_with_sparse_fan_out_yield(self):
+        collector = self._setup_collector()
+        for _ in range(6):
+            collector.record_query("unknown", 0, [])
+        for _ in range(4):
+            collector.record_query("unknown", 3, [0.9, 0.8, 0.7])
+
+        observer = RetrievalObserver()
+        assert observer.is_healthy() is True
+        assert observer.has_errors() is False
+
     def test_no_errors_below_min_queries(self):
         collector = self._setup_collector()
         # Only 3 queries (below the 5-query minimum for error flagging)


### PR DESCRIPTION
## 动机

修复 #3155。

`RetrievalObserver` 目前只看累计 zero-result rate：只要空结果查询达到 50%，就把整个 retrieval 组件标记为 unhealthy。type-quota / fan-out recall 会把多个独立分支分别记为查询，其中没有相关内容的空分支是正常现象；即使其他分支已经返回了足够结果，当前逻辑仍会误报系统故障。

实际复现中，10 个分支里 6 个为空、4 个各返回 3 条结果，总共得到 12 条结果、平均 1.2 条/查询，但 observer 仍返回 `is_healthy=False` 和 `has_errors=True`。

## 改动思路

保留 zero-result rate 作为质量信号，但只有它同时伴随低聚合产出时才判定 unhealthy。这里把“低产出”定义为平均每次查询少于 1 条结果，避免正常的稀疏 fan-out 分支把整个组件误判为故障。

## 关键逻辑（pseudocode）

```text
low_yield = zero_result_rate >= 0.5
            and avg_results_per_query < 1.0

is_healthy = total_queries == 0 or not low_yield
has_errors = total_queries >= 5 and low_yield
```

关键变化是把“空分支多”与“整体没有产出”组合判断；已有最少 5 次查询的 error gate 保持不变。

## 具体改动

- 为 `RetrievalObserver` 增加聚合产出下限。
- 统一 `is_healthy` 与 `has_errors` 的 unhealthy-yield 判断。
- 新增回归测试，覆盖 60% 空分支但整体返回 12 条结果的健康 workload。
- 保留现有 80% 空分支且平均仅 0.2 条/查询的 unhealthy 用例。

## 修复后复现建议

observer 没有独立 OV CLI 写入入口，最直接的验证是运行相关测试代码：

```bash
uv run --extra dev --extra test pytest -o addopts="" -q \
  tests/unit/retrieve/test_retrieval_stats.py
```

重点场景可用以下等价代码复现：

```python
collector = RetrievalObserver._get_collector()
for _ in range(6):
    collector.record_query("unknown", 0, [])
for _ in range(4):
    collector.record_query("unknown", 3, [0.9, 0.8, 0.7])

observer = RetrievalObserver()
assert observer.is_healthy() is True
assert observer.has_errors() is False
```

## 验证

- 修复前新增回归：1 failed, 17 passed。
- `uv run --extra dev --extra test pytest -o addopts="" --tb=short -q tests/unit/retrieve/test_retrieval_stats.py` — 18 passed。
- `uv run --extra dev ruff check openviking/storage/observers/retrieval_observer.py tests/unit/retrieve/test_retrieval_stats.py` — passed。
- `uv run --extra dev ruff format --check openviking/storage/observers/retrieval_observer.py tests/unit/retrieve/test_retrieval_stats.py` — 2 files already formatted。

## 对主干的风险与未覆盖

该改动只影响 retrieval observer 的健康判断，不改变检索、排序或返回结果。阈值仍基于进程生命周期内的累计统计，没有把多个 fan-out 分支聚合成一次逻辑 recall，也没有引入滚动时间窗口；这些属于后续更大的观测模型设计。