### PR TITLE
fix(agent): compute ToolContext.workspace_id per-instance (was always None)

### DIFF
--- a/bot/vikingbot/agent/tools/base.py
+++ b/bot/vikingbot/agent/tools/base.py
@@ -23,8 +23,8 @@ class ToolContext:
         workspace_id: Workspace identifier for the session's sandbox directory.
             Computed per-instance in __post_init__ from the instance's
             sandbox_manager and session_key. An explicitly-passed value takes
-            precedence and prevents automatic derivation.  Set to None when
-            no sandbox manager is available.
+            precedence and prevents automatic derivation. Remains None when
+            either sandbox_manager or session_key is missing.
         sender_id: Optional identifier for the message sender, used for tracking
             and permission checks.
         actor_peer_id: Authenticated OpenViking peer identity for memory and file tools.
@@ -58,7 +58,11 @@ class ToolContext:
     channel_metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
-        if self.workspace_id is None and self.sandbox_manager is not None and self.session_key is not None:
+        if (
+            self.workspace_id is None
+            and self.sandbox_manager is not None
+            and self.session_key is not None
+        ):
             self.workspace_id = self.sandbox_manager.to_workspace_id(self.session_key)
         if self.memory_owner_user_ids is None and self.memory_user_ids is not None:
             self.memory_owner_user_ids = self.memory_user_ids

--- a/bot/vikingbot/agent/tools/base.py
+++ b/bot/vikingbot/agent/tools/base.py
@@ -20,8 +20,11 @@ class ToolContext:
             'channel:chat_id'.
         sandbox_manager: Optional manager for sandbox operations like file access and
             command execution. If provided, tools can perform sandboxed operations.
-        workspace_id: Computed workspace identifier derived from the sandbox_manager
-            and session_key. This determines the sandbox directory for the session.
+        workspace_id: Workspace identifier for the session's sandbox directory.
+            Computed per-instance in __post_init__ from the instance's
+            sandbox_manager and session_key. An explicitly-passed value takes
+            precedence and prevents automatic derivation.  Set to None when
+            no sandbox manager is available.
         sender_id: Optional identifier for the message sender, used for tracking
             and permission checks.
         actor_peer_id: Authenticated OpenViking peer identity for memory and file tools.

--- a/bot/vikingbot/agent/tools/base.py
+++ b/bot/vikingbot/agent/tools/base.py
@@ -45,7 +45,7 @@ class ToolContext:
 
     session_key: SessionKey = None
     sandbox_manager: SandboxManager | None = None
-    workspace_id: str = sandbox_manager.to_workspace_id(session_key) if sandbox_manager else None
+    workspace_id: str | None = None
     sender_id: str | None = None
     actor_peer_id: str | None = None
     memory_peer_ids: list[str] | None = None
@@ -55,6 +55,8 @@ class ToolContext:
     channel_metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
+        if self.workspace_id is None and self.sandbox_manager is not None and self.session_key is not None:
+            self.workspace_id = self.sandbox_manager.to_workspace_id(self.session_key)
         if self.memory_owner_user_ids is None and self.memory_user_ids is not None:
             self.memory_owner_user_ids = self.memory_user_ids
         elif self.memory_user_ids is None and self.memory_owner_user_ids is not None:

--- a/bot/vikingbot/tests/unit/test_agent/test_tool_context_workspace_id.py
+++ b/bot/vikingbot/tests/unit/test_agent/test_tool_context_workspace_id.py
@@ -46,3 +46,13 @@ def test_explicit_workspace_id_is_preserved():
 
     assert ctx.workspace_id == "explicit-id"
     assert manager.calls == []
+
+
+def test_workspace_id_stays_none_when_session_key_missing():
+    """workspace_id remains None when sandbox_manager is present but session_key is None."""
+    manager = _FakeSandboxManager("should-not-be-used")
+
+    ctx = ToolContext(session_key=None, sandbox_manager=manager)
+
+    assert ctx.workspace_id is None
+    assert manager.calls == []

--- a/bot/vikingbot/tests/unit/test_agent/test_tool_context_workspace_id.py
+++ b/bot/vikingbot/tests/unit/test_agent/test_tool_context_workspace_id.py
@@ -1,0 +1,48 @@
+"""Tests for ToolContext.workspace_id derivation in __post_init__."""
+
+from types import SimpleNamespace
+
+from vikingbot.agent.tools.base import ToolContext
+
+
+class _FakeSandboxManager:
+    """Minimal stand-in exposing to_workspace_id(session_key)."""
+
+    def __init__(self, workspace_id: str):
+        self._workspace_id = workspace_id
+        self.calls = []
+
+    def to_workspace_id(self, session_key):
+        self.calls.append(session_key)
+        return self._workspace_id
+
+
+def test_workspace_id_computed_from_sandbox_manager():
+    session_key = SimpleNamespace(name="telegram:12345")
+    manager = _FakeSandboxManager("ws-telegram-12345")
+
+    ctx = ToolContext(session_key=session_key, sandbox_manager=manager)
+
+    assert ctx.workspace_id == "ws-telegram-12345"
+    assert manager.calls == [session_key]
+
+
+def test_workspace_id_none_without_sandbox_manager():
+    session_key = SimpleNamespace(name="telegram:12345")
+
+    ctx = ToolContext(session_key=session_key, sandbox_manager=None)
+
+    assert ctx.workspace_id is None
+
+
+def test_explicit_workspace_id_is_preserved():
+    manager = _FakeSandboxManager("computed-id")
+
+    ctx = ToolContext(
+        session_key=SimpleNamespace(name="telegram:12345"),
+        sandbox_manager=manager,
+        workspace_id="explicit-id",
+    )
+
+    assert ctx.workspace_id == "explicit-id"
+    assert manager.calls == []


### PR DESCRIPTION
## Summary
`ToolContext.workspace_id` was effectively always `None`. It was declared as a dataclass field whose default value was computed once at **class definition time** from the (then-`None`) `sandbox_manager`, so every instance inherited `None` regardless of the `sandbox_manager` / `session_key` actually passed in.

## Problem
```python
workspace_id: str = sandbox_manager.to_workspace_id(session_key) if sandbox_manager else None
```
Inside the class body, `sandbox_manager` refers to the class-level default (`None`), so the ternary always evaluates to `None` at import time — never per instance. Any tool relying on `context.workspace_id` to resolve the sandbox workspace got `None`: e.g. the OV file tools fell back to a single shared `"__default__"` client/workspace for all sessions instead of per-session isolation.

## Fix
Make `workspace_id` a plain defaulted field (`str | None = None`) and derive it in `__post_init__` from the instance's `sandbox_manager` and `session_key`. An explicitly-passed value takes precedence; it remains `None` when either `sandbox_manager` or `session_key` is missing.

## Tests
`bot/vikingbot/tests/unit/test_agent/test_tool_context_workspace_id.py` (4 tests):
- derived from the provided `sandbox_manager`/`session_key` (manager called exactly once);
- stays `None` without a sandbox manager;
- explicit `workspace_id` is preserved and suppresses derivation;
- stays `None` when a manager is present but `session_key` is missing.
