### PR TITLE
fix(queue): recover stale non-tree lock handoffs

### DIFF
--- a/openviking/storage/queuefs/semantic_lock.py
+++ b/openviking/storage/queuefs/semantic_lock.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Callable, Iterable, Optional
 
 from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.transaction import (
@@ -46,7 +46,9 @@ class SemanticLockScope:
         lock_handoff: Optional[LockHandoffRef],
         *,
         caller_lock: LockLease = NO_LOCK,
+        fallback_path_factory: Optional[Callable[[], str]] = None,
     ) -> "SemanticLockScope":
+        """Resolve a live lock, lazily deriving a path for stale legacy handoffs."""
         if lock_handoff and caller_lock.active:
             raise ValueError("semantic lock must come from either message or caller, not both")
         if caller_lock is not NO_LOCK and not caller_lock.active:
@@ -59,6 +61,8 @@ class SemanticLockScope:
                 return cls(await OwnedLockLease.from_handoff(lock_handoff, manager=manager))
             except LockAcquisitionError as exc:
                 tree_paths = _tree_paths_from_handoff(lock_handoff.lock_paths)
+                if not tree_paths and fallback_path_factory:
+                    tree_paths = [fallback_path_factory()]
                 if not tree_paths:
                     raise
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -368,6 +368,9 @@ class SemanticProcessor(DequeueHandlerBase):
                     semantic_lock = await SemanticLockScope.resolve(
                         msg.lock_handoff,
                         caller_lock=lock,
+                        fallback_path_factory=lambda: get_viking_fs()._uri_to_path(
+                            msg.uri, ctx=current_ctx
+                        ),
                     )
                     lock_transferred = False
                     try:

--- a/tests/storage/test_semantic_processor_lock_ownership.py
+++ b/tests/storage/test_semantic_processor_lock_ownership.py
@@ -41,6 +41,38 @@ class _FakeLockManager:
         return True
 
 
+class _RecoveringLockManager:
+    def __init__(self):
+        self._handles = {}
+        self.acquire_tree_calls = []
+        self.release_calls = []
+
+    async def get_handle_async(self, handle_id):
+        return self._handles.get(handle_id)
+
+    async def adopt_handle_async(self, handle_id, lock_paths):
+        del handle_id, lock_paths
+        return None
+
+    def get_handle(self, handle_id):
+        return self._handles.get(handle_id)
+
+    def create_handle(self):
+        handle = _FakeHandle("new-lock")
+        handle.locks = []
+        self._handles[handle.id] = handle
+        return handle
+
+    async def acquire_tree(self, handle, lock_path):
+        self.acquire_tree_calls.append(lock_path)
+        handle.locks.append(f"{lock_path}/.path.ovlock")
+        return True
+
+    async def release(self, handle):
+        self.release_calls.append(handle.id)
+        self._handles.pop(handle.id, None)
+
+
 class _FakeVikingFS:
     async def exists(self, uri, ctx=None):
         del uri, ctx
@@ -59,6 +91,7 @@ async def test_semantic_processor_borrows_caller_owned_lock(monkeypatch):
     class _FakeDagExecutor:
         def __init__(self, **kwargs):
             self.lock = kwargs["lock"]
+            self.stale = False
 
         async def run(self, root_uri):
             assert root_uri == "viking://resources/demo"
@@ -93,40 +126,56 @@ async def test_semantic_processor_borrows_caller_owned_lock(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_semantic_processor_recovers_stale_non_tree_handoff(monkeypatch):
+    processor = SemanticProcessor()
+    lock_manager = _RecoveringLockManager()
+
+    class _FakeDagExecutor:
+        def __init__(self, **kwargs):
+            self.lock = kwargs["lock"]
+            self.stale = False
+
+        async def run(self, root_uri):
+            assert root_uri == "viking://resources/demo"
+            assert self.lock.handle_id == "new-lock"
+            await self.lock.close()
+
+        def get_stats(self):
+            return DagStats()
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: _FakeVikingFS(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticDagExecutor",
+        lambda **kwargs: _FakeDagExecutor(**kwargs),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_lock.get_lock_manager",
+        lambda: lock_manager,
+    )
+
+    await processor.on_dequeue(
+        SemanticMsg(
+            uri="viking://resources/demo",
+            context_type="resource",
+            recursive=False,
+            lock_handoff=LockHandoffRef(
+                handle_id="stale-lock",
+                lock_paths=("/fake/viking/resources/.mw_exact_demo.deadbeef",),
+            ),
+        ).to_dict()
+    )
+
+    assert lock_manager.acquire_tree_calls == ["/fake/viking/resources/demo"]
+    assert lock_manager.release_calls == ["new-lock"]
+
+
+@pytest.mark.asyncio
 async def test_semantic_lock_scope_reacquires_tree_lock_when_handoff_handle_is_stale(
     monkeypatch,
 ):
-    class _RecoveringLockManager:
-        def __init__(self):
-            self._handles = {}
-            self.acquire_tree_calls = []
-            self.release_calls = []
-
-        async def get_handle_async(self, handle_id):
-            return self._handles.get(handle_id)
-
-        async def adopt_handle_async(self, handle_id, lock_paths):
-            del handle_id, lock_paths
-            return None
-
-        def get_handle(self, handle_id):
-            return self._handles.get(handle_id)
-
-        def create_handle(self):
-            handle = _FakeHandle("new-lock")
-            handle.locks = []
-            self._handles[handle.id] = handle
-            return handle
-
-        async def acquire_tree(self, handle, lock_path):
-            self.acquire_tree_calls.append(lock_path)
-            handle.locks.append(f"{lock_path}/.path.ovlock")
-            return True
-
-        async def release(self, handle):
-            self.release_calls.append(handle.id)
-            self._handles.pop(handle.id, None)
-
     lock_manager = _RecoveringLockManager()
     monkeypatch.setattr(
         "openviking.storage.queuefs.semantic_lock.get_lock_manager",
@@ -137,12 +186,42 @@ async def test_semantic_lock_scope_reacquires_tree_lock_when_handoff_handle_is_s
         LockHandoffRef(
             handle_id="stale-lock",
             lock_paths=("/local/default/resources/CONTRIBUTING_CN_3/.path.ovlock",),
-        )
+        ),
+        fallback_path_factory=lambda: (_ for _ in ()).throw(
+            AssertionError("tree handoffs must not evaluate the fallback path")
+        ),
     )
 
     try:
         assert scope.lock.handle_id == "new-lock"
         assert lock_manager.acquire_tree_calls == ["/local/default/resources/CONTRIBUTING_CN_3"]
+    finally:
+        await scope.close()
+
+    assert lock_manager.release_calls == ["new-lock"]
+
+
+@pytest.mark.asyncio
+async def test_semantic_lock_scope_reacquires_fallback_path_for_stale_non_tree_handoff(
+    monkeypatch,
+):
+    lock_manager = _RecoveringLockManager()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_lock.get_lock_manager",
+        lambda: lock_manager,
+    )
+
+    scope = await SemanticLockScope.resolve(
+        LockHandoffRef(
+            handle_id="stale-lock",
+            lock_paths=("/local/default/resources/.mw_exact_demo.deadbeef",),
+        ),
+        fallback_path_factory=lambda: "/local/default/resources/demo",
+    )
+
+    try:
+        assert scope.lock.handle_id == "new-lock"
+        assert lock_manager.acquire_tree_calls == ["/local/default/resources/demo"]
     finally:
         await scope.close()
 


### PR DESCRIPTION
## 动机

修复 #3150。

服务重启后，持久化的 semantic message 可能携带已经失效的 lock handoff；其中的路径可能是 exact-lock 或旧格式条目，而不是 `/.path.ovlock` tree lock。此时 `SemanticLockScope.resolve()` 无法推导 tree path，会再次抛出 `LockAcquisitionError`；processor 随后把未变化的消息重新入队，导致同一个 stale handoff 反复失败。

## 改动思路

保持现有恢复顺序，只增加一个窄 fallback：

1. 原 handoff handle 仍有效时，直接 adopt；
2. 否则恢复 handoff 中已编码的 tree path；
3. 只有完全无法推导 tree path 时，才延迟地把当前 message URI 映射到 storage path，并重新获取该 scope。

fallback 保持 lazy，避免正常 handoff 和 caller-owned lock 引入新的 VikingFS 依赖。

## 关键代码 / 伪代码

```text
try adopt(handoff)
except stale_handle:
    paths = tree_paths_from(handoff)
    if paths is empty:
        paths = [current_message_uri_to_path()]
    return reacquire_tree(paths)
```

## 具体改动

- 仅当 stale handoff 无法恢复 tree path 时，允许 `SemanticLockScope.resolve()` 请求 fallback path；
- `SemanticProcessor` 基于 message URI 和 request context 提供该 path；
- 覆盖直接 fallback 恢复、processor 端到端 handoff、lock release，以及普通 tree handoff 不触发 fallback 的回归测试。

## 修复后复现

```bash
pytest -q --no-cov \
  tests/storage/test_semantic_processor_lock_ownership.py \
  tests/storage/test_semantic_processor_target_preexisting.py
```

新增回归在当前 `main` 上会失败，因为 `resolve()` 没有 fallback path 合同；应用本 PR 后，stale exact-lock handoff 能恢复，DAG 会收到新 lock。

## 验证

- [x] 基线回归：在 `origin/main` 上按预期失败 1 项
- [x] focused storage tests：7 passed
- [x] 所有改动 Python 文件通过 `ruff check`
- [x] 通过 `ruff format --check`
- [x] 通过 `git diff --check`

## 对主干的风险与未覆盖面

行为只在 handoff adopt 失败且 handoff 中没有可恢复 tree path 时改变；既有 tree-handoff 与 caller-lock 路径保持不变。本 PR 修复 #3150 中确定性的 stale-handoff 循环，不为其他 lock contention 引入通用 retry counter 或 dead-letter policy。未运行完整仓库测试套件。

## 变更类型

- [x] Bug fix
- [x] Test update