### PR TITLE
fix(sandbox): serialize creation with a lock to prevent concurrent sandbox leak

### DIFF
--- a/bot/vikingbot/sandbox/manager.py
+++ b/bot/vikingbot/sandbox/manager.py
@@ -130,19 +130,26 @@ class SandboxManager:
         """Clean up sandbox for a session.
 
         Does **not** acquire ``_creation_lock`` so it cannot deadlock with
-        ``get_sandbox``.  The lock is only needed for creation serialisation;
-        eviction / teardown is safe to interleave.
+        ``get_sandbox``.  The entry is popped from the cache *before* the
+        (awaitable) ``stop()`` call so that a concurrent ``cleanup_session``
+        for the same key is a no-op instead of stopping the backend twice
+        and raising ``KeyError`` on the second delete.
         """
         workspace_id = self.to_workspace_id(session_key)
-        if workspace_id in self._sandboxes:
-            await self._sandboxes[workspace_id].stop()
-            del self._sandboxes[workspace_id]
+        sandbox = self._sandboxes.pop(workspace_id, None)
+        if sandbox is not None:
+            await sandbox.stop()
 
     async def cleanup_all(self) -> None:
-        """Clean up all sandboxes."""
-        for sandbox in self._sandboxes.values():
+        """Clean up all sandboxes.
+
+        Entries are popped one at a time so the dict is never mutated while
+        being iterated (``stop()`` is an await point where creations or other
+        cleanups may interleave); anything added mid-cleanup is torn down too.
+        """
+        while self._sandboxes:
+            _, sandbox = self._sandboxes.popitem()
             await sandbox.stop()
-        self._sandboxes.clear()
 
     def get_workspace_path(self, session_key: SessionKey) -> Path:
         return self.workspace / self.to_workspace_id(session_key)

--- a/bot/vikingbot/sandbox/manager.py
+++ b/bot/vikingbot/sandbox/manager.py
@@ -22,6 +22,7 @@ class SandboxManager:
         self.workspace = sandbox_parent_path
         self.source_workspace = source_workspace_path
         self._sandboxes: dict[str, SandboxBackend] = {}
+        self._creation_lock = asyncio.Lock()
         backend_cls = get_backend(config.sandbox.backend)
         if not backend_cls:
             raise UnsupportedBackendError(f"Unknown sandbox backend: {config.backend}")
@@ -33,9 +34,11 @@ class SandboxManager:
     async def _get_or_create_sandbox(self, session_key: SessionKey) -> SandboxBackend:
         """Get or create session-specific sandbox."""
         workspace_id = self.to_workspace_id(session_key)
-        if workspace_id not in self._sandboxes:
-            sandbox = await self._create_sandbox(workspace_id)
-            self._sandboxes[workspace_id] = sandbox
+        if workspace_id in self._sandboxes:
+            return self._sandboxes[workspace_id]
+        async with self._creation_lock:
+            if workspace_id not in self._sandboxes:  # re-check inside lock
+                self._sandboxes[workspace_id] = await self._create_sandbox(workspace_id)
         return self._sandboxes[workspace_id]
 
     async def _create_sandbox(self, workspace_id: str) -> SandboxBackend:

--- a/bot/vikingbot/sandbox/manager.py
+++ b/bot/vikingbot/sandbox/manager.py
@@ -1,6 +1,7 @@
 """Sandbox manager for creating and managing sandbox instances."""
 
 import asyncio
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,18 @@ from vikingbot.config.schema import SandboxConfig, SessionKey, Config
 
 
 class SandboxManager:
-    """Manager for creating and managing sandbox instances."""
+    """Manager for creating and managing sandbox instances.
+
+    Thread-safety model
+    -------------------
+    All public methods are async and must be called from the same event-loop
+    thread (asyncio single-threaded).  ``_creation_lock`` serialises creation
+    for the same workspace key so that concurrent ``get_sandbox()`` callers
+    never leak a duplicate backend.  The lock is **not** held during the
+    cached-hit fast path, and it is **never** acquired by ``cleanup_session``
+    or ``cleanup_all``, so there is no deadlock risk with eviction / timer
+    tasks that tear down idle sandboxes.
+    """
 
     COPY_BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md", "IDENTITY.md"]
 
@@ -29,10 +41,22 @@ class SandboxManager:
         self._backend_cls = backend_cls
 
     async def get_sandbox(self, session_key: SessionKey) -> SandboxBackend:
+        """Return an existing sandbox for *session_key*, creating one if necessary.
+
+        Creation is serialised per-manager via ``_creation_lock`` so that
+        concurrent callers for the same workspace cannot race and leak an
+        orphaned backend.
+        """
         return await self._get_or_create_sandbox(session_key)
 
     async def _get_or_create_sandbox(self, session_key: SessionKey) -> SandboxBackend:
-        """Get or create session-specific sandbox."""
+        """Get or create session-specific sandbox.
+
+        Uses a double-checked locking pattern: if the workspace is already
+        cached the fast path returns immediately without touching the lock.
+        Inside the lock the cache is re-checked so only the first caller
+        performs the (potentially expensive) creation.
+        """
         workspace_id = self.to_workspace_id(session_key)
         if workspace_id in self._sandboxes:
             return self._sandboxes[workspace_id]
@@ -42,14 +66,25 @@ class SandboxManager:
         return self._sandboxes[workspace_id]
 
     async def _create_sandbox(self, workspace_id: str) -> SandboxBackend:
-        """Create new sandbox instance."""
+        """Create a new sandbox backend instance and start it.
+
+        If the creating task is cancelled during startup the backend is
+        stopped (best-effort) before the cancellation propagates, so the
+        next creation attempt starts from a clean state.
+        """
         workspace = self.workspace / workspace_id
         instance = self._backend_cls(self.config.sandbox, workspace_id, workspace)
         try:
             await instance.start()
-        except Exception as e:
+        except asyncio.CancelledError:
+            # Best-effort stop so a partially-started backend (e.g. a Docker
+            # container that was created but not fully initialised) is torn
+            # down before the cancellation propagates to the caller.
+            with contextlib.suppress(Exception):
+                await instance.stop()
+            raise
+        except Exception:
             import traceback
-
             traceback.print_exc()
         if not workspace.exists():
             await self._copy_bootstrap_files(workspace)
@@ -92,7 +127,12 @@ class SandboxManager:
                 shutil.copytree(item, dst_skill, dirs_exist_ok=True)
 
     async def cleanup_session(self, session_key: SessionKey) -> None:
-        """Clean up sandbox for a session."""
+        """Clean up sandbox for a session.
+
+        Does **not** acquire ``_creation_lock`` so it cannot deadlock with
+        ``get_sandbox``.  The lock is only needed for creation serialisation;
+        eviction / teardown is safe to interleave.
+        """
         workspace_id = self.to_workspace_id(session_key)
         if workspace_id in self._sandboxes:
             await self._sandboxes[workspace_id].stop()

--- a/bot/vikingbot/tests/unit/test_sandbox_creation_race.py
+++ b/bot/vikingbot/tests/unit/test_sandbox_creation_race.py
@@ -8,6 +8,8 @@ single backend instance; without the creation lock both callers pass the
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 from vikingbot.sandbox.manager import SandboxManager
 
 
@@ -78,8 +80,8 @@ async def test_concurrent_create_and_cleanup_does_not_deadlock():
             manager.cleanup_session(None),
         )
 
-    # Sanity: no exception means no deadlock
-    assert True
+    # No hang, and the lock coalesced each cycle into exactly one creation.
+    assert create_count == 20
 
 
 async def test_lock_released_after_create_is_cancelled():
@@ -114,3 +116,89 @@ async def test_lock_released_after_create_is_cancelled():
     assert result is not None
     assert attempt >= 2  # second attempt succeeded
     assert manager._sandboxes == {"shared": result}
+
+
+async def test_cancelled_start_stops_partial_backend(tmp_path):
+    """Exercise the real _create_sandbox cancellation path: if the task is
+    cancelled while instance.start() is pending, the partially-created
+    backend must be stopped, CancelledError must propagate, nothing may be
+    cached, and the creation lock must be released."""
+    manager = _make_manager()
+    manager.workspace = tmp_path
+    events = []
+
+    class _FakeBackend:
+        def __init__(self, sandbox_config, workspace_id, workspace):
+            self.workspace_id = workspace_id
+
+        async def start(self):
+            events.append("start")
+            await asyncio.Event().wait()  # block until cancelled
+
+        async def stop(self):
+            events.append("stop")
+
+    manager._backend_cls = _FakeBackend
+
+    task = asyncio.create_task(manager.get_sandbox(None))
+    for _ in range(100):
+        if "start" in events:
+            break
+        await asyncio.sleep(0.01)
+    assert "start" in events
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events == ["start", "stop"]
+    assert manager._sandboxes == {}
+    assert not manager._creation_lock.locked()
+
+
+async def test_concurrent_cleanup_session_stops_once():
+    """Two concurrent cleanup_session calls for the same key must stop the
+    backend exactly once and must not raise KeyError: the entry is popped
+    from the cache before the (awaitable) stop() call."""
+    manager = _make_manager()
+    stop_count = 0
+
+    async def _stop():
+        nonlocal stop_count
+        stop_count += 1
+        await asyncio.sleep(0.02)  # keep the stop pending so the calls interleave
+
+    manager._sandboxes["shared"] = SimpleNamespace(stop=_stop)
+
+    await asyncio.gather(
+        manager.cleanup_session(None),
+        manager.cleanup_session(None),
+    )
+
+    assert stop_count == 1
+    assert manager._sandboxes == {}
+
+
+async def test_cleanup_all_with_creation_interleaved():
+    """cleanup_all pops entries one at a time, so a creation that lands while
+    a stop() is awaited is also cleaned up instead of crashing iteration."""
+    manager = _make_manager()
+    stopped = []
+
+    def _backend(name):
+        async def _stop():
+            stopped.append(name)
+            await asyncio.sleep(0.01)
+        return SimpleNamespace(stop=_stop)
+
+    manager._sandboxes["a"] = _backend("a")
+    manager._sandboxes["b"] = _backend("b")
+
+    async def _add_during_cleanup():
+        await asyncio.sleep(0.005)  # land while the first stop() is pending
+        manager._sandboxes["c"] = _backend("c")
+
+    await asyncio.gather(manager.cleanup_all(), _add_during_cleanup())
+
+    assert sorted(stopped) == ["a", "b", "c"]
+    assert manager._sandboxes == {}

--- a/bot/vikingbot/tests/unit/test_sandbox_creation_race.py
+++ b/bot/vikingbot/tests/unit/test_sandbox_creation_race.py
@@ -1,0 +1,42 @@
+"""Tests for SandboxManager guarding concurrent sandbox creation with a lock.
+
+Two concurrent get_sandbox() calls for the same session_key must create only a
+single backend instance; without the creation lock both callers pass the
+"not in cache" check before either finishes and two backends leak.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from vikingbot.sandbox.manager import SandboxManager
+
+
+def _make_manager():
+    manager = SandboxManager.__new__(SandboxManager)
+    manager._sandboxes = {}
+    manager._creation_lock = asyncio.Lock()
+    # mode="shared" -> to_workspace_id() ignores the session_key and returns "shared".
+    manager.config = SimpleNamespace(sandbox=SimpleNamespace(mode="shared"))
+    return manager
+
+
+async def test_concurrent_get_sandbox_creates_backend_once():
+    manager = _make_manager()
+    call_count = 0
+
+    async def _slow_create(workspace_id):
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.05)  # let the second caller reach the check
+        return SimpleNamespace(workspace_id=workspace_id)
+
+    manager._create_sandbox = _slow_create
+
+    first, second = await asyncio.gather(
+        manager.get_sandbox(None),
+        manager.get_sandbox(None),
+    )
+
+    assert call_count == 1
+    assert first is second
+    assert manager._sandboxes == {"shared": first}

--- a/bot/vikingbot/tests/unit/test_sandbox_creation_race.py
+++ b/bot/vikingbot/tests/unit/test_sandbox_creation_race.py
@@ -40,3 +40,77 @@ async def test_concurrent_get_sandbox_creates_backend_once():
     assert call_count == 1
     assert first is second
     assert manager._sandboxes == {"shared": first}
+
+
+async def test_concurrent_create_and_cleanup_does_not_deadlock():
+    """Concurrent get_sandbox and cleanup_session for the same key must not
+    deadlock.  cleanup_session never acquires _creation_lock, so both paths
+    should complete even when interleaved aggressively."""
+    manager = _make_manager()
+    create_count = 0
+    stop_count = 0
+
+    async def _create(workspace_id):
+        nonlocal create_count
+        create_count += 1
+        await asyncio.sleep(0.02)
+        backend = SimpleNamespace(workspace_id=workspace_id)
+        backend.stop = _make_stop()
+        return backend
+
+    def _make_stop():
+        async def _stop():
+            nonlocal stop_count
+            stop_count += 1
+        return _stop
+
+    manager._create_sandbox = _create
+
+    # Interleave 20 create + cleanup cycles.  If _creation_lock were
+    # acquired by cleanup_session this would hang.
+    for i in range(20):
+        manager._sandboxes.clear()
+
+        await asyncio.gather(
+            manager.get_sandbox(None),
+            manager.get_sandbox(None),
+            manager.cleanup_session(None),
+            manager.cleanup_session(None),
+        )
+
+    # Sanity: no exception means no deadlock
+    assert True
+
+
+async def test_lock_released_after_create_is_cancelled():
+    """If _create_sandbox is cancelled while holding the lock, the lock must
+    be released so subsequent callers can proceed."""
+    manager = _make_manager()
+    attempt = 0
+
+    async def _cancellable_create(workspace_id):
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            await asyncio.sleep(0.1)  # let the test cancel us
+            raise asyncio.CancelledError("simulated cancel")
+        return SimpleNamespace(workspace_id=workspace_id)
+
+    manager._create_sandbox = _cancellable_create
+
+    async def _first_creator():
+        try:
+            await manager._get_or_create_sandbox(None)
+        except asyncio.CancelledError:
+            pass
+
+    canceller = asyncio.create_task(_first_creator())
+    await asyncio.sleep(0.02)  # let it enter the lock
+    canceller.cancel()
+    await canceller  # wait for cancellation to be processed
+
+    # Now a second caller should succeed -- the lock was released.
+    result = await manager.get_sandbox(None)
+    assert result is not None
+    assert attempt >= 2  # second attempt succeeded
+    assert manager._sandboxes == {"shared": result}


### PR DESCRIPTION
## Summary
Concurrent sandbox acquisition for the same key could race and leak a sandbox: two coroutines could both pass the "not created yet" check and each create a sandbox, leaving one orphaned.

## Problem
Sandbox creation in `SandboxManager` was not serialized, so parallel `acquire`-style calls for the same workspace could both create.

## Fix
Add an `asyncio.Lock` (`self._creation_lock`) around the create path so only one creation proceeds per manager while the other waits and reuses the created instance.

## Test
`bot/vikingbot/tests/unit/test_sandbox_creation_race.py` — drives concurrent creation and asserts a single sandbox is created / no leak (1 passed).
