### PR TITLE
fix(session): order lists by latest activity

### DIFF
--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -17,11 +17,17 @@ from openviking.privacy import (
 )
 from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext
+from openviking.service.session_activity import (
+    is_session_root_uri,
+    project_session_activity,
+    session_activity_value,
+    sort_session_entries_by_activity,
+)
 from openviking.session.memory.memory_updater import MemoryUpdater
 from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
-from openviking.storage.viking_fs import VikingFS
+from openviking.storage.viking_fs import LS_ALL_NODES, VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import build_queue_status_payload
@@ -110,6 +116,7 @@ class FSService:
         """
         viking_fs = self._ensure_initialized()
         uri = validate_viking_uri(uri)
+        project_activity = not recursive and not simple and is_session_root_uri(uri, ctx)
 
         if simple:
             # Only return URIs — skip expensive abstract fetching to save tokens
@@ -134,6 +141,44 @@ class FSService:
                 )
             return [e.get("uri", "") for e in entries]
 
+        if project_activity and sort_by == "mtime":
+            # Session activity lives in each child metadata file, so storage
+            # cannot sort correctly before applying its node limit. Enumerate
+            # raw entries first and avoid fetching directory abstracts that the
+            # session tree does not use.
+            entries = await viking_fs.ls(
+                uri,
+                ctx=ctx,
+                output="original",
+                show_all_hidden=show_all_hidden,
+                node_limit=LS_ALL_NODES,
+            )
+            entries = await project_session_activity(
+                entries,
+                root_uri=uri,
+                viking_fs=viking_fs,
+                ctx=ctx,
+            )
+            entries = sort_session_entries_by_activity(
+                entries,
+                descending=sort_order == "desc",
+            )[:node_limit]
+            if output == "original":
+                return entries
+            if output == "agent":
+                return [
+                    {
+                        "uri": entry.get("uri", ""),
+                        "size": 0 if entry.get("isDir") else entry.get("size", 0),
+                        "isDir": entry.get("isDir", False),
+                        "modTime": entry.get("modTime", ""),
+                        "activityTime": session_activity_value(entry),
+                        "abstract": "",
+                    }
+                    for entry in entries
+                ]
+            raise ValueError(f"Invalid output format: {output}")
+
         if recursive:
             entries = await viking_fs.tree(
                 uri,
@@ -154,6 +199,13 @@ class FSService:
                 node_limit=node_limit,
                 sort_by=sort_by,
                 sort_order=sort_order,
+            )
+        if project_activity:
+            entries = await project_session_activity(
+                entries,
+                root_uri=uri,
+                viking_fs=viking_fs,
+                ctx=ctx,
             )
         return entries
 

--- a/openviking/service/session_activity.py
+++ b/openviking/service/session_activity.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Project canonical session activity timestamps onto session directory entries."""
+
+import asyncio
+import json
+from typing import Any, Dict, Iterable, List
+
+from openviking.core.namespace import canonical_session_uri
+from openviking.server.identity import RequestContext
+from openviking.storage.viking_fs import VikingFS
+from openviking.utils.time_utils import parse_iso_datetime
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+SESSION_LIST_LIMIT = 1000
+_META_READ_CONCURRENCY = 16
+
+
+def is_session_root_uri(uri: str, ctx: RequestContext) -> bool:
+    """Return whether *uri* is a canonical or legacy session collection root."""
+    normalized = uri.rstrip("/")
+    return normalized in {canonical_session_uri(ctx), "viking://session"}
+
+
+def session_activity_value(entry: Dict[str, Any]) -> str:
+    """Return the logical activity timestamp, falling back to filesystem mtime."""
+    for key in ("activityTime", "modTime", "mod_time"):
+        value = entry.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def session_activity_sort_key(entry: Dict[str, Any]) -> tuple[bool, float]:
+    """Build a key that keeps missing/invalid timestamps below valid ones."""
+    value = session_activity_value(entry)
+    if value:
+        try:
+            return True, parse_iso_datetime(value).timestamp()
+        except (TypeError, ValueError, OverflowError):
+            pass
+    return False, 0.0
+
+
+def sort_session_entries_by_activity(
+    entries: Iterable[Dict[str, Any]], *, descending: bool = True
+) -> List[Dict[str, Any]]:
+    """Sort session entries by logical activity while preserving stable ties."""
+    return sorted(entries, key=session_activity_sort_key, reverse=descending)
+
+
+async def project_session_activity(
+    entries: Iterable[Dict[str, Any]],
+    *,
+    root_uri: str,
+    viking_fs: VikingFS,
+    ctx: RequestContext,
+) -> List[Dict[str, Any]]:
+    """Attach ``activityTime`` using ``.meta.json.updated_at`` when available.
+
+    Per-entry failures deliberately fall back to the directory's real mtime so
+    a corrupt or legacy metadata file cannot make session listing fail.
+    """
+    semaphore = asyncio.Semaphore(_META_READ_CONCURRENCY)
+
+    async def project(entry: Dict[str, Any]) -> Dict[str, Any]:
+        projected = dict(entry)
+        fallback = session_activity_value(projected)
+        name = str(projected.get("name") or "")
+        if not projected.get("isDir") or name in {"", ".", ".."}:
+            projected["activityTime"] = fallback
+            return projected
+
+        entry_uri = str(projected.get("uri") or f"{root_uri.rstrip('/')}/{name}")
+        projected["uri"] = entry_uri
+        try:
+            async with semaphore:
+                raw = await viking_fs.read_file(f"{entry_uri}/.meta.json", ctx=ctx)
+            payload = json.loads(raw or "")
+            updated_at = payload.get("updated_at") if isinstance(payload, dict) else None
+            if isinstance(updated_at, str) and updated_at:
+                parse_iso_datetime(updated_at)
+                projected["activityTime"] = updated_at
+                return projected
+        except Exception:
+            logger.debug("Failed to read session activity for %s", entry_uri, exc_info=True)
+
+        projected["activityTime"] = fallback
+        return projected
+
+    return list(await asyncio.gather(*(project(entry) for entry in entries)))

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -11,12 +11,18 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from openviking.core.namespace import canonical_session_uri
 from openviking.server.config import ToolOutputExternalizationConfig
 from openviking.server.identity import RequestContext
+from openviking.service.session_activity import (
+    SESSION_LIST_LIMIT,
+    project_session_activity,
+    session_activity_value,
+    sort_session_entries_by_activity,
+)
 from openviking.service.task_tracker import get_task_tracker
 from openviking.session import Session
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory_policy import MemoryPolicy
 from openviking.storage import VikingDBManager
-from openviking.storage.viking_fs import VikingFS
+from openviking.storage.viking_fs import LS_ALL_NODES, VikingFS
 from openviking_cli.exceptions import (
     AlreadyExistsError,
     NotFoundError,
@@ -196,8 +202,13 @@ class SessionService:
         try:
             entries = await self._viking_fs.ls(
                 session_base_uri,
-                sort_by="mtime",
-                sort_order="desc",
+                node_limit=LS_ALL_NODES,
+                ctx=ctx,
+            )
+            entries = await project_session_activity(
+                entries,
+                root_uri=session_base_uri,
+                viking_fs=self._viking_fs,
                 ctx=ctx,
             )
             for entry in entries:
@@ -208,7 +219,7 @@ class SessionService:
                     "session_id": name,
                     "uri": f"{session_base_uri}/{name}",
                     "is_dir": entry.get("isDir", False),
-                    "mod_time": entry.get("modTime", ""),
+                    "mod_time": session_activity_value(entry),
                 }
         except Exception:
             logger.debug("Failed to list sessions", exc_info=True)
@@ -216,8 +227,13 @@ class SessionService:
         try:
             entries = await self._viking_fs.ls(
                 "viking://session",
-                sort_by="mtime",
-                sort_order="desc",
+                node_limit=LS_ALL_NODES,
+                ctx=ctx,
+            )
+            entries = await project_session_activity(
+                entries,
+                root_uri="viking://session",
+                viking_fs=self._viking_fs,
                 ctx=ctx,
             )
             for entry in entries:
@@ -228,11 +244,11 @@ class SessionService:
                     "session_id": name,
                     "uri": entry.get("uri", f"viking://session/{name}"),
                     "is_dir": entry.get("isDir", False),
-                    "mod_time": entry.get("modTime", ""),
+                    "mod_time": session_activity_value(entry),
                 }
         except Exception:
             logger.debug("Failed to list legacy sessions", exc_info=True)
-        return list(sessions_by_id.values())
+        return sort_session_entries_by_activity(sessions_by_id.values())[:SESSION_LIST_LIMIT]
 
     async def delete(self, session_id: str, ctx: RequestContext) -> bool:
         """Delete a session.

--- a/tests/server/test_api_fs_ls_sort.py
+++ b/tests/server/test_api_fs_ls_sort.py
@@ -3,6 +3,7 @@
 
 """End-to-end coverage for ordered, limited filesystem listings."""
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -67,7 +68,11 @@ async def test_session_list_keeps_newest_directory_past_storage_limit(client, se
 
     newest_uri = f"{root_uri}/zz-newest"
     await service.viking_fs.mkdir(newest_uri, ctx=ctx)
-    await service.viking_fs.mkdir(f"{newest_uri}/activity", ctx=ctx)
+    await service.viking_fs.write_file(
+        f"{newest_uri}/.meta.json",
+        json.dumps({"updated_at": "2099-01-01T00:00:00Z"}),
+        ctx=ctx,
+    )
 
     response = await client.get("/api/v1/sessions")
 
@@ -75,3 +80,42 @@ async def test_session_list_keeps_newest_directory_past_storage_limit(client, se
     sessions = response.json()["result"]
     assert len(sessions) == 1000
     assert sessions[0]["session_id"] == "zz-newest"
+
+
+async def test_session_fs_list_orders_by_meta_activity(client, service):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    root_uri = canonical_session_uri(ctx)
+    await service.viking_fs.mkdir(root_uri, exist_ok=True, ctx=ctx)
+
+    older_directory = f"{root_uri}/recently-active"
+    newer_directory = f"{root_uri}/newer-directory"
+    await service.viking_fs.mkdir(older_directory, ctx=ctx)
+    await service.viking_fs.mkdir(newer_directory, ctx=ctx)
+    await service.viking_fs.write_file(
+        f"{older_directory}/.meta.json",
+        json.dumps({"updated_at": "2026-07-14T01:00:00Z"}),
+        ctx=ctx,
+    )
+    await service.viking_fs.write_file(
+        f"{newer_directory}/.meta.json",
+        json.dumps({"updated_at": "2026-07-13T01:00:00Z"}),
+        ctx=ctx,
+    )
+
+    response = await client.get(
+        "/api/v1/fs/ls",
+        params={
+            "uri": root_uri,
+            "output": "original",
+            "sort_by": "mtime",
+            "sort_order": "desc",
+        },
+    )
+
+    assert response.status_code == 200
+    entries = response.json()["result"]
+    assert [entry["name"] for entry in entries] == [
+        "recently-active",
+        "newer-directory",
+    ]
+    assert entries[0]["activityTime"] == "2026-07-14T01:00:00Z"

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -151,6 +151,28 @@ async def test_list_sessions(client: httpx.AsyncClient):
     assert isinstance(body["result"], list)
 
 
+async def test_adding_message_moves_existing_session_to_front(client: httpx.AsyncClient):
+    await client.post("/api/v1/sessions", json={"session_id": "older-session"})
+    await asyncio.sleep(0.01)
+    await client.post("/api/v1/sessions", json={"session_id": "newer-session"})
+    await asyncio.sleep(0.01)
+
+    add_response = await client.post(
+        "/api/v1/sessions/older-session/messages",
+        json=_message_request("user", content="new activity"),
+    )
+    assert add_response.status_code == 200
+
+    response = await client.get("/api/v1/sessions")
+
+    assert response.status_code == 200
+    sessions = response.json()["result"]
+    assert [session["session_id"] for session in sessions[:2]] == [
+        "older-session",
+        "newer-session",
+    ]
+
+
 async def test_get_session(client: httpx.AsyncClient):
     create_resp = await client.post("/api/v1/sessions", json={})
     session_id = create_resp.json()["result"]["session_id"]

--- a/tests/service/test_session_service_metrics.py
+++ b/tests/service/test_session_service_metrics.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import json
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -9,6 +10,7 @@ import openviking.service.session_service as session_service_module
 from openviking.metrics.datasources.session import SessionLifecycleDataSource
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
+from openviking.storage.viking_fs import LS_ALL_NODES
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -91,7 +93,7 @@ async def test_sessions_merges_canonical_and_legacy_session_scope():
     ctx = _make_ctx()
 
     async def _ls(uri, ctx, **kwargs):
-        assert kwargs == {"sort_by": "mtime", "sort_order": "desc"}
+        assert kwargs == {"node_limit": LS_ALL_NODES}
         if uri == "viking://user/alice/sessions":
             return [
                 {"name": "duplicate", "isDir": True, "modTime": "2026-07-13T01:00:00Z"},
@@ -115,21 +117,22 @@ async def test_sessions_merges_canonical_and_legacy_session_scope():
         raise AssertionError(uri)
 
     service._viking_fs.ls = AsyncMock(side_effect=_ls)
+    service._viking_fs.read_file = AsyncMock(return_value=None)
 
     result = await service.sessions(ctx)
 
     assert result == [
         {
-            "session_id": "duplicate",
-            "uri": "viking://user/alice/sessions/duplicate",
-            "is_dir": True,
-            "mod_time": "2026-07-13T01:00:00Z",
-        },
-        {
             "session_id": "new-session",
             "uri": "viking://user/alice/sessions/new-session",
             "is_dir": True,
             "mod_time": "2026-07-13T02:00:00Z",
+        },
+        {
+            "session_id": "duplicate",
+            "uri": "viking://user/alice/sessions/duplicate",
+            "is_dir": True,
+            "mod_time": "2026-07-13T01:00:00Z",
         },
         {
             "session_id": "legacy-session",
@@ -138,3 +141,46 @@ async def test_sessions_merges_canonical_and_legacy_session_scope():
             "mod_time": "2026-07-12T01:00:00Z",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_sessions_orders_by_meta_activity_instead_of_directory_mtime():
+    service = SessionService(viking_fs=Mock())
+    ctx = _make_ctx()
+
+    async def _ls(uri, ctx, **kwargs):
+        assert kwargs == {"node_limit": LS_ALL_NODES}
+        if uri == "viking://user/alice/sessions":
+            return [
+                {
+                    "name": "recently-active",
+                    "isDir": True,
+                    "modTime": "2026-07-12T01:00:00Z",
+                },
+                {
+                    "name": "newer-directory",
+                    "isDir": True,
+                    "modTime": "2026-07-13T01:00:00Z",
+                },
+            ]
+        if uri == "viking://session":
+            return []
+        raise AssertionError(uri)
+
+    async def _read_file(uri, ctx):
+        updated_at = {
+            "viking://user/alice/sessions/recently-active/.meta.json": ("2026-07-14T01:00:00Z"),
+            "viking://user/alice/sessions/newer-directory/.meta.json": ("2026-07-13T01:00:00Z"),
+        }[uri]
+        return json.dumps({"updated_at": updated_at})
+
+    service._viking_fs.ls = AsyncMock(side_effect=_ls)
+    service._viking_fs.read_file = AsyncMock(side_effect=_read_file)
+
+    result = await service.sessions(ctx)
+
+    assert [item["session_id"] for item in result] == [
+        "recently-active",
+        "newer-directory",
+    ]
+    assert result[0]["mod_time"] == "2026-07-14T01:00:00Z"

--- a/web-studio/src/routes/playground/route.tsx
+++ b/web-studio/src/routes/playground/route.tsx
@@ -494,7 +494,10 @@ function PlaygroundWorkbench() {
             onOpenProcessingTasks={handleOpenProcessingTasks}
             onOpenSearch={handleOpenSearch}
             onRefresh={() => {
-              void invalidateList(currentUri)
+              // Expanded directories use independent list-query keys. Refresh
+              // all active lists so a session's new activity order is not
+              // hidden by a still-fresh expanded subtree cache.
+              void invalidateList()
               void listQuery.refetch()
             }}
           />

--- a/web-studio/src/routes/resources/-lib/api.test.ts
+++ b/web-studio/src/routes/resources/-lib/api.test.ts
@@ -35,4 +35,29 @@ describe('fetchFsList', () => {
       }),
     })
   })
+
+  it('prefers logical session activity over directory mtime', async () => {
+    getFsLsMock.mockResolvedValue({
+      data: {
+        status: 'ok',
+        result: [
+          {
+            name: 'session-a',
+            uri: 'viking://user/default/sessions/session-a',
+            isDir: true,
+            modTime: '2026-07-12T01:00:00Z',
+            activityTime: '2026-07-14T01:00:00Z',
+          },
+        ],
+      },
+      headers: {},
+      status: 200,
+    })
+
+    const result = await fetchFsList('viking://user/default/sessions')
+
+    expect(result.entries[0]?.modTimestamp).toBe(
+      Date.parse('2026-07-14T01:00:00Z'),
+    )
+  })
 })

--- a/web-studio/src/routes/resources/-lib/normalize.ts
+++ b/web-studio/src/routes/resources/-lib/normalize.ts
@@ -361,6 +361,8 @@ export function normalizeFsEntry(
       item.contentLength,
     ])
     const modRaw = pickFirstNonEmpty([
+      item.activityTime,
+      item.activity_time,
       item.modTime,
       item.mod_time,
       item.modified_at,


### PR DESCRIPTION
## Description

会话列表原先把 session 目录的真实 `mtime` 当作最近活动时间；向 `messages.jsonl` 追加消息只会更新文件和 `.meta.json.updated_at`，不会可靠更新父目录，因此 API 与 Playground 都可能继续显示旧顺序。

本 PR 在服务层引入共享的 session activity 投影：保留底层真实 `mtime`，同时以 `.meta.json.updated_at` 作为规范活动时间。`GET /api/v1/sessions` 与 session 根目录的 `/fs/ls` 使用同一投影，先按活动时间排序、再应用原有 1000/请求上限。Playground 显式消费 `activityTime`，手动刷新时也会失效所有已展开目录查询。

关键行为由：

```text
before: directory.modTime -> sort -> limit
after:  .meta.json.updated_at (fallback directory.modTime) -> sort -> limit
```

元数据读取并发限制为 16；损坏或缺失的 legacy `.meta.json` 会逐项 fail-open 到目录时间，不会使整个列表失败。

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3234

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 共享 `.meta.json.updated_at` 活动时间投影，并保持 legacy/损坏元数据回退。
- API 和文件树都在截断前按规范活动时间排序；agent 文件树路径避免为全部 session 预取无用 abstract。
- Playground 优先使用 `activityTime`，刷新时同步失效已展开的 session 子树缓存。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- `9 passed`：SessionService、FS list、真实 add-message 排序回归。
- `2 passed`：Web Studio activityTime 归一化测试。
- Python Ruff、前端 Prettier/ESLint 通过。
- 扩大到完整 `test_api_sessions.py` 后为 `39 passed, 1 failed`；唯一失败 `test_tool_result_externalization_respects_server_config_disabled` 可独立复现为请求未带认证头返回 401，本 PR 未修改认证路径。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用；该问题是列表排序和缓存失效语义。

## Additional Notes

底层文件系统的 `modTime` 仍表示真实文件时间；逻辑活动时间通过独立字段投影，避免把 session 业务语义泄漏成通用文件系统语义。
