### PR TITLE
fix(parse): match nested .gitignore directory patterns at any depth

### DIFF
--- a/openviking/parse/gitignore.py
+++ b/openviking/parse/gitignore.py
@@ -41,10 +41,17 @@ def _transform_gitignore_line(line: str, base_rel: str) -> str:
         return raw
 
     scoped = pattern
+    # A trailing "/" only marks a directory-only match in gitignore semantics;
+    # it does not anchor the pattern. Only a separator at the start or middle of
+    # the pattern anchors it to the .gitignore's own directory. Ignore a lone
+    # trailing slash when deciding whether the pattern contains such a separator,
+    # so a directory idiom like "build/" in a nested .gitignore keeps matching at
+    # any depth below base_rel (mirroring `git check-ignore`).
+    core = scoped[:-1] if scoped.endswith("/") else scoped
     if scoped.startswith("/"):
         scoped = scoped.lstrip("/")
         scoped = f"{base_rel}/{scoped}" if scoped else base_rel
-    elif "/" in scoped:
+    elif "/" in core:
         scoped = f"{base_rel}/{scoped}"
     else:
         scoped = f"{base_rel}/**/{scoped}" if scoped else base_rel

--- a/tests/parse/test_gitignore.py
+++ b/tests/parse/test_gitignore.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for gitignore-aware matching helpers."""
+
+from pathlib import Path
+
+from openviking.parse.gitignore import GitignoreMatcher, _transform_gitignore_line
+
+
+class TestTransformGitignoreLine:
+    """Directory-only patterns (trailing '/') must not be treated as anchored."""
+
+    def test_trailing_slash_only_pattern_matches_any_depth(self) -> None:
+        # A bare "build/" has no beginning/middle separator, so per git it should
+        # match a `build` directory at any depth below the nested .gitignore.
+        assert _transform_gitignore_line("build/", "pkg") == "pkg/**/build/"
+
+    def test_no_slash_pattern_matches_any_depth(self) -> None:
+        assert _transform_gitignore_line("*.tmp", "pkg") == "pkg/**/*.tmp"
+
+    def test_middle_slash_pattern_is_anchored(self) -> None:
+        assert _transform_gitignore_line("logs/app.log", "pkg") == "pkg/logs/app.log"
+
+    def test_leading_slash_pattern_is_anchored(self) -> None:
+        assert _transform_gitignore_line("/build", "pkg") == "pkg/build"
+
+    def test_negated_trailing_slash_pattern_matches_any_depth(self) -> None:
+        assert _transform_gitignore_line("!build/", "pkg") == "!pkg/**/build/"
+
+
+class TestNestedGitignoreDirectoryPattern:
+    """A directory pattern in a nested .gitignore must match at any depth below it."""
+
+    def test_directory_pattern_matches_direct_and_nested(self, tmp_path: Path) -> None:
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg" / ".gitignore").write_text("build/\n", encoding="utf-8")
+
+        direct = tmp_path / "pkg" / "build"
+        direct.mkdir()
+        nested = tmp_path / "pkg" / "nested" / "build"
+        nested.mkdir(parents=True)
+
+        matcher = GitignoreMatcher(tmp_path)
+
+        # Direct child pkg/build is pruned (spec of its parent dir "pkg").
+        spec_pkg = matcher.spec_for_dir(tmp_path / "pkg")
+        assert matcher.is_ignored_dir(direct, spec_pkg)
+
+        # Deeply-nested pkg/nested/build must also be pruned; this is the
+        # regression: previously "build/" was rewritten to the anchored
+        # "pkg/build/" and never matched pkg/nested/build.
+        spec_nested = matcher.spec_for_dir(tmp_path / "pkg" / "nested")
+        assert matcher.is_ignored_dir(nested, spec_nested)


### PR DESCRIPTION
## Summary

Directory-only patterns (e.g. `build/`, `node_modules/`, `dist/`, `__pycache__/`) in a **nested** `.gitignore` were only matched at the exact `.gitignore` directory level, not at deeper levels. This diverges from `git` semantics and lets files that should be excluded slip into directory scan / import.

## Root cause

`_transform_gitignore_line()` in `openviking/parse/gitignore.py` rewrites a nested `.gitignore` pattern to be root-relative. It decides whether a pattern is *anchored* to the `.gitignore` directory with `elif "/" in scoped:`.

Per `gitignore(5)`, a pattern is anchored only when it has a separator **at the beginning or middle**. A **trailing** slash merely marks a directory-only match and must **not** anchor the pattern. But `"/" in scoped` is also `True` for a trailing-slash-only pattern like `build/`, so for a `.gitignore` at `pkg/` the pattern was rewritten to the anchored `pkg/build/`, which matches only `pkg/build` — never `pkg/nested/build`.

## Fix

Ignore a lone trailing slash when testing for an anchoring separator, so trailing-slash-only directory patterns fall into the "match at any depth" branch and become `pkg/**/build/`:

```python
core = scoped[:-1] if scoped.endswith("/") else scoped
...
elif "/" in core:
    scoped = f"{base_rel}/{scoped}"
else:
    scoped = f"{base_rel}/**/{scoped}" if scoped else base_rel
```

Leading-slash anchoring, middle-slash anchoring, and no-slash "match anywhere" patterns are unchanged.

## Correctness / verification

Validated against real `git check-ignore` as ground truth: for `build/` in `pkg/.gitignore`, git ignores both `pkg/build/` and `pkg/nested/build/`; the current code ignored only the former, the fix ignores both. A regression sweep over leading-slash, middle-slash, no-slash, and directory-idiom patterns matches `git check-ignore` in every case after the fix, with no change to the previously-correct cases.

Added `tests/parse/test_gitignore.py` covering the transform output and the nested directory-pattern pruning. The new tests were **executed**: they fail on the unfixed module (the deep-nested `build/` directory is not pruned) and pass after the fix. `python -m py_compile` passes on both changed files.
