### PR TITLE
Fix: 10 LOW-severity findings from bug bash

### DIFF
--- a/bot/vikingbot/cli/commands.py
+++ b/bot/vikingbot/cli/commands.py
@@ -7,6 +7,7 @@ import select
 import socket
 import sys
 import time
+import uuid
 import warnings
 from pathlib import Path
 from typing import Any, Optional
@@ -129,7 +130,8 @@ def _redirect_openviking_logs_to_stderr() -> None:
 def get_or_create_machine_id() -> str:
     """Get a unique machine ID using py-machineid.
 
-    Uses the system's machine ID, falls back to "default" if unavailable.
+    Uses the system's machine ID, falls back to a unique synthetic identifier
+    if the system machine ID cannot be retrieved.
     """
     try:
         from machineid import machine_id
@@ -138,11 +140,12 @@ def get_or_create_machine_id() -> str:
     except ImportError:
         # Fallback if py-machineid is not installed
         pass
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to read system machine id (%s); using fallback", exc)
 
-    # Default fallback
-    return "default"
+    # Unique fallback ID so concurrent installs on the same host do not
+    # collide on the literal string "default".
+    return f"default-{uuid.uuid4().hex[:8]}"
 
 
 def _init_bot_data(config):

--- a/openviking/parse/converter.py
+++ b/openviking/parse/converter.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -34,8 +35,14 @@ class DocumentConverter:
 
     async def _convert_with_libreoffice(self, file_path: Path) -> Optional[Path]:
         """Convert using LibreOffice (soffice)."""
-        output_dir = self.temp_dir or Path(tempfile.gettempdir())
-        output_path = output_dir / f"{file_path.stem}.pdf"
+        # Use a per-call isolated temp dir + uuid-suffixed output name to avoid
+        # collisions when two requests convert files sharing the same stem.
+        if self.temp_dir is not None:
+            output_dir = self.temp_dir
+        else:
+            output_dir = Path(tempfile.mkdtemp(prefix="ov-conv-"))
+        unique_suffix = uuid.uuid4().hex[:8]
+        output_path = output_dir / f"{file_path.stem}-{unique_suffix}.pdf"
 
         try:
             cmd = [

--- a/openviking/session/memory/merge_op/patch_handler.py
+++ b/openviking/session/memory/merge_op/patch_handler.py
@@ -829,7 +829,7 @@ class MultiSearchReplaceDiffStrategy:
                 if line.startswith(":start_line:"):
                     try:
                         start_line = int(line.split(":")[1].strip())
-                    except:
+                    except (ValueError, IndexError):
                         pass
 
             matches.append(

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -389,7 +389,9 @@ After exploring, analyze the conversation and output ALL memory write/edit/delet
 
         return self._truncate_prefetch_query_text(query, _PREFETCH_SEARCH_QUERY_MAX_CHARS)
 
-    def create_tool_context(self, default_search_uris=[]):
+    def create_tool_context(self, default_search_uris=None):
+        if default_search_uris is None:
+            default_search_uris = []
         extract_context = self.get_extract_context()
         tool_ctx = ToolContext(
             viking_fs=self._viking_fs,

--- a/openviking/session/memory/utils/messages.py
+++ b/openviking/session/memory/utils/messages.py
@@ -66,7 +66,7 @@ def pretty_print_messages(messages: List[Dict[str, Any]]) -> None:
                     try:
                         args_json = json.loads(args_str)
                         output.append(json.dumps(args_json, indent=2, ensure_ascii=False))
-                    except:
+                    except (json.JSONDecodeError, TypeError):
                         output.append(args_str)
                 else:
                     output.append(f"\n[{role} tool_calls]")

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -37,7 +37,7 @@ from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.model_retry import is_retryable_api_error, retry_async
 from openviking.utils.time_utils import get_current_timestamp
 from openviking.utils.token_estimation import estimate_text_tokens
-from openviking_cli.exceptions import FailedPreconditionError
+from openviking_cli.exceptions import FailedPreconditionError, NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger, run_async
 from openviking_cli.utils.config import get_openviking_config
@@ -2053,7 +2053,7 @@ class Session:
                 await self._viking_fs.read_file(f"{archive['archive_uri']}/.done", ctx=self.ctx)
                 latest_completed_index = max(latest_completed_index, archive["index"])
                 continue
-            except Exception:
+            except (FileNotFoundError, NotFoundError):
                 pass
 
             try:
@@ -2062,7 +2062,7 @@ class Session:
                     ctx=self.ctx,
                 )
                 continue
-            except Exception:
+            except (FileNotFoundError, NotFoundError):
                 pass
 
             pending_archives.append(archive)

--- a/openviking/storage/vectordb/utils/validation.py
+++ b/openviking/storage/vectordb/utils/validation.py
@@ -262,7 +262,7 @@ def _handle_validation_error(e: PydanticValidationError):
         err = e.errors()[0]
         field = ".".join(str(x) for x in err["loc"])
         msg = f"{err['msg']} (field: {field})"
-    except:
+    except (KeyError, IndexError, TypeError, AttributeError):
         pass
     raise ValidationError(msg)
 

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -2913,7 +2913,8 @@ class VikingFS:
                             await _collect(full_path)
                     else:
                         uris.append(self._path_to_uri(full_path, ctx=ctx))
-            except Exception:
+            except (FileNotFoundError, NotFoundError):
+                # Path may have been removed concurrently; treat as empty.
                 pass
 
         await _collect(path)

--- a/tests/integration/test_compressor_v2_e2e.py
+++ b/tests/integration/test_compressor_v2_e2e.py
@@ -226,9 +226,10 @@ class TestCompressorV2EndToEnd:
         print("Server uses its own ov.conf configuration")
         print("Note: Data cleanup is handled by test_restart_openviking_server.sh")
 
-        # The test passes if it doesn't throw an exception
-        # Memory extraction happens in background, v2 writes directly to storage
-        assert True
+        # The test passes if the background task completed successfully
+        # and the user-memories listing returned a list (empty or otherwise).
+        assert task_result["status"] == "completed"
+        assert isinstance(user_memories, list)
 
     @pytest.mark.integration
     @pytest.mark.asyncio

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -504,8 +504,14 @@ class TestBoundaryConditions:
         # Should handle circular links without infinite recursion
         try:
             result = await upload_directory(tmp_path, "viking://test/", MockFS())
-            # Should complete without hanging
-            assert result is None or result is not None
+            # Should complete without hanging and report uploaded files.
+            # With os.walk's default followlinks=False, the symlink loop is
+            # never followed, so only test.txt (in dir_a) gets uploaded.
+            assert isinstance(result, tuple)
+            assert len(result) == 2
+            uploaded_count, warnings = result
+            assert uploaded_count == 1, f"expected 1 file uploaded, got {uploaded_count}"
+            assert isinstance(warnings, list)
         except Exception as e:
             # Acceptable to raise exception for circular links
             assert "recursion" in str(e).lower() or "circular" in str(e).lower()

--- a/tests/test_low_batch_regressions.py
+++ b/tests/test_low_batch_regressions.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for the LOW-severity bug-bash batch.
+
+Each test exercises a specific fix from the batch PR so future refactors
+do not silently regress the behavior.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: create_tool_context must not share a mutable default list.
+# ---------------------------------------------------------------------------
+
+
+def test_create_tool_context_signature_does_not_use_mutable_default():
+    """Static check: the default argument must be None (not a mutable literal)."""
+    import inspect
+
+    from openviking.session.memory.session_extract_context_provider import (
+        SessionExtractContextProvider,
+    )
+
+    sig = inspect.signature(SessionExtractContextProvider.create_tool_context)
+    param = sig.parameters["default_search_uris"]
+    assert param.default is None, (
+        f"default_search_uris default must be None (mutable-default footgun), got {param.default!r}"
+    )
+
+
+def test_create_tool_context_default_does_not_mutate_across_calls():
+    """Two default-arg calls must yield independent lists (no shared mutable)."""
+    from openviking.server.identity import ToolContext
+    from openviking.session.memory.session_extract_context_provider import (
+        SessionExtractContextProvider,
+    )
+
+    captured = []
+
+    def _fake_tool_ctx(**kwargs):
+        captured.append(kwargs["default_search_uris"])
+        return ToolContext(**kwargs)
+
+    provider = SessionExtractContextProvider.__new__(SessionExtractContextProvider)
+    provider._viking_fs = MagicMock()
+    provider._ctx = MagicMock()
+    provider._transaction_handle = MagicMock()
+    provider._read_file_contents = {}
+    provider.messages = []
+
+    class _StubExtract:
+        page_id_map = {}
+
+    provider.get_extract_context = lambda: _StubExtract()
+
+    from openviking.session.memory import session_extract_context_provider as mod
+
+    original_tool_ctx = mod.ToolContext
+    mod.ToolContext = _fake_tool_ctx
+    try:
+        provider.create_tool_context()
+        provider.create_tool_context()
+    finally:
+        mod.ToolContext = original_tool_ctx
+
+    assert len(captured) == 2
+    assert captured[0] == []
+    assert captured[1] == []
+    assert captured[0] is not captured[1], (
+        "default_factory should produce a fresh list per call, not reuse a shared one"
+    )
+
+
+def test_create_tool_context_explicit_list_is_passed_through():
+    """Explicit argument must be used verbatim, not replaced."""
+    from openviking.server.identity import ToolContext
+    from openviking.session.memory.session_extract_context_provider import (
+        SessionExtractContextProvider,
+    )
+
+    captured = {}
+
+    def _fake_tool_ctx(**kwargs):
+        captured.update(kwargs)
+        return ToolContext(**kwargs)
+
+    provider = SessionExtractContextProvider.__new__(SessionExtractContextProvider)
+    provider._viking_fs = MagicMock()
+    provider._ctx = MagicMock()
+    provider._transaction_handle = MagicMock()
+    provider._read_file_contents = {}
+    provider.messages = []
+
+    class _StubExtract:
+        page_id_map = {}
+
+    provider.get_extract_context = lambda: _StubExtract()
+
+    from openviking.session.memory import session_extract_context_provider as mod
+
+    original_tool_ctx = mod.ToolContext
+    mod.ToolContext = _fake_tool_ctx
+    try:
+        explicit = ["viking://a", "viking://b"]
+        provider.create_tool_context(default_search_uris=explicit)
+    finally:
+        mod.ToolContext = original_tool_ctx
+
+    assert captured["default_search_uris"] is explicit
+
+
+# ---------------------------------------------------------------------------
+# Finding 3: start_line parser must catch only (ValueError, IndexError).
+# ---------------------------------------------------------------------------
+
+
+def _find_start_line_function():
+    """Locate the inner helper that parses `:start_line:N` headers."""
+    from openviking.session.memory.merge_op import patch_handler
+
+    source = Path(patch_handler.__file__).read_text(encoding="utf-8")
+    assert "except (ValueError, IndexError):" in source, (
+        "patch_handler should narrow the bare except around start_line parsing"
+    )
+
+
+def test_patch_handler_start_line_uses_typed_exceptions():
+    _find_start_line_function()
+
+
+def test_patch_handler_start_line_ignores_malformed_header_without_crashing():
+    """The narrowed except must swallow ValueError/IndexError for bad headers.
+
+    We don't assert the parsed value (that depends on the upstream format
+    convention); we only assert that bad input produces a sane default
+    rather than crashing the entire patch parse.
+    """
+    from openviking.session.memory.merge_op.patch_handler import (
+        MultiSearchReplaceDiffStrategy,
+    )
+
+    parser = MultiSearchReplaceDiffStrategy()
+    haystack = (
+        "before\n"
+        "<<<<<<< SEARCH\n"
+        ":start_line:not-a-number\n"
+        "old text\n"
+        "=======\n"
+        "new text\n"
+        ">>>>>>> REPLACE\n"
+        "after\n"
+    )
+    matches = parser._parse_diff_blocks(haystack)
+    assert len(matches) == 1
+    # startLine should default to 0 (the parser's safe fallback).
+    assert matches[0]["startLine"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Finding 4: tool-call argument formatting must only catch JSON/Type errors.
+# ---------------------------------------------------------------------------
+
+
+def test_messages_format_tool_calls_invalid_json_does_not_crash():
+    """Malformed JSON args fall through to the raw string instead of raising."""
+    from openviking.session.memory.utils.messages import pretty_print_messages
+
+    msg = {
+        "role": "assistant",
+        "content": "calling tool",
+        "tool_calls": [
+            {
+                "id": "t1",
+                "function": {"name": "noop", "arguments": "{not-valid-json"},
+            }
+        ],
+    }
+    # Should not raise.
+    pretty_print_messages([msg])
+
+
+def test_messages_format_tool_calls_valid_json_does_not_crash():
+    """Valid JSON args do not raise and are pretty-printed."""
+    from openviking.session.memory.utils.messages import pretty_print_messages
+
+    msg = {
+        "role": "assistant",
+        "content": "calling tool",
+        "tool_calls": [
+            {
+                "id": "t2",
+                "function": {"name": "echo", "arguments": json.dumps({"k": "v"})},
+            }
+        ],
+    }
+    pretty_print_messages([msg])
+
+
+# ---------------------------------------------------------------------------
+# Finding 5: validation error formatter must catch only lookup/type errors.
+# ---------------------------------------------------------------------------
+
+
+def test_validation_module_uses_typed_exception_handlers():
+    """The bare-except around the field formatter has been narrowed."""
+    from openviking.storage.vectordb.utils import validation
+
+    source = Path(validation.__file__).read_text(encoding="utf-8")
+    assert "except (KeyError, IndexError, TypeError, AttributeError):" in source, (
+        "validation._handle_validation_error should narrow the bare except"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 10: machine-id fallback must be unique per call.
+# ---------------------------------------------------------------------------
+
+
+def _extract_machine_id_function():
+    """Locate the get_or_create_machine_id function from commands.py via AST."""
+    import ast
+
+    commands_path = (
+        Path(__file__).resolve().parent.parent / "bot" / "vikingbot" / "cli" / "commands.py"
+    )
+    tree = ast.parse(commands_path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "get_or_create_machine_id":
+            return node
+    raise AssertionError("get_or_create_machine_id not found in commands.py")
+
+
+def test_get_or_create_machine_id_uses_unique_fallback():
+    """The fallback path must not return the literal 'default' string."""
+    import ast
+
+    func = _extract_machine_id_function()
+    src = ast.unparse(func)
+    assert "default-" in src, "fallback should be a unique prefix like 'default-<uuid>'"
+    assert '"default"' not in src and "'default'" not in src, (
+        "fallback must not return the literal string 'default' (it would collide "
+        "across concurrent installs)"
+    )
+    assert "uuid" in src, "fallback should use uuid.uuid4 for uniqueness"
+
+
+def test_get_or_create_machine_id_logs_failure():
+    """The except Exception branch should warn rather than silently swallow."""
+    import ast
+
+    func = _extract_machine_id_function()
+    # Walk the function body looking for a logger.warning() call inside an
+    # except handler.
+    found_warning = False
+    for node in ast.walk(func):
+        if isinstance(node, ast.ExceptHandler) and node.type is not None:
+            type_name = ast.unparse(node.type)
+            if "Exception" in type_name:
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Attribute)
+                        and sub.func.attr == "warning"
+                    ):
+                        found_warning = True
+                        break
+    assert found_warning, (
+        "the broad `except Exception` branch should call logger.warning so "
+        "operators can diagnose missing-machineid issues"
+    )
+
+
+def test_get_or_create_machine_id_runtime_unique_fallback_v2():
+    """Runtime check: simulate missing machineid and confirm uniqueness.
+
+    bot.vikingbot.cli.commands pulls in many heavy optional deps at module
+    import time. To avoid that, we extract just the function via AST and exec
+    it in an isolated namespace with a fake `from machineid import machine_id`
+    raising ImportError on entry.
+    """
+    import ast
+
+    commands_path = (
+        Path(__file__).resolve().parent.parent / "bot" / "vikingbot" / "cli" / "commands.py"
+    )
+    tree = ast.parse(commands_path.read_text(encoding="utf-8"))
+    func_node = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "get_or_create_machine_id"
+    )
+    func_src = ast.unparse(func_node)
+
+    # Stub `from machineid import machine_id` so the inner import raises.
+    setup = (
+        "import builtins as _b\n"
+        "_real = _b.__import__\n"
+        "def _stub(name, globals=None, locals=None, fromlist=(), level=0):\n"
+        "    if name == 'machineid':\n"
+        "        raise ImportError('simulated missing dependency')\n"
+        "    return _real(name, globals, locals, fromlist, level)\n"
+        "_b.__import__ = _stub\n"
+        # loguru.logger used inside the except branch needs a no-op stub.
+        "class _Logger:\n"
+        "    def warning(self, *a, **k):\n"
+        "        return None\n"
+        "    def info(self, *a, **k):\n"
+        "        return None\n"
+        "    def debug(self, *a, **k):\n"
+        "        return None\n"
+        "    def error(self, *a, **k):\n"
+        "        return None\n"
+        "logger = _Logger()\n"
+    )
+
+    # Stub loguru.logger so warning() does not blow up.
+    restore = "_b.__import__ = _real\n"
+
+    import uuid as _uuid_mod
+
+    ns = {"_stub": None, "uuid": _uuid_mod}
+    try:
+        exec(setup + func_src + "\n" + restore, ns)
+        a = ns["get_or_create_machine_id"]()
+        b = ns["get_or_create_machine_id"]()
+    except Exception:
+        # Ensure import is restored even on failure.
+        raise
+
+    assert a != "default"
+    assert b != "default"
+    assert a != b
+    assert a.startswith("default-")
+    assert b.startswith("default-")


### PR DESCRIPTION
## Summary

Process all 10 LOW-severity findings from the OpenViking bug bash into one commit, with regression tests for the easy-to-cover ones.

## Fixes (by group)

### Bare `except:` / `except Exception:` -> typed exceptions
1. `openviking/session/memory/merge_op/patch_handler.py:832` — `start_line` parser now catches `(ValueError, IndexError)` instead of bare `except`.
2. `openviking/session/memory/utils/messages.py:69` — tool-call arg JSON formatter now catches `(json.JSONDecodeError, TypeError)`.
3. `openviking/storage/vectordb/utils/validation.py:265` — `_handle_validation_error` now catches `(KeyError, IndexError, TypeError, AttributeError)`.
4. `openviking/session/session.py:2056/2065` — `_get_pending_archive_messages` now catches `(FileNotFoundError, NotFoundError)`; the latter is imported from `openviking_cli.exceptions`.
5. `openviking/storage/viking_fs.py:2916` — `_collect_uris` now catches `(FileNotFoundError, NotFoundError)` so unexpected errors still propagate.

### Mutable default argument -> None factory
6. `openviking/session/memory/session_extract_context_provider.py:392` — `create_tool_context(default_search_uris=[])` replaced with `default=None` + a fresh list inside the method.

### Fragile fallbacks -> unique / safer
7. `openviking/parse/converter.py:35` — `_convert_with_libreoffice` now uses `tempfile.mkdtemp(prefix="ov-conv-")` + a `uuid.uuid4().hex[:8]` suffix on the output PDF so concurrent conversions of files with the same stem can no longer collide.
8. `bot/vikingbot/cli/commands.py:130` — `get_or_create_machine_id` fallback now returns `f"default-{uuid.uuid4().hex[:8]}"` and the broad `except Exception` branch now logs the failure via `loguru.logger.warning`.

### Tautological test asserts -> real assertions
9. `tests/integration/test_compressor_v2_e2e.py:231` — `assert True` replaced with `assert task_result["status"] == "completed"` and `assert isinstance(user_memories, list)`.
10. `tests/test_edge_cases.py:508` — tautological `assert result is None or result is not None` replaced with concrete assertions on the returned `(uploaded_count, warnings)` tuple (expects 1 uploaded file from the test fixture).

## Regression tests
Added `tests/test_low_batch_regressions.py` (11 tests) covering findings 1, 3, 4, 5, 10:
- AST/inspector checks for typed exceptions in patch_handler, validation, and the new machine-id fallback (no machineid collision, warning logged).
- Runtime checks for `create_tool_context` mutable-default behaviour (signature default is `None`, fresh list per call, explicit list passed through).
- Runtime check for malformed JSON args in `pretty_print_messages`.
- Runtime check that `get_or_create_machine_id` returns unique fallbacks when the `machineid` import is faked to fail (the function body is exec'd in an isolated namespace with stubbed `loguru.logger`).

## Verification
- `ruff format` on all 11 changed Python files (no diff).
- `ruff check` on changed files: only pre-existing `F401`/`F811` warnings about `ToolPart` in `session_extract_context_provider.py` — unrelated to this PR.
- `pytest tests/test_low_batch_regressions.py` — 11/11 pass.

## Out-of-scope notes
- The pre-existing off-by-one in `patch_handler._parse_diff_blocks` where `int(line.split(":")[1].strip())` reads index 1 (`"start_line"`) instead of index 2 (the actual number) is a deeper logic bug and is **not** addressed here. The batch only covered the type narrowing of the surrounding `except`. Test `test_patch_handler_start_line_ignores_malformed_header_without_crashing` confirms the narrowed except path returns 0 instead of crashing, without asserting a specific parsed value.