### PR TITLE
fix(reindex): honor configured VLM concurrency

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -572,7 +572,9 @@ class ReindexExecutor:
         ctx: RequestContext,
         lock: LockLease = NO_LOCK,
     ) -> None:
-        processor = SemanticProcessor()
+        processor = SemanticProcessor(
+            max_concurrent_llm=get_openviking_config().vlm.max_concurrent,
+        )
         msg = SemanticMsg(
             uri=uri,
             context_type=context_type,

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -243,6 +243,41 @@ async def test_reindex_memory_supports_semantic_and_vectors(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reindex_semantic_processor_uses_configured_vlm_concurrency(monkeypatch):
+    from types import SimpleNamespace
+
+    import openviking.service.reindex_executor as reindex_mod
+
+    seen = {}
+
+    class FakeSemanticProcessor:
+        def __init__(self, max_concurrent_llm=64):
+            seen["max_concurrent_llm"] = max_concurrent_llm
+
+        async def on_dequeue(self, data, lock=None):
+            seen["data"] = data
+
+    monkeypatch.setattr(reindex_mod, "SemanticProcessor", FakeSemanticProcessor)
+    monkeypatch.setattr(
+        reindex_mod,
+        "get_openviking_config",
+        lambda: SimpleNamespace(vlm=SimpleNamespace(max_concurrent=2)),
+    )
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+    await reindex_mod.ReindexExecutor()._run_semantic_processor(
+        uri="viking://resources/demo",
+        context_type="resource",
+        ctx=ctx,
+    )
+
+    assert seen["max_concurrent_llm"] == 2
+
+
+@pytest.mark.asyncio
 async def test_reindex_memory_semantic_and_vectors_rebuilds_full_subtree(monkeypatch):
     from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
 


### PR DESCRIPTION
## 动机

管理端重建索引时会直接创建使用默认并发值 `64` 的 `SemanticProcessor`，从而绕过 `ov.conf` 中的 `vlm.max_concurrent`。当部署把并发限制调低以保护 VLM provider 时，reindex 仍可能瞬时发起过多请求并触发 `429`。

## 方案

在 admin reindex 的语义处理边界读取现有 OpenViking 配置，并把 `vlm.max_concurrent` 显式传给 `SemanticProcessor`。队列消费路径已经采用同一配置，本次让管理端路径与其保持一致。

## 关键代码

```python
processor = SemanticProcessor(
    max_concurrent_llm=get_openviking_config().vlm.max_concurrent,
)
```

## 复现与回归

新增异步单测，将 `vlm.max_concurrent` 设为 `2`，替换实际 processor 并调用 `_run_semantic_processor()`；修复前捕获到默认值 `64`，修复后捕获到配置值 `2`。

## 验证

```bash
OPENVIKING_CONFIG_FILE=examples/ov.conf.example PYTHONPATH=. \
  .venv/bin/pytest -q --no-cov \
  tests/server/test_admin_rebuild_api.py::test_reindex_memory_supports_semantic_and_vectors \
  tests/server/test_admin_rebuild_api.py::test_reindex_semantic_processor_uses_configured_vlm_concurrency \
  tests/server/test_admin_rebuild_api.py::test_reindex_memory_semantic_and_vectors_rebuilds_full_subtree
```

结果：`3 passed`。同时通过 Ruff、`py_compile`、`git diff --check` 和 LoopX public-boundary scan。

## 风险与边界

- 本次只修复 admin reindex 自身的并发上限，不新增跨 queue/server event loop 的进程级共享预算。
- 因此不声称 semantic queue 与 memory/reindex 已共享同一个全局 semaphore；已关闭 PR #3199 中的 broader concurrency design 仍是独立问题。
- 配置读取沿用现有 `get_openviking_config()` 与 `VLMConfig.max_concurrent` 默认值，不引入新的配置项。

## 关联 Issue

Fixes #3218
