### PR TITLE
docs: clarify config reload and hybrid search boundaries

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -522,6 +522,21 @@ Supported task types: `RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`, `SEMANTIC_SIMILAR
 }
 ```
 
+Sparse output is a provider capability, not an endpoint inferred from
+`storage.vectordb.sparse_weight`. OpenViking currently implements `sparse` and
+`hybrid` embedding providers for `volcengine` and `vikingdb`. The
+OpenAI-compatible, Ollama, and built-in `local` providers are dense-only; a
+self-hosted `/v1/embeddings` endpoint is therefore not treated as a sparse
+endpoint, and OpenViking does not probe a separate
+`/v1/embeddings/sparse` route.
+
+There is no automatic BM25 or other sparse-vector fallback when the configured
+embedder returns only dense vectors. To use hybrid retrieval, configure a
+supported sparse/hybrid provider and set `storage.vectordb.sparse_weight > 0`.
+Model memory requirements are provider/model-specific and are not controlled by
+OpenViking; size self-hosted models against their provider documentation before
+enabling them in production.
+
 #### Hybrid Embedding
 
 Two approaches are supported:
@@ -1298,6 +1313,26 @@ OpenViking uses two config files:
 | `ovcli.conf` | HTTP client and CLI connection to remote server | `~/.openviking/ovcli.conf` |
 
 When config files are at the default path, OpenViking loads them automatically — no additional setup needed.
+
+> **Root-key two-file rule:** `server.root_api_key` in `ov.conf` is the
+> credential accepted by the server. `root_api_key` in `ovcli.conf` is the
+> client-side copy used by `ov --sudo`. If that CLI manages this server, keep
+> the two values identical and rotate both files together. The normal
+> tenant-scoped `api_key` remains a separate user/admin credential.
+
+### Reload boundary
+
+The server reads `ov.conf` during process startup and does not watch the file
+for changes. Editing `embedding`, `vlm`, `rerank`, `retrieval`, `storage`, or
+`server` settings requires restarting the OpenViking server. Queue work that is
+already running is not migrated to the new configuration, so use the normal
+service-manager restart procedure and verify with `openviking-server doctor`
+after the process comes back.
+
+`ovcli.conf` is client-side configuration. A new `ov` command or newly created
+HTTP client reads the current file; an already-running client or plugin may keep
+the values it loaded at construction time and should be restarted when its
+connection or credential settings change.
 
 If config files are at a different location, there are two ways to specify:
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -492,6 +492,19 @@ openviking-server doctor
 }
 ```
 
+Sparse 输出是 embedding provider 的能力，不会因为设置
+`storage.vectordb.sparse_weight` 就自动出现。OpenViking 当前只为
+`volcengine` 和 `vikingdb` 实现了 `sparse` / `hybrid` embedding provider；
+OpenAI 兼容接口、Ollama 和内置 `local` provider 目前都只支持 dense。
+因此，自托管的 `/v1/embeddings` 不会被自动当成 sparse 接口，OpenViking
+也不会额外探测 `/v1/embeddings/sparse` 路由。
+
+当 provider 只返回 dense vector 时，OpenViking 不会自动补充 BM25 或其他
+sparse-vector 兜底。若要启用混合检索，需要配置受支持的 sparse/hybrid
+provider，并设置 `storage.vectordb.sparse_weight > 0`。自托管模型的内存需求
+取决于具体 provider 和模型，不由 OpenViking 控制；生产启用前请按模型文档
+评估资源占用。
+
 #### Hybrid Embedding
 
 支持两种方式：
@@ -1271,6 +1284,22 @@ OpenViking 使用两个配置文件：
 | `ovcli.conf` | HTTP 客户端和 CLI 连接远程服务端 | `~/.openviking/ovcli.conf` |
 
 配置文件放在默认路径时，OpenViking 自动加载，无需额外设置。
+
+> **Root key 双文件规则：** `ov.conf` 中的 `server.root_api_key` 是服务端
+> 接受的凭据；`ovcli.conf` 中的 `root_api_key` 是 `ov --sudo` 使用的客户端
+> 副本。如果该 CLI 用于管理这个服务端，两处值必须一致，并在轮换时同时更新。
+> 普通租户数据使用的 `api_key` 仍是另一把 user/admin 凭据。
+
+### 配置重载边界
+
+服务端只在进程启动时读取 `ov.conf`，不会监听文件变化。修改 `embedding`、
+`vlm`、`rerank`、`retrieval`、`storage` 或 `server` 配置后，需要重启
+OpenViking 服务。已经运行中的队列任务不会自动迁移到新配置；请使用部署环境
+原有的服务管理方式重启，并在服务恢复后运行 `openviking-server doctor` 验证。
+
+`ovcli.conf` 属于客户端配置。新的 `ov` 命令或新建的 HTTP client 会读取当前
+文件；已经运行中的 client 或插件可能继续使用构造时加载的连接与凭据，修改后
+应重启对应客户端或插件。
 
 如果配置文件在其他位置，有两种指定方式：
 


### PR DESCRIPTION
## 动机

修复 #3125。现有文档已经分别介绍了 `ov.conf` / `ovcli.conf` 和 ROOT / tenant 权限，但仍缺少一处可直接执行的总说明：配置是否热更新、root key 轮换时两个文件如何配合，以及自托管 dense embedding 是否会自动获得 sparse / BM25 能力。

## 做法

- 在中英文配置指南中明确 root key 的双文件规则：服务端读取 `ov.conf`，`ov --sudo` 读取 `ovcli.conf`，轮换时需同步更新。
- 明确 `ov.conf` 只在服务启动时读取；修改模型、检索、存储或服务配置后需要重启并运行 doctor 验证。
- 说明新建 CLI / HTTP client 才会读取最新 `ovcli.conf`，长期运行的 client / plugin 需要重启。
- 给出 sparse / hybrid provider 能力边界：当前由 `volcengine` 或 `vikingdb` 提供；OpenAI-compatible、Ollama 与内置 local provider 是 dense-only。
- 明确 `sparse_weight` 不会合成 sparse vector，也不会自动启用 BM25 或探测 `/v1/embeddings/sparse`。

## 关键规则

```text
ov.conf:     server.root_api_key  -> 服务端接受的 ROOT 凭据
ovcli.conf:  root_api_key         -> ov --sudo 使用的客户端副本

修改 ov.conf -> 重启 server -> openviking-server doctor
只有 dense vector -> 不会因 sparse_weight > 0 自动变成 hybrid
```

## 复现与改动效果

改动前，在配置指南中搜索 `hot reload`、`/v1/embeddings/sparse` 或 root key 双文件轮换都得不到明确答案，容易把 `sparse_weight` 误解为 sparse 能力开关。改动后，这三类操作边界在中英文同一位置可直接查到。

## 验证

- `git diff --check`
- `npm --prefix docs run check:api`
  - 459 个 HTTP 示例与 130 个 TypeScript SDK 调用通过合约检查
- `npm --prefix docs run docs:build`
  - VitePress 中英文站点构建成功

## 风险

仅修改文档，不改变运行时代码或默认行为。描述基于当前 provider factory 和服务启动配置加载路径；未来新增 generic sparse provider 或热更新能力时需要同步更新本节。