### PR TITLE
fix(vlm): enforce global async concurrency limit

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -19,7 +19,7 @@ from openviking.telemetry import tracer
 from openviking.utils.model_retry import retry_async, retry_sync
 from openviking_cli.utils import get_logger
 
-from ..base import ToolCall, VLMBase, VLMResponse
+from ..base import ToolCall, VLMBase, VLMResponse, limit_async_vlm_concurrency
 
 logger = get_logger(__name__)
 
@@ -434,6 +434,7 @@ class LiteLLMVLMProvider(VLMBase):
         )
 
     @tracer("litellm.vlm.call", ignore_result=True, ignore_args=["messages"])
+    @limit_async_vlm_concurrency
     async def get_completion_async(
         self,
         prompt: str = "",
@@ -492,6 +493,7 @@ class LiteLLMVLMProvider(VLMBase):
             operation_name="LiteLLM VLM vision completion",
         )
 
+    @limit_async_vlm_concurrency
     async def get_vision_completion_async(
         self,
         prompt: str = "",

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -20,7 +20,7 @@ except ImportError:
 
 from openviking.utils.model_retry import retry_async, retry_sync
 
-from ..base import ToolCall, VLMBase, VLMResponse
+from ..base import ToolCall, VLMBase, VLMResponse, limit_async_vlm_concurrency
 from ..registry import DEFAULT_AZURE_API_VERSION
 
 logger = get_logger(__name__)
@@ -318,6 +318,7 @@ class OpenAIVLM(VLMBase):
         )
 
     @tracer("openai.vlm.call", ignore_result=True, ignore_args=["messages"])
+    @limit_async_vlm_concurrency
     async def get_completion_async(
         self,
         prompt: str = "",
@@ -433,6 +434,7 @@ class OpenAIVLM(VLMBase):
             operation_name="OpenAI VLM vision completion",
         )
 
+    @limit_async_vlm_concurrency
     async def get_vision_completion_async(
         self,
         prompt: str = "",

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Union
 from openviking.telemetry import tracer
 from openviking_cli.utils import get_logger
 
-from ..base import ToolCall, VLMResponse
+from ..base import ToolCall, VLMResponse, limit_async_vlm_concurrency
 from .openai_vlm import OpenAIVLM
 
 logger = get_logger(__name__)
@@ -147,6 +147,7 @@ class VolcEngineVLM(OpenAIVLM):
         return self._clean_response(str(result))
 
     @tracer("volcengine.vlm.call", ignore_result=True, ignore_args=False)
+    @limit_async_vlm_concurrency
     async def get_completion_async(
         self,
         prompt: str = "",
@@ -362,6 +363,7 @@ class VolcEngineVLM(OpenAIVLM):
             return result
         return self._clean_response(str(result))
 
+    @limit_async_vlm_concurrency
     async def get_vision_completion_async(
         self,
         prompt: str = "",

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: AGPL-3.0
 """VLM base interface and abstract classes"""
 
+import asyncio
 import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from functools import wraps
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+from weakref import WeakKeyDictionary
 
 from openviking.utils.exceptions import AllCredentialsFailedError
 from openviking.utils.model_retry import (
@@ -68,6 +71,7 @@ class VLMBase(ABC):
         self.temperature = config.get("temperature", 0.0)
         self.max_retries = config.get("max_retries", 3)
         self.timeout = config.get("timeout", 600.0)
+        self.max_concurrent = max(1, int(config.get("max_concurrent", 64)))
         self.max_tokens = config.get("max_tokens")
         self.extra_headers = config.get("extra_headers")
         self.extra_request_body = dict(config.get("extra_request_body") or {})
@@ -76,6 +80,19 @@ class VLMBase(ABC):
 
         # Token usage tracking
         self._token_tracker = TokenUsageTracker()
+        self._async_concurrency_semaphores: WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Semaphore
+        ] = WeakKeyDictionary()
+
+    def _get_async_concurrency_semaphore(self) -> asyncio.Semaphore:
+        """Return this provider's semaphore for the current event loop."""
+
+        loop = asyncio.get_running_loop()
+        semaphore = self._async_concurrency_semaphores.get(loop)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(self.max_concurrent)
+            self._async_concurrency_semaphores[loop] = semaphore
+        return semaphore
 
     @abstractmethod
     def get_completion(
@@ -280,6 +297,19 @@ class VLMBase(ABC):
         if isinstance(response, str):
             return response
         return response.choices[0].message.content or ""
+
+
+def limit_async_vlm_concurrency(
+    method: Callable[..., Awaitable[Any]],
+) -> Callable[..., Awaitable[Any]]:
+    """Apply the configured provider-wide concurrency budget to an async call."""
+
+    @wraps(method)
+    async def wrapper(self: VLMBase, *args: Any, **kwargs: Any) -> Any:
+        async with self._get_async_concurrency_semaphore():
+            return await method(self, *args, **kwargs)
+
+    return wrapper
 
 
 class VLMFactory:

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -93,7 +93,8 @@ class VLMConfig(BaseModel):
     thinking: bool = Field(default=False, description="Enable thinking mode for VolcEngine models")
 
     max_concurrent: int = Field(
-        default=64, description="Maximum number of concurrent LLM calls for semantic processing"
+        default=64,
+        description="Maximum concurrent async VLM calls across semantic and memory processing",
     )
 
     api_version: Optional[str] = Field(
@@ -551,6 +552,7 @@ class VLMConfig(BaseModel):
             "thinking": self.thinking,
             "max_tokens": self.max_tokens,
             "stream": credential.stream if credential.stream is not None else self.stream,
+            "max_concurrent": self.max_concurrent,
             "api_version": credential.api_version,
         }
 
@@ -585,6 +587,7 @@ class VLMConfig(BaseModel):
             "thinking": self.thinking,
             "max_tokens": self.max_tokens,
             "stream": stream,
+            "max_concurrent": self.max_concurrent,
             "api_version": self.api_version,
         }
 

--- a/tests/models/vlm/test_concurrency_config.py
+++ b/tests/models/vlm/test_concurrency_config.py
@@ -1,0 +1,83 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+from openviking_cli.utils.config.vlm_config import VLMConfig
+
+
+class BlockingCompletions:
+    def __init__(self, limit: int):
+        self.limit = limit
+        self.active = 0
+        self.peak = 0
+        self.limit_reached = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def create(self, **_kwargs):
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        if self.active == self.limit:
+            self.limit_reached.set()
+        try:
+            await self.release.wait()
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+                usage=None,
+            )
+        finally:
+            self.active -= 1
+
+
+@pytest.mark.asyncio
+async def test_max_concurrent_limits_text_and_vision_calls_together(monkeypatch):
+    completions = BlockingCompletions(limit=2)
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "test-model",
+            "api_key": "test-key",
+            "max_concurrent": 2,
+            "max_retries": 0,
+        }
+    )
+    monkeypatch.setattr(vlm, "get_async_client", lambda: client)
+
+    tasks = [
+        asyncio.create_task(vlm.get_completion_async(prompt="one")),
+        asyncio.create_task(vlm.get_vision_completion_async(prompt="two")),
+        asyncio.create_task(vlm.get_completion_async(prompt="three")),
+        asyncio.create_task(vlm.get_vision_completion_async(prompt="four")),
+    ]
+
+    await asyncio.wait_for(completions.limit_reached.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert completions.peak == 2
+
+    completions.release.set()
+    assert await asyncio.gather(*tasks) == ["ok", "ok", "ok", "ok"]
+
+
+def test_vlm_config_forwards_max_concurrent_to_provider_instances():
+    config = VLMConfig(
+        provider="openai",
+        model="test-model",
+        api_key="test-key",
+        max_concurrent=3,
+    )
+
+    assert config.get_vlm_instance().max_concurrent == 3
+
+    credential_config = VLMConfig(
+        model="test-model",
+        max_concurrent=5,
+        credentials=[
+            {
+                "provider": "openai",
+                "api_key": "test-key",
+            }
+        ],
+    )
+    assert credential_config.get_vlm_instance().max_concurrent == 5


### PR DESCRIPTION
## 动机

修复 #3008。

`vlm.max_concurrent` 此前只控制 semantic queue worker。Session memory extraction 会直接复用 provider instance 并并发调用 `get_completion_async`，因此多个 session 同时 commit 时可以绕过该限制，形成 VLM 请求突发并触发 429。

## 改动思路

把并发预算放到所有调用路径都会经过的 provider 异步入口，而不是只修 memory extraction 某一个调用点：

- 将 `VLMConfig.max_concurrent` 传给单凭据和多凭据 provider instance。
- 每个 provider instance 按当前 event loop 懒创建 semaphore。
- OpenAI、VolcEngine、LiteLLM 的文本和视觉异步入口共享同一个预算。
- 同步调用、重试策略和 extraction queue 保持不变。

关键逻辑：

```python
async with self._get_async_concurrency_semaphore():
    return await provider_call(...)
```

这样 memory extraction 即使直接使用 `get_vlm_instance()`，也不能绕过配置限制。

## 修复后复现

设置 `vlm.max_concurrent=2`，同时发起两次文本和两次视觉异步调用：

- 修复前：4 个 provider 请求可同时进入。
- 修复后：观测到的并发峰值稳定为 2；前两个完成后，其余请求继续执行。

## 验证

- 新增文本与视觉共享并发预算回归。
- `tests/models/vlm/test_concurrency_config.py`
- `tests/models/vlm/test_timeout_config.py`
- `tests/unit/test_vlm_failover.py`
- `tests/unit/test_extra_headers_vlm.py`
- 相关测试共 91 passed。
- Ruff check / format、`py_compile`、`git diff --check` 通过。

扩展检查中，现有 `test_vlm_config_default_provider_resolves_codex` 仍因 provider 空配置被 Pydantic 规范化为含 None 字段而失败；该失败与本 PR 的并发路径无关，未混入本次改动。

## 对主干的风险与未覆盖

- 默认并发值仍为 64，不改变未配置用户的上限。
- semaphore 覆盖一次调用的完整 retry/backoff 生命周期；限流时宁可降低失败阶段吞吐，也不在退避期间释放名额制造新的请求突发。
- 未使用真实受限 VLM endpoint 做 429 压测；focused test 验证了触发问题的共享并发边界。

## 变更类型

- [x] Bug fix
- [x] Tests