### PR TITLE
fix(recall): hide memory fields metadata

### DIFF
--- a/openviking/retrieve/type_quota_recall.py
+++ b/openviking/retrieve/type_quota_recall.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping
 
 from openviking.core.namespace import canonical_user_root
 from openviking.server.identity import RequestContext
+from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 
 TYPE_ORDER = ("events", "entities", "preferences", "experiences")
 DEFAULT_QUOTAS = {"events": 10, "entities": 10, "preferences": 3, "experiences": 0}
@@ -399,7 +400,11 @@ async def search_type_quota_recall(
         abstract = _abstract(item)
         content = ""
         try:
-            content = await service.fs.read(uri, ctx=read_ctx)
+            raw_content = await service.fs.read(uri, ctx=read_ctx)
+            if isinstance(raw_content, bytes):
+                raw_content = raw_content.decode("utf-8")
+            if isinstance(raw_content, str):
+                content = MemoryFileUtils.read(raw_content, uri=uri).content
         except Exception:
             content = ""
 

--- a/tests/retrieve/test_type_quota_recall.py
+++ b/tests/retrieve/test_type_quota_recall.py
@@ -112,3 +112,51 @@ async def test_parallel_search_preserves_type_order():
 
     assert [entry.type for entry in result.entries] == ["events", "entities"]
     assert [entry.rank for entry in result.entries] == [1, 1]
+
+
+async def test_recall_hides_persisted_memory_fields_metadata():
+    memory_uri = "viking://user/test_user/memories/events/example.md"
+    raw_memory = """Visible memory body
+
+<!-- MEMORY_FIELDS
+{
+  "event_name": "internal-event",
+  "user_id": "test_user",
+  "memory_type": "events"
+}
+-->"""
+
+    async def fake_find(**kwargs):
+        if kwargs["target_uri"].endswith("/events") and "/peers/" not in kwargs["target_uri"]:
+            return _FakeFindResult([{"uri": memory_uri, "score": 0.9}])
+        return _FakeFindResult()
+
+    async def fake_read(uri, **kwargs):
+        del kwargs
+        assert uri == memory_uri
+        return raw_memory
+
+    service = SimpleNamespace(
+        search=SimpleNamespace(find=fake_find),
+        fs=SimpleNamespace(read=fake_read),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier.the_default_user("test_user"),
+        role=Role.USER,
+        actor_peer_id="current",
+    )
+
+    result = await search_type_quota_recall(
+        service=service,
+        ctx=ctx,
+        query="visible memory",
+        peer_scope="actor",
+        quotas={"events": 1, "entities": 0, "preferences": 0, "experiences": 0},
+        max_chars=10_000,
+    )
+
+    assert len(result.entries) == 1
+    assert result.entries[0].content == "Visible memory body"
+    assert "Visible memory body" in result.rendered
+    assert "MEMORY_FIELDS" not in result.rendered
+    assert "internal-event" not in result.rendered


### PR DESCRIPTION
## Description

`type_quota_recall` 目前直接读取持久化 memory 文件，导致 `<!-- MEMORY_FIELDS ... -->` 内部元数据进入 `RecallEntry.content` 和最终的 `<memory>` 输出。正常 content API 已通过 `MemoryFileUtils` 返回可见正文；本修复让 recall 路径遵循同一语义，在去重、字符预算、摘要和渲染前移除持久化元数据。

修复前，召回正文可能包含：

```text
Visible memory body
<!-- MEMORY_FIELDS { ... } -->
```

修复后只向调用方返回：

```text
Visible memory body
```

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3239

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 使用 `MemoryFileUtils.read(...).content` 解析 recall 读取到的持久化 memory，使其与非 raw content API 保持一致。
- 兼容文件系统返回 `bytes` 的情况，再统一解析可见正文。
- 增加回归测试，验证 entry 与 rendered output 均不会暴露 `MEMORY_FIELDS` 或其中的内部字段。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```text
PYTHONPATH=. python -m pytest -o addopts='' tests/retrieve/test_type_quota_recall.py -q
3 passed

uvx ruff check openviking/retrieve/type_quota_recall.py tests/retrieve/test_type_quota_recall.py
All checks passed!
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

改动只影响 recall 对已持久化 memory 正文的读取方式，不改变 memory 文件格式、搜索结果排序或配额策略。
