### PR TITLE
fix(auth): allow root key on trusted admin targets

### DIFF
--- a/openviking/server/auth/plugins/trusted.py
+++ b/openviking/server/auth/plugins/trusted.py
@@ -127,20 +127,22 @@ class TrustedAuthPlugin(AuthPlugin):
         effective_account_id = explicit_account_id or x_openviking_account
         effective_user_id = explicit_user_id or x_openviking_user
 
-        # Admin paths may omit identity completely, but partial identity is rejected.
+        # A verified Root key is the caller identity for admin routes. Path
+        # parameters such as ``account_id`` identify the managed resource, so
+        # they must not be mistaken for a partial caller identity.
         is_admin_path = request.url.path.startswith(_TRUSTED_RELAXED_IDENTITY_PREFIXES)
         if is_admin_path:
-            if bool(effective_account_id) != bool(effective_user_id):
-                raise InvalidArgumentError(
-                    "Trusted mode requests must include "
-                    "X-OpenViking-Account or explicit account_id in the URL and "
-                    "X-OpenViking-User or explicit user_id in the URL."
-                )
             if configured_root_api_key:
                 return ResolvedIdentity(
                     role=Role.ROOT,
                     account_id=effective_account_id or "trusted",
                     user_id=effective_user_id or "trusted",
+                )
+            if bool(effective_account_id) != bool(effective_user_id):
+                raise InvalidArgumentError(
+                    "Trusted mode requests must include "
+                    "X-OpenViking-Account or explicit account_id in the URL and "
+                    "X-OpenViking-User or explicit user_id in the URL."
                 )
             if not effective_account_id and not effective_user_id:
                 return ResolvedIdentity(

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -1318,11 +1318,7 @@ async def test_trusted_mode_admin_can_list_users_without_account_or_user_headers
 
     resp = await trusted_admin_client.get(
         f"/api/v1/admin/accounts/{acct}/users",
-        headers={
-            "X-API-Key": ROOT_KEY,
-            "X-OpenViking-Account": acct,
-            "X-OpenViking-User": "alice",
-        },
+        headers={"X-API-Key": ROOT_KEY},
     )
     assert resp.status_code == 200
     assert any(user["user_id"] == "alice" for user in resp.json()["result"])

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1386,6 +1386,23 @@ async def test_trusted_mode_admin_api_with_partial_identity_still_requires_full_
         )
 
 
+async def test_trusted_mode_root_key_can_target_account_without_caller_identity():
+    """A verified Root key should not treat a target account as partial caller identity."""
+    request = _make_request(
+        "/api/v1/admin/accounts/acme/users",
+        headers={"X-API-Key": ROOT_KEY},
+        auth_mode="trusted",
+        root_api_key=ROOT_KEY,
+    )
+    request.scope["path_params"] = {"account_id": "acme"}
+
+    identity = await resolve_identity(request, x_api_key=ROOT_KEY)
+
+    assert identity.role == Role.ROOT
+    assert identity.account_id == "acme"
+    assert identity.user_id == "trusted"
+
+
 async def test_trusted_mode_get_request_context_exempts_admin_paths():
     """get_request_context should exempt admin paths from identity checks in trusted mode."""
     # Admin path with ROOT identity from default


### PR DESCRIPTION
## Description

trusted 模式下，Studio 用户管理会使用配置中的 Root API key 请求指定 account 的 admin users 接口，但不会额外携带调用者的 account/user 头。现有鉴权把 URL 中的目标 `account_id` 误判为“不完整的调用者身份”，导致请求在 Root key 判定前返回 400。

本 PR 让已验证的 Root key 在 admin 路径上先建立 Root 调用者身份，再保留 URL 中的 account/user 作为目标资源。普通 trusted 请求、非 Root key 请求以及 header/path 身份冲突的校验不变。

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3246

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 在 trusted admin 路径中，将已配置且已验证的 Root key 判定提前到 partial-identity 拒绝之前。
- 保留 header/path mismatch 校验以及没有 Root key 时必须提供完整 caller identity 的约束。
- 增加鉴权单测，并修正 HTTP 回归测试，使其真实复现 Studio 只发送 `X-API-Key` 的请求。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已验证：

- trusted auth 目标回归：3 passed
- admin users HTTP 回归：1 passed
- Ruff 与 `git diff --check`：通过
- 完整相邻套件存在 current-main 既有、与本补丁无关的失败：admin 34 passed / 1 failed；auth 66 passed / 3 failed。新增及受影响的 trusted-mode 用例均通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

复现截图见 #3246；本修复不改变 UI。

## Additional Notes

本轮重新核对了 Studio 与服务端的调用边界：

- Studio 的 admin client 自引入以来就只发送控制面凭证 `X-API-Key`；它的 `AdminConnection` 虽包含 account/user，但不会把两者作为 caller header 发送。
- Studio 的 data-plane client 才在 trusted 模式下通过 `identityHeaders` 注入 `X-OpenViking-Account` 与 `X-OpenViking-User`。
- 因此这里不应让 Studio 为 Root 控制面请求伪造用户身份；修复点应留在服务端 admin 鉴权边界，将 URL account/user 解释为被管理资源，而不是 Root caller 身份。
- 风险仍被限制在 trusted 模式的 `/api/v1/admin` 路径且仅在配置中的 Root key 验证成功后生效；非 admin 数据接口、非 Root key 以及 header/path 冲突仍走原约束。