### PR TITLE
fix(resource): preserve lock contention during auto-naming

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -230,12 +230,16 @@ class ResourceService:
                 except ConflictError:
                     raise
                 except Exception as e:
-                    logger.warning(f"[ResourceService] Failed to create watch task for {watch_to}: {e}")
+                    logger.warning(
+                        f"[ResourceService] Failed to create watch task for {watch_to}: {e}"
+                    )
             elif target.to:
                 try:
                     await self._handle_watch_task_cancellation(to_uri=target.to, ctx=ctx)
                 except Exception as e:
-                    logger.warning(f"[ResourceService] Failed to cancel watch task for {target.to}: {e}")
+                    logger.warning(
+                        f"[ResourceService] Failed to cancel watch task for {target.to}: {e}"
+                    )
 
     def _normalize_add_resource_args(
         self,
@@ -722,7 +726,10 @@ class ResourceService:
                 )
                 doc_name = self._target_doc_name(path, source_name, source_info)
                 source_path = source_info.source_path or source_name or path
-                root_uri, candidate_uri = await self._resource_processor.tree_builder.resolve_target_uri(
+                (
+                    root_uri,
+                    candidate_uri,
+                ) = await self._resource_processor.tree_builder.resolve_target_uri(
                     ctx=ctx,
                     doc_name=doc_name,
                     scope="resources",
@@ -743,7 +750,9 @@ class ResourceService:
                 async def _reserve_tree(uri: str) -> LockLease:
                     dst_path = self._viking_fs._uri_to_path(uri, ctx=ctx)
                     try:
-                        return await OwnedLockLease.acquire_tree(lock_manager, dst_path, timeout=0.0)
+                        return await OwnedLockLease.acquire_tree(
+                            lock_manager, dst_path, timeout=0.0
+                        )
                     except LockAcquisitionError as exc:
                         raise ResourceBusyError(
                             f"Resource is busy: {uri}",
@@ -753,23 +762,10 @@ class ResourceService:
                         ) from exc
 
                 if candidate_uri:
-                    max_attempts = 100
-                    reserved = False
-                    for attempt in range(max_attempts + 1):
-                        attempt_uri = candidate_uri if attempt == 0 else f"{candidate_uri}_{attempt}"
-                        if await self._viking_fs.exists(attempt_uri, ctx=ctx):
-                            continue
-                        try:
-                            lock_lease = await _reserve_tree(attempt_uri)
-                            root_uri = attempt_uri
-                            reserved = True
-                            break
-                        except ResourceBusyError:
-                            continue
-                    if not reserved:
-                        raise FileExistsError(
-                            f"Cannot resolve unique name for {candidate_uri} after {max_attempts} attempts"
-                        )
+                    root_uri, lock_lease = await self._resource_processor.reserve_unique_candidate(
+                        candidate_uri=candidate_uri,
+                        ctx=ctx,
+                    )
                 else:
                     lock_lease = await _reserve_tree(root_uri)
 

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -17,13 +17,13 @@ from openviking.parse.tree_builder import TreeBuilder
 from openviking.server.identity import RequestContext
 from openviking.storage import VikingDBManager
 from openviking.storage.errors import LockAcquisitionError
+from openviking.storage.internal_names import STORAGE_INTERNAL_ENTRY_NAMES
 from openviking.storage.transaction import (
     LOCK_TIMEOUT_DEFAULT,
     NO_LOCK,
     LockLease,
     OwnedLockLease,
 )
-from openviking.storage.internal_names import STORAGE_INTERNAL_ENTRY_NAMES
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.embedding_utils import index_resource
@@ -430,6 +430,7 @@ class ResourceProcessor:
 
         viking_fs = get_viking_fs()
         lock_manager = get_lock_manager()
+        last_busy_error: Optional[ResourceBusyError] = None
 
         for attempt in range(max_attempts + 1):
             root_uri = candidate_uri if attempt == 0 else f"{candidate_uri}_{attempt}"
@@ -442,8 +443,18 @@ class ResourceProcessor:
                     lock_manager, dst_path, uri=root_uri, timeout=0.0
                 )
                 return root_uri, resource_lock
-            except ResourceBusyError:
+            except ResourceBusyError as exc:
+                last_busy_error = exc
                 continue
+
+        if last_busy_error is not None:
+            raise ResourceBusyError(
+                f"All auto-named candidates are temporarily busy for {candidate_uri} "
+                f"after checking {max_attempts + 1} candidates",
+                uri=candidate_uri,
+                conflict_type="auto_name_reservation_busy",
+                retryable=True,
+            ) from last_busy_error
 
         raise FileExistsError(
             f"Cannot resolve unique name for {candidate_uri} after {max_attempts} attempts"

--- a/tests/unit/test_resource_reservation.py
+++ b/tests/unit/test_resource_reservation.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.storage.errors import ResourceBusyError
+from openviking.utils import resource_processor as resource_processor_module
+from openviking.utils.resource_processor import ResourceProcessor
+
+
+class _FakeVikingFS:
+    def __init__(self, existing=()):
+        self.existing = set(existing)
+
+    async def exists(self, uri, *, ctx):
+        return uri in self.existing
+
+    def _uri_to_path(self, uri, *, ctx):
+        return f"/agfs/{uri}"
+
+
+def _make_processor(monkeypatch, *, existing=()):
+    processor = ResourceProcessor.__new__(ResourceProcessor)
+    viking_fs = _FakeVikingFS(existing)
+    monkeypatch.setattr(resource_processor_module, "get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: object(),
+    )
+    return processor
+
+
+@pytest.mark.asyncio
+async def test_reservation_exhaustion_reports_retryable_lock_contention(monkeypatch):
+    processor = _make_processor(monkeypatch)
+    processor.acquire_resource_lock = AsyncMock(
+        side_effect=ResourceBusyError(
+            "busy",
+            uri="viking://resources/report",
+            conflict_type="path_busy",
+        )
+    )
+
+    with pytest.raises(ResourceBusyError) as exc_info:
+        await processor.reserve_unique_candidate(
+            candidate_uri="viking://resources/report",
+            ctx=object(),
+            max_attempts=2,
+        )
+
+    assert exc_info.value.uri == "viking://resources/report"
+    assert exc_info.value.conflict_type == "auto_name_reservation_busy"
+    assert exc_info.value.retryable is True
+    assert "checking 3 candidates" in str(exc_info.value)
+    assert processor.acquire_resource_lock.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_true_auto_name_exhaustion_remains_file_exists(monkeypatch):
+    candidates = {
+        "viking://resources/report",
+        "viking://resources/report_1",
+        "viking://resources/report_2",
+    }
+    processor = _make_processor(monkeypatch, existing=candidates)
+    processor.acquire_resource_lock = AsyncMock()
+
+    with pytest.raises(FileExistsError):
+        await processor.reserve_unique_candidate(
+            candidate_uri="viking://resources/report",
+            ctx=object(),
+            max_attempts=2,
+        )
+
+    processor.acquire_resource_lock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reservation_returns_first_available_lock(monkeypatch):
+    processor = _make_processor(
+        monkeypatch,
+        existing={"viking://resources/report"},
+    )
+    lease = object()
+    processor.acquire_resource_lock = AsyncMock(return_value=lease)
+
+    uri, acquired = await processor.reserve_unique_candidate(
+        candidate_uri="viking://resources/report",
+        ctx=object(),
+        max_attempts=2,
+    )
+
+    assert uri == "viking://resources/report_1"
+    assert acquired is lease


### PR DESCRIPTION
## 动机

修复 #3122 在当前 main 上仍存在的误导性错误。Embedding/Semantic circuit breaker 已会等待 `retry_after` 再 requeue，但自动命名会把 101 个候选 URI 的锁竞争全部吞掉，最后统一抛 `FileExistsError`；即使磁盘上没有同名路径，调用方也会误判为文件冲突。异步 understanding 路径还复制了一份相同逻辑。

## 改动思路

保留两种失败语义：

- 候选路径确实全部存在：继续抛 `FileExistsError`；
- 至少一个不存在的候选仅因锁占用失败：抛可重试的 `ResourceBusyError`，并给出 `auto_name_reservation_busy` conflict type。

异步 understanding 路径不再维护第二份 100 次循环，改为调用 `ResourceProcessor.reserve_unique_candidate()`。

## 关键代码

```python
last_busy_error = None
for candidate in auto_named_candidates:
    if exists(candidate):
        continue
    try:
        return reserve(candidate)
    except ResourceBusyError as exc:
        last_busy_error = exc

if last_busy_error:
    raise ResourceBusyError(retryable=True, conflict_type="auto_name_reservation_busy")
raise FileExistsError(...)
```

## 复现与验证

```bash
python -m pytest \
  tests/unit/test_resource_reservation.py \
  tests/server/test_error_mapping.py \
  -q --disable-warnings --no-cov
```

结果：18 passed。新增覆盖包括全候选锁竞争、真实路径全部存在、以及跳过已存在名称后成功取得下一候选。Ruff check、compileall、`git diff --check` 均通过。

扩展运行的 `resource_processor_mv` 与 `resource_service_watch` 暴露了未初始化 VikingFS/TaskTracker 的既有 fixture 漂移；在未修改的 origin/main 上用相同测试可稳定复现，因此未混入本 runtime PR，已独立记录后续。

## 风险与边界

本改动不改变候选命名顺序、最大尝试次数或锁获取策略，只修正耗尽后的异常分类并去除重复实现。调用方现在会收到结构化 409 conflict，应该按 `retryable=true` 退避重试，而不是创建更多编号副本或检查磁盘重名。