### PR TITLE
feat: track trajectory sources and snapshot experience updates

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -84,6 +84,34 @@ _TRAINING_FAST_PATH_MEMORY_TYPES = frozenset({"cases", "trajectories", "experien
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
 
 
+async def _commit_experience_snapshot(
+    viking_fs: Any,
+    *,
+    ctx: RequestContext,
+    experience_uris: list[str],
+    archive_uri: str = "",
+) -> None:
+    commit = getattr(viking_fs, "commit", None)
+    if not callable(commit):
+        return
+    paths = [
+        uri
+        for uri in dict.fromkeys(str(uri or "") for uri in experience_uris)
+        if "/memories/experiences/" in uri and uri.endswith(".md")
+    ]
+    if not paths:
+        return
+    archive_name = archive_uri.rstrip("/").rsplit("/", 1)[-1] if archive_uri else "unknown"
+    try:
+        await commit(
+            message=f"Update experience memories from session commit {archive_name}",
+            paths=paths,
+            ctx=ctx,
+        )
+    except Exception as exc:
+        logger.warning("Failed to commit experience snapshot for %s: %s", paths, exc, exc_info=True)
+
+
 class SessionCompressorV3:
     """Session compressor with lock-free patch-merge user memory extraction."""
 
@@ -583,6 +611,7 @@ class SessionCompressorV3:
                 request_context=ctx,
                 strict_extract_errors=strict_extract_errors,
                 include_session_skills=skill_enabled,
+                source_archive_uri=archive_uri or "",
             )
             exp_trainer = await get_streaming_policy_trainer(
                 key=make_streaming_policy_trainer_key(
@@ -685,6 +714,17 @@ class SessionCompressorV3:
                         apply_result=exp_training_result.apply_result,
                         ctx=ctx,
                         viking_fs=viking_fs,
+                    )
+                exp_apply_result = getattr(exp_training_result, "apply_result", None)
+                if exp_apply_result is not None:
+                    await _commit_experience_snapshot(
+                        viking_fs,
+                        ctx=ctx,
+                        experience_uris=[
+                            *list(getattr(exp_apply_result, "written_uris", []) or []),
+                            *list(getattr(exp_apply_result, "deleted_uris", []) or []),
+                        ],
+                        archive_uri=archive_uri,
                     )
                 # Skill path: co-extracted skill gradients go directly to skill trainer
                 if skill_trainer is not None and analysis.gradients:

--- a/openviking/session/train/components/trajectory_analyzer.py
+++ b/openviking/session/train/components/trajectory_analyzer.py
@@ -54,6 +54,7 @@ class TrajectoryAnalyzerContext:
     evaluator_context: Any = None
     inject_evaluation_feedback: bool = True
     include_session_skills: bool = False
+    source_archive_uri: str = ""
 
 
 @dataclass(slots=True)
@@ -92,6 +93,7 @@ class TrajectoryRolloutAnalyzer:
             latest_archive_overview=context.latest_archive_overview,
             include_session_skills=context.include_session_skills,
             case_name=getattr(rollout.case, "name", ""),
+            source_archive_uri=context.source_archive_uri,
         )
         contexts = list((result or {}).get("contexts", []))
         skill_gradients = list((result or {}).get("skill_gradients", []))
@@ -139,6 +141,7 @@ class TrajectoryRolloutAnalyzer:
         latest_archive_overview: str = "",
         include_session_skills: bool = False,
         case_name: str = "",
+        source_archive_uri: str = "",
     ) -> dict[str, list[Any]]:
         """Extract and persist trajectory memories from rollout messages.
 
@@ -165,6 +168,7 @@ class TrajectoryRolloutAnalyzer:
             strict_extract_errors=strict_extract_errors,
             include_session_skills=include_session_skills,
             case_name=case_name,
+            source_archive_uri=source_archive_uri,
         )
         if phase_result is None:
             return empty_result
@@ -181,6 +185,7 @@ class TrajectoryRolloutAnalyzer:
         strict_extract_errors: bool,
         include_session_skills: bool = False,
         case_name: str = "",
+        source_archive_uri: str = "",
     ) -> tuple[list[str], list[str], list[Context], list[PatchSemanticGradient]] | None:
         config = get_openviking_config()
         vlm = self.vlm or config.vlm.get_vlm_instance()
@@ -235,6 +240,7 @@ class TrajectoryRolloutAnalyzer:
             )
 
             _ensure_trajectory_case_name(traj_ops, case_name=case_name)
+            _apply_trajectory_source_archive_uri(traj_ops, source_archive_uri)
 
             memory_result = await self._apply_trajectory_operations(
                 operations=traj_ops,
@@ -285,7 +291,9 @@ class TrajectoryRolloutAnalyzer:
             isolation_handler=isolation_handler,
         )
 
-    @tracer("train.rollout_analyzer.trajectory.read_trajectories", ignore_result=True, ignore_args=True)
+    @tracer(
+        "train.rollout_analyzer.trajectory.read_trajectories", ignore_result=True, ignore_args=True
+    )
     async def _read_trajectories(
         self,
         trajectory_uris: list[str],
@@ -327,11 +335,9 @@ class TrajectoryRolloutAnalyzer:
         return trajectories
 
 
-
 def _log_operations(operations: ResolvedOperations) -> None:
     op_items = [
-        f"{op.memory_type}(uris={op.uris!r})"
-        for op in getattr(operations, "upsert_operations", [])
+        f"{op.memory_type}(uris={op.uris!r})" for op in getattr(operations, "upsert_operations", [])
     ]
     delete_uris = [dc.uri for dc in getattr(operations, "delete_file_contents", [])]
     tracer.info(f"[trajectory] LLM operations: ops={op_items}, delete_uris={delete_uris}")
@@ -379,6 +385,22 @@ def _ensure_trajectory_case_name(operations: ResolvedOperations, *, case_name: s
             fields["case_name"] = case_name
 
 
+def _apply_trajectory_source_archive_uri(
+    operations: ResolvedOperations,
+    source_archive_uri: str,
+) -> None:
+    source_archive_uri = str(source_archive_uri or "").rstrip("/")
+    if not source_archive_uri:
+        return
+    for op in getattr(operations, "upsert_operations", []) or []:
+        if getattr(op, "memory_type", None) != _TRAJECTORY_MEMORY_TYPE:
+            continue
+        fields = getattr(op, "memory_fields", None)
+        if not isinstance(fields, dict):
+            continue
+        fields["source_archive_uri"] = source_archive_uri
+
+
 def _messages_with_evaluation_feedback(
     messages: list[Message],
     *,
@@ -404,8 +426,7 @@ def _evaluation_feedback_message(evaluation: RubricEvaluation) -> Message:
     evidence_lines: list[str] = []
     for criterion in evaluation.criterion_results:
         criterion_lines.append(
-            f"- {criterion.criterion_name}: "
-            f"passed={criterion.passed}, score={criterion.score}"
+            f"- {criterion.criterion_name}: passed={criterion.passed}, score={criterion.score}"
         )
         criterion_lines.extend(f"  feedback: {item}" for item in criterion.feedback)
         evidence_lines.extend(criterion.evidence)
@@ -424,24 +445,17 @@ def _split_operations_by_type(
     operations: ResolvedOperations, *, target_type: str
 ) -> tuple[ResolvedOperations, ResolvedOperations]:
     """Split operations into (target_type_ops, other_ops)."""
-    target_upserts = [
-        op for op in operations.upsert_operations if op.memory_type == target_type
-    ]
-    other_upserts = [
-        op for op in operations.upsert_operations if op.memory_type != target_type
-    ]
-    target_deletes = [
-        dc for dc in operations.delete_file_contents if dc.memory_type == target_type
-    ]
-    other_deletes = [
-        dc for dc in operations.delete_file_contents if dc.memory_type != target_type
-    ]
+    target_upserts = [op for op in operations.upsert_operations if op.memory_type == target_type]
+    other_upserts = [op for op in operations.upsert_operations if op.memory_type != target_type]
+    target_deletes = [dc for dc in operations.delete_file_contents if dc.memory_type == target_type]
+    other_deletes = [dc for dc in operations.delete_file_contents if dc.memory_type != target_type]
     target_ops = ResolvedOperations(
         upsert_operations=target_upserts,
         delete_file_contents=target_deletes,
         errors=list(operations.errors),
         resolved_links=[
-            link for link in operations.resolved_links
+            link
+            for link in operations.resolved_links
             if getattr(link, "from_uri", "").endswith("/trajectories/")
             or target_type in getattr(link, "from_uri", "")
         ],
@@ -497,9 +511,7 @@ def _skill_operations_to_gradients(
                 stored = link if isinstance(link, StoredLink) else StoredLink(**dict(link))
                 if stored.link_type == "derived_from" and stored.to_uri:
                     if "/memories/trajectories/" in stored.to_uri:
-                        links.append(
-                            stored.model_copy(update={"from_uri": target_uri or ""})
-                        )
+                        links.append(stored.model_copy(update={"from_uri": target_uri or ""}))
             except Exception:
                 continue
 

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -929,9 +929,11 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
     case_uri = "viking://user/u/memories/cases/duplicate_booking.md"
     traj_uri = "viking://user/u/memories/trajectories/duplicate_booking.md"
     exp_uri = "viking://user/u/memories/experiences/booking_duplicate_handling.md"
+    deleted_exp_uri = "viking://user/u/memories/experiences/legacy_booking_handling.md"
 
     class FakeFS:
         def __init__(self):
+            self.commits = []
             self.files = {
                 case_uri: MemoryFileUtils.write(
                     MemoryFile(
@@ -997,6 +999,9 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
             del uri, output, ctx
             return []
 
+        async def commit(self, **kwargs):
+            self.commits.append(kwargs)
+
     class FakeTrainer:
         policy_set = ExperienceSet(root_uri="viking://user/u/memories/experiences", policies=[])
 
@@ -1034,6 +1039,7 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
                         policies=[],
                     ),
                     written_uris=[exp_uri],
+                    deleted_uris=[deleted_exp_uri],
                     errors=[],
                 ),
                 metadata={},
@@ -1095,6 +1101,8 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
         case_uri_by_name={"duplicate_booking": case_uri},
         messages=_messages(),
         ctx=_ctx(),
+        session_id="session-1",
+        archive_uri="viking://user/u/sessions/session-1/history/archive_001",
     )
 
     assert result["submitted"] == 1
@@ -1125,3 +1133,10 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
     assert any(link["from_uri"] == case_uri for link in traj_file.backlinks)
     exp_file = MemoryFileUtils.read(fs.files[exp_uri], uri=exp_uri)
     assert any(link["from_uri"] == case_uri for link in exp_file.backlinks)
+    assert fs.commits == [
+        {
+            "message": "Update experience memories from session commit archive_001",
+            "paths": [exp_uri, deleted_exp_uri],
+            "ctx": _ctx(),
+        }
+    ]

--- a/tests/session/train/test_trajectory_analyzer_component.py
+++ b/tests/session/train/test_trajectory_analyzer_component.py
@@ -127,7 +127,8 @@ async def test_trajectory_rollout_analyzer_extracts_and_persists_trajectory(monk
         request_context=SimpleNamespace(
             user=SimpleNamespace(account_id="default", user_id="u"),
             account_id="default",
-        )
+        ),
+        source_archive_uri="viking://user/u/sessions/s1/history/archive_001",
     )
 
     analysis = await analyzer.analyze(_rollout(), context)
@@ -137,12 +138,19 @@ async def test_trajectory_rollout_analyzer_extracts_and_persists_trajectory(monk
     assert created_loop._transaction_handle is None
     provider = created_loop.kwargs["context_provider"]
     assert provider._transaction_handle is None
-    assert [schema.memory_type for schema in provider.get_memory_schemas(context.request_context)] == [
-        "trajectories"
-    ]
+    assert [
+        schema.memory_type for schema in provider.get_memory_schemas(context.request_context)
+    ] == ["trajectories"]
     assert len(fs.writes) == 1
     assert fs.writes[0][0] == "viking://user/u/memories/trajectories/task_20260607120000.md"
     assert '"case_name": "case"' in fs.writes[0][1]
+    assert (
+        '"source_archive_uri": "viking://user/u/sessions/s1/history/archive_001"' in fs.writes[0][1]
+    )
+    assert '"source_session_id"' not in fs.writes[0][1]
+    assert '"source_messages_uri"' not in fs.writes[0][1]
+    assert '"source_task_id"' not in fs.writes[0][1]
+    assert '"source_trace_id"' not in fs.writes[0][1]
     assert len(analysis.trajectories) == 1
     traj = analysis.trajectories[0]
     assert traj.name == "task"


### PR DESCRIPTION
## Description

Adds the lineage and versioning hooks required by Agent Evolution:
- records the source session archive URI on generated trajectory memories;
- creates VikingFS snapshots when experience files are written or deleted;
- keeps snapshot creation best-effort so memory extraction is not failed by snapshot errors.

## Related Issue

N/A

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Tests

## Changes Made

- Persist `source_archive_uri` in trajectory memory fields.
- Collect written and deleted experience URIs from the V3 training result.
- Commit affected experience paths to snapshot storage after training.
- Add focused lineage and snapshot tests, including experience deletion.

## Testing

- `tests/session/train/test_trajectory_analyzer_component.py`: 2 passed.
- `test_v3_training_links_case_to_trajectory_and_experience_via_trajectory`: 1 passed.
- Ruff check, Ruff format check, and `git diff --check` passed.
- The full fixture-based suite could not initialize locally because the installed native wheel does not expose `PersistStore`.

## Checklist

- [x] Code follows the project style.
- [x] Tests cover the new behavior.
- [x] Changes are scoped to trajectory lineage and experience snapshots.
- [x] No unrelated user configuration or usage reporting changes are included.

## Screenshots

N/A

## Additional Notes

Snapshot commit failures are logged and do not fail the memory extraction task.
