### PR TITLE
fix: vectorize SVG resources as text

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -148,6 +148,7 @@ def get_resource_content_type(file_name: str) -> Optional[ResourceContentType]:
         ".json",
         ".jsonl",
         ".xml",
+        ".svg",
         ".py",
         ".js",
         ".ts",
@@ -200,7 +201,7 @@ def get_resource_content_type(file_name: str) -> Optional[ResourceContentType]:
         ".jl",
         ".mm",
     }
-    image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", ".webp"}
+    image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
     video_extensions = {".mp4", ".avi", ".mov", ".wmv", ".flv"}
     audio_extensions = {".mp3", ".wav", ".aac", ".flac"}
 

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -315,6 +315,36 @@ async def test_vectorize_image_file_enqueues_summary_and_image(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_vectorize_svg_file_uses_summary_and_indexes_markup(monkeypatch):
+    queue = DummyQueue()
+    svg_content = '<svg xmlns="http://www.w3.org/2000/svg"><text>queue flow</text></svg>'
+    fs = DummyFS(svg_content)
+    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: fs)
+    monkeypatch.setattr(
+        embedding_utils,
+        "get_openviking_config",
+        lambda: types.SimpleNamespace(
+            embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
+        ),
+    )
+
+    await embedding_utils.vectorize_file(
+        file_path="viking://user/default/resources/diagram.svg",
+        summary_dict={"name": "diagram.svg", "summary": "queue processing diagram"},
+        parent_uri="viking://user/default/resources",
+        ctx=DummyReq(),
+    )
+
+    assert len(queue.items) == 1
+    msg = queue.items[0]
+    assert msg.message == "queue processing diagram"
+    assert msg.context_data["content"] == svg_content
+    assert fs.read_file_calls == 1
+    assert fs.read_file_bytes_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_vectorize_image_file_falls_back_to_summary_when_image_unreadable(monkeypatch):
     class UnreadableImageFS(DummyFS):
         async def read_file_bytes(self, _path, ctx=None):


### PR DESCRIPTION
## 动机

整仓导入当前 `main` 时，4 个 SVG 资源在 embedding 阶段稳定返回 `Invalid base64 image_url`。原因是 `.svg` 与 PNG/JPEG 一样被归类为 raster image，随后以 `data:image/svg+xml` 传给多模态 embedding provider；其余 4,365 个向量成功，但这 4 个输入留下永久错误并使索引健康状态失败。

## 方案

SVG 本质上是可读 XML。向量化阶段将 `.svg` 归入文本类型：embedding 使用已有语义摘要，full-text/BM25 保留原始 SVG markup；PNG、JPEG、GIF、BMP、WebP 的多模态图片路径保持不变。

## 具体改动

- 将 `.svg` 从 raster image 扩展集合移到 text 扩展集合。
- 增加 focused regression，验证 SVG 不生成 `image_url`、使用摘要文本进行 embedding，并保留原始 markup 供 full-text 检索。

## 验证

- 新测试在修复前精确失败，显示 `data:image/svg+xml` 被加入 embedding payload。
- `tests/unit/test_vectorize_file_strategy.py`: 17 passed。
- Ruff check 与 format check 通过。
- `git diff --check` 与 LoopX public-boundary scan 通过。

## 风险与未覆盖项

- 行为变化仅限 SVG 的 embedding 输入类型；其他图片格式由相邻测试覆盖且保持多模态输入。
- 真实 provider 的同目标整仓 refresh 将在本 PR 合入后执行，用于验证 4 个已观察 SVG 错误不再出现；本 PR 不声称该外部验证已完成。

Fixes #3183
