### PR TITLE
fix(vectordb): delete legacy records with corrupt fields

### DIFF
--- a/openviking/storage/vectordb/index/local_index.py
+++ b/openviking/storage/vectordb/index/local_index.py
@@ -405,11 +405,17 @@ class LocalIndex(IIndex):
         if self.dense_search:
             with self._dense_search_lock.write():
                 if self.engine_proxy:
-                    self.engine_proxy.delete_data(self._convert_delta_list_for_index(delta_list))
+                    self.engine_proxy.delete_data(
+                        self._convert_delta_list_for_index(
+                            delta_list, tolerate_invalid_old_fields=True
+                        )
+                    )
                 self.dense_search.delete(delta_list)
                 self._schedule_dense_rebuild()
         elif self.engine_proxy:
-            self.engine_proxy.delete_data(self._convert_delta_list_for_index(delta_list))
+            self.engine_proxy.delete_data(
+                self._convert_delta_list_for_index(delta_list, tolerate_invalid_old_fields=True)
+            )
 
     def _schedule_dense_rebuild(self) -> None:
         if not self._auto_background_rebuild or self.dense_search is None:
@@ -921,7 +927,12 @@ class LocalIndex(IIndex):
             return self.engine_proxy.get_data_count()
         return 0
 
-    def _convert_delta_list_for_index(self, delta_list: List[DeltaRecord]) -> List[DeltaRecord]:
+    def _convert_delta_list_for_index(
+        self,
+        delta_list: List[DeltaRecord],
+        *,
+        tolerate_invalid_old_fields: bool = False,
+    ) -> List[DeltaRecord]:
         if not self.field_type_converter:
             return delta_list
         converted: List[DeltaRecord] = []
@@ -936,11 +947,22 @@ class LocalIndex(IIndex):
                 if data.fields
                 else data.fields
             )
-            item.old_fields = (
-                self.field_type_converter.convert_fields_for_index(data.old_fields)
-                if data.old_fields
-                else data.old_fields
-            )
+            if data.old_fields:
+                try:
+                    item.old_fields = self.field_type_converter.convert_fields_for_index(
+                        data.old_fields
+                    )
+                except json.JSONDecodeError:
+                    if not tolerate_invalid_old_fields:
+                        raise
+                    logger.warning(
+                        "Ignoring unparseable old_fields while deleting legacy record "
+                        "label=%s; scalar-index cleanup will be best-effort",
+                        data.label,
+                    )
+                    item.old_fields = ""
+            else:
+                item.old_fields = data.old_fields
             converted.append(item)
         return converted
 

--- a/tests/vectordb/test_local_index_legacy_delete.py
+++ b/tests/vectordb/test_local_index_legacy_delete.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import json
+
+import pytest
+
+from openviking.storage.vectordb.index import local_index as local_index_module
+from openviking.storage.vectordb.index.local_index import LocalIndex
+from openviking.storage.vectordb.store.data import DeltaRecord
+
+
+class _JsonFieldConverter:
+    def convert_fields_for_index(self, fields_json: str) -> str:
+        return json.dumps(json.loads(fields_json), separators=(",", ":"))
+
+
+class _RecordingEngineProxy:
+    def __init__(self):
+        self.deleted = []
+        self.upserted = []
+
+    def delete_data(self, delta_list):
+        self.deleted.extend(delta_list)
+
+    def upsert_data(self, delta_list):
+        self.upserted.extend(delta_list)
+
+
+def _make_index() -> tuple[LocalIndex, _RecordingEngineProxy]:
+    index = LocalIndex.__new__(LocalIndex)
+    proxy = _RecordingEngineProxy()
+    index.field_type_converter = _JsonFieldConverter()
+    index.dense_search = None
+    index.engine_proxy = proxy
+    return index, proxy
+
+
+def test_delete_legacy_record_ignores_unparseable_old_fields(monkeypatch):
+    index, proxy = _make_index()
+    warnings = []
+    monkeypatch.setattr(
+        local_index_module.logger,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
+    record = DeltaRecord(
+        type=DeltaRecord.Type.DELETE,
+        label=41,
+        old_fields='{"truncated":',
+    )
+
+    index.delete_data([record])
+
+    assert len(proxy.deleted) == 1
+    assert proxy.deleted[0].label == 41
+    assert proxy.deleted[0].old_fields == ""
+    assert warnings == [
+        "Ignoring unparseable old_fields while deleting legacy record label=41; "
+        "scalar-index cleanup will be best-effort"
+    ]
+
+
+def test_upsert_legacy_record_keeps_invalid_old_fields_fail_closed():
+    index, proxy = _make_index()
+    record = DeltaRecord(
+        type=DeltaRecord.Type.UPSERT,
+        label=41,
+        fields='{"current":true}',
+        old_fields='{"truncated":',
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        index.upsert_data([record])
+
+    assert proxy.upserted == []
+
+
+def test_delete_valid_old_fields_still_converts_them():
+    index, proxy = _make_index()
+    record = DeltaRecord(
+        type=DeltaRecord.Type.DELETE,
+        label=42,
+        old_fields='{ "name": "healthy" }',
+    )
+
+    index.delete_data([record])
+
+    assert proxy.deleted[0].old_fields == '{"name":"healthy"}'


### PR DESCRIPTION
## 动机

修复 #2966。旧版本可能把超长 `fields` 按 uint16 长度截断；升级后读取路径能跳过这类记录，但删除仍会在 `json.loads(old_fields)` 处失败，使向量记录永久残留。

## 改动思路

删除的真实标识是 `label`，`old_fields` 只用于尽力清理标量倒排。因此仅在 `LocalIndex.delete_data()` 路径容忍无法解析的旧字段：记录不包含原文的 warning，并把传给 native engine 的 `old_fields` 置空；upsert 仍保持 fail-closed，避免在不知道旧字段时留下错误的标量匹配。

## 关键代码

```python
converted = convert(delta, tolerate_invalid_old_fields=True)  # delete only
try:
    old_fields = convert_fields(record.old_fields)
except JSONDecodeError:
    warn(label=record.label)
    old_fields = ""  # engine 仍按 label 删除向量
```

## 复现与验证

```bash
python -m pytest \
  tests/vectordb/test_local_index_legacy_delete.py \
  tests/vectordb/test_data_processor.py \
  -q --disable-warnings --no-cov
```

结果：11 passed。新增回归覆盖：

- 损坏 `old_fields` 的 delete 仍进入 engine，且只记录 label；
- 相同输入的 upsert 继续抛 `JSONDecodeError`，没有部分写入；
- 健康 `old_fields` 继续完成正常转换。

同时通过 Ruff format/check、`compileall` 和 `git diff --check`。额外的 `test_cuvs_collection.py` 在本机因现有 wheel 缺少 native `VolatileStore/PersistStore` 无法启动，失败发生在 collection 初始化、未进入本次改动路径。

## 风险与边界

损坏记录删除时无法精确清理其历史标量倒排项，但 native vector 会按 label 删除，查询不再召回该记录。此 PR 不实现离线 fsck，也不放宽 upsert；后者仍需有可验证的旧字段或专门的重建机制。