### PR TITLE
fix(plugins): harden durable write queues

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/auto-capture.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-capture.mjs
@@ -77,7 +77,9 @@ async function saveState(sessionId, state) {
   try {
     await mkdir(STATE_DIR, { recursive: true });
     await writeFile(stateFilePath(sessionId), JSON.stringify(state));
-  } catch { /* best effort */ }
+  } catch {
+    /* best effort */
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -94,16 +96,20 @@ const MEMORY_TRIGGERS = [
   /(?:favorite|favourite|love|hate|enjoy|dislike|admire|idol|fan of)/i,
 ];
 
-const RELEVANT_MEMORIES_BLOCK_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>/gi;
-const OPENVIKING_CTX_BLOCK_RE = /<openviking-context>[\s\S]*?<\/openviking-context>/gi;
-const SYSTEM_REMINDER_BLOCK_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/gi;
-const SUBAGENT_CONTEXT_LINE_RE = /^\[Subagent Context\][^\n]*$/gmi;
+const RELEVANT_MEMORIES_BLOCK_RE =
+  /<relevant-memories>[\s\S]*?<\/relevant-memories>/gi;
+const OPENVIKING_CTX_BLOCK_RE =
+  /<openviking-context>[\s\S]*?<\/openviking-context>/gi;
+const SYSTEM_REMINDER_BLOCK_RE =
+  /<system-reminder>[\s\S]*?<\/system-reminder>/gi;
+const SUBAGENT_CONTEXT_LINE_RE = /^\[Subagent Context\][^\n]*$/gim;
 const COMMAND_TEXT_RE = /^\/[a-z0-9_-]{1,64}\b/i;
 const NON_CONTENT_TEXT_RE = /^[\p{P}\p{S}\s]+$/u;
 const CJK_CHAR_RE = /[぀-ヿ㐀-鿿豈-﫿가-힯]/;
 // Question-only heuristic (ported from openclaw-plugin/text-utils.ts
 // looksLikeQuestionOnlyText). Pure interrogatives rarely yield memories.
-const QUESTION_ONLY_RE = /^(who|what|when|where|why|how|is|are|does|did|can|could|would|should|may|might|will|谁|什么|何|哪|为什么|怎么|如何|是|会|能|能否)\b.{0,200}[?？]$/i;
+const QUESTION_ONLY_RE =
+  /^(who|what|when|where|why|how|is|are|does|did|can|could|would|should|may|might|will|谁|什么|何|哪|为什么|怎么|如何|是|会|能|能否)\b.{0,200}[?？]$/i;
 
 // Strip plugin-injected blocks (auto-recall context, system reminders,
 // subagent context, relevant-memories) without collapsing whitespace —
@@ -121,9 +127,7 @@ function stripInjectedBlocks(text) {
 }
 
 function sanitize(text) {
-  return stripInjectedBlocks(text)
-    .replace(/\s+/g, " ")
-    .trim();
+  return stripInjectedBlocks(text).replace(/\s+/g, " ").trim();
 }
 
 function shouldCapture(text) {
@@ -151,7 +155,11 @@ function shouldCapture(text) {
   if (cfg.captureMode === "keyword") {
     for (const trigger of MEMORY_TRIGGERS) {
       if (trigger.test(normalized)) {
-        return { capture: true, reason: `trigger:${trigger}`, text: normalized };
+        return {
+          capture: true,
+          reason: `trigger:${trigger}`,
+          text: normalized,
+        };
       }
     }
     return { capture: false, reason: "no_trigger", text: normalized };
@@ -169,12 +177,18 @@ function parseTranscript(content) {
   try {
     const data = JSON.parse(content);
     if (Array.isArray(data)) return data;
-  } catch { /* not a JSON array */ }
+  } catch {
+    /* not a JSON array */
+  }
 
-  const lines = content.split("\n").filter(l => l.trim());
+  const lines = content.split("\n").filter((l) => l.trim());
   const messages = [];
   for (const line of lines) {
-    try { messages.push(JSON.parse(line)); } catch { /* skip */ }
+    try {
+      messages.push(JSON.parse(line));
+    } catch {
+      /* skip */
+    }
   }
   return messages;
 }
@@ -280,11 +294,14 @@ function buildParts(content, toolNameById) {
         tool_id: typeof block.id === "string" ? block.id : undefined,
         tool_name: block.name,
         tool_input:
-          block.input && typeof block.input === "object" ? block.input : undefined,
+          block.input && typeof block.input === "object"
+            ? block.input
+            : undefined,
         tool_status: "running",
       });
     } else if (block.type === "tool_result") {
-      const id = typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+      const id =
+        typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
       out.push({
         type: "tool",
         tool_id: id,
@@ -323,12 +340,19 @@ function extractAllTurns(messages) {
           if (!block || typeof block !== "object") continue;
           if (block.type === "text" && typeof block.text === "string") {
             parts.push(block.text);
-          } else if (block.type === "tool_use" && typeof block.name === "string") {
+          } else if (
+            block.type === "tool_use" &&
+            typeof block.name === "string"
+          ) {
             toolNames.push(block.name);
-            parts.push(`[tool: ${block.name}]\n${formatToolInput(block.input)}`);
+            parts.push(
+              `[tool: ${block.name}]\n${formatToolInput(block.input)}`,
+            );
           } else if (block.type === "tool_result") {
             const resultText = extractToolResultText(block.content);
-            const truncated = resultText ? truncateToolResult(resultText) : null;
+            const truncated = resultText
+              ? truncateToolResult(resultText)
+              : null;
             if (truncated) {
               parts.push(`[tool result]\n${truncated}`);
             }
@@ -423,7 +447,12 @@ async function enqueueTurnsToPending(ovSessionId, turns, peerId = "") {
 
     const payload = { role: turn.role, parts };
     if (peerId) payload.peer_id = peerId;
-    const res = await enqueuePendingDirectly("addMessage", ovSessionId, payload);
+    const res = await enqueuePendingDirectly(
+      "addMessage",
+      ovSessionId,
+      payload,
+      fetchJSON.queueScope,
+    );
     if (res.ok) queued++;
     else failed++;
   }
@@ -456,9 +485,15 @@ async function main() {
   const transcriptPath = input.transcript_path;
   const sessionId = input.session_id || "unknown";
   const cwd = input.cwd;
-  const ovSessionId = sessionId !== "unknown" ? deriveOvSessionId(sessionId) : null;
+  const ovSessionId =
+    sessionId !== "unknown" ? deriveOvSessionId(sessionId) : null;
   const effectivePeer = getEffectivePeerId(cfg, { sessionId, cwd });
-  log("start", { sessionId, ovSessionId, transcriptPath, peerSource: effectivePeer.source });
+  log("start", {
+    sessionId,
+    ovSessionId,
+    transcriptPath,
+    peerSource: effectivePeer.source,
+  });
 
   if (isBypassed(cfg, { sessionId, cwd })) {
     log("skip", { reason: "bypass_session_pattern" });
@@ -467,7 +502,10 @@ async function main() {
   }
 
   if (!transcriptPath || !ovSessionId) {
-    log("skip", { stage: "input_check", reason: "no transcript_path or session_id" });
+    log("skip", {
+      stage: "input_check",
+      reason: "no transcript_path or session_id",
+    });
     approve();
     return;
   }
@@ -490,7 +528,10 @@ async function main() {
   const messages = parseTranscript(transcriptContent);
   const allTurns = extractAllTurns(messages);
   if (allTurns.length === 0) {
-    log("skip", { stage: "transcript_parse", reason: "no user/assistant turns found" });
+    log("skip", {
+      stage: "transcript_parse",
+      reason: "no user/assistant turns found",
+    });
     approve();
     return;
   }
@@ -499,7 +540,7 @@ async function main() {
   const newTurns = allTurns.slice(state.capturedTurnCount);
   const captureTurns = cfg.captureAssistantTurns
     ? newTurns
-    : newTurns.filter(turn => turn.role === "user");
+    : newTurns.filter((turn) => turn.role === "user");
   log("transcript_parse", {
     totalTurns: allTurns.length,
     previouslyCaptured: state.capturedTurnCount,
@@ -516,7 +557,10 @@ async function main() {
 
   if (captureTurns.length === 0) {
     await saveState(sessionId, { capturedTurnCount: allTurns.length });
-    log("state_update", { newCapturedTurnCount: allTurns.length, reason: "assistant_only_increment" });
+    log("state_update", {
+      newCapturedTurnCount: allTurns.length,
+      reason: "assistant_only_increment",
+    });
     approve();
     return;
   }
@@ -548,7 +592,10 @@ async function main() {
         MEMORY_TRIGGERS.some((re) => re.test(sanitize(t.text))),
     );
     if (!hasTrigger) {
-      log("skip", { stage: "keyword_mode_no_trigger", turns: captureTurns.length });
+      log("skip", {
+        stage: "keyword_mode_no_trigger",
+        turns: captureTurns.length,
+      });
       await saveState(sessionId, { capturedTurnCount: allTurns.length });
       approve();
       return;
@@ -557,17 +604,29 @@ async function main() {
 
   log("should_capture", {
     capture: true,
-    reason: cfg.captureMode === "keyword" ? "keyword_trigger_matched" : "semantic",
+    reason:
+      cfg.captureMode === "keyword" ? "keyword_trigger_matched" : "semantic",
     combinedLength: combined.length,
   });
 
   const health = await fetchJSON("/health");
   let result;
   if (health.ok) {
-    result = await pushTurnsToOv(ovSessionId, captureTurns, effectivePeer.peerId);
+    result = await pushTurnsToOv(
+      ovSessionId,
+      captureTurns,
+      effectivePeer.peerId,
+    );
   } else if (isRetryableFailure(health)) {
-    logError("health_check", "server unreachable or unhealthy; enqueuing capture");
-    result = await enqueueTurnsToPending(ovSessionId, captureTurns, effectivePeer.peerId);
+    logError(
+      "health_check",
+      "server unreachable or unhealthy; enqueuing capture",
+    );
+    result = await enqueueTurnsToPending(
+      ovSessionId,
+      captureTurns,
+      effectivePeer.peerId,
+    );
     log("push_turns", {
       ovSessionId,
       ok: result.ok,
@@ -575,12 +634,18 @@ async function main() {
       failed: result.failed,
     });
     if (result.failed > 0) {
-      logError("pending_enqueue", "some turns failed to enqueue; state not advanced");
+      logError(
+        "pending_enqueue",
+        "some turns failed to enqueue; state not advanced",
+      );
       approve();
       return;
     }
     await saveState(sessionId, { capturedTurnCount: allTurns.length });
-    log("state_update", { newCapturedTurnCount: allTurns.length, reason: "pending_queued" });
+    log("state_update", {
+      newCapturedTurnCount: allTurns.length,
+      reason: "pending_queued",
+    });
     writeJsonState("last-capture.json", {
       turns_captured: 0,
       turns_queued: result.queued,
@@ -593,10 +658,17 @@ async function main() {
       ov_session_id: ovSessionId,
       cc_session_id: sessionId,
     });
-    approve(result.queued > 0 ? `queued ${result.queued} turns to pending queue` : undefined);
+    approve(
+      result.queued > 0
+        ? `queued ${result.queued} turns to pending queue`
+        : undefined,
+    );
     return;
   } else {
-    logError("health_check", `non-retryable status ${health.status || "unknown"}`);
+    logError(
+      "health_check",
+      `non-retryable status ${health.status || "unknown"}`,
+    );
     approve();
     return;
   }
@@ -609,7 +681,10 @@ async function main() {
   });
 
   if (result.enqueueFailed > 0) {
-    logError("pending_enqueue", "some retryable failures could not be enqueued; state not advanced");
+    logError(
+      "pending_enqueue",
+      "some retryable failures could not be enqueued; state not advanced",
+    );
     approve();
     return;
   }
@@ -632,7 +707,11 @@ async function main() {
     pendingTokens = Number(meta?.pending_tokens || 0);
     commitCount = Number(meta?.commit_count || 0);
     totalMessageCount = Number(meta?.total_message_count || 0);
-    log("pending_tokens", { ovSessionId, pending: pendingTokens, threshold: cfg.commitTokenThreshold });
+    log("pending_tokens", {
+      ovSessionId,
+      pending: pendingTokens,
+      threshold: cfg.commitTokenThreshold,
+    });
     if (pendingTokens >= cfg.commitTokenThreshold) {
       const commitRes = await commitSession(fetchJSON, ovSessionId, {
         keep_recent_count: cfg.commitKeepRecentCount,
@@ -678,11 +757,14 @@ async function main() {
   if (result.ok > 0) {
     approve(
       `captured ${result.ok} turns to ov session ${ovSessionId}` +
-      (committed ? " (committed)" : ""),
+        (committed ? " (committed)" : ""),
     );
   } else {
     approve();
   }
 }
 
-main().catch((err) => { logError("uncaught", err); approve(); });
+main().catch((err) => {
+  logError("uncaught", err);
+  approve();
+});

--- a/examples/claude-code-memory-plugin/scripts/lib/ov-session.mjs
+++ b/examples/claude-code-memory-plugin/scripts/lib/ov-session.mjs
@@ -24,6 +24,7 @@ import {
   deriveHarnessSessionId,
   isBypassed,
 } from "../shared/session-model.mjs";
+import { createQueueScope, enqueue } from "../shared/pending-queue.mjs";
 
 /**
  * Check whether a CC session_id or cwd matches any bypass pattern.
@@ -48,7 +49,7 @@ export function deriveOvSessionId(ccSessionId, suffix = "") {
  */
 export function makeFetchJSON(cfg, timeoutKey = "timeoutMs") {
   const timeoutMs = Math.max(1000, cfg[timeoutKey] || cfg.timeoutMs || 10000);
-  return async function fetchJSON(path, init = {}, options = {}) {
+  const fetchJSON = async function fetchJSON(path, init = {}, options = {}) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
@@ -58,10 +59,18 @@ export function makeFetchJSON(cfg, timeoutKey = "timeoutMs") {
       if (cfg.userId) headers["X-OpenViking-User"] = cfg.userId;
       const actorPeerId = options.actorPeerId ?? "";
       if (actorPeerId) headers["X-OpenViking-Actor-Peer"] = actorPeerId;
-      const res = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
+      const res = await fetch(`${cfg.baseUrl}${path}`, {
+        ...init,
+        headers,
+        signal: controller.signal,
+      });
       const body = await res.json().catch(() => ({}));
       if (!res.ok || body.status === "error") {
-        return { ok: false, status: res.status, error: body.error || { message: `HTTP ${res.status}` } };
+        return {
+          ok: false,
+          status: res.status,
+          error: body.error || { message: `HTTP ${res.status}` },
+        };
       }
       return { ok: true, result: body.result ?? body };
     } catch (err) {
@@ -70,6 +79,22 @@ export function makeFetchJSON(cfg, timeoutKey = "timeoutMs") {
       clearTimeout(timer);
     }
   };
+  let queueScope;
+  fetchJSON.queueScope = () => {
+    if (!queueScope) queueScope = queueScopeForConfig(cfg);
+    return queueScope;
+  };
+  return fetchJSON;
+}
+
+export function queueScopeForConfig(cfg) {
+  return createQueueScope({
+    producer: "claude-code",
+    baseUrl: cfg.baseUrl,
+    account: cfg.accountId,
+    user: cfg.userId,
+    apiKey: cfg.apiKey,
+  });
 }
 
 export function isRetryableFailure(res) {
@@ -88,10 +113,16 @@ function warnNonRetryable(operation, res) {
   );
 }
 
-export async function enqueuePendingDirectly(type, sessionId, payload = {}) {
+export async function enqueuePendingDirectly(
+  type,
+  sessionId,
+  payload = {},
+  queueScope,
+) {
   try {
-    const { enqueue } = await import("./pending-queue.mjs");
-    return await enqueue(type, sessionId, payload);
+    if (!queueScope) throw new Error("queue scope is required");
+    const scope = typeof queueScope === "function" ? queueScope() : queueScope;
+    return await enqueue(await scope, type, sessionId, payload);
   } catch {
     return { ok: false };
   }
@@ -106,13 +137,21 @@ export async function enqueuePendingDirectly(type, sessionId, payload = {}) {
  * { role, parts: [...] } (parts-mode, for tier-1 structured capture).
  */
 export async function addMessage(fetchJSON, sessionId, payload) {
-  const res = await fetchJSON(`/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  const res = await fetchJSON(
+    `/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
   if (!res.ok) {
     if (isRetryableFailure(res)) {
-      const queued = await enqueuePendingDirectly("addMessage", sessionId, payload);
+      const queued = await enqueuePendingDirectly(
+        "addMessage",
+        sessionId,
+        payload,
+        fetchJSON.queueScope,
+      );
       if (queued.ok) res.pendingQueued = true;
       else res.pendingEnqueueFailed = true;
     } else {
@@ -127,13 +166,21 @@ export async function addMessage(fetchJSON, sessionId, payload) {
  * call repeatedly: if there are no pending messages the server is a no-op.
  */
 export async function commitSession(fetchJSON, sessionId, payload = {}) {
-  const res = await fetchJSON(`/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`, {
-    method: "POST",
-    body: JSON.stringify(payload || {}),
-  });
+  const res = await fetchJSON(
+    `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload || {}),
+    },
+  );
   if (!res.ok) {
     if (isRetryableFailure(res)) {
-      const queued = await enqueuePendingDirectly("commitSession", sessionId, {});
+      const queued = await enqueuePendingDirectly(
+        "commitSession",
+        sessionId,
+        {},
+        fetchJSON.queueScope,
+      );
       if (queued.ok) res.pendingQueued = true;
       else res.pendingEnqueueFailed = true;
     } else {
@@ -147,7 +194,11 @@ export async function commitSession(fetchJSON, sessionId, payload = {}) {
  * Get assembled session context (includes latest_archive_overview).
  * Returns null when the session does not exist or the request fails.
  */
-export async function getSessionContext(fetchJSON, sessionId, tokenBudget = 128000) {
+export async function getSessionContext(
+  fetchJSON,
+  sessionId,
+  tokenBudget = 128000,
+) {
   const res = await fetchJSON(
     `/api/v1/sessions/${encodeURIComponent(sessionId)}/context?token_budget=${tokenBudget}`,
   );
@@ -158,8 +209,14 @@ export async function getSessionContext(fetchJSON, sessionId, tokenBudget = 1280
  * Fetch session meta. Returns null if the session does not exist (unless
  * autoCreate=true).
  */
-export async function getSession(fetchJSON, sessionId, { autoCreate = false } = {}) {
+export async function getSession(
+  fetchJSON,
+  sessionId,
+  { autoCreate = false } = {},
+) {
   const q = autoCreate ? "?auto_create=true" : "";
-  const res = await fetchJSON(`/api/v1/sessions/${encodeURIComponent(sessionId)}${q}`);
+  const res = await fetchJSON(
+    `/api/v1/sessions/${encodeURIComponent(sessionId)}${q}`,
+  );
   return res.ok ? res.result : null;
 }

--- a/examples/claude-code-memory-plugin/scripts/lib/pending-queue.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/lib/pending-queue.test.mjs
@@ -1,12 +1,22 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 
 import { addMessage } from "./ov-session.mjs";
 import {
   claimForReplay,
+  createQueueScope,
   enqueue,
   listPending,
   replayPending,
@@ -14,37 +24,61 @@ import {
 
 const originalEnv = {
   dir: process.env.OPENVIKING_PENDING_DIR,
+  keyFile: process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE,
   maxRetries: process.env.OPENVIKING_PENDING_MAX_RETRIES,
   replayLimit: process.env.OPENVIKING_PENDING_REPLAY_LIMIT,
   ttlDays: process.env.OPENVIKING_PENDING_TTL_DAYS,
 };
+const execFileAsync = promisify(execFile);
 
 async function withPendingDir(fn) {
   const dir = await mkdtemp(join(tmpdir(), "openviking-pending-test-"));
   process.env.OPENVIKING_PENDING_DIR = dir;
+  process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE = join(dir, "scope.key");
   delete process.env.OPENVIKING_PENDING_MAX_RETRIES;
   delete process.env.OPENVIKING_PENDING_REPLAY_LIMIT;
   delete process.env.OPENVIKING_PENDING_TTL_DAYS;
   try {
-    return await fn(dir);
+    const scope = await createQueueScope({
+      producer: "claude-code",
+      baseUrl: "https://ov.example.test",
+      apiKey: "test-key",
+    });
+    return await fn(dir, scope);
   } finally {
-    if (originalEnv.dir === undefined) delete process.env.OPENVIKING_PENDING_DIR;
+    if (originalEnv.dir === undefined)
+      delete process.env.OPENVIKING_PENDING_DIR;
     else process.env.OPENVIKING_PENDING_DIR = originalEnv.dir;
-    if (originalEnv.maxRetries === undefined) delete process.env.OPENVIKING_PENDING_MAX_RETRIES;
+    if (originalEnv.keyFile === undefined)
+      delete process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE;
+    else process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE = originalEnv.keyFile;
+    if (originalEnv.maxRetries === undefined)
+      delete process.env.OPENVIKING_PENDING_MAX_RETRIES;
     else process.env.OPENVIKING_PENDING_MAX_RETRIES = originalEnv.maxRetries;
-    if (originalEnv.replayLimit === undefined) delete process.env.OPENVIKING_PENDING_REPLAY_LIMIT;
+    if (originalEnv.replayLimit === undefined)
+      delete process.env.OPENVIKING_PENDING_REPLAY_LIMIT;
     else process.env.OPENVIKING_PENDING_REPLAY_LIMIT = originalEnv.replayLimit;
-    if (originalEnv.ttlDays === undefined) delete process.env.OPENVIKING_PENDING_TTL_DAYS;
+    if (originalEnv.ttlDays === undefined)
+      delete process.env.OPENVIKING_PENDING_TTL_DAYS;
     else process.env.OPENVIKING_PENDING_TTL_DAYS = originalEnv.ttlDays;
     await rm(dir, { recursive: true, force: true });
   }
 }
 
+function queueAwareFetch(scope, implementation) {
+  implementation.queueScope = () => Promise.resolve(scope);
+  return implementation;
+}
+
 test("addMessage queues retryable failures", async () => {
-  await withPendingDir(async () => {
+  await withPendingDir(async (_dir, scope) => {
     const payload = { role: "user", content: "remember this" };
     const res = await addMessage(
-      async () => ({ ok: false, status: 503, error: { message: "unavailable" } }),
+      queueAwareFetch(scope, async () => ({
+        ok: false,
+        status: 503,
+        error: { message: "unavailable" },
+      })),
       "cc-test-session",
       payload,
     );
@@ -52,7 +86,7 @@ test("addMessage queues retryable failures", async () => {
     assert.equal(res.ok, false);
     assert.equal(res.pendingQueued, true);
 
-    const pending = await listPending();
+    const pending = await listPending(scope);
     assert.equal(pending.length, 1);
     assert.equal(pending[0].entry.type, "addMessage");
     assert.equal(pending[0].entry.sessionId, "cc-test-session");
@@ -61,10 +95,14 @@ test("addMessage queues retryable failures", async () => {
 });
 
 test("addMessage does not queue non-retryable client failures", async () => {
-  await withPendingDir(async () => {
+  await withPendingDir(async (_dir, scope) => {
     for (const status of [401, 403, 404, 422]) {
       const res = await addMessage(
-        async () => ({ ok: false, status, error: { message: `HTTP ${status}` } }),
+        queueAwareFetch(scope, async () => ({
+          ok: false,
+          status,
+          error: { message: `HTTP ${status}` },
+        })),
         `cc-client-error-${status}`,
         { role: "user", content: `bad request ${status}` },
       );
@@ -74,71 +112,241 @@ test("addMessage does not queue non-retryable client failures", async () => {
       assert.equal(res.pendingEnqueueFailed, undefined);
     }
 
-    assert.deepEqual(await listPending(), []);
+    assert.deepEqual(await listPending(scope), []);
   });
 });
 
 test("replayPending sends queued entries and removes them after success", async () => {
-  await withPendingDir(async () => {
+  await withPendingDir(async (_dir, scope) => {
     const payload = { role: "assistant", content: "queued response" };
-    await enqueue("addMessage", "cc-replay", payload);
+    await enqueue(scope, "addMessage", "cc-replay", payload);
 
     const calls = [];
-    const result = await replayPending(async (path, init) => {
-      calls.push({ path, init });
-      return { ok: true };
-    }, () => {});
+    const result = await replayPending(
+      scope,
+      async (path, init) => {
+        calls.push({ path, init });
+        return { ok: true };
+      },
+      () => {},
+    );
 
-    assert.deepEqual(result, { replayed: 1, failed: 0, skipped: 0, deferred: 0 });
+    assert.deepEqual(result, {
+      replayed: 1,
+      failed: 0,
+      skipped: 0,
+      deferred: 0,
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].path, "/api/v1/sessions/cc-replay/messages");
     assert.deepEqual(JSON.parse(calls[0].init.body), payload);
-    assert.deepEqual(await listPending(), []);
+    assert.deepEqual(await listPending(scope), []);
   });
 });
 
 test("enqueue deduplicates identical payloads", async () => {
-  await withPendingDir(async () => {
+  await withPendingDir(async (_dir, scope) => {
     const payload = { role: "user", parts: [{ type: "text", text: "same" }] };
-    const first = await enqueue("addMessage", "cc-dedup", payload);
-    const second = await enqueue("addMessage", "cc-dedup", payload);
+    const first = await enqueue(scope, "addMessage", "cc-dedup", payload);
+    const second = await enqueue(scope, "addMessage", "cc-dedup", payload);
 
     assert.equal(first.ok, true);
     assert.equal(second.ok, true);
     assert.equal(second.deduped, true);
-    assert.equal((await listPending()).length, 1);
+    assert.equal((await listPending(scope)).length, 1);
+  });
+});
+
+test("enqueue preserves operation identity and promotes manual provenance", async () => {
+  await withPendingDir(async (_dir, scope) => {
+    const payload = {
+      role: "user",
+      content: "same operation across an upgrade",
+    };
+    const legacy = await enqueue(scope, "addMessage", "cc-upgrade", payload);
+
+    const automatic = await enqueue(
+      scope,
+      "addMessage",
+      "cc-upgrade",
+      payload,
+      { provenance: "autoCapture" },
+    );
+    assert.equal(automatic.deduped, true);
+    assert.equal(automatic.dedupKey, legacy.dedupKey);
+    let pending = await listPending(scope);
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].entry.provenance, undefined);
+
+    const manual = await enqueue(scope, "addMessage", "cc-upgrade", payload, {
+      provenance: "manual",
+    });
+    assert.equal(manual.deduped, true);
+    pending = await listPending(scope);
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].entry.provenance, "manual");
   });
 });
 
 test("replayPending honors the per-run replay limit", async () => {
-  await withPendingDir(async () => {
+  await withPendingDir(async (_dir, scope) => {
     process.env.OPENVIKING_PENDING_REPLAY_LIMIT = "1";
-    await enqueue("addMessage", "cc-limit", { role: "user", content: "one" });
-    await enqueue("addMessage", "cc-limit", { role: "user", content: "two" });
+    await enqueue(scope, "addMessage", "cc-limit", {
+      role: "user",
+      content: "one",
+    });
+    await enqueue(scope, "addMessage", "cc-limit", {
+      role: "user",
+      content: "two",
+    });
 
     const calls = [];
-    const result = await replayPending(async (path, init) => {
-      calls.push({ path, init });
-      return { ok: true };
-    }, () => {});
+    const result = await replayPending(
+      scope,
+      async (path, init) => {
+        calls.push({ path, init });
+        return { ok: true };
+      },
+      () => {},
+    );
 
     assert.equal(result.replayed, 1);
     assert.equal(result.deferred, 1);
     assert.equal(calls.length, 1);
-    assert.equal((await listPending()).length, 1);
+    assert.equal((await listPending(scope)).length, 1);
   });
 });
 
 test("claimForReplay atomically claims a file only once", async () => {
-  await withPendingDir(async (dir) => {
-    await enqueue("commitSession", "cc-claim", {});
-    const [{ filename }] = await listPending();
+  await withPendingDir(async (_dir, scope) => {
+    await enqueue(scope, "commitSession", "cc-claim", {});
+    const [{ filename }] = await listPending(scope);
 
-    const firstClaim = await claimForReplay(filename);
-    const secondClaim = await claimForReplay(filename);
+    const firstClaim = await claimForReplay(scope, filename);
+    const secondClaim = await claimForReplay(scope, filename);
 
     assert.match(firstClaim, /\.processing$/);
     assert.equal(secondClaim, null);
-    assert.deepEqual(await readdir(dir), [firstClaim]);
+    assert.deepEqual(await readdir(scope.dir), [firstClaim]);
+  });
+});
+
+test("queue scopes isolate producers, targets, and legacy unscoped files", async () => {
+  await withPendingDir(async (dir, scope) => {
+    const otherProducer = await createQueueScope({
+      producer: "opencode",
+      baseUrl: "https://ov.example.test",
+      apiKey: "test-key",
+    });
+    const otherTarget = await createQueueScope({
+      producer: "claude-code",
+      baseUrl: "https://other.example.test",
+      apiKey: "other-key",
+    });
+    await enqueue(scope, "addMessage", "cc-isolated", {
+      role: "user",
+      content: "only here",
+    });
+    await writeFile(
+      join(dir, "legacy_0.json"),
+      JSON.stringify({ type: "addMessage" }),
+      { mode: 0o600 },
+    );
+
+    assert.equal((await listPending(scope)).length, 1);
+    assert.deepEqual(await listPending(otherProducer), []);
+    assert.deepEqual(await listPending(otherTarget), []);
+    assert.notEqual(scope.dir, otherProducer.dir);
+    assert.notEqual(scope.dir, otherTarget.dir);
+  });
+});
+
+test("manual promotion is durable under concurrent enqueue and removed at terminal replay", async () => {
+  await withPendingDir(async (_dir, scope) => {
+    const payload = { role: "user", content: "same operation" };
+    const results = await Promise.all(
+      Array.from({ length: 200 }, (_, index) =>
+        enqueue(scope, "addMessage", "cc-concurrent", payload, {
+          provenance: index % 2 ? "manual" : "autoCapture",
+        }),
+      ),
+    );
+    assert.equal(
+      results.every((result) => result.ok),
+      true,
+    );
+    const pending = await listPending(scope);
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].entry.provenance, "manual");
+
+    const replay = await replayPending(
+      scope,
+      async () => ({ ok: true }),
+      () => {},
+    );
+    assert.equal(replay.replayed, 1);
+    assert.deepEqual(await readdir(scope.dir), []);
+  });
+});
+
+test("scope key is stable, private, and raw target credentials never enter queue paths", async () => {
+  await withPendingDir(async (dir, scope) => {
+    const keyPath = process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE;
+    const firstKey = await readFile(keyPath);
+    const firstMode = (await stat(keyPath)).mode;
+    const again = await createQueueScope({
+      producer: "claude-code",
+      baseUrl: "https://ov.example.test",
+      apiKey: "test-key",
+    });
+    assert.deepEqual(await readFile(keyPath), firstKey);
+    assert.equal(again.dir, scope.dir);
+    if (process.platform !== "win32") assert.equal(firstMode & 0o077, 0);
+
+    await enqueue(scope, "addMessage", "credential-check", {
+      role: "user",
+      content: "safe payload",
+    });
+    const paths = await readdir(dir, { recursive: true });
+    assert.equal(
+      paths.some(
+        (path) =>
+          String(path).includes("test-key") ||
+          String(path).includes("ov.example.test"),
+      ),
+      false,
+    );
+  });
+});
+
+test("deduplication and manual promotion are safe across independent processes", async () => {
+  await withPendingDir(async (_dir, scope) => {
+    const moduleURL = new URL("./pending-queue.mjs", import.meta.url).href;
+    const child = String.raw`
+      const [moduleURL, provenance] = process.argv.slice(1);
+      const { createQueueScope, enqueue } = await import(moduleURL);
+      const scope = await createQueueScope({ producer: "claude-code", baseUrl: "https://ov.example.test", apiKey: "test-key" });
+      const result = await enqueue(scope, "addMessage", "cc-multiprocess", { role: "user", content: "same operation" }, { provenance });
+      if (!result.ok) throw new Error(result.error || "enqueue failed");
+    `;
+    await Promise.all(
+      Array.from({ length: 16 }, (_, index) =>
+        execFileAsync(
+          process.execPath,
+          [
+            "--input-type=module",
+            "--eval",
+            child,
+            moduleURL,
+            index % 2 ? "manual" : "autoCapture",
+          ],
+          { env: process.env },
+        ),
+      ),
+    );
+
+    const pending = await listPending(scope);
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].entry.provenance, "manual");
   });
 });

--- a/examples/claude-code-memory-plugin/scripts/session-end.mjs
+++ b/examples/claude-code-memory-plugin/scripts/session-end.mjs
@@ -48,7 +48,9 @@ async function main() {
   let input = {};
   try {
     input = JSON.parse((await readHookStdin()) || "{}");
-  } catch { /* best effort */ }
+  } catch {
+    /* best effort */
+  }
 
   const sessionId = input.session_id;
   const cwd = input.cwd;
@@ -67,13 +69,26 @@ async function main() {
   const ovSessionId = deriveOvSessionId(sessionId);
   const health = await fetchJSON("/health");
   if (!health.ok && isRetryableFailure(health)) {
-    const queued = await enqueuePendingDirectly("commitSession", ovSessionId, {});
-    log("commit", { ovSessionId, ok: false, queued: queued.ok, reason: "health_retryable" });
+    const queued = await enqueuePendingDirectly(
+      "commitSession",
+      ovSessionId,
+      {},
+      fetchJSON.queueScope,
+    );
+    log("commit", {
+      ovSessionId,
+      ok: false,
+      queued: queued.ok,
+      reason: "health_retryable",
+    });
     approve();
     return;
   }
   if (!health.ok) {
-    logError("health_check", `non-retryable status ${health.status || "unknown"}`);
+    logError(
+      "health_check",
+      `non-retryable status ${health.status || "unknown"}`,
+    );
     approve();
     return;
   }
@@ -89,4 +104,7 @@ async function main() {
   approve();
 }
 
-main().catch((err) => { logError("uncaught", err); approve(); });
+main().catch((err) => {
+  logError("uncaught", err);
+  approve();
+});

--- a/examples/claude-code-memory-plugin/scripts/session-start.mjs
+++ b/examples/claude-code-memory-plugin/scripts/session-start.mjs
@@ -31,6 +31,7 @@ import {
   getSessionContext,
   isBypassed,
   makeFetchJSON,
+  queueScopeForConfig,
 } from "./lib/ov-session.mjs";
 import { replayPending } from "./lib/pending-queue.mjs";
 import { buildProfileBlock, estimateTokens } from "./lib/profile-inject.mjs";
@@ -71,7 +72,9 @@ function formatArchiveSection(sessionCtx) {
   if (!overview) return null;
 
   const abstracts = Array.isArray(sessionCtx.pre_archive_abstracts)
-    ? sessionCtx.pre_archive_abstracts.filter((a) => typeof a === "string" && a.trim())
+    ? sessionCtx.pre_archive_abstracts.filter(
+        (a) => typeof a === "string" && a.trim(),
+      )
     : [];
 
   const lines = [
@@ -101,7 +104,9 @@ async function main() {
     const chunks = [];
     for await (const chunk of process.stdin) chunks.push(chunk);
     input = JSON.parse(Buffer.concat(chunks).toString() || "{}");
-  } catch { /* best effort */ }
+  } catch {
+    /* best effort */
+  }
 
   const source = input.source || "startup";
   const sessionId = input.session_id;
@@ -116,7 +121,8 @@ async function main() {
   }
 
   const willInjectProfile = !cfg.noAutoInject;
-  const willInjectArchive = (source === "resume" || source === "compact") && !!sessionId;
+  const willInjectArchive =
+    (source === "resume" || source === "compact") && !!sessionId;
 
   const health = await fetchJSON("/health");
   if (!health.ok) {
@@ -129,8 +135,16 @@ async function main() {
   // disable injection but still expect failed writes from prior short-lived
   // coding sessions to be recovered when OpenViking is healthy again.
   try {
-    const replayResult = await replayPending(fetchJSON, log);
-    if (replayResult.replayed > 0 || replayResult.failed > 0 || replayResult.deferred > 0) {
+    const replayResult = await replayPending(
+      await queueScopeForConfig(cfg),
+      fetchJSON,
+      log,
+    );
+    if (
+      replayResult.replayed > 0 ||
+      replayResult.failed > 0 ||
+      replayResult.deferred > 0
+    ) {
       log("pending-replay", replayResult);
     }
   } catch (err) {
@@ -138,7 +152,11 @@ async function main() {
   }
 
   if (!willInjectProfile && !willInjectArchive) {
-    log("skip", { reason: "no_injection_planned", source, noAutoInject: cfg.noAutoInject });
+    log("skip", {
+      reason: "no_injection_planned",
+      source,
+      noAutoInject: cfg.noAutoInject,
+    });
     approve();
     return;
   }
@@ -147,7 +165,11 @@ async function main() {
   let profile = null;
   if (!cfg.noAutoInject) {
     try {
-      profile = await buildProfileBlock(fetchJSON, cfg.profileTokenBudget, effectivePeer.peerId);
+      profile = await buildProfileBlock(
+        fetchJSON,
+        cfg.profileTokenBudget,
+        effectivePeer.peerId,
+      );
     } catch (err) {
       logError("profile_inject", err);
     }
@@ -158,7 +180,11 @@ async function main() {
   let ovSessionId = null;
   if ((source === "resume" || source === "compact") && sessionId) {
     ovSessionId = deriveOvSessionId(sessionId);
-    const sessionCtx = await getSessionContext(fetchJSON, ovSessionId, cfg.resumeContextBudget);
+    const sessionCtx = await getSessionContext(
+      fetchJSON,
+      ovSessionId,
+      cfg.resumeContextBudget,
+    );
     archiveSection = formatArchiveSection(sessionCtx);
   }
 
@@ -191,9 +217,11 @@ async function main() {
   if (cfg.debug) {
     process.stderr.write(
       `[ov] session-start injected ~${composed.length} chars / ~${estimateTokens(composed)} tokens` +
-      (profile ? ` (profile=${profile.profileChars} chars, prefs=${profile.prefCount}${profile.droppedPref ? `(+${profile.droppedPref} dropped)` : ""}, entities=${profile.entCount}${profile.droppedEnt ? `(+${profile.droppedEnt} dropped)` : ""})` : "") +
-      (archiveSection ? " +archive" : "") +
-      "\n",
+        (profile
+          ? ` (profile=${profile.profileChars} chars, prefs=${profile.prefCount}${profile.droppedPref ? `(+${profile.droppedPref} dropped)` : ""}, entities=${profile.entCount}${profile.droppedEnt ? `(+${profile.droppedEnt} dropped)` : ""})`
+          : "") +
+        (archiveSection ? " +archive" : "") +
+        "\n",
     );
   }
 
@@ -214,4 +242,7 @@ async function main() {
   approve(composed);
 }
 
-main().catch((err) => { logError("uncaught", err); approve(); });
+main().catch((err) => {
+  logError("uncaught", err);
+  approve();
+});

--- a/examples/claude-code-memory-plugin/scripts/shared/pending-queue.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/pending-queue.mjs
@@ -1,85 +1,150 @@
 // GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
 /**
- * Local pending queue for offline resilience.
+ * Durable retry queue for OpenViking plugin writes.
  *
- * When the OpenViking server is temporarily unreachable, write operations
- * (addMessage, commitSession) serialize their payloads to
- * `~/.openviking/pending/` as JSON files. On the next session-start, the
- * queue is replayed in small batches. This is a session-start-triggered retry
- * path with maxRetries/TTL, not a long-running background worker.
+ * Queue data is partitioned by producer and authenticated OpenViking target:
+ *   <base>/<producer>/<target-hmac>/
  *
- * Each file contains: { type, sessionId, payload, createdAt, retries, dedupKey }
- *
- * Config (env vars):
- *   OPENVIKING_PENDING_DIR         pending queue directory
- *                                  (default: ~/.openviking/pending)
- *   OPENVIKING_PENDING_MAX_RETRIES max retry attempts per item (default: 3)
- *   OPENVIKING_PENDING_TTL_DAYS    max age in days before stale cleanup
- *                                  (default: 7)
- *   OPENVIKING_PENDING_REPLAY_LIMIT max items replayed per session-start
- *                                  (default: 50)
+ * The HMAC key is stable in normal user-local operation. Tests may point
+ * OPENVIKING_QUEUE_SCOPE_KEY_FILE at an environment-scoped 0600 file; the
+ * surrounding environment owns deleting that file during cleanup.
  */
 
-import { mkdir, readdir, readFile, rename, writeFile, unlink, stat, chmod } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { createHmac, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_TTL_DAYS = 7;
 const DEFAULT_REPLAY_LIMIT = 50;
 const PROCESSING_STALE_MS = 10 * 60 * 1000;
-const DEFAULT_PENDING_DIR = () => join(homedir(), ".openviking", "pending");
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const SCOPE_MARKER = Symbol("openviking-pending-queue-scope");
 
-// Pending queue files may contain raw memory payload / transcript content.
-// Use restrictive permissions explicitly so we don't depend on umask.
-//   - dir: 0o700  (owner: rwx; group/other: none)
-//   - file: 0o600 (owner: rw;  group/other: none)
-const PENDING_DIR_MODE = 0o700;
-const PENDING_FILE_MODE = 0o600;
+const pendingBaseDir = () =>
+  process.env.OPENVIKING_PENDING_DIR ||
+  join(homedir(), ".openviking", "pending");
+const scopeKeyFile = () =>
+  process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE ||
+  join(homedir(), ".openviking", "queue-scope.key");
 
-/**
- * Ensure the pending directory exists with 0o700 permissions. If the
- * directory was created by a previous version of this code (or by hand)
- * with looser permissions, best-effort chmod it on first use.
- */
-async function ensurePendingDir(dir) {
-  await mkdir(dir, { recursive: true, mode: PENDING_DIR_MODE });
-  try {
-    await chmod(dir, PENDING_DIR_MODE);
-  } catch {
-    // Best effort: chmod may fail on some platforms (e.g. Windows); not fatal.
-  }
-}
-
-function getPendingDir() {
-  return process.env.OPENVIKING_PENDING_DIR || DEFAULT_PENDING_DIR();
-}
-
-function getMaxRetries() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_MAX_RETRIES || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_MAX_RETRIES;
-}
-
-function getTTLDays() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_TTL_DAYS || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_TTL_DAYS;
-}
-
-function getReplayLimit() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_REPLAY_LIMIT || "", 10);
-  return Number.isFinite(v) && v > 0 ? v : DEFAULT_REPLAY_LIMIT;
+function envInt(name, fallback, allowZero = true) {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && (allowZero ? value >= 0 : value > 0)
+    ? value
+    : fallback;
 }
 
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   const keys = Object.keys(value).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function normalizedTarget({ baseUrl, account = "", user = "", apiKey = "" }) {
+  let endpoint;
+  try {
+    const parsed = new URL(String(baseUrl || "").trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      throw new Error("unsupported protocol");
+    if (parsed.username || parsed.password || parsed.search || parsed.hash)
+      throw new Error("embedded credentials");
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    endpoint = parsed.toString().replace(/\/$/, "");
+  } catch {
+    throw new Error(
+      "pending queue scope requires an HTTP(S) OpenViking base URL without embedded credentials",
+    );
+  }
+  const identity =
+    account || user
+      ? `identity:${String(account)}\0${String(user)}`
+      : apiKey
+        ? `api-key:${String(apiKey)}`
+        : "anonymous-local";
+  return `${endpoint}\n${identity}`;
+}
+
+async function ensureDir(path) {
+  await mkdir(path, { recursive: true, mode: DIR_MODE });
+  try {
+    const info = await lstat(path);
+    if (!info.isDirectory() || info.isSymbolicLink())
+      throw new Error(`not a private directory: ${path}`);
+    await chmod(path, DIR_MODE);
+  } catch (error) {
+    throw new Error(
+      `pending queue directory is unsafe: ${error?.message || error}`,
+    );
+  }
+}
+
+async function loadOrCreateScopeKey() {
+  const path = scopeKeyFile();
+  await ensureDir(dirname(path));
+  try {
+    await writeFile(path, randomBytes(32), { flag: "wx", mode: FILE_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  let info = await lstat(path);
+  if (!info.isFile() || info.isSymbolicLink())
+    throw new Error("pending queue scope key must be a regular file");
+  try {
+    await chmod(path, FILE_MODE);
+  } catch {
+    /* Windows and read-only stores may reject chmod. */
+  }
+  info = await lstat(path);
+  if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    throw new Error(
+      "pending queue scope key must not be accessible by group or others",
+    );
+  }
+  const key = await readFile(path);
+  if (key.length < 32) throw new Error("pending queue scope key is too short");
+  return key;
+}
+
+/** Create an opaque queue capability for one producer and authenticated target. */
+export async function createQueueScope(options = {}) {
+  const producer = String(options.producer || "")
+    .trim()
+    .toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(producer)) {
+    throw new Error("pending queue scope requires a safe producer name");
+  }
+  const key = await loadOrCreateScopeKey();
+  const targetHash = createHmac("sha256", key)
+    .update(normalizedTarget(options))
+    .digest("hex");
+  const dir = join(pendingBaseDir(), producer, targetHash);
+  await ensureDir(dir);
+  return Object.freeze({ [SCOPE_MARKER]: true, producer, targetHash, dir });
+}
+
+function scopeDir(scope) {
+  if (!scope || scope[SCOPE_MARKER] !== true || typeof scope.dir !== "string") {
+    throw new Error("pending queue operation requires a queue scope");
+  }
+  return scope.dir;
 }
 
 function makeDedupKey(type, sessionId, payload) {
-  return createHash("sha256")
+  return createHmac("sha256", "openviking-pending-dedup-v1")
     .update(type)
     .update("\n")
     .update(sessionId)
@@ -88,35 +153,53 @@ function makeDedupKey(type, sessionId, payload) {
     .digest("hex");
 }
 
-function pendingFilename(dedupKey, retries = 0) {
-  return `${dedupKey}_${Math.max(0, Number(retries) || 0)}.json`;
-}
+const pendingFilename = (key, retries = 0) =>
+  `${key}_${Math.max(0, Number(retries) || 0)}.json`;
+const processingFilename = (filename) =>
+  filename.replace(/\.json$/, ".processing");
+const pendingFromProcessingFilename = (filename) =>
+  filename.replace(/\.processing$/, ".json");
+const manualFilename = (dedupKey) => `${dedupKey}.manual`;
 
 function retryFilename(filename, retries) {
   const bare = filename.replace(/\.(json|processing)$/, "");
-  const nextBare = /_\d+$/.test(bare)
-    ? bare.replace(/_\d+$/, `_${retries}`)
-    : `${bare}_${retries}`;
-  return `${nextBare}.json`;
+  return `${/_\d+$/.test(bare) ? bare.replace(/_\d+$/, `_${retries}`) : `${bare}_${retries}`}.json`;
 }
 
-function processingFilename(filename) {
-  return filename.replace(/\.json$/, ".processing");
-}
-
-function pendingFromProcessingFilename(filename) {
-  return filename.replace(/\.processing$/, ".json");
-}
-
-function isRetryableReplayFailure(res) {
-  if (!res || res.ok) return false;
-  const status = Number(res.status || 0);
-  return !status || status >= 500 || status === 408 || status === 429;
+function dedupKeyFromFilename(filename) {
+  const match = /^([0-9a-f]{64})_(?:\d+)\.(?:json|processing)$/.exec(filename);
+  return match?.[1] || "";
 }
 
 async function readEntry(dir, filename) {
-  const raw = await readFile(join(dir, filename), "utf-8");
-  return JSON.parse(raw);
+  return JSON.parse(await readFile(join(dir, filename), "utf-8"));
+}
+
+async function hasManualMarker(dir, dedupKey) {
+  try {
+    await stat(join(dir, manualFilename(dedupKey)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureManualMarker(dir, dedupKey) {
+  try {
+    await writeFile(join(dir, manualFilename(dedupKey)), "manual\n", {
+      flag: "wx",
+      mode: FILE_MODE,
+    });
+    return { ok: true, created: true };
+  } catch (error) {
+    if (error?.code === "EEXIST") return { ok: true, created: false };
+    return { ok: false, error: error?.message || String(error) };
+  }
+}
+
+async function removeManualMarker(dir, dedupKey) {
+  if (dedupKey)
+    await unlink(join(dir, manualFilename(dedupKey))).catch(() => {});
 }
 
 async function findExistingByDedupKey(dir, dedupKey) {
@@ -126,25 +209,18 @@ async function findExistingByDedupKey(dir, dedupKey) {
   } catch {
     return null;
   }
-
-  // Fast path: filenames are `${dedupKey}_${retries}.json` (or
-  // .processing). `dedupKey` is a sha256 hex produced by makeDedupKey
-  // (no underscores), so `${dedupKey}_` is a unique prefix per key.
-  // Filter on prefix BEFORE opening the file to avoid readFile +
-  // JSON.parse on every entry in the directory on every enqueue call —
-  // the previous implementation was O(n²) in queue size. Worst case here
-  // is O(n) readdir entries, but only the (typically single) prefix
-  // match actually gets opened and parsed.
   const prefix = `${dedupKey}_`;
-
-  for (const f of files) {
-    if (!f.startsWith(prefix)) continue;
-    if (!f.endsWith(".json") && !f.endsWith(".processing")) continue;
+  for (const filename of files) {
+    if (
+      !filename.startsWith(prefix) ||
+      (!filename.endsWith(".json") && !filename.endsWith(".processing"))
+    )
+      continue;
     try {
-      const entry = await readEntry(dir, f);
-      if (entry?.dedupKey === dedupKey) return { filename: f, entry };
+      const entry = await readEntry(dir, filename);
+      if (entry?.dedupKey === dedupKey) return { filename, entry };
     } catch {
-      // Corrupted file - ignore for dedup lookup.
+      // Corrupt entries never establish deduplication or cleanup authority.
     }
   }
   return null;
@@ -157,83 +233,81 @@ async function recoverStaleProcessing(dir) {
   } catch {
     return 0;
   }
-
-  const now = Date.now();
   let recovered = 0;
-  for (const f of files) {
-    if (!f.endsWith(".processing")) continue;
-    const from = join(dir, f);
+  for (const filename of files) {
+    if (!filename.endsWith(".processing")) continue;
     try {
-      const s = await stat(from);
-      if (now - s.mtimeMs < PROCESSING_STALE_MS) continue;
-      const to = join(dir, pendingFromProcessingFilename(f));
-      await rename(from, to);
+      if (
+        Date.now() - (await stat(join(dir, filename))).mtimeMs <
+        PROCESSING_STALE_MS
+      )
+        continue;
+      await rename(
+        join(dir, filename),
+        join(dir, pendingFromProcessingFilename(filename)),
+      );
       recovered++;
     } catch {
-      // Best effort. A concurrent process may have already handled it.
+      // Another process may own or have recovered the entry.
     }
   }
   return recovered;
 }
 
-/**
- * Enqueue a failed operation to local disk.
- *
- * @param {string} type - "addMessage" or "commitSession"
- * @param {string} sessionId - OV session ID
- * @param {object} payload - the data that failed to send
- */
-export async function enqueue(type, sessionId, payload) {
-  const dir = getPendingDir();
-  const now = Date.now();
+export async function enqueue(scope, type, sessionId, payload, options = {}) {
+  const dir = scopeDir(scope);
+  const provenance =
+    typeof options.provenance === "string" ? options.provenance : "";
   const dedupKey = makeDedupKey(type, sessionId, payload);
-  const filename = pendingFilename(dedupKey, 0);
+  const filename = pendingFilename(dedupKey);
   const entry = {
     type,
     sessionId,
     payload,
-    createdAt: now,
+    ...(provenance && provenance !== "manual" ? { provenance } : {}),
+    createdAt: Date.now(),
     retries: 0,
     dedupKey,
   };
 
-  try {
-    await ensurePendingDir(dir);
-  } catch (err) {
-    return { ok: false, error: err?.message || String(err), dedupKey };
+  await ensureDir(dir);
+  let markerCreated = false;
+  if (provenance === "manual") {
+    const marker = await ensureManualMarker(dir, dedupKey);
+    if (!marker.ok) return { ok: false, error: marker.error, dedupKey };
+    markerCreated = marker.created;
   }
 
   const existing = await findExistingByDedupKey(dir, dedupKey);
-  if (existing) {
+  if (existing)
     return { ok: true, path: existing.filename, deduped: true, dedupKey };
-  }
 
   try {
     await writeFile(join(dir, filename), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
     return { ok: true, path: filename, dedupKey };
-  } catch (err) {
-    if (err?.code !== "EEXIST") {
-      return { ok: false, error: err?.message || String(err), dedupKey };
+  } catch (error) {
+    if (error?.code !== "EEXIST") {
+      if (markerCreated) await removeManualMarker(dir, dedupKey);
+      return { ok: false, error: error?.message || String(error), dedupKey };
     }
   }
-
   const duplicate = await findExistingByDedupKey(dir, dedupKey);
-  if (duplicate) {
+  if (duplicate)
     return { ok: true, path: duplicate.filename, deduped: true, dedupKey };
-  }
-  return { ok: false, error: `pending file exists but dedup entry was not readable: ${filename}`, dedupKey };
+  if (markerCreated) await removeManualMarker(dir, dedupKey);
+  return {
+    ok: false,
+    error: `pending file exists but is unreadable: ${filename}`,
+    dedupKey,
+  };
 }
 
-/**
- * List all pending queue entries.
- * Returns array of { filename, entry } sorted by createdAt ascending.
- */
-export async function listPending() {
-  const dir = getPendingDir();
+export async function listPending(scope) {
+  const dir = scopeDir(scope);
   let files;
   try {
     await recoverStaleProcessing(dir);
@@ -241,29 +315,25 @@ export async function listPending() {
   } catch {
     return [];
   }
-
   const entries = [];
-  for (const f of files) {
-    if (!f.endsWith(".json")) continue;
+  for (const filename of files) {
+    if (!filename.endsWith(".json")) continue;
     try {
-      const entry = await readEntry(dir, f);
-      entries.push({ filename: f, entry });
+      const entry = await readEntry(dir, filename);
+      if (await hasManualMarker(dir, entry.dedupKey))
+        entry.provenance = "manual";
+      entries.push({ filename, entry });
     } catch {
-      // Corrupted file - skip.
+      // Corrupt entries fail closed and remain available for operator inspection.
     }
   }
-
   entries.sort((a, b) => (a.entry.createdAt || 0) - (b.entry.createdAt || 0));
   return entries;
 }
 
-/**
- * Atomically claim a pending file for replay. Only the process that successfully
- * renames the file may send the HTTP replay.
- */
-export async function claimForReplay(filename) {
+export async function claimForReplay(scope, filename) {
+  const dir = scopeDir(scope);
   if (!filename.endsWith(".json")) return null;
-  const dir = getPendingDir();
   const claimed = processingFilename(filename);
   try {
     await rename(join(dir, filename), join(dir, claimed));
@@ -273,149 +343,151 @@ export async function claimForReplay(filename) {
   }
 }
 
-/**
- * Remove a pending entry after successful replay.
- */
-export async function dequeue(filename) {
-  const dir = getPendingDir();
+export async function dequeue(scope, filename) {
+  const dir = scopeDir(scope);
+  let dedupKey = dedupKeyFromFilename(filename);
+  if (!dedupKey) {
+    try {
+      dedupKey = (await readEntry(dir, filename))?.dedupKey || "";
+    } catch {
+      /* ignore */
+    }
+  }
   try {
     await unlink(join(dir, filename));
+    await removeManualMarker(dir, dedupKey);
     return true;
   } catch {
     return false;
   }
 }
 
-/**
- * Increment retry count on a pending entry. Returns false if max retries exceeded.
- */
-export async function incrementRetry(filename, entry) {
-  const dir = getPendingDir();
-  const maxRetries = getMaxRetries();
+export async function incrementRetry(scope, filename, entry) {
+  const dir = scopeDir(scope);
   entry.retries = (entry.retries || 0) + 1;
-
-  if (entry.retries > maxRetries) {
-    try {
-      await unlink(join(dir, filename));
-    } catch {
-      // Best effort.
-    }
+  if (
+    entry.retries >
+    envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+  ) {
+    await unlink(join(dir, filename)).catch(() => {});
+    await removeManualMarker(
+      dir,
+      entry.dedupKey || dedupKeyFromFilename(filename),
+    );
     return false;
   }
-
-  const newFilename = retryFilename(filename, entry.retries);
-  // Atomic write: write to a unique temp file in the same directory, then
-  // rename into place. Avoids leaving a half-written JSON if the process
-  // crashes mid-write.
-  const tmpFilename = `${newFilename}.tmp.${process.pid}.${Date.now()}`;
+  const next = retryFilename(filename, entry.retries);
+  const temp = `${next}.tmp.${process.pid}.${Date.now()}`;
   try {
-    await writeFile(join(dir, tmpFilename), JSON.stringify(entry), {
+    await writeFile(join(dir, temp), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
-    await rename(join(dir, tmpFilename), join(dir, newFilename));
+    await rename(join(dir, temp), join(dir, next));
     await unlink(join(dir, filename)).catch(() => {});
     return true;
   } catch {
-    await unlink(join(dir, tmpFilename)).catch(() => {});
+    await unlink(join(dir, temp)).catch(() => {});
     return false;
   }
 }
 
-/**
- * Clean up stale entries older than TTL.
- */
-export async function cleanStale() {
-  const ttlMs = getTTLDays() * 24 * 60 * 60 * 1000;
-  const now = Date.now();
-  const pending = await listPending();
+export async function cleanStale(scope) {
+  const ttlMs =
+    envInt("OPENVIKING_PENDING_TTL_DAYS", DEFAULT_TTL_DAYS) *
+    24 *
+    60 *
+    60 *
+    1000;
   let cleaned = 0;
-
-  for (const { filename, entry } of pending) {
-    const age = now - (entry.createdAt || 0);
-    if (age > ttlMs) {
-      await dequeue(filename);
+  for (const { filename, entry } of await listPending(scope)) {
+    if (
+      Date.now() - (entry.createdAt || 0) > ttlMs &&
+      (await dequeue(scope, filename))
+    )
       cleaned++;
-    }
   }
   return cleaned;
 }
 
-/**
- * Replay pending entries. Call this during session-start when the server is
- * healthy. Each run processes at most OPENVIKING_PENDING_REPLAY_LIMIT items so
- * a just-recovered server is not hit with an unbounded replay burst.
- *
- * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
- * @param {Function} log - logger function
- * @returns {{ replayed: number, failed: number, skipped: number, deferred: number }}
- */
-export async function replayPending(fetchJSON, log) {
-  const pending = await listPending();
+function retryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  return !status || status >= 500 || status === 408 || status === 429;
+}
 
-  if (pending.length === 0) {
+export async function replayPending(scope, fetchJSON, log, options = {}) {
+  const pending = await listPending(scope);
+  if (pending.length === 0)
     return { replayed: 0, failed: 0, skipped: 0, deferred: 0 };
-  }
-
-  const replayLimit = getReplayLimit();
-  log("pending-queue", { count: pending.length, replayLimit, action: "replay-start" });
-
-  let replayed = 0;
-  let failed = 0;
-  let skipped = 0;
-  let deferred = 0;
-  let processed = 0;
-
+  const limit = envInt(
+    "OPENVIKING_PENDING_REPLAY_LIMIT",
+    DEFAULT_REPLAY_LIMIT,
+    false,
+  );
+  log("pending-queue", {
+    count: pending.length,
+    replayLimit: limit,
+    action: "replay-start",
+  });
+  let replayed = 0,
+    failed = 0,
+    skipped = 0,
+    deferred = 0,
+    processed = 0;
   for (const { filename, entry } of pending) {
-    if (processed >= replayLimit) {
+    if (options.shouldReplay && !options.shouldReplay(entry)) {
       deferred++;
       continue;
     }
-
-    if ((entry.retries || 0) >= getMaxRetries()) {
-      await dequeue(filename);
+    if (processed >= limit) {
+      deferred++;
+      continue;
+    }
+    if (
+      (entry.retries || 0) >=
+      envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+    ) {
+      await dequeue(scope, filename);
       skipped++;
       continue;
     }
-
-    const claimedFilename = await claimForReplay(filename);
-    if (!claimedFilename) {
+    const claimed = await claimForReplay(scope, filename);
+    if (!claimed) {
       skipped++;
       continue;
     }
     processed++;
-
-    let res;
+    let result;
     try {
-      const encodedSid = encodeURIComponent(entry.sessionId);
+      const sid = encodeURIComponent(entry.sessionId);
       if (entry.type === "addMessage") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/messages`, {
           method: "POST",
           body: JSON.stringify(entry.payload),
         });
       } else if (entry.type === "commitSession") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/commit`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/commit`, {
           method: "POST",
           body: JSON.stringify(entry.payload || {}),
         });
       } else {
-        await dequeue(claimedFilename);
+        await dequeue(scope, claimed);
         skipped++;
         continue;
       }
     } catch {
-      res = { ok: false };
+      result = { ok: false };
     }
-
-    if (res?.ok) {
-      await dequeue(claimedFilename);
+    if (result?.ok) {
+      await dequeue(scope, claimed);
       replayed++;
-    } else if (!isRetryableReplayFailure(res)) {
-      await dequeue(claimedFilename);
+    } else if (!retryable(result)) {
+      await dequeue(scope, claimed);
       skipped++;
     } else {
-      await incrementRetry(claimedFilename, entry);
+      await incrementRetry(scope, claimed, entry);
       failed++;
       if (entry.type === "addMessage") {
         deferred += Math.max(0, pending.length - processed);
@@ -423,9 +495,7 @@ export async function replayPending(fetchJSON, log) {
       }
     }
   }
-
-  const cleaned = await cleanStale();
-
+  const cleaned = await cleanStale(scope);
   log("pending-queue", {
     action: "replay-done",
     replayed,
@@ -434,6 +504,5 @@ export async function replayPending(fetchJSON, log) {
     deferred,
     cleaned,
   });
-
   return { replayed, failed, skipped, deferred };
 }

--- a/examples/claude-code-memory-plugin/scripts/subagent-stop.mjs
+++ b/examples/claude-code-memory-plugin/scripts/subagent-stop.mjs
@@ -70,10 +70,14 @@ async function loadState(subagentId) {
 }
 
 function parseTranscript(content) {
-  const lines = content.split("\n").filter(l => l.trim());
+  const lines = content.split("\n").filter((l) => l.trim());
   const out = [];
   for (const line of lines) {
-    try { out.push(JSON.parse(line)); } catch { /* skip */ }
+    try {
+      out.push(JSON.parse(line));
+    } catch {
+      /* skip */
+    }
   }
   return out;
 }
@@ -159,11 +163,14 @@ function buildParts(content, toolNameById) {
         tool_id: typeof block.id === "string" ? block.id : undefined,
         tool_name: block.name,
         tool_input:
-          block.input && typeof block.input === "object" ? block.input : undefined,
+          block.input && typeof block.input === "object"
+            ? block.input
+            : undefined,
         tool_status: "running",
       });
     } else if (block.type === "tool_result") {
-      const id = typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+      const id =
+        typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
       out.push({
         type: "tool",
         tool_id: id,
@@ -201,12 +208,19 @@ function extractTurns(messages) {
           if (!block || typeof block !== "object") continue;
           if (block.type === "text" && typeof block.text === "string") {
             parts.push(block.text);
-          } else if (block.type === "tool_use" && typeof block.name === "string") {
+          } else if (
+            block.type === "tool_use" &&
+            typeof block.name === "string"
+          ) {
             toolNames.push(block.name);
-            parts.push(`[tool: ${block.name}]\n${formatToolInput(block.input)}`);
+            parts.push(
+              `[tool: ${block.name}]\n${formatToolInput(block.input)}`,
+            );
           } else if (block.type === "tool_result") {
             const resultText = extractToolResultText(block.content);
-            const truncated = resultText ? truncateToolResult(resultText) : null;
+            const truncated = resultText
+              ? truncateToolResult(resultText)
+              : null;
             if (truncated) {
               parts.push(`[tool result]\n${truncated}`);
             }
@@ -233,7 +247,11 @@ function extractTurns(messages) {
   return turns;
 }
 
-async function pushTurns(ovSessionId, turns, { peerId = null, enqueueOnly = false } = {}) {
+async function pushTurns(
+  ovSessionId,
+  turns,
+  { peerId = null, enqueueOnly = false } = {},
+) {
   const fetchJSON = makeFetchJSON(cfg);
   let ok = 0;
   let queued = 0;
@@ -249,7 +267,12 @@ async function pushTurns(ovSessionId, turns, { peerId = null, enqueueOnly = fals
     const payload = { role: turn.role, parts };
     if (peerId) payload.peer_id = peerId;
     const res = enqueueOnly
-      ? await enqueuePendingDirectly("addMessage", ovSessionId, payload)
+      ? await enqueuePendingDirectly(
+          "addMessage",
+          ovSessionId,
+          payload,
+          fetchJSON.queueScope,
+        )
       : await addMessage(fetchJSON, ovSessionId, payload);
     if (enqueueOnly && res.ok) queued++;
     else if (res.ok) ok++;
@@ -263,10 +286,17 @@ async function pushTurns(ovSessionId, turns, { peerId = null, enqueueOnly = fals
   let commitQueued = false;
   if (ok + queued > 0) {
     const commitRes = enqueueOnly
-      ? await enqueuePendingDirectly("commitSession", ovSessionId, {})
+      ? await enqueuePendingDirectly(
+          "commitSession",
+          ovSessionId,
+          {},
+          fetchJSON.queueScope,
+        )
       : await commitSession(fetchJSON, ovSessionId);
     committed = !enqueueOnly && commitRes.ok;
-    commitQueued = enqueueOnly ? Boolean(commitRes.ok) : Boolean(commitRes.pendingQueued);
+    commitQueued = enqueueOnly
+      ? Boolean(commitRes.ok)
+      : Boolean(commitRes.pendingQueued);
     if (enqueueOnly && !commitRes.ok) enqueueFailed++;
     else if (!enqueueOnly && commitRes.pendingEnqueueFailed) enqueueFailed++;
   }
@@ -287,7 +317,9 @@ async function main() {
   let input = {};
   try {
     input = JSON.parse((await readHookStdin()) || "{}");
-  } catch { /* best effort */ }
+  } catch {
+    /* best effort */
+  }
 
   const sessionId = input.session_id;
   const cwd = input.cwd;
@@ -309,7 +341,9 @@ async function main() {
   // Prefer state from SubagentStart (may carry ovSessionId from config snapshot);
   // fall back to live derivation if state file is missing.
   const state = await loadState(subagentId);
-  const ovSessionId = state?.ovSessionId || deriveOvSessionId(sessionId, `subagent:${subagentId}`);
+  const ovSessionId =
+    state?.ovSessionId ||
+    deriveOvSessionId(sessionId, `subagent:${subagentId}`);
 
   let transcript;
   try {
@@ -344,14 +378,20 @@ async function main() {
     logError("health_check", "server unreachable; enqueuing subagent capture");
     result = await pushTurns(ovSessionId, turns, { peerId, enqueueOnly: true });
   } else {
-    logError("health_check", `non-retryable status ${health.status || "unknown"}`);
+    logError(
+      "health_check",
+      `non-retryable status ${health.status || "unknown"}`,
+    );
     approve();
     return;
   }
   log("push_turns", { ovSessionId, ...result });
 
   if (result.enqueueFailed > 0) {
-    logError("pending_enqueue", "some turns failed to enqueue; state file retained");
+    logError(
+      "pending_enqueue",
+      "some turns failed to enqueue; state file retained",
+    );
     approve();
     return;
   }
@@ -360,4 +400,7 @@ async function main() {
   approve();
 }
 
-main().catch((err) => { logError("uncaught", err); approve(); });
+main().catch((err) => {
+  logError("uncaught", err);
+  approve();
+});

--- a/examples/codex-memory-plugin/scripts/shared/pending-queue.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/pending-queue.mjs
@@ -1,85 +1,150 @@
 // GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
 /**
- * Local pending queue for offline resilience.
+ * Durable retry queue for OpenViking plugin writes.
  *
- * When the OpenViking server is temporarily unreachable, write operations
- * (addMessage, commitSession) serialize their payloads to
- * `~/.openviking/pending/` as JSON files. On the next session-start, the
- * queue is replayed in small batches. This is a session-start-triggered retry
- * path with maxRetries/TTL, not a long-running background worker.
+ * Queue data is partitioned by producer and authenticated OpenViking target:
+ *   <base>/<producer>/<target-hmac>/
  *
- * Each file contains: { type, sessionId, payload, createdAt, retries, dedupKey }
- *
- * Config (env vars):
- *   OPENVIKING_PENDING_DIR         pending queue directory
- *                                  (default: ~/.openviking/pending)
- *   OPENVIKING_PENDING_MAX_RETRIES max retry attempts per item (default: 3)
- *   OPENVIKING_PENDING_TTL_DAYS    max age in days before stale cleanup
- *                                  (default: 7)
- *   OPENVIKING_PENDING_REPLAY_LIMIT max items replayed per session-start
- *                                  (default: 50)
+ * The HMAC key is stable in normal user-local operation. Tests may point
+ * OPENVIKING_QUEUE_SCOPE_KEY_FILE at an environment-scoped 0600 file; the
+ * surrounding environment owns deleting that file during cleanup.
  */
 
-import { mkdir, readdir, readFile, rename, writeFile, unlink, stat, chmod } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { createHmac, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_TTL_DAYS = 7;
 const DEFAULT_REPLAY_LIMIT = 50;
 const PROCESSING_STALE_MS = 10 * 60 * 1000;
-const DEFAULT_PENDING_DIR = () => join(homedir(), ".openviking", "pending");
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const SCOPE_MARKER = Symbol("openviking-pending-queue-scope");
 
-// Pending queue files may contain raw memory payload / transcript content.
-// Use restrictive permissions explicitly so we don't depend on umask.
-//   - dir: 0o700  (owner: rwx; group/other: none)
-//   - file: 0o600 (owner: rw;  group/other: none)
-const PENDING_DIR_MODE = 0o700;
-const PENDING_FILE_MODE = 0o600;
+const pendingBaseDir = () =>
+  process.env.OPENVIKING_PENDING_DIR ||
+  join(homedir(), ".openviking", "pending");
+const scopeKeyFile = () =>
+  process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE ||
+  join(homedir(), ".openviking", "queue-scope.key");
 
-/**
- * Ensure the pending directory exists with 0o700 permissions. If the
- * directory was created by a previous version of this code (or by hand)
- * with looser permissions, best-effort chmod it on first use.
- */
-async function ensurePendingDir(dir) {
-  await mkdir(dir, { recursive: true, mode: PENDING_DIR_MODE });
-  try {
-    await chmod(dir, PENDING_DIR_MODE);
-  } catch {
-    // Best effort: chmod may fail on some platforms (e.g. Windows); not fatal.
-  }
-}
-
-function getPendingDir() {
-  return process.env.OPENVIKING_PENDING_DIR || DEFAULT_PENDING_DIR();
-}
-
-function getMaxRetries() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_MAX_RETRIES || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_MAX_RETRIES;
-}
-
-function getTTLDays() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_TTL_DAYS || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_TTL_DAYS;
-}
-
-function getReplayLimit() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_REPLAY_LIMIT || "", 10);
-  return Number.isFinite(v) && v > 0 ? v : DEFAULT_REPLAY_LIMIT;
+function envInt(name, fallback, allowZero = true) {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && (allowZero ? value >= 0 : value > 0)
+    ? value
+    : fallback;
 }
 
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   const keys = Object.keys(value).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function normalizedTarget({ baseUrl, account = "", user = "", apiKey = "" }) {
+  let endpoint;
+  try {
+    const parsed = new URL(String(baseUrl || "").trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      throw new Error("unsupported protocol");
+    if (parsed.username || parsed.password || parsed.search || parsed.hash)
+      throw new Error("embedded credentials");
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    endpoint = parsed.toString().replace(/\/$/, "");
+  } catch {
+    throw new Error(
+      "pending queue scope requires an HTTP(S) OpenViking base URL without embedded credentials",
+    );
+  }
+  const identity =
+    account || user
+      ? `identity:${String(account)}\0${String(user)}`
+      : apiKey
+        ? `api-key:${String(apiKey)}`
+        : "anonymous-local";
+  return `${endpoint}\n${identity}`;
+}
+
+async function ensureDir(path) {
+  await mkdir(path, { recursive: true, mode: DIR_MODE });
+  try {
+    const info = await lstat(path);
+    if (!info.isDirectory() || info.isSymbolicLink())
+      throw new Error(`not a private directory: ${path}`);
+    await chmod(path, DIR_MODE);
+  } catch (error) {
+    throw new Error(
+      `pending queue directory is unsafe: ${error?.message || error}`,
+    );
+  }
+}
+
+async function loadOrCreateScopeKey() {
+  const path = scopeKeyFile();
+  await ensureDir(dirname(path));
+  try {
+    await writeFile(path, randomBytes(32), { flag: "wx", mode: FILE_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  let info = await lstat(path);
+  if (!info.isFile() || info.isSymbolicLink())
+    throw new Error("pending queue scope key must be a regular file");
+  try {
+    await chmod(path, FILE_MODE);
+  } catch {
+    /* Windows and read-only stores may reject chmod. */
+  }
+  info = await lstat(path);
+  if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    throw new Error(
+      "pending queue scope key must not be accessible by group or others",
+    );
+  }
+  const key = await readFile(path);
+  if (key.length < 32) throw new Error("pending queue scope key is too short");
+  return key;
+}
+
+/** Create an opaque queue capability for one producer and authenticated target. */
+export async function createQueueScope(options = {}) {
+  const producer = String(options.producer || "")
+    .trim()
+    .toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(producer)) {
+    throw new Error("pending queue scope requires a safe producer name");
+  }
+  const key = await loadOrCreateScopeKey();
+  const targetHash = createHmac("sha256", key)
+    .update(normalizedTarget(options))
+    .digest("hex");
+  const dir = join(pendingBaseDir(), producer, targetHash);
+  await ensureDir(dir);
+  return Object.freeze({ [SCOPE_MARKER]: true, producer, targetHash, dir });
+}
+
+function scopeDir(scope) {
+  if (!scope || scope[SCOPE_MARKER] !== true || typeof scope.dir !== "string") {
+    throw new Error("pending queue operation requires a queue scope");
+  }
+  return scope.dir;
 }
 
 function makeDedupKey(type, sessionId, payload) {
-  return createHash("sha256")
+  return createHmac("sha256", "openviking-pending-dedup-v1")
     .update(type)
     .update("\n")
     .update(sessionId)
@@ -88,35 +153,53 @@ function makeDedupKey(type, sessionId, payload) {
     .digest("hex");
 }
 
-function pendingFilename(dedupKey, retries = 0) {
-  return `${dedupKey}_${Math.max(0, Number(retries) || 0)}.json`;
-}
+const pendingFilename = (key, retries = 0) =>
+  `${key}_${Math.max(0, Number(retries) || 0)}.json`;
+const processingFilename = (filename) =>
+  filename.replace(/\.json$/, ".processing");
+const pendingFromProcessingFilename = (filename) =>
+  filename.replace(/\.processing$/, ".json");
+const manualFilename = (dedupKey) => `${dedupKey}.manual`;
 
 function retryFilename(filename, retries) {
   const bare = filename.replace(/\.(json|processing)$/, "");
-  const nextBare = /_\d+$/.test(bare)
-    ? bare.replace(/_\d+$/, `_${retries}`)
-    : `${bare}_${retries}`;
-  return `${nextBare}.json`;
+  return `${/_\d+$/.test(bare) ? bare.replace(/_\d+$/, `_${retries}`) : `${bare}_${retries}`}.json`;
 }
 
-function processingFilename(filename) {
-  return filename.replace(/\.json$/, ".processing");
-}
-
-function pendingFromProcessingFilename(filename) {
-  return filename.replace(/\.processing$/, ".json");
-}
-
-function isRetryableReplayFailure(res) {
-  if (!res || res.ok) return false;
-  const status = Number(res.status || 0);
-  return !status || status >= 500 || status === 408 || status === 429;
+function dedupKeyFromFilename(filename) {
+  const match = /^([0-9a-f]{64})_(?:\d+)\.(?:json|processing)$/.exec(filename);
+  return match?.[1] || "";
 }
 
 async function readEntry(dir, filename) {
-  const raw = await readFile(join(dir, filename), "utf-8");
-  return JSON.parse(raw);
+  return JSON.parse(await readFile(join(dir, filename), "utf-8"));
+}
+
+async function hasManualMarker(dir, dedupKey) {
+  try {
+    await stat(join(dir, manualFilename(dedupKey)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureManualMarker(dir, dedupKey) {
+  try {
+    await writeFile(join(dir, manualFilename(dedupKey)), "manual\n", {
+      flag: "wx",
+      mode: FILE_MODE,
+    });
+    return { ok: true, created: true };
+  } catch (error) {
+    if (error?.code === "EEXIST") return { ok: true, created: false };
+    return { ok: false, error: error?.message || String(error) };
+  }
+}
+
+async function removeManualMarker(dir, dedupKey) {
+  if (dedupKey)
+    await unlink(join(dir, manualFilename(dedupKey))).catch(() => {});
 }
 
 async function findExistingByDedupKey(dir, dedupKey) {
@@ -126,25 +209,18 @@ async function findExistingByDedupKey(dir, dedupKey) {
   } catch {
     return null;
   }
-
-  // Fast path: filenames are `${dedupKey}_${retries}.json` (or
-  // .processing). `dedupKey` is a sha256 hex produced by makeDedupKey
-  // (no underscores), so `${dedupKey}_` is a unique prefix per key.
-  // Filter on prefix BEFORE opening the file to avoid readFile +
-  // JSON.parse on every entry in the directory on every enqueue call —
-  // the previous implementation was O(n²) in queue size. Worst case here
-  // is O(n) readdir entries, but only the (typically single) prefix
-  // match actually gets opened and parsed.
   const prefix = `${dedupKey}_`;
-
-  for (const f of files) {
-    if (!f.startsWith(prefix)) continue;
-    if (!f.endsWith(".json") && !f.endsWith(".processing")) continue;
+  for (const filename of files) {
+    if (
+      !filename.startsWith(prefix) ||
+      (!filename.endsWith(".json") && !filename.endsWith(".processing"))
+    )
+      continue;
     try {
-      const entry = await readEntry(dir, f);
-      if (entry?.dedupKey === dedupKey) return { filename: f, entry };
+      const entry = await readEntry(dir, filename);
+      if (entry?.dedupKey === dedupKey) return { filename, entry };
     } catch {
-      // Corrupted file - ignore for dedup lookup.
+      // Corrupt entries never establish deduplication or cleanup authority.
     }
   }
   return null;
@@ -157,83 +233,81 @@ async function recoverStaleProcessing(dir) {
   } catch {
     return 0;
   }
-
-  const now = Date.now();
   let recovered = 0;
-  for (const f of files) {
-    if (!f.endsWith(".processing")) continue;
-    const from = join(dir, f);
+  for (const filename of files) {
+    if (!filename.endsWith(".processing")) continue;
     try {
-      const s = await stat(from);
-      if (now - s.mtimeMs < PROCESSING_STALE_MS) continue;
-      const to = join(dir, pendingFromProcessingFilename(f));
-      await rename(from, to);
+      if (
+        Date.now() - (await stat(join(dir, filename))).mtimeMs <
+        PROCESSING_STALE_MS
+      )
+        continue;
+      await rename(
+        join(dir, filename),
+        join(dir, pendingFromProcessingFilename(filename)),
+      );
       recovered++;
     } catch {
-      // Best effort. A concurrent process may have already handled it.
+      // Another process may own or have recovered the entry.
     }
   }
   return recovered;
 }
 
-/**
- * Enqueue a failed operation to local disk.
- *
- * @param {string} type - "addMessage" or "commitSession"
- * @param {string} sessionId - OV session ID
- * @param {object} payload - the data that failed to send
- */
-export async function enqueue(type, sessionId, payload) {
-  const dir = getPendingDir();
-  const now = Date.now();
+export async function enqueue(scope, type, sessionId, payload, options = {}) {
+  const dir = scopeDir(scope);
+  const provenance =
+    typeof options.provenance === "string" ? options.provenance : "";
   const dedupKey = makeDedupKey(type, sessionId, payload);
-  const filename = pendingFilename(dedupKey, 0);
+  const filename = pendingFilename(dedupKey);
   const entry = {
     type,
     sessionId,
     payload,
-    createdAt: now,
+    ...(provenance && provenance !== "manual" ? { provenance } : {}),
+    createdAt: Date.now(),
     retries: 0,
     dedupKey,
   };
 
-  try {
-    await ensurePendingDir(dir);
-  } catch (err) {
-    return { ok: false, error: err?.message || String(err), dedupKey };
+  await ensureDir(dir);
+  let markerCreated = false;
+  if (provenance === "manual") {
+    const marker = await ensureManualMarker(dir, dedupKey);
+    if (!marker.ok) return { ok: false, error: marker.error, dedupKey };
+    markerCreated = marker.created;
   }
 
   const existing = await findExistingByDedupKey(dir, dedupKey);
-  if (existing) {
+  if (existing)
     return { ok: true, path: existing.filename, deduped: true, dedupKey };
-  }
 
   try {
     await writeFile(join(dir, filename), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
     return { ok: true, path: filename, dedupKey };
-  } catch (err) {
-    if (err?.code !== "EEXIST") {
-      return { ok: false, error: err?.message || String(err), dedupKey };
+  } catch (error) {
+    if (error?.code !== "EEXIST") {
+      if (markerCreated) await removeManualMarker(dir, dedupKey);
+      return { ok: false, error: error?.message || String(error), dedupKey };
     }
   }
-
   const duplicate = await findExistingByDedupKey(dir, dedupKey);
-  if (duplicate) {
+  if (duplicate)
     return { ok: true, path: duplicate.filename, deduped: true, dedupKey };
-  }
-  return { ok: false, error: `pending file exists but dedup entry was not readable: ${filename}`, dedupKey };
+  if (markerCreated) await removeManualMarker(dir, dedupKey);
+  return {
+    ok: false,
+    error: `pending file exists but is unreadable: ${filename}`,
+    dedupKey,
+  };
 }
 
-/**
- * List all pending queue entries.
- * Returns array of { filename, entry } sorted by createdAt ascending.
- */
-export async function listPending() {
-  const dir = getPendingDir();
+export async function listPending(scope) {
+  const dir = scopeDir(scope);
   let files;
   try {
     await recoverStaleProcessing(dir);
@@ -241,29 +315,25 @@ export async function listPending() {
   } catch {
     return [];
   }
-
   const entries = [];
-  for (const f of files) {
-    if (!f.endsWith(".json")) continue;
+  for (const filename of files) {
+    if (!filename.endsWith(".json")) continue;
     try {
-      const entry = await readEntry(dir, f);
-      entries.push({ filename: f, entry });
+      const entry = await readEntry(dir, filename);
+      if (await hasManualMarker(dir, entry.dedupKey))
+        entry.provenance = "manual";
+      entries.push({ filename, entry });
     } catch {
-      // Corrupted file - skip.
+      // Corrupt entries fail closed and remain available for operator inspection.
     }
   }
-
   entries.sort((a, b) => (a.entry.createdAt || 0) - (b.entry.createdAt || 0));
   return entries;
 }
 
-/**
- * Atomically claim a pending file for replay. Only the process that successfully
- * renames the file may send the HTTP replay.
- */
-export async function claimForReplay(filename) {
+export async function claimForReplay(scope, filename) {
+  const dir = scopeDir(scope);
   if (!filename.endsWith(".json")) return null;
-  const dir = getPendingDir();
   const claimed = processingFilename(filename);
   try {
     await rename(join(dir, filename), join(dir, claimed));
@@ -273,149 +343,151 @@ export async function claimForReplay(filename) {
   }
 }
 
-/**
- * Remove a pending entry after successful replay.
- */
-export async function dequeue(filename) {
-  const dir = getPendingDir();
+export async function dequeue(scope, filename) {
+  const dir = scopeDir(scope);
+  let dedupKey = dedupKeyFromFilename(filename);
+  if (!dedupKey) {
+    try {
+      dedupKey = (await readEntry(dir, filename))?.dedupKey || "";
+    } catch {
+      /* ignore */
+    }
+  }
   try {
     await unlink(join(dir, filename));
+    await removeManualMarker(dir, dedupKey);
     return true;
   } catch {
     return false;
   }
 }
 
-/**
- * Increment retry count on a pending entry. Returns false if max retries exceeded.
- */
-export async function incrementRetry(filename, entry) {
-  const dir = getPendingDir();
-  const maxRetries = getMaxRetries();
+export async function incrementRetry(scope, filename, entry) {
+  const dir = scopeDir(scope);
   entry.retries = (entry.retries || 0) + 1;
-
-  if (entry.retries > maxRetries) {
-    try {
-      await unlink(join(dir, filename));
-    } catch {
-      // Best effort.
-    }
+  if (
+    entry.retries >
+    envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+  ) {
+    await unlink(join(dir, filename)).catch(() => {});
+    await removeManualMarker(
+      dir,
+      entry.dedupKey || dedupKeyFromFilename(filename),
+    );
     return false;
   }
-
-  const newFilename = retryFilename(filename, entry.retries);
-  // Atomic write: write to a unique temp file in the same directory, then
-  // rename into place. Avoids leaving a half-written JSON if the process
-  // crashes mid-write.
-  const tmpFilename = `${newFilename}.tmp.${process.pid}.${Date.now()}`;
+  const next = retryFilename(filename, entry.retries);
+  const temp = `${next}.tmp.${process.pid}.${Date.now()}`;
   try {
-    await writeFile(join(dir, tmpFilename), JSON.stringify(entry), {
+    await writeFile(join(dir, temp), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
-    await rename(join(dir, tmpFilename), join(dir, newFilename));
+    await rename(join(dir, temp), join(dir, next));
     await unlink(join(dir, filename)).catch(() => {});
     return true;
   } catch {
-    await unlink(join(dir, tmpFilename)).catch(() => {});
+    await unlink(join(dir, temp)).catch(() => {});
     return false;
   }
 }
 
-/**
- * Clean up stale entries older than TTL.
- */
-export async function cleanStale() {
-  const ttlMs = getTTLDays() * 24 * 60 * 60 * 1000;
-  const now = Date.now();
-  const pending = await listPending();
+export async function cleanStale(scope) {
+  const ttlMs =
+    envInt("OPENVIKING_PENDING_TTL_DAYS", DEFAULT_TTL_DAYS) *
+    24 *
+    60 *
+    60 *
+    1000;
   let cleaned = 0;
-
-  for (const { filename, entry } of pending) {
-    const age = now - (entry.createdAt || 0);
-    if (age > ttlMs) {
-      await dequeue(filename);
+  for (const { filename, entry } of await listPending(scope)) {
+    if (
+      Date.now() - (entry.createdAt || 0) > ttlMs &&
+      (await dequeue(scope, filename))
+    )
       cleaned++;
-    }
   }
   return cleaned;
 }
 
-/**
- * Replay pending entries. Call this during session-start when the server is
- * healthy. Each run processes at most OPENVIKING_PENDING_REPLAY_LIMIT items so
- * a just-recovered server is not hit with an unbounded replay burst.
- *
- * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
- * @param {Function} log - logger function
- * @returns {{ replayed: number, failed: number, skipped: number, deferred: number }}
- */
-export async function replayPending(fetchJSON, log) {
-  const pending = await listPending();
+function retryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  return !status || status >= 500 || status === 408 || status === 429;
+}
 
-  if (pending.length === 0) {
+export async function replayPending(scope, fetchJSON, log, options = {}) {
+  const pending = await listPending(scope);
+  if (pending.length === 0)
     return { replayed: 0, failed: 0, skipped: 0, deferred: 0 };
-  }
-
-  const replayLimit = getReplayLimit();
-  log("pending-queue", { count: pending.length, replayLimit, action: "replay-start" });
-
-  let replayed = 0;
-  let failed = 0;
-  let skipped = 0;
-  let deferred = 0;
-  let processed = 0;
-
+  const limit = envInt(
+    "OPENVIKING_PENDING_REPLAY_LIMIT",
+    DEFAULT_REPLAY_LIMIT,
+    false,
+  );
+  log("pending-queue", {
+    count: pending.length,
+    replayLimit: limit,
+    action: "replay-start",
+  });
+  let replayed = 0,
+    failed = 0,
+    skipped = 0,
+    deferred = 0,
+    processed = 0;
   for (const { filename, entry } of pending) {
-    if (processed >= replayLimit) {
+    if (options.shouldReplay && !options.shouldReplay(entry)) {
       deferred++;
       continue;
     }
-
-    if ((entry.retries || 0) >= getMaxRetries()) {
-      await dequeue(filename);
+    if (processed >= limit) {
+      deferred++;
+      continue;
+    }
+    if (
+      (entry.retries || 0) >=
+      envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+    ) {
+      await dequeue(scope, filename);
       skipped++;
       continue;
     }
-
-    const claimedFilename = await claimForReplay(filename);
-    if (!claimedFilename) {
+    const claimed = await claimForReplay(scope, filename);
+    if (!claimed) {
       skipped++;
       continue;
     }
     processed++;
-
-    let res;
+    let result;
     try {
-      const encodedSid = encodeURIComponent(entry.sessionId);
+      const sid = encodeURIComponent(entry.sessionId);
       if (entry.type === "addMessage") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/messages`, {
           method: "POST",
           body: JSON.stringify(entry.payload),
         });
       } else if (entry.type === "commitSession") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/commit`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/commit`, {
           method: "POST",
           body: JSON.stringify(entry.payload || {}),
         });
       } else {
-        await dequeue(claimedFilename);
+        await dequeue(scope, claimed);
         skipped++;
         continue;
       }
     } catch {
-      res = { ok: false };
+      result = { ok: false };
     }
-
-    if (res?.ok) {
-      await dequeue(claimedFilename);
+    if (result?.ok) {
+      await dequeue(scope, claimed);
       replayed++;
-    } else if (!isRetryableReplayFailure(res)) {
-      await dequeue(claimedFilename);
+    } else if (!retryable(result)) {
+      await dequeue(scope, claimed);
       skipped++;
     } else {
-      await incrementRetry(claimedFilename, entry);
+      await incrementRetry(scope, claimed, entry);
       failed++;
       if (entry.type === "addMessage") {
         deferred += Math.max(0, pending.length - processed);
@@ -423,9 +495,7 @@ export async function replayPending(fetchJSON, log) {
       }
     }
   }
-
-  const cleaned = await cleanStale();
-
+  const cleaned = await cleanStale(scope);
   log("pending-queue", {
     action: "replay-done",
     replayed,
@@ -434,6 +504,5 @@ export async function replayPending(fetchJSON, log) {
     deferred,
     cleaned,
   });
-
   return { replayed, failed, skipped, deferred };
 }

--- a/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
+++ b/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 
 import { resolveOpenVikingCredentials } from "./credentials.mjs";
 import { createLogger } from "./debug-log.mjs";
-import { enqueue, replayPending } from "./pending-queue.mjs";
+import { createQueueScope, enqueue, replayPending } from "./pending-queue.mjs";
 import { buildProfileBlock } from "./profile-inject.mjs";
 import { buildRecallBlock } from "./recall-core.mjs";
 import { deriveHarnessSessionId, isBypassed } from "./session-model.mjs";
@@ -164,6 +164,13 @@ export async function writeHookState(clientId, nativeSessionId, value) {
 
 export function makeAgentFetchJSON(cfg, cwd = process.cwd()) {
   const effectivePeer = resolveEffectivePeerId({ cfg, cwd });
+  const queueScope = createQueueScope({
+    producer: cfg.clientId,
+    baseUrl: cfg.baseUrl,
+    account: cfg.account,
+    user: cfg.user,
+    apiKey: cfg.apiKey,
+  });
   const fetchJSON = async (path, init = {}, options = {}) => {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), cfg.timeoutMs);
@@ -186,6 +193,7 @@ export function makeAgentFetchJSON(cfg, cwd = process.cwd()) {
       clearTimeout(timer);
     }
   };
+  fetchJSON.queueScope = queueScope;
   return { fetchJSON, effectivePeer };
 }
 
@@ -199,7 +207,7 @@ export async function addAgentMessage(fetchJSON, sessionId, payload) {
     method: "POST",
     body: JSON.stringify(payload),
   });
-  if (!result.ok && retryable(result)) await enqueue("addMessage", sessionId, payload);
+  if (!result.ok && retryable(result)) await enqueue(await fetchJSON.queueScope, "addMessage", sessionId, payload);
   return result;
 }
 
@@ -208,12 +216,12 @@ export async function commitAgentSession(fetchJSON, sessionId) {
     method: "POST",
     body: "{}",
   });
-  if (!result.ok && retryable(result)) await enqueue("commitSession", sessionId, {});
+  if (!result.ok && retryable(result)) await enqueue(await fetchJSON.queueScope, "commitSession", sessionId, {});
   return result;
 }
 
 export async function replayAgentPending(fetchJSON, log = () => {}) {
-  return replayPending(fetchJSON, log);
+  return replayPending(await fetchJSON.queueScope, fetchJSON, log);
 }
 
 export async function recallForPrompt(fetchJSON, cfg, prompt, cwd, log = () => {}) {

--- a/examples/memory-plugin-shared/lib/pending-queue.mjs
+++ b/examples/memory-plugin-shared/lib/pending-queue.mjs
@@ -1,84 +1,149 @@
 /**
- * Local pending queue for offline resilience.
+ * Durable retry queue for OpenViking plugin writes.
  *
- * When the OpenViking server is temporarily unreachable, write operations
- * (addMessage, commitSession) serialize their payloads to
- * `~/.openviking/pending/` as JSON files. On the next session-start, the
- * queue is replayed in small batches. This is a session-start-triggered retry
- * path with maxRetries/TTL, not a long-running background worker.
+ * Queue data is partitioned by producer and authenticated OpenViking target:
+ *   <base>/<producer>/<target-hmac>/
  *
- * Each file contains: { type, sessionId, payload, createdAt, retries, dedupKey }
- *
- * Config (env vars):
- *   OPENVIKING_PENDING_DIR         pending queue directory
- *                                  (default: ~/.openviking/pending)
- *   OPENVIKING_PENDING_MAX_RETRIES max retry attempts per item (default: 3)
- *   OPENVIKING_PENDING_TTL_DAYS    max age in days before stale cleanup
- *                                  (default: 7)
- *   OPENVIKING_PENDING_REPLAY_LIMIT max items replayed per session-start
- *                                  (default: 50)
+ * The HMAC key is stable in normal user-local operation. Tests may point
+ * OPENVIKING_QUEUE_SCOPE_KEY_FILE at an environment-scoped 0600 file; the
+ * surrounding environment owns deleting that file during cleanup.
  */
 
-import { mkdir, readdir, readFile, rename, writeFile, unlink, stat, chmod } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { createHmac, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_TTL_DAYS = 7;
 const DEFAULT_REPLAY_LIMIT = 50;
 const PROCESSING_STALE_MS = 10 * 60 * 1000;
-const DEFAULT_PENDING_DIR = () => join(homedir(), ".openviking", "pending");
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const SCOPE_MARKER = Symbol("openviking-pending-queue-scope");
 
-// Pending queue files may contain raw memory payload / transcript content.
-// Use restrictive permissions explicitly so we don't depend on umask.
-//   - dir: 0o700  (owner: rwx; group/other: none)
-//   - file: 0o600 (owner: rw;  group/other: none)
-const PENDING_DIR_MODE = 0o700;
-const PENDING_FILE_MODE = 0o600;
+const pendingBaseDir = () =>
+  process.env.OPENVIKING_PENDING_DIR ||
+  join(homedir(), ".openviking", "pending");
+const scopeKeyFile = () =>
+  process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE ||
+  join(homedir(), ".openviking", "queue-scope.key");
 
-/**
- * Ensure the pending directory exists with 0o700 permissions. If the
- * directory was created by a previous version of this code (or by hand)
- * with looser permissions, best-effort chmod it on first use.
- */
-async function ensurePendingDir(dir) {
-  await mkdir(dir, { recursive: true, mode: PENDING_DIR_MODE });
-  try {
-    await chmod(dir, PENDING_DIR_MODE);
-  } catch {
-    // Best effort: chmod may fail on some platforms (e.g. Windows); not fatal.
-  }
-}
-
-function getPendingDir() {
-  return process.env.OPENVIKING_PENDING_DIR || DEFAULT_PENDING_DIR();
-}
-
-function getMaxRetries() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_MAX_RETRIES || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_MAX_RETRIES;
-}
-
-function getTTLDays() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_TTL_DAYS || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_TTL_DAYS;
-}
-
-function getReplayLimit() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_REPLAY_LIMIT || "", 10);
-  return Number.isFinite(v) && v > 0 ? v : DEFAULT_REPLAY_LIMIT;
+function envInt(name, fallback, allowZero = true) {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && (allowZero ? value >= 0 : value > 0)
+    ? value
+    : fallback;
 }
 
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   const keys = Object.keys(value).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function normalizedTarget({ baseUrl, account = "", user = "", apiKey = "" }) {
+  let endpoint;
+  try {
+    const parsed = new URL(String(baseUrl || "").trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      throw new Error("unsupported protocol");
+    if (parsed.username || parsed.password || parsed.search || parsed.hash)
+      throw new Error("embedded credentials");
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    endpoint = parsed.toString().replace(/\/$/, "");
+  } catch {
+    throw new Error(
+      "pending queue scope requires an HTTP(S) OpenViking base URL without embedded credentials",
+    );
+  }
+  const identity =
+    account || user
+      ? `identity:${String(account)}\0${String(user)}`
+      : apiKey
+        ? `api-key:${String(apiKey)}`
+        : "anonymous-local";
+  return `${endpoint}\n${identity}`;
+}
+
+async function ensureDir(path) {
+  await mkdir(path, { recursive: true, mode: DIR_MODE });
+  try {
+    const info = await lstat(path);
+    if (!info.isDirectory() || info.isSymbolicLink())
+      throw new Error(`not a private directory: ${path}`);
+    await chmod(path, DIR_MODE);
+  } catch (error) {
+    throw new Error(
+      `pending queue directory is unsafe: ${error?.message || error}`,
+    );
+  }
+}
+
+async function loadOrCreateScopeKey() {
+  const path = scopeKeyFile();
+  await ensureDir(dirname(path));
+  try {
+    await writeFile(path, randomBytes(32), { flag: "wx", mode: FILE_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  let info = await lstat(path);
+  if (!info.isFile() || info.isSymbolicLink())
+    throw new Error("pending queue scope key must be a regular file");
+  try {
+    await chmod(path, FILE_MODE);
+  } catch {
+    /* Windows and read-only stores may reject chmod. */
+  }
+  info = await lstat(path);
+  if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    throw new Error(
+      "pending queue scope key must not be accessible by group or others",
+    );
+  }
+  const key = await readFile(path);
+  if (key.length < 32) throw new Error("pending queue scope key is too short");
+  return key;
+}
+
+/** Create an opaque queue capability for one producer and authenticated target. */
+export async function createQueueScope(options = {}) {
+  const producer = String(options.producer || "")
+    .trim()
+    .toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(producer)) {
+    throw new Error("pending queue scope requires a safe producer name");
+  }
+  const key = await loadOrCreateScopeKey();
+  const targetHash = createHmac("sha256", key)
+    .update(normalizedTarget(options))
+    .digest("hex");
+  const dir = join(pendingBaseDir(), producer, targetHash);
+  await ensureDir(dir);
+  return Object.freeze({ [SCOPE_MARKER]: true, producer, targetHash, dir });
+}
+
+function scopeDir(scope) {
+  if (!scope || scope[SCOPE_MARKER] !== true || typeof scope.dir !== "string") {
+    throw new Error("pending queue operation requires a queue scope");
+  }
+  return scope.dir;
 }
 
 function makeDedupKey(type, sessionId, payload) {
-  return createHash("sha256")
+  return createHmac("sha256", "openviking-pending-dedup-v1")
     .update(type)
     .update("\n")
     .update(sessionId)
@@ -87,35 +152,53 @@ function makeDedupKey(type, sessionId, payload) {
     .digest("hex");
 }
 
-function pendingFilename(dedupKey, retries = 0) {
-  return `${dedupKey}_${Math.max(0, Number(retries) || 0)}.json`;
-}
+const pendingFilename = (key, retries = 0) =>
+  `${key}_${Math.max(0, Number(retries) || 0)}.json`;
+const processingFilename = (filename) =>
+  filename.replace(/\.json$/, ".processing");
+const pendingFromProcessingFilename = (filename) =>
+  filename.replace(/\.processing$/, ".json");
+const manualFilename = (dedupKey) => `${dedupKey}.manual`;
 
 function retryFilename(filename, retries) {
   const bare = filename.replace(/\.(json|processing)$/, "");
-  const nextBare = /_\d+$/.test(bare)
-    ? bare.replace(/_\d+$/, `_${retries}`)
-    : `${bare}_${retries}`;
-  return `${nextBare}.json`;
+  return `${/_\d+$/.test(bare) ? bare.replace(/_\d+$/, `_${retries}`) : `${bare}_${retries}`}.json`;
 }
 
-function processingFilename(filename) {
-  return filename.replace(/\.json$/, ".processing");
-}
-
-function pendingFromProcessingFilename(filename) {
-  return filename.replace(/\.processing$/, ".json");
-}
-
-function isRetryableReplayFailure(res) {
-  if (!res || res.ok) return false;
-  const status = Number(res.status || 0);
-  return !status || status >= 500 || status === 408 || status === 429;
+function dedupKeyFromFilename(filename) {
+  const match = /^([0-9a-f]{64})_(?:\d+)\.(?:json|processing)$/.exec(filename);
+  return match?.[1] || "";
 }
 
 async function readEntry(dir, filename) {
-  const raw = await readFile(join(dir, filename), "utf-8");
-  return JSON.parse(raw);
+  return JSON.parse(await readFile(join(dir, filename), "utf-8"));
+}
+
+async function hasManualMarker(dir, dedupKey) {
+  try {
+    await stat(join(dir, manualFilename(dedupKey)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureManualMarker(dir, dedupKey) {
+  try {
+    await writeFile(join(dir, manualFilename(dedupKey)), "manual\n", {
+      flag: "wx",
+      mode: FILE_MODE,
+    });
+    return { ok: true, created: true };
+  } catch (error) {
+    if (error?.code === "EEXIST") return { ok: true, created: false };
+    return { ok: false, error: error?.message || String(error) };
+  }
+}
+
+async function removeManualMarker(dir, dedupKey) {
+  if (dedupKey)
+    await unlink(join(dir, manualFilename(dedupKey))).catch(() => {});
 }
 
 async function findExistingByDedupKey(dir, dedupKey) {
@@ -125,25 +208,18 @@ async function findExistingByDedupKey(dir, dedupKey) {
   } catch {
     return null;
   }
-
-  // Fast path: filenames are `${dedupKey}_${retries}.json` (or
-  // .processing). `dedupKey` is a sha256 hex produced by makeDedupKey
-  // (no underscores), so `${dedupKey}_` is a unique prefix per key.
-  // Filter on prefix BEFORE opening the file to avoid readFile +
-  // JSON.parse on every entry in the directory on every enqueue call —
-  // the previous implementation was O(n²) in queue size. Worst case here
-  // is O(n) readdir entries, but only the (typically single) prefix
-  // match actually gets opened and parsed.
   const prefix = `${dedupKey}_`;
-
-  for (const f of files) {
-    if (!f.startsWith(prefix)) continue;
-    if (!f.endsWith(".json") && !f.endsWith(".processing")) continue;
+  for (const filename of files) {
+    if (
+      !filename.startsWith(prefix) ||
+      (!filename.endsWith(".json") && !filename.endsWith(".processing"))
+    )
+      continue;
     try {
-      const entry = await readEntry(dir, f);
-      if (entry?.dedupKey === dedupKey) return { filename: f, entry };
+      const entry = await readEntry(dir, filename);
+      if (entry?.dedupKey === dedupKey) return { filename, entry };
     } catch {
-      // Corrupted file - ignore for dedup lookup.
+      // Corrupt entries never establish deduplication or cleanup authority.
     }
   }
   return null;
@@ -156,83 +232,81 @@ async function recoverStaleProcessing(dir) {
   } catch {
     return 0;
   }
-
-  const now = Date.now();
   let recovered = 0;
-  for (const f of files) {
-    if (!f.endsWith(".processing")) continue;
-    const from = join(dir, f);
+  for (const filename of files) {
+    if (!filename.endsWith(".processing")) continue;
     try {
-      const s = await stat(from);
-      if (now - s.mtimeMs < PROCESSING_STALE_MS) continue;
-      const to = join(dir, pendingFromProcessingFilename(f));
-      await rename(from, to);
+      if (
+        Date.now() - (await stat(join(dir, filename))).mtimeMs <
+        PROCESSING_STALE_MS
+      )
+        continue;
+      await rename(
+        join(dir, filename),
+        join(dir, pendingFromProcessingFilename(filename)),
+      );
       recovered++;
     } catch {
-      // Best effort. A concurrent process may have already handled it.
+      // Another process may own or have recovered the entry.
     }
   }
   return recovered;
 }
 
-/**
- * Enqueue a failed operation to local disk.
- *
- * @param {string} type - "addMessage" or "commitSession"
- * @param {string} sessionId - OV session ID
- * @param {object} payload - the data that failed to send
- */
-export async function enqueue(type, sessionId, payload) {
-  const dir = getPendingDir();
-  const now = Date.now();
+export async function enqueue(scope, type, sessionId, payload, options = {}) {
+  const dir = scopeDir(scope);
+  const provenance =
+    typeof options.provenance === "string" ? options.provenance : "";
   const dedupKey = makeDedupKey(type, sessionId, payload);
-  const filename = pendingFilename(dedupKey, 0);
+  const filename = pendingFilename(dedupKey);
   const entry = {
     type,
     sessionId,
     payload,
-    createdAt: now,
+    ...(provenance && provenance !== "manual" ? { provenance } : {}),
+    createdAt: Date.now(),
     retries: 0,
     dedupKey,
   };
 
-  try {
-    await ensurePendingDir(dir);
-  } catch (err) {
-    return { ok: false, error: err?.message || String(err), dedupKey };
+  await ensureDir(dir);
+  let markerCreated = false;
+  if (provenance === "manual") {
+    const marker = await ensureManualMarker(dir, dedupKey);
+    if (!marker.ok) return { ok: false, error: marker.error, dedupKey };
+    markerCreated = marker.created;
   }
 
   const existing = await findExistingByDedupKey(dir, dedupKey);
-  if (existing) {
+  if (existing)
     return { ok: true, path: existing.filename, deduped: true, dedupKey };
-  }
 
   try {
     await writeFile(join(dir, filename), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
     return { ok: true, path: filename, dedupKey };
-  } catch (err) {
-    if (err?.code !== "EEXIST") {
-      return { ok: false, error: err?.message || String(err), dedupKey };
+  } catch (error) {
+    if (error?.code !== "EEXIST") {
+      if (markerCreated) await removeManualMarker(dir, dedupKey);
+      return { ok: false, error: error?.message || String(error), dedupKey };
     }
   }
-
   const duplicate = await findExistingByDedupKey(dir, dedupKey);
-  if (duplicate) {
+  if (duplicate)
     return { ok: true, path: duplicate.filename, deduped: true, dedupKey };
-  }
-  return { ok: false, error: `pending file exists but dedup entry was not readable: ${filename}`, dedupKey };
+  if (markerCreated) await removeManualMarker(dir, dedupKey);
+  return {
+    ok: false,
+    error: `pending file exists but is unreadable: ${filename}`,
+    dedupKey,
+  };
 }
 
-/**
- * List all pending queue entries.
- * Returns array of { filename, entry } sorted by createdAt ascending.
- */
-export async function listPending() {
-  const dir = getPendingDir();
+export async function listPending(scope) {
+  const dir = scopeDir(scope);
   let files;
   try {
     await recoverStaleProcessing(dir);
@@ -240,29 +314,25 @@ export async function listPending() {
   } catch {
     return [];
   }
-
   const entries = [];
-  for (const f of files) {
-    if (!f.endsWith(".json")) continue;
+  for (const filename of files) {
+    if (!filename.endsWith(".json")) continue;
     try {
-      const entry = await readEntry(dir, f);
-      entries.push({ filename: f, entry });
+      const entry = await readEntry(dir, filename);
+      if (await hasManualMarker(dir, entry.dedupKey))
+        entry.provenance = "manual";
+      entries.push({ filename, entry });
     } catch {
-      // Corrupted file - skip.
+      // Corrupt entries fail closed and remain available for operator inspection.
     }
   }
-
   entries.sort((a, b) => (a.entry.createdAt || 0) - (b.entry.createdAt || 0));
   return entries;
 }
 
-/**
- * Atomically claim a pending file for replay. Only the process that successfully
- * renames the file may send the HTTP replay.
- */
-export async function claimForReplay(filename) {
+export async function claimForReplay(scope, filename) {
+  const dir = scopeDir(scope);
   if (!filename.endsWith(".json")) return null;
-  const dir = getPendingDir();
   const claimed = processingFilename(filename);
   try {
     await rename(join(dir, filename), join(dir, claimed));
@@ -272,149 +342,151 @@ export async function claimForReplay(filename) {
   }
 }
 
-/**
- * Remove a pending entry after successful replay.
- */
-export async function dequeue(filename) {
-  const dir = getPendingDir();
+export async function dequeue(scope, filename) {
+  const dir = scopeDir(scope);
+  let dedupKey = dedupKeyFromFilename(filename);
+  if (!dedupKey) {
+    try {
+      dedupKey = (await readEntry(dir, filename))?.dedupKey || "";
+    } catch {
+      /* ignore */
+    }
+  }
   try {
     await unlink(join(dir, filename));
+    await removeManualMarker(dir, dedupKey);
     return true;
   } catch {
     return false;
   }
 }
 
-/**
- * Increment retry count on a pending entry. Returns false if max retries exceeded.
- */
-export async function incrementRetry(filename, entry) {
-  const dir = getPendingDir();
-  const maxRetries = getMaxRetries();
+export async function incrementRetry(scope, filename, entry) {
+  const dir = scopeDir(scope);
   entry.retries = (entry.retries || 0) + 1;
-
-  if (entry.retries > maxRetries) {
-    try {
-      await unlink(join(dir, filename));
-    } catch {
-      // Best effort.
-    }
+  if (
+    entry.retries >
+    envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+  ) {
+    await unlink(join(dir, filename)).catch(() => {});
+    await removeManualMarker(
+      dir,
+      entry.dedupKey || dedupKeyFromFilename(filename),
+    );
     return false;
   }
-
-  const newFilename = retryFilename(filename, entry.retries);
-  // Atomic write: write to a unique temp file in the same directory, then
-  // rename into place. Avoids leaving a half-written JSON if the process
-  // crashes mid-write.
-  const tmpFilename = `${newFilename}.tmp.${process.pid}.${Date.now()}`;
+  const next = retryFilename(filename, entry.retries);
+  const temp = `${next}.tmp.${process.pid}.${Date.now()}`;
   try {
-    await writeFile(join(dir, tmpFilename), JSON.stringify(entry), {
+    await writeFile(join(dir, temp), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
-    await rename(join(dir, tmpFilename), join(dir, newFilename));
+    await rename(join(dir, temp), join(dir, next));
     await unlink(join(dir, filename)).catch(() => {});
     return true;
   } catch {
-    await unlink(join(dir, tmpFilename)).catch(() => {});
+    await unlink(join(dir, temp)).catch(() => {});
     return false;
   }
 }
 
-/**
- * Clean up stale entries older than TTL.
- */
-export async function cleanStale() {
-  const ttlMs = getTTLDays() * 24 * 60 * 60 * 1000;
-  const now = Date.now();
-  const pending = await listPending();
+export async function cleanStale(scope) {
+  const ttlMs =
+    envInt("OPENVIKING_PENDING_TTL_DAYS", DEFAULT_TTL_DAYS) *
+    24 *
+    60 *
+    60 *
+    1000;
   let cleaned = 0;
-
-  for (const { filename, entry } of pending) {
-    const age = now - (entry.createdAt || 0);
-    if (age > ttlMs) {
-      await dequeue(filename);
+  for (const { filename, entry } of await listPending(scope)) {
+    if (
+      Date.now() - (entry.createdAt || 0) > ttlMs &&
+      (await dequeue(scope, filename))
+    )
       cleaned++;
-    }
   }
   return cleaned;
 }
 
-/**
- * Replay pending entries. Call this during session-start when the server is
- * healthy. Each run processes at most OPENVIKING_PENDING_REPLAY_LIMIT items so
- * a just-recovered server is not hit with an unbounded replay burst.
- *
- * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
- * @param {Function} log - logger function
- * @returns {{ replayed: number, failed: number, skipped: number, deferred: number }}
- */
-export async function replayPending(fetchJSON, log) {
-  const pending = await listPending();
+function retryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  return !status || status >= 500 || status === 408 || status === 429;
+}
 
-  if (pending.length === 0) {
+export async function replayPending(scope, fetchJSON, log, options = {}) {
+  const pending = await listPending(scope);
+  if (pending.length === 0)
     return { replayed: 0, failed: 0, skipped: 0, deferred: 0 };
-  }
-
-  const replayLimit = getReplayLimit();
-  log("pending-queue", { count: pending.length, replayLimit, action: "replay-start" });
-
-  let replayed = 0;
-  let failed = 0;
-  let skipped = 0;
-  let deferred = 0;
-  let processed = 0;
-
+  const limit = envInt(
+    "OPENVIKING_PENDING_REPLAY_LIMIT",
+    DEFAULT_REPLAY_LIMIT,
+    false,
+  );
+  log("pending-queue", {
+    count: pending.length,
+    replayLimit: limit,
+    action: "replay-start",
+  });
+  let replayed = 0,
+    failed = 0,
+    skipped = 0,
+    deferred = 0,
+    processed = 0;
   for (const { filename, entry } of pending) {
-    if (processed >= replayLimit) {
+    if (options.shouldReplay && !options.shouldReplay(entry)) {
       deferred++;
       continue;
     }
-
-    if ((entry.retries || 0) >= getMaxRetries()) {
-      await dequeue(filename);
+    if (processed >= limit) {
+      deferred++;
+      continue;
+    }
+    if (
+      (entry.retries || 0) >=
+      envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+    ) {
+      await dequeue(scope, filename);
       skipped++;
       continue;
     }
-
-    const claimedFilename = await claimForReplay(filename);
-    if (!claimedFilename) {
+    const claimed = await claimForReplay(scope, filename);
+    if (!claimed) {
       skipped++;
       continue;
     }
     processed++;
-
-    let res;
+    let result;
     try {
-      const encodedSid = encodeURIComponent(entry.sessionId);
+      const sid = encodeURIComponent(entry.sessionId);
       if (entry.type === "addMessage") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/messages`, {
           method: "POST",
           body: JSON.stringify(entry.payload),
         });
       } else if (entry.type === "commitSession") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/commit`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/commit`, {
           method: "POST",
           body: JSON.stringify(entry.payload || {}),
         });
       } else {
-        await dequeue(claimedFilename);
+        await dequeue(scope, claimed);
         skipped++;
         continue;
       }
     } catch {
-      res = { ok: false };
+      result = { ok: false };
     }
-
-    if (res?.ok) {
-      await dequeue(claimedFilename);
+    if (result?.ok) {
+      await dequeue(scope, claimed);
       replayed++;
-    } else if (!isRetryableReplayFailure(res)) {
-      await dequeue(claimedFilename);
+    } else if (!retryable(result)) {
+      await dequeue(scope, claimed);
       skipped++;
     } else {
-      await incrementRetry(claimedFilename, entry);
+      await incrementRetry(scope, claimed, entry);
       failed++;
       if (entry.type === "addMessage") {
         deferred += Math.max(0, pending.length - processed);
@@ -422,9 +494,7 @@ export async function replayPending(fetchJSON, log) {
       }
     }
   }
-
-  const cleaned = await cleanStale();
-
+  const cleaned = await cleanStale(scope);
   log("pending-queue", {
     action: "replay-done",
     replayed,
@@ -433,6 +503,5 @@ export async function replayPending(fetchJSON, log) {
     deferred,
     cleaned,
   });
-
   return { replayed, failed, skipped, deferred };
 }

--- a/examples/opencode-plugin/lib/memory-session.mjs
+++ b/examples/opencode-plugin/lib/memory-session.mjs
@@ -9,6 +9,7 @@ import {
   deriveHarnessSessionId,
 } from "./shared/session-model.mjs"
 import {
+  createQueueScope,
   enqueue,
   replayPending,
 } from "./shared/pending-queue.mjs"
@@ -25,16 +26,36 @@ export function createMemorySessionManager({ config, pluginRoot }) {
   const oldSessionMapPath = path.join(pluginRoot, "openviking-session-map.json")
   let saveTimer = null
 
+  let queueScopePromise = null
+  function queueScope() {
+    if (!queueScopePromise) {
+      queueScopePromise = createQueueScope({
+        producer: "opencode",
+        baseUrl: config.endpoint,
+        account: config.account,
+        user: config.user,
+        apiKey: config.apiKey,
+      })
+    }
+    return queueScopePromise
+  }
+
   async function init() {
     await migrateLegacySessionMap()
     await loadState()
     const health = await fetchJSON(config, "/health", {}, { timeoutMs: 5000 })
-    if (health.ok) {
-      await replayPending(
-        (endpoint, init = {}, options = {}) => fetchJSON(config, endpoint, init, options),
-        (stage, data) => log("DEBUG", "pending", stage, data),
-      )
-    }
+    if (health.ok) await replayPendingWrites()
+  }
+
+  async function replayPendingWrites() {
+    return replayPending(
+      await queueScope(),
+      (endpoint, init = {}, options = {}) => fetchJSON(config, endpoint, init, options),
+      (stage, data) => log("DEBUG", "pending", stage, data),
+      {
+        shouldReplay: (entry) => config.autoCapture || entry?.provenance === "manual",
+      },
+    )
   }
 
   async function loadState() {
@@ -153,12 +174,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     const state = getOrCreateSession(sessionId, event)
     debouncedSaveState()
     const health = await fetchJSON(config, "/health", {}, { timeoutMs: 5000 })
-    if (health.ok) {
-      await replayPending(
-        (endpoint, init = {}, options = {}) => fetchJSON(config, endpoint, init, options),
-        (stage, data) => log("DEBUG", "pending", stage, data),
-      )
-    }
+    if (health.ok) await replayPendingWrites()
     log("INFO", "event", "OpenViking session derived", {
       opencode_session: sessionId,
       openviking_session: state.ovSessionId,
@@ -257,7 +273,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
 
     const added = await flushPendingMessages(opencodeSessionId, state)
     if (commit) {
-      await commitOvSession(state.ovSessionId, { force: true, reason })
+      await commitOvSession(state.ovSessionId, { force: true, reason, provenance: "autoCapture" })
     } else if (added > 0) {
       await maybeCommitByThreshold(state)
     }
@@ -270,7 +286,12 @@ export function createMemorySessionManager({ config, pluginRoot }) {
       const state = sessions.get(opencodeSessionId)
       if (state) await flushPendingMessages(opencodeSessionId, state)
     }
-    return commitOvSession(sessionId, { force: true, abortSignal, reason: "tool" })
+    return commitOvSession(sessionId, {
+      force: true,
+      abortSignal,
+      reason: "tool",
+      provenance: "manual",
+    })
   }
 
   return {
@@ -381,7 +402,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
   async function addMessageToSession(ovSessionId, body) {
     const health = await fetchJSON(config, "/health", {}, { timeoutMs: 5000 })
     if (!health.ok) {
-      await enqueue("addMessage", ovSessionId, body)
+      await enqueue(await queueScope(), "addMessage", ovSessionId, body, { provenance: "autoCapture" })
       return true
     }
     const res = await fetchJSON(config, `/api/v1/sessions/${encodeURIComponent(ovSessionId)}/messages`, {
@@ -390,7 +411,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     }, { timeoutMs: 10000 })
     if (res.ok) return true
     if (isRetryableFailure(res)) {
-      const queued = await enqueue("addMessage", ovSessionId, body)
+      const queued = await enqueue(await queueScope(), "addMessage", ovSessionId, body, { provenance: "autoCapture" })
       return Boolean(queued.ok)
     }
     log("ERROR", "message", "Failed to add message to OpenViking session", {
@@ -414,10 +435,17 @@ export function createMemorySessionManager({ config, pluginRoot }) {
       threshold: config.commitTokenThreshold,
     })
     if (!meta.ok || pendingTokens < config.commitTokenThreshold) return { committed: false, pendingTokens }
-    return commitOvSession(state.ovSessionId, { force: true, reason: "threshold" })
+    return commitOvSession(state.ovSessionId, {
+      force: true,
+      reason: "threshold",
+      provenance: "autoCapture",
+    })
   }
 
-  async function commitOvSession(ovSessionId, { force = false, reason = "manual", abortSignal } = {}) {
+  async function commitOvSession(
+    ovSessionId,
+    { force = false, reason = "manual", abortSignal, provenance = "manual" } = {},
+  ) {
     if (!force && config.commitTokenThreshold <= 0) return { status: "skipped" }
     const body = { keep_recent_count: config.commitKeepRecentCount }
     const res = await fetchJSON(config, `/api/v1/sessions/${encodeURIComponent(ovSessionId)}/commit`, {
@@ -433,7 +461,8 @@ export function createMemorySessionManager({ config, pluginRoot }) {
       return { status: "accepted", result: res.result }
     }
     if (isRetryableFailure(res)) {
-      await enqueue("commitSession", ovSessionId, body)
+      const queued = await enqueue(await queueScope(), "commitSession", ovSessionId, body, { provenance })
+      if (!queued.ok) throw new Error(`Failed to queue OpenViking session commit: ${queued.error || "unknown error"}`)
       log("WARN", "session", "Queued OpenViking session commit", { openviking_session: ovSessionId, reason })
       return { status: "queued" }
     }
@@ -451,7 +480,11 @@ export function createMemorySessionManager({ config, pluginRoot }) {
       }
       for (const ovSessionId of ovSessionIds) {
         try {
-          await commitOvSession(ovSessionId, { force: true, reason: "legacy-migration" })
+          await commitOvSession(ovSessionId, {
+            force: true,
+            reason: "legacy-migration",
+            provenance: "autoCapture",
+          })
         } catch (error) {
           log("WARN", "migration", "Legacy orphan session commit failed", {
             openviking_session: ovSessionId,

--- a/examples/opencode-plugin/lib/shared/pending-queue.mjs
+++ b/examples/opencode-plugin/lib/shared/pending-queue.mjs
@@ -1,85 +1,150 @@
 // GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
 /**
- * Local pending queue for offline resilience.
+ * Durable retry queue for OpenViking plugin writes.
  *
- * When the OpenViking server is temporarily unreachable, write operations
- * (addMessage, commitSession) serialize their payloads to
- * `~/.openviking/pending/` as JSON files. On the next session-start, the
- * queue is replayed in small batches. This is a session-start-triggered retry
- * path with maxRetries/TTL, not a long-running background worker.
+ * Queue data is partitioned by producer and authenticated OpenViking target:
+ *   <base>/<producer>/<target-hmac>/
  *
- * Each file contains: { type, sessionId, payload, createdAt, retries, dedupKey }
- *
- * Config (env vars):
- *   OPENVIKING_PENDING_DIR         pending queue directory
- *                                  (default: ~/.openviking/pending)
- *   OPENVIKING_PENDING_MAX_RETRIES max retry attempts per item (default: 3)
- *   OPENVIKING_PENDING_TTL_DAYS    max age in days before stale cleanup
- *                                  (default: 7)
- *   OPENVIKING_PENDING_REPLAY_LIMIT max items replayed per session-start
- *                                  (default: 50)
+ * The HMAC key is stable in normal user-local operation. Tests may point
+ * OPENVIKING_QUEUE_SCOPE_KEY_FILE at an environment-scoped 0600 file; the
+ * surrounding environment owns deleting that file during cleanup.
  */
 
-import { mkdir, readdir, readFile, rename, writeFile, unlink, stat, chmod } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { createHmac, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_TTL_DAYS = 7;
 const DEFAULT_REPLAY_LIMIT = 50;
 const PROCESSING_STALE_MS = 10 * 60 * 1000;
-const DEFAULT_PENDING_DIR = () => join(homedir(), ".openviking", "pending");
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const SCOPE_MARKER = Symbol("openviking-pending-queue-scope");
 
-// Pending queue files may contain raw memory payload / transcript content.
-// Use restrictive permissions explicitly so we don't depend on umask.
-//   - dir: 0o700  (owner: rwx; group/other: none)
-//   - file: 0o600 (owner: rw;  group/other: none)
-const PENDING_DIR_MODE = 0o700;
-const PENDING_FILE_MODE = 0o600;
+const pendingBaseDir = () =>
+  process.env.OPENVIKING_PENDING_DIR ||
+  join(homedir(), ".openviking", "pending");
+const scopeKeyFile = () =>
+  process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE ||
+  join(homedir(), ".openviking", "queue-scope.key");
 
-/**
- * Ensure the pending directory exists with 0o700 permissions. If the
- * directory was created by a previous version of this code (or by hand)
- * with looser permissions, best-effort chmod it on first use.
- */
-async function ensurePendingDir(dir) {
-  await mkdir(dir, { recursive: true, mode: PENDING_DIR_MODE });
-  try {
-    await chmod(dir, PENDING_DIR_MODE);
-  } catch {
-    // Best effort: chmod may fail on some platforms (e.g. Windows); not fatal.
-  }
-}
-
-function getPendingDir() {
-  return process.env.OPENVIKING_PENDING_DIR || DEFAULT_PENDING_DIR();
-}
-
-function getMaxRetries() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_MAX_RETRIES || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_MAX_RETRIES;
-}
-
-function getTTLDays() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_TTL_DAYS || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_TTL_DAYS;
-}
-
-function getReplayLimit() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_REPLAY_LIMIT || "", 10);
-  return Number.isFinite(v) && v > 0 ? v : DEFAULT_REPLAY_LIMIT;
+function envInt(name, fallback, allowZero = true) {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && (allowZero ? value >= 0 : value > 0)
+    ? value
+    : fallback;
 }
 
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   const keys = Object.keys(value).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function normalizedTarget({ baseUrl, account = "", user = "", apiKey = "" }) {
+  let endpoint;
+  try {
+    const parsed = new URL(String(baseUrl || "").trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      throw new Error("unsupported protocol");
+    if (parsed.username || parsed.password || parsed.search || parsed.hash)
+      throw new Error("embedded credentials");
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    endpoint = parsed.toString().replace(/\/$/, "");
+  } catch {
+    throw new Error(
+      "pending queue scope requires an HTTP(S) OpenViking base URL without embedded credentials",
+    );
+  }
+  const identity =
+    account || user
+      ? `identity:${String(account)}\0${String(user)}`
+      : apiKey
+        ? `api-key:${String(apiKey)}`
+        : "anonymous-local";
+  return `${endpoint}\n${identity}`;
+}
+
+async function ensureDir(path) {
+  await mkdir(path, { recursive: true, mode: DIR_MODE });
+  try {
+    const info = await lstat(path);
+    if (!info.isDirectory() || info.isSymbolicLink())
+      throw new Error(`not a private directory: ${path}`);
+    await chmod(path, DIR_MODE);
+  } catch (error) {
+    throw new Error(
+      `pending queue directory is unsafe: ${error?.message || error}`,
+    );
+  }
+}
+
+async function loadOrCreateScopeKey() {
+  const path = scopeKeyFile();
+  await ensureDir(dirname(path));
+  try {
+    await writeFile(path, randomBytes(32), { flag: "wx", mode: FILE_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  let info = await lstat(path);
+  if (!info.isFile() || info.isSymbolicLink())
+    throw new Error("pending queue scope key must be a regular file");
+  try {
+    await chmod(path, FILE_MODE);
+  } catch {
+    /* Windows and read-only stores may reject chmod. */
+  }
+  info = await lstat(path);
+  if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    throw new Error(
+      "pending queue scope key must not be accessible by group or others",
+    );
+  }
+  const key = await readFile(path);
+  if (key.length < 32) throw new Error("pending queue scope key is too short");
+  return key;
+}
+
+/** Create an opaque queue capability for one producer and authenticated target. */
+export async function createQueueScope(options = {}) {
+  const producer = String(options.producer || "")
+    .trim()
+    .toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(producer)) {
+    throw new Error("pending queue scope requires a safe producer name");
+  }
+  const key = await loadOrCreateScopeKey();
+  const targetHash = createHmac("sha256", key)
+    .update(normalizedTarget(options))
+    .digest("hex");
+  const dir = join(pendingBaseDir(), producer, targetHash);
+  await ensureDir(dir);
+  return Object.freeze({ [SCOPE_MARKER]: true, producer, targetHash, dir });
+}
+
+function scopeDir(scope) {
+  if (!scope || scope[SCOPE_MARKER] !== true || typeof scope.dir !== "string") {
+    throw new Error("pending queue operation requires a queue scope");
+  }
+  return scope.dir;
 }
 
 function makeDedupKey(type, sessionId, payload) {
-  return createHash("sha256")
+  return createHmac("sha256", "openviking-pending-dedup-v1")
     .update(type)
     .update("\n")
     .update(sessionId)
@@ -88,35 +153,53 @@ function makeDedupKey(type, sessionId, payload) {
     .digest("hex");
 }
 
-function pendingFilename(dedupKey, retries = 0) {
-  return `${dedupKey}_${Math.max(0, Number(retries) || 0)}.json`;
-}
+const pendingFilename = (key, retries = 0) =>
+  `${key}_${Math.max(0, Number(retries) || 0)}.json`;
+const processingFilename = (filename) =>
+  filename.replace(/\.json$/, ".processing");
+const pendingFromProcessingFilename = (filename) =>
+  filename.replace(/\.processing$/, ".json");
+const manualFilename = (dedupKey) => `${dedupKey}.manual`;
 
 function retryFilename(filename, retries) {
   const bare = filename.replace(/\.(json|processing)$/, "");
-  const nextBare = /_\d+$/.test(bare)
-    ? bare.replace(/_\d+$/, `_${retries}`)
-    : `${bare}_${retries}`;
-  return `${nextBare}.json`;
+  return `${/_\d+$/.test(bare) ? bare.replace(/_\d+$/, `_${retries}`) : `${bare}_${retries}`}.json`;
 }
 
-function processingFilename(filename) {
-  return filename.replace(/\.json$/, ".processing");
-}
-
-function pendingFromProcessingFilename(filename) {
-  return filename.replace(/\.processing$/, ".json");
-}
-
-function isRetryableReplayFailure(res) {
-  if (!res || res.ok) return false;
-  const status = Number(res.status || 0);
-  return !status || status >= 500 || status === 408 || status === 429;
+function dedupKeyFromFilename(filename) {
+  const match = /^([0-9a-f]{64})_(?:\d+)\.(?:json|processing)$/.exec(filename);
+  return match?.[1] || "";
 }
 
 async function readEntry(dir, filename) {
-  const raw = await readFile(join(dir, filename), "utf-8");
-  return JSON.parse(raw);
+  return JSON.parse(await readFile(join(dir, filename), "utf-8"));
+}
+
+async function hasManualMarker(dir, dedupKey) {
+  try {
+    await stat(join(dir, manualFilename(dedupKey)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureManualMarker(dir, dedupKey) {
+  try {
+    await writeFile(join(dir, manualFilename(dedupKey)), "manual\n", {
+      flag: "wx",
+      mode: FILE_MODE,
+    });
+    return { ok: true, created: true };
+  } catch (error) {
+    if (error?.code === "EEXIST") return { ok: true, created: false };
+    return { ok: false, error: error?.message || String(error) };
+  }
+}
+
+async function removeManualMarker(dir, dedupKey) {
+  if (dedupKey)
+    await unlink(join(dir, manualFilename(dedupKey))).catch(() => {});
 }
 
 async function findExistingByDedupKey(dir, dedupKey) {
@@ -126,25 +209,18 @@ async function findExistingByDedupKey(dir, dedupKey) {
   } catch {
     return null;
   }
-
-  // Fast path: filenames are `${dedupKey}_${retries}.json` (or
-  // .processing). `dedupKey` is a sha256 hex produced by makeDedupKey
-  // (no underscores), so `${dedupKey}_` is a unique prefix per key.
-  // Filter on prefix BEFORE opening the file to avoid readFile +
-  // JSON.parse on every entry in the directory on every enqueue call —
-  // the previous implementation was O(n²) in queue size. Worst case here
-  // is O(n) readdir entries, but only the (typically single) prefix
-  // match actually gets opened and parsed.
   const prefix = `${dedupKey}_`;
-
-  for (const f of files) {
-    if (!f.startsWith(prefix)) continue;
-    if (!f.endsWith(".json") && !f.endsWith(".processing")) continue;
+  for (const filename of files) {
+    if (
+      !filename.startsWith(prefix) ||
+      (!filename.endsWith(".json") && !filename.endsWith(".processing"))
+    )
+      continue;
     try {
-      const entry = await readEntry(dir, f);
-      if (entry?.dedupKey === dedupKey) return { filename: f, entry };
+      const entry = await readEntry(dir, filename);
+      if (entry?.dedupKey === dedupKey) return { filename, entry };
     } catch {
-      // Corrupted file - ignore for dedup lookup.
+      // Corrupt entries never establish deduplication or cleanup authority.
     }
   }
   return null;
@@ -157,83 +233,81 @@ async function recoverStaleProcessing(dir) {
   } catch {
     return 0;
   }
-
-  const now = Date.now();
   let recovered = 0;
-  for (const f of files) {
-    if (!f.endsWith(".processing")) continue;
-    const from = join(dir, f);
+  for (const filename of files) {
+    if (!filename.endsWith(".processing")) continue;
     try {
-      const s = await stat(from);
-      if (now - s.mtimeMs < PROCESSING_STALE_MS) continue;
-      const to = join(dir, pendingFromProcessingFilename(f));
-      await rename(from, to);
+      if (
+        Date.now() - (await stat(join(dir, filename))).mtimeMs <
+        PROCESSING_STALE_MS
+      )
+        continue;
+      await rename(
+        join(dir, filename),
+        join(dir, pendingFromProcessingFilename(filename)),
+      );
       recovered++;
     } catch {
-      // Best effort. A concurrent process may have already handled it.
+      // Another process may own or have recovered the entry.
     }
   }
   return recovered;
 }
 
-/**
- * Enqueue a failed operation to local disk.
- *
- * @param {string} type - "addMessage" or "commitSession"
- * @param {string} sessionId - OV session ID
- * @param {object} payload - the data that failed to send
- */
-export async function enqueue(type, sessionId, payload) {
-  const dir = getPendingDir();
-  const now = Date.now();
+export async function enqueue(scope, type, sessionId, payload, options = {}) {
+  const dir = scopeDir(scope);
+  const provenance =
+    typeof options.provenance === "string" ? options.provenance : "";
   const dedupKey = makeDedupKey(type, sessionId, payload);
-  const filename = pendingFilename(dedupKey, 0);
+  const filename = pendingFilename(dedupKey);
   const entry = {
     type,
     sessionId,
     payload,
-    createdAt: now,
+    ...(provenance && provenance !== "manual" ? { provenance } : {}),
+    createdAt: Date.now(),
     retries: 0,
     dedupKey,
   };
 
-  try {
-    await ensurePendingDir(dir);
-  } catch (err) {
-    return { ok: false, error: err?.message || String(err), dedupKey };
+  await ensureDir(dir);
+  let markerCreated = false;
+  if (provenance === "manual") {
+    const marker = await ensureManualMarker(dir, dedupKey);
+    if (!marker.ok) return { ok: false, error: marker.error, dedupKey };
+    markerCreated = marker.created;
   }
 
   const existing = await findExistingByDedupKey(dir, dedupKey);
-  if (existing) {
+  if (existing)
     return { ok: true, path: existing.filename, deduped: true, dedupKey };
-  }
 
   try {
     await writeFile(join(dir, filename), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
     return { ok: true, path: filename, dedupKey };
-  } catch (err) {
-    if (err?.code !== "EEXIST") {
-      return { ok: false, error: err?.message || String(err), dedupKey };
+  } catch (error) {
+    if (error?.code !== "EEXIST") {
+      if (markerCreated) await removeManualMarker(dir, dedupKey);
+      return { ok: false, error: error?.message || String(error), dedupKey };
     }
   }
-
   const duplicate = await findExistingByDedupKey(dir, dedupKey);
-  if (duplicate) {
+  if (duplicate)
     return { ok: true, path: duplicate.filename, deduped: true, dedupKey };
-  }
-  return { ok: false, error: `pending file exists but dedup entry was not readable: ${filename}`, dedupKey };
+  if (markerCreated) await removeManualMarker(dir, dedupKey);
+  return {
+    ok: false,
+    error: `pending file exists but is unreadable: ${filename}`,
+    dedupKey,
+  };
 }
 
-/**
- * List all pending queue entries.
- * Returns array of { filename, entry } sorted by createdAt ascending.
- */
-export async function listPending() {
-  const dir = getPendingDir();
+export async function listPending(scope) {
+  const dir = scopeDir(scope);
   let files;
   try {
     await recoverStaleProcessing(dir);
@@ -241,29 +315,25 @@ export async function listPending() {
   } catch {
     return [];
   }
-
   const entries = [];
-  for (const f of files) {
-    if (!f.endsWith(".json")) continue;
+  for (const filename of files) {
+    if (!filename.endsWith(".json")) continue;
     try {
-      const entry = await readEntry(dir, f);
-      entries.push({ filename: f, entry });
+      const entry = await readEntry(dir, filename);
+      if (await hasManualMarker(dir, entry.dedupKey))
+        entry.provenance = "manual";
+      entries.push({ filename, entry });
     } catch {
-      // Corrupted file - skip.
+      // Corrupt entries fail closed and remain available for operator inspection.
     }
   }
-
   entries.sort((a, b) => (a.entry.createdAt || 0) - (b.entry.createdAt || 0));
   return entries;
 }
 
-/**
- * Atomically claim a pending file for replay. Only the process that successfully
- * renames the file may send the HTTP replay.
- */
-export async function claimForReplay(filename) {
+export async function claimForReplay(scope, filename) {
+  const dir = scopeDir(scope);
   if (!filename.endsWith(".json")) return null;
-  const dir = getPendingDir();
   const claimed = processingFilename(filename);
   try {
     await rename(join(dir, filename), join(dir, claimed));
@@ -273,149 +343,151 @@ export async function claimForReplay(filename) {
   }
 }
 
-/**
- * Remove a pending entry after successful replay.
- */
-export async function dequeue(filename) {
-  const dir = getPendingDir();
+export async function dequeue(scope, filename) {
+  const dir = scopeDir(scope);
+  let dedupKey = dedupKeyFromFilename(filename);
+  if (!dedupKey) {
+    try {
+      dedupKey = (await readEntry(dir, filename))?.dedupKey || "";
+    } catch {
+      /* ignore */
+    }
+  }
   try {
     await unlink(join(dir, filename));
+    await removeManualMarker(dir, dedupKey);
     return true;
   } catch {
     return false;
   }
 }
 
-/**
- * Increment retry count on a pending entry. Returns false if max retries exceeded.
- */
-export async function incrementRetry(filename, entry) {
-  const dir = getPendingDir();
-  const maxRetries = getMaxRetries();
+export async function incrementRetry(scope, filename, entry) {
+  const dir = scopeDir(scope);
   entry.retries = (entry.retries || 0) + 1;
-
-  if (entry.retries > maxRetries) {
-    try {
-      await unlink(join(dir, filename));
-    } catch {
-      // Best effort.
-    }
+  if (
+    entry.retries >
+    envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+  ) {
+    await unlink(join(dir, filename)).catch(() => {});
+    await removeManualMarker(
+      dir,
+      entry.dedupKey || dedupKeyFromFilename(filename),
+    );
     return false;
   }
-
-  const newFilename = retryFilename(filename, entry.retries);
-  // Atomic write: write to a unique temp file in the same directory, then
-  // rename into place. Avoids leaving a half-written JSON if the process
-  // crashes mid-write.
-  const tmpFilename = `${newFilename}.tmp.${process.pid}.${Date.now()}`;
+  const next = retryFilename(filename, entry.retries);
+  const temp = `${next}.tmp.${process.pid}.${Date.now()}`;
   try {
-    await writeFile(join(dir, tmpFilename), JSON.stringify(entry), {
+    await writeFile(join(dir, temp), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
-    await rename(join(dir, tmpFilename), join(dir, newFilename));
+    await rename(join(dir, temp), join(dir, next));
     await unlink(join(dir, filename)).catch(() => {});
     return true;
   } catch {
-    await unlink(join(dir, tmpFilename)).catch(() => {});
+    await unlink(join(dir, temp)).catch(() => {});
     return false;
   }
 }
 
-/**
- * Clean up stale entries older than TTL.
- */
-export async function cleanStale() {
-  const ttlMs = getTTLDays() * 24 * 60 * 60 * 1000;
-  const now = Date.now();
-  const pending = await listPending();
+export async function cleanStale(scope) {
+  const ttlMs =
+    envInt("OPENVIKING_PENDING_TTL_DAYS", DEFAULT_TTL_DAYS) *
+    24 *
+    60 *
+    60 *
+    1000;
   let cleaned = 0;
-
-  for (const { filename, entry } of pending) {
-    const age = now - (entry.createdAt || 0);
-    if (age > ttlMs) {
-      await dequeue(filename);
+  for (const { filename, entry } of await listPending(scope)) {
+    if (
+      Date.now() - (entry.createdAt || 0) > ttlMs &&
+      (await dequeue(scope, filename))
+    )
       cleaned++;
-    }
   }
   return cleaned;
 }
 
-/**
- * Replay pending entries. Call this during session-start when the server is
- * healthy. Each run processes at most OPENVIKING_PENDING_REPLAY_LIMIT items so
- * a just-recovered server is not hit with an unbounded replay burst.
- *
- * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
- * @param {Function} log - logger function
- * @returns {{ replayed: number, failed: number, skipped: number, deferred: number }}
- */
-export async function replayPending(fetchJSON, log) {
-  const pending = await listPending();
+function retryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  return !status || status >= 500 || status === 408 || status === 429;
+}
 
-  if (pending.length === 0) {
+export async function replayPending(scope, fetchJSON, log, options = {}) {
+  const pending = await listPending(scope);
+  if (pending.length === 0)
     return { replayed: 0, failed: 0, skipped: 0, deferred: 0 };
-  }
-
-  const replayLimit = getReplayLimit();
-  log("pending-queue", { count: pending.length, replayLimit, action: "replay-start" });
-
-  let replayed = 0;
-  let failed = 0;
-  let skipped = 0;
-  let deferred = 0;
-  let processed = 0;
-
+  const limit = envInt(
+    "OPENVIKING_PENDING_REPLAY_LIMIT",
+    DEFAULT_REPLAY_LIMIT,
+    false,
+  );
+  log("pending-queue", {
+    count: pending.length,
+    replayLimit: limit,
+    action: "replay-start",
+  });
+  let replayed = 0,
+    failed = 0,
+    skipped = 0,
+    deferred = 0,
+    processed = 0;
   for (const { filename, entry } of pending) {
-    if (processed >= replayLimit) {
+    if (options.shouldReplay && !options.shouldReplay(entry)) {
       deferred++;
       continue;
     }
-
-    if ((entry.retries || 0) >= getMaxRetries()) {
-      await dequeue(filename);
+    if (processed >= limit) {
+      deferred++;
+      continue;
+    }
+    if (
+      (entry.retries || 0) >=
+      envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+    ) {
+      await dequeue(scope, filename);
       skipped++;
       continue;
     }
-
-    const claimedFilename = await claimForReplay(filename);
-    if (!claimedFilename) {
+    const claimed = await claimForReplay(scope, filename);
+    if (!claimed) {
       skipped++;
       continue;
     }
     processed++;
-
-    let res;
+    let result;
     try {
-      const encodedSid = encodeURIComponent(entry.sessionId);
+      const sid = encodeURIComponent(entry.sessionId);
       if (entry.type === "addMessage") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/messages`, {
           method: "POST",
           body: JSON.stringify(entry.payload),
         });
       } else if (entry.type === "commitSession") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/commit`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/commit`, {
           method: "POST",
           body: JSON.stringify(entry.payload || {}),
         });
       } else {
-        await dequeue(claimedFilename);
+        await dequeue(scope, claimed);
         skipped++;
         continue;
       }
     } catch {
-      res = { ok: false };
+      result = { ok: false };
     }
-
-    if (res?.ok) {
-      await dequeue(claimedFilename);
+    if (result?.ok) {
+      await dequeue(scope, claimed);
       replayed++;
-    } else if (!isRetryableReplayFailure(res)) {
-      await dequeue(claimedFilename);
+    } else if (!retryable(result)) {
+      await dequeue(scope, claimed);
       skipped++;
     } else {
-      await incrementRetry(claimedFilename, entry);
+      await incrementRetry(scope, claimed, entry);
       failed++;
       if (entry.type === "addMessage") {
         deferred += Math.max(0, pending.length - processed);
@@ -423,9 +495,7 @@ export async function replayPending(fetchJSON, log) {
       }
     }
   }
-
-  const cleaned = await cleanStale();
-
+  const cleaned = await cleanStale(scope);
   log("pending-queue", {
     action: "replay-done",
     replayed,
@@ -434,6 +504,5 @@ export async function replayPending(fetchJSON, log) {
     deferred,
     cleaned,
   });
-
   return { replayed, failed, skipped, deferred };
 }

--- a/examples/opencode-plugin/tests/memory-session.test.mjs
+++ b/examples/opencode-plugin/tests/memory-session.test.mjs
@@ -5,6 +5,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { createMemorySessionManager } from "../lib/memory-session.mjs"
+import { createQueueScope, enqueue, listPending } from "../lib/shared/pending-queue.mjs"
 
 async function withTempDir(prefix, fn) {
   const dir = await mkdtemp(join(tmpdir(), prefix))
@@ -53,6 +54,7 @@ function baseConfig(endpoint) {
     user: "",
     peerId: "",
     timeoutMs: 5000,
+    autoCapture: true,
     captureAssistantTurns: true,
     captureToolMaxChars: 2000,
     captureMode: "semantic",
@@ -62,6 +64,65 @@ function baseConfig(endpoint) {
   }
 }
 
+test("autoCapture=false defers queued automatic writes but replays manual commits", async () => {
+  await withCaptureServer(async ({ endpoint, requests }) => {
+    await withTempDir("ov-oc-session-", async (dir) => {
+      const previousPendingDir = process.env.OPENVIKING_PENDING_DIR
+      const previousKeyFile = process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE
+      process.env.OPENVIKING_PENDING_DIR = join(dir, "pending")
+      process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE = join(dir, "queue-scope.key")
+      try {
+        const config = { ...baseConfig(endpoint), autoCapture: false }
+        const scope = await createQueueScope({
+          producer: "opencode", baseUrl: config.endpoint, account: config.account,
+          user: config.user, apiKey: config.apiKey,
+        })
+        await enqueue(scope,
+          "addMessage",
+          "oc-queued-auto",
+          { role: "user", content: "Queued automatic capture must remain deferred." },
+          { provenance: "autoCapture" },
+        )
+        await enqueue(scope,
+          "commitSession",
+          "oc-queued-manual",
+          { keep_recent_count: 0 },
+          { provenance: "manual" },
+        )
+
+        const manager = createMemorySessionManager({
+          config,
+          pluginRoot: dir,
+        })
+        await manager.init()
+        await manager.handleEvent({
+          type: "session.created",
+          properties: { info: { id: "oc-session-after-disabled-init" } },
+        })
+
+        assert.equal(
+          requests.some((request) => request.url === "/api/v1/sessions/oc-queued-auto/messages"),
+          false,
+          "disabled automatic capture must not replay queued conversation writes",
+        )
+        assert.equal(
+          requests.some((request) => request.url === "/api/v1/sessions/oc-queued-manual/commit"),
+          true,
+          "manual queued commits must remain replayable",
+        )
+        const pending = await listPending(scope)
+        assert.equal(pending.length, 1)
+        assert.equal(pending[0].entry.provenance, "autoCapture")
+        await manager.flushAll({ commit: false })
+      } finally {
+        if (previousPendingDir === undefined) delete process.env.OPENVIKING_PENDING_DIR
+        else process.env.OPENVIKING_PENDING_DIR = previousPendingDir
+        if (previousKeyFile === undefined) delete process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE
+        else process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE = previousKeyFile
+      }
+    })
+  })
+})
 test("session.idle event flushes pending OpenCode capture", async () => {
   await withCaptureServer(async ({ endpoint, requests }) => {
     await withTempDir("ov-oc-session-", async (dir) => {

--- a/examples/pi-coding-agent-extension/shared/pending-queue.d.mts
+++ b/examples/pi-coding-agent-extension/shared/pending-queue.d.mts
@@ -1,7 +1,20 @@
-export function enqueue(type: string, sessionId: string, payload: Record<string, any>): Promise<{ ok: boolean; path?: string; error?: string }>;
-export function listPending(): Promise<Array<{ filename: string; entry: Record<string, any> }>>;
+export interface QueueScope {
+  readonly producer: string;
+  readonly targetHash: string;
+  readonly dir: string;
+}
+export function createQueueScope(options: {
+  producer: string;
+  baseUrl: string;
+  account?: string;
+  user?: string;
+  apiKey?: string;
+}): Promise<QueueScope>;
+export function enqueue(scope: QueueScope, type: string, sessionId: string, payload: Record<string, any>, options?: { provenance?: string }): Promise<{ ok: boolean; path?: string; error?: string; deduped?: boolean; dedupKey?: string }>;
+export function listPending(scope: QueueScope): Promise<Array<{ filename: string; entry: Record<string, any> }>>;
 export function replayPending(
+  scope: QueueScope,
   fetchJSON: (path: string, init?: any) => Promise<{ ok: boolean; status?: number; result?: any; error?: any }>,
   log: (stage: string, data?: any) => void,
 ): Promise<{ replayed: number; failed: number; skipped: number; deferred: number }>;
-export function cleanStale(): Promise<number>;
+export function cleanStale(scope: QueueScope): Promise<number>;

--- a/examples/pi-coding-agent-extension/shared/pending-queue.mjs
+++ b/examples/pi-coding-agent-extension/shared/pending-queue.mjs
@@ -1,85 +1,150 @@
 // GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
 /**
- * Local pending queue for offline resilience.
+ * Durable retry queue for OpenViking plugin writes.
  *
- * When the OpenViking server is temporarily unreachable, write operations
- * (addMessage, commitSession) serialize their payloads to
- * `~/.openviking/pending/` as JSON files. On the next session-start, the
- * queue is replayed in small batches. This is a session-start-triggered retry
- * path with maxRetries/TTL, not a long-running background worker.
+ * Queue data is partitioned by producer and authenticated OpenViking target:
+ *   <base>/<producer>/<target-hmac>/
  *
- * Each file contains: { type, sessionId, payload, createdAt, retries, dedupKey }
- *
- * Config (env vars):
- *   OPENVIKING_PENDING_DIR         pending queue directory
- *                                  (default: ~/.openviking/pending)
- *   OPENVIKING_PENDING_MAX_RETRIES max retry attempts per item (default: 3)
- *   OPENVIKING_PENDING_TTL_DAYS    max age in days before stale cleanup
- *                                  (default: 7)
- *   OPENVIKING_PENDING_REPLAY_LIMIT max items replayed per session-start
- *                                  (default: 50)
+ * The HMAC key is stable in normal user-local operation. Tests may point
+ * OPENVIKING_QUEUE_SCOPE_KEY_FILE at an environment-scoped 0600 file; the
+ * surrounding environment owns deleting that file during cleanup.
  */
 
-import { mkdir, readdir, readFile, rename, writeFile, unlink, stat, chmod } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { createHmac, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_TTL_DAYS = 7;
 const DEFAULT_REPLAY_LIMIT = 50;
 const PROCESSING_STALE_MS = 10 * 60 * 1000;
-const DEFAULT_PENDING_DIR = () => join(homedir(), ".openviking", "pending");
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const SCOPE_MARKER = Symbol("openviking-pending-queue-scope");
 
-// Pending queue files may contain raw memory payload / transcript content.
-// Use restrictive permissions explicitly so we don't depend on umask.
-//   - dir: 0o700  (owner: rwx; group/other: none)
-//   - file: 0o600 (owner: rw;  group/other: none)
-const PENDING_DIR_MODE = 0o700;
-const PENDING_FILE_MODE = 0o600;
+const pendingBaseDir = () =>
+  process.env.OPENVIKING_PENDING_DIR ||
+  join(homedir(), ".openviking", "pending");
+const scopeKeyFile = () =>
+  process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE ||
+  join(homedir(), ".openviking", "queue-scope.key");
 
-/**
- * Ensure the pending directory exists with 0o700 permissions. If the
- * directory was created by a previous version of this code (or by hand)
- * with looser permissions, best-effort chmod it on first use.
- */
-async function ensurePendingDir(dir) {
-  await mkdir(dir, { recursive: true, mode: PENDING_DIR_MODE });
-  try {
-    await chmod(dir, PENDING_DIR_MODE);
-  } catch {
-    // Best effort: chmod may fail on some platforms (e.g. Windows); not fatal.
-  }
-}
-
-function getPendingDir() {
-  return process.env.OPENVIKING_PENDING_DIR || DEFAULT_PENDING_DIR();
-}
-
-function getMaxRetries() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_MAX_RETRIES || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_MAX_RETRIES;
-}
-
-function getTTLDays() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_TTL_DAYS || "", 10);
-  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_TTL_DAYS;
-}
-
-function getReplayLimit() {
-  const v = parseInt(process.env.OPENVIKING_PENDING_REPLAY_LIMIT || "", 10);
-  return Number.isFinite(v) && v > 0 ? v : DEFAULT_REPLAY_LIMIT;
+function envInt(name, fallback, allowZero = true) {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && (allowZero ? value >= 0 : value > 0)
+    ? value
+    : fallback;
 }
 
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   const keys = Object.keys(value).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function normalizedTarget({ baseUrl, account = "", user = "", apiKey = "" }) {
+  let endpoint;
+  try {
+    const parsed = new URL(String(baseUrl || "").trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      throw new Error("unsupported protocol");
+    if (parsed.username || parsed.password || parsed.search || parsed.hash)
+      throw new Error("embedded credentials");
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    endpoint = parsed.toString().replace(/\/$/, "");
+  } catch {
+    throw new Error(
+      "pending queue scope requires an HTTP(S) OpenViking base URL without embedded credentials",
+    );
+  }
+  const identity =
+    account || user
+      ? `identity:${String(account)}\0${String(user)}`
+      : apiKey
+        ? `api-key:${String(apiKey)}`
+        : "anonymous-local";
+  return `${endpoint}\n${identity}`;
+}
+
+async function ensureDir(path) {
+  await mkdir(path, { recursive: true, mode: DIR_MODE });
+  try {
+    const info = await lstat(path);
+    if (!info.isDirectory() || info.isSymbolicLink())
+      throw new Error(`not a private directory: ${path}`);
+    await chmod(path, DIR_MODE);
+  } catch (error) {
+    throw new Error(
+      `pending queue directory is unsafe: ${error?.message || error}`,
+    );
+  }
+}
+
+async function loadOrCreateScopeKey() {
+  const path = scopeKeyFile();
+  await ensureDir(dirname(path));
+  try {
+    await writeFile(path, randomBytes(32), { flag: "wx", mode: FILE_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  let info = await lstat(path);
+  if (!info.isFile() || info.isSymbolicLink())
+    throw new Error("pending queue scope key must be a regular file");
+  try {
+    await chmod(path, FILE_MODE);
+  } catch {
+    /* Windows and read-only stores may reject chmod. */
+  }
+  info = await lstat(path);
+  if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    throw new Error(
+      "pending queue scope key must not be accessible by group or others",
+    );
+  }
+  const key = await readFile(path);
+  if (key.length < 32) throw new Error("pending queue scope key is too short");
+  return key;
+}
+
+/** Create an opaque queue capability for one producer and authenticated target. */
+export async function createQueueScope(options = {}) {
+  const producer = String(options.producer || "")
+    .trim()
+    .toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(producer)) {
+    throw new Error("pending queue scope requires a safe producer name");
+  }
+  const key = await loadOrCreateScopeKey();
+  const targetHash = createHmac("sha256", key)
+    .update(normalizedTarget(options))
+    .digest("hex");
+  const dir = join(pendingBaseDir(), producer, targetHash);
+  await ensureDir(dir);
+  return Object.freeze({ [SCOPE_MARKER]: true, producer, targetHash, dir });
+}
+
+function scopeDir(scope) {
+  if (!scope || scope[SCOPE_MARKER] !== true || typeof scope.dir !== "string") {
+    throw new Error("pending queue operation requires a queue scope");
+  }
+  return scope.dir;
 }
 
 function makeDedupKey(type, sessionId, payload) {
-  return createHash("sha256")
+  return createHmac("sha256", "openviking-pending-dedup-v1")
     .update(type)
     .update("\n")
     .update(sessionId)
@@ -88,35 +153,53 @@ function makeDedupKey(type, sessionId, payload) {
     .digest("hex");
 }
 
-function pendingFilename(dedupKey, retries = 0) {
-  return `${dedupKey}_${Math.max(0, Number(retries) || 0)}.json`;
-}
+const pendingFilename = (key, retries = 0) =>
+  `${key}_${Math.max(0, Number(retries) || 0)}.json`;
+const processingFilename = (filename) =>
+  filename.replace(/\.json$/, ".processing");
+const pendingFromProcessingFilename = (filename) =>
+  filename.replace(/\.processing$/, ".json");
+const manualFilename = (dedupKey) => `${dedupKey}.manual`;
 
 function retryFilename(filename, retries) {
   const bare = filename.replace(/\.(json|processing)$/, "");
-  const nextBare = /_\d+$/.test(bare)
-    ? bare.replace(/_\d+$/, `_${retries}`)
-    : `${bare}_${retries}`;
-  return `${nextBare}.json`;
+  return `${/_\d+$/.test(bare) ? bare.replace(/_\d+$/, `_${retries}`) : `${bare}_${retries}`}.json`;
 }
 
-function processingFilename(filename) {
-  return filename.replace(/\.json$/, ".processing");
-}
-
-function pendingFromProcessingFilename(filename) {
-  return filename.replace(/\.processing$/, ".json");
-}
-
-function isRetryableReplayFailure(res) {
-  if (!res || res.ok) return false;
-  const status = Number(res.status || 0);
-  return !status || status >= 500 || status === 408 || status === 429;
+function dedupKeyFromFilename(filename) {
+  const match = /^([0-9a-f]{64})_(?:\d+)\.(?:json|processing)$/.exec(filename);
+  return match?.[1] || "";
 }
 
 async function readEntry(dir, filename) {
-  const raw = await readFile(join(dir, filename), "utf-8");
-  return JSON.parse(raw);
+  return JSON.parse(await readFile(join(dir, filename), "utf-8"));
+}
+
+async function hasManualMarker(dir, dedupKey) {
+  try {
+    await stat(join(dir, manualFilename(dedupKey)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureManualMarker(dir, dedupKey) {
+  try {
+    await writeFile(join(dir, manualFilename(dedupKey)), "manual\n", {
+      flag: "wx",
+      mode: FILE_MODE,
+    });
+    return { ok: true, created: true };
+  } catch (error) {
+    if (error?.code === "EEXIST") return { ok: true, created: false };
+    return { ok: false, error: error?.message || String(error) };
+  }
+}
+
+async function removeManualMarker(dir, dedupKey) {
+  if (dedupKey)
+    await unlink(join(dir, manualFilename(dedupKey))).catch(() => {});
 }
 
 async function findExistingByDedupKey(dir, dedupKey) {
@@ -126,25 +209,18 @@ async function findExistingByDedupKey(dir, dedupKey) {
   } catch {
     return null;
   }
-
-  // Fast path: filenames are `${dedupKey}_${retries}.json` (or
-  // .processing). `dedupKey` is a sha256 hex produced by makeDedupKey
-  // (no underscores), so `${dedupKey}_` is a unique prefix per key.
-  // Filter on prefix BEFORE opening the file to avoid readFile +
-  // JSON.parse on every entry in the directory on every enqueue call —
-  // the previous implementation was O(n²) in queue size. Worst case here
-  // is O(n) readdir entries, but only the (typically single) prefix
-  // match actually gets opened and parsed.
   const prefix = `${dedupKey}_`;
-
-  for (const f of files) {
-    if (!f.startsWith(prefix)) continue;
-    if (!f.endsWith(".json") && !f.endsWith(".processing")) continue;
+  for (const filename of files) {
+    if (
+      !filename.startsWith(prefix) ||
+      (!filename.endsWith(".json") && !filename.endsWith(".processing"))
+    )
+      continue;
     try {
-      const entry = await readEntry(dir, f);
-      if (entry?.dedupKey === dedupKey) return { filename: f, entry };
+      const entry = await readEntry(dir, filename);
+      if (entry?.dedupKey === dedupKey) return { filename, entry };
     } catch {
-      // Corrupted file - ignore for dedup lookup.
+      // Corrupt entries never establish deduplication or cleanup authority.
     }
   }
   return null;
@@ -157,83 +233,81 @@ async function recoverStaleProcessing(dir) {
   } catch {
     return 0;
   }
-
-  const now = Date.now();
   let recovered = 0;
-  for (const f of files) {
-    if (!f.endsWith(".processing")) continue;
-    const from = join(dir, f);
+  for (const filename of files) {
+    if (!filename.endsWith(".processing")) continue;
     try {
-      const s = await stat(from);
-      if (now - s.mtimeMs < PROCESSING_STALE_MS) continue;
-      const to = join(dir, pendingFromProcessingFilename(f));
-      await rename(from, to);
+      if (
+        Date.now() - (await stat(join(dir, filename))).mtimeMs <
+        PROCESSING_STALE_MS
+      )
+        continue;
+      await rename(
+        join(dir, filename),
+        join(dir, pendingFromProcessingFilename(filename)),
+      );
       recovered++;
     } catch {
-      // Best effort. A concurrent process may have already handled it.
+      // Another process may own or have recovered the entry.
     }
   }
   return recovered;
 }
 
-/**
- * Enqueue a failed operation to local disk.
- *
- * @param {string} type - "addMessage" or "commitSession"
- * @param {string} sessionId - OV session ID
- * @param {object} payload - the data that failed to send
- */
-export async function enqueue(type, sessionId, payload) {
-  const dir = getPendingDir();
-  const now = Date.now();
+export async function enqueue(scope, type, sessionId, payload, options = {}) {
+  const dir = scopeDir(scope);
+  const provenance =
+    typeof options.provenance === "string" ? options.provenance : "";
   const dedupKey = makeDedupKey(type, sessionId, payload);
-  const filename = pendingFilename(dedupKey, 0);
+  const filename = pendingFilename(dedupKey);
   const entry = {
     type,
     sessionId,
     payload,
-    createdAt: now,
+    ...(provenance && provenance !== "manual" ? { provenance } : {}),
+    createdAt: Date.now(),
     retries: 0,
     dedupKey,
   };
 
-  try {
-    await ensurePendingDir(dir);
-  } catch (err) {
-    return { ok: false, error: err?.message || String(err), dedupKey };
+  await ensureDir(dir);
+  let markerCreated = false;
+  if (provenance === "manual") {
+    const marker = await ensureManualMarker(dir, dedupKey);
+    if (!marker.ok) return { ok: false, error: marker.error, dedupKey };
+    markerCreated = marker.created;
   }
 
   const existing = await findExistingByDedupKey(dir, dedupKey);
-  if (existing) {
+  if (existing)
     return { ok: true, path: existing.filename, deduped: true, dedupKey };
-  }
 
   try {
     await writeFile(join(dir, filename), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
     return { ok: true, path: filename, dedupKey };
-  } catch (err) {
-    if (err?.code !== "EEXIST") {
-      return { ok: false, error: err?.message || String(err), dedupKey };
+  } catch (error) {
+    if (error?.code !== "EEXIST") {
+      if (markerCreated) await removeManualMarker(dir, dedupKey);
+      return { ok: false, error: error?.message || String(error), dedupKey };
     }
   }
-
   const duplicate = await findExistingByDedupKey(dir, dedupKey);
-  if (duplicate) {
+  if (duplicate)
     return { ok: true, path: duplicate.filename, deduped: true, dedupKey };
-  }
-  return { ok: false, error: `pending file exists but dedup entry was not readable: ${filename}`, dedupKey };
+  if (markerCreated) await removeManualMarker(dir, dedupKey);
+  return {
+    ok: false,
+    error: `pending file exists but is unreadable: ${filename}`,
+    dedupKey,
+  };
 }
 
-/**
- * List all pending queue entries.
- * Returns array of { filename, entry } sorted by createdAt ascending.
- */
-export async function listPending() {
-  const dir = getPendingDir();
+export async function listPending(scope) {
+  const dir = scopeDir(scope);
   let files;
   try {
     await recoverStaleProcessing(dir);
@@ -241,29 +315,25 @@ export async function listPending() {
   } catch {
     return [];
   }
-
   const entries = [];
-  for (const f of files) {
-    if (!f.endsWith(".json")) continue;
+  for (const filename of files) {
+    if (!filename.endsWith(".json")) continue;
     try {
-      const entry = await readEntry(dir, f);
-      entries.push({ filename: f, entry });
+      const entry = await readEntry(dir, filename);
+      if (await hasManualMarker(dir, entry.dedupKey))
+        entry.provenance = "manual";
+      entries.push({ filename, entry });
     } catch {
-      // Corrupted file - skip.
+      // Corrupt entries fail closed and remain available for operator inspection.
     }
   }
-
   entries.sort((a, b) => (a.entry.createdAt || 0) - (b.entry.createdAt || 0));
   return entries;
 }
 
-/**
- * Atomically claim a pending file for replay. Only the process that successfully
- * renames the file may send the HTTP replay.
- */
-export async function claimForReplay(filename) {
+export async function claimForReplay(scope, filename) {
+  const dir = scopeDir(scope);
   if (!filename.endsWith(".json")) return null;
-  const dir = getPendingDir();
   const claimed = processingFilename(filename);
   try {
     await rename(join(dir, filename), join(dir, claimed));
@@ -273,149 +343,151 @@ export async function claimForReplay(filename) {
   }
 }
 
-/**
- * Remove a pending entry after successful replay.
- */
-export async function dequeue(filename) {
-  const dir = getPendingDir();
+export async function dequeue(scope, filename) {
+  const dir = scopeDir(scope);
+  let dedupKey = dedupKeyFromFilename(filename);
+  if (!dedupKey) {
+    try {
+      dedupKey = (await readEntry(dir, filename))?.dedupKey || "";
+    } catch {
+      /* ignore */
+    }
+  }
   try {
     await unlink(join(dir, filename));
+    await removeManualMarker(dir, dedupKey);
     return true;
   } catch {
     return false;
   }
 }
 
-/**
- * Increment retry count on a pending entry. Returns false if max retries exceeded.
- */
-export async function incrementRetry(filename, entry) {
-  const dir = getPendingDir();
-  const maxRetries = getMaxRetries();
+export async function incrementRetry(scope, filename, entry) {
+  const dir = scopeDir(scope);
   entry.retries = (entry.retries || 0) + 1;
-
-  if (entry.retries > maxRetries) {
-    try {
-      await unlink(join(dir, filename));
-    } catch {
-      // Best effort.
-    }
+  if (
+    entry.retries >
+    envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+  ) {
+    await unlink(join(dir, filename)).catch(() => {});
+    await removeManualMarker(
+      dir,
+      entry.dedupKey || dedupKeyFromFilename(filename),
+    );
     return false;
   }
-
-  const newFilename = retryFilename(filename, entry.retries);
-  // Atomic write: write to a unique temp file in the same directory, then
-  // rename into place. Avoids leaving a half-written JSON if the process
-  // crashes mid-write.
-  const tmpFilename = `${newFilename}.tmp.${process.pid}.${Date.now()}`;
+  const next = retryFilename(filename, entry.retries);
+  const temp = `${next}.tmp.${process.pid}.${Date.now()}`;
   try {
-    await writeFile(join(dir, tmpFilename), JSON.stringify(entry), {
+    await writeFile(join(dir, temp), JSON.stringify(entry), {
       encoding: "utf-8",
       flag: "wx",
-      mode: PENDING_FILE_MODE,
+      mode: FILE_MODE,
     });
-    await rename(join(dir, tmpFilename), join(dir, newFilename));
+    await rename(join(dir, temp), join(dir, next));
     await unlink(join(dir, filename)).catch(() => {});
     return true;
   } catch {
-    await unlink(join(dir, tmpFilename)).catch(() => {});
+    await unlink(join(dir, temp)).catch(() => {});
     return false;
   }
 }
 
-/**
- * Clean up stale entries older than TTL.
- */
-export async function cleanStale() {
-  const ttlMs = getTTLDays() * 24 * 60 * 60 * 1000;
-  const now = Date.now();
-  const pending = await listPending();
+export async function cleanStale(scope) {
+  const ttlMs =
+    envInt("OPENVIKING_PENDING_TTL_DAYS", DEFAULT_TTL_DAYS) *
+    24 *
+    60 *
+    60 *
+    1000;
   let cleaned = 0;
-
-  for (const { filename, entry } of pending) {
-    const age = now - (entry.createdAt || 0);
-    if (age > ttlMs) {
-      await dequeue(filename);
+  for (const { filename, entry } of await listPending(scope)) {
+    if (
+      Date.now() - (entry.createdAt || 0) > ttlMs &&
+      (await dequeue(scope, filename))
+    )
       cleaned++;
-    }
   }
   return cleaned;
 }
 
-/**
- * Replay pending entries. Call this during session-start when the server is
- * healthy. Each run processes at most OPENVIKING_PENDING_REPLAY_LIMIT items so
- * a just-recovered server is not hit with an unbounded replay burst.
- *
- * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
- * @param {Function} log - logger function
- * @returns {{ replayed: number, failed: number, skipped: number, deferred: number }}
- */
-export async function replayPending(fetchJSON, log) {
-  const pending = await listPending();
+function retryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  return !status || status >= 500 || status === 408 || status === 429;
+}
 
-  if (pending.length === 0) {
+export async function replayPending(scope, fetchJSON, log, options = {}) {
+  const pending = await listPending(scope);
+  if (pending.length === 0)
     return { replayed: 0, failed: 0, skipped: 0, deferred: 0 };
-  }
-
-  const replayLimit = getReplayLimit();
-  log("pending-queue", { count: pending.length, replayLimit, action: "replay-start" });
-
-  let replayed = 0;
-  let failed = 0;
-  let skipped = 0;
-  let deferred = 0;
-  let processed = 0;
-
+  const limit = envInt(
+    "OPENVIKING_PENDING_REPLAY_LIMIT",
+    DEFAULT_REPLAY_LIMIT,
+    false,
+  );
+  log("pending-queue", {
+    count: pending.length,
+    replayLimit: limit,
+    action: "replay-start",
+  });
+  let replayed = 0,
+    failed = 0,
+    skipped = 0,
+    deferred = 0,
+    processed = 0;
   for (const { filename, entry } of pending) {
-    if (processed >= replayLimit) {
+    if (options.shouldReplay && !options.shouldReplay(entry)) {
       deferred++;
       continue;
     }
-
-    if ((entry.retries || 0) >= getMaxRetries()) {
-      await dequeue(filename);
+    if (processed >= limit) {
+      deferred++;
+      continue;
+    }
+    if (
+      (entry.retries || 0) >=
+      envInt("OPENVIKING_PENDING_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+    ) {
+      await dequeue(scope, filename);
       skipped++;
       continue;
     }
-
-    const claimedFilename = await claimForReplay(filename);
-    if (!claimedFilename) {
+    const claimed = await claimForReplay(scope, filename);
+    if (!claimed) {
       skipped++;
       continue;
     }
     processed++;
-
-    let res;
+    let result;
     try {
-      const encodedSid = encodeURIComponent(entry.sessionId);
+      const sid = encodeURIComponent(entry.sessionId);
       if (entry.type === "addMessage") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/messages`, {
           method: "POST",
           body: JSON.stringify(entry.payload),
         });
       } else if (entry.type === "commitSession") {
-        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/commit`, {
+        result = await fetchJSON(`/api/v1/sessions/${sid}/commit`, {
           method: "POST",
           body: JSON.stringify(entry.payload || {}),
         });
       } else {
-        await dequeue(claimedFilename);
+        await dequeue(scope, claimed);
         skipped++;
         continue;
       }
     } catch {
-      res = { ok: false };
+      result = { ok: false };
     }
-
-    if (res?.ok) {
-      await dequeue(claimedFilename);
+    if (result?.ok) {
+      await dequeue(scope, claimed);
       replayed++;
-    } else if (!isRetryableReplayFailure(res)) {
-      await dequeue(claimedFilename);
+    } else if (!retryable(result)) {
+      await dequeue(scope, claimed);
       skipped++;
     } else {
-      await incrementRetry(claimedFilename, entry);
+      await incrementRetry(scope, claimed, entry);
       failed++;
       if (entry.type === "addMessage") {
         deferred += Math.max(0, pending.length - processed);
@@ -423,9 +495,7 @@ export async function replayPending(fetchJSON, log) {
       }
     }
   }
-
-  const cleaned = await cleanStale();
-
+  const cleaned = await cleanStale(scope);
   log("pending-queue", {
     action: "replay-done",
     replayed,
@@ -434,6 +504,5 @@ export async function replayPending(fetchJSON, log) {
     deferred,
     cleaned,
   });
-
   return { replayed, failed, skipped, deferred };
 }

--- a/examples/pi-coding-agent-extension/sync.ts
+++ b/examples/pi-coding-agent-extension/sync.ts
@@ -1,7 +1,8 @@
 import type { OVClient } from "./client.js";
 import type { OVConfig } from "./config.js";
 import { deriveHarnessSessionId } from "./shared/session-model.mjs";
-import { enqueue, listPending, replayPending } from "./shared/pending-queue.mjs";
+import { createQueueScope, enqueue, listPending, replayPending } from "./shared/pending-queue.mjs";
+import type { QueueScope } from "./shared/pending-queue.mjs";
 import { extractBranchCapturePayloads } from "./lib/capture-adapter.mjs";
 import { countUndeliveredForSession, estimatePayloadTokens } from "./lib/takeover-core.mjs";
 
@@ -23,10 +24,24 @@ export class SyncManager {
   private config: OVConfig;
   private ovSessionId: string | null = null;
   private syncedEntryCount = 0;
+  private queueScope: Promise<QueueScope> | null = null;
 
   constructor(client: OVClient, config: OVConfig) {
     this.client = client;
     this.config = config;
+  }
+
+  private getQueueScope(): Promise<QueueScope> {
+    if (!this.queueScope) {
+      this.queueScope = createQueueScope({
+        producer: "pi",
+        baseUrl: this.config.endpoint,
+        account: this.config.account,
+        user: this.config.user,
+        apiKey: this.config.apiKey,
+      });
+    }
+    return this.queueScope;
   }
 
   get sessionId(): string | null { return this.ovSessionId; }
@@ -48,6 +63,7 @@ export class SyncManager {
   async replayPending(): Promise<void> {
     if (!this.client.connected) return;
     await replayPending(
+      await this.getQueueScope(),
       (path: string, init?: any) => this.client.fetchJSON(path, init, 10000),
       () => {},
     );
@@ -56,7 +72,7 @@ export class SyncManager {
   async flushForTakeover(): Promise<boolean> {
     if (!this.ovSessionId) return false;
     await this.replayPending();
-    const pending = await listPending();
+    const pending = await listPending(await this.getQueueScope());
     return countUndeliveredForSession(pending, this.ovSessionId) === 0;
   }
 
@@ -88,7 +104,8 @@ export class SyncManager {
     if (!this.ovSessionId) return { accepted: false, delivered: false };
     const ok = await this.client.addMessagePayload(this.ovSessionId, payload);
     if (ok) return { accepted: true, delivered: true };
-    await enqueue("addMessage", this.ovSessionId, payload);
+    const queued = await enqueue(await this.getQueueScope(), "addMessage", this.ovSessionId, payload);
+    if (!queued.ok) return { accepted: false, delivered: false };
     return { accepted: true, delivered: false };
   }
 
@@ -109,9 +126,10 @@ export class SyncManager {
     );
     if (!result) {
       if (opts.queueOnFailure !== false) {
-        await enqueue("commitSession", this.ovSessionId, {
+        const queued = await enqueue(await this.getQueueScope(), "commitSession", this.ovSessionId, {
           keep_recent_count: opts.keepRecentCount ?? this.config.commitKeepRecentCount,
         });
+        if (!queued.ok) return null;
       }
       return null;
     }

--- a/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
@@ -4,10 +4,14 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SyncManager } from "../sync.ts";
-import { enqueue, listPending } from "../shared/pending-queue.mjs";
+import { createQueueScope, enqueue, listPending } from "../shared/pending-queue.mjs";
 
 function config(overrides = {}) {
   return {
+	endpoint: "https://ov.example.test",
+	apiKey: "test-key",
+	account: "",
+	user: "",
     commitTokenThreshold: 20000,
     commitKeepRecentCount: 10,
     captureAssistantTurns: true,
@@ -16,6 +20,13 @@ function config(overrides = {}) {
     takeoverEnabled: true,
     ...overrides,
   };
+}
+
+async function testScope(overrides = {}) {
+	const cfg = config(overrides);
+	return createQueueScope({
+		producer: "pi", baseUrl: cfg.endpoint, account: cfg.account, user: cfg.user, apiKey: cfg.apiKey,
+	});
 }
 
 function client(overrides = {}) {
@@ -31,13 +42,17 @@ function client(overrides = {}) {
 
 async function withPendingDir(fn) {
   const previous = process.env.OPENVIKING_PENDING_DIR;
+	const previousKeyFile = process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE;
   const dir = await mkdtemp(join(tmpdir(), "ov-pi-pending-"));
   process.env.OPENVIKING_PENDING_DIR = dir;
+	process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE = join(dir, "queue-scope.key");
   try {
     return await fn(dir);
   } finally {
     if (previous === undefined) delete process.env.OPENVIKING_PENDING_DIR;
     else process.env.OPENVIKING_PENDING_DIR = previous;
+	if (previousKeyFile === undefined) delete process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE;
+	else process.env.OPENVIKING_QUEUE_SCOPE_KEY_FILE = previousKeyFile;
     await rm(dir, { recursive: true, force: true });
   }
 }
@@ -75,12 +90,12 @@ test("queued addMessage makes takeover flush barrier false until replay succeeds
 
     assert.equal(result.added, 1);
     assert.equal(result.allDelivered, false);
-    assert.equal((await listPending()).length, 1);
+	assert.equal((await listPending(await testScope())).length, 1);
     assert.equal(await sync.flushForTakeover(), false);
 
     replayOk = true;
     assert.equal(await sync.flushForTakeover(), true);
-    assert.equal((await listPending()).length, 0);
+	assert.equal((await listPending(await testScope())).length, 0);
   });
 });
 
@@ -96,7 +111,7 @@ test("current-session addMessage 500 remains queued and keeps barrier closed", a
     await sync.addPayload({ role: "user", content: "Queued content with retryable server failure." });
 
     assert.equal(await sync.flushForTakeover(), false);
-    const pending = await listPending();
+	const pending = await listPending(await testScope());
     assert.equal(pending.length, 1);
     assert.equal(pending[0].entry.type, "addMessage");
     assert.equal(pending[0].entry.sessionId, sync.sessionId);
@@ -111,8 +126,9 @@ test("other-session addMessage and commit queue entries do not block takeover ba
     const sync = new SyncManager(c, config());
     await sync.ensureSession("pi-session");
 
-    await enqueue("addMessage", "different-session", { role: "user", content: "other" });
-    await enqueue("commitSession", sync.sessionId, { keep_recent_count: 1 });
+	const scope = await testScope();
+	await enqueue(scope, "addMessage", "different-session", { role: "user", content: "other" });
+	await enqueue(scope, "commitSession", sync.sessionId, { keep_recent_count: 1 });
 
     assert.equal(await sync.flushForTakeover(), true);
   });


### PR DESCRIPTION
## Description

This draft isolates broader durable-write and lifecycle hardening from the focused plugin contract fixes in #3232. It is preserved for later design review and is not required by the current release-gate work.

## Human Involvement

- [x] A human participated in the implementation and review loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Partition pending writes by producer and authenticated OpenViking target without exposing raw credentials in queue paths.
- Use a stable protected scope key and process-safe queue claims, deduplication, replay limits, and automatic-to-manual provenance promotion.
- Keep Claude Code lifecycle and subagent commits behind pending-write delivery barriers.
- Scope OpenCode pending writes and preserve explicit manual replay semantics.
- Prevent Pi takeover compaction from advancing past undelivered writes for the current session.
- Synchronize generated queue implementations and Pi declarations with the canonical shared implementation.

## Testing

- [x] I have added focused tests for the proposed behavior
- [x] Targeted suites pass locally
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Current draft validation:

- Claude Code queue and integration tests: 21/21 passed.
- OpenCode syntax checks and tests: 15/15 passed.
- Pi extension tests: 39/39 passed.
- Shared generated-source synchronization passed.
- Repository memory-plugin suite: 146/147 passed from a clean standard checkout.

Known failure:

- `Cursor replays offline capture on the next SessionStart` still counts queue files directly in the configured root. The proposed scoped queue stores them below producer/target directories, so the assertion reports zero instead of two. This draft intentionally leaves that integration contract unresolved for later work.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the extracted scope
- [x] I have documented the known failing integration test
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in targeted suites
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR is deliberately parked as a draft. It should not be merged or used as a prerequisite for the current OpenViking harness release-gate pipeline.
