### PR TITLE
fix(semantic): 修复目录摘要失败状态传播

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -837,8 +837,6 @@ class SemanticDagExecutor:
             except Exception as e:
                 logger.error(f"Failed to schedule vectorization for {dir_uri}: {e}", exc_info=True)
 
-        except Exception as e:
-            logger.error(f"Failed to generate overview for {dir_uri}: {e}", exc_info=True)
         finally:
             self._stats.done_nodes += 1
             self._stats.in_progress_nodes = max(0, self._stats.in_progress_nodes - 1)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1405,30 +1405,22 @@ class SemanticProcessor(DequeueHandlerBase):
         config = get_openviking_config()
         vlm = config.vlm
 
-        try:
-            prompt = render_prompt(
-                "semantic.overview_generation",
-                {
-                    "dir_name": dir_uri.split("/")[-1],
-                    "file_summaries": file_summaries_str,
-                    "children_abstracts": children_abstracts_str,
-                    "output_language": output_language,
-                },
-            )
+        prompt = render_prompt(
+            "semantic.overview_generation",
+            {
+                "dir_name": dir_uri.split("/")[-1],
+                "file_summaries": file_summaries_str,
+                "children_abstracts": children_abstracts_str,
+                "output_language": output_language,
+            },
+        )
 
-            with bind_telemetry_stage("resource_summarize"):
-                overview = await vlm.get_completion_async(prompt)
+        with bind_telemetry_stage("resource_summarize"):
+            overview = await vlm.get_completion_async(prompt)
 
-            overview = self._replace_index_references(overview, file_index_map)
+        overview = self._replace_index_references(overview, file_index_map)
 
-            return overview.strip()
-
-        except Exception as e:
-            logger.error(
-                f"Failed to generate overview for {dir_uri}: {e}",
-                exc_info=True,
-            )
-            return f"# {dir_uri.split('/')[-1]}\n\n[Directory overview is not generated]"
+        return overview.strip()
 
     async def _batched_generate_overview(
         self,
@@ -1459,10 +1451,9 @@ class SemanticProcessor(DequeueHandlerBase):
         # Generate partial overviews concurrently using global file indices.
         if llm_sem is None:
             llm_sem = asyncio.Semaphore(self.max_concurrent_llm)
-        partial_overviews = [None] * len(batches)
-        batch_prompts: List[Tuple[int, str, Dict[int, str]]] = []
+        batch_prompts: List[Tuple[str, Dict[int, str]]] = []
 
-        for batch_idx, batch in enumerate(batches):
+        for batch in batches:
             batch_lines = []
             child_lines = []
             batch_index_map = {}
@@ -1483,26 +1474,22 @@ class SemanticProcessor(DequeueHandlerBase):
                     "output_language": output_language,
                 },
             )
-            batch_prompts.append((batch_idx, prompt, batch_index_map))
+            batch_prompts.append((prompt, batch_index_map))
 
-        async def _run_batch(batch_idx: int, prompt: str, batch_index_map: Dict[int, str]) -> None:
-            try:
-                async with llm_sem:
-                    with bind_telemetry_stage("resource_summarize"):
-                        partial = await vlm.get_completion_async(prompt)
-                partial = self._replace_index_references(partial, batch_index_map)
-                partial_overviews[batch_idx] = partial.strip()
-            except Exception as e:
-                logger.warning(
-                    f"Failed to generate partial overview batch "
-                    f"{batch_idx + 1}/{len(batches)} for {dir_uri}: {e}"
-                )
+        async def _run_batch(prompt: str, batch_index_map: Dict[int, str]) -> str:
+            async with llm_sem:
+                with bind_telemetry_stage("resource_summarize"):
+                    partial = await vlm.get_completion_async(prompt)
+            partial = self._replace_index_references(partial, batch_index_map)
+            return partial.strip()
 
-        await asyncio.gather(*[_run_batch(*bp) for bp in batch_prompts])
-        partial_overviews = [p for p in partial_overviews if p is not None]
-
-        if not partial_overviews:
-            return f"# {dir_name}\n\n[Directory overview is not generated]"
+        batch_results = await asyncio.gather(
+            *[_run_batch(*bp) for bp in batch_prompts], return_exceptions=True
+        )
+        for result in batch_results:
+            if isinstance(result, BaseException):
+                raise result
+        partial_overviews = [result for result in batch_results if isinstance(result, str)]
 
         # If only one batch succeeded, use it directly
         if len(partial_overviews) == 1:
@@ -1510,26 +1497,19 @@ class SemanticProcessor(DequeueHandlerBase):
 
         # Merge partials only; each child abstract is already represented once.
         combined = "\n\n---\n\n".join(partial_overviews)
-        try:
-            prompt = render_prompt(
-                "semantic.overview_generation",
-                {
-                    "dir_name": dir_name,
-                    "file_summaries": combined,
-                    "children_abstracts": "None",
-                    "output_language": output_language,
-                },
-            )
-            with bind_telemetry_stage("resource_summarize"):
-                overview = await vlm.get_completion_async(prompt)
-            overview = self._replace_index_references(overview, file_index_map)
-            return overview.strip()
-        except Exception as e:
-            logger.error(
-                f"Failed to merge partial overviews for {dir_uri}: {e}",
-                exc_info=True,
-            )
-            return partial_overviews[0]
+        prompt = render_prompt(
+            "semantic.overview_generation",
+            {
+                "dir_name": dir_name,
+                "file_summaries": combined,
+                "children_abstracts": "None",
+                "output_language": output_language,
+            },
+        )
+        with bind_telemetry_stage("resource_summarize"):
+            overview = await vlm.get_completion_async(prompt)
+        overview = self._replace_index_references(overview, file_index_map)
+        return overview.strip()
 
     async def _vectorize_directory(
         self,

--- a/tests/storage/test_semantic_overview_failure.py
+++ b/tests/storage/test_semantic_overview_failure.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs import semantic_dag as semantic_dag_module
+from openviking.storage.queuefs import semantic_processor as semantic_processor_module
+from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _patch_overview_config(monkeypatch, vlm, *, batch_size=1):
+    config = SimpleNamespace(
+        vlm=vlm,
+        semantic=SimpleNamespace(overview_batch_size=batch_size),
+    )
+    monkeypatch.setattr(semantic_processor_module, "get_openviking_config", lambda: config)
+
+
+class _EmptyVikingFS:
+    def __init__(self):
+        self.writes = []
+
+    async def ls(self, _uri, node_limit=None, ctx=None):
+        return []
+
+    async def write_file(self, path, content, ctx=None):
+        self.writes.append((path, content))
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri.replace("viking://", "/local/account/")
+
+
+class _FailingOverviewProcessor:
+    async def _generate_overview(self, _dir_uri, _file_summaries, _children_abstracts):
+        raise TimeoutError("directory overview timed out")
+
+    def _normalize_overview_generation(self, overview):
+        return overview, "abstract"
+
+
+@pytest.mark.asyncio
+async def test_single_overview_generation_propagates_vlm_error(monkeypatch):
+    error = TimeoutError("VLM request timed out")
+    vlm = SimpleNamespace(get_completion_async=AsyncMock(side_effect=error))
+    _patch_overview_config(monkeypatch, vlm)
+    monkeypatch.setattr(
+        semantic_processor_module, "render_prompt", lambda *_args, **_kwargs: "prompt"
+    )
+
+    processor = SemanticProcessor()
+
+    with pytest.raises(TimeoutError, match="VLM request timed out"):
+        await processor._single_generate_overview(
+            "viking://resources/docs",
+            "[1] README.md: project overview",
+            "None",
+            {1: "README.md"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_batched_overview_propagates_partial_batch_error(monkeypatch):
+    async def get_completion(prompt):
+        if "bad.md" in prompt:
+            raise TimeoutError("partial batch timed out")
+        return "successful partial overview"
+
+    vlm = SimpleNamespace(get_completion_async=get_completion)
+    _patch_overview_config(monkeypatch, vlm)
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "render_prompt",
+        lambda _name, values: values["file_summaries"],
+    )
+    processor = SemanticProcessor(max_concurrent_llm=2)
+
+    with pytest.raises(TimeoutError, match="partial batch timed out"):
+        await processor._batched_generate_overview(
+            "viking://resources/docs",
+            [
+                {"name": "good.md", "summary": "good"},
+                {"name": "bad.md", "summary": "bad"},
+            ],
+            [],
+            {1: "good.md", 2: "bad.md"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_batched_overview_propagates_partial_batch_cancellation(monkeypatch):
+    async def get_completion(prompt):
+        if "cancelled.md" in prompt:
+            raise asyncio.CancelledError
+        return "successful partial overview"
+
+    vlm = SimpleNamespace(get_completion_async=get_completion)
+    _patch_overview_config(monkeypatch, vlm)
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "render_prompt",
+        lambda _name, values: values["file_summaries"],
+    )
+    processor = SemanticProcessor(max_concurrent_llm=2)
+
+    with pytest.raises(asyncio.CancelledError):
+        await processor._batched_generate_overview(
+            "viking://resources/docs",
+            [
+                {"name": "good.md", "summary": "good"},
+                {"name": "cancelled.md", "summary": "cancelled"},
+            ],
+            [],
+            {1: "good.md", 2: "cancelled.md"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_batched_overview_propagates_merge_error(monkeypatch):
+    error = TimeoutError("overview merge timed out")
+    vlm = SimpleNamespace(
+        get_completion_async=AsyncMock(side_effect=["first partial", "second partial", error])
+    )
+    _patch_overview_config(monkeypatch, vlm)
+    monkeypatch.setattr(
+        semantic_processor_module, "render_prompt", lambda *_args, **_kwargs: "prompt"
+    )
+    processor = SemanticProcessor(max_concurrent_llm=2)
+
+    with pytest.raises(TimeoutError, match="overview merge timed out"):
+        await processor._batched_generate_overview(
+            "viking://resources/docs",
+            [
+                {"name": "one.md", "summary": "one"},
+                {"name": "two.md", "summary": "two"},
+            ],
+            [],
+            {1: "one.md", 2: "two.md"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_batched_overview_returns_merged_result_on_success(monkeypatch):
+    vlm = SimpleNamespace(
+        get_completion_async=AsyncMock(
+            side_effect=["first partial", "second partial", "Combined [1] and [2]"]
+        )
+    )
+    _patch_overview_config(monkeypatch, vlm)
+    monkeypatch.setattr(
+        semantic_processor_module, "render_prompt", lambda *_args, **_kwargs: "prompt"
+    )
+    processor = SemanticProcessor(max_concurrent_llm=2)
+
+    overview = await processor._batched_generate_overview(
+        "viking://resources/docs",
+        [
+            {"name": "one.md", "summary": "one"},
+            {"name": "two.md", "summary": "two"},
+        ],
+        [],
+        {1: "one.md", 2: "two.md"},
+    )
+
+    assert overview == "Combined one.md and two.md"
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_propagates_overview_error_without_writing_sidecars(monkeypatch):
+    viking_fs = _EmptyVikingFS()
+    monkeypatch.setattr(semantic_dag_module, "get_viking_fs", lambda: viking_fs)
+    executor = SemanticDagExecutor(
+        processor=_FailingOverviewProcessor(),
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("account", "user"), role=Role.USER),
+    )
+
+    with pytest.raises(TimeoutError, match="directory overview timed out"):
+        await executor.run("viking://resources/docs")
+
+    assert viking_fs.writes == []


### PR DESCRIPTION
## 变更说明

修复目录摘要生成失败被错误标记为处理成功的问题。

此前，单次摘要生成、分批生成以及最终合并过程中发生的异常，可能会被吞掉或替换为占位内容、部分结果。DAG 的目录摘要任务也会捕获这些异常，导致现有的失败分类和重试流程无法正确处理。

本次修改让生成异常和任务取消继续向上传播，使目录摘要失败能够被正确标记，并进入项目已有的重试流程。

## 关联 Issue

Fixes #3151

## 变更类型

- [x] Bug 修复（不破坏现有兼容性）
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构
- [ ] 性能优化
- [x] 测试更新

## 主要改动

- 单次目录摘要生成失败时直接传播异常，不再返回占位内容。
- 等待所有并发批次结束，并在任一批次失败时传播异常，不再接受部分结果。
- 最终摘要合并失败时传播异常，不再返回第一批摘要。
- 保持 `asyncio.CancelledError` 的取消语义，不将取消任务视为部分成功。
- 让 DAG 摘要异常进入现有的失败分类和重试流程。
- 增加单次生成失败、部分批次失败、合并失败、任务取消、正常合并及 DAG 异常传播的回归测试。

## 测试情况

- [x] 已添加能够验证修复有效性的测试
- [ ] 本地所有新旧单元测试均通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

相关回归测试结果：

```text
24 passed
```

已执行以下检查：

- 目录摘要和 DAG 相关回归测试
- Ruff 格式检查
- Ruff Lint 检查
- Python 编译检查
- Git diff 空白字符检查

## 检查清单

- [x] 代码符合项目代码风格
- [x] 已完成代码自审
- [x] 复杂逻辑已通过清晰代码和测试说明
- [x] 已确认本次修改无需更新文档（不涉及公共 API 或用户使用方式）
- [x] 本次修改没有产生新的警告
- [x] 依赖变更已合并并发布

## 截图

不适用。

## 补充说明

本次修改不涉及文档、依赖或公共 API 变更。

相关回归测试已在本地通过。由于当前上游代码存在与本次修改无关的基线失败和环境相关失败，因此没有勾选“本地所有新旧单元测试均通过”。

