### PR TITLE
fix: allow users to reindex their own namespace

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import Response as FastAPIResponse
 from pydantic import BaseModel, ConfigDict
 
+from openviking.core.namespace import is_accessible
 from openviking.core.path_variables import resolve_path_variables
 from openviking.core.uri_validation import validate_viking_uri
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSNotFoundError
@@ -21,7 +22,7 @@ from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
-from openviking_cli.exceptions import NotFoundError
+from openviking_cli.exceptions import NotFoundError, PermissionDeniedError
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -239,11 +240,19 @@ async def set_tags(
 @router.post("/reindex")
 async def reindex(
     body: ReindexRequest = Body(...),
-    ctx: RequestContext = require_role(Role.ROOT, Role.ADMIN),
+    ctx: RequestContext = Depends(get_request_context),
 ):
     """Reindex semantic/vector artifacts for a URI-scoped maintenance target."""
     uri = resolve_path_variables(body.uri)
     uri = _validate_reindex_uri(uri)
+
+    # Require ROOT/ADMIN for non-user scopes, but allow users to reindex their own private scopes.
+    if ctx.role not in (Role.ROOT, Role.ADMIN):
+        if not is_accessible(uri, ctx):
+            raise PermissionDeniedError(
+                "Access denied for this URI, or you lack root/admin privileges."
+            )
+
     service = get_service()
     result = await service.reindex(
         uri=uri,

--- a/tests/server/test_api_content.py
+++ b/tests/server/test_api_content.py
@@ -174,6 +174,53 @@ async def test_reindex_uses_request_tenant_for_exists(monkeypatch):
     assert seen["ctx"] == ctx
 
 
+@pytest.mark.asyncio
+async def test_reindex_user_private_scope(monkeypatch):
+    """Users should be able to reindex their own private scope."""
+    seen = {}
+
+    class FakeService:
+        async def reindex(self, *, uri, mode, wait, ctx):
+            seen["uri"] = uri
+            seen["ctx"] = ctx
+            return {"status": "completed"}
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.USER,
+    )
+    request = ReindexRequest(
+        uri="viking://user/alice/resources/",
+        mode="vectors_only",
+        wait=True,
+    )
+
+    monkeypatch.setattr("openviking.server.routers.content.get_service", lambda: FakeService())
+
+    response = await reindex(body=request, ctx=ctx)
+    assert response.status == "ok"
+    assert seen["uri"] == "viking://user/alice/resources/"
+
+
+@pytest.mark.asyncio
+async def test_reindex_user_private_scope_denied(monkeypatch):
+    """Users should NOT be able to reindex another user's private scope."""
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.USER,
+    )
+    request = ReindexRequest(
+        uri="viking://user/bob/resources/",
+        mode="vectors_only",
+        wait=True,
+    )
+
+    from openviking_cli.exceptions import PermissionDeniedError
+    with pytest.raises(PermissionDeniedError):
+        await reindex(body=request, ctx=ctx)
+
+
 async def test_content_rebuild_endpoint_removed(client):
     response = await client.post(
         "/api/v1/content/rebuild",


### PR DESCRIPTION
Fixes #3194

Users should be able to reindex their own private scope.

This checks if the caller's role is not root or admin, and validates that the requested URI is accessible to the caller before executing the reindex.