### PR TITLE
fix(retrieve): preserve rerank fallback for empty documents

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -346,23 +346,33 @@ class HierarchicalRetriever:
         if not self._rerank_client or not documents:
             return fallback_scores
 
+        rerank_documents = [
+            (index, document) for index, document in enumerate(documents) if document.strip()
+        ]
+        if not rerank_documents:
+            return fallback_scores
+
         try:
-            scores = await asyncio.to_thread(self._rerank_client.rerank_batch, query, documents)
+            scores = await asyncio.to_thread(
+                self._rerank_client.rerank_batch,
+                query,
+                [document for _, document in rerank_documents],
+            )
         except Exception as e:
             logger.warning(
                 "[HierarchicalRetriever] Rerank failed, fallback to vector scores: %s", e
             )
             return fallback_scores
 
-        if not scores or len(scores) != len(documents):
+        if not scores or len(scores) != len(rerank_documents):
             logger.warning(
                 "[HierarchicalRetriever] Invalid rerank result, fallback to vector scores"
             )
             return fallback_scores
 
-        normalized_scores: List[float] = []
-        for score, fallback in zip(scores, fallback_scores, strict=True):
-            normalized_scores.append(self._finite_score(score, fallback))
+        normalized_scores = list(fallback_scores)
+        for score, (index, _) in zip(scores, rerank_documents, strict=True):
+            normalized_scores[index] = self._finite_score(score, fallback_scores[index])
         return normalized_scores
 
     async def _recursive_search(

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -265,6 +265,30 @@ async def test_retrieve_uses_rerank_scores_in_thinking_mode(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_rerank_scores_preserves_fallbacks_for_empty_documents(monkeypatch):
+    fake_client = FakeRerankClient([0.95, 0.05])
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.RerankClient.from_config",
+        lambda config: fake_client,
+    )
+
+    retriever = HierarchicalRetriever(
+        storage=DummyStorage(),
+        embedder=DummyEmbedder(),
+        rerank_config=_config(),
+    )
+
+    scores = await retriever._rerank_scores(
+        "hello",
+        ["root A", "", "   ", "root D"],
+        [0.2, 0.8, 0.7, 0.4],
+    )
+
+    assert scores == [0.95, 0.8, 0.7, 0.05]
+    assert fake_client.calls == [("hello", ["root A", "root D"])]
+
+
+@pytest.mark.asyncio
 async def test_retrieve_falls_back_to_vector_scores_when_rerank_returns_none(monkeypatch):
     class NoneRerankClient(FakeRerankClient):
         def rerank_batch(self, query: str, documents: list[str]):


### PR DESCRIPTION
## Description

### 动机

Issue #2330 报告：当候选上下文中存在空 `abstract` 时，rerank provider 会拒绝整批请求，当前实现随后把整批候选都退回向量分数。这样一个缺失摘要会让同批其他有效候选失去 rerank 信号。

### 方案

1. 调用 rerank provider 前，过滤空字符串和纯空白文档，同时保留原始下标。
2. provider 只处理有效文档；空文档保留各自的向量 fallback score。
3. 将 rerank 结果按原始下标写回，继续复用现有有限值校验和整批异常 fallback。

### 关键代码 / 伪代码

```python
valid = [(index, doc) for index, doc in enumerate(documents) if doc.strip()]
scores = await rerank([doc for _, doc in valid])

result = list(fallback_scores)
for score, (index, _) in zip(scores, valid):
    result[index] = finite_or_fallback(score, fallback_scores[index])
```

### 修复前后示例

输入四个候选文档，其中第二、第三个分别为空字符串和纯空白：

```text
documents = ["root A", "", "   ", "root D"]
fallback  = [0.2, 0.8, 0.7, 0.4]
```

- 修复前：provider 收到整批文档并可能报错，四项全部退回 fallback。
- 修复后：provider 只收到 `root A` 和 `root D`；假设返回 `[0.95, 0.05]`，最终结果为 `[0.95, 0.8, 0.7, 0.05]`。

## Related Issue

Fixed #2330

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 过滤空白 rerank 文档并保留原始下标。
- 只将有效文档发送给 provider，再把结果映射回原位置。
- 为空文档保留其向量 fallback，并新增混合空/非空输入的索引回归测试。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- `tests/retrieve/test_hierarchical_retriever_rerank.py`：13 passed
- `tests/retrieve`：30 passed
- `uvx ruff check openviking/retrieve/hierarchical_retriever.py tests/retrieve/test_hierarchical_retriever_rerank.py`
- `python -m compileall openviking/retrieve/hierarchical_retriever.py tests/retrieve/test_hierarchical_retriever_rerank.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

- 已有 PR #2572 采用“过滤空文本、按原下标写回”的最小修复思路，但它基于旧版同步调用路径，与当前 `main` 的异步 `_rerank_scores` 发生内容冲突；本 PR 在 current main 上复用其最小语义。
- PR #2791 还引入了文件内容回退，范围更大，本 PR 未采用该扩展。
- 行为变化仅发生在混有空文本的 rerank 批次；provider 异常、返回空结果或长度不匹配时，仍按原逻辑整批 fail-open 到向量分数。
