### PR TITLE
fix(vlm): preserve GitHub Copilot routes

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -120,6 +120,7 @@ EXPLICIT_LITELLM_PREFIXES: tuple[str, ...] = (
     "sagemaker_chat/",
     "sagemaker_nova/",
     "vertex_ai/",
+    "github_copilot/",
 )
 
 # These explicit routes normally authenticate through cloud-native credential

--- a/tests/unit/test_litellm_vlm_provider_detection.py
+++ b/tests/unit/test_litellm_vlm_provider_detection.py
@@ -53,6 +53,17 @@ class TestLiteLLMVLMProviderDetection:
         assert _vlm(model)._resolve_model(model) == model
 
     @pytest.mark.parametrize(
+        "model",
+        [
+            "github_copilot/claude-opus-4.8",
+            "github_copilot/gpt-4o",
+        ],
+    )
+    def test_github_copilot_route_is_left_alone(self, model):
+        assert detect_provider_by_model(model) is None
+        assert _vlm(model)._resolve_model(model) == model
+
+    @pytest.mark.parametrize(
         ("model", "provider"),
         [
             ("gemini-3.1-flash-lite-preview", "gemini"),


### PR DESCRIPTION
## Summary

- Treat `github_copilot/` model names as authoritative LiteLLM routes.
- Prevent the inner model name from being re-detected as another provider.
- Add regression coverage for both Claude and GPT models routed through GitHub Copilot.

## Problem

`github_copilot/claude-opus-4.8` is already a complete LiteLLM route. However, OpenViking currently runs keyword detection over the entire string, matches `claude`, and resolves the request through the Anthropic provider. The same problem affects `github_copilot/gpt-4o`, which is detected as OpenAI.

In practice, a valid GitHub Copilot configuration can fail with an unrelated provider-authentication error such as `Missing Anthropic API Key`, even though LiteLLM can route the original model name through GitHub Copilot directly.

## Fix

Add `github_copilot/` to `EXPLICIT_LITELLM_PREFIXES`, alongside the native LiteLLM routes introduced in #2111. This preserves the complete route before keyword detection. It is intentionally not added to `NATIVE_AUTH_LITELLM_PREFIXES`, so Copilot keeps using its normal token flow.

## Testing

- Regression test before the fix: `2 failed, 9 passed`
  - Claude route was detected as `anthropic`.
  - GPT route was detected as `openai`.
- Regression test after the fix: `11 passed`.
- Related VLM test set: `71 passed`.
- Mutation check: removing the new prefix makes both new cases fail again; restoring it returns the suite to `11 passed`.
- `ruff check` passed.
- `ruff format --check` passed.
- `git diff --check` passed.

## Type of Change

- [x] Bug fix
- [x] Test update
