### PR TITLE
fix(memory): reject undistilled extraction output

### DIFF
--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -46,6 +46,10 @@ _CANNED_REFUSAL_RE = re.compile(
     re.IGNORECASE,
 )
 
+_MEMORY_FIELD_TARGET_CHARS = 2_000
+_MEMORY_FIELD_HARD_MAX_CHARS = 4_000
+_VERBATIM_COPY_MIN_CHARS = 1_000
+
 
 def _looks_like_canned_refusal(content: str) -> bool:
     """Return whether a non-JSON LLM response looks like a generic refusal."""
@@ -77,6 +81,27 @@ def _preview_text(content: str, *, limit: int = 240) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 3] + "..."
+
+
+def _iter_string_fields(value: Any, prefix: str = ""):
+    """Yield nested string fields without exposing their contents."""
+
+    if isinstance(value, str):
+        yield prefix or "value", value
+        return
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            yield from _iter_string_fields(child, child_prefix)
+        return
+    if isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            child_prefix = f"{prefix}[{index}]" if prefix else f"[{index}]"
+            yield from _iter_string_fields(child, child_prefix)
+
+
+def _normalize_copy_text(value: str) -> str:
+    return " ".join(str(value or "").split())
 
 
 class ExtractLoop:
@@ -142,6 +167,80 @@ class ExtractLoop:
 
         self._tool_ctx = None
 
+    def _source_conversation_texts(self) -> List[str]:
+        """Return normalized source text used only for verbatim-copy detection."""
+
+        texts: List[str] = []
+        for message in getattr(self.context_provider, "messages", []) or []:
+            content = getattr(message, "content", None)
+            if content:
+                texts.append(_normalize_copy_text(content))
+            for part in getattr(message, "parts", []) or []:
+                text = getattr(part, "text", None)
+                if text:
+                    texts.append(_normalize_copy_text(text))
+        if texts:
+            return [text for text in texts if text]
+
+        get_conversation_text = getattr(self.context_provider, "get_conversation_text", None)
+        if callable(get_conversation_text):
+            text = _normalize_copy_text(get_conversation_text())
+            return [text] if text else []
+
+        extract_context = getattr(self, "_extract_context", None)
+        for message in getattr(extract_context, "messages", []) or []:
+            content = getattr(message, "content", None)
+            if content:
+                texts.append(_normalize_copy_text(content))
+            for part in getattr(message, "parts", []) or []:
+                text = getattr(part, "text", None)
+                if text:
+                    texts.append(_normalize_copy_text(text))
+        return [text for text in texts if text]
+
+    def _find_undistilled_operations(self, operations: ResolvedOperations) -> Dict[int, List[str]]:
+        """Find memory fields that are too large or copy source text verbatim."""
+
+        source_texts = self._source_conversation_texts()
+        invalid: Dict[int, List[str]] = {}
+        for index, operation in enumerate(operations.upsert_operations):
+            field_errors: List[str] = []
+            for field_name, value in _iter_string_fields(operation.memory_fields):
+                normalized = _normalize_copy_text(value)
+                if len(value) > _MEMORY_FIELD_HARD_MAX_CHARS:
+                    field_errors.append(
+                        f"{field_name}: {len(value)} chars exceeds {_MEMORY_FIELD_HARD_MAX_CHARS}"
+                    )
+                    continue
+                if len(normalized) < _VERBATIM_COPY_MIN_CHARS:
+                    continue
+                if any(
+                    normalized in source
+                    or (len(source) >= _VERBATIM_COPY_MIN_CHARS and source in normalized)
+                    for source in source_texts
+                ):
+                    field_errors.append(f"{field_name}: contains a large verbatim source span")
+            if field_errors:
+                invalid[index] = field_errors
+        return invalid
+
+    @staticmethod
+    def _build_distillation_repair_instruction(
+        operations: ResolvedOperations, invalid: Dict[int, List[str]]
+    ) -> str:
+        details = []
+        for index, errors in invalid.items():
+            memory_type = operations.upsert_operations[index].memory_type
+            details.append(f"- operation {index} ({memory_type}): {', '.join(errors)}")
+        return (
+            "Your proposed memory operations contain undistilled content:\n"
+            + "\n".join(details)
+            + "\nRewrite those memory items as atomic, durable facts. Do not copy skill definitions, "
+            "documents, transcripts, tool output, or templates verbatim. Keep each text field "
+            f"near {_MEMORY_FIELD_TARGET_CHARS} characters or fewer. Return the complete JSON "
+            "object again, including any already-valid operations."
+        )
+
     async def run(self) -> Tuple[Optional[Any], List[Dict[str, Any]]]:
         """
         Run the simplified ReAct loop for memory updates.
@@ -157,6 +256,7 @@ class ExtractLoop:
         # Reset format retry counter for each run
         self._format_retry_count = 0
         patch_repair_count = 0
+        distillation_repair_count = 0
 
         # 从 provider 获取 schemas（内部自动加载 registry）
         schemas = self.context_provider.get_memory_schemas(self.ctx)
@@ -283,6 +383,35 @@ The final output of the model must strictly follow the JSON Schema format shown 
             # If model returned final operations, check if refetch is needed
             if operations is not None:
                 final_operations, raw_links = await self.resolve_operations(operations)
+                undistilled = self._find_undistilled_operations(final_operations)
+                if undistilled and distillation_repair_count == 0:
+                    distillation_repair_count += 1
+                    max_iterations += 1
+                    self._disable_tools_for_iteration = True
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": self._build_distillation_repair_instruction(
+                                final_operations, undistilled
+                            ),
+                        }
+                    )
+                    tracer.info(
+                        f"Extended max_iterations to {max_iterations} for memory distillation repair",
+                        console=True,
+                    )
+                    continue
+                if undistilled:
+                    rejected = set(undistilled)
+                    final_operations.upsert_operations = [
+                        op
+                        for index, op in enumerate(final_operations.upsert_operations)
+                        if index not in rejected
+                    ]
+                    final_operations.errors.append(
+                        "Skipped undistilled memory operations after one repair attempt: "
+                        + ", ".join(str(index) for index in sorted(rejected))
+                    )
                 # Check if any write_uris target existing files that weren't read
                 refetch_uris = await self._check_unread_existing_files(final_operations)
                 if refetch_uris:
@@ -324,9 +453,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
             if self._format_retry_count == 0:
                 self._format_retry_count += 1
                 max_iterations += 1
-                retry_reason = (
-                    "refusal_text" if failure_kind == "refusal_text" else "format_retry"
-                )
+                retry_reason = "refusal_text" if failure_kind == "refusal_text" else "format_retry"
                 tracer.info(f"Extended max_iterations to {max_iterations} for {retry_reason}")
                 self._add_format_error_message(messages)
 
@@ -485,7 +612,6 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     break
 
         return resolved, raw_links
-
 
     def _normalize_delete_ids(self, raw_delete_ids: List[Any]) -> List[DeleteId]:
         delete_ids: List[DeleteId] = []

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -10,7 +10,7 @@ import os
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from openviking.message.part import TextPart, ToolPart
+from openviking.message.part import TextPart
 from openviking.prompts.manager import PromptManager
 from openviking.server.identity import RequestContext, ToolContext
 from openviking.session.memory.core import ExtractContextProvider
@@ -221,6 +221,11 @@ class SessionExtractContextProvider(ExtractContextProvider):
 - ONLY read and search tools are available - DO NOT use write tool
 - Before editing ANY existing memory file, you MUST first read its complete content
 - ONLY read URIs that are explicitly listed in ls/search tool results, returned by previous tool calls{resource_deletion_read_source}
+
+## Distillation
+- Store atomic, durable facts rather than raw source material.
+- Do NOT copy skill definitions, documents, transcripts, tool output, or templates verbatim.
+- Keep each text field near 2000 characters or fewer. Split independent facts into separate memory items.
 
 ## Target Output Language
 All memory content MUST be written in {output_language}.

--- a/tests/session/memory/test_memory_react.py
+++ b/tests/session/memory/test_memory_react.py
@@ -10,11 +10,19 @@ import pytest
 
 from openviking.session.memory.dataclass import (
     MemoryTypeSchema,
+    ResolvedOperation,
+    ResolvedOperations,
 )
 from openviking.session.memory.extract_loop import (
     ExtractLoop,
 )
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
+
+
+@pytest.fixture(autouse=True)
+def _drain_background_tasks():
+    """These pure unit tests do not need the session integration client."""
+    yield
 
 
 class TestPreFetchFileFiltering:
@@ -265,3 +273,63 @@ class TestExtractLoopFinalJsonRetry:
         assert final_prompts
         assert '"delete_ids": []' in final_prompts[-1]
         assert '"preferences": []' in final_prompts[-1]
+
+
+class TestMemoryDistillationGuard:
+    @staticmethod
+    def _loop(source_text: str) -> ExtractLoop:
+        loop = object.__new__(ExtractLoop)
+        loop.context_provider = MagicMock()
+        loop.context_provider.get_conversation_text.return_value = source_text
+        return loop
+
+    @staticmethod
+    def _operations(content: str) -> ResolvedOperations:
+        return ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    memory_fields={"content": content},
+                    memory_type="experiences",
+                    uris=["viking://user/test/memories/experiences/example.md"],
+                )
+            ],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+    def test_flags_memory_field_over_hard_limit(self):
+        loop = self._loop("")
+
+        invalid = loop._find_undistilled_operations(self._operations("x" * 4_001))
+
+        assert invalid == {0: ["content: 4001 chars exceeds 4000"]}
+
+    def test_flags_large_verbatim_copy_below_hard_limit(self):
+        source = "durable source sentence " * 60
+        loop = self._loop(source)
+
+        invalid = loop._find_undistilled_operations(self._operations(source))
+
+        assert invalid == {0: ["content: contains a large verbatim source span"]}
+
+    def test_allows_concise_distilled_fact(self):
+        source = "raw transcript " * 500
+        loop = self._loop(source)
+
+        invalid = loop._find_undistilled_operations(
+            self._operations("The user prefers concise technical summaries.")
+        )
+
+        assert invalid == {}
+
+    def test_repair_instruction_does_not_echo_raw_memory_content(self):
+        raw = "sensitive raw source " * 250
+        operations = self._operations(raw)
+
+        instruction = ExtractLoop._build_distillation_repair_instruction(
+            operations, {0: ["content: 5250 chars exceeds 4000"]}
+        )
+
+        assert raw not in instruction
+        assert "operation 0 (experiences)" in instruction
+        assert "Do not copy skill definitions" in instruction

--- a/tests/session/memory/test_memory_react_system_prompt.py
+++ b/tests/session/memory/test_memory_react_system_prompt.py
@@ -4,9 +4,17 @@
 Test that provider instruction correctly instructs LLM.
 """
 
+import pytest
+
 from openviking.message import ImagePart, Message, TextPart, ToolPart
 from openviking.session.memory.session_extract_context_provider import SessionExtractContextProvider
 from openviking.session.memory.vision_message_normalizer import IMAGE_DESCRIPTION_PROMPT
+
+
+@pytest.fixture(autouse=True)
+def _drain_background_tasks():
+    """These pure unit tests do not need the session integration client."""
+    yield
 
 
 class TestProviderInstruction:
@@ -40,6 +48,15 @@ class TestProviderInstruction:
         # Check that output language instruction is present
         assert "Target Output Language" in instruction
         assert "All memory content MUST be written in" in instruction
+
+    def test_instruction_requires_concise_distillation(self):
+        provider = SessionExtractContextProvider(messages=[])
+
+        instruction = provider.instruction()
+
+        assert "Store atomic, durable facts rather than raw source material" in instruction
+        assert "Do NOT copy skill definitions" in instruction
+        assert "near 2000 characters or fewer" in instruction
 
     def test_instruction_explains_peer_memory_routing(self):
         provider = SessionExtractContextProvider(messages=[])
@@ -232,8 +249,6 @@ class TestSessionConversationToolFiltering:
 
         assert provider._detect_language() == "zh-CN"
 
-
-
     async def test_prepare_extraction_messages_replaces_image_part_with_vlm_description(self):
         class FakeVisionVLM:
             def __init__(self):
@@ -340,6 +355,7 @@ class TestSessionConversationToolFiltering:
         assert len(messages) == 1
         assert any(isinstance(part, ImagePart) for part in messages[0].parts)
         assert provider.messages is not messages
+
 
 def test_session_provider_empty_messages_still_uses_environment_fallback(monkeypatch):
     monkeypatch.setenv("TZ", "Asia/Shanghai")


### PR DESCRIPTION
## Description

修复会话记忆抽取把技能定义、文档、转录或工具输出大段照抄进长期记忆的问题。现有输入分块只能控制送入模型的上下文，无法阻止模型输出 42KB/74KB 的逐字副本；这些文件会污染记忆空间，并可能超过 embedding 上下文。

本 PR 在现行 ReAct 输出边界增加“提示 + 验证 + 一次修复”的闭环：目标文本字段保持约 2000 字符以内；超过 4000 字符或包含至少 1000 字符逐字源片段的 operation 会被要求重新蒸馏。若修复轮次仍不合格，仅跳过对应 operation 并记录错误，避免把 dead memory 写入存储；其他有效 operation 继续执行。

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3006

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 在 session memory extraction 指令中明确要求原子化、蒸馏后的持久事实，禁止复制原始技能、文档、转录、工具输出或模板。
- 在 `ExtractLoop` 解析 operation 后检测超长文本与大段逐字复制；只提供字段名、长度和 operation 类型给修复提示，不回显原始内容。
- 最多增加一次无工具的蒸馏修复轮次；再次失败时跳过不合格 operation 并保留可观测错误，不影响同批有效记忆。
- 增加超长、逐字复制、正常精简事实和修复提示不泄漏原文的回归测试；纯单元测试不再初始化无关 session client。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证命令：

```bash
ruff format --check openviking/session/memory/extract_loop.py openviking/session/memory/session_extract_context_provider.py tests/session/memory/test_memory_react.py tests/session/memory/test_memory_react_system_prompt.py
ruff check openviking/session/memory/extract_loop.py openviking/session/memory/session_extract_context_provider.py tests/session/memory/test_memory_react.py tests/session/memory/test_memory_react_system_prompt.py
pytest -o addopts='' tests/session/memory/test_memory_react.py tests/session/memory/test_memory_react_system_prompt.py -q
```

结果：`28 passed`；目标文件 ruff 与 compile 检查通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- 本 PR 复用了已关闭 PR #1530 的“记忆应精简”方向，但适配当前动态 schema + ReAct 架构，并增加运行时确定性护栏。
- 已合并 PR #2543 负责切分长输入，本 PR 负责约束模型输出，两者边界互补。
- 不做静默截断：截断可能把半段文档伪装成完整事实；本实现优先重新蒸馏，失败后拒绝单个不合格 operation。
