### PR TITLE
chore: remove automatic pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
-    hooks:
-      - id: ruff
-        args: [ --fix ]
-      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,17 +200,6 @@ We use the following tools to maintain code consistency:
 | **Ruff** | Linting, Formatting, Import sorting | `pyproject.toml` |
 | **mypy** | Type checking | `pyproject.toml` |
 
-### Automated Checks (Recommended)
-
-We use [pre-commit](https://pre-commit.com/) to automatically run these checks before every commit. This ensures your code always meets the standards without manual effort.
-
-1. **Install the git hooks**:
-   ```bash
-   uvx pre-commit install
-   ```
-
-Now, `ruff` (check & format) will run automatically when you run `git commit`. If any check fails, it may automatically fix the file. You just need to add the changes and commit again.
-
 ### Running Checks
 
 ```bash
@@ -506,8 +495,6 @@ Maintainers can manually trigger the following workflows from the "Actions" tab 
 
 #### A. Lint Checks (`11. _Lint Checks`)
 Runs code style checks (Ruff) and type checks (Mypy). No arguments required.
-
-> **Tip**: It is recommended to install [pre-commit](https://pre-commit.com/) locally to run these checks automatically before committing (see [Automated Checks](#automated-checks-recommended) section above).
 
 #### B. Test Suite (Lite) (`12. _Test Suite (Lite)`)
 Runs fast integration tests, supports custom matrix configuration.

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -196,22 +196,6 @@ openviking/
 | **Ruff** | Linting, 格式化, 导入排序 | `pyproject.toml` |
 | **mypy** | 类型检查 | `pyproject.toml` |
 
-### 自动检查（推荐）
-
-我们使用 [pre-commit](https://pre-commit.com/) 在每次提交前自动运行这些检查。这确保您的代码无需手动努力即可符合标准。
-
-1. **安装 pre-commit**：
-   ```bash
-   pip install pre-commit
-   ```
-
-2. **安装 git hooks**：
-   ```bash
-   pre-commit install
-   ```
-
-现在，当您运行 `git commit` 时，`ruff`（检查和格式化）将自动运行。如果任何检查失败，它可能会自动修复文件。您只需添加更改并再次提交即可。
-
 ### 运行检查
 
 ```bash
@@ -507,8 +491,6 @@ git commit -m "refactor(storage): simplify interface methods"
 
 #### A. 代码检查 (`11. _Lint Checks`)
 运行代码风格检查 (Ruff) 和类型检查 (Mypy) 。无需参数。
-
-> **提示**：建议在本地安装 [pre-commit](https://pre-commit.com/) 以在提交前自动运行这些检查（详见上文[自动检查](#自动检查推荐)章节）。
 
 #### B. 简易测试 (`12. _Test Suite (Lite)`)
 运行快速集成测试，支持自定义矩阵配置。

--- a/CONTRIBUTING_JA.md
+++ b/CONTRIBUTING_JA.md
@@ -198,22 +198,6 @@ openviking/
 | **Ruff** | リンティング、フォーマット、インポートソート | `pyproject.toml` |
 | **mypy** | 型チェック | `pyproject.toml` |
 
-### 自動チェック（推奨）
-
-[pre-commit](https://pre-commit.com/)を使用して、コミット前にこれらのチェックを自動実行します。これにより、手動の作業なしでコードが常に基準を満たすことが保証されます。
-
-1. **pre-commitのインストール**:
-   ```bash
-   pip install pre-commit
-   ```
-
-2. **gitフックのインストール**:
-   ```bash
-   pre-commit install
-   ```
-
-これで、`git commit`実行時に`ruff`（チェックとフォーマット）が自動的に実行されます。チェックが失敗した場合、ファイルが自動修正されることがあります。変更をaddして再度コミットするだけです。
-
 ### チェックの実行
 
 ```bash
@@ -436,8 +420,6 @@ git commit -m "refactor(storage): simplify interface methods"
 
 #### A. Lintチェック (`11. _Lint Checks`)
 コードスタイルチェック（Ruff）と型チェック（Mypy）を実行。引数は不要です。
-
-> **ヒント**: コミット前にこれらのチェックを自動的に実行するため、ローカルに[pre-commit](https://pre-commit.com/)をインストールすることを推奨します（上記の[自動チェック](#自動チェック推奨)セクションを参照）。
 
 #### B. テストスイート（Lite）(`12. _Test Suite (Lite)`)
 高速統合テストを実行し、カスタムマトリックス設定をサポートします。


### PR DESCRIPTION
## Description

Remove the repository's automatic pre-commit hooks so local commits no longer run or modify files through Ruff. Manual Ruff commands and CI checks remain available.

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Remove `.pre-commit-config.yaml`.
- Remove pre-commit installation and automatic-check instructions from the English, Chinese, and Japanese contribution guides.
- Keep manual Ruff formatting and lint commands documented.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: tooling and documentation only)
- [ ] New and existing unit tests pass locally with my changes (not run: no runtime code changes)
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated with `git diff --check` and confirmed there are no remaining pre-commit references.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable: no code changes)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (not applicable: no dependencies)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

CI lint checks are unchanged.
