### PR TITLE
improve(helm): production hardening for the OpenViking chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -19,18 +19,25 @@ helm install openviking ./deploy/helm/openviking \
   --set-string config.vlm.api_key="YOUR_VOLCENGINE_API_KEY"
 ```
 
-The chart deploys `ghcr.io/volcengine/openviking:latest` by default. To choose
-a different image tag:
+> **`root_api_key` is required by default.** When `config.server.host` is
+> `0.0.0.0` (the default), the server refuses to start without a root API key.
+> The chart now fails fast at `helm install/upgrade` time if it is missing,
+> rather than leaving you to discover a `CrashLoopBackOff`. See
+> [Using Secrets for API Keys](#using-secrets-for-api-keys) for the production
+> pattern, or set `config.server.host: "127.0.0.1"` to run without one.`
+
+The chart deploys `ghcr.io/volcengine/openviking:{appVersion}` by default (the
+release this chart was tested with). To choose a different image tag:
 
 ```bash
 # newest image from the main branch
 helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=main
 
-# pinned release image
-helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=v0.3.17
+# explicit latest (mutable, use Always pullPolicy)
+helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=latest
 
-# use the default latest image
-helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=
+# pinned release image
+helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=v0.4.9
 ```
 
 ### Install with Custom Values
@@ -140,10 +147,12 @@ Secrets.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `replicaCount` | Number of replicas | `1` |
+| `replicaCount` | Number of replicas (1 by default; see Multi-Instance Deployment) | `1` |
+| `strategy` | Deployment update strategy (defaults to `Recreate`) | unset |
+| `autoscaling.enabled` | Create a HorizontalPodAutoscaler (requires multi-instance setup) | `false` |
 | `image.repository` | Container image repository | `ghcr.io/volcengine/openviking` |
-| `image.tag` | Container image tag (`latest`, `main`, pinned release, or empty for `latest`) | `latest` |
-| `image.pullPolicy` | Image pull policy | `Always` |
+| `image.tag` | Container image tag (empty resolves to `appVersion`) | `""` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `service.type` | Kubernetes service type | `ClusterIP` |
 | `service.port` | Service port | `1933` |
 | `persistence.enabled` | Enable persistent storage | `true` |
@@ -157,9 +166,82 @@ Secrets.
 | `resources.requests.cpu` | CPU request | `500m` |
 | `resources.requests.memory` | Memory request | `1Gi` |
 | `ingress.enabled` | Enable ingress | `false` |
-| `config.server.root_api_key` | API key required when server binds to 0.0.0.0 | `""` |
+| `config.server.root_api_key` | API key required when server binds to 0.0.0.0; **fail-fast if missing** | `null` |
 | `config` | Full ov.conf configuration object | See `values.yaml` |
+| `config.server.observability` | OpenTelemetry exporters (metrics/traces/logs); disabled by default | See `values.yaml` |
+| `serviceAccount.create` | Create a dedicated ServiceAccount for the pod | `false` |
+| `serviceAccount.name` | Name of the ServiceAccount to use (generated when `create: true` and unset) | `""` |
 | `extraEnv` | Additional environment variables | `[]` |
+| `monitoring.serviceMonitor.enabled` | Create a Prometheus ServiceMonitor for the `/metrics` endpoint | `false` |
+| `monitoring.serviceMonitor.labels` | Extra labels for ServiceMonitor (set the Prometheus release label here) | `{}` |
+| `monitoring.serviceMonitor.relabelings` | Target relabeling rules | `[]` |
+| `monitoring.serviceMonitor.metricRelabelings` | Metric-level relabeling rules | `[]` |
+| `podDisruptionBudget.enabled` | Create a PodDisruptionBudget (multi-instance only) | `false` |
+| `networkPolicy.enabled` | Create a NetworkPolicy restricting ingress | `false` |
+| `networkPolicy.ingress` | Custom ingress rules (default allows http from any source) | unset |
+
+## Observability
+
+OpenViking exposes a Prometheus `/metrics` endpoint (enabled by default in the
+app) and supports OpenTelemetry exporters for metrics, traces, and logs.
+
+### Prometheus (ServiceMonitor)
+
+If you run the Prometheus operator, enable the ServiceMonitor and set the label
+that matches your Prometheus release:
+
+```yaml
+monitoring:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus  # match your Prometheus Helm release
+```
+
+### OpenTelemetry
+
+OTel exporters are disabled by default in `values.yaml` under
+`config.server.observability`. Enable the signal(s) you need and point them at
+your OTel Collector:
+
+```yaml
+config:
+  server:
+    observability:
+      metrics:
+        enabled: true
+        exporters:
+          otel:
+            enabled: true
+            endpoint: "otel-collector.monitoring.svc.cluster.local:4317"
+      traces:
+        enabled: true
+        endpoint: "otel-collector.monitoring.svc.cluster.local:4317"
+      logs:
+        enabled: true
+        endpoint: "otel-collector.monitoring.svc.cluster.local:4317"
+```
+
+### ServiceMonitor relabeling
+
+The ServiceMonitor supports `relabelings` (target relabeling) and
+`metricRelabelings` (metric-level filtering) for advanced Prometheus setups:
+
+```yaml
+monitoring:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+    relabelings:
+      - sourceLabels: [__address__]
+        targetLabel: cluster
+        replacement: my-cluster
+    metricRelabelings:
+      - action: drop
+        sourceLabels: [__name__]
+        regex: 'openviking_encryption_.*'
+```
 
 ## Upgrading
 
@@ -167,8 +249,95 @@ Secrets.
 helm upgrade openviking ./deploy/helm/openviking -f my-values.yaml
 ```
 
-The deployment uses a `Recreate` strategy to avoid data corruption from
-multiple pods accessing the same RocksDB volume simultaneously.
+The default strategy is `Recreate` (the pod is terminated and recreated on each
+upgrade). This is the safe choice for single-replica with the local backend.
+For multi-instance deployments, set `strategy.type: RollingUpdate` to avoid
+downtime during upgrades.
+
+## Multi-Instance Deployment
+
+By default the chart runs a single replica with local backends. OpenViking
+supports multi-instance when pods share the same data — either via **remote
+backends** or a **shared filesystem**. See the
+[official deployment guide](https://docs.openviking.ai/zh/guides/03-deployment#多实例部署注意事项)
+for the full reference.
+
+### Option A: Remote backends (recommended for cloud)
+
+AGFS and VectorDB both use cloud services, so all pods access the same data
+regardless of PVC:
+
+```yaml
+config:
+  storage:
+    vectordb:
+      backend: "volcengine"   # or "qdrant", "http", etc.
+    agfs:
+      backend: "s3"
+```
+
+> **Both backends must be remote.** Setting only `agfs.backend: "s3"` while
+> leaving `vectordb.backend: "local"` causes each pod's vector index (RocksDB)
+> to live on its own PVC — indexes silently diverge.
+
+### Option B: Shared filesystem (NFS / CephFS / RWX PVC)
+
+Keep `local` backends but mount a shared `ReadWriteMany` volume so all pods
+read/write the same workspace:
+
+```yaml
+persistence:
+  accessMode: ReadWriteMany
+  storageClass: "nfs-client"   # your RWX storage class
+```
+
+### Required ov.conf settings (both options)
+
+```yaml
+config:
+  server:
+    temp_upload:
+      default_mode: "shared"
+    observability:
+      usage_audit:
+        sqlite_path: "/var/lib/openviking-local/usage_audit.sqlite3"
+  storage:
+    skip_process_lock: true            # REQUIRED — skip .openviking.pid
+    agfs:
+      queuefs:
+        db_path: "/var/lib/openviking-local/queue.db"  # per-pod SQLite
+```
+
+### Chart guards
+
+The chart fails fast if multi-instance is requested without the prerequisites:
+
+1. **`skip_process_lock=true`** is required (the `.openviking.pid` process lock
+   prevents concurrent access by design).
+2. **Shared data** is required — either remote backends for BOTH agfs and
+   vectordb, OR `persistence.accessMode: ReadWriteMany` for a shared volume.
+   With local backends on a `ReadWriteOnce` PVC, each pod gets divergent data.
+
+### Enabling HPA and PDB
+
+Once the prerequisites are met:
+
+```yaml
+replicaCount: 1
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
 
 ## Uninstalling
 
@@ -176,8 +345,9 @@ multiple pods accessing the same RocksDB volume simultaneously.
 helm uninstall openviking
 ```
 
-Note: The PersistentVolumeClaim is not deleted automatically. To remove stored
-data:
+The PersistentVolumeClaim is annotated with `helm.sh/resource-policy: keep`, so
+it survives `helm uninstall` and protects your data from accidental removal. To
+reclaim the storage after uninstalling:
 
 ```bash
 kubectl delete pvc openviking-data

--- a/deploy/helm/openviking/Chart.yaml
+++ b/deploy/helm/openviking/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: openviking
 description: OpenViking - The Context Database for AI Agents
 type: application
-version: 0.1.1
+version: 0.1.2
+appVersion: v0.4.9
 keywords:
   - openviking
   - ai

--- a/deploy/helm/openviking/templates/NOTES.txt
+++ b/deploy/helm/openviking/templates/NOTES.txt
@@ -28,14 +28,13 @@ IMPORTANT: Make sure to configure your embedding and VLM API keys in values.yaml
 or via extraEnv before using OpenViking. The server will not function correctly
 without valid model provider credentials.
 
-{{- if not .Values.config.server.root_api_key }}
+To use the in-pod `ov` CLI, create a CLI config interactively (this writes
+ovcli.conf into the persistent volume, so it survives restarts):
 
-WARNING: config.server.root_api_key is not set. When the server binds to 0.0.0.0
-(the default), a root_api_key is REQUIRED for security. The server will refuse to
-start without it.
+  CLI_POD=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath='{.items[0].metadata.name}')
+  kubectl exec -it -n {{ .Release.Namespace }} "$CLI_POD" -- ov config
 
-Set it via:
+Replace `<chart>` with your chart path when running helm commands, e.g.:
 
-  helm upgrade {{ .Release.Name }} <chart> --set config.server.root_api_key="YOUR_SECRET_KEY"
+  helm upgrade {{ .Release.Name }} ./deploy/helm/openviking -f my-values.yaml
 
-{{- end }}

--- a/deploy/helm/openviking/templates/_helpers.tpl
+++ b/deploy/helm/openviking/templates/_helpers.tpl
@@ -64,16 +64,31 @@ Create the name of the service account to use.
 {{- end }}
 
 {{/*
+Resolve the effective image tag.
+Priority: explicit image.tag > Chart.appVersion > "latest".
+An empty tag (the default) resolves to Chart.appVersion so the chart deploys
+the release it was tested with, rather than a mutable "latest".
+*/}}
+{{- define "openviking.imageTag" -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{- if $tag -}}
+{{- $tag -}}
+{{- else -}}
+{{- default "latest" .Chart.AppVersion -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the deployed app version label.
+Uses the resolved tag (same logic as the image).
 */}}
 {{- define "openviking.appVersion" -}}
-{{- default "latest" .Values.image.tag -}}
+{{- include "openviking.imageTag" . -}}
 {{- end }}
 
 {{/*
 Return the image name including tag.
 */}}
 {{- define "openviking.image" -}}
-{{- $tag := default "latest" .Values.image.tag -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository (include "openviking.imageTag" .) -}}
 {{- end }}

--- a/deploy/helm/openviking/templates/deployment.yaml
+++ b/deploy/helm/openviking/templates/deployment.yaml
@@ -1,5 +1,22 @@
-{{- if gt (int .Values.replicaCount) 1 }}
-{{- fail "replicaCount must be 1. OpenViking uses RocksDB which does not support concurrent access from multiple pods sharing the same PVC." }}
+{{- $multiReplica := or (gt (int .Values.replicaCount) 1) .Values.autoscaling.enabled }}
+{{- if $multiReplica }}
+{{- if not .Values.config.storage.skip_process_lock }}
+{{- fail "replicaCount > 1 (or autoscaling.enabled) requires config.storage.skip_process_lock=true. See README 'Multi-Instance Deployment'." }}
+{{- end }}
+{{- /* Data must be shared across pods: either remote backends OR a shared (RWX) volume. */ -}}
+{{- $agfsBackend := default "local" .Values.config.storage.agfs.backend }}
+{{- $vdbBackend := default "local" .Values.config.storage.vectordb.backend }}
+{{- $localBackends := list "local" "cuvs" "memory" }}
+{{- $hasLocalBackend := or (has $agfsBackend $localBackends) (has $vdbBackend $localBackends) }}
+{{- $accessMode := default "ReadWriteOnce" .Values.persistence.accessMode }}
+{{- $sharedVolume := eq $accessMode "ReadWriteMany" }}
+{{- if and $hasLocalBackend (not $sharedVolume) }}
+{{- fail (printf "Multi-instance with local backends (agfs=%q, vectordb=%q) requires a shared volume — set persistence.accessMode to ReadWriteMany (NFS/CephFS/etc.), or switch to remote backends (agfs.backend=\"s3\", vectordb.backend=\"volcengine\"/\"qdrant\"/\"http\"/etc.). With ReadWriteOnce each pod gets its own data and silently diverges. See README 'Multi-Instance Deployment'." $agfsBackend $vdbBackend) }}
+{{- end }}
+{{- end }}
+{{- $loopback := list "127.0.0.1" "localhost" "::1" -}}
+{{- if and (not (has .Values.config.server.host $loopback)) (not .Values.config.server.root_api_key) }}
+{{- fail (printf "config.server.root_api_key is required when config.server.host is %q (non-loopback). The server refuses to start without it. Set it to a literal or a ${VAR} placeholder (resolved at runtime from env/Secret), or bind to loopback (127.0.0.1) to run without one." .Values.config.server.host) }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
@@ -8,12 +25,18 @@ metadata:
   labels:
     {{- include "openviking.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "openviking.selectorLabels" . | nindent 6 }}
   strategy:
+    {{- if .Values.strategy }}
+    {{- toYaml .Values.strategy | nindent 4 }}
+    {{- else }}
     type: Recreate
+    {{- end }}
   template:
     metadata:
       annotations:
@@ -31,7 +54,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "openviking.serviceAccountName" . }}
       {{- end }}
       {{- with .Values.podSecurityContext }}

--- a/deploy/helm/openviking/templates/hpa.yaml
+++ b/deploy/helm/openviking/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "openviking.fullname" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "openviking.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/openviking/templates/networkpolicy.yaml
+++ b/deploy/helm/openviking/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openviking.fullname" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openviking.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- if .Values.networkPolicy.ingress }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
+    # Default: allow ingress on the http port from any source.
+    # Tighten this for production by setting networkPolicy.ingress with
+    # namespaceSelector / podSelector rules.
+    - ports:
+        - port: http
+          protocol: TCP
+    {{- end }}
+{{- end }}

--- a/deploy/helm/openviking/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/openviking/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openviking.fullname" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openviking.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/openviking/templates/pvc.yaml
+++ b/deploy/helm/openviking/templates/pvc.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "openviking.fullname" . }}-data
   labels:
     {{- include "openviking.labels" . | nindent 4 }}
+  annotations:
+    # Keep the PVC when the release is uninstalled so data survives accidental
+    # removals. Delete the PVC manually to reclaim the storage.
+    helm.sh/resource-policy: keep
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode }}

--- a/deploy/helm/openviking/templates/service.yaml
+++ b/deploy/helm/openviking/templates/service.yaml
@@ -4,8 +4,22 @@ metadata:
   name: {{ include "openviking.fullname" . }}
   labels:
     {{- include "openviking.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/deploy/helm/openviking/templates/serviceaccount.yaml
+++ b/deploy/helm/openviking/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openviking.serviceAccountName" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount | default true }}
+{{- end }}

--- a/deploy/helm/openviking/templates/servicemonitor.yaml
+++ b/deploy/helm/openviking/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openviking.fullname" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "openviking.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.monitoring.serviceMonitor.path | default "/metrics" | quote }}
+      interval: {{ .Values.monitoring.serviceMonitor.interval | default "30s" | quote }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | default "10s" | quote }}
+      {{- with .Values.monitoring.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.monitoring.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/openviking/values.yaml
+++ b/deploy/helm/openviking/values.yaml
@@ -1,16 +1,38 @@
 # Default values for openviking.
 
+# Single-replica by default. Multi-instance requires remote backends (S3 +
+# VikingDB) and specific ov.conf settings — see README "Multi-Instance
+# Deployment" before changing this.
 replicaCount: 1
+
+# Deployment update strategy. Defaults to Recreate (safe for single-replica).
+# For multi-instance, RollingUpdate avoids downtime during upgrades.
+# strategy:
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+
+# HorizontalPodAutoscaler (requires multi-instance setup).
+# WARNING: enabling this without config.storage.skip_process_lock=true will
+# cause helm to fail — see README "Multi-Instance Deployment".
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
 
 image:
   repository: ghcr.io/volcengine/openviking
-  # Use Always for the default moving tag. Pin a version and set IfNotPresent if
-  # you want Kubernetes to reuse cached immutable images.
-  pullPolicy: Always
-  # Image tag to deploy. Defaults to the latest released OpenViking image.
-  # Set to "main" for the newest image from the main branch, a version such as
-  # "v0.3.17" for a pinned release, or "" to use latest.
-  tag: latest
+  # IfNotPresent reuses cached images for immutable (version-pinned) tags,
+  # which is the default since tag:"" resolves to a pinned appVersion.
+  # Switch to Always if you use moving tags like "latest" or "main".
+  pullPolicy: IfNotPresent
+  # Image tag. Empty (the default) resolves to Chart.appVersion (the release
+  # this chart was tested with). Set to "latest" or "main" for moving tags, or
+  # a specific version like "v0.4.9" to pin.
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -19,6 +41,8 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created.
   create: false
+  # Automatically mount a ServiceAccount's API credentials.
+  automount: true
   # Annotations to add to the service account.
   annotations: {}
   # The name of the service account to use.
@@ -38,6 +62,14 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 1933
+  annotations: {}
+  # Set when type is LoadBalancer (some cloud providers ignore this field).
+  loadBalancerIP: ""
+  # Local preserves client source IP and avoids a second hop for
+  # LoadBalancer/NodePort; use Cluster for the old behavior.
+  externalTrafficPolicy: ""
+  # Restrict LB source ranges (CIDR list). Only used when type is LoadBalancer.
+  loadBalancerSourceRanges: []
 
 ingress:
   enabled: false
@@ -105,6 +137,23 @@ config:
     root_api_key: null
     cors_origins:
       - "*"
+    # Observability via OpenTelemetry. Disabled by default — enable the
+    # exporters you need and point them at your OTel Collector.
+    # The Prometheus /metrics endpoint is always served regardless of this
+    # setting (use monitoring.serviceMonitor to scrape it).
+    observability:
+      metrics:
+        enabled: false
+        exporters:
+          otel:
+            enabled: false
+            endpoint: "otel-collector.monitoring.svc.cluster.local:4317"
+      traces:
+        enabled: false
+        endpoint: "otel-collector.monitoring.svc.cluster.local:4317"
+      logs:
+        enabled: false
+        endpoint: "otel-collector.monitoring.svc.cluster.local:4317"
   embedding:
     dense:
       api_base: "https://ark.cn-beijing.volces.com/api/v3"
@@ -155,3 +204,46 @@ readinessProbe:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Prometheus ServiceMonitor for the /metrics endpoint.
+# Requires the prometheus-operator CRD. The labels below are merged onto the
+# ServiceMonitor so the operator picks it up — typically you set the release
+# label that matches your Prometheus install, e.g. { release: prometheus }.
+monitoring:
+  serviceMonitor:
+    enabled: false
+    labels: {}
+    # path: /metrics
+    # interval: 30s
+    # scrapeTimeout: 10s
+    # relabelings:
+    #   - sourceLabels: [__address__]
+    #     targetLabel: cluster
+    #     replacement: my-cluster
+    # metricRelabelings:
+    #   - action: drop
+    #     sourceLabels: [__name__]
+    #     regex: 'openviking_encryption_.*'
+
+# NetworkPolicy restricting ingress to the pod.
+# Disabled by default. When enabled with no ingress rules, allows traffic on
+# the http port from any source. Tighten by setting custom ingress rules with
+# namespaceSelector / podSelector for your environment.
+networkPolicy:
+  enabled: false
+  # ingress:
+  #   - from:
+  #       - namespaceSelector:
+  #           matchLabels:
+  #             name: monitoring
+  #     ports:
+  #       - port: http
+  #         protocol: TCP
+
+# PodDisruptionBudget for voluntary evictions (node drains).
+# Only meaningful for multi-instance deployments. For single-replica, a PDB is
+# either a no-op (maxUnavailable: 1) or blocks all drains (minAvailable: 1).
+podDisruptionBudget:
+  enabled: false
+  # maxUnavailable: 1
+  # minAvailable: 1


### PR DESCRIPTION
Production hardening for the OpenViking Helm chart (deploy/helm/openviking/)

Correctness

* Added a fail-fast check for root_api_key. Since the server requires a root API key for any non-loopback bind, installation now fails whenever server.host is set to a non-loopback address and root_api_key is not configured.
* Changed the default image.tag from the mutable latest to Chart.appVersion (v0.4.9), and updated image.pullPolicy to IfNotPresent.
* Added the missing ServiceAccount template.
* Fixed the [app.kubernetes.io/version](http://app.kubernetes.io/version) label to use the actual application version instead of always reporting latest.
* Added helm.sh/resource-policy: keep to the PVC so persistent data is retained after helm uninstall.

Multi-instance support (disabled by default)

* Added optional support for HPA, PodDisruptionBudget, and configurable Deployment update strategies.
* Added validation to prevent unsupported multi-instance configurations. Scaling beyond one replica now requires both:
    * skip_process_lock: true
    * shared storage (either a remote backend or a ReadWriteMany PVC)
* When HPA is enabled, the chart omits the replicas field so replica management is left entirely to the HPA controller.
* Documented the setup in a new Multi-Instance Deployment section in the README.

Optional resources

* Added an optional ServiceMonitor with configurable labels, relabelings, and metric relabelings.
* Added an optional NetworkPolicy for restricting ingress traffic.

Service improvements

* Added support for common Service settings, including:
    * annotations
    * loadBalancerIP
    * externalTrafficPolicy
    * loadBalancerSourceRanges

Observability

* Added a disabled-by-default config.server.observability section for configuring OpenTelemetry metrics, traces, and logs.

Validation

* helm lint passes.
* Verified chart rendering across 13 deployment scenarios, including all multi-instance validation paths.