### PR TITLE
fix(mcp): expose context_type filter

### DIFF
--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -133,8 +133,8 @@ Once connected, OpenViking exposes 16 tools:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `find` | Fast semantic retrieval without session context | `query`, `target_uri` (optional), `limit`, `min_score`, `level` (optional), `context_type` (optional), `filter` (optional) |
-| `search` | Deep semantic retrieval with optional session context and intent analysis | `query`, `target_uri` (optional), `session_id` (optional), `limit`, `min_score`, `level` (optional), `context_type` (optional), `filter` (optional) |
+| `find` | Fast semantic retrieval without session context | `query`, `target_uri` (optional), `limit`, `min_score`, `level` (optional), `context_type` (optional) |
+| `search` | Deep semantic retrieval with optional session context and intent analysis | `query`, `target_uri` (optional), `session_id` (optional), `limit`, `min_score`, `level` (optional), `context_type` (optional) |
 | `recall` | Type-quota recall across memory categories | `query`, `quotas` (optional), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty` (optional) |
 | `read` | Read one or more `viking://` URIs | `uris` (single string or array) |
 | `list` | List entries under a `viking://` directory | `uri`, `recursive` (optional) |

--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -133,8 +133,8 @@ Once connected, OpenViking exposes 16 tools:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `find` | Fast semantic retrieval without session context | `query`, `target_uri` (optional), `limit`, `min_score`, `level` (optional) |
-| `search` | Deep semantic retrieval with optional session context and intent analysis | `query`, `target_uri` (optional), `session_id` (optional), `limit`, `min_score`, `level` (optional) |
+| `find` | Fast semantic retrieval without session context | `query`, `target_uri` (optional), `limit`, `min_score`, `level` (optional), `context_type` (optional), `filter` (optional) |
+| `search` | Deep semantic retrieval with optional session context and intent analysis | `query`, `target_uri` (optional), `session_id` (optional), `limit`, `min_score`, `level` (optional), `context_type` (optional), `filter` (optional) |
 | `recall` | Type-quota recall across memory categories | `query`, `quotas` (optional), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty` (optional) |
 | `read` | Read one or more `viking://` URIs | `uris` (single string or array) |
 | `list` | List entries under a `viking://` directory | `uri`, `recursive` (optional) |

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -125,8 +125,8 @@ claude mcp add --transport http openviking \
 
 | 工具 | 说明 | 主要参数 |
 |------|------|----------|
-| `find` | 无 session 上下文的快速语义检索 | `query`, `target_uri`(可选), `limit`, `min_score`, `level`(可选) |
-| `search` | 支持可选 session 上下文和意图分析的深度语义检索 | `query`, `target_uri`(可选), `session_id`(可选), `limit`, `min_score`, `level`(可选) |
+| `find` | 无 session 上下文的快速语义检索 | `query`, `target_uri`(可选), `limit`, `min_score`, `level`(可选), `context_type`(可选), `filter`(可选) |
+| `search` | 支持可选 session 上下文和意图分析的深度语义检索 | `query`, `target_uri`(可选), `session_id`(可选), `limit`, `min_score`, `level`(可选), `context_type`(可选), `filter`(可选) |
 | `recall` | 按记忆类别配额召回 | `query`, `quotas`(可选), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty`(可选) |
 | `read` | 读取一个或多个 `viking://` URI 的内容 | `uris`（单个字符串或数组） |
 | `list` | 列出 `viking://` 目录下的条目 | `uri`, `recursive`(可选) |

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -125,8 +125,8 @@ claude mcp add --transport http openviking \
 
 | 工具 | 说明 | 主要参数 |
 |------|------|----------|
-| `find` | 无 session 上下文的快速语义检索 | `query`, `target_uri`(可选), `limit`, `min_score`, `level`(可选), `context_type`(可选), `filter`(可选) |
-| `search` | 支持可选 session 上下文和意图分析的深度语义检索 | `query`, `target_uri`(可选), `session_id`(可选), `limit`, `min_score`, `level`(可选), `context_type`(可选), `filter`(可选) |
+| `find` | 无 session 上下文的快速语义检索 | `query`, `target_uri`(可选), `limit`, `min_score`, `level`(可选), `context_type`(可选) |
+| `search` | 支持可选 session 上下文和意图分析的深度语义检索 | `query`, `target_uri`(可选), `session_id`(可选), `limit`, `min_score`, `level`(可选), `context_type`(可选) |
 | `recall` | 按记忆类别配额召回 | `query`, `quotas`(可选), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty`(可选) |
 | `read` | 读取一个或多个 `viking://` URI 的内容 | `uris`（单个字符串或数组） |
 | `list` | 列出 `viking://` 目录下的条目 | `uri`, `recursive`(可选) |

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -223,12 +223,11 @@ mcp = FastMCP(
 # -- find / search ---------------------------------------------------------
 
 
-def _resolve_search_filter(
-    request_filter: Optional[Dict[str, Any]],
+def _resolve_context_type_filter(
     context_type: Optional[SearchContextTypeInput],
 ) -> Optional[Dict[str, Any]]:
     try:
-        return merge_search_filter(request_filter, context_type=context_type)
+        return merge_search_filter(None, context_type=context_type)
     except ValueError as exc:
         raise InvalidArgumentError(str(exc)) from exc
 
@@ -241,7 +240,6 @@ async def find(
     min_score: float = 0.35,
     level: Optional[List[int]] = None,
     context_type: Optional[Union[str, List[str]]] = None,
-    filter: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
@@ -251,7 +249,7 @@ async def find(
         target_uri=target_uri,
         limit=limit,
         score_threshold=min_score,
-        filter=_resolve_search_filter(filter, context_type),
+        filter=_resolve_context_type_filter(context_type),
         level=level,
     )
     return _format_search_result(result)
@@ -266,7 +264,6 @@ async def search(
     min_score: float = 0.35,
     level: Optional[List[int]] = None,
     context_type: Optional[Union[str, List[str]]] = None,
-    filter: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Deep semantic retrieval with optional session context and intent analysis. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
@@ -282,7 +279,7 @@ async def search(
         session=session,
         limit=limit,
         score_threshold=min_score,
-        filter=_resolve_search_filter(filter, context_type),
+        filter=_resolve_context_type_filter(context_type),
         level=level,
     )
     return _format_search_result(result)

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -21,7 +21,7 @@ import contextvars
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 from urllib.parse import quote
 
 from mcp.server.fastmcp import FastMCP
@@ -54,6 +54,7 @@ from openviking.server.local_input_guard import (
 from openviking.server.resource_ingest import ingest_temp_upload
 from openviking.server.temp_upload_store import TempUploadStore
 from openviking.server.upload_token_store import upload_token_store
+from openviking.utils.search_filters import SearchContextTypeInput, merge_search_filter
 from openviking_cli.exceptions import (
     InvalidArgumentError,
     PermissionDeniedError,
@@ -222,6 +223,16 @@ mcp = FastMCP(
 # -- find / search ---------------------------------------------------------
 
 
+def _resolve_search_filter(
+    request_filter: Optional[Dict[str, Any]],
+    context_type: Optional[SearchContextTypeInput],
+) -> Optional[Dict[str, Any]]:
+    try:
+        return merge_search_filter(request_filter, context_type=context_type)
+    except ValueError as exc:
+        raise InvalidArgumentError(str(exc)) from exc
+
+
 @mcp.tool()
 async def find(
     query: str,
@@ -229,6 +240,8 @@ async def find(
     limit: int = 10,
     min_score: float = 0.35,
     level: Optional[List[int]] = None,
+    context_type: Optional[Union[str, List[str]]] = None,
+    filter: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
@@ -238,6 +251,7 @@ async def find(
         target_uri=target_uri,
         limit=limit,
         score_threshold=min_score,
+        filter=_resolve_search_filter(filter, context_type),
         level=level,
     )
     return _format_search_result(result)
@@ -251,6 +265,8 @@ async def search(
     limit: int = 10,
     min_score: float = 0.35,
     level: Optional[List[int]] = None,
+    context_type: Optional[Union[str, List[str]]] = None,
+    filter: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Deep semantic retrieval with optional session context and intent analysis. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
@@ -266,6 +282,7 @@ async def search(
         session=session,
         limit=limit,
         score_threshold=min_score,
+        filter=_resolve_search_filter(filter, context_type),
         level=level,
     )
     return _format_search_result(result)

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -120,13 +120,13 @@ async def test_search_respects_min_score(service):
     assert isinstance(result, str)
 
 
-async def test_search_tools_expose_context_type_and_filter_parameters():
+async def test_search_tools_expose_only_context_type_parameter():
     tools = {tool.name: tool for tool in await mcp_endpoint.mcp.list_tools()}
 
     for tool_name in ("find", "search"):
         properties = tools[tool_name].inputSchema["properties"]
         assert "context_type" in properties
-        assert "filter" in properties
+        assert "filter" not in properties
 
 
 async def test_find_tool_calls_lightweight_find(service, monkeypatch):
@@ -144,7 +144,6 @@ async def test_find_tool_calls_lightweight_find(service, monkeypatch):
         limit=2,
         min_score=0.2,
         context_type=["memory", "resource"],
-        filter={"op": "must", "field": "category", "conds": ["docs"]},
     )
 
     assert result == "No matching context found."
@@ -154,15 +153,9 @@ async def test_find_tool_calls_lightweight_find(service, monkeypatch):
     assert captured["limit"] == 2
     assert captured["score_threshold"] == 0.2
     assert captured["filter"] == {
-        "op": "and",
-        "conds": [
-            {"op": "must", "field": "category", "conds": ["docs"]},
-            {
-                "op": "must",
-                "field": "context_type",
-                "conds": ["memory", "resource"],
-            },
-        ],
+        "op": "must",
+        "field": "context_type",
+        "conds": ["memory", "resource"],
     }
 
 
@@ -198,7 +191,6 @@ async def test_search_tool_calls_context_aware_search_with_session(service, monk
         limit=4,
         min_score=0.1,
         context_type="skill",
-        filter={"op": "must", "field": "category", "conds": ["tools"]},
     )
 
     assert result == "No matching context found."
@@ -212,11 +204,9 @@ async def test_search_tool_calls_context_aware_search_with_session(service, monk
     assert captured["limit"] == 4
     assert captured["score_threshold"] == 0.1
     assert captured["filter"] == {
-        "op": "and",
-        "conds": [
-            {"op": "must", "field": "category", "conds": ["tools"]},
-            {"op": "must", "field": "context_type", "conds": ["skill"]},
-        ],
+        "op": "must",
+        "field": "context_type",
+        "conds": ["skill"],
     }
 
 

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -120,6 +120,15 @@ async def test_search_respects_min_score(service):
     assert isinstance(result, str)
 
 
+async def test_search_tools_expose_context_type_and_filter_parameters():
+    tools = {tool.name: tool for tool in await mcp_endpoint.mcp.list_tools()}
+
+    for tool_name in ("find", "search"):
+        properties = tools[tool_name].inputSchema["properties"]
+        assert "context_type" in properties
+        assert "filter" in properties
+
+
 async def test_find_tool_calls_lightweight_find(service, monkeypatch):
     captured = {}
 
@@ -134,6 +143,8 @@ async def test_find_tool_calls_lightweight_find(service, monkeypatch):
         target_uri="viking://resources",
         limit=2,
         min_score=0.2,
+        context_type=["memory", "resource"],
+        filter={"op": "must", "field": "category", "conds": ["docs"]},
     )
 
     assert result == "No matching context found."
@@ -142,6 +153,17 @@ async def test_find_tool_calls_lightweight_find(service, monkeypatch):
     assert captured["target_uri"] == "viking://resources"
     assert captured["limit"] == 2
     assert captured["score_threshold"] == 0.2
+    assert captured["filter"] == {
+        "op": "and",
+        "conds": [
+            {"op": "must", "field": "category", "conds": ["docs"]},
+            {
+                "op": "must",
+                "field": "context_type",
+                "conds": ["memory", "resource"],
+            },
+        ],
+    }
 
 
 async def test_search_tool_calls_context_aware_search_with_session(service, monkeypatch):
@@ -175,6 +197,8 @@ async def test_search_tool_calls_context_aware_search_with_session(service, monk
         session_id="session-1",
         limit=4,
         min_score=0.1,
+        context_type="skill",
+        filter={"op": "must", "field": "category", "conds": ["tools"]},
     )
 
     assert result == "No matching context found."
@@ -187,6 +211,13 @@ async def test_search_tool_calls_context_aware_search_with_session(service, monk
     assert captured["session"] == session
     assert captured["limit"] == 4
     assert captured["score_threshold"] == 0.1
+    assert captured["filter"] == {
+        "op": "and",
+        "conds": [
+            {"op": "must", "field": "category", "conds": ["tools"]},
+            {"op": "must", "field": "context_type", "conds": ["skill"]},
+        ],
+    }
 
 
 async def test_recall_tool_returns_type_quota_memory_groups(service, monkeypatch):


### PR DESCRIPTION
## 动机

修复 #2990。

MCP 的 `find` 和 `search` 目前无法按 `context_type` 限定检索范围，而 REST、SDK、CLI 与底层 search service 已支持该输入。调用方因此只能依赖 URI 前缀等方式绕行。

根据 maintainer review，本 PR 只补齐 `context_type`，不向 MCP 暴露通用 metadata `filter`。

## 改动思路

复用现有 search-filter normalization，把 MCP 的可选 `context_type` 转为底层 effective filter，再传给 `SearchService.find` / `SearchService.search`。不传该参数时行为保持不变，非法输入继续返回 `InvalidArgumentError`。

## 关键调用链 / 伪代码

```text
MCP find/search(query, context_type?)
  -> merge_search_filter(None, context_type=context_type)
  -> effective_filter
  -> SearchService.find/search(..., filter=effective_filter)
```

## 具体改动

- 为两个 MCP retrieval tools 暴露可选 `context_type`；
- 将归一化后的 context-type filter 传给 search service；
- 不暴露通用 metadata `filter`；
- 同步更新中英文 MCP 文档；
- 增加 MCP schema 与参数转发回归覆盖。

## 修复后复现建议

通过 MCP 分别调用 `find` / `search`：

```text
context_type = "memory"
```

修复前 MCP schema 不接受该参数；修复后 schema 会暴露 `context_type`，service 收到对应 effective filter。省略参数时结果与修复前一致，schema 中仍不包含通用 `filter`。

## 验证

- `tests/server/test_mcp_endpoint.py`：49 passed；
- FastMCP schema：`find` / `search` 包含 `context_type`，不包含 `filter`；
- Ruff check / format：passed；
- `git diff --check`：passed。

## 对主干的风险与未覆盖

改动仅涉及 MCP 输入与既有 search service 参数传递；不传新参数时保持原行为。本 PR 不增加 metadata `filter`、tag 或 time-range 快捷参数。