### PR TITLE
fix: sync media vectorization extensions

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -202,8 +202,8 @@ def get_resource_content_type(file_name: str) -> Optional[ResourceContentType]:
         ".mm",
     }
     image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
-    video_extensions = {".mp4", ".avi", ".mov", ".wmv", ".flv"}
-    audio_extensions = {".mp3", ".wav", ".aac", ".flac"}
+    video_extensions = {".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv", ".webm"}
+    audio_extensions = {".mp3", ".wav", ".aac", ".flac", ".ogg", ".m4a", ".opus", ".ac3"}
 
     if any(file_name.endswith(ext) for ext in text_extensions):
         return ResourceContentType.TEXT

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from openviking.core.context import Context
+from openviking.core.context import Context, ResourceContentType
 from openviking.utils import embedding_utils
 
 
@@ -62,6 +62,31 @@ class DummyReq:
     def __init__(self):
         self.user = DummyUser()
         self.account_id = "default"
+
+
+@pytest.mark.parametrize("extension", [".ogg", ".m4a", ".opus", ".ac3"])
+def test_get_resource_content_type_recognizes_supported_audio_extensions(extension):
+    assert (
+        embedding_utils.get_resource_content_type(f"recording{extension}")
+        == ResourceContentType.AUDIO
+    )
+
+
+@pytest.mark.parametrize("extension", [".mkv", ".webm"])
+def test_get_resource_content_type_recognizes_supported_video_extensions(extension):
+    assert (
+        embedding_utils.get_resource_content_type(f"recording{extension}")
+        == ResourceContentType.VIDEO
+    )
+
+
+def test_get_resource_content_type_media_extensions_are_case_insensitive():
+    assert embedding_utils.get_resource_content_type("RECORDING.OPUS") == ResourceContentType.AUDIO
+    assert embedding_utils.get_resource_content_type("RECORDING.WEBM") == ResourceContentType.VIDEO
+
+
+def test_get_resource_content_type_keeps_ts_as_text():
+    assert embedding_utils.get_resource_content_type("source.ts") == ResourceContentType.TEXT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

  Synchronize resource vectorization type detection with the media formats already supported by the parser. This prevents
  supported audio and video files from being incorrectly handled as unknown files.

  ## Human Involvement

  - [x] A human participated in the implementation or review loop
  - [ ] This PR was generated entirely by AI agents without human participation in the loop

  ## Related Issue

  N/A

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)

  ## Changes Made

  - Classify `.ogg`, `.m4a`, `.opus`, and `.ac3` resources as audio during vectorization.
  - Classify `.mkv` and `.webm` resources as video during vectorization.
  - Add regression tests covering the new extensions, case-insensitive filenames, and preservation of the current `.ts` text
  classification.

  ## Testing

  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have tested this on the following platforms:
    - [ ] Linux
    - [x] macOS
    - [ ] Windows

  Commands executed:

  ```bash
  uv run --frozen --extra test pytest tests/unit/test_vectorize_file_strategy.py -q --no-cov
  uv run --frozen --extra dev ruff check openviking/utils/embedding_utils.py tests/unit/test_vectorize_file_strategy.py
```

  Result: 25 tests passed and Ruff reported no issues.

  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes

  The .ts extension remains classified as text in the vectorization layer. Since .ts can represent either TypeScript source
  code or MPEG Transport Stream video, resolving that ambiguity requires a separate change using MIME information, source
  context, parser metadata, or content-based detection.