### PR TITLE
fix(server): default OAuth client scope for scope-less DCR (ChatGPT invalid_scope)

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -609,10 +609,21 @@ def create_app(
             app.state.oauth_store = _route_store
             app.state.oauth_provider = _route_provider
 
+            from openviking.server.oauth.provider import MCP_SCOPE
+
             sdk_routes = create_auth_routes(
                 provider=_route_provider,
                 issuer_url=AnyHttpUrl(_route_issuer),
-                client_registration_options=ClientRegistrationOptions(enabled=True),
+                # default_scopes covers clients whose DCR omits `scope`
+                # (ChatGPT does): without it they register scope-less and then
+                # fail /authorize with invalid_scope when they request the
+                # "mcp" scope advertised in the PRM document. valid_scopes is
+                # deliberately NOT set — the SDK would 400 any DCR that carries
+                # a scope outside the list, and clients like Claude register
+                # with their own scope strings.
+                client_registration_options=ClientRegistrationOptions(
+                    enabled=True, default_scopes=[MCP_SCOPE]
+                ),
                 revocation_options=RevocationOptions(enabled=True),
             )
             app.routes.extend(sdk_routes)

--- a/openviking/server/oauth/provider.py
+++ b/openviking/server/oauth/provider.py
@@ -42,6 +42,11 @@ ACCESS_TOKEN_PREFIX = "ovat_"
 REFRESH_TOKEN_PREFIX = "ovrt_"
 AUTH_CODE_PREFIX = "ovac_"
 
+# The only scope OpenViking defines. Single source for the three places that
+# must agree on it: the RFC 9728 PRM document (router.py), the DCR default
+# (app.py ClientRegistrationOptions), and the missing-scope fallback below.
+MCP_SCOPE = "mcp"
+
 # Primary authorize page: a /studio SPA route that runs in the same tab as
 # the user's Studio session, so it can read the session-stored API key.
 DEFAULT_AUTHORIZE_PAGE = "/studio/oauth/consent"
@@ -120,7 +125,13 @@ class OpenVikingOAuthProvider(
             token_endpoint_auth_method=record["token_endpoint_auth_method"],
             grant_types=record["grant_types"],
             response_types=record["response_types"],
-            scope=record.get("scope"),
+            # Clients registered without a scope (ChatGPT's DCR omits the
+            # field; rows predating #2921's scope column are NULL) would fail
+            # /authorize with invalid_scope as soon as they request the "mcp"
+            # scope our PRM document advertises — the SDK's validate_scope
+            # treats a scope-less client as "nothing authorized". Fall back to
+            # the default grant instead.
+            scope=record.get("scope") or MCP_SCOPE,
             client_name=record.get("client_name"),
             client_id_issued_at=record["created_at"],
         )

--- a/openviking/server/oauth/router.py
+++ b/openviking/server/oauth/router.py
@@ -34,7 +34,7 @@ from pydantic import AnyHttpUrl, BaseModel, Field
 
 from openviking.server.auth import get_request_context
 from openviking.server.identity import RequestContext
-from openviking.server.oauth.provider import OpenVikingOAuthProvider
+from openviking.server.oauth.provider import MCP_SCOPE, OpenVikingOAuthProvider
 from openviking.server.oauth.storage import OAuthStore
 from openviking_cli.exceptions import (
     InvalidArgumentError,
@@ -237,7 +237,7 @@ async def oauth_protected_resource(request: Request) -> JSONResponse:
     metadata = ProtectedResourceMetadata(
         resource=AnyHttpUrl(resource),
         authorization_servers=[AnyHttpUrl(issuer)],
-        scopes_supported=["mcp"],
+        scopes_supported=[MCP_SCOPE],
         bearer_methods_supported=["header"],
         resource_name="OpenViking MCP",
     )

--- a/tests/server/oauth/test_router.py
+++ b/tests/server/oauth/test_router.py
@@ -36,6 +36,7 @@ from openviking.server.identity import Role
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS
 from openviking.server.oauth.provider import (
     FALLBACK_AUTHORIZE_PAGE,
+    MCP_SCOPE,
     OpenVikingOAuthProvider,
 )
 from openviking.server.oauth.router import router as oauth_router
@@ -120,7 +121,10 @@ async def app_with_oauth(tmp_path):
     sdk_routes = create_auth_routes(
         provider=provider,
         issuer_url=AnyHttpUrl(issuer),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        # Mirror app.py's wiring: default_scopes covers DCRs that omit `scope`.
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True, default_scopes=[MCP_SCOPE]
+        ),
         revocation_options=RevocationOptions(enabled=True),
     )
     app.routes.extend(sdk_routes)
@@ -215,6 +219,67 @@ async def test_dcr_registers_client(client):
     body = resp.json()
     assert body["client_id"]
     assert body["redirect_uris"] == ["https://claude.ai/cb"]
+
+
+async def _authorize_with_mcp_scope(client, client_id: str, redirect_uri: str) -> str:
+    """GET /authorize requesting scope=mcp; return the redirect Location."""
+    _, challenge = _pkce_pair()
+    resp = await client.get(
+        "/authorize",
+        params={
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": redirect_uri,
+            "scope": MCP_SCOPE,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "resource": "http://127.0.0.1/mcp",
+            "state": "s1",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302, resp.text
+    return resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_authorize_scope_mcp_after_scopeless_dcr(client):
+    """ChatGPT regression (#2920/#2921 follow-up): its DCR omits `scope`, then
+    it requests the "mcp" scope advertised in the PRM document at /authorize.
+    Registration must default the scope so authorize proceeds to the consent
+    redirect instead of bouncing back with error=invalid_scope."""
+    redirect_uri = "https://chatgpt.com/connector/oauth/cb"
+    reg = await client.post(
+        "/register",
+        json={
+            "redirect_uris": [redirect_uri],
+            "client_name": "ChatGPT",
+            "token_endpoint_auth_method": "none",
+        },
+    )
+    assert reg.status_code == 201, reg.text
+    assert reg.json().get("scope") == MCP_SCOPE
+
+    location = await _authorize_with_mcp_scope(client, reg.json()["client_id"], redirect_uri)
+    assert FALLBACK_AUTHORIZE_PAGE in location and "pending=" in location
+    assert not location.startswith(redirect_uri)
+
+
+@pytest.mark.asyncio
+async def test_authorize_scope_mcp_for_legacy_scopeless_client(app_with_oauth, client):
+    """Clients already registered with a NULL scope (rows predating the DCR
+    default) must clear scope validation via the get_client fallback."""
+    _, store, _ = app_with_oauth
+    redirect_uri = "https://chatgpt.com/connector/oauth/cb"
+    record = await store.register_client(
+        redirect_uris=[redirect_uri],
+        client_name="ChatGPT (legacy row)",
+        scope=None,
+    )
+
+    location = await _authorize_with_mcp_scope(client, record["client_id"], redirect_uri)
+    assert FALLBACK_AUTHORIZE_PAGE in location and "pending=" in location
+    assert not location.startswith(redirect_uri)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/oauth/test_storage.py
+++ b/tests/server/oauth/test_storage.py
@@ -119,6 +119,45 @@ async def test_get_client_missing(store):
     assert await store.get_client("nope") is None
 
 
+@pytest.mark.asyncio
+async def test_provider_get_client_defaults_missing_scope(store):
+    """A client registered without a scope (ChatGPT's DCR omits the field;
+    rows predating #2921 are NULL) must still pass validate_scope for the
+    "mcp" scope the PRM document advertises. #2921 persisted the scope when
+    the registrar sent one; this covers the scope-less registration."""
+    from openviking.server.oauth.provider import MCP_SCOPE, OpenVikingOAuthProvider
+
+    record = await store.register_client(
+        redirect_uris=["https://chatgpt.com/connector/oauth/cb"],
+        client_name="ChatGPT",
+        scope=None,
+    )
+    provider = OpenVikingOAuthProvider(store=store, issuer="https://ov.test")
+    client = await provider.get_client(record["client_id"])
+    assert client is not None
+    assert client.scope == MCP_SCOPE
+    # The exact request that failed in the field: /authorize?scope=mcp.
+    assert client.validate_scope(MCP_SCOPE) == [MCP_SCOPE]
+
+
+@pytest.mark.asyncio
+async def test_provider_get_client_keeps_registered_scope(store):
+    """The missing-scope fallback must not clobber an explicitly registered
+    scope (e.g. Claude registers its own scope string via DCR)."""
+    from openviking.server.oauth.provider import OpenVikingOAuthProvider
+
+    record = await store.register_client(
+        redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+        client_name="Claude.ai",
+        scope="claudeai",
+    )
+    provider = OpenVikingOAuthProvider(store=store, issuer="https://ov.test")
+    client = await provider.get_client(record["client_id"])
+    assert client is not None
+    assert client.scope == "claudeai"
+    assert client.validate_scope("claudeai") == ["claudeai"]
+
+
 def _insert_code(store, code, *, account_id="a", user_id="u", ttl_seconds=300):
     return store.insert_auth_code(
         code_plain=code,


### PR DESCRIPTION
## Description

Connecting ChatGPT to an OpenViking MCP server fails with no consent page: `/authorize` immediately 302s back to `chatgpt.com` with `error=invalid_scope&error_description=Client+was+not+registered+with+scope+mcp` (reproduced live against a deployment by replaying the authorize URL).

This is a follow-up to #2921, which persisted the DCR client scope and started advertising `scopes_supported=["mcp"]` in the RFC 9728 PRM document. ChatGPT's Dynamic Client Registration omits the `scope` field entirely, so its client registers scope-less — then it requests the very `scope=mcp` our PRM advertises, and the MCP SDK's `validate_scope()` treats a scope-less client as "nothing authorized" and rejects with an error redirect before any consent UI renders. Clients that skip the scope parameter at `/authorize` (e.g. Claude) never hit this, which is why #2921 looked complete.

## Related Issue

Follow-up to #2920 / #2921.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `app.py`: pass `default_scopes=["mcp"]` to `ClientRegistrationOptions` so DCRs that omit `scope` register with the default grant. `valid_scopes` is deliberately left unset — the SDK would 400 any DCR carrying a scope outside that list, and some clients register their own scope strings.
- `provider.py`: introduce `MCP_SCOPE = "mcp"` as the single source for the scope name; `get_client()` falls back to it when the stored scope is NULL, repairing already-registered clients (including rows predating #2921's scope column) without migration or re-registration.
- `router.py`: reuse `MCP_SCOPE` in the PRM `scopes_supported` so all three sites stay in sync.
- Tests: provider-level fallback unit tests (scope-less registration defaults to `mcp`; an explicitly registered scope is not clobbered) and two end-to-end regressions in `test_router.py` mimicking ChatGPT (scope-less DCR → `/authorize?scope=mcp`, and a legacy NULL-scope client row → `/authorize?scope=mcp`), both asserting the 302 goes to the consent page instead of bouncing back to the client with an error.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Red/green verified: with the source changes reverted, the ChatGPT path reproduces the exact production error (`InvalidScopeError: Client was not registered with scope mcp`); with the fix applied, all 4 new tests pass and the full `tests/server/oauth/` suite is green except `test_oauth_user_role_rejects_account_override`, which fails identically on unmodified `main` (pre-existing, unrelated).

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

## Additional Notes

After deployment, an existing broken ChatGPT connector recovers without re-registration: its stored client row keeps its NULL scope, but `get_client()` now reports the default grant, so the previously failing `/authorize?scope=mcp` proceeds to the consent redirect.
