### PR TITLE
test: isolate resource fixtures from global services

### DIFF
--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -118,8 +118,16 @@ class _FakeVikingFS:
         self.persist_calls.append((temp_uri, target_uri))
         self.agfs.write(self._uri_to_path(target_uri, ctx=ctx), b"content")
 
+    async def glob(self, pattern, uri=None, ctx=None):
+        return {"matches": []}
+
     def _uri_to_path(self, uri, ctx=None):
         return f"/mock/{uri.replace('viking://', '')}"
+
+
+def _patch_viking_fs(monkeypatch, fake_fs):
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr("openviking.parse.image_rewrite.get_viking_fs", lambda: fake_fs)
 
 
 @pytest.mark.asyncio
@@ -134,7 +142,7 @@ async def test_resource_processor_first_add_summarizes_from_committed_uri(monkey
         "openviking.utils.resource_processor.get_current_telemetry",
         lambda: _DummyTelemetry(),
     )
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    _patch_viking_fs(monkeypatch, fake_fs)
     monkeypatch.setattr(
         "openviking.storage.transaction.get_lock_manager",
         lambda: fake_lock_manager,
@@ -186,7 +194,7 @@ async def test_resource_processor_second_add_preserves_temp_uri_for_incremental(
         "openviking.utils.resource_processor.get_current_telemetry",
         lambda: _DummyTelemetry(),
     )
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    _patch_viking_fs(monkeypatch, fake_fs)
     monkeypatch.setattr(
         "openviking.storage.transaction.get_lock_manager",
         lambda: fake_lock_manager,
@@ -237,7 +245,7 @@ async def test_resource_processor_auto_candidate_skips_existing_and_busy(monkeyp
         "openviking.utils.resource_processor.get_current_telemetry",
         lambda: _DummyTelemetry(),
     )
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: fake_fs)
+    _patch_viking_fs(monkeypatch, fake_fs)
     monkeypatch.setattr(
         "openviking.storage.transaction.get_lock_manager",
         lambda: fake_lock_manager,

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -57,7 +57,11 @@ class MockVikingDB:
 
 
 class NoopTaskTracker:
+    def __init__(self):
+        self._count = 0
+
     async def create(self, *_args, **_kwargs):
+        self._count += 1
         return SimpleNamespace(task_id="test-task")
 
     async def start(self, *_args, **_kwargs):
@@ -66,12 +70,25 @@ class NoopTaskTracker:
     async def complete(self, *_args, **_kwargs):
         pass
 
+    def count(self):
+        return self._count
+
 
 def disable_task_tracker(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "openviking.service.task_tracker.get_task_tracker",
         lambda: NoopTaskTracker(),
     )
+
+
+@pytest.fixture(autouse=True)
+def isolate_service_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    task_tracker = NoopTaskTracker()
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: task_tracker,
+    )
+    monkeypatch.setattr(resource_service_module, "is_git_repo_url", lambda _path: False)
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## 动机

Fixes #3202。

资源处理与 watch service 的测试 fixture 没有跟随新引入的 image rewrite、共享 TaskTracker 和 Git URL 配置读取更新。结果是两组测试在干净 `main` 上出现 21 个失败，并且结果会受开发机全局服务状态和本地配置影响。

## 改动思路

- ResourceProcessor fake 同时注入处理模块与 image rewrite 使用的 VikingFS getter，并提供该阶段需要的最小空 `glob` 结果。
- watch 测试为每个用例安装独立、可计数的 Noop TaskTracker，模拟真实服务启动时的共享 tracker 注入。
- watch 测试固定跳过与目标无关的 Git URL 识别，避免读取开发机 OpenViking 配置。
- 只修改测试 fixture，不修改运行时代码。

## 关键代码

```python
def _patch_viking_fs(monkeypatch, fake_fs):
    patch(resource_processor.get_viking_fs, fake_fs)
    patch(image_rewrite.get_viking_fs, fake_fs)

@pytest.fixture(autouse=True)
def isolate_service_dependencies(monkeypatch):
    install(NoopTaskTracker())
    patch(is_git_repo_url, False)
```

## 复现与验证

修复前：

- `test_resource_processor_mv.py` 与 `test_resource_service_watch.py`：21 failed, 2 passed。

修复后：

```bash
.venv/bin/pytest -q --no-cov \
  tests/misc/test_resource_processor_mv.py \
  tests/service/test_resource_service_watch.py \
  tests/test_task_tracker.py
```

- 65 passed。
- Ruff check 与 format check 通过。
- `git diff --check` 通过。

## 风险与边界

改动仅隔离测试依赖，不改变 ResourceProcessor、ResourceService、TaskTracker 或配置加载的生产行为。Git URL 判断只在本测试模块中固定为 false；对应产品路径仍由独立测试覆盖。
