### PR TITLE
fix(sandbox): snapshot workspace existence before start() so bootstrap files copy

### DIFF
--- a/bot/vikingbot/sandbox/manager.py
+++ b/bot/vikingbot/sandbox/manager.py
@@ -39,13 +39,20 @@ class SandboxManager:
         return self._sandboxes[workspace_id]
 
     async def _create_sandbox(self, workspace_id: str) -> SandboxBackend:
-        """Create new sandbox instance."""
+        """Create new sandbox instance.
+
+        Captures workspace existence *before* ``instance.start()`` because
+        start() itself materialises the workspace directory on disk.  Using
+        a post-start existence check would always see the directory present
+        and would therefore never copy bootstrap files into a fresh
+        workspace.
+        """
         workspace = self.workspace / workspace_id
         workspace_existed = workspace.exists()
         instance = self._backend_cls(self.config.sandbox, workspace_id, workspace)
         try:
             await instance.start()
-        except Exception as e:
+        except Exception:
             import traceback
 
             traceback.print_exc()

--- a/bot/vikingbot/sandbox/manager.py
+++ b/bot/vikingbot/sandbox/manager.py
@@ -41,6 +41,7 @@ class SandboxManager:
     async def _create_sandbox(self, workspace_id: str) -> SandboxBackend:
         """Create new sandbox instance."""
         workspace = self.workspace / workspace_id
+        workspace_existed = workspace.exists()
         instance = self._backend_cls(self.config.sandbox, workspace_id, workspace)
         try:
             await instance.start()
@@ -48,7 +49,7 @@ class SandboxManager:
             import traceback
 
             traceback.print_exc()
-        if not workspace.exists():
+        if not workspace_existed:
             await self._copy_bootstrap_files(workspace)
         return instance
 

--- a/bot/vikingbot/tests/unit/test_sandbox_bootstrap.py
+++ b/bot/vikingbot/tests/unit/test_sandbox_bootstrap.py
@@ -1,0 +1,53 @@
+"""Tests for SandboxManager._create_sandbox bootstrap-copy behavior.
+
+The bootstrap files must be copied for a freshly created workspace. The
+"workspace exists" check has to be captured BEFORE instance.start(), because
+start() itself creates the workspace directory -- otherwise the post-start
+existence check always sees the directory and never copies bootstrap files.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from vikingbot.sandbox.manager import SandboxManager
+
+
+class _FakeBackend:
+    """Backend whose start() materializes the workspace directory."""
+
+    def __init__(self, sandbox_config, workspace_id, workspace):
+        self.workspace = Path(workspace)
+
+    async def start(self):
+        self.workspace.mkdir(parents=True, exist_ok=True)
+
+
+def _make_manager(tmp_path: Path):
+    manager = SandboxManager.__new__(SandboxManager)
+    manager.workspace = tmp_path
+    manager.config = SimpleNamespace(sandbox=SimpleNamespace())
+    manager._backend_cls = _FakeBackend
+    manager._copy_calls = []
+
+    async def _spy_copy(sandbox_workspace):
+        manager._copy_calls.append(sandbox_workspace)
+
+    manager._copy_bootstrap_files = _spy_copy
+    return manager
+
+
+async def test_bootstrap_copied_for_fresh_workspace(tmp_path):
+    manager = _make_manager(tmp_path)
+
+    await manager._create_sandbox("fresh_ws")
+
+    assert manager._copy_calls == [tmp_path / "fresh_ws"]
+
+
+async def test_bootstrap_not_copied_when_workspace_existed(tmp_path):
+    manager = _make_manager(tmp_path)
+    (tmp_path / "existing_ws").mkdir(parents=True, exist_ok=True)
+
+    await manager._create_sandbox("existing_ws")
+
+    assert manager._copy_calls == []


### PR DESCRIPTION
## Summary
Sandbox bootstrap files were never copied into a workspace that already existed on disk, so a reused workspace never received its bootstrap content.

## Problem
The bootstrap-copy decision was made after `start()` had already created the workspace directory, so the "does the workspace exist?" check always saw it as present and skipped the copy.

## Fix
Capture `workspace_existed = workspace.exists()` **before** calling `start()`, and drive the bootstrap-copy decision off that pre-start snapshot, so a genuinely new workspace gets its bootstrap files.

## Test
`bot/vikingbot/tests/unit/test_sandbox_bootstrap.py` — covers bootstrap copy on a fresh workspace vs skip on a pre-existing one (2 passed).
