### PR TITLE
fix(qdrant): return vectors in fetch_data so set_tags works with dense-only configs

### DIFF
--- a/openviking/storage/vectordb/collection/qdrant_collection.py
+++ b/openviking/storage/vectordb/collection/qdrant_collection.py
@@ -98,9 +98,52 @@ def _hash_sparse_term(term: str) -> int:
     return xxhash.xxh64_intdigest(str(term)) % QDRANT_SPARSE_INDEX_MAX
 
 
-def _sparse_to_qdrant(sparse_vector: Optional[Dict[str, float]]) -> Optional[Dict[str, List[Any]]]:
+def _maybe_qdrant_sparse_payload(
+    value: Any,
+) -> Optional[Dict[str, List[Any]]]:
+    """Return the value unchanged if it is already a Qdrant-encoded sparse vector.
+
+    Qdrant serializes sparse vectors as ``{"indices": [int, ...], "values":
+    [float, ...]}``. Records read back from Qdrant with ``with_vector=True``
+    (e.g. via :meth:`QdrantCollection.fetch_data`) carry this encoded shape, and
+    when such a record is upserted again we must emit it verbatim instead of
+    re-hashing the list-valued entries (which would discard the sparse vector).
+    """
+    if not isinstance(value, dict):
+        return None
+    indices = value.get("indices")
+    values = value.get("values")
+    if not isinstance(indices, list) or not isinstance(values, list):
+        return None
+    if len(indices) != len(values) or not indices:
+        return None
+    coerced_indices: List[int] = []
+    for index in indices:
+        if isinstance(index, bool) or not isinstance(index, int):
+            return None
+        coerced_indices.append(index)
+    coerced_values: List[float] = []
+    for raw_value in values:
+        try:
+            coerced_values.append(float(raw_value))
+        except (TypeError, ValueError):
+            return None
+    return {"indices": coerced_indices, "values": coerced_values}
+
+
+def _sparse_to_qdrant(sparse_vector: Optional[Dict[str, Any]]) -> Optional[Dict[str, List[Any]]]:
     if not sparse_vector:
         return None
+    # Qdrant returns sparse vectors in its own {indices, values} encoding when a
+    # point is read back with with_vector=True (e.g. fetch_data). When such a
+    # record is fed back into _make_point on a full-record upsert (update_search_tags,
+    # update_data, ...), we must pass the already-encoded sparse vector through
+    # unchanged rather than re-hashing the list-valued entries, which would
+    # silently drop the sparse vector. The {term: weight} shape produced by the
+    # search/embedding path still goes through the hash+merge pipeline below.
+    encoded = _maybe_qdrant_sparse_payload(sparse_vector)
+    if encoded is not None:
+        return encoded
     merged: Dict[int, float] = {}
     hashed_terms: Dict[int, str] = {}
     collisions: List[tuple[str, str, int]] = []

--- a/openviking/storage/vectordb/collection/qdrant_collection.py
+++ b/openviking/storage/vectordb/collection/qdrant_collection.py
@@ -1142,7 +1142,11 @@ class QdrantCollection(ICollection):
             json_body={
                 "ids": [_to_qdrant_point_id(pk) for pk in primary_keys],
                 "with_payload": True,
-                "with_vector": False,
+                # Return vectors so that callers performing a full-record
+                # upsert (e.g. update_search_tags -> get -> upsert) have the
+                # vector available. Without this, _make_point raises
+                # "Qdrant point requires at least one dense or sparse vector".
+                "with_vector": True,
             },
         )
         points = _extract_points(response)
@@ -1152,6 +1156,13 @@ class QdrantCollection(ICollection):
             if not isinstance(point, dict):
                 continue
             original_id, payload = self._point_payload_for_read(point)
+            # Preserve vectors in the returned fields so subsequent full
+            # upserts (which require vectors) can reuse them.
+            dense_vector, sparse_vector = self._extract_named_vectors(point)
+            if dense_vector is not None:
+                payload[self._dense_vector_name] = dense_vector
+            if sparse_vector is not None:
+                payload[self._sparse_vector_name] = sparse_vector
             found_ids.add(str(original_id))
             items.append(DataItem(id=original_id, fields=payload))
         return FetchDataInCollectionResult(

--- a/tests/storage/test_qdrant_collection.py
+++ b/tests/storage/test_qdrant_collection.py
@@ -69,6 +69,86 @@ def test_sparse_to_qdrant_warns_on_hash_collision(monkeypatch, caplog):
     assert "hash collision detected" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        {"indices": [7, 9, 13], "values": [1.0, 2.5, 4.0]},
+        # Numeric strings in values are tolerated; indices stay ints.
+        {"indices": [1], "values": ["0.5"]},
+    ],
+)
+def test_sparse_to_qdrant_passes_through_qdrant_encoded_shape(encoded):
+    # Records read back from Qdrant with with_vector=True carry sparse vectors
+    # in the {"indices": [...], "values": [...]} encoding. Feeding them back
+    # into _make_point on a full-record upsert must emit them verbatim instead
+    # of silently dropping the sparse vector.
+    payload = _sparse_to_qdrant(encoded)
+
+    assert payload == {"indices": encoded["indices"], "values": [float(v) for v in encoded["values"]]}
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {"indices": [1, 2], "values": [1.0]},  # length mismatch
+        {"indices": [], "values": []},  # empty
+        {"indices": ["a"], "values": [1.0]},  # non-int index
+        {"indices": [1, 2]},  # missing values
+        {"values": [1.0, 2.0]},  # missing indices
+    ],
+)
+def test_sparse_to_qdrant_falls_back_to_hashing_for_malformed_encoded_shape(malformed):
+    # A malformed {"indices":...} dict must not short-circuit; it should be
+    # treated as a {term: weight} map. "indices"/"values" are not float-able
+    # weights, so they are skipped and the result is None.
+    assert _sparse_to_qdrant(malformed) is None
+
+
+def test_fetch_data_then_update_preserves_both_dense_and_sparse_vectors():
+    # Regression test for the set_tags / update_search_tags full-record upsert
+    # on a hybrid (dense + sparse) point: fetch_data must surface both vectors,
+    # and the subsequent update_data (which re-fetches the point itself) must
+    # re-emit both vectors unchanged rather than silently dropping the sparse
+    # vector read back in Qdrant-encoded form.
+    point_id = _to_qdrant_point_id("doc_1")
+    hybrid_point = {
+        "id": point_id,
+        "payload": {ORIGINAL_ID_FIELD: "doc_1", "name": "Before"},
+        "vector": {
+            "vector": [0.1, 0.2, 0.3],
+            "sparse_vector": {"indices": [7, 9], "values": [1.0, 4.0]},
+        },
+    }
+    client = _StubClient(
+        [
+            # 1) explicit fetch_data() call.
+            {"result": [hybrid_point]},
+            # 2) update_data() re-fetches the existing point internally.
+            {"result": [hybrid_point]},
+            # 3) update_data() upserts the merged record.
+            {"status": "ok"},
+        ]
+    )
+    collection = _build_collection_stub(client)
+
+    fetched = collection.fetch_data(["doc_1"])
+    assert fetched.items[0].fields["vector"] == [0.1, 0.2, 0.3]
+    assert fetched.items[0].fields["sparse_vector"] == {"indices": [7, 9], "values": [1.0, 4.0]}
+
+    collection.update_data([{"id": "doc_1", "name": "After"}])
+
+    # The last recorded request is the upsert; the one before it is the
+    # re-fetch that update_data performed internally.
+    upsert_call = client.calls[-1]
+    assert upsert_call["method"] == "PUT"
+    upsert_point = upsert_call["json_body"]["points"][0]
+    assert upsert_point["vector"]["vector"] == [0.1, 0.2, 0.3]
+    # The sparse vector read back in Qdrant-encoded form must be re-emitted
+    # verbatim, NOT silently dropped.
+    assert upsert_point["vector"]["sparse_vector"] == {"indices": [7, 9], "values": [1.0, 4.0]}
+    assert upsert_point["payload"]["name"] == "After"
+
+
 def test_scroll_points_stops_on_repeated_next_page_offset(caplog):
     client = _StubClient(
         [


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test

## Summary

The `set_tags` API (`POST /api/v1/content/set_tags`) fails with `Qdrant point requires at least one dense or sparse vector` when OpenViking runs against the **Qdrant** backend with a **dense-only** embedding configuration (no sparse vector). Since `add_resource` does not accept a `tags` field, `set_tags` is the only way to attach `k=v` search tags — so this bug completely blocks the `search_tags` retrieval-filtering feature for Qdrant users.

**Root cause:** `update_search_tags` reads the existing record via `get` → `fetch_data`, but `fetch_data` sets `with_vector: False`, so the returned record has no `dense_vector`. The subsequent full upsert (`_make_point`) then finds no vector and raises.

This PR makes `fetch_data` return vectors (`with_vector: True`) and extracts them into `DataItem.fields`, so that metadata-only update flows (`set_tags`, and any future get-modify-upsert caller) retain the vector and can upsert successfully.

## Changes

- `openviking/storage/vectordb/collection/qdrant_collection.py` — `fetch_data`:
  - Changed `"with_vector": False` → `True`
  - Extract dense/sparse vectors via `_extract_named_vectors` and store them in the returned `DataItem.fields`

Single-method change, ~12 lines added.

## Why this approach (and not alternatives)

| Option | Verdict |
|--------|---------|
| **A. `fetch_data` returns vectors (this PR)** | Minimal, fixes the root cause for all get-modify-upsert flows. Safe: `_make_point` already strips vector fields from the payload (line 348). ✅ |
| B. Pass `partial_update=True` in `update_search_tags` | Does **not** work — the partial-update path also reads via `get` → `fetch_data` (`with_vector=False`), so it still has no vector. ❌ |
| C. Add `dense_vector` to `FETCH_BY_URI_OUTPUT_FIELDS` | Used by the `filter` path, not by `get`/`fetch_data`; doesn't fix the actual read path. ❌ |
| D. Dedicated `setPayload`-based metadata update | Cleaner architecturally but a larger change. Better as a follow-up. |

## Verification

### Before (broken)

```
POST /api/v1/content/set_tags
{"uri":"viking://resources/test/doc.md","tags":["version=v1"],"mode":"replace"}
→ {"status":"error","error":{"code":"INVALID_ARGUMENT",
   "message":"Qdrant point requires at least one dense or sparse vector"}}
```

### After (fixed)

```
POST /api/v1/content/set_tags
{"uri":"viking://resources/test/doc.md","tags":["version=v1"],"mode":"replace"}
→ {"status":"ok","result":{"success_count":1,"tags_updated":true,
   "tags":["version=v1"]}}
```

Full end-to-end retrieval matrix (tags written via `set_tags`, queried via `find`):

| Query | Expected | Result |
|-------|----------|--------|
| `tags=["version=v1"]` | 1 doc | ✅ 1 |
| `tags=["version=v2"]` | 1 doc | ✅ 1 |
| `tags=["version=v3"]` (nonexistent) | 0 | ✅ 0 |
| `tags=["product=alpha"]` | 2 docs | ✅ 2 |
| `tags=["version=v1","version=v2"]` (OR) | 2 docs | ✅ 2 |

## Root cause trace

```
update_search_tags (viking_vector_index_backend.py:863)
  → self.get([id])                                    # reads record
    → base._fetch_and_normalize → fetch_data          # with_vector=False → no vector!
  → self.upsert(updated_record)                       # record has no vector
    → _make_point                                      # dense_vector is None
      → raise ValueError("Qdrant point requires...")  # 💥
```

## Test plan

- [x] Manual: `set_tags` (replace mode) succeeds on Qdrant + dense-only config
- [x] Manual: `set_tags` (append mode) succeeds
- [x] Manual: `find` with `tags` filter returns correct results (6 test cases)
- [ ] CI: existing qdrant-related tests pass
- [ ] Regression: `fetch_data` consumers that don't need vectors are unaffected

## Environment

- OpenViking 0.4.7
- Qdrant backend, dense-only embedding (`BAAI/bge-m3`, dim 1024)
- Python 3.13