### PR TITLE
fix(hooks): route OpenVikingPostCallHook through the sync path so enriched results aren't discarded

### DIFF
--- a/bot/vikingbot/hooks/builtins/openviking_hooks.py
+++ b/bot/vikingbot/hooks/builtins/openviking_hooks.py
@@ -256,10 +256,12 @@ class OpenVikingCompactHook(Hook):
 
 class OpenVikingPostCallHook(Hook):
     name = "openviking_post_call"
-    # Hook execute() is genuinely async (it awaits ov_client search/read), but it
-    # MUST return its mutated kwargs dict to the caller so result transformations
-    # (like experience injection) reach tool.post_call.  Route it through the sync
-    # path so the hook manager threads the return value back into kwargs.
+    # is_sync=True routes through the HookManager sync path, where each hook's
+    # return value is threaded back into kwargs:
+    #     `kwargs = await hook.execute(context, **kwargs)`
+    # The default is_sync=False routes through asyncio.gather, which discards
+    # return values — the enriched {tool_name, params, result} dict would be
+    # silently dropped.
     is_sync = True
 
     async def _get_client(self, workspace_id: str, config: Any = None) -> VikingClient:
@@ -383,7 +385,8 @@ class OpenVikingPostCallHook(Hook):
 
     async def execute(self, context: HookContext, tool_name, params, result) -> Any:
         if tool_name == "read_file":
-            if result and not isinstance(result, Exception):
+            # Guard: result must be a non-empty string before running regex.
+            if isinstance(result, str) and result and not isinstance(result, Exception):
                 match = re.search(r"^---\s*\nname:\s*(.+?)\s*\n", result, re.MULTILINE)
                 if match:
                     skill_name = match.group(1).strip()

--- a/bot/vikingbot/hooks/builtins/openviking_hooks.py
+++ b/bot/vikingbot/hooks/builtins/openviking_hooks.py
@@ -385,8 +385,11 @@ class OpenVikingPostCallHook(Hook):
 
     async def execute(self, context: HookContext, tool_name, params, result) -> Any:
         if tool_name == "read_file":
-            # Guard: result must be a non-empty string before running regex.
-            if isinstance(result, str) and result and not isinstance(result, Exception):
+            # Only inspect non-empty string results. Tool failures reach this hook
+            # as Exception instances (the registry stores the raised exception as
+            # the result), and re.search would raise TypeError on non-str values —
+            # which, on the sync hook path, would escalate into a tool-call failure.
+            if isinstance(result, str) and result:
                 match = re.search(r"^---\s*\nname:\s*(.+?)\s*\n", result, re.MULTILINE)
                 if match:
                     skill_name = match.group(1).strip()

--- a/bot/vikingbot/hooks/builtins/openviking_hooks.py
+++ b/bot/vikingbot/hooks/builtins/openviking_hooks.py
@@ -256,10 +256,11 @@ class OpenVikingCompactHook(Hook):
 
 class OpenVikingPostCallHook(Hook):
     name = "openviking_post_call"
-    # Hook execute() is genuinely async (it awaits ov_client search/read). Mark it
-    # async so the hook manager routes it through asyncio.gather with other async
-    # hooks instead of the sequential sync_hooks path.
-    is_sync = False
+    # Hook execute() is genuinely async (it awaits ov_client search/read), but it
+    # MUST return its mutated kwargs dict to the caller so result transformations
+    # (like experience injection) reach tool.post_call.  Route it through the sync
+    # path so the hook manager threads the return value back into kwargs.
+    is_sync = True
 
     async def _get_client(self, workspace_id: str, config: Any = None) -> VikingClient:
         return await get_global_client(workspace_id, config=config)

--- a/bot/vikingbot/tests/unit/test_hooks_sync_routing.py
+++ b/bot/vikingbot/tests/unit/test_hooks_sync_routing.py
@@ -49,3 +49,83 @@ async def test_async_hook_return_is_discarded():
     # Async path routes through asyncio.gather and does not thread returns back.
     assert "injected_by" not in result
     assert result == {"value": 1}
+
+
+class _StubbedSearchPostCallHook(OpenVikingPostCallHook):
+    """OpenVikingPostCallHook with the network-backed experience search stubbed."""
+
+    def __init__(self):
+        self.search_queries = []
+
+    async def _search_skill_experiences(
+        self, workspace_id, query, config=None, openviking_connection=None
+    ):
+        self.search_queries.append(query)
+        return "remembered experience"
+
+
+def _post_call_context() -> HookContext:
+    return HookContext(event_type="tool.post_call", workspace_id="ws-test")
+
+
+async def test_post_call_passes_exception_result_through():
+    """Tool failures arrive as Exception results; the hook must not touch them.
+
+    On the sync path a TypeError from re.search would escalate into a
+    tool-call failure, so the str guard is load-bearing here.
+    """
+    hook = _StubbedSearchPostCallHook()
+    error = RuntimeError("tool blew up")
+
+    out = await hook.execute(_post_call_context(), tool_name="read_file", params={}, result=error)
+
+    assert out == {"tool_name": "read_file", "params": {}, "result": error}
+    assert hook.search_queries == []
+
+
+async def test_post_call_passes_non_string_result_through():
+    hook = _StubbedSearchPostCallHook()
+    payload = {"content": "not a string"}
+
+    out = await hook.execute(_post_call_context(), tool_name="read_file", params={}, result=payload)
+
+    assert out["result"] is payload
+    assert hook.search_queries == []
+
+
+async def test_post_call_ignores_other_tools():
+    hook = _StubbedSearchPostCallHook()
+    skill_md = "---\nname: web_search\n---\n"
+
+    out = await hook.execute(
+        _post_call_context(), tool_name="exec_shell", params={}, result=skill_md
+    )
+
+    assert out["result"] == skill_md
+    assert hook.search_queries == []
+
+
+async def test_post_call_appends_experiences_for_skill_markdown():
+    hook = _StubbedSearchPostCallHook()
+    skill_md = "---\nname: web_search\ndescription: Search the web for facts\n---\nUsage notes."
+
+    out = await hook.execute(
+        _post_call_context(), tool_name="read_file", params={}, result=skill_md
+    )
+
+    assert hook.search_queries == ["Search the web for facts"]
+    assert out["result"].startswith(skill_md)
+    assert "## Related Experiences" in out["result"]
+    assert "remembered experience" in out["result"]
+
+
+async def test_post_call_skips_experience_loader_skill():
+    hook = _StubbedSearchPostCallHook()
+    skill_md = "---\nname: experience_loader\ndescription: loads experiences\n---\n"
+
+    out = await hook.execute(
+        _post_call_context(), tool_name="read_file", params={}, result=skill_md
+    )
+
+    assert out["result"] == skill_md
+    assert hook.search_queries == []

--- a/bot/vikingbot/tests/unit/test_hooks_sync_routing.py
+++ b/bot/vikingbot/tests/unit/test_hooks_sync_routing.py
@@ -1,0 +1,51 @@
+"""Tests for hook is_sync routing and sync-path return threading.
+
+OpenVikingPostCallHook.execute() is async but MUST return its mutated kwargs so
+result transformations reach tool.post_call. That only happens when the hook is
+routed through the sync path (is_sync=True); the async path discards returns.
+"""
+
+from vikingbot.hooks.base import Hook, HookContext
+from vikingbot.hooks.builtins.openviking_hooks import OpenVikingPostCallHook
+from vikingbot.hooks.manager import HookManager
+
+
+def test_openviking_post_call_hook_is_sync():
+    assert OpenVikingPostCallHook.is_sync is True
+
+
+class _SyncEchoHook(Hook):
+    name = "sync_echo"
+    is_sync = True
+
+    async def execute(self, context: HookContext, **kwargs):
+        return {**kwargs, "injected_by": "sync"}
+
+
+class _AsyncEchoHook(Hook):
+    name = "async_echo"
+    is_sync = False
+
+    async def execute(self, context: HookContext, **kwargs):
+        return {**kwargs, "injected_by": "async"}
+
+
+async def test_sync_hook_return_is_threaded_back():
+    manager = HookManager()
+    manager._hooks["tool.post_call"].append(_SyncEchoHook())
+
+    result = await manager.execute_hooks(HookContext(event_type="tool.post_call"), value=1)
+
+    assert result["injected_by"] == "sync"
+    assert result["value"] == 1
+
+
+async def test_async_hook_return_is_discarded():
+    manager = HookManager()
+    manager._hooks["tool.post_call"].append(_AsyncEchoHook())
+
+    result = await manager.execute_hooks(HookContext(event_type="tool.post_call"), value=1)
+
+    # Async path routes through asyncio.gather and does not thread returns back.
+    assert "injected_by" not in result
+    assert result == {"value": 1}


### PR DESCRIPTION
## Summary
`OpenVikingPostCallHook.execute()` enriches `read_file` results for skill files with related experience memories, returning `{tool_name, params, result}`. Since #2503 flipped the hook to `is_sync = False`, that return value has been silently discarded: the enrichment never reaches the model.

## Problem
`HookManager.execute_hooks` has two paths:

- **async path** (`is_sync = False`): `asyncio.gather(...)` — results are only inspected for error logging and then **dropped**;
- **sync path** (`is_sync = True`): `kwargs = await hook.execute(context, **kwargs)` — the return value is **threaded back** and ultimately consumed by the tool registry via `hook_result.get("result")`.

#2503 moved this hook to the async path on the reasoning that "execute() is genuinely async". But both paths await coroutines (the sync path also `await`s), and `execute_hooks` awaits the gather before returning anyway — so the async path buys no latency here; it only loses the return value. Result: the appended "Related Experiences" block silently vanished from every `read_file` on a skill file.

## Fix
- Restore `is_sync = True` with a comment documenting the routing contract (sync path = return values threaded back; async path = returns discarded).
- Add an `isinstance(result, str)` guard before running the regex. Tool failures reach this hook as `Exception` instances (the registry stores the raised exception as the result), and `re.search` raises `TypeError` on non-str input. On the sync path such an exception would now propagate and turn a completed tool call into a failure, so the guard is load-bearing. The previous `not isinstance(result, Exception)` check is dropped: a `str` can never also be an `Exception` (CPython rejects that MI with "multiple bases have instance lay-out conflict"), so it was dead code.

## Tests
`bot/vikingbot/tests/unit/test_hooks_sync_routing.py` (8 tests):
- routing: post-call hook is marked sync; sync-path returns are threaded back; async-path returns are discarded (documents the manager contract this fix relies on);
- `execute()` behavior with the network search stubbed: `Exception`/dict results pass through untouched, non-`read_file` tools are ignored, skill markdown gets the experiences appended, and the `experience_loader` skill is skipped.
