### PR TITLE
fix(content-write): anchor user resources at direct parent

### DIFF
--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -849,7 +849,12 @@ class ContentWriteCoordinator:
                     raise InvalidArgumentError(
                         f"resource write target must be inside a resource directory: {uri}"
                     )
-                root_uri = VikingURI.build(*parts[: resources_idx + 2])
+                if anchor_to_parent:
+                    parent = parsed.parent
+                    if parent is not None:
+                        root_uri = parent.uri
+                else:
+                    root_uri = VikingURI.build(*parts[: resources_idx + 2])
             else:
                 try:
                     memories_idx = parts.index("memories")

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -1062,17 +1062,33 @@ class _AnyDirVikingFS:
         return {"isDir": uri != self._file_uri}
 
 
+@pytest.mark.parametrize(
+    ("file_uri", "parent_uri", "project_root"),
+    [
+        (
+            "viking://resources/dir1/sub_dir/sub_dir_1/test.md",
+            "viking://resources/dir1/sub_dir/sub_dir_1",
+            "viking://resources/dir1",
+        ),
+        (
+            "viking://user/default/resources/dir1/sub_dir/sub_dir_1/test.md",
+            "viking://user/default/resources/dir1/sub_dir/sub_dir_1",
+            "viking://user/default/resources/dir1",
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_resource_write_anchors_nested_file_to_direct_parent():
+async def test_resource_write_anchors_nested_file_to_direct_parent(
+    file_uri,
+    parent_uri,
+    project_root,
+):
     """A resource content write anchors the semantic refresh at the written file's
     direct parent directory (anchor_to_parent=True), so the changed file is a direct
     child of the DAG run root: its own L2 vector and the parent's L0/L1 are generated
     from a single-directory run instead of a recursive walk of the whole project subtree.
     set_tags keeps the project-root collapse (the default), which the derived
     ``.abstract.md`` sidecar mapping relies on."""
-    file_uri = "viking://resources/dir1/sub_dir/sub_dir_1/test.md"
-    parent_uri = "viking://resources/dir1/sub_dir/sub_dir_1"
-    project_root = "viking://resources/dir1"
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
     coordinator = ContentWriteCoordinator(viking_fs=_AnyDirVikingFS(file_uri))
 


### PR DESCRIPTION
## 动机

修复 #3152 在当前 `main` 上仍存在的 user-scope 分支问题：写入深层嵌套的 `viking://user/<uid>/resources/<resource>/...` 文件时，语义刷新仍锚定到资源根目录，且以 `recursive=False` 执行，因此无法覆盖嵌套文件及其直接父目录。

## 改动思路

让 user-scope resource URI 与已有的 global resource URI 遵循同一条 `anchor_to_parent` 语义：内容写入锚定到目标文件的直接父目录；未请求该行为的调用仍折叠到 resource project root。

## 具体改动

- 在 `_resolve_root_uri` 的 user/resources 分支中处理 `anchor_to_parent=True`，返回目标文件的直接父目录。
- 将现有 direct-parent service test 参数化，同时覆盖 global 与 user-scoped resource URI。
- 保留 `set_tags` 的 project-root 折叠行为，避免改变 sidecar/tag 刷新语义。

## 验证

- 回归测试先失败：user-scoped case 实际返回 `viking://user/default/resources/dir1`，而不是嵌套文件的直接父目录。
- `pytest` focused validation：3 passed。
- `ruff check`：passed。
- `ruff format --check`：2 files already formatted。
- `py_compile`、`git diff --check`、LoopX public-boundary scan：passed。

## 对主干的风险与未覆盖

风险较低：补丁只改变 user-scope resource 且 `anchor_to_parent=True` 的根 URI 解析；global resource、memory URI 和 `set_tags` 默认路径均保持原行为。未在本地运行依赖完整服务和向量后端的端到端测试，交由仓库 CI 覆盖。

Fixes #3152
