### PR TITLE
test: update stats API fixtures for auth plugins

### DIFF
--- a/tests/unit/stats/test_stats_api.py
+++ b/tests/unit/stats/test_stats_api.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from openviking.server.auth import get_request_context
 from openviking.server.routers.stats import router
 
 
@@ -27,7 +28,7 @@ def mock_service():
     mock_stats.contexts_used = 2
     mock_stats.skills_used = 1
     mock_session.stats = mock_stats
-    service.sessions.session.return_value = mock_session
+    service.sessions.get = AsyncMock(return_value=mock_session)
 
     return service
 
@@ -42,12 +43,10 @@ def mock_ctx():
 def client(mock_service, mock_ctx):
     """Create a test client with mocked dependencies."""
     app = FastAPI()
+    app.dependency_overrides[get_request_context] = lambda: mock_ctx
     app.include_router(router)
 
-    with (
-        patch("openviking.server.routers.stats.get_service", return_value=mock_service),
-        patch("openviking.server.routers.stats.get_request_context", return_value=mock_ctx),
-    ):
+    with patch("openviking.server.routers.stats.get_service", return_value=mock_service):
         yield TestClient(app)
 
 
@@ -101,7 +100,7 @@ class TestGetSessionStats:
 
     def test_session_not_found(self, client, mock_service):
         """Missing session returns NOT_FOUND error."""
-        mock_service.sessions.session.side_effect = KeyError("nonexistent")
+        mock_service.sessions.get.side_effect = KeyError("nonexistent")
         response = client.get("/api/v1/stats/sessions/nonexistent")
         assert response.status_code == 200
         data = response.json()
@@ -110,7 +109,7 @@ class TestGetSessionStats:
 
     def test_session_internal_error(self, client, mock_service):
         """Unexpected exception returns INTERNAL_ERROR, not NOT_FOUND."""
-        mock_service.sessions.session.side_effect = RuntimeError("db timeout")
+        mock_service.sessions.get.side_effect = RuntimeError("db timeout")
         response = client.get("/api/v1/stats/sessions/some-session")
         assert response.status_code == 200
         data = response.json()


### PR DESCRIPTION
## 动机

修复 #3207。

stats API 的 7 个单测在当前 `main` 上都会在业务断言前失败：plugin auth 迁移后，测试 fixture 继续 patch 路由模块属性，但 FastAPI 已在注册路由时捕获原依赖，因此请求实际进入真实认证并报 `Auth plugin not initialized`。session 测试同时仍在 mock 已废弃的 `sessions.session()`，而实现已经调用异步 `sessions.get()`。

## 做法

- 使用 FastAPI 官方的 `app.dependency_overrides[get_request_context]` 注入测试 request context。
- 保留生产 `get_request_context` 和 plugin auth 行为不变。
- 将 session fixture 与异常分支改为 mock 当前的异步 `service.sessions.get()`。

## 关键代码

```python
app.dependency_overrides[get_request_context] = lambda: mock_ctx
service.sessions.get = AsyncMock(return_value=mock_session)
```

请求链路变为：

```text
TestClient request
  -> FastAPI dependency override
  -> stats handler
  -> mocked service.sessions.get(...)
  -> existing response assertions
```

## 复现与改动效果

改动前：

```bash
uv run pytest -q tests/unit/stats/test_stats_api.py --tb=short
# 7 failed: Auth plugin not initialized
```

改动后：同一命令 `7 passed`。

## 验证

```bash
python -m pytest -q \
  tests/unit/stats/test_stats_api.py \
  tests/unit/stats/test_stats_aggregator.py --tb=short
# 19 passed

git diff --check
```

扩大到 `tests/unit` 后，stats 测试已全部通过；随后在第 356 个用例被本机 OpenViking 配置包含当前 checkout 尚不认识的字段打断，属于独立的本地配置/schema 问题，不由本 PR 修改。

## 风险

仅修改测试 fixture，不改变服务器认证、stats 路由或 session 生产逻辑。主要风险是隐藏认证集成问题，因此 override 只放在这个 isolated router test app 内。

Fixes #3207