### PR TITLE
fix(openclaw-plugin): honor peer_role when writing session memory

### DIFF
--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -331,6 +331,7 @@ const contextEnginePlugin = {
       createTempSessionId: createMemoryStoreTempSessionId,
       extractSenderId: extractToolSenderId,
       toRoleId,
+      peerRole: cfg.peer_role,
       resolvePluginSessionRouting,
       isBypassedSession,
       makeBypassedToolResult,

--- a/examples/openclaw-plugin/plugin/openviking-memory-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-memory-tools.ts
@@ -4,6 +4,8 @@ import type { CommitSessionResult, FindResultItem } from "../client.js";
 import { clampScore, postProcessMemories } from "../memory-ranking.js";
 import { isMemoryUri } from "../routing/memory-uri.js";
 
+type OpenVikingPeerRole = "none" | "assistant" | "person";
+
 export type OpenVikingMemoryToolContext = {
   sessionKey?: string;
   sessionId?: string;
@@ -26,7 +28,7 @@ export type OpenVikingMemoryClient = {
     parts: Array<{ type: "text"; text: string }>,
     agentId?: string,
     createdAt?: string,
-    roleId?: string,
+    peerId?: string,
   ) => Promise<void>;
   commitSession: (
     sessionId: string,
@@ -47,6 +49,7 @@ export type OpenVikingMemoryToolsDeps = {
   createTempSessionId: () => string;
   extractSenderId: (ctx?: OpenVikingMemoryToolContext) => string | undefined;
   toRoleId: (senderId?: string) => string | undefined;
+  peerRole?: OpenVikingPeerRole;
   resolvePluginSessionRouting: (ctx?: OpenVikingMemoryToolContext) => OpenVikingMemorySession;
   isBypassedSession: (ctx?: OpenVikingMemoryToolContext) => boolean;
   makeBypassedToolResult: (toolName: string) => unknown;
@@ -63,6 +66,25 @@ function totalCommitMemories(r: CommitSessionResult): number {
   const m = r.memories_extracted;
   if (!m || typeof m !== "object") return 0;
   return Object.values(m).reduce((sum, n) => sum + (n ?? 0), 0);
+}
+
+function normalizeSessionWritePeerRole(peerRole: unknown): OpenVikingPeerRole {
+  return peerRole === "none" || peerRole === "assistant" ? peerRole : "person";
+}
+
+function sessionWritePeerId(
+  peerRole: OpenVikingPeerRole,
+  agentId: string,
+  senderId: string | undefined,
+  toRoleId: (senderId?: string) => string | undefined,
+): string | undefined {
+  if (peerRole === "none") {
+    return undefined;
+  }
+  if (peerRole === "assistant") {
+    return toRoleId(agentId);
+  }
+  return toRoleId(senderId);
 }
 
 export function registerOpenVikingMemoryTools(deps: OpenVikingMemoryToolsDeps): void {
@@ -102,19 +124,45 @@ export function registerOpenVikingMemoryTools(deps: OpenVikingMemoryToolsDeps): 
         let sessionId = explicitSessionId;
         let usedTempSession = false;
         try {
+          const peerRole = normalizeSessionWritePeerRole(deps.peerRole);
+          const peerId = role === "user"
+            ? sessionWritePeerId(
+                peerRole,
+                session.agentId,
+                deps.extractSenderId(ctx),
+                deps.toRoleId,
+              )
+            : undefined;
+          if (role === "user" && peerRole === "person" && !peerId) {
+            deps.logger.warn(
+              "openviking: memory_store skipped because peer_role=person but senderId was unavailable",
+            );
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Memory was not stored because peer_role=person requires sender identity.",
+                },
+              ],
+              details: {
+                action: "skipped",
+                reason: "missing_person_peer_id",
+              },
+            };
+          }
+
           const client = await deps.getClient();
           if (!sessionId) {
             sessionId = deps.createTempSessionId();
             usedTempSession = true;
           }
-          const roleId = role === "user" ? deps.toRoleId(deps.extractSenderId(ctx)) : undefined;
           await client.addSessionMessage(
             sessionId,
             role,
             [{ type: "text", text }],
             session.agentId,
             undefined,
-            roleId,
+            peerId,
           );
           const commitResult = await client.commitSession(sessionId, {
             wait: true,

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -15,6 +15,7 @@ import {
 } from "./context-message-adapter.js";
 
 type ExtractedTurnMessage = ReturnType<typeof extractNewTurnMessages>["messages"][number];
+type OpenVikingPeerRole = "none" | "assistant" | "person";
 
 export type ContextEngineLifecycleLogger = {
   info: (msg: string) => void;
@@ -131,6 +132,7 @@ export type AfterTurnOpenVikingSessionParams = {
     commitTokenThresholdRatio: number;
     commitKeepRecentCount: number;
     logFindRequests: boolean;
+    peer_role: OpenVikingPeerRole;
   };
   getClient: () => Promise<AfterTurnClient>;
   logger: ContextEngineLifecycleLogger;
@@ -168,6 +170,20 @@ const PHASE2_POLL_MAX_MS = DEFAULT_PHASE2_POLL_TIMEOUT_MS;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sessionWritePeerId(
+  peerRole: OpenVikingPeerRole,
+  agentId: string,
+  senderId?: string,
+): string | undefined {
+  if (peerRole === "none") {
+    return undefined;
+  }
+  if (peerRole === "assistant") {
+    return toRoleId(agentId);
+  }
+  return toRoleId(senderId);
 }
 
 /**
@@ -874,7 +890,20 @@ export async function afterTurnOpenVikingSession({
 
     const client = await getClient();
     const createdAt = pickLatestCreatedAt(turnMessages);
-    const senderRoleId = toRoleId(sender.senderId);
+    const userPeerId = sessionWritePeerId(cfg.peer_role, agentId, sender.senderId);
+    const missingPersonPeerId = cfg.peer_role === "person" && !userPeerId;
+    if (missingPersonPeerId) {
+      logger.warn?.(
+        "openviking: afterTurn skipped session writes because peer_role=person but senderId was unavailable",
+      );
+      diag("afterTurn_skip", ovSessionId, {
+        reason: "missing_person_peer_id",
+        senderIdFound: sender.found,
+        senderId: sender.senderId ?? null,
+      });
+      return;
+    }
+    let storedMessageCount = 0;
     for (const msg of extractedMessages) {
       const ovParts = msg.parts.map((part) => {
         if (part.type === "text") {
@@ -901,9 +930,19 @@ export async function afterTurnOpenVikingSession({
           ovParts,
           agentId,
           createdAt,
-          msg.role === "user" ? senderRoleId : undefined,
+          msg.role === "user" ? userPeerId : undefined,
         );
+        storedMessageCount += 1;
       }
+    }
+
+    if (storedMessageCount === 0) {
+      diag("afterTurn_skip", ovSessionId, {
+        reason: "no_session_messages_written",
+        senderIdFound: sender.found,
+        senderId: sender.senderId ?? null,
+      });
+      return;
     }
 
     const session = await client.getSession(ovSessionId, agentId);

--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { OpenVikingClient } from "../../client.js";
+import { OpenVikingClient } from "../../client.js";
 import { memoryOpenVikingConfigSchema } from "../../config.js";
 import { createMemoryOpenVikingContextEngine } from "../../context-engine.js";
 
@@ -12,12 +12,20 @@ function makeLogger() {
   };
 }
 
+function okResponse(result: unknown): Response {
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 function makeEngine(opts?: {
   autoCapture?: boolean;
   commitTokenThresholdRatio?: number;
   getSession?: Record<string, unknown>;
   addSessionMessageError?: Error;
   cfgOverrides?: Record<string, unknown>;
+  agentId?: string;
 }) {
   const cfg = memoryOpenVikingConfigSchema.parse({
     mode: "remote",
@@ -55,7 +63,7 @@ function makeEngine(opts?: {
   } as unknown as OpenVikingClient;
 
   const getClient = vi.fn().mockResolvedValue(client);
-  const resolveAgentId = vi.fn((_sid: string) => "test-agent");
+  const resolveAgentId = vi.fn((_sid: string) => opts?.agentId ?? "test-agent");
 
   const engine = createMemoryOpenVikingContextEngine({
     id: "openviking",
@@ -221,7 +229,7 @@ describe("context-engine afterTurn()", () => {
     );
   });
 
-  it("passes sanitized senderId as role_id", async () => {
+  it("uses agentId as peer_id when peer_role defaults to assistant", async () => {
     const { engine, client } = makeEngine();
 
     await engine.afterTurn!({
@@ -233,7 +241,139 @@ describe("context-engine afterTurn()", () => {
     });
 
     expect(client.addSessionMessage).toHaveBeenCalledTimes(1);
+    expect(client.addSessionMessage.mock.calls[0][5]).toBe("test-agent");
+  });
+
+  it("sends peer_id instead of role_id for default assistant afterTurn writes", async () => {
+    const cfg = memoryOpenVikingConfigSchema.parse({
+      mode: "remote",
+      baseUrl: "http://127.0.0.1:1933",
+      autoCapture: true,
+      autoRecall: false,
+      emitStandardDiagnostics: true,
+    });
+    const logger = makeLogger();
+    const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes("/api/v1/sessions/") && url.includes("/messages")) {
+        return okResponse({ session_id: "s1" });
+      }
+      if (url.includes("/api/v1/sessions/")) {
+        return okResponse({ pending_tokens: 0 });
+      }
+      return okResponse({});
+    });
+    const client = new OpenVikingClient(
+      cfg.baseUrl,
+      cfg.apiKey,
+      cfg.peer_prefix,
+      cfg.timeoutMs,
+      cfg.accountId,
+      cfg.userId,
+      undefined,
+      { transport: openVikingTransport },
+    );
+    const engine = createMemoryOpenVikingContextEngine({
+      id: "openviking",
+      name: "Test Engine",
+      version: "test",
+      cfg,
+      logger,
+      getClient: vi.fn().mockResolvedValue(client),
+      resolveAgentId: vi.fn(() => "test-agent"),
+    });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages: [{ role: "user", content: "hello world" }],
+      prePromptMessageCount: 0,
+      runtimeContext: { senderId: "telegram:12345" },
+    });
+
+    const messageCall = openVikingTransport.mock.calls.find(([url]) =>
+      String(url).includes("/api/v1/sessions/") && String(url).includes("/messages"),
+    );
+    expect(messageCall).toBeDefined();
+    const [, init] = messageCall as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body.peer_id).toBe("test-agent");
+    expect(body).not.toHaveProperty("role_id");
+  });
+
+  it("sanitizes assistant agentId before using it as peer_id", async () => {
+    const { engine, client } = makeEngine({ agentId: "agent:main" });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages: [{ role: "user", content: "hello world" }],
+      prePromptMessageCount: 0,
+      runtimeContext: { senderId: "telegram:12345" },
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(1);
+    expect(client.addSessionMessage.mock.calls[0][5]).toBe("agent_main");
+  });
+
+  it("passes sanitized senderId as peer_id when peer_role is person", async () => {
+    const { engine, client } = makeEngine({
+      cfgOverrides: {
+        peer_role: "person",
+      },
+    });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages: [{ role: "user", content: "hello world" }],
+      prePromptMessageCount: 0,
+      runtimeContext: { senderId: "telegram:12345" },
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(1);
     expect(client.addSessionMessage.mock.calls[0][5]).toBe("telegram_12345");
+  });
+
+  it("skips person-scoped turn writes when senderId is unavailable", async () => {
+    const { engine, client, logger } = makeEngine({
+      cfgOverrides: {
+        peer_role: "person",
+      },
+    });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages: [
+        { role: "user", content: "hello world" },
+        { role: "assistant", content: "hi there" },
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    expect(client.addSessionMessage).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("peer_role=person but senderId was unavailable"),
+    );
+  });
+
+  it("omits peer_id when peer_role is none", async () => {
+    const { engine, client } = makeEngine({
+      cfgOverrides: {
+        peer_role: "none",
+      },
+    });
+
+    await engine.afterTurn!({
+      sessionId: "s1",
+      sessionFile: "",
+      messages: [{ role: "user", content: "hello world" }],
+      prePromptMessageCount: 0,
+      runtimeContext: { senderId: "telegram:12345" },
+    });
+
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(1);
+    expect(client.addSessionMessage.mock.calls[0][5]).toBeUndefined();
   });
 
   it("sanitizes <relevant-memories> from user content but not from assistant", async () => {

--- a/examples/openclaw-plugin/tests/ut/tools.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tools.test.ts
@@ -10,8 +10,10 @@ import {
   parseOVSearchCommandArgs,
   tokenizeCommandArgs,
 } from "../../plugin/openviking-command-args.js";
+import { registerOpenVikingMemoryTools } from "../../plugin/openviking-memory-tools.js";
 import type { FindResultItem } from "../../client.js";
 import { openClawSessionToOvStorageId } from "../../routing/identity-routing.js";
+import { toRoleId } from "../../services/context-message-adapter.js";
 
 type ToolDef = {
   name: string;
@@ -444,6 +446,56 @@ describe("Tool: memory_recall (registration)", () => {
 });
 
 describe("Tool: memory_store (behavioral)", () => {
+  async function executeDirectMemoryStore(peerRole: unknown = "__omit__") {
+    let factory: ((ctx: Record<string, unknown>) => ToolDef) | undefined;
+    const addSessionMessage = vi.fn().mockResolvedValue(undefined);
+    const commitSession = vi.fn().mockResolvedValue({
+      status: "completed",
+      archived: false,
+      memories_extracted: { core: 1 },
+    });
+    const deps: any = {
+      registerTool: vi.fn((toolFactory: unknown, opts?: { name: string }) => {
+        if (opts?.name === "memory_store") {
+          factory = toolFactory as (ctx: Record<string, unknown>) => ToolDef;
+        }
+      }),
+      getClient: vi.fn().mockResolvedValue({
+        addSessionMessage,
+        commitSession,
+        deleteUri: vi.fn().mockResolvedValue(undefined),
+        find: vi.fn().mockResolvedValue({ memories: [] }),
+      }),
+      normalizeSessionId: (sessionId: string) => sessionId,
+      createTempSessionId: () => "memory-store-temp",
+      extractSenderId: (ctx?: Record<string, unknown>) =>
+        typeof ctx?.requesterSenderId === "string" ? ctx.requesterSenderId : undefined,
+      toRoleId,
+      resolvePluginSessionRouting: () => ({
+        sessionId: "runtime-session",
+        agentId: "agent:main",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: () => ({ content: [] }),
+      defaultTargetUri: "viking://user/default",
+      defaultRecallScoreThreshold: 0.15,
+      logFindRequests: false,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    };
+    if (peerRole !== "__omit__") {
+      deps.peerRole = peerRole;
+    }
+
+    registerOpenVikingMemoryTools(deps);
+    expect(factory).toBeDefined();
+    const tool = factory!({ requesterSenderId: "wx/user-01@abc" });
+    await tool.execute("tc-memory-store", { text: "hello from tool" });
+    return addSessionMessage.mock.calls[0][5];
+  }
+
   it("registers with correct name and description", () => {
     const { tools, api } = setupPlugin();
     contextEnginePlugin.register(api as any);
@@ -455,7 +507,15 @@ describe("Tool: memory_store (behavioral)", () => {
     expect(store!.description).toContain("threshold/commit dependent");
   });
 
-  it("uses requesterSenderId to populate peer_id for user writes", async () => {
+  it("preserves sender peer_id routing when memory tool peerRole is missing", async () => {
+    await expect(executeDirectMemoryStore()).resolves.toBe("wx_user-01_abc");
+  });
+
+  it("preserves sender peer_id routing when memory tool peerRole is invalid", async () => {
+    await expect(executeDirectMemoryStore("invalid")).resolves.toBe("wx_user-01_abc");
+  });
+
+  it("uses session agentId to populate peer_id when peer_role defaults to assistant", async () => {
     const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith("/api/v1/system/status")) {
         return okResponse({ user: "default" });
@@ -494,7 +554,122 @@ describe("Tool: memory_store (behavioral)", () => {
     const [, init] = messageCall as [string, RequestInit];
     const body = JSON.parse(String(init.body));
     expect(body.role).toBe("user");
+    expect(body.peer_id).toBe("main");
+    expect(body).not.toHaveProperty("role_id");
+  });
+
+  it("uses requesterSenderId to populate peer_id when peer_role is person", async () => {
+    const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/v1/system/status")) {
+        return okResponse({ user: "default" });
+      }
+      if (url.includes("/messages")) {
+        return okResponse({ session_id: "sess-1" });
+      }
+      if (url.endsWith("/commit")) {
+        return okResponse({
+          status: "completed",
+          archived: false,
+          memories_extracted: { core: 1 },
+        });
+      }
+      return okResponse({});
+    });
+
+    const { factoryTools, api } = setupPlugin(undefined, { peer_role: "person" });
+    (api as any).openVikingTransport = openVikingTransport;
+    contextEnginePlugin.register(api as any);
+    const factory = factoryTools.get("memory_store");
+    expect(factory).toBeDefined();
+
+    const tool = factory!({
+      sessionId: "runtime-session",
+      sessionKey: "agent:main:main",
+      requesterSenderId: "wx/user-01@abc",
+    });
+
+    await tool.execute("tc-memory-store", { text: "hello from tool" });
+
+    const messageCall = openVikingTransport.mock.calls.find(([url]) =>
+      String(url).includes("/api/v1/sessions/") && String(url).includes("/messages"),
+    );
+    expect(messageCall).toBeDefined();
+    const [, init] = messageCall as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body.role).toBe("user");
     expect(body.peer_id).toBe("wx_user-01_abc");
+    expect(body).not.toHaveProperty("role_id");
+  });
+
+  it("skips memory_store when peer_role is person and sender identity is unavailable", async () => {
+    const openVikingTransport = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/v1/system/status")) {
+        return okResponse({ user: "default" });
+      }
+      if (url.includes("/messages")) {
+        return okResponse({ session_id: "sess-1" });
+      }
+      if (url.endsWith("/commit")) {
+        return okResponse({ status: "completed", archived: false, memories_extracted: {} });
+      }
+      return okResponse({});
+    });
+
+    const { factoryTools, api } = setupPlugin(undefined, { peer_role: "person" });
+    (api as any).openVikingTransport = openVikingTransport;
+    contextEnginePlugin.register(api as any);
+    const tool = factoryTools.get("memory_store")!({
+      sessionId: "runtime-session",
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("tc-memory-store", { text: "hello from tool" }) as ToolResult;
+
+    expect(openVikingTransport).not.toHaveBeenCalled();
+    expect(result.details.action).toBe("skipped");
+    expect(result.details.reason).toBe("missing_person_peer_id");
+  });
+
+  it("omits peer_id for user writes when peer_role is none", async () => {
+    const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/v1/system/status")) {
+        return okResponse({ user: "default" });
+      }
+      if (url.includes("/messages")) {
+        return okResponse({ session_id: "sess-1" });
+      }
+      if (url.endsWith("/commit")) {
+        return okResponse({
+          status: "completed",
+          archived: false,
+          memories_extracted: { core: 1 },
+        });
+      }
+      return okResponse({});
+    });
+
+    const { factoryTools, api } = setupPlugin(undefined, { peer_role: "none" });
+    (api as any).openVikingTransport = openVikingTransport;
+    contextEnginePlugin.register(api as any);
+    const factory = factoryTools.get("memory_store");
+    expect(factory).toBeDefined();
+
+    const tool = factory!({
+      sessionId: "runtime-session",
+      sessionKey: "agent:main:main",
+      requesterSenderId: "wx/user-01@abc",
+    });
+
+    await tool.execute("tc-memory-store", { text: "hello from tool" });
+
+    const messageCall = openVikingTransport.mock.calls.find(([url]) =>
+      String(url).includes("/api/v1/sessions/") && String(url).includes("/messages"),
+    );
+    expect(messageCall).toBeDefined();
+    const [, init] = messageCall as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body.role).toBe("user");
+    expect(body).not.toHaveProperty("peer_id");
     expect(body).not.toHaveProperty("role_id");
   });
 


### PR DESCRIPTION
## Summary
- Route OpenClaw user session writes through the parsed `peer_role` setting for both automatic `afterTurn` capture and explicit `memory_store` writes.
- For `peer_role="assistant"`, write `peer_id` as the resolved session agent; for `peer_role="person"`, write the sanitized sender id; for `peer_role="none"`, omit `peer_id`.
- Fail closed for `peer_role="person"` when no sender identity is available: auto-capture skips the turn, and `memory_store` returns a skipped result instead of writing an unscoped message.

## Compatibility note
The plugin config already defaults `peer_role` to `assistant`; this change makes session writes honor that documented default instead of the previous sender-derived write path. Deployments that intentionally relied on sender-scoped writes can set `peer_role: "person"`. Direct `registerOpenVikingMemoryTools` callers that do not pass the new optional `peerRole` dependency keep the legacy sender/requester-derived fallback.

Fixes #3141.

## Tests
- `npx vitest run tests/ut/context-engine-afterTurn.test.ts tests/ut/tools.test.ts`
- `npm run typecheck`
