### PR TITLE
fix(metrics): actually run async bootstrap_encryption in encryption readiness probe

### DIFF
--- a/openviking/metrics/datasources/encryption.py
+++ b/openviking/metrics/datasources/encryption.py
@@ -17,6 +17,7 @@ Instrumentation policy:
 from __future__ import annotations
 
 from openviking.metrics.core.base import ReadEnvelope
+from openviking_cli.utils import run_async
 
 from .base import EventMetricDataSource, ProbeMetricDataSource
 
@@ -125,7 +126,11 @@ class EncryptionProbeDataSource(ProbeMetricDataSource):
         def _read() -> tuple[bool, str]:
             cfg = self._config_provider()
             provider = str(getattr(getattr(cfg, "encryption", None), "provider", "") or "unknown")
-            bootstrap_encryption()
+            # ``bootstrap_encryption`` is an async coroutine that requires the full
+            # configuration mapping. Materializing it here is what actually verifies
+            # the encryption subsystem can be initialized (mirroring how the model
+            # provider / retrieval backend probes materialize their dependencies).
+            run_async(bootstrap_encryption(cfg.to_dict()))
             return True, provider
 
         default_provider = "unknown"

--- a/tests/metrics/datasources/test_event_datasources.py
+++ b/tests/metrics/datasources/test_event_datasources.py
@@ -68,7 +68,10 @@ def test_encryption_probe_datasource_ok_and_provider(monkeypatch):
     class _Cfg:
         encryption = SimpleNamespace(provider="volcengine")
 
-    def _bootstrap():
+        def to_dict(self):
+            return {"encryption": {"provider": "volcengine"}}
+
+    async def _bootstrap(config):
         return None
 
     monkeypatch.setattr("openviking.crypto.config.bootstrap_encryption", _bootstrap)
@@ -84,7 +87,10 @@ def test_encryption_probe_datasource_returns_default_on_exception(monkeypatch):
     class _Cfg:
         encryption = SimpleNamespace(provider="volcengine")
 
-    def _boom():
+        def to_dict(self):
+            return {"encryption": {"provider": "volcengine"}}
+
+    async def _boom(config):
         raise RuntimeError("bootstrap failed")
 
     monkeypatch.setattr("openviking.crypto.config.bootstrap_encryption", _boom)


### PR DESCRIPTION
## Problem

`EncryptionProbeDataSource.read_probe_state` (in `openviking/metrics/datasources/encryption.py`) is supposed to check "whether encryption bootstrap succeeds" and feed the `openviking_encryption_component_health` / `_root_key_ready` / `_kms_provider_ready` gauges emitted by `EncryptionProbeCollector`. Its inner probe does:

```python
def _read() -> tuple[bool, str]:
    cfg = self._config_provider()
    provider = str(getattr(getattr(cfg, "encryption", None), "provider", "") or "unknown")
    bootstrap_encryption()          # <-- bug
    return True, provider
```

But the callee in `openviking/crypto/config.py` is:

```python
async def bootstrap_encryption(config: Dict[str, Any]) -> Optional[FileEncryptor]:
    encryption_config = config.get("encryption", {})
    ...
```

Two independent defects make `_read()` fail on every invocation:

1. **Missing required argument.** `bootstrap_encryption` requires a positional `config`; calling `bootstrap_encryption()` raises `TypeError: bootstrap_encryption() missing 1 required positional argument: 'config'` at call time. It cannot succeed for any input.
2. **Never awaited.** `bootstrap_encryption` is `async`, so even with the argument supplied the call would only build a coroutine that is never run — the actual bootstrap check never executes.

`_read` runs under `safe_value_probe` -> `MetricDataSource.safe_read`, which swallows the `TypeError` and returns `ReadEnvelope(ok=False, value=(False, provider))`. Net effect: the encryption readiness probe can **never** report healthy. The encryption health gauges are permanently pinned to the not-ready / `valid="0"` state even when encryption is correctly configured and working, and the encrypt-path validation the probe is meant to perform never runs — a silently broken health signal.

The sibling probes in `openviking/metrics/datasources/probes.py` show the intended pattern: `RetrievalBackendProbeDataSource` materializes its dependency with `run_async(vikingdb.health_check())`, and `ModelProviderProbeDataSource` materializes the VLM client each refresh.

### Why the unit tests didn't catch it

`tests/metrics/datasources/test_event_datasources.py` monkeypatched `bootstrap_encryption` with a **zero-arg, synchronous** stub (`def _bootstrap(): return None`), whose signature does not match the real `async def bootstrap_encryption(config)`. The stub masked both defects, so the tests passed while production always failed.

## Fix

- Call the coroutine correctly with the resolved config dict and run it to completion, mirroring the other probes:

```python
run_async(bootstrap_encryption(cfg.to_dict()))
```

  (`config_provider` is `get_openviking_config`, whose `OpenVikingConfig.to_dict()` returns the `model_dump()` mapping that `bootstrap_encryption` expects. When encryption is disabled — the default — `bootstrap_encryption` returns `None` early with no side effects, so the probe reports healthy, matching the existing test's `(True, provider)` contract.)

- Update the two probe tests to stub `bootstrap_encryption` with the real async signature (`async def _bootstrap(config)`) and give the fake config a `to_dict()`, so they exercise the real call shape.

## Verification

- `python -m py_compile` passes on both changed files.
- The behavior is verified by reading: the async signature mismatch guarantees the `TypeError`; the fix uses the same `run_async(coro)` pattern already used by `RetrievalBackendProbeDataSource`. Full pytest was not run in this environment (heavy optional deps), so the suite was not executed here.