### PR TITLE
fix(plugins): pin MCP-Protocol-Version header to the negotiated version

### DIFF
--- a/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
+++ b/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Long-term semantic memory for Claude Code, powered by OpenViking. Auto-recall relevant memories at session start and capture important information during conversations.",
   "author": {
     "name": "OpenViking",

--- a/examples/claude-code-memory-plugin/package-lock.json
+++ b/examples/claude-code-memory-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-openviking-memory",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^4.3.6"

--- a/examples/claude-code-memory-plugin/package.json
+++ b/examples/claude-code-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "OpenViking memory plugin for Claude Code — semantic long-term memory",
   "type": "module",
   "scripts": {

--- a/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -201,11 +201,14 @@ export function createOpenVikingMcpProxy({
     return true;
   }
 
-  function headersForRequest(includeSession = true, message = null) {
+  function headersForRequest(includeSession = true) {
     const headers = {
       "Content-Type": "application/json",
       "Accept": "application/json, text/event-stream",
-      "MCP-Protocol-Version": message?.params?.protocolVersion || protocolVersion,
+      // Always the proxy's current version (default, then server-negotiated) —
+      // never the client's un-negotiated ask, which strict upstreams reject
+      // with HTTP 400 before initialize negotiation can run.
+      "MCP-Protocol-Version": protocolVersion,
     };
     if (includeSession && sessionId) headers["Mcp-Session-Id"] = sessionId;
     if (proxyConfig.apiKey) headers.Authorization = `Bearer ${proxyConfig.apiKey}`;
@@ -265,7 +268,7 @@ export function createOpenVikingMcpProxy({
     try {
       const res = await fetchImpl(proxyConfig.mcpUrl, {
         method: "POST",
-        headers: headersForRequest(includeSession, message),
+        headers: headersForRequest(includeSession),
         body: JSON.stringify(message),
         signal: controller.signal,
       });
@@ -273,6 +276,10 @@ export function createOpenVikingMcpProxy({
       const messages = parseHttpBody(res.headers.get("content-type"), text);
       const nextSessionId = res.headers.get("mcp-session-id");
       if (nextSessionId) sessionId = nextSessionId;
+      if (message?.method === "initialize" && res.ok) {
+        const negotiated = messages.find((m) => typeof m?.result?.protocolVersion === "string")?.result.protocolVersion;
+        if (negotiated) protocolVersion = negotiated;
+      }
       if (!res.ok) {
         throw new HttpStatusError(res.status, res.statusText, text, messages);
       }
@@ -366,7 +373,7 @@ export function createOpenVikingMcpProxy({
     const expectsResponse = isRequest(message);
     if (message.method === "initialize") {
       initializeRequest = cloneMessage(message);
-      protocolVersion = message.params?.protocolVersion || protocolVersion || DEFAULT_PROTOCOL_VERSION;
+      protocolVersion = DEFAULT_PROTOCOL_VERSION;
       sessionId = "";
     }
     if (message.method === "notifications/initialized") {

--- a/examples/codex-memory-plugin/.codex-plugin/plugin.json
+++ b/examples/codex-memory-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Long-term semantic memory for Codex, powered by OpenViking. Recall on UserPromptSubmit, incremental add_message on Stop (per turn), commit on PreCompact, and active-window heuristic + idle-TTL sweep on SessionStart (source=startup|clear). Includes a local stdio MCP proxy that reads OpenViking credentials from env/ovcli.conf.",
   "author": {
     "name": "OpenViking",

--- a/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -201,11 +201,14 @@ export function createOpenVikingMcpProxy({
     return true;
   }
 
-  function headersForRequest(includeSession = true, message = null) {
+  function headersForRequest(includeSession = true) {
     const headers = {
       "Content-Type": "application/json",
       "Accept": "application/json, text/event-stream",
-      "MCP-Protocol-Version": message?.params?.protocolVersion || protocolVersion,
+      // Always the proxy's current version (default, then server-negotiated) —
+      // never the client's un-negotiated ask, which strict upstreams reject
+      // with HTTP 400 before initialize negotiation can run.
+      "MCP-Protocol-Version": protocolVersion,
     };
     if (includeSession && sessionId) headers["Mcp-Session-Id"] = sessionId;
     if (proxyConfig.apiKey) headers.Authorization = `Bearer ${proxyConfig.apiKey}`;
@@ -265,7 +268,7 @@ export function createOpenVikingMcpProxy({
     try {
       const res = await fetchImpl(proxyConfig.mcpUrl, {
         method: "POST",
-        headers: headersForRequest(includeSession, message),
+        headers: headersForRequest(includeSession),
         body: JSON.stringify(message),
         signal: controller.signal,
       });
@@ -273,6 +276,10 @@ export function createOpenVikingMcpProxy({
       const messages = parseHttpBody(res.headers.get("content-type"), text);
       const nextSessionId = res.headers.get("mcp-session-id");
       if (nextSessionId) sessionId = nextSessionId;
+      if (message?.method === "initialize" && res.ok) {
+        const negotiated = messages.find((m) => typeof m?.result?.protocolVersion === "string")?.result.protocolVersion;
+        if (negotiated) protocolVersion = negotiated;
+      }
       if (!res.ok) {
         throw new HttpStatusError(res.status, res.statusText, text, messages);
       }
@@ -366,7 +373,7 @@ export function createOpenVikingMcpProxy({
     const expectsResponse = isRequest(message);
     if (message.method === "initialize") {
       initializeRequest = cloneMessage(message);
-      protocolVersion = message.params?.protocolVersion || protocolVersion || DEFAULT_PROTOCOL_VERSION;
+      protocolVersion = DEFAULT_PROTOCOL_VERSION;
       sessionId = "";
     }
     if (message.method === "notifications/initialized") {

--- a/examples/codex-memory-plugin/servers/mcp-proxy.test.mjs
+++ b/examples/codex-memory-plugin/servers/mcp-proxy.test.mjs
@@ -102,6 +102,65 @@ test("captures initialize session id and forwards SSE JSON-RPC response", async 
   });
 });
 
+test("never forwards the client's un-negotiated protocol version header", async () => {
+  await withServer((_req, res, entry) => {
+    // Strict upstreams 400 on unsupported MCP-Protocol-Version before
+    // negotiation runs, so the header must stay on a proxy-known version
+    // even when the client asks for a newer spec (Trae sends 2025-11-25).
+    assert.equal(entry.headers["mcp-protocol-version"], "2025-06-18");
+    res.writeHead(200, {
+      "content-type": "application/json",
+      "mcp-session-id": "sid-np",
+    });
+    if (entry.body.method === "initialize") {
+      res.end(JSON.stringify(jsonRpc(entry.body.id, { protocolVersion: "2025-06-18" })));
+      return;
+    }
+    res.end(JSON.stringify(jsonRpc(entry.body.id, { tools: [] })));
+  }, async ({ url, requests }) => {
+    const { proxy } = makeProxy({ url });
+    await proxy.handleMessage({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-11-25" },
+    });
+    await proxy.handleMessage({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    assert.equal(requests.length, 2);
+    // The initialize body still carries the client's ask end-to-end; only the
+    // transport header is pinned until the server negotiates.
+    assert.equal(requests[0].body.params.protocolVersion, "2025-11-25");
+  });
+});
+
+test("adopts the server-negotiated protocol version for subsequent requests", async () => {
+  await withServer((_req, res, entry) => {
+    if (entry.body.method === "initialize") {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "mcp-session-id": "sid-nv",
+      });
+      res.end(JSON.stringify(jsonRpc(entry.body.id, { protocolVersion: "2025-03-26" })));
+      return;
+    }
+    assert.equal(entry.headers["mcp-protocol-version"], "2025-03-26");
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(jsonRpc(entry.body.id, { tools: [] })));
+  }, async ({ url, requests }) => {
+    const { proxy } = makeProxy({ url });
+    // Client asks 2025-06-18 but the server negotiates down: follow-up
+    // requests must carry the response's version, not the request's.
+    await proxy.handleMessage({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    await proxy.handleMessage({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    assert.equal(requests.length, 2);
+  });
+});
+
 test("forwards notifications and writes no stdout for HTTP 202", async () => {
   await withServer((_req, res, entry) => {
     assert.equal(entry.body.method, "notifications/initialized");

--- a/examples/cursor-memory-plugin/.cursor-plugin/plugin.json
+++ b/examples/cursor-memory-plugin/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openviking-memory",
   "displayName": "OpenViking Memory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Automatic long-term memory recall and conversation capture for Cursor",
   "author": {
     "name": "OpenViking"

--- a/examples/cursor-memory-plugin/openviking.integration.json
+++ b/examples/cursor-memory-plugin/openviking.integration.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "openviking-memory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "clients": ["cursor"],
   "capabilities": ["hooks", "mcp", "rules", "skills"]
 }

--- a/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
+++ b/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
@@ -200,11 +200,14 @@ export function createOpenVikingMcpProxy({
     return true;
   }
 
-  function headersForRequest(includeSession = true, message = null) {
+  function headersForRequest(includeSession = true) {
     const headers = {
       "Content-Type": "application/json",
       "Accept": "application/json, text/event-stream",
-      "MCP-Protocol-Version": message?.params?.protocolVersion || protocolVersion,
+      // Always the proxy's current version (default, then server-negotiated) —
+      // never the client's un-negotiated ask, which strict upstreams reject
+      // with HTTP 400 before initialize negotiation can run.
+      "MCP-Protocol-Version": protocolVersion,
     };
     if (includeSession && sessionId) headers["Mcp-Session-Id"] = sessionId;
     if (proxyConfig.apiKey) headers.Authorization = `Bearer ${proxyConfig.apiKey}`;
@@ -264,7 +267,7 @@ export function createOpenVikingMcpProxy({
     try {
       const res = await fetchImpl(proxyConfig.mcpUrl, {
         method: "POST",
-        headers: headersForRequest(includeSession, message),
+        headers: headersForRequest(includeSession),
         body: JSON.stringify(message),
         signal: controller.signal,
       });
@@ -272,6 +275,10 @@ export function createOpenVikingMcpProxy({
       const messages = parseHttpBody(res.headers.get("content-type"), text);
       const nextSessionId = res.headers.get("mcp-session-id");
       if (nextSessionId) sessionId = nextSessionId;
+      if (message?.method === "initialize" && res.ok) {
+        const negotiated = messages.find((m) => typeof m?.result?.protocolVersion === "string")?.result.protocolVersion;
+        if (negotiated) protocolVersion = negotiated;
+      }
       if (!res.ok) {
         throw new HttpStatusError(res.status, res.statusText, text, messages);
       }
@@ -365,7 +372,7 @@ export function createOpenVikingMcpProxy({
     const expectsResponse = isRequest(message);
     if (message.method === "initialize") {
       initializeRequest = cloneMessage(message);
-      protocolVersion = message.params?.protocolVersion || protocolVersion || DEFAULT_PROTOCOL_VERSION;
+      protocolVersion = DEFAULT_PROTOCOL_VERSION;
       sessionId = "";
     }
     if (message.method === "notifications/initialized") {

--- a/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
+++ b/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
@@ -201,11 +201,14 @@ export function createOpenVikingMcpProxy({
     return true;
   }
 
-  function headersForRequest(includeSession = true, message = null) {
+  function headersForRequest(includeSession = true) {
     const headers = {
       "Content-Type": "application/json",
       "Accept": "application/json, text/event-stream",
-      "MCP-Protocol-Version": message?.params?.protocolVersion || protocolVersion,
+      // Always the proxy's current version (default, then server-negotiated) —
+      // never the client's un-negotiated ask, which strict upstreams reject
+      // with HTTP 400 before initialize negotiation can run.
+      "MCP-Protocol-Version": protocolVersion,
     };
     if (includeSession && sessionId) headers["Mcp-Session-Id"] = sessionId;
     if (proxyConfig.apiKey) headers.Authorization = `Bearer ${proxyConfig.apiKey}`;
@@ -265,7 +268,7 @@ export function createOpenVikingMcpProxy({
     try {
       const res = await fetchImpl(proxyConfig.mcpUrl, {
         method: "POST",
-        headers: headersForRequest(includeSession, message),
+        headers: headersForRequest(includeSession),
         body: JSON.stringify(message),
         signal: controller.signal,
       });
@@ -273,6 +276,10 @@ export function createOpenVikingMcpProxy({
       const messages = parseHttpBody(res.headers.get("content-type"), text);
       const nextSessionId = res.headers.get("mcp-session-id");
       if (nextSessionId) sessionId = nextSessionId;
+      if (message?.method === "initialize" && res.ok) {
+        const negotiated = messages.find((m) => typeof m?.result?.protocolVersion === "string")?.result.protocolVersion;
+        if (negotiated) protocolVersion = negotiated;
+      }
       if (!res.ok) {
         throw new HttpStatusError(res.status, res.statusText, text, messages);
       }
@@ -366,7 +373,7 @@ export function createOpenVikingMcpProxy({
     const expectsResponse = isRequest(message);
     if (message.method === "initialize") {
       initializeRequest = cloneMessage(message);
-      protocolVersion = message.params?.protocolVersion || protocolVersion || DEFAULT_PROTOCOL_VERSION;
+      protocolVersion = DEFAULT_PROTOCOL_VERSION;
       sessionId = "";
     }
     if (message.method === "notifications/initialized") {

--- a/examples/opencode-plugin/package.json
+++ b/examples/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openviking/opencode-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "@openviking",
   "description": "Unified OpenCode plugin for OpenViking repository retrieval and long-term memory",
   "type": "module",

--- a/examples/trae-memory-hooks/openviking.integration.json
+++ b/examples/trae-memory-hooks/openviking.integration.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "openviking-memory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "clients": ["trae", "trae-cn"],
   "capabilities": ["hooks", "mcp"]
 }


### PR DESCRIPTION
## Problem

The shared stdio→streamable-HTTP proxy (`memory-plugin-shared/lib/mcp-proxy-core.mjs`, used by the Claude Code / Codex / Cursor / OpenCode / TRAE integrations) sets the `MCP-Protocol-Version` header from the client's **requested** `protocolVersion`:

- on `initialize`, the header carries the client's un-negotiated ask;
- afterwards, the proxy caches that requested version and never reads the version the server actually negotiated in the `initialize` **response**.

Per the MCP spec, the header on post-initialize requests must be the **negotiated** version. Some strict upstream implementations validate the header on every request — including `initialize` — and reject unsupported values with `HTTP 400 Bad Request: Unsupported protocol version` before body negotiation can run. Net effect: a client on a newer spec revision than such an upstream supports (e.g. clients already sending `protocolVersion: 2025-11-25`) fails MCP registration outright, and every future spec bump can reproduce this against upstreams that haven't caught up yet.

## Fix

- `initialize` goes out with the proxy default header (2025-06-18); the forwarded **body** still carries the client's original ask, so end-to-end version negotiation is preserved.
- The proxy adopts `result.protocolVersion` from the initialize response (also on session re-init) and uses it for all subsequent request headers.

## Also

Patch version bump for every integration that ships the proxy: claude-code 0.4.2, codex 0.7.2, cursor 0.1.1, trae 0.1.1, opencode 0.2.2.

## Tests

Two regression cases in `codex-memory-plugin/servers/mcp-proxy.test.mjs` (both fail against the previous proxy code):
- client asks 2025-11-25 → the header stays on a proxy-known version for initialize and follow-ups; the forwarded body keeps 2025-11-25;
- server negotiates down (2025-06-18 → 2025-03-26) → follow-up headers carry the response's version, not the request's.

`node --test` over memory-plugin-shared + opencode + codex suites: 30/30 pass. Vendored copies regenerated via `sync.mjs`.