### PR TITLE
perf: parallelize type quota recall searches

### DIFF
--- a/openviking/retrieve/type_quota_recall.py
+++ b/openviking/retrieve/type_quota_recall.py
@@ -9,6 +9,7 @@ block that degrades from full content to summary to URI-only entries.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from dataclasses import dataclass, field, replace
 from typing import Any, Mapping
@@ -303,17 +304,12 @@ async def search_type_quota_recall(
     user_root = canonical_user_root(ctx)
     roots = memory_target_roots(ctx)
     open_ctx = replace(ctx, actor_peer_id=None, legacy_agent_id=None)
-    raw_by_type: dict[str, list[Any]] = {}
+    raw_by_type: dict[str, list[Any]] = {memory_type: [] for memory_type in TYPE_ORDER}
     selected: list[tuple[str, Any, int, str, RequestContext]] = []
 
-    for memory_type in TYPE_ORDER:
-        quota = normalized_quotas.get(memory_type, 0)
-        if quota <= 0:
-            raw_by_type[memory_type] = []
-            continue
-        found: list[Any] = []
-        for root in roots:
-            result = await service.search.find(
+    async def search_type(memory_type: str, quota: int) -> list[Any]:
+        searches = [
+            service.search.find(
                 query=query,
                 ctx=ctx,
                 target_uri=_type_target(root, memory_type),
@@ -321,22 +317,42 @@ async def search_type_quota_recall(
                 score_threshold=min_score,
                 level=None,
             )
-            found.extend(_extract_memories(result))
+            for root in roots
+        ]
         if peer_scope == "all":
-            result = await service.search.find(
-                query=query,
-                ctx=open_ctx,
-                target_uri=f"{user_root}/peers",
-                limit=max(quota * OTHER_PEER_OVERFETCH, quota),
-                score_threshold=min_score,
-                level=None,
+            searches.append(
+                service.search.find(
+                    query=query,
+                    ctx=open_ctx,
+                    target_uri=f"{user_root}/peers",
+                    limit=max(quota * OTHER_PEER_OVERFETCH, quota),
+                    score_threshold=min_score,
+                    level=None,
+                )
             )
+
+        results = await asyncio.gather(*searches)
+        found = [item for result in results[: len(roots)] for item in _extract_memories(result)]
+        if peer_scope == "all":
             found.extend(
                 item
-                for item in _extract_memories(result)
+                for item in _extract_memories(results[-1])
                 if f"/memories/{memory_type}/" in _uri(item)
                 and _origin_for_uri(_uri(item), ctx.actor_peer_id, user_root) == "other_peer"
             )
+        return found
+
+    active_types = [
+        (memory_type, normalized_quotas[memory_type])
+        for memory_type in TYPE_ORDER
+        if normalized_quotas[memory_type] > 0
+    ]
+    found_by_type = await asyncio.gather(
+        *(search_type(memory_type, quota) for memory_type, quota in active_types)
+    )
+
+    for (memory_type, quota), found in zip(active_types, found_by_type, strict=True):
+        if peer_scope == "all":
             found = _dedupe(found)
             raw_by_type[memory_type] = found
             ranked = _limit_with_peer_penalties(

--- a/tests/retrieve/test_type_quota_recall.py
+++ b/tests/retrieve/test_type_quota_recall.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import asyncio
+from types import SimpleNamespace
+
+from openviking.retrieve.type_quota_recall import search_type_quota_recall
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeFindResult:
+    def __init__(self, memories=None):
+        self.memories = memories or []
+
+
+async def test_independent_type_searches_start_concurrently():
+    started_targets: list[str] = []
+    all_started = asyncio.Event()
+
+    async def fake_find(**kwargs):
+        started_targets.append(kwargs["target_uri"])
+        if len(started_targets) == 4:
+            all_started.set()
+        await all_started.wait()
+        return _FakeFindResult()
+
+    service = SimpleNamespace(
+        search=SimpleNamespace(find=fake_find),
+        fs=SimpleNamespace(),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier.the_default_user("test_user"),
+        role=Role.USER,
+        actor_peer_id="current",
+    )
+
+    result = await asyncio.wait_for(
+        search_type_quota_recall(
+            service=service,
+            ctx=ctx,
+            query="parallel recall",
+            peer_scope="actor",
+            quotas={
+                "events": 1,
+                "entities": 1,
+                "preferences": 0,
+                "experiences": 0,
+            },
+        ),
+        timeout=1.0,
+    )
+
+    assert set(started_targets) == {
+        "viking://user/test_user/memories/events",
+        "viking://user/test_user/peers/current/memories/events",
+        "viking://user/test_user/memories/entities",
+        "viking://user/test_user/peers/current/memories/entities",
+    }
+    assert result.stats["searched"] == {
+        "events": 0,
+        "entities": 0,
+        "preferences": 0,
+        "experiences": 0,
+    }
+
+
+async def test_parallel_search_preserves_type_order():
+    async def fake_find(**kwargs):
+        target_uri = kwargs["target_uri"]
+        memory_type = target_uri.rsplit("/", 1)[-1]
+        if memory_type == "events":
+            await asyncio.sleep(0.02)
+        if "/peers/" in target_uri:
+            return _FakeFindResult()
+        return _FakeFindResult(
+            [
+                {
+                    "uri": f"{target_uri}/{memory_type}.md",
+                    "score": 0.9,
+                    "abstract": f"{memory_type} abstract",
+                }
+            ]
+        )
+
+    async def fake_read(uri, **kwargs):
+        del kwargs
+        return f"content for {uri}"
+
+    service = SimpleNamespace(
+        search=SimpleNamespace(find=fake_find),
+        fs=SimpleNamespace(read=fake_read),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier.the_default_user("test_user"),
+        role=Role.USER,
+        actor_peer_id="current",
+    )
+
+    result = await search_type_quota_recall(
+        service=service,
+        ctx=ctx,
+        query="deterministic recall",
+        peer_scope="actor",
+        quotas={
+            "events": 1,
+            "entities": 1,
+            "preferences": 0,
+            "experiences": 0,
+        },
+    )
+
+    assert [entry.type for entry in result.entries] == ["events", "entities"]
+    assert [entry.rank for entry in result.entries] == [1, 1]


### PR DESCRIPTION
## 动机

修复 #3156。type-quota recall 当前按 memory type 和 target root 串行等待彼此独立的 search，端到端延迟会随分支数量累加。

## 改动思路

只并发调度互不依赖的 search I/O；所有结果仍按既有 TYPE_ORDER 和 root 顺序汇总，再进入原有 dedupe、peer penalty、quota、rank 与 rendering 流程，避免让完成时序改变返回语义。

## 具体改动

- 在 type-quota recall 内并发查询 active memory types、各 target roots 与可选的 open-peer 分支。
- 保持原有 other-peer 过滤、去重、惩罚和配额逻辑不变。
- 新增纯单元回归：用 barrier 证明独立分支会同时启动，并用反向完成顺序证明最终 type/rank 顺序稳定。

## 验证

- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ... pytest tests/retrieve/test_type_quota_recall.py -q：2 passed
- pytest tests/server/test_recall_peer_scope.py::test_normalize_penalties_defaults_scalar_dict_and_clamp -q：1 passed
- uvx ruff check openviking/retrieve/type_quota_recall.py tests/retrieve/test_type_quota_recall.py：passed
- uvx ruff format --check openviking/retrieve/type_quota_recall.py tests/retrieve/test_type_quota_recall.py：passed
- python -m py_compile：passed
- git diff --check：passed

## 对主干的风险与未覆盖

风险集中在并发 I/O 对下游 search service 的瞬时请求数；并发量仍由当前请求中 active types、roots 与 peer scope 的既有有限分支决定，没有引入后台任务或无界 fan-out。未在本机运行完整 server endpoint suite，因为本机缺少该 fixture 所需的原生 RAGFS binding；新增回归使用无服务依赖的 fake search 边界，完整集成覆盖交由 CI 验证。