### PR TITLE
fix: fail embedding writes on empty upsert id

### DIFF
--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -765,10 +765,11 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         partial_update=True,
                     )
                     record_id = result
-                    if record_id:
-                        logger.debug(
-                            f"Successfully wrote embedding to database: {record_id} abstract {inserted_data['abstract']} vector {inserted_data['vector'][:5]}"
-                        )
+                    if not record_id:
+                        raise RuntimeError("Vector database upsert returned an empty record ID")
+                    logger.debug(
+                        f"Successfully wrote embedding to database: {record_id} abstract {inserted_data['abstract']} vector {inserted_data['vector'][:5]}"
+                    )
                 except CollectionNotFoundError as db_err:
                     # During shutdown, queue workers may finish one dequeued item.
                     if self._vikingdb.is_closing:

--- a/tests/storage/test_text_embedding_handler.py
+++ b/tests/storage/test_text_embedding_handler.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import pytest
+
+from openviking.models.embedder.base import EmbedResult
+from openviking.storage import collection_schemas
+from openviking.storage.collection_schemas import TextEmbeddingHandler
+from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
+from openviking.utils.circuit_breaker import CircuitBreaker
+
+
+@pytest.mark.asyncio
+async def test_embedding_write_with_empty_record_id_is_reported_as_failure(monkeypatch):
+    class _VikingDB:
+        is_closing = False
+        has_queue_manager = False
+
+        async def upsert(self, data, *, ctx, partial_update):
+            del data, ctx, partial_update
+            return ""
+
+    async def _embed_compat(embedder, message, *, is_query):
+        del embedder, message, is_query
+        return EmbedResult(dense_vector=[0.1, 0.2])
+
+    handler = TextEmbeddingHandler.__new__(TextEmbeddingHandler)
+    handler._vikingdb = _VikingDB()
+    handler._embedder = object()
+    handler._vector_dim = 2
+    handler._circuit_breaker = CircuitBreaker()
+    handler._breaker_open_last_log_at = 0.0
+    handler._breaker_open_suppressed_count = 0
+    handler._breaker_open_log_interval = 30.0
+
+    successes = []
+    errors = []
+    request_successes = []
+    request_failures = []
+    handler.set_callbacks(
+        on_success=lambda: successes.append(True),
+        on_requeue=lambda: None,
+        on_error=lambda message, data: errors.append((message, data)),
+    )
+    handler._record_request_success = lambda message: request_successes.append(message)
+    handler._record_request_failure = lambda message, error: request_failures.append(
+        (message, error)
+    )
+    monkeypatch.setattr(collection_schemas, "embed_compat", _embed_compat)
+
+    message = EmbeddingMsg(
+        message="hello",
+        context_data={
+            "uri": "viking://resources/example.md",
+            "level": 2,
+            "abstract": "example",
+            "account_id": "acc1",
+        },
+        telemetry_id="empty-record-id",
+    )
+    queue_data = {"data": message.to_json()}
+
+    result = await handler.on_dequeue(queue_data)
+
+    assert result is None
+    assert successes == []
+    assert request_successes == []
+    assert len(errors) == 1
+    assert "empty record id" in errors[0][0].lower()
+    assert errors[0][1] == queue_data
+    assert len(request_failures) == 1
+    assert "empty record id" in request_failures[0][1].lower()
+    stats = handler.consume_request_stats("empty-record-id")
+    assert stats is not None
+    assert stats.processed == 0
+    assert stats.error_count == 1


### PR DESCRIPTION
## Summary

- treat an empty record ID returned by the vector database upsert as a write failure
- route that failure through the existing embedding error accounting and callbacks
- add a regression test covering queue errors, request failure tracking, and request stats

## Problem

`TextEmbeddingHandler.on_dequeue()` currently records an embedding message as processed even when `VikingVectorIndexBackend.upsert()` returns an empty string. The backend uses an empty ID to signal several failed/no-op write paths. Because the handler only logs when the ID is truthy and then unconditionally reports success, reindex can report hundreds of rebuilt records while the vector collection remains empty.

Observed against OpenViking Service v0.4.8:

- embedding queue processed: 751
- reported rebuilt records in a narrow reindex: 369
- vector count after completion: 0
- semantic `find`: 0 results

## Fix

Require a non-empty record ID after upsert. An empty ID raises into the existing database error branch, which already:

- increments embedding `error_count`
- records request failure
- invokes the queue error callback
- avoids the success callback and processed count

This does not change successful write behavior or shutdown handling.

## Test plan

```text
pytest -q --no-cov tests/storage/test_text_embedding_handler.py
ruff check openviking/storage/collection_schemas.py tests/storage/test_text_embedding_handler.py
```

Both pass locally on Python 3.11.15.
