### PR TITLE
fix(codex): compress type-quota recall results

### DIFF
--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -154,7 +154,7 @@ Earlier plugin versions configured tuning fields under a `codex` block in `~/.op
       │                 │                │                   │
       │             ┌───▼────────────────▼───────────────────▼──┐
       └────────────►│        OpenViking REST API                │
-                    │ /api/v1/search/search                      │
+                    │ /api/v1/search/{recall,search}             │
                     │ /api/v1/sessions [+/{id}/{messages,commit}]│
                     │ /api/v1/content/read                      │
                     └─────────────────┬─────────────────────────┘
@@ -192,7 +192,7 @@ On `resume`, the script skips commit/sweep. If local state has no live `ovSessio
 
 ### Auto-recall (every UserPromptSubmit)
 
-`auto-recall.mjs` reads `prompt` and `session_id` from stdin, derives the long-lived OpenViking session id (`cx-<safe-session-id>`) directly from the Codex session id (no plugin state read, so a corrupt state file can't crash recall), calls `/api/v1/search/search` with that `session_id`, ranks results, reads full content for top-ranked leaves, and emits:
+`auto-recall.mjs` reads `prompt` and `session_id` from stdin. It first asks `/api/v1/search/recall` for bounded, type-quota candidates and passes those entries through the same relevance compressor used by the fallback path. If that endpoint is unavailable, the hook derives the long-lived OpenViking session id (`cx-<safe-session-id>`) directly from the Codex session id (no plugin state read, so a corrupt state file can't crash recall), calls `/api/v1/search/search` with that `session_id`, ranks results, and reads full content for top-ranked leaves before compression.
 
 ```json
 { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "<openviking-context source=\"auto-recall\" format=\"digest\">\nOpenViking memory digest:\n- ...\n</openviking-context>" } }

--- a/examples/codex-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.mjs
@@ -36,6 +36,7 @@ const effectivePeer = resolveEffectivePeerId({ cfg, cwd: process.cwd() });
 let emitted = false;
 let activeCompressor = null;
 let recallDeadline = null;
+const DEFAULT_FINAL_RECALL_CHARS = 6500;
 
 function output(obj, exitAfter = false) {
   if (emitted) return;
@@ -306,7 +307,9 @@ async function recallViaTypeQuotaEndpoint(query) {
       preferences: Math.max(1, Math.min(cfg.recallLimit, 3)),
       experiences: 0,
     },
-    max_chars: cfg.recallCompressMaxInputChars || 6500,
+    max_chars: cfg.recallCompress
+      ? cfg.recallCompressMaxInputChars
+      : DEFAULT_FINAL_RECALL_CHARS,
     min_score: cfg.scoreThreshold,
     render: true,
   };
@@ -317,13 +320,26 @@ async function recallViaTypeQuotaEndpoint(query) {
     return null;
   }
   const rendered = String(result.result?.rendered || "").trim();
-  if (!rendered) return "";
-  return [
-    "OpenViking memory digest:",
-    rendered,
-    "",
-    "More detail: use the OpenViking MCP recall/read/search tools with cited viking:// URIs if needed.",
-  ].join("\n");
+  const entries = Array.isArray(result.result?.entries) ? result.result.entries : [];
+  const items = entries
+    .map((entry) => ({
+      uri: String(entry?.uri || "").trim(),
+      category: String(entry?.type || "memory").trim() || "memory",
+      score: clampScore(entry?.score),
+      text: String(
+        entry?.content || entry?.summary || entry?.abstract || entry?.uri || "",
+      ).trim(),
+    }))
+    .filter((entry) => entry.uri && entry.text);
+  const context = rendered
+    ? [
+        "OpenViking memory digest:",
+        rendered,
+        "",
+        "More detail: use the OpenViking MCP recall/read/search tools with cited viking:// URIs if needed.",
+      ].join("\n")
+    : "";
+  return { context, items };
 }
 
 function truncateText(text, maxChars) {
@@ -556,13 +572,31 @@ async function main() {
 
   const endpointRecall = await recallViaTypeQuotaEndpoint(userPrompt);
   if (endpointRecall !== null) {
-    if (!endpointRecall) {
+    if (!endpointRecall.context && endpointRecall.items.length === 0) {
       log("skip", { stage: "recall_endpoint", reason: "no results" });
       emit();
       return;
     }
-    log("recall_endpoint", { chars: endpointRecall.length });
-    emit(endpointRecall);
+    const compressedContext = endpointRecall.items.length > 0
+      ? await compressMemoryContext(userPrompt, endpointRecall.items)
+      : null;
+    const endpointFallback = cfg.recallCompress && endpointRecall.items.length > 0
+      ? fallbackDigest(endpointRecall.items)
+      : endpointRecall.context;
+    const memoryContext = compressedContext === null
+      ? endpointFallback
+      : compressedContext;
+    if (!memoryContext) {
+      log("skip", { stage: "recall_endpoint", reason: "compressor found no relevant memory" });
+      emit();
+      return;
+    }
+    log("recall_endpoint", {
+      chars: memoryContext.length,
+      compressed: compressedContext !== null,
+      entryCount: endpointRecall.items.length,
+    });
+    emit(memoryContext);
     return;
   }
 

--- a/examples/codex-memory-plugin/scripts/auto-recall.test.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -75,6 +75,91 @@ function runAutoRecall(input, env) {
     });
     child.stdin.end(JSON.stringify(input));
   });
+}
+
+async function withFakeCodex(output, fn, { exitCode = 0 } = {}) {
+  const binDir = await mkdtemp(join(tmpdir(), "ov-fake-codex-"));
+  const executable = join(binDir, "codex");
+  const callLog = join(binDir, "calls.log");
+  await writeFile(executable, `#!/bin/sh
+output_path=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output-last-message" ]; then
+    shift
+    output_path="$1"
+  fi
+  shift
+done
+cat >/dev/null
+printf 'called\\n' >> "$FAKE_CODEX_CALL_LOG"
+if [ "$FAKE_CODEX_EXIT_CODE" -ne 0 ]; then
+  exit "$FAKE_CODEX_EXIT_CODE"
+fi
+printf '%s' "$FAKE_CODEX_OUTPUT" > "$output_path"
+`);
+  await chmod(executable, 0o755);
+  try {
+    return await fn({
+      callLog,
+      env: {
+        PATH: `${binDir}:${process.env.PATH}`,
+        FAKE_CODEX_CALL_LOG: callLog,
+        FAKE_CODEX_EXIT_CODE: String(exitCode),
+        FAKE_CODEX_OUTPUT: output,
+      },
+    });
+  } finally {
+    await rm(binDir, { recursive: true, force: true });
+  }
+}
+
+async function runEndpointCompressionCase({ prompt, entry, rendered, compressorOutput, exitCode = 0 }) {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-auto-recall-endpoint-compress-"));
+  let requestBody = null;
+  try {
+    return await withFakeCodex(compressorOutput, async ({ callLog, env }) => {
+      const result = await withMockOpenViking(async (req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/health") {
+          writeJson(res, { status: "ok", result: { ok: true } });
+          return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/v1/search/recall") {
+          requestBody = await readRequestBody(req);
+          writeJson(res, {
+            status: "ok",
+            result: { entries: [entry], rendered, stats: { returned: 1 } },
+          });
+          return;
+        }
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "error", error: "not found" }));
+      }, async (baseUrl) => runAutoRecall(
+        { prompt, session_id: "codex:endpoint-compress" },
+        {
+          ...env,
+          OPENVIKING_AUTO_RECALL: "1",
+          OPENVIKING_CODEX_STATE_DIR: stateDir,
+          OPENVIKING_CONFIG_FILE: join(stateDir, "missing-ov.conf"),
+          OPENVIKING_CLI_CONFIG_FILE: join(stateDir, "missing-ovcli.conf"),
+          OPENVIKING_CREDENTIAL_SOURCE: "env",
+          OPENVIKING_RECALL_COMPRESS: "1",
+          OPENVIKING_RECALL_TIMEOUT_MS: "10000",
+          OPENVIKING_MIN_QUERY_LENGTH: "1",
+          OPENVIKING_SCORE_THRESHOLD: "0",
+          OPENVIKING_TIMEOUT_MS: "5000",
+          OPENVIKING_URL: baseUrl,
+        },
+      ));
+      return {
+        output: JSON.parse(result.stdout.trim()),
+        compressorCalls: (await readFile(callLog, "utf-8")).trim().split("\n").length,
+        requestBody,
+      };
+    }, { exitCode });
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
 }
 
 test("auto-recall uses context-aware search with the derived OpenViking session id", async () => {
@@ -219,9 +304,49 @@ test("auto-recall prefers the server recall endpoint when available", async () =
 
     assert.deepEqual(requests.map((request) => request.path), ["/api/v1/search/recall"]);
     assert.equal(requests[0].body.quotas.events, 2);
+    assert.equal(requests[0].body.max_chars, 6500);
   } finally {
     await rm(stateDir, { recursive: true, force: true });
   }
+});
+
+test("auto-recall applies the relevance compressor to server recall entries", async () => {
+  const result = await runEndpointCompressionCase({
+    prompt: "Explain HTTP 429",
+    entry: {
+      uri: "viking://user/zeus/memories/events/unrelated.md",
+      score: 0.42,
+      type: "events",
+      mode: "summary",
+      summary: "Unrelated remembered detail",
+    },
+    rendered: "<memory_group>Unrelated remembered detail</memory_group>",
+    compressorOutput: "NO_RELEVANT_MEMORY",
+  });
+
+  assert.deepEqual(result.output, {});
+  assert.equal(result.compressorCalls, 1);
+  assert.equal(result.requestBody.max_chars, 18000);
+});
+
+test("auto-recall falls back to a bounded deterministic digest when endpoint compression fails", async () => {
+  const result = await runEndpointCompressionCase({
+    prompt: "Which editor do I prefer?",
+    entry: {
+      uri: "viking://user/zeus/memories/preferences/editor.md",
+      score: 0.91,
+      type: "preferences",
+      mode: "summary",
+      summary: "Use Vim",
+    },
+    rendered: "<memory_group>Use Vim</memory_group>",
+    compressorOutput: "",
+    exitCode: 1,
+  });
+
+  assert.match(result.output.hookSpecificOutput.additionalContext, /Use Vim/);
+  assert.doesNotMatch(result.output.hookSpecificOutput.additionalContext, /<memory_group>/);
+  assert.equal(result.compressorCalls, 1);
 });
 
 test("auto-recall expands configured user in memory search target", async () => {


### PR DESCRIPTION
## Description

Codex memory plugin 自 #3039 优先使用 `/api/v1/search/recall` 后，endpoint 成功路径会直接注入 server-rendered digest，并在现有 relevance compressor 之前提前返回。结果是 `OPENVIKING_RECALL_COMPRESS=1` 对正常路径失效，`NO_RELEVANT_MEMORY` 无法阻止无关记忆注入，同时 18,000 字符的 compressor 候选预算被误当成最终注入预算。

本 PR 恢复 README 已声明的合同：type-quota endpoint 仍负责有界候选选择，plugin 将 `entries` 规范化后交给现有 compressor 决定最终注入；compressor 明确判定无相关记忆时返回 `{}`。关闭 compression 时继续使用 server digest；compressor 不可用时 fail-open 到由 endpoint entries 生成的短确定性 digest。

关键路径：

```text
before: /search/recall.rendered -> inject
after:  /search/recall.entries -> existing compressor -> inject or {}
        compressor failure -> bounded deterministic digest
```

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3247

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 将 type-quota endpoint 的 `entries` 映射到现有 compressor item，不再绕过 relevance 判断。
- 区分 18,000 字符候选输入预算与 6,500 字符确定性最终 fallback；disabled/失败路径均保持 fail-open。
- 更新 Codex plugin 架构说明，并用 fake compressor 覆盖一次调用、`NO_RELEVANT_MEMORY`、disabled 与失败 fallback。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- `node --test examples/codex-memory-plugin/scripts/*.test.mjs`：35/35 通过。
- `node --check`：修改后的脚本与测试语法检查通过。
- 真实本地 OV/Codex smoke（不记录 raw memory）：负查询 2.625s、零注入；正查询 16.269s、最终 1,132 字符。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用；这是 hook 数据流与注入语义修复。

## Additional Notes

- 正命中仍会承担现有 Codex compressor 的明显延迟；本 PR 恢复已文档化的 relevance 行为，并未宣称解决 compressor 成本。真实 smoke 的 16.3s 已显式列入验证结果。
- 本次不修改 server `RecallRequest` 或 session-aware 检索合同；若后续把 relevance/continuation ownership 下沉到 server，应单独做效果、延迟与兼容性评估。
- Agentic project-peer recall 仅返回了低相关 PR-description 偏好，已忽略；实现决策来自 current-main 代码、issue 复现与测试。
