### PR TITLE
fix(parse): preserve filters for local git repositories

### DIFF
--- a/openviking/parse/parsers/code/code.py
+++ b/openviking/parse/parsers/code/code.py
@@ -17,7 +17,7 @@ import time
 import urllib.request
 import zipfile
 from pathlib import Path, PurePosixPath
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Set, Tuple, Union
 from urllib.parse import unquote, urlparse
 
 from openviking.parse.base import (
@@ -170,7 +170,14 @@ class CodeRepositoryParser(BaseParser):
             logger.info(f"Uploading to VikingFS: {target_root_uri}")
 
             # 4. Upload to VikingFS (filtering on the fly)
-            file_count = await self._upload_directory(local_dir, target_root_uri, viking_fs)
+            file_count = await self._upload_directory(
+                local_dir,
+                target_root_uri,
+                viking_fs,
+                ignore_dirs=kwargs.get("ignore_dirs"),
+                include=kwargs.get("include"),
+                exclude=kwargs.get("exclude"),
+            )
 
             logger.info(f"Uploaded {file_count} files to {target_root_uri}")
 
@@ -572,7 +579,23 @@ class CodeRepositoryParser(BaseParser):
 
         return name
 
-    async def _upload_directory(self, local_dir: Path, viking_uri_base: str, viking_fs: Any) -> int:
+    async def _upload_directory(
+        self,
+        local_dir: Path,
+        viking_uri_base: str,
+        viking_fs: Any,
+        *,
+        ignore_dirs: Optional[Union[Set[str], List[str], str]] = None,
+        include: Optional[str] = None,
+        exclude: Optional[str] = None,
+    ) -> int:
         """Recursively upload directory to VikingFS using shared upload utilities."""
-        count, _ = await upload_directory(local_dir, viking_uri_base, viking_fs)
+        count, _ = await upload_directory(
+            local_dir,
+            viking_uri_base,
+            viking_fs,
+            ignore_dirs=ignore_dirs,
+            include=include,
+            exclude=exclude,
+        )
         return count

--- a/openviking/parse/parsers/upload_utils.py
+++ b/openviking/parse/parsers/upload_utils.py
@@ -142,20 +142,38 @@ async def upload_directory(
     local_dir: Path,
     viking_uri_base: str,
     viking_fs: Any,
-    ignore_dirs: Optional[Set[str]] = None,
+    ignore_dirs: Optional[Union[Set[str], List[str], str]] = None,
     ignore_extensions: Optional[Set[str]] = None,
     max_file_size: int = 10 * 1024 * 1024,
+    include: Optional[str] = None,
+    exclude: Optional[str] = None,
 ) -> Tuple[int, List[str]]:
     """Upload an entire directory recursively and return uploaded count with warnings.
 
     Optimized: collects all files in one pass, pre-creates directories upfront,
     then uploads all files concurrently (up to _UPLOAD_CONCURRENCY at a time).
     """
-    effective_ignore_dirs = ignore_dirs if ignore_dirs is not None else IGNORE_DIRS
     effective_ignore_extensions = (
         ignore_extensions if ignore_extensions is not None else IGNORE_EXTENSIONS
     )
     gitignore_matcher = GitignoreMatcher(local_dir)
+    # Keep repository uploads aligned with DirectoryParser's public filtering
+    # contract without duplicating its path/glob semantics.
+    from openviking.parse.directory_scan import (
+        _matches_exclude,
+        _matches_include,
+        _parse_patterns,
+        _should_skip_directory,
+    )
+
+    if isinstance(ignore_dirs, str):
+        parsed_ignore_dirs: Optional[Set[str]] = set(_parse_patterns(ignore_dirs)) or None
+    elif ignore_dirs:
+        parsed_ignore_dirs = {str(item) for item in ignore_dirs}
+    else:
+        parsed_ignore_dirs = None
+    include_patterns = _parse_patterns(include)
+    exclude_patterns = _parse_patterns(exclude)
 
     warnings: List[str] = []
 
@@ -171,7 +189,11 @@ async def upload_directory(
         kept = []
         for d in dirs:
             sub_dir_path = dir_path / d
-            should_skip = should_skip_directory(d, ignore_dirs=effective_ignore_dirs)
+            should_skip, _ = _should_skip_directory(
+                sub_dir_path,
+                local_dir,
+                parsed_ignore_dirs,
+            )
             if should_skip:
                 continue
 
@@ -196,6 +218,14 @@ async def upload_directory(
                 continue
 
             rel_path_str = str(file_path.relative_to(local_dir)).replace(os.sep, "/")
+            if include_patterns and not _matches_include(file_name, include_patterns):
+                continue
+            if exclude_patterns and _matches_exclude(
+                rel_path_str,
+                file_name,
+                exclude_patterns,
+            ):
+                continue
             try:
                 target_uri = safe_join_viking_uri(viking_uri_base, rel_path_str)
             except ValueError as exc:

--- a/tests/parse/test_add_directory.py
+++ b/tests/parse/test_add_directory.py
@@ -208,6 +208,37 @@ class TestDirectoryParserBasic:
         p = DirectoryParser()
         assert p.can_parse(tmp_path) is True
 
+    @pytest.mark.asyncio
+    async def test_git_repository_preserves_directory_filters(
+        self, tmp_path: Path, fake_fs: FakeVikingFS
+    ) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "notes").mkdir()
+        (tmp_path / "08_Attachments").mkdir()
+        (tmp_path / "notes" / "article.md").write_text("keep", encoding="utf-8")
+        (tmp_path / "notes" / "private.excalidraw.md").write_text(
+            "exclude", encoding="utf-8"
+        )
+        (tmp_path / "08_Attachments" / "diagram.md").write_text(
+            "ignore", encoding="utf-8"
+        )
+        (tmp_path / "main.py").write_text("exclude by include", encoding="utf-8")
+
+        with (
+            patch.object(BaseParser, "_get_viking_fs", return_value=fake_fs),
+            patch.object(DirectoryParser, "_add_git_metadata", new=AsyncMock()),
+        ):
+            result = await DirectoryParser().parse(
+                str(tmp_path),
+                ignore_dirs="08_Attachments",
+                include="*.md",
+                exclude="*.excalidraw.md",
+            )
+
+        uploaded_paths = {uri.split("/repository/", 1)[-1] for uri in fake_fs.files}
+        assert result.parser_name == "CodeRepositoryParser"
+        assert uploaded_paths == {"notes/article.md"}
+
     def test_can_parse_file(self, tmp_path: Path):
         f = tmp_path / "test.md"
         f.write_text("hello")


### PR DESCRIPTION
## 动机

修复 #3187。

`DirectoryParser` 识别到本地 Git 仓库后，会把 `ignore_dirs`、`include` 和 `exclude` 传给 `CodeRepositoryParser`，但后者在调用共享目录上传逻辑前丢失了这三个参数。因此，同一个本地目录仅因存在 `.git/`，就会生成不同的资源树；watch 刷新也会重复这一不一致行为。

## 改动思路

复用普通目录扫描器已有的过滤语义，而不是为 Git 仓库定义第二套过滤语言：让 `CodeRepositoryParser` 将三个过滤参数完整传到共享 uploader，再由 uploader 统一组合内置忽略目录、`.gitignore`、include/exclude glob、扩展名和文件大小限制。

## 关键调用链 / 伪代码

```text
DirectoryParser(local_git_repo, filters)
  -> CodeRepositoryParser.parse(filters)
  -> upload_directory(filters)
  -> built_in_ignores + .gitignore
  -> include(path/name) and exclude(path/name)
  -> upload only matching files
```

watch task 已经把这些参数保存在 `processor_kwargs`，因此后续刷新会自动走修复后的同一路径。

## 具体改动

- 经由 `CodeRepositoryParser` 继续传递 `ignore_dirs`、`include` 和 `exclude`；
- 在共享 repository uploader 中应用现有 `DirectoryParser` 的 path/glob 过滤语义；
- 保持内置忽略目录、`.gitignore`、忽略扩展名、文件大小限制和并发上传行为不变。

## 修复后复现

可以直接对任意本地 Git checkout 调用公开 parser API：

```python
result = await DirectoryParser().parse(
    "/path/to/local/repo",
    ignore_dirs="08_Attachments",
    include="*.md",
    exclude="*.excalidraw.md",
)
assert result.parser_name == "CodeRepositoryParser"
```

在回归 fixture 中，修复后上传结果应只包含 `notes/article.md`；`main.py`、`08_Attachments/diagram.md` 和 `notes/private.excalidraw.md` 均应被排除。

## 验证

在 `origin/main` revision `5bfa9b617ecff478f825ca435a35bc4222b30582` 上，新回归测试先失败：即使设置了

```text
ignore_dirs=08_Attachments
include=*.md
exclude=*.excalidraw.md
```

fixture 仍上传 4 个文件。应用修复后只保留 `notes/article.md`。

- `tests/test_upload_utils.py`、`tests/parse/test_directory_scan.py` 及 focused Git repository regression：82 passed；
- 所有改动 Python 文件 Ruff passed；
- `py_compile` passed；
- `git diff --check` passed。

## 对主干的风险与未覆盖

风险较低且仅限 repository upload filtering。未显式传入过滤参数的调用保持原行为；自定义 `ignore_dirs` 继续与内置忽略项叠加，与普通目录 parser 的契约一致。
