### PR TITLE
fix: initialize users under actor-peer view

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -7,7 +7,7 @@ OpenViking uses a virtual filesystem where all directories are data records.
 This module defines the preset directory structure that is created on initialization.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from openviking.core.context import Context, Vectorize
@@ -193,6 +193,12 @@ class DirectoryInitializer:
         if "user" not in PRESET_DIRECTORIES:
             return 0
         user_space_root = canonical_user_root(ctx)
+        # Preset initialization is a server-controlled write to the current
+        # user's own root and first-level directories.  Actor-peer view must
+        # still protect peer subtrees during normal filesystem mutations, but
+        # it must not prevent a fresh user from creating the container that
+        # owns those subtrees in the first place.
+        initialization_ctx = replace(ctx, actor_peer_id=None, legacy_agent_id=None)
         user_tree = PRESET_DIRECTORIES["user"]
         parent_uri = "viking://user"
         count = 0
@@ -201,7 +207,7 @@ class DirectoryInitializer:
             parent_uri=parent_uri,
             defn=user_tree,
             scope="user",
-            ctx=ctx,
+            ctx=initialization_ctx,
         ):
             count += 1
 
@@ -212,7 +218,7 @@ class DirectoryInitializer:
                 parent_uri=user_space_root,
                 defn=child,
                 scope="user",
-                ctx=ctx,
+                ctx=initialization_ctx,
             ):
                 count += 1
 

--- a/tests/unit/test_directory_initializer.py
+++ b/tests/unit/test_directory_initializer.py
@@ -1,7 +1,7 @@
 import pytest
 
 from openviking.core.directories import PRESET_DIRECTORIES, DirectoryInitializer
-from openviking.core.namespace import canonical_user_root
+from openviking.core.namespace import canonical_user_root, may_include_hidden_actor_peers
 from openviking.server.identity import RequestContext, Role
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -27,6 +27,8 @@ class _FakeVikingFS:
         return self.contexts[uri]["abstract"]
 
     async def write_context(self, uri, abstract, overview, is_leaf, ctx):
+        if ctx.actor_peer_id and may_include_hidden_actor_peers(uri, ctx):
+            raise PermissionError(f"actor peer cannot mutate {uri}")
         self.contexts[uri] = {
             "abstract": abstract,
             "overview": overview,
@@ -55,4 +57,27 @@ async def test_initialize_user_directories_creates_root_and_first_level_only():
     second_count = await initializer.initialize_user_directories(ctx)
 
     assert second_count == 0
+    assert set(viking_fs.contexts) == expected_uris
+
+
+@pytest.mark.asyncio
+async def test_initialize_user_directories_ignores_actor_peer_view_for_preset_structure():
+    vikingdb = _FakeVikingDB()
+    viking_fs = _FakeVikingFS()
+    initializer = DirectoryInitializer(vikingdb, viking_fs=viking_fs)
+    ctx = RequestContext(
+        user=UserIdentifier("acme", "support-bot"),
+        role=Role.USER,
+        actor_peer_id="customer-a",
+        legacy_agent_id="customer-a",
+    )
+
+    count = await initializer.initialize_user_directories(ctx)
+
+    user_root = canonical_user_root(ctx)
+    expected_uris = {
+        user_root,
+        *(f"{user_root}/{child.path}" for child in PRESET_DIRECTORIES["user"].children),
+    }
+    assert count == len(expected_uris)
     assert set(viking_fs.contexts) == expected_uris


### PR DESCRIPTION
## 动机

修复 #3195。

当一个全新用户通过带 `agent_id` 的 CLI 首次执行 `ov session new` 或 `ov add-memory` 时，`agent_id` 会启用 actor-peer 视图。用户预置目录初始化随后尝试创建 `viking://user/<user-id>`，却被通用 peer 集合写保护拒绝，返回 `PERMISSION_DENIED`。去掉 `agent_id` 初始化一次后再恢复配置则能成功，导致首次使用行为依赖隐藏的初始化顺序。

## 改动思路

不放宽通用 VikingFS ACL。仅在服务端控制的用户预置目录初始化过程中，复制当前请求上下文并清除 actor-peer 视图；账户、用户和角色保持不变。普通 filesystem 写入仍使用原上下文，因此其他 peer 的目录和 peer 集合继续受保护。

关键逻辑：

```python
initialization_ctx = replace(
    ctx,
    actor_peer_id=None,
    legacy_agent_id=None,
)

for preset_directory in current_user_preset_directories:
    ensure_directory(preset_directory, ctx=initialization_ctx)
```

## 修复后复现

1. 使用一个尚未初始化的 account/user，并在 CLI 配置中设置 `agent_id`。
2. 执行 `ov session new`。
3. 当前用户根目录及一级预置目录可以创建，session 正常返回。
4. 对其他 peer 的读写、删除及 peer 集合变更仍返回权限错误。

## 验证

- 新增 fresh-user + actor-peer 目录初始化回归：先红后绿。
- `tests/unit/test_directory_initializer.py`：2 passed。
- actor-peer ACL 回归：跨 peer 读写和 peer 集合变更测试 2 passed。
- Ruff check / format、`py_compile`、`git diff --check` 均通过。

## 对主干的风险与未覆盖

- 变更只影响预置用户目录首次初始化，不改变普通 filesystem mutation 的 ACL。
- 未启动第二套完整外部模型服务做端到端测试；真实现网式复现已在 `0.4.9.dev40` 本地服务确认，focused test 覆盖了导致 403 的 context 边界。

## 变更类型

- [x] Bug fix
- [x] Tests
