### PR TITLE
fix: allow owners to reindex user scope

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -8,6 +8,12 @@ from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import Response as FastAPIResponse
 from pydantic import BaseModel, ConfigDict
 
+from openviking.core.namespace import (
+    canonicalize_uri,
+    is_hidden_by_actor_peer_view,
+    may_include_hidden_actor_peers,
+    resolve_uri,
+)
 from openviking.core.path_variables import resolve_path_variables
 from openviking.core.uri_validation import validate_viking_uri
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSNotFoundError
@@ -21,7 +27,7 @@ from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
-from openviking_cli.exceptions import NotFoundError
+from openviking_cli.exceptions import NotFoundError, PermissionDeniedError
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
@@ -68,6 +74,26 @@ def _validate_reindex_uri(uri: str) -> str:
     if raw_uri.startswith("viking://"):
         return raw_uri
     return validate_viking_uri(raw_uri)
+
+
+def _authorize_reindex_uri(uri: str, ctx: RequestContext) -> str:
+    """Allow users to reindex only their own private namespace."""
+    if ctx.role != Role.USER:
+        return uri
+
+    canonical_uri = canonicalize_uri(uri, ctx)
+    target = resolve_uri(canonical_uri, ctx=ctx, require_canonical=True)
+    if (
+        target.scope != "user"
+        or target.owner_user_id != ctx.user.user_id
+        or is_hidden_by_actor_peer_view(canonical_uri, ctx)
+        or may_include_hidden_actor_peers(canonical_uri, ctx)
+    ):
+        raise PermissionDeniedError(
+            "USER can only reindex their own user namespace.",
+            resource=canonical_uri,
+        )
+    return canonical_uri
 
 
 @router.get("/read")
@@ -239,11 +265,12 @@ async def set_tags(
 @router.post("/reindex")
 async def reindex(
     body: ReindexRequest = Body(...),
-    ctx: RequestContext = require_role(Role.ROOT, Role.ADMIN),
+    ctx: RequestContext = require_role(Role.ROOT, Role.ADMIN, Role.USER),
 ):
     """Reindex semantic/vector artifacts for a URI-scoped maintenance target."""
     uri = resolve_path_variables(body.uri)
     uri = _validate_reindex_uri(uri)
+    uri = _authorize_reindex_uri(uri, ctx)
     service = get_service()
     result = await service.reindex(
         uri=uri,

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -5,7 +5,7 @@ import pytest
 
 from openviking.core.context import ContextLevel
 from openviking.server.identity import RequestContext, Role
-from openviking_cli.exceptions import OpenVikingError
+from openviking_cli.exceptions import OpenVikingError, PermissionDeniedError
 from openviking_cli.session.user_id import UserIdentifier
 from tests.server.test_admin_api import ROOT_KEY
 from tests.server.test_admin_api import admin_app as _admin_app_fixture
@@ -34,6 +34,74 @@ async def test_reindex_requires_admin_role(admin_client: httpx.AsyncClient):
         json={"uri": "viking://resources/demo", "mode": "vectors_only"},
     )
     assert resp.status_code == 401
+
+
+async def test_reindex_user_can_only_target_own_user_scope(monkeypatch):
+    from inspect import signature
+
+    from openviking.server.routers.content import ReindexRequest, reindex
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="reindex_user_scope", user_id="bob"),
+        role=Role.USER,
+    )
+    role_dependency = signature(reindex).parameters["ctx"].default.dependency
+    assert await role_dependency(ctx=ctx) == ctx
+    seen = {}
+
+    class FakeService:
+        async def reindex(self, *, uri, mode, wait, ctx):
+            seen.update(uri=uri, mode=mode, wait=wait, ctx=ctx)
+            return {"status": "completed", "uri": uri, "mode": mode}
+
+    monkeypatch.setattr("openviking.server.routers.content.get_service", lambda: FakeService())
+
+    own_scope = await reindex(
+        body=ReindexRequest(uri="viking://user/resources", mode="vectors_only"),
+        ctx=ctx,
+    )
+    assert own_scope.status == "ok"
+    assert seen["uri"] == "viking://user/bob/resources"
+    assert seen["ctx"].role == Role.USER
+    assert seen["ctx"].account_id == "reindex_user_scope"
+
+    with pytest.raises(PermissionDeniedError):
+        await reindex(
+            body=ReindexRequest(uri="viking://resources/shared", mode="vectors_only"),
+            ctx=ctx,
+        )
+
+    with pytest.raises(PermissionDeniedError):
+        await reindex(
+            body=ReindexRequest(uri="viking://user/alice/resources", mode="vectors_only"),
+            ctx=ctx,
+        )
+
+    peer_ctx = RequestContext(
+        user=ctx.user,
+        role=Role.USER,
+        actor_peer_id="peer-a",
+    )
+    peer_scope = await reindex(
+        body=ReindexRequest(
+            uri="viking://user/bob/peers/peer-a/resources",
+            mode="vectors_only",
+        ),
+        ctx=peer_ctx,
+    )
+    assert peer_scope.status == "ok"
+    assert seen["uri"] == "viking://user/bob/peers/peer-a/resources"
+
+    for hidden_uri in (
+        "viking://user/bob",
+        "viking://user/bob/peers",
+        "viking://user/bob/peers/peer-b/resources",
+    ):
+        with pytest.raises(PermissionDeniedError):
+            await reindex(
+                body=ReindexRequest(uri=hidden_uri, mode="vectors_only"),
+                ctx=peer_ctx,
+            )
 
 
 async def test_reindex_rejects_unsupported_uri(admin_client: httpx.AsyncClient):


### PR DESCRIPTION
## 动机

修复 #3194。

开启鉴权后，`POST /api/v1/content/reindex` 只允许 root/admin 调用，但私有 user scope 又只允许所属用户访问，导致 `viking://user/<user>/...` 实际上没有任何身份可以完成 reindex。

## 改动方案

允许 `Role.USER` 进入 reindex 路由，并在调用 reindex executor 前收紧 URI 授权：

```text
resolve shorthand / validate URI
        ↓
canonicalize with request context
        ↓
USER target must be viking://user/<self>/...
        ↓
actor peer view must not include hidden peers
        ↓
execute reindex with the original request context
```

具体边界：

- 用户可重建自己的 user namespace，例如 `viking://user/resources` 会规范化为 `viking://user/<self>/resources`。
- 用户不能重建共享资源、其他用户的私有空间。
- actor peer 只能重建自己的 peer 子树；用户根目录、`peers` 容器及其他 peer 子树会被拒绝，避免递归操作越过可见性边界。
- root/admin 的现有行为不变。

## 复现与验证

修复前，用户 API key 执行：

```bash
ov reindex --mode semantic_and_vectors viking://user/resources
```

会在路由层返回 `PERMISSION_DENIED: Requires role: root, admin`。

修复后，所属用户可以执行该命令；共享空间、其他用户空间和隐藏 peer 范围仍返回权限错误。

验证结果：

- focused 路由授权测试：先红后绿。
- 相关 reindex / tenant / namespace 回归：11 passed。
- `ruff check`：通过。
- `py_compile`：通过。

## 风险

改动只放宽 reindex 路由的入口角色，实际 USER 范围在执行前按 canonical owner 和 actor-peer 可见性显式校验。没有改变普通读写权限、root/admin 路径或 reindex executor 的处理逻辑。

Fixes #3194
