### PR TITLE
fix(cron): don't cancel an executing job when re-arming the timer

### DIFF
--- a/bot/vikingbot/cron/service.py
+++ b/bot/vikingbot/cron/service.py
@@ -169,6 +169,7 @@ class CronService:
     def stop(self) -> None:
         """Stop the cron service."""
         self._running = False
+        self._executing = False
         if self._timer_task:
             self._timer_task.cancel()
             self._timer_task = None
@@ -192,9 +193,16 @@ class CronService:
         return min(times) if times else None
 
     def _arm_timer(self) -> None:
-        """Schedule the next timer tick."""
+        """Schedule the next timer tick.
+
+        Does nothing when a tick is currently executing jobs
+        (_executing is True), because cancelling the timer task would
+        interrupt the in-flight job execution.  The executing tick
+        re-arms the timer in its own finally block once all jobs
+        have completed.
+        """
         if self._executing:
-            return  # tick is running jobs; it will re-arm after
+            return
         if self._timer_task:
             self._timer_task.cancel()
 
@@ -213,9 +221,18 @@ class CronService:
         self._timer_task = asyncio.create_task(tick())
 
     async def _on_timer(self) -> None:
-        """Handle timer tick - run due jobs."""
+        """Handle timer tick -- run every job that is now due.
+
+        Sets _executing = True so that external callers (add_job,
+        remove_job, enable_job, etc.) do not cancel the timer task
+        while we are still executing.  Re-arms the timer in the
+        ``finally`` block once all due jobs have been processed.
+        """
         if not self._store:
             return
+
+        if self._executing:
+            return  # re-entrancy guard: a tick is already in progress
 
         now = _now_ms()
         due_jobs = [

--- a/bot/vikingbot/cron/service.py
+++ b/bot/vikingbot/cron/service.py
@@ -58,6 +58,7 @@ class CronService:
         self._store: CronStore | None = None
         self._timer_task: asyncio.Task | None = None
         self._running = False
+        self._executing = False
 
     def _load_store(self) -> CronStore:
         """Load jobs from disk."""
@@ -192,6 +193,8 @@ class CronService:
 
     def _arm_timer(self) -> None:
         """Schedule the next timer tick."""
+        if self._executing:
+            return  # tick is running jobs; it will re-arm after
         if self._timer_task:
             self._timer_task.cancel()
 
@@ -221,11 +224,14 @@ class CronService:
             if j.enabled and j.state.next_run_at_ms and now >= j.state.next_run_at_ms
         ]
 
-        for job in due_jobs:
-            await self._execute_job(job)
-
-        self._save_store()
-        self._arm_timer()
+        self._executing = True
+        try:
+            for job in due_jobs:
+                await self._execute_job(job)
+            self._save_store()
+        finally:
+            self._executing = False
+            self._arm_timer()
 
     async def _execute_job(self, job: CronJob) -> None:
         """Execute a single job."""

--- a/bot/vikingbot/cron/service.py
+++ b/bot/vikingbot/cron/service.py
@@ -167,7 +167,13 @@ class CronService:
         )
 
     def stop(self) -> None:
-        """Stop the cron service."""
+        """Stop the cron service.
+
+        Safe to call while a tick is executing: cancelling the timer
+        task delivers CancelledError to the in-flight _on_timer, which
+        resets _executing and skips re-arming (``_running`` is already
+        False by then, so no new timer task can be created).
+        """
         self._running = False
         self._executing = False
         if self._timer_task:
@@ -198,8 +204,8 @@ class CronService:
         Does nothing when a tick is currently executing jobs
         (_executing is True), because cancelling the timer task would
         interrupt the in-flight job execution.  The executing tick
-        re-arms the timer in its own finally block once all jobs
-        have completed.
+        re-arms the timer itself once all jobs have completed (unless
+        the tick was cancelled, e.g. by stop()).
         """
         if self._executing:
             return
@@ -225,8 +231,11 @@ class CronService:
 
         Sets _executing = True so that external callers (add_job,
         remove_job, enable_job, etc.) do not cancel the timer task
-        while we are still executing.  Re-arms the timer in the
-        ``finally`` block once all due jobs have been processed.
+        while we are still executing.  Re-arms the timer once all due
+        jobs have been processed -- also on job errors, but not when
+        the tick itself is cancelled (service stop or event-loop
+        shutdown), where scheduling a new timer task would leak a
+        pending task.
         """
         if not self._store:
             return
@@ -242,13 +251,20 @@ class CronService:
         ]
 
         self._executing = True
+        rearm = True
         try:
             for job in due_jobs:
                 await self._execute_job(job)
             self._save_store()
+        except asyncio.CancelledError:
+            # The tick task itself was cancelled (stop() or event-loop
+            # shutdown): propagate without scheduling a new timer task.
+            rearm = False
+            raise
         finally:
             self._executing = False
-            self._arm_timer()
+            if rearm:
+                self._arm_timer()
 
     async def _execute_job(self, job: CronJob) -> None:
         """Execute a single job."""

--- a/bot/vikingbot/tests/unit/test_cron_service.py
+++ b/bot/vikingbot/tests/unit/test_cron_service.py
@@ -1,0 +1,57 @@
+"""Tests for CronService._arm_timer guarding against re-arm while executing."""
+
+import asyncio
+import contextlib
+
+from vikingbot.cron.service import CronService
+
+
+async def test_arm_timer_does_not_cancel_running_tick(tmp_path):
+    """While a tick is executing jobs, _arm_timer must not cancel/replace the timer."""
+    service = CronService(store_path=tmp_path / "cron.json")
+    service._running = True
+
+    async def _long_sleep():
+        await asyncio.sleep(3600)
+
+    original_task = asyncio.create_task(_long_sleep())
+    service._timer_task = original_task
+    service._executing = True  # simulate a tick in progress
+
+    service._arm_timer()
+
+    # Yield control so any (buggy) cancellation would take effect.
+    await asyncio.sleep(0)
+
+    assert service._timer_task is original_task
+    assert not original_task.cancelled()
+
+    original_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await original_task
+
+
+async def test_arm_timer_reschedules_when_not_executing(tmp_path):
+    """Sanity check: when not executing, _arm_timer replaces the timer task."""
+    service = CronService(store_path=tmp_path / "cron.json")
+    service._running = True
+
+    async def _long_sleep():
+        await asyncio.sleep(3600)
+
+    stale_task = asyncio.create_task(_long_sleep())
+    service._timer_task = stale_task
+    service._executing = False
+
+    service._arm_timer()
+    await asyncio.sleep(0)
+
+    # No jobs scheduled -> _get_next_wake_ms returns None -> no new task armed,
+    # but the stale task must have been cancelled (not left running).
+    assert stale_task.cancelled()
+
+    for task in {stale_task, service._timer_task}:
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task

--- a/bot/vikingbot/tests/unit/test_cron_service.py
+++ b/bot/vikingbot/tests/unit/test_cron_service.py
@@ -1,9 +1,10 @@
-"""Tests for CronService._arm_timer guarding against re-arm while executing."""
+"""Tests for CronService timer re-arm behavior around executing ticks."""
 
 import asyncio
 import contextlib
 
 from vikingbot.cron.service import CronService
+from vikingbot.cron.types import CronJob, CronJobState, CronPayload, CronSchedule, CronStore
 
 
 async def test_arm_timer_does_not_cancel_running_tick(tmp_path):
@@ -55,3 +56,47 @@ async def test_arm_timer_reschedules_when_not_executing(tmp_path):
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+
+
+async def test_cancelled_tick_does_not_rearm(tmp_path):
+    """A tick cancelled mid-execution (stop or loop shutdown) must not arm a new timer."""
+    service = CronService(store_path=tmp_path / "cron.json")
+    service._running = True
+    service._store = CronStore(
+        jobs=[
+            CronJob(
+                id="job1",
+                name="job1",
+                enabled=True,
+                schedule=CronSchedule(kind="every", every_ms=60_000),
+                payload=CronPayload(message="hi"),
+                state=CronJobState(next_run_at_ms=1),
+            )
+        ]
+    )
+
+    job_started = asyncio.Event()
+
+    async def on_job(job):
+        job_started.set()
+        await asyncio.sleep(3600)
+
+    service.on_job = on_job
+
+    tick_task = asyncio.create_task(service._on_timer())
+    service._timer_task = tick_task
+
+    await asyncio.wait_for(job_started.wait(), timeout=5)
+    tick_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await tick_task
+
+    new_timer = service._timer_task
+    # Clean up first so a failure does not leak a pending task.
+    if new_timer is not None and new_timer is not tick_task:
+        new_timer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await new_timer
+
+    assert service._executing is False
+    assert new_timer is tick_task


### PR DESCRIPTION
## Summary
When the cron scheduler re-armed its timer while a job was still executing, it could cancel the in-flight job, so long-running scheduled jobs were interrupted by the next arm tick.

## Problem
The arm/timer path did not track whether a job was currently executing, so re-arming tore down the running task.

## Fix
Add an `_executing` guard so the arm path does not cancel a job that is currently running; the timer re-arms around the active execution instead of aborting it.

## Test
`bot/vikingbot/tests/unit/test_cron_service.py` — covers re-arm while executing not cancelling the job (2 passed).
