### PR TITLE
docs: disclose agent provenance in contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,17 @@ body:
       value: |
         Thanks for taking the time to report a bug! Please fill out the form below.
 
+  - type: dropdown
+    id: issue-origin
+    attributes:
+      label: Issue Origin
+      description: Was this issue observed in a real environment or inferred by an AI agent?
+      options:
+        - Observed or reproduced in a real environment
+        - Inferred by an AI agent and not observed or reproduced
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,17 @@ body:
       value: |
         Thanks for suggesting a feature! Please fill out the form below.
 
+  - type: dropdown
+    id: issue-origin
+    attributes:
+      label: Issue Origin
+      description: Was this issue observed in a real environment or inferred by an AI agent?
+      options:
+        - Observed or reproduced in a real environment
+        - Inferred by an AI agent and not observed or reproduced
+    validations:
+      required: true
+
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,6 +8,17 @@ body:
       value: |
         Have a question about OpenViking? We're here to help!
 
+  - type: dropdown
+    id: issue-origin
+    attributes:
+      label: Issue Origin
+      description: Was this issue observed in a real environment or inferred by an AI agent?
+      options:
+        - Observed or reproduced in a real environment
+        - Inferred by an AI agent and not observed or reproduced
+    validations:
+      required: true
+
   - type: textarea
     id: question
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,13 @@
 
 <!-- Provide a brief description of the changes in this PR -->
 
+## Human Involvement
+
+<!-- Select exactly one option -->
+
+- [ ] A human participated in the implementation or review loop
+- [ ] This PR was generated entirely by AI agents without human participation in the loop
+
 ## Related Issue
 
 <!-- Link to the related issue (if applicable) -->


### PR DESCRIPTION
## Description

Add provenance disclosures to Issue forms and the pull request template so maintainers can distinguish observed problems and human-in-the-loop contributions from agent-only output.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add a required Issue Origin dropdown to all Issue forms
- Distinguish observed or reproduced issues from unverified AI-agent inferences
- Add a human-involvement declaration to the pull request template

## Testing

Validated all Issue form YAML files with Ruby's YAML parser and ran `git diff --check`.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The pull request checkboxes are declarative; GitHub does not enforce selecting exactly one option.
