### PR TITLE
fix(studio): sort limited listings by mtime

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -364,6 +364,8 @@ List directory contents.
 | abs_limit | int | No | 256 | Abstract length limit for `agent` output |
 | show_all_hidden | bool | No | False | Include hidden files like `-a` |
 | node_limit | int | No | 1000 | Maximum number of results |
+| sort_by | str | No | None | Sort directories and files within their groups by `name` or `mtime` before applying `node_limit`; directories remain first |
+| sort_order | str | No | `asc` | Sort direction: `asc` or `desc` |
 
 **Entry Structure**
 
@@ -383,7 +385,12 @@ List directory contents.
 **Python SDK (Embedded / HTTP)**
 
 ```python
-entries = client.ls("viking://resources/")
+entries = client.ls(
+    "viking://resources/",
+    node_limit=200,
+    sort_by="mtime",
+    sort_order="desc",
+)
 for entry in entries:
     type_str = "dir" if entry['isDir'] else "file"
     print(f"{entry['name']} - {type_str}")

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -365,6 +365,8 @@ openviking write viking://resources/docs/api.md \
 | show_all_hidden | bool | 否 | False | 像 `-a` 一样包含隐藏文件 |
 | node_limit | int | 否 | 1000 | 最大返回节点数 |
 | limit | int | 否 | None | `node_limit` 的别名 |
+| sort_by | str | 否 | None | 在应用 `node_limit` 前，分别按 `name` 或 `mtime` 排序目录组和文件组；目录仍优先 |
+| sort_order | str | 否 | `asc` | 排序方向：`asc` 或 `desc` |
 
 **条目结构**
 
@@ -384,7 +386,12 @@ openviking write viking://resources/docs/api.md \
 **Python SDK (Embedded / HTTP)**
 
 ```python
-entries = client.ls("viking://resources/")
+entries = client.ls(
+    "viking://resources/",
+    node_limit=200,
+    sort_by="mtime",
+    sort_order="desc",
+)
 for entry in entries:
     type_str = "dir" if entry['isDir'] else "file"
     print(f"{entry['name']} - {type_str}")

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -668,6 +668,9 @@ class AsyncOpenViking:
             uri: Viking URI
             simple: Return only relative path list (bool, default: False)
             recursive: List all subdirectories recursively (bool, default: False)
+            node_limit: Maximum number of entries to return (int, default: 1000)
+            sort_by: Optional sort field, "name" or "mtime"
+            sort_order: Sort direction, "asc" or "desc"
         """
         await self._ensure_initialized()
         recursive = kwargs.get("recursive", False)
@@ -675,6 +678,9 @@ class AsyncOpenViking:
         output = kwargs.get("output", "original")
         abs_limit = kwargs.get("abs_limit", 256)
         show_all_hidden = kwargs.get("show_all_hidden", True)
+        node_limit = kwargs.get("node_limit", 1000)
+        sort_by = kwargs.get("sort_by")
+        sort_order = kwargs.get("sort_order", "asc")
         return await self._client.ls(
             uri,
             recursive=recursive,
@@ -682,6 +688,9 @@ class AsyncOpenViking:
             output=output,
             abs_limit=abs_limit,
             show_all_hidden=show_all_hidden,
+            node_limit=node_limit,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
 
     async def rm(

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -536,6 +536,9 @@ class LocalClient(BaseClient):
         output: str = "original",
         abs_limit: int = 256,
         show_all_hidden: bool = False,
+        node_limit: int = 1000,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
     ) -> List[Any]:
         """List directory contents."""
         return await self._service.fs.ls(
@@ -546,6 +549,9 @@ class LocalClient(BaseClient):
             output=output,
             abs_limit=abs_limit,
             show_all_hidden=show_all_hidden,
+            node_limit=node_limit,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
 
     async def tree(

--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Filesystem endpoints for OpenViking HTTP Server."""
 
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, Query
 from pydantic import BaseModel
@@ -15,7 +15,8 @@ from openviking.server.dependencies import get_service
 from openviking.server.error_mapping import map_exception
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
-from openviking.server.routers.content import SetTagsRequest, set_tags as content_set_tags
+from openviking.server.routers.content import SetTagsRequest
+from openviking.server.routers.content import set_tags as content_set_tags
 from openviking.storage import VikingDBManagerProxy
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
 
@@ -64,6 +65,11 @@ async def ls(
     show_all_hidden: bool = Query(False, description="List all hidden files, like -a"),
     node_limit: int = Query(1000, description="Maximum number of nodes to list"),
     limit: Optional[int] = Query(None, description="Alias for node_limit"),
+    sort_by: Optional[Literal["name", "mtime"]] = Query(
+        None,
+        description="Sort directory and file groups before applying node_limit",
+    ),
+    sort_order: Literal["asc", "desc"] = Query("asc", description="Sort direction"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """List directory contents."""
@@ -81,6 +87,8 @@ async def ls(
             abs_limit=abs_limit,
             show_all_hidden=show_all_hidden,
             node_limit=actual_node_limit,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -92,6 +92,8 @@ class FSService:
         show_all_hidden: bool = False,
         node_limit: int = 1000,
         level_limit: int = 3,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
     ) -> List[Any]:
         """List directory contents.
 
@@ -103,6 +105,8 @@ class FSService:
             abs_limit: int = 256 if output == "agent" else ignore
             show_all_hidden: bool = False (list all hidden files, like -a)
             node_limit: int = 1000 (maximum number of nodes to list)
+            sort_by: Optional sort field for non-recursive listings
+            sort_order: Sort direction, "asc" or "desc"
         """
         viking_fs = self._ensure_initialized()
         uri = validate_viking_uri(uri)
@@ -125,6 +129,8 @@ class FSService:
                     output="original",
                     show_all_hidden=show_all_hidden,
                     node_limit=node_limit,
+                    sort_by=sort_by,
+                    sort_order=sort_order,
                 )
             return [e.get("uri", "") for e in entries]
 
@@ -146,6 +152,8 @@ class FSService:
                 abs_limit=abs_limit,
                 show_all_hidden=show_all_hidden,
                 node_limit=node_limit,
+                sort_by=sort_by,
+                sort_order=sort_order,
             )
         return entries
 

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -194,7 +194,12 @@ class SessionService:
         sessions_by_id: Dict[str, Dict[str, Any]] = {}
 
         try:
-            entries = await self._viking_fs.ls(session_base_uri, ctx=ctx)
+            entries = await self._viking_fs.ls(
+                session_base_uri,
+                sort_by="mtime",
+                sort_order="desc",
+                ctx=ctx,
+            )
             for entry in entries:
                 name = entry.get("name", "")
                 if name in [".", ".."]:
@@ -209,7 +214,12 @@ class SessionService:
             logger.debug("Failed to list sessions", exc_info=True)
 
         try:
-            entries = await self._viking_fs.ls("viking://session", ctx=ctx)
+            entries = await self._viking_fs.ls(
+                "viking://session",
+                sort_by="mtime",
+                sort_order="desc",
+                ctx=ctx,
+            )
             for entry in entries:
                 name = entry.get("name", "")
                 if name in [".", ".."] or name in sessions_by_id:

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -3312,6 +3312,8 @@ class VikingFS:
         abs_limit: int = 256,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
         ctx: Optional[RequestContext] = None,
     ) -> List[Dict[str, Any]]:
         """
@@ -3323,6 +3325,8 @@ class VikingFS:
             abs_limit: int = 256
             show_all_hidden: bool = False (list all hidden files, like -a)
             node_limit: int = 1000 (maximum number of nodes to list)
+            sort_by: Optional sort field, "name" or "mtime"
+            sort_order: Sort direction, "asc" or "desc"
 
         output="original"
         [{'name': '.abstract.md', 'size': 100, 'mode': 420, 'modTime': '2026-02-11T16:52:16.256334192+08:00', 'isDir': False, 'meta': {'Name': 'localfs', 'Type': 'local', 'Content': None}, 'uri': 'viking://resources/.abstract.md'}]
@@ -3331,12 +3335,90 @@ class VikingFS:
         [{'name': '.abstract.md', 'size': 100, 'modTime': '2026-02-11T08:52:16.256Z', 'isDir': False, 'uri': 'viking://resources/.abstract.md', 'abstract': "..."}]
         """
         self._ensure_access(uri, ctx)
+        if sort_by not in {None, "name", "mtime"}:
+            raise ValueError("sort_by must be 'name' or 'mtime'")
+        if sort_order not in {"asc", "desc"}:
+            raise ValueError("sort_order must be 'asc' or 'desc'")
         if output == "original":
-            return await self._ls_original(uri, show_all_hidden, node_limit, ctx=ctx)
+            return await self._ls_original(
+                uri,
+                show_all_hidden,
+                node_limit,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                ctx=ctx,
+            )
         elif output == "agent":
-            return await self._ls_agent(uri, abs_limit, show_all_hidden, node_limit, ctx=ctx)
+            return await self._ls_agent(
+                uri,
+                abs_limit,
+                show_all_hidden,
+                node_limit,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                ctx=ctx,
+            )
         else:
             raise ValueError(f"Invalid output format: {output}")
+
+    @staticmethod
+    def _ls_entry_mtime(entry: Dict[str, Any]) -> Optional[float]:
+        raw_time = entry.get("modTime")
+        if isinstance(raw_time, (int, float)):
+            return float(raw_time)
+        if isinstance(raw_time, str) and raw_time:
+            try:
+                return parse_iso_datetime(raw_time).timestamp()
+            except (TypeError, ValueError, OverflowError):
+                return None
+
+        legacy_time = entry.get("mtime")
+        if isinstance(legacy_time, (int, float)):
+            return float(legacy_time)
+        return None
+
+    @classmethod
+    def _sort_ls_entry_items(
+        cls,
+        entry_items: List[tuple[Dict[str, Any], str]],
+        sort_by: Optional[str],
+        sort_order: str,
+    ) -> List[tuple[Dict[str, Any], str]]:
+        if sort_by is None:
+            return entry_items
+
+        descending = sort_order == "desc"
+        directories = [item for item in entry_items if item[0].get("isDir", False)]
+        files = [item for item in entry_items if not item[0].get("isDir", False)]
+
+        if sort_by == "name":
+
+            def name_key(item: tuple[Dict[str, Any], str]) -> tuple[str, str]:
+                name = str(item[0].get("name", ""))
+                return name.lower(), name
+
+            directories.sort(key=name_key, reverse=descending)
+            files.sort(key=name_key, reverse=descending)
+            return directories + files
+
+        def sort_by_mtime(
+            items: List[tuple[Dict[str, Any], str]],
+        ) -> List[tuple[Dict[str, Any], str]]:
+            timestamped = []
+            missing = []
+            for item in items:
+                timestamp = cls._ls_entry_mtime(item[0])
+                if timestamp is None:
+                    missing.append(item)
+                else:
+                    timestamped.append((timestamp, item))
+            timestamped.sort(
+                key=lambda pair: pair[0],
+                reverse=descending,
+            )
+            return [item for _, item in timestamped] + missing
+
+        return sort_by_mtime(directories) + sort_by_mtime(files)
 
     async def _ls_agent(
         self,
@@ -3344,11 +3426,14 @@ class VikingFS:
         abs_limit: int,
         show_all_hidden: bool,
         node_limit: int = 1000,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
         ctx: Optional[RequestContext] = None,
     ) -> List[Dict[str, Any]]:
         """List directory contents (URI version)."""
         real_ctx = self._ctx_or_default(ctx)
         entry_items = await self._list_read_path_items(uri, ctx=ctx)
+        entry_items = self._sort_ls_entry_items(entry_items, sort_by, sort_order)
         # basic info
         fallback_time = datetime.now(timezone.utc)
         all_entries = []
@@ -3390,12 +3475,15 @@ class VikingFS:
         uri: str,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
         ctx: Optional[RequestContext] = None,
     ) -> List[Dict[str, Any]]:
         """List directory contents (URI version)."""
         real_ctx = self._ctx_or_default(ctx)
         try:
             entry_items = await self._list_read_path_items(uri, ctx=ctx)
+            entry_items = self._sort_ls_entry_items(entry_items, sort_by, sort_order)
             # AGFS returns read-only structure, need to create new dict
             all_entries = []
             for entry, entry_uri in entry_items:

--- a/openviking_cli/client/base.py
+++ b/openviking_cli/client/base.py
@@ -158,6 +158,8 @@ class BaseClient(ABC):
         abs_limit: int = 256,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
     ) -> List[Any]:
         """List directory contents."""
         ...

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -166,6 +166,34 @@ func TestFindOmitsSearchFiltersWhenUnset(t *testing.T) {
 	}
 }
 
+func TestListSendsOrderingOptions(t *testing.T) {
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/fs/ls" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("node_limit"); got != "200" {
+			t.Fatalf("node_limit = %q", got)
+		}
+		if got := r.URL.Query().Get("sort_by"); got != "mtime" {
+			t.Fatalf("sort_by = %q", got)
+		}
+		if got := r.URL.Query().Get("sort_order"); got != "desc" {
+			t.Fatalf("sort_order = %q", got)
+		}
+		writeOK(t, w, []any{})
+	}))
+	defer closeServer()
+
+	_, err := client.List(context.Background(), "viking://session", &ListOptions{
+		NodeLimit: 200,
+		SortBy:    "mtime",
+		SortOrder: "desc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFindSendsImageQuery(t *testing.T) {
 	imagePath := filepath.Join(t.TempDir(), "query.png")
 	if err := os.WriteFile(imagePath, []byte("\x89PNG\r\n\x1a\n"), 0o600); err != nil {

--- a/sdk/go/filesystem.go
+++ b/sdk/go/filesystem.go
@@ -31,6 +31,12 @@ func (c *Client) List(ctx context.Context, uri string, opts *ListOptions) ([]any
 	queryInt(query, "abs_limit", absLimit)
 	queryBool(query, "show_all_hidden", opts.ShowAllHidden)
 	queryInt(query, "node_limit", nodeLimit)
+	if opts.SortBy != "" {
+		query.Set("sort_by", opts.SortBy)
+	}
+	if opts.SortOrder != "" {
+		query.Set("sort_order", opts.SortOrder)
+	}
 	var result []any
 	err := c.doJSON(ctx, http.MethodGet, "/api/v1/fs/ls", query, nil, &result)
 	return result, err

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -148,6 +148,8 @@ type ListOptions struct {
 	AbsLimit      int
 	ShowAllHidden bool
 	NodeLimit     int
+	SortBy        string
+	SortOrder     string
 }
 
 // TreeOptions controls Tree.

--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -882,19 +882,25 @@ class AsyncHTTPClient:
         abs_limit: int = 256,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
     ) -> List[Any]:
+        params: Dict[str, Any] = {
+            "uri": VikingURI.normalize(uri),
+            "simple": simple,
+            "recursive": recursive,
+            "output": output,
+            "abs_limit": abs_limit,
+            "show_all_hidden": show_all_hidden,
+            "node_limit": node_limit,
+        }
+        if sort_by is not None:
+            params["sort_by"] = sort_by
+            params["sort_order"] = sort_order
         response = await self._request(
             "GET",
             "/api/v1/fs/ls",
-            params={
-                "uri": VikingURI.normalize(uri),
-                "simple": simple,
-                "recursive": recursive,
-                "output": output,
-                "abs_limit": abs_limit,
-                "show_all_hidden": show_all_hidden,
-                "node_limit": node_limit,
-            },
+            params=params,
         )
         return self._handle_response(response)
 
@@ -1859,6 +1865,8 @@ class SyncHTTPClient:
         abs_limit: int = 256,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        sort_by: Optional[str] = None,
+        sort_order: str = "asc",
     ) -> List[Any]:
         return run_async(
             self._async_client.ls(
@@ -1869,6 +1877,8 @@ class SyncHTTPClient:
                 abs_limit=abs_limit,
                 show_all_hidden=show_all_hidden,
                 node_limit=node_limit,
+                sort_by=sort_by,
+                sort_order=sort_order,
             )
         )
 

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -557,6 +557,8 @@ async def test_ls_passes_full_query_params():
         abs_limit=32,
         show_all_hidden=True,
         node_limit=44,
+        sort_by="mtime",
+        sort_order="desc",
     )
 
     fake_http.get.assert_awaited_once_with(
@@ -569,6 +571,8 @@ async def test_ls_passes_full_query_params():
             "abs_limit": 32,
             "show_all_hidden": True,
             "node_limit": 44,
+            "sort_by": "mtime",
+            "sort_order": "desc",
         },
     )
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -422,6 +422,8 @@ export class OpenVikingClient {
         abs_limit: options.absLimit ?? 256,
         show_all_hidden: options.showAllHidden ?? false,
         node_limit: options.nodeLimit ?? 1000,
+        sort_by: options.sortBy,
+        sort_order: options.sortOrder,
       },
     });
   }

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -117,6 +117,8 @@ export interface ListOptions {
   absLimit?: number;
   showAllHidden?: boolean;
   nodeLimit?: number;
+  sortBy?: "name" | "mtime";
+  sortOrder?: "asc" | "desc";
 }
 /** Directory tree options. */
 export interface TreeOptions {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -99,6 +99,25 @@ describe("OpenVikingClient", () => {
     );
   });
 
+  it("passes directory list ordering to the server", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(ok([]));
+    const client = new OpenVikingClient({
+      baseUrl: "https://example.com",
+      fetch: fetcher,
+    });
+
+    await client.list("viking://session", {
+      nodeLimit: 200,
+      sortBy: "mtime",
+      sortOrder: "desc",
+    });
+
+    const url = new URL(String(fetcher.mock.calls[0]![0]));
+    expect(url.searchParams.get("node_limit")).toBe("200");
+    expect(url.searchParams.get("sort_by")).toBe("mtime");
+    expect(url.searchParams.get("sort_order")).toBe("desc");
+  });
+
   it("converts an existing Node.js image path to a data URI", async () => {
     const directory = await mkdtemp(join(tmpdir(), "openviking-sdk-image-"));
     const path = join(directory, "photo.png");

--- a/tests/client/test_ls_forwarding.py
+++ b/tests/client/test_ls_forwarding.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Filesystem option forwarding at the public embedded-client boundary."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from openviking.async_client import AsyncOpenViking
+
+
+async def test_async_openviking_ls_forwards_ordering_and_limit_options():
+    client = object.__new__(AsyncOpenViking)
+    client._ensure_initialized = AsyncMock()
+    client._client = SimpleNamespace(ls=AsyncMock(return_value=[]))
+
+    await client.ls(
+        "viking://session",
+        node_limit=200,
+        sort_by="mtime",
+        sort_order="desc",
+    )
+
+    client._client.ls.assert_awaited_once_with(
+        "viking://session",
+        recursive=False,
+        simple=False,
+        output="original",
+        abs_limit=256,
+        show_all_hidden=True,
+        node_limit=200,
+        sort_by="mtime",
+        sort_order="desc",
+    )

--- a/tests/server/test_api_fs_ls_sort.py
+++ b/tests/server/test_api_fs_ls_sort.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""End-to-end coverage for ordered, limited filesystem listings."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.core.namespace import canonical_session_uri
+from openviking.server.identity import RequestContext, Role
+from openviking.service.fs_service import FSService
+from openviking.service.session_service import SessionService
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.session.user_id import UserIdentifier
+from tests.utils.mock_agfs import MockLocalAGFS
+
+
+@pytest.fixture
+def service(temp_dir):
+    mock_agfs = MockLocalAGFS(root_path=temp_dir / "mock_agfs_root")
+    viking_fs = VikingFS(agfs=mock_agfs)
+    return SimpleNamespace(
+        fs=FSService(viking_fs=viking_fs),
+        sessions=SessionService(viking_fs=viking_fs),
+        viking_fs=viking_fs,
+    )
+
+
+async def test_ls_sorts_by_mtime_before_applying_node_limit(client, service):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    root_uri = "viking://resources/mtime-before-limit"
+    await service.viking_fs.mkdir(root_uri, exist_ok=True, ctx=ctx)
+
+    for index in range(200):
+        await service.viking_fs.mkdir(f"{root_uri}/a-{index:03d}", ctx=ctx)
+
+    newest_uri = f"{root_uri}/zz-newest"
+    await service.viking_fs.mkdir(newest_uri, ctx=ctx)
+    await service.viking_fs.mkdir(f"{newest_uri}/activity", ctx=ctx)
+    await service.viking_fs.write_file(f"{root_uri}/newer-file.md", "newer", ctx=ctx)
+
+    response = await client.get(
+        "/api/v1/fs/ls",
+        params={
+            "uri": root_uri,
+            "output": "original",
+            "node_limit": 200,
+            "sort_by": "mtime",
+            "sort_order": "desc",
+        },
+    )
+
+    assert response.status_code == 200
+    entries = response.json()["result"]
+    assert len(entries) == 200
+    assert entries[0]["name"] == "zz-newest"
+
+
+async def test_session_list_keeps_newest_directory_past_storage_limit(client, service):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    root_uri = canonical_session_uri(ctx)
+    await service.viking_fs.mkdir(root_uri, exist_ok=True, ctx=ctx)
+
+    for index in range(1000):
+        await service.viking_fs.mkdir(f"{root_uri}/a-{index:04d}", ctx=ctx)
+
+    newest_uri = f"{root_uri}/zz-newest"
+    await service.viking_fs.mkdir(newest_uri, ctx=ctx)
+    await service.viking_fs.mkdir(f"{newest_uri}/activity", ctx=ctx)
+
+    response = await client.get("/api/v1/sessions")
+
+    assert response.status_code == 200
+    sessions = response.json()["result"]
+    assert len(sessions) == 1000
+    assert sessions[0]["session_id"] == "zz-newest"

--- a/tests/service/test_session_service_metrics.py
+++ b/tests/service/test_session_service_metrics.py
@@ -90,16 +90,27 @@ async def test_sessions_merges_canonical_and_legacy_session_scope():
     service = SessionService(viking_fs=Mock())
     ctx = _make_ctx()
 
-    async def _ls(uri, ctx):
+    async def _ls(uri, ctx, **kwargs):
+        assert kwargs == {"sort_by": "mtime", "sort_order": "desc"}
         if uri == "viking://user/alice/sessions":
             return [
-                {"name": "duplicate", "isDir": True},
-                {"name": "new-session", "isDir": True},
+                {"name": "duplicate", "isDir": True, "modTime": "2026-07-13T01:00:00Z"},
+                {"name": "new-session", "isDir": True, "modTime": "2026-07-13T02:00:00Z"},
             ]
         if uri == "viking://session":
             return [
-                {"name": "duplicate", "uri": "viking://session/duplicate", "isDir": True},
-                {"name": "legacy-session", "uri": "viking://session/legacy-session", "isDir": True},
+                {
+                    "name": "duplicate",
+                    "uri": "viking://session/duplicate",
+                    "isDir": True,
+                    "modTime": "2026-07-13T01:00:00Z",
+                },
+                {
+                    "name": "legacy-session",
+                    "uri": "viking://session/legacy-session",
+                    "isDir": True,
+                    "modTime": "2026-07-12T01:00:00Z",
+                },
             ]
         raise AssertionError(uri)
 
@@ -112,15 +123,18 @@ async def test_sessions_merges_canonical_and_legacy_session_scope():
             "session_id": "duplicate",
             "uri": "viking://user/alice/sessions/duplicate",
             "is_dir": True,
+            "mod_time": "2026-07-13T01:00:00Z",
         },
         {
             "session_id": "new-session",
             "uri": "viking://user/alice/sessions/new-session",
             "is_dir": True,
+            "mod_time": "2026-07-13T02:00:00Z",
         },
         {
             "session_id": "legacy-session",
             "uri": "viking://session/legacy-session",
             "is_dir": True,
+            "mod_time": "2026-07-12T01:00:00Z",
         },
     ]

--- a/web-studio/src/gen/ov-client/types.gen.ts
+++ b/web-studio/src/gen/ov-client/types.gen.ts
@@ -1537,6 +1537,18 @@ export type GetFsLsData = {
          * Alias for node_limit
          */
         limit?: number | null;
+        /**
+         * Sort By
+         *
+         * Sort directory and file groups before applying node_limit
+         */
+        sort_by?: 'name' | 'mtime' | null;
+        /**
+         * Sort Order
+         *
+         * Sort direction
+         */
+        sort_order?: 'asc' | 'desc';
     };
     url: '/api/v1/fs/ls';
 };

--- a/web-studio/src/lib/sessions/use-sessions.ts
+++ b/web-studio/src/lib/sessions/use-sessions.ts
@@ -34,10 +34,9 @@ export function useSessionList() {
 /**
  * Session list ordered by recency (newest first).
  *
- * The list API returns sessions in name order. Each entry carries a
- * `mod_time` (filesystem mtime of the session directory) from the backend,
- * so we sort by that descending — no per-session detail requests needed.
- * Sessions without a timestamp sort to the bottom.
+ * The list API requests recent sessions before applying its storage limit.
+ * We keep a client-side sort for deterministic display and put sessions
+ * without a timestamp at the bottom.
  */
 export function useSessionListByRecency() {
   const { data: sessions, isLoading } = useSessionList()

--- a/web-studio/src/routes/resources/-lib/api.test.ts
+++ b/web-studio/src/routes/resources/-lib/api.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchFsList } from './api'
+
+const { getFsLsMock } = vi.hoisted(() => ({
+  getFsLsMock: vi.fn(),
+}))
+
+vi.mock('#/lib/ov-client', async (importOriginal) => {
+  const original = await importOriginal()
+  return {
+    ...original,
+    getFsLs: getFsLsMock,
+  }
+})
+
+describe('fetchFsList', () => {
+  beforeEach(() => {
+    getFsLsMock.mockReset()
+    getFsLsMock.mockResolvedValue({
+      data: { status: 'ok', result: [] },
+      headers: {},
+      status: 200,
+    })
+  })
+
+  it('requests newest entries before the server applies node_limit', async () => {
+    await fetchFsList('viking://session', { nodeLimit: 200 })
+
+    expect(getFsLsMock).toHaveBeenCalledWith({
+      query: expect.objectContaining({
+        node_limit: 200,
+        sort_by: 'mtime',
+        sort_order: 'desc',
+      }),
+    })
+  })
+})

--- a/web-studio/src/routes/resources/-lib/api.ts
+++ b/web-studio/src/routes/resources/-lib/api.ts
@@ -66,6 +66,8 @@ export async function fetchFsList(
           abs_limit: options.absLimit,
           recursive: options.recursive,
           simple: options.simple,
+          sort_by: options.sortBy ?? 'mtime',
+          sort_order: options.sortOrder ?? 'desc',
         },
       }),
     )

--- a/web-studio/src/routes/resources/-types/viking-fm.ts
+++ b/web-studio/src/routes/resources/-types/viking-fm.ts
@@ -27,6 +27,8 @@ export interface VikingListQueryOptions {
   absLimit?: number
   recursive?: boolean
   simple?: boolean
+  sortBy?: 'name' | 'mtime'
+  sortOrder?: 'asc' | 'desc'
 }
 
 export interface VikingTreeQueryOptions {


### PR DESCRIPTION
## 根因与修复

- Studio 的目录列表会设置 `node_limit`（Context Tree 常见为 200）；sessions 列表则受 VikingFS 默认 1000 条限制。
- 修复前，`_list_read_path_items` 先取回目录的完整直系子项，但 `_ls_original/_ls_agent` 会按存储层既有顺序（通常是目录优先、名称序）遍历，并在达到 `node_limit` 时停止。Studio 随后只能对已经截断的残缺结果按 mtime 排序，因此名称靠后的最新目录，特别是 sessions 目录，可能完全不在返回集合中。
- 本 PR 为非递归 `/api/v1/fs/ls` 增加可选的 `sort_by=name|mtime` 与 `sort_order=asc|desc`。VikingFS 在完整结果上保持目录优先，并在目录组、文件组内完成排序后再应用 `node_limit`；未传排序参数时保留原行为。
- Studio 的目录读取默认请求 `mtime desc`；SessionService 的 canonical/legacy session 列表也显式请求 `mtime desc`，确保限制范围内优先保留最新目录。

## 顺带提供的周边能力

- 同步更新 OpenAPI 生成类型、中英文 API 文档，以及 embedded、Python、Go、TypeScript 客户端的排序参数透传。
- 补齐高层 `AsyncOpenViking/SyncOpenViking` 到 LocalClient 的 `node_limit/sort_by/sort_order` 透传，避免 embedded 调用静默丢参数。
- Rust CLI 当前支持 `ov ls -l/--abs-limit` 和 `-n/--node-limit`，但没有 `sort_by/sort_order` 对应参数，Rust HTTP client 也不会发送这两个 query；CLI 支持不在本 PR 范围内。

## 已知现状

- `_list_read_path_items` 及其下层 `AGFS.ls/read_dir` 当前不支持传入 `node_limit`：会读取全部直系子项，完成内部项过滤、兼容路径合并和 URI 去重后，再由 VikingFS 排序并截断。
- 这是当前分层下保证“按 mtime 排序后的 top-N”正确性的前提。超大目录需要完整扫描并占用相应内存属于已知限制；存储层原生 sorted top-N / 分页下推暂不在本 PR 处理。

## 验证

- `uv run --no-sync pytest -q --no-cov tests/client/test_ls_forwarding.py tests/server/test_api_fs_ls_sort.py tests/service/test_fs_service.py tests/service/test_session_service_metrics.py`（18 passed）
- `uv run --no-sync pytest -q --no-cov sdk/python/tests/test_async_client_behaviors.py -k "not test_glob_normalizes_scope_uri"`（33 passed；排除项已在未修改工作树复现为基线失败）
- `web-studio: npm test`（19 passed）；`web-studio: npm run build`（构建成功）；改动文件定向 ESLint 通过
- `sdk/typescript: npm test`（28 passed）；typecheck、build、node-types 通过
- `sdk/go: go test ./...`
- 独立 `review-pr` 首轮发现 embedded 高层透传遗漏，修复后基于 HEAD `fa1bafe9` 复核结果为 CLEAN。
