### PR TITLE
fix(vectordb): restore missing local index

### DIFF
--- a/openviking/storage/vectordb_adapters/local_adapter.py
+++ b/openviking/storage/vectordb_adapters/local_adapter.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb.collection.local_collection import get_or_create_local_collection
+from openviking_cli.utils.logger import default_logger as logger
 
 from .base import CollectionAdapter
 
@@ -81,6 +82,52 @@ class LocalCollectionAdapter(CollectionAdapter):
             path=collection_path,
             config=self._collection_config,
         )
+
+    def create_collection(
+        self,
+        name: str,
+        schema: Dict[str, Any],
+        *,
+        distance: str,
+        sparse_weight: float,
+        index_name: str,
+    ) -> bool:
+        """Create the collection or restore its configured index when it is missing."""
+        with self._load_lock:
+            if not self.collection_exists():
+                return super().create_collection(
+                    name,
+                    schema,
+                    distance=distance,
+                    sparse_weight=sparse_weight,
+                    index_name=index_name,
+                )
+
+            collection = self.get_collection()
+            if collection.has_index(index_name):
+                return False
+
+            collection_meta = collection.get_meta_data() or {}
+            scalar_index_fields = self._sanitize_scalar_index_fields(
+                scalar_index_fields=schema.get(
+                    "ScalarIndex", collection_meta.get("ScalarIndex", [])
+                ),
+                fields_meta=collection_meta.get("Fields", schema.get("Fields", [])),
+            )
+            index_meta = self._build_default_index_meta(
+                index_name=index_name,
+                distance=distance,
+                use_sparse=sparse_weight > 0.0,
+                sparse_weight=sparse_weight,
+                scalar_index_fields=scalar_index_fields,
+            )
+            logger.warning(
+                "Local collection %s has no configured index %s; rebuilding it",
+                self._collection_name,
+                index_name,
+            )
+            collection.create_index(index_name, index_meta)
+            return False
 
     def update_data(self, data_list: List[Dict[str, Any]]):
         collection = self.get_collection()

--- a/tests/storage/test_local_adapter_index_recovery.py
+++ b/tests/storage/test_local_adapter_index_recovery.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import shutil
+
+import pytest
+
+from openviking.storage.vectordb.engine import ENGINE_VARIANT
+from openviking.storage.vectordb_adapters.local_adapter import LocalCollectionAdapter
+
+
+def _schema() -> dict:
+    return {
+        "CollectionName": "context",
+        "Fields": [
+            {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": 4},
+            {"FieldName": "kind", "FieldType": "string"},
+        ],
+        "ScalarIndex": ["kind"],
+    }
+
+
+class _ExistingCollection:
+    def __init__(self, *, indexes: set[str]) -> None:
+        self.indexes = indexes
+        self.created_indexes: list[tuple[str, dict]] = []
+
+    def has_index(self, index_name: str) -> bool:
+        return index_name in self.indexes
+
+    def get_meta_data(self) -> dict:
+        return _schema()
+
+    def create_index(self, index_name: str, meta_data: dict) -> None:
+        self.created_indexes.append((index_name, meta_data))
+        self.indexes.add(index_name)
+
+
+def test_existing_local_collection_rebuilds_missing_configured_index() -> None:
+    adapter = LocalCollectionAdapter(
+        collection_name="context",
+        project_path="",
+        index_name="configured_index",
+    )
+    collection = _ExistingCollection(indexes=set())
+    adapter._collection = collection
+
+    created = adapter.create_collection(
+        "context",
+        _schema(),
+        distance="cosine",
+        sparse_weight=0.25,
+        index_name="configured_index",
+    )
+
+    assert created is False
+    assert collection.created_indexes == [
+        (
+            "configured_index",
+            {
+                "IndexName": "configured_index",
+                "VectorIndex": {
+                    "IndexType": "flat_hybrid",
+                    "Distance": "cosine",
+                    "Quant": "int8",
+                    "EnableSparse": True,
+                    "SearchWithSparseLogitAlpha": 0.25,
+                },
+                "ScalarIndex": ["kind"],
+            },
+        )
+    ]
+
+
+def test_existing_local_collection_keeps_healthy_configured_index() -> None:
+    adapter = LocalCollectionAdapter(
+        collection_name="context",
+        project_path="",
+        index_name="configured_index",
+    )
+    collection = _ExistingCollection(indexes={"configured_index"})
+    adapter._collection = collection
+
+    created = adapter.create_collection(
+        "context",
+        _schema(),
+        distance="cosine",
+        sparse_weight=0.25,
+        index_name="configured_index",
+    )
+
+    assert created is False
+    assert collection.created_indexes == []
+
+
+@pytest.mark.skipif(
+    ENGINE_VARIANT == "unavailable",
+    reason="vectordb native engine is not available",
+)
+def test_local_adapter_restores_missing_index_from_persisted_store(tmp_path) -> None:
+    project_path = tmp_path / "vectordb"
+    collection_path = project_path / "context"
+    index_name = "configured_index"
+    adapter = LocalCollectionAdapter(
+        collection_name="context",
+        project_path=str(project_path),
+        index_name=index_name,
+    )
+    assert (
+        adapter.create_collection(
+            "context",
+            _schema(),
+            distance="cosine",
+            sparse_weight=0.0,
+            index_name=index_name,
+        )
+        is True
+    )
+    adapter.get_collection().upsert_data(
+        [{"id": "record-1", "vector": [0.1, 0.2, 0.3, 0.4], "kind": "example"}]
+    )
+    adapter.close()
+
+    shutil.rmtree(collection_path / "index")
+
+    recovered = LocalCollectionAdapter(
+        collection_name="context",
+        project_path=str(project_path),
+        index_name=index_name,
+    )
+    try:
+        assert (
+            recovered.create_collection(
+                "context",
+                _schema(),
+                distance="cosine",
+                sparse_weight=0.0,
+                index_name=index_name,
+            )
+            is False
+        )
+        collection = recovered.get_collection()
+        assert collection.has_index(index_name)
+        assert collection.get_index_meta_data(index_name)["VectorIndex"]["Distance"] == "cosine"
+        result = collection.search_by_vector(
+            index_name,
+            dense_vector=[0.1, 0.2, 0.3, 0.4],
+            limit=1,
+        )
+        assert [item.id for item in result.data] == ["record-1"]
+    finally:
+        recovered.close()


### PR DESCRIPTION
## 动机

修复 #2118。

本地 VectorDB 的 collection/store 已持久化、但配置的 index 目录丢失或未落盘时，重启后的 `create_collection()` 会因为 collection 已存在而直接返回，既不重建 index，也不报错。数据仍可 fetch，但后续向量检索一直不可用。

旧 PR #2644 的修复方向正确，但混入了多个无关模块，并在底层硬编码 `default + flat/l2`；maintainer 因此要求拆成 focused PR。本 PR 只处理 Local adapter 的启动恢复路径。

## 改动方法

Local adapter 在正常 collection bootstrap 时检查“当前配置期望的 index 是否存在”：

```text
load existing local collection
        ↓
configured index exists? ── yes ──> keep current behavior
        │ no
        ↓
rebuild index metadata from current bootstrap config
(index_name / distance / sparse_weight / scalar fields)
        ↓
create index over persisted store records
```

这样恢复出来的索引仍使用当前部署配置，不会擅自改成 `default flat/l2`。新建 collection 与健康 index 的行为保持不变；`create_collection()` 的返回值仍只表示 collection 是否新建。

## 复现与验证

新增回归测试会：

1. 创建 local collection 与 `configured_index`（cosine）；
2. 写入一条记录并关闭；
3. 只删除 index 目录，保留 store；
4. 用相同配置重新启动；
5. 验证索引被恢复、distance 仍为 cosine，并能检索原记录。

验证结果：

- baseline：missing index 不会重建，回归断言失败；
- 修复后：`3 passed`；
- 相关 Local/CuVS/schema 选择性回归：`9 passed`；
- Ruff check / format、`py_compile`、`git diff --check` 通过；
- public/private 边界扫描无异常。

## 风险

恢复只发生在 Local adapter 已发现 collection、但缺少当前配置指定 index 时。健康 index 不重复创建；远端 VectorDB adapter 不受影响。若重建本身失败，异常继续向上传播，避免服务带着“有数据但不可搜索”的假健康状态启动。
