### PR TITLE
fix(retrieve): keep L2 abstracts out of recursive rerank

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -470,8 +470,19 @@ class HierarchicalRetriever:
 
                 query_scores = [self._finite_score(r.get("_score", 0.0)) for r in results]
                 if self._rerank_client and mode == RetrieverMode.THINKING:
-                    documents = [str(r.get("abstract", "")) for r in results]
-                    query_scores = await self._rerank_scores(query, documents, query_scores)
+                    rerank_indices = [
+                        index for index, result in enumerate(results) if result.get("level", 2) != 2
+                    ]
+                    if rerank_indices:
+                        documents = [
+                            str(results[index].get("abstract", "")) for index in rerank_indices
+                        ]
+                        fallback_scores = [query_scores[index] for index in rerank_indices]
+                        reranked_scores = await self._rerank_scores(
+                            query, documents, fallback_scores
+                        )
+                        for index, score in zip(rerank_indices, reranked_scores, strict=True):
+                            query_scores[index] = score
 
                 for r, score in zip(results, query_scores, strict=True):
                     uri = r.get("uri", "")

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -194,6 +194,35 @@ class DirectChildProxy:
         ]
 
 
+class MixedLevelChildProxy:
+    async def search_children_in_tenant(
+        self,
+        parent_uri: str,
+        query_vector=None,
+        sparse_query_vector=None,
+        context_type=None,
+        target_directories=None,
+        extra_filter=None,
+        limit: int = 10,
+    ):
+        if parent_uri != "viking://resources":
+            return []
+        return [
+            _result(
+                "viking://resources/directory",
+                0.2,
+                level=1,
+                abstract="directory overview",
+            ),
+            _result(
+                "viking://resources/large-file",
+                0.8,
+                level=2,
+                abstract="large file abstract",
+            ),
+        ]
+
+
 class FakeRerankClient:
     def __init__(self, scores):
         self.scores = list(scores)
@@ -240,7 +269,7 @@ def test_retriever_initializes_rerank_client(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_retrieve_uses_rerank_scores_in_thinking_mode(monkeypatch):
-    fake_client = FakeRerankClient([0.95, 0.05, 0.11, 0.95])
+    fake_client = FakeRerankClient([0.95, 0.05])
     monkeypatch.setattr(
         "openviking.retrieve.hierarchical_retriever.RerankClient.from_config",
         lambda config: fake_client,
@@ -260,7 +289,7 @@ async def test_retrieve_uses_rerank_scores_in_thinking_mode(monkeypatch):
         "viking://resources/file-a",
     ]
     assert fake_client.calls[0] == ("hello", ["root A", "root B"])
-    assert fake_client.calls[1] == ("hello", ["child A", "child B"])
+    assert len(fake_client.calls) == 1
     assert storage.search_calls[0]["level"] == [0, 1]
 
 
@@ -494,6 +523,36 @@ async def test_score_propagation_alpha_uses_configured_weight():
 
     assert candidates[0]["uri"] == "viking://resources/file-b"
     assert candidates[0]["_final_score"] == pytest.approx(0.8)
+
+
+@pytest.mark.asyncio
+async def test_recursive_search_reranks_only_directory_levels():
+    retriever = HierarchicalRetriever(
+        storage=DummyStorage(),
+        embedder=None,
+        rerank_config=None,
+        retrieval_config=RetrievalConfig(score_propagation_alpha=1.0),
+    )
+    fake_client = FakeRerankClient([0.95, 0.05])
+    retriever._rerank_client = fake_client
+
+    candidates = await retriever._recursive_search(
+        vector_proxy=MixedLevelChildProxy(),
+        query="hello",
+        query_vector=None,
+        sparse_query_vector=None,
+        starting_points=[("viking://resources", 0.0)],
+        limit=2,
+        mode=RetrieverMode.THINKING,
+    )
+
+    assert fake_client.calls == [("hello", ["directory overview"])]
+    assert [candidate["uri"] for candidate in candidates] == [
+        "viking://resources/directory",
+        "viking://resources/large-file",
+    ]
+    assert candidates[0]["_final_score"] == pytest.approx(0.95)
+    assert candidates[1]["_final_score"] == pytest.approx(0.8)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 动机

修复 #3004。

thinking mode 的递归检索目前会把所有子节点摘要都送入 reranker。L2 节点是完整文件，其摘要可能远大于 L0/L1 目录摘要；这些文件结果应保留向量检索分数，而不是进入目录摘要的重排批次。

## 改动思路

只对 L0/L1 目录候选执行递归 rerank，再把新分数按原索引映射回结果列表。L2 文件候选不进入 reranker，继续保留原始向量分数。候选发现、递归过程和最终结果集合均不改变。

## 关键代码 / 伪代码

```python
rerank_indices = [i for i, result in enumerate(results) if result.level != 2]
reranked = rerank(query, abstracts_at(rerank_indices))
query_scores.update_at(rerank_indices, reranked)
# L2 结果继续使用 vector-search score
```

## 具体改动

- 递归 rerank batch 只包含 L0/L1 子结果；
- rerank 返回分数按目录候选的原始索引写回；
- L2 文件候选及其向量分数保持不变；
- 增加混合层级回归测试，并更新既有 thinking-mode 预期。

## 修复后复现与验证

新增回归在修复前会观察到 reranker 同时收到 `directory overview` 和 `large file abstract`。修复后，reranker 只收到目录摘要，同时 L2 文件仍在结果集中并保留向量分数。

- `pytest tests/retrieve/test_hierarchical_retriever_rerank.py tests/retrieve/test_hierarchical_retriever_image.py`：15 passed；
- 两个改动文件的 `ruff check`：passed；
- `git diff --check`：passed。

## 对主干的风险与未覆盖

改动仅影响 thinking mode 的递归 rerank 输入。候选发现与递归逻辑不变；L2 文件只是不再进入 reranker。未运行完整仓库测试套件。
