### PR TITLE
feat(docs): add VikingBot assistant

### DIFF
--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,0 +1,2 @@
+# Optional override for the VikingBot API endpoint.
+VITE_VIKINGBOT_API_BASE_URL=https://sd7aepg2caqr3a7a3g870.apigateway-cn-shanghai.volceapi.com/api/v1

--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,2 +1,0 @@
-# Optional override for the VikingBot API endpoint.
-VITE_VIKINGBOT_API_BASE_URL=https://sd7aepg2caqr3a7a3g870.apigateway-cn-shanghai.volceapi.com/api/v1

--- a/docs/.vitepress/theme/LlmsTxtLink.vue
+++ b/docs/.vitepress/theme/LlmsTxtLink.vue
@@ -106,6 +106,7 @@ async function copyLlmsTxt() {
   align-items: center;
   gap: 12px;
   margin-bottom: 8px;
+  white-space: nowrap;
 }
 
 .llms-link,

--- a/docs/.vitepress/theme/OpenVikingSearch.vue
+++ b/docs/.vitepress/theme/OpenVikingSearch.vue
@@ -126,11 +126,13 @@ function shouldIgnoreShortcut(event: KeyboardEvent) {
 
 function handleKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape' && isModeMenuOpen.value) {
+    event.preventDefault()
     isModeMenuOpen.value = false
     return
   }
 
   if (event.key === 'Escape' && isOpen.value) {
+    event.preventDefault()
     closeSearch()
     return
   }

--- a/docs/.vitepress/theme/VikingBotAssistant.vue
+++ b/docs/.vitepress/theme/VikingBotAssistant.vue
@@ -43,7 +43,6 @@ const copy = computed(() => isZh.value ? {
   copied: '已复制',
   thinking: '正在查找答案…',
   close: '关闭 VikingBot',
-  hint: 'Enter 发送 · Shift + Enter 换行',
   empty: '请输入问题',
   tooLong: '问题不能超过 500 个字符',
   timeout: '请求超时，请稍后重试。',
@@ -61,7 +60,6 @@ const copy = computed(() => isZh.value ? {
   copied: 'Copied',
   thinking: 'Looking for an answer…',
   close: 'Close VikingBot',
-  hint: 'Enter to send · Shift + Enter for a new line',
   empty: 'Please enter a question',
   tooLong: 'Questions cannot exceed 500 characters',
   timeout: 'The request timed out. Please try again.',
@@ -352,7 +350,6 @@ onBeforeUnmount(() => {
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 14-7-4.7 14-2.8-5.5L5 12Zm6.5 1.5 3-3" /></svg>
             </button>
           </div>
-          <small>{{ copy.hint }}</small>
         </form>
       </aside>
     </Transition>

--- a/docs/.vitepress/theme/VikingBotAssistant.vue
+++ b/docs/.vitepress/theme/VikingBotAssistant.vue
@@ -1,0 +1,342 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useData, withBase } from 'vitepress'
+import MarkdownIt from 'markdown-it'
+import { chatWithVikingBot, VikingBotApiError } from './vikingbot-api'
+
+type ChatMessage = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+}
+
+const { lang } = useData()
+const isOpen = ref(false)
+const input = ref('')
+const loading = ref(false)
+const messages = ref<ChatMessage[]>([])
+const copiedMessageId = ref('')
+const scrollArea = ref<HTMLElement>()
+const inputArea = ref<HTMLTextAreaElement>()
+const logoUrl = withBase('/ov-logo.png')
+const panelWidth = ref(368)
+const isResizing = ref(false)
+const PANEL_WIDTH_KEY = 'openviking-vikingbot-panel-width'
+const MIN_PANEL_WIDTH = 320
+const MAX_PANEL_WIDTH = 640
+const markdown = new MarkdownIt({
+  html: false,
+  breaks: true,
+  linkify: true,
+  typographer: true
+})
+
+const defaultLinkOpen = markdown.renderer.rules.link_open
+markdown.renderer.rules.link_open = (tokens, index, options, env, self) => {
+  tokens[index].attrSet('target', '_blank')
+  tokens[index].attrSet('rel', 'noopener noreferrer')
+  return defaultLinkOpen
+    ? defaultLinkOpen(tokens, index, options, env, self)
+    : self.renderToken(tokens, index, options)
+}
+
+const isZh = computed(() => lang.value.startsWith('zh'))
+const copy = computed(() => isZh.value ? {
+  trigger: '问问 VikingBot',
+  title: 'VikingBot',
+  subtitle: 'OpenViking 文档助手',
+  welcome: '你好！我是 VikingBot。你可以问我 OpenViking 的使用方式、核心概念或 API 集成问题。',
+  placeholder: '输入你的问题…',
+  send: '发送',
+  copy: '复制',
+  copied: '已复制',
+  thinking: '正在查找答案…',
+  close: '关闭 VikingBot',
+  hint: 'Enter 发送 · Shift + Enter 换行',
+  empty: '请输入问题',
+  tooLong: '问题不能超过 500 个字符',
+  timeout: '请求超时，请稍后重试。',
+  invalid: 'VikingBot 返回了无法识别的响应。',
+  failed: '暂时无法连接 VikingBot，请稍后重试。'
+} : {
+  trigger: 'Ask VikingBot',
+  title: 'VikingBot',
+  subtitle: 'OpenViking docs assistant',
+  welcome: 'Hi! I’m VikingBot. Ask me about OpenViking concepts, usage, or API integration.',
+  placeholder: 'Ask a question…',
+  send: 'Send',
+  copy: 'Copy',
+  copied: 'Copied',
+  thinking: 'Looking for an answer…',
+  close: 'Close VikingBot',
+  hint: 'Enter to send · Shift + Enter for a new line',
+  empty: 'Please enter a question',
+  tooLong: 'Questions cannot exceed 500 characters',
+  timeout: 'The request timed out. Please try again.',
+  invalid: 'VikingBot returned an invalid response.',
+  failed: 'VikingBot is unavailable right now. Please try again later.'
+})
+
+function openPanel() {
+  isOpen.value = true
+  nextTick(() => inputArea.value?.focus())
+}
+
+function closePanel() {
+  isOpen.value = false
+}
+
+function clampPanelWidth(width: number) {
+  const viewportLimit = Math.max(MIN_PANEL_WIDTH, window.innerWidth - 480)
+  return Math.min(Math.max(width, MIN_PANEL_WIDTH), Math.min(MAX_PANEL_WIDTH, viewportLimit))
+}
+
+function applyPanelWidth(width: number) {
+  panelWidth.value = clampPanelWidth(width)
+  document.documentElement.style.setProperty('--vikingbot-panel-width', `${panelWidth.value}px`)
+}
+
+function onResizeMove(event: PointerEvent) {
+  if (!isResizing.value) return
+  applyPanelWidth(window.innerWidth - event.clientX)
+}
+
+function stopResize() {
+  if (!isResizing.value) return
+  isResizing.value = false
+  document.documentElement.classList.remove('vikingbot-assistant-resizing')
+  window.removeEventListener('pointermove', onResizeMove)
+  window.removeEventListener('pointercancel', stopResize)
+  window.removeEventListener('blur', stopResize)
+  localStorage.setItem(PANEL_WIDTH_KEY, String(panelWidth.value))
+}
+
+function startResize(event: PointerEvent) {
+  if (window.innerWidth < 768) return
+  event.preventDefault()
+  isResizing.value = true
+  document.documentElement.classList.add('vikingbot-assistant-resizing')
+  window.addEventListener('pointermove', onResizeMove)
+  window.addEventListener('pointerup', stopResize, { once: true })
+  window.addEventListener('pointercancel', stopResize, { once: true })
+  window.addEventListener('blur', stopResize, { once: true })
+}
+
+function onWindowResize() {
+  if (window.innerWidth >= 768) applyPanelWidth(panelWidth.value)
+}
+
+function errorMessage(error: unknown) {
+  if (!(error instanceof VikingBotApiError)) return copy.value.failed
+  if (error.message === 'empty_query') return copy.value.empty
+  if (error.message === 'query_too_long') return copy.value.tooLong
+  if (error.message === 'request_timeout') return copy.value.timeout
+  if (error.message === 'invalid_response') return copy.value.invalid
+  return error.message && !error.message.startsWith('HTTP ') ? error.message : copy.value.failed
+}
+
+function renderMarkdown(content: string) {
+  return markdown.render(content)
+}
+
+async function copyAnswer(message: ChatMessage) {
+  try {
+    await navigator.clipboard.writeText(message.content)
+  } catch {
+    const textarea = document.createElement('textarea')
+    textarea.value = message.content
+    textarea.style.position = 'fixed'
+    textarea.style.opacity = '0'
+    document.body.appendChild(textarea)
+    textarea.select()
+    document.execCommand('copy')
+    textarea.remove()
+  }
+
+  copiedMessageId.value = message.id
+  window.setTimeout(() => {
+    if (copiedMessageId.value === message.id) copiedMessageId.value = ''
+  }, 1600)
+}
+
+async function scrollToBottom() {
+  await nextTick()
+  scrollArea.value?.scrollTo({ top: scrollArea.value.scrollHeight, behavior: 'smooth' })
+}
+
+async function sendMessage() {
+  if (loading.value) return
+  const query = input.value.trim()
+  if (!query) return
+
+  const userMessage: ChatMessage = {
+    id: `${Date.now()}-user`,
+    role: 'user',
+    content: query
+  }
+  messages.value.push(userMessage)
+  input.value = ''
+  loading.value = true
+  await scrollToBottom()
+
+  try {
+    const result = await chatWithVikingBot(query)
+    messages.value.push({
+      id: `${Date.now()}-assistant`,
+      role: 'assistant',
+      content: result.text
+    })
+  } catch (error) {
+    messages.value.push({
+      id: `${Date.now()}-error`,
+      role: 'assistant',
+      content: errorMessage(error)
+    })
+  } finally {
+    loading.value = false
+    await scrollToBottom()
+    inputArea.value?.focus()
+  }
+}
+
+function onInputKeydown(event: KeyboardEvent) {
+  if (event.key !== 'Enter' || event.shiftKey || event.isComposing) return
+  event.preventDefault()
+  void sendMessage()
+}
+
+function onEscape(event: KeyboardEvent) {
+  if (event.key === 'Escape' && isOpen.value) closePanel()
+}
+
+watch(isOpen, (open) => {
+  document.documentElement.classList.toggle('vikingbot-assistant-open', open)
+})
+
+onMounted(() => {
+  const storedWidth = Number(localStorage.getItem(PANEL_WIDTH_KEY))
+  applyPanelWidth(Number.isFinite(storedWidth) && storedWidth > 0 ? storedWidth : 368)
+  window.addEventListener('keydown', onEscape)
+  window.addEventListener('resize', onWindowResize)
+})
+
+onBeforeUnmount(() => {
+  document.documentElement.classList.remove('vikingbot-assistant-open')
+  document.documentElement.classList.remove('vikingbot-assistant-resizing')
+  document.documentElement.style.removeProperty('--vikingbot-panel-width')
+  window.removeEventListener('keydown', onEscape)
+  window.removeEventListener('resize', onWindowResize)
+  window.removeEventListener('pointermove', onResizeMove)
+  window.removeEventListener('pointerup', stopResize)
+  window.removeEventListener('pointercancel', stopResize)
+  window.removeEventListener('blur', stopResize)
+})
+</script>
+
+<template>
+  <button
+    class="vikingbot-trigger"
+    type="button"
+    :aria-expanded="isOpen"
+    aria-controls="vikingbot-assistant-panel"
+    @click="isOpen ? closePanel() : openPanel()"
+  >
+    <span class="vikingbot-spark" aria-hidden="true">✦</span>
+    <span class="vikingbot-trigger-label">{{ copy.trigger }}</span>
+  </button>
+
+  <Teleport to="body">
+    <Transition name="vikingbot-panel">
+      <aside
+        v-if="isOpen"
+        id="vikingbot-assistant-panel"
+        class="vikingbot-panel"
+        aria-label="VikingBot"
+      >
+        <button
+          class="vikingbot-resize-handle"
+          type="button"
+          aria-label="Resize VikingBot panel"
+          @pointerdown="startResize"
+        />
+        <header class="vikingbot-panel-header">
+          <div class="vikingbot-identity">
+            <span class="vikingbot-avatar" aria-hidden="true">
+              <img :src="logoUrl" alt="" />
+            </span>
+            <span>
+              <strong>{{ copy.title }}</strong>
+              <small>{{ copy.subtitle }}</small>
+            </span>
+          </div>
+          <button class="vikingbot-close" type="button" :aria-label="copy.close" @click="closePanel">
+            <span aria-hidden="true">×</span>
+          </button>
+        </header>
+
+        <div ref="scrollArea" class="vikingbot-messages" aria-live="polite">
+          <div class="vikingbot-message is-assistant">
+            <span class="vikingbot-message-mark" aria-hidden="true">
+              <img :src="logoUrl" alt="" />
+            </span>
+            <div class="vikingbot-markdown" v-html="renderMarkdown(copy.welcome)" />
+          </div>
+          <div
+            v-for="message in messages"
+            :key="message.id"
+            class="vikingbot-message"
+            :class="`is-${message.role}`"
+          >
+            <span v-if="message.role === 'assistant'" class="vikingbot-message-mark" aria-hidden="true">
+              <img :src="logoUrl" alt="" />
+            </span>
+            <p v-if="message.role === 'user'">{{ message.content }}</p>
+            <div v-else class="vikingbot-answer">
+              <div
+                class="vikingbot-markdown"
+                v-html="renderMarkdown(message.content)"
+              />
+              <button
+                class="vikingbot-copy-answer"
+                type="button"
+                @click="copyAnswer(message)"
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M8 8h10v11H8z" />
+                  <path d="M6 16H4V5h10v2" />
+                </svg>
+                {{ copiedMessageId === message.id ? copy.copied : copy.copy }}
+              </button>
+            </div>
+          </div>
+          <div
+            v-if="loading"
+            class="vikingbot-message is-loading"
+            role="status"
+            :aria-label="copy.thinking"
+          >
+            <span class="vikingbot-dots" aria-hidden="true"><i /><i /><i /></span>
+          </div>
+        </div>
+
+        <form class="vikingbot-composer" @submit.prevent="sendMessage">
+          <div class="vikingbot-input-shell">
+            <textarea
+              ref="inputArea"
+              v-model="input"
+              :placeholder="copy.placeholder"
+              :disabled="loading"
+              maxlength="500"
+              rows="3"
+              @keydown="onInputKeydown"
+            />
+            <button type="submit" :disabled="loading || !input.trim()" :aria-label="copy.send">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 14-7-4.7 14-2.8-5.5L5 12Zm6.5 1.5 3-3" /></svg>
+            </button>
+          </div>
+          <small>{{ copy.hint }}</small>
+        </form>
+      </aside>
+    </Transition>
+  </Teleport>
+</template>

--- a/docs/.vitepress/theme/VikingBotAssistant.vue
+++ b/docs/.vitepress/theme/VikingBotAssistant.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useData, withBase } from 'vitepress'
-import MarkdownIt from 'markdown-it'
 import { chatWithVikingBot, VikingBotApiError } from './vikingbot-api'
+import { renderVikingBotMarkdown } from './vikingbot-markdown'
 
 type ChatMessage = {
   id: string
@@ -18,27 +18,18 @@ const messages = ref<ChatMessage[]>([])
 const copiedMessageId = ref('')
 const scrollArea = ref<HTMLElement>()
 const inputArea = ref<HTMLTextAreaElement>()
+const triggerArea = ref<HTMLButtonElement>()
 const logoUrl = withBase('/ov-logo.png')
 const panelWidth = ref(368)
+const preferredPanelWidth = ref(368)
+const panelMaxWidth = ref(640)
 const isResizing = ref(false)
 const PANEL_WIDTH_KEY = 'openviking-vikingbot-panel-width'
 const MIN_PANEL_WIDTH = 320
 const MAX_PANEL_WIDTH = 640
-const markdown = new MarkdownIt({
-  html: false,
-  breaks: true,
-  linkify: true,
-  typographer: true
-})
-
-const defaultLinkOpen = markdown.renderer.rules.link_open
-markdown.renderer.rules.link_open = (tokens, index, options, env, self) => {
-  tokens[index].attrSet('target', '_blank')
-  tokens[index].attrSet('rel', 'noopener noreferrer')
-  return defaultLinkOpen
-    ? defaultLinkOpen(tokens, index, options, env, self)
-    : self.renderToken(tokens, index, options)
-}
+const MIN_COMPACT_DOC_WIDTH = 400
+const MIN_FULL_DOC_WIDTH = 760
+const RESIZE_STEP = 16
 
 const isZh = computed(() => lang.value.startsWith('zh'))
 const copy = computed(() => isZh.value ? {
@@ -57,7 +48,8 @@ const copy = computed(() => isZh.value ? {
   tooLong: '问题不能超过 500 个字符',
   timeout: '请求超时，请稍后重试。',
   invalid: 'VikingBot 返回了无法识别的响应。',
-  failed: '暂时无法连接 VikingBot，请稍后重试。'
+  failed: '暂时无法连接 VikingBot，请稍后重试。',
+  resize: '调整 VikingBot 面板宽度'
 } : {
   trigger: 'Ask VikingBot',
   title: 'VikingBot',
@@ -74,7 +66,8 @@ const copy = computed(() => isZh.value ? {
   tooLong: 'Questions cannot exceed 500 characters',
   timeout: 'The request timed out. Please try again.',
   invalid: 'VikingBot returned an invalid response.',
-  failed: 'VikingBot is unavailable right now. Please try again later.'
+  failed: 'VikingBot is unavailable right now. Please try again later.',
+  resize: 'Resize VikingBot panel'
 })
 
 function openPanel() {
@@ -83,16 +76,21 @@ function openPanel() {
 }
 
 function closePanel() {
+  const shouldRestoreFocus = isOpen.value
   isOpen.value = false
+  if (shouldRestoreFocus) nextTick(() => triggerArea.value?.focus())
 }
 
-function clampPanelWidth(width: number) {
-  const viewportLimit = Math.max(MIN_PANEL_WIDTH, window.innerWidth - 480)
-  return Math.min(Math.max(width, MIN_PANEL_WIDTH), Math.min(MAX_PANEL_WIDTH, viewportLimit))
+function maxPanelWidthForViewport() {
+  if (window.innerWidth < 768) return MAX_PANEL_WIDTH
+  const reservedWidth = window.innerWidth < 1280 ? MIN_COMPACT_DOC_WIDTH : MIN_FULL_DOC_WIDTH
+  return Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, window.innerWidth - reservedWidth))
 }
 
-function applyPanelWidth(width: number) {
-  panelWidth.value = clampPanelWidth(width)
+function applyPanelWidth(width: number, remember = true) {
+  panelMaxWidth.value = maxPanelWidthForViewport()
+  panelWidth.value = Math.min(Math.max(width, MIN_PANEL_WIDTH), panelMaxWidth.value)
+  if (remember) preferredPanelWidth.value = panelWidth.value
   document.documentElement.style.setProperty('--vikingbot-panel-width', `${panelWidth.value}px`)
 }
 
@@ -108,7 +106,7 @@ function stopResize() {
   window.removeEventListener('pointermove', onResizeMove)
   window.removeEventListener('pointercancel', stopResize)
   window.removeEventListener('blur', stopResize)
-  localStorage.setItem(PANEL_WIDTH_KEY, String(panelWidth.value))
+  localStorage.setItem(PANEL_WIDTH_KEY, String(preferredPanelWidth.value))
 }
 
 function startResize(event: PointerEvent) {
@@ -122,21 +120,30 @@ function startResize(event: PointerEvent) {
   window.addEventListener('blur', stopResize, { once: true })
 }
 
+function onResizeKeydown(event: KeyboardEvent) {
+  let nextWidth: number | undefined
+  if (event.key === 'ArrowLeft') nextWidth = panelWidth.value + RESIZE_STEP
+  if (event.key === 'ArrowRight') nextWidth = panelWidth.value - RESIZE_STEP
+  if (event.key === 'Home') nextWidth = MIN_PANEL_WIDTH
+  if (event.key === 'End') nextWidth = panelMaxWidth.value
+  if (nextWidth === undefined) return
+
+  event.preventDefault()
+  applyPanelWidth(nextWidth)
+  localStorage.setItem(PANEL_WIDTH_KEY, String(preferredPanelWidth.value))
+}
+
 function onWindowResize() {
-  if (window.innerWidth >= 768) applyPanelWidth(panelWidth.value)
+  if (window.innerWidth >= 768) applyPanelWidth(preferredPanelWidth.value, false)
 }
 
 function errorMessage(error: unknown) {
   if (!(error instanceof VikingBotApiError)) return copy.value.failed
-  if (error.message === 'empty_query') return copy.value.empty
-  if (error.message === 'query_too_long') return copy.value.tooLong
-  if (error.message === 'request_timeout') return copy.value.timeout
-  if (error.message === 'invalid_response') return copy.value.invalid
-  return error.message && !error.message.startsWith('HTTP ') ? error.message : copy.value.failed
-}
-
-function renderMarkdown(content: string) {
-  return markdown.render(content)
+  if (error.code === 'empty_query') return copy.value.empty
+  if (error.code === 'query_too_long') return copy.value.tooLong
+  if (error.code === 'request_timeout') return copy.value.timeout
+  if (error.code === 'invalid_response') return copy.value.invalid
+  return copy.value.failed
 }
 
 async function copyAnswer(message: ChatMessage) {
@@ -206,7 +213,9 @@ function onInputKeydown(event: KeyboardEvent) {
 }
 
 function onEscape(event: KeyboardEvent) {
-  if (event.key === 'Escape' && isOpen.value) closePanel()
+  if (event.key !== 'Escape' || event.defaultPrevented || !isOpen.value) return
+  event.preventDefault()
+  closePanel()
 }
 
 watch(isOpen, (open) => {
@@ -215,7 +224,8 @@ watch(isOpen, (open) => {
 
 onMounted(() => {
   const storedWidth = Number(localStorage.getItem(PANEL_WIDTH_KEY))
-  applyPanelWidth(Number.isFinite(storedWidth) && storedWidth > 0 ? storedWidth : 368)
+  preferredPanelWidth.value = Number.isFinite(storedWidth) && storedWidth > 0 ? storedWidth : 368
+  applyPanelWidth(preferredPanelWidth.value, false)
   window.addEventListener('keydown', onEscape)
   window.addEventListener('resize', onWindowResize)
 })
@@ -235,8 +245,10 @@ onBeforeUnmount(() => {
 
 <template>
   <button
+    ref="triggerArea"
     class="vikingbot-trigger"
     type="button"
+    :aria-label="copy.trigger"
     :aria-expanded="isOpen"
     aria-controls="vikingbot-assistant-panel"
     @click="isOpen ? closePanel() : openPanel()"
@@ -253,10 +265,16 @@ onBeforeUnmount(() => {
         class="vikingbot-panel"
         aria-label="VikingBot"
       >
-        <button
+        <div
           class="vikingbot-resize-handle"
-          type="button"
-          aria-label="Resize VikingBot panel"
+          role="separator"
+          tabindex="0"
+          aria-orientation="vertical"
+          :aria-label="copy.resize"
+          :aria-valuemin="MIN_PANEL_WIDTH"
+          :aria-valuemax="panelMaxWidth"
+          :aria-valuenow="panelWidth"
+          @keydown="onResizeKeydown"
           @pointerdown="startResize"
         />
         <header class="vikingbot-panel-header">
@@ -279,7 +297,7 @@ onBeforeUnmount(() => {
             <span class="vikingbot-message-mark" aria-hidden="true">
               <img :src="logoUrl" alt="" />
             </span>
-            <div class="vikingbot-markdown" v-html="renderMarkdown(copy.welcome)" />
+            <div class="vikingbot-markdown" v-html="renderVikingBotMarkdown(copy.welcome)" />
           </div>
           <div
             v-for="message in messages"
@@ -294,7 +312,7 @@ onBeforeUnmount(() => {
             <div v-else class="vikingbot-answer">
               <div
                 class="vikingbot-markdown"
-                v-html="renderMarkdown(message.content)"
+                v-html="renderVikingBotMarkdown(message.content)"
               />
               <button
                 class="vikingbot-copy-answer"

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,4 +1,5 @@
 :root {
+  --vikingbot-panel-width: 368px;
   --vp-layout-max-width: 100vw;
   --vp-c-brand-1: #0f766e;
   --vp-c-brand-2: #115e59;
@@ -76,6 +77,25 @@
 }
 
 @media (min-width: 960px) {
+  .VPNav {
+    box-sizing: border-box;
+    background-color: var(--vp-c-bg);
+    border-bottom: 1px solid var(--vp-c-divider);
+  }
+
+  .VPNavBar,
+  .VPNavBar.has-sidebar {
+    background-color: var(--vp-c-bg);
+  }
+
+  .VPNavBar .divider {
+    display: none;
+  }
+
+  .VPNav .VPNavBarTitle.has-sidebar .title {
+    border-bottom: 0 !important;
+  }
+
   .VPNavBarTranslations {
     display: flex !important;
   }
@@ -94,6 +114,527 @@
   display: flex;
   align-items: center;
   margin-right: 12px;
+}
+
+/* VikingBot docs assistant */
+.vikingbot-trigger {
+  display: inline-flex;
+  height: 40px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  margin-right: 12px;
+  padding: 0 14px;
+  border: 1px solid color-mix(in srgb, var(--vp-c-brand-1) 32%, var(--vp-c-divider));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 45%, var(--vp-c-bg));
+  color: var(--vp-c-brand-1);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.2s, background-color 0.2s, transform 0.2s;
+}
+
+.vikingbot-trigger:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  transform: translateY(-1px);
+}
+
+.vikingbot-spark {
+  font-size: 17px;
+  line-height: 1;
+}
+
+.vikingbot-panel {
+  position: fixed;
+  z-index: 90;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  width: min(var(--vikingbot-panel-width), 100vw);
+  flex-direction: column;
+  border-left: 1px solid var(--vp-c-divider);
+  background:
+    radial-gradient(circle at 90% 0, color-mix(in srgb, var(--vp-c-brand-soft) 55%, transparent), transparent 230px),
+    var(--vp-c-bg);
+}
+
+.vikingbot-resize-handle {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  bottom: 0;
+  left: -6px;
+  width: 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.vikingbot-resize-handle::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 5px;
+  width: 1px;
+  background: var(--vp-c-divider);
+  content: '';
+  transition: width 0.15s, background-color 0.15s;
+}
+
+.vikingbot-resize-handle:hover::before,
+.vikingbot-assistant-resizing .vikingbot-resize-handle::before {
+  width: 2px;
+  background: color-mix(in srgb, var(--vp-c-brand-1) 72%, var(--vp-c-divider));
+}
+
+html.vikingbot-assistant-resizing,
+html.vikingbot-assistant-resizing * {
+  cursor: col-resize !important;
+  user-select: none !important;
+}
+
+.vikingbot-panel-header {
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.vikingbot-identity {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.vikingbot-identity > span:last-child {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.vikingbot-identity strong {
+  color: var(--vp-c-text-1);
+  font-size: 15px;
+}
+
+.vikingbot-identity small {
+  color: var(--vp-c-text-3);
+  font-size: 11px;
+}
+
+.vikingbot-avatar,
+.vikingbot-message-mark {
+  display: block;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+}
+
+.vikingbot-avatar img,
+.vikingbot-message-mark img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.vikingbot-avatar {
+  width: 36px;
+  height: 36px;
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--vp-c-brand-1) 24%, transparent);
+}
+
+.vikingbot-close {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.vikingbot-close:hover {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+}
+
+.vikingbot-messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 22px 16px;
+  overscroll-behavior: contain;
+}
+
+.vikingbot-message {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin-bottom: 18px;
+}
+
+.vikingbot-message.is-user {
+  justify-content: flex-end;
+}
+
+.vikingbot-message-mark {
+  width: 25px;
+  height: 25px;
+  margin-top: 2px;
+  border-radius: 7px;
+  font-size: 11px;
+}
+
+.vikingbot-message > p,
+.vikingbot-markdown {
+  max-width: calc(100% - 36px);
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px 14px 14px 14px;
+  background: var(--vp-c-bg-elv);
+  color: var(--vp-c-text-1);
+  font-size: 13px;
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+}
+
+.vikingbot-answer {
+  display: flex;
+  width: calc(100% - 36px);
+  max-width: calc(100% - 36px);
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.vikingbot-answer .vikingbot-markdown {
+  width: 100%;
+  max-width: none;
+}
+
+.vikingbot-copy-answer {
+  display: inline-flex;
+  height: 28px;
+  align-items: center;
+  gap: 5px;
+  margin-top: 7px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--vp-c-text-3);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.vikingbot-copy-answer:hover {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+}
+
+.vikingbot-copy-answer svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.vikingbot-message > p { white-space: pre-wrap; }
+.vikingbot-markdown { white-space: normal; }
+
+.vikingbot-message.is-user > p {
+  border-color: transparent;
+  border-radius: 14px 4px 14px 14px;
+  background: var(--vp-c-brand-soft);
+}
+
+.vikingbot-message.is-loading {
+  align-items: center;
+  min-height: 24px;
+  margin: 2px 0 18px 3px;
+}
+
+.vikingbot-markdown > :first-child { margin-top: 0; }
+.vikingbot-markdown > :last-child { margin-bottom: 0; }
+
+.vikingbot-markdown p,
+.vikingbot-markdown ul,
+.vikingbot-markdown ol,
+.vikingbot-markdown pre,
+.vikingbot-markdown blockquote,
+.vikingbot-markdown table {
+  margin: 0 0 10px;
+}
+
+.vikingbot-markdown ul,
+.vikingbot-markdown ol {
+  padding-left: 18px;
+}
+
+.vikingbot-markdown li + li { margin-top: 4px; }
+
+.vikingbot-markdown h1,
+.vikingbot-markdown h2,
+.vikingbot-markdown h3,
+.vikingbot-markdown h4 {
+  margin: 14px 0 7px;
+  color: var(--vp-c-text-1);
+  font-weight: 750;
+  line-height: 1.35;
+}
+
+.vikingbot-markdown h1 { font-size: 17px; }
+.vikingbot-markdown h2 { font-size: 15px; }
+.vikingbot-markdown h3,
+.vikingbot-markdown h4 { font-size: 14px; }
+
+.vikingbot-markdown a {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.vikingbot-markdown code {
+  padding: 2px 4px;
+  border-radius: 4px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-brand-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.9em;
+}
+
+.vikingbot-markdown pre {
+  overflow-x: auto;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--vp-code-block-bg);
+}
+
+.vikingbot-markdown pre code {
+  padding: 0;
+  background: transparent;
+  color: var(--vp-code-block-color);
+  white-space: pre;
+}
+
+.vikingbot-markdown blockquote {
+  padding-left: 10px;
+  border-left: 3px solid var(--vp-c-brand-1);
+  color: var(--vp-c-text-2);
+}
+
+.vikingbot-markdown table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.vikingbot-markdown th,
+.vikingbot-markdown td {
+  padding: 6px 8px;
+  border: 1px solid var(--vp-c-divider);
+  text-align: left;
+}
+
+.vikingbot-markdown th { background: var(--vp-c-bg-soft); }
+
+.vikingbot-composer {
+  flex: 0 0 auto;
+  padding: 12px 14px 14px;
+  border-top: 1px solid var(--vp-c-divider);
+  background: color-mix(in srgb, var(--vp-c-bg) 94%, transparent);
+}
+
+.vikingbot-input-shell {
+  position: relative;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg-elv);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.vikingbot-input-shell:focus-within {
+  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 0 0 3px var(--vp-c-brand-soft);
+}
+
+.vikingbot-input-shell textarea {
+  display: block;
+  width: 100%;
+  min-height: 86px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  padding: 12px 48px 12px 12px;
+  background: transparent;
+  color: var(--vp-c-text-1);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.vikingbot-input-shell button {
+  position: absolute;
+  right: 9px;
+  bottom: 9px;
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: var(--vp-c-brand-1);
+  color: var(--vp-c-bg);
+  cursor: pointer;
+}
+
+.vikingbot-input-shell button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.vikingbot-input-shell svg {
+  width: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.vikingbot-composer > small {
+  display: block;
+  margin-top: 7px;
+  color: var(--vp-c-text-3);
+  font-size: 10px;
+  text-align: center;
+}
+
+.vikingbot-dots {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.vikingbot-dots i {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--vp-c-brand-1);
+  animation: vikingbot-pulse 1.1s infinite ease-in-out;
+}
+
+.vikingbot-dots i:nth-child(2) { animation-delay: 0.15s; }
+.vikingbot-dots i:nth-child(3) { animation-delay: 0.3s; }
+
+.vikingbot-panel-enter-active,
+.vikingbot-panel-leave-active { transition: transform 0.24s ease, opacity 0.2s ease; }
+.vikingbot-panel-enter-from,
+.vikingbot-panel-leave-to { opacity: 0; transform: translateX(24px); }
+
+@keyframes vikingbot-pulse {
+  0%, 60%, 100% { opacity: 0.28; transform: translateY(0); }
+  30% { opacity: 1; transform: translateY(-2px); }
+}
+
+@media (min-width: 1280px) {
+  html.vikingbot-assistant-open {
+    --vp-layout-max-width: 100vw;
+  }
+
+  html.vikingbot-assistant-open .Layout,
+  html.vikingbot-assistant-open .VPNav {
+    padding-right: var(--vikingbot-panel-width);
+  }
+
+  html.vikingbot-assistant-open .VPNavBar.has-sidebar .wrapper {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  html.vikingbot-assistant-open .VPNavBar.has-sidebar .container > .title {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: auto;
+    flex: 0 0 auto;
+    padding: 0;
+  }
+
+  html.vikingbot-assistant-open .VPNavBar.has-sidebar .container > .content {
+    padding-right: 0;
+    padding-left: 24px;
+  }
+
+  html.vikingbot-assistant-open .VPNavBarTitle .logo {
+    display: block;
+    width: 28px;
+    height: 28px;
+    flex: 0 0 28px;
+    object-fit: cover;
+  }
+
+  html.vikingbot-assistant-open .VPSidebar {
+    width: var(--vp-sidebar-width);
+    padding-left: 60px;
+  }
+
+  html.vikingbot-assistant-open .VPContent .VPDoc {
+    padding-right: 60px;
+    padding-left: 60px;
+  }
+
+  html.vikingbot-assistant-open .VPContent .VPDoc.has-aside > .container > .content {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  html.vikingbot-assistant-open .VPContent .VPDoc > .container > .aside {
+    max-width: 240px;
+    padding-left: 16px;
+  }
+
+  html.vikingbot-assistant-open .Layout,
+  html.vikingbot-assistant-open .VPNav,
+  html.vikingbot-assistant-open .VPSidebar {
+    transition: padding-right 0.24s ease, right 0.24s ease;
+  }
+}
+
+@media (max-width: 1279px) {
+  .vikingbot-trigger-label { display: none; }
+  .vikingbot-trigger { width: 40px; justify-content: center; padding: 0; }
+}
+
+@media (max-width: 767px) {
+  .vikingbot-trigger { margin-right: 8px; }
+  .vikingbot-panel { z-index: 200; width: 100vw; }
+  .vikingbot-resize-handle { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vikingbot-trigger,
+  .vikingbot-panel-enter-active,
+  .vikingbot-panel-leave-active { transition: none; }
+  .vikingbot-dots i { animation: none; }
 }
 
 .ov-docs-search-trigger {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -188,9 +188,14 @@
 }
 
 .vikingbot-resize-handle:hover::before,
+.vikingbot-resize-handle:focus-visible::before,
 .vikingbot-assistant-resizing .vikingbot-resize-handle::before {
   width: 2px;
   background: color-mix(in srgb, var(--vp-c-brand-1) 72%, var(--vp-c-divider));
+}
+
+.vikingbot-resize-handle:focus-visible {
+  outline: 0;
 }
 
 html.vikingbot-assistant-resizing,
@@ -555,7 +560,7 @@ html.vikingbot-assistant-resizing * {
   30% { opacity: 1; transform: translateY(-2px); }
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 768px) {
   html.vikingbot-assistant-open {
     --vp-layout-max-width: 100vw;
   }
@@ -592,11 +597,6 @@ html.vikingbot-assistant-resizing * {
     object-fit: cover;
   }
 
-  html.vikingbot-assistant-open .VPSidebar {
-    width: var(--vp-sidebar-width);
-    padding-left: 60px;
-  }
-
   html.vikingbot-assistant-open .VPContent .VPDoc {
     padding-right: 60px;
     padding-left: 60px;
@@ -607,15 +607,57 @@ html.vikingbot-assistant-resizing * {
     padding-left: 0;
   }
 
-  html.vikingbot-assistant-open .VPContent .VPDoc > .container > .aside {
-    max-width: 240px;
-    padding-left: 16px;
-  }
-
   html.vikingbot-assistant-open .Layout,
   html.vikingbot-assistant-open .VPNav,
   html.vikingbot-assistant-open .VPSidebar {
     transition: padding-right 0.24s ease, right 0.24s ease;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1279px) {
+  html.vikingbot-assistant-open .VPSidebar {
+    display: none;
+  }
+
+  html.vikingbot-assistant-open .VPContent.has-sidebar {
+    padding-left: 0;
+  }
+
+  html.vikingbot-assistant-open .VPContent .VPDoc > .container > .aside,
+  html.vikingbot-assistant-open .VPNavBar .menu,
+  html.vikingbot-assistant-open .VPNavBar .translations,
+  html.vikingbot-assistant-open .VPNavBar .appearance,
+  html.vikingbot-assistant-open .VPNavBar .social-links,
+  html.vikingbot-assistant-open .VPNavBar .extra {
+    display: none !important;
+  }
+
+  html.vikingbot-assistant-open .ov-docs-search-trigger {
+    width: 40px;
+    min-width: 40px;
+    justify-content: center;
+    padding: 0;
+  }
+
+  html.vikingbot-assistant-open .ov-docs-search-trigger-label,
+  html.vikingbot-assistant-open .ov-docs-search-trigger kbd {
+    display: none;
+  }
+
+  html.vikingbot-assistant-open .ov-docs-search-trigger-compact {
+    display: block;
+  }
+}
+
+@media (min-width: 1280px) {
+  html.vikingbot-assistant-open .VPSidebar {
+    width: var(--vp-sidebar-width);
+    padding-left: 60px;
+  }
+
+  html.vikingbot-assistant-open .VPContent .VPDoc > .container > .aside {
+    max-width: 240px;
+    padding-left: 16px;
   }
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -641,6 +641,13 @@ html.vikingbot-assistant-resizing * {
   }
 }
 
+@media (min-width: 768px) and (max-width: 1599px) {
+  html.vikingbot-assistant-open .VPContent .VPDoc {
+    padding-right: 32px;
+    padding-left: 32px;
+  }
+}
+
 @media (min-width: 1280px) {
   html.vikingbot-assistant-open .VPSidebar {
     width: var(--vp-sidebar-width);
@@ -930,19 +937,24 @@ html.vikingbot-assistant-resizing * {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 16px;
   margin-bottom: 16px;
 }
 
 .doc-page-actions > .llms-link-wrap,
 .doc-page-actions > .copy-md-wrap {
+  flex: 0 0 auto;
   margin-bottom: 0;
+}
+
+.doc-page-actions > .copy-md-wrap {
+  margin-left: auto;
 }
 
 @media (max-width: 640px) {
   .doc-page-actions {
     align-items: center;
-    flex-wrap: wrap;
   }
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -206,10 +206,11 @@ html.vikingbot-assistant-resizing * {
 
 .vikingbot-panel-header {
   display: flex;
-  min-height: 72px;
+  height: calc(var(--vp-nav-height) + 1px);
+  min-height: calc(var(--vp-nav-height) + 1px);
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: 7px 16px;
   border-bottom: 1px solid var(--vp-c-divider);
 }
 
@@ -255,7 +256,6 @@ html.vikingbot-assistant-resizing * {
 .vikingbot-avatar {
   width: 36px;
   height: 36px;
-  box-shadow: 0 8px 18px color-mix(in srgb, var(--vp-c-brand-1) 24%, transparent);
 }
 
 .vikingbot-close {
@@ -524,14 +524,6 @@ html.vikingbot-assistant-resizing * {
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 1.8;
-}
-
-.vikingbot-composer > small {
-  display: block;
-  margin-top: 7px;
-  color: var(--vp-c-text-3);
-  font-size: 10px;
-  text-align: center;
 }
 
 .vikingbot-dots {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,6 +5,7 @@ import CopyMarkdownButton from './CopyMarkdownButton.vue'
 import LlmsTxtLink from './LlmsTxtLink.vue'
 import OpenVikingSearch from './OpenVikingSearch.vue'
 import ApiExampleTabsEnhancer from './ApiExampleTabsEnhancer.vue'
+import VikingBotAssistant from './VikingBotAssistant.vue'
 import { trackPageView } from './track'
 import './custom.css'
 
@@ -308,7 +309,7 @@ export default {
         h(CopyMarkdownButton)
       ]),
       'doc-after': () => h(ApiExampleTabsEnhancer),
-      'nav-bar-content-before': () => h(OpenVikingSearch)
+      'nav-bar-content-before': () => [h(OpenVikingSearch), h(VikingBotAssistant)]
     })
   },
   enhanceApp({ router }: EnhanceAppContext) {

--- a/docs/.vitepress/theme/vikingbot-api.test.ts
+++ b/docs/.vitepress/theme/vikingbot-api.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getVikingBotUserId, normalizeVikingBotQuery, VikingBotApiError } from './vikingbot-api.ts'
+
+test('normalizes VikingBot queries and enforces the UI limit', () => {
+  assert.equal(normalizeVikingBotQuery('  How does memory work?  '), 'How does memory work?')
+
+  assert.throws(
+    () => normalizeVikingBotQuery('   '),
+    (error) => error instanceof VikingBotApiError && error.message === 'empty_query'
+  )
+  assert.throws(
+    () => normalizeVikingBotQuery('x'.repeat(501)),
+    (error) => error instanceof VikingBotApiError && error.message === 'query_too_long'
+  )
+})
+
+test('reuses the stable VikingBot user id from storage', () => {
+  const values = new Map<string, string>([['client_id', 'existing-user']])
+  const storage = {
+    getItem(key: string) {
+      return values.get(key) ?? null
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value)
+    }
+  }
+
+  assert.equal(getVikingBotUserId(storage), 'existing-user')
+  assert.equal(values.size, 1)
+})

--- a/docs/.vitepress/theme/vikingbot-api.test.ts
+++ b/docs/.vitepress/theme/vikingbot-api.test.ts
@@ -7,11 +7,11 @@ test('normalizes VikingBot queries and enforces the UI limit', () => {
 
   assert.throws(
     () => normalizeVikingBotQuery('   '),
-    (error) => error instanceof VikingBotApiError && error.message === 'empty_query'
+    (error) => error instanceof VikingBotApiError && error.code === 'empty_query'
   )
   assert.throws(
     () => normalizeVikingBotQuery('x'.repeat(501)),
-    (error) => error instanceof VikingBotApiError && error.message === 'query_too_long'
+    (error) => error instanceof VikingBotApiError && error.code === 'query_too_long'
   )
 })
 

--- a/docs/.vitepress/theme/vikingbot-api.ts
+++ b/docs/.vitepress/theme/vikingbot-api.ts
@@ -1,0 +1,111 @@
+const DEFAULT_API_BASE_URL =
+  'https://sd7aepg2caqr3a7a3g870.apigateway-cn-shanghai.volceapi.com/api/v1'
+const VIKINGBOT_API_KEY = 'kjWSxIHxa0hRk9C/0gSFvA=='
+const REQUEST_TIMEOUT_MS = 60_000
+const CLIENT_ID_KEY = 'client_id'
+
+type ApiResponse<T> = {
+  status: string
+  err_code: string
+  err_msg: string
+  result: T
+}
+
+export type VikingBotChatResult = {
+  text: string
+}
+
+export class VikingBotApiError extends Error {
+  readonly code: string
+  readonly httpStatus?: number
+
+  constructor(
+    message: string,
+    code = '',
+    httpStatus?: number
+  ) {
+    super(message)
+    this.name = 'VikingBotApiError'
+    this.code = code
+    this.httpStatus = httpStatus
+  }
+}
+
+export function getVikingBotUserId(storage: Pick<Storage, 'getItem' | 'setItem'> = localStorage) {
+  let id = storage.getItem(CLIENT_ID_KEY)
+  if (!id) {
+    id = crypto.randomUUID()
+    storage.setItem(CLIENT_ID_KEY, id)
+  }
+  return id
+}
+
+export function normalizeVikingBotQuery(query: string) {
+  const normalized = query.trim()
+  if (!normalized) throw new VikingBotApiError('empty_query')
+  if (normalized.length > 500) throw new VikingBotApiError('query_too_long')
+  return normalized
+}
+
+export async function chatWithVikingBot(query: string): Promise<VikingBotChatResult> {
+  const normalizedQuery = normalizeVikingBotQuery(query)
+  const apiBaseUrl = import.meta.env.VITE_VIKINGBOT_API_BASE_URL || DEFAULT_API_BASE_URL
+
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/bot/chat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-OpenViking-Bot-Key': VIKINGBOT_API_KEY
+      },
+      body: JSON.stringify({
+        user_id: getVikingBotUserId(),
+        query: normalizedQuery
+      }),
+      signal: controller.signal
+    })
+
+    let data: ApiResponse<VikingBotChatResult>
+    try {
+      data = (await response.json()) as ApiResponse<VikingBotChatResult>
+    } catch {
+      throw new VikingBotApiError(
+        response.ok ? 'invalid_response' : `HTTP ${response.status}`,
+        '',
+        response.status
+      )
+    }
+
+    if (!response.ok) {
+      throw new VikingBotApiError(
+        data.err_msg || `HTTP ${response.status}`,
+        data.err_code,
+        response.status
+      )
+    }
+
+    if (data.status !== 'ok') {
+      throw new VikingBotApiError(
+        data.err_msg || data.err_code || 'api_error',
+        data.err_code,
+        response.status
+      )
+    }
+
+    if (!data.result || typeof data.result.text !== 'string') {
+      throw new VikingBotApiError('invalid_response', '', response.status)
+    }
+
+    return data.result
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new VikingBotApiError('request_timeout')
+    }
+    throw error
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}

--- a/docs/.vitepress/theme/vikingbot-api.ts
+++ b/docs/.vitepress/theme/vikingbot-api.ts
@@ -11,22 +11,33 @@ type ApiResponse<T> = {
   result: T
 }
 
+export type VikingBotApiErrorCode =
+  | 'api_error'
+  | 'empty_query'
+  | 'http_error'
+  | 'invalid_response'
+  | 'network_error'
+  | 'query_too_long'
+  | 'request_timeout'
+
 export type VikingBotChatResult = {
   text: string
 }
 
 export class VikingBotApiError extends Error {
-  readonly code: string
+  readonly code: VikingBotApiErrorCode
+  readonly apiCode: string
   readonly httpStatus?: number
 
   constructor(
-    message: string,
-    code = '',
+    code: VikingBotApiErrorCode,
+    apiCode = '',
     httpStatus?: number
   ) {
-    super(message)
+    super(code)
     this.name = 'VikingBotApiError'
     this.code = code
+    this.apiCode = apiCode
     this.httpStatus = httpStatus
   }
 }
@@ -49,13 +60,12 @@ export function normalizeVikingBotQuery(query: string) {
 
 export async function chatWithVikingBot(query: string): Promise<VikingBotChatResult> {
   const normalizedQuery = normalizeVikingBotQuery(query)
-  const apiBaseUrl = import.meta.env.VITE_VIKINGBOT_API_BASE_URL || DEFAULT_API_BASE_URL
 
   const controller = new AbortController()
   const timeout = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
 
   try {
-    const response = await fetch(`${apiBaseUrl}/bot/chat`, {
+    const response = await fetch(`${DEFAULT_API_BASE_URL}/bot/chat`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -73,7 +83,7 @@ export async function chatWithVikingBot(query: string): Promise<VikingBotChatRes
       data = (await response.json()) as ApiResponse<VikingBotChatResult>
     } catch {
       throw new VikingBotApiError(
-        response.ok ? 'invalid_response' : `HTTP ${response.status}`,
+        response.ok ? 'invalid_response' : 'http_error',
         '',
         response.status
       )
@@ -81,7 +91,7 @@ export async function chatWithVikingBot(query: string): Promise<VikingBotChatRes
 
     if (!response.ok) {
       throw new VikingBotApiError(
-        data.err_msg || `HTTP ${response.status}`,
+        'http_error',
         data.err_code,
         response.status
       )
@@ -89,7 +99,7 @@ export async function chatWithVikingBot(query: string): Promise<VikingBotChatRes
 
     if (data.status !== 'ok') {
       throw new VikingBotApiError(
-        data.err_msg || data.err_code || 'api_error',
+        'api_error',
         data.err_code,
         response.status
       )
@@ -104,7 +114,8 @@ export async function chatWithVikingBot(query: string): Promise<VikingBotChatRes
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw new VikingBotApiError('request_timeout')
     }
-    throw error
+    if (error instanceof VikingBotApiError) throw error
+    throw new VikingBotApiError('network_error')
   } finally {
     window.clearTimeout(timeout)
   }

--- a/docs/.vitepress/theme/vikingbot-markdown.test.ts
+++ b/docs/.vitepress/theme/vikingbot-markdown.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { renderVikingBotMarkdown } from './vikingbot-markdown.ts'
+
+test('renders supported VikingBot Markdown', () => {
+  const result = renderVikingBotMarkdown('## Install\n\n```bash\nnpm install openviking\n```')
+
+  assert.match(result, /<h2>Install<\/h2>/)
+  assert.match(result, /<code class="language-bash">/)
+})
+
+test('sanitizes VikingBot Markdown output', () => {
+  const result = renderVikingBotMarkdown([
+    '<img src=x onerror=alert(1)>',
+    '[unsafe](javascript:alert(1))',
+    '[safe](https://openviking.ai)'
+  ].join('\n\n'))
+
+  assert.doesNotMatch(result, /<img/i)
+  assert.doesNotMatch(result, /href="javascript:/i)
+  assert.match(result, /href="https:\/\/openviking\.ai"/)
+  assert.match(result, /target="_blank"/)
+  assert.match(result, /rel="noopener noreferrer"/)
+})

--- a/docs/.vitepress/theme/vikingbot-markdown.ts
+++ b/docs/.vitepress/theme/vikingbot-markdown.ts
@@ -1,0 +1,50 @@
+import MarkdownIt from 'markdown-it'
+import { FilterXSS } from 'xss'
+
+const markdown = new MarkdownIt({
+  html: false,
+  breaks: true,
+  linkify: true,
+  typographer: true
+})
+
+const defaultLinkOpen = markdown.renderer.rules.link_open
+markdown.renderer.rules.link_open = (tokens, index, options, env, self) => {
+  tokens[index].attrSet('target', '_blank')
+  tokens[index].attrSet('rel', 'noopener noreferrer')
+  return defaultLinkOpen
+    ? defaultLinkOpen(tokens, index, options, env, self)
+    : self.renderToken(tokens, index, options)
+}
+
+const sanitizer = new FilterXSS({
+  whiteList: {
+    a: ['href', 'title', 'target', 'rel'],
+    blockquote: [],
+    br: [],
+    code: ['class'],
+    em: [],
+    h1: [],
+    h2: [],
+    h3: [],
+    h4: [],
+    li: [],
+    ol: [],
+    p: [],
+    pre: [],
+    strong: [],
+    table: [],
+    tbody: [],
+    td: [],
+    th: [],
+    thead: [],
+    tr: [],
+    ul: []
+  },
+  stripIgnoreTag: true,
+  stripIgnoreTagBody: ['script', 'style']
+})
+
+export function renderVikingBotMarkdown(content: string) {
+  return sanitizer.process(markdown.render(content))
+}

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "openviking-docs",
       "version": "0.0.0",
       "devDependencies": {
+        "markdown-it": "^14.1.0",
         "vitepress": "1.6.4"
       }
     },
@@ -877,9 +878,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,9 +892,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -911,9 +906,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,9 +920,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,9 +934,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -962,9 +948,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -979,9 +962,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,9 +976,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1013,9 +990,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1030,9 +1004,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1018,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,9 +1032,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1081,9 +1046,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1625,6 +1587,13 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -1886,6 +1855,26 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1902,6 +1891,37 @@
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
@@ -1924,6 +1944,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
@@ -2129,6 +2156,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -2309,6 +2346,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,8 +8,9 @@
       "name": "openviking-docs",
       "version": "0.0.0",
       "devDependencies": {
-        "markdown-it": "^14.1.0",
-        "vitepress": "1.6.4"
+        "markdown-it": "^14.3.0",
+        "vitepress": "1.6.4",
+        "xss": "^1.0.15"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1648,6 +1649,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
@@ -1663,6 +1671,13 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1893,15 +1908,25 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -2579,6 +2604,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/zwitch": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "test:search": "node --experimental-strip-types --test .vitepress/theme/openviking-search-*.test.ts"
   },
   "devDependencies": {
+    "markdown-it": "^14.1.0",
     "vitepress": "1.6.4"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,8 @@
     "test:search": "node --experimental-strip-types --test .vitepress/theme/openviking-search-*.test.ts"
   },
   "devDependencies": {
-    "markdown-it": "^14.1.0",
-    "vitepress": "1.6.4"
+    "markdown-it": "^14.3.0",
+    "vitepress": "1.6.4",
+    "xss": "^1.0.15"
   }
 }


### PR DESCRIPTION
## Description

Add a VikingBot assistant to the documentation site so readers can ask OpenViking questions without leaving the current page. The assistant opens as a resizable right-side panel and renders API responses as Markdown.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add a localized VikingBot navigation entry and a full-height, resizable right-side assistant panel with responsive document layout.
- Integrate the VikingBot chat API with stable client IDs, timeout/error handling, Markdown rendering, loading feedback, and answer copying.
- Align the panel with the OpenViking docs theme in light and dark modes, and add unit coverage for query normalization and stable user IDs.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Verified locally against the Chinese documentation in both light and dark modes, with the assistant open and closed.

<img width="1280" height="720" alt="clipboard" src="https://github.com/user-attachments/assets/349b5062-3a1c-4309-85e4-babec109d7ca" />

## Additional Notes

Validation completed with:

- `npm run test:theme`
- `npm run check:api`
- `npm run docs:build`

The existing syntax-highlighting fallback notices for `promql` and `caddyfile` remain unchanged.
