### PR TITLE
fix(migration): ignore legacy structural user partitions

### DIFF
--- a/openviking/service/legacy_migration.py
+++ b/openviking/service/legacy_migration.py
@@ -19,12 +19,15 @@ from openviking.storage.viking_fs import VikingFS
 from openviking_cli.exceptions import FailedPreconditionError
 from openviking_cli.session.user_id import UserIdentifier, validate_user_id
 
-
 # Reserved sub-directories of viking://agent/ that belong to the new public
 # scope layout (skills, endpoints, tools, payments). They must not be treated
 # as legacy ``agent_id`` directories by either the migration planner or the
 # cleanup planner.
 _AGENT_RESERVED_SUBDIRS = frozenset({"skills", "endpoints", "tools", "payments"})
+
+# Legacy ``agent/<agent_id>/user`` trees also contained payload partitions.
+# Their names are valid user IDs, so filter them before identity registration.
+_LEGACY_AGENT_USER_RESERVED_SUBDIRS = frozenset({"resources", "skills", "memories", "instructions"})
 
 
 @dataclass(frozen=True)
@@ -223,9 +226,7 @@ class LegacyDataMigration:
                     if entry["name"] in _AGENT_RESERVED_SUBDIRS:
                         continue
                     legacy_path = f"{agent_path}/{entry['name']}"
-                    plan.targets.append(
-                        self._cleanup_target(account_id, legacy_path, "agent")
-                    )
+                    plan.targets.append(self._cleanup_target(account_id, legacy_path, "agent"))
 
             session_path = f"/local/{account_id}/session"
             if await self._exists(session_path):
@@ -436,6 +437,15 @@ class LegacyDataMigration:
                 if not user_entry["is_dir"]:
                     continue
                 user_id = user_entry["name"]
+                if user_id in _LEGACY_AGENT_USER_RESERVED_SUBDIRS:
+                    plan.skipped.append(
+                        {
+                            "type": "agent_user_partition",
+                            "source": self._path_to_uri(account_id, f"{user_root}/{user_id}"),
+                            "reason": "reserved legacy storage partition",
+                        }
+                    )
+                    continue
                 if not self._ensure_plan_user(account_id, user_id, plan):
                     continue
                 await self._plan_agent_tree(

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -981,6 +981,12 @@ async def test_legacy_migration_covers_all_accounts_and_agent_user_layout(
         f"/local/{acct}/agent/review-agent/user/charlie/skills/review/SKILL.md",
         "review skill",
     )
+    for structural_name in ("resources", "skills", "memories", "instructions"):
+        await _agfs_write(
+            admin_service,
+            f"/local/{acct}/agent/review-agent/user/{structural_name}/marker.txt",
+            "legacy structural payload",
+        )
     await _agfs_write(
         admin_service,
         f"/local/{other_acct}/agent/code-agent/memories/facts/other.md",
@@ -997,8 +1003,15 @@ async def test_legacy_migration_covers_all_accounts_and_agent_user_layout(
         item["account_id"] == acct and item["user_id"] == "charlie"
         for item in result["created_users"]
     )
+    assert {
+        item["source"].rsplit("/", 1)[-1]
+        for item in result["skipped"]
+        if item["type"] == "agent_user_partition"
+    } == {"resources", "skills", "memories", "instructions"}
     manager = admin_app.state.api_key_manager
     assert manager.has_user(acct, "charlie")
+    for structural_name in ("resources", "skills", "memories", "instructions"):
+        assert not manager.has_user(acct, structural_name)
     assert (
         await _agfs_read_text(
             admin_service,


### PR DESCRIPTION
## Description

修复 0.3.x 遗留数据迁移把 agent `user` 分区下的结构目录误注册为用户的问题。迁移规划现在会在身份注册前过滤 `resources`、`skills`、`memories` 和 `instructions`，同时保留合法遗留用户迁移。

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3238

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 定义遗留 agent-user 布局的结构分区保留名，并在 `_ensure_plan_user()` 前过滤。
- 将被过滤的物理分区写入 migration `skipped` 结果，便于审计迁移决策。
- 使用真实受影响目录形态增加回归测试，并验证同一账户下的合法用户仍可迁移。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- `pytest tests/server/test_admin_api.py -q --no-cov -k 'legacy_migration'`：4 passed
- `ruff check openviking/service/legacy_migration.py tests/server/test_admin_api.py`
- `ruff format --check openviking/service/legacy_migration.py tests/server/test_admin_api.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

完整的 legacy migration 测试组中，4 个 migration 用例通过；相邻 cleanup 用例仍复现 current `main` 已有的 URI 断言差异（期望 `viking://agent`，实际为 `viking://agent/code-agent`），与本补丁修改的迁移规划路径无交叉。
