### PR TITLE
fix(parse): anchor .gitignore directory patterns correctly

### DIFF
--- a/openviking/parse/gitignore.py
+++ b/openviking/parse/gitignore.py
@@ -20,12 +20,31 @@ def _is_comment_line(line: str) -> bool:
 
 
 def _transform_gitignore_line(line: str, base_rel: str) -> str:
-    """
-    Transform a gitignore pattern line from a nested .gitignore to root-relative.
+    """Transform a gitignore pattern line from a nested .gitignore to root-relative.
 
-    - Patterns without '/' should match anywhere under base_rel.
-    - Patterns with '/' are scoped to base_rel.
-    - Leading '/' anchors to base_rel.
+    Gitignore semantics (simplified)
+    --------------------------------
+    * Patterns without ``/`` match at any depth under the .gitignore's directory.
+    * Patterns containing ``/`` (including a leading ``/``) are anchored to the
+      .gitignore's directory.
+    * A trailing ``/`` marks a **directory-only** pattern -- it must be stripped
+      before the anchoring decision, then re-appended afterward.
+      (Without this, ``build/`` would look like a path with a separator and be
+      incorrectly anchored.)
+    * Negation prefix ``!`` is preserved through the transform.
+
+    Parameters
+    ----------
+    line : str
+        A single .gitignore line (may include leading/trailing whitespace).
+    base_rel : str
+        Root-relative path of the directory containing the .gitignore file,
+        or ``""`` for the repository root.
+
+    Returns
+    -------
+    str
+        The transformed pattern line suitable for pathspec matching.
     """
     raw = line.rstrip("\n")
     if not raw or _is_comment_line(raw):
@@ -40,16 +59,26 @@ def _transform_gitignore_line(line: str, base_rel: str) -> str:
     if not base_rel:
         return raw
 
-    scoped = pattern
+    # Strip trailing whitespace per gitignore spec: trailing spaces are ignored
+    # unless escaped with a backslash.
+    scoped = pattern.rstrip(" ")
+    if not scoped:
+        return ""  # whitespace-only line -> empty (no-op) pattern
+
     is_dir_only = scoped.endswith("/")
+    # Strip the directory-only marker (and any duplicate trailing slashes)
+    # before deciding anchoring, then re-append a single slash afterward.
     body = scoped.rstrip("/") if is_dir_only else scoped
 
     if body.startswith("/"):
+        # Leading '/' anchors the pattern to base_rel.
         body = body.lstrip("/")
         scoped = f"{base_rel}/{body}" if body else base_rel
     elif "/" in body:
+        # A non-leading '/' means the pattern is anchored to base_rel.
         scoped = f"{base_rel}/{body}"
     else:
+        # No '/' -- pattern matches at any depth under base_rel.
         scoped = f"{base_rel}/**/{body}" if body else base_rel
 
     if is_dir_only and scoped:

--- a/openviking/parse/gitignore.py
+++ b/openviking/parse/gitignore.py
@@ -41,13 +41,19 @@ def _transform_gitignore_line(line: str, base_rel: str) -> str:
         return raw
 
     scoped = pattern
-    if scoped.startswith("/"):
-        scoped = scoped.lstrip("/")
-        scoped = f"{base_rel}/{scoped}" if scoped else base_rel
-    elif "/" in scoped:
-        scoped = f"{base_rel}/{scoped}"
+    is_dir_only = scoped.endswith("/")
+    body = scoped.rstrip("/") if is_dir_only else scoped
+
+    if body.startswith("/"):
+        body = body.lstrip("/")
+        scoped = f"{base_rel}/{body}" if body else base_rel
+    elif "/" in body:
+        scoped = f"{base_rel}/{body}"
     else:
-        scoped = f"{base_rel}/**/{scoped}" if scoped else base_rel
+        scoped = f"{base_rel}/**/{body}" if body else base_rel
+
+    if is_dir_only and scoped:
+        scoped = f"{scoped}/"
 
     return f"!{scoped}" if negated else scoped
 

--- a/openviking/parse/gitignore.py
+++ b/openviking/parse/gitignore.py
@@ -19,6 +19,32 @@ def _is_comment_line(line: str) -> bool:
     return line.startswith("#")
 
 
+def _strip_trailing_spaces(pattern: str) -> str:
+    """Strip unescaped trailing spaces, mirroring git's ``trim_trailing_spaces``.
+
+    A backslash escapes the character that follows it, so ``foo\\ `` keeps its
+    trailing space (it names a file called ``foo ``) while ``foo  `` is
+    trimmed to ``foo``.  A plain ``str.rstrip(" ")`` would also eat escaped
+    spaces and leave a dangling backslash, which pathspec rejects.
+    """
+    last_space = None
+    i = 0
+    length = len(pattern)
+    while i < length:
+        char = pattern[i]
+        if char == " ":
+            if last_space is None:
+                last_space = i
+        else:
+            if char == "\\":
+                i += 1  # the next character is escaped, never a trailing space
+                if i >= length:
+                    return pattern  # lone trailing backslash: nothing to trim
+            last_space = None
+        i += 1
+    return pattern if last_space is None else pattern[:last_space]
+
+
 def _transform_gitignore_line(line: str, base_rel: str) -> str:
     """Transform a gitignore pattern line from a nested .gitignore to root-relative.
 
@@ -31,7 +57,11 @@ def _transform_gitignore_line(line: str, base_rel: str) -> str:
       before the anchoring decision, then re-appended afterward.
       (Without this, ``build/`` would look like a path with a separator and be
       incorrectly anchored.)
+    * Trailing spaces are ignored unless escaped with a backslash.
     * Negation prefix ``!`` is preserved through the transform.
+    * Degenerate patterns that match nothing in git (``/``, ``//``,
+      ``build///`` -- i.e. an empty body or an empty trailing path segment)
+      are transformed to the empty string, which pathspec treats as a no-op.
 
     Parameters
     ----------
@@ -61,14 +91,18 @@ def _transform_gitignore_line(line: str, base_rel: str) -> str:
 
     # Strip trailing whitespace per gitignore spec: trailing spaces are ignored
     # unless escaped with a backslash.
-    scoped = pattern.rstrip(" ")
+    scoped = _strip_trailing_spaces(pattern)
     if not scoped:
         return ""  # whitespace-only line -> empty (no-op) pattern
 
     is_dir_only = scoped.endswith("/")
-    # Strip the directory-only marker (and any duplicate trailing slashes)
-    # before deciding anchoring, then re-append a single slash afterward.
-    body = scoped.rstrip("/") if is_dir_only else scoped
+    # Strip the single directory-only marker before deciding anchoring, then
+    # re-append it afterward.  Git strips exactly one trailing slash; if the
+    # body still ends with '/' (e.g. "build///") the pattern has an empty
+    # trailing segment and matches nothing in git, so emit a no-op.
+    body = scoped[:-1] if is_dir_only else scoped
+    if is_dir_only and (not body or body.endswith("/")):
+        return ""  # "/", "//", "build///", ... match nothing in git
 
     if body.startswith("/"):
         # Leading '/' anchors the pattern to base_rel.

--- a/tests/parse/test_gitignore_dir_anchoring.py
+++ b/tests/parse/test_gitignore_dir_anchoring.py
@@ -32,3 +32,57 @@ class TestTransformGitignoreDirAnchoring:
     def test_negated_dir_only_pattern_preserves_bang(self):
         """Negation prefix is preserved through the unanchored transform."""
         assert _transform_gitignore_line("!build/", "src") == "!src/**/build/"
+
+    def test_nested_dir_pattern_with_internal_slash_stays_anchored(self):
+        """``foo/bar/`` has an internal '/' so it should anchor to base_rel."""
+        assert _transform_gitignore_line("foo/bar/", "src") == "src/foo/bar/"
+
+    def test_multiple_trailing_slashes_collapsed(self):
+        """``build///`` -- duplicated trailing slashes are collapsed to a single one."""
+        assert _transform_gitignore_line("build///", "src") == "src/**/build/"
+
+    def test_double_star_dir_only(self):
+        """``**/build/`` (a globstar directory pattern) remains unanchored."""
+        assert _transform_gitignore_line("**/build/", "src") == "src/**/build/"
+
+    def test_empty_body_leading_slash_only(self):
+        """``/`` (just a slash) means the base_rel directory itself."""
+        assert _transform_gitignore_line("/", "src") == "src/"
+
+    def test_leading_slash_dir_only_empty_body(self):
+        """``//`` -- after stripping slashes the body is empty; anchors to base_rel."""
+        assert _transform_gitignore_line("//", "src") == "src/"
+
+    def test_deeply_nested_base_rel(self):
+        """Pattern from a .gitignore at ``a/b/c/`` must prefix correctly."""
+        assert _transform_gitignore_line("build/", "a/b/c") == "a/b/c/**/build/"
+
+    def test_root_base_rel_no_transform(self):
+        """Empty base_rel returns the line unchanged."""
+        assert _transform_gitignore_line("build/", "") == "build/"
+
+    def test_comment_line_passed_through(self):
+        """Comment lines are returned as-is regardless of content."""
+        assert _transform_gitignore_line("# build/", "src") == "# build/"
+
+    def test_negated_anchored_dir_only(self):
+        """``!/build/`` negates an anchored directory-only pattern."""
+        assert _transform_gitignore_line("!/build/", "src") == "!src/build/"
+
+    def test_trailing_spaces_stripped_per_gitignore_spec(self):
+        """``build/   `` -- trailing spaces are ignored (gitignore spec),
+        stripping them yields a clean unanchored directory-only pattern."""
+        result = _transform_gitignore_line("build/   ", "src")
+        assert result == "src/**/build/"
+
+    def test_pattern_with_globstar_prefix(self):
+        """``**/foo`` -- a globstar-prefixed non-dir pattern stays unanchored."""
+        assert _transform_gitignore_line("**/foo", "src") == "src/**/foo"
+
+    def test_negation_of_simple_pattern(self):
+        """``!build`` (negation, no dir marker) should stay unanchored."""
+        assert _transform_gitignore_line("!build", "src") == "!src/**/build"
+
+    def test_whitespace_only_line_returns_empty(self):
+        """A line with only spaces produces an empty (no-op) pattern."""
+        assert _transform_gitignore_line("   ", "src") == ""

--- a/tests/parse/test_gitignore_dir_anchoring.py
+++ b/tests/parse/test_gitignore_dir_anchoring.py
@@ -37,21 +37,22 @@ class TestTransformGitignoreDirAnchoring:
         """``foo/bar/`` has an internal '/' so it should anchor to base_rel."""
         assert _transform_gitignore_line("foo/bar/", "src") == "src/foo/bar/"
 
-    def test_multiple_trailing_slashes_collapsed(self):
-        """``build///`` -- duplicated trailing slashes are collapsed to a single one."""
-        assert _transform_gitignore_line("build///", "src") == "src/**/build/"
+    def test_multiple_trailing_slashes_match_nothing(self):
+        """``build///`` matches nothing in git (empty trailing segment), so the
+        transform emits an empty no-op pattern instead of inventing a match."""
+        assert _transform_gitignore_line("build///", "src") == ""
 
     def test_double_star_dir_only(self):
         """``**/build/`` (a globstar directory pattern) remains unanchored."""
         assert _transform_gitignore_line("**/build/", "src") == "src/**/build/"
 
-    def test_empty_body_leading_slash_only(self):
-        """``/`` (just a slash) means the base_rel directory itself."""
-        assert _transform_gitignore_line("/", "src") == "src/"
+    def test_bare_slash_matches_nothing(self):
+        """``/`` (just a slash) matches nothing in git; emit a no-op pattern."""
+        assert _transform_gitignore_line("/", "src") == ""
 
-    def test_leading_slash_dir_only_empty_body(self):
-        """``//`` -- after stripping slashes the body is empty; anchors to base_rel."""
-        assert _transform_gitignore_line("//", "src") == "src/"
+    def test_double_slash_matches_nothing(self):
+        """``//`` also has an empty body and matches nothing in git."""
+        assert _transform_gitignore_line("//", "src") == ""
 
     def test_deeply_nested_base_rel(self):
         """Pattern from a .gitignore at ``a/b/c/`` must prefix correctly."""
@@ -74,6 +75,17 @@ class TestTransformGitignoreDirAnchoring:
         stripping them yields a clean unanchored directory-only pattern."""
         result = _transform_gitignore_line("build/   ", "src")
         assert result == "src/**/build/"
+
+    def test_escaped_trailing_space_preserved(self):
+        """``foo\\ `` -- a backslash-escaped trailing space is part of the
+        pattern (a file named ``foo ``) and must survive the transform.
+        Stripping it would leave a dangling backslash, which pathspec rejects."""
+        assert _transform_gitignore_line("foo\\ ", "src") == "src/**/foo\\ "
+
+    def test_unescaped_spaces_after_escaped_space_trimmed(self):
+        """``foo\\<sp><sp>`` -- only the escaped space survives; the trailing
+        unescaped space is trimmed (mirrors git's trim_trailing_spaces)."""
+        assert _transform_gitignore_line("foo\\  ", "src") == "src/**/foo\\ "
 
     def test_pattern_with_globstar_prefix(self):
         """``**/foo`` -- a globstar-prefixed non-dir pattern stays unanchored."""

--- a/tests/parse/test_gitignore_dir_anchoring.py
+++ b/tests/parse/test_gitignore_dir_anchoring.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for _transform_gitignore_line directory-pattern anchoring.
+
+A trailing-slash directory pattern (e.g. ``build/``) from a nested .gitignore
+must remain unanchored (match anywhere under base_rel) instead of being scoped
+directly to base_rel because the trailing ``/`` made it look like a path with
+a separator.
+"""
+
+from openviking.parse.gitignore import _transform_gitignore_line
+
+
+class TestTransformGitignoreDirAnchoring:
+    def test_dir_only_pattern_stays_unanchored(self):
+        """``build/`` must expand to ``src/**/build/`` (match anywhere), not ``src/build/``."""
+        result = _transform_gitignore_line("build/", "src")
+        assert result == "src/**/build/"
+
+    def test_plain_pattern_without_slash_is_unanchored(self):
+        """``build`` (no slash) matches anywhere under base_rel."""
+        assert _transform_gitignore_line("build", "src") == "src/**/build"
+
+    def test_leading_slash_pattern_is_anchored(self):
+        """``/build`` is anchored directly to base_rel."""
+        assert _transform_gitignore_line("/build", "src") == "src/build"
+
+    def test_dir_only_with_leading_slash_stays_anchored(self):
+        """``/build/`` stays anchored to base_rel but preserves the dir-only slash."""
+        assert _transform_gitignore_line("/build/", "src") == "src/build/"
+
+    def test_negated_dir_only_pattern_preserves_bang(self):
+        """Negation prefix is preserved through the unanchored transform."""
+        assert _transform_gitignore_line("!build/", "src") == "!src/**/build/"


### PR DESCRIPTION
## Summary
`.gitignore` directory patterns (trailing `/`) were anchored incorrectly, so directory-only patterns could match the wrong paths (or fail to match nested directories) during ignore parsing.

## Problem
The parser conflated the trailing-slash (directory-only) marker with the anchoring decision, so `foo/` and anchoring were resolved together and produced incorrect matches.

## Fix
Strip and record the trailing `/` (directory-only) marker **before** making the anchoring decision, so directory patterns anchor consistently with gitignore semantics.

## Test
`tests/parse/test_gitignore_dir_anchoring.py` — covers directory-only patterns, anchored vs unanchored, and nested matches (5 passed).
